### PR TITLE
test(ci): recover unified pipeline for TwoFactorManager mocks

### DIFF
--- a/docs/status/WAVE2_GATE_DECISION.md
+++ b/docs/status/WAVE2_GATE_DECISION.md
@@ -1,0 +1,59 @@
+# Wave 2 Gate Decision (Recheck After Wave 1.96)
+
+Date: 2026-03-06  
+Wave: 1.96 CI Recovery  
+Verdict: **READY_FOR_WAVE2**
+
+## 1) CI Readiness
+
+Unified pipeline now has a fresh green run after Wave 1.96 fix:
+- Workflow: `ci-cd-unified.yml`
+- Run ID: `22762302449`
+- URL: https://github.com/drsapaev/final/actions/runs/22762302449
+- Head SHA: `aabcae9040ffb0de226c34fea9d460ab39697eeb`
+- Conclusion: `success`
+
+Conclusion: CI readiness is **confirmed** for the post-fix SHA.
+
+## 2) Test Stability
+
+Wave 1.96 local recheck stayed green:
+- `cd frontend && npm run test:run` -> `24` files, `173` tests passed.
+- `cd backend && pytest -q` -> `645 passed, 3 skipped`.
+- RBAC checks (`test_rbac_matrix`, `validate_role_integrity`) -> green.
+
+Conclusion: test stability remains **sufficient and reproducible**.
+
+## 3) Security Baseline
+
+No new remediation slice in Wave 1.96; baseline remains from Wave 1.95:
+- `pip-audit`: `15` vulnerable packages / `33` records.
+- `bandit` app-scope parity: `158` total, `15` high, `B701=11`, `B324=4`.
+- `npm audit`: `11` total (`1 critical`, `3 high`, `7 moderate`).
+
+Conclusion: security baseline is **stable without regression**.
+
+## 4) Protected Zone Risk
+
+Protected-zone decisions from Wave 1.9/1.95 remain applied:
+- payment `B324` accepted risk with mitigation and defer rationale.
+- print/PDF `B701` deferred to controlled hardening slice.
+- AI/Telegram `B701` classified as non-browser false-positive class for XSS gate.
+
+Conclusion: protected-zone risk is **reviewed and documented**.
+
+## 5) Dependency Risk
+
+- `jspdf@3.0.2` critical advisory remains tracked technical debt.
+- Human-reviewed temporary mitigation remains in force.
+- Major upgrade remains deferred to a dedicated controlled slice in Wave 2.
+
+Conclusion: dependency risk is **known and explicitly accepted/deferred**.
+
+## Remaining Blockers
+
+No Wave 1 gate blockers remain after successful unified CI run `22762302449`.
+
+## Final Gate Verdict
+
+**READY_FOR_WAVE2**

--- a/docs/status/WAVE2_GATE_DECISION.md
+++ b/docs/status/WAVE2_GATE_DECISION.md
@@ -8,9 +8,9 @@ Verdict: **READY_FOR_WAVE2**
 
 Unified pipeline now has a fresh green run after Wave 1.96 fix:
 - Workflow: `ci-cd-unified.yml`
-- Run ID: `22762302449`
-- URL: https://github.com/drsapaev/final/actions/runs/22762302449
-- Head SHA: `aabcae9040ffb0de226c34fea9d460ab39697eeb`
+- Run ID: `22762620308`
+- URL: https://github.com/drsapaev/final/actions/runs/22762620308
+- Head SHA: `c0686c36aaf7128a7979c541ae5254449f904074`
 - Conclusion: `success`
 
 Conclusion: CI readiness is **confirmed** for the post-fix SHA.

--- a/docs/status/wave196/W196_ENV_DIFF.md
+++ b/docs/status/wave196/W196_ENV_DIFF.md
@@ -1,0 +1,42 @@
+# W1.96 Environment Diff (Local vs CI)
+
+Date: 2026-03-06  
+Branch: `codex/w196-ci-recovery`  
+Status: `done`
+
+## Local Versions
+
+Commands:
+
+```bash
+node -v
+npm -v
+python -V
+```
+
+Results:
+- Node: `v22.17.1`
+- npm: `10.9.2`
+- Python: `3.11.1`
+
+## CI Target Versions (`ci-cd-unified.yml`)
+
+From workflow env:
+- `NODE_VERSION: 20`
+- `PYTHON_VERSION: 3.11.10`
+
+From latest failed unified run logs (`22748643145`, job `🎨 Frontend тесты`):
+- Node runtime: `v20.20.0`
+- npm runtime: `10.8.2`
+
+## Mismatch Summary
+
+1. Node mismatch: local `22.17.1` vs CI `20.20.0`.
+2. npm mismatch: local `10.9.2` vs CI `10.8.2`.
+3. Python patch mismatch: local `3.11.1` vs CI `3.11.10`.
+
+## Impact
+
+- Mismatch exists and can affect reproducibility.
+- Despite mismatch, clean local run reproduced the previously failing area (`TwoFactorManager` tests) and passed after applying/finalizing the targeted mock fix.
+

--- a/docs/status/wave196/W196_LOCAL_CLEAN_RUN.md
+++ b/docs/status/wave196/W196_LOCAL_CLEAN_RUN.md
@@ -1,0 +1,58 @@
+# W1.96 Local Clean Run
+
+Date: 2026-03-06  
+Branch: `codex/w196-ci-recovery`  
+Status: `done`
+
+## Clean Environment Preparation
+
+### Frontend
+
+```bash
+cd frontend
+rm -rf node_modules
+npm ci
+```
+
+Result:
+- `npm ci` completed successfully.
+- Installed packages: `800`.
+- Audit summary after install: `11` vulnerabilities (`1 critical`, `3 high`, `7 moderate`).
+
+### Backend
+
+```bash
+cd backend
+pip install -r requirements.txt
+```
+
+Result:
+- install completed successfully.
+- requirements-aligned packages were installed/updated in local environment (including `fastapi`, `aiohttp`, `weasyprint`, `protobuf`, `pillow`, `aiogram`, `python-multipart`).
+- pip reported non-blocking resolver warnings for external tool deps (`mcp`) not part of app runtime gate.
+
+## Mandatory Post-Install Test Check
+
+### Frontend tests
+
+```bash
+cd frontend
+npm run test:run
+```
+
+Result:
+- exit code `0`
+- `24` test files passed
+- `173` tests passed
+
+### Backend tests
+
+```bash
+cd backend
+pytest -q
+```
+
+Result:
+- exit code `0`
+- `645 passed, 3 skipped`
+

--- a/docs/status/wave196/W196_TEST_FIX.md
+++ b/docs/status/wave196/W196_TEST_FIX.md
@@ -1,0 +1,40 @@
+# W1.96 Test Fix (TwoFactorManager / tokenManager mismatch)
+
+Date: 2026-03-06  
+Branch: `codex/w196-ci-recovery`  
+Status: `done`
+
+## CI Failure Signature
+
+From unified run `22748643145` (`🎨 Frontend тесты`):
+- failing step: `🧪 Тесты frontend`
+- error:
+  - `[vitest] No "tokenManager" export is defined on the "../../../utils/tokenManager" mock`
+  - trace reached `src/api/client.js` and `src/components/security/TwoFactorManager.jsx`
+
+## Root Cause
+
+The old test mocking strategy expected a `tokenManager` export shape that did not match module usage path during `TwoFactorManager` import chain in CI.
+
+## Minimal Fix Applied
+
+File:
+- `frontend/src/components/security/__tests__/TwoFactorManager.test.jsx`
+
+Change approach:
+1. Replace fragile `tokenManager`-oriented mock path with direct mock of `../../../api/client`.
+2. Mock `api.get/api.post/api.delete` explicitly via `vi.hoisted`.
+3. Remove brittle `global.fetch` test plumbing and assert on API client calls used by component logic.
+
+Scope constraints respected:
+- no frontend business logic changes
+- no component architecture changes
+- no backend changes
+- test-only targeted patch
+
+## Why This Fix Is Correct
+
+- `TwoFactorManager` consumes API client methods; mocking the same boundary avoids export-shape drift.
+- Fix addresses the exact CI error class (`mock/export mismatch`) without broad refactor.
+- Local clean and post-fix test runs confirm deterministic pass.
+

--- a/docs/status/wave196/W196_TEST_SIGNAL.md
+++ b/docs/status/wave196/W196_TEST_SIGNAL.md
@@ -1,0 +1,48 @@
+# W1.96 Test Signal Recheck (Post-Fix)
+
+Date: 2026-03-06  
+Branch: `codex/w196-ci-recovery`  
+Status: `done`
+
+## Commands and Results
+
+### Frontend
+
+```bash
+cd frontend
+npm run test:run
+```
+
+Result:
+- exit code `0`
+- `24` files passed
+- `173` tests passed
+
+### Backend
+
+```bash
+cd backend
+pytest -q
+```
+
+Result:
+- exit code `0`
+- `645 passed, 3 skipped`
+
+### RBAC checks
+
+```bash
+cd backend
+pytest tests/integration/test_rbac_matrix.py -q
+python scripts/ci/validate_role_integrity.py
+```
+
+Result:
+- `test_rbac_matrix.py`: `19 passed`
+- `validate_role_integrity`: `role.integrity.check.success`
+
+## Signal Quality
+
+- No flaky behavior observed in required checks during this pass.
+- Required local gate checks are green and reproducible after clean install and test fix.
+

--- a/docs/status/wave196/W196_UNIFIED_CI_RESULT.md
+++ b/docs/status/wave196/W196_UNIFIED_CI_RESULT.md
@@ -7,13 +7,13 @@ Workflow: `ci-cd-unified.yml` (`🏥 CI/CD Pipeline - Клиника (Unified)`)
 
 ## Run Evidence
 
-- Run ID: `22762302449`
-- URL: https://github.com/drsapaev/final/actions/runs/22762302449
-- Head SHA: `aabcae9040ffb0de226c34fea9d460ab39697eeb`
+- Run ID: `22762620308`
+- URL: https://github.com/drsapaev/final/actions/runs/22762620308
+- Head SHA: `c0686c36aaf7128a7979c541ae5254449f904074`
 - Status: `completed`
 - Conclusion: `success`
-- Started: `2026-03-06T11:52:50Z`
-- Completed: `2026-03-06T12:00:32Z`
+- Started: `2026-03-06T12:02:38Z`
+- Completed: `2026-03-06T12:10:35Z`
 
 ## Job Summary
 

--- a/docs/status/wave196/W196_UNIFIED_CI_RESULT.md
+++ b/docs/status/wave196/W196_UNIFIED_CI_RESULT.md
@@ -1,0 +1,25 @@
+# Wave 1.96 — Unified CI Result
+
+Date: 2026-03-06  
+Branch: `codex/w196-ci-recovery`  
+PR: `#56`  
+Workflow: `ci-cd-unified.yml` (`🏥 CI/CD Pipeline - Клиника (Unified)`)
+
+## Run Evidence
+
+- Run ID: `22762302449`
+- URL: https://github.com/drsapaev/final/actions/runs/22762302449
+- Head SHA: `aabcae9040ffb0de226c34fea9d460ab39697eeb`
+- Status: `completed`
+- Conclusion: `success`
+- Started: `2026-03-06T11:52:50Z`
+- Completed: `2026-03-06T12:00:32Z`
+
+## Job Summary
+
+- Success: `CI Scope`, `Frontend tests`, `Backend tests`, `Code quality`, `Context Boundary Integrity`, `Documentation generation`, `Frontend-Backend Parity`, `Notifications`.
+- Skipped by workflow conditions: `DAST ZAP (Nightly)`, `Docker build`, `Security scanning`, `Integration tests`, `Load Tests (k6)`, `Deploy Staging`, `Deploy Production`.
+
+## Result
+
+Wave 1.96 objective is met: one fresh green `ci-cd-unified.yml` run is confirmed.

--- a/frontend/src/components/security/__tests__/TwoFactorManager.test.jsx
+++ b/frontend/src/components/security/__tests__/TwoFactorManager.test.jsx
@@ -4,15 +4,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ThemeProvider } from '../../../contexts/ThemeContext.jsx';
 import { MacOSThemeProvider } from '../../../theme/macosTheme.jsx';
 
-const { getAccessToken, loggerInfo, loggerError } = vi.hoisted(() => ({
-  getAccessToken: vi.fn(() => 'test-token'),
+const { apiGet, apiPost, apiDelete, loggerInfo, loggerError } = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+  apiDelete: vi.fn(),
   loggerInfo: vi.fn(),
   loggerError: vi.fn(),
 }));
 
-vi.mock('../../../utils/tokenManager', () => ({
-  default: {
-    getAccessToken,
+vi.mock('../../../api/client', () => ({
+  api: {
+    get: apiGet,
+    post: apiPost,
+    delete: apiDelete,
   },
 }));
 
@@ -25,11 +29,59 @@ vi.mock('../../../utils/logger', () => ({
 
 import TwoFactorManager from '../TwoFactorManager.jsx';
 
-function jsonResponse(data, ok = true, status = 200) {
-  return Promise.resolve({
-    ok,
-    status,
-    json: async () => data,
+const disabledStatus = {
+  enabled: false,
+  totp_enabled: false,
+  totp_verified: false,
+  backup_codes_generated: false,
+  backup_codes_count: 0,
+  recovery_enabled: false,
+  recovery_email: null,
+  recovery_phone: null,
+  trusted_devices_count: 0,
+  last_used: null,
+};
+
+const enabledStatus = {
+  enabled: true,
+  totp_enabled: true,
+  totp_verified: true,
+  backup_codes_generated: true,
+  backup_codes_count: 10,
+  recovery_enabled: false,
+  recovery_email: null,
+  recovery_phone: null,
+  trusted_devices_count: 1,
+  last_used: '2026-03-03T10:00:00Z',
+};
+
+function mockApiGetState({ statusSequence = [disabledStatus], devices = [], logs = [], methods = [] } = {}) {
+  let statusCalls = 0;
+
+  apiGet.mockImplementation((url) => {
+    if (url === '/2fa/status') {
+      const index = Math.min(statusCalls, statusSequence.length - 1);
+      statusCalls += 1;
+      return Promise.resolve({ data: statusSequence[index] });
+    }
+
+    if (url === '/2fa/devices') {
+      return Promise.resolve({ data: { devices } });
+    }
+
+    if (url === '/2fa/security-logs') {
+      return Promise.resolve({ data: { logs } });
+    }
+
+    if (url === '/2fa/recovery-methods') {
+      return Promise.resolve({ data: { methods } });
+    }
+
+    if (url === '/2fa/backup-codes') {
+      return Promise.resolve({ data: { backup_codes: [] } });
+    }
+
+    return Promise.reject(new Error(`Unhandled api.get call in test: ${url}`));
   });
 }
 
@@ -46,38 +98,9 @@ function renderManager() {
 describe('TwoFactorManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    global.fetch = vi.fn((input, init) => {
-      const url = String(input);
-
-      if (url.endsWith('/api/v1/2fa/status')) {
-        return jsonResponse({
-          enabled: false,
-          totp_enabled: false,
-          totp_verified: false,
-          backup_codes_generated: false,
-          backup_codes_count: 0,
-          recovery_enabled: false,
-          recovery_email: null,
-          recovery_phone: null,
-          trusted_devices_count: 0,
-          last_used: null,
-        });
-      }
-
-      if (url.endsWith('/api/v1/2fa/devices')) {
-        return jsonResponse({ devices: [] });
-      }
-
-      if (url.endsWith('/api/v1/2fa/security-logs')) {
-        return jsonResponse({ logs: [] });
-      }
-
-      if (url.endsWith('/api/v1/2fa/recovery-methods')) {
-        return jsonResponse({ methods: [] });
-      }
-
-      throw new Error(`Unhandled fetch: ${url} ${(init?.method || 'GET')}`);
-    });
+    mockApiGetState();
+    apiPost.mockResolvedValue({ data: {} });
+    apiDelete.mockResolvedValue({ data: { success: true } });
   });
 
   it('does not expose backup-code regeneration before 2FA is enabled', async () => {
@@ -85,85 +108,41 @@ describe('TwoFactorManager', () => {
 
     expect(await screen.findByText(/Резервные коды пока недоступны/i)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /создать новый комплект/i })).not.toBeInTheDocument();
-    expect(
-      global.fetch.mock.calls.some(([url]) => String(url).includes('/api/v1/2fa/backup-codes/regenerate'))
-    ).toBe(false);
+    expect(apiPost.mock.calls.some(([url]) => url === '/2fa/backup-codes/regenerate')).toBe(false);
   });
 
   it('verifies setup before allowing backup code regeneration', async () => {
-    let statusCalls = 0;
+    mockApiGetState({ statusSequence: [disabledStatus, enabledStatus] });
 
-    global.fetch = vi.fn((input, init) => {
-      const url = String(input);
-      const method = init?.method || 'GET';
-
-      if (url.endsWith('/api/v1/2fa/status')) {
-        statusCalls += 1;
-        return jsonResponse(
-          statusCalls === 1
-            ? {
-              enabled: false,
-              totp_enabled: false,
-              totp_verified: false,
-              backup_codes_generated: false,
-              backup_codes_count: 0,
-              recovery_enabled: false,
-              recovery_email: null,
-              recovery_phone: null,
-              trusted_devices_count: 0,
-              last_used: null,
-            }
-            : {
-              enabled: true,
-              totp_enabled: true,
-              totp_verified: true,
-              backup_codes_generated: true,
-              backup_codes_count: 10,
-              recovery_enabled: false,
-              recovery_email: null,
-              recovery_phone: null,
-              trusted_devices_count: 0,
-              last_used: null,
-            }
-        );
-      }
-
-      if (url.endsWith('/api/v1/2fa/devices')) {
-        return jsonResponse({ devices: [] });
-      }
-
-      if (url.endsWith('/api/v1/2fa/security-logs')) {
-        return jsonResponse({ logs: [] });
-      }
-
-      if (url.endsWith('/api/v1/2fa/recovery-methods')) {
-        return jsonResponse({ methods: [] });
-      }
-
-      if (url.endsWith('/api/v1/2fa/setup') && method === 'POST') {
-        return jsonResponse({
-          qr_code_url: 'data:image/png;base64,abc',
-          secret_key: 'SECRETKEY123',
-          backup_codes: ['AAAA1111', 'BBBB2222'],
-          recovery_token: null,
-          expires_at: null,
+    apiPost.mockImplementation((url, _data, config) => {
+      if (url === '/2fa/setup') {
+        return Promise.resolve({
+          data: {
+            qr_code_url: 'data:image/png;base64,abc',
+            secret_key: 'SECRETKEY123',
+            backup_codes: ['AAAA1111', 'BBBB2222'],
+            recovery_token: null,
+            expires_at: null,
+          },
         });
       }
 
-      if (url.includes('/api/v1/2fa/verify-setup?totp_code=123456') && method === 'POST') {
-        return jsonResponse({
-          success: true,
-          message: 'TOTP setup verified successfully',
+      if (url === '/2fa/verify-setup') {
+        if (config?.params?.totp_code !== '123456') {
+          return Promise.resolve({ data: { success: false, message: 'invalid code' } });
+        }
+        return Promise.resolve({
+          data: { success: true, message: 'TOTP setup verified successfully' },
         });
       }
 
-      if (url.endsWith('/api/v1/2fa/backup-codes/regenerate') && method === 'POST') {
-        return jsonResponse({
-          backup_codes: ['CCCC3333', 'DDDD4444'],
+      if (url === '/2fa/backup-codes/regenerate') {
+        return Promise.resolve({
+          data: { backup_codes: ['CCCC3333', 'DDDD4444'] },
         });
       }
 
-      throw new Error(`Unhandled fetch: ${url} ${method}`);
+      return Promise.reject(new Error(`Unhandled api.post call in test: ${url}`));
     });
 
     renderManager();
@@ -177,9 +156,10 @@ describe('TwoFactorManager', () => {
     fireEvent.click(screen.getByRole('button', { name: /Подтвердить и включить 2FA/i }));
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/api/v1/2fa/verify-setup?totp_code=123456'),
-        expect.objectContaining({ method: 'POST' })
+      expect(apiPost).toHaveBeenCalledWith(
+        '/2fa/verify-setup',
+        null,
+        expect.objectContaining({ params: { totp_code: '123456' } })
       );
     });
 
@@ -189,62 +169,26 @@ describe('TwoFactorManager', () => {
     fireEvent.click(await screen.findByRole('button', { name: /Подтвердить обновление кодов/i }));
 
     expect(await screen.findByText('CCCC3333')).toBeInTheDocument();
-    expect(global.fetch).toHaveBeenCalledWith(
-      '/api/v1/2fa/backup-codes/regenerate',
-      expect.objectContaining({ method: 'POST' })
-    );
+    await waitFor(() => {
+      expect(apiPost).toHaveBeenCalledWith('/2fa/backup-codes/regenerate');
+    });
   });
 
   it('revokes trusted devices through the supported delete endpoint', async () => {
-    global.fetch = vi.fn((input, init) => {
-      const url = String(input);
-      const method = init?.method || 'GET';
-
-      if (url.endsWith('/api/v1/2fa/status')) {
-        return jsonResponse({
-          enabled: true,
-          totp_enabled: true,
-          totp_verified: true,
-          backup_codes_generated: true,
-          backup_codes_count: 10,
-          recovery_enabled: false,
-          recovery_email: null,
-          recovery_phone: null,
-          trusted_devices_count: 1,
+    mockApiGetState({
+      statusSequence: [enabledStatus],
+      devices: [
+        {
+          id: 7,
+          device_name: 'Clinic Desktop',
+          device_type: 'desktop',
+          trusted: true,
+          active: true,
+          ip_address: '127.0.0.1',
+          user_agent: 'Chrome',
           last_used: '2026-03-03T10:00:00Z',
-        });
-      }
-
-      if (url.endsWith('/api/v1/2fa/devices') && method === 'GET') {
-        return jsonResponse({
-          devices: [
-            {
-              id: 7,
-              device_name: 'Clinic Desktop',
-              device_type: 'desktop',
-              trusted: true,
-              active: true,
-              ip_address: '127.0.0.1',
-              user_agent: 'Chrome',
-              last_used: '2026-03-03T10:00:00Z',
-            },
-          ],
-        });
-      }
-
-      if (url.endsWith('/api/v1/2fa/security-logs')) {
-        return jsonResponse({ logs: [] });
-      }
-
-      if (url.endsWith('/api/v1/2fa/recovery-methods')) {
-        return jsonResponse({ methods: [] });
-      }
-
-      if (url.endsWith('/api/v1/2fa/devices/7') && method === 'DELETE') {
-        return jsonResponse({ success: true, message: 'Device untrusted successfully' });
-      }
-
-      throw new Error(`Unhandled fetch: ${url} ${method}`);
+        },
+      ],
     });
 
     renderManager();
@@ -254,10 +198,7 @@ describe('TwoFactorManager', () => {
     fireEvent.click(await screen.findByRole('button', { name: /Подтвердить отзыв/i }));
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
-        '/api/v1/2fa/devices/7',
-        expect.objectContaining({ method: 'DELETE' })
-      );
+      expect(apiDelete).toHaveBeenCalledWith('/2fa/devices/7');
     });
   });
 });


### PR DESCRIPTION
## Summary\n- align TwoFactorManager tests with API-client mocking to avoid tokenManager export mismatch in CI\n- add Wave 1.96 evidence artifacts for env diff, clean run, test fix and test signal\n\n## Validation\n- cd frontend && npm run test:run\n- cd backend && pytest -q\n- cd backend && pytest tests/integration/test_rbac_matrix.py -q\n- cd backend && python scripts/ci/validate_role_integrity.py\n\n## Scope\n- test-only frontend fix\n- no business logic changes\n- no protected-zone runtime changes