### PR TITLE
fix(ci): align RBAC parity checker with route registry

### DIFF
--- a/ops/scripts/build_frontend_backend_parity.py
+++ b/ops/scripts/build_frontend_backend_parity.py
@@ -513,8 +513,153 @@ def _normalize_route_path(path: str) -> str:
     return f"/{path}"
 
 
-def parse_frontend_route_roles(frontend_app_path: Path) -> dict[str, list[str]]:
-    content = frontend_app_path.read_text(encoding="utf-8")
+def _extract_top_level_js_objects(array_body: str) -> list[str]:
+    objects: list[str] = []
+    start: int | None = None
+    brace_depth = 0
+    in_string: str | None = None
+    escaped = False
+
+    for index, char in enumerate(array_body):
+        if in_string:
+            if escaped:
+                escaped = False
+                continue
+            if char == "\\":
+                escaped = True
+                continue
+            if char == in_string:
+                in_string = None
+                continue
+            continue
+
+        if char in {"'", '"', "`"}:
+            in_string = char
+            continue
+
+        if char == "{":
+            if brace_depth == 0:
+                start = index
+            brace_depth += 1
+            continue
+
+        if char == "}":
+            brace_depth -= 1
+            if brace_depth == 0 and start is not None:
+                objects.append(array_body[start : index + 1])
+                start = None
+
+    return objects
+
+
+def _extract_route_registry_body(content: str) -> str | None:
+    marker = "ROUTE_REGISTRY"
+    marker_index = content.find(marker)
+    if marker_index == -1:
+        return None
+
+    array_start = content.find("[", marker_index)
+    if array_start == -1:
+        return None
+
+    bracket_depth = 0
+    in_string: str | None = None
+    escaped = False
+    for index in range(array_start, len(content)):
+        char = content[index]
+        if in_string:
+            if escaped:
+                escaped = False
+                continue
+            if char == "\\":
+                escaped = True
+                continue
+            if char == in_string:
+                in_string = None
+                continue
+            continue
+
+        if char in {"'", '"', "`"}:
+            in_string = char
+            continue
+
+        if char == "[":
+            bracket_depth += 1
+            continue
+
+        if char == "]":
+            bracket_depth -= 1
+            if bracket_depth == 0:
+                return content[array_start + 1 : index]
+
+    return None
+
+
+def _parse_route_registry_roles(route_registry_path: Path) -> dict[str, list[str]]:
+    content = route_registry_path.read_text(encoding="utf-8")
+    registry_body = _extract_route_registry_body(content)
+    if registry_body is None:
+        return {}
+
+    role_to_paths: dict[str, set[str]] = defaultdict(set)
+    for route_object in _extract_top_level_js_objects(registry_body):
+        path_match = re.search(r"\bpath:\s*['\"]([^'\"]+)['\"]", route_object)
+        roles_match = re.search(r"\broles:\s*\[(?P<roles>[^\]]*)\]", route_object, re.DOTALL)
+        if path_match is None or roles_match is None:
+            continue
+
+        route_paths = [_normalize_route_path(path_match.group(1).strip())]
+        legacy_match = re.search(
+            r"\blegacyRedirectFrom:\s*\[(?P<paths>[^\]]*)\]",
+            route_object,
+            re.DOTALL,
+        )
+        if legacy_match:
+            route_paths.extend(
+                _normalize_route_path(candidate.strip())
+                for group in ROLE_LITERAL_PATTERN.findall(legacy_match.group("paths"))
+                for candidate in group
+                if candidate.strip()
+            )
+
+        roles = [
+            candidate.strip()
+            for group in ROLE_LITERAL_PATTERN.findall(roles_match.group("roles"))
+            for candidate in group
+            if candidate.strip()
+        ]
+        for role in roles:
+            role_to_paths[role].update(route_paths)
+
+    output = {role: sorted(paths) for role, paths in role_to_paths.items()}
+    LOGGER.info(
+        "frontend_backend_parity.frontend_route_registry_roles_loaded file=%s roles=%d",
+        route_registry_path.as_posix(),
+        len(output),
+    )
+    return output
+
+
+def _resolve_route_registry_path(frontend_app_path: Path, content: str) -> Path | None:
+    match = re.search(
+        r"import\s+\{\s*ROUTE_REGISTRY\s*\}\s+from\s+['\"](?P<path>[^'\"]+)['\"]",
+        content,
+    )
+    if match:
+        import_path = match.group("path")
+        candidate = (frontend_app_path.parent / import_path).resolve()
+        if candidate.suffix == "":
+            candidate = candidate.with_suffix(".js")
+        if candidate.exists():
+            return candidate
+
+    fallback = frontend_app_path.parent / "routing" / "routeRegistry.js"
+    if fallback.exists():
+        return fallback
+    return None
+
+
+def _parse_inline_app_route_roles(content: str) -> dict[str, list[str]]:
     pattern = re.compile(
         r"<Route\s+path=\"(?P<path>[^\"]+)\"[^>]*element=\{<RequireAuth\s+roles=\{\[(?P<roles>[^\]]*)\]\}",
         re.DOTALL,
@@ -533,6 +678,19 @@ def parse_frontend_route_roles(frontend_app_path: Path) -> dict[str, list[str]]:
         for role in roles:
             role_to_paths[role].add(route_path)
 
+    return {role: sorted(paths) for role, paths in role_to_paths.items()}
+
+
+def parse_frontend_route_roles(frontend_app_path: Path) -> dict[str, list[str]]:
+    content = frontend_app_path.read_text(encoding="utf-8")
+
+    route_registry_path = _resolve_route_registry_path(frontend_app_path, content)
+    if route_registry_path is not None:
+        registry_roles = _parse_route_registry_roles(route_registry_path)
+        if registry_roles:
+            return registry_roles
+
+    role_to_paths = _parse_inline_app_route_roles(content)
     output = {role: sorted(paths) for role, paths in role_to_paths.items()}
     LOGGER.info(
         "frontend_backend_parity.frontend_roles_loaded file=%s roles=%d",


### PR DESCRIPTION
﻿## Summary

- Fixes the backend CI RBAC parity cluster after PR #222 by teaching the parity checker to read the canonical frontend ROUTE_REGISTRY instead of the retired inline App.jsx RequireAuth route shape.
- Preserves compatibility proof by including legacyRedirectFrom paths, so backend ROLE_ROUTES entries such as /registrar-panel and /doctor-panel still match frontend legacy aliases.

## Contract Impact

- Canonical surface: frontend/src/routing/routeRegistry.js role-scoped route metadata as consumed by frontend/src/App.jsx.
- Request shape: not applicable - no API request contract changes were made.
- Response shape: not applicable - no API response contract changes were made.
- Status codes: not applicable - no backend endpoint behavior or status code changed.
- Frontend consumer: App.jsx renders ROUTE_REGISTRY through RouteRenderer and RouteAccessBoundary.
- Compatibility path or alias: legacyRedirectFrom aliases are parsed as compatibility paths for existing backend ROLE_ROUTES expectations.
- Contract proof: diagnostic import returned RBAC alignment pass with 8 frontend roles, 8 backend roles, and zero route mismatches.

## RBAC / Permissions

- Roles allowed: Admin, Registrar, Lab, Doctor, Cashier, cardio, derma, dentist from ROUTE_REGISTRY role-scoped entries.
- Roles denied: not applicable - this checker-only change does not alter runtime allow/deny decisions.
- Positive auth proof: parity diagnostic found all backend CRITICAL_ROLES represented in frontend route metadata.
- Negative auth proof: no runtime guard behavior changed; the proof is limited to static frontend/backend RBAC parity.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime payload, ack, read/unread, reconnect, or delivery behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no UI data rendering path changed.
- Partial data proof: not applicable - no UI partial-data path changed.
- Forbidden secondary path behavior: not applicable - no secondary browser route or forbidden fallback behavior changed.
- Missing draft/resource behavior: not applicable - no draft or resource loader behavior changed.
- Stale route/deep-link behavior: not applicable - no runtime deep-link handling changed.

## Scope Gate

- Allowed paths: ops/scripts/build_frontend_backend_parity.py.
- Denied paths: backend runtime endpoints/services/models, frontend runtime components/routes, migrations, lockfiles, generated artifacts.
- Migration/docs/test impact: no migration and no docs change; existing backend parity unit should now pass the current route registry shape.
- Rollback note: revert the single checker-script change to restore old inline App.jsx parsing behavior.

## Validation

- Targeted tests or smoke run: python -m py_compile ops/scripts/build_frontend_backend_parity.py; diagnostic import of build_frontend_backend_parity.py, parse_frontend_route_roles(App.jsx), and evaluate_rbac_alignment(...).
- Result: py_compile passed; diagnostic status pass with frontend_roles_total=8, backend_roles_total=8, frontend_only_roles=0, backend_only_roles=0, route_mismatches=0.
- Not checked: pytest target because this fresh temp clone Python has no pytest installed; full GitHub unified CI is pending after PR creation.
