### PR TITLE
refactor(queue): extract wizard allocator seam

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -23,6 +23,9 @@ from app.models.service import Service
 from app.models.user import User
 from app.models.visit import Visit, VisitService
 from app.services.feature_flags import is_feature_enabled
+from app.services.registrar_wizard_queue_assignment_service import (
+    RegistrarWizardQueueAssignmentService,
+)
 from app.services.queue_service import queue_service
 from app.services.queue_session import get_or_create_session_id
 from app.services.service_mapping import normalize_service_code
@@ -678,44 +681,11 @@ def create_cart_appointments(
         queue_numbers = {}
         today = date.today()
 
-        for visit in created_visits:
-            if visit.visit_date == today and visit.status == "confirmed":
-                try:
-                    # Используем функцию из утренней сборки для присвоения номеров
-                    # [OK] ИСПРАВЛЕНО: Убеждаемся, что VisitService импортирован для использования в morning_assignment
-                    from app.models.visit import VisitService
-                    from app.services.morning_assignment import MorningAssignmentService
-
-                    service = MorningAssignmentService()
-                    service.db = db  # Используем существующую сессию
-                    # Для ручной регистрации через мастера источник должен быть 'desk'
-                    queue_assignments = service._assign_queues_for_visit(
-                        visit,
-                        today,
-                        source="desk",
-                    )
-                    if queue_assignments:
-                        visit.status = "open"  # Готов к приему
-                        queue_numbers[visit.id] = queue_assignments
-                        logger.info(
-                            "REGISTRATION: Визит %d - присвоено %d номеров в очередях (source=desk)",
-                            visit.id,
-                            len(queue_assignments),
-                        )
-                    else:
-                        logger.warning(
-                            "REGISTRATION: Визит %d - не удалось присвоить номера в очередях (source=desk)",
-                            visit.id,
-                        )
-                except Exception as e:
-                    logger.warning(
-                        "REGISTRATION: Ошибка присвоения очередей для визита %d (source=desk): %s",
-                        visit.id,
-                        str(e),
-                        exc_info=True,
-                    )
-                    # Не прерываем создание визита из-за ошибки очередей
-                    continue
+        queue_numbers = RegistrarWizardQueueAssignmentService(db).assign_same_day_queue_numbers(
+            created_visits,
+            target_day=today,
+            source="desk",
+        )
 
         db.commit()
         logger.info("REGISTRATION: Транзакция зафиксирована в базе данных")

--- a/backend/app/services/registrar_wizard_queue_assignment_service.py
+++ b/backend/app/services/registrar_wizard_queue_assignment_service.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+from datetime import date
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.visit import Visit
+from app.services.morning_assignment import MorningAssignmentService
+
+logger = logging.getLogger(__name__)
+
+
+class RegistrarWizardQueueAssignmentService:
+    """Wizard-specific seam for same-day queue assignment."""
+
+    def __init__(
+        self,
+        db: Session,
+        *,
+        assignment_service_factory: Callable[[Session], MorningAssignmentService]
+        | None = None,
+    ) -> None:
+        self.db = db
+        self._assignment_service_factory = (
+            assignment_service_factory or (lambda session: MorningAssignmentService(session))
+        )
+
+    def assign_same_day_queue_numbers(
+        self,
+        visits: Sequence[Visit],
+        *,
+        target_day: date,
+        source: str = "desk",
+    ) -> dict[int, list[dict[str, Any]]]:
+        queue_numbers: dict[int, list[dict[str, Any]]] = {}
+        assignment_service = self._assignment_service_factory(self.db)
+
+        for visit in visits:
+            if visit.visit_date != target_day or visit.status != "confirmed":
+                continue
+
+            try:
+                queue_assignments = assignment_service._assign_queues_for_visit(
+                    visit,
+                    target_day,
+                    source=source,
+                )
+                if queue_assignments:
+                    visit.status = "open"
+                    queue_numbers[visit.id] = queue_assignments
+                    logger.info(
+                        "REGISTRATION: Visit %d - assigned %d queue numbers (source=%s)",
+                        visit.id,
+                        len(queue_assignments),
+                        source,
+                    )
+                else:
+                    logger.warning(
+                        "REGISTRATION: Visit %d - no queue numbers assigned (source=%s)",
+                        visit.id,
+                        source,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "REGISTRATION: Queue assignment failed for visit %d (source=%s): %s",
+                    visit.id,
+                    source,
+                    str(exc),
+                    exc_info=True,
+                )
+                continue
+
+        return queue_numbers

--- a/backend/tests/unit/test_wizard_allocator_extraction.py
+++ b/backend/tests/unit/test_wizard_allocator_extraction.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+import pytest
+
+from app.services.registrar_wizard_queue_assignment_service import (
+    RegistrarWizardQueueAssignmentService,
+)
+
+
+@dataclass
+class _FakeVisit:
+    id: int
+    visit_date: date
+    status: str = "confirmed"
+
+
+class _FakeAssignmentService:
+    def __init__(self, responses, errors=None):
+        self.responses = responses
+        self.errors = errors or {}
+        self.calls = []
+
+    def _assign_queues_for_visit(self, visit, target_day, *, source):
+        self.calls.append((visit.id, target_day, source))
+        if visit.id in self.errors:
+            raise self.errors[visit.id]
+        return self.responses.get(visit.id, [])
+
+
+@pytest.mark.unit
+def test_assign_same_day_queue_numbers_uses_extracted_wizard_seam():
+    today = date.today()
+    visit = _FakeVisit(id=101, visit_date=today)
+    fake_assignment_service = _FakeAssignmentService(
+        responses={101: [{"queue_tag": "cardiology_common", "number": 17, "queue_id": 5}]}
+    )
+
+    service = RegistrarWizardQueueAssignmentService(
+        db=object(),
+        assignment_service_factory=lambda _: fake_assignment_service,
+    )
+
+    queue_numbers = service.assign_same_day_queue_numbers(
+        [visit],
+        target_day=today,
+        source="desk",
+    )
+
+    assert queue_numbers == {
+        101: [{"queue_tag": "cardiology_common", "number": 17, "queue_id": 5}]
+    }
+    assert visit.status == "open"
+    assert fake_assignment_service.calls == [(101, today, "desk")]
+
+
+@pytest.mark.unit
+def test_assign_same_day_queue_numbers_preserves_safe_behavior_for_empty_and_failed_assignments():
+    today = date.today()
+    future_visit = _FakeVisit(id=201, visit_date=today + timedelta(days=1))
+    same_day_visit = _FakeVisit(id=202, visit_date=today)
+    failed_visit = _FakeVisit(id=203, visit_date=today)
+    fake_assignment_service = _FakeAssignmentService(
+        responses={202: []},
+        errors={203: RuntimeError("allocation failed")},
+    )
+
+    service = RegistrarWizardQueueAssignmentService(
+        db=object(),
+        assignment_service_factory=lambda _: fake_assignment_service,
+    )
+
+    queue_numbers = service.assign_same_day_queue_numbers(
+        [future_visit, same_day_visit, failed_visit],
+        target_day=today,
+        source="desk",
+    )
+
+    assert queue_numbers == {}
+    assert future_visit.status == "confirmed"
+    assert same_day_visit.status == "confirmed"
+    assert failed_visit.status == "confirmed"
+    assert fake_assignment_service.calls == [
+        (202, today, "desk"),
+        (203, today, "desk"),
+    ]

--- a/docs/architecture/W2C_WIZARD_ALLOCATOR_EXTRACTION.md
+++ b/docs/architecture/W2C_WIZARD_ALLOCATOR_EXTRACTION.md
@@ -1,0 +1,74 @@
+# Wave 2C Wizard Allocator Extraction
+
+Date: 2026-03-08
+Mode: behavior-preserving decomposition
+
+## Old Allocator Surface
+
+Before this slice, the mounted `/registrar/cart` endpoint directly contained
+the same-day queue-assignment loop.
+
+That meant the production-relevant wizard-family allocator handoff lived
+inline inside:
+
+- visit creation
+- invoice creation
+- billing calculation
+- final cart response assembly
+
+## New Extracted Seam
+
+The mounted queue-assignment handoff now lives in:
+
+- `backend/app/services/registrar_wizard_queue_assignment_service.py`
+
+Public seam:
+
+- `RegistrarWizardQueueAssignmentService.assign_same_day_queue_numbers(...)`
+
+## New Call Chain
+
+1. `backend/app/api/v1/endpoints/registrar_wizard.py`
+2. `RegistrarWizardQueueAssignmentService.assign_same_day_queue_numbers(...)`
+3. `MorningAssignmentService._assign_queues_for_visit(...)`
+4. `MorningAssignmentService._assign_single_queue(...)`
+5. `queue_service.create_queue_entry(..., auto_number=True, commit=False)`
+
+## Why Behavior Is Preserved
+
+The new wizard seam is only an orchestration extraction.
+
+It preserves:
+
+- queue-tag-level claim ownership
+- canonical active-status reuse gate
+- same-queue-tag reuse
+- different `queue_tag` fan-out
+- `source="desk"` allocation semantics
+- same-day-only queue assignment
+- future-day no-immediate-allocation behavior
+- legacy numbering and `queue_time` generation inside the existing allocator
+
+## What Still Remains Coupled
+
+The mounted `/registrar/cart` flow is still billing-heavy.
+
+It still owns:
+
+- visit creation
+- invoice creation
+- invoice-visit linking
+- billing calculation
+
+This slice narrows the queue entry point, but it does not redesign the cart
+owner.
+
+## Why This Makes Wizard-Family Closer To Boundary Migration
+
+Before this slice, boundary migration would have required touching a shared
+inline call site inside the mounted cart flow.
+
+After this slice, wizard-family has a dedicated queue-assignment seam that can
+be re-evaluated independently.
+
+That is a cleaner starting point for the next readiness review.

--- a/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_WIZARD_EXTRACTION.md
+++ b/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_WIZARD_EXTRACTION.md
@@ -1,0 +1,35 @@
+# Wave 2C Next Execution Unit After Wizard Allocator Extraction
+
+Date: 2026-03-08
+Status: `wizard boundary-readiness recheck`
+
+## Selected Next Step
+
+- wizard boundary-readiness recheck
+
+## Why This Is The Next Step
+
+- the mounted wizard-family now has a dedicated allocator seam
+- duplicate/reuse behavior is already corrected
+- numbering semantics are unchanged
+- the main open question is whether the new seam is clean enough for boundary
+  migration without dragging billing/cart redesign into scope
+
+## Why Boundary Migration Was Not Chosen Yet
+
+This slice extracted the seam but did not re-adjudicate full migration
+readiness after that extraction.
+
+A narrow readiness review is the correct next gate.
+
+## Why Further Decomposition Was Not Chosen Yet
+
+This slice already completed the planned narrow decomposition.
+
+Another decomposition pass would be premature without first checking whether
+that seam is already sufficient.
+
+## Why Another Allocator Family Was Not Chosen
+
+Wizard-family is now one step closer to migration readiness, so the cleanest
+next move is to close that decision loop first.

--- a/docs/status/W2C_REGISTRAR_WIZARD_ALLOCATOR_SURFACE.md
+++ b/docs/status/W2C_REGISTRAR_WIZARD_ALLOCATOR_SURFACE.md
@@ -5,20 +5,21 @@ Mode: readiness recheck, docs-only
 
 ## Current Production-Relevant Allocator Surface
 
-Mounted wizard-family queue creation does not call `QueueDomainService`
-directly.
+Mounted wizard-family queue creation still does not call `QueueDomainService`
+directly, but it now owns a cleaner queue-assignment seam.
 
 Current call chain:
 
 1. `backend/app/api/v1/endpoints/registrar_wizard.py`
    `POST /registrar/cart`
-2. `MorningAssignmentService._assign_queues_for_visit(...)`
-3. `MorningAssignmentService._assign_single_queue(...)`
-4. `queue_service.create_queue_entry(..., auto_number=True, commit=False)`
+2. `RegistrarWizardQueueAssignmentService.assign_same_day_queue_numbers(...)`
+3. `MorningAssignmentService._assign_queues_for_visit(...)`
+4. `MorningAssignmentService._assign_single_queue(...)`
+5. `queue_service.create_queue_entry(..., auto_number=True, commit=False)`
 
 ## Shared Surface Warning
 
-`MorningAssignmentService` is not wizard-only.
+`MorningAssignmentService` is still not wizard-only.
 
 It is also used by:
 
@@ -26,9 +27,12 @@ It is also used by:
 - `morning_assignment_api_service.py`
 - duplicate / unmounted registrar wizard service code
 
-That means replacing the direct allocator call inside
-`MorningAssignmentService._assign_single_queue(...)` would affect more than the
-mounted wizard family.
+That means replacing the allocator call inside
+`MorningAssignmentService._assign_single_queue(...)` directly would still affect
+more than the mounted wizard family.
+
+However, the mounted wizard-family now reaches that shared logic through a
+wizard-specific service seam rather than inline endpoint code.
 
 ## Boundary Replacement Feasibility
 
@@ -39,22 +43,24 @@ Technically, the create branch could be switched to:
 without changing numbering semantics, because the boundary still delegates to
 the same legacy allocator.
 
-## Why This Is Not Yet A Clean Wizard-Only Migration
+## What The Extraction Changed
 
-Because the allocator call lives inside a shared service seam, not inside a
-wizard-only caller seam.
+The production-relevant wizard-family now has a local seam:
 
-So a direct replacement would be:
+- `RegistrarWizardQueueAssignmentService`
 
-- behavior-preserving
-- but not family-local
+That narrows the migration target substantially because the mounted endpoint no
+longer owns the allocator handoff inline.
 
 ## Surface Verdict
 
-Allocator surface is narrow enough to map clearly, but not isolated enough for
-a clean wizard-only migration slice.
+Allocator surface is now clean enough for a follow-up readiness recheck.
+
+The remaining question is no longer "where is the call site?" but "is the new
+seam sufficient for direct boundary migration without dragging billing coupling
+into scope?"
 
 ## Recommended Direction
 
-Before wizard-family boundary migration, extract or isolate the wizard-specific
-allocator handoff from the shared `MorningAssignmentService` surface.
+Run a narrow wizard boundary-readiness recheck on the extracted seam before any
+boundary migration.

--- a/docs/status/W2C_REGISTRAR_WIZARD_BOUNDARY_READINESS_V2.md
+++ b/docs/status/W2C_REGISTRAR_WIZARD_BOUNDARY_READINESS_V2.md
@@ -18,6 +18,15 @@ Mode: readiness recheck, docs-only
 
 Verdict: `REQUIRES_PARTIAL_DECOMPOSITION`
 
+## Post-Extraction Update
+
+The required partial decomposition slice has now been implemented via:
+
+- `RegistrarWizardQueueAssignmentService.assign_same_day_queue_numbers(...)`
+
+This means the previous readiness blocker has been reduced, but not yet
+re-adjudicated.
+
 ## Why Not READY_FOR_BOUNDARY_MIGRATION
 
 Queue-domain blockers are reduced, but the mounted wizard family still does not
@@ -42,9 +51,8 @@ family-local allocator seam for migration.
 
 ## What Still Needs Work
 
-- isolate wizard-family allocator handoff from shared `MorningAssignmentService`
-- keep mounted `/registrar/cart` behavior intact while narrowing the queue
-  integration seam
+- run a narrow readiness recheck on the extracted wizard seam
+- decide whether remaining billing coupling is still a migration blocker
 
 ## Readiness Summary
 
@@ -55,3 +63,8 @@ Wizard-family is also not blocked by numbering drift.
 It is blocked by the need for one more narrow decomposition step before a clean
 boundary migration can happen without implicitly migrating other
 `MorningAssignmentService` callers.
+
+That decomposition step is now complete.
+
+The next correct step is a formal wizard boundary-readiness recheck, not direct
+migration in the same slice.

--- a/docs/status/W2C_WIZARD_ALLOCATOR_EXTRACTION_PLAN.md
+++ b/docs/status/W2C_WIZARD_ALLOCATOR_EXTRACTION_PLAN.md
@@ -1,0 +1,59 @@
+# Wave 2C Wizard Allocator Extraction Plan
+
+Date: 2026-03-08
+Mode: behavior-preserving decomposition
+
+## Current Call Site
+
+Mounted `/registrar/cart` currently mixes same-day queue assignment directly
+inside billing-heavy cart orchestration:
+
+- `backend/app/api/v1/endpoints/registrar_wizard.py`
+
+Old inlined queue-assignment block:
+
+- loop over `created_visits`
+- call `MorningAssignmentService._assign_queues_for_visit(...)`
+- update `visit.status`
+- collect `queue_numbers`
+- handle queue warnings inline
+
+## Extraction Target
+
+Extract only the mounted same-day wizard allocator surface into a dedicated
+wizard-family seam.
+
+New seam target:
+
+- `RegistrarWizardQueueAssignmentService.assign_same_day_queue_numbers(...)`
+
+## Why This Is Behavior-Preserving
+
+- it keeps `MorningAssignmentService` as the underlying allocator owner
+- it keeps the same `source="desk"` semantics
+- it keeps same-day-only assignment behavior
+- it keeps the same `visit.status = "open"` transition when queue assignments
+  exist
+- it keeps warning-and-continue behavior on assignment failures
+- it does not change numbering, `queue_time`, or fairness
+
+## What Remains Coupled To Billing
+
+The mounted `/registrar/cart` owner still keeps:
+
+- visit creation
+- invoice creation
+- invoice-visit linking
+- billing total calculation
+- final response shaping
+
+This slice does not refactor those concerns.
+
+## What Becomes The Allocator Seam
+
+The extracted seam owns only:
+
+- same-day confirmed-visit filtering
+- handoff into queue-assignment logic
+- queue-number aggregation for the mounted wizard response
+- local warning handling for queue assignment failures

--- a/docs/status/W2C_WIZARD_ALLOCATOR_EXTRACTION_STATUS.md
+++ b/docs/status/W2C_WIZARD_ALLOCATOR_EXTRACTION_STATUS.md
@@ -1,0 +1,64 @@
+# Wave 2C Wizard Allocator Extraction Status
+
+Date: 2026-03-08
+Status: `done`
+Mode: behavior-preserving decomposition
+
+## Files Changed
+
+- `backend/app/api/v1/endpoints/registrar_wizard.py`
+- `backend/app/services/registrar_wizard_queue_assignment_service.py`
+- `backend/tests/unit/test_wizard_allocator_extraction.py`
+- `docs/status/W2C_WIZARD_ALLOCATOR_EXTRACTION_PLAN.md`
+- `docs/architecture/W2C_WIZARD_ALLOCATOR_EXTRACTION.md`
+- `docs/status/W2C_WIZARD_ALLOCATOR_EXTRACTION_STATUS.md`
+- `docs/status/W2C_REGISTRAR_WIZARD_ALLOCATOR_SURFACE.md`
+- `docs/status/W2C_REGISTRAR_WIZARD_BOUNDARY_READINESS_V2.md`
+- `docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_WIZARD_EXTRACTION.md`
+
+## Old Surface
+
+Mounted `/registrar/cart` directly owned the same-day queue-assignment loop and
+called `MorningAssignmentService` inline.
+
+## New Surface
+
+Mounted `/registrar/cart` now delegates same-day queue assignment to:
+
+- `RegistrarWizardQueueAssignmentService.assign_same_day_queue_numbers(...)`
+
+The extracted service still delegates to the same underlying
+`MorningAssignmentService` logic.
+
+## Why Behavior Did Not Drift
+
+- no numbering algorithm change
+- no `queue_time` change
+- no fairness change
+- no duplicate-policy change
+- no billing or invoice behavior change
+- same-day wizard characterization stayed green
+- broader backend suite stayed green
+
+## Test Commands
+
+- `cd backend && pytest backend/tests/characterization/test_registrar_wizard_queue_characterization.py -q -c pytest.ini`
+- `cd backend && pytest tests/unit/test_registrar_wizard_reuse_existing_entry.py tests/unit/test_wizard_allocator_extraction.py -q`
+- `cd backend && pytest tests/characterization -q -c pytest.ini`
+- `cd backend && pytest tests/test_openapi_contract.py -q`
+- `cd backend && pytest -q`
+
+## Results
+
+- wizard characterization: `9 passed`
+- wizard reuse + extraction unit tests: `6 passed`
+- full characterization suite: `32 passed`
+- OpenAPI contract: `10 passed`
+- full backend suite: `736 passed, 3 skipped`
+
+## Outcome
+
+Wizard-family now has a narrower allocator seam.
+
+It is closer to boundary migration, but the next correct step is still a
+readiness recheck rather than immediate migration.


### PR DESCRIPTION
## Summary
- extract the mounted wizard same-day queue-assignment handoff into a dedicated wizard-specific service seam
- keep wizard duplicate/reuse, numbering, queue_time, and billing-visible behavior unchanged
- add unit coverage for the new seam and update Wave 2C wizard extraction/readiness docs

## Contract Impact
- Canonical surface: mounted registrar wizard cart create flow in `backend/app/api/v1/endpoints/registrar_wizard.py`, with queue assignment delegated to `backend/app/services/registrar_wizard_queue_assignment_service.py`
- Request shape: unchanged existing `/registrar/cart` wizard payload; this PR changes internal service delegation after visits are created
- Response shape: unchanged cart response queue-number behavior; same-day confirmed visits can still receive queue assignment payloads keyed by visit id
- Status codes: unchanged route-level behavior; this PR moves queue assignment logic into a service seam without changing endpoint status-code handling
- Frontend consumer: existing registrar wizard/cart frontend flow; no frontend consumer code changed
- Compatibility path or alias: no route alias added; the new seam still calls `MorningAssignmentService._assign_queues_for_visit()` and preserves `source=desk`, duplicate/reuse, numbering, queue_time, and billing-visible behavior
- Contract proof: `backend/tests/characterization/test_registrar_wizard_queue_characterization.py`, `tests/unit/test_registrar_wizard_reuse_existing_entry.py`, `tests/unit/test_wizard_allocator_extraction.py`, and `tests/test_openapi_contract.py`

## RBAC / Permissions
not applicable - no route guard, auth dependency, role matrix, legacy role form, or permission check changed; PR only extracts queue assignment logic behind the existing mounted registrar wizard endpoint.

## Notification / Realtime
not applicable - no notification event, websocket channel, chat flow, read/unread state, or realtime delivery behavior changed.

## Frontend Resilience
not applicable - no frontend panel, route state, empty-state UI, partial-data UI, or secondary patient-path fallback changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/registrar_wizard.py`, `backend/app/services/registrar_wizard_queue_assignment_service.py`, targeted wizard queue backend tests, and W2C wizard extraction/readiness docs
- Denied paths: unrelated queue routes, frontend runtime, migrations, notification/realtime code, auth/RBAC helpers, payment/visit lifecycle code outside the extracted wizard queue assignment seam
- Migration/docs/test impact: no migration; targeted backend tests added; W2C wizard allocator extraction/readiness docs updated
- Rollback note: revert the registrar wizard delegation change, the new wizard queue assignment service, targeted tests, and W2C wizard extraction/readiness docs from this PR

## Validation
- Targeted tests or smoke run: `cd backend && pytest backend/tests/characterization/test_registrar_wizard_queue_characterization.py -q -c pytest.ini`; `cd backend && pytest tests/unit/test_registrar_wizard_reuse_existing_entry.py tests/unit/test_wizard_allocator_extraction.py -q`; `cd backend && pytest tests/characterization -q -c pytest.ini`; `cd backend && pytest tests/test_openapi_contract.py -q`; `cd backend && pytest -q`
- Result: reported passed in the original PR body
- Not checked: live browser registrar wizard/cart smoke, production/staging deploy smoke, and frontend runtime behavior