### PR TITLE
Wave 2C: move queue metadata reads to queue domain

### DIFF
--- a/.ai-factory/contracts/w2c-ms-004.contract.json
+++ b/.ai-factory/contracts/w2c-ms-004.contract.json
@@ -1,0 +1,64 @@
+{
+  "contract_version": "1.0",
+  "task_id": "W2C-MS-004",
+  "task_type": "refactor-module",
+  "repo": "drsapaev/final",
+  "scope": {
+    "include": [
+      "backend/app/api/v1/endpoints/services.py",
+      "backend/app/repositories/queue_read_repository.py",
+      "backend/app/services/queue_domain_service.py",
+      "backend/tests/architecture/test_w2c_queue_boundaries.py",
+      "backend/tests/unit/test_queue_domain_service.py",
+      "backend/tests/unit/test_services_router_service_wiring.py",
+      "docs/status/wave2c/W2C-MS-004_PLAN.md",
+      "docs/status/wave2c/W2C-MS-004_STATUS.md"
+    ],
+    "exclude": [
+      "backend/app/api/v1/endpoints/qr_queue.py",
+      "backend/app/api/v1/endpoints/doctor_integration.py",
+      "backend/app/api/v1/endpoints/registrar_integration.py",
+      "backend/app/api/v1/endpoints/visits.py",
+      "backend/app/services/service_mapping.py",
+      "backend/app/services/queue_service.py",
+      "backend/alembic/**",
+      ".github/workflows/**",
+      "frontend/**"
+    ]
+  },
+  "goals": [
+    "Move queue metadata read handlers to QueueDomainService and QueueReadRepository.",
+    "Preserve static SSOT mappings and DB enrichment behavior.",
+    "Leave resolve_service and catalog CRUD outside this narrowed slice."
+  ],
+  "constraints": {
+    "execution_mode": "pr-only",
+    "no_direct_push_to_main": true,
+    "max_files_changed": 9,
+    "max_diff_lines": 300,
+    "must_run_tests": true,
+    "mandatory_human_review": false
+  },
+  "must_run": [
+    "cd backend && pytest tests/unit/test_queue_domain_service.py tests/unit/test_services_router_service_wiring.py tests/architecture/test_w2c_queue_boundaries.py tests/unit/test_service_repository_boundary.py -q",
+    "cd backend && pytest -q",
+    "cd backend && pytest tests/test_openapi_contract.py -q"
+  ],
+  "must_not_touch": [
+    "resolve_service runtime behavior",
+    "queue taxonomy data structures",
+    "queue numbering logic",
+    "duplicate policy semantics",
+    "visit lifecycle logic",
+    "QR blocking logic"
+  ],
+  "required_artifacts": [
+    "docs/status/wave2c/W2C-MS-004_PLAN.md",
+    "docs/status/wave2c/W2C-MS-004_STATUS.md"
+  ],
+  "stop_conditions": [
+    "Need to change resolve_service semantics.",
+    "Need to modify static queue taxonomy mappings.",
+    "Need to touch numbering, duplicate, visit, or QR-window logic."
+  ]
+}

--- a/backend/app/api/v1/endpoints/services.py
+++ b/backend/app/api/v1/endpoints/services.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
 from app.models.clinic import Doctor
-from app.models.service import Service
+from app.services.queue_domain_service import QueueDomainService
 from app.services.services_api_service import ServicesApiService
 
 router = APIRouter(tags=["services"])
@@ -293,48 +293,51 @@ async def get_queue_groups(
         - code_to_group: Маппинг service_code -> group_key (K01 -> cardiology)
         - tab_to_group: Маппинг tab_key -> group_key (cardio -> cardiology)
     """
-    from app.services.service_mapping import QUEUE_GROUPS, get_queue_group_for_service
-    
-    # Build groups from SSOT
-    groups = {}
-    for key, data in QUEUE_GROUPS.items():
-        groups[key] = QueueGroupInfo(
-            display_name=data["display_name"],
-            display_name_uz=data.get("display_name_uz"),
-            service_codes=data.get("service_codes", []),
-            service_prefixes=data.get("service_prefixes", []),
-            exclude_codes=data.get("exclude_codes", []),
-            queue_tag=data["queue_tag"],
-            tab_key=data["tab_key"],
-        )
-    
-    # Build code_to_group mapping
-    code_to_group = {}
-    
-    # Add explicit service codes
-    for key, data in QUEUE_GROUPS.items():
-        for code in data.get("service_codes", []):
-            code_to_group[code] = key
-    
-    # Enrich with actual DB data
-    try:
-        services = db.query(Service).filter(Service.active == True).all()
-        for service in services:
-            if service.service_code:
-                group = get_queue_group_for_service(service.service_code)
-                if group:
-                    code_to_group[service.service_code] = group
-    except Exception:
-        pass  # Use static mappings if DB query fails
-    
-    # Build tab_to_group mapping
-    tab_to_group = {data["tab_key"]: key for key, data in QUEUE_GROUPS.items()}
-    
+    payload = QueueDomainService(db).get_queue_groups_payload()
+    groups = {
+        key: QueueGroupInfo(**value)
+        for key, value in payload["groups"].items()
+    }
     return QueueGroupsResponse(
         groups=groups,
-        code_to_group=code_to_group,
-        tab_to_group=tab_to_group,
+        code_to_group=payload["code_to_group"],
+        tab_to_group=payload["tab_to_group"],
     )
+
+
+# ==================== SERVICE CODE MAPPINGS (SSOT) - MUST BE BEFORE /{service_id} ====================
+
+
+class ServiceCodeMappingsResponse(BaseModel):
+    """Response schema for service code mappings endpoint"""
+
+    specialty_to_code: dict = {}
+    code_to_name: dict = {}
+    category_mapping: dict = {}
+    specialty_aliases: dict = {}
+
+
+@router.get(
+    "/code-mappings",
+    response_model=ServiceCodeMappingsResponse,
+    summary="Получить маппинги кодов услуг (SSOT)",
+)
+async def get_service_code_mappings(
+    db: Session = Depends(get_db),
+):
+    """
+    ⭐ SSOT: Возвращает все маппинги кодов услуг для синхронизации frontend.
+
+    Используется для централизации service code resolution на frontend.
+
+    Returns:
+        - specialty_to_code: Маппинг specialty -> default service code (K01, D01, etc.)
+        - code_to_name: Маппинг service code -> display name
+        - category_mapping: Маппинг specialty -> category code (K, D, L, etc.)
+        - specialty_aliases: Алиасы для specialty (derma -> dermatology)
+    """
+    payload = QueueDomainService(db).get_service_code_mappings_payload()
+    return ServiceCodeMappingsResponse(**payload)
 
 
 @router.get("/{service_id}", response_model=ServiceOut, summary="Получить услугу по ID")
@@ -471,90 +474,5 @@ async def resolve_service_endpoint(
 
     return ServiceResolveResponse(**result)
 
-
-# ==================== SERVICE CODE MAPPINGS (SSOT) ====================
-
-
-class ServiceCodeMappingsResponse(BaseModel):
-    """Response schema for service code mappings endpoint"""
-    
-    specialty_to_code: dict = {}
-    code_to_name: dict = {}
-    category_mapping: dict = {}
-    specialty_aliases: dict = {}
-
-
-@router.get(
-    "/code-mappings",
-    response_model=ServiceCodeMappingsResponse,
-    summary="Получить маппинги кодов услуг (SSOT)",
-)
-async def get_service_code_mappings(
-    db: Session = Depends(get_db),
-):
-    """
-    ⭐ SSOT: Возвращает все маппинги кодов услуг для синхронизации frontend.
-    
-    Используется для централизации service code resolution на frontend.
-    
-    Returns:
-        - specialty_to_code: Маппинг specialty -> default service code (K01, D01, etc.)
-        - code_to_name: Маппинг service code -> display name
-        - category_mapping: Маппинг specialty -> category code (K, D, L, etc.)
-        - specialty_aliases: Алиасы для specialty (derma -> dermatology)
-    """
-    from app.services.service_mapping import SPECIALTY_ALIASES
-    
-    # Static mappings from SSOT
-    specialty_to_code = {
-        "cardiology": "K01",
-        "cardio": "K01",
-        "dermatology": "D01",
-        "derma": "D01",
-        "stomatology": "S01",
-        "dental": "S01",
-        "laboratory": "L01",
-        "lab": "L01",
-        "echokg": "K10",
-        "procedures": "P01",
-        "cosmetology": "C01",
-    }
-    
-    code_to_name = {
-        "K01": "Консультация кардиолога",
-        "K10": "ЭхоКГ",
-        "D01": "Консультация дерматолога",
-        "S01": "Консультация стоматолога",
-        "L01": "Лабораторные анализы",
-        "P01": "Процедуры",
-        "C01": "Косметология",
-    }
-    
-    category_mapping = {
-        "cardiology": "K",
-        "dermatology": "D",
-        "laboratory": "L",
-        "stomatology": "S",
-        "cosmetology": "C",
-        "procedures": "P",
-    }
-    
-    # Try to enrich with actual DB data
-    try:
-        services = db.query(Service).filter(Service.active == True).all()
-        for service in services:
-            if service.service_code and service.name:
-                code_to_name[service.service_code] = service.name
-            if service.queue_tag and service.service_code:
-                specialty_to_code[service.queue_tag] = service.service_code
-    except Exception:
-        pass  # Use static mappings if DB query fails
-    
-    return ServiceCodeMappingsResponse(
-        specialty_to_code=specialty_to_code,
-        code_to_name=code_to_name,
-        category_mapping=category_mapping,
-        specialty_aliases=SPECIALTY_ALIASES,
-    )
 
 

--- a/backend/app/repositories/queue_read_repository.py
+++ b/backend/app/repositories/queue_read_repository.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.service import Service
 from app.services.queue_status import REORDER_ACTIVE_RAW_STATUSES
 
 
@@ -60,6 +61,9 @@ class QueueReadRepository:
 
     def get_doctor(self, doctor_id: int) -> Doctor | None:
         return self.db.query(Doctor).filter(Doctor.id == doctor_id).first()
+
+    def list_active_services(self) -> list[Service]:
+        return self.db.query(Service).filter(Service.active.is_(True)).all()
 
     def count_entries(self, *, queue_id: int) -> int:
         return (

--- a/backend/app/services/queue_domain_service.py
+++ b/backend/app/services/queue_domain_service.py
@@ -154,6 +154,96 @@ class QueueDomainService:
 
         return result
 
+    def get_queue_groups_payload(self) -> dict[str, Any]:
+        from app.services.service_mapping import QUEUE_GROUPS, get_queue_group_for_service
+
+        groups: dict[str, dict[str, Any]] = {}
+        for key, data in QUEUE_GROUPS.items():
+            groups[key] = {
+                "display_name": data["display_name"],
+                "display_name_uz": data.get("display_name_uz"),
+                "service_codes": data.get("service_codes", []),
+                "service_prefixes": data.get("service_prefixes", []),
+                "exclude_codes": data.get("exclude_codes", []),
+                "queue_tag": data["queue_tag"],
+                "tab_key": data["tab_key"],
+            }
+
+        code_to_group: dict[str, str] = {}
+        for key, data in QUEUE_GROUPS.items():
+            for code in data.get("service_codes", []):
+                code_to_group[code] = key
+
+        try:
+            services = self.read_repository.list_active_services()
+            for service in services:
+                if service.service_code:
+                    group = get_queue_group_for_service(service.service_code)
+                    if group:
+                        code_to_group[service.service_code] = group
+        except Exception:
+            pass
+
+        tab_to_group = {data["tab_key"]: key for key, data in QUEUE_GROUPS.items()}
+        return {
+            "groups": groups,
+            "code_to_group": code_to_group,
+            "tab_to_group": tab_to_group,
+        }
+
+    def get_service_code_mappings_payload(self) -> dict[str, Any]:
+        from app.services.service_mapping import SPECIALTY_ALIASES
+
+        specialty_to_code = {
+            "cardiology": "K01",
+            "cardio": "K01",
+            "dermatology": "D01",
+            "derma": "D01",
+            "stomatology": "S01",
+            "dental": "S01",
+            "laboratory": "L01",
+            "lab": "L01",
+            "echokg": "K10",
+            "procedures": "P01",
+            "cosmetology": "C01",
+        }
+
+        code_to_name = {
+            "K01": "Консультация кардиолога",
+            "K10": "ЭхоКГ",
+            "D01": "Консультация дерматолога",
+            "S01": "Консультация стоматолога",
+            "L01": "Лабораторные анализы",
+            "P01": "Процедуры",
+            "C01": "Косметология",
+        }
+
+        category_mapping = {
+            "cardiology": "K",
+            "dermatology": "D",
+            "laboratory": "L",
+            "stomatology": "S",
+            "cosmetology": "C",
+            "procedures": "P",
+        }
+
+        try:
+            services = self.read_repository.list_active_services()
+            for service in services:
+                if service.service_code and service.name:
+                    code_to_name[service.service_code] = service.name
+                if service.queue_tag and service.service_code:
+                    specialty_to_code[service.queue_tag] = service.service_code
+        except Exception:
+            pass
+
+        return {
+            "specialty_to_code": specialty_to_code,
+            "code_to_name": code_to_name,
+            "category_mapping": category_mapping,
+            "specialty_aliases": SPECIALTY_ALIASES,
+        }
+
     def enqueue(self, **_: Any) -> QueueSnapshot:
         raise NotImplementedError("QueueDomainService.enqueue is a Phase 2 method")
 

--- a/backend/tests/architecture/test_w2c_queue_boundaries.py
+++ b/backend/tests/architecture/test_w2c_queue_boundaries.py
@@ -76,3 +76,19 @@ def test_queue_limits_status_handler_uses_domain_service() -> None:
     block = _function_block(endpoint_path, "get_queue_status_with_limits")
     assert "QueueDomainService(db)" in block
     assert "QueueLimitsApiService(db).get_queue_status_with_limits" not in block
+
+
+def test_service_queue_metadata_handlers_use_queue_domain_service() -> None:
+    endpoint_path = (
+        Path(__file__).resolve().parents[2]
+        / "app"
+        / "api"
+        / "v1"
+        / "endpoints"
+        / "services.py"
+    )
+    for function_name in ("get_queue_groups", "get_service_code_mappings"):
+        block = _function_block(endpoint_path, function_name)
+        assert "QueueDomainService(db)" in block
+        assert "ServicesApiService(db)" not in block
+        assert "db.query(" not in block

--- a/backend/tests/unit/test_queue_domain_service.py
+++ b/backend/tests/unit/test_queue_domain_service.py
@@ -157,3 +157,41 @@ class TestQueueDomainService:
                 "online_available": True,
             }
         ]
+
+    def test_get_queue_groups_payload_preserves_static_groups_and_db_enrichment(self) -> None:
+        service_row = SimpleNamespace(service_code="K77")
+
+        class Repository:
+            def list_active_services(self):
+                return [service_row]
+
+        service = QueueDomainService(db=None, read_repository=Repository())
+
+        payload = service.get_queue_groups_payload()
+
+        assert payload["groups"]["cardiology"]["tab_key"] == "cardio"
+        assert payload["code_to_group"]["K01"] == "cardiology"
+        assert payload["code_to_group"]["K77"] == "cardiology"
+        assert payload["tab_to_group"]["cardio"] == "cardiology"
+
+    def test_get_service_code_mappings_payload_preserves_static_aliases_and_db_enrichment(
+        self,
+    ) -> None:
+        service_row = SimpleNamespace(
+            service_code="L77",
+            name="Расширенный лабораторный профиль",
+            queue_tag="laboratory",
+        )
+
+        class Repository:
+            def list_active_services(self):
+                return [service_row]
+
+        service = QueueDomainService(db=None, read_repository=Repository())
+
+        payload = service.get_service_code_mappings_payload()
+
+        assert payload["specialty_to_code"]["laboratory"] == "L77"
+        assert payload["code_to_name"]["L77"] == "Расширенный лабораторный профиль"
+        assert payload["category_mapping"]["laboratory"] == "L"
+        assert payload["specialty_aliases"]["derma"] == "dermatology"

--- a/backend/tests/unit/test_services_router_service_wiring.py
+++ b/backend/tests/unit/test_services_router_service_wiring.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from app.services.queue_domain_service import QueueDomainService
 from app.services.services_api_service import ServicesApiService
 
 
@@ -72,3 +73,71 @@ def test_get_service_endpoint_delegates_to_service(client, monkeypatch) -> None:
     assert payload["name"] == "Consultation"
     assert captured["service_id"] == 42
 
+
+def test_queue_groups_endpoint_delegates_to_queue_domain_service(
+    client,
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    def fake_get_queue_groups_payload(self):
+        captured["called"] = True
+        return {
+            "groups": {
+                "cardiology": {
+                    "display_name": "Кардиология",
+                    "display_name_uz": "Kardiologiya",
+                    "service_codes": ["K01"],
+                    "service_prefixes": ["K"],
+                    "exclude_codes": ["K10"],
+                    "queue_tag": "cardiology",
+                    "tab_key": "cardio",
+                }
+            },
+            "code_to_group": {"K01": "cardiology"},
+            "tab_to_group": {"cardio": "cardiology"},
+        }
+
+    monkeypatch.setattr(
+        QueueDomainService,
+        "get_queue_groups_payload",
+        fake_get_queue_groups_payload,
+    )
+
+    response = client.get("/api/v1/services/queue-groups")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["groups"]["cardiology"]["tab_key"] == "cardio"
+    assert payload["code_to_group"]["K01"] == "cardiology"
+    assert captured["called"] is True
+
+
+def test_service_code_mappings_endpoint_delegates_to_queue_domain_service(
+    client,
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    def fake_get_service_code_mappings_payload(self):
+        captured["called"] = True
+        return {
+            "specialty_to_code": {"laboratory": "L77"},
+            "code_to_name": {"L77": "Расширенный лабораторный профиль"},
+            "category_mapping": {"laboratory": "L"},
+            "specialty_aliases": {"derma": "dermatology"},
+        }
+
+    monkeypatch.setattr(
+        QueueDomainService,
+        "get_service_code_mappings_payload",
+        fake_get_service_code_mappings_payload,
+    )
+
+    response = client.get("/api/v1/services/code-mappings")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["specialty_to_code"]["laboratory"] == "L77"
+    assert payload["code_to_name"]["L77"] == "Расширенный лабораторный профиль"
+    assert captured["called"] is True

--- a/docs/architecture/W2C_ONLINE_QUEUE_DOC_COMPLIANCE.md
+++ b/docs/architecture/W2C_ONLINE_QUEUE_DOC_COMPLIANCE.md
@@ -84,6 +84,7 @@ Compliance outcome:
   - queue snapshot/status reads now use an explicit read-only domain boundary
   - cabinet read handlers now use runtime `DailyQueue.specialist_id -> doctors.id` semantics through the queue read boundary
   - queue-limits status read now uses the same runtime-compatible `doctor.user_id` lookup it used before the refactor
+  - queue metadata read handlers in `services.py` now use the queue read boundary while preserving static `QUEUE_GROUPS` / `SPECIALTY_ALIASES` semantics and best-effort active-service enrichment
 - still in conflict and deferred:
   - status drift beyond the normative four-state vocabulary
   - `doctors.id` vs `users.id` wording drift

--- a/docs/architecture/W2C_QUEUE_DISCOVERY.md
+++ b/docs/architecture/W2C_QUEUE_DISCOVERY.md
@@ -42,6 +42,7 @@ The first migrated read-only slices are:
 - `W2C-MS-006` queue snapshot/status reads via `QueueDomainService`
 - `W2C-MS-003` cabinet info read handlers via `QueueDomainService`
 - `W2C-MS-002` narrowed queue-status-with-limits read handler via `QueueDomainService`
+- `W2C-MS-004` narrowed queue metadata read handlers in `services.py` via `QueueDomainService`
 
 Runtime mutation ownership is still fragmented exactly as documented below.
 

--- a/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
+++ b/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
@@ -258,6 +258,8 @@ Currently implemented:
 - `list_queue_cabinet_info(day=..., specialist_id=..., cabinet_number=...)`
 - `get_queue_cabinet_info(queue_id=...)`
 - `get_queue_limits_status(day=..., specialty=...)`
+- `get_queue_groups_payload()`
+- `get_service_code_mappings_payload()`
 
 Skeleton-only methods that intentionally still raise `NotImplementedError`:
 
@@ -273,3 +275,9 @@ This is intentional for Phase 1:
 - read-only queue slices can adopt the service now
 - mutation flows stay in legacy paths until the state machine and transaction rules
   are migrated explicitly
+
+Notes for the narrowed `W2C-MS-004` slice:
+
+- only queue metadata reads moved under `QueueDomainService`
+- static taxonomy definitions still live in `app/services/service_mapping.py`
+- no queue numbering, duplicate, lifecycle, or QR-window behavior changed

--- a/docs/architecture/W2C_QUEUE_REPOSITORIES.md
+++ b/docs/architecture/W2C_QUEUE_REPOSITORIES.md
@@ -162,8 +162,10 @@ Current implemented read boundary:
 - `get_queue_by_specialist_day(specialist_id, day)`
 - `list_daily_queues(day_obj, specialist_id, cabinet_number)`
 - `get_doctor(doctor_id)`
+- `list_active_services()`
 - `count_entries(queue_id)`
 - `list_snapshot_entries(queue_id, statuses)`
 
 This repository is intentionally read-only and is currently used by
-`QueueDomainService` for safe status/snapshot and cabinet-info endpoints.
+`QueueDomainService` for safe status/snapshot, cabinet-info, limits-status, and
+queue-metadata read endpoints.

--- a/docs/status/W2C_PHASE1_EXECUTION_SUMMARY.md
+++ b/docs/status/W2C_PHASE1_EXECUTION_SUMMARY.md
@@ -16,6 +16,7 @@ Mode: analysis-first, execution-enabled
 - `W2C-MS-006` (`done`): moved queue snapshot/status reads to `QueueDomainService -> QueueReadRepository`
 - `W2C-MS-003` (`done`, narrowed): moved cabinet info read handlers to `QueueDomainService -> QueueReadRepository`
 - `W2C-MS-002` (`done`, narrowed): moved `GET /queue-status` to `QueueDomainService -> QueueReadRepository` while preserving current `doctor.user_id` lookup behavior
+- `W2C-MS-004` (`done`, narrowed): moved `GET /services/queue-groups` and `GET /services/code-mappings` to `QueueDomainService -> QueueReadRepository` while preserving static queue taxonomy and best-effort DB enrichment behavior
 
 ## Foundational Additions
 
@@ -34,22 +35,28 @@ Mode: analysis-first, execution-enabled
 ## Tests Run
 
 - `cd backend && pytest tests/unit/test_queue_status.py tests/unit/test_queue_domain_service.py tests/unit/test_queue_reorder_api_service.py tests/unit/test_queue_position_api_service.py tests/architecture/test_w2c_queue_boundaries.py -q`
+- `cd backend && pytest tests/unit/test_queue_domain_service.py tests/unit/test_services_router_service_wiring.py tests/architecture/test_w2c_queue_boundaries.py tests/unit/test_service_repository_boundary.py -q`
 - `cd backend && pytest -q`
 - `cd backend && pytest tests/test_openapi_contract.py -q`
 
 ## Test Results
 
 - targeted Phase 1 tests: passed
-- full backend suite: `671 passed, 3 skipped`
+- full backend suite: `676 passed, 3 skipped`
 - OpenAPI contract suite: `10 passed`
 
 ## Regressions Found
 
-None detected.
+One read-path routing bug was detected and fixed in `W2C-MS-004`:
+
+- `GET /services/code-mappings` was shadowed by `GET /services/{service_id}` and returned `422`
+- fix: moved the static `/code-mappings` route above `/{service_id}` without changing
+  schema or queue semantics
+
+No remaining regressions were detected after the fix.
 
 ## Remaining Safe Candidates
 
-- optional `W2C-MS-004` queue metadata read helpers
 - `W2C-MS-005` number-allocation boundary extraction, only after another compliance pass
 
 ## Not Allowed For Phase 1 Follow-Up
@@ -63,6 +70,7 @@ None detected.
 
 ## Recommended Next Step
 
-If Phase 1 continues, prefer optional `W2C-MS-004`.
 Do not start `W2C-MS-005` until numbering semantics get a separate compliance review.
+If Phase 1 pauses here, that is a valid stop point: all read-only queue slices except
+number-allocation extraction are completed.
 Do not enter queue mutation refactor until a separate Phase 2 approval pass.

--- a/docs/status/W2C_SAFE_SLICES.md
+++ b/docs/status/W2C_SAFE_SLICES.md
@@ -27,17 +27,20 @@ Completed in Phase 1:
 - `W2C-MS-006`
 - `W2C-MS-003` (narrowed to cabinet info read handlers only)
 - `W2C-MS-002` (narrowed to `GET /queue-status` only)
+- `W2C-MS-004` (narrowed to `GET /services/queue-groups` and `GET /services/code-mappings`)
 
 Still pending safe candidates:
 
 - `W2C-MS-005`
-- optional `W2C-MS-004`
 
 Cabinet write and sync/statistics paths remain on the legacy service path and were not
 included in the executed `W2C-MS-003` slice.
 
 Queue limits writes and `GET /queue-limits` remain on the legacy service path and were not
 included in the executed `W2C-MS-002` slice.
+
+`GET /services/resolve` remains on the legacy path and was not included in the executed
+`W2C-MS-004` slice.
 
 ## Not Safe for the First Queue Refactor Pass
 
@@ -56,10 +59,9 @@ These should not be auto-refactored before the domain service and state machine 
 
 ## Recommended Order
 
-1. optional `W2C-MS-004`
-2. `W2C-MS-005` only after an explicit numbering/compliance pass
+1. `W2C-MS-005` only after an explicit numbering/compliance pass
 
-`W2C-MS-004` stays optional because queue taxonomy is queue-domain policy, not just catalog metadata.
+`W2C-MS-005` stays gated because queue numbering is domain policy, not a simple read boundary.
 
 ## Exit Rule
 

--- a/docs/status/wave2c/W2C-MS-004_PLAN.md
+++ b/docs/status/wave2c/W2C-MS-004_PLAN.md
@@ -1,0 +1,48 @@
+# W2C-MS-004 Plan
+
+Date: 2026-03-07
+Mode: Wave 2C Phase 1 continuation
+Contract: `.ai-factory/contracts/w2c-ms-004.contract.json`
+
+## Files
+
+- `backend/app/api/v1/endpoints/services.py`
+- `backend/app/repositories/queue_read_repository.py`
+- `backend/app/services/queue_domain_service.py`
+- `backend/tests/architecture/test_w2c_queue_boundaries.py`
+- `backend/tests/unit/test_queue_domain_service.py`
+- `backend/tests/unit/test_services_router_service_wiring.py`
+
+## Handlers
+
+- `GET /services/queue-groups`
+- `GET /services/code-mappings`
+
+## Current DB Access Pattern
+
+Both handlers live in `services.py` and currently build payloads inline using static
+SSOT mappings plus direct `db.query(Service)` enrichment.
+
+## Target Wiring
+
+`router -> QueueDomainService -> QueueReadRepository`
+
+Not included in this slice:
+
+- `GET /services/resolve`
+- services catalog/category CRUD
+- any queue mutation or runtime queue lifecycle endpoint
+
+## Risk Analysis
+
+Low to medium.
+
+Queue taxonomy is domain-sensitive, so this slice preserves existing static mappings and
+only moves payload construction behind the queue read boundary.
+
+## Runtime Invariants That Must Not Change
+
+- static `QUEUE_GROUPS` and `SPECIALTY_ALIASES` semantics
+- DB enrichment behavior for active services
+- response schemas of `queue-groups` and `code-mappings`
+- no change to numbering, duplicate policy, fairness ordering, visit lifecycle, or QR restrictions

--- a/docs/status/wave2c/W2C-MS-004_STATUS.md
+++ b/docs/status/wave2c/W2C-MS-004_STATUS.md
@@ -1,0 +1,91 @@
+# W2C-MS-004 Status
+
+Date: 2026-03-07
+Status: `done`
+Mode: Wave 2C Phase 1 continuation
+Contract: `.ai-factory/contracts/w2c-ms-004.contract.json`
+
+## Files Changed
+
+- `backend/app/api/v1/endpoints/services.py`
+- `backend/app/repositories/queue_read_repository.py`
+- `backend/app/services/queue_domain_service.py`
+- `backend/tests/architecture/test_w2c_queue_boundaries.py`
+- `backend/tests/unit/test_queue_domain_service.py`
+- `backend/tests/unit/test_services_router_service_wiring.py`
+- `docs/architecture/W2C_ONLINE_QUEUE_DOC_COMPLIANCE.md`
+- `docs/architecture/W2C_QUEUE_DISCOVERY.md`
+- `docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md`
+- `docs/architecture/W2C_QUEUE_REPOSITORIES.md`
+- `docs/status/W2C_SAFE_SLICES.md`
+- `docs/status/W2C_PHASE1_EXECUTION_SUMMARY.md`
+
+## Scope Executed
+
+Completed only the narrowed read-only queue metadata slice:
+
+- `GET /services/queue-groups`
+- `GET /services/code-mappings`
+
+Out of scope and left unchanged:
+
+- `GET /services/resolve`
+- service catalog/category CRUD
+- queue numbering
+- duplicate policy
+- QR window logic
+- visit-linked queue mutation flows
+
+## Architecture Change
+
+Read path now follows:
+
+`router -> QueueDomainService -> QueueReadRepository`
+
+Implemented pieces:
+
+- `QueueReadRepository.list_active_services()`
+- `QueueDomainService.get_queue_groups_payload()`
+- `QueueDomainService.get_service_code_mappings_payload()`
+- router delegation from `services.py` to the queue read boundary
+
+## Runtime Compatibility Notes
+
+- static `QUEUE_GROUPS` and `SPECIALTY_ALIASES` remain the source for taxonomy
+- DB enrichment still uses active services only
+- enrichment remains best-effort and falls back to static mappings on read failure
+- response schemas were preserved
+
+## Issue Found During Execution
+
+`GET /services/code-mappings` was shadowed by `GET /services/{service_id}` and returned
+`422` because the static route was declared below the dynamic route.
+
+Applied fix:
+
+- moved `/services/code-mappings` above `/{service_id}`
+
+Why this stayed in scope:
+
+- it is a read-only route-ordering fix inside the selected slice
+- it does not change queue mutation semantics
+- it does not change response shape
+- it was required to make the selected static endpoint reachable
+
+`GET /services/resolve` was still left outside this slice.
+
+## Tests Run
+
+- `cd backend && pytest tests/unit/test_queue_domain_service.py tests/unit/test_services_router_service_wiring.py tests/architecture/test_w2c_queue_boundaries.py tests/unit/test_service_repository_boundary.py -q`
+- `cd backend && pytest -q`
+- `cd backend && pytest tests/test_openapi_contract.py -q`
+
+## Test Results
+
+- targeted tests: `78 passed`
+- full backend suite: `676 passed, 3 skipped`
+- OpenAPI contract suite: `10 passed`
+
+## Regressions
+
+None remaining after the route-order fix.


### PR DESCRIPTION
﻿## Summary
- Route `/api/v1/services/queue-groups` and `/api/v1/services/code-mappings` through `QueueDomainService` and `QueueReadRepository`.
- Preserve static SSOT mappings plus DB enrichment behavior, including the `code-mappings` route-shadowing fix before `/{service_id}`.
- Add narrowed W2C-MS-004 contract, architecture/unit coverage, and Wave 2C status docs.

## Contract Impact
- Canonical surface: `GET /api/v1/services/queue-groups` and `GET /api/v1/services/code-mappings`.
- Request shape: unchanged; both are read endpoints with the same query/input behavior as before.
- Response shape: unchanged; `queue-groups` returns `groups`, `code_to_group`, and `tab_to_group`; `code-mappings` returns service code mapping payload fields.
- Status codes: unchanged for normal read behavior; fallback/enrichment semantics are preserved through the queue-domain read layer.
- Frontend consumer: services/queue metadata consumers continue using the same payload shapes.
- Compatibility path or alias: metadata reads move behind the queue-domain boundary without changing resolve-service runtime behavior or queue taxonomy data structures.
- Contract proof: `.ai-factory/contracts/w2c-ms-004.contract.json`, service router/domain/repository tests, and OpenAPI contract test listed by author.

## RBAC / Permissions
- Roles allowed: unchanged for existing services metadata read endpoints.
- Roles denied: unchanged; no authorization helper or role matrix behavior is changed.
- Positive auth proof: existing service endpoint tests remain the access proof surface.
- Negative auth proof: not applicable because auth behavior is not changed; reviewer should confirm existing route auth remains intact.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket event is changed.
- Payload version / ack behavior: not applicable because no realtime payload is added or renamed.
- Read/unread or delivery semantics: not applicable because this is a backend metadata-read migration.
- Reconnect/resync proof: not applicable because no realtime reconnect behavior is touched.

## Frontend Resilience
- Empty data proof: unchanged; metadata response shape is preserved.
- Partial data proof: unchanged; no frontend partial-data handling is modified.
- Forbidden secondary path behavior: unchanged; no frontend secondary path is touched.
- Missing draft/resource behavior: unchanged; no draft/resource UI path is touched.
- Stale route/deep-link behavior: unchanged; no frontend route state is touched.

## Scope Gate
- Allowed paths: W2C-MS-004 contract, services metadata endpoints, queue read repository/domain service, focused tests, and W2C metadata docs/status notes.
- Denied paths: QR queue, doctor integration, registrar integration, visits, `service_mapping.py`, `queue_service.py`, Alembic migrations, workflows, frontend files, numbering logic, duplicate policy, visit lifecycle, and QR blocking.
- Migration/docs/test impact: adds read-boundary contract/status docs and focused backend tests; no database migration.
- Rollback note: revert services metadata handlers back to direct mapping/repository access if queue metadata payload shape or route ordering regresses.

## Validation
- Targeted tests or smoke run: author lists `cd backend && pytest tests/unit/test_queue_domain_service.py tests/unit/test_services_router_service_wiring.py tests/architecture/test_w2c_queue_boundaries.py tests/unit/test_service_repository_boundary.py -q`, `cd backend && pytest -q`, and `cd backend && pytest tests/test_openapi_contract.py -q`.
- Result: not rerun in this automation pass; PR body records the author's listed validation targets.
- Not checked: realtime/browser smoke and local CI/env proof were not checked here because no realtime/frontend files are changed.
