### PR TITLE
refactor(queue): replace queue batch boundary dispatch

### DIFF
--- a/backend/app/services/queue_batch_service.py
+++ b/backend/app/services/queue_batch_service.py
@@ -11,7 +11,7 @@ from zoneinfo import ZoneInfo
 from sqlalchemy.orm import Session
 
 from app.repositories.queue_batch_repository import QueueBatchRepository
-from app.services.queue_service import queue_service
+from app.services.queue_domain_service import QueueDomainService
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +49,7 @@ class QueueBatchService:
 
     def __init__(self, db: Session):
         self.repository = QueueBatchRepository(db)
+        self.queue_domain_service = QueueDomainService(db)
 
     def create_entries(
         self,
@@ -146,14 +147,15 @@ class QueueBatchService:
                 )
 
                 try:
-                    queue_entry = queue_service.create_queue_entry(
-                        db=self.repository.db,
+                    queue_entry = self.queue_domain_service.allocate_ticket(
+                        allocation_mode="create_entry",
                         daily_queue=daily_queue,
                         patient_id=patient_id,
                         patient_name=patient_name,
                         phone=patient_phone,
                         source=source,
                         queue_time=current_time,
+                        auto_number=True,
                         commit=False,
                     )
                 except ValueError as exc:

--- a/backend/app/services/queue_domain_service.py
+++ b/backend/app/services/queue_domain_service.py
@@ -9,6 +9,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from app.repositories.queue_read_repository import QueueReadRepository
+from app.services.queue_service import queue_service
 from app.services.queue_status import REORDER_ACTIVE_RAW_STATUSES
 
 
@@ -133,6 +134,12 @@ class QueueDomainService:
         if not queue:
             raise QueueDomainReadError(404, "Очередь не найдена")
         return self._build_cabinet_payload(queue)
+
+    def allocate_ticket(self, *, allocation_mode: str, **kwargs: Any) -> object:
+        if allocation_mode != "create_entry":
+            raise ValueError(f"Unsupported queue allocation mode: {allocation_mode}")
+        db = self.read_repository.db
+        return queue_service.create_queue_entry(db=db, **kwargs)
 
     def enqueue(self, **_: Any) -> QueueSnapshot:
         raise NotImplementedError("QueueDomainService.enqueue is a Phase 2 method")

--- a/backend/tests/unit/test_queue_batch_service.py
+++ b/backend/tests/unit/test_queue_batch_service.py
@@ -14,7 +14,9 @@ from app.repositories.queue_batch_repository import (
 
 def _service_with_repo(monkeypatch: pytest.MonkeyPatch, repo: Mock):
     monkeypatch.setattr(batch_module, "QueueBatchRepository", lambda db: repo)
-    return batch_module.QueueBatchService(db=Mock())
+    service = batch_module.QueueBatchService(db=Mock())
+    service.queue_domain_service = Mock()
+    return service
 
 
 def test_create_entries_fails_when_patient_not_found(
@@ -114,9 +116,6 @@ def test_create_entries_reuses_existing_entry(
         )
     ]
 
-    create_queue_entry = Mock()
-    monkeypatch.setattr(batch_module.queue_service, "create_queue_entry", create_queue_entry)
-
     service = _service_with_repo(monkeypatch, repo)
     result = service.create_entries(
         patient_id=1,
@@ -130,7 +129,7 @@ def test_create_entries_reuses_existing_entry(
     assert "уже существовала" in result.message
     repo.commit.assert_called_once()
     repo.rollback.assert_not_called()
-    create_queue_entry.assert_not_called()
+    service.queue_domain_service.allocate_ticket.assert_not_called()
 
 
 def test_create_entries_creates_new_queue_entry(
@@ -154,10 +153,8 @@ def test_create_entries_creates_new_queue_entry(
         number=1,
         queue_time=datetime(2026, 1, 1, 9, 0, 0),
     )
-    create_queue_entry = Mock(return_value=queue_entry)
-    monkeypatch.setattr(batch_module.queue_service, "create_queue_entry", create_queue_entry)
-
     service = _service_with_repo(monkeypatch, repo)
+    service.queue_domain_service.allocate_ticket.return_value = queue_entry
     result = service.create_entries(
         patient_id=1,
         source="online",
@@ -170,9 +167,22 @@ def test_create_entries_creates_new_queue_entry(
     assert "Создано 1 запись" in result.message
     repo.commit.assert_called_once()
     repo.rollback.assert_not_called()
-    create_queue_entry.assert_called_once()
-    assert create_queue_entry.call_args.kwargs["db"] is repo.db
-    assert create_queue_entry.call_args.kwargs["commit"] is False
+    service.queue_domain_service.allocate_ticket.assert_called_once()
+    assert service.queue_domain_service.allocate_ticket.call_args.kwargs[
+        "allocation_mode"
+    ] == "create_entry"
+    assert service.queue_domain_service.allocate_ticket.call_args.kwargs[
+        "daily_queue"
+    ] is repo.get_or_create_daily_queue.return_value
+    assert service.queue_domain_service.allocate_ticket.call_args.kwargs[
+        "patient_id"
+    ] == 1
+    assert service.queue_domain_service.allocate_ticket.call_args.kwargs[
+        "auto_number"
+    ] is True
+    assert service.queue_domain_service.allocate_ticket.call_args.kwargs[
+        "commit"
+    ] is False
 
 
 def test_create_entries_wraps_unexpected_error(
@@ -191,13 +201,8 @@ def test_create_entries_wraps_unexpected_error(
     repo.find_existing_active_entries.return_value = []
     repo.get_or_create_daily_queue.return_value = SimpleNamespace(id=44)
 
-    monkeypatch.setattr(
-        batch_module.queue_service,
-        "create_queue_entry",
-        Mock(side_effect=RuntimeError("boom")),
-    )
-
     service = _service_with_repo(monkeypatch, repo)
+    service.queue_domain_service.allocate_ticket.side_effect = RuntimeError("boom")
 
     with pytest.raises(batch_module.QueueBatchDomainError) as exc:
         service.create_entries(
@@ -230,9 +235,6 @@ def test_create_entries_rejects_ambiguous_active_entries(
         SimpleNamespace(queue_id=55, number=2, queue_time=datetime(2026, 1, 1, 8, 5, 0)),
     ]
 
-    create_queue_entry = Mock()
-    monkeypatch.setattr(batch_module.queue_service, "create_queue_entry", create_queue_entry)
-
     service = _service_with_repo(monkeypatch, repo)
 
     with pytest.raises(batch_module.QueueBatchDomainError) as exc:
@@ -246,7 +248,7 @@ def test_create_entries_rejects_ambiguous_active_entries(
     assert "Неоднозначная активная запись очереди" in exc.value.detail
     repo.rollback.assert_called_once()
     repo.commit.assert_not_called()
-    create_queue_entry.assert_not_called()
+    service.queue_domain_service.allocate_ticket.assert_not_called()
 
 
 def test_registrar_batch_active_duplicate_statuses_include_live_claims() -> None:

--- a/backend/tests/unit/test_queue_domain_service.py
+++ b/backend/tests/unit/test_queue_domain_service.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
+from app.services import queue_domain_service as domain_module
 
 from app.services.queue_domain_service import (
     QueueDomainReadError,
@@ -112,3 +114,47 @@ class TestQueueDomainService:
             service.get_queue_cabinet_info(queue_id=5)
 
         assert exc_info.value.status_code == 404
+
+    def test_allocate_ticket_delegates_create_entry_mode(self, monkeypatch) -> None:
+        db = Mock()
+        queue_entry = SimpleNamespace(id=9)
+        create_queue_entry = Mock(return_value=queue_entry)
+        monkeypatch.setattr(
+            domain_module.queue_service,
+            "create_queue_entry",
+            create_queue_entry,
+        )
+
+        class Repository:
+            def __init__(self):
+                self.db = db
+
+        service = QueueDomainService(db=db, read_repository=Repository())
+        result = service.allocate_ticket(
+            allocation_mode="create_entry",
+            daily_queue=SimpleNamespace(id=3),
+            patient_id=7,
+            patient_name="Test Patient",
+            phone="+998901234567",
+            source="desk",
+            auto_number=True,
+            commit=False,
+        )
+
+        assert result is queue_entry
+        create_queue_entry.assert_called_once()
+        assert create_queue_entry.call_args.kwargs["db"] is db
+        assert create_queue_entry.call_args.kwargs["patient_id"] == 7
+        assert create_queue_entry.call_args.kwargs["auto_number"] is True
+        assert create_queue_entry.call_args.kwargs["commit"] is False
+
+    def test_allocate_ticket_rejects_unknown_mode(self) -> None:
+        class Repository:
+            db = None
+
+        service = QueueDomainService(db=None, read_repository=Repository())
+
+        with pytest.raises(ValueError) as exc_info:
+            service.allocate_ticket(allocation_mode="direct_sql")
+
+        assert "Unsupported queue allocation mode" in str(exc_info.value)


### PR DESCRIPTION
﻿## Summary
- Replacement for stale stacked PR #80, rebuilt on current main after #245 moved registrar batch duplicate handling to the canonical queue batch layer.
- Adds `QueueDomainService.allocate_ticket(allocation_mode="create_entry")` as a compatibility boundary delegating to legacy `queue_service.create_queue_entry()`.
- Routes the `QueueBatchService` create branch through that boundary while preserving reuse-existing-entry and ambiguous-active-claim `409` behavior.

## Contract Impact
- Canonical surface: current `QueueBatchService -> QueueDomainService -> queue_service.create_queue_entry` registrar batch creation path.
- Request shape: unchanged; batch create inputs remain patient, source, and service/specialist rows.
- Response shape: unchanged; successful responses still return queue ticket fields from created or reused entries.
- Status codes: unchanged for clear reuse/create paths; ambiguous multiple active claims still return `409` before allocation.
- Frontend consumer: registrar batch queue creation flow keeps the same payload shape.
- Compatibility path or alias: old PR #80 endpoint patch is not reused because current main canonical owner is `QueueBatchService`; the new domain boundary delegates to the legacy allocator internally.
- Contract proof: focused unit coverage added for domain boundary delegation and queue batch service boundary dispatch; GitHub backend CI is the validation source.

## RBAC / Permissions
- Roles allowed: unchanged for existing registrar batch endpoint dependencies.
- Roles denied: unchanged; no authorization helper or role matrix behavior is changed.
- Positive auth proof: existing endpoint auth coverage remains the proof surface.
- Negative auth proof: not applicable because authorization behavior is not changed.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket event is changed.
- Payload version / ack behavior: not applicable because no realtime payload is added or renamed.
- Read/unread or delivery semantics: not applicable because this is backend allocation dispatch for registrar batch queue creation.
- Reconnect/resync proof: not applicable because no realtime reconnect behavior is touched.

## Frontend Resilience
- Empty data proof: unchanged; no frontend empty-state handling is modified.
- Partial data proof: unchanged; no frontend partial-data handling is modified.
- Forbidden secondary path behavior: unchanged; no frontend secondary path is touched.
- Missing draft/resource behavior: unchanged; no draft/resource UI path is touched.
- Stale route/deep-link behavior: unchanged; no frontend route state is touched.

## Scope Gate
- Allowed paths: `queue_domain_service.py`, `queue_batch_service.py`, and focused unit tests for those services.
- Denied paths: stale `registrar_integration.py` patch from old #80, frontend routes, RBAC helpers, notifications, realtime, migrations, workflows, queue fairness redesign, and numbering redesign.
- Migration/docs/test impact: no database migration; focused unit tests updated for current-main canonical ownership.
- Rollback note: revert `QueueBatchService` to direct `queue_service.create_queue_entry()` and remove `QueueDomainService.allocate_ticket()` if boundary dispatch regresses.

## Validation
- Targeted tests or smoke run: local `py_compile` for touched Python files and `git diff --check` passed; PR body gate passed.
- Result: local static validation passed; fresh GitHub CI is required before merge decision.
- Not checked: local pytest was not run because the temp clone lacks pytest; browser/realtime smoke not checked because no frontend/realtime files are touched.

Replaces stale stacked PR #80. Old #80 should not be merged directly because its original endpoint patch targets stale ownership after #245.
