### PR TITLE
[codex] Remove unused firebase-admin dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,6 @@ httpx>=0.25,<0.29
 python-multipart>=0.0.26,<0.0.27
 jinja2>=3.1,<3.2
 pyserial>=3.5,<4.0
-firebase-admin>=6.0.0,<7.0.0
 aiohttp>=3.13.3,<3.14
 aiofiles>=24.1,<25.0
 beautifulsoup4>=4.14.3,<5.0


### PR DESCRIPTION
## Summary
- Removes the unused `firebase-admin` requirement from `backend/requirements.txt`.
- Follows up on the #213 compatibility review, where the firebase-admin bump was closed because active FCM code does not import or use the Firebase Admin SDK.

## Why
- Backend scoped usage checks found no `firebase_admin` / `firebase-admin` usage outside the dependency manifest.
- Active FCM paths use direct HTTP/google-auth integration instead of firebase-admin:
  - `backend/app/services/fcm_service.py`
  - `backend/app/services/firebase_service.py`
  - `backend/app/api/v1/endpoints/fcm_notifications.py`

## Validation
- Backend scoped scan after removal: `NO_BACKEND_FIREBASE_ADMIN_USAGE_FOUND`.
- Diff scope check: only `backend/requirements.txt` changed.
- `git diff --check` passed.

## Scope
- No runtime FCM code changed.
- No frontend, migration, docs, or ops files changed.

## Rollback
- Re-add `firebase-admin>=6.0.0,<7.0.0` to `backend/requirements.txt` if hidden deployment packaging proves it is still required.