### PR TITLE
fix: reuse active queue entries on confirmation

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -2619,9 +2619,16 @@ def confirm_visit_by_registrar(
 
         # Если визит на сегодня - присваиваем номера в очередях
         if visit.visit_date == date.today():
-            queue_numbers, print_tickets = _assign_queue_numbers_on_confirmation(
-                db, visit
+            from app.services.visit_confirmation_service import (
+                VisitConfirmationDomainError,
             )
+
+            try:
+                queue_numbers, print_tickets = _assign_queue_numbers_on_confirmation(
+                    db, visit
+                )
+            except VisitConfirmationDomainError as exc:
+                raise HTTPException(status_code=exc.status_code, detail=exc.detail)
             visit.status = "open"  # Готов к приему
 
         db.commit()
@@ -2650,173 +2657,17 @@ def _assign_queue_numbers_on_confirmation(
     db: Session, visit: Visit
 ) -> tuple[Dict[str, Any], List[Dict[str, Any]]]:
     """
-    Присваивает номера в очередях при подтверждении визита на сегодня
-    Возвращает (queue_numbers, print_tickets)
+    Присваивает или переиспользует номера в очередях при подтверждении визита.
+    Возвращает `(queue_numbers, print_tickets)` в прежнем формате registrar API.
     """
-    from app.models.online_queue import DailyQueue, OnlineQueueEntry
+    from app.services.visit_confirmation_service import VisitConfirmationService
 
-    # Получаем услуги визита
-    visit_services = (
-        db.query(VisitService).filter(VisitService.visit_id == visit.id).all()
+    service = VisitConfirmationService(db)
+    queue_numbers_list, print_tickets = service.assign_queue_numbers_on_confirmation(
+        visit
     )
-
-    # Определяем уникальные queue_tag из услуг
-    unique_queue_tags = set()
-    for vs in visit_services:
-        service = db.query(Service).filter(Service.id == vs.service_id).first()
-        if service and service.queue_tag:
-            unique_queue_tags.add(service.queue_tag)
-
-    if not unique_queue_tags:
-        department_to_queue = {
-            "cardiology": "cardiology_common",
-            "dermatology": "dermatology",
-            "stomatology": "stomatology",
-            "cosmetology": "cosmetology",
-            "lab": "lab",
-            "ecg": "ecg",
-        }
-        fallback_tag = department_to_queue.get((visit.department or "").lower())
-        if fallback_tag:
-            unique_queue_tags.add(fallback_tag)
-        else:
-            return {}, []
-
-    today = date.today()
-    queue_numbers = {}
-    print_tickets = []
-
-    # Получаем настройки очередей
-    queue_settings = {}  # Можно загрузить из настроек
-
-    for queue_tag in unique_queue_tags:
-        # Определяем врача для очереди
-        doctor_id = visit.doctor_id
-
-        # Для очередей без конкретного врача используем ресурс-врачей
-        if queue_tag == "ecg" and not doctor_id:
-            ecg_resource = (
-                db.query(User)
-                .filter(User.username == "ecg_resource", User.is_active == True)
-                .first()
-            )
-            if ecg_resource:
-                doctor_id = ecg_resource.id
-            else:
-                continue
-
-        elif queue_tag == "lab" and not doctor_id:
-            lab_resource = (
-                db.query(User)
-                .filter(User.username == "lab_resource", User.is_active == True)
-                .first()
-            )
-            if lab_resource:
-                # ✅ ИСПРАВЛЕНО: Находим Doctor по user_id для правильного specialist_id
-                lab_doctor = (
-                    db.query(Doctor).filter(Doctor.user_id == lab_resource.id).first()
-                )
-                if lab_doctor:
-                    doctor_id = lab_doctor.id  # Используем doctor_id, а не user_id
-                    logger.info(
-                        f"Для queue_tag={queue_tag} используется ресурс-врач: lab_resource (Doctor ID: {doctor_id})"
-                    )
-                else:
-                    logger.warning(
-                        f"У ресурс-пользователя lab_resource (User ID: {lab_resource.id}) нет записи в таблице doctors"
-                    )
-                    continue
-            else:
-                continue
-
-        if not doctor_id:
-            continue
-
-        # Получаем или создаем дневную очередь
-        daily_queue = crud_queue.get_or_create_daily_queue(
-            db, today, doctor_id, queue_tag
-        )
-
-        start_number = queue_settings.get("start_numbers", {}).get(queue_tag, 1)
-        next_number = queue_service.get_next_queue_number(
-            db,
-            daily_queue=daily_queue,
-            queue_tag=queue_tag,
-            default_start=start_number,
-        )
-
-        # Создаем запись в очереди
-        # queue_time - бизнес-время регистрации
-        from datetime import datetime
-        from zoneinfo import ZoneInfo
-
-        queue_settings = crud_clinic.get_queue_settings(db)
-        timezone = ZoneInfo(queue_settings.get("timezone", "Asia/Tashkent"))
-        queue_time = datetime.now(timezone)
-
-        # ⭐ session_id для группировки услуг пациента в одной очереди
-        session_id = get_or_create_session_id(
-            db, visit.patient_id, daily_queue.id, today
-        ) if visit.patient_id else f"confirmation_{visit.id}"
-
-        queue_entry = OnlineQueueEntry(
-            queue_id=daily_queue.id,
-            patient_id=visit.patient_id,
-            visit_id=visit.id,
-            number=next_number,
-            status="waiting",
-            source="confirmation",  # Источник: подтверждение визита
-            queue_time=queue_time,  # Устанавливаем время регистрации
-            session_id=session_id,  # ⭐ NEW: Session grouping
-        )
-        db.add(queue_entry)
-
-        queue_numbers[queue_tag] = {
-            "queue_tag": queue_tag,
-            "number": next_number,
-            "queue_id": daily_queue.id,
-        }
-
-        # Подготавливаем данные для печати талона
-        queue_names = {
-            "ecg": "ЭКГ",
-            "cardiology_common": "Кардиолог",
-            "dermatology": "Дерматолог",
-            "stomatology": "Стоматолог",
-            "cosmetology": "Косметолог",
-            "lab": "Лаборатория",
-            "general": "Общая очередь",
-        }
-
-        doctor = (
-            db.query(Doctor).filter(Doctor.id == visit.doctor_id).first()
-            if visit.doctor_id
-            else None
-        )
-        patient = db.query(Patient).filter(Patient.id == visit.patient_id).first()
-
-        # [OK] ИСПРАВЛЕНО: User имеет full_name, а не first_name/last_name
-        doctor_name = "Без врача"
-        if doctor and doctor.user_id:
-            user = db.query(User).filter(User.id == doctor.user_id).first()
-            doctor_name = (user.full_name or user.username) if user else "Без врача"
-
-        print_tickets.append(
-            {
-                "visit_id": visit.id,
-                "queue_tag": queue_tag,
-                "queue_name": queue_names.get(queue_tag, queue_tag),
-                "queue_number": next_number,
-                "queue_id": daily_queue.id,
-                "patient_id": visit.patient_id,
-                "patient_name": (
-                    patient.short_name() if patient else "Неизвестный пациент"
-                ),
-                "doctor_name": doctor_name,
-                "department": visit.department,
-                "visit_date": visit.visit_date.isoformat(),
-                "visit_time": visit.visit_time,
-            }
-        )
-
+    queue_numbers = {
+        item["queue_tag"]: item
+        for item in queue_numbers_list
+    }
     return queue_numbers, print_tickets

--- a/backend/app/repositories/visit_confirmation_repository.py
+++ b/backend/app/repositories/visit_confirmation_repository.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.crud import online_queue as crud_queue
 from app.models.clinic import Doctor
+from app.models.online_queue import OnlineQueueEntry
 from app.models.patient import Patient
 from app.models.service import Service
 from app.models.user import User
@@ -54,6 +55,19 @@ class VisitConfirmationRepository:
 
     def get_or_create_daily_queue(self, day: date, specialist_id: int, queue_tag: str):
         return crud_queue.get_or_create_daily_queue(self.db, day, specialist_id, queue_tag)
+
+    def get_active_queue_entries(
+        self, *, queue_id: int, active_statuses: tuple[str, ...]
+    ) -> list[OnlineQueueEntry]:
+        return (
+            self.db.query(OnlineQueueEntry)
+            .filter(
+                OnlineQueueEntry.queue_id == queue_id,
+                OnlineQueueEntry.status.in_(active_statuses),
+            )
+            .order_by(OnlineQueueEntry.number.asc(), OnlineQueueEntry.id.asc())
+            .all()
+        )
 
     def commit(self) -> None:
         self.db.commit()

--- a/backend/app/services/visit_confirmation_service.py
+++ b/backend/app/services/visit_confirmation_service.py
@@ -7,11 +7,20 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Any
 
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.repositories.visit_confirmation_repository import VisitConfirmationRepository
 from app.services.confirmation_security import ConfirmationSecurityService
 from app.services.queue_service import queue_service
+from app.utils.validators import normalize_phone_uz
 
 logger = logging.getLogger(__name__)
+
+CANONICAL_ACTIVE_CONFIRMATION_STATUSES = (
+    "waiting",
+    "called",
+    "in_service",
+    "diagnostics",
+)
 
 
 @dataclass
@@ -96,6 +105,7 @@ class VisitConfirmationService:
                 visit=visit,
                 confirmed_by=f"telegram_{telegram_user_id or 'unknown'}",
                 channel="telegram",
+                confirmation_telegram_id=telegram_user_id,
             )
 
             self.security_service.record_confirmation_attempt(
@@ -195,6 +205,7 @@ class VisitConfirmationService:
                 visit=visit,
                 confirmed_by=f"pwa_{source_ip or 'unknown'}",
                 channel="pwa",
+                confirmation_phone=patient_phone,
             )
             self.security_service.record_confirmation_attempt(
                 visit_id=visit.id, success=True, channel="pwa"
@@ -289,6 +300,8 @@ class VisitConfirmationService:
         visit,
         confirmed_by: str,
         channel: str,
+        confirmation_phone: str | None = None,
+        confirmation_telegram_id: str | None = None,
     ) -> dict[str, Any]:
         visit.confirmed_at = datetime.utcnow()
         visit.confirmed_by = confirmed_by
@@ -297,7 +310,11 @@ class VisitConfirmationService:
         queue_numbers: list[dict[str, Any]] = []
         print_tickets: list[dict[str, Any]] = []
         if visit.visit_date == date.today():
-            queue_numbers, print_tickets = self._assign_queue_numbers_on_confirmation(visit)
+            queue_numbers, print_tickets = self.assign_queue_numbers_on_confirmation(
+                visit,
+                confirmation_phone=confirmation_phone,
+                confirmation_telegram_id=confirmation_telegram_id,
+            )
             visit.status = "open"
 
         self.repository.commit()
@@ -323,8 +340,164 @@ class VisitConfirmationService:
             "print_tickets": print_tickets,
         }
 
+    def assign_queue_numbers_on_confirmation(
+        self,
+        visit,
+        *,
+        confirmation_phone: str | None = None,
+        confirmation_telegram_id: str | None = None,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        return self._assign_queue_numbers_on_confirmation(
+            visit,
+            confirmation_phone=confirmation_phone,
+            confirmation_telegram_id=confirmation_telegram_id,
+        )
+
+    @staticmethod
+    def _normalize_confirmation_phone(phone: str | None) -> str | None:
+        if not phone:
+            return None
+        normalized_phone = normalize_phone_uz(phone)
+        return normalized_phone or None
+
+    @staticmethod
+    def _normalize_confirmation_telegram_id(
+        telegram_id: str | int | None,
+    ) -> int | None:
+        if telegram_id in (None, ""):
+            return None
+        try:
+            return int(str(telegram_id).strip())
+        except (TypeError, ValueError):
+            return None
+
+    def _resolve_existing_active_entry(
+        self,
+        *,
+        daily_queue: DailyQueue,
+        visit,
+        patient,
+        confirmation_phone: str | None,
+        confirmation_telegram_id: str | None,
+    ) -> OnlineQueueEntry | None:
+        active_entries = self.repository.get_active_queue_entries(
+            queue_id=daily_queue.id,
+            active_statuses=CANONICAL_ACTIVE_CONFIRMATION_STATUSES,
+        )
+        if not active_entries:
+            return None
+
+        candidate_entries: dict[int, OnlineQueueEntry] = {}
+
+        if visit.patient_id:
+            for entry in active_entries:
+                if entry.patient_id == visit.patient_id:
+                    candidate_entries[entry.id] = entry
+
+        normalized_phone = self._normalize_confirmation_phone(
+            confirmation_phone or (patient.phone if patient else None)
+        )
+        if normalized_phone:
+            for entry in active_entries:
+                entry_phone = self._normalize_confirmation_phone(entry.phone)
+                if entry_phone and entry_phone == normalized_phone:
+                    candidate_entries[entry.id] = entry
+
+        normalized_telegram_id = self._normalize_confirmation_telegram_id(
+            confirmation_telegram_id
+        )
+        if normalized_telegram_id is not None:
+            for entry in active_entries:
+                if entry.telegram_id == normalized_telegram_id:
+                    candidate_entries[entry.id] = entry
+
+        if not candidate_entries:
+            return None
+
+        if len(candidate_entries) > 1:
+            raise VisitConfirmationDomainError(
+                status_code=409,
+                detail=(
+                    "Невозможно однозначно определить существующую запись очереди "
+                    "для подтверждения"
+                ),
+            )
+
+        existing_entry = next(iter(candidate_entries.values()))
+
+        if existing_entry.patient_id not in (None, visit.patient_id):
+            raise VisitConfirmationDomainError(
+                status_code=409,
+                detail=(
+                    "Невозможно однозначно определить существующую запись очереди "
+                    "для подтверждения"
+                ),
+            )
+
+        if existing_entry.visit_id not in (None, visit.id):
+            raise VisitConfirmationDomainError(
+                status_code=409,
+                detail=(
+                    "Невозможно однозначно определить существующую запись очереди "
+                    "для подтверждения"
+                ),
+            )
+
+        return existing_entry
+
+    def _reuse_existing_active_entry(
+        self,
+        *,
+        existing_entry: OnlineQueueEntry,
+        visit,
+    ) -> None:
+        if existing_entry.patient_id is None:
+            existing_entry.patient_id = visit.patient_id
+        if existing_entry.visit_id is None:
+            existing_entry.visit_id = visit.id
+
+    def _build_confirmation_print_ticket(
+        self,
+        *,
+        visit,
+        queue_tag: str,
+        queue_id: int,
+        queue_number: int,
+    ) -> dict[str, Any]:
+        queue_names = {
+            "ecg": "ЭКГ",
+            "cardiology_common": "Кардиолог",
+            "dermatology": "Дерматолог",
+            "stomatology": "Стоматолог",
+            "cosmetology": "Косметолог",
+            "lab": "Лаборатория",
+            "general": "Общая очередь",
+        }
+        doctor = self.repository.get_doctor(visit.doctor_id) if visit.doctor_id else None
+        patient = self.repository.get_patient(visit.patient_id)
+
+        return {
+            "visit_id": visit.id,
+            "queue_tag": queue_tag,
+            "queue_name": queue_names.get(queue_tag, queue_tag),
+            "queue_number": queue_number,
+            "queue_id": queue_id,
+            "patient_id": visit.patient_id,
+            "patient_name": patient.short_name() if patient else "Неизвестный пациент",
+            "doctor_name": (
+                doctor.user.full_name if doctor and doctor.user else "Без врача"
+            ),
+            "department": visit.department,
+            "visit_date": visit.visit_date.isoformat(),
+            "visit_time": visit.visit_time,
+        }
+
     def _assign_queue_numbers_on_confirmation(
-        self, visit
+        self,
+        visit,
+        *,
+        confirmation_phone: str | None = None,
+        confirmation_telegram_id: str | None = None,
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         visit_services = self.repository.get_visit_services(visit.id)
 
@@ -352,6 +525,7 @@ class VisitConfirmationService:
         today = date.today()
         queue_numbers: list[dict[str, Any]] = []
         print_tickets: list[dict[str, Any]] = []
+        patient = self.repository.get_patient(visit.patient_id)
 
         for queue_tag in unique_queue_tags:
             specialist_user_id: int | None = None
@@ -397,59 +571,53 @@ class VisitConfirmationService:
                 queue_tag=queue_tag,
             )
 
-            next_number = queue_service.get_next_queue_number(
-                self.repository.db,
+            existing_entry = self._resolve_existing_active_entry(
                 daily_queue=daily_queue,
-                queue_tag=queue_tag,
+                visit=visit,
+                patient=patient,
+                confirmation_phone=confirmation_phone,
+                confirmation_telegram_id=confirmation_telegram_id,
             )
+            if existing_entry:
+                self._reuse_existing_active_entry(
+                    existing_entry=existing_entry,
+                    visit=visit,
+                )
+                queue_number = existing_entry.number
+                queue_id = existing_entry.queue_id
+            else:
+                next_number = queue_service.get_next_queue_number(
+                    self.repository.db,
+                    daily_queue=daily_queue,
+                    queue_tag=queue_tag,
+                )
 
-            queue_service.create_queue_entry(
-                self.repository.db,
-                daily_queue=daily_queue,
-                patient_id=visit.patient_id,
-                visit_id=visit.id,
-                number=next_number,
-                source="confirmation",
-            )
+                queue_service.create_queue_entry(
+                    self.repository.db,
+                    daily_queue=daily_queue,
+                    patient_id=visit.patient_id,
+                    visit_id=visit.id,
+                    number=next_number,
+                    source="confirmation",
+                )
+                queue_number = next_number
+                queue_id = daily_queue.id
 
             queue_numbers.append(
                 {
-                "queue_tag": queue_tag,
-                "number": next_number,
-                "queue_id": daily_queue.id,
+                    "queue_tag": queue_tag,
+                    "number": queue_number,
+                    "queue_id": queue_id,
                 }
             )
 
-            queue_names = {
-                "ecg": "ЭКГ",
-                "cardiology_common": "Кардиолог",
-                "dermatology": "Дерматолог",
-                "stomatology": "Стоматолог",
-                "cosmetology": "Косметолог",
-                "lab": "Лаборатория",
-                "general": "Общая очередь",
-            }
-            doctor = self.repository.get_doctor(visit.doctor_id) if visit.doctor_id else None
-            patient = self.repository.get_patient(visit.patient_id)
-
             print_tickets.append(
-                {
-                    "visit_id": visit.id,
-                    "queue_tag": queue_tag,
-                    "queue_name": queue_names.get(queue_tag, queue_tag),
-                    "queue_number": next_number,
-                    "queue_id": daily_queue.id,
-                    "patient_id": visit.patient_id,
-                    "patient_name": (
-                        patient.short_name() if patient else "Неизвестный пациент"
-                    ),
-                    "doctor_name": (
-                        doctor.user.full_name if doctor and doctor.user else "Без врача"
-                    ),
-                    "department": visit.department,
-                    "visit_date": visit.visit_date.isoformat(),
-                    "visit_time": visit.visit_time,
-                }
+                self._build_confirmation_print_ticket(
+                    visit=visit,
+                    queue_tag=queue_tag,
+                    queue_id=queue_id,
+                    queue_number=queue_number,
+                )
             )
 
         return queue_numbers, print_tickets

--- a/backend/tests/characterization/test_confirmation_split_flow_characterization.py
+++ b/backend/tests/characterization/test_confirmation_split_flow_characterization.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from decimal import Decimal
 
 import pytest
@@ -127,7 +128,7 @@ def test_confirmation_split_flow_replay_returns_error_and_keeps_single_queue_row
 @pytest.mark.integration
 @pytest.mark.queue
 @pytest.mark.confirmation
-def test_confirmation_split_flow_with_existing_active_entry_creates_second_active_row(
+def test_confirmation_split_flow_with_existing_active_entry_reuses_existing_row(
     client,
     db_session,
     test_visit,
@@ -136,6 +137,7 @@ def test_confirmation_split_flow_with_existing_active_entry_creates_second_activ
     test_patient,
 ):
     _attach_visit_service(db_session, test_visit, test_service)
+    original_queue_time = datetime.utcnow().replace(microsecond=0)
 
     existing_active_entry = OnlineQueueEntry(
         queue_id=test_daily_queue.id,
@@ -145,6 +147,7 @@ def test_confirmation_split_flow_with_existing_active_entry_creates_second_activ
         phone=test_patient.phone,
         source="online",
         status="waiting",
+        queue_time=original_queue_time,
     )
     db_session.add(existing_active_entry)
     db_session.commit()
@@ -158,6 +161,7 @@ def test_confirmation_split_flow_with_existing_active_entry_creates_second_activ
     )
 
     assert response.status_code == 200
+    payload = response.json()
 
     same_patient_entries = (
         db_session.query(OnlineQueueEntry)
@@ -170,9 +174,79 @@ def test_confirmation_split_flow_with_existing_active_entry_creates_second_activ
         .all()
     )
 
-    assert [entry.number for entry in same_patient_entries] == [1, 2]
-    assert [entry.source for entry in same_patient_entries] == ["online", "confirmation"]
-    assert same_patient_entries[1].visit_id == test_visit.id
+    db_session.refresh(existing_active_entry)
+
+    assert len(same_patient_entries) == 1
+    assert same_patient_entries[0].id == existing_active_entry.id
+    assert same_patient_entries[0].number == 1
+    assert same_patient_entries[0].source == "online"
+    assert same_patient_entries[0].visit_id == test_visit.id
+    assert same_patient_entries[0].queue_time == original_queue_time
+    assert payload["queue_numbers"] == [
+        {
+            "queue_tag": "cardiology_common",
+            "number": 1,
+            "queue_id": test_daily_queue.id,
+        }
+    ]
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+@pytest.mark.confirmation
+def test_confirmation_split_flow_returns_explicit_error_on_ambiguous_existing_entries(
+    client,
+    db_session,
+    test_visit,
+    test_daily_queue,
+    test_service,
+    test_patient,
+):
+    _attach_visit_service(db_session, test_visit, test_service)
+
+    first_entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=1,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        source="online",
+        status="waiting",
+    )
+    second_entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=2,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        source="desk",
+        status="called",
+    )
+    db_session.add(first_entry)
+    db_session.add(second_entry)
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/telegram/visits/confirm",
+        json={
+            "token": test_visit.confirmation_token,
+            "telegram_user_id": "123456789",
+        },
+    )
+
+    assert response.status_code == 409
+    assert "однозначно" in response.json()["detail"]
+
+    entries = (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.queue_id == test_daily_queue.id)
+        .order_by(OnlineQueueEntry.number.asc())
+        .all()
+    )
+    assert [entry.number for entry in entries] == [1, 2]
+    assert _queue_entries_for_visit(db_session, test_visit.id) == []
+    db_session.refresh(test_visit)
+    assert test_visit.status == "pending_confirmation"
 
 
 @pytest.mark.integration
@@ -210,3 +284,64 @@ def test_confirmation_split_flow_registrar_bridge_creates_confirmation_source_en
 
     assert payload["status"] == "open"
     assert payload["queue_numbers"]["cardiology_common"]["number"] == entries[0].number
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+@pytest.mark.confirmation
+def test_confirmation_split_flow_registrar_bridge_reuses_existing_active_entry(
+    client,
+    db_session,
+    test_visit,
+    test_daily_queue,
+    test_service,
+    test_patient,
+    registrar_auth_headers,
+):
+    _attach_visit_service(db_session, test_visit, test_service)
+    original_queue_time = datetime.utcnow().replace(microsecond=0)
+
+    existing_active_entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=3,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        source="online",
+        status="waiting",
+        queue_time=original_queue_time,
+    )
+    db_session.add(existing_active_entry)
+    db_session.commit()
+
+    response = client.post(
+        f"/api/v1/registrar/visits/{test_visit.id}/confirm",
+        headers=registrar_auth_headers,
+        json={
+            "confirmation_method": "manual",
+            "confirmed_by": "registrar_test",
+            "notes": "reuse-existing-entry",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    same_patient_entries = (
+        db_session.query(OnlineQueueEntry)
+        .filter(
+            OnlineQueueEntry.queue_id == test_daily_queue.id,
+            OnlineQueueEntry.patient_id == test_patient.id,
+            OnlineQueueEntry.status == "waiting",
+        )
+        .order_by(OnlineQueueEntry.number.asc())
+        .all()
+    )
+
+    db_session.refresh(existing_active_entry)
+    assert len(same_patient_entries) == 1
+    assert same_patient_entries[0].id == existing_active_entry.id
+    assert same_patient_entries[0].number == 3
+    assert same_patient_entries[0].visit_id == test_visit.id
+    assert same_patient_entries[0].queue_time == original_queue_time
+    assert payload["queue_numbers"]["cardiology_common"]["number"] == 3

--- a/backend/tests/unit/test_confirmation_reuse_existing_entry.py
+++ b/backend/tests/unit/test_confirmation_reuse_existing_entry.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+
+from app.models.online_queue import OnlineQueueEntry
+from app.models.visit import VisitService
+from app.services.queue_service import queue_service
+from app.services.visit_confirmation_service import (
+    VisitConfirmationDomainError,
+    VisitConfirmationService,
+)
+
+
+def _attach_visit_service(db_session, visit, service) -> None:
+    db_session.add(
+        VisitService(
+            visit_id=visit.id,
+            service_id=service.id,
+            code=service.code,
+            name=service.name,
+            qty=1,
+            price=Decimal("100000.00"),
+            currency="UZS",
+        )
+    )
+    db_session.commit()
+
+
+@pytest.mark.unit
+@pytest.mark.queue
+@pytest.mark.confirmation
+def test_assign_queue_numbers_on_confirmation_reuses_existing_entry_without_allocating(
+    db_session,
+    test_visit,
+    test_daily_queue,
+    test_service,
+    test_patient,
+    monkeypatch,
+):
+    _attach_visit_service(db_session, test_visit, test_service)
+    original_queue_time = datetime.utcnow().replace(microsecond=0)
+
+    existing_entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=5,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        source="online",
+        status="waiting",
+        queue_time=original_queue_time,
+    )
+    db_session.add(existing_entry)
+    db_session.commit()
+
+    def _unexpected_number(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("queue number allocation should not run for reuse path")
+
+    def _unexpected_create(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("create_queue_entry should not run for reuse path")
+
+    monkeypatch.setattr(queue_service, "get_next_queue_number", _unexpected_number)
+    monkeypatch.setattr(queue_service, "create_queue_entry", _unexpected_create)
+
+    service = VisitConfirmationService(db_session)
+    queue_numbers, print_tickets = service.assign_queue_numbers_on_confirmation(
+        test_visit,
+        confirmation_telegram_id="123456789",
+    )
+
+    db_session.flush()
+    db_session.refresh(existing_entry)
+
+    assert queue_numbers == [
+        {
+            "queue_tag": "cardiology_common",
+            "number": 5,
+            "queue_id": test_daily_queue.id,
+        }
+    ]
+    assert print_tickets[0]["queue_number"] == 5
+    assert existing_entry.visit_id == test_visit.id
+    assert existing_entry.queue_time == original_queue_time
+
+
+@pytest.mark.unit
+@pytest.mark.queue
+@pytest.mark.confirmation
+def test_assign_queue_numbers_on_confirmation_raises_explicit_error_on_ambiguity(
+    db_session,
+    test_visit,
+    test_daily_queue,
+    test_service,
+    test_patient,
+    monkeypatch,
+):
+    _attach_visit_service(db_session, test_visit, test_service)
+
+    db_session.add(
+        OnlineQueueEntry(
+            queue_id=test_daily_queue.id,
+            number=1,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            source="online",
+            status="waiting",
+        )
+    )
+    db_session.add(
+        OnlineQueueEntry(
+            queue_id=test_daily_queue.id,
+            number=2,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            source="desk",
+            status="called",
+        )
+    )
+    db_session.commit()
+
+    def _unexpected_number(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("queue number allocation should not run on ambiguity")
+
+    def _unexpected_create(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("create_queue_entry should not run on ambiguity")
+
+    monkeypatch.setattr(queue_service, "get_next_queue_number", _unexpected_number)
+    monkeypatch.setattr(queue_service, "create_queue_entry", _unexpected_create)
+
+    service = VisitConfirmationService(db_session)
+
+    with pytest.raises(VisitConfirmationDomainError) as exc_info:
+        service.assign_queue_numbers_on_confirmation(
+            test_visit,
+            confirmation_telegram_id="123456789",
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "однозначно" in exc_info.value.detail
+    assert (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.visit_id == test_visit.id)
+        .count()
+        == 0
+    )

--- a/docs/architecture/W2C_CONFIRMATION_BEHAVIOR_CORRECTION.md
+++ b/docs/architecture/W2C_CONFIRMATION_BEHAVIOR_CORRECTION.md
@@ -1,0 +1,140 @@
+# Wave 2C Confirmation Behavior Correction
+
+Date: 2026-03-07
+Mode: behaviour-correction, small-diff execution
+
+## Scope
+
+This slice corrected only the confirmation family behavior around same-queue
+active-entry reuse.
+
+Included:
+
+- mounted public confirmation flow in
+  `backend/app/services/visit_confirmation_service.py`
+- mounted registrar confirmation bridge in
+  `backend/app/api/v1/endpoints/registrar_wizard.py`
+
+Not included:
+
+- allocator algorithm redesign
+- `qr_queue` migration
+- `OnlineDay` legacy migration
+- broad registrar family migration
+
+## Pre-Correction Runtime Behavior
+
+Before this slice, same-day confirmation behaved like this:
+
+1. resolve queue/day and queue tag
+2. call legacy `get_next_queue_number(...)`
+3. create a fresh `OnlineQueueEntry(source="confirmation")`
+
+That happened even when an active queue row already existed for the same
+patient in the same queue/day.
+
+Observed consequences:
+
+- a second active row could be created in the same queue
+- a new historical ticket number could be consumed unnecessarily
+- duplicate-policy contract was bypassed inside confirmation
+
+## Corrected Runtime Behavior
+
+The mounted confirmation paths now apply a narrow canonical active-entry gate
+before queue creation.
+
+### Canonical active statuses
+
+- `waiting`
+- `called`
+- `in_service`
+- `diagnostics`
+
+### Canonical identity preference
+
+1. `patient_id`
+2. normalized phone
+3. normalized telegram id
+
+### New decision tree
+
+#### Clear existing active row found
+
+- do not call `create_queue_entry()`
+- do not allocate a new ticket number
+- reuse the existing row
+- preserve `number`
+- preserve `queue_time`
+- preserve fairness ordering
+- link the row to the confirmed visit if `visit_id` was empty
+- backfill `patient_id` only if the reused row had no `patient_id`
+
+#### No active row found
+
+- current legacy queue-entry creation path still runs
+- numbering algorithm stays unchanged
+
+#### Ambiguous existing rows
+
+If multiple active rows match the canonical identity, or the only matched row is
+already linked to another visit/patient in a conflicting way:
+
+- confirmation returns an explicit conflict error
+- no new queue row is created
+
+## Why This Matches The Design Better
+
+This correction now matches the clarified design intent:
+
+- multiple rows remain valid across different queue claims
+- confirmation no longer creates a second active row in the same queue/day by
+  default
+- existing queue ownership is reused when it is already clear
+
+## Why This Matches The Domain Contracts Better
+
+### Duplicate-policy contract
+
+Now confirmation no longer silently allocates another queue row when an active
+claim already exists in the same queue/day.
+
+### Active-entry contract
+
+The gate now uses the canonical active set instead of the old narrower
+`waiting/called` assumption.
+
+### Numbering contract
+
+Number allocation remains:
+
+- monotonic
+- queue-local
+- day-scoped
+
+But it now runs only when confirmation actually needs a new queue row.
+
+## Remaining Ambiguity Cases
+
+The correction intentionally does not "best-effort" ambiguous situations.
+
+Explicit conflict remains when:
+
+- multiple active rows match the same canonical queue claim
+- the matching row is already linked to a different visit
+- identity signals point to conflicting active rows
+
+This is intentional and matches the approved fallback contract.
+
+## Later Boundary Migration Readiness
+
+After this correction, the mounted confirmation family is ready for a later
+narrow migration through `QueueDomainService.allocate_ticket()`:
+
+- the duplicate-versus-reuse rule is now explicit
+- mounted public and registrar confirmation paths share the same corrected
+  queue-assignment logic
+- allocator algorithm itself remains legacy and unchanged
+
+This slice did not perform that migration. It only removed the contract drift
+that previously blocked it.

--- a/docs/status/W2C_CONFIRMATION_BOUNDARY_READINESS.md
+++ b/docs/status/W2C_CONFIRMATION_BOUNDARY_READINESS.md
@@ -1,45 +1,39 @@
 # Wave 2C Confirmation Boundary Readiness
 
 Date: 2026-03-07
-Mode: characterization-first
-Decision: `READY_AFTER_CONTRACT_CLARIFICATION`
+Mode: post-correction review
+Decision: `READY_FOR_BOUNDARY_MIGRATION`
 
-## Why This Is Not Boundary-Ready Yet
+## Why The Readiness Status Changed
 
-Characterization now proves the public confirmation flow well enough to avoid
-guessing, but the family is still not ready for a direct migration to
-`QueueDomainService.allocate_ticket()` for three reasons:
+Earlier characterization blocked boundary migration because:
 
-1. Confirmation still has two mounted implementations:
-   - public token flow in `visit_confirmation.py`
-   - registrar bridge in `registrar_wizard.py`
-2. Current runtime behavior allows confirmation to create a second active queue
-   row when the patient already has a waiting row in the same queue.
-3. Parallel validation and pending-visit lookup can both observe the same
-   `pending_confirmation` visit before status flips, so any migration that
-   reorders validation and persistence could change behavior.
+1. confirmation could create a second active queue row in the same queue/day
+2. duplicate-versus-reuse intent was still unclear
+3. public and registrar confirmation paths did not share corrected semantics
 
-## What Characterization Confirmed
+This slice corrected the mounted confirmation behavior without changing the
+legacy allocator algorithm.
 
-- same-day public confirmation allocates the next number and creates a queue row
-  with `source="confirmation"`
-- created queue row links back to `visit_id`
-- replayed public confirmation returns an error and does not create a second
-  confirmation row
-- registrar confirmation also creates `source="confirmation"` queue rows
-- pre-existing active queue rows do not block confirmation-based queue creation
+## Current Confirmation Properties
 
-## What Still Needs Clarification
+- clear existing active row is reused
+- no new ticket is allocated in reuse case
+- ambiguous ownership returns explicit conflict
+- no same-queue duplicate active row is created by mounted confirmation flows
+- public and registrar confirmation now use the same corrected assignment logic
 
-- Should confirmation preserve the current "create another active row" behavior
-  when an active queue entry already exists for that patient?
-- Should public confirmation and registrar confirmation be migrated as one
-  family or as two separate compatibility slices?
-- Is `allocate_ticket(allocation_mode="create_entry")` enough for confirmation,
-  or should the boundary own the split allocation preconditions too?
+## What Still Remains Legacy
+
+- ticket allocation still uses legacy queue-service calls when a new row is
+  actually needed
+- validation and persistence ordering are still legacy
+- allocator race characteristics are unchanged by this slice
+
+These remaining items do not block a later narrow boundary migration anymore.
 
 ## Current Verdict
 
-`QueueDomainService.allocate_ticket()` can support the persistence side of the
-flow, but migrating the confirmation family safely still requires a domain-level
-decision on duplicate-preserving behavior and family boundaries.
+`QueueDomainService.allocate_ticket()` can now be introduced as a later
+compatibility boundary for the mounted confirmation family without preserving
+the old duplicate-creating drift.

--- a/docs/status/W2C_CONFIRMATION_NEXT_EXECUTION_UNIT_V2.md
+++ b/docs/status/W2C_CONFIRMATION_NEXT_EXECUTION_UNIT_V2.md
@@ -1,47 +1,36 @@
 # Wave 2C Confirmation Next Execution Unit V2
 
 Date: 2026-03-07
-Mode: analysis-first, docs-only
+Mode: post-correction planning
 
 ## Recommended Next Step
 
-`confirmation reuse-existing-entry change`
+`confirmation boundary migration slice`
 
 ## Why This Is The Right Next Unit
 
-The contract clarification is now sufficient to reject the current
-duplicate-creating behavior as the target design.
+The reuse-existing-entry correction is complete for the mounted confirmation
+family.
 
-The next execution unit should therefore be a narrow behavior-change slice that:
+The next narrow step can focus on plumbing, not contract repair:
 
-- checks for an existing active queue row for the same canonical queue claim
-- reuses that row instead of allocating a second one
-- fails explicitly when ownership is ambiguous
-- leaves allocator-family migration for later
+- keep the corrected reuse/ambiguity semantics
+- route the creation branch through `QueueDomainService.allocate_ticket()`
+- preserve legacy numbering behavior inside the boundary
+- avoid touching `qr_queue`, `OnlineDay`, or unrelated allocator families
 
-## Why Not Boundary Migration Yet
+## Why This Is Safe Now
 
-Direct migration to `QueueDomainService.allocate_ticket()` would move plumbing
-without first resolving the actual domain drift.
-
-That would preserve the wrong behavior behind a cleaner boundary.
-
-## Why Not Defer Entirely
-
-The conflict is now clarified enough to define a narrow follow-up slice.
-
-The blocker is no longer "insufficient understanding". The blocker is "runtime
-behavior needs a deliberate domain correction before migration".
+The main blocker was the duplicate-creating confirmation drift.
+That blocker has now been removed and regression-tested.
 
 ## Suggested Scope For The Next Unit
 
-- public confirmation flow in `visit_confirmation_service.py`
-- registrar confirmation bridge only if its behavior is intentionally aligned in
-  the same slice, otherwise defer it explicitly
-- characterization updates proving:
-  - existing active row is reused
-  - second active row is no longer created
-  - ambiguous duplicate ownership returns an explicit conflict path
+- `backend/app/services/visit_confirmation_service.py`
+- the confirmation branch in `backend/app/api/v1/endpoints/registrar_wizard.py`
+- no allocator algorithm change
+- no broader registrar migration
+- no queue-policy redesign outside confirmation
 
 ## Status
 

--- a/docs/status/W2C_CONFIRMATION_REUSE_FIX_STATUS.md
+++ b/docs/status/W2C_CONFIRMATION_REUSE_FIX_STATUS.md
@@ -1,0 +1,70 @@
+# Wave 2C Confirmation Reuse Fix Status
+
+Date: 2026-03-07
+Status: `done`
+Mode: behaviour-correction, small diff
+
+## Files Changed
+
+- `backend/app/repositories/visit_confirmation_repository.py`
+- `backend/app/services/visit_confirmation_service.py`
+- `backend/app/api/v1/endpoints/registrar_wizard.py`
+- `backend/tests/characterization/test_confirmation_split_flow_characterization.py`
+- `backend/tests/unit/test_confirmation_reuse_existing_entry.py`
+- `docs/architecture/W2C_CONFIRMATION_BEHAVIOR_CORRECTION.md`
+- `docs/status/W2C_CONFIRMATION_REUSE_FIX_STATUS.md`
+- `docs/status/W2C_CONFIRMATION_BOUNDARY_READINESS.md`
+- `docs/status/W2C_CONFIRMATION_NEXT_EXECUTION_UNIT_V2.md`
+
+## Old Behavior Corrected
+
+Old behavior:
+
+- same-day confirmation created a fresh `source="confirmation"` queue row even
+  when an active row already existed in the same queue/day
+
+New behavior:
+
+- clear existing active row is reused
+- no new ticket number is allocated in reuse case
+- ambiguous ownership returns explicit `409`
+- fresh row is still created through the legacy allocator only when no active
+  row exists
+
+## How Reuse Now Works
+
+For each confirmation queue claim:
+
+1. determine queue/day as before
+2. search active rows using canonical statuses
+3. resolve identity with `patient_id -> phone -> telegram_id`
+4. if exactly one compatible row exists, reuse it
+5. if none exists, create a new row as before
+6. if more than one compatible row exists, return explicit conflict
+
+## Tests Run
+
+- `pytest backend/tests/characterization/test_confirmation_split_flow_characterization.py -q -c backend/pytest.ini`
+- `pytest backend/tests/characterization/test_confirmation_split_flow_concurrency.py -q -c backend/pytest.ini`
+- `cd backend && pytest tests/unit/test_confirmation_reuse_existing_entry.py tests/unit/test_visit_confirmation_service.py -q`
+- `cd backend && pytest tests/characterization -q -c pytest.ini`
+- `cd backend && pytest tests/test_openapi_contract.py -q`
+- `cd backend && pytest -q`
+
+## Results
+
+- confirmation characterization: `6 passed`
+- confirmation concurrency characterization: `2 passed`
+- focused unit tests: `5 passed`
+- full characterization suite: `15 passed`
+- OpenAPI contract: `10 passed`
+- full backend suite: `703 passed, 3 skipped`
+
+## Guardrail Outcome
+
+- numbering algorithm unchanged
+- fairness ordering unchanged
+- existing `queue_time` unchanged on reused rows
+- no `OnlineDay` changes
+- no `qr_queue` migration
+- no broad registrar migration


### PR DESCRIPTION
﻿## Summary
- Correct mounted confirmation flows to reuse an existing active queue entry instead of creating a duplicate in the same queue.
- Add explicit ambiguity handling for conflicting active queue entries during confirmation.
- Align the registrar confirmation bridge with `VisitConfirmationService` and add characterization/unit coverage plus W2C status docs.

## Contract Impact
- Canonical surface: mounted registrar wizard confirmation flow handled by `confirm_visit_by_registrar` and `_assign_queue_numbers_on_confirmation()`.
- Request shape: unchanged; confirmation callers do not need to send new fields.
- Response shape: unchanged; queue numbers and print ticket payloads are returned in the existing registrar API format.
- Status codes: success behavior remains; ambiguous active queue entries can now surface an explicit domain `409` instead of silently creating another duplicate.
- Frontend consumer: registrar confirmation workflow remains the consumer; no frontend payload or route change is introduced.
- Compatibility path or alias: registrar endpoint keeps its adapter shape while delegating queue assignment behavior to `VisitConfirmationService`.
- Contract proof: confirmation split-flow characterization/concurrency tests, reuse-existing-entry unit test, service test, and OpenAPI contract test listed by author.

## RBAC / Permissions
- Roles allowed: unchanged registrar confirmation access through existing registrar wizard endpoint dependencies.
- Roles denied: unchanged; no authorization helper or role matrix behavior is changed.
- Positive auth proof: existing registrar confirmation route tests remain the auth proof surface.
- Negative auth proof: not applicable because RBAC code is not touched; reviewer should confirm existing endpoint auth coverage before merge.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket event is changed.
- Payload version / ack behavior: not applicable because no realtime payload is added or renamed.
- Read/unread or delivery semantics: not applicable because this is backend confirmation queue assignment/reuse behavior.
- Reconnect/resync proof: not applicable because no realtime reconnect behavior is touched.

## Frontend Resilience
- Empty data proof: unchanged; no frontend empty-state handling is modified.
- Partial data proof: unchanged; no frontend partial-data handling is modified.
- Forbidden secondary path behavior: unchanged; no frontend secondary path is touched.
- Missing draft/resource behavior: unchanged; no draft/resource UI path is touched.
- Stale route/deep-link behavior: unchanged; no frontend route state is touched.

## Scope Gate
- Allowed paths: registrar wizard confirmation adapter, visit confirmation repository/service, focused confirmation tests, and W2C confirmation docs/status notes.
- Denied paths: unrelated queue allocator migration, RBAC helper changes, frontend UI changes, notification/realtime changes, and migrations.
- Migration/docs/test impact: updates W2C confirmation behavior/readiness/status docs and focused backend tests; no database migration.
- Rollback note: revert the confirmation adapter/service reuse path if confirmation queue assignment starts returning wrong queue numbers or incorrect ambiguity errors.

## Validation
- Targeted tests or smoke run: author lists confirmation characterization/concurrency tests, `tests/unit/test_confirmation_reuse_existing_entry.py`, `tests/unit/test_visit_confirmation_service.py`, characterization suite, OpenAPI contract test, and full backend pytest.
- Result: not rerun in this automation pass; PR body records the author's listed validation targets.
- Not checked: realtime/browser smoke and local CI/env proof were not checked here because no realtime/frontend files are changed.
