### PR TITLE
docs(architecture): replace W2A human review pass

### DIFF
--- a/docs/architecture/W2A_DOMAIN_FLOW_ANALYSIS.md
+++ b/docs/architecture/W2A_DOMAIN_FLOW_ANALYSIS.md
@@ -1,0 +1,68 @@
+# Wave 2A Domain Flow Analysis
+
+Date: 2026-03-06
+Mode: analysis-first, docs-only
+Purpose: classify remaining router-layer DB access by domain flow before any further refactor.
+
+## Review Scope
+
+- Primary target slices:
+  - `W2A-SR-011` (`services.py` queue-adjacent metadata handlers)
+  - `W2A-SR-040` (`visits.py` queue-coupled write handlers)
+- Additional review set:
+  - queue state handlers
+  - visit lifecycle handlers
+  - registrar/payment orchestration handlers
+  - admin reporting/query handlers that still live in routers
+
+## Handler Matrix
+
+| Slice / Area | File | Handler | DB operations | Transaction boundary | Side effects | Queue interactions | Payment interactions | Risk |
+|---|---|---|---|---|---|---|---|---|
+| `W2A-SR-011` | `backend/app/api/v1/endpoints/services.py` | `get_queue_groups` | `db.query(Service)` read-only enrichment over static `QUEUE_GROUPS` | None in router | Builds frontend/registrar queue metadata payload | Maps `service_code -> group -> queue_tag/tab` | None | Medium |
+| `W2A-SR-011` | `backend/app/api/v1/endpoints/services.py` | `resolve_service_endpoint` | No direct `db.*` in router; delegates to `resolve_service(service_id, code, db)` | None in router | Resolves normalized code/category/UI type | Indirect, because result feeds queue grouping and registrar tabs | None | Low to Medium |
+| `W2A-SR-011` | `backend/app/api/v1/endpoints/services.py` | `get_service_code_mappings` | `db.query(Service)` read-only enrichment over static mappings | None in router | Builds frontend service-code lookup tables | Enriches `queue_tag -> service_code` mapping | None | Medium |
+| `W2A-SR-040` | `backend/app/api/v1/endpoints/visits.py` | `set_status` | `db.query(Visit)`, raw `db.execute(...)` on `queue_entries`, `db.commit`, `db.refresh` | Single commit after visit update plus optional queue update | Mutates visit lifecycle timestamps and status | Cancels linked queue entry when visit becomes `canceled` | None | High |
+| `W2A-SR-040` | `backend/app/api/v1/endpoints/visits.py` | `reschedule_visit` | reflected-table `db.execute(select/update)`, `db.commit` | Single commit after visit-date update plus queue status update | Moves visit date | Marks linked queue entry as `rescheduled` | None | High |
+| `W2A-SR-040` | `backend/app/api/v1/endpoints/visits.py` | `reschedule_visit_tomorrow` | reflected-table `db.execute(select/update)`, `db.commit` | Same as `reschedule_visit` | Moves visit to tomorrow | Marks linked queue entry as `rescheduled` | None | High |
+| Queue config | `backend/app/api/v1/endpoints/admin_departments.py` | `create_department` | `db.query`, `db.add`, `db.flush`, two `db.commit` calls, `db.refresh` | Split transaction boundary: department commit first, queue/reg settings commit second | Boots department integrations and default queue/registration settings | Creates queue settings and registrar settings | None | High |
+| Queue config | `backend/app/api/v1/endpoints/admin_departments.py` | `initialize_department` | `db.query`, `db.add`, `db.commit`, `db.rollback` | Single try/commit with rollback on failure | Creates missing queue settings, registration settings, optional service + department binding | Yes, queue settings bootstrap | None | High |
+| Queue config | `backend/app/api/v1/endpoints/admin_departments.py` | `update_queue_settings` | `db.query`, optional `db.add`, `db.commit`, `db.refresh` | Simple single commit | Updates department queue policy/config | Directly mutates queue settings | None | Medium |
+| Doctor queue | `backend/app/api/v1/endpoints/doctor_integration.py` | `get_doctor_queue_today` | `db.query(...)` read-only joins/lookups | None in router | Builds doctor dashboard payload | Reads queue state and visit status for doctor-facing queue | None | Medium |
+| Doctor lifecycle | `backend/app/api/v1/endpoints/doctor_integration.py` | `complete_patient_visit` | many `db.query`, `db.commit`, `db.refresh`, `db.rollback` branches | Multi-branch transaction logic; commit path depends on visit/appointment/queue-entry branch | Completes visit/appointment, may create payment via `BillingService`, may create/update visit from queue entry | Serves queue entry and reconciles queue-derived visit state | Yes, may create/reconcile payment state | Very High |
+| Doctor lifecycle | `backend/app/api/v1/endpoints/doctor_integration.py` | `schedule_next_visit` | `db.query`, `db.add`, `db.flush`, `db.commit`, `db.refresh`, `db.rollback` | Multi-step write with rollback | Creates next visit / follow-up scheduling data | Indirect, because follow-up scheduling feeds queue/visit lifecycle | None direct in router | High |
+| Registrar flow | `backend/app/api/v1/endpoints/registrar_integration.py` | `create_registrar_appointment` | `db.query`, `db.add`, `db.commit`, `db.refresh` | Single commit, but domain flow spans appointment + queue/profile context | Creates registrar-facing appointment | Appointment participates in queue/registrar flow | Indirect payment readiness | High |
+| Registrar flow | `backend/app/api/v1/endpoints/registrar_integration.py` | `start_queue_visit` | `db.query`, `db.commit`, `db.refresh` | Single commit after queue/visit transition | Starts queue-backed visit | Direct queue state transition to in-progress | Payment state is read/derived in nearby flow | High |
+| Registrar flow | `backend/app/api/v1/endpoints/registrar_integration.py` | `get_today_queues` | `db.query`, `db.execute` in a very large read-model handler | None in router | Builds large registrar dashboard/read model | Reads queue, visit, appointment, doctor, queue-profile state | Includes payment-derived status shaping | High |
+| Registrar flow | `backend/app/api/v1/endpoints/registrar_integration.py` | `create_queue_entries_batch` | `db.query`, `db.add`, `db.flush`, `db.commit`, `db.rollback` | Batch write transaction | Creates multiple queue entries/tickets in one request | Direct queue creation | None direct in router | Very High |
+| Registrar checkout | `backend/app/api/v1/endpoints/registrar_wizard.py` | `init_invoice_payment` | `db.query(PaymentInvoice)`, `db.commit` | Single commit after external provider init | Calls payment provider, updates invoice to `processing` | None direct | Yes, external Click/PayMe initiation | High |
+| Registrar checkout | `backend/app/api/v1/endpoints/registrar_wizard.py` | `check_invoice_status` | `db.query`, `db.commit` | Single commit after provider check, but external state drives local mutation | Calls payment provider status API, updates invoice, may create payments via `BillingService` | None direct | Yes, provider + invoice + billing reconciliation | Very High |
+| Registrar checkout | `backend/app/api/v1/endpoints/registrar_wizard.py` | `create_cart_appointments` | `db.query`, `db.add`, `db.flush`, `db.commit`, `db.rollback` | Large multi-entity transaction | Creates visits, services, queue entries, invoice/payment context, price overrides | Yes, queue entries created | Yes, invoice/payment path created | Very High |
+| Registrar checkout | `backend/app/api/v1/endpoints/registrar_wizard.py` | `mark_visit_as_paid` | `db.query`, `db.execute`, `db.commit`, `db.refresh`, `db.rollback` | Single commit but payment status drives visit mutation | Marks visit paid | Indirect via visit lifecycle | Yes | Very High |
+| Registrar checkout | `backend/app/api/v1/endpoints/registrar_wizard.py` | `mark_queue_entry_as_paid` | `db.query`, `db.execute`, `db.commit`, `db.refresh`, `db.rollback` | Single commit but queue + payment state change together | Marks queue-backed visit as paid | Yes, queue entry linked to payment status | Yes | Very High |
+| Cashier | `backend/app/api/v1/endpoints/cashier.py` | `create_payment` | `db.query(Visit/Payment)`, `db.add(Payment)`, `db.commit`, `db.refresh`, `db.rollback` | Single commit with rollback | Creates payment and broadcasts cashier websocket event | Indirect via visit debt/status | Yes | Very High |
+| Cashier | `backend/app/api/v1/endpoints/cashier.py` | `confirm_payment` | `db.query`, `db.add`, `db.commit` | Single commit | Confirms existing payment | Indirect via visit/payment reconciliation | Yes | High |
+| Cashier | `backend/app/api/v1/endpoints/cashier.py` | `refund_payment` | `db.query`, `db.add`, `db.commit`, `db.refresh`, `db.rollback` | Single commit with rollback | Refunds payment and mutates visit/payment state | Indirect via visit state rollback | Yes | Very High |
+| Cashier | `backend/app/api/v1/endpoints/cashier.py` | `mark_visit_as_paid` | `db.query`, `db.add`, `db.commit`, `db.rollback` | Single commit with rollback | Marks visit paid from cashier side | Indirect via visit state | Yes | Very High |
+| Queue runtime | `backend/app/api/v1/endpoints/qr_queue.py` | `call_next_patient` | router does `db.query(OnlineQueueEntry)` for notifications; mutation happens inside `QRQueueService.call_next_patient(...)` | Effective transaction is inside service, not visible at router | Sends user notification and display websocket event | Yes, advances queue state to next patient | None direct | High |
+| Queue runtime | `backend/app/api/v1/endpoints/qr_queue.py` | `update_online_entry` | `db.query`, `db.commit`, `db.refresh` | Single commit | Mutates one online queue entry | Yes | None | High |
+| Queue runtime | `backend/app/api/v1/endpoints/qr_queue.py` | `full_update_online_entry` | `db.query`, `db.execute`, `db.add`, `db.flush`, `db.commit`, `db.refresh`, `db.rollback` | Large multi-step transaction | Rewrites queue entry, visit/payment/state links | Yes, heavy queue lifecycle mutation | May touch payment/status side effects | Very High |
+| Queue runtime | `backend/app/api/v1/endpoints/qr_queue.py` | `cancel_service_in_entry` | `db.query`, `db.commit`, `db.refresh`, `db.rollback` | Single commit with rollback | Cancels service inside queue entry | Yes | None direct | High |
+| Mixed read model | `backend/app/api/v1/endpoints/appointments.py` | `list_appointments` | `db.query(Appointment/Patient/Service)` read-only enrichment | None in router | Builds appointment list with patient/service names | None direct | Indirect, because payment amounts are exposed in response | Medium |
+| Mixed read model | `backend/app/api/v1/endpoints/appointments.py` | `get_pending_payments` | many `db.query(...)` over appointments, visits, invoices, services | None in router | Builds pending-payments unified dashboard payload | Reads queue-adjacent visit status | Yes, direct pending-payment aggregation | High |
+| Queue admin | `backend/app/api/v1/endpoints/appointments.py` | `open_day` | `_upsert_queue_setting(...)`, `db.commit` | Single commit | Writes queue day settings and triggers `_broadcast(...)` | Yes, opens online queue day | None | High |
+| Queue admin | `backend/app/api/v1/endpoints/appointments.py` | `close_day` | `get_or_create_day(...)`, `db.commit` | Single commit | Closes queue day | Yes | None | Medium to High |
+| Analytics | `backend/app/api/v1/endpoints/admin_stats.py` | `get_admin_stats` | many `db.query(...).count()/scalar()` read-only queries | None in router | Builds admin summary metrics | Indirect via visits/appointments counts | Direct revenue/payment summary | Medium |
+| Analytics | `backend/app/api/v1/endpoints/admin_stats.py` | `get_recent_activities` | many `db.query(...)` read-only queries | None in router | Builds combined activity feed from appointments, payments, users | Indirect via visit/appointment status strings | Direct payment activity feed | Medium |
+| Analytics | `backend/app/api/v1/endpoints/admin_stats.py` | `get_analytics_overview` | many `db.query(...)`, in-memory aggregation | None in router | Builds filtered analytics overview and doctor leaderboard | Indirect via appointment state | Direct payment aggregation | Medium |
+
+## Observations
+
+1. `W2A-SR-011` is queue-adjacent, but its handlers are read-model and metadata focused. The risk is not transaction correctness; the risk is breaking queue taxonomy shared by registrar/frontend flows.
+2. `W2A-SR-040` is genuinely transaction-critical. Each handler mutates both visit lifecycle state and queue state inside the same request.
+3. The remaining backlog is no longer a generic service/repository cleanup problem. It is mostly domain orchestration:
+   - queue lifecycle
+   - registrar orchestration
+   - payment reconciliation
+   - admin read models spanning multiple aggregates
+4. Some routers already have service methods implemented (`services_api_service.py`, `visits_api_service.py`), but delegating blindly is not sufficient if the domain boundary is unclear or the service itself still embeds transaction policy.

--- a/docs/architecture/W2A_REFACTOR_OPTIONS.md
+++ b/docs/architecture/W2A_REFACTOR_OPTIONS.md
@@ -1,0 +1,89 @@
+# Wave 2A Refactor Options
+
+Date: 2026-03-06
+Purpose: propose reviewable options before touching queue/payment/lifecycle slices.
+
+## `W2A-SR-011` `services.py` queue-adjacent metadata
+
+### Option A: Partial Service Extraction
+
+- Move only `get_queue_groups`, `resolve_service_endpoint`, and `get_service_code_mappings` to the existing `ServicesApiService`.
+- Keep route paths and response models unchanged.
+- Good when the goal is only router-boundary cleanup for read-only metadata.
+
+### Option B: Dedicated Queue Metadata Service
+
+- Extract queue-group and service-code mapping concerns into a dedicated read-model service.
+- Keep catalog CRUD in `ServicesApiService`.
+- Better if queue taxonomy will evolve independently from service catalog CRUD.
+
+### Option C: Defer to Wave 2C
+
+- Treat queue metadata as part of queue lifecycle architecture because it defines registrar tabs and routing semantics.
+- Best when product owners expect queue taxonomy changes together with queue lifecycle work.
+
+## `W2A-SR-040` `visits.py` queue-coupled write handlers
+
+### Option A: Partial Service Delegation to Existing `VisitsApiService`
+
+- Reuse the already-written `set_status` / `reschedule_*` service methods.
+- Add targeted lifecycle regression tests before switching the router.
+- Good only if human review accepts the current queue status semantics as canonical.
+
+### Option B: Dedicated `VisitLifecycleService`
+
+- Split visit lifecycle (`status`, `started_at`, `finished_at`, reschedule rules) from generic visit CRUD.
+- Move queue-entry updates behind a dedicated orchestration boundary.
+- Better when visit lifecycle needs explicit invariants and auditability.
+
+### Option C: Defer to Wave 2C
+
+- Treat visit status + queue-entry status as queue lifecycle work, not Wave 2A cleanup.
+- Best when queue semantics are still under review or likely to change.
+
+## `W2A-SR-020` / `W2A-SR-030` / `W2A-SR-050` / `W2A-SR-070` queue-heavy orchestration
+
+### Option A: Extract Read Models First
+
+- Move read-only dashboard/query handlers first.
+- Leave mutating queue transitions in routers until queue invariants are documented.
+
+### Option B: Introduce Dedicated Queue Domain Services
+
+- `DepartmentProvisioningService`
+- `DoctorQueueLifecycleService`
+- `RegistrarQueueService`
+- `QueueLifecycleService`
+
+This gives cleaner transaction boundaries, but it is architectural work, not a safe cleanup slice.
+
+### Option C: Defer to Wave 2C
+
+- Use Wave 2C to redesign queue lifecycle boundaries explicitly.
+- Recommended if queue status, display notifications, and registrar workflow must stay coherent.
+
+## `W2A-SR-060` / `W2A-SR-080` / `W2A-SR-090` / `W2A-SR-100` payment-heavy or mixed reporting
+
+### Option A: Read-Only Reporting Extraction
+
+- Extract read-only analytics/listing handlers (`list_appointments`, `admin_stats` analytics) into reporting services.
+- Keep payment mutations untouched.
+
+### Option B: Dedicated Payment Domain Services
+
+- `RegistrarCheckoutService`
+- `CashierPaymentService`
+- `PaymentReadModelService`
+- `PaymentAnalyticsService`
+
+This is the correct long-term shape, but it should be handled as a payment track, not as generic router cleanup.
+
+### Option C: Defer to Wave 2D
+
+- Recommended for anything that changes invoice/provider/payment status or visit payment reconciliation.
+
+## Decision Tree
+
+1. If the handler mutates queue status or queue settings: default to Wave 2C.
+2. If the handler calls payment providers, mutates invoice/payment state, or derives visit payment status: default to Wave 2D.
+3. If the handler is read-only but shapes shared queue/payment read models: allow only narrow micro-slices with explicit human acknowledgement.

--- a/docs/architecture/W2A_SERVICE_REPOSITORY_DISCOVERY.md
+++ b/docs/architecture/W2A_SERVICE_REPOSITORY_DISCOVERY.md
@@ -1,7 +1,7 @@
 # Wave 2A Service/Repository Discovery
 
-Date: 2026-03-06  
-Scope: `backend/app/api/v1/endpoints/**`  
+Date: 2026-03-06
+Scope: `backend/app/api/v1/endpoints/**`
 Goal: find API handlers where router layer still owns ORM/session/query logic instead of delegating to service/repository.
 
 ## Baseline Method
@@ -11,18 +11,20 @@ Goal: find API handlers where router layer still owns ORM/session/query logic in
 3. Cross-check that parallel `*_api_service.py` and `*_api_repository.py` already exist for affected modules.
 
 Result baseline:
-- Files with confirmed router-layer DB anti-pattern: `11`
-- Route handlers with confirmed direct DB operations: `122`
+- Original first-pass baseline: `11` files / `122` route handlers
+- Current remaining router-layer DB anti-pattern: `10` files / `101` route handlers
+- Completed safe slices removed direct router DB access from `messages.py`, catalog-only handlers in `services.py`, and safe handlers in `visits.py`
 - Existing service/repository scaffolding found for all affected modules: `yes` (but not consistently wired from routers).
 
 ## Priority Groups
 
-- Safe non-protected (can execute first): `messages.py`, catalog-only handlers in `services.py`
+- Safe non-protected (completed): `messages.py`, catalog-only handlers in `services.py`, read-only + non-queue write handlers in `visits.py`
+- Safe non-protected (remaining candidate): none confirmed in current discovery pass
 - Touches payments: `cashier.py`, `appointments.py`, `admin_stats.py`, `registrar_wizard.py`
-- Touches queue: `registrar_wizard.py`, `registrar_integration.py`, `qr_queue.py`, `admin_departments.py`, `doctor_integration.py`, `services.py`, `visits.py`
+- Touches queue: `registrar_wizard.py`, `registrar_integration.py`, `qr_queue.py`, `admin_departments.py`, `doctor_integration.py`, queue-adjacent handlers in `services.py`, queue-coupled write handlers in `visits.py`
 - Touches auth: none in this scan set with direct DB calls at router level
 - Touches EMR: none in this scan set with direct DB calls at router level
-- Unclear / needs human review: mixed modules where file includes both safe catalog endpoints and queue-adjacent endpoints (`services.py`)
+- Unclear / needs human review: mixed modules where file includes both safe and protected endpoints (`services.py`, `visits.py`)
 
 ## Detailed Findings
 
@@ -30,9 +32,10 @@ Result baseline:
 |---|---|---|---|---|---|---|
 | `backend/app/api/v1/endpoints/messages.py` | `send_message`, `get_conversation`, `send_voice_message`, `upload_file_message` | Router validates recipient, loads ORM entities, writes audit/file/message rows, commits transaction | Router delegates to `MessagesApiService`, DB access via `MessagesApiRepository` | Low | No | 1 |
 | `backend/app/api/v1/endpoints/services.py` | catalog handlers: `list_service_categories`, `create_service`, `update_service`, `delete_service`, `list_doctors_temp`; queue-adjacent handlers: `get_queue_groups`, `resolve_service_endpoint`, `get_service_code_mappings` | Router mixed safe catalog CRUD with queue-adjacent lookup logic in one module | Keep catalog handlers on service/repo flow; leave queue-adjacent handlers isolated for separate review | Medium | Partial (queue-adjacent) | 4 |
+| `backend/app/api/v1/endpoints/visits.py` | read-only handlers: `list_visits`, `get_visit` | Router built reflected tables, executed selects, and returned mapped rows directly | Router delegates to `VisitsApiService`, DB access via `VisitsApiRepository` | Low | No | 5 |
+| `backend/app/api/v1/endpoints/visits.py` | remaining queue-coupled writes: `set_status`, `reschedule_visit`, `reschedule_visit_tomorrow` | Router updates visit state and queue state in the same handler | Encapsulate queue-aware transaction flow in service/repository only after explicit review | High | Yes (queue) | Pending human review |
 | `backend/app/api/v1/endpoints/admin_departments.py` | `create_department`, `update_queue_settings`, `initialize_department` | Router contains multi-step writes and queue/registration settings persistence | Router thin, orchestration in service, DB in repository | High | Yes (queue) | Pending human review |
 | `backend/app/api/v1/endpoints/doctor_integration.py` | `get_doctor_queue_today`, `complete_patient_visit`, `schedule_next_visit` | Router mixes queue flow orchestration + transaction logic | Move flow orchestration to service layer | High | Yes (queue) | Pending human review |
-| `backend/app/api/v1/endpoints/visits.py` | `set_status`, `reschedule_visit`, `reschedule_visit_tomorrow` | Router updates visits and queue state in same handler | Encapsulate write flow in service with clear transaction boundary | High | Yes (queue) | Pending human review |
 | `backend/app/api/v1/endpoints/registrar_integration.py` | `create_registrar_appointment`, `start_queue_visit`, `get_today_queues` | Router includes heavy query composition + queue transaction branches | Service orchestrates, repository isolates query builders | High | Yes (queue) | Pending human review |
 | `backend/app/api/v1/endpoints/registrar_wizard.py` | `create_cart_appointments`, `mark_visit_as_paid`, `mark_queue_entry_as_paid` | Router owns queue + payment state transitions and commits | Service use-case orchestration with repository adapters | High | Yes (queue + payments) | Pending human review |
 | `backend/app/api/v1/endpoints/qr_queue.py` | `full_update_online_entry`, `update_online_entry`, `cancel_service_in_entry` | Router has very dense queue mutation transaction logic | Service transaction orchestration + repository helpers | High | Yes (queue) | Pending human review |
@@ -46,10 +49,22 @@ Result baseline:
 2. `W2A-SR-002` messages media/reaction router-thinning (`/reactions`, `/users/available`, `/send-voice`, `/voice/{id}/stream`, `/upload`)
 3. `W2A-SR-003` architecture guard for router DB anti-patterns in completed module(s)
 4. `W2A-SR-010` services catalog-only handlers
-5. `W2A-SR-011+` mixed/queue-adjacent modules only after explicit human review
+5. `W2A-SR-012` visits read-only handlers (`list_visits`, `get_visit`)
+6. `W2A-SR-013` visits non-queue writes (`create_visit`, `add_service`) if audit/transaction scope stays local
+7. `W2A-SR-011+` mixed/queue-adjacent modules only after explicit human review
 
 ## Zones Deferred From Wave 2A Initial Pass
 
 - Queue-heavy modules: `registrar_*`, `qr_queue`, `doctor_integration`, queue-related parts of `services.py`, `visits.py`, `admin_departments.py`
 - Payment-heavy modules: `cashier.py`, `appointments.py` payment endpoints, `admin_stats.py`, payment paths in `registrar_wizard.py`
 - Any slice requiring changes in protected modules is deferred to `pending human review`.
+
+## Human Review Pass Outcome
+
+- `W2A-SR-011` is no longer a generic cleanup slice; it is queue-adjacent metadata with a small read-only micro-slice candidate.
+- `W2A-SR-040` is queue-coupled and transaction-critical; it should not be auto-refactored.
+- No broad non-protected slice remains after `W2A-SR-013`.
+- Remaining work naturally separates into:
+  - `Wave 2C` queue lifecycle
+  - `Wave 2D` payment flow hardening
+  - a few read-only micro-slices that can still be handled under `Wave 2A` or `Wave 2B`

--- a/docs/architecture/WAVE2_TRACK_MAP.md
+++ b/docs/architecture/WAVE2_TRACK_MAP.md
@@ -1,0 +1,74 @@
+# Wave 2 Track Map
+
+Date: 2026-03-06
+Source: Wave 2A human review pass
+
+## Wave 2A: Service/Repository Completion
+
+- Goal:
+  - finish safe router -> service -> repository conversions where domain semantics are already stable
+- Typical scope:
+  - read-only metadata endpoints
+  - simple CRUD or read-model handlers without queue/payment lifecycle mutations
+- Current state:
+  - almost exhausted after `W2A-SR-001`, `002`, `003`, `010`, `012`, `013`
+- Entry rule:
+  - no queue-state mutation
+  - no payment reconciliation
+  - no cross-module transaction redesign
+
+## Wave 2B: API Contract Hardening
+
+- Goal:
+  - stabilize OpenAPI, response shapes, frontend/backend alignment, and contract tests
+- Typical scope:
+  - schema normalization
+  - response consistency
+  - frontend/backend parity gates
+  - read-only listing/reporting endpoints that mainly need contract discipline
+- Candidate overlap:
+  - `appointments.py:list_appointments`
+  - read-only admin/reporting endpoints
+
+## Wave 2C: Queue Lifecycle Refactor
+
+- Goal:
+  - isolate queue lifecycle rules, queue state transitions, and registrar/doctor queue orchestration
+- Typical scope:
+  - `W2A-SR-011` if queue metadata is treated as queue policy
+  - `W2A-SR-040`
+  - `W2A-SR-020`
+  - `W2A-SR-030`
+  - `W2A-SR-050`
+  - `W2A-SR-070`
+- Required guardrails:
+  - human review
+  - explicit state-transition matrix
+  - regression tests around queue statuses, display notifications, and registrar dashboards
+
+## Wave 2D: Payment Flow Hardening
+
+- Goal:
+  - isolate invoice/provider/payment reconciliation and payment-heavy reporting
+- Typical scope:
+  - `W2A-SR-060`
+  - `W2A-SR-080`
+  - payment-heavy parts of `W2A-SR-090`
+  - payment analytics in `W2A-SR-100`
+- Required guardrails:
+  - human review
+  - provider integration test plan
+  - explicit accepted-risk decisions for billing/payment status coupling
+
+## Recommended Sequencing
+
+1. Finish Human Review Pass.
+2. If a micro-slice is read-only and stable, execute it under Wave 2A or Wave 2B.
+3. Move queue-lifecycle work to Wave 2C.
+4. Move payment/provider work to Wave 2D.
+
+## Stop / Go Guidance
+
+- Continue Wave 2A only if the slice is read-only or metadata-only.
+- Switch to Wave 2C when queue state, visit lifecycle, or registrar queue flows are involved.
+- Switch to Wave 2D when invoice/provider/payment state is involved.

--- a/docs/status/W2A_EXECUTION_SUMMARY.md
+++ b/docs/status/W2A_EXECUTION_SUMMARY.md
@@ -1,7 +1,7 @@
 # Wave 2A Execution Summary
 
-Date: 2026-03-06  
-Track: `W2A = Service/Repository Completion`  
+Date: 2026-03-06
+Track: `W2A = Service/Repository Completion`
 Current pass: first architectural slices only (non-protected).
 
 ## Completed Slices
@@ -10,21 +10,42 @@ Current pass: first architectural slices only (non-protected).
 - `W2A-SR-002` (`done`): media/reaction messaging endpoints moved to service-first routing.
 - `W2A-SR-003` (`done`): architecture guard added to prevent router-level DB regression in completed module.
 - `W2A-SR-010` (`done`): services catalog handlers moved to service/repository flow while queue-adjacent handlers remained untouched.
+- `W2A-SR-012` (`done`): read-only visits handlers (`list_visits`, `get_visit`) moved to service/repository flow while write handlers remained untouched.
+- `W2A-SR-013` (`done`): safe visit write handlers (`create_visit`, `add_service`) moved to service/repository flow while queue-coupled handlers remained untouched.
 
 ## Partial Slices
 
 - None in this pass.
 
+## Remaining Non-Protected Slice Candidates
+
+- No additional non-protected slice is confirmed in the current discovery pass.
+
+## Human Review Pass
+
+- Human review pass completed for `W2A-SR-011`, `W2A-SR-040`, and adjacent queue/payment/registrar slices.
+- New analysis artifacts:
+  - `docs/architecture/W2A_DOMAIN_FLOW_ANALYSIS.md`
+  - `docs/status/W2A_HUMAN_REVIEW_CLASSIFICATION.md`
+  - `docs/architecture/W2A_REFACTOR_OPTIONS.md`
+  - `docs/architecture/WAVE2_TRACK_MAP.md`
+  - `docs/status/W2A_MICRO_SLICES.md`
+- Result:
+  - no broad safe Wave 2A slice remains
+  - only narrow read-only micro-slices are still plausible
+  - larger work should move to `Wave 2C` (queue) or `Wave 2D` (payment)
+
 ## Pending Human Review Slices
 
 - `W2A-SR-011` and above (mixed/protected modules), including:
-  - queue-adjacent: `services.py` (`queue-groups`, `resolve`, `code-mappings`), `admin_departments.py`, `doctor_integration.py`, `visits.py`, `registrar_*`, `qr_queue.py`
+  - queue-adjacent: `services.py` (`queue-groups`, `resolve`, `code-mappings`), queue-coupled writes in `visits.py` (`set_status`, `reschedule_*`), `admin_departments.py`, `doctor_integration.py`, `registrar_*`, `qr_queue.py`
   - payments: `cashier.py`, `appointments.py` payment paths, `admin_stats.py`, payment parts of `registrar_wizard.py`
 
 ## Tests Run
 
-- `cd backend && pytest -q` -> `652 passed, 3 skipped`
+- `cd backend && pytest -q` -> `658 passed, 3 skipped`
 - `cd backend && pytest tests/test_openapi_contract.py -q` -> `10 passed`
+- `cd backend && pytest tests/unit -q` -> `383 passed`
 
 ## Regressions Found
 
@@ -37,11 +58,16 @@ Current pass: first architectural slices only (non-protected).
 - Slices plan: `docs/status/W2A_SERVICE_REPOSITORY_SLICES.md`
 - Guards: `docs/architecture/W2A_ARCHITECTURE_GUARDS.md`
 - Slice statuses:
-  - `docs/status/wave2a/W2A-SR-001_STATUS.md`
-  - `docs/status/wave2a/W2A-SR-002_STATUS.md`
-  - `docs/status/wave2a/W2A-SR-003_STATUS.md`
-  - `docs/status/wave2a/W2A-SR-010_STATUS.md`
+- `docs/status/wave2a/W2A-SR-001_STATUS.md`
+- `docs/status/wave2a/W2A-SR-002_STATUS.md`
+- `docs/status/wave2a/W2A-SR-003_STATUS.md`
+- `docs/status/wave2a/W2A-SR-010_STATUS.md`
+- `docs/status/wave2a/W2A-SR-012_PLAN.md`
+- `docs/status/wave2a/W2A-SR-012_STATUS.md`
+- `docs/status/wave2a/W2A-SR-013_PLAN.md`
+- `docs/status/wave2a/W2A-SR-013_STATUS.md`
 
 ## Next Recommended Slice
 
-- Continue Wave 2A only after explicit human decision on `W2A-SR-011` queue-adjacent handlers inside `services.py`, or by identifying another clearly non-protected module not already completed.
+- If one more tiny slice is desired, use `W2A-MS-011A` / `W2A-MS-011B` from `docs/status/W2A_MICRO_SLICES.md`.
+- Otherwise, stop Wave 2A and open specialized planning for `Wave 2C` (queue lifecycle) or `Wave 2D` (payment flow hardening).

--- a/docs/status/W2A_HUMAN_REVIEW_CLASSIFICATION.md
+++ b/docs/status/W2A_HUMAN_REVIEW_CLASSIFICATION.md
@@ -1,0 +1,33 @@
+# Wave 2A Human Review Classification
+
+Date: 2026-03-06
+Mode: analysis-first
+
+## Classification Rules
+
+- `SAFE_REFACTOR`: read-only or narrowly scoped router logic; no queue/payment/lifecycle mutation.
+- `QUEUE_COUPLED`: handler mutates queue state, queue settings, or queue-derived routing semantics.
+- `PAYMENT_COUPLED`: handler creates or reconciles payments, invoices, providers, or revenue state.
+- `TRANSACTION_CRITICAL`: handler coordinates multiple writes or relies on commit/rollback ordering.
+- `MIXED_LOGIC`: handler mixes read-model shaping, orchestration, and persistence policy in one router block.
+
+## Slice Classification
+
+| Slice / Area | Classification | Why |
+|---|---|---|
+| `W2A-SR-011` (`services.py` queue-adjacent handlers) | `MIXED_LOGIC`, `QUEUE_COUPLED` | Handlers are read-only, but they define queue taxonomy and registrar/frontend grouping semantics. Existing service methods exist, yet the business meaning of these mappings is queue-domain policy, not generic catalog CRUD. |
+| `W2A-SR-040` (`visits.py` status/reschedule handlers) | `QUEUE_COUPLED`, `TRANSACTION_CRITICAL`, `MIXED_LOGIC` | Router mutates visit status/date and linked queue-entry status in the same request. Transaction ordering matters because visit lifecycle and queue lifecycle must stay coherent. |
+| `W2A-SR-020` (`admin_departments.py`) | `QUEUE_COUPLED`, `TRANSACTION_CRITICAL`, `MIXED_LOGIC` | Department bootstrap and queue settings creation are interleaved with registration settings and optional service provisioning. |
+| `W2A-SR-030` (`doctor_integration.py`) | `QUEUE_COUPLED`, `TRANSACTION_CRITICAL`, `PAYMENT_COUPLED` | Doctor flow completes visits, may create payments through billing, and derives visit state from queue state. |
+| `W2A-SR-050` (`registrar_integration.py`) | `QUEUE_COUPLED`, `TRANSACTION_CRITICAL`, `MIXED_LOGIC` | Registrar endpoints combine queue read models, queue start transitions, and batch queue creation logic. |
+| `W2A-SR-060` (`registrar_wizard.py`) | `QUEUE_COUPLED`, `PAYMENT_COUPLED`, `TRANSACTION_CRITICAL`, `MIXED_LOGIC` | Cart/invoice/payment flow is the strongest crossover slice: visits, queue entries, invoices, price overrides, provider callbacks. |
+| `W2A-SR-070` (`qr_queue.py`) | `QUEUE_COUPLED`, `TRANSACTION_CRITICAL` | High-density queue lifecycle mutations plus notifications and display side effects. |
+| `W2A-SR-080` (`cashier.py`) | `PAYMENT_COUPLED`, `TRANSACTION_CRITICAL` | Cashier endpoints create/confirm/refund payments and reconcile visit state. |
+| `W2A-SR-090` (`appointments.py`) | `MIXED_LOGIC`, `PAYMENT_COUPLED` | File mixes read-only appointment listing, pending-payment aggregation, and queue open/close administration. |
+| `W2A-SR-100` (`admin_stats.py`) | `PAYMENT_COUPLED`, `SAFE_REFACTOR` | Handlers are read-only analytics, but the domain is payment-heavy reporting. Safe extraction is possible, yet it belongs to a reporting/payment track more than to core Wave 2A cleanup. |
+
+## Human Review Outcome
+
+- Continue automatic Wave 2A refactor only for clearly bounded micro-slices with no domain-state mutation.
+- Treat queue lifecycle, visit lifecycle, registrar orchestration, and payment reconciliation as separate architecture tracks.
+- Do not auto-refactor `W2A-SR-040`, `W2A-SR-060`, `W2A-SR-070`, or `W2A-SR-080`.

--- a/docs/status/W2A_MICRO_SLICES.md
+++ b/docs/status/W2A_MICRO_SLICES.md
@@ -1,0 +1,31 @@
+# Wave 2A Micro-Slices
+
+Date: 2026-03-06
+Purpose: identify the few remaining bounded slices that could still move without redesigning queue/payment semantics.
+
+## Candidate Micro-Slices
+
+| ID | Scope | Why it is relatively safe | Recommended track | Execute now? |
+|---|---|---|---|---|
+| `W2A-MS-011A` | `services.py:resolve_service_endpoint` | Router already has no direct `db.*` calls and existing `ServicesApiService.resolve_service(...)` path exists. Main risk is shared queue taxonomy semantics, not transaction state. | `Wave 2A` | `Conditional yes` |
+| `W2A-MS-011B` | `services.py:get_queue_groups` + `get_service_code_mappings` | Read-only metadata builders with no commit/rollback. Existing service methods already exist. | `Wave 2A` or `Wave 2C pre-work` | `Conditional yes` |
+| `W2A-MS-090A` | `appointments.py:list_appointments` | Pure read-model endpoint; no transaction writes. Complexity is data shaping, not lifecycle mutation. | `Wave 2B` | `Conditional yes` |
+| `W2A-MS-100A` | `admin_stats.py` read-only analytics handlers | Pure reporting queries; no writes or external side effects. | `Wave 2B` or `Wave 2D reporting` | `Conditional yes` |
+| `W2A-MS-030A` | `doctor_integration.py:get_doctor_queue_today` | Read-only queue dashboard query. No commit/rollback in router. | `Wave 2C` | `Not before Wave 2C` |
+| `W2A-MS-090B` | `appointments.py:get_pending_payments` | Read-only, but crosses appointments, visits, invoices, and payment semantics in one large aggregation. | `Wave 2D` | `No` |
+
+## Micro-Slices Rejected For Now
+
+- `visits.py:set_status` / `reschedule_*`
+  - rejected because they mutate both visit and queue state
+- `registrar_wizard.py:create_cart_appointments`
+  - rejected because it spans visits, queue entries, invoice creation, and payment setup
+- `qr_queue.py:full_update_online_entry`
+  - rejected because it is a queue state machine, not a cleanup slice
+- `cashier.py:create_payment` / `refund_payment`
+  - rejected because payment reconciliation is a dedicated track
+
+## Recommendation
+
+- If the user wants one more bounded Wave 2A slice, prefer `W2A-MS-011A` first.
+- If the user wants architectural momentum over another tiny slice, stop Wave 2A and open Wave 2C / Wave 2D planning.

--- a/docs/status/W2A_SERVICE_REPOSITORY_SLICES.md
+++ b/docs/status/W2A_SERVICE_REPOSITORY_SLICES.md
@@ -1,7 +1,7 @@
 # Wave 2A Service/Repository Slices
 
-Date: 2026-03-06  
-Track: W2A (Service/Repository Completion)  
+Date: 2026-03-06
+Track: W2A (Service/Repository Completion)
 Execution rule: low-risk non-protected first.
 
 ## Slice Backlog
@@ -12,10 +12,12 @@ Execution rule: low-risk non-protected first.
 | `W2A-SR-002` | `backend/app/api/v1/endpoints/messages.py` | Same module and architecture pattern; bounded to media/reaction endpoints | Router delegates to service for reactions, available users, voice upload/stream, file upload | `cd backend && pytest -q` | `docs/status/wave2a/W2A-SR-002_STATUS.md` | No | `done` |
 | `W2A-SR-003` | `backend/tests/architecture/**` or `backend/tests/unit/**` | Lightweight guard only for completed module boundaries | Add robust check: router layer should not own direct ORM calls for finished module(s) | `cd backend && pytest -q` | `docs/architecture/W2A_ARCHITECTURE_GUARDS.md`, `docs/status/wave2a/W2A-SR-003_STATUS.md` | No | `done` |
 | `W2A-SR-010` | `backend/app/api/v1/endpoints/services.py` (catalog handlers only) | Existing `ServicesApiService`/`ServicesApiRepository` already cover catalog CRUD; queue-adjacent handlers can stay untouched | Thin router for category CRUD, service CRUD/list/get, temp doctors list | `cd backend && pytest -q` + `pytest tests/test_openapi_contract.py -q` | `docs/status/wave2a/W2A-SR-010_STATUS.md` | No | `done` |
+| `W2A-SR-012` | `backend/app/api/v1/endpoints/visits.py` (`list_visits`, `get_visit`) | Existing `VisitsApiService`/`VisitsApiRepository` already cover the read-only path; no queue/payment state changes in selected handlers | Thin router for visit list/card handlers only | `cd backend && pytest -q` + `pytest tests/test_openapi_contract.py -q` + `pytest tests/unit -q` | `docs/status/wave2a/W2A-SR-012_PLAN.md`, `docs/status/wave2a/W2A-SR-012_STATUS.md` | No | `done` |
+| `W2A-SR-013` | `backend/app/api/v1/endpoints/visits.py` (`create_visit`, `add_service`) | Same module already has service/repository coverage; selected handlers are not queue-coupled if audit/transaction semantics stay local | Thin router for visit create/add-service handlers while preserving audit and insert semantics | `cd backend && pytest -q` + `pytest tests/test_openapi_contract.py -q` + `pytest tests/unit -q` | `docs/status/wave2a/W2A-SR-013_PLAN.md`, `docs/status/wave2a/W2A-SR-013_STATUS.md` | No | `done` |
 | `W2A-SR-011` | `backend/app/api/v1/endpoints/services.py` (`queue-groups`, `resolve`, `code-mappings`) | Same file, but these handlers are queue-adjacent and should stay isolated from catalog slice | Separate queue-aware review before any refactor | `cd backend && pytest -q` + `pytest tests/test_openapi_contract.py -q` | `docs/status/wave2a/W2A-SR-011_STATUS.md` | Yes (queue-adjacent) | `pending human review` |
 | `W2A-SR-020` | `backend/app/api/v1/endpoints/admin_departments.py` | Contains queue settings endpoints | Router -> service -> repository with queue settings isolation | `cd backend && pytest -q` | `docs/status/wave2a/W2A-SR-020_STATUS.md` | Yes (queue) | `pending human review` |
 | `W2A-SR-030` | `backend/app/api/v1/endpoints/doctor_integration.py` | Queue-coupled workflow | Move orchestration out of router | `cd backend && pytest -q` | `docs/status/wave2a/W2A-SR-030_STATUS.md` | Yes (queue) | `pending human review` |
-| `W2A-SR-040` | `backend/app/api/v1/endpoints/visits.py` | Updates queue state alongside visit state | Extract transaction flow into service/repository | `cd backend && pytest -q` + targeted integration | `docs/status/wave2a/W2A-SR-040_STATUS.md` | Yes (queue) | `pending human review` |
+| `W2A-SR-040` | `backend/app/api/v1/endpoints/visits.py` (`set_status`, `reschedule_visit`, `reschedule_visit_tomorrow`) | Remaining visit write handlers update queue state alongside visit state | Extract transaction flow into service/repository only after queue review | `cd backend && pytest -q` + targeted integration | `docs/status/wave2a/W2A-SR-040_STATUS.md` | Yes (queue) | `pending human review` |
 | `W2A-SR-050` | `backend/app/api/v1/endpoints/registrar_integration.py` | Queue-heavy orchestration | Service use-case orchestration + repository query isolation | `cd backend && pytest -q` | `docs/status/wave2a/W2A-SR-050_STATUS.md` | Yes (queue) | `pending human review` |
 | `W2A-SR-060` | `backend/app/api/v1/endpoints/registrar_wizard.py` | Queue + payment crossover | Decompose router transactions into service/repository | `cd backend && pytest -q` | `docs/status/wave2a/W2A-SR-060_STATUS.md` | Yes (queue + payments) | `pending human review` |
 | `W2A-SR-070` | `backend/app/api/v1/endpoints/qr_queue.py` | High-density queue mutation logic | Service transaction orchestration, repository DB operations | `cd backend && pytest -q` | `docs/status/wave2a/W2A-SR-070_STATUS.md` | Yes (queue) | `pending human review` |
@@ -25,5 +27,12 @@ Execution rule: low-risk non-protected first.
 
 ## Initial Execution Selection
 
-- Executed: `W2A-SR-001`, `W2A-SR-002`, `W2A-SR-003`, `W2A-SR-010`
-- Deferred: `W2A-SR-011+` (protected or mixed-protected modules)
+- Executed: `W2A-SR-001`, `W2A-SR-002`, `W2A-SR-003`, `W2A-SR-010`, `W2A-SR-012`, `W2A-SR-013`
+- Deferred protected: `W2A-SR-011`, `W2A-SR-020+`
+- Next safe candidate: none confirmed; next Wave 2A step requires human review on `W2A-SR-011` or `W2A-SR-040`
+
+## Human Review Notes
+
+- `W2A-SR-011`: queue-adjacent read-model / metadata slice. Possible micro-slices exist, but queue taxonomy impact should be acknowledged before execution.
+- `W2A-SR-040`: queue-coupled transaction slice. Do not continue automatically.
+- `W2A-SR-090` and `W2A-SR-100` contain read-only reporting micro-slices, but they align better with `Wave 2B` / `Wave 2D` than with core Wave 2A cleanup.


### PR DESCRIPTION
## Summary
- Replacement for stale stacked PR #60 from current main.
- Preserves only the useful W2A Human Review Pass documentation slice: queue/payment classification, refactor options, track map, service repository discovery, execution summary, and remaining micro-slices docs.
- Does not include stale parent runtime changes from the old stacked branch.

## Contract Impact
- Canonical surface: documentation/status/architecture files listed in Scope Gate.
- Request shape: not applicable because this replacement changes documentation only and no API request contract.
- Response shape: not applicable because this replacement changes documentation only and no API response contract.
- Status codes: not applicable because this replacement changes documentation only and no API status-code behavior.
- Frontend consumer: not applicable because this replacement changes documentation only and no frontend consumer contract.
- Compatibility path or alias: not applicable because this replacement changes documentation only and no route alias or legacy path.
- Contract proof: docs-only replacement; no runtime contract test is required.

## RBAC / Permissions
- Roles allowed: unchanged because this replacement changes documentation only.
- Roles denied: unchanged because this replacement changes documentation only.
- Positive auth proof: not applicable because no auth or endpoint code is changed.
- Negative auth proof: not applicable because no auth or endpoint code is changed.

## Notification / Realtime
- Event type or websocket channel: not applicable because this replacement changes documentation only and no event or websocket channel.
- Payload version / ack behavior: not applicable because this replacement changes documentation only and no realtime payload.
- Read/unread or delivery semantics: not applicable because this replacement changes documentation only and no delivery behavior.
- Reconnect/resync proof: not applicable because this replacement changes documentation only and no reconnect behavior.

## Frontend Resilience
- Empty data proof: not applicable because this replacement changes documentation only and no frontend empty state.
- Partial data proof: not applicable because this replacement changes documentation only and no frontend partial data path.
- Forbidden secondary path behavior: not applicable because this replacement changes documentation only and no frontend secondary path.
- Missing draft/resource behavior: not applicable because this replacement changes documentation only and no draft or resource behavior.
- Stale route/deep-link behavior: not applicable because this replacement changes documentation only and no route state.

## Scope Gate
- Allowed paths: docs/architecture/W2A_DOMAIN_FLOW_ANALYSIS.md; docs/architecture/W2A_REFACTOR_OPTIONS.md; docs/architecture/W2A_SERVICE_REPOSITORY_DISCOVERY.md; docs/architecture/WAVE2_TRACK_MAP.md; docs/status/W2A_EXECUTION_SUMMARY.md; docs/status/W2A_HUMAN_REVIEW_CLASSIFICATION.md; docs/status/W2A_MICRO_SLICES.md; docs/status/W2A_SERVICE_REPOSITORY_SLICES.md.
- Denied paths: backend runtime, frontend runtime, tests, contracts, Alembic migrations, GitHub workflows, RBAC helpers, queue/payment runtime code, notification code, and realtime code.
- Migration/docs/test impact: docs-only impact; no database migration; no runtime test required.
- Rollback note: revert this docs replacement if the recorded review classification or Wave 2A planning context is inaccurate.

## Validation
- Targeted tests or smoke run: copied only allowlisted docs files from PR #60 head onto fresh main; stripped trailing whitespace; scoped file allowlist check; git diff --check on allowed docs files; PR body gate passed from body file.
- Result: local replacement checks passed before push; live PR body file gate passed after opening.
- Not checked: runtime tests, browser smoke, contract tests, RBAC tests, and realtime tests because no runtime files are changed.