### PR TITLE
refactor(visits): replace W2A-SR-013 safe write slice

### DIFF
--- a/.ai-factory/contracts/w2a-sr-013.contract.json
+++ b/.ai-factory/contracts/w2a-sr-013.contract.json
@@ -1,0 +1,33 @@
+{
+  "contract_version": "1.0",
+  "task_id": "W2A-SR-013",
+  "task_type": "refactor-module",
+  "repo": "drsapaev/final",
+  "scope": {
+    "include": [
+      "backend/app/api/v1/endpoints/visits.py",
+      "backend/app/services/visits_api_service.py",
+      "backend/app/repositories/visits_api_repository.py",
+      "backend/tests/architecture/test_w2a_router_boundaries.py",
+      "backend/tests/unit/test_visits_router_service_wiring.py"
+    ],
+    "exclude": [
+      "frontend/**",
+      ".github/workflows/**",
+      "backend/alembic/**",
+      "backend/app/api/v1/endpoints/queue*.py",
+      "backend/app/api/v1/endpoints/payment*.py",
+      "backend/app/api/v1/endpoints/emr*.py"
+    ]
+  },
+  "goals": [
+    "Route only safe non-queue visits write handlers through VisitsApiService.",
+    "Preserve existing routes, response shapes, audit behavior, transaction behavior, and source fallback.",
+    "Leave status/reschedule queue-coupled handlers unchanged."
+  ],
+  "stop_conditions": [
+    "Need to change queue-coupled visit handlers.",
+    "Need to change audit or transaction semantics beyond preserving existing behavior.",
+    "Need to change route paths or response contracts."
+  ]
+}

--- a/backend/app/api/v1/endpoints/visits.py
+++ b/backend/app/api/v1/endpoints/visits.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from datetime import date, datetime, timedelta
 from typing import List, Optional
 
@@ -12,9 +11,7 @@ from sqlalchemy import MetaData, select, Table
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
-from app.services.service_mapping import normalize_service_code
 from app.services.visits_api_service import VisitsApiService
-from app.core.audit import log_critical_change, extract_model_changes
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -102,125 +99,12 @@ def create_visit(
     db: Session = Depends(get_db),
     current_user = Depends(require_roles("Admin", "Registrar", "Doctor")),
 ):
-    """
-    Создать визит.
-
-    Использует feature flag USE_CRUD_VISITS для переключения между старой (Table API)
-    и новой (CRUD) реализацией. По умолчанию используется старая реализация для безопасности.
-    """
-    # Feature flag для безопасной миграции на CRUD
-    use_crud = os.getenv("USE_CRUD_VISITS", "false").lower() == "true"
-
-    if use_crud:
-        # Новая реализация через CRUD (Single Source of Truth)
-        from app.crud.visit import create_visit as crud_create_visit
-
-        visit = crud_create_visit(
-            db=db,
-            patient_id=payload.patient_id,
-            doctor_id=payload.doctor_id,
-            visit_date=payload.planned_date,  # planned_date -> visit_date
-            notes=payload.notes,
-            source=payload.source or "desk",
-            status="open",
-            auto_status=False,  # Статус уже установлен
-            notify=False,
-            log=True,
-        )
-        
-        # ✅ AUDIT LOG: Логируем создание визита (CRUD путь)
-        _, new_data = extract_model_changes(None, visit)
-        log_critical_change(
-            db=db,
-            user_id=getattr(current_user, 'id', None) or 0,
-            action="CREATE",
-            table_name="visits",
-            row_id=visit.id,
-            old_data=None,
-            new_data=new_data,
-            request=request,
-            description=f"Создан визит ID={visit.id}",
-        )
-        db.commit()
-
-        return VisitOut(
-            id=visit.id,
-            patient_id=visit.patient_id,
-            doctor_id=visit.doctor_id,
-            status=visit.status,
-            created_at=visit.created_at,
-            started_at=None,
-            finished_at=None,
-            notes=visit.notes,
-            planned_date=visit.visit_date,
-            source=getattr(visit, "source", None) or payload.source or "desk",
-        )
-    else:
-        # Старая реализация через Table API (для обратной совместимости)
-        t = _visits(db)
-        ins_values = {
-            "patient_id": payload.patient_id,
-            "doctor_id": payload.doctor_id,
-            "status": "open",
-            "notes": payload.notes,
-            "created_at": datetime.utcnow(),  # ✅ FIX: Add created_at for Table API
-            "discount_mode": "none",  # ✅ FIX: Add discount_mode default (from Visit model)
-            "approval_status": "none",  # ✅ FIX: Add approval_status default (from Visit model)
-        }
-        if payload.department is not None:
-            ins_values["department"] = payload.department
-            try:
-                from app.models.department import Department
-
-                department_row = (
-                    db.query(Department)
-                    .filter(Department.key == payload.department)
-                    .first()
-                )
-                if department_row:
-                    ins_values["department_id"] = department_row.id
-            except Exception:
-                logger.debug(
-                    "Could not resolve department_id for department=%s in legacy table path",
-                    payload.department,
-                )
-        # если передали planned_date — добавим в insert (если колонка есть)
-        if hasattr(t.c, "planned_date") and payload.planned_date is not None:
-            ins_values["planned_date"] = payload.planned_date
-        if hasattr(t.c, "source"):
-            ins_values["source"] = payload.source or "desk"
-
-        ins = t.insert().values(**ins_values).returning(t)
-        row = db.execute(ins).mappings().first()
-        assert row is not None
-        
-        # ✅ AUDIT LOG: Log visit creation for Table API path (BEFORE commit for atomicity)
-        visit_id = row["id"]
-        # Convert row to dict and serialize datetime objects to strings for JSON
-        new_data = {}
-        for key, value in dict(row).items():
-            if isinstance(value, datetime):
-                new_data[key] = value.isoformat()
-            elif isinstance(value, date):
-                new_data[key] = value.isoformat()
-            else:
-                new_data[key] = value
-        log_critical_change(
-            db=db,
-            user_id=getattr(current_user, 'id', None) or 0,  # ✅ FIX: Consistent with CRUD path
-            action="CREATE",
-            table_name="visits",
-            row_id=visit_id,
-            old_data=None,
-            new_data=new_data,
-            request=request,
-            description=f"Создан визит ID={visit_id}",
-        )
-        # ✅ FIX: Single commit after both visit creation and audit log for atomicity
-        # If audit log fails, the entire transaction (including visit) will be rolled back
-        db.commit()
-        
-        return VisitOut(**row)  # type: ignore[arg-type]
+    result = VisitsApiService(db).create_visit(
+        request=request,
+        payload=payload,
+        current_user=current_user,
+    )
+    return VisitOut(**result)
 
 
 @router.get(
@@ -240,29 +124,7 @@ def get_visit(visit_id: int, db: Session = Depends(get_db)):
     summary="Добавить услугу к визиту",
 )
 def add_service(visit_id: int, item: VisitServiceIn, db: Session = Depends(get_db)):
-    t = _visits(db)
-    s = _vservices(db)
-    exists = db.execute(select(t.c.id).where(t.c.id == visit_id)).first()
-    if not exists:
-        raise HTTPException(404, "Visit not found")
-
-    # Normalize service code before using it
-    normalized_code = normalize_service_code(item.code) if item.code else None
-
-    ins = (
-        s.insert()
-        .values(
-            visit_id=visit_id,
-            code=normalized_code,
-            name=item.name,
-            price=item.price,
-            qty=item.qty,
-        )
-        .returning(s)
-    )
-    row = db.execute(ins).mappings().first()
-    db.commit()
-    return {"ok": True, "service": dict(row)}
+    return VisitsApiService(db).add_service(visit_id=visit_id, item=item)
 
 
 @router.post(

--- a/backend/app/services/visits_api_service.py
+++ b/backend/app/services/visits_api_service.py
@@ -102,7 +102,7 @@ class VisitsApiService:
                 "finished_at": None,
                 "notes": visit.notes,
                 "planned_date": visit.visit_date,
-                "source": getattr(visit, "source", None),
+                "source": getattr(visit, "source", None) or payload.source or "desk",
             }
 
         table = self._visits()

--- a/backend/tests/architecture/test_w2a_router_boundaries.py
+++ b/backend/tests/architecture/test_w2a_router_boundaries.py
@@ -98,3 +98,26 @@ def test_visits_read_only_handlers_use_service_layer() -> None:
             block,
         )
         assert forbidden is None, handler_name
+
+
+def test_visits_safe_write_handlers_use_service_layer() -> None:
+    endpoint_path = (
+        Path(__file__).resolve().parents[2]
+        / "app"
+        / "api"
+        / "v1"
+        / "endpoints"
+        / "visits.py"
+    )
+    safe_handlers = [
+        "create_visit",
+        "add_service",
+    ]
+    for handler_name in safe_handlers:
+        block = _function_block(endpoint_path, handler_name)
+        assert "VisitsApiService(db)" in block
+        forbidden = re.search(
+            r"db\.(query|add|commit|refresh|rollback|delete|execute|flush)\(",
+            block,
+        )
+        assert forbidden is None, handler_name

--- a/backend/tests/unit/test_visits_router_service_wiring.py
+++ b/backend/tests/unit/test_visits_router_service_wiring.py
@@ -109,3 +109,104 @@ def test_get_visit_endpoint_delegates_to_service(client, monkeypatch) -> None:
     assert payload["visit"]["notes"] == "visit card"
     assert payload["services"][0]["name"] == "Consultation"
     assert captured["visit_id"] == 42
+
+
+def test_create_visit_endpoint_delegates_to_service(
+    client,
+    monkeypatch,
+    auth_headers,
+) -> None:
+    captured = {}
+
+    def fake_create_visit(self, *, request, payload, current_user):
+        captured.update(
+            {
+                "payload": payload,
+                "current_user_role": current_user.role,
+                "has_request": request is not None,
+            }
+        )
+        return {
+            "id": 81,
+            "patient_id": payload.patient_id,
+            "doctor_id": payload.doctor_id,
+            "status": "open",
+            "created_at": None,
+            "started_at": None,
+            "finished_at": None,
+            "notes": payload.notes,
+            "planned_date": payload.planned_date,
+            "source": payload.source or "desk",
+        }
+
+    monkeypatch.setattr(VisitsApiService, "create_visit", fake_create_visit)
+
+    response = client.post(
+        "/api/v1/visits/visits",
+        json={
+            "patient_id": 2,
+            "doctor_id": 3,
+            "notes": "created via service",
+            "planned_date": "2026-03-07",
+            "source": "desk",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["id"] == 81
+    assert payload["notes"] == "created via service"
+    assert payload["planned_date"] == "2026-03-07"
+    assert payload["source"] == "desk"
+    assert captured["payload"].patient_id == 2
+    assert captured["payload"].doctor_id == 3
+    assert captured["payload"].planned_date == date(2026, 3, 7)
+    assert captured["current_user_role"] == "Admin"
+    assert captured["has_request"] is True
+
+
+def test_add_service_endpoint_delegates_to_service(
+    client,
+    monkeypatch,
+    auth_headers,
+    test_visit,
+) -> None:
+    captured = {}
+
+    def fake_add_service(self, *, visit_id: int, item):
+        captured["visit_id"] = visit_id
+        captured["item"] = item
+        return {
+            "ok": True,
+            "service": {
+                "id": 501,
+                "visit_id": visit_id,
+                "code": item.code,
+                "name": item.name,
+                "price": item.price,
+                "qty": item.qty,
+            },
+        }
+
+    monkeypatch.setattr(VisitsApiService, "add_service", fake_add_service)
+
+    response = client.post(
+        f"/api/v1/visits/visits/{test_visit.id}/services",
+        json={
+            "code": "CONSULT",
+            "name": "Consultation",
+            "price": 125000,
+            "qty": 1,
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["service"]["visit_id"] == test_visit.id
+    assert payload["service"]["name"] == "Consultation"
+    assert captured["visit_id"] == test_visit.id
+    assert captured["item"].code == "CONSULT"
+    assert captured["item"].price == 125000

--- a/docs/status/wave2a/W2A-SR-013_PLAN.md
+++ b/docs/status/wave2a/W2A-SR-013_PLAN.md
@@ -1,0 +1,22 @@
+# W2A-SR-013 Plan
+
+Date: 2026-05-04
+Replacement for: PR #59
+
+## Scope
+
+- `POST /api/v1/visits/visits` -> `create_visit`
+- `POST /api/v1/visits/visits/{visit_id}/services` -> `add_service`
+
+## Target
+
+- Router delegates safe visit writes to `VisitsApiService`.
+- Service/repository remain the DB, audit, normalization, and commit boundary.
+- Route paths, response models, audit behavior, transaction behavior, and source fallback stay unchanged.
+
+## Explicit Non-Scope
+
+- `set_status`
+- `reschedule_visit`
+- `reschedule_visit_tomorrow`
+- Queue, payment, EMR, migration, workflow, lockfile, and frontend files

--- a/docs/status/wave2a/W2A-SR-013_STATUS.md
+++ b/docs/status/wave2a/W2A-SR-013_STATUS.md
@@ -1,0 +1,22 @@
+# W2A-SR-013 Status
+
+Status: `replacement-pr-opened`
+Date: 2026-05-04
+Replacement for: PR #59
+
+## Applied Shape
+
+- `create_visit` delegates to `VisitsApiService.create_visit(...)`.
+- `add_service` delegates to `VisitsApiService.add_service(...)`.
+- `VisitsApiService.create_visit` preserves the previous CRUD-path `source` fallback.
+- Queue-coupled handlers in `visits.py` are intentionally unchanged.
+
+## Proof Added
+
+- Router delegation tests for both safe write endpoints.
+- Architecture guard for completed safe write handlers only.
+- Narrow contract file documenting scope and stop conditions.
+
+## Validation
+
+- See replacement PR checks for current results.


### PR DESCRIPTION
## Summary

- Fresh replacement for PR #59 on current main.
- Route only safe non-queue visits write handlers through existing VisitsApiService / VisitsApiRepository boundary.
- Do not merge old stacked #59 directly because it is far behind main and carries stale parent-branch context.

## Contract Impact

- Canonical surface: POST /api/v1/visits/visits and POST /api/v1/visits/visits/{visit_id}/services
- Request shape: unchanged VisitCreate and VisitServiceIn request models.
- Response shape: unchanged VisitOut create response and add-service object response.
- Status codes: unchanged; create remains 201 and add-service remains 200/404 behavior through VisitsApiService.
- Frontend consumer: not applicable - no frontend files or frontend consumers changed.
- Compatibility path or alias: no route aliases changed; status/reschedule visit paths remain untouched compatibility surface.
- Contract proof: router wiring tests plus architecture guard prove safe write handlers delegate to VisitsApiService without route path or response model changes.

## RBAC / Permissions

- Roles allowed: unchanged Admin, Registrar, Doctor for create_visit; unchanged Admin, Registrar, Doctor, Cashier for add_service.
- Roles denied: unchanged; this PR does not add or remove require_roles dependencies.
- Positive auth proof: router wiring tests call both endpoints with existing auth_headers and verify successful delegation.
- Negative auth proof: not applicable - no RBAC gate, role helper, or protected role behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, event payload, ack, read/unread, delivery, reconnect, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - backend-only router delegation, no frontend data rendering changed.
- Partial data proof: unchanged optional VisitOut fields and add-service response shape.
- Forbidden secondary path behavior: not applicable - no frontend secondary path or authorization fallback changed.
- Missing draft/resource behavior: not applicable - visits write endpoints do not create or reopen frontend drafts/resources.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link state changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/visits.py; backend/app/services/visits_api_service.py; backend/tests/architecture/test_w2a_router_boundaries.py; backend/tests/unit/test_visits_router_service_wiring.py; .ai-factory/contracts/w2a-sr-013.contract.json; docs/status/wave2a/W2A-SR-013_PLAN.md; docs/status/wave2a/W2A-SR-013_STATUS.md
- Denied paths: frontend, migrations, workflows, lockfiles, queue/payment/EMR endpoints, old stacked branches.
- Migration/docs/test impact: no migration; W2A-SR-013 replacement docs and targeted tests added.
- Rollback note: revert this PR to restore direct safe-write DB/audit logic in visits.py.

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/api/v1/endpoints/visits.py backend/app/services/visits_api_service.py; static AST delegation/no-direct-db check; source fallback static check; scoped git diff --check; PR review gate body checker.
- Result: compile/static/scoped-diff/body checks passed; pytest not available in the fresh temp clone Python.
- Not checked: local pytest execution and full backend suite; expected to run in GitHub CI.
