### PR TITLE
fix(queue): tighten registrar wizard duplicate gate

### DIFF
--- a/backend/app/services/morning_assignment.py
+++ b/backend/app/services/morning_assignment.py
@@ -20,6 +20,17 @@ from app.services.queue_service import queue_service
 
 logger = logging.getLogger(__name__)
 
+WIZARD_DUPLICATE_ACTIVE_STATUSES = (
+    "waiting",
+    "called",
+    "in_service",
+    "diagnostics",
+)
+
+
+class MorningAssignmentClaimError(ValueError):
+    """Raised when a wizard-family queue claim cannot be resolved safely."""
+
 
 class MorningAssignmentService:
     """Сервис утренней сборки для присвоения номеров в очередях"""
@@ -420,8 +431,6 @@ class MorningAssignmentService:
             f"Используем doctor_id={doctor_id} для queue_tag={queue_tag}, visit_id={visit.id}"
         )
 
-        # ✅ ИСПРАВЛЕНО: Используем SSOT queue_service для получения/создания очереди
-        # Получаем информацию о враче для defaults
         defaults = {}
         if doctor:
             defaults = {
@@ -433,15 +442,10 @@ class MorningAssignmentService:
                 ),
             }
 
-        # Сначала пытаемся использовать уже созданную очередь на текущую дату.
-        daily_queue = (
-            self.db.query(DailyQueue)
-            .filter(
-                DailyQueue.day == target_date,
-                DailyQueue.queue_tag == queue_tag,
-                DailyQueue.active == True,
-            )
-            .first()
+        daily_queue, existing_entry = self._resolve_existing_queue_claim_or_raise(
+            patient_id=visit.patient_id,
+            target_date=target_date,
+            queue_tag=queue_tag,
         )
 
         if not daily_queue:
@@ -453,18 +457,6 @@ class MorningAssignmentService:
                 queue_tag=queue_tag,
                 defaults=defaults,
             )
-
-        # Проверяем нет ли уже записи для этого пациента в этой очереди
-        existing_entry = (
-            self.db.query(OnlineQueueEntry)
-            .filter(
-                and_(
-                    OnlineQueueEntry.queue_id == daily_queue.id,
-                    OnlineQueueEntry.patient_id == visit.patient_id,
-                )
-            )
-            .first()
-        )
 
         if existing_entry:
             logger.info(f"Пациент {visit.patient_id} уже есть в очереди {queue_tag}")
@@ -562,6 +554,62 @@ class MorningAssignmentService:
             "number": queue_entry.number,
             "status": "assigned",
         }
+
+    def _resolve_existing_queue_claim_or_raise(
+        self,
+        *,
+        patient_id: int,
+        target_date: date,
+        queue_tag: str,
+    ) -> tuple[DailyQueue | None, OnlineQueueEntry | None]:
+        active_queues = (
+            self.db.query(DailyQueue)
+            .filter(
+                DailyQueue.day == target_date,
+                DailyQueue.queue_tag == queue_tag,
+                DailyQueue.active == True,
+            )
+            .order_by(DailyQueue.id.asc())
+            .all()
+        )
+
+        if not active_queues:
+            return None, None
+
+        active_entries = (
+            self.db.query(OnlineQueueEntry)
+            .filter(
+                OnlineQueueEntry.queue_id.in_([queue.id for queue in active_queues]),
+                OnlineQueueEntry.patient_id == patient_id,
+                OnlineQueueEntry.status.in_(WIZARD_DUPLICATE_ACTIVE_STATUSES),
+            )
+            .order_by(OnlineQueueEntry.queue_time.asc(), OnlineQueueEntry.id.asc())
+            .all()
+        )
+
+        if len(active_entries) > 1:
+            raise MorningAssignmentClaimError(
+                "Неоднозначная активная запись очереди для queue_tag="
+                f"{queue_tag} и пациента {patient_id}"
+            )
+
+        if len(active_entries) == 1:
+            queue_by_id = {queue.id: queue for queue in active_queues}
+            matched_queue = queue_by_id.get(active_entries[0].queue_id)
+            if matched_queue is None:
+                raise MorningAssignmentClaimError(
+                    "Не удалось безопасно сопоставить активную запись очереди с "
+                    f"queue_tag={queue_tag} и пациентом {patient_id}"
+                )
+            return matched_queue, active_entries[0]
+
+        if len(active_queues) > 1:
+            raise MorningAssignmentClaimError(
+                "Неоднозначная очередь для queue_tag="
+                f"{queue_tag} и пациента {patient_id}"
+            )
+
+        return active_queues[0], None
 
     def get_morning_assignment_stats(
         self, target_date: date | None = None

--- a/backend/tests/characterization/test_registrar_wizard_queue_characterization.py
+++ b/backend/tests/characterization/test_registrar_wizard_queue_characterization.py
@@ -177,6 +177,7 @@ def test_registrar_wizard_characterization_same_day_cart_creates_desk_queue_entr
 
 @pytest.mark.integration
 @pytest.mark.queue
+@pytest.mark.parametrize("existing_status", ["waiting", "called", "in_service", "diagnostics"])
 def test_registrar_wizard_characterization_reuses_existing_same_queue_row(
     client,
     db_session,
@@ -184,6 +185,7 @@ def test_registrar_wizard_characterization_reuses_existing_same_queue_row(
     test_patient,
     test_doctor,
     test_service,
+    existing_status,
 ):
     daily_queue = _create_daily_queue(
         db_session,
@@ -201,7 +203,7 @@ def test_registrar_wizard_characterization_reuses_existing_same_queue_row(
         phone=test_patient.phone,
         visit_id=None,
         number=17,
-        status="waiting",
+        status=existing_status,
         source="online",
         queue_time=preserved_queue_time,
     )
@@ -240,6 +242,7 @@ def test_registrar_wizard_characterization_reuses_existing_same_queue_row(
     assert patient_entries[0].id == existing_entry.id
     assert patient_entries[0].number == existing_entry.number
     assert patient_entries[0].queue_time == preserved_queue_time.replace(tzinfo=None)
+    assert patient_entries[0].status == existing_status
     assert payload["queue_numbers"][str(visit_id)][0]["number"] == existing_entry.number
 
 
@@ -425,4 +428,92 @@ def test_registrar_wizard_characterization_future_day_cart_defers_queue_creation
 
     assert payload["queue_numbers"] == {}
     assert entry is None
+    assert visit.status == "confirmed"
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_registrar_wizard_characterization_ambiguous_same_queue_tag_claim_skips_allocation(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+    test_service,
+):
+    second_doctor = _create_specialist(
+        db_session,
+        username="wizard_ambiguous_doctor",
+        email="wizard_ambiguous_doctor@test.local",
+        full_name="Wizard Ambiguous Doctor",
+        specialty="Cardiology",
+    )
+    first_queue = _create_daily_queue(
+        db_session,
+        specialist_id=test_doctor.id,
+        queue_tag=test_service.queue_tag,
+    )
+    second_queue = _create_daily_queue(
+        db_session,
+        specialist_id=second_doctor.id,
+        queue_tag=test_service.queue_tag,
+    )
+    _create_queue_entry(
+        db_session,
+        queue_id=first_queue.id,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        visit_id=None,
+        number=10,
+        status="waiting",
+        source="online",
+        queue_time=datetime.now(ZoneInfo("Asia/Tashkent")).replace(microsecond=0),
+    )
+    _create_queue_entry(
+        db_session,
+        queue_id=second_queue.id,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        visit_id=None,
+        number=11,
+        status="diagnostics",
+        source="online",
+        queue_time=datetime.now(ZoneInfo("Asia/Tashkent")).replace(microsecond=0),
+    )
+
+    response = client.post(
+        "/api/v1/registrar/cart",
+        headers=registrar_auth_headers,
+        json=_cart_payload(
+            patient_id=test_patient.id,
+            visits=[
+                {
+                    "doctor_id": test_doctor.id,
+                    "visit_date": date.today().isoformat(),
+                    "department": "cardiology",
+                    "services": [
+                        {
+                            "service_id": test_service.id,
+                            "quantity": 1,
+                        }
+                    ],
+                }
+            ],
+        ),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    visit_id = payload["visit_ids"][0]
+    visit = db_session.query(Visit).filter(Visit.id == visit_id).one()
+    patient_entries = (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.patient_id == test_patient.id)
+        .all()
+    )
+
+    assert payload["queue_numbers"] == {}
+    assert len(patient_entries) == 2
     assert visit.status == "confirmed"

--- a/backend/tests/unit/test_registrar_wizard_reuse_existing_entry.py
+++ b/backend/tests/unit/test_registrar_wizard_reuse_existing_entry.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.models.clinic import Doctor
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.user import User
+from app.models.visit import Visit, VisitService
+from app.services.morning_assignment import (
+    MorningAssignmentClaimError,
+    MorningAssignmentService,
+)
+
+
+def _create_visit_for_queue_tag(
+    db_session,
+    *,
+    patient_id: int,
+    doctor_id: int,
+    service_id: int,
+    service_code: str,
+    service_name: str,
+) -> Visit:
+    visit = Visit(
+        patient_id=patient_id,
+        doctor_id=doctor_id,
+        visit_date=date.today(),
+        visit_time="10:00",
+        status="confirmed",
+        discount_mode="none",
+        approval_status="approved",
+        department="cardiology",
+        source="desk",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+
+    visit_service = VisitService(
+        visit_id=visit.id,
+        service_id=service_id,
+        code=service_code,
+        name=service_name,
+        qty=1,
+        price=Decimal("100000.00"),
+    )
+    db_session.add(visit_service)
+    db_session.commit()
+    db_session.refresh(visit)
+    return visit
+
+
+def _create_daily_queue(
+    db_session,
+    *,
+    specialist_id: int,
+    queue_tag: str,
+) -> DailyQueue:
+    queue = DailyQueue(
+        day=date.today(),
+        specialist_id=specialist_id,
+        queue_tag=queue_tag,
+        active=True,
+    )
+    db_session.add(queue)
+    db_session.commit()
+    db_session.refresh(queue)
+    return queue
+
+
+def _create_doctor(
+    db_session,
+    *,
+    username: str,
+    email: str,
+    full_name: str,
+    specialty: str,
+) -> Doctor:
+    user = User(
+        username=username,
+        email=email,
+        full_name=full_name,
+        hashed_password="hashed",
+        role="Doctor",
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    doctor = Doctor(
+        user_id=user.id,
+        specialty=specialty,
+        active=True,
+    )
+    db_session.add(doctor)
+    db_session.commit()
+    db_session.refresh(doctor)
+    return doctor
+
+
+def _create_entry(
+    db_session,
+    *,
+    queue_id: int,
+    patient_id: int,
+    number: int,
+    status: str,
+) -> OnlineQueueEntry:
+    entry = OnlineQueueEntry(
+        queue_id=queue_id,
+        patient_id=patient_id,
+        patient_name=f"Patient {patient_id}",
+        phone="+998901234567",
+        number=number,
+        status=status,
+        source="online",
+        queue_time=datetime.now(ZoneInfo("Asia/Tashkent")).replace(microsecond=0),
+    )
+    db_session.add(entry)
+    db_session.commit()
+    db_session.refresh(entry)
+    return entry
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("existing_status", ["in_service", "diagnostics"])
+def test_resolve_existing_queue_claim_reuses_canonical_active_entry(
+    db_session,
+    test_patient,
+    test_doctor,
+    test_service,
+    existing_status,
+):
+    service = MorningAssignmentService(db_session)
+    visit = _create_visit_for_queue_tag(
+        db_session,
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        service_id=test_service.id,
+        service_code=test_service.code,
+        service_name=test_service.name,
+    )
+    daily_queue = _create_daily_queue(
+        db_session,
+        specialist_id=test_doctor.id,
+        queue_tag=test_service.queue_tag,
+    )
+    existing_entry = _create_entry(
+        db_session,
+        queue_id=daily_queue.id,
+        patient_id=test_patient.id,
+        number=15,
+        status=existing_status,
+    )
+
+    resolved_queue, resolved_entry = service._resolve_existing_queue_claim_or_raise(
+        patient_id=visit.patient_id,
+        target_date=date.today(),
+        queue_tag=test_service.queue_tag,
+    )
+
+    assert resolved_queue.id == daily_queue.id
+    assert resolved_entry.id == existing_entry.id
+    assert resolved_entry.status == existing_status
+
+
+@pytest.mark.unit
+def test_resolve_existing_queue_claim_ignores_inactive_rows(
+    db_session,
+    test_patient,
+    test_doctor,
+    test_service,
+):
+    service = MorningAssignmentService(db_session)
+    _create_visit_for_queue_tag(
+        db_session,
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        service_id=test_service.id,
+        service_code=test_service.code,
+        service_name=test_service.name,
+    )
+    daily_queue = _create_daily_queue(
+        db_session,
+        specialist_id=test_doctor.id,
+        queue_tag=test_service.queue_tag,
+    )
+    _create_entry(
+        db_session,
+        queue_id=daily_queue.id,
+        patient_id=test_patient.id,
+        number=18,
+        status="served",
+    )
+
+    resolved_queue, resolved_entry = service._resolve_existing_queue_claim_or_raise(
+        patient_id=test_patient.id,
+        target_date=date.today(),
+        queue_tag=test_service.queue_tag,
+    )
+
+    assert resolved_queue.id == daily_queue.id
+    assert resolved_entry is None
+
+
+@pytest.mark.unit
+def test_resolve_existing_queue_claim_raises_on_ambiguous_active_rows(
+    db_session,
+    test_patient,
+    test_doctor,
+    test_service,
+):
+    service = MorningAssignmentService(db_session)
+    second_doctor = _create_doctor(
+        db_session,
+        username="wizard_unit_ambiguous_doctor",
+        email="wizard_unit_ambiguous_doctor@test.local",
+        full_name="Wizard Unit Ambiguous Doctor",
+        specialty="Cardiology",
+    )
+    _create_visit_for_queue_tag(
+        db_session,
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        service_id=test_service.id,
+        service_code=test_service.code,
+        service_name=test_service.name,
+    )
+    first_queue = _create_daily_queue(
+        db_session,
+        specialist_id=test_doctor.id,
+        queue_tag=test_service.queue_tag,
+    )
+    second_queue = _create_daily_queue(
+        db_session,
+        specialist_id=second_doctor.id,
+        queue_tag=test_service.queue_tag,
+    )
+    _create_entry(
+        db_session,
+        queue_id=first_queue.id,
+        patient_id=test_patient.id,
+        number=21,
+        status="waiting",
+    )
+    _create_entry(
+        db_session,
+        queue_id=second_queue.id,
+        patient_id=test_patient.id,
+        number=22,
+        status="diagnostics",
+    )
+
+    with pytest.raises(MorningAssignmentClaimError, match="Неоднозначная активная запись очереди"):
+        service._resolve_existing_queue_claim_or_raise(
+            patient_id=test_patient.id,
+            target_date=date.today(),
+            queue_tag=test_service.queue_tag,
+        )

--- a/docs/architecture/W2C_REGISTRAR_WIZARD_BEHAVIOR_CORRECTION.md
+++ b/docs/architecture/W2C_REGISTRAR_WIZARD_BEHAVIOR_CORRECTION.md
@@ -1,0 +1,112 @@
+# Wave 2C Registrar Wizard Behavior Correction
+
+Date: 2026-03-08
+Mode: behavior-correction, narrow scope
+
+## Scope
+
+Only the mounted `/registrar/cart` same-day queue-assignment path was corrected.
+
+Changed runtime owner:
+
+- `backend/app/services/morning_assignment.py`
+
+Unchanged:
+
+- numbering algorithm
+- `queue_time` semantics
+- fairness ordering
+- billing / invoice orchestration
+- future-day defer behavior
+- batch-family behavior
+- QR, `OnlineDay`, force-majeure families
+
+## Old Runtime Behavior
+
+The old reuse gate in `MorningAssignmentService._assign_single_queue()`:
+
+- resolved the queue by `queue_tag`
+- then reused the first `OnlineQueueEntry` for that concrete queue and patient
+- did not explicitly restrict reuse to canonical active statuses
+- did not protect against ambiguous same-claim ownership
+
+Practical consequences:
+
+- `diagnostics` and `in_service` were not explicitly part of the contract
+- ambiguity inside the same queue-tag claim could be silently flattened
+- claim ownership was already queue-tag-driven in practice, but the duplicate gate
+  was looser than the target contract
+
+## Corrected Behavior
+
+The corrected duplicate gate now:
+
+- keeps wizard-family claim ownership at `patient_id + queue_tag + queue_day`
+- looks for active rows using canonical active statuses only:
+  - `waiting`
+  - `called`
+  - `in_service`
+  - `diagnostics`
+- reuses one compatible active row if ownership is clear
+- does not allocate a new number in that case
+- does not change the reused row’s `queue_time`
+- raises a safe claim error when same-claim ownership is ambiguous
+
+Inside the mounted `/registrar/cart` flow that ambiguity is handled via the
+existing safe failure path:
+
+- no new queue row is created
+- no new number is allocated
+- `queue_numbers` remains empty for that visit
+- the broader billing/cart response shape stays unchanged
+
+## Why Queue-Tag-Level Claim Is Preserved
+
+This correction does **not** collapse wizard-family into batch-family semantics.
+
+Wizard-family still allows:
+
+- multiple active rows for the same specialist/day when `queue_tag` differs
+- one visit to expand into multiple queue claims
+
+That remains consistent with:
+
+- `docs/ONLINE_QUEUE_SYSTEM_IMPLEMENTATION.md`
+- `docs/architecture/W2C_REGISTRAR_WIZARD_CLAIM_CONTRACT.md`
+
+## Why Same-Queue Duplicates Are Prevented
+
+Inside one resolved queue-tag claim:
+
+- one compatible active row is reused
+- more than one compatible active row is treated as ambiguous and unsafe
+- no new row is created in the ambiguous case
+
+This aligns the mounted wizard path with:
+
+- `docs/architecture/W2C_ACTIVE_ENTRY_CONTRACT.md`
+- `docs/architecture/W2C_DUPLICATE_POLICY_CONTRACT.md`
+
+## Why Different Queue Tags Still Allow Multiple Rows
+
+Different `queue_tag` values remain different queue claims in wizard-family
+scope.
+
+So:
+
+- same patient
+- same specialist
+- same day
+- different `queue_tag`
+
+may still legitimately produce multiple active rows.
+
+## Remaining Limitation
+
+The family is still not ready for direct boundary migration because the mounted
+`/registrar/cart` runtime owner remains coupled to:
+
+- visit creation
+- invoice creation
+- invoice-visit linking
+- same-day queue assignment

--- a/docs/status/W2C_REGISTRAR_WIZARD_CLASSIFICATION.md
+++ b/docs/status/W2C_REGISTRAR_WIZARD_CLASSIFICATION.md
@@ -1,13 +1,13 @@
 # Wave 2C Registrar Wizard Classification
 
 Date: 2026-03-08
-Mode: characterization-only
+Mode: post-correction classification
 
 | Subflow | Current runtime owner | Classification | Why |
 |---|---|---|---|
-| `RW-SF-01` same-day cart create with immediate queue assignment | `registrar_wizard.py` + `MorningAssignmentService` | `BLOCKED_BY_BILLING_COUPLING` | visit creation, invoice creation, and queue allocation happen in one mounted request |
-| `RW-SF-02` same-day cart create with existing queue claim reuse | `registrar_wizard.py` + `MorningAssignmentService` | `BLOCKED_BY_CLAIM_AMBIGUITY` | reuse is queue-local and not aligned to the canonical active-entry contract |
-| `RW-SF-03` same specialist with different `queue_tag` values | `registrar_wizard.py` + `MorningAssignmentService` | `BLOCKED_BY_CLAIM_AMBIGUITY` | one visit can expand into multiple queue claims, so specialist-level ownership is not yet the correct migration assumption |
+| `RW-SF-01` same-day cart create with immediate queue assignment | `registrar_wizard.py` + `MorningAssignmentService` | `BLOCKED_BY_BILLING_COUPLING` | queue assignment now follows queue-tag-level claim semantics, but the mounted owner is still mixed with visit and invoice creation |
+| `RW-SF-02` same-day cart create with existing queue claim reuse | `registrar_wizard.py` + `MorningAssignmentService` | `BLOCKED_BY_BILLING_COUPLING` | duplicate-gate drift is corrected and reuse is queue-tag-level, but the mounted runtime still lives inside billing-coupled cart orchestration |
+| `RW-SF-03` same specialist with different `queue_tag` values | `registrar_wizard.py` + `MorningAssignmentService` | `BLOCKED_BY_BILLING_COUPLING` | queue-tag fan-out remains intentional wizard-family behavior; remaining blocker is still cart/invoice coupling |
 | `RW-SF-04` multi-visit cart for different specialists | `registrar_wizard.py` + `MorningAssignmentService` | `BLOCKED_BY_BILLING_COUPLING` | queue allocation still runs inside shared invoice/cart orchestration |
 | `RW-SF-05` future-day cart create | `registrar_wizard.py` | `READY_FOR_CHARACTERIZED_CORRECTION` | no immediate allocator action, but still part of the same mixed runtime family |
 | `RW-SF-06` registrar confirmation bridge | `visit_confirmation_service.py` | `READY_FOR_BOUNDARY_MIGRATION` | already clarified and migrated in its own family track; not part of this pass |
@@ -18,7 +18,6 @@ Mode: characterization-only
 
 The broader registrar wizard family is not ready for direct boundary migration.
 
-The dominant blockers are:
+The dominant blocker is now:
 
 - billing coupling inside the mounted `/registrar/cart` request
-- unresolved claim semantics caused by queue-tag expansion

--- a/docs/status/W2C_REGISTRAR_WIZARD_DUPLICATE_FIX_STATUS.md
+++ b/docs/status/W2C_REGISTRAR_WIZARD_DUPLICATE_FIX_STATUS.md
@@ -1,0 +1,65 @@
+# Wave 2C Registrar Wizard Duplicate Fix Status
+
+Date: 2026-03-08
+Status: `done`
+Mode: behavior-correction, narrow mounted scope
+
+## Files Changed
+
+- `backend/app/services/morning_assignment.py`
+- `backend/tests/characterization/test_registrar_wizard_queue_characterization.py`
+- `backend/tests/unit/test_registrar_wizard_reuse_existing_entry.py`
+- `docs/architecture/W2C_REGISTRAR_WIZARD_BEHAVIOR_CORRECTION.md`
+- `docs/status/W2C_REGISTRAR_WIZARD_DUPLICATE_FIX_STATUS.md`
+- `docs/status/W2C_REGISTRAR_WIZARD_CLASSIFICATION.md`
+- `docs/status/W2C_REGISTRAR_WIZARD_NEXT_STEP_V3.md`
+
+## Old Runtime Behavior
+
+- same-day wizard reuse was queue-local but did not explicitly use canonical
+  active statuses
+- ambiguity inside the same queue-tag claim could fall through to unsafe reuse
+  or unsafe creation paths
+
+## Corrected Behavior
+
+- wizard-family duplicate gate remains queue-tag-level
+- canonical active statuses are now used:
+  - `waiting`
+  - `called`
+  - `in_service`
+  - `diagnostics`
+- one compatible active row is reused
+- different `queue_tag` claims still allow separate rows
+- ambiguous same-claim ownership now results in safe no-allocation behavior in
+  the mounted `/registrar/cart` flow
+
+## Why Behavior Stayed Safe
+
+- numbering still delegates to the same legacy allocator path
+- `queue_time` for reused rows is preserved
+- `queue_time` for new rows is still allocated the old way
+- billing and visit creation were not refactored
+- future-day flows still skip immediate queue allocation
+
+## Test Commands
+
+- `cd backend && pytest backend/tests/characterization/test_registrar_wizard_queue_characterization.py -q -c pytest.ini`
+- `cd backend && pytest tests/unit/test_registrar_wizard_reuse_existing_entry.py -q`
+- `cd backend && pytest tests/characterization -q -c pytest.ini`
+- `cd backend && pytest tests/test_openapi_contract.py -q`
+- `cd backend && pytest -q`
+
+## Results
+
+- wizard characterization: `9 passed`
+- wizard reuse-entry unit tests: `4 passed`
+- full characterization suite: `32 passed`
+- OpenAPI contract: `10 passed`
+- full backend suite: `734 passed, 3 skipped`
+
+## Readiness Outcome
+
+- claim ambiguity is no longer the primary blocker
+- broader wizard-family is still not ready for boundary migration
+- next safe step is a boundary-readiness recheck, not migration

--- a/docs/status/W2C_REGISTRAR_WIZARD_NEXT_STEP_V3.md
+++ b/docs/status/W2C_REGISTRAR_WIZARD_NEXT_STEP_V3.md
@@ -1,0 +1,34 @@
+# Wave 2C Registrar Wizard Next Step V3
+
+Date: 2026-03-08
+Status: `narrow wizard boundary-readiness recheck`
+
+## Recommended Next Step
+
+Run a narrow readiness recheck for the mounted wizard family after the
+duplicate-gate correction.
+
+## Why This Is The Next Step
+
+- queue-tag claim ownership is now clarified
+- duplicate-gate behavior is now corrected
+- the next open question is whether the mounted `/registrar/cart` family is still
+  blocked only by billing coupling, or whether any queue-specific blocker
+  remains
+
+## Why Boundary Migration Was Not Chosen
+
+- the mounted runtime is still billing-coupled
+- direct migration would mix queue-boundary work with payment/invoice
+  orchestration risk
+
+## Why Additional Characterization Was Not Chosen
+
+- current characterization plus the new correction tests already cover the known
+  duplicate/reuse drift
+
+## Why Deferral Was Not Chosen
+
+- the family just changed in a narrow, well-tested way
+- a readiness recheck is the cleanest next decision point before touching any
+  architectural migration


### PR DESCRIPTION
## Summary
- tighten the mounted `/registrar/cart` same-day duplicate gate to use wizard-family `queue_tag` claims
- treat `waiting`, `called`, `in_service`, and `diagnostics` as canonical active statuses for mounted wizard reuse
- add characterization/unit coverage for reuse, different `queue_tag` fan-out, and ambiguity safe-failure behavior

## Contract Impact
- Canonical surface: mounted registrar wizard same-day queue assignment behavior inside `backend/app/services/morning_assignment.py`
- Request shape: unchanged existing registrar wizard/cart request flow; this PR changes duplicate-claim resolution after the visit/service data already exists
- Response shape: unchanged queue assignment payload; reused entries still return `queue_tag`, `queue_id`, `number`, `status=existing`, and newly assigned entries still return `status=assigned`
- Status codes: unchanged route-level behavior; ambiguity is handled inside the queue assignment service path rather than changing endpoint status-code contract
- Frontend consumer: existing registrar wizard/cart frontend flow; no frontend consumer code changed
- Compatibility path or alias: no route alias added; legacy queue assignment flow remains, but active duplicate detection now scopes by wizard-family `queue_tag` and active statuses
- Contract proof: `backend/tests/characterization/test_registrar_wizard_queue_characterization.py`, `tests/unit/test_registrar_wizard_reuse_existing_entry.py`, and `tests/test_openapi_contract.py`

## RBAC / Permissions
not applicable - no route guard, auth dependency, role matrix, legacy role form, or permission check changed; PR only changes queue duplicate-claim resolution under the existing mounted registrar wizard flow.

## Notification / Realtime
not applicable - no notification event, websocket channel, chat flow, read/unread state, or realtime delivery behavior changed.

## Frontend Resilience
not applicable - no frontend panel, route state, empty-state UI, partial-data UI, or secondary patient-path fallback changed.

## Scope Gate
- Allowed paths: `backend/app/services/morning_assignment.py`, targeted registrar wizard characterization/unit tests, and W2C registrar wizard behavior/status docs
- Denied paths: unrelated queue routes, frontend runtime, migrations, notification/realtime code, auth/RBAC helpers, payment/visit lifecycle code outside duplicate queue assignment behavior
- Migration/docs/test impact: no migration; targeted backend tests added/updated; W2C registrar wizard duplicate-fix docs/status artifacts updated
- Rollback note: revert the active-status duplicate-claim helper, targeted tests, and W2C registrar wizard duplicate-fix docs/status updates from this PR

## Validation
- Targeted tests or smoke run: `cd backend && pytest backend/tests/characterization/test_registrar_wizard_queue_characterization.py -q -c pytest.ini`; `cd backend && pytest tests/unit/test_registrar_wizard_reuse_existing_entry.py -q`; `cd backend && pytest tests/characterization -q -c pytest.ini`; `cd backend && pytest tests/test_openapi_contract.py -q`; `cd backend && pytest -q`
- Result: reported passed in the original PR body
- Not checked: live browser registrar wizard/cart smoke, production/staging deploy smoke, and frontend runtime behavior