### PR TITLE
fix: reuse active registrar batch entries

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -3017,6 +3017,49 @@ class BatchQueueEntriesResponse(BaseModel):
     message: str
 
 
+REGISTRAR_BATCH_ACTIVE_DUPLICATE_STATUSES = (
+    "waiting",
+    "called",
+    "in_service",
+    "diagnostics",
+)
+
+
+def _find_registrar_batch_existing_entry_or_raise(
+    db: Session,
+    *,
+    queue_id: int,
+    patient_id: int,
+):
+    """Returns a single active batch claim or raises a 409 ambiguity error."""
+    from app.models.online_queue import OnlineQueueEntry
+
+    active_entries = (
+        db.query(OnlineQueueEntry)
+        .filter(
+            OnlineQueueEntry.queue_id == queue_id,
+            OnlineQueueEntry.patient_id == patient_id,
+            OnlineQueueEntry.status.in_(REGISTRAR_BATCH_ACTIVE_DUPLICATE_STATUSES),
+        )
+        .order_by(OnlineQueueEntry.id.asc())
+        .all()
+    )
+
+    if not active_entries:
+        return None
+
+    if len(active_entries) > 1:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Неоднозначная активная запись очереди для пациента у "
+                "специалиста на сегодня"
+            ),
+        )
+
+    return active_entries[0]
+
+
 @router.post(
     "/registrar-integration/queue/entries/batch",
     response_model=BatchQueueEntriesResponse,
@@ -3046,7 +3089,7 @@ def create_queue_entries_batch(
     import logging
     from zoneinfo import ZoneInfo
 
-    from app.models.online_queue import DailyQueue, OnlineQueueEntry
+    from app.models.online_queue import DailyQueue
     from app.models.patient import Patient
 
     logger = logging.getLogger(__name__)
@@ -3135,24 +3178,19 @@ def create_queue_entries_batch(
                 db.add(daily_queue)
                 db.flush()
 
-            # Проверяем дубликаты (для любых source)
+            # Проверяем дубликаты (для любых source) в рамках specialist-level claim
             if daily_queue:
-                existing_entry = (
-                    db.query(OnlineQueueEntry)
-                    .filter(
-                        OnlineQueueEntry.queue_id == daily_queue.id,
-                        OnlineQueueEntry.patient_id == request.patient_id,
-                        OnlineQueueEntry.status.in_(
-                            ["waiting", "called"]
-                        ),  # Активные записи
-                    )
-                    .first()
+                existing_entry = _find_registrar_batch_existing_entry_or_raise(
+                    db,
+                    queue_id=daily_queue.id,
+                    patient_id=request.patient_id,
                 )
 
                 if existing_entry:
                     logger.warning(
                         f"[create_queue_entries_batch] Пациент {request.patient_id} уже в очереди "
-                        f"к специалисту {specialist_id} (queue_id={daily_queue.id}, entry_id={existing_entry.id})"
+                        f"к специалисту {specialist_id} (queue_id={daily_queue.id}, entry_id={existing_entry.id}, "
+                        f"status={existing_entry.status})"
                     )
                     # Пропускаем создание дубликата, но добавляем существующую запись в ответ
                     created_entries.append(

--- a/backend/tests/characterization/test_registrar_batch_allocator_characterization.py
+++ b/backend/tests/characterization/test_registrar_batch_allocator_characterization.py
@@ -71,6 +71,35 @@ def _create_daily_queue(
     return queue
 
 
+def _create_existing_entry(
+    db_session,
+    *,
+    queue_id: int,
+    patient_id: int,
+    patient_name: str,
+    phone: str | None,
+    number: int,
+    status: str,
+    source: str = "online",
+    queue_time: datetime | None = None,
+) -> OnlineQueueEntry:
+    entry = OnlineQueueEntry(
+        queue_id=queue_id,
+        number=number,
+        patient_id=patient_id,
+        patient_name=patient_name,
+        phone=phone,
+        source=source,
+        status=status,
+        queue_time=queue_time
+        or datetime.now(ZoneInfo("Asia/Tashkent")).replace(microsecond=0),
+    )
+    db_session.add(entry)
+    db_session.commit()
+    db_session.refresh(entry)
+    return entry
+
+
 @pytest.mark.integration
 @pytest.mark.queue
 def test_registrar_batch_characterization_preserves_request_source_on_create(
@@ -258,7 +287,7 @@ def test_registrar_batch_characterization_mixed_specialist_batch_reuses_one_and_
 
 @pytest.mark.integration
 @pytest.mark.queue
-def test_registrar_batch_characterization_existing_diagnostics_entry_still_allocates_new_row(
+def test_registrar_batch_characterization_existing_diagnostics_entry_reuses_existing_row(
     client,
     db_session,
     registrar_auth_headers,
@@ -267,18 +296,16 @@ def test_registrar_batch_characterization_existing_diagnostics_entry_still_alloc
     test_service,
 ):
     existing_queue = _create_daily_queue(db_session, specialist_id=cardio_user.id)
-    diagnostics_entry = OnlineQueueEntry(
+    diagnostics_entry = _create_existing_entry(
+        db_session,
         queue_id=existing_queue.id,
-        number=5,
         patient_id=test_patient.id,
         patient_name=test_patient.short_name(),
         phone=test_patient.phone,
-        source="online",
+        number=5,
         status="diagnostics",
-        queue_time=datetime.now(ZoneInfo("Asia/Tashkent")).replace(microsecond=0),
+        source="online",
     )
-    db_session.add(diagnostics_entry)
-    db_session.commit()
 
     response = client.post(
         "/api/v1/registrar-integration/queue/entries/batch",
@@ -299,6 +326,7 @@ def test_registrar_batch_characterization_existing_diagnostics_entry_still_alloc
     assert response.status_code == 200
     payload = response.json()
     assert payload["success"] is True
+    assert len(payload["entries"]) == 1
 
     queue_entries = (
         db_session.query(OnlineQueueEntry)
@@ -310,8 +338,138 @@ def test_registrar_batch_characterization_existing_diagnostics_entry_still_alloc
         .all()
     )
 
-    assert len(queue_entries) == 2
-    assert [entry.status for entry in queue_entries] == ["diagnostics", "waiting"]
+    assert len(queue_entries) == 1
+    assert queue_entries[0].id == diagnostics_entry.id
+    assert queue_entries[0].status == "diagnostics"
     assert queue_entries[0].number == 5
-    assert queue_entries[1].number > queue_entries[0].number
-    assert payload["entries"][0]["number"] == queue_entries[1].number
+    assert payload["entries"][0]["number"] == diagnostics_entry.number
+    assert payload["entries"][0]["queue_time"].startswith(
+        queue_entries[0].queue_time.isoformat()
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_registrar_batch_characterization_existing_in_service_entry_reuses_existing_row(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    cardio_user,
+    test_service,
+):
+    existing_queue = _create_daily_queue(db_session, specialist_id=cardio_user.id)
+    in_service_entry = _create_existing_entry(
+        db_session,
+        queue_id=existing_queue.id,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        number=9,
+        status="in_service",
+        source="online",
+    )
+
+    response = client.post(
+        "/api/v1/registrar-integration/queue/entries/batch",
+        headers=registrar_auth_headers,
+        json={
+            "patient_id": test_patient.id,
+            "source": "desk",
+            "services": [
+                {
+                    "specialist_id": cardio_user.id,
+                    "service_id": test_service.id,
+                    "quantity": 1,
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert len(payload["entries"]) == 1
+
+    queue_entries = (
+        db_session.query(OnlineQueueEntry)
+        .filter(
+            OnlineQueueEntry.queue_id == existing_queue.id,
+            OnlineQueueEntry.patient_id == test_patient.id,
+        )
+        .order_by(OnlineQueueEntry.number.asc())
+        .all()
+    )
+
+    assert len(queue_entries) == 1
+    assert queue_entries[0].id == in_service_entry.id
+    assert queue_entries[0].status == "in_service"
+    assert payload["entries"][0]["number"] == in_service_entry.number
+    assert payload["entries"][0]["queue_time"].startswith(
+        queue_entries[0].queue_time.isoformat()
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_registrar_batch_characterization_ambiguous_active_rows_return_409(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    cardio_user,
+    test_service,
+):
+    existing_queue = _create_daily_queue(db_session, specialist_id=cardio_user.id)
+    _create_existing_entry(
+        db_session,
+        queue_id=existing_queue.id,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        number=4,
+        status="waiting",
+        source="online",
+    )
+    _create_existing_entry(
+        db_session,
+        queue_id=existing_queue.id,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        number=5,
+        status="diagnostics",
+        source="online",
+    )
+
+    response = client.post(
+        "/api/v1/registrar-integration/queue/entries/batch",
+        headers=registrar_auth_headers,
+        json={
+            "patient_id": test_patient.id,
+            "source": "desk",
+            "services": [
+                {
+                    "specialist_id": cardio_user.id,
+                    "service_id": test_service.id,
+                    "quantity": 1,
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 409
+    payload = response.json()
+    assert "Неоднозначная активная запись очереди" in payload["detail"]
+
+    queue_entries = (
+        db_session.query(OnlineQueueEntry)
+        .filter(
+            OnlineQueueEntry.queue_id == existing_queue.id,
+            OnlineQueueEntry.patient_id == test_patient.id,
+        )
+        .order_by(OnlineQueueEntry.number.asc())
+        .all()
+    )
+    assert len(queue_entries) == 2
+    assert [entry.status for entry in queue_entries] == ["waiting", "diagnostics"]

--- a/backend/tests/unit/test_registrar_batch_reuse_existing_entry.py
+++ b/backend/tests/unit/test_registrar_batch_reuse_existing_entry.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.endpoints.registrar_integration import (
+    REGISTRAR_BATCH_ACTIVE_DUPLICATE_STATUSES,
+    _find_registrar_batch_existing_entry_or_raise,
+)
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
+
+
+def _create_daily_queue(db_session, *, specialist_id: int) -> DailyQueue:
+    queue = DailyQueue(
+        day=date.today(),
+        specialist_id=specialist_id,
+        queue_tag=None,
+        active=True,
+    )
+    db_session.add(queue)
+    db_session.commit()
+    db_session.refresh(queue)
+    return queue
+
+
+def _create_entry(
+    db_session,
+    *,
+    queue_id: int,
+    patient_id: int,
+    patient_name: str,
+    phone: str | None,
+    number: int,
+    status: str,
+) -> OnlineQueueEntry:
+    entry = OnlineQueueEntry(
+        queue_id=queue_id,
+        number=number,
+        patient_id=patient_id,
+        patient_name=patient_name,
+        phone=phone,
+        source="online",
+        status=status,
+        queue_time=datetime.now(ZoneInfo("Asia/Tashkent")).replace(microsecond=0),
+    )
+    db_session.add(entry)
+    db_session.commit()
+    db_session.refresh(entry)
+    return entry
+
+
+def test_registrar_batch_duplicate_gate_supports_canonical_active_statuses():
+    assert REGISTRAR_BATCH_ACTIVE_DUPLICATE_STATUSES == (
+        "waiting",
+        "called",
+        "in_service",
+        "diagnostics",
+    )
+
+
+def test_registrar_batch_duplicate_gate_returns_existing_called_entry(
+    db_session,
+    test_patient,
+    cardio_user,
+):
+    queue = _create_daily_queue(db_session, specialist_id=cardio_user.id)
+    existing_entry = _create_entry(
+        db_session,
+        queue_id=queue.id,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        number=7,
+        status="called",
+    )
+
+    resolved_entry = _find_registrar_batch_existing_entry_or_raise(
+        db_session,
+        queue_id=queue.id,
+        patient_id=test_patient.id,
+    )
+
+    assert resolved_entry is not None
+    assert resolved_entry.id == existing_entry.id
+    assert resolved_entry.status == "called"
+
+
+def test_registrar_batch_duplicate_gate_returns_existing_in_service_entry(
+    db_session,
+    test_patient,
+    cardio_user,
+):
+    queue = _create_daily_queue(db_session, specialist_id=cardio_user.id)
+    existing_entry = _create_entry(
+        db_session,
+        queue_id=queue.id,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        number=11,
+        status="in_service",
+    )
+
+    resolved_entry = _find_registrar_batch_existing_entry_or_raise(
+        db_session,
+        queue_id=queue.id,
+        patient_id=test_patient.id,
+    )
+
+    assert resolved_entry is not None
+    assert resolved_entry.id == existing_entry.id
+    assert resolved_entry.status == "in_service"
+
+
+def test_registrar_batch_duplicate_gate_returns_none_when_no_active_entry(
+    db_session,
+    test_patient,
+    cardio_user,
+):
+    queue = _create_daily_queue(db_session, specialist_id=cardio_user.id)
+
+    resolved_entry = _find_registrar_batch_existing_entry_or_raise(
+        db_session,
+        queue_id=queue.id,
+        patient_id=test_patient.id,
+    )
+
+    assert resolved_entry is None
+
+
+def test_registrar_batch_duplicate_gate_raises_409_on_ambiguous_active_rows(
+    db_session,
+    test_patient,
+    cardio_user,
+):
+    queue = _create_daily_queue(db_session, specialist_id=cardio_user.id)
+    _create_entry(
+        db_session,
+        queue_id=queue.id,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        number=3,
+        status="waiting",
+    )
+    _create_entry(
+        db_session,
+        queue_id=queue.id,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        number=4,
+        status="diagnostics",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _find_registrar_batch_existing_entry_or_raise(
+            db_session,
+            queue_id=queue.id,
+            patient_id=test_patient.id,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "Неоднозначная активная запись очереди" in exc_info.value.detail

--- a/docs/architecture/W2C_REGISTRAR_BATCH_BEHAVIOR_CORRECTION.md
+++ b/docs/architecture/W2C_REGISTRAR_BATCH_BEHAVIOR_CORRECTION.md
@@ -1,0 +1,90 @@
+# Wave 2C Registrar Batch Behavior Correction
+
+Date: 2026-03-08
+Mode: behaviour-correction, small diff
+Scope: mounted registrar batch-only flow
+
+## Old Runtime Behavior
+
+Before this slice, mounted registrar batch duplicate gate reused existing rows
+only when status was:
+
+- `waiting`
+- `called`
+
+That caused two concrete problems:
+
+1. an existing `diagnostics` row did not block a new allocation
+2. an existing `in_service` row would also have been ignored by the same gate
+
+Result:
+
+- batch add could create a new `waiting` row for the same
+  `patient_id + specialist_user_id + queue_day`
+- a new number could be allocated even though the patient already had a live
+  specialist-day claim
+
+## Corrected Behavior
+
+Mounted registrar batch duplicate gate now treats these statuses as active:
+
+- `waiting`
+- `called`
+- `in_service`
+- `diagnostics`
+
+That means:
+
+- if exactly one active row exists for the same specialist-day claim, it is
+  reused
+- no new queue row is created
+- no new number is allocated
+- existing `queue_time` is preserved
+- existing `source` is preserved
+
+## Ambiguity Handling
+
+If more than one active row already exists for the same:
+
+- `patient_id`
+- `queue_id`
+
+the mounted batch path now returns explicit `409 Conflict` instead of choosing
+one row implicitly or allocating another row.
+
+This is the safe behavior for a specialist-level claim model because ownership
+is already inconsistent in that case.
+
+## Why This Matches The Approved Contracts
+
+The correction aligns runtime with:
+
+- [W2C_ACTIVE_ENTRY_CONTRACT.md](C:/final/docs/architecture/W2C_ACTIVE_ENTRY_CONTRACT.md)
+- [W2C_DUPLICATE_POLICY_CONTRACT.md](C:/final/docs/architecture/W2C_DUPLICATE_POLICY_CONTRACT.md)
+- [W2C_REGISTRAR_BATCH_DUPLICATE_CONTRACT.md](C:/final/docs/architecture/W2C_REGISTRAR_BATCH_DUPLICATE_CONTRACT.md)
+- [W2C_REGISTRAR_BATCH_CLAIM_MODEL.md](C:/final/docs/architecture/W2C_REGISTRAR_BATCH_CLAIM_MODEL.md)
+
+Specifically:
+
+- `diagnostics` is now treated as active for this family
+- registrar batch-only claim remains specialist-level
+- no same-claim duplicate row is created when ownership is clear
+
+## What Did Not Change
+
+- numbering algorithm
+- queue-time assignment for newly created rows
+- fairness ordering
+- source passthrough on create
+- broader registrar wizard orchestration
+- QR allocator behavior
+- `OnlineDay`
+- force-majeure paths
+
+## Readiness Impact
+
+This slice removes the main behavior drift that blocked registrar batch-only
+boundary migration.
+
+The family is still narrow in scope, but it is now clean enough for the next
+step to be caller-path migration rather than more contract clarification.

--- a/docs/status/W2C_REGISTRAR_BATCH_BOUNDARY_READINESS.md
+++ b/docs/status/W2C_REGISTRAR_BATCH_BOUNDARY_READINESS.md
@@ -1,70 +1,56 @@
 # Wave 2C Registrar Batch Boundary Readiness
 
-Date: 2026-03-07
-Mode: characterization-first
-Decision: `READY_AFTER_CONTRACT_CLARIFICATION`
+Date: 2026-03-08
+Mode: post-correction readiness review
+Decision: `READY_FOR_BOUNDARY_MIGRATION`
 
-## Why It Is Not Ready Yet
+## What Is Now True
 
-### 1. Active-entry contract conflict
+- active-entry contract for batch duplicate gate is clarified
+- specialist-level claim model for this family is clarified
+- mounted runtime now reuses compatible active rows in:
+  - `waiting`
+  - `called`
+  - `in_service`
+  - `diagnostics`
+- ambiguity now returns explicit `409`
 
-Mounted runtime duplicate detection reuses only:
+## Why The Family Is Ready Now
 
-- `waiting`
-- `called`
+### 1. The main behavior drift is corrected
 
-Characterization now shows:
+The mounted batch path no longer creates a second `waiting` row when the
+patient already has a compatible active specialist-day claim.
 
-- existing `diagnostics` row does not block new allocation
+### 2. Numbering and fairness were preserved
 
-That conflicts with the canonical active-entry contract where `diagnostics` is
-active.
+This correction did not change:
 
-### 2. Grouping contract is still ambiguous
+- legacy numbering algorithm
+- `queue_time` handling
+- fairness ordering
 
-Mounted runtime groups by resolved `specialist_id`, not by `queue_tag` or
-canonical queue claim.
+### 3. The family remains narrowly scoped
 
-Characterization shows:
+Still out of scope:
 
-- two services for the same specialist but different `queue_tag` values still
-  produce one queue row
+- QR allocator families
+- `OnlineDay`
+- force-majeure
+- broader registrar wizard orchestration
 
-That behavior may be correct, but it needs an explicit contract decision before
-boundary migration freezes it.
+That means boundary migration can stay narrow and behavior-preserving.
 
-### 3. Mounted runtime owner is still the router
+## Remaining Deferred Concerns
 
-The mounted API path still owns:
+These are not blockers for the next narrow step:
 
-- patient/service validation
-- specialist normalization
-- duplicate pre-check
-- daily queue creation
-- response shaping
+- mounted runtime owner is still router-level
+- cleaner service seam is not yet runtime owner
 
-A cleaner `QueueBatchService` seam exists, but it is not runtime truth.
-
-## What Is Favorable
-
-- direct billing/payment side effects are not part of this subfamily
-- visit linkage is not part of this subfamily
-- row creation still goes through SSOT `queue_service.create_queue_entry(...)`
-- repeated batch submission is stable for `waiting/called` duplicates
-
-## What Contract Clarification Is Needed
-
-1. Should batch-only duplicate reuse treat `diagnostics` and `in_service` as
-   active blockers?
-2. Is same-specialist grouping intended to collapse different `queue_tag`
-   services into one row?
-3. Should registrar batch endpoint continue accepting `source="morning_assignment"`
-   as passthrough input?
+Those concerns are exactly what the next boundary-migration slice should reduce.
 
 ## Verdict
 
-`QueueDomainService.allocate_ticket()` should **not** be the next registrar
-batch change yet.
-
-The family is close enough for targeted follow-up work, but only after the
-batch-specific contract is clarified.
+Registrar batch-only family is now ready for a narrow caller-path migration
+through `QueueDomainService.allocate_ticket()`.

--- a/docs/status/W2C_REGISTRAR_BATCH_DIAGNOSTICS_FIX_STATUS.md
+++ b/docs/status/W2C_REGISTRAR_BATCH_DIAGNOSTICS_FIX_STATUS.md
@@ -1,0 +1,60 @@
+# Wave 2C Registrar Batch Diagnostics Fix Status
+
+Date: 2026-03-08
+Status: `done`
+Mode: behaviour-correction, small diff
+
+## Files Changed
+
+- `backend/app/api/v1/endpoints/registrar_integration.py`
+- `backend/tests/characterization/test_registrar_batch_allocator_characterization.py`
+- `backend/tests/unit/test_registrar_batch_reuse_existing_entry.py`
+- `docs/architecture/W2C_REGISTRAR_BATCH_BEHAVIOR_CORRECTION.md`
+- `docs/status/W2C_REGISTRAR_BATCH_BOUNDARY_READINESS.md`
+- `docs/status/W2C_REGISTRAR_BATCH_NEXT_STEP_V3.md`
+
+## Old Behavior
+
+- duplicate gate reused only `waiting` / `called`
+- existing `diagnostics` row did not block new allocation
+- existing `in_service` row would also have been ignored
+- ambiguous multi-row active state had no explicit domain error
+
+## Corrected Behavior
+
+- duplicate gate now checks `waiting`, `called`, `in_service`, `diagnostics`
+- existing compatible active row is reused
+- no new number is allocated when row is reused
+- ambiguity returns explicit `409`
+
+## Commands Run
+
+- `cd backend && pytest tests/characterization/test_registrar_batch_allocator_characterization.py -q -c pytest.ini`
+- `cd backend && pytest tests/characterization/test_registrar_batch_allocator_concurrency.py -q -c pytest.ini`
+- `cd backend && pytest tests/unit/test_registrar_batch_reuse_existing_entry.py -q`
+- `cd backend && pytest tests/characterization -q -c pytest.ini`
+- `cd backend && pytest tests/test_openapi_contract.py -q`
+- `cd backend && pytest -q`
+
+## Results
+
+- registrar batch characterization: `6 passed`
+- registrar batch concurrency characterization: `2 passed`
+- registrar batch unit tests: `5 passed`
+- full characterization suite: `23 passed`
+- OpenAPI contract: `10 passed`
+- full backend suite: `718 passed, 3 skipped`
+
+## Stop Conditions Check
+
+No stop condition was hit:
+
+- numbering semantics unchanged
+- fairness ordering unchanged
+- no payment/billing behavior touched
+- scope remained inside mounted registrar batch-only path
+
+## Outcome
+
+Registrar batch-only family is now aligned with its clarified active-entry and
+specialist-level claim contract.

--- a/docs/status/W2C_REGISTRAR_BATCH_NEXT_STEP_V3.md
+++ b/docs/status/W2C_REGISTRAR_BATCH_NEXT_STEP_V3.md
@@ -1,0 +1,48 @@
+# Wave 2C Registrar Batch Next Step V3
+
+Date: 2026-03-08
+Status: `registrar batch-only boundary migration`
+
+## Recommended Next Step
+
+Migrate the mounted registrar batch-only create path to the
+`QueueDomainService.allocate_ticket()` compatibility boundary.
+
+## Why This Is Now Safe
+
+- contract clarification is complete
+- active-entry drift is corrected
+- characterization tests are green
+- full backend suite is green
+- numbering and fairness semantics were preserved
+
+## Scope For The Next Slice
+
+Allowed:
+
+- mounted registrar batch-only flow
+- narrow caller-path migration only
+- reuse existing specialist-level claim behavior
+
+Not allowed:
+
+- broader registrar wizard refactor
+- QR allocator migration
+- `OnlineDay`
+- force-majeure
+- numbering redesign
+
+## Why Other Options Were Not Chosen
+
+### `more registrar batch characterization needed`
+
+Current evidence is already enough for the next narrow step.
+
+### `human review needed`
+
+No additional human policy decision is required for this local family.
+
+### `defer to broader registrar family track`
+
+Not necessary. The batch-only subfamily is now clean enough to move forward on
+its own.


### PR DESCRIPTION
﻿## Summary
- Correct registrar batch duplicate detection so `diagnostics` and `in_service` entries are treated as active specialist-day claims.
- Reuse a single existing active entry and return explicit `409` when multiple active claims make the batch request ambiguous.
- Add characterization/unit coverage for reuse and ambiguity behavior, then update W2C readiness/status docs.

## Contract Impact
- Canonical surface: `POST /api/v1/registrar-integration/queue/entries/batch`.
- Request shape: unchanged; the batch request still accepts `patient_id`, `source`, and requested specialist/service rows.
- Response shape: unchanged; successful responses still return `success`, `entries`, and queue ticket data.
- Status codes: single active `waiting`, `called`, `in_service`, or `diagnostics` row is reused with `200`; multiple active rows return `409` ambiguity before creating a new entry.
- Frontend consumer: registrar batch queue creation flow remains the consumer; frontend payload shape is not changed.
- Compatibility path or alias: mounted registrar batch route is preserved while duplicate detection is tightened before later queue-domain boundary migration.
- Contract proof: registrar batch characterization/concurrency tests, reuse-existing-entry unit test, characterization suite, and OpenAPI contract test listed by author.

## RBAC / Permissions
- Roles allowed: unchanged registrar access through existing registrar integration endpoint dependencies.
- Roles denied: unchanged; no authorization helper or role matrix behavior is changed.
- Positive auth proof: existing registrar-auth endpoint tests continue to exercise this route.
- Negative auth proof: not applicable because authorization code is not touched; reviewer should confirm existing endpoint auth coverage before merge.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket event is changed.
- Payload version / ack behavior: not applicable because no realtime payload is added or renamed.
- Read/unread or delivery semantics: not applicable because this is backend duplicate/reuse semantics for registrar batch queue creation.
- Reconnect/resync proof: not applicable because no realtime reconnect behavior is touched.

## Frontend Resilience
- Empty data proof: unchanged; no frontend empty-state handling is modified.
- Partial data proof: unchanged; no frontend partial-data handling is modified.
- Forbidden secondary path behavior: unchanged; no frontend secondary path is touched.
- Missing draft/resource behavior: unchanged; no draft/resource UI path is touched.
- Stale route/deep-link behavior: unchanged; no frontend route state is touched.

## Scope Gate
- Allowed paths: registrar batch endpoint duplicate-gate logic, focused characterization/unit tests, and W2C behavior/readiness documentation.
- Denied paths: unrelated queue allocator rewrites, queue fairness changes, RBAC helper changes, frontend route/UI work, notification/realtime changes, and migrations.
- Migration/docs/test impact: updates W2C registrar batch behavior correction/readiness/status docs and focused backend tests; no database migration.
- Rollback note: revert `_find_registrar_batch_existing_entry_or_raise()` and the expanded active status set if corrected reuse/ambiguity behavior regresses.

## Validation
- Targeted tests or smoke run: author lists registrar batch characterization/concurrency tests, `tests/unit/test_registrar_batch_reuse_existing_entry.py`, characterization suite, OpenAPI contract test, and full backend pytest.
- Result: not rerun in this automation pass; PR body records the author's listed validation targets.
- Not checked: realtime/browser smoke and local CI/env proof were not checked here because no realtime/frontend files are changed.
