### PR TITLE
fix(dental): remove service db fallback

### DIFF
--- a/backend/app/services/dental_api_service.py
+++ b/backend/app/services/dental_api_service.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import Session
 from app.models.doctor_price_override import DoctorPriceOverride
 from app.models.user import User
 from app.repositories.dental_api_repository import DentalApiRepository
-from app.services.service_mapping import get_service_code
 from app.services.notifications import notification_sender_service
 
 logger = logging.getLogger(__name__)
@@ -34,6 +33,16 @@ class DentalApiService:
         repository: DentalApiRepository | None = None,
     ):
         self.repository = repository or DentalApiRepository(db)
+
+    @staticmethod
+    def _service_code(service) -> str | None:
+        if not service:
+            return None
+        service_code = getattr(service, "service_code", None)
+        if service_code:
+            return service_code
+        service_id = getattr(service, "id", None)
+        return str(service_id) if service_id is not None else None
 
     async def create_dental_price_override(self, *, override_data, user: User) -> DoctorPriceOverride:
         visit = self.repository.get_visit(override_data.visit_id)
@@ -106,7 +115,7 @@ class DentalApiService:
             "Изменение цены стоматологом\n\n"
             f"Врач: {doctor_name}\n"
             f"{patient_info}\n"
-            f"Услуга: {service.name} ({service.service_code or get_service_code(service.id, self.repository.db)})\n"
+            f"Услуга: {service.name} ({self._service_code(service)})\n"
             f"Цена: {price_override.original_price} -> {price_override.new_price} UZS\n"
             f"Причина: {price_override.reason}\n"
             f"{details_line}"
@@ -280,12 +289,7 @@ class DentalApiService:
                     "service": {
                         "id": service.id if service else None,
                         "name": service.name if service else f"Услуга #{override.service_id}",
-                        "code": (
-                            service.service_code
-                            or get_service_code(service.id, self.repository.db)
-                            if service
-                            else None
-                        ),
+                        "code": self._service_code(service),
                     },
                     "original_price": float(override.original_price),
                     "new_price": float(override.new_price),


### PR DESCRIPTION
﻿## Summary

- Fixes the dental service/repository boundary failure after PR #225 by removing direct `self.repository.db` usage from dental service display-code fallback logic.
- Keeps service display code generation inside the loaded service object: `service.service_code` first, then stable service id fallback.

## Contract Impact

- Canonical surface: DentalApiService price override notification/list payload service code field.
- Request shape: not applicable - no endpoint input or request payload changed.
- Response shape: unchanged field names; service code fallback now uses loaded service metadata instead of DB-backed mapping lookup from the service layer.
- Status codes: not applicable - no endpoint status-code behavior changed.
- Frontend consumer: dental/admin price override consumers still receive the existing service code field.
- Compatibility path or alias: not applicable - no route alias or legacy path changed.
- Contract proof: local static check found no `repository.db`, `get_service_code`, or `.query(` tokens in dental service; py_compile passed.

## RBAC / Permissions

- Roles allowed: unchanged from existing dental endpoint wiring.
- Roles denied: unchanged from existing dental endpoint wiring.
- Positive auth proof: not applicable - this service-boundary fix does not alter authorization decisions.
- Negative auth proof: not applicable - this service-boundary fix does not alter authorization denial behavior.

## Notification / Realtime

- Event type or websocket channel: existing notification side effect is unchanged; only service code fallback source changed.
- Payload version / ack behavior: unchanged - no notification payload version or ack contract changed.
- Read/unread or delivery semantics: unchanged - no delivery or read semantics changed.
- Reconnect/resync proof: not applicable - no websocket reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend empty-state path changed.
- Partial data proof: missing service_code now falls back to service id without service-layer DB access.
- Forbidden secondary path behavior: not applicable - no secondary frontend path changed.
- Missing draft/resource behavior: not applicable - no draft or resource loader behavior changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: backend/app/services/dental_api_service.py.
- Denied paths: dental endpoints, repositories, models, migrations, frontend panels, generated artifacts.
- Migration/docs/test impact: no migration and no docs change; existing service/repository boundary unit should stop failing for dental service.
- Rollback note: revert the single dental service change to restore DB-backed service_mapping fallback from the service layer.

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/services/dental_api_service.py; git diff --check for the changed service file; static token check for `repository.db`, `get_service_code`, and `.query(`.
- Result: py_compile passed; diff check passed; static token check returned no matches.
- Not checked: local pytest target because this fresh temp clone Python has no pytest installed; full GitHub unified CI is pending after PR creation.
