### PR TITLE
fix(queue): replace registrar wizard duplicate gate runtime

### DIFF
--- a/backend/app/services/morning_assignment.py
+++ b/backend/app/services/morning_assignment.py
@@ -21,6 +21,28 @@ from app.services.service_mapping import get_service_code
 
 logger = logging.getLogger(__name__)
 
+WIZARD_DUPLICATE_ACTIVE_STATUSES = (
+    "waiting",
+    "called",
+    "in_service",
+    "diagnostics",
+)
+
+
+class MorningAssignmentClaimError(ValueError):
+    """Raised when a wizard-family queue claim cannot be resolved safely."""
+
+WIZARD_DUPLICATE_ACTIVE_STATUSES = (
+    "waiting",
+    "called",
+    "in_service",
+    "diagnostics",
+)
+
+
+class MorningAssignmentClaimError(ValueError):
+    """Raised when a wizard-family queue claim cannot be resolved safely."""
+
 
 class MorningAssignmentService:
     """Сервис утренней сборки для присвоения номеров в очередях"""
@@ -434,48 +456,29 @@ class MorningAssignmentService:
                 ),
             }
 
-        # Сначала пытаемся использовать уже созданную очередь на текущую дату.
-        daily_queue = (
-            self.db.query(DailyQueue)
-            .filter(
-                DailyQueue.day == target_date,
-                DailyQueue.queue_tag == queue_tag,
-                DailyQueue.active == True,
-            )
-            .first()
+        daily_queue, existing_entry = self._resolve_existing_queue_claim_or_raise(
+            patient_id=visit.patient_id,
+            target_date=target_date,
+            queue_tag=queue_tag,
         )
 
         if not daily_queue:
-            # ✅ ИСПРАВЛЕНО: specialist_id должен быть doctor.id (ForeignKey на doctors.id)
             daily_queue = queue_service.get_or_create_daily_queue(
                 self.db,
                 day=target_date,
-                specialist_id=doctor_id,  # ✅ Используем doctor_id, а не user_id
+                specialist_id=doctor_id,
                 queue_tag=queue_tag,
                 defaults=defaults,
             )
 
-        # Проверяем нет ли уже записи для этого пациента в этой очереди
-        existing_entry = (
-            self.db.query(OnlineQueueEntry)
-            .filter(
-                and_(
-                    OnlineQueueEntry.queue_id == daily_queue.id,
-                    OnlineQueueEntry.patient_id == visit.patient_id,
-                )
-            )
-            .first()
-        )
-
         if existing_entry:
-            logger.info(f"Пациент {visit.patient_id} уже есть в очереди {queue_tag}")
+            logger.info(f"Patient {visit.patient_id} already has active queue entry for {queue_tag}")
             return {
                 "queue_tag": queue_tag,
                 "queue_id": daily_queue.id,
                 "number": existing_entry.number,
                 "status": "existing",
             }
-
         # ✅ ИСПРАВЛЕНО: Используем SSOT queue_service для создания записи
         # Получаем информацию о пациенте для передачи в create_queue_entry
         patient = self.db.query(Patient).filter(Patient.id == visit.patient_id).first()
@@ -563,6 +566,61 @@ class MorningAssignmentService:
             "status": "assigned",
         }
 
+    def _resolve_existing_queue_claim_or_raise(
+        self,
+        *,
+        patient_id: int,
+        target_date: date,
+        queue_tag: str,
+    ) -> tuple[DailyQueue | None, OnlineQueueEntry | None]:
+        active_queues = (
+            self.db.query(DailyQueue)
+            .filter(
+                DailyQueue.day == target_date,
+                DailyQueue.queue_tag == queue_tag,
+                DailyQueue.active == True,
+            )
+            .order_by(DailyQueue.id.asc())
+            .all()
+        )
+
+        if not active_queues:
+            return None, None
+
+        active_entries = (
+            self.db.query(OnlineQueueEntry)
+            .filter(
+                OnlineQueueEntry.queue_id.in_([queue.id for queue in active_queues]),
+                OnlineQueueEntry.patient_id == patient_id,
+                OnlineQueueEntry.status.in_(WIZARD_DUPLICATE_ACTIVE_STATUSES),
+            )
+            .order_by(OnlineQueueEntry.queue_time.asc(), OnlineQueueEntry.id.asc())
+            .all()
+        )
+
+        if len(active_entries) > 1:
+            raise MorningAssignmentClaimError(
+                "Ambiguous active queue entry for "
+                f"queue_tag={queue_tag} and patient_id={patient_id}"
+            )
+
+        if len(active_entries) == 1:
+            queue_by_id = {queue.id: queue for queue in active_queues}
+            matched_queue = queue_by_id.get(active_entries[0].queue_id)
+            if matched_queue is None:
+                raise MorningAssignmentClaimError(
+                    "Could not safely match active queue entry for "
+                    f"queue_tag={queue_tag} and patient_id={patient_id}"
+                )
+            return matched_queue, active_entries[0]
+
+        if len(active_queues) > 1:
+            raise MorningAssignmentClaimError(
+                "Ambiguous active queue for "
+                f"queue_tag={queue_tag} and patient_id={patient_id}"
+            )
+
+        return active_queues[0], None
     def get_morning_assignment_stats(
         self, target_date: date | None = None
     ) -> dict[str, any]:


### PR DESCRIPTION
## Summary
- Replacement runtime slice for stale PR #83 on current main.
- Tightens the mounted registrar wizard same-day duplicate gate to resolve active claims by wizard-family `queue_tag`.
- Treats `waiting`, `called`, `in_service`, and `diagnostics` as canonical active statuses for mounted wizard reuse.

## Contract Impact
- Canonical surface: mounted registrar wizard same-day queue assignment behavior inside `backend/app/services/morning_assignment.py`.
- Request shape: unchanged existing registrar wizard/cart request flow; this PR changes duplicate-claim resolution after visit/service data already exists.
- Response shape: unchanged queue assignment payload; reused entries still return `queue_tag`, `queue_id`, `number`, `status=existing`, and newly assigned entries still return `status=assigned`.
- Status codes: unchanged route-level behavior; ambiguity is handled inside the queue assignment service path rather than changing endpoint status-code contract.
- Frontend consumer: existing registrar wizard/cart frontend flow; no frontend consumer code changed.
- Compatibility path or alias: no route alias added; legacy queue assignment flow remains, but active duplicate detection now scopes by wizard-family `queue_tag` and active statuses.
- Contract proof: local `py_compile` plus fresh PR CI; old PR #83 tests/docs were not ported in this first gate-approved runtime slice.

## RBAC / Permissions
- Roles allowed: unchanged because no route guard, auth dependency, role matrix, legacy role form, or permission check is changed.
- Roles denied: unchanged because no auth code is changed.
- Positive auth proof: existing mounted registrar wizard auth path remains unchanged because no route guard or dependency is modified in this runtime service slice.
- Negative auth proof: not applicable because this PR only changes queue duplicate-claim resolution under the existing mounted registrar wizard flow.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification event or websocket channel is changed.
- Payload version / ack behavior: not applicable because no realtime payload is added or renamed.
- Read/unread or delivery semantics: not applicable because no notification delivery/read state is changed.
- Reconnect/resync proof: not applicable because no realtime reconnect behavior is touched.

## Frontend Resilience
- Empty data proof: unchanged because no frontend empty-state handling is modified.
- Partial data proof: unchanged because no frontend partial-data handling is modified.
- Forbidden secondary path behavior: unchanged because no frontend secondary path is touched.
- Missing draft/resource behavior: unchanged because no draft/resource UI path is touched.
- Stale route/deep-link behavior: unchanged because no frontend route state is touched.

## Scope Gate
- Allowed paths: `backend/app/services/morning_assignment.py` only for this first runtime replacement slice.
- Denied paths: old stacked parent runtime/contracts/docs/tests, unrelated queue routes, frontend runtime, migrations, notification/realtime code, auth/RBAC helpers, payment/visit lifecycle code outside duplicate queue assignment behavior.
- Migration/docs/test impact: no migration; no docs/tests touched in this gate-approved first slice.
- Rollback note: revert the active-status duplicate-claim constants/helper and the `_assign_single_queue` resolution call in `morning_assignment.py`.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/services/morning_assignment.py`; `git diff --check -- backend/app/services/morning_assignment.py`; PR body gate.
- Result: passed locally in the fresh current-main replacement clone.
- Not checked: live browser registrar wizard/cart smoke, production/staging deploy smoke, and full targeted pytest were left to fresh GitHub CI because the local runtime clone does not own the broader stale tests/docs slice.