### PR TITLE
[codex] fix(ci): resolve baseline F821 blockers

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -97,7 +97,7 @@ def _resolve_payment_truth(
             from app.models.payment import Payment
 
             payment = (
-                _repo(db).query(Payment)
+                db.query(Payment)
                 .filter(Payment.visit_id == visit_id)
                 .order_by(Payment.created_at.desc())
                 .first()

--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 from app.crud.clinic import get_queue_settings
 from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue, OnlineQueueEntry, QueueToken
+from app.models.user import User
 from app.services.queue_session import (
     get_or_create_session_id,
 )


### PR DESCRIPTION
## Summary
Fixes existing main-branch Flake8 F821 blockers currently preventing PR #215 from getting a green code-quality check.

## Scope
- `backend/app/api/v1/endpoints/registrar_integration.py`: use the existing SQLAlchemy session directly for `Payment` lookup instead of undefined `_repo`.
- `backend/app/services/queue_service.py`: import `User` for existing type annotations.

## Validation
- `python -m py_compile backend/app/api/v1/endpoints/registrar_integration.py backend/app/services/queue_service.py`
- `python -m flake8 backend/app/api/v1/endpoints/registrar_integration.py backend/app/services/queue_service.py --select=F821`
- `git diff --check -- backend/app/api/v1/endpoints/registrar_integration.py backend/app/services/queue_service.py`

## Relationship to PR #215
These F821 errors are unchanged versus `origin/main` and are not introduced by PR #215. This PR keeps the baseline fix separate to avoid contaminating the replacement parent PR.