### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to form icon buttons

### DIFF
--- a/frontend/src/components/forms/ModernInput.jsx
+++ b/frontend/src/components/forms/ModernInput.jsx
@@ -179,7 +179,8 @@ const ModernInput = ({
             className="input-action-btn"
             onClick={() => setShowPassword(!showPassword)}
             tabIndex={-1}
-            aria-label={showPassword ? 'Скрыть пароль' : 'Показать пароль'}>
+            aria-label={showPassword ? 'Скрыть пароль' : 'Показать пароль'}
+            title={showPassword ? 'Скрыть пароль' : 'Показать пароль'}>
             
               {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
             </button>
@@ -192,7 +193,8 @@ const ModernInput = ({
             className="input-action-btn"
             onClick={handleClear}
             tabIndex={-1}
-            aria-label="Очистить поле">
+            aria-label="Очистить поле"
+            title="Очистить поле">
             
               <X size={16} />
             </button>

--- a/frontend/src/components/forms/ModernSelect.jsx
+++ b/frontend/src/components/forms/ModernSelect.jsx
@@ -246,7 +246,9 @@ const ModernSelect = ({
                   type="button"
                   className="tag-remove"
                   onClick={(e) => handleRemoveOption(e, val)}
-                  tabIndex={-1}>
+                  tabIndex={-1}
+                  aria-label="Удалить"
+                  title="Удалить">
                   
                   <X size={12} />
                 </button>
@@ -345,7 +347,8 @@ const ModernSelect = ({
             className="select-action-btn"
             onClick={handleClear}
             tabIndex={-1}
-            aria-label="Очистить выбор">
+            aria-label="Очистить выбор"
+            title="Очистить выбор">
             
               <X size={16} />
             </button>

--- a/frontend/src/components/ui/macos/MacOSInput.jsx
+++ b/frontend/src/components/ui/macos/MacOSInput.jsx
@@ -152,6 +152,7 @@ const MacOSInput = React.forwardRef(({
         <button
           type="button"
           aria-label="Clear input"
+          title="Clear input"
           style={clearButtonStyle}
           onClick={(e) => {
             e.stopPropagation();


### PR DESCRIPTION
## Summary

- Add native `title` tooltips and accessible names to icon-only buttons in shared frontend form components.
- Keep the existing button behavior unchanged; this PR is an accessibility metadata improvement only.

## Contract Impact

- Canonical surface: shared frontend form components `ModernInput`, `ModernSelect`, and `MacOSInput`
- Request shape: not applicable - no HTTP/API request is changed.
- Response shape: not applicable - no backend/API response is changed.
- Status codes: not applicable - no endpoint or status-code behavior is changed.
- Frontend consumer: forms using these shared input/select components receive improved button titles/labels with unchanged props and behavior.
- Compatibility path or alias: not applicable - no route, alias, or compatibility path is changed.
- Contract proof: GitHub frontend tests and frontend-backend parity checks passed for this frontend-only metadata change.

## RBAC / Permissions

- Roles allowed: unchanged - no auth or permission surface is changed.
- Roles denied: unchanged - no auth or permission surface is changed.
- Positive auth proof: not applicable - no protected backend route or RBAC behavior changed.
- Negative auth proof: not applicable - no protected backend route or RBAC behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - existing empty input/select behavior is preserved; only button metadata was added.
- Partial data proof: unchanged - existing partial option/value behavior is preserved; only button metadata was added.
- Forbidden secondary path behavior: not applicable - no secondary request path or forbidden fallback changed.
- Missing draft/resource behavior: not applicable - these components do not create or reopen drafts/resources in this patch.
- Stale route/deep-link behavior: not applicable - no route state or deep-link behavior changed.

## Scope Gate

- Allowed paths: `frontend/src/components/forms/ModernInput.jsx`, `frontend/src/components/forms/ModernSelect.jsx`, `frontend/src/components/ui/macos/MacOSInput.jsx`
- Denied paths: backend runtime, database/migrations, routing registry, dependency files, generated output
- Migration/docs/test impact: no migration; no docs required; existing frontend CI and parity checks cover the narrow metadata-only change.
- Rollback note: revert the three frontend component attribute changes.

## Validation

- Targeted tests or smoke run: GitHub CI for PR #231, including CI Scope, code quality, frontend tests, backend tests, frontend-backend parity, security scan, docs, notifications, GitGuardian, and Vercel.
- Result: passed.
- Not checked: manual browser/screen-reader smoke; existing `tabIndex={-1}` focus behavior was intentionally not changed by this PR.

## Residual Risk

- Existing `tabIndex={-1}` on these icon buttons remains unchanged, so this PR improves labels/tooltips but does not claim complete keyboard focusability remediation.