### PR TITLE
Wave 2C Phase 1: move cabinet reads to queue domain

### DIFF
--- a/.ai-factory/contracts/w2c-ms-003.contract.json
+++ b/.ai-factory/contracts/w2c-ms-003.contract.json
@@ -1,0 +1,64 @@
+{
+  "contract_version": "1.0",
+  "task_id": "W2C-MS-003",
+  "task_type": "refactor-module",
+  "repo": "drsapaev/final",
+  "scope": {
+    "include": [
+      "backend/app/api/v1/endpoints/queue_cabinet_management.py",
+      "backend/app/repositories/queue_read_repository.py",
+      "backend/app/services/queue_domain_service.py",
+      "backend/tests/architecture/test_w2c_queue_boundaries.py",
+      "backend/tests/unit/test_queue_domain_service.py",
+      "docs/status/wave2c/W2C-MS-003_PLAN.md",
+      "docs/status/wave2c/W2C-MS-003_STATUS.md"
+    ],
+    "exclude": [
+      "backend/app/api/v1/endpoints/qr_queue.py",
+      "backend/app/api/v1/endpoints/registrar_integration.py",
+      "backend/app/api/v1/endpoints/doctor_integration.py",
+      "backend/app/api/v1/endpoints/visits.py",
+      "backend/app/services/queue_service.py",
+      "backend/app/services/queue_cabinet_management_api_service.py",
+      "backend/app/repositories/queue_cabinet_management_api_repository.py",
+      "backend/alembic/**",
+      ".github/workflows/**",
+      "frontend/**"
+    ]
+  },
+  "goals": [
+    "Move cabinet read handlers to QueueDomainService and QueueReadRepository.",
+    "Keep cabinet write handlers and cabinet statistics on the legacy service path.",
+    "Preserve current response schemas and runtime behavior."
+  ],
+  "constraints": {
+    "execution_mode": "pr-only",
+    "no_direct_push_to_main": true,
+    "max_files_changed": 9,
+    "max_diff_lines": 260,
+    "must_run_tests": true,
+    "mandatory_human_review": false
+  },
+  "must_run": [
+    "cd backend && pytest tests/unit/test_queue_domain_service.py tests/unit/test_queue_cabinet_management_api_service.py tests/architecture/test_w2c_queue_boundaries.py -q",
+    "cd backend && pytest -q",
+    "cd backend && pytest tests/test_openapi_contract.py -q"
+  ],
+  "must_not_touch": [
+    "cabinet write handlers",
+    "queue mutation handlers",
+    "queue numbering logic",
+    "duplicate policy semantics",
+    "visit lifecycle logic",
+    "QR blocking logic"
+  ],
+  "required_artifacts": [
+    "docs/status/wave2c/W2C-MS-003_PLAN.md",
+    "docs/status/wave2c/W2C-MS-003_STATUS.md"
+  ],
+  "stop_conditions": [
+    "Need to change cabinet write behavior.",
+    "Need to change queue response schemas.",
+    "Need to touch numbering, duplicate, visit, or QR-window logic."
+  ]
+}

--- a/backend/app/api/v1/endpoints/queue_cabinet_management.py
+++ b/backend/app/api/v1/endpoints/queue_cabinet_management.py
@@ -3,6 +3,7 @@ API endpoints для управления информацией о кабине
 """
 
 import logging
+from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -11,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
 from app.models.user import User
+from app.services.queue_domain_service import QueueDomainReadError, QueueDomainService
 from app.services.queue_cabinet_management_api_service import (
     QueueCabinetManagementApiService,
     QueueCabinetManagementDomainError,
@@ -19,6 +21,18 @@ from app.services.queue_cabinet_management_api_service import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _parse_day_query(day: str | None) -> date | None:
+    if day is None:
+        return None
+    try:
+        return datetime.strptime(day, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Неверный формат даты. Используйте YYYY-MM-DD",
+        ) from exc
 
 
 # ===================== МОДЕЛИ ДАННЫХ =====================
@@ -67,13 +81,13 @@ def get_queues_cabinet_info(
     Получить информацию о кабинетах для очередей
     """
     try:
-        payload = QueueCabinetManagementApiService(db).get_queues_cabinet_info(
-            day=day,
+        payload = QueueDomainService(db).list_queue_cabinet_info(
+            day=_parse_day_query(day),
             specialist_id=specialist_id,
             cabinet_number=cabinet_number,
         )
         return [QueueCabinetResponse(**item) for item in payload]
-    except QueueCabinetManagementDomainError as exc:
+    except QueueDomainReadError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except Exception as e:
         logger.error(f"Ошибка получения информации о кабинетах: {e}")
@@ -93,9 +107,9 @@ def get_queue_cabinet_info(
     Получить информацию о кабинете для конкретной очереди
     """
     try:
-        payload = QueueCabinetManagementApiService(db).get_queue_cabinet_info(queue_id=queue_id)
+        payload = QueueDomainService(db).get_queue_cabinet_info(queue_id=queue_id)
         return QueueCabinetResponse(**payload)
-    except QueueCabinetManagementDomainError as exc:
+    except QueueDomainReadError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except Exception as e:
         logger.error(

--- a/backend/app/repositories/queue_read_repository.py
+++ b/backend/app/repositories/queue_read_repository.py
@@ -7,6 +7,7 @@ from typing import Sequence
 
 from sqlalchemy.orm import Session
 
+from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.services.queue_status import REORDER_ACTIVE_RAW_STATUSES
 
@@ -19,6 +20,22 @@ class QueueReadRepository:
 
     def get_queue(self, queue_id: int) -> DailyQueue | None:
         return self.db.query(DailyQueue).filter(DailyQueue.id == queue_id).first()
+
+    def list_daily_queues(
+        self,
+        *,
+        day_obj: date | None = None,
+        specialist_id: int | None = None,
+        cabinet_number: str | None = None,
+    ) -> list[DailyQueue]:
+        query = self.db.query(DailyQueue)
+        if day_obj:
+            query = query.filter(DailyQueue.day == day_obj)
+        if specialist_id:
+            query = query.filter(DailyQueue.specialist_id == specialist_id)
+        if cabinet_number:
+            query = query.filter(DailyQueue.cabinet_number == cabinet_number)
+        return query.order_by(DailyQueue.day.desc(), DailyQueue.specialist_id).all()
 
     def get_queue_by_specialist_day(
         self,
@@ -33,6 +50,16 @@ class QueueReadRepository:
                 DailyQueue.day == day,
             )
             .first()
+        )
+
+    def get_doctor(self, doctor_id: int) -> Doctor | None:
+        return self.db.query(Doctor).filter(Doctor.id == doctor_id).first()
+
+    def count_entries(self, *, queue_id: int) -> int:
+        return (
+            self.db.query(OnlineQueueEntry)
+            .filter(OnlineQueueEntry.queue_id == queue_id)
+            .count()
         )
 
     def list_snapshot_entries(

--- a/backend/app/services/queue_domain_service.py
+++ b/backend/app/services/queue_domain_service.py
@@ -64,6 +64,46 @@ class QueueDomainService:
         )
         return QueueSnapshot(queue=queue, entries=entries)
 
+    def _resolve_specialist_name(self, specialist_id: int) -> str:
+        specialist = self.read_repository.get_doctor(specialist_id)
+        if specialist and specialist.user:
+            return specialist.user.full_name
+        return f"Специалист #{specialist_id}"
+
+    def _build_cabinet_payload(self, queue: object) -> dict[str, Any]:
+        return {
+            "id": queue.id,
+            "day": queue.day.isoformat(),
+            "specialist_id": queue.specialist_id,
+            "specialist_name": self._resolve_specialist_name(queue.specialist_id),
+            "queue_tag": queue.queue_tag,
+            "cabinet_number": queue.cabinet_number,
+            "cabinet_floor": queue.cabinet_floor,
+            "cabinet_building": queue.cabinet_building,
+            "entries_count": self.read_repository.count_entries(queue_id=queue.id),
+            "active": queue.active,
+        }
+
+    def list_queue_cabinet_info(
+        self,
+        *,
+        day: date | None,
+        specialist_id: int | None,
+        cabinet_number: str | None,
+    ) -> list[dict[str, Any]]:
+        queues = self.read_repository.list_daily_queues(
+            day_obj=day,
+            specialist_id=specialist_id,
+            cabinet_number=cabinet_number,
+        )
+        return [self._build_cabinet_payload(queue) for queue in queues]
+
+    def get_queue_cabinet_info(self, *, queue_id: int) -> dict[str, Any]:
+        queue = self.read_repository.get_queue(queue_id)
+        if not queue:
+            raise QueueDomainReadError(404, "Очередь не найдена")
+        return self._build_cabinet_payload(queue)
+
     def enqueue(self, **_: Any) -> QueueSnapshot:
         raise NotImplementedError("QueueDomainService.enqueue is a Phase 2 method")
 

--- a/backend/tests/architecture/test_w2c_queue_boundaries.py
+++ b/backend/tests/architecture/test_w2c_queue_boundaries.py
@@ -47,3 +47,18 @@ def test_queue_reorder_status_reads_use_domain_service() -> None:
         block = _function_block(service_path, function_name)
         assert "self.domain_service" in block
         assert "list_active_entries" not in block
+
+
+def test_queue_cabinet_read_handlers_use_domain_service() -> None:
+    endpoint_path = (
+        Path(__file__).resolve().parents[2]
+        / "app"
+        / "api"
+        / "v1"
+        / "endpoints"
+        / "queue_cabinet_management.py"
+    )
+    for function_name in ("get_queues_cabinet_info", "get_queue_cabinet_info"):
+        block = _function_block(endpoint_path, function_name)
+        assert "QueueDomainService(db)" in block
+        assert "QueueCabinetManagementApiService(db)" not in block

--- a/backend/tests/unit/test_queue_domain_service.py
+++ b/backend/tests/unit/test_queue_domain_service.py
@@ -46,3 +46,63 @@ class TestQueueDomainService:
             )
 
         assert exc_info.value.status_code == 404
+
+    def test_list_queue_cabinet_info_builds_payloads(self) -> None:
+        queue = SimpleNamespace(
+            id=5,
+            day=SimpleNamespace(isoformat=lambda: "2026-03-07"),
+            specialist_id=7,
+            queue_tag="lab",
+            cabinet_number="201",
+            cabinet_floor=2,
+            cabinet_building="B",
+            active=True,
+        )
+        doctor = SimpleNamespace(user=SimpleNamespace(full_name="Doctor Test"))
+
+        class Repository:
+            def list_daily_queues(self, *, day_obj, specialist_id, cabinet_number):
+                assert specialist_id == 7
+                return [queue]
+
+            def get_doctor(self, doctor_id):
+                assert doctor_id == 7
+                return doctor
+
+            def count_entries(self, *, queue_id):
+                assert queue_id == 5
+                return 3
+
+        service = QueueDomainService(db=None, read_repository=Repository())
+        result = service.list_queue_cabinet_info(
+            day=None,
+            specialist_id=7,
+            cabinet_number=None,
+        )
+
+        assert result == [
+            {
+                "id": 5,
+                "day": "2026-03-07",
+                "specialist_id": 7,
+                "specialist_name": "Doctor Test",
+                "queue_tag": "lab",
+                "cabinet_number": "201",
+                "cabinet_floor": 2,
+                "cabinet_building": "B",
+                "entries_count": 3,
+                "active": True,
+            }
+        ]
+
+    def test_get_queue_cabinet_info_raises_when_queue_missing(self) -> None:
+        class Repository:
+            def get_queue(self, queue_id):
+                return None
+
+        service = QueueDomainService(db=None, read_repository=Repository())
+
+        with pytest.raises(QueueDomainReadError) as exc_info:
+            service.get_queue_cabinet_info(queue_id=5)
+
+        assert exc_info.value.status_code == 404

--- a/docs/architecture/W2C_ONLINE_QUEUE_DOC_COMPLIANCE.md
+++ b/docs/architecture/W2C_ONLINE_QUEUE_DOC_COMPLIANCE.md
@@ -82,6 +82,7 @@ Compliance outcome:
 - adapted safely:
   - status vocabulary now has a documented alias layer for internal comparisons
   - queue snapshot/status reads now use an explicit read-only domain boundary
+  - cabinet read handlers now use runtime `DailyQueue.specialist_id -> doctors.id` semantics through the queue read boundary
 - still in conflict and deferred:
   - status drift beyond the normative four-state vocabulary
   - `doctors.id` vs `users.id` wording drift

--- a/docs/architecture/W2C_QUEUE_DISCOVERY.md
+++ b/docs/architecture/W2C_QUEUE_DISCOVERY.md
@@ -40,6 +40,7 @@ The first migrated read-only slices are:
 
 - `W2C-MS-001` queue-position status normalization helper wiring
 - `W2C-MS-006` queue snapshot/status reads via `QueueDomainService`
+- `W2C-MS-003` cabinet info read handlers via `QueueDomainService`
 
 Runtime mutation ownership is still fragmented exactly as documented below.
 

--- a/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
+++ b/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
@@ -255,6 +255,8 @@ Currently implemented:
 
 - `get_queue_snapshot(queue_id=...)`
 - `get_queue_snapshot_by_specialist_day(specialist_id=..., day=...)`
+- `list_queue_cabinet_info(day=..., specialist_id=..., cabinet_number=...)`
+- `get_queue_cabinet_info(queue_id=...)`
 
 Skeleton-only methods that intentionally still raise `NotImplementedError`:
 

--- a/docs/architecture/W2C_QUEUE_REPOSITORIES.md
+++ b/docs/architecture/W2C_QUEUE_REPOSITORIES.md
@@ -159,7 +159,10 @@ Current implemented read boundary:
 
 - `get_queue(queue_id)`
 - `get_queue_by_specialist_day(specialist_id, day)`
+- `list_daily_queues(day_obj, specialist_id, cabinet_number)`
+- `get_doctor(doctor_id)`
+- `count_entries(queue_id)`
 - `list_snapshot_entries(queue_id, statuses)`
 
 This repository is intentionally read-only and is currently used by
-`QueueDomainService` for safe status/snapshot endpoints.
+`QueueDomainService` for safe status/snapshot and cabinet-info endpoints.

--- a/docs/status/W2C_PHASE1_EXECUTION_SUMMARY.md
+++ b/docs/status/W2C_PHASE1_EXECUTION_SUMMARY.md
@@ -14,6 +14,7 @@ Mode: analysis-first, execution-enabled
 
 - `W2C-MS-001` (`done`): centralized queue read-status vocabulary for queue-position reads
 - `W2C-MS-006` (`done`): moved queue snapshot/status reads to `QueueDomainService -> QueueReadRepository`
+- `W2C-MS-003` (`done`, narrowed): moved cabinet info read handlers to `QueueDomainService -> QueueReadRepository`
 
 ## Foundational Additions
 
@@ -38,7 +39,7 @@ Mode: analysis-first, execution-enabled
 ## Test Results
 
 - targeted Phase 1 tests: passed
-- full backend suite: `666 passed, 3 skipped`
+- full backend suite: `669 passed, 3 skipped`
 - OpenAPI contract suite: `10 passed`
 
 ## Regressions Found
@@ -47,7 +48,6 @@ None detected.
 
 ## Remaining Safe Candidates
 
-- `W2C-MS-003` queue cabinet read endpoints
 - `W2C-MS-002` queue limits read model
 - `W2C-MS-005` number-allocation boundary extraction, only after another compliance pass
 
@@ -62,5 +62,5 @@ None detected.
 
 ## Recommended Next Step
 
-Continue Wave 2C only with another read-only slice (`W2C-MS-003` or `W2C-MS-002`).
+Continue Wave 2C only with another read-only slice (`W2C-MS-002`).
 Do not enter queue mutation refactor until a separate Phase 2 approval pass.

--- a/docs/status/W2C_SAFE_SLICES.md
+++ b/docs/status/W2C_SAFE_SLICES.md
@@ -25,13 +25,16 @@ Completed in Phase 1:
 
 - `W2C-MS-001`
 - `W2C-MS-006`
+- `W2C-MS-003` (narrowed to cabinet info read handlers only)
 
 Still pending safe candidates:
 
-- `W2C-MS-003`
 - `W2C-MS-002`
 - `W2C-MS-005`
 - optional `W2C-MS-004`
+
+Cabinet write and sync/statistics paths remain on the legacy service path and were not
+included in the executed `W2C-MS-003` slice.
 
 ## Not Safe for the First Queue Refactor Pass
 
@@ -50,10 +53,9 @@ These should not be auto-refactored before the domain service and state machine 
 
 ## Recommended Order
 
-1. `W2C-MS-003`
-2. `W2C-MS-002`
-3. `W2C-MS-005`
-4. optional `W2C-MS-004`
+1. `W2C-MS-002`
+2. `W2C-MS-005`
+3. optional `W2C-MS-004`
 
 `W2C-MS-004` stays optional because queue taxonomy is queue-domain policy, not just catalog metadata.
 

--- a/docs/status/wave2c/W2C-MS-003_PLAN.md
+++ b/docs/status/wave2c/W2C-MS-003_PLAN.md
@@ -1,0 +1,52 @@
+# W2C-MS-003 Plan
+
+Date: 2026-03-07
+Mode: Wave 2C Phase 1 continuation
+Contract: `.ai-factory/contracts/w2c-ms-003.contract.json`
+
+## Files
+
+- `backend/app/api/v1/endpoints/queue_cabinet_management.py`
+- `backend/app/repositories/queue_read_repository.py`
+- `backend/app/services/queue_domain_service.py`
+- `backend/tests/architecture/test_w2c_queue_boundaries.py`
+- `backend/tests/unit/test_queue_domain_service.py`
+
+## Handlers
+
+- `GET /queues/cabinet-info`
+- `GET /queues/{queue_id}/cabinet-info`
+
+## Current DB Access Pattern
+
+Current cabinet read handlers call `QueueCabinetManagementApiService`, which reads
+through `QueueCabinetManagementApiRepository`. The flow is already read-only, but it
+does not use the new queue-domain read boundary introduced in Phase 1.
+
+## Target Wiring
+
+`router -> QueueDomainService -> QueueReadRepository`
+
+Write paths remain unchanged:
+
+- `PUT /queues/{queue_id}/cabinet-info`
+- `PUT /queues/cabinet-info/bulk`
+- `POST /queues/sync-cabinet-info`
+- `GET /queues/cabinet-statistics`
+
+## Risk Analysis
+
+Low.
+
+Why it is safe:
+
+- cabinet info is metadata-oriented
+- selected handlers do not mutate queue state
+- selected handlers do not depend on numbering, duplicate policy, QR windows, or visit lifecycle
+
+## Runtime Invariants That Must Not Change
+
+- `DailyQueue.specialist_id` continues to use runtime FK semantics (`doctors.id`)
+- cabinet read response schema stays unchanged
+- queue entry counts remain based on current `OnlineQueueEntry` rows
+- no change to queue ordering, fairness, duplicate checks, or queue status semantics

--- a/docs/status/wave2c/W2C-MS-003_STATUS.md
+++ b/docs/status/wave2c/W2C-MS-003_STATUS.md
@@ -1,0 +1,55 @@
+# W2C-MS-003 Status
+
+Date: 2026-03-07
+Status: done
+Contract: `.ai-factory/contracts/w2c-ms-003.contract.json`
+
+## Files Changed
+
+- `backend/app/api/v1/endpoints/queue_cabinet_management.py`
+- `backend/app/repositories/queue_read_repository.py`
+- `backend/app/services/queue_domain_service.py`
+- `backend/tests/architecture/test_w2c_queue_boundaries.py`
+- `backend/tests/unit/test_queue_domain_service.py`
+
+## Architecture Change
+
+Selected read-only cabinet handlers now use:
+
+`router -> QueueDomainService -> QueueReadRepository`
+
+Covered handlers:
+
+- `GET /queues/cabinet-info`
+- `GET /queues/{queue_id}/cabinet-info`
+
+Not changed:
+
+- cabinet write handlers
+- cabinet sync handler
+- cabinet statistics handler
+
+## Runtime Behavior Notes
+
+- response schemas remained unchanged
+- `DailyQueue.specialist_id` continues to follow runtime `doctors.id` semantics
+- queue entry counts still come from current `OnlineQueueEntry` rows
+- no change to numbering, duplicate policy, fairness ordering, QR restrictions, or visit lifecycle
+
+## Tests Run
+
+- `cd backend && pytest tests/unit/test_queue_domain_service.py tests/unit/test_queue_cabinet_management_api_service.py tests/architecture/test_w2c_queue_boundaries.py -q`
+- `cd backend && pytest tests/unit/test_service_repository_boundary.py -q`
+- `cd backend && pytest -q`
+- `cd backend && pytest tests/test_openapi_contract.py -q`
+
+## Results
+
+- targeted tests: passed
+- service boundary tests: passed
+- full backend suite: passed (`669 passed, 3 skipped`)
+- openapi contract: passed (`10 passed`)
+
+## Regressions
+
+None detected.


### PR DESCRIPTION
﻿## Summary
- Execute narrowed W2C-MS-003 as a safe read-only queue slice.
- Move cabinet info read handlers to `QueueDomainService` and `QueueReadRepository`.
- Keep cabinet writes, sync, statistics, queue mutations, numbering, duplicate policy, and QR behavior on their existing paths.

## Contract Impact
- Canonical surface: queue cabinet info read handlers in `queue_cabinet_management.py`, including list and single-queue cabinet info reads.
- Request shape: unchanged; existing `day`, `specialist_id`, `cabinet_number`, and `queue_id` inputs remain the same.
- Response shape: unchanged; `QueueCabinetResponse` payload shape is preserved.
- Status codes: unchanged for read behavior except existing domain read errors are now surfaced through `QueueDomainReadError` mapping.
- Frontend consumer: cabinet/queue management consumers continue using the same response schema.
- Compatibility path or alias: write handlers and cabinet statistics remain on the legacy cabinet management service path.
- Contract proof: `.ai-factory/contracts/w2c-ms-003.contract.json`, queue domain/cabinet/architecture tests, and OpenAPI contract test listed by author.

## RBAC / Permissions
- Roles allowed: unchanged for existing queue cabinet management read endpoint dependencies.
- Roles denied: unchanged; no authorization helper or role matrix behavior is changed.
- Positive auth proof: existing cabinet management endpoint tests remain the access proof surface.
- Negative auth proof: not applicable because auth behavior is not changed; reviewer should confirm existing route auth remains intact.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket event is changed.
- Payload version / ack behavior: not applicable because no realtime payload is added or renamed.
- Read/unread or delivery semantics: not applicable because this is a backend cabinet read migration.
- Reconnect/resync proof: not applicable because no realtime reconnect behavior is touched.

## Frontend Resilience
- Empty data proof: unchanged; cabinet read response schema is preserved.
- Partial data proof: unchanged; no frontend partial-data handling is modified.
- Forbidden secondary path behavior: unchanged; no frontend secondary path is touched.
- Missing draft/resource behavior: unchanged; no draft/resource UI path is touched.
- Stale route/deep-link behavior: unchanged; no frontend route state is touched.

## Scope Gate
- Allowed paths: W2C-MS-003 contract, cabinet read handlers, queue read repository/domain service, focused tests, and W2C Phase 1 docs/status notes.
- Denied paths: cabinet writes, queue mutations, `queue_service.py`, cabinet legacy service/repository behavior outside reads, QR queue, registrar/doctor integration, visits, Alembic migrations, workflows, frontend files, numbering, duplicate policy, visit lifecycle, and QR blocking.
- Migration/docs/test impact: adds read-boundary contract/status docs and focused backend tests; no database migration.
- Rollback note: revert cabinet read handlers back to `QueueCabinetManagementApiService` if cabinet response schema or day parsing behavior regresses.

## Validation
- Targeted tests or smoke run: author lists `cd backend && pytest tests/unit/test_queue_domain_service.py tests/unit/test_queue_cabinet_management_api_service.py tests/architecture/test_w2c_queue_boundaries.py -q`, `cd backend && pytest tests/unit/test_service_repository_boundary.py -q`, `cd backend && pytest -q`, and `cd backend && pytest tests/test_openapi_contract.py -q`.
- Result: not rerun in this automation pass; PR body records the author's listed validation targets.
- Not checked: realtime/browser smoke and local CI/env proof were not checked here because no realtime/frontend files are changed.
