### PR TITLE
fix(payments): preserve provider init failure response

### DIFF
--- a/backend/app/services/payment_init_service.py
+++ b/backend/app/services/payment_init_service.py
@@ -158,14 +158,26 @@ class PaymentInitService:
             )
             self.repository.commit()
             self.repository.refresh(payment)
-            self._notify_payment_status(
-                payment_id=payment.id,
-                visit_id=visit.id,
-                current_user_id=current_user_id,
-                change_type="failed_init",
-                reason=result.error_message,
-                provider=provider,
-            )
+            try:
+                self._notify_payment_status(
+                    payment_id=payment.id,
+                    visit_id=visit.id,
+                    current_user_id=current_user_id,
+                    change_type="failed_init",
+                    reason=result.error_message,
+                    provider=provider,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "payment_init_service.failed_init_notification_error",
+                    extra={
+                        "payment_id": payment.id,
+                        "visit_id": visit.id,
+                        "provider": provider,
+                        "error": str(exc),
+                    },
+                    exc_info=True,
+                )
             return {
                 "success": False,
                 "payment_id": payment.id,


### PR DESCRIPTION
﻿## Summary

- Fixes the payment init backend-test cluster after PR #223 by preventing best-effort failed-payment notification work from masking the provider failure response.
- Keeps the persisted failed payment status and original provider error message (`provider timeout`) as the returned contract when provider initialization fails.

## Contract Impact

- Canonical surface: PaymentInitService.init_payment failed-provider path for online payment initialization.
- Request shape: not applicable - no request payload or endpoint input contract changed.
- Response shape: failed provider init continues returning success=false, payment_id, and the provider error_message.
- Status codes: not applicable - service return contract only; no endpoint status-code behavior changed in this slice.
- Frontend consumer: cashier/payment initialization consumer receives the original provider error instead of a notification-side-effect error.
- Compatibility path or alias: not applicable - no route alias or legacy endpoint path changed.
- Contract proof: local py_compile passed and CI backend test rerun is required to confirm the exact unit test.

## RBAC / Permissions

- Roles allowed: unchanged from the existing payment initialization endpoint/service wiring.
- Roles denied: unchanged from the existing payment initialization endpoint/service wiring.
- Positive auth proof: not applicable - this service-only fix does not alter authorization decisions.
- Negative auth proof: not applicable - this service-only fix does not alter authorization denial behavior.

## Notification / Realtime

- Event type or websocket channel: existing `payment_notification` side-effect remains best-effort for failed payment initialization.
- Payload version / ack behavior: unchanged; no payload version or ack contract changed.
- Read/unread or delivery semantics: unchanged; notification delivery failure no longer masks the payment provider failure response.
- Reconnect/resync proof: not applicable - no websocket reconnect or realtime resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend empty-state rendering changed.
- Partial data proof: not applicable - no frontend partial-data rendering changed.
- Forbidden secondary path behavior: not applicable - no secondary frontend path changed.
- Missing draft/resource behavior: not applicable - no draft or resource loader behavior changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: backend/app/services/payment_init_service.py.
- Denied paths: payment endpoints, payment models, repositories, migrations, frontend payment UI, notification policy modules, generated artifacts.
- Migration/docs/test impact: no migration and no docs change; existing payment init unit test should stop seeing notification errors mask provider errors.
- Rollback note: revert the single service change to restore previous notification-side-effect exception behavior.

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/services/payment_init_service.py; git diff --check for the changed service file.
- Result: py_compile passed; diff check passed with only the existing Windows LF-to-CRLF working-copy warning.
- Not checked: local pytest target because this fresh temp clone Python has no pytest installed; full GitHub unified CI is pending after PR creation.
