### PR TITLE
[codex] Support keyboard feedback on theme toggle

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Sun, Moon } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
 import { colors } from '../theme/tokens';
@@ -5,6 +6,8 @@ import PropTypes from 'prop-types';
 
 const ThemeToggle = ({ size = 'md', className = '', style = {} }) => {
   const { isDark, toggleTheme, getSpacing } = useTheme();
+  const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
 
   const sizes = {
     sm: { size: 16, padding: getSpacing('xs') },
@@ -40,14 +43,17 @@ const ThemeToggle = ({ size = 'md', className = '', style = {} }) => {
     `0 4px 20px ${colors.semantic.surface.overlay}` :
     `0 4px 20px ${colors.semantic.surface.overlay}`
   };
+  const activeStyle = isHovered || isFocused ? { ...buttonStyle, ...hoverStyle } : buttonStyle;
 
   return (
     <button
       onClick={toggleTheme}
       className={`clinic-theme-toggle ${className}`}
-      style={buttonStyle}
-      onMouseEnter={(e) => Object.assign(e.target.style, hoverStyle)}
-      onMouseLeave={(e) => Object.assign(e.target.style, buttonStyle)}
+      style={activeStyle}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onFocus={() => setIsFocused(true)}
+      onBlur={() => setIsFocused(false)}
       title={`Переключить на ${isDark ? 'светлую' : 'темную'} тему`}
       aria-label={`Переключить на ${isDark ? 'светлую' : 'темную'} тему`}>
       


### PR DESCRIPTION
## Summary
- Replaces direct DOM style mutation in `ThemeToggle` with React state.
- Applies the same active visual treatment for mouse hover and keyboard focus.
- Keeps the replacement PR frontend-only, without the unrelated backend changes present in #216.

## Why
- #216 contains a useful accessibility fix, but also includes unrelated backend files and has conflicts/failing backend checks.
- This PR extracts only the useful ThemeToggle keyboard-accessibility behavior into a narrow patch.

## Validation
- Local diff scope check: only `frontend/src/components/ThemeToggle.jsx` changed.
- `git diff --check` passed.
- No local test suite was run; GitHub CI should provide the merge proof.

## Scope
- No backend files changed.
- No docs/generated files changed.
- No runtime theme contract changed beyond hover/focus feedback behavior.

## Rollback
- Revert this PR to restore the prior mouse-only inline style mutation behavior.