### PR TITLE
test(notification): cover queue burst anti-noise policy

### DIFF
--- a/.ai-factory/IMPLEMENTATION_NOTIFICATION_CATALOG_SSOT.md
+++ b/.ai-factory/IMPLEMENTATION_NOTIFICATION_CATALOG_SSOT.md
@@ -67,6 +67,10 @@ Scope: Unified persistent inbox notifications (`/notifications/inbox`, `/notific
 - Quiet-hours / weekend suppression (queue-family only):
   - respects `UserNotificationSettings.quiet_hours_start`, `quiet_hours_end`, `weekend_notifications`
   - applies to queue family: `queue_update`, `queue_call`, `queue_position`, `queue_reminder`, `diagnostics_return_needed`, `queue_status_changed`
+- Anti-noise realtime burst suppression:
+  - queue-family websocket broadcasts are additionally suppressed when a similar queue-family delivery was already recorded for the same recipient in a short window
+  - persistence stays canonical; only realtime broadcast is skipped
+  - `queue_call` is intentionally excluded from this burst guardrail
 
 ## Producer Wiring Status
 
@@ -108,6 +112,7 @@ Backend:
 - `python -m py_compile backend/app/services/patient_service.py`
 - `python -m pytest backend/tests/integration/test_notification_catalog_slice1.py backend/tests/unit/test_messages_notification_catalog_slice1.py -q`
 - `python -m pytest backend/tests/unit/test_notification_platform_contract.py -q`
+- `python -m pytest backend/tests/unit/test_notification_platform_contract.py -q` (covers quiet-hours, critical override, and queue burst suppression)
 - `python -m pytest backend/tests/integration/test_notification_catalog_slice3_legacy_webhooks.py -q`
 
 Frontend:

--- a/ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md
+++ b/ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md
@@ -2628,3 +2628,41 @@ Recommendation:
 - current stack sufficient: partial
 - would LightRAG likely help here: yes
 - Better relationship retrieval should keep known-root-cause anchoring stable and still expose adjacent test/doc ownership without forcing single-file override fallbacks.
+
+## Task 75 - Manual override for anti-noise policy coverage
+
+### User task
+делай manual override и выполняй
+
+### Gate result
+- mode: execute
+- handoff required: yes
+- handoff used: yes, via narrow override prompt
+- gate_misroute: yes
+- override_used: yes
+- known_root_cause_file: backend/app/services/notification_platform_service.py
+
+### What handoff solved well
+- It confirmed the canonical runtime owner for anti-noise policy, even though the gate would not expand scope to tests/docs.
+- It prevented accidental edits outside the notification policy area.
+
+### Missing relationship mapping
+- The gate did not connect runtime anti-noise policy to the adjacent contract-test and SSOT note files the user explicitly wanted updated.
+- That relationship had to be reconstructed manually from the notification policy surface and existing contract test structure.
+
+### Manual reconstruction needed
+- Manually added contract tests for queue-family realtime burst suppression and `queue_call` bypass.
+- Manually refreshed the SSOT note to state that burst suppression is realtime-only and does not affect inbox persistence.
+- Manually appended this evidence entry because the work was a real risky change-task, not just a docs-only cleanup.
+
+### Signals observed
+- multi-hop gap: yes
+- ownership ambiguity: no
+- manual graph reconstruction: yes
+- gate_misroute: yes
+- override_used: yes
+
+### Short verdict
+- current stack sufficient: partial
+- would LightRAG likely help here: yes
+- The gap was not the runtime owner itself, but the adjacent test/docs relationships that the gate would not surface without manual override.

--- a/backend/tests/unit/test_notification_platform_contract.py
+++ b/backend/tests/unit/test_notification_platform_contract.py
@@ -235,6 +235,134 @@ def test_realtime_policy_respects_event_push_setting_mapping(db_session):
 
 
 @pytest.mark.asyncio
+async def test_queue_burst_realtime_is_suppressed_but_inbox_persistence_remains(
+    db_session,
+    monkeypatch,
+):
+    service = NotificationPlatformService(db_session)
+    service.ws_manager = SimpleNamespace(send_json=AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_is_within_quiet_hours", lambda **_: False)
+
+    user = SimpleNamespace(
+        id=93001,
+        role="patient",
+        is_superuser=False,
+        profile=SimpleNamespace(department=None, timezone="Asia/Tashkent"),
+        preferences=SimpleNamespace(desktop_notifications=True, timezone="Asia/Tashkent"),
+        notification_settings=SimpleNamespace(
+            push_system_updates=True,
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            weekend_notifications=True,
+        ),
+    )
+
+    first_delivery = await service.record_delivery_for_user(
+        user=user,
+        event_type="queue_update",
+        title="Обновление очереди",
+        message="Пациент вызван к врачу",
+        source_module="queue",
+        severity="info",
+        priority="normal",
+        entity_type="visit",
+        entity_id="visit-100",
+        payload_snapshot={
+            "title": "Обновление очереди",
+            "message": "Пациент вызван к врачу",
+            "metadata": {"source": "queue", "attempt": 1},
+        },
+        deep_link="/queue",
+    )
+    second_delivery = await service.record_delivery_for_user(
+        user=user,
+        event_type="queue_update",
+        title="Обновление очереди",
+        message="Пациент вызван к врачу",
+        source_module="queue",
+        severity="info",
+        priority="normal",
+        entity_type="visit",
+        entity_id="visit-100",
+        payload_snapshot={
+            "title": "Обновление очереди",
+            "message": "Пациент вызван к врачу",
+            "metadata": {"source": "queue", "attempt": 2},
+        },
+        deep_link="/queue",
+    )
+
+    assert first_delivery.delivery_id != second_delivery.delivery_id
+    assert db_session.query(NotificationDelivery).count() == 2
+    assert db_session.query(NotificationEvent).count() == 2
+    assert service.ws_manager.send_json.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_queue_call_is_not_suppressed_by_burst_guard(
+    db_session,
+    monkeypatch,
+):
+    service = NotificationPlatformService(db_session)
+    service.ws_manager = SimpleNamespace(send_json=AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_is_within_quiet_hours", lambda **_: False)
+
+    user = SimpleNamespace(
+        id=93002,
+        role="patient",
+        is_superuser=False,
+        profile=SimpleNamespace(department=None, timezone="Asia/Tashkent"),
+        preferences=SimpleNamespace(desktop_notifications=True, timezone="Asia/Tashkent"),
+        notification_settings=SimpleNamespace(
+            push_system_updates=True,
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            weekend_notifications=True,
+        ),
+    )
+
+    first_delivery = await service.record_delivery_for_user(
+        user=user,
+        event_type="queue_call",
+        title="Пациент вызван",
+        message="Подойдите к кабинету",
+        source_module="queue",
+        severity="info",
+        priority="normal",
+        entity_type="visit",
+        entity_id="visit-200",
+        payload_snapshot={
+            "title": "Пациент вызван",
+            "message": "Подойдите к кабинету",
+            "metadata": {"source": "queue", "attempt": 1},
+        },
+        deep_link="/queue",
+    )
+    second_delivery = await service.record_delivery_for_user(
+        user=user,
+        event_type="queue_call",
+        title="Пациент вызван",
+        message="Подойдите к кабинету",
+        source_module="queue",
+        severity="info",
+        priority="normal",
+        entity_type="visit",
+        entity_id="visit-200",
+        payload_snapshot={
+            "title": "Пациент вызван",
+            "message": "Подойдите к кабинету",
+            "metadata": {"source": "queue", "attempt": 2},
+        },
+        deep_link="/queue",
+    )
+
+    assert first_delivery.delivery_id != second_delivery.delivery_id
+    assert db_session.query(NotificationDelivery).count() == 2
+    assert db_session.query(NotificationEvent).count() == 2
+    assert service.ws_manager.send_json.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_record_delivery_for_users_keeps_inbox_but_filters_realtime_by_settings(
     db_session,
     monkeypatch,


### PR DESCRIPTION
## Summary
- add contract coverage for queue-family realtime burst suppression
- verify same-entity queue bursts still persist inbox records but suppress duplicate websocket broadcasts
- verify `queue_call` is not suppressed by the burst guardrail
- refresh SSOT note and append LightRAG evidence entry for the manual override slice

## Validation
- `python -m pytest backend/tests/unit/test_notification_platform_contract.py -q`

## Scope
- narrow notification policy tests/docs slice
- no runtime code changes in this PR