### PR TITLE
feat(notification): wire slice2 producers and frontend catalog parity

### DIFF
--- a/backend/app/api/v1/endpoints/cashier.py
+++ b/backend/app/api/v1/endpoints/cashier.py
@@ -18,7 +18,9 @@ from app.api import deps
 from app.models.payment import Payment
 from app.models.visit import Visit
 from app.models.patient import Patient
+from app.models.user import User
 from app.services.payment_read_service import PaymentReadService
+from app.services.notifications import notification_sender_service
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +152,113 @@ def get_patient_name(patient: Optional[Patient], patient_id: int) -> str:
             if parts:
                 return " ".join(parts)
     return f"Пациент #{patient_id}"
+
+
+def _decimal_to_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+async def _emit_payment_notification(
+    *,
+    db: Session,
+    payment: Payment,
+    current_user: Any,
+    change_type: str,
+    patient_id: Optional[int] = None,
+    visit: Optional[Visit] = None,
+    reason: Optional[str] = None,
+    extra_metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Emit canonical payment_notification for patient inbox without breaking cashier flow."""
+    try:
+        resolved_visit = visit
+        if resolved_visit is None and payment.visit_id:
+            resolved_visit = db.query(Visit).filter(Visit.id == payment.visit_id).first()
+
+        resolved_patient_id = patient_id or (resolved_visit.patient_id if resolved_visit else None)
+        if not resolved_patient_id:
+            return
+
+        patient = db.query(Patient).filter(Patient.id == resolved_patient_id).first()
+        if not patient or not patient.user_id:
+            return
+
+        recipient = (
+            db.query(User)
+            .filter(User.id == patient.user_id, User.is_active.is_(True))
+            .first()
+        )
+        if not recipient:
+            return
+
+        amount_value = _decimal_to_float(getattr(payment, "amount", None))
+        metadata: Dict[str, Any] = {
+            "payment_id": payment.id,
+            "visit_id": payment.visit_id,
+            "patient_id": resolved_patient_id,
+            "payment_status": payment.status,
+            "payment_method": getattr(payment, "method", None),
+            "change_type": change_type,
+        }
+        if amount_value is not None:
+            metadata["amount"] = amount_value
+        if reason:
+            metadata["reason"] = reason
+        if extra_metadata:
+            metadata.update(extra_metadata)
+
+        title_map = {
+            "paid": "Оплата подтверждена",
+            "paid_manual": "Оплата подтверждена",
+            "cancelled": "Платеж отменен",
+            "partial_refund": "Частичный возврат выполнен",
+            "full_refund": "Возврат выполнен",
+            "failed": "Платеж не выполнен",
+        }
+        message_map = {
+            "paid": "Ваш платеж успешно проведен.",
+            "paid_manual": "Ваш платеж подтвержден кассиром.",
+            "cancelled": "Платеж был отменен.",
+            "partial_refund": "Выполнен частичный возврат по вашему платежу.",
+            "full_refund": "Средства по вашему платежу полностью возвращены.",
+            "failed": "Не удалось завершить платеж.",
+        }
+        title = title_map.get(change_type, "Обновление статуса платежа")
+        message = message_map.get(change_type, "Статус платежа обновлен.")
+        if amount_value is not None:
+            message = f"{message} Сумма: {amount_value:,.2f} UZS."
+
+        await notification_sender_service.send_canonical_notification_to_user(
+            db=db,
+            recipient=recipient,
+            event_type="payment_notification",
+            title=title,
+            message=message,
+            source_module="cashier",
+            metadata=metadata,
+            deep_link="/patient",
+            severity="warning" if change_type in {"cancelled", "failed", "full_refund"} else "info",
+            priority="high" if change_type in {"cancelled", "failed", "full_refund"} else "normal",
+            actor_id=getattr(current_user, "id", None),
+            actor_role=getattr(current_user, "role", None),
+            entity_type="payment",
+            entity_id=str(payment.id),
+        )
+    except Exception as notify_error:
+        logger.warning(
+            "[FIX:NOTIFICATIONS] failed to emit payment_notification",
+            extra={
+                "payment_id": getattr(payment, "id", None),
+                "visit_id": getattr(payment, "visit_id", None),
+                "change_type": change_type,
+                "error": str(notify_error),
+            },
+        )
 
 
 # ===================== API ENDPOINTS =====================
@@ -713,6 +822,7 @@ async def create_payment(
     try:
         # Определяем patient_id
         patient_id = payment_data.patient_id
+        visit = None
         
         if payment_data.visit_id:
             # ✅ FIX: Use lazy load to ensure consistency with get_pending_payments
@@ -777,6 +887,15 @@ async def create_payment(
         db.add(new_payment)
         db.commit()
         db.refresh(new_payment)
+
+        await _emit_payment_notification(
+            db=db,
+            payment=new_payment,
+            current_user=current_user,
+            change_type="paid",
+            patient_id=patient_id,
+            visit=visit,
+        )
         
         # 🔔 WebSocket: Broadcast payment_created event
         try:
@@ -885,6 +1004,7 @@ async def cancel_payment(
             payment.note = f"Отменён: {cancel_data.reason}"
 
         # Возвращаем только operational статус визита; registration type не трогаем.
+        visit = None
         if payment.visit_id:
             visit = db.query(Visit).filter(Visit.id == payment.visit_id).first()
             if visit and visit.status == 'paid':
@@ -892,6 +1012,16 @@ async def cancel_payment(
                 db.add(visit)
         
         db.commit()
+
+        await _emit_payment_notification(
+            db=db,
+            payment=payment,
+            current_user=current_user,
+            change_type="cancelled",
+            patient_id=visit.patient_id if visit else None,
+            visit=visit,
+            reason=cancel_data.reason,
+        )
         
         return {
             "success": True,
@@ -955,6 +1085,16 @@ async def mark_visit_as_paid(
 
         db.commit()
 
+        if total_amount > 0:
+            await _emit_payment_notification(
+                db=db,
+                payment=new_payment,
+                current_user=current_user,
+                change_type="paid",
+                patient_id=visit.patient_id,
+                visit=visit,
+            )
+
         return {
             "success": True,
             "message": "Визит отмечен как оплаченный",
@@ -1002,6 +1142,7 @@ async def confirm_payment(
         payment.provider_transaction_id = f"MANUAL-{payment_id}-{int(datetime.utcnow().timestamp())}"
     
     # Обновляем только operational статус визита; registration type не меняем.
+    visit = None
     if payment.visit_id:
          visit = db.query(Visit).filter(Visit.id == payment.visit_id).first()
          if visit:
@@ -1009,6 +1150,15 @@ async def confirm_payment(
               db.add(visit)
     
     db.commit()
+    await _emit_payment_notification(
+        db=db,
+        payment=payment,
+        current_user=current_user,
+        change_type="paid_manual",
+        patient_id=visit.patient_id if visit else None,
+        visit=visit,
+        extra_metadata={"confirmation_mode": "manual"},
+    )
     return {"success": True, "status": "paid"}
 
 
@@ -1070,6 +1220,22 @@ async def refund_payment(
         
         db.commit()
         db.refresh(payment)
+
+        refund_change_type = "full_refund" if payment.status == "refunded" else "partial_refund"
+        refund_visit = db.query(Visit).filter(Visit.id == payment.visit_id).first() if payment.visit_id else None
+        await _emit_payment_notification(
+            db=db,
+            payment=payment,
+            current_user=current_user,
+            change_type=refund_change_type,
+            patient_id=refund_visit.patient_id if refund_visit else None,
+            visit=refund_visit,
+            reason=refund_data.reason,
+            extra_metadata={
+                "refund_amount": _decimal_to_float(refund_data.amount),
+                "remaining_amount": _decimal_to_float(payment.amount - new_refunded_amount),
+            },
+        )
         
         return RefundResponse(
             id=payment.id,

--- a/backend/app/api/v1/endpoints/payment_webhooks.py
+++ b/backend/app/api/v1/endpoints/payment_webhooks.py
@@ -8,9 +8,98 @@ from fastapi import APIRouter, Depends, Request
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
+from app.models.patient import Patient
+from app.models.payment import Payment
+from app.models.user import User
+from app.models.visit import Visit
+from app.services.notifications import notification_sender_service
 from app.services.provider_webhook_service import ProviderWebhookService
 
 router = APIRouter()
+
+
+async def _emit_payment_notification_from_webhook_result(
+    *,
+    db: Session,
+    result: Dict[str, Any],
+    webhook_kind: str,
+) -> None:
+    payment_id = result.get("payment_id")
+    payment_status = str(result.get("payment_status") or "").strip().lower()
+    provider = str(result.get("payment_provider") or webhook_kind).strip().lower()
+
+    if not payment_id or payment_status not in {"paid", "failed", "cancelled", "refunded"}:
+        return
+
+    payment = db.query(Payment).filter(Payment.id == payment_id).first()
+    if not payment or not payment.visit_id:
+        return
+
+    visit = db.query(Visit).filter(Visit.id == payment.visit_id).first()
+    if not visit:
+        return
+
+    patient = db.query(Patient).filter(Patient.id == visit.patient_id).first()
+    if not patient or not patient.user_id:
+        return
+
+    recipient = (
+        db.query(User)
+        .filter(User.id == patient.user_id, User.is_active.is_(True))
+        .first()
+    )
+    if not recipient:
+        return
+
+    change_type_map = {
+        "paid": "paid",
+        "failed": "failed",
+        "cancelled": "cancelled",
+        "refunded": "full_refund",
+    }
+    title_map = {
+        "paid": "Оплата подтверждена",
+        "failed": "Платеж не выполнен",
+        "cancelled": "Платеж отменен",
+        "refunded": "Возврат выполнен",
+    }
+    message_map = {
+        "paid": "Онлайн-платеж успешно обработан.",
+        "failed": "Онлайн-платеж не был завершен.",
+        "cancelled": "Онлайн-платеж был отменен.",
+        "refunded": "По вашему платежу выполнен возврат.",
+    }
+
+    await notification_sender_service.send_canonical_notification_to_user(
+        db=db,
+        recipient=recipient,
+        event_type="payment_notification",
+        title=title_map[payment_status],
+        message=message_map[payment_status],
+        source_module="payments_webhook",
+        metadata={
+            "payment_id": payment.id,
+            "visit_id": payment.visit_id,
+            "patient_id": patient.id,
+            "payment_status": payment_status,
+            "change_type": change_type_map[payment_status],
+            "provider": provider,
+            "webhook_kind": webhook_kind,
+        },
+        deep_link="/patient",
+        severity="warning" if payment_status in {"failed", "cancelled", "refunded"} else "info",
+        priority="high" if payment_status in {"failed", "cancelled", "refunded"} else "normal",
+        entity_type="payment",
+        entity_id=str(payment.id),
+    )
+
+
+def _strip_internal_payment_fields(result: Dict[str, Any]) -> Dict[str, Any]:
+    sanitized = dict(result or {})
+    sanitized.pop("payment_id", None)
+    sanitized.pop("payment_status", None)
+    sanitized.pop("payment_provider", None)
+    return sanitized
 
 
 @router.post("/click")
@@ -19,7 +108,13 @@ async def click_webhook(
 ) -> Dict[str, Any]:
     """Webhook для Click платежной системы"""
     webhook_data = await request.json()
-    return ProviderWebhookService(db).process_click_webhook(webhook_data)
+    result = ProviderWebhookService(db).process_click_webhook(webhook_data)
+    await _emit_payment_notification_from_webhook_result(
+        db=db,
+        result=result,
+        webhook_kind="click",
+    )
+    return _strip_internal_payment_fields(result)
 
 
 @router.post("/payme")
@@ -29,7 +124,13 @@ async def payme_webhook(
     """Webhook для Payme платежной системы (JSON-RPC)"""
     webhook_data = await request.json()
     auth_header = request.headers.get("Authorization")
-    return ProviderWebhookService(db).process_payme_webhook(webhook_data, auth_header)
+    result = ProviderWebhookService(db).process_payme_webhook(webhook_data, auth_header)
+    await _emit_payment_notification_from_webhook_result(
+        db=db,
+        result=result,
+        webhook_kind="payme",
+    )
+    return _strip_internal_payment_fields(result)
 
 
 @router.post("/kaspi")
@@ -38,4 +139,10 @@ async def kaspi_webhook(
 ) -> Dict[str, Any]:
     """Webhook для Kaspi Pay платежной системы"""
     webhook_data = await request.json()
-    return ProviderWebhookService(db).process_kaspi_webhook(webhook_data)
+    result = ProviderWebhookService(db).process_kaspi_webhook(webhook_data)
+    await _emit_payment_notification_from_webhook_result(
+        db=db,
+        result=result,
+        webhook_kind="kaspi",
+    )
+    return _strip_internal_payment_fields(result)

--- a/backend/app/services/payment_init_service.py
+++ b/backend/app/services/payment_init_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 
@@ -10,12 +11,15 @@ from fastapi import Request
 from app.core.audit import extract_model_changes, log_critical_change
 from app.core.config import settings
 from app.models.enums import PaymentStatus
+from app.models.patient import Patient
+from app.models.user import User
 from app.repositories.payment_init_repository import PaymentInitRepository
 from app.services.billing_service import BillingService
 from app.services.context_facades.queue_facade import (
     QueueContextFacade,
     QueueServiceContractAdapter,
 )
+from app.services.notifications import notification_sender_service
 from app.services.queue_service import queue_service
 
 logger = logging.getLogger(__name__)
@@ -154,6 +158,14 @@ class PaymentInitService:
             )
             self.repository.commit()
             self.repository.refresh(payment)
+            self._notify_payment_status(
+                payment_id=payment.id,
+                visit_id=visit.id,
+                current_user_id=current_user_id,
+                change_type="failed_init",
+                reason=result.error_message,
+                provider=provider,
+            )
             return {
                 "success": False,
                 "payment_id": payment.id,
@@ -174,3 +186,85 @@ class PaymentInitService:
                 "success": False,
                 "error_message": f"Ошибка инициализации платежа: {exc}",
             }
+
+    def _notify_payment_status(
+        self,
+        *,
+        payment_id: int,
+        visit_id: int | None,
+        current_user_id: int | None,
+        change_type: str,
+        reason: str | None = None,
+        provider: str | None = None,
+    ) -> None:
+        """Best-effort canonical payment_notification emit for sync init flow."""
+        if visit_id is None:
+            return
+
+        visit = self.repository.get_visit(visit_id)
+        if not visit:
+            return
+
+        patient = (
+            self.repository.db.query(Patient)
+            .filter(Patient.id == visit.patient_id)
+            .first()
+        )
+        if not patient or not patient.user_id:
+            return
+
+        recipient = (
+            self.repository.db.query(User)
+            .filter(User.id == patient.user_id, User.is_active.is_(True))
+            .first()
+        )
+        if not recipient:
+            return
+
+        actor_user = None
+        if current_user_id:
+            actor_user = self.repository.db.query(User).filter(User.id == current_user_id).first()
+
+        title = "Ошибка инициализации платежа"
+        message = "Не удалось инициализировать онлайн-платеж. Попробуйте снова."
+        if reason:
+            message = f"{message} Причина: {reason}"
+
+        async def _send() -> None:
+            await notification_sender_service.send_canonical_notification_to_user(
+                db=self.repository.db,
+                recipient=recipient,
+                event_type="payment_notification",
+                title=title,
+                message=message,
+                source_module="payments",
+                metadata={
+                    "payment_id": payment_id,
+                    "visit_id": visit_id,
+                    "patient_id": visit.patient_id,
+                    "payment_status": "failed",
+                    "change_type": change_type,
+                    "provider": provider,
+                    "reason": reason,
+                },
+                deep_link="/payment/cancel",
+                severity="warning",
+                priority="high",
+                actor_id=getattr(actor_user, "id", None),
+                actor_role=getattr(actor_user, "role", None),
+                entity_type="payment",
+                entity_id=str(payment_id),
+            )
+
+        try:
+            asyncio.run(_send())
+        except Exception as exc:
+            logger.warning(
+                "[FIX:NOTIFICATIONS] failed to emit payment init notification",
+                extra={
+                    "payment_id": payment_id,
+                    "visit_id": visit_id,
+                    "change_type": change_type,
+                    "error": str(exc),
+                },
+            )

--- a/backend/app/services/provider_webhook_service.py
+++ b/backend/app/services/provider_webhook_service.py
@@ -67,6 +67,9 @@ class ProviderWebhookService:
                     "merchant_prepare_id": existing_transaction.webhook_id or 0,
                     "error": 0,
                     "error_note": "Already processed",
+                    "payment_id": getattr(existing_transaction, "payment_id", None),
+                    "payment_status": None,
+                    "payment_provider": "click",
                 }
 
             with transaction_ctx(self.db):
@@ -88,6 +91,7 @@ class ProviderWebhookService:
                     webhook.processed_at = datetime.utcnow()
 
                     payment = None
+                    mapped_status = None
                     if result.payment_id:
                         payment_id_from_order = self._extract_payment_id_from_order(
                             result.payment_id
@@ -98,9 +102,8 @@ class ProviderWebhookService:
                             )
 
                     if payment:
-                        payment.status = self._map_provider_status_to_payment_status(
-                            result.status
-                        )
+                        mapped_status = self._map_provider_status_to_payment_status(result.status)
+                        payment.status = mapped_status
                         if payment.status == "paid":
                             payment.paid_at = datetime.utcnow()
 
@@ -131,11 +134,26 @@ class ProviderWebhookService:
                         "merchant_prepare_id": webhook.id,
                         "error": error,
                         "error_note": "" if error == 0 else "Payment processing error",
+                        "payment_id": payment.id if payment else None,
+                        "payment_status": mapped_status,
+                        "payment_provider": "click",
                     }
 
                 webhook.status = "failed"
                 webhook.error_message = result.error_message
                 webhook.processed_at = datetime.utcnow()
+
+                failed_payment = None
+                if result.payment_id:
+                    payment_id_from_order = self._extract_payment_id_from_order(result.payment_id)
+                    if payment_id_from_order:
+                        failed_payment = self.repository.get_payment_by_id(payment_id_from_order)
+                if failed_payment:
+                    failed_payment.status = "failed"
+                    failed_payment.provider_data = {
+                        **(failed_payment.provider_data or {}),
+                        "webhook_error": result.error_message,
+                    }
 
                 return {
                     "click_trans_id": webhook_data.get("click_trans_id"),
@@ -143,6 +161,9 @@ class ProviderWebhookService:
                     "merchant_prepare_id": webhook.id,
                     "error": -1,
                     "error_note": result.error_message or "Processing error",
+                    "payment_id": failed_payment.id if failed_payment else None,
+                    "payment_status": "failed" if failed_payment else None,
+                    "payment_provider": "click",
                 }
 
         except Exception as exc:
@@ -212,6 +233,9 @@ class ProviderWebhookService:
                             "state": 1,
                         },
                         "id": request_id,
+                        "payment_id": getattr(existing_transaction, "payment_id", None),
+                        "payment_status": None,
+                        "payment_provider": "payme",
                     }
                 if method == "PerformTransaction":
                     return {
@@ -221,6 +245,9 @@ class ProviderWebhookService:
                             "state": 2,
                         },
                         "id": request_id,
+                        "payment_id": getattr(existing_transaction, "payment_id", None),
+                        "payment_status": None,
+                        "payment_provider": "payme",
                     }
                 if method == "CancelTransaction":
                     return {
@@ -230,8 +257,17 @@ class ProviderWebhookService:
                             "state": -1,
                         },
                         "id": request_id,
+                        "payment_id": getattr(existing_transaction, "payment_id", None),
+                        "payment_status": None,
+                        "payment_provider": "payme",
                     }
-                return {"result": {}, "id": request_id}
+                return {
+                    "result": {},
+                    "id": request_id,
+                    "payment_id": getattr(existing_transaction, "payment_id", None),
+                    "payment_status": None,
+                    "payment_provider": "payme",
+                }
 
             with transaction_ctx(self.db):
                 webhook_id = f"payme_{uuid.uuid4().hex[:8]}"
@@ -251,6 +287,7 @@ class ProviderWebhookService:
                     webhook.processed_at = datetime.utcnow()
 
                     payment = None
+                    mapped_status = None
                     if result.payment_id:
                         payment_id_from_order = self._extract_payment_id_from_order(
                             result.payment_id
@@ -261,9 +298,8 @@ class ProviderWebhookService:
                             )
 
                     if payment:
-                        payment.status = self._map_provider_status_to_payment_status(
-                            result.status
-                        )
+                        mapped_status = self._map_provider_status_to_payment_status(result.status)
+                        payment.status = mapped_status
                         if payment.status == "paid":
                             payment.paid_at = datetime.utcnow()
 
@@ -288,7 +324,13 @@ class ProviderWebhookService:
                         )
 
                     if method == "CheckPerformTransaction":
-                        return {"result": {"allow": True}, "id": request_id}
+                        return {
+                            "result": {"allow": True},
+                            "id": request_id,
+                            "payment_id": payment.id if payment else None,
+                            "payment_status": mapped_status,
+                            "payment_provider": "payme",
+                        }
                     if method == "CreateTransaction":
                         return {
                             "result": {
@@ -297,6 +339,9 @@ class ProviderWebhookService:
                                 "state": 1,
                             },
                             "id": request_id,
+                            "payment_id": payment.id if payment else None,
+                            "payment_status": mapped_status,
+                            "payment_provider": "payme",
                         }
                     if method == "PerformTransaction":
                         return {
@@ -306,6 +351,9 @@ class ProviderWebhookService:
                                 "state": 2,
                             },
                             "id": request_id,
+                            "payment_id": payment.id if payment else None,
+                            "payment_status": mapped_status,
+                            "payment_provider": "payme",
                         }
                     if method == "CancelTransaction":
                         return {
@@ -315,12 +363,33 @@ class ProviderWebhookService:
                                 "state": -1,
                             },
                             "id": request_id,
+                            "payment_id": payment.id if payment else None,
+                            "payment_status": mapped_status,
+                            "payment_provider": "payme",
                         }
-                    return {"result": {}, "id": request_id}
+                    return {
+                        "result": {},
+                        "id": request_id,
+                        "payment_id": payment.id if payment else None,
+                        "payment_status": mapped_status,
+                        "payment_provider": "payme",
+                    }
 
                 webhook.status = "failed"
                 webhook.error_message = result.error_message
                 webhook.processed_at = datetime.utcnow()
+
+                failed_payment = None
+                if result.payment_id:
+                    payment_id_from_order = self._extract_payment_id_from_order(result.payment_id)
+                    if payment_id_from_order:
+                        failed_payment = self.repository.get_payment_by_id(payment_id_from_order)
+                if failed_payment:
+                    failed_payment.status = "failed"
+                    failed_payment.provider_data = {
+                        **(failed_payment.provider_data or {}),
+                        "webhook_error": result.error_message,
+                    }
 
                 return {
                     "error": {
@@ -328,6 +397,9 @@ class ProviderWebhookService:
                         "message": result.error_message or "Processing error",
                     },
                     "id": request_id,
+                    "payment_id": failed_payment.id if failed_payment else None,
+                    "payment_status": "failed" if failed_payment else None,
+                    "payment_provider": "payme",
                 }
 
         except Exception as exc:
@@ -363,15 +435,15 @@ class ProviderWebhookService:
                 webhook.processed_at = datetime.utcnow()
 
                 payment = None
+                mapped_status = None
                 if result.payment_id:
                     payment = self.repository.get_payment_by_provider_payment_id(
                         result.payment_id
                     )
 
                 if payment:
-                    payment.status = self._map_provider_status_to_payment_status(
-                        result.status
-                    )
+                    mapped_status = self._map_provider_status_to_payment_status(result.status)
+                    payment.status = mapped_status
                     if payment.status == "paid":
                         payment.paid_at = datetime.utcnow()
 
@@ -396,16 +468,35 @@ class ProviderWebhookService:
                     )
 
                 self.db.commit()
-                return {"status": "success", "message": "Webhook processed successfully"}
+                return {
+                    "status": "success",
+                    "message": "Webhook processed successfully",
+                    "payment_id": payment.id if payment else None,
+                    "payment_status": mapped_status,
+                    "payment_provider": "kaspi",
+                }
 
             webhook.status = "failed"
             webhook.error_message = result.error_message
             webhook.processed_at = datetime.utcnow()
+
+            failed_payment = None
+            if result.payment_id:
+                failed_payment = self.repository.get_payment_by_provider_payment_id(result.payment_id)
+            if failed_payment:
+                failed_payment.status = "failed"
+                failed_payment.provider_data = {
+                    **(failed_payment.provider_data or {}),
+                    "webhook_error": result.error_message,
+                }
             self.db.commit()
 
             return {
                 "status": "error",
                 "message": result.error_message or "Processing error",
+                "payment_id": failed_payment.id if failed_payment else None,
+                "payment_status": "failed" if failed_payment else None,
+                "payment_provider": "kaspi",
             }
         except Exception as exc:
             logger.error("Kaspi webhook error: %s", exc)

--- a/backend/tests/integration/test_notification_catalog_slice2_cashier.py
+++ b/backend/tests/integration/test_notification_catalog_slice2_cashier.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import date
+
+from app.core.security import get_password_hash
+from app.models.notification import NotificationDelivery, NotificationEvent
+from app.models.patient import Patient
+from app.models.payment import Payment
+from app.models.user import User
+from app.models.visit import Visit
+
+
+def _payment_event_deliveries(db_session, *, recipient_id: int):
+    return (
+        db_session.query(NotificationDelivery, NotificationEvent)
+        .join(NotificationEvent, NotificationEvent.id == NotificationDelivery.event_id)
+        .filter(
+            NotificationEvent.event_type == "payment_notification",
+            NotificationDelivery.recipient_id == recipient_id,
+        )
+        .order_by(NotificationDelivery.id.asc())
+        .all()
+    )
+
+
+def test_cashier_create_payment_creates_canonical_payment_notification(
+    client,
+    db_session,
+    auth_headers,
+):
+    patient_user = User(
+        username="cashier_payment_patient",
+        email="cashier_payment_patient@test.local",
+        full_name="Cashier Payment Patient",
+        hashed_password=get_password_hash("patient123"),
+        role="Patient",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(patient_user)
+    db_session.commit()
+    db_session.refresh(patient_user)
+
+    patient = Patient(
+        first_name="Игорь",
+        last_name="Платежный",
+        phone="+998901000100",
+        birth_date=date(1992, 3, 3),
+        user_id=patient_user.id,
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+
+    visit = Visit(
+        patient_id=patient.id,
+        status="waiting",
+        discount_mode="none",
+        approval_status="none",
+        source="desk",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+
+    response = client.post(
+        "/api/v1/cashier/payments",
+        json={
+            "visit_id": visit.id,
+            "amount": 45000,
+            "method": "cash",
+            "note": "slice2 payment",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    deliveries = _payment_event_deliveries(db_session, recipient_id=patient_user.id)
+    assert len(deliveries) == 1
+
+    delivery, event = deliveries[0]
+    assert delivery.role == "patient"
+    assert event.entity_type == "payment"
+    assert event.source_module == "cashier"
+    assert event.deep_link == "/patient"
+    assert event.payload_snapshot["metadata"]["change_type"] == "paid"
+    assert event.payload_snapshot["metadata"]["payment_status"] == "paid"
+    assert event.payload_snapshot["metadata"]["visit_id"] == visit.id
+
+
+def test_cashier_cancel_payment_creates_cancelled_payment_notification(
+    client,
+    db_session,
+    auth_headers,
+):
+    patient_user = User(
+        username="cashier_cancel_patient",
+        email="cashier_cancel_patient@test.local",
+        full_name="Cashier Cancel Patient",
+        hashed_password=get_password_hash("patient123"),
+        role="Patient",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(patient_user)
+    db_session.commit()
+    db_session.refresh(patient_user)
+
+    patient = Patient(
+        first_name="Анвар",
+        last_name="Возвратов",
+        phone="+998901000200",
+        birth_date=date(1991, 6, 6),
+        user_id=patient_user.id,
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+
+    visit = Visit(
+        patient_id=patient.id,
+        status="waiting",
+        discount_mode="none",
+        approval_status="none",
+        source="desk",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+
+    payment = Payment(
+        visit_id=visit.id,
+        amount=70000,
+        method="cash",
+        status="paid",
+    )
+    db_session.add(payment)
+    db_session.commit()
+    db_session.refresh(payment)
+
+    response = client.post(
+        f"/api/v1/cashier/payments/{payment.id}/cancel",
+        json={"reason": "patient requested cancel"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    deliveries = _payment_event_deliveries(db_session, recipient_id=patient_user.id)
+    assert len(deliveries) == 1
+
+    _, event = deliveries[0]
+    assert event.payload_snapshot["metadata"]["change_type"] == "cancelled"
+    assert event.payload_snapshot["metadata"]["payment_status"] == "cancelled"
+    assert event.payload_snapshot["metadata"]["reason"] == "patient requested cancel"

--- a/backend/tests/integration/test_notification_catalog_slice2_online_payments.py
+++ b/backend/tests/integration/test_notification_catalog_slice2_online_payments.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+from app.core.security import get_password_hash
+from app.models.notification import NotificationDelivery, NotificationEvent
+from app.models.patient import Patient
+from app.models.payment import Payment
+from app.models.user import User
+from app.models.visit import Visit
+
+
+def _payment_event_deliveries(db_session, *, recipient_id: int):
+    return (
+        db_session.query(NotificationDelivery, NotificationEvent)
+        .join(NotificationEvent, NotificationEvent.id == NotificationDelivery.event_id)
+        .filter(
+            NotificationEvent.event_type == "payment_notification",
+            NotificationDelivery.recipient_id == recipient_id,
+        )
+        .order_by(NotificationDelivery.id.asc())
+        .all()
+    )
+
+
+def _create_patient_visit_with_user(db_session, *, username: str):
+    patient_user = User(
+        username=username,
+        email=f"{username}@test.local",
+        full_name=f"{username} full name",
+        hashed_password=get_password_hash("patient123"),
+        role="Patient",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(patient_user)
+    db_session.commit()
+    db_session.refresh(patient_user)
+
+    patient = Patient(
+        first_name="Тест",
+        last_name="Пациент",
+        phone="+998901234500",
+        birth_date=date(1990, 1, 1),
+        user_id=patient_user.id,
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+
+    visit = Visit(
+        patient_id=patient.id,
+        status="waiting",
+        discount_mode="none",
+        approval_status="none",
+        source="desk",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+
+    return patient_user, patient, visit
+
+
+def test_click_webhook_creates_payment_notification_and_hides_internal_fields(
+    client,
+    db_session,
+    monkeypatch,
+):
+    patient_user, patient, visit = _create_patient_visit_with_user(
+        db_session, username="slice2_webhook_patient"
+    )
+
+    payment = Payment(
+        visit_id=visit.id,
+        amount=120000,
+        currency="UZS",
+        method="online",
+        status="pending",
+        provider="click",
+    )
+    db_session.add(payment)
+    db_session.commit()
+    db_session.refresh(payment)
+
+    def _fake_click_webhook(self, webhook_data):
+        return {
+            "click_trans_id": webhook_data.get("click_trans_id", 111),
+            "merchant_trans_id": webhook_data.get("merchant_trans_id", "test-order"),
+            "merchant_prepare_id": 123,
+            "error": 0,
+            "error_note": "",
+            "payment_id": payment.id,
+            "payment_status": "paid",
+            "payment_provider": "click",
+        }
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.payment_webhooks.ProviderWebhookService.process_click_webhook",
+        _fake_click_webhook,
+    )
+
+    response = client.post(
+        "/api/v1/payments/webhook/click",
+        json={
+            "click_trans_id": 777,
+            "merchant_trans_id": "demo-merchant-777",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    response_data = response.json()
+    assert "payment_id" not in response_data
+    assert "payment_status" not in response_data
+    assert "payment_provider" not in response_data
+
+    deliveries = _payment_event_deliveries(db_session, recipient_id=patient_user.id)
+    assert len(deliveries) == 1
+
+    _, event = deliveries[0]
+    assert event.source_module == "payments_webhook"
+    assert event.entity_type == "payment"
+    assert event.payload_snapshot["metadata"]["payment_id"] == payment.id
+    assert event.payload_snapshot["metadata"]["visit_id"] == visit.id
+    assert event.payload_snapshot["metadata"]["patient_id"] == patient.id
+    assert event.payload_snapshot["metadata"]["payment_status"] == "paid"
+    assert event.payload_snapshot["metadata"]["change_type"] == "paid"
+    assert event.payload_snapshot["metadata"]["provider"] == "click"
+    assert event.payload_snapshot["metadata"]["webhook_kind"] == "click"
+
+
+def test_payment_init_failed_creates_payment_notification(
+    client,
+    db_session,
+    auth_headers,
+    monkeypatch,
+):
+    patient_user, _, visit = _create_patient_visit_with_user(
+        db_session, username="slice2_init_failure_patient"
+    )
+
+    class _FakePaymentManager:
+        def get_providers_for_currency(self, currency):
+            return ["click"]
+
+        def create_payment(
+            self,
+            *,
+            provider_name,
+            amount,
+            currency,
+            order_id,
+            description,
+            return_url,
+            cancel_url,
+        ):
+            return SimpleNamespace(
+                success=False,
+                payment_id=None,
+                payment_url=None,
+                status="failed",
+                error_message="provider temporarily unavailable",
+                provider_data={"debug": "forced-failure"},
+            )
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.payments.get_payment_manager",
+        lambda: _FakePaymentManager(),
+    )
+
+    response = client.post(
+        "/api/v1/payments/init",
+        headers=auth_headers,
+        json={
+            "visit_id": visit.id,
+            "provider": "click",
+            "amount": 95000,
+            "currency": "UZS",
+            "description": "slice2 init fail",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["success"] is False
+    assert body["payment_id"] is not None
+
+    deliveries = _payment_event_deliveries(db_session, recipient_id=patient_user.id)
+    assert len(deliveries) == 1
+
+    _, event = deliveries[0]
+    assert event.source_module == "payments"
+    assert event.entity_type == "payment"
+    assert event.payload_snapshot["metadata"]["visit_id"] == visit.id
+    assert event.payload_snapshot["metadata"]["payment_status"] == "failed"
+    assert event.payload_snapshot["metadata"]["change_type"] == "failed_init"
+    assert event.payload_snapshot["metadata"]["provider"] == "click"
+    assert event.payload_snapshot["metadata"]["reason"] == "provider temporarily unavailable"

--- a/backend/tests/integration/test_notification_catalog_slice3_patient_registration.py
+++ b/backend/tests/integration/test_notification_catalog_slice3_patient_registration.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import date
+
+from app.models.notification import NotificationDelivery, NotificationEvent
+from app.models.patient import Patient
+
+
+def _patient_registered_deliveries(db_session):
+    return (
+        db_session.query(NotificationDelivery, NotificationEvent)
+        .join(NotificationEvent, NotificationEvent.id == NotificationDelivery.event_id)
+        .filter(NotificationEvent.event_type == "patient_registered")
+        .order_by(NotificationDelivery.id.asc())
+        .all()
+    )
+
+
+def test_create_patient_emits_patient_registered_to_admin_and_registrar(
+    client,
+    db_session,
+    auth_headers,
+    admin_user,
+    registrar_user,
+):
+    _ = admin_user
+    _ = registrar_user
+
+    response = client.post(
+        "/api/v1/patients/",
+        headers=auth_headers,
+        json={
+            "last_name": "Нотиф",
+            "first_name": "Пациент",
+            "birth_date": "1993-05-11",
+            "phone": "+998901345678",
+            "address": "Tashkent",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    patient_id = response.json()["id"]
+
+    deliveries = _patient_registered_deliveries(db_session)
+    recipient_ids = {delivery.recipient_id for delivery, _ in deliveries}
+    assert recipient_ids == {admin_user.id, registrar_user.id}
+
+    for _, event in deliveries:
+        assert event.source_module == "patients"
+        assert event.entity_type == "patient"
+        assert int(event.entity_id) == patient_id
+        assert event.payload_snapshot["metadata"]["patient_id"] == patient_id
+        assert (
+            event.payload_snapshot["metadata"]["registration_source"]
+            == "registrar_panel"
+        )
+
+
+def test_update_patient_does_not_emit_patient_registered_event(
+    client,
+    db_session,
+    auth_headers,
+):
+    patient = Patient(
+        first_name="Старый",
+        last_name="Пациент",
+        phone="+998907777700",
+        birth_date=date(1990, 2, 2),
+        address="Old address",
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+
+    response = client.put(
+        f"/api/v1/patients/{patient.id}",
+        headers=auth_headers,
+        json={
+            "first_name": "Обновленный",
+            "last_name": patient.last_name,
+            "phone": "+998907777701",
+            "address": "New address",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    deliveries = _patient_registered_deliveries(db_session)
+    assert len(deliveries) == 0

--- a/backend/tests/unit/test_lab_notification_catalog_slice3.py
+++ b/backend/tests/unit/test_lab_notification_catalog_slice3.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from app.models.notification import NotificationDelivery, NotificationEvent
+from app.services.notifications import notification_sender_service
+
+
+@pytest.mark.asyncio
+async def test_send_lab_results_creates_canonical_delivery(
+    db_session,
+    admin_user,
+):
+    created = await notification_sender_service.send_lab_event_notification(
+        db=db_session,
+        recipient=admin_user,
+        event_type="lab_results",
+        metadata={
+            "order_id": 101,
+            "patient_id": 202,
+        },
+    )
+
+    assert created is True
+    delivery = (
+        db_session.query(NotificationDelivery)
+        .join(NotificationEvent, NotificationEvent.id == NotificationDelivery.event_id)
+        .filter(
+            NotificationEvent.event_type == "lab_results",
+            NotificationDelivery.recipient_id == admin_user.id,
+        )
+        .one()
+    )
+    event = (
+        db_session.query(NotificationEvent)
+        .filter(NotificationEvent.id == delivery.event_id)
+        .one()
+    )
+
+    assert event.source_module == "lab"
+    assert event.severity == "info"
+    assert event.priority == "high"
+    assert event.entity_type == "lab_result"
+    assert event.entity_id == "101"
+    assert event.deep_link == "/lab/results"
+    assert delivery.role == "admin"
+    assert delivery.payload_snapshot["metadata"]["order_id"] == 101
+
+
+@pytest.mark.asyncio
+async def test_send_lab_critical_result_sets_critical_priority_and_actor(
+    db_session,
+    admin_user,
+    registrar_user,
+):
+    created = await notification_sender_service.send_lab_event_notification(
+        db=db_session,
+        recipient=admin_user,
+        event_type="lab_critical_result",
+        metadata={
+            "result_id": 501,
+            "order_id": 301,
+            "patient_id": 401,
+        },
+        actor_user=registrar_user,
+    )
+
+    assert created is True
+    delivery = (
+        db_session.query(NotificationDelivery)
+        .join(NotificationEvent, NotificationEvent.id == NotificationDelivery.event_id)
+        .filter(
+            NotificationEvent.event_type == "lab_critical_result",
+            NotificationDelivery.recipient_id == admin_user.id,
+        )
+        .one()
+    )
+    event = (
+        db_session.query(NotificationEvent)
+        .filter(NotificationEvent.id == delivery.event_id)
+        .one()
+    )
+
+    assert event.severity == "critical"
+    assert event.priority == "urgent"
+    assert event.actor_id == registrar_user.id
+    assert event.actor_role == registrar_user.role
+    assert event.entity_type == "lab_result"
+    assert event.entity_id == "501"
+    assert delivery.payload_snapshot["metadata"]["result_id"] == 501
+
+
+@pytest.mark.asyncio
+async def test_send_lab_event_rejects_unsupported_type(
+    db_session,
+    admin_user,
+):
+    created = await notification_sender_service.send_lab_event_notification(
+        db=db_session,
+        recipient=admin_user,
+        event_type="lab_result_ready_legacy",
+        metadata={"order_id": 999},
+    )
+
+    assert created is False
+    count = (
+        db_session.query(NotificationEvent)
+        .filter(NotificationEvent.event_type == "lab_result_ready_legacy")
+        .count()
+    )
+    assert count == 0

--- a/backend/tests/unit/test_queue_notifications_catalog_slice3.py
+++ b/backend/tests/unit/test_queue_notifications_catalog_slice3.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+
+from app.models.notification import NotificationDelivery, NotificationEvent
+from app.services.notifications import notification_sender_service
+
+
+@pytest.mark.asyncio
+async def test_send_queue_position_event_creates_canonical_delivery(
+    db_session,
+    admin_user,
+):
+    created = await notification_sender_service.send_queue_position_event_notification(
+        db=db_session,
+        recipient=admin_user,
+        event_type="queue_position",
+        title="Ваша очередь обновлена",
+        message="Номер очереди изменился",
+        metadata={"queue_id": 44, "position": 3},
+    )
+
+    assert created is True
+    delivery = (
+        db_session.query(NotificationDelivery)
+        .join(NotificationEvent, NotificationEvent.id == NotificationDelivery.event_id)
+        .filter(
+            NotificationEvent.event_type == "queue_position",
+            NotificationDelivery.recipient_id == admin_user.id,
+        )
+        .one()
+    )
+    event = (
+        db_session.query(NotificationEvent)
+        .filter(NotificationEvent.id == delivery.event_id)
+        .one()
+    )
+
+    assert event.source_module == "queue"
+    assert event.entity_type == "queue"
+    assert event.entity_id == "44"
+    assert event.deep_link == "/queue"
+    assert event.priority == "high"
+    assert delivery.role == "admin"
+    assert delivery.payload_snapshot["metadata"]["position"] == 3
+
+
+@pytest.mark.asyncio
+async def test_send_diagnostics_return_needed_event_uses_same_queue_family_contract(
+    db_session,
+    admin_user,
+    registrar_user,
+):
+    created = await notification_sender_service.send_queue_position_event_notification(
+        db=db_session,
+        recipient=admin_user,
+        event_type="diagnostics_return_needed",
+        title="Нужно вернуться на диагностику",
+        message="Пожалуйста, вернитесь в кабинет",
+        metadata={"queue_id": 77, "entry_id": 888},
+        actor_user=registrar_user,
+    )
+
+    assert created is True
+    delivery = (
+        db_session.query(NotificationDelivery)
+        .join(NotificationEvent, NotificationEvent.id == NotificationDelivery.event_id)
+        .filter(
+            NotificationEvent.event_type == "diagnostics_return_needed",
+            NotificationDelivery.recipient_id == admin_user.id,
+        )
+        .one()
+    )
+    event = (
+        db_session.query(NotificationEvent)
+        .filter(NotificationEvent.id == delivery.event_id)
+        .one()
+    )
+
+    assert event.severity == "info"
+    assert event.priority == "high"
+    assert event.actor_id == registrar_user.id
+    assert event.actor_role == registrar_user.role
+    assert event.entity_type == "queue"
+    assert event.entity_id == "77"
+    assert delivery.payload_snapshot["metadata"]["entry_id"] == 888
+
+
+@pytest.mark.asyncio
+async def test_send_queue_position_event_rejects_unknown_type(
+    db_session,
+    admin_user,
+):
+    created = await notification_sender_service.send_queue_position_event_notification(
+        db=db_session,
+        recipient=admin_user,
+        event_type="queue_position_legacy_runtime_type",
+        title="Legacy event",
+        message="Legacy event payload",
+        metadata={"queue_id": 999},
+    )
+
+    assert created is False
+    count = (
+        db_session.query(NotificationEvent)
+        .filter(NotificationEvent.event_type == "queue_position_legacy_runtime_type")
+        .count()
+    )
+    assert count == 0

--- a/frontend/src/components/notifications/__tests__/NotificationInbox.test.jsx
+++ b/frontend/src/components/notifications/__tests__/NotificationInbox.test.jsx
@@ -1,98 +1,147 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { useNotificationCenterMock, loggerWarn } = vi.hoisted(() => ({
-  useNotificationCenterMock: vi.fn(),
-  loggerWarn: vi.fn()
-}));
+import NotificationInbox from '../NotificationInbox.jsx';
+
+const {
+  store,
+  getNotificationsByRole,
+  markAsRead,
+  markAsSeen,
+  archiveNotification,
+  markAllAsRead,
+} = vi.hoisted(() => {
+  const store = { notifications: [] };
+  return {
+    store,
+    getNotificationsByRole: vi.fn(() => store.notifications),
+    markAsRead: vi.fn(async () => {}),
+    markAsSeen: vi.fn(async () => {}),
+    archiveNotification: vi.fn(async () => {}),
+    markAllAsRead: vi.fn(async () => {}),
+  };
+});
 
 vi.mock('../../../contexts/NotificationCenterContext', () => ({
-  useNotificationCenter: () => useNotificationCenterMock()
+  useNotificationCenter: () => ({
+    getNotificationsByRole,
+    markAsRead,
+    markAsSeen,
+    archiveNotification,
+    markAllAsRead,
+  }),
 }));
 
 vi.mock('../../../utils/logger', () => ({
   default: {
-    info: vi.fn(),
-    warn: loggerWarn,
-    error: vi.fn()
-  }
+    warn: vi.fn(),
+  },
 }));
 
-import NotificationInbox from '../NotificationInbox.jsx';
+function createNotification(overrides = {}) {
+  return {
+    id: 'notification-1',
+    title: 'Тестовое уведомление',
+    message: 'Тестовое сообщение',
+    type: 'system_alert',
+    eventType: 'system_alert',
+    createdAt: '2026-04-17T08:00:00Z',
+    sequenceId: 1,
+    isRead: false,
+    isSeen: false,
+    isArchived: false,
+    ...overrides,
+  };
+}
 
-describe('NotificationInbox', () => {
-  let notificationCenterState;
-
-  const notifications = [
-    {
-      id: 'delivery-1',
-      title: 'Очередь обновлена',
-      message: 'Пациент вызван к врачу',
-      type: 'queue_changed',
-      eventType: 'queue_changed',
-      severity: 'warning',
-      isRead: false,
-      isSeen: false,
-      isArchived: false,
-      sequenceId: 2,
-      createdAt: '2026-03-30T10:00:00.000Z'
-    },
-    {
-      id: 'delivery-2',
-      title: 'Системное уведомление',
-      message: 'Архивный элемент',
-      type: 'system_alert',
-      eventType: 'system_alert',
-      severity: 'info',
-      isRead: true,
-      isSeen: true,
-      isArchived: false,
-      sequenceId: 1,
-      createdAt: '2026-03-29T10:00:00.000Z'
-    }
-  ];
+describe('NotificationInbox routing', () => {
+  let pushStateSpy;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    notificationCenterState = {
-      getNotificationsByRole: vi.fn().mockReturnValue(notifications),
-      markAsRead: vi.fn().mockResolvedValue({ ok: true }),
-      markAsSeen: vi.fn().mockResolvedValue({ ok: true }),
-      archiveNotification: vi.fn().mockResolvedValue({ ok: true }),
-      markAllAsRead: vi.fn().mockResolvedValue({ ok: true })
-    };
-    useNotificationCenterMock.mockReturnValue(notificationCenterState);
+    store.notifications = [];
+    pushStateSpy = vi.spyOn(window.history, 'pushState');
   });
 
-  it('renders a keyboard-accessible inbox item and wires read/archive actions', async () => {
-    // eslint-disable-next-line jsx-a11y/aria-role
-    render(<NotificationInbox role="admin" onClose={vi.fn()} />);
-    window.history.pushState({}, '', '/');
+  afterEach(() => {
+    pushStateSpy.mockRestore();
+  });
 
-    expect(screen.getByRole('dialog', { name: /центр уведомлений/i })).toBeInTheDocument();
+  it.each([
+    { role: 'admin', type: 'all_free_requested', expectedTarget: '/admin/all-free-requests' },
+    {
+      role: 'admin',
+      type: 'message_received',
+      payloadSnapshot: { metadata: { conversation_id: 'conv-42' } },
+      expectedTarget: '/messages?conversation=conv-42',
+    },
+    { role: 'doctor', type: 'lab_critical_result', expectedTarget: '/lab/results?critical=1' },
+    { role: 'registrar', type: 'patient_registered', expectedTarget: '/registrar/patients' },
+    { role: 'doctor', type: 'queue_position', expectedTarget: '/queue' },
+    { role: 'admin', type: 'security_alert', expectedTarget: '/admin' },
+    { role: 'admin', type: 'payment_notification', deepLink: '/patient', expectedTarget: '/patient' },
+    { role: 'admin', type: 'system_alert', expectedTarget: '/admin' },
+    { role: 'registrar', type: 'system_alert', expectedTarget: '/registrar' },
+  ])(
+    'navigates $type to $expectedTarget',
+    async ({ role, type, expectedTarget, payloadSnapshot, deepLink }) => {
+      store.notifications = [
+        createNotification({
+          id: `notification-${type}-${role}`,
+          type,
+          eventType: type,
+          payloadSnapshot,
+          deepLink,
+        }),
+      ];
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /Открыть уведомление: Очередь обновлена/i })
-    );
+      render(<NotificationInbox role={role} onClose={() => {}} />);
+      fireEvent.click(screen.getByLabelText(/Открыть уведомление:/i));
+
+      await waitFor(() => {
+        expect(pushStateSpy).toHaveBeenCalledWith({}, '', expectedTarget);
+      });
+
+      expect(markAsSeen).toHaveBeenCalledTimes(1);
+      expect(markAsRead).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('uses explicit deep link over type-based routing', async () => {
+    store.notifications = [
+      createNotification({
+        id: 'notification-explicit-deep-link',
+        type: 'all_free_requested',
+        eventType: 'all_free_requested',
+        deepLink: '/custom-target',
+      }),
+    ];
+
+    render(<NotificationInbox role="admin" onClose={() => {}} />);
+    fireEvent.click(screen.getByLabelText(/Открыть уведомление:/i));
 
     await waitFor(() => {
-      expect(notificationCenterState.markAsSeen).toHaveBeenCalledWith('delivery-1');
-      expect(notificationCenterState.markAsRead).toHaveBeenCalledWith('delivery-1');
+      expect(pushStateSpy).toHaveBeenCalledWith({}, '', '/custom-target');
     });
+  });
+
+  it('does not navigate when notification type is unknown and no deep link exists', async () => {
+    store.notifications = [
+      createNotification({
+        id: 'notification-unknown-type',
+        type: 'unknown_runtime_event',
+        eventType: 'unknown_runtime_event',
+        deepLink: '',
+      }),
+    ];
+
+    render(<NotificationInbox role="admin" onClose={() => {}} />);
+    fireEvent.click(screen.getByLabelText(/Открыть уведомление:/i));
+
     await waitFor(() => {
-      expect(window.location.pathname).toBe('/queue');
+      expect(markAsSeen).toHaveBeenCalledTimes(1);
+      expect(markAsRead).toHaveBeenCalledTimes(1);
     });
-
-    fireEvent.click(screen.getByRole('button', { name: /^Прочитать все$/i }));
-
-    await waitFor(() => {
-      expect(notificationCenterState.markAllAsRead).toHaveBeenCalledWith('admin');
-    });
-
-    fireEvent.click(screen.getAllByRole('button', { name: /^Архив$/i })[0]);
-
-    await waitFor(() => {
-      expect(notificationCenterState.archiveNotification).toHaveBeenCalledWith('delivery-1');
-    });
+    expect(pushStateSpy).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/contexts/NotificationCenterContext.jsx
+++ b/frontend/src/contexts/NotificationCenterContext.jsx
@@ -140,6 +140,7 @@ export const ROLE_NOTIFICATION_TYPES = {
 
 const TYPE_ALIASES = {
   queue_changed: 'queue_update',
+  diagnostics_return: 'diagnostics_return_needed',
   queue_status: 'queue_status_changed',
   payment_update: 'payment_notification',
   payment_success: 'payment_notification',

--- a/frontend/src/contexts/NotificationWebSocketContext.jsx
+++ b/frontend/src/contexts/NotificationWebSocketContext.jsx
@@ -21,14 +21,17 @@ function normalizePayload(payload = {}) {
     payload.event_type ||
     payload.notification_type ||
     'notification';
-  const type = String(rawType).toLowerCase() === 'queue_update'
-    ? 'queue_changed'
-    : String(rawType).toLowerCase();
+  const normalizedRawType = String(rawType).toLowerCase();
+  const typeAliases = {
+    queue_changed: 'queue_update',
+    diagnostics_return: 'diagnostics_return_needed',
+  };
+  const type = typeAliases[normalizedRawType] || normalizedRawType;
 
   const title =
     nested.title ||
     nested.subject ||
-    (type === 'queue_changed' ? 'Обновление очереди' : 'Уведомление');
+    (type === 'queue_update' ? 'Обновление очереди' : 'Уведомление');
   const message = nested.message || nested.content || payload.message || payload.content || '';
 
   return { type, title, message, raw: payload, nested };
@@ -148,7 +151,8 @@ export function NotificationWebSocketProvider({ children }) {
 
       if (
         normalized.type === 'notification' ||
-        normalized.type === 'queue_changed' ||
+        normalized.type === 'queue_update' ||
+        normalized.type === 'diagnostics_return_needed' ||
         normalized.type === 'system_alert'
       ) {
         invalidateNotificationCache();

--- a/frontend/src/contexts/__tests__/NotificationWebSocketContext.test.jsx
+++ b/frontend/src/contexts/__tests__/NotificationWebSocketContext.test.jsx
@@ -99,6 +99,10 @@ class MockWebSocket {
     this.readyState = MockWebSocket.OPEN;
     this.onopen?.();
   }
+
+  triggerMessage(payload) {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
 }
 
 MockWebSocket.instances = [];
@@ -159,5 +163,54 @@ describe('NotificationWebSocketContext', () => {
 
     expect(MockWebSocket.instances).toHaveLength(0);
     expect(tokenManagerMock.isTokenValid).not.toHaveBeenCalled();
+  });
+
+  it('normalizes legacy queue_changed websocket events to queue_update', async () => {
+    renderProvider('/doctor/cardiology');
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    const socket = MockWebSocket.instances[0];
+    await act(async () => {
+      socket.triggerMessage({
+        notification: {
+          event_type: 'queue_changed',
+          message: 'Пациент вызван',
+        },
+      });
+    });
+
+    expect(notificationCenterMock.appendNotification).toHaveBeenCalledTimes(1);
+    const [notification, source] = notificationCenterMock.appendNotification.mock.calls[0];
+    expect(notification.type).toBe('queue_update');
+    expect(notification.title).toBe('Обновление очереди');
+    expect(source).toBe('ws');
+  });
+
+  it('normalizes diagnostics_return websocket events to diagnostics_return_needed', async () => {
+    renderProvider('/doctor/cardiology');
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    const socket = MockWebSocket.instances[0];
+    await act(async () => {
+      socket.triggerMessage({
+        notification: {
+          event_type: 'diagnostics_return',
+          title: 'Повторная диагностика',
+          message: 'Нужно вернуться на диагностику',
+        },
+      });
+    });
+
+    expect(notificationCenterMock.appendNotification).toHaveBeenCalledTimes(1);
+    const [notification, source] = notificationCenterMock.appendNotification.mock.calls[0];
+    expect(notification.type).toBe('diagnostics_return_needed');
+    expect(notification.title).toBe('Повторная диагностика');
+    expect(source).toBe('ws');
   });
 });


### PR DESCRIPTION
## Summary
- wire payment/cashier and provider webhook flows to canonical notification events
- align frontend Notification Center / WebSocket alias handling for canonical catalog parity
- add targeted backend integration/unit coverage for slice2/slice3 event families
- extend frontend tests for inbox and websocket normalization behavior

## Validation
- `python -m pytest backend/tests/integration/test_notification_catalog_slice2_cashier.py backend/tests/integration/test_notification_catalog_slice2_online_payments.py backend/tests/integration/test_notification_catalog_slice3_patient_registration.py backend/tests/unit/test_lab_notification_catalog_slice3.py backend/tests/unit/test_queue_notifications_catalog_slice3.py -q`
- `npm run test:run -- src/contexts/__tests__/NotificationWebSocketContext.test.jsx src/components/notifications/__tests__/NotificationInbox.test.jsx`

## Scope
- backend producer wiring and contract tests only for this slice
- frontend catalog/alias consumer parity only
- no notification policy UI, quiet-hours, or cross-domain refactors