### PR TITLE
feat(notifications): enforce realtime policy and webhook idempotency

### DIFF
--- a/.ai-factory/IMPLEMENTATION_NOTIFICATION_CATALOG_SSOT.md
+++ b/.ai-factory/IMPLEMENTATION_NOTIFICATION_CATALOG_SSOT.md
@@ -1,6 +1,6 @@
 # Notification Catalog SSOT - Active Implementation Note
 
-Updated: 2026-04-16  
+Updated: 2026-04-17  
 Scope: Unified persistent inbox notifications (`/notifications/inbox`, `/notifications/unread-count`, WS sync) without new API surface.
 
 ## Canonical Catalog (Backend SSOT)
@@ -38,11 +38,35 @@ Scope: Unified persistent inbox notifications (`/notifications/inbox`, `/notific
 
 - Persistent inbox (SSOT): all catalog events above are backend-owned records via notification platform APIs.
 - Ephemeral chat realtime only (non-inbox): typing, read receipts, presence, reaction updates.
+- Runtime delivery split:
+  - inbox persistence is always written for canonical events.
+  - websocket realtime delivery is policy-gated in `NotificationPlatformService`.
 - Alias normalization:
   - `result_ready` -> `lab_results`
   - `payment_update` -> `payment_notification`
   - `appointment_rescheduled` -> `schedule_change`
-  - `queue_changed` -> `queue_update` on frontend normalization
+  - `queue_changed` -> `queue_update` (backend + frontend normalization)
+  - `diagnostics_return` -> `diagnostics_return_needed` (backend + frontend normalization)
+
+## Runtime Policy Contract (Realtime Only)
+
+- Policy owner: `backend/app/services/notification_platform_service.py`
+- Critical break-through (always allow realtime):
+  - event types: `security_alert`, `billing_alert`, `lab_critical_result`
+  - or `severity=critical`
+  - or `priority=urgent`
+- Global realtime suppressor:
+  - `UserPreferences.desktop_notifications = false` -> realtime suppressed
+- Event-level realtime suppressor (via `UserNotificationSettings.push_*`):
+  - `appointment_reminder` -> `push_appointment_reminder`
+  - `appointment_confirmation`, `visit_confirmation`, `new_appointment` -> `push_appointment_confirmation`
+  - `schedule_change` -> `push_appointment_cancellation`
+  - `payment_notification` -> `push_payment_receipt`
+  - `security_alert` -> `push_security_alerts`
+  - `system_alert`, `registrar_system_alert`, `price_change`, `all_free_*`, queue family, `patient_registered` -> `push_system_updates`
+- Quiet-hours / weekend suppression (queue-family only):
+  - respects `UserNotificationSettings.quiet_hours_start`, `quiet_hours_end`, `weekend_notifications`
+  - applies to queue family: `queue_update`, `queue_call`, `queue_position`, `queue_reminder`, `diagnostics_return_needed`, `queue_status_changed`
 
 ## Producer Wiring Status
 
@@ -84,6 +108,7 @@ Backend:
 - `python -m py_compile backend/app/services/patient_service.py`
 - `python -m pytest backend/tests/integration/test_notification_catalog_slice1.py backend/tests/unit/test_messages_notification_catalog_slice1.py -q`
 - `python -m pytest backend/tests/unit/test_notification_platform_contract.py -q`
+- `python -m pytest backend/tests/integration/test_notification_catalog_slice3_legacy_webhooks.py -q`
 
 Frontend:
 - `npx eslint src/contexts/NotificationCenterContext.jsx`

--- a/ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md
+++ b/ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md
@@ -2369,3 +2369,190 @@ PLEASE IMPLEMENT THIS PLAN: Full Plan: Unified Notification Catalog and SSOT Com
 Recommendation:
 - For notification-domain tasks, prioritize relationship retrieval that binds `event_type` catalog -> producer services -> frontend consumer files before generating first-touch sets.
 - Keep known-root-cause retry, but add a catalog-aware ownership heuristic to reduce repeated single-file misroutes on multi-slice work.
+
+## Task 68 - Notification SSOT Phase 1 alias/type normalization (queue + diagnostics)
+
+### User task
+теперь можешь продолжать
+
+### Gate result
+- mode: canonical
+- handoff required: yes
+- handoff used: yes, via narrow override prompt
+- gate_misroute: yes
+- override_used: yes
+- known_root_cause_file: backend/app/services/notification_platform_service.py
+
+### What handoff solved well
+- It constrained the risky slice to a single confirmed owner file after misroute retry.
+- It preserved stop conditions and prevented broad multi-file edits in one step.
+
+### Missing relationship mapping
+- Gate retry still collapsed a cross-stack alias task (backend + frontend + tests) into one backend file.
+- Missing mapping from canonical alias direction changes to impacted frontend normalization and contract tests.
+
+### Manual reconstruction needed
+- Manually aligned alias decisions with the active dossier/handoff contract.
+- Manually validated impact with the nearest contract test and confirmed expected failure due stale old canonical assertion (`queue_changed`).
+
+### Signals observed
+- multi-hop gap: yes
+- ownership ambiguity: yes
+- manual graph reconstruction: yes
+- gate_misroute: yes
+- override_used: yes
+
+### Short verdict
+- current stack sufficient: partial
+- would LightRAG likely help here: yes
+- Relationship-aware retrieval should map alias direction changes across backend normalizer, frontend ingress aliases, and contract tests to avoid repeated narrow-file misroutes.
+
+## Task 69 - Legacy webhook path canonical payment_notification alignment
+
+### User task
+продолжай
+
+### Gate result
+- mode: gate_known_root_cause
+- handoff required: yes
+- handoff used: yes, via narrow override prompt
+- gate_misroute: yes
+- override_used: yes
+- known_root_cause_file: backend/app/services/payment_webhook_api_service.py
+
+### What handoff solved well
+- It enforced a strict narrow patch scope after misroute and prevented cross-file edits in endpoints/repositories.
+- It preserved a compile-first verification target for the approved root-cause file.
+
+### Missing relationship mapping
+- Retry still did not map that legacy webhook endpoint behavior depends on both repository transaction linkage and notification-platform recipient resolution.
+- Canonical producer insertion point had to be reconstructed manually inside the legacy API service path.
+
+### Manual reconstruction needed
+- Manually derived recipient resolution chain (`PaymentWebhook` -> `PaymentTransaction`/`Payment`/`Visit` -> `Patient.user`).
+- Manually added canonical `payment_notification` emit semantics while preserving legacy response contract (`ok/message/webhook_id`).
+
+### Signals observed
+- multi-hop gap: yes
+- ownership ambiguity: yes
+- manual graph reconstruction: yes
+- gate_misroute: yes
+- override_used: yes
+
+### Short verdict
+- current stack sufficient: partial
+- would LightRAG likely help here: yes
+- Better relationship retrieval should surface the legacy path ownership graph and recipient linkage path up front to reduce narrow-override cycles.
+
+## Task 70 - Legacy webhook duplicate callback idempotency for canonical payment_notification
+
+### User task
+продолжай
+
+### Gate result
+- mode: gate_known_root_cause
+- handoff required: yes
+- handoff used: yes, via narrow override prompt
+- gate_misroute: yes
+- override_used: yes
+- known_root_cause_file: backend/app/services/payment_webhook_api_service.py
+
+### What handoff solved well
+- It constrained the fix to a single approved runtime file and prevented notification-platform wide changes.
+- It provided explicit stop conditions and kept verification narrow (`py_compile` + targeted integration tests).
+
+### Missing relationship mapping
+- Gate did not surface that event dedup in `NotificationPlatformService` includes message/payload fields, so dynamic webhook reason text can break idempotency.
+- This cross-file dedup dependency had to be inferred manually from service internals.
+
+### Manual reconstruction needed
+- Manually traced failing duplicate callback test to dynamic body mutation (`Причина: ...`) in legacy webhook canonical emit path.
+- Manually stabilized canonical payload body so repeated callbacks resolve to existing event/delivery dedup keys.
+
+### Signals observed
+- multi-hop gap: yes
+- ownership ambiguity: no
+- manual graph reconstruction: yes
+- gate_misroute: yes
+- override_used: yes
+
+### Short verdict
+- current stack sufficient: partial
+- would LightRAG likely help here: yes
+- Relationship-aware retrieval linking producer payload shaping to platform dedup seed fields would shorten this debug loop.
+
+## Task 71 - Runtime policy enforcement for realtime notification broadcast
+
+### User task
+продолжай
+
+### Gate result
+- mode: execute
+- handoff required: yes
+- handoff used: yes, via narrow override prompt
+- gate_misroute: yes
+- override_used: yes
+- known_root_cause_file: backend/app/services/notification_platform_service.py
+
+### What handoff solved well
+- It enforced strict single-file scope for the first runtime policy slice.
+- It kept verification discipline narrow (`py_compile` + notification regression pack) and prevented broad cross-layer edits.
+
+### Missing relationship mapping
+- Initial handoff misrouted to queue service files despite a clear notification-platform root-cause.
+- Retry still needed manual override to reach the canonical owner (`NotificationPlatformService`).
+
+### Manual reconstruction needed
+- Manually mapped which settings can safely affect realtime behavior without breaking inbox SSOT:
+  - `preferences.desktop_notifications`
+  - `notification_settings.quiet_hours_*`
+  - `notification_settings.weekend_notifications`
+- Manually implemented critical break-through semantics and queue-family quiet-hours suppression in service-level broadcast policy.
+
+### Signals observed
+- multi-hop gap: yes
+- ownership ambiguity: yes
+- manual graph reconstruction: yes
+- gate_misroute: yes
+- override_used: yes
+
+### Short verdict
+- current stack sufficient: partial
+- would LightRAG likely help here: yes
+- Better graph retrieval should directly bind settings models and runtime delivery service ownership to avoid repeated queue-domain misroutes for notification-policy tasks.
+
+## Task 72 - Per-event realtime policy mapping via push settings
+
+### User task
+продолжай
+
+### Gate result
+- mode: execute
+- handoff required: yes
+- handoff used: yes
+- gate_misroute: no
+- override_used: no
+- known_root_cause_file: backend/app/services/notification_platform_service.py
+
+### What handoff solved well
+- It selected canonical notification owner files and kept first patch slice anchored in `NotificationPlatformService`.
+- Verification targets were aligned with notification contract tests.
+
+### Missing relationship mapping
+- none
+
+### Manual reconstruction needed
+- Manually mapped canonical event types to existing `UserNotificationSettings.push_*` fields because settings schema is channel-based while event catalog is domain-based.
+- Preserved critical break-through and existing quiet-hours suppression semantics while adding event-level setting enforcement.
+
+### Signals observed
+- multi-hop gap: no
+- ownership ambiguity: no
+- manual graph reconstruction: yes
+- gate_misroute: no
+- override_used: no
+
+### Short verdict
+- current stack sufficient: yes
+- would LightRAG likely help here: no
+- Gate already selected the correct owner and boundaries; only routine domain mapping was required.

--- a/backend/app/services/notification_platform_service.py
+++ b/backend/app/services/notification_platform_service.py
@@ -8,6 +8,7 @@ import logging
 import re
 from datetime import datetime, timedelta
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, selectinload
@@ -31,6 +32,47 @@ class NotificationPlatformService:
     TRANSPORT_NOTIFICATION = "notification"
     TRANSPORT_QUEUE_UPDATE = "queue_update"
     TRANSPORT_SYSTEM_ALERT = "system_alert"
+    DEFAULT_TIMEZONE = "Asia/Tashkent"
+
+    CRITICAL_EVENT_TYPES = {
+        "security_alert",
+        "billing_alert",
+        "lab_critical_result",
+    }
+
+    QUIET_HOURS_QUEUE_EVENT_TYPES = {
+        "queue_update",
+        "queue_changed",
+        "queue_call",
+        "queue_position",
+        "queue_reminder",
+        "diagnostics_return_needed",
+        "diagnostics_return",
+        "queue_status_changed",
+    }
+
+    REALTIME_PUSH_SETTING_BY_EVENT_TYPE = {
+        "appointment_reminder": "push_appointment_reminder",
+        "appointment_confirmation": "push_appointment_confirmation",
+        "visit_confirmation": "push_appointment_confirmation",
+        "new_appointment": "push_appointment_confirmation",
+        "schedule_change": "push_appointment_cancellation",
+        "payment_notification": "push_payment_receipt",
+        "security_alert": "push_security_alerts",
+        "system_alert": "push_system_updates",
+        "registrar_system_alert": "push_system_updates",
+        "price_change": "push_system_updates",
+        "all_free_requested": "push_system_updates",
+        "all_free_approved": "push_system_updates",
+        "all_free_rejected": "push_system_updates",
+        "queue_update": "push_system_updates",
+        "queue_call": "push_system_updates",
+        "queue_position": "push_system_updates",
+        "queue_reminder": "push_system_updates",
+        "diagnostics_return_needed": "push_system_updates",
+        "queue_status_changed": "push_system_updates",
+        "patient_registered": "push_system_updates",
+    }
 
     ROLE_ALIASES = {
         "admin": "admin",
@@ -67,7 +109,8 @@ class NotificationPlatformService:
     }
 
     LEGACY_EVENT_TYPE_ALIASES = {
-        "queue_update": "queue_changed",
+        "queue_changed": "queue_update",
+        "diagnostics_return": "diagnostics_return_needed",
     }
 
     def __init__(self, db: Session):
@@ -105,6 +148,157 @@ class NotificationPlatformService:
     @staticmethod
     def _now() -> datetime:
         return datetime.utcnow()
+
+    @staticmethod
+    def _parse_hhmm(value: str | None, fallback: tuple[int, int]) -> tuple[int, int]:
+        if not value:
+            return fallback
+        try:
+            hour, minute = str(value).split(":", maxsplit=1)
+            parsed_hour = max(0, min(23, int(hour)))
+            parsed_minute = max(0, min(59, int(minute)))
+            return parsed_hour, parsed_minute
+        except (TypeError, ValueError):
+            return fallback
+
+    def _resolve_timezone_name_for_user(self, user: User) -> str:
+        user_preferences = getattr(user, "preferences", None)
+        user_profile = getattr(user, "profile", None)
+        candidate = (
+            getattr(user_preferences, "timezone", None)
+            or getattr(user_profile, "timezone", None)
+            or self.DEFAULT_TIMEZONE
+        )
+        try:
+            ZoneInfo(candidate)
+            return candidate
+        except Exception:
+            return self.DEFAULT_TIMEZONE
+
+    def _is_within_quiet_hours(self, *, now_local: datetime, start: str | None, end: str | None) -> bool:
+        start_h, start_m = self._parse_hhmm(start, (22, 0))
+        end_h, end_m = self._parse_hhmm(end, (8, 0))
+        now_minutes = now_local.hour * 60 + now_local.minute
+        start_minutes = start_h * 60 + start_m
+        end_minutes = end_h * 60 + end_m
+        if start_minutes == end_minutes:
+            return False
+        if start_minutes < end_minutes:
+            return start_minutes <= now_minutes < end_minutes
+        return now_minutes >= start_minutes or now_minutes < end_minutes
+
+    def _is_critical_breakthrough_event(
+        self,
+        *,
+        event_type: str,
+        severity: str | None,
+        priority: str | None,
+    ) -> bool:
+        normalized_type = self.normalize_event_type(event_type)
+        normalized_severity = self.normalize_slug(severity)
+        normalized_priority = self.normalize_slug(priority)
+        if normalized_type in self.CRITICAL_EVENT_TYPES:
+            return True
+        if normalized_severity in {"critical"}:
+            return True
+        if normalized_priority in {"urgent"}:
+            return True
+        return False
+
+    def _resolve_realtime_push_setting_key(self, *, event_type: str) -> str | None:
+        normalized_type = self.normalize_event_type(event_type)
+        return self.REALTIME_PUSH_SETTING_BY_EVENT_TYPE.get(normalized_type)
+
+    def _is_realtime_event_enabled_in_settings(
+        self,
+        *,
+        notification_settings: Any,
+        event_type: str,
+    ) -> tuple[bool, str]:
+        setting_key = self._resolve_realtime_push_setting_key(event_type=event_type)
+        if not setting_key:
+            return True, "event_not_mapped_to_push_setting"
+        if bool(getattr(notification_settings, setting_key, True)) is False:
+            return False, f"setting_disabled:{setting_key}"
+        return True, f"setting_enabled:{setting_key}"
+
+    def _should_broadcast_realtime(
+        self,
+        *,
+        user: User,
+        event_type: str,
+        severity: str | None,
+        priority: str | None,
+    ) -> tuple[bool, str]:
+        normalized_type = self.normalize_event_type(event_type)
+        if self._is_critical_breakthrough_event(
+            event_type=normalized_type,
+            severity=severity,
+            priority=priority,
+        ):
+            return True, "critical_breakthrough"
+
+        user_preferences = getattr(user, "preferences", None)
+        if user_preferences is not None and getattr(user_preferences, "desktop_notifications", True) is False:
+            return False, "desktop_notifications_disabled"
+
+        notification_settings = getattr(user, "notification_settings", None)
+        if notification_settings is None:
+            return True, "no_notification_settings"
+
+        enabled_in_settings, settings_reason = self._is_realtime_event_enabled_in_settings(
+            notification_settings=notification_settings,
+            event_type=normalized_type,
+        )
+        if not enabled_in_settings:
+            return False, settings_reason
+
+        timezone_name = self._resolve_timezone_name_for_user(user)
+        now_local = datetime.now(ZoneInfo(timezone_name))
+        if (
+            getattr(notification_settings, "weekend_notifications", True) is False
+            and now_local.weekday() >= 5
+            and normalized_type in self.QUIET_HOURS_QUEUE_EVENT_TYPES
+        ):
+            return False, "weekend_suppression"
+
+        if normalized_type in self.QUIET_HOURS_QUEUE_EVENT_TYPES and self._is_within_quiet_hours(
+            now_local=now_local,
+            start=getattr(notification_settings, "quiet_hours_start", None),
+            end=getattr(notification_settings, "quiet_hours_end", None),
+        ):
+            return False, "quiet_hours_queue_suppression"
+
+        return True, "default_allow"
+
+    async def _broadcast_delivery_with_policy(
+        self,
+        *,
+        user: User,
+        delivery: NotificationDelivery,
+        event_type: str,
+        severity: str | None,
+        priority: str | None,
+    ) -> bool:
+        should_broadcast, reason = self._should_broadcast_realtime(
+            user=user,
+            event_type=event_type,
+            severity=severity,
+            priority=priority,
+        )
+        if not should_broadcast:
+            logger.info(
+                "[Notifications] websocket broadcast suppressed by policy",
+                extra={
+                    "recipient_id": user.id,
+                    "delivery_id": delivery.delivery_id,
+                    "event_type": event_type,
+                    "reason": reason,
+                },
+            )
+            return False
+        await self._broadcast_delivery(user.id, delivery)
+        return True
 
     def _hash_seed(self, seed: dict[str, Any]) -> str:
         packed = json.dumps(seed, sort_keys=True, default=str, ensure_ascii=False)
@@ -408,7 +602,7 @@ class NotificationPlatformService:
     async def _broadcast_delivery(self, user_id: int, delivery: NotificationDelivery) -> None:
         event = delivery.event
         transport_type = self.TRANSPORT_NOTIFICATION
-        if event.event_type == "queue_changed":
+        if event.event_type in {"queue_update", "queue_changed"}:
             transport_type = self.TRANSPORT_QUEUE_UPDATE
         elif event.event_type == "system_alert":
             transport_type = self.TRANSPORT_SYSTEM_ALERT
@@ -738,7 +932,13 @@ class NotificationPlatformService:
             payload_snapshot=snapshot,
         )
         self.repository.commit()
-        await self._broadcast_delivery(user.id, delivery)
+        await self._broadcast_delivery_with_policy(
+            user=user,
+            delivery=delivery,
+            event_type=normalized_event_type,
+            severity=severity,
+            priority=priority,
+        )
         return delivery
 
     async def record_delivery_for_users(
@@ -809,7 +1009,13 @@ class NotificationPlatformService:
         self.repository.commit()
 
         for user, delivery in zip(users, deliveries):
-            await self._broadcast_delivery(user.id, delivery)
+            await self._broadcast_delivery_with_policy(
+                user=user,
+                delivery=delivery,
+                event_type=normalized_event_type,
+                severity=severity,
+                priority=priority,
+            )
 
         return deliveries
 

--- a/backend/app/services/payment_webhook_api_service.py
+++ b/backend/app/services/payment_webhook_api_service.py
@@ -2,11 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from dataclasses import dataclass
 from typing import Any
 
+from app.models.patient import Patient
+from app.models.payment import Payment
+from app.models.payment_webhook import PaymentTransaction
+from app.models.user import User
+from app.models.visit import Visit
 from app.repositories.payment_webhook_api_repository import PaymentWebhookApiRepository
 from app.schemas.payment_webhook import PaymentProviderCreate, PaymentProviderUpdate
+from app.services.notification_platform_service import NotificationPlatformService
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -26,6 +36,12 @@ class PaymentWebhookApiService:
             success, message, webhook = self.repository.process_payme_webhook(
                 data, signature
             )
+            self._emit_legacy_payment_notification(
+                webhook=webhook,
+                provider="payme",
+                success=bool(success),
+                message=message,
+            )
             return {
                 "ok": bool(success),
                 "message": message,
@@ -37,6 +53,12 @@ class PaymentWebhookApiService:
     def process_click_webhook(self, *, data: dict[str, Any]) -> dict[str, Any]:
         try:
             success, message, webhook = self.repository.process_click_webhook(data)
+            self._emit_legacy_payment_notification(
+                webhook=webhook,
+                provider="click",
+                success=bool(success),
+                message=message,
+            )
             return {
                 "ok": bool(success),
                 "message": message,
@@ -124,3 +146,213 @@ class PaymentWebhookApiService:
         if not webhook:
             raise PaymentWebhookApiDomainError(status_code=404, detail="Webhook not found")
         return webhook
+
+    def _emit_legacy_payment_notification(
+        self,
+        *,
+        webhook: Any,
+        provider: str,
+        success: bool,
+        message: str,
+    ) -> None:
+        """Best-effort canonical payment_notification for legacy webhook endpoints."""
+        if webhook is None:
+            return
+
+        db = self.repository.db
+        try:
+            payment_status, change_type = self._resolve_legacy_payment_state(
+                success=success,
+                webhook_status=getattr(webhook, "status", None),
+            )
+            if not payment_status:
+                return
+
+            recipient, resolution = self._resolve_legacy_webhook_recipient(webhook)
+            if recipient is None:
+                logger.info(
+                    "[FIX:NOTIFICATIONS] legacy webhook notification skipped: recipient unresolved",
+                    extra={
+                        "webhook_id": getattr(webhook, "id", None),
+                        "provider": provider,
+                        "payment_status": payment_status,
+                    },
+                )
+                return
+
+            title = "Оплата подтверждена" if payment_status == "paid" else "Платеж не выполнен"
+            body = (
+                "Онлайн-платеж успешно обработан."
+                if payment_status == "paid"
+                else "Онлайн-платеж не был завершен."
+            )
+            # Keep canonical inbox payload deterministic for webhook retries.
+            # Dynamic provider reasons ("already processed", etc.) can differ
+            # across repeated callbacks and would break event-level dedup.
+
+            platform_service = NotificationPlatformService(db)
+            event_type = platform_service.normalize_event_type("payment_notification")
+            metadata = {
+                "provider": provider,
+                "payment_status": payment_status,
+                "change_type": change_type,
+                "webhook_id": getattr(webhook, "id", None),
+                "transaction_id": getattr(webhook, "transaction_id", None),
+                "visit_id": resolution.get("visit_id"),
+                "patient_id": resolution.get("patient_id"),
+                "payment_id": resolution.get("payment_id"),
+                "legacy_webhook_path": True,
+            }
+            payload_snapshot = platform_service._build_payload_snapshot(
+                title=title,
+                message=body,
+                deep_link="/patient",
+                metadata=metadata,
+            )
+            role = platform_service.resolve_panel_role_for_user(recipient)
+            department_key = platform_service.normalize_department_key(
+                getattr(getattr(recipient, "profile", None), "department", None)
+            )
+            correlation_id = f"legacy_webhook:{provider}:{getattr(webhook, 'id', 'unknown')}"
+            event = platform_service._create_or_get_event(
+                event_type=event_type,
+                source_module="payments_webhook_legacy",
+                scope_key=f"user:{recipient.id}",
+                title=title,
+                message=body,
+                severity="warning" if payment_status == "failed" else "info",
+                priority="high" if payment_status == "failed" else "normal",
+                correlation_id=correlation_id,
+                actor_id=None,
+                actor_role=None,
+                entity_type="payment",
+                entity_id=(
+                    str(resolution["payment_id"])
+                    if resolution.get("payment_id") is not None
+                    else str(getattr(webhook, "id", ""))
+                ),
+                payload_snapshot=payload_snapshot,
+                deep_link="/patient",
+                expires_at=None,
+            )
+            delivery = platform_service._create_or_get_delivery(
+                event=event,
+                recipient_type="user",
+                recipient_id=recipient.id,
+                role=role,
+                department_key=department_key,
+                channel=NotificationPlatformService.INBOX_CHANNEL,
+                payload_snapshot=payload_snapshot,
+            )
+            db.commit()
+
+            try:
+                running_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                running_loop = None
+            if running_loop and not running_loop.is_closed():
+                running_loop.create_task(
+                    platform_service._broadcast_delivery(recipient.id, delivery)
+                )
+
+        except Exception as exc:
+            db.rollback()
+            logger.warning(
+                "[FIX:NOTIFICATIONS] failed legacy webhook canonical emit",
+                extra={
+                    "webhook_id": getattr(webhook, "id", None),
+                    "provider": provider,
+                    "error": str(exc),
+                },
+            )
+
+    @staticmethod
+    def _resolve_legacy_payment_state(
+        *,
+        success: bool,
+        webhook_status: str | None,
+    ) -> tuple[str | None, str | None]:
+        normalized_status = str(webhook_status or "").strip().lower()
+        paid_statuses = {"processed", "success", "completed", "visit_updated", "visit_created", "appointment_created"}
+        failed_statuses = {"failed", "error"}
+
+        if normalized_status in paid_statuses:
+            return "paid", "paid"
+        if normalized_status in failed_statuses:
+            return "failed", "failed"
+        if success:
+            return "paid", "paid"
+        return "failed", "failed"
+
+    def _resolve_legacy_webhook_recipient(self, webhook: Any) -> tuple[User | None, dict[str, int | None]]:
+        db = self.repository.db
+        patient_id = self._safe_int(getattr(webhook, "patient_id", None))
+        visit_id = self._safe_int(getattr(webhook, "visit_id", None))
+        payment_id = None
+
+        transaction = (
+            db.query(PaymentTransaction)
+            .filter(PaymentTransaction.webhook_id == getattr(webhook, "id", None))
+            .order_by(PaymentTransaction.id.desc())
+            .first()
+        )
+        if transaction:
+            payment_id = self._safe_int(getattr(transaction, "payment_id", None))
+            if visit_id is None:
+                visit_id = self._safe_int(getattr(transaction, "visit_id", None))
+
+        if payment_id is not None:
+            payment = db.query(Payment).filter(Payment.id == payment_id).first()
+            if payment and visit_id is None:
+                visit_id = self._safe_int(getattr(payment, "visit_id", None))
+
+        if visit_id is not None and patient_id is None:
+            visit = db.query(Visit).filter(Visit.id == visit_id).first()
+            if visit:
+                patient_id = self._safe_int(getattr(visit, "patient_id", None))
+
+        if patient_id is None:
+            raw_data = getattr(webhook, "raw_data", None)
+            patient_id = self._extract_patient_id_from_raw_data(raw_data)
+
+        if patient_id is None:
+            return None, {"patient_id": None, "visit_id": visit_id, "payment_id": payment_id}
+
+        patient = db.query(Patient).filter(Patient.id == patient_id).first()
+        if not patient or not patient.user_id:
+            return None, {"patient_id": patient_id, "visit_id": visit_id, "payment_id": payment_id}
+
+        recipient = (
+            db.query(User)
+            .filter(User.id == patient.user_id, User.is_active.is_(True))
+            .first()
+        )
+        return recipient, {"patient_id": patient_id, "visit_id": visit_id, "payment_id": payment_id}
+
+    @staticmethod
+    def _extract_patient_id_from_raw_data(raw_data: Any) -> int | None:
+        if not isinstance(raw_data, dict):
+            return None
+        for key in ("patient_id", "patientId", "client_id", "clientId"):
+            candidate = PaymentWebhookApiService._safe_int(raw_data.get(key))
+            if candidate is not None:
+                return candidate
+
+        params = raw_data.get("params")
+        if isinstance(params, dict):
+            account = params.get("account")
+            if isinstance(account, dict):
+                for key in ("patient_id", "patientId", "client_id", "clientId"):
+                    candidate = PaymentWebhookApiService._safe_int(account.get(key))
+                    if candidate is not None:
+                        return candidate
+        return None
+
+    @staticmethod
+    def _safe_int(value: Any) -> int | None:
+        try:
+            if value is None:
+                return None
+            return int(value)
+        except (TypeError, ValueError):
+            return None

--- a/backend/tests/integration/test_notification_catalog_slice1.py
+++ b/backend/tests/integration/test_notification_catalog_slice1.py
@@ -2,11 +2,19 @@ from __future__ import annotations
 
 from datetime import date
 
+import pytest
+
 from app.core.security import get_password_hash
 from app.models.notification import NotificationDelivery, NotificationEvent
 from app.models.patient import Patient
 from app.models.user import User
+from app.models.user_profile import (
+    UserNotificationSettings,
+    UserPreferences,
+    UserProfile,
+)
 from app.models.visit import Visit
+from app.services.notification_platform_service import NotificationPlatformService
 
 
 def _event_deliveries(db_session, event_type: str):
@@ -16,6 +24,64 @@ def _event_deliveries(db_session, event_type: str):
         .filter(NotificationEvent.event_type == event_type)
         .all()
     )
+
+
+def _ensure_notification_policy_settings(
+    db_session,
+    *,
+    user: User,
+    desktop_notifications: bool,
+    push_system_updates: bool,
+) -> None:
+    profile = (
+        db_session.query(UserProfile)
+        .filter(UserProfile.user_id == user.id)
+        .first()
+    )
+    if profile is None:
+        profile = UserProfile(user_id=user.id)
+        db_session.add(profile)
+        db_session.commit()
+        db_session.refresh(profile)
+
+    preferences = (
+        db_session.query(UserPreferences)
+        .filter(UserPreferences.user_id == user.id)
+        .first()
+    )
+    if preferences is None:
+        preferences = UserPreferences(
+            user_id=user.id,
+            profile_id=profile.id,
+        )
+        db_session.add(preferences)
+    preferences.desktop_notifications = desktop_notifications
+
+    settings = (
+        db_session.query(UserNotificationSettings)
+        .filter(UserNotificationSettings.user_id == user.id)
+        .first()
+    )
+    if settings is None:
+        settings = UserNotificationSettings(
+            user_id=user.id,
+            profile_id=profile.id,
+        )
+        db_session.add(settings)
+    settings.push_system_updates = push_system_updates
+    settings.weekend_notifications = True
+    settings.quiet_hours_start = "00:00"
+    settings.quiet_hours_end = "00:00"
+
+    db_session.commit()
+
+
+class _FakeNotificationWsManager:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send_json(self, payload, user_id):  # type: ignore[no-untyped-def]
+        self.sent.append({"user_id": user_id, "payload": payload})
 
 
 def test_registrar_cart_creates_all_free_request_notification(
@@ -133,3 +199,250 @@ def test_admin_all_free_approval_creates_registrar_and_patient_notifications(
         assert event.entity_type == "visit"
         assert event.actor_id == admin_user.id
         assert event.payload_snapshot["metadata"]["approval_status"] == "approved"
+
+
+def test_admin_all_free_reject_creates_rejected_notifications_with_reason(
+    client,
+    db_session,
+    auth_headers,
+    admin_user,
+    registrar_user,
+    test_doctor,
+):
+    patient_user = User(
+        username="all_free_patient_reject_user",
+        email="all_free_patient_reject@test.local",
+        full_name="All Free Patient Reject User",
+        hashed_password=get_password_hash("patient123"),
+        role="Patient",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(patient_user)
+    db_session.commit()
+    db_session.refresh(patient_user)
+
+    patient = Patient(
+        first_name="Елена",
+        last_name="Отклонова",
+        phone="+998901112244",
+        birth_date=date(1991, 4, 4),
+        user_id=patient_user.id,
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+
+    visit = Visit(
+        patient_id=patient.id,
+        doctor_id=test_doctor.id,
+        visit_date=date.today(),
+        visit_time="11:30",
+        status="confirmed",
+        discount_mode="all_free",
+        approval_status="pending",
+        department="cardiology",
+        confirmed_by=f"registrar_{registrar_user.id}",
+        source="desk",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+
+    response = client.post(
+        "/api/v1/admin/all-free-approve",
+        json={
+            "visit_id": visit.id,
+            "action": "reject",
+            "rejection_reason": "missing eligibility documents",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    deliveries = _event_deliveries(db_session, "all_free_rejected")
+    recipient_ids = {delivery.recipient_id for delivery, _ in deliveries}
+
+    assert recipient_ids == {registrar_user.id, patient_user.id}
+    for _, event in deliveries:
+        assert event.entity_type == "visit"
+        assert event.actor_id == admin_user.id
+        assert event.payload_snapshot["metadata"]["approval_status"] == "rejected"
+        assert (
+            event.payload_snapshot["metadata"]["rejection_reason"]
+            == "missing eligibility documents"
+        )
+
+
+def test_all_free_requested_updates_inbox_and_unread_when_realtime_suppressed(
+    client,
+    db_session,
+    monkeypatch,
+    registrar_auth_headers,
+    auth_headers,
+    registrar_user,
+    admin_user,
+    test_patient,
+    test_doctor,
+    test_service,
+):
+    _ = registrar_user
+    _ensure_notification_policy_settings(
+        db_session,
+        user=admin_user,
+        desktop_notifications=True,
+        push_system_updates=False,
+    )
+
+    fake_ws_manager = _FakeNotificationWsManager()
+    monkeypatch.setattr(
+        "app.services.notification_platform_service.get_notification_ws_manager",
+        lambda: fake_ws_manager,
+    )
+
+    payload = {
+        "patient_id": test_patient.id,
+        "discount_mode": "all_free",
+        "all_free": True,
+        "payment_method": "cash",
+        "visits": [
+            {
+                "doctor_id": test_doctor.id,
+                "visit_date": date.today().isoformat(),
+                "visit_time": "12:15",
+                "department": "cardiology",
+                "services": [
+                    {
+                        "service_id": test_service.id,
+                        "quantity": 1,
+                    }
+                ],
+            }
+        ],
+    }
+
+    response = client.post(
+        "/api/v1/registrar/cart",
+        json=payload,
+        headers=registrar_auth_headers,
+    )
+    assert response.status_code == 200, response.text
+
+    deliveries = _event_deliveries(db_session, "all_free_requested")
+    assert len(deliveries) == 1
+    delivery, _event = deliveries[0]
+    assert delivery.recipient_id == admin_user.id
+    assert fake_ws_manager.sent == []
+
+    inbox_response = client.get(
+        "/api/v1/notifications/inbox",
+        params={
+            "event_type": "all_free_requested",
+            "recipient_id": admin_user.id,
+            "limit": 20,
+        },
+        headers=auth_headers,
+    )
+    assert inbox_response.status_code == 200, inbox_response.text
+    inbox_payload = inbox_response.json()
+    assert inbox_payload["total"] >= 1
+    assert inbox_payload["unread_count"] >= 1
+    assert any(
+        item["event_type"] == "all_free_requested"
+        and item["recipient_id"] == admin_user.id
+        for item in inbox_payload["items"]
+    )
+
+    unread_response = client.get(
+        "/api/v1/notifications/unread-count",
+        params={"recipient_id": admin_user.id},
+        headers=auth_headers,
+    )
+    assert unread_response.status_code == 200, unread_response.text
+    unread_payload = unread_response.json()
+    assert unread_payload["total"] >= 1
+
+    sync_response = client.get(
+        "/api/v1/notifications/sync",
+        params={
+            "event_type": "all_free_requested",
+            "recipient_id": admin_user.id,
+            "limit": 20,
+        },
+        headers=auth_headers,
+    )
+    assert sync_response.status_code == 200, sync_response.text
+    sync_payload = sync_response.json()
+    assert sync_payload["total"] >= 1
+    assert any(
+        item["event_type"] == "all_free_requested"
+        and item["recipient_id"] == admin_user.id
+        for item in sync_payload["items"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_security_alert_breaks_through_realtime_even_when_policy_disabled(
+    client,
+    db_session,
+    monkeypatch,
+    auth_headers,
+    admin_user,
+):
+    _ensure_notification_policy_settings(
+        db_session,
+        user=admin_user,
+        desktop_notifications=False,
+        push_system_updates=False,
+    )
+    settings = (
+        db_session.query(UserNotificationSettings)
+        .filter(UserNotificationSettings.user_id == admin_user.id)
+        .first()
+    )
+    assert settings is not None
+    settings.push_security_alerts = False
+    db_session.commit()
+
+    fake_ws_manager = _FakeNotificationWsManager()
+    monkeypatch.setattr(
+        "app.services.notification_platform_service.get_notification_ws_manager",
+        lambda: fake_ws_manager,
+    )
+    platform_service = NotificationPlatformService(db_session)
+
+    delivery = await platform_service.record_delivery_for_user(
+        user=admin_user,
+        event_type="security_alert",
+        title="Security alert",
+        message="Suspicious activity detected",
+        source_module="security",
+        severity="warning",
+        priority="normal",
+    )
+    assert delivery.recipient_id == admin_user.id
+    assert len(fake_ws_manager.sent) == 1
+    assert fake_ws_manager.sent[0]["user_id"] == admin_user.id
+    assert (
+        fake_ws_manager.sent[0]["payload"]["event_type"]
+        == "security_alert"
+    )
+
+    inbox_response = client.get(
+        "/api/v1/notifications/inbox",
+        params={
+            "event_type": "security_alert",
+            "recipient_id": admin_user.id,
+            "limit": 20,
+        },
+        headers=auth_headers,
+    )
+    assert inbox_response.status_code == 200, inbox_response.text
+    inbox_payload = inbox_response.json()
+    assert inbox_payload["total"] >= 1
+    assert inbox_payload["unread_count"] >= 1
+    assert any(
+        item["event_type"] == "security_alert"
+        and item["recipient_id"] == admin_user.id
+        for item in inbox_payload["items"]
+    )

--- a/backend/tests/integration/test_notification_catalog_slice3_legacy_webhooks.py
+++ b/backend/tests/integration/test_notification_catalog_slice3_legacy_webhooks.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+from app.core.security import get_password_hash
+from app.models.notification import NotificationDelivery, NotificationEvent
+from app.models.patient import Patient
+from app.models.user import User
+
+
+def _payment_event_deliveries(db_session, *, recipient_id: int):
+    return (
+        db_session.query(NotificationDelivery, NotificationEvent)
+        .join(NotificationEvent, NotificationEvent.id == NotificationDelivery.event_id)
+        .filter(
+            NotificationEvent.event_type == "payment_notification",
+            NotificationDelivery.recipient_id == recipient_id,
+            NotificationEvent.source_module == "payments_webhook_legacy",
+        )
+        .order_by(NotificationDelivery.id.asc())
+        .all()
+    )
+
+
+def _create_patient_user(db_session, *, username: str):
+    user = User(
+        username=username,
+        email=f"{username}@test.local",
+        full_name=f"{username} full name",
+        hashed_password=get_password_hash("patient123"),
+        role="Patient",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    patient = Patient(
+        first_name="Легаси",
+        last_name="Пациент",
+        phone="+998901556677",
+        birth_date=date(1992, 8, 8),
+        user_id=user.id,
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+    return user, patient
+
+
+def test_legacy_click_webhook_emits_canonical_payment_notification(
+    client,
+    db_session,
+    monkeypatch,
+):
+    patient_user, patient = _create_patient_user(
+        db_session, username="legacy_webhook_click_patient"
+    )
+
+    fake_webhook = SimpleNamespace(
+        id=501,
+        provider="click",
+        status="processed",
+        transaction_id="legacy-click-501",
+        patient_id=patient.id,
+        visit_id=None,
+        raw_data={"patient_id": patient.id},
+    )
+
+    def _fake_process_click_webhook(self, data):
+        return True, "Webhook processed successfully", fake_webhook
+
+    monkeypatch.setattr(
+        "app.services.payment_webhook_api_service.PaymentWebhookApiRepository.process_click_webhook",
+        _fake_process_click_webhook,
+    )
+
+    response = client.post(
+        "/api/v1/webhooks/payment/click",
+        data={"merchant_trans_id": "legacy-click-order"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "ok": True,
+        "message": "Webhook processed successfully",
+        "webhook_id": 501,
+    }
+
+    deliveries = _payment_event_deliveries(db_session, recipient_id=patient_user.id)
+    assert len(deliveries) == 1
+    _, event = deliveries[0]
+    assert event.payload_snapshot["metadata"]["provider"] == "click"
+    assert event.payload_snapshot["metadata"]["payment_status"] == "paid"
+    assert event.payload_snapshot["metadata"]["change_type"] == "paid"
+    assert event.payload_snapshot["metadata"]["legacy_webhook_path"] is True
+
+
+def test_legacy_payme_webhook_emits_failed_payment_notification(
+    client,
+    db_session,
+    monkeypatch,
+):
+    patient_user, patient = _create_patient_user(
+        db_session, username="legacy_webhook_payme_patient"
+    )
+
+    fake_webhook = SimpleNamespace(
+        id=701,
+        provider="payme",
+        status="failed",
+        transaction_id="legacy-payme-701",
+        patient_id=patient.id,
+        visit_id=None,
+        raw_data={"params": {"account": {"patient_id": patient.id}}},
+    )
+
+    def _fake_process_payme_webhook(self, data, signature):
+        return False, "provider failure", fake_webhook
+
+    monkeypatch.setattr(
+        "app.services.payment_webhook_api_service.PaymentWebhookApiRepository.process_payme_webhook",
+        _fake_process_payme_webhook,
+    )
+
+    response = client.post(
+        "/api/v1/webhooks/payment/payme",
+        json={"id": "legacy-payme-rpc-id"},
+        headers={"X-Payme-Signature": "test-signature"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "ok": False,
+        "message": "provider failure",
+        "webhook_id": 701,
+    }
+
+    deliveries = _payment_event_deliveries(db_session, recipient_id=patient_user.id)
+    assert len(deliveries) == 1
+    _, event = deliveries[0]
+    assert event.payload_snapshot["metadata"]["provider"] == "payme"
+    assert event.payload_snapshot["metadata"]["payment_status"] == "failed"
+    assert event.payload_snapshot["metadata"]["change_type"] == "failed"
+    assert event.payload_snapshot["metadata"]["legacy_webhook_path"] is True
+
+
+def test_legacy_click_webhook_duplicate_callback_does_not_create_duplicate_delivery(
+    client,
+    db_session,
+    monkeypatch,
+):
+    patient_user, patient = _create_patient_user(
+        db_session, username="legacy_webhook_click_duplicate_patient"
+    )
+
+    fake_webhook = SimpleNamespace(
+        id=901,
+        provider="click",
+        status="processed",
+        transaction_id="legacy-click-901",
+        patient_id=patient.id,
+        visit_id=None,
+        raw_data={"patient_id": patient.id},
+    )
+
+    call_counter = {"value": 0}
+
+    def _fake_process_click_webhook(self, data):
+        call_counter["value"] += 1
+        if call_counter["value"] == 1:
+            return True, "Webhook processed successfully", fake_webhook
+        return False, "Webhook already processed", fake_webhook
+
+    monkeypatch.setattr(
+        "app.services.payment_webhook_api_service.PaymentWebhookApiRepository.process_click_webhook",
+        _fake_process_click_webhook,
+    )
+
+    first_response = client.post(
+        "/api/v1/webhooks/payment/click",
+        data={"merchant_trans_id": "legacy-click-duplicate"},
+    )
+    second_response = client.post(
+        "/api/v1/webhooks/payment/click",
+        data={"merchant_trans_id": "legacy-click-duplicate"},
+    )
+
+    assert first_response.status_code == 200, first_response.text
+    assert second_response.status_code == 200, second_response.text
+    assert first_response.json()["webhook_id"] == 901
+    assert second_response.json()["webhook_id"] == 901
+
+    deliveries = _payment_event_deliveries(db_session, recipient_id=patient_user.id)
+    assert len(deliveries) == 1
+
+
+def test_legacy_payme_webhook_duplicate_callback_does_not_create_duplicate_delivery(
+    client,
+    db_session,
+    monkeypatch,
+):
+    patient_user, patient = _create_patient_user(
+        db_session, username="legacy_webhook_payme_duplicate_patient"
+    )
+
+    fake_webhook = SimpleNamespace(
+        id=902,
+        provider="payme",
+        status="failed",
+        transaction_id="legacy-payme-902",
+        patient_id=patient.id,
+        visit_id=None,
+        raw_data={"params": {"account": {"patient_id": patient.id}}},
+    )
+
+    call_counter = {"value": 0}
+
+    def _fake_process_payme_webhook(self, data, signature):
+        call_counter["value"] += 1
+        if call_counter["value"] == 1:
+            return False, "provider failure", fake_webhook
+        return False, "Webhook already processed", fake_webhook
+
+    monkeypatch.setattr(
+        "app.services.payment_webhook_api_service.PaymentWebhookApiRepository.process_payme_webhook",
+        _fake_process_payme_webhook,
+    )
+
+    first_response = client.post(
+        "/api/v1/webhooks/payment/payme",
+        json={"id": "legacy-payme-duplicate"},
+        headers={"X-Payme-Signature": "test-signature"},
+    )
+    second_response = client.post(
+        "/api/v1/webhooks/payment/payme",
+        json={"id": "legacy-payme-duplicate"},
+        headers={"X-Payme-Signature": "test-signature"},
+    )
+
+    assert first_response.status_code == 200, first_response.text
+    assert second_response.status_code == 200, second_response.text
+    assert first_response.json()["webhook_id"] == 902
+    assert second_response.json()["webhook_id"] == 902
+
+    deliveries = _payment_event_deliveries(db_session, recipient_id=patient_user.id)
+    assert len(deliveries) == 1

--- a/backend/tests/unit/test_notification_platform_contract.py
+++ b/backend/tests/unit/test_notification_platform_contract.py
@@ -50,7 +50,7 @@ async def test_notification_platform_service_creates_persistent_delivery_and_ded
         .one()
     )
 
-    assert persisted_event.event_type == "queue_changed"
+    assert persisted_event.event_type == "queue_update"
     assert persisted_delivery.delivery_status == "delivered"
     assert persisted_delivery.role == "admin"
     assert persisted_delivery.sequence_id == 1
@@ -80,7 +80,7 @@ async def test_notification_platform_service_creates_persistent_delivery_and_ded
     assert inbox["total"] == 1
     assert inbox["unread_count"] == 1
     assert inbox["items"][0]["id"] == delivery.delivery_id
-    assert inbox["items"][0]["event_type"] == "queue_changed"
+    assert inbox["items"][0]["event_type"] == "queue_update"
 
     seen_delivery = await service.mark_seen(current_user=admin_user, delivery_id=delivery.delivery_id)
     assert seen_delivery.seen_at is not None
@@ -138,3 +138,227 @@ def test_notification_history_scope_allows_same_recipient_even_if_type_differs(
         recipient_id=admin_user.id,
         recipient_type='doctor',
     )
+
+
+def test_realtime_policy_suppresses_when_desktop_notifications_disabled(db_session):
+    service = NotificationPlatformService(db_session)
+    user = SimpleNamespace(
+        preferences=SimpleNamespace(desktop_notifications=False, timezone="Asia/Tashkent"),
+        profile=SimpleNamespace(timezone="Asia/Tashkent"),
+        notification_settings=SimpleNamespace(
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            weekend_notifications=True,
+        ),
+    )
+
+    allowed, reason = service._should_broadcast_realtime(
+        user=user,
+        event_type="queue_update",
+        severity="info",
+        priority="normal",
+    )
+
+    assert allowed is False
+    assert reason == "desktop_notifications_disabled"
+
+
+def test_realtime_policy_allows_critical_breakthrough_even_when_desktop_disabled(db_session):
+    service = NotificationPlatformService(db_session)
+    user = SimpleNamespace(
+        preferences=SimpleNamespace(desktop_notifications=False, timezone="Asia/Tashkent"),
+        profile=SimpleNamespace(timezone="Asia/Tashkent"),
+        notification_settings=SimpleNamespace(
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            weekend_notifications=False,
+        ),
+    )
+
+    allowed, reason = service._should_broadcast_realtime(
+        user=user,
+        event_type="security_alert",
+        severity="warning",
+        priority="normal",
+    )
+
+    assert allowed is True
+    assert reason == "critical_breakthrough"
+
+
+def test_realtime_policy_suppresses_queue_events_during_quiet_hours(monkeypatch, db_session):
+    service = NotificationPlatformService(db_session)
+    user = SimpleNamespace(
+        preferences=SimpleNamespace(desktop_notifications=True, timezone="Asia/Tashkent"),
+        profile=SimpleNamespace(timezone="Asia/Tashkent"),
+        notification_settings=SimpleNamespace(
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            weekend_notifications=True,
+        ),
+    )
+    monkeypatch.setattr(service, "_is_within_quiet_hours", lambda **_: True)
+
+    allowed, reason = service._should_broadcast_realtime(
+        user=user,
+        event_type="queue_position",
+        severity="info",
+        priority="normal",
+    )
+
+    assert allowed is False
+    assert reason == "quiet_hours_queue_suppression"
+
+
+def test_realtime_policy_respects_event_push_setting_mapping(db_session):
+    service = NotificationPlatformService(db_session)
+    user = SimpleNamespace(
+        preferences=SimpleNamespace(desktop_notifications=True, timezone="Asia/Tashkent"),
+        profile=SimpleNamespace(timezone="Asia/Tashkent"),
+        notification_settings=SimpleNamespace(
+            push_system_updates=False,
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            weekend_notifications=True,
+        ),
+    )
+
+    allowed, reason = service._should_broadcast_realtime(
+        user=user,
+        event_type="queue_update",
+        severity="info",
+        priority="normal",
+    )
+
+    assert allowed is False
+    assert reason == "setting_disabled:push_system_updates"
+
+
+@pytest.mark.asyncio
+async def test_record_delivery_for_users_keeps_inbox_but_filters_realtime_by_settings(
+    db_session,
+    monkeypatch,
+):
+    service = NotificationPlatformService(db_session)
+    service.ws_manager = SimpleNamespace(send_json=AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_is_within_quiet_hours", lambda **_: False)
+
+    user_realtime_off = SimpleNamespace(
+        id=91001,
+        role="patient",
+        is_superuser=False,
+        profile=SimpleNamespace(department=None, timezone="Asia/Tashkent"),
+        preferences=SimpleNamespace(desktop_notifications=True, timezone="Asia/Tashkent"),
+        notification_settings=SimpleNamespace(
+            push_system_updates=False,
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            weekend_notifications=True,
+        ),
+    )
+    user_realtime_on = SimpleNamespace(
+        id=91002,
+        role="patient",
+        is_superuser=False,
+        profile=SimpleNamespace(department=None, timezone="Asia/Tashkent"),
+        preferences=SimpleNamespace(desktop_notifications=True, timezone="Asia/Tashkent"),
+        notification_settings=SimpleNamespace(
+            push_system_updates=True,
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            weekend_notifications=True,
+        ),
+    )
+
+    deliveries = await service.record_delivery_for_users(
+        users=[user_realtime_off, user_realtime_on],
+        event_type="queue_update",
+        title="Обновление очереди",
+        message="Очередь изменилась",
+        source_module="queue",
+        severity="info",
+        priority="normal",
+    )
+
+    assert len(deliveries) == 2
+    assert db_session.query(NotificationDelivery).count() == 2
+    assert db_session.query(NotificationEvent).count() == 1
+    assert service.ws_manager.send_json.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_record_delivery_for_user_persists_inbox_when_realtime_suppressed_by_event_setting(
+    db_session,
+    monkeypatch,
+):
+    service = NotificationPlatformService(db_session)
+    service.ws_manager = SimpleNamespace(send_json=AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_is_within_quiet_hours", lambda **_: False)
+
+    user = SimpleNamespace(
+        id=92001,
+        role="patient",
+        is_superuser=False,
+        profile=SimpleNamespace(department=None, timezone="Asia/Tashkent"),
+        preferences=SimpleNamespace(desktop_notifications=True, timezone="Asia/Tashkent"),
+        notification_settings=SimpleNamespace(
+            push_system_updates=False,
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            weekend_notifications=True,
+        ),
+    )
+
+    delivery = await service.record_delivery_for_user(
+        user=user,
+        event_type="queue_update",
+        title="Обновление очереди",
+        message="Очередь изменилась",
+        source_module="queue",
+        severity="info",
+        priority="normal",
+    )
+
+    assert delivery is not None
+    assert db_session.query(NotificationDelivery).count() == 1
+    assert db_session.query(NotificationEvent).count() == 1
+    assert service.ws_manager.send_json.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_record_delivery_for_user_allows_critical_breakthrough_even_if_settings_disabled(
+    db_session,
+    monkeypatch,
+):
+    service = NotificationPlatformService(db_session)
+    service.ws_manager = SimpleNamespace(send_json=AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_is_within_quiet_hours", lambda **_: True)
+
+    user = SimpleNamespace(
+        id=92002,
+        role="patient",
+        is_superuser=False,
+        profile=SimpleNamespace(department=None, timezone="Asia/Tashkent"),
+        preferences=SimpleNamespace(desktop_notifications=False, timezone="Asia/Tashkent"),
+        notification_settings=SimpleNamespace(
+            push_security_alerts=False,
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            weekend_notifications=False,
+        ),
+    )
+
+    delivery = await service.record_delivery_for_user(
+        user=user,
+        event_type="security_alert",
+        title="Security alert",
+        message="Suspicious activity detected",
+        source_module="security",
+        severity="warning",
+        priority="normal",
+    )
+
+    assert delivery is not None
+    assert db_session.query(NotificationDelivery).count() == 1
+    assert db_session.query(NotificationEvent).count() == 1
+    assert service.ws_manager.send_json.await_count == 1


### PR DESCRIPTION
## Summary
- enforce backend realtime notification policy in `NotificationPlatformService` while preserving inbox SSOT
- add event-type -> `push_*` preference mapping and quiet-hours/weekend suppression for queue-family events
- keep critical break-through (`security_alert`, `billing_alert`, `lab_critical_result`) for realtime delivery
- harden legacy webhook canonical emit path and dedup behavior (`payment_notification`)
- add unit/integration coverage for realtime suppression/break-through and legacy webhook idempotency
- refresh active SSOT implementation note and LightRAG readiness evidence entries

## Validation
- `python -m py_compile backend/app/services/notification_platform_service.py backend/app/services/payment_webhook_api_service.py`
- `python -m pytest backend/tests/unit/test_notification_platform_contract.py backend/tests/integration/test_notification_catalog_slice1.py backend/tests/integration/test_notification_catalog_slice3_legacy_webhooks.py -q`
- broader pack validated earlier in thread (backend notification unit+integration + frontend notification tests)
