### PR TITLE
Wave 2C: extract wizard create-branch handoff

### DIFF
--- a/backend/app/services/morning_assignment.py
+++ b/backend/app/services/morning_assignment.py
@@ -4,7 +4,9 @@
 """
 
 import logging
+from dataclasses import dataclass
 from datetime import date, datetime
+from typing import Any
 
 from sqlalchemy import and_
 from sqlalchemy.orm import Session
@@ -30,6 +32,29 @@ WIZARD_DUPLICATE_ACTIVE_STATUSES = (
 
 class MorningAssignmentClaimError(ValueError):
     """Raised when a wizard-family queue claim cannot be resolved safely."""
+
+
+@dataclass(frozen=True)
+class MorningAssignmentCreateBranchHandoff:
+    """Wizard-local handoff for the create-entry branch."""
+
+    queue_tag: str
+    daily_queue: DailyQueue
+    create_entry_kwargs: dict[str, Any]
+
+    def build_assigned_payload(self, *, number: int) -> dict[str, Any]:
+        return {
+            "queue_tag": self.queue_tag,
+            "queue_id": self.daily_queue.id,
+            "number": number,
+            "status": "assigned",
+        }
+
+
+@dataclass(frozen=True)
+class MorningAssignmentPreparedQueueAssignment:
+    assignment: dict[str, Any] | None = None
+    create_handoff: MorningAssignmentCreateBranchHandoff | None = None
 
 
 class MorningAssignmentService:
@@ -349,6 +374,44 @@ class MorningAssignmentService:
     ) -> dict[str, any] | None:
         """Присваивает номер в конкретной очереди"""
 
+        prepared_assignment = self.prepare_wizard_queue_assignment(
+            visit,
+            queue_tag,
+            target_date,
+            source=source,
+        )
+        if prepared_assignment is None:
+            return None
+
+        if prepared_assignment.assignment is not None:
+            return prepared_assignment.assignment
+
+        create_handoff = prepared_assignment.create_handoff
+        if create_handoff is None:
+            return None
+
+        queue_entry = queue_service.create_queue_entry(
+            self.db,
+            **create_handoff.create_entry_kwargs,
+        )
+
+        service_codes_for_entry = create_handoff.create_entry_kwargs.get("service_codes", [])
+        logger.info(
+            f"Присвоен номер {queue_entry.number} в очереди {queue_tag} для пациента {visit.patient_id} (через SSOT), услуги: {service_codes_for_entry}"
+        )
+
+        return create_handoff.build_assigned_payload(number=queue_entry.number)
+
+    def prepare_wizard_queue_assignment(
+        self,
+        visit: Visit,
+        queue_tag: str,
+        target_date: date,
+        *,
+        source: str = "morning_assignment",
+    ) -> MorningAssignmentPreparedQueueAssignment | None:
+        """Resolve wizard queue claim and expose create-branch handoff."""
+
         # Определяем врача для очереди
         doctor_id = visit.doctor_id
         doctor = None
@@ -460,13 +523,32 @@ class MorningAssignmentService:
 
         if existing_entry:
             logger.info(f"Пациент {visit.patient_id} уже есть в очереди {queue_tag}")
-            return {
-                "queue_tag": queue_tag,
-                "queue_id": daily_queue.id,
-                "number": existing_entry.number,
-                "status": "existing",
-            }
+            return MorningAssignmentPreparedQueueAssignment(
+                assignment={
+                    "queue_tag": queue_tag,
+                    "queue_id": daily_queue.id,
+                    "number": existing_entry.number,
+                    "status": "existing",
+                }
+            )
 
+        return MorningAssignmentPreparedQueueAssignment(
+            create_handoff=self._build_create_branch_handoff(
+                visit,
+                queue_tag,
+                daily_queue,
+                source=source,
+            )
+        )
+
+    def _build_create_branch_handoff(
+        self,
+        visit: Visit,
+        queue_tag: str,
+        daily_queue: DailyQueue,
+        *,
+        source: str,
+    ) -> MorningAssignmentCreateBranchHandoff:
         # ✅ ИСПРАВЛЕНО: Используем SSOT queue_service для создания записи
         # Получаем информацию о пациенте для передачи в create_queue_entry
         patient = self.db.query(Patient).filter(Patient.id == visit.patient_id).first()
@@ -527,33 +609,24 @@ class MorningAssignmentService:
                             "price": float(vs.price) if vs.price else 0,
                         })
 
-        # ✅ ИСПРАВЛЕНО: Используем SSOT метод для создания записи С услугами
-        queue_entry = queue_service.create_queue_entry(
-            self.db,
+        return MorningAssignmentCreateBranchHandoff(
+            queue_tag=queue_tag,
             daily_queue=daily_queue,
-            patient_id=visit.patient_id,
-            patient_name=patient_name,
-            phone=phone,
-            visit_id=visit.id,
-            source=source,  # Источник: зависит от сценария (desk / morning_assignment / confirmation)
-            status="waiting",
-            queue_time=queue_time,  # Бизнес-время регистрации
-            services=services_for_entry,  # ⭐ ДОБАВЛЕНО: услуги с кодами
-            service_codes=service_codes_for_entry,  # ⭐ ДОБАВЛЕНО: коды услуг
-            auto_number=True,  # Автоматически присваиваем номер
-            commit=False,  # Не коммитим сразу, коммит будет в run_morning_assignment
+            create_entry_kwargs={
+                "daily_queue": daily_queue,
+                "patient_id": visit.patient_id,
+                "patient_name": patient_name,
+                "phone": phone,
+                "visit_id": visit.id,
+                "source": source,
+                "status": "waiting",
+                "queue_time": queue_time,
+                "services": services_for_entry,
+                "service_codes": service_codes_for_entry,
+                "auto_number": True,
+                "commit": False,
+            },
         )
-
-        logger.info(
-            f"Присвоен номер {queue_entry.number} в очереди {queue_tag} для пациента {visit.patient_id} (через SSOT), услуги: {service_codes_for_entry}"
-        )
-
-        return {
-            "queue_tag": queue_tag,
-            "queue_id": daily_queue.id,
-            "number": queue_entry.number,
-            "status": "assigned",
-        }
 
     def _resolve_existing_queue_claim_or_raise(
         self,

--- a/backend/app/services/registrar_wizard_queue_assignment_service.py
+++ b/backend/app/services/registrar_wizard_queue_assignment_service.py
@@ -8,7 +8,12 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from app.models.visit import Visit
-from app.services.morning_assignment import MorningAssignmentService
+from app.services.morning_assignment import (
+    MorningAssignmentCreateBranchHandoff,
+    MorningAssignmentPreparedQueueAssignment,
+    MorningAssignmentService,
+)
+from app.services.queue_service import queue_service
 
 logger = logging.getLogger(__name__)
 
@@ -22,10 +27,18 @@ class RegistrarWizardQueueAssignmentService:
         *,
         assignment_service_factory: Callable[[Session], MorningAssignmentService]
         | None = None,
+        create_entry_allocator: Callable[
+            [MorningAssignmentCreateBranchHandoff],
+            Any,
+        ]
+        | None = None,
     ) -> None:
         self.db = db
         self._assignment_service_factory = (
             assignment_service_factory or (lambda session: MorningAssignmentService(session))
+        )
+        self._create_entry_allocator = (
+            create_entry_allocator or self._allocate_create_branch_handoff
         )
 
     def assign_same_day_queue_numbers(
@@ -43,7 +56,8 @@ class RegistrarWizardQueueAssignmentService:
                 continue
 
             try:
-                queue_assignments = assignment_service._assign_queues_for_visit(
+                queue_assignments = self._assign_same_day_queues_for_visit(
+                    assignment_service,
                     visit,
                     target_day,
                     source=source,
@@ -74,3 +88,76 @@ class RegistrarWizardQueueAssignmentService:
                 continue
 
         return queue_numbers
+
+    def _assign_same_day_queues_for_visit(
+        self,
+        assignment_service: MorningAssignmentService,
+        visit: Visit,
+        target_day: date,
+        *,
+        source: str,
+    ) -> list[dict[str, Any]]:
+        unique_queue_tags = assignment_service._get_visit_queue_tags(visit)
+        if not unique_queue_tags:
+            logger.warning("Визит %d: нет queue_tag в услугах", visit.id)
+            return []
+
+        queue_assignments: list[dict[str, Any]] = []
+        for queue_tag in unique_queue_tags:
+            try:
+                prepared_assignment = assignment_service.prepare_wizard_queue_assignment(
+                    visit,
+                    queue_tag,
+                    target_day,
+                    source=source,
+                )
+                assignment = self._materialize_prepared_assignment(prepared_assignment)
+                if assignment:
+                    queue_assignments.append(assignment)
+            except Exception as exc:
+                logger.error(
+                    "Ошибка присвоения очереди %s для визита %d: %s",
+                    queue_tag,
+                    visit.id,
+                    str(exc),
+                    exc_info=True,
+                )
+                self._rollback_session()
+
+        return queue_assignments
+
+    def _materialize_prepared_assignment(
+        self,
+        prepared_assignment: MorningAssignmentPreparedQueueAssignment | None,
+    ) -> dict[str, Any] | None:
+        if prepared_assignment is None:
+            return None
+
+        if prepared_assignment.assignment is not None:
+            return prepared_assignment.assignment
+
+        create_handoff = prepared_assignment.create_handoff
+        if create_handoff is None:
+            return None
+
+        queue_entry = self._create_entry_allocator(create_handoff)
+        return create_handoff.build_assigned_payload(number=queue_entry.number)
+
+    def _allocate_create_branch_handoff(
+        self,
+        handoff: MorningAssignmentCreateBranchHandoff,
+    ) -> Any:
+        return queue_service.create_queue_entry(
+            self.db,
+            **handoff.create_entry_kwargs,
+        )
+
+    def _rollback_session(self) -> None:
+        rollback = getattr(self.db, "rollback", None)
+        if not callable(rollback):
+            return
+
+        try:
+            rollback()
+        except Exception as rollback_error:
+            logger.error("Ошибка при rollback wizard queue assignment: %s", rollback_error)

--- a/backend/tests/unit/test_wizard_allocator_extraction.py
+++ b/backend/tests/unit/test_wizard_allocator_extraction.py
@@ -5,6 +5,7 @@ from datetime import date, timedelta
 
 import pytest
 
+from app.services.morning_assignment import MorningAssignmentPreparedQueueAssignment
 from app.services.registrar_wizard_queue_assignment_service import (
     RegistrarWizardQueueAssignmentService,
 )
@@ -18,16 +19,21 @@ class _FakeVisit:
 
 
 class _FakeAssignmentService:
-    def __init__(self, responses, errors=None):
-        self.responses = responses
+    def __init__(self, queue_tags, prepared_assignments, errors=None):
+        self.queue_tags = queue_tags
+        self.prepared_assignments = prepared_assignments
         self.errors = errors or {}
         self.calls = []
 
-    def _assign_queues_for_visit(self, visit, target_day, *, source):
-        self.calls.append((visit.id, target_day, source))
-        if visit.id in self.errors:
-            raise self.errors[visit.id]
-        return self.responses.get(visit.id, [])
+    def _get_visit_queue_tags(self, visit):
+        return self.queue_tags.get(visit.id, set())
+
+    def prepare_wizard_queue_assignment(self, visit, queue_tag, target_day, *, source):
+        self.calls.append((visit.id, queue_tag, target_day, source))
+        key = (visit.id, queue_tag)
+        if key in self.errors:
+            raise self.errors[key]
+        return self.prepared_assignments.get(key)
 
 
 @pytest.mark.unit
@@ -35,7 +41,12 @@ def test_assign_same_day_queue_numbers_uses_extracted_wizard_seam():
     today = date.today()
     visit = _FakeVisit(id=101, visit_date=today)
     fake_assignment_service = _FakeAssignmentService(
-        responses={101: [{"queue_tag": "cardiology_common", "number": 17, "queue_id": 5}]}
+        queue_tags={101: {"cardiology_common"}},
+        prepared_assignments={
+            (101, "cardiology_common"): MorningAssignmentPreparedQueueAssignment(
+                assignment={"queue_tag": "cardiology_common", "number": 17, "queue_id": 5}
+            )
+        },
     )
 
     service = RegistrarWizardQueueAssignmentService(
@@ -53,7 +64,7 @@ def test_assign_same_day_queue_numbers_uses_extracted_wizard_seam():
         101: [{"queue_tag": "cardiology_common", "number": 17, "queue_id": 5}]
     }
     assert visit.status == "open"
-    assert fake_assignment_service.calls == [(101, today, "desk")]
+    assert fake_assignment_service.calls == [(101, "cardiology_common", today, "desk")]
 
 
 @pytest.mark.unit
@@ -63,8 +74,9 @@ def test_assign_same_day_queue_numbers_preserves_safe_behavior_for_empty_and_fai
     same_day_visit = _FakeVisit(id=202, visit_date=today)
     failed_visit = _FakeVisit(id=203, visit_date=today)
     fake_assignment_service = _FakeAssignmentService(
-        responses={202: []},
-        errors={203: RuntimeError("allocation failed")},
+        queue_tags={202: {"cardiology_common"}, 203: {"cardiology_common"}},
+        prepared_assignments={},
+        errors={(203, "cardiology_common"): RuntimeError("allocation failed")},
     )
 
     service = RegistrarWizardQueueAssignmentService(
@@ -83,6 +95,6 @@ def test_assign_same_day_queue_numbers_preserves_safe_behavior_for_empty_and_fai
     assert same_day_visit.status == "confirmed"
     assert failed_visit.status == "confirmed"
     assert fake_assignment_service.calls == [
-        (202, today, "desk"),
-        (203, today, "desk"),
+        (202, "cardiology_common", today, "desk"),
+        (203, "cardiology_common", today, "desk"),
     ]

--- a/backend/tests/unit/test_wizard_create_branch_extraction.py
+++ b/backend/tests/unit/test_wizard_create_branch_extraction.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.morning_assignment import (
+    MorningAssignmentCreateBranchHandoff,
+    MorningAssignmentPreparedQueueAssignment,
+)
+from app.services.registrar_wizard_queue_assignment_service import (
+    RegistrarWizardQueueAssignmentService,
+)
+
+
+class _FakeVisit:
+    def __init__(self, *, visit_id: int, visit_date: date, status: str = "confirmed") -> None:
+        self.id = visit_id
+        self.visit_date = visit_date
+        self.status = status
+
+
+class _FakeAssignmentService:
+    def __init__(self, prepared_assignments):
+        self.prepared_assignments = prepared_assignments
+        self.calls = []
+
+    def _get_visit_queue_tags(self, visit):
+        return {"cardiology_common"}
+
+    def prepare_wizard_queue_assignment(self, visit, queue_tag, target_day, *, source):
+        self.calls.append((visit.id, queue_tag, target_day, source))
+        return self.prepared_assignments[(visit.id, queue_tag)]
+
+
+@pytest.mark.unit
+def test_assign_same_day_queue_numbers_uses_explicit_create_branch_handoff():
+    today = date.today()
+    visit = _FakeVisit(visit_id=301, visit_date=today)
+    create_handoff = MorningAssignmentCreateBranchHandoff(
+        queue_tag="cardiology_common",
+        daily_queue=SimpleNamespace(id=9),
+        create_entry_kwargs={
+            "daily_queue": SimpleNamespace(id=9),
+            "patient_id": 77,
+            "patient_name": "Wizard Patient",
+            "phone": "+998901112233",
+            "visit_id": 301,
+            "source": "desk",
+            "status": "waiting",
+            "queue_time": object(),
+            "services": [{"id": 1, "code": "K01", "name": "Consult", "price": 100000.0}],
+            "service_codes": ["K01"],
+            "auto_number": True,
+            "commit": False,
+        },
+    )
+    fake_assignment_service = _FakeAssignmentService(
+        {
+            (301, "cardiology_common"): MorningAssignmentPreparedQueueAssignment(
+                create_handoff=create_handoff
+            )
+        }
+    )
+    captured_handoffs = []
+
+    service = RegistrarWizardQueueAssignmentService(
+        db=object(),
+        assignment_service_factory=lambda _: fake_assignment_service,
+        create_entry_allocator=lambda handoff: (
+            captured_handoffs.append(handoff) or SimpleNamespace(number=23)
+        ),
+    )
+
+    queue_numbers = service.assign_same_day_queue_numbers(
+        [visit],
+        target_day=today,
+        source="desk",
+    )
+
+    assert queue_numbers == {
+        301: [
+            {
+                "queue_tag": "cardiology_common",
+                "queue_id": 9,
+                "number": 23,
+                "status": "assigned",
+            }
+        ]
+    }
+    assert visit.status == "open"
+    assert fake_assignment_service.calls == [(301, "cardiology_common", today, "desk")]
+    assert captured_handoffs == [create_handoff]

--- a/docs/architecture/W2C_WIZARD_CREATE_BRANCH_EXTRACTION.md
+++ b/docs/architecture/W2C_WIZARD_CREATE_BRANCH_EXTRACTION.md
@@ -1,0 +1,75 @@
+# Wave 2C Wizard Create-Branch Extraction
+
+Date: 2026-03-09
+Mode: behaviour-preserving extraction
+
+## Old Hidden Handoff
+
+Before this slice, mounted `/registrar/cart` already delegated same-day queue
+assignment to `RegistrarWizardQueueAssignmentService`, but the create-entry
+branch itself was still hidden inside
+`MorningAssignmentService._assign_single_queue(...)`.
+
+That meant wizard-family still depended on a shared morning-assignment method
+for all of the following in one place:
+
+- queue-tag claim resolution
+- duplicate/reuse gate
+- daily queue resolution
+- create-entry kwargs assembly
+- direct call to `queue_service.create_queue_entry(...)`
+
+## New Explicit Wizard-Local Seam
+
+This slice split the last two concerns apart:
+
+- `MorningAssignmentService.prepare_wizard_queue_assignment(...)` now resolves
+  the queue-tag claim and returns either:
+  - an existing-assignment payload, or
+  - `MorningAssignmentCreateBranchHandoff`
+- `RegistrarWizardQueueAssignmentService` now materializes the create branch
+  through its own explicit handoff path
+
+The mounted wizard-family path now looks like this:
+
+1. `/registrar/cart`
+2. `RegistrarWizardQueueAssignmentService.assign_same_day_queue_numbers(...)`
+3. `MorningAssignmentService.prepare_wizard_queue_assignment(...)`
+4. if existing row exists -> reuse payload returned immediately
+5. if create branch is needed -> wizard-local handoff is materialized via
+   `RegistrarWizardQueueAssignmentService._allocate_create_branch_handoff(...)`
+6. allocator still delegates to legacy `queue_service.create_queue_entry(...)`
+
+## What Stayed Shared
+
+- queue-tag-level claim resolution
+- canonical active-status duplicate gate
+- daily queue resolution / creation
+- legacy numbering implementation
+- future-day no-immediate-allocation behavior
+
+## What Became Explicitly Wizard-Local
+
+- the create-branch handoff object
+- the mounted wizard caller that materializes the handoff
+- the exact future replacement point for
+  `QueueDomainService.allocate_ticket(...)`
+
+## Why Behavior Was Preserved
+
+- the same legacy allocator is still used
+- `auto_number=True` is preserved
+- `commit=False` is preserved
+- `queue_time` is still generated in the same shared logic
+- queue-tag-level reuse rules are unchanged
+- different `queue_tag` fan-out remains unchanged
+- billing/invoice orchestration is untouched
+
+## Remaining Shared Boundary
+
+Wizard-family is closer to boundary migration, but this slice did not migrate
+to `QueueDomainService.allocate_ticket(...)`.
+
+The remaining question is no longer "where is the create call hidden?" but
+"is the extracted seam now isolated enough for a direct boundary swap without
+behavior drift?"

--- a/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_WIZARD_CREATE_BRANCH.md
+++ b/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_WIZARD_CREATE_BRANCH.md
@@ -1,0 +1,38 @@
+# Wave 2C Next Execution Unit After Wizard Create-Branch Extraction
+
+Date: 2026-03-09
+
+## Decision
+
+Recommended next execution unit: `wizard boundary-readiness recheck`
+
+## Why This Step
+
+The previous blocker was the hidden create-branch handoff inside shared
+`MorningAssignmentService`.
+
+That blocker is now removed:
+
+- wizard-family has an explicit outer seam
+- wizard-family now has an explicit create-branch handoff seam
+- behavior-preserving tests remain green
+
+The next responsible step is not immediate migration, but a narrow readiness
+recheck to verify:
+
+- the extracted seam is isolated enough
+- billing coupling is no longer the primary blocker
+- `QueueDomainService.allocate_ticket(...)` can replace the wizard-local
+  create branch without altering numbering or fairness semantics
+
+## Not Chosen
+
+- `wizard boundary migration`
+  Not chosen because this slice was extraction-only and readiness still needs
+  an explicit recheck.
+
+- `further wizard decomposition needed`
+  Not chosen because the known create-branch blocker has already been isolated.
+
+- `defer wizard and move to another allocator family`
+  Not chosen because wizard-family is now close to a clean boundary decision.

--- a/docs/status/W2C_WIZARD_ALLOCATOR_SURFACE.md
+++ b/docs/status/W2C_WIZARD_ALLOCATOR_SURFACE.md
@@ -1,0 +1,53 @@
+# Wave 2C Wizard Allocator Surface
+
+Date: 2026-03-09
+Mode: post-extraction surface map
+
+## Old Surface
+
+Mounted `/registrar/cart` delegated same-day queue assignment to
+`RegistrarWizardQueueAssignmentService`, but the exact create-entry handoff was
+still hidden inside `MorningAssignmentService._assign_single_queue(...)`.
+
+That meant the true wizard migration point was still buried in shared
+morning-assignment logic.
+
+## Current Surface
+
+The mounted wizard-family allocator surface is now split into:
+
+### Wizard-Local Outer Seam
+
+- `RegistrarWizardQueueAssignmentService.assign_same_day_queue_numbers(...)`
+- `RegistrarWizardQueueAssignmentService._assign_same_day_queues_for_visit(...)`
+- `RegistrarWizardQueueAssignmentService._materialize_prepared_assignment(...)`
+- `RegistrarWizardQueueAssignmentService._allocate_create_branch_handoff(...)`
+
+### Shared Resolution Surface
+
+- `MorningAssignmentService._get_visit_queue_tags(...)`
+- `MorningAssignmentService.prepare_wizard_queue_assignment(...)`
+- `MorningAssignmentService._resolve_existing_queue_claim_or_raise(...)`
+- `MorningAssignmentService._build_create_branch_handoff(...)`
+
+### Legacy Allocator Surface
+
+- `queue_service.create_queue_entry(...)`
+
+## What This Means
+
+The mounted wizard-family no longer depends on a hidden inline create branch.
+
+The remaining shared dependency is now explicit and narrow:
+
+- shared morning-assignment code still assembles create-entry kwargs
+- wizard-local code now owns the caller handoff that materializes the create
+  branch
+
+## Migration Implication
+
+The future boundary migration can now target one explicit wizard-local call
+site instead of rewriting broader `/registrar/cart` or billing orchestration.
+
+That still requires a readiness recheck before swapping the handoff to
+`QueueDomainService.allocate_ticket(...)`.

--- a/docs/status/W2C_WIZARD_BOUNDARY_READINESS_V3.md
+++ b/docs/status/W2C_WIZARD_BOUNDARY_READINESS_V3.md
@@ -1,45 +1,53 @@
 # Wave 2C Wizard Boundary Readiness V3
 
-Date: 2026-03-08
-Mode: readiness recheck, docs-only
+Date: 2026-03-09
+Mode: post-extraction status
 
-## Inputs Reviewed
+## Previous Verdict
 
-- `docs/status/W2C_WIZARD_SEAM_VERIFICATION.md`
-- `docs/status/W2C_WIZARD_CONTRACT_COMPLIANCE_RECHECK.md`
-- `docs/architecture/W2C_WIZARD_BILLING_COUPLING_RECHECK.md`
-- `docs/status/W2C_WIZARD_BOUNDARY_FEASIBILITY.md`
-- `docs/status/W2C_REGISTRAR_WIZARD_BOUNDARY_READINESS_V2.md`
+Before the create-branch extraction slice, wizard-family was:
 
-## Decision
+`REQUIRES_ONE_MORE_NARROW_EXTRACTION`
 
-Verdict: `REQUIRES_ONE_MORE_NARROW_EXTRACTION`
+That blocker is now closed.
 
-## Why Not READY_FOR_BOUNDARY_MIGRATION
+## Current Status
 
-The mounted wizard family now has the right outer seam, but the exact
-create-entry handoff still lives inside shared `MorningAssignmentService`.
+Post-extraction status: `READY_FOR_BOUNDARY_READINESS_RECHECK`
 
-That means a direct migration now would still need to touch shared internal
-logic rather than only the wizard-specific seam.
+## What Changed
 
-## Why Not BLOCKED_BY_BILLING_COUPLING
+- outer wizard seam already existed
+- create-branch handoff is no longer hidden inside
+  `MorningAssignmentService._assign_single_queue(...)`
+- mounted wizard-family now has an explicit wizard-local create-branch
+  materialization point
 
-Billing coupling remains present, but the extraction reduced it from the
-primary blocker to a secondary concern.
+## What Stayed Stable
 
-The sharper blocker is now the remaining shared create-branch logic.
+- queue-tag-level claim model
+- canonical active statuses
+- same `queue_tag` reuse
+- different `queue_tag` fan-out
+- numbering semantics
+- queue_time / fairness
+- billing and invoice observed behavior
 
-## Why Not DEFER_WIZARD_FAMILY
+## Why This Is Not Yet A Migration Verdict
 
-Wizard-family is close to migration readiness.
+This slice extracted the blocker, but did not itself perform the readiness
+review needed before swapping to `QueueDomainService.allocate_ticket(...)`.
 
-The remaining gap is narrow and well-defined.
+The remaining question is now narrow and local:
 
-## Readiness Summary
+- is the extracted seam isolated enough for a direct boundary swap without
+  behavior drift?
 
-- outer seam: ready
+## Summary
+
+- outer seam: explicit
+- create-branch seam: explicit
 - contract compliance: preserved
 - numbering semantics: unchanged
-- billing coupling: medium
-- exact create-branch migration point: not isolated enough yet
+- billing coupling: reduced but still present in the mounted request flow
+- next step: readiness recheck

--- a/docs/status/W2C_WIZARD_CREATE_BRANCH_EXTRACTION_PLAN.md
+++ b/docs/status/W2C_WIZARD_CREATE_BRANCH_EXTRACTION_PLAN.md
@@ -1,0 +1,47 @@
+# Wave 2C Wizard Create-Branch Extraction Plan
+
+Date: 2026-03-09
+Mode: behaviour-preserving extraction
+
+## Current Handoff
+
+Mounted `/registrar/cart` already delegates same-day queue assignment to
+`RegistrarWizardQueueAssignmentService`, but the exact create-entry handoff is
+still hidden inside `MorningAssignmentService._assign_single_queue(...)`.
+
+That shared method currently:
+
+- resolves wizard queue-tag claim and duplicate/reuse semantics
+- builds create-entry kwargs for the legacy allocator
+- calls `queue_service.create_queue_entry(...)` inline
+
+## Extraction Target
+
+Extract only the wizard-local create branch so that:
+
+- `MorningAssignmentService` still owns shared queue-tag claim resolution
+- `MorningAssignmentService` still owns shared duplicate/reuse logic
+- wizard-family gets an explicit create-branch handoff object
+- mounted wizard seam can materialize the create branch without touching
+  billing/invoice orchestration
+
+## What Remains Shared
+
+- `MorningAssignmentService._get_visit_queue_tags(...)`
+- `MorningAssignmentService._resolve_existing_queue_claim_or_raise(...)`
+- daily queue resolution / creation
+- legacy allocator implementation and numbering behavior
+
+## What Becomes Wizard-Local
+
+- explicit create-branch handoff from shared morning-assignment logic
+- wizard-local materialization of that handoff inside
+  `RegistrarWizardQueueAssignmentService`
+
+## Why This Is Safe
+
+- no numbering algorithm changes
+- no queue_time or fairness changes
+- no duplicate-policy redesign
+- no billing or invoice refactor
+- future-day behavior stays untouched

--- a/docs/status/W2C_WIZARD_CREATE_BRANCH_EXTRACTION_STATUS.md
+++ b/docs/status/W2C_WIZARD_CREATE_BRANCH_EXTRACTION_STATUS.md
@@ -1,0 +1,65 @@
+# Wave 2C Wizard Create-Branch Extraction Status
+
+Date: 2026-03-09
+Status: done
+Mode: behaviour-preserving extraction
+
+## Files Changed
+
+- `backend/app/services/morning_assignment.py`
+- `backend/app/services/registrar_wizard_queue_assignment_service.py`
+- `backend/tests/unit/test_wizard_allocator_extraction.py`
+- `backend/tests/unit/test_wizard_create_branch_extraction.py`
+- `docs/status/W2C_WIZARD_CREATE_BRANCH_EXTRACTION_PLAN.md`
+- `docs/architecture/W2C_WIZARD_CREATE_BRANCH_EXTRACTION.md`
+- `docs/status/W2C_WIZARD_ALLOCATOR_SURFACE.md`
+- `docs/status/W2C_WIZARD_BOUNDARY_READINESS_V3.md`
+- `docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_WIZARD_CREATE_BRANCH.md`
+
+## Corrected Hidden Surface
+
+Old hidden handoff:
+
+- mounted wizard same-day flow reached
+  `MorningAssignmentService._assign_single_queue(...)`
+- shared morning-assignment code both prepared and executed the create branch
+
+New explicit seam:
+
+- `MorningAssignmentService.prepare_wizard_queue_assignment(...)` now returns
+  either reuse payload or `MorningAssignmentCreateBranchHandoff`
+- `RegistrarWizardQueueAssignmentService` now materializes the create branch
+  explicitly in wizard-local code
+
+## Behavior Preservation Notes
+
+- numbering still comes from legacy `queue_service.create_queue_entry(...)`
+- queue-tag-level claim model is unchanged
+- same `queue_tag` reuse is unchanged
+- different `queue_tag` rows are still allowed
+- `queue_time` and fairness ordering are unchanged
+- billing/invoice observed behavior is untouched
+
+## Tests Run
+
+- `pytest backend/tests/characterization/test_registrar_wizard_queue_characterization.py -q -c backend/pytest.ini`
+- `pytest backend/tests/unit/test_registrar_wizard_reuse_existing_entry.py backend/tests/unit/test_wizard_allocator_extraction.py backend/tests/unit/test_wizard_create_branch_extraction.py -q`
+- `cd backend && pytest tests/characterization -q -c pytest.ini`
+- `cd backend && pytest tests/test_openapi_contract.py -q`
+- `cd backend && pytest -q`
+
+## Results
+
+- wizard characterization: `9 passed`
+- wizard reuse/extraction unit tests: `7 passed`
+- full characterization suite: `32 passed`
+- OpenAPI contract: `10 passed`
+- full backend suite: `737 passed, 3 skipped`
+
+## Outcome
+
+The create-branch blocker was extracted successfully.
+
+Wizard-family is now closer to boundary migration, but this slice does not
+declare it migration-ready by itself. The next step is a narrow readiness
+recheck on the extracted seam.


### PR DESCRIPTION
## Summary
- extract the wizard-specific create-branch handoff out of the shared morning-assignment path
- keep mounted `/registrar/cart` behavior unchanged while making the create branch explicit in the wizard seam
- add unit/docs coverage for the extracted handoff and update Wave 2C readiness artifacts

## Contract Impact
- Canonical surface: mounted registrar wizard same-day queue assignment flow backed by `backend/app/services/morning_assignment.py` and `backend/app/services/registrar_wizard_queue_assignment_service.py`
- Request shape: unchanged existing wizard queue assignment input; this PR extracts the create-branch handoff but keeps the existing visit/date/source inputs
- Response shape: unchanged queue assignment payload; existing entries still return `queue_tag`, `queue_id`, `number`, `status=existing`, and created entries still return `queue_tag`, `queue_id`, `number`, `status=assigned`
- Status codes: unchanged route-level behavior; this PR changes service seam structure, not mounted endpoint status-code handling
- Frontend consumer: existing registrar cart/wizard flow; no frontend consumer code changed
- Compatibility path or alias: no route alias added; extracted `MorningAssignmentCreateBranchHandoff` preserves the existing `queue_service.create_queue_entry()` kwargs contract for the create branch
- Contract proof: `backend/tests/characterization/test_registrar_wizard_queue_characterization.py`, `backend/tests/unit/test_registrar_wizard_reuse_existing_entry.py`, `backend/tests/unit/test_wizard_allocator_extraction.py`, `backend/tests/unit/test_wizard_create_branch_extraction.py`, and `tests/test_openapi_contract.py`

## RBAC / Permissions
not applicable - no route guard, auth dependency, role matrix, legacy role form, or permission check changed; PR only extracts the service seam under the existing mounted registrar wizard flow.

## Notification / Realtime
not applicable - no notification event, websocket channel, chat flow, read/unread state, or realtime delivery behavior changed.

## Frontend Resilience
not applicable - no frontend panel, route state, empty-state UI, partial-data UI, or secondary patient-path fallback changed.

## Scope Gate
- Allowed paths: `backend/app/services/morning_assignment.py`, `backend/app/services/registrar_wizard_queue_assignment_service.py`, targeted wizard queue backend tests, and W2C wizard extraction/readiness docs
- Denied paths: unrelated queue routes, frontend runtime, migrations, notification/realtime code, auth/RBAC helpers, payment/visit lifecycle code outside the extracted seam
- Migration/docs/test impact: no migration; targeted backend tests added/updated; W2C wizard create-branch extraction docs/status artifacts updated
- Rollback note: revert the handoff dataclasses, wizard materialization seam, targeted tests, and W2C wizard extraction docs/status updates from this PR

## Validation
- Targeted tests or smoke run: `pytest backend/tests/characterization/test_registrar_wizard_queue_characterization.py -q -c backend/pytest.ini`; `pytest backend/tests/unit/test_registrar_wizard_reuse_existing_entry.py backend/tests/unit/test_wizard_allocator_extraction.py backend/tests/unit/test_wizard_create_branch_extraction.py -q`; `cd backend && pytest tests/characterization -q -c pytest.ini`; `cd backend && pytest tests/test_openapi_contract.py -q`; `cd backend && pytest -q`
- Result: reported passed in the original PR body
- Not checked: live browser registrar cart/wizard smoke, production/staging deploy smoke, and frontend runtime behavior