### PR TITLE
docs(evidence): append LightRAG readiness entry for slice2 merge

### DIFF
--- a/ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md
+++ b/ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md
@@ -2556,3 +2556,38 @@ Recommendation:
 - current stack sufficient: yes
 - would LightRAG likely help here: no
 - Gate already selected the correct owner and boundaries; only routine domain mapping was required.
+
+## Task 73 - Slice2 producer parity merge + full notification regression
+
+### User task
+продолжай
+
+### Gate result
+- mode: execute
+- handoff required: no (continuation from prepared slice branch)
+- handoff used: no
+- gate_misroute: no
+- override_used: no
+- known_root_cause_file: none
+
+### What handoff solved well
+- none
+
+### Missing relationship mapping
+- none
+
+### Manual reconstruction needed
+- Manual branch-lineage cleanup was required to remove accidental parent commit drift before PR merge (`rebase --onto` to keep only slice commit).
+- Manual verification bundling was required to run unified backend/frontend notification regression on `main` after merge.
+
+### Signals observed
+- multi-hop gap: no
+- ownership ambiguity: no
+- manual graph reconstruction: no
+- gate_misroute: no
+- override_used: no
+
+### Short verdict
+- current stack sufficient: yes
+- would LightRAG likely help here: no
+- For this step the bottleneck was git lineage hygiene, not graph retrieval; canonical anchors and tests were already explicit.


### PR DESCRIPTION
## Summary
- append factual evidence entry for Task 73 in `ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md`
- capture branch-lineage cleanup and full notification regression outcome after slice2 merge
- keep scope strictly docs/evidence (no runtime code changes)

## Validation
- `python -m pytest backend/tests/integration/test_notification_catalog_slice1.py backend/tests/integration/test_notification_catalog_slice2_cashier.py backend/tests/integration/test_notification_catalog_slice2_online_payments.py backend/tests/integration/test_notification_catalog_slice3_legacy_webhooks.py backend/tests/integration/test_notification_catalog_slice3_patient_registration.py backend/tests/unit/test_notification_platform_contract.py backend/tests/unit/test_messages_notification_catalog_slice1.py backend/tests/unit/test_lab_notification_catalog_slice3.py backend/tests/unit/test_queue_notifications_catalog_slice3.py -q`
- `npm run test:run -- src/components/notifications/__tests__/NotificationInbox.test.jsx src/contexts/__tests__/NotificationCenterContext.test.jsx src/contexts/__tests__/NotificationWebSocketContext.test.jsx src/components/notifications/__tests__/RoleNotificationCenter.test.jsx src/__tests__/notificationGuardrails.test.js`