### PR TITLE
fix(notification): wire lab producer parity

### DIFF
--- a/.ai-factory/IMPLEMENTATION_NOTIFICATION_CATALOG_SSOT.md
+++ b/.ai-factory/IMPLEMENTATION_NOTIFICATION_CATALOG_SSOT.md
@@ -78,7 +78,7 @@ Scope: Unified persistent inbox notifications (`/notifications/inbox`, `/notific
 |---|---|---|
 | `all_free_*` | `backend/app/api/v1/endpoints/registrar_wizard.py` -> `notification_sender_service` | implemented |
 | `message_received` | `backend/app/services/messages_api_service.py` | implemented |
-| `lab_results`, `lab_critical_result`, `diagnostics_return_needed` | `backend/app/services/lab_notification_service.py` | implemented |
+| `lab_results`, `lab_critical_result`, `lab_new_study`, `lab_critical_finding`, `lab_result_sent_confirmation`, `diagnostics_return_needed` | `backend/app/services/lab_notification_service.py` | implemented |
 | registrar operational (`new_appointment`, `price_change`, `queue_status_changed`, alert family) | `backend/app/services/registrar_notification_service.py` | implemented |
 | `patient_registered` (create only) | `backend/app/services/patient_service.py` | implemented |
 | typed helper catalog (`lab_*`, queue family, registrar/admin family) | `backend/app/services/notifications.py` | implemented |
@@ -110,6 +110,7 @@ Backend:
 - `python -m py_compile backend/app/services/lab_notification_service.py`
 - `python -m py_compile backend/app/services/registrar_notification_service.py`
 - `python -m py_compile backend/app/services/patient_service.py`
+- `python -m pytest backend/tests/unit/test_lab_notification_catalog_slice3.py backend/tests/unit/test_lab_reporting_service.py -q`
 - `python -m pytest backend/tests/integration/test_notification_catalog_slice1.py backend/tests/unit/test_messages_notification_catalog_slice1.py -q`
 - `python -m pytest backend/tests/unit/test_notification_platform_contract.py -q`
 - `python -m pytest backend/tests/unit/test_notification_platform_contract.py -q` (covers quiet-hours, critical override, and queue burst suppression)

--- a/ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md
+++ b/ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md
@@ -2666,3 +2666,41 @@ Recommendation:
 - current stack sufficient: partial
 - would LightRAG likely help here: yes
 - The gap was not the runtime owner itself, but the adjacent test/docs relationships that the gate would not surface without manual override.
+
+## Task 76 - Lab producer parity follow-up after manual override
+
+### User task
+продолжаем
+
+### Gate result
+- mode: execute
+- handoff required: yes
+- handoff used: yes, via narrow override prompt
+- gate_misroute: yes
+- override_used: yes
+- known_root_cause_file: backend/app/services/lab_notification_service.py
+
+### What handoff solved well
+- It kept the lab slice anchored to the correct service layer while expanding only to the adjacent tests that validated canonical producer output.
+- It preserved the boundary between runtime producer wiring and doc/evidence updates.
+
+### Missing relationship mapping
+- The gate path did not surface the model-shape mismatch around `LabResult`/`LabOrder` ownership, so the service change had to be reconciled manually against the actual schema.
+- The adjacency between new producer events (`lab_new_study`, `lab_critical_finding`, `lab_result_sent_confirmation`) and their regression tests was not explicit in the handoff.
+
+### Manual reconstruction needed
+- Manually replaced nonexistent dedupe flags with model-compatible canonical delivery flow.
+- Manually fixed the critical-value path to resolve patient ownership through `LabOrder`.
+- Manually aligned the lab SSOT note and validation commands to the real producer/test surface.
+
+### Signals observed
+- multi-hop gap: yes
+- ownership ambiguity: no
+- manual graph reconstruction: yes
+- gate_misroute: yes
+- override_used: yes
+
+### Short verdict
+- current stack sufficient: partial
+- would LightRAG likely help here: yes
+- This task benefited from a retrieval layer that can connect service ownership, model shape, tests, and docs in one pass; manual reconstruction was still required, but the gap was adjacent rather than central.

--- a/backend/app/services/lab_notification_service.py
+++ b/backend/app/services/lab_notification_service.py
@@ -6,12 +6,14 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any
 
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
+from app.models.clinic import Doctor
 from app.models.lab import LabOrder, LabResult
 from app.models.patient import Patient
 from app.models.user import User
+from app.models.visit import Visit
 from app.services.notifications import notification_sender_service
 
 logger = logging.getLogger(__name__)
@@ -51,18 +53,9 @@ class LabNotificationService:
             Статистика отправленных уведомлений
         """
         try:
-            # Находим готовые результаты без уведомления
-            ready_orders = (
-                self.db.query(LabOrder)
-                .filter(
-                    LabOrder.status == "completed",
-                    or_(
-                        LabOrder.notification_sent == False,
-                        LabOrder.notification_sent.is_(None),
-                    ),
-                )
-                .all()
-            )
+            # Находим готовые результаты. Дедупликация здесь не хранится в модели,
+            # поэтому этот сервис отвечает только за canonical delivery.
+            ready_orders = self.db.query(LabOrder).filter(LabOrder.status == "completed").all()
 
             notifications_sent = 0
             errors = []
@@ -70,8 +63,6 @@ class LabNotificationService:
             for order in ready_orders:
                 try:
                     await self._notify_patient_results_ready(order)
-                    order.notification_sent = True
-                    order.notification_sent_at = datetime.utcnow()
                     notifications_sent += 1
                 except Exception as e:
                     errors.append({"order_id": order.id, "error": str(e)})
@@ -134,6 +125,24 @@ class LabNotificationService:
                     "[FIX:NOTIFICATIONS] lab_results canonical delivery failed",
                     extra={"order_id": order.id, "patient_user_id": user.id},
                 )
+            else:
+                confirmation_created = await notification_sender_service.send_lab_event_notification(
+                    db=self.db,
+                    recipient=user,
+                    event_type="lab_result_sent_confirmation",
+                    title="Результат исследования отправлен",
+                    message=f"Результаты по заказу #{order.id} отправлены в личный кабинет.",
+                    metadata={
+                        "order_id": order.id,
+                        "patient_id": order.patient_id,
+                        "result_id": None,
+                    },
+                )
+                if not confirmation_created:
+                    logger.warning(
+                        "[FIX:NOTIFICATIONS] lab_result_sent_confirmation canonical delivery failed",
+                        extra={"order_id": order.id, "patient_user_id": user.id},
+                    )
 
             if hasattr(user, 'telegram_id') and user.telegram_id:
                 await notification_sender_service.send_telegram_message(
@@ -159,17 +168,7 @@ class LabNotificationService:
             # Находим результаты за последние 24 часа
             yesterday = datetime.utcnow() - timedelta(hours=24)
 
-            recent_results = (
-                self.db.query(LabResult)
-                .filter(
-                    LabResult.created_at >= yesterday,
-                    or_(
-                        LabResult.critical_notified == False,
-                        LabResult.critical_notified.is_(None),
-                    ),
-                )
-                .all()
-            )
+            recent_results = self.db.query(LabResult).filter(LabResult.created_at >= yesterday).all()
 
             critical_found = []
 
@@ -182,9 +181,11 @@ class LabNotificationService:
                         try:
                             value = float(result.value)
                             if value < thresholds["low"] or value > thresholds["high"]:
+                                order = self.db.query(LabOrder).filter(LabOrder.id == result.order_id).first()
+                                patient_id = order.patient_id if order else None
                                 critical_found.append({
                                     "result_id": result.id,
-                                    "patient_id": result.patient_id,
+                                    "patient_id": patient_id,
                                     "test_name": result.test_name,
                                     "value": value,
                                     "unit": thresholds["unit"],
@@ -194,9 +195,6 @@ class LabNotificationService:
 
                                 # Уведомляем врача
                                 await self._notify_doctor_critical_value(result, value, thresholds)
-
-                                result.critical_notified = True
-                                result.critical_notified_at = datetime.utcnow()
                         except (ValueError, TypeError):
                             pass
 
@@ -219,12 +217,21 @@ class LabNotificationService:
         thresholds: dict,
     ):
         """Уведомляет врача о критическом значении"""
-        # Получаем назначившего врача
         order = self.db.query(LabOrder).filter(LabOrder.id == result.order_id).first()
-        if not order or not order.doctor_id:
+        if not order:
             return
 
-        patient = self.db.query(Patient).filter(Patient.id == result.patient_id).first()
+        visit = None
+        if order.visit_id:
+            visit = self.db.query(Visit).filter(Visit.id == order.visit_id).first()
+        if not visit or not visit.doctor_id:
+            return
+
+        doctor = self.db.query(Doctor).filter(Doctor.id == visit.doctor_id).first()
+        if not doctor or not doctor.user_id:
+            return
+
+        patient = self.db.query(Patient).filter(Patient.id == order.patient_id).first()
 
         alert_type = "⬇️ КРИТИЧЕСКИ НИЗКОЕ" if value < thresholds["low"] else "⬆️ КРИТИЧЕСКИ ВЫСОКОЕ"
 
@@ -237,24 +244,24 @@ class LabNotificationService:
 📈 Значение: {value} {thresholds.get('unit', '')}
 📉 Норма: {thresholds['low']} - {thresholds['high']}
 
-👤 Пациент: {patient.short_name() if patient else f'ID {result.patient_id}'}
+👤 Пациент: {patient.short_name() if patient else f'ID {order.patient_id}'}
 
 Требуется срочное внимание!
         """.strip()
 
         # Отправляем врачу
-        doctor_user = self.db.query(User).filter(User.id == order.doctor_id).first()
+        doctor_user = self.db.query(User).filter(User.id == doctor.user_id).first()
         if doctor_user:
             canonical_created = await notification_sender_service.send_lab_event_notification(
                 db=self.db,
                 recipient=doctor_user,
                 event_type="lab_critical_result",
                 title="Критический результат анализа",
-                message=f"{result.test_name}: {value} {thresholds.get('unit', '')} у пациента #{result.patient_id}.",
+                message=f"{result.test_name}: {value} {thresholds.get('unit', '')} у пациента #{order.patient_id}.",
                 metadata={
                     "result_id": result.id,
                     "order_id": result.order_id,
-                    "patient_id": result.patient_id,
+                    "patient_id": order.patient_id,
                     "test_name": result.test_name,
                     "value": value,
                     "unit": thresholds.get("unit", ""),
@@ -269,9 +276,37 @@ class LabNotificationService:
                     extra={
                         "result_id": result.id,
                         "doctor_user_id": doctor_user.id,
+                    "order_id": result.order_id,
+                },
+            )
+            else:
+                finding_created = await notification_sender_service.send_lab_event_notification(
+                    db=self.db,
+                    recipient=doctor_user,
+                    event_type="lab_critical_finding",
+                    title="Критическая находка в исследовании",
+                    message=f"В анализе {result.test_name} у пациента #{order.patient_id} обнаружена критическая находка.",
+                    metadata={
+                        "result_id": result.id,
                         "order_id": result.order_id,
+                        "patient_id": order.patient_id,
+                        "test_name": result.test_name,
+                        "value": value,
+                        "unit": thresholds.get("unit", ""),
+                        "critical_low": thresholds["low"],
+                        "critical_high": thresholds["high"],
+                        "is_critical": True,
                     },
                 )
+                if not finding_created:
+                    logger.warning(
+                        "[FIX:NOTIFICATIONS] lab_critical_finding canonical delivery failed",
+                        extra={
+                            "result_id": result.id,
+                            "doctor_user_id": doctor_user.id,
+                            "order_id": result.order_id,
+                        },
+                    )
 
             if hasattr(doctor_user, 'telegram_id') and doctor_user.telegram_id:
                 await notification_sender_service.send_telegram_message(

--- a/backend/app/services/lab_reporting_service.py
+++ b/backend/app/services/lab_reporting_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -11,6 +12,7 @@ from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.models.lab import (
@@ -27,6 +29,7 @@ from app.models.lab import (
     LabReportValue,
     LabTemplateServiceBinding,
 )
+from app.models.user import User
 from app.repositories.lab_reporting_api_repository import LabReportingApiRepository
 from app.services.canonical_visit_service import (
     CanonicalVisitResolutionError,
@@ -41,6 +44,7 @@ from app.services.lab_seed_data import DEFAULT_LAB_TEMPLATE_DEFINITIONS
 from app.services.lab_template_binding_seed_data import (
     DEFAULT_LAB_TEMPLATE_BINDING_DEFINITIONS,
 )
+from app.services.notifications import notification_sender_service
 from app.services.service_mapping import normalize_service_code
 
 logger = logging.getLogger(__name__)
@@ -461,7 +465,7 @@ class LabReportingService:
             service_codes=payload.get("service_codes"),
             service_items=payload.get("service_items"),
         )
-        order = self._resolve_or_create_order(
+        order, created_new_order = self._resolve_or_create_order(
             order_id=payload.get("order_id"),
             patient_id=patient.id,
             visit_id=visit_id,
@@ -486,6 +490,12 @@ class LabReportingService:
         )
         self.repository.add_instance(instance)
         self.repository.commit()
+        if created_new_order and order is not None:
+            self._emit_lab_new_study_notification(
+                order=order,
+                patient_id=patient.id,
+                visit_id=visit_id,
+            )
         logger.info("[LAB] create_instance created instance_id=%s", instance.id)
         return self.get_instance(instance.id)
 
@@ -1134,18 +1144,18 @@ class LabReportingService:
         order_id: int | None,
         patient_id: int,
         visit_id: int | None,
-    ) -> LabOrder | None:
+    ) -> tuple[LabOrder | None, bool]:
         if order_id:
             order = self.repository.get_order(order_id)
             if not order:
                 raise LabReportingDomainError(404, "Lab order not found")
-            return order
+            return order, False
         order = self.repository.find_order_by_visit_and_patient(
             visit_id=visit_id,
             patient_id=patient_id,
         )
         if order:
-            return order
+            return order, False
         logger.info(
             "[LAB] creating synthetic lab order patient_id=%s visit_id=%s",
             patient_id,
@@ -1158,7 +1168,72 @@ class LabReportingService:
                 status="ordered",
                 notes="Auto-created from lab report workflow",
             )
+        ), True
+
+    def _emit_lab_new_study_notification(
+        self,
+        *,
+        order: LabOrder,
+        patient_id: int,
+        visit_id: int | None,
+    ) -> None:
+        recipients = (
+            self.db.query(User)
+            .filter(
+                User.is_active.is_(True),
+                func.lower(User.role).in_(["lab", "labtechnician", "lab_technician"]),
+            )
+            .all()
         )
+        if not recipients:
+            return
+
+        async def _send(recipient: User) -> bool:
+            return await notification_sender_service.send_lab_event_notification(
+                db=self.db,
+                recipient=recipient,
+                event_type="lab_new_study",
+                title="Назначено новое исследование",
+                message=f"Для пациента #{patient_id} создано новое исследование.",
+                metadata={
+                    "order_id": order.id,
+                    "patient_id": patient_id,
+                    "visit_id": visit_id,
+                },
+            )
+
+        for recipient in recipients:
+            try:
+                canonical_created = asyncio.run(_send(recipient))
+                if not canonical_created:
+                    logger.warning(
+                        "[FIX:NOTIFICATIONS] lab_new_study canonical delivery failed",
+                        extra={
+                            "order_id": order.id,
+                            "patient_id": patient_id,
+                            "recipient_id": recipient.id,
+                        },
+                    )
+            except RuntimeError as exc:
+                logger.warning(
+                    "[FIX:NOTIFICATIONS] lab_new_study canonical delivery skipped due runtime context",
+                    extra={
+                        "order_id": order.id,
+                        "patient_id": patient_id,
+                        "recipient_id": recipient.id,
+                        "error": str(exc),
+                    },
+                )
+            except Exception as exc:
+                logger.error(
+                    "[FIX:NOTIFICATIONS] lab_new_study canonical delivery error",
+                    extra={
+                        "order_id": order.id,
+                        "patient_id": patient_id,
+                        "recipient_id": recipient.id,
+                        "error": str(exc),
+                    },
+                )
 
     def _validate_template_selection_for_context(
         self,

--- a/backend/tests/unit/test_lab_notification_catalog_slice3.py
+++ b/backend/tests/unit/test_lab_notification_catalog_slice3.py
@@ -1,9 +1,36 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from app.models.notification import NotificationDelivery, NotificationEvent
+from app.models.lab import LabOrder, LabResult
+from app.models.patient import Patient
+from app.models.user import User
+from app.models.visit import Visit
+from app.services.lab_notification_service import LabNotificationService
 from app.services.notifications import notification_sender_service
+
+
+def _create_user(db_session, *, username: str, role: str, full_name: str) -> User:
+    existing = db_session.query(User).filter(User.username == username).first()
+    if existing:
+        return existing
+
+    user = User(
+        username=username,
+        email=f"{username}@test.com",
+        full_name=full_name,
+        hashed_password="hashed-password",
+        role=role,
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
 
 
 @pytest.mark.asyncio
@@ -109,3 +136,89 @@ async def test_send_lab_event_rejects_unsupported_type(
         .count()
     )
     assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_check_and_notify_ready_results_emits_confirmation_event(
+    db_session,
+    test_patient,
+    monkeypatch,
+):
+    patient_user = _create_user(
+        db_session,
+        username="patient_lab_ready",
+        role="patient",
+        full_name="Patient Lab Ready",
+    )
+    test_patient.user_id = patient_user.id
+    db_session.commit()
+
+    order = LabOrder(
+        patient_id=test_patient.id,
+        status="completed",
+    )
+    db_session.add(order)
+    db_session.commit()
+    db_session.refresh(order)
+
+    send_mock = AsyncMock(side_effect=[True, True])
+    monkeypatch.setattr(
+        notification_sender_service,
+        "send_lab_event_notification",
+        send_mock,
+    )
+
+    service = LabNotificationService(db_session)
+    result = await service.check_and_notify_ready_results()
+
+    assert result["notifications_sent"] == 1
+    assert send_mock.await_count == 2
+    assert send_mock.await_args_list[0].kwargs["event_type"] == "lab_results"
+    assert send_mock.await_args_list[1].kwargs["event_type"] == "lab_result_sent_confirmation"
+
+
+@pytest.mark.asyncio
+async def test_check_critical_values_emits_critical_finding_event(
+    db_session,
+    test_patient,
+    test_visit,
+    cardio_user,
+    monkeypatch,
+):
+    order = LabOrder(
+        patient_id=test_patient.id,
+        visit_id=test_visit.id,
+        status="completed",
+    )
+    db_session.add(order)
+    db_session.commit()
+    db_session.refresh(order)
+
+    result = LabResult(
+        order_id=order.id,
+        test_name="Glucose",
+        value="24.4",
+        abnormal=True,
+    )
+    db_session.add(result)
+    db_session.commit()
+    db_session.refresh(result)
+
+    send_mock = AsyncMock(side_effect=[True, True])
+    monkeypatch.setattr(
+        notification_sender_service,
+        "send_lab_event_notification",
+        send_mock,
+    )
+
+    service = LabNotificationService(db_session)
+    outcome = await service.check_critical_values()
+
+    assert outcome["critical_found"] == 1
+    assert send_mock.await_count == 2
+    first_call = send_mock.await_args_list[0]
+    second_call = send_mock.await_args_list[1]
+    assert first_call.kwargs["event_type"] == "lab_critical_result"
+    assert second_call.kwargs["event_type"] == "lab_critical_finding"
+    assert first_call.kwargs["recipient"].id == cardio_user.id
+    assert second_call.kwargs["recipient"].id == cardio_user.id

--- a/backend/tests/unit/test_lab_reporting_service.py
+++ b/backend/tests/unit/test_lab_reporting_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 from datetime import date
 from decimal import Decimal
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import delete
@@ -17,7 +18,9 @@ from app.models.lab import (
     LabReportTemplateVersion,
 )
 from app.models.service import Service
+from app.models.user import User
 from app.models.visit import VisitService
+from app.services.notifications import notification_sender_service
 from app.services.lab_reporting_service import (
     LabReportingDomainError,
     LabReportingService,
@@ -744,3 +747,49 @@ class TestLabReportingService:
         assert field["resolved_flag"] == "low"
         assert field["resolved_flag_source"] == "catalog_reference"
         assert field["resolved_flag_meta"]["matched_threshold"]["value"] == "130"
+
+    def test_create_instance_emits_lab_new_study_for_lab_staff(
+        self,
+        db_session,
+        test_patient,
+        test_visit,
+    ):
+        lab_user = db_session.query(User).filter(User.username == "test_lab_user").first()
+        if not lab_user:
+            lab_user = User(
+                username="test_lab_user",
+                email="lab@test.com",
+                full_name="Test Lab",
+                hashed_password="hashed-password",
+                role="Lab",
+                is_active=True,
+                is_superuser=False,
+            )
+            db_session.add(lab_user)
+            db_session.commit()
+            db_session.refresh(lab_user)
+
+        service = LabReportingService(db_session)
+        template = next(
+            template for template in service.list_templates() if template.code == "cbc_oak"
+        )
+        send_mock = AsyncMock(return_value=True)
+        original = notification_sender_service.send_lab_event_notification
+        notification_sender_service.send_lab_event_notification = send_mock
+        try:
+            instance = service.create_instance(
+                {
+                    "patient_id": test_patient.id,
+                    "visit_id": test_visit.id,
+                    "template_id": template.id,
+                }
+            )
+        finally:
+            notification_sender_service.send_lab_event_notification = original
+
+        assert instance.order_id is not None
+        assert send_mock.await_count == 1
+        assert send_mock.await_args.kwargs["event_type"] == "lab_new_study"
+        assert send_mock.await_args.kwargs["recipient"].id == lab_user.id
+        assert send_mock.await_args.kwargs["metadata"]["patient_id"] == test_patient.id
+        assert send_mock.await_args.kwargs["metadata"]["visit_id"] == test_visit.id


### PR DESCRIPTION
Lab notification slice:

- wire canonical follow-up events in lab service: `lab_result_sent_confirmation` and `lab_critical_finding`
- emit `lab_new_study` from lab reporting on synthetic order creation
- align tests with the actual `LabOrder` / `LabResult` schema
- update notification SSOT note and LightRAG evidence log

Validation:
- `python -m pytest backend/tests/unit/test_lab_notification_catalog_slice3.py backend/tests/unit/test_lab_reporting_service.py -q`
- `python -m py_compile backend/app/services/lab_notification_service.py backend/app/services/lab_reporting_service.py backend/tests/unit/test_lab_notification_catalog_slice3.py backend/tests/unit/test_lab_reporting_service.py`