### PR TITLE
refactor(visits): replace W2A-SR-012 read-only slice

### DIFF
--- a/.ai-factory/contracts/w2a-sr-012.contract.json
+++ b/.ai-factory/contracts/w2a-sr-012.contract.json
@@ -1,0 +1,33 @@
+{
+  "contract_version": "1.0",
+  "task_id": "W2A-SR-012",
+  "task_type": "refactor-module",
+  "repo": "drsapaev/final",
+  "scope": {
+    "include": [
+      "backend/app/api/v1/endpoints/visits.py",
+      "backend/app/services/visits_api_service.py",
+      "backend/app/repositories/visits_api_repository.py",
+      "backend/tests/architecture/test_w2a_router_boundaries.py",
+      "backend/tests/unit/test_visits_router_service_wiring.py"
+    ],
+    "exclude": [
+      "frontend/**",
+      ".github/workflows/**",
+      "backend/alembic/**",
+      "backend/app/api/v1/endpoints/queue*.py",
+      "backend/app/api/v1/endpoints/payment*.py",
+      "backend/app/api/v1/endpoints/emr*.py"
+    ]
+  },
+  "goals": [
+    "Route only read-only visits handlers through VisitsApiService.",
+    "Preserve existing routes and response shapes.",
+    "Leave write, status, reschedule and queue-coupled handlers unchanged."
+  ],
+  "stop_conditions": [
+    "Need to change queue-coupled visit handlers.",
+    "Need to change route paths or response contracts.",
+    "The refactor expands into cross-module visit or queue work."
+  ]
+}

--- a/backend/app/api/v1/endpoints/visits.py
+++ b/backend/app/api/v1/endpoints/visits.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
 from app.services.service_mapping import normalize_service_code
+from app.services.visits_api_service import VisitsApiService
 from app.core.audit import log_critical_change, extract_model_changes
 
 router = APIRouter()
@@ -77,23 +78,14 @@ def list_visits(
     offset: int = Query(default=0, ge=0),
     db: Session = Depends(get_db),
 ):
-    t = _visits(db)
-    stmt = select(t)
-    if patient_id is not None:
-        stmt = stmt.where(t.c.patient_id == patient_id)
-    if doctor_id is not None:
-        stmt = stmt.where(t.c.doctor_id == doctor_id)
-    if status_q:
-        stmt = stmt.where(t.c.status == status_q)
-    if planned is not None:
-        # фильтр по planned_date (если столбец есть)
-        if "planned_date" in t.c:
-            stmt = stmt.where(t.c.planned_date == planned)
-        else:
-            # если столбца нет — просто возвращаем пустой список или raise (выбрал мягкое поведение)
-            return []
-    stmt = stmt.order_by(t.c.id.desc()).limit(limit).offset(offset)
-    rows = db.execute(stmt).mappings().all()
+    rows = VisitsApiService(db).list_visits(
+        patient_id=patient_id,
+        doctor_id=doctor_id,
+        status_q=status_q,
+        planned=planned,
+        limit=limit,
+        offset=offset,
+    )
     return [VisitOut(**row) for row in rows]  # type: ignore[arg-type]
 
 
@@ -235,19 +227,10 @@ def create_visit(
     "/visits/{visit_id}", response_model=VisitWithServices, summary="Карточка визита"
 )
 def get_visit(visit_id: int, db: Session = Depends(get_db)):
-    t = _visits(db)
-    s = _vservices(db)
-    vrow = db.execute(select(t).where(t.c.id == visit_id)).mappings().first()
-    if not vrow:
-        raise HTTPException(404, "Visit not found")
-    items = (
-        db.execute(select(s).where(s.c.visit_id == visit_id).order_by(s.c.id.asc()))
-        .mappings()
-        .all()
-    )
+    payload = VisitsApiService(db).get_visit(visit_id=visit_id)
     return VisitWithServices(
-        visit=VisitOut(**vrow),  # type: ignore[arg-type]
-        services=[VisitServiceIn(**it) for it in items],  # type: ignore[list-item]
+        visit=VisitOut(**payload["visit"]),
+        services=[VisitServiceIn(**item) for item in payload["services"]],
     )
 
 

--- a/backend/tests/architecture/test_w2a_router_boundaries.py
+++ b/backend/tests/architecture/test_w2a_router_boundaries.py
@@ -75,3 +75,26 @@ def test_services_catalog_handlers_use_service_layer() -> None:
             block,
         )
         assert forbidden is None, handler_name
+
+
+def test_visits_read_only_handlers_use_service_layer() -> None:
+    endpoint_path = (
+        Path(__file__).resolve().parents[2]
+        / "app"
+        / "api"
+        / "v1"
+        / "endpoints"
+        / "visits.py"
+    )
+    safe_handlers = [
+        "list_visits",
+        "get_visit",
+    ]
+    for handler_name in safe_handlers:
+        block = _function_block(endpoint_path, handler_name)
+        assert "VisitsApiService(db)" in block
+        forbidden = re.search(
+            r"db\.(query|add|commit|refresh|rollback|delete|execute|flush)\(",
+            block,
+        )
+        assert forbidden is None, handler_name

--- a/backend/tests/unit/test_visits_router_service_wiring.py
+++ b/backend/tests/unit/test_visits_router_service_wiring.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from datetime import date
+
+from app.services.visits_api_service import VisitsApiService
+
+
+def test_list_visits_endpoint_delegates_to_service(client, monkeypatch) -> None:
+    captured = {}
+
+    def fake_list_visits(
+        self,
+        *,
+        patient_id,
+        doctor_id,
+        status_q,
+        planned,
+        limit,
+        offset,
+    ):
+        captured.update(
+            {
+                "patient_id": patient_id,
+                "doctor_id": doctor_id,
+                "status_q": status_q,
+                "planned": planned,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+        return [
+            {
+                "id": 17,
+                "patient_id": patient_id,
+                "doctor_id": doctor_id,
+                "status": status_q or "open",
+                "created_at": None,
+                "started_at": None,
+                "finished_at": None,
+                "notes": "router wiring",
+                "planned_date": planned,
+                "source": "desk",
+            }
+        ]
+
+    monkeypatch.setattr(VisitsApiService, "list_visits", fake_list_visits)
+
+    response = client.get(
+        "/api/v1/visits/visits",
+        params={
+            "patient_id": 4,
+            "doctor_id": 9,
+            "status_q": "open",
+            "planned_date": "2026-03-06",
+            "limit": 5,
+            "offset": 2,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload[0]["id"] == 17
+    assert payload[0]["notes"] == "router wiring"
+    assert captured == {
+        "patient_id": 4,
+        "doctor_id": 9,
+        "status_q": "open",
+        "planned": date(2026, 3, 6),
+        "limit": 5,
+        "offset": 2,
+    }
+
+
+def test_get_visit_endpoint_delegates_to_service(client, monkeypatch) -> None:
+    captured = {}
+
+    def fake_get_visit(self, *, visit_id: int):
+        captured["visit_id"] = visit_id
+        return {
+            "visit": {
+                "id": visit_id,
+                "patient_id": 5,
+                "doctor_id": 8,
+                "status": "open",
+                "created_at": None,
+                "started_at": None,
+                "finished_at": None,
+                "notes": "visit card",
+                "planned_date": None,
+                "source": "desk",
+            },
+            "services": [
+                {
+                    "code": "CONSULT",
+                    "name": "Consultation",
+                    "price": 125000.0,
+                    "qty": 1,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(VisitsApiService, "get_visit", fake_get_visit)
+
+    response = client.get("/api/v1/visits/visits/42")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["visit"]["id"] == 42
+    assert payload["visit"]["notes"] == "visit card"
+    assert payload["services"][0]["name"] == "Consultation"
+    assert captured["visit_id"] == 42

--- a/docs/status/wave2a/W2A-SR-012_PLAN.md
+++ b/docs/status/wave2a/W2A-SR-012_PLAN.md
@@ -1,0 +1,24 @@
+# W2A-SR-012 Plan
+
+Date: 2026-05-04
+Replacement for: PR #58
+
+## Scope
+
+- `GET /api/v1/visits/visits` -> `list_visits`
+- `GET /api/v1/visits/visits/{visit_id}` -> `get_visit`
+
+## Target
+
+- Router delegates read-only visit access to `VisitsApiService`.
+- Service/repository remain the DB boundary.
+- Route paths and response models stay unchanged.
+
+## Explicit Non-Scope
+
+- `create_visit`
+- `add_service`
+- `set_status`
+- `reschedule_visit`
+- `reschedule_visit_tomorrow`
+- Queue, payment, EMR, migration, workflow, and frontend files

--- a/docs/status/wave2a/W2A-SR-012_STATUS.md
+++ b/docs/status/wave2a/W2A-SR-012_STATUS.md
@@ -1,0 +1,21 @@
+# W2A-SR-012 Status
+
+Status: `replacement-pr-opened`
+Date: 2026-05-04
+Replacement for: PR #58
+
+## Applied Shape
+
+- `list_visits` delegates to `VisitsApiService.list_visits(...)`.
+- `get_visit` delegates to `VisitsApiService.get_visit(...)`.
+- Write and queue-coupled handlers in `visits.py` are intentionally unchanged.
+
+## Proof Added
+
+- Router delegation tests for both read-only endpoints.
+- Architecture guard for completed read-only handlers only.
+- Narrow contract file documenting scope and stop conditions.
+
+## Validation
+
+- See replacement PR checks for current results.


### PR DESCRIPTION
## Summary

- Fresh replacement for PR #58 on current main.
- Route only read-only visits handlers through existing VisitsApiService / VisitsApiRepository boundary.
- Do not merge old stacked #58 directly because it is far behind main and carries stale parent-branch context.

## Contract Impact

- Canonical surface: GET /api/v1/visits/visits and GET /api/v1/visits/visits/{visit_id}
- Request shape: unchanged query/path inputs; no request body added.
- Response shape: unchanged VisitOut list and VisitWithServices response models.
- Status codes: unchanged; missing visit card still maps to 404 through VisitsApiService.
- Frontend consumer: not applicable - no frontend files or frontend consumers changed.
- Compatibility path or alias: no route aliases changed; write/status/reschedule visit paths remain untouched compatibility surface.
- Contract proof: router wiring tests plus architecture guard prove read-only handlers delegate to VisitsApiService without route path or response model changes.

## RBAC / Permissions

- Roles allowed: unchanged from existing read-only visits routes.
- Roles denied: unchanged; this PR does not add or remove require_roles dependencies.
- Positive auth proof: not applicable - selected read-only handlers have no changed auth dependency.
- Negative auth proof: not applicable - no RBAC gate, role helper, or protected route behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, event payload, ack, read/unread, delivery, reconnect, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: unchanged backend response model; frontend not touched.
- Partial data proof: unchanged optional VisitOut/VisitWithServices fields; frontend not touched.
- Forbidden secondary path behavior: not applicable - no frontend secondary path or authorization fallback changed.
- Missing draft/resource behavior: not applicable - visits read-only endpoints do not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link state changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/visits.py; backend/tests/architecture/test_w2a_router_boundaries.py; backend/tests/unit/test_visits_router_service_wiring.py; .ai-factory/contracts/w2a-sr-012.contract.json; docs/status/wave2a/W2A-SR-012_PLAN.md; docs/status/wave2a/W2A-SR-012_STATUS.md
- Denied paths: frontend, migrations, workflows, queue/payment/EMR endpoints, old stacked branches.
- Migration/docs/test impact: no migration; W2A-SR-012 replacement docs and targeted tests added.
- Rollback note: revert this PR to restore direct read-only DB access in visits.py.

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/api/v1/endpoints/visits.py; static AST delegation/no-direct-db check; static mojibake check; git diff --check; PR review gate body checker.
- Result: compile/static/diff/body checks passed; pytest not available in the fresh temp clone Python.
- Not checked: local pytest execution and full backend suite; expected to run in GitHub CI.
