### PR TITLE
fix(queue): tolerate legacy cabinet metadata updates

### DIFF
--- a/backend/app/services/queue_cabinet_management_api_service.py
+++ b/backend/app/services/queue_cabinet_management_api_service.py
@@ -54,7 +54,7 @@ class QueueCabinetManagementApiService:
         if doctor and getattr(doctor, "cabinet", None):
             raise QueueCabinetManagementDomainError(
                 400,
-                "Canonical cabinet number cannot be changed from this panel. Update the doctor cabinet and run sync.",
+                "Канонический номер кабинета нельзя менять из этой панели. Обновите кабинет в карточке врача и выполните синхронизацию.",
             )
         queue.cabinet_number = value
 

--- a/backend/app/services/queue_cabinet_management_api_service.py
+++ b/backend/app/services/queue_cabinet_management_api_service.py
@@ -43,12 +43,30 @@ class QueueCabinetManagementApiService:
             return user.full_name or user.username or f"Специалист #{specialist_id}"
         return f"Специалист #{specialist_id}"
 
+    def _doctor_for_queue(self, queue):
+        specialist_id = getattr(queue, "specialist_id", None)
+        if specialist_id is None or not hasattr(self.repository, "get_doctor"):
+            return None
+        return self.repository.get_doctor(specialist_id)
+
+    def _assign_queue_cabinet_number(self, queue, value: Any) -> None:
+        doctor = self._doctor_for_queue(queue)
+        if doctor and getattr(doctor, "cabinet", None):
+            raise QueueCabinetManagementDomainError(
+                400,
+                "Canonical cabinet number cannot be changed from this panel. Update the doctor cabinet and run sync.",
+            )
+        queue.cabinet_number = value
+
     def _build_queue_payload(self, queue) -> dict[str, Any]:
-        doctor = self.repository.get_doctor(queue.specialist_id)
-        doctor_cabinet = doctor.cabinet if doctor else None
+        queue_id = getattr(queue, "id", None)
+        queue_day = getattr(queue, "day", None)
+        specialist_id = getattr(queue, "specialist_id", None)
+        doctor = self._doctor_for_queue(queue)
+        doctor_cabinet = getattr(doctor, "cabinet", None) if doctor else None
         linked_doctor_found = doctor is not None
         doctor_has_cabinet = bool(doctor_cabinet)
-        queue_cabinet = queue.cabinet_number
+        queue_cabinet = getattr(queue, "cabinet_number", None)
         effective_cabinet = queue_cabinet or doctor_cabinet
         integrity_warnings: list[str] = []
 
@@ -68,18 +86,26 @@ class QueueCabinetManagementApiService:
             integrity_warnings.append("effective_cabinet_missing")
 
         return {
-            "id": queue.id,
-            "day": queue.day.isoformat(),
-            "specialist_id": queue.specialist_id,
-            "specialist_name": self._resolve_specialist_name(queue.specialist_id),
-            "queue_tag": queue.queue_tag,
+            "id": queue_id,
+            "day": queue_day.isoformat() if queue_day else None,
+            "specialist_id": specialist_id,
+            "specialist_name": (
+                self._resolve_specialist_name(specialist_id)
+                if specialist_id is not None
+                else None
+            ),
+            "queue_tag": getattr(queue, "queue_tag", None),
             "cabinet_number": queue_cabinet,
             "doctor_cabinet": doctor_cabinet,
             "effective_cabinet": effective_cabinet,
-            "cabinet_floor": queue.cabinet_floor,
-            "cabinet_building": queue.cabinet_building,
-            "entries_count": self.repository.count_entries(queue_id=queue.id),
-            "active": queue.active,
+            "cabinet_floor": getattr(queue, "cabinet_floor", None),
+            "cabinet_building": getattr(queue, "cabinet_building", None),
+            "entries_count": (
+                self.repository.count_entries(queue_id=queue_id)
+                if queue_id is not None and hasattr(self.repository, "count_entries")
+                else 0
+            ),
+            "active": getattr(queue, "active", None),
             "linked_doctor_found": linked_doctor_found,
             "doctor_has_cabinet": doctor_has_cabinet,
             "sync_status": sync_status,
@@ -128,10 +154,8 @@ class QueueCabinetManagementApiService:
 
         updated = False
         if "cabinet_number" in cabinet_info:
-            raise QueueCabinetManagementDomainError(
-                400,
-                "Канонический номер кабинета нельзя менять из этой панели. Обновите кабинет в карточке врача и выполните синхронизацию.",
-            )
+            self._assign_queue_cabinet_number(queue, cabinet_info["cabinet_number"])
+            updated = True
         if "cabinet_floor" in cabinet_info:
             queue.cabinet_floor = cabinet_info["cabinet_floor"]
             updated = True
@@ -171,13 +195,12 @@ class QueueCabinetManagementApiService:
             updated = False
 
             if "cabinet_number" in cabinet_info:
-                errors.append(
-                    {
-                        "queue_id": update["queue_id"],
-                        "error": "Канонический кабинет нельзя менять вручную из этой панели",
-                    }
-                )
-                continue
+                try:
+                    self._assign_queue_cabinet_number(queue, cabinet_info["cabinet_number"])
+                    updated = True
+                except QueueCabinetManagementDomainError as exc:
+                    errors.append({"queue_id": update["queue_id"], "error": exc.detail})
+                    continue
             if "cabinet_floor" in cabinet_info:
                 queue.cabinet_floor = cabinet_info["cabinet_floor"]
                 updated = True


### PR DESCRIPTION
﻿## Summary

- Fixes the queue cabinet management backend-test cluster after PR #224 by allowing cabinet_number updates only for queues without a linked canonical doctor cabinet.
- Keeps doctor-profile cabinet ownership protected when a doctor cabinet exists, while making queue payload generation tolerant of partial legacy/orphan queue and doctor objects.

## Contract Impact

- Canonical surface: QueueCabinetManagementApiService update and payload generation for queue cabinet management.
- Request shape: unchanged; cabinet_info may already include cabinet_number, cabinet_floor, and cabinet_building.
- Response shape: unchanged top-level success payload; cabinet_info now tolerates missing optional queue/doctor fields instead of raising AttributeError.
- Status codes: unchanged for missing queue and locked canonical doctor-cabinet updates; orphan/legacy queue cabinet_number updates no longer return a false 400.
- Frontend consumer: admin queue cabinet management panel receives updated cabinet metadata for legacy/orphan queues and stable payloads for partial doctor records.
- Compatibility path or alias: legacy/orphan queues without a doctor cabinet remain compatibility paths for manual queue cabinet metadata.
- Contract proof: local py_compile and diff check passed; GitHub unified backend CI is required to confirm the three queue cabinet unit failures.

## RBAC / Permissions

- Roles allowed: unchanged from existing queue cabinet management endpoint wiring.
- Roles denied: unchanged from existing queue cabinet management endpoint wiring.
- Positive auth proof: not applicable - this service-only fix does not alter authorization decisions.
- Negative auth proof: not applicable - this service-only fix does not alter authorization denial behavior.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification or websocket producer changed.
- Payload version / ack behavior: not applicable - no realtime payload or ack behavior changed.
- Read/unread or delivery semantics: not applicable - no delivery/read semantics changed.
- Reconnect/resync proof: not applicable - no websocket reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: partial queue payloads now return None/0 defaults instead of crashing when optional queue fields are absent.
- Partial data proof: doctor objects without cabinet still resolve specialist_name from user.full_name or username.
- Forbidden secondary path behavior: not applicable - no secondary frontend path behavior changed.
- Missing draft/resource behavior: not applicable - no draft or resource loader behavior changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: backend/app/services/queue_cabinet_management_api_service.py.
- Denied paths: queue endpoints, queue models, repositories, frontend admin panel, migrations, generated artifacts.
- Migration/docs/test impact: no migration and no docs change; existing queue cabinet unit tests should stop failing update/clear/fallback cases.
- Rollback note: revert the single service change to restore strict cabinet_number rejection and strict payload attribute access.

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/services/queue_cabinet_management_api_service.py; git diff --check for the changed service file.
- Result: py_compile passed; diff check passed.
- Not checked: local pytest target because this fresh temp clone Python has no pytest installed; full GitHub unified CI is pending after PR creation.
