### PR TITLE
fix(queue): replace registrar batch active duplicate handling

### DIFF
--- a/backend/app/repositories/queue_batch_repository.py
+++ b/backend/app/repositories/queue_batch_repository.py
@@ -13,6 +13,14 @@ from app.models.patient import Patient
 from app.models.service import Service
 
 
+REGISTRAR_BATCH_ACTIVE_DUPLICATE_STATUSES = (
+    "waiting",
+    "called",
+    "in_service",
+    "diagnostics",
+)
+
+
 class QueueBatchRepository:
     """Encapsulates ORM queries used by queue batch service."""
 
@@ -45,13 +53,13 @@ class QueueBatchRepository:
             queue_tag=None,
         )
 
-    def find_existing_active_entry(
+    def find_existing_active_entries(
         self,
         *,
         specialist_id: int,
         day: date,
         patient_id: int,
-    ) -> OnlineQueueEntry | None:
+    ) -> list[OnlineQueueEntry]:
         return (
             self.db.query(OnlineQueueEntry)
             .join(DailyQueue, DailyQueue.id == OnlineQueueEntry.queue_id)
@@ -59,10 +67,25 @@ class QueueBatchRepository:
                 DailyQueue.specialist_id == specialist_id,
                 DailyQueue.day == day,
                 OnlineQueueEntry.patient_id == patient_id,
-                OnlineQueueEntry.status.in_(["waiting", "called"]),
+                OnlineQueueEntry.status.in_(REGISTRAR_BATCH_ACTIVE_DUPLICATE_STATUSES),
             )
-            .first()
+            .order_by(OnlineQueueEntry.id.asc())
+            .all()
         )
+
+    def find_existing_active_entry(
+        self,
+        *,
+        specialist_id: int,
+        day: date,
+        patient_id: int,
+    ) -> OnlineQueueEntry | None:
+        entries = self.find_existing_active_entries(
+            specialist_id=specialist_id,
+            day=day,
+            patient_id=patient_id,
+        )
+        return entries[0] if entries else None
 
     def commit(self) -> None:
         self.db.commit()

--- a/backend/app/services/queue_batch_service.py
+++ b/backend/app/services/queue_batch_service.py
@@ -107,10 +107,22 @@ class QueueBatchService:
             patient_phone = patient.phone or None
 
             for specialist_id in services_by_specialist:
-                existing_entry = self.repository.find_existing_active_entry(
+                existing_active_entries = self.repository.find_existing_active_entries(
                     specialist_id=specialist_id,
                     day=today,
                     patient_id=patient_id,
+                )
+                if len(existing_active_entries) > 1:
+                    raise QueueBatchDomainError(
+                        status_code=409,
+                        detail=(
+                            "Неоднозначная активная запись очереди для пациента у "
+                            "специалиста на сегодня"
+                        ),
+                    )
+
+                existing_entry = (
+                    existing_active_entries[0] if existing_active_entries else None
                 )
                 if existing_entry:
                     existing_entries_count += 1

--- a/backend/tests/unit/test_queue_batch_service.py
+++ b/backend/tests/unit/test_queue_batch_service.py
@@ -7,6 +7,9 @@ from unittest.mock import Mock
 import pytest
 
 from app.services import queue_batch_service as batch_module
+from app.repositories.queue_batch_repository import (
+    REGISTRAR_BATCH_ACTIVE_DUPLICATE_STATUSES,
+)
 
 
 def _service_with_repo(monkeypatch: pytest.MonkeyPatch, repo: Mock):
@@ -103,11 +106,13 @@ def test_create_entries_reuses_existing_entry(
     )
     repo.get_active_service.return_value = SimpleNamespace(id=11)
     repo.resolve_specialist_user_id.return_value = (101, False)
-    repo.find_existing_active_entry.return_value = SimpleNamespace(
+    repo.find_existing_active_entries.return_value = [
+        SimpleNamespace(
         queue_id=22,
         number=5,
         queue_time=datetime(2026, 1, 1, 8, 0, 0),
-    )
+        )
+    ]
 
     create_queue_entry = Mock()
     monkeypatch.setattr(batch_module.queue_service, "create_queue_entry", create_queue_entry)
@@ -141,7 +146,7 @@ def test_create_entries_creates_new_queue_entry(
     )
     repo.get_active_service.return_value = SimpleNamespace(id=12)
     repo.resolve_specialist_user_id.return_value = (202, False)
-    repo.find_existing_active_entry.return_value = None
+    repo.find_existing_active_entries.return_value = []
     repo.get_or_create_daily_queue.return_value = SimpleNamespace(id=33)
 
     queue_entry = SimpleNamespace(
@@ -183,7 +188,7 @@ def test_create_entries_wraps_unexpected_error(
     )
     repo.get_active_service.return_value = SimpleNamespace(id=13)
     repo.resolve_specialist_user_id.return_value = (303, False)
-    repo.find_existing_active_entry.return_value = None
+    repo.find_existing_active_entries.return_value = []
     repo.get_or_create_daily_queue.return_value = SimpleNamespace(id=44)
 
     monkeypatch.setattr(
@@ -205,3 +210,49 @@ def test_create_entries_wraps_unexpected_error(
     assert "массового создания" in exc.value.detail
     repo.rollback.assert_called_once()
     repo.commit.assert_not_called()
+
+
+def test_create_entries_rejects_ambiguous_active_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = Mock()
+    repo.db = Mock()
+    repo.get_patient.return_value = SimpleNamespace(
+        first_name="Test",
+        last_name="Patient",
+        phone="+998901234567",
+        short_name=lambda: "Test Patient",
+    )
+    repo.get_active_service.return_value = SimpleNamespace(id=14)
+    repo.resolve_specialist_user_id.return_value = (404, False)
+    repo.find_existing_active_entries.return_value = [
+        SimpleNamespace(queue_id=55, number=1, queue_time=datetime(2026, 1, 1, 8, 0, 0)),
+        SimpleNamespace(queue_id=55, number=2, queue_time=datetime(2026, 1, 1, 8, 5, 0)),
+    ]
+
+    create_queue_entry = Mock()
+    monkeypatch.setattr(batch_module.queue_service, "create_queue_entry", create_queue_entry)
+
+    service = _service_with_repo(monkeypatch, repo)
+
+    with pytest.raises(batch_module.QueueBatchDomainError) as exc:
+        service.create_entries(
+            patient_id=1,
+            source="desk",
+            services=[batch_module.QueueBatchServiceItem(specialist_id=404, service_id=14)],
+        )
+
+    assert exc.value.status_code == 409
+    assert "Неоднозначная активная запись очереди" in exc.value.detail
+    repo.rollback.assert_called_once()
+    repo.commit.assert_not_called()
+    create_queue_entry.assert_not_called()
+
+
+def test_registrar_batch_active_duplicate_statuses_include_live_claims() -> None:
+    assert REGISTRAR_BATCH_ACTIVE_DUPLICATE_STATUSES == (
+        "waiting",
+        "called",
+        "in_service",
+        "diagnostics",
+    )


### PR DESCRIPTION
﻿## Summary
- Replacement for stale stacked PR #79, rebuilt on current main after the old registrar batch files were superseded.
- Preserves the useful behavior: registrar batch duplicate detection now treats `waiting`, `called`, `in_service`, and `diagnostics` as active patient-specialist-day claims.
- Reuses exactly one existing active entry and returns `409` when multiple active entries make the claim ambiguous.

## Contract Impact
- Canonical surface: current `QueueBatchService -> QueueBatchRepository` registrar batch creation boundary.
- Request shape: unchanged; batch create inputs remain patient, source, and service/specialist rows.
- Response shape: unchanged for success; reused entries still return queue ticket fields.
- Status codes: unchanged for clear reuse/create paths; ambiguous multiple active claims now return `409` instead of silently choosing or allocating.
- Frontend consumer: registrar batch queue creation flow keeps the same payload shape.
- Compatibility path or alias: old `registrar_integration.py` stacked slice is not reused because current main moved canonical ownership to queue batch service/repository.
- Contract proof: focused unit coverage added for active status set and ambiguous active claim behavior; GitHub backend CI is the validation source.

## RBAC / Permissions
- Roles allowed: unchanged for existing registrar batch endpoint dependencies.
- Roles denied: unchanged; no authorization helper or role matrix behavior is changed.
- Positive auth proof: existing endpoint auth coverage remains the proof surface.
- Negative auth proof: not applicable because authorization behavior is not changed.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket event is changed.
- Payload version / ack behavior: not applicable because no realtime payload is added or renamed.
- Read/unread or delivery semantics: not applicable because this is backend duplicate/reuse semantics for registrar batch queue creation.
- Reconnect/resync proof: not applicable because no realtime reconnect behavior is touched.

## Frontend Resilience
- Empty data proof: unchanged; no frontend empty-state handling is modified.
- Partial data proof: unchanged; no frontend partial-data handling is modified.
- Forbidden secondary path behavior: unchanged; no frontend secondary path is touched.
- Missing draft/resource behavior: unchanged; no draft/resource UI path is touched.
- Stale route/deep-link behavior: unchanged; no frontend route state is touched.

## Scope Gate
- Allowed paths: `queue_batch_repository.py`, `queue_batch_service.py`, and focused queue batch unit tests.
- Denied paths: old stacked registrar integration files, deleted characterization docs/tests, queue fairness redesign, numbering redesign, frontend, notifications, realtime, migrations, and workflows.
- Migration/docs/test impact: no database migration; focused unit tests updated for canonical main ownership.
- Rollback note: revert the active status tuple and multiple-active-entry `409` check if registrar batch duplicate/reuse behavior regresses.

## Validation
- Targeted tests or smoke run: local `py_compile` for touched Python files and `git diff --check` passed; PR body gate passed.
- Result: local static validation passed; fresh GitHub CI is required before merge decision.
- Not checked: local pytest was not run because the temp clone lacks pytest; browser/realtime smoke not checked because no frontend/realtime files are touched.

Replaces stale stacked PR #79. Old #79 should not be merged directly because its original files are stale against current main.
