### PR TITLE
refactor(queue): route registrar batch through boundary

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -19,6 +19,7 @@ from app.crud import clinic as crud_clinic, online_queue as crud_queue
 from app.models.department import Department, DepartmentService
 from app.models.service import Service
 from app.models.user import User
+from app.services.queue_domain_service import QueueDomainService
 from app.services.queue_service import queue_service
 from app.services.service_mapping import get_service_code
 
@@ -29,6 +30,10 @@ from app.services.service_mapping import get_service_code
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _queue_domain_service(db: Session) -> QueueDomainService:
+    return QueueDomainService(db)
 
 # ===================== ОТДЕЛЕНИЯ ДЛЯ РЕГИСТРАТУРЫ =====================
 
@@ -3154,6 +3159,7 @@ def create_queue_entries_batch(
         # Создаем записи в очереди для каждого специалиста
         created_entries = []
         reused_entries_count = 0
+        queue_domain_service = _queue_domain_service(db)
 
         for specialist_id, services_list in services_by_specialist.items():
             # Проверяем, есть ли очередь у специалиста на сегодня
@@ -3224,9 +3230,10 @@ def create_queue_entries_batch(
                 )
                 patient_phone = patient.phone or None
 
-                # Создаем запись через SSOT
-                queue_entry = queue_service.create_queue_entry(
-                    db,
+                # Caller migration only: create path now goes through the queue-domain
+                # compatibility boundary while preserving legacy allocator behavior.
+                queue_entry = queue_domain_service.allocate_ticket(
+                    allocation_mode="create_entry",
                     daily_queue=daily_queue,
                     patient_id=request.patient_id,
                     patient_name=patient_name,

--- a/backend/tests/unit/test_registrar_batch_allocator_boundary.py
+++ b/backend/tests/unit/test_registrar_batch_allocator_boundary.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from types import SimpleNamespace
+from unittest.mock import Mock
+from zoneinfo import ZoneInfo
+
+import app.api.v1.endpoints.registrar_integration as registrar_integration_module
+import pytest
+
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
+
+
+def _create_daily_queue(db_session, *, specialist_id: int) -> DailyQueue:
+    queue = DailyQueue(
+        day=date.today(),
+        specialist_id=specialist_id,
+        queue_tag=None,
+        active=True,
+    )
+    db_session.add(queue)
+    db_session.commit()
+    db_session.refresh(queue)
+    return queue
+
+
+def _create_entry(
+    db_session,
+    *,
+    queue_id: int,
+    patient_id: int,
+    patient_name: str,
+    phone: str | None,
+    number: int,
+    status: str,
+) -> OnlineQueueEntry:
+    entry = OnlineQueueEntry(
+        queue_id=queue_id,
+        number=number,
+        patient_id=patient_id,
+        patient_name=patient_name,
+        phone=phone,
+        source="online",
+        status=status,
+        queue_time=datetime.now(ZoneInfo("Asia/Tashkent")).replace(microsecond=0),
+    )
+    db_session.add(entry)
+    db_session.commit()
+    db_session.refresh(entry)
+    return entry
+
+
+@pytest.mark.unit
+def test_registrar_batch_create_uses_queue_domain_boundary(
+    client,
+    registrar_auth_headers,
+    test_patient,
+    cardio_user,
+    test_service,
+    monkeypatch,
+):
+    domain_service = Mock()
+
+    def _allocate(**kwargs):
+        return SimpleNamespace(
+            queue_id=kwargs["daily_queue"].id,
+            number=12,
+            queue_time=kwargs["queue_time"],
+        )
+
+    domain_service.allocate_ticket.side_effect = _allocate
+    monkeypatch.setattr(
+        registrar_integration_module,
+        "_queue_domain_service",
+        lambda db: domain_service,
+    )
+
+    response = client.post(
+        "/api/v1/registrar-integration/queue/entries/batch",
+        headers=registrar_auth_headers,
+        json={
+            "patient_id": test_patient.id,
+            "source": "desk",
+            "services": [
+                {
+                    "specialist_id": cardio_user.id,
+                    "service_id": test_service.id,
+                    "quantity": 1,
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["entries"][0]["number"] == 12
+
+    domain_service.allocate_ticket.assert_called_once()
+    call = domain_service.allocate_ticket.call_args
+    assert call.kwargs["allocation_mode"] == "create_entry"
+    assert call.kwargs["patient_id"] == test_patient.id
+    assert call.kwargs["patient_name"] == test_patient.short_name()
+    assert call.kwargs["phone"] == test_patient.phone
+    assert call.kwargs["source"] == "desk"
+    assert call.kwargs["auto_number"] is True
+    assert call.kwargs["commit"] is False
+    assert call.kwargs["daily_queue"].specialist_id == cardio_user.id
+
+
+@pytest.mark.unit
+def test_registrar_batch_reuse_path_does_not_call_boundary(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    cardio_user,
+    test_service,
+    monkeypatch,
+):
+    existing_queue = _create_daily_queue(db_session, specialist_id=cardio_user.id)
+    existing_entry = _create_entry(
+        db_session,
+        queue_id=existing_queue.id,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        number=7,
+        status="diagnostics",
+    )
+
+    domain_service = Mock()
+    monkeypatch.setattr(
+        registrar_integration_module,
+        "_queue_domain_service",
+        lambda db: domain_service,
+    )
+
+    response = client.post(
+        "/api/v1/registrar-integration/queue/entries/batch",
+        headers=registrar_auth_headers,
+        json={
+            "patient_id": test_patient.id,
+            "source": "desk",
+            "services": [
+                {
+                    "specialist_id": cardio_user.id,
+                    "service_id": test_service.id,
+                    "quantity": 1,
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["entries"][0]["number"] == existing_entry.number
+    domain_service.allocate_ticket.assert_not_called()
+
+
+@pytest.mark.unit
+def test_registrar_batch_ambiguity_returns_409_before_boundary_call(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    cardio_user,
+    test_service,
+    monkeypatch,
+):
+    existing_queue = _create_daily_queue(db_session, specialist_id=cardio_user.id)
+    _create_entry(
+        db_session,
+        queue_id=existing_queue.id,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        number=3,
+        status="waiting",
+    )
+    _create_entry(
+        db_session,
+        queue_id=existing_queue.id,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        number=4,
+        status="diagnostics",
+    )
+
+    domain_service = Mock()
+    monkeypatch.setattr(
+        registrar_integration_module,
+        "_queue_domain_service",
+        lambda db: domain_service,
+    )
+
+    response = client.post(
+        "/api/v1/registrar-integration/queue/entries/batch",
+        headers=registrar_auth_headers,
+        json={
+            "patient_id": test_patient.id,
+            "source": "desk",
+            "services": [
+                {
+                    "specialist_id": cardio_user.id,
+                    "service_id": test_service.id,
+                    "quantity": 1,
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 409
+    payload = response.json()
+    assert "Неоднозначная активная запись очереди" in payload["detail"]
+    domain_service.allocate_ticket.assert_not_called()

--- a/docs/architecture/W2C_ALLOCATOR_COMPATIBILITY_LAYER.md
+++ b/docs/architecture/W2C_ALLOCATOR_COMPATIBILITY_LAYER.md
@@ -65,12 +65,15 @@ After the confirmation migration slice, the boundary is used in:
   confirmation allocation when a new queue row is needed
 - mounted registrar confirmation bridge indirectly through
   `VisitConfirmationService.assign_queue_numbers_on_confirmation()`
+- `backend/app/api/v1/endpoints/registrar_integration.py::create_queue_entries_batch()`
+  for the mounted batch-only create branch when no active specialist-day claim
+  exists
 
 This is a limited production rollout.
 
 It is intentionally **not** yet wired into:
 
-- registrar batch writers
+- broader registrar batch/runtime service ownership beyond the mounted create branch
 - force-majeure allocator paths
 - direct SQL allocator branches
 - legacy `OnlineDay` callers
@@ -118,3 +121,18 @@ row creation while keeping the number lookup helper unchanged:
 
 This preserves the corrected confirmation behavior while removing the direct
 confirmation-family dependency on legacy queue-row creation.
+
+## Registrar Batch Migration Update
+
+Mounted registrar batch-only flow now uses the compatibility boundary for the
+create branch only:
+
+1. mounted batch duplicate gate / reuse logic
+2. `QueueDomainService.allocate_ticket(...)`
+3. legacy `queue_service.create_queue_entry(...)`
+
+This keeps:
+
+- active-row reuse in the mounted path
+- explicit `409` ambiguity handling in the mounted path
+- numbering and fairness inside the legacy allocator

--- a/docs/architecture/W2C_ALLOCATOR_MIGRATION_STRATEGY.md
+++ b/docs/architecture/W2C_ALLOCATOR_MIGRATION_STRATEGY.md
@@ -29,7 +29,7 @@ Migration must follow this order:
 |---|---|---|---|
 | `queue_service` path | Main SSOT-style allocator and entry-creation helper | Convert into internal implementation behind `QueueDomainService.allocate_ticket()` first; keep behavior-compatible adapter during transition | Medium |
 | `qr_queue.py` direct SQL allocator | High-risk inline allocator in add-service/update flows | Do not migrate early. First add characterization tests, then replace direct allocation with domain-service orchestration only after duplicate/fairness contract is stable | High |
-| Registrar batch path | Modern registrar write path using `create_queue_entry(auto_number=True)` | Repoint registrar application service to `QueueDomainService` once duplicate-policy contract is implemented; preserve current batch semantics during first cut | Medium |
+| Registrar batch path | Modern registrar write path using `create_queue_entry(auto_number=True)` | Mounted batch-only create branch is now migrated to `QueueDomainService.allocate_ticket()`; keep duplicate/reuse logic local and defer broader service/runtime seam migration | Medium |
 | Registrar legacy count-based path | Older desk path with `start_number + current_count` | Treat as legacy compatibility slice. Replace only after characterization tests prove operator-visible behavior can be preserved or intentionally superseded | High |
 | Confirmation flows | Split "get number, then create row" flows | Mounted confirmation family is now migrated to the compatibility boundary for row creation; keep standalone number lookup legacy for now and defer unmounted/duplicate cleanup | Medium |
 | Force majeure transfer allocator | Exceptional tomorrow-transfer allocator | Keep separate initially, but force it to call the same internal reservation primitive once transfer semantics are modeled | High |
@@ -69,7 +69,7 @@ Why these callers were safe:
 Preferred early caller families:
 
 - SSOT queue-service-backed online join
-- registrar batch path only after explicit duplicate-policy review
+- mounted registrar batch-only create path after explicit duplicate-policy review
 
 Later only:
 
@@ -147,3 +147,16 @@ Still deferred inside the broader confirmation/registrar surface:
 - standalone number lookup remains legacy
 - unmounted duplicate confirmation modules
 - broader registrar wizard/batch allocator families
+
+## Registrar Batch Migration Update
+
+Completed in the current slice:
+
+- mounted registrar batch-only create path now goes through
+  `QueueDomainService.allocate_ticket()`
+
+Still deferred:
+
+- broader registrar wizard branches
+- `queue_batch_service.py` as future runtime owner/seam
+- legacy count-based registrar paths

--- a/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
+++ b/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
@@ -305,6 +305,9 @@ Current production callers through `allocate_ticket()`:
 - `backend/app/services/visit_confirmation_service.py` through
   `QueueContextFacade(QueueDomainServiceContractAdapter)` when a new queue row
   is needed during mounted confirmation
+- `backend/app/api/v1/endpoints/registrar_integration.py::create_queue_entries_batch()`
+  for mounted batch-only create flow when duplicate gate does not reuse an
+  existing specialist-day claim
 
 ## Phase 2.2 Boundary Limits
 
@@ -317,7 +320,8 @@ Still outside the safe boundary:
 - `qr_queue.py` direct SQL allocator branches
 - force-majeure transfer allocator
 - all `OnlineDay` legacy allocators
-- registrar batch allocator family
+- broader registrar batch service/runtime ownership beyond the mounted create
+  branch
 - unmounted duplicate confirmation modules
 
 Reason:
@@ -336,6 +340,14 @@ Mounted confirmation is no longer blocked here:
   compatibility boundary
 - remaining confirmation work is limited to cleanup/dead-path clarification, not
   allocator ownership
+
+### Registrar batch-only note
+
+Mounted registrar batch-only family is now partially migrated:
+
+- reuse and ambiguity logic still live in the mounted router path
+- create branch now routes through `QueueDomainService.allocate_ticket()`
+- broader registrar wizard/batch service migration is still deferred
 
 Notes for the narrowed `W2C-MS-004` slice:
 

--- a/docs/architecture/W2C_REGISTRAR_BATCH_BOUNDARY_MIGRATION.md
+++ b/docs/architecture/W2C_REGISTRAR_BATCH_BOUNDARY_MIGRATION.md
@@ -1,0 +1,60 @@
+# Wave 2C Registrar Batch Boundary Migration
+
+Date: 2026-03-08
+Mode: behaviour-preserving migration
+
+## Old Path
+
+Mounted registrar batch-only create branch used:
+
+1. mounted router duplicate gate
+2. direct `queue_service.create_queue_entry(...)`
+
+That meant the caller still depended directly on the legacy allocator path even
+after the batch-specific contract and behavior correction were already defined.
+
+## New Path
+
+Mounted registrar batch-only create branch now uses:
+
+1. mounted router duplicate gate
+2. `QueueDomainService.allocate_ticket(allocation_mode="create_entry", ...)`
+3. legacy allocator delegation inside `QueueDomainService`
+
+## Why Behaviour Is Preserved
+
+The migration changes only the caller path.
+
+It does **not** change:
+
+- numbering algorithm
+- `queue_time` handling
+- fairness ordering
+- active-entry reuse logic
+- explicit `409` ambiguity handling
+- source passthrough semantics
+
+The boundary still delegates internally to the same legacy allocator.
+
+## What Remains Outside The Boundary
+
+Still deferred:
+
+- broader registrar wizard branches
+- `queue_batch_service.py` as future runtime seam
+- QR direct SQL allocator family
+- force-majeure family
+- `OnlineDay` legacy family
+- legacy count-based registrar paths
+
+## Outcome
+
+Mounted registrar batch-only family is now aligned with the same compatibility
+strategy already used by:
+
+- mounted online join
+- QR session completion
+- mounted confirmation allocation
+
+This narrows the live allocator surface area without redesigning queue
+allocation itself.

--- a/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_BATCH.md
+++ b/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_BATCH.md
@@ -1,0 +1,37 @@
+# Wave 2C Next Execution Unit After Batch
+
+Date: 2026-03-08
+Status: `broader registrar wizard characterization`
+
+## Recommended Next Step
+
+Run a characterization/review-first pass for broader registrar wizard queue
+branches outside the mounted batch-only family.
+
+## Why This Is The Next Step
+
+- mounted confirmation family is migrated
+- mounted registrar batch-only family is now migrated
+- the next closest deferred family is broader registrar wizard orchestration
+- it is still likely safer than jumping directly into `qr_queue.py` direct SQL
+  or `OnlineDay`
+
+## Why Other Options Were Not Chosen
+
+### `qr_queue direct SQL characterization/migration-prep`
+
+Still needed, but it remains the highest-risk live allocator family.
+
+### `force_majeure characterization`
+
+Valid later, but it is more exceptional and less central than the remaining
+registrar family surface.
+
+### `legacy OnlineDay isolation review`
+
+Still needed, but it is a separate legacy track rather than the next adjacent
+queue-family migration.
+
+### `defer pending human decision`
+
+Not necessary yet. The next family is already identifiable.

--- a/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_CONFIRMATION.md
+++ b/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_CONFIRMATION.md
@@ -3,6 +3,12 @@
 Date: 2026-03-07
 Status: `SAFE_NEXT_STEP_IDENTIFIED`
 
+> Superseded by later Wave 2C passes.
+> Registrar batch characterization, contract clarification, behavior correction,
+> and boundary migration are now completed. Use
+> [W2C_NEXT_EXECUTION_UNIT_AFTER_BATCH.md](C:/final/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_BATCH.md)
+> for the current next-step decision.
+
 ## Recommended Next Step
 
 `registrar batch-only characterization`

--- a/docs/status/W2C_PHASE21_DEFERRED_CALLERS.md
+++ b/docs/status/W2C_PHASE21_DEFERRED_CALLERS.md
@@ -7,7 +7,7 @@ Mode: behavior-preserving execution
 |---|---|---|---|---|
 | `backend/app/api/v1/endpoints/queue.py` | `join_queue()` | Legacy-prefixed route with low current signal; not part of primary QR/public join flow for this pass | Legacy/deprecated path | Review before later safe migration pass |
 | `backend/app/services/morning_assignment.py` | `_assign_single_queue()` | `morning_assignment` source semantics and visit-opening flow should be migrated only with dedicated characterization around scheduled queue population | Lifecycle/source semantics | Later safe pass or pre-2C high-risk review |
-| `backend/app/api/v1/endpoints/registrar_integration.py` | `create_queue_entries_batch()` | Registrar batch orchestration mixes allocator call with duplicate decisions and operator-visible batch behavior | Registrar orchestration / duplicate-policy sensitivity | Review before high-risk allocator migration |
+| `backend/app/api/v1/endpoints/registrar_integration.py` | broader registrar queue creation branches outside mounted batch-only create path | Mounted batch-only create path is migrated, but broader registrar orchestration still mixes allocator behavior with wizard/runtime concerns | Registrar orchestration / mixed logic | Broader registrar family track |
 | `backend/app/services/queue_batch_service.py` | `create_entries()` | Batch writer path with broader side effects than thin join callers | Batch write semantics | Review before high-risk allocator migration |
 | `backend/app/api/v1/endpoints/registrar_wizard.py` | non-confirmation queue creation branches | Mounted confirmation bridge is migrated separately, but broader wizard queue creation still mixes numbering, persistence, and orchestration | Mixed logic | High-risk allocator migration |
 | `backend/app/services/registrar_wizard_api_service.py` | queue creation branches | Same mixed allocator behavior as router counterpart | Mixed logic | High-risk allocator migration |
@@ -32,3 +32,7 @@ readiness and ordering now live in:
 
 Mounted confirmation family is no longer deferred. It now uses the compatibility
 boundary for queue-row creation.
+
+Mounted registrar batch-only create path is also no longer deferred. It now
+uses the compatibility boundary while keeping local reuse/ambiguity logic in
+place.

--- a/docs/status/W2C_REGISTRAR_BATCH_BOUNDARY_MIGRATION_PLAN.md
+++ b/docs/status/W2C_REGISTRAR_BATCH_BOUNDARY_MIGRATION_PLAN.md
@@ -1,0 +1,47 @@
+# Wave 2C Registrar Batch Boundary Migration Plan
+
+Date: 2026-03-08
+Mode: behaviour-preserving migration
+Scope: mounted registrar batch-only family
+
+## Files In Scope
+
+- `backend/app/api/v1/endpoints/registrar_integration.py`
+- `backend/tests/characterization/test_registrar_batch_allocator_characterization.py`
+- `backend/tests/characterization/test_registrar_batch_allocator_concurrency.py`
+- `backend/tests/unit/test_registrar_batch_reuse_existing_entry.py`
+- `backend/tests/unit/test_registrar_batch_allocator_boundary.py`
+- `docs/architecture/W2C_REGISTRAR_BATCH_BOUNDARY_MIGRATION.md`
+- `docs/status/W2C_REGISTRAR_BATCH_BOUNDARY_MIGRATION_STATUS.md`
+- `docs/architecture/W2C_ALLOCATOR_COMPATIBILITY_LAYER.md`
+- `docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md`
+- `docs/architecture/W2C_ALLOCATOR_MIGRATION_STRATEGY.md`
+- `docs/status/W2C_PHASE21_DEFERRED_CALLERS.md`
+- `docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_BATCH.md`
+
+## Why This Is Safe
+
+- contract clarification is complete
+- mounted batch duplicate-gate behavior is already corrected
+- numbering stays inside legacy allocator
+- create branch can switch caller path without redesigning allocator internals
+- reuse and ambiguity logic remain in the mounted batch path
+
+## Behaviour-Preservation Rules
+
+- reuse-existing-entry logic stays unchanged
+- `409` ambiguity handling stays unchanged
+- if no active row exists, only the caller path changes
+- numbering algorithm stays legacy
+- `queue_time` and fairness stay unchanged
+- no billing/payment logic is moved
+
+## Explicitly Out Of Scope
+
+- broader registrar wizard orchestration
+- `queue_batch_service.py` as runtime owner
+- QR allocator families
+- `OnlineDay`
+- force-majeure
+- legacy count-based registrar paths
+- non-batch registrar write flows

--- a/docs/status/W2C_REGISTRAR_BATCH_BOUNDARY_MIGRATION_STATUS.md
+++ b/docs/status/W2C_REGISTRAR_BATCH_BOUNDARY_MIGRATION_STATUS.md
@@ -1,0 +1,63 @@
+# Wave 2C Registrar Batch Boundary Migration Status
+
+Date: 2026-03-08
+Status: `done`
+Mode: behaviour-preserving migration
+
+## Files Changed
+
+- `backend/app/api/v1/endpoints/registrar_integration.py`
+- `backend/tests/unit/test_registrar_batch_allocator_boundary.py`
+- `docs/status/W2C_REGISTRAR_BATCH_BOUNDARY_MIGRATION_PLAN.md`
+- `docs/architecture/W2C_REGISTRAR_BATCH_BOUNDARY_MIGRATION.md`
+- `docs/status/W2C_REGISTRAR_BATCH_BOUNDARY_MIGRATION_STATUS.md`
+- `docs/architecture/W2C_ALLOCATOR_COMPATIBILITY_LAYER.md`
+- `docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md`
+- `docs/architecture/W2C_ALLOCATOR_MIGRATION_STRATEGY.md`
+- `docs/status/W2C_PHASE21_DEFERRED_CALLERS.md`
+- `docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_BATCH.md`
+
+## Old Path
+
+- mounted batch-only create branch called `queue_service.create_queue_entry(...)`
+  directly
+
+## New Path
+
+- mounted batch-only create branch now calls
+  `QueueDomainService.allocate_ticket(allocation_mode="create_entry", ...)`
+- `QueueDomainService` still delegates to the legacy allocator internally
+
+## Why Behaviour Stayed Stable
+
+- reuse-existing-entry branch was not moved
+- ambiguity `409` branch was not moved
+- only create branch changed caller path
+- numbering and `queue_time` behavior stayed inside the same legacy allocator
+
+## Test Commands
+
+- `cd backend && pytest tests/characterization/test_registrar_batch_allocator_characterization.py -q -c pytest.ini`
+- `cd backend && pytest tests/characterization/test_registrar_batch_allocator_concurrency.py -q -c pytest.ini`
+- `cd backend && pytest tests/unit/test_registrar_batch_allocator_boundary.py -q`
+- `cd backend && pytest tests/unit/test_registrar_batch_reuse_existing_entry.py tests/unit/test_queue_allocator_boundary.py -q`
+- `cd backend && pytest tests/characterization -q -c pytest.ini`
+- `cd backend && pytest tests/test_openapi_contract.py -q`
+- `cd backend && pytest -q`
+
+## Results
+
+- registrar batch characterization: `6 passed`
+- registrar batch concurrency characterization: `2 passed`
+- registrar batch boundary unit tests: `3 passed`
+- registrar batch reuse tests + queue boundary tests: `9 passed`
+- full characterization suite: `23 passed`
+- OpenAPI contract: `10 passed`
+- full backend suite: `721 passed, 3 skipped`
+
+## Deferred After This Slice
+
+- broader registrar wizard characterization
+- QR direct SQL family
+- force-majeure family
+- `OnlineDay` legacy isolation


### PR DESCRIPTION
﻿## Summary
- Route the registrar batch-only queue create branch through `QueueDomainService.allocate_ticket()` with `allocation_mode="create_entry"`.
- Preserve existing reuse-existing-entry behavior and ambiguity `409` behavior before the new boundary call.
- Add unit coverage for the new boundary handoff and update W2C migration/status docs.

## Contract Impact
- Canonical surface: `POST /api/v1/registrar-integration/queue/entries/batch`.
- Request shape: unchanged; the request still accepts `patient_id`, `source`, and per-service specialist/service/quantity data.
- Response shape: unchanged; successful responses still return `success`, created/reused `entries`, and queue ticket numbers.
- Status codes: existing `200` success/reuse behavior is preserved; existing ambiguity/conflict `409` path remains before allocator dispatch.
- Frontend consumer: registrar batch queue creation flow remains the consumer; no route or UI contract change is introduced.
- Compatibility path or alias: caller migration goes through the queue-domain compatibility boundary, not removal of legacy queue behavior.
- Contract proof: `backend/tests/unit/test_registrar_batch_allocator_boundary.py`, registrar batch characterization/concurrency tests, reuse-existing-entry tests, characterization suite, and OpenAPI contract test listed by author.

## RBAC / Permissions
- Roles allowed: unchanged registrar access through existing registrar integration endpoint dependencies.
- Roles denied: unchanged; no authorization helper or role matrix behavior is changed.
- Positive auth proof: existing registrar-auth endpoint tests continue to exercise this route.
- Negative auth proof: not applicable because RBAC code is not touched; reviewer should confirm existing endpoint auth coverage before merge.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket event is changed.
- Payload version / ack behavior: not applicable because no realtime payload is added or renamed.
- Read/unread or delivery semantics: not applicable because this is backend queue allocation dispatch for registrar batch creation.
- Reconnect/resync proof: not applicable because no realtime reconnect behavior is touched.

## Frontend Resilience
- Empty data proof: unchanged; no frontend empty-state handling is modified.
- Partial data proof: unchanged; no frontend partial-data handling is modified.
- Forbidden secondary path behavior: unchanged; no frontend secondary path is touched.
- Missing draft/resource behavior: unchanged; no draft/resource UI path is touched.
- Stale route/deep-link behavior: unchanged; no frontend route state is touched.

## Scope Gate
- Allowed paths: registrar batch endpoint boundary call, new focused unit tests, and W2C migration/status documentation.
- Denied paths: unrelated queue fairness rewrites, RBAC helper changes, frontend route/UI changes, notification/realtime changes, and migrations.
- Migration/docs/test impact: updates W2C allocator/queue-domain migration docs and status notes; no database migration.
- Rollback note: revert the endpoint call back to `queue_service.create_queue_entry()` if the queue-domain boundary path regresses.

## Validation
- Targeted tests or smoke run: author lists registrar batch characterization/concurrency tests, `tests/unit/test_registrar_batch_allocator_boundary.py`, reuse/queue allocator boundary tests, characterization suite, OpenAPI contract test, and full backend pytest.
- Result: not rerun in this automation pass; PR body records the author's listed validation targets.
- Not checked: realtime/browser smoke and local CI/env proof were not checked here because no realtime/frontend files are changed.
