### PR TITLE
fix(openapi): remove duplicate reports router registration

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -134,9 +134,6 @@ from app.api.v1.endpoints import (
 from app.api.v1.endpoints import (
     health as health_ep,
 )
-from app.api.v1.endpoints import (
-    reports as reports_ep,
-)
 from app.api.v1.endpoints.migration_management import (
     router as migration_management_router,
 )
@@ -277,7 +274,6 @@ api_router.include_router(
     display_websocket.router, prefix="/display", tags=["display-websocket"]
 )
 api_router.include_router(board_ep.router, tags=["board"])
-api_router.include_router(reports_ep.router, prefix="/reports", tags=["reports"])
 api_router.include_router(payment_webhook.router, tags=["webhooks"])
 api_router.include_router(payment_reconciliation.router, prefix="/payments", tags=["payment-reconciliation"])
 api_router.include_router(admin_ai.router, prefix="/admin", tags=["admin"])


### PR DESCRIPTION
﻿## Summary

- Fix one backend CI baseline cluster by removing duplicate reports router registration from `backend/app/api/v1/api.py`.
- Preserve the existing `/api/v1/reports/*` API surface through the canonical `reports.router` include.

## Contract Impact

- Canonical surface: `/api/v1/reports/*` published from `backend/app/api/v1/endpoints/reports.py` through `backend/app/api/v1/api.py`
- Request shape: unchanged for all reports endpoints
- Response shape: unchanged for all reports endpoints
- Status codes: unchanged for all reports endpoints
- Frontend consumer: unchanged; existing reports consumers keep the same `/api/v1/reports/*` paths
- Compatibility path or alias: no compatibility alias changed; duplicate registration of the same path is removed
- Contract proof: expected to resolve `tests/test_openapi_contract.py::test_openapi_has_no_duplicate_operation_id_warnings` duplicate reports operation IDs

## RBAC / Permissions

- Roles allowed: unchanged; route dependencies remain in `backend/app/api/v1/endpoints/reports.py`
- Roles denied: unchanged; no role helper or auth dependency changed
- Positive auth proof: not applicable - this PR does not change auth behavior or allowed role lists
- Negative auth proof: not applicable - this PR does not change auth behavior or denied role lists

## Notification / Realtime

not applicable - reports router registration does not touch notifications, websocket, chat, or realtime behavior.

## Frontend Resilience

- Empty data proof: not applicable - no frontend panel or data rendering path changed
- Partial data proof: not applicable - no response schema or UI consumer changed
- Forbidden secondary path behavior: unchanged; no frontend fallback path changed
- Missing draft/resource behavior: not applicable - reports router registration does not affect drafts or resources
- Stale route/deep-link behavior: existing `/api/v1/reports/*` API paths remain available through the canonical registration

## Scope Gate

- Allowed paths: `backend/app/api/v1/api.py`
- Denied paths: frontend runtime files, reports endpoint implementation, auth/RBAC helpers, database migrations
- Migration/docs/test impact: no migration; no docs required; expected test impact is removal of OpenAPI duplicate reports operation IDs
- Rollback note: restore the removed duplicate `reports_ep` import/include if hidden behavior requires it, but that would reintroduce duplicate OpenAPI warnings

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/api.py`; `git diff --check -- backend/app/api/v1/api.py`
- Result: passed in the temp clone before push
- Not checked: full backend test suite not run locally; manual unified CI should be run on this stacked branch to confirm backend failures drop from 8 to 7
