### PR TITLE
[codex] stabilize theme context and queue boundary

### DIFF
--- a/backend/app/repositories/visit_confirmation_repository.py
+++ b/backend/app/repositories/visit_confirmation_repository.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import date
 
 from sqlalchemy.orm import Session
 
+from app.crud import clinic as crud_clinic
 from app.models.clinic import Doctor
 from app.models.patient import Patient
 from app.models.service import Service
+from app.models.online_queue import DailyQueue
 from app.models.user import User
 from app.models.visit import Visit, VisitService
-from app.services.queue_service import queue_service
+
+logger = logging.getLogger(__name__)
 
 
 class VisitConfirmationRepository:
@@ -53,12 +57,89 @@ class VisitConfirmationRepository:
         )
 
     def get_or_create_daily_queue(self, day: date, specialist_id: int, queue_tag: str):
-        return queue_service.get_or_create_daily_queue(
-            self.db,
-            day=day,
-            specialist_id=specialist_id,
-            queue_tag=queue_tag,
+        doctor = self.db.query(Doctor).filter(Doctor.id == specialist_id).first()
+        if not doctor:
+            logger.error(
+                "[FIX] Cannot create DailyQueue: Doctor with ID=%s does not exist",
+                specialist_id,
+            )
+            raise ValueError(
+                f"Врач с ID {specialist_id} не найден. Невозможно создать очередь."
+            )
+
+        actual_specialist_id = doctor.id
+
+        if queue_tag:
+            existing_by_tag = (
+                self.db.query(DailyQueue)
+                .filter(
+                    DailyQueue.day == day,
+                    DailyQueue.queue_tag == queue_tag,
+                    DailyQueue.active == True,
+                )
+                .first()
+            )
+            if existing_by_tag:
+                logger.info(
+                    "[FIX] Reusing existing DailyQueue id=%s day=%s specialist=%s queue_tag=%s",
+                    existing_by_tag.id,
+                    day,
+                    actual_specialist_id,
+                    queue_tag,
+                )
+                return existing_by_tag
+
+        query = self.db.query(DailyQueue).filter(
+            DailyQueue.day == day,
+            DailyQueue.specialist_id == actual_specialist_id,
         )
+        if queue_tag:
+            query = query.filter(DailyQueue.queue_tag == queue_tag)
+
+        daily_queue = query.first()
+        if daily_queue:
+            logger.info(
+                "[FIX] Reusing existing DailyQueue id=%s day=%s specialist=%s queue_tag=%s",
+                daily_queue.id,
+                day,
+                actual_specialist_id,
+                queue_tag,
+            )
+            return daily_queue
+
+        settings = crud_clinic.get_queue_settings(self.db)
+        queue_start_hour = settings.get("queue_start_hour", 7)
+        queue_end_hour = settings.get("queue_end_hour", 9)
+
+        daily_queue = DailyQueue(
+            day=day,
+            specialist_id=actual_specialist_id,
+            queue_tag=queue_tag,
+            active=True,
+            online_start_time=f"{int(queue_start_hour):02d}:00",
+            online_end_time=f"{int(queue_end_hour):02d}:00",
+        )
+        self.db.add(daily_queue)
+
+        try:
+            self.db.flush()
+            logger.info(
+                "[FIX] Created DailyQueue id=%s day=%s specialist=%s queue_tag=%s",
+                daily_queue.id,
+                day,
+                actual_specialist_id,
+                queue_tag,
+            )
+            return daily_queue
+        except Exception:
+            self.db.rollback()
+            logger.exception(
+                "[FIX] Failed to create DailyQueue day=%s specialist=%s queue_tag=%s",
+                day,
+                actual_specialist_id,
+                queue_tag,
+            )
+            raise
 
     def commit(self) -> None:
         self.db.commit()

--- a/frontend/src/__tests__/notificationGuardrails.test.js
+++ b/frontend/src/__tests__/notificationGuardrails.test.js
@@ -61,6 +61,6 @@ describe('notification guardrails', () => {
     expect(context).not.toContain('[unreadSnapshot]');
 
     expect(roleCenter).toContain('useEffect(() => {');
-    expect(roleCenter).toContain('[refreshNotifications, role]');
+    expect(roleCenter).toContain('[runLoadNotifications, role]');
   });
 });

--- a/frontend/src/components/security/__tests__/TwoFactorManager.test.jsx
+++ b/frontend/src/components/security/__tests__/TwoFactorManager.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import { ThemeProvider } from '../../../contexts/ThemeContext.jsx';
 import { MacOSThemeProvider } from '../../../theme/macosTheme.jsx';
 
@@ -87,11 +88,13 @@ function mockApiGetState({ statusSequence = [disabledStatus], devices = [], logs
 
 function renderManager() {
   return render(
-    <MacOSThemeProvider>
-      <ThemeProvider>
-        <TwoFactorManager />
-      </ThemeProvider>
-    </MacOSThemeProvider>
+    <MemoryRouter>
+      <MacOSThemeProvider>
+        <ThemeProvider>
+          <TwoFactorManager />
+        </ThemeProvider>
+      </MacOSThemeProvider>
+    </MemoryRouter>
   );
 }
 

--- a/frontend/src/contexts/ThemeContext.jsx
+++ b/frontend/src/contexts/ThemeContext.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useInRouterContext, useLocation } from 'react-router-dom';
 import tokens, { colors as tokenColors } from '../theme/tokens';
 import {
   applyColorSchemeToDom,
@@ -37,6 +37,16 @@ function getAuthTokenSnapshot() {
 function isPublicPath(pathname) {
   const normalizedPath = String(pathname || '/').toLowerCase();
   return normalizedPath === '/' || PUBLIC_PATH_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix));
+}
+
+function ThemeRouteSync({ onPathnameChange }) {
+  const location = useLocation();
+
+  useEffect(() => {
+    onPathnameChange(location.pathname);
+  }, [location.pathname, onPathnameChange]);
+
+  return null;
 }
 
 function getCachedThemePreference(token) {
@@ -84,7 +94,10 @@ export const useTheme = () => {
 };
 
 export const ThemeProvider = ({ children }) => {
-  const location = useLocation();
+  const hasRouterContext = useInRouterContext();
+  const [pathname, setPathname] = useState(() => (
+    typeof window !== 'undefined' ? window.location.pathname : '/'
+  ));
   const [systemTheme, setSystemTheme] = useState(() => getSystemTheme());
   const [colorScheme, setColorSchemeState] = useState(() => getStoredColorScheme());
   const [authToken, setAuthToken] = useState(() => getAuthTokenSnapshot());
@@ -93,6 +106,7 @@ export const ThemeProvider = ({ children }) => {
   const skipNextRemoteSaveRef = useRef(false);
   const lastSavedPreferenceRef = useRef(null);
   const saveTimeoutRef = useRef(null);
+  const routerFallbackLoggedRef = useRef(false);
 
   const theme = resolveThemeMode(colorScheme, systemTheme);
   const isDark = theme === 'dark';
@@ -215,6 +229,17 @@ export const ThemeProvider = ({ children }) => {
   }, [colorScheme, theme]);
 
   useEffect(() => {
+    if (hasRouterContext || routerFallbackLoggedRef.current) {
+      return;
+    }
+
+    routerFallbackLoggedRef.current = true;
+    logger.info('[FIX:THEME] Router context missing, using window pathname fallback', {
+      pathname,
+    });
+  }, [hasRouterContext, pathname]);
+
+  useEffect(() => {
     const root = document.documentElement;
     const computedStyle = window.getComputedStyle(root);
     const macBgPrimary = computedStyle.getPropertyValue('--mac-bg-primary').trim() || tokenColors.semantic.background.primary;
@@ -292,7 +317,7 @@ export const ThemeProvider = ({ children }) => {
 
   useEffect(() => {
     let cancelled = false;
-    const currentPath = location.pathname;
+    const currentPath = pathname;
 
     if (!authToken || isPublicPath(currentPath)) {
       hydratedTokenRef.current = null;
@@ -428,7 +453,7 @@ export const ThemeProvider = ({ children }) => {
     return () => {
       cancelled = true;
     };
-  }, [authToken]);
+  }, [authToken, pathname]);
 
   useEffect(() => {
     if (saveTimeoutRef.current) {
@@ -436,7 +461,7 @@ export const ThemeProvider = ({ children }) => {
       saveTimeoutRef.current = null;
     }
 
-    if (!authToken || !preferencesReady || isPublicPath(location.pathname)) {
+    if (!authToken || !preferencesReady || isPublicPath(pathname)) {
       return undefined;
     }
 
@@ -476,7 +501,7 @@ export const ThemeProvider = ({ children }) => {
         saveTimeoutRef.current = null;
       }
     };
-  }, [authToken, colorScheme, preferencesReady]);
+  }, [authToken, colorScheme, preferencesReady, pathname]);
 
   const value = useMemo(() => ({
     theme,
@@ -510,8 +535,10 @@ export const ThemeProvider = ({ children }) => {
 
   return (
     <ThemeContext.Provider value={value}>
+      {hasRouterContext ? <ThemeRouteSync onPathnameChange={setPathname} /> : null}
       {children}
-    </ThemeContext.Provider>);
+    </ThemeContext.Provider>
+  );
 
 };
 


### PR DESCRIPTION
Fixes the shared router-context failure in ThemeContext, removes the direct queue_service import from visit_confirmation_repository, and updates the two stale frontend tests.

Validation:
- frontend router/theme-related test slice
- backend queue integration tests
- backend architecture boundary test
- py_compile on visit_confirmation_repository