### PR TITLE
Wave 2C Phase 1: move limits status read to queue domain

### DIFF
--- a/.ai-factory/contracts/w2c-ms-002.contract.json
+++ b/.ai-factory/contracts/w2c-ms-002.contract.json
@@ -1,0 +1,65 @@
+{
+  "contract_version": "1.0",
+  "task_id": "W2C-MS-002",
+  "task_type": "refactor-module",
+  "repo": "drsapaev/final",
+  "scope": {
+    "include": [
+      "backend/app/api/v1/endpoints/queue_limits.py",
+      "backend/app/repositories/queue_read_repository.py",
+      "backend/app/services/queue_domain_service.py",
+      "backend/tests/architecture/test_w2c_queue_boundaries.py",
+      "backend/tests/unit/test_queue_domain_service.py",
+      "backend/tests/unit/test_queue_limits_api_service.py",
+      "docs/status/wave2c/W2C-MS-002_PLAN.md",
+      "docs/status/wave2c/W2C-MS-002_STATUS.md"
+    ],
+    "exclude": [
+      "backend/app/services/queue_service.py",
+      "backend/app/api/v1/endpoints/qr_queue.py",
+      "backend/app/api/v1/endpoints/doctor_integration.py",
+      "backend/app/api/v1/endpoints/registrar_integration.py",
+      "backend/app/api/v1/endpoints/visits.py",
+      "backend/app/repositories/queue_limits_repository.py",
+      "backend/alembic/**",
+      ".github/workflows/**",
+      "frontend/**"
+    ]
+  },
+  "goals": [
+    "Move the queue-status-with-limits read endpoint to QueueDomainService and QueueReadRepository.",
+    "Preserve current runtime lookup semantics, including Doctor.user_id based queue lookup.",
+    "Keep queue limits writes and settings updates unchanged."
+  ],
+  "constraints": {
+    "execution_mode": "pr-only",
+    "no_direct_push_to_main": true,
+    "max_files_changed": 9,
+    "max_diff_lines": 280,
+    "must_run_tests": true,
+    "mandatory_human_review": false
+  },
+  "must_run": [
+    "cd backend && pytest tests/unit/test_queue_domain_service.py tests/unit/test_queue_limits_api_service.py tests/architecture/test_w2c_queue_boundaries.py -q",
+    "cd backend && pytest tests/unit/test_service_repository_boundary.py -q",
+    "cd backend && pytest -q",
+    "cd backend && pytest tests/test_openapi_contract.py -q"
+  ],
+  "must_not_touch": [
+    "queue limits write handlers",
+    "queue numbering logic",
+    "duplicate policy semantics",
+    "visit lifecycle logic",
+    "QR blocking logic",
+    "DailyQueue.specialist_id runtime behavior"
+  ],
+  "required_artifacts": [
+    "docs/status/wave2c/W2C-MS-002_PLAN.md",
+    "docs/status/wave2c/W2C-MS-002_STATUS.md"
+  ],
+  "stop_conditions": [
+    "Need to change queue lookup semantics from Doctor.user_id to Doctor.id.",
+    "Need to change queue limits write behavior.",
+    "Need to touch numbering, duplicate, visit, or QR-window logic."
+  ]
+}

--- a/backend/app/api/v1/endpoints/queue_limits.py
+++ b/backend/app/api/v1/endpoints/queue_limits.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
 from app.models.user import User
+from app.services.queue_domain_service import QueueDomainService
 from app.services.queue_limits_api_service import QueueLimitsApiService
 
 router = APIRouter()
@@ -139,7 +140,7 @@ def get_queue_status_with_limits(
         if day is None:
             day = date.today()
 
-        result = QueueLimitsApiService(db).get_queue_status_with_limits(
+        result = QueueDomainService(db).get_queue_limits_status(
             day=day,
             specialty=specialty,
         )

--- a/backend/app/repositories/queue_read_repository.py
+++ b/backend/app/repositories/queue_read_repository.py
@@ -21,6 +21,12 @@ class QueueReadRepository:
     def get_queue(self, queue_id: int) -> DailyQueue | None:
         return self.db.query(DailyQueue).filter(DailyQueue.id == queue_id).first()
 
+    def list_active_doctors(self, *, specialty: str | None) -> list[Doctor]:
+        query = self.db.query(Doctor).filter(Doctor.active.is_(True))
+        if specialty:
+            query = query.filter(Doctor.specialty == specialty)
+        return query.all()
+
     def list_daily_queues(
         self,
         *,

--- a/backend/app/services/queue_domain_service.py
+++ b/backend/app/services/queue_domain_service.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
-from typing import Any
+from typing import Any, Callable
 
 from sqlalchemy.orm import Session
 
+from app.crud.clinic import get_queue_settings
 from app.repositories.queue_read_repository import QueueReadRepository
 from app.services.queue_status import REORDER_ACTIVE_RAW_STATUSES
 
@@ -31,8 +32,11 @@ class QueueDomainService:
         self,
         db: Session,
         read_repository: QueueReadRepository | None = None,
+        get_settings: Callable[[Session], dict] | None = None,
     ):
+        self.db = db
         self.read_repository = read_repository or QueueReadRepository(db)
+        self._get_settings = get_settings or get_queue_settings
 
     def get_queue_snapshot(self, *, queue_id: int) -> QueueSnapshot:
         queue = self.read_repository.get_queue(queue_id)
@@ -103,6 +107,52 @@ class QueueDomainService:
         if not queue:
             raise QueueDomainReadError(404, "Очередь не найдена")
         return self._build_cabinet_payload(queue)
+
+    def get_queue_limits_status(
+        self,
+        *,
+        day: date,
+        specialty: str | None,
+    ) -> list[dict[str, Any]]:
+        queue_settings = self._get_settings(self.db) or {}
+        max_per_day_settings = queue_settings.get("max_per_day", {})
+        doctors = self.read_repository.list_active_doctors(specialty=specialty)
+
+        result: list[dict[str, Any]] = []
+        for doctor in doctors:
+            # Preserve current runtime behavior: limits read paths resolve DailyQueue
+            # by Doctor.user_id even though DailyQueue.specialist_id is modeled
+            # against doctors.id.
+            daily_queue = self.read_repository.get_queue_by_specialist_day(
+                specialist_id=doctor.user_id,
+                day=day,
+            )
+
+            current_entries = 0
+            queue_opened = False
+            if daily_queue:
+                current_entries = self.read_repository.count_entries(queue_id=daily_queue.id)
+                queue_opened = daily_queue.opened_at is not None
+
+            max_entries = max_per_day_settings.get(doctor.specialty, 15)
+            result.append(
+                {
+                    "doctor_id": doctor.id,
+                    "doctor_name": (
+                        doctor.user.full_name if doctor.user else f"Врач #{doctor.id}"
+                    ),
+                    "specialty": doctor.specialty,
+                    "cabinet": doctor.cabinet,
+                    "day": day,
+                    "current_entries": current_entries,
+                    "max_entries": max_entries,
+                    "limit_reached": current_entries >= max_entries,
+                    "queue_opened": queue_opened,
+                    "online_available": (not queue_opened and current_entries < max_entries),
+                }
+            )
+
+        return result
 
     def enqueue(self, **_: Any) -> QueueSnapshot:
         raise NotImplementedError("QueueDomainService.enqueue is a Phase 2 method")

--- a/backend/tests/architecture/test_w2c_queue_boundaries.py
+++ b/backend/tests/architecture/test_w2c_queue_boundaries.py
@@ -62,3 +62,17 @@ def test_queue_cabinet_read_handlers_use_domain_service() -> None:
         block = _function_block(endpoint_path, function_name)
         assert "QueueDomainService(db)" in block
         assert "QueueCabinetManagementApiService(db)" not in block
+
+
+def test_queue_limits_status_handler_uses_domain_service() -> None:
+    endpoint_path = (
+        Path(__file__).resolve().parents[2]
+        / "app"
+        / "api"
+        / "v1"
+        / "endpoints"
+        / "queue_limits.py"
+    )
+    block = _function_block(endpoint_path, "get_queue_status_with_limits")
+    assert "QueueDomainService(db)" in block
+    assert "QueueLimitsApiService(db).get_queue_status_with_limits" not in block

--- a/backend/tests/unit/test_queue_domain_service.py
+++ b/backend/tests/unit/test_queue_domain_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import date
 from types import SimpleNamespace
 
 import pytest
@@ -106,3 +107,53 @@ class TestQueueDomainService:
             service.get_queue_cabinet_info(queue_id=5)
 
         assert exc_info.value.status_code == 404
+
+    def test_get_queue_limits_status_preserves_runtime_user_id_lookup(self) -> None:
+        doctor = SimpleNamespace(
+            id=3,
+            user_id=33,
+            specialty="cardio",
+            cabinet="101",
+            user=SimpleNamespace(full_name="Doctor Test"),
+        )
+        queue = SimpleNamespace(id=9, opened_at=None)
+
+        class Repository:
+            def list_active_doctors(self, *, specialty):
+                assert specialty == "cardio"
+                return [doctor]
+
+            def get_queue_by_specialist_day(self, *, specialist_id, day):
+                assert specialist_id == 33
+                assert day.isoformat() == "2026-03-07"
+                return queue
+
+            def count_entries(self, *, queue_id):
+                assert queue_id == 9
+                return 4
+
+        service = QueueDomainService(
+            db="db",
+            read_repository=Repository(),
+            get_settings=lambda db: {"max_per_day": {"cardio": 5}},
+        )
+
+        result = service.get_queue_limits_status(
+            day=date(2026, 3, 7),
+            specialty="cardio",
+        )
+
+        assert result == [
+            {
+                "doctor_id": 3,
+                "doctor_name": "Doctor Test",
+                "specialty": "cardio",
+                "cabinet": "101",
+                "day": date(2026, 3, 7),
+                "current_entries": 4,
+                "max_entries": 5,
+                "limit_reached": False,
+                "queue_opened": False,
+                "online_available": True,
+            }
+        ]

--- a/docs/architecture/W2C_ONLINE_QUEUE_DOC_COMPLIANCE.md
+++ b/docs/architecture/W2C_ONLINE_QUEUE_DOC_COMPLIANCE.md
@@ -83,6 +83,7 @@ Compliance outcome:
   - status vocabulary now has a documented alias layer for internal comparisons
   - queue snapshot/status reads now use an explicit read-only domain boundary
   - cabinet read handlers now use runtime `DailyQueue.specialist_id -> doctors.id` semantics through the queue read boundary
+  - queue-limits status read now uses the same runtime-compatible `doctor.user_id` lookup it used before the refactor
 - still in conflict and deferred:
   - status drift beyond the normative four-state vocabulary
   - `doctors.id` vs `users.id` wording drift

--- a/docs/architecture/W2C_QUEUE_DISCOVERY.md
+++ b/docs/architecture/W2C_QUEUE_DISCOVERY.md
@@ -41,6 +41,7 @@ The first migrated read-only slices are:
 - `W2C-MS-001` queue-position status normalization helper wiring
 - `W2C-MS-006` queue snapshot/status reads via `QueueDomainService`
 - `W2C-MS-003` cabinet info read handlers via `QueueDomainService`
+- `W2C-MS-002` narrowed queue-status-with-limits read handler via `QueueDomainService`
 
 Runtime mutation ownership is still fragmented exactly as documented below.
 

--- a/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
+++ b/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
@@ -257,6 +257,7 @@ Currently implemented:
 - `get_queue_snapshot_by_specialist_day(specialist_id=..., day=...)`
 - `list_queue_cabinet_info(day=..., specialist_id=..., cabinet_number=...)`
 - `get_queue_cabinet_info(queue_id=...)`
+- `get_queue_limits_status(day=..., specialty=...)`
 
 Skeleton-only methods that intentionally still raise `NotImplementedError`:
 

--- a/docs/architecture/W2C_QUEUE_REPOSITORIES.md
+++ b/docs/architecture/W2C_QUEUE_REPOSITORIES.md
@@ -158,6 +158,7 @@ Wave 2C Phase 1 introduced `QueueReadRepository` in
 Current implemented read boundary:
 
 - `get_queue(queue_id)`
+- `list_active_doctors(specialty)`
 - `get_queue_by_specialist_day(specialist_id, day)`
 - `list_daily_queues(day_obj, specialist_id, cabinet_number)`
 - `get_doctor(doctor_id)`

--- a/docs/status/W2C_PHASE1_EXECUTION_SUMMARY.md
+++ b/docs/status/W2C_PHASE1_EXECUTION_SUMMARY.md
@@ -15,6 +15,7 @@ Mode: analysis-first, execution-enabled
 - `W2C-MS-001` (`done`): centralized queue read-status vocabulary for queue-position reads
 - `W2C-MS-006` (`done`): moved queue snapshot/status reads to `QueueDomainService -> QueueReadRepository`
 - `W2C-MS-003` (`done`, narrowed): moved cabinet info read handlers to `QueueDomainService -> QueueReadRepository`
+- `W2C-MS-002` (`done`, narrowed): moved `GET /queue-status` to `QueueDomainService -> QueueReadRepository` while preserving current `doctor.user_id` lookup behavior
 
 ## Foundational Additions
 
@@ -39,7 +40,7 @@ Mode: analysis-first, execution-enabled
 ## Test Results
 
 - targeted Phase 1 tests: passed
-- full backend suite: `669 passed, 3 skipped`
+- full backend suite: `671 passed, 3 skipped`
 - OpenAPI contract suite: `10 passed`
 
 ## Regressions Found
@@ -48,7 +49,7 @@ None detected.
 
 ## Remaining Safe Candidates
 
-- `W2C-MS-002` queue limits read model
+- optional `W2C-MS-004` queue metadata read helpers
 - `W2C-MS-005` number-allocation boundary extraction, only after another compliance pass
 
 ## Not Allowed For Phase 1 Follow-Up
@@ -62,5 +63,6 @@ None detected.
 
 ## Recommended Next Step
 
-Continue Wave 2C only with another read-only slice (`W2C-MS-002`).
+If Phase 1 continues, prefer optional `W2C-MS-004`.
+Do not start `W2C-MS-005` until numbering semantics get a separate compliance review.
 Do not enter queue mutation refactor until a separate Phase 2 approval pass.

--- a/docs/status/W2C_SAFE_SLICES.md
+++ b/docs/status/W2C_SAFE_SLICES.md
@@ -26,15 +26,18 @@ Completed in Phase 1:
 - `W2C-MS-001`
 - `W2C-MS-006`
 - `W2C-MS-003` (narrowed to cabinet info read handlers only)
+- `W2C-MS-002` (narrowed to `GET /queue-status` only)
 
 Still pending safe candidates:
 
-- `W2C-MS-002`
 - `W2C-MS-005`
 - optional `W2C-MS-004`
 
 Cabinet write and sync/statistics paths remain on the legacy service path and were not
 included in the executed `W2C-MS-003` slice.
+
+Queue limits writes and `GET /queue-limits` remain on the legacy service path and were not
+included in the executed `W2C-MS-002` slice.
 
 ## Not Safe for the First Queue Refactor Pass
 
@@ -53,9 +56,8 @@ These should not be auto-refactored before the domain service and state machine 
 
 ## Recommended Order
 
-1. `W2C-MS-002`
-2. `W2C-MS-005`
-3. optional `W2C-MS-004`
+1. optional `W2C-MS-004`
+2. `W2C-MS-005` only after an explicit numbering/compliance pass
 
 `W2C-MS-004` stays optional because queue taxonomy is queue-domain policy, not just catalog metadata.
 

--- a/docs/status/wave2c/W2C-MS-002_PLAN.md
+++ b/docs/status/wave2c/W2C-MS-002_PLAN.md
@@ -1,0 +1,51 @@
+# W2C-MS-002 Plan
+
+Date: 2026-03-07
+Mode: Wave 2C Phase 1 continuation
+Contract: `.ai-factory/contracts/w2c-ms-002.contract.json`
+
+## Files
+
+- `backend/app/api/v1/endpoints/queue_limits.py`
+- `backend/app/repositories/queue_read_repository.py`
+- `backend/app/services/queue_domain_service.py`
+- `backend/tests/architecture/test_w2c_queue_boundaries.py`
+- `backend/tests/unit/test_queue_domain_service.py`
+
+## Handlers
+
+- `GET /queue-status`
+
+## Current DB Access Pattern
+
+The queue-limits read model lives in `QueueLimitsApiService`, which uses
+`QueueLimitsRepository` to iterate active doctors, find the queue for a day, and count
+entries. The current runtime lookup uses `doctor.user_id` when querying
+`DailyQueue.specialist_id`.
+
+## Target Wiring
+
+`router -> QueueDomainService -> QueueReadRepository`
+
+Not included in this slice:
+
+- `GET /queue-limits`
+- `PUT /queue-limits`
+- `PUT /doctor-queue-limit`
+- `POST /reset-queue-limits`
+
+## Risk Analysis
+
+Low to medium.
+
+Main risk is not queue mutation; it is accidental cleanup of existing runtime drift.
+This slice must preserve current lookup behavior exactly, including the `doctor.user_id`
+based queue lookup.
+
+## Runtime Invariants That Must Not Change
+
+- current `doctor.user_id` based queue lookup in limits read path
+- response schema of `GET /queue-status`
+- queue entry counting behavior
+- queue opened/online available flags
+- numbering, duplicate, fairness, visit lifecycle, and QR rules

--- a/docs/status/wave2c/W2C-MS-002_STATUS.md
+++ b/docs/status/wave2c/W2C-MS-002_STATUS.md
@@ -1,0 +1,55 @@
+# W2C-MS-002 Status
+
+Date: 2026-03-07
+Status: done
+Contract: `.ai-factory/contracts/w2c-ms-002.contract.json`
+
+## Files Changed
+
+- `backend/app/api/v1/endpoints/queue_limits.py`
+- `backend/app/repositories/queue_read_repository.py`
+- `backend/app/services/queue_domain_service.py`
+- `backend/tests/architecture/test_w2c_queue_boundaries.py`
+- `backend/tests/unit/test_queue_domain_service.py`
+
+## Architecture Change
+
+Selected read-only limits handler now uses:
+
+`router -> QueueDomainService -> QueueReadRepository`
+
+Covered handler:
+
+- `GET /queue-status`
+
+Not changed:
+
+- `GET /queue-limits`
+- `PUT /queue-limits`
+- `PUT /doctor-queue-limit`
+- `POST /reset-queue-limits`
+
+## Runtime Behavior Notes
+
+- preserved current `doctor.user_id` based `DailyQueue` lookup in the limits read path
+- response schema of `GET /queue-status` stayed unchanged
+- queue entry counts, `queue_opened`, and `online_available` logic stayed unchanged
+- no change to numbering, duplicate policy, fairness ordering, visit lifecycle, or QR restrictions
+
+## Tests Run
+
+- `cd backend && pytest tests/unit/test_queue_domain_service.py tests/unit/test_queue_limits_api_service.py tests/architecture/test_w2c_queue_boundaries.py -q`
+- `cd backend && pytest tests/unit/test_service_repository_boundary.py -q`
+- `cd backend && pytest -q`
+- `cd backend && pytest tests/test_openapi_contract.py -q`
+
+## Results
+
+- targeted tests: passed
+- service boundary tests: passed
+- full backend suite: passed (`671 passed, 3 skipped`)
+- openapi contract: passed (`10 passed`)
+
+## Regressions
+
+None detected.


### PR DESCRIPTION
﻿## Summary
- Execute narrowed W2C-MS-002 for the queue limits `GET /queue-status` read path only.
- Move limits status reads to `QueueDomainService` and `QueueReadRepository` while preserving current runtime-compatible `Doctor.user_id` based `DailyQueue` lookup.
- Add W2C-MS-002 contract, architecture/unit coverage, and Wave 2C status docs.

## Contract Impact
- Canonical surface: queue limits `GET /queue-status` handler implemented by `get_queue_status_with_limits()`.
- Request shape: unchanged; existing `day` and `specialty` query behavior is preserved.
- Response shape: unchanged; per-doctor queue limit/status rows keep current entries, max entries, limit state, queue-opened state, and online availability.
- Status codes: unchanged for the read path; write/update behavior is explicitly out of scope.
- Frontend consumer: queue limits/status consumers continue using the same payload shape.
- Compatibility path or alias: existing runtime lookup semantics are preserved, including `Doctor.user_id` based daily queue lookup.
- Contract proof: `.ai-factory/contracts/w2c-ms-002.contract.json`, queue domain/limits/architecture tests, and OpenAPI contract test listed by author.

## RBAC / Permissions
- Roles allowed: unchanged for existing queue limits status read endpoint dependencies.
- Roles denied: unchanged; no authorization helper or role matrix behavior is changed.
- Positive auth proof: existing queue limits endpoint tests remain the access proof surface.
- Negative auth proof: not applicable because auth behavior is not changed; reviewer should confirm existing route auth remains intact.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket event is changed.
- Payload version / ack behavior: not applicable because no realtime payload is added or renamed.
- Read/unread or delivery semantics: not applicable because this is a backend read-path migration.
- Reconnect/resync proof: not applicable because no realtime reconnect behavior is touched.

## Frontend Resilience
- Empty data proof: unchanged; status rows and defaults are preserved.
- Partial data proof: unchanged; no frontend partial-data handling is modified.
- Forbidden secondary path behavior: unchanged; no frontend secondary path is touched.
- Missing draft/resource behavior: unchanged; no draft/resource UI path is touched.
- Stale route/deep-link behavior: unchanged; no frontend route state is touched.

## Scope Gate
- Allowed paths: W2C-MS-002 contract, queue limits read endpoint, queue read repository/domain service, focused tests, and W2C Phase 1 docs/status notes.
- Denied paths: queue limits writes, `queue_service.py`, QR queue, doctor integration, registrar integration, visits, Alembic migrations, workflows, frontend files, numbering, duplicate policy, visit lifecycle, and QR blocking.
- Migration/docs/test impact: adds read-boundary contract/status docs and focused backend tests; no database migration.
- Rollback note: revert `get_queue_status_with_limits()` to `QueueLimitsApiService` if status rows, daily queue lookup, or online availability behavior regresses.

## Validation
- Targeted tests or smoke run: author lists `cd backend && pytest tests/unit/test_queue_domain_service.py tests/unit/test_queue_limits_api_service.py tests/architecture/test_w2c_queue_boundaries.py tests/unit/test_service_repository_boundary.py -q`, `cd backend && pytest -q`, and `cd backend && pytest tests/test_openapi_contract.py -q`.
- Result: not rerun in this automation pass; PR body records the author's listed validation targets.
- Not checked: realtime/browser smoke and local CI/env proof were not checked here because no realtime/frontend files are changed.
