### PR TITLE
test(queue): preserve allocator compatibility boundary replacement

### DIFF
--- a/backend/app/services/queue_domain_service.py
+++ b/backend/app/services/queue_domain_service.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.crud.clinic import get_queue_settings
 from app.repositories.queue_read_repository import QueueReadRepository
-from app.services.queue_service import get_queue_service
+from app.services.queue_service import queue_service
 from app.services.queue_status import REORDER_ACTIVE_RAW_STATUSES
 
 
@@ -39,7 +39,7 @@ class QueueDomainService:
         self.db = db
         self.read_repository = read_repository or QueueReadRepository(db)
         self._get_settings = get_settings or get_queue_settings
-        self.allocator_service = allocator_service or get_queue_service()
+        self.allocator_service = allocator_service or queue_service
 
     def get_queue_snapshot(self, *, queue_id: int) -> QueueSnapshot:
         queue = self.read_repository.get_queue(queue_id)
@@ -296,7 +296,7 @@ class QueueDomainService:
             return self.allocator_service.create_queue_entry(self.db, **kwargs)
         if allocation_mode == "join_with_token":
             return self.allocator_service.join_queue_with_token(self.db, **kwargs)
-        raise ValueError(f"Unsupported allocation_mode: {allocation_mode}")
+        raise ValueError(f"Unsupported queue allocation mode: {allocation_mode}")
 
     def enqueue(self, **_: Any) -> QueueSnapshot:
         raise NotImplementedError("QueueDomainService.enqueue is a Phase 2 method")

--- a/backend/app/services/queue_domain_service.py
+++ b/backend/app/services/queue_domain_service.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 from sqlalchemy.orm import Session
 
 from app.crud.clinic import get_queue_settings
 from app.repositories.queue_read_repository import QueueReadRepository
-from app.services.queue_service import queue_service
+from app.services.queue_service import get_queue_service
 from app.services.queue_status import REORDER_ACTIVE_RAW_STATUSES
 
 
@@ -34,10 +34,12 @@ class QueueDomainService:
         db: Session,
         read_repository: QueueReadRepository | None = None,
         get_settings: Callable[[Session], dict] | None = None,
+        allocator_service: Any | None = None,
     ):
         self.db = db
         self.read_repository = read_repository or QueueReadRepository(db)
         self._get_settings = get_settings or get_queue_settings
+        self.allocator_service = allocator_service or get_queue_service()
 
     def get_queue_snapshot(self, *, queue_id: int) -> QueueSnapshot:
         queue = self.read_repository.get_queue(queue_id)
@@ -276,11 +278,25 @@ class QueueDomainService:
             "specialty_aliases": SPECIALTY_ALIASES,
         }
 
-    def allocate_ticket(self, *, allocation_mode: str, **kwargs: Any) -> object:
-        if allocation_mode != "create_entry":
-            raise ValueError(f"Unsupported queue allocation mode: {allocation_mode}")
-        db = self.read_repository.db
-        return queue_service.create_queue_entry(db=db, **kwargs)
+    def allocate_ticket(
+        self,
+        *,
+        allocation_mode: Literal["create_entry", "join_with_token"] = "create_entry",
+        **kwargs: Any,
+    ) -> Any:
+        """Compatibility boundary for current allocator behavior.
+
+        Phase 2 keeps runtime semantics unchanged. This method is only a public
+        queue-domain facade over the existing allocators:
+        - ``create_entry`` delegates to ``queue_service.create_queue_entry()``.
+        - ``join_with_token`` delegates to ``queue_service.join_queue_with_token()``.
+        """
+
+        if allocation_mode == "create_entry":
+            return self.allocator_service.create_queue_entry(self.db, **kwargs)
+        if allocation_mode == "join_with_token":
+            return self.allocator_service.join_queue_with_token(self.db, **kwargs)
+        raise ValueError(f"Unsupported allocation_mode: {allocation_mode}")
 
     def enqueue(self, **_: Any) -> QueueSnapshot:
         raise NotImplementedError("QueueDomainService.enqueue is a Phase 2 method")

--- a/backend/app/services/queue_domain_service.py
+++ b/backend/app/services/queue_domain_service.py
@@ -293,9 +293,9 @@ class QueueDomainService:
         """
 
         if allocation_mode == "create_entry":
-            return self.allocator_service.create_queue_entry(self.db, **kwargs)
+            return self.allocator_service.create_queue_entry(db=self.db, **kwargs)
         if allocation_mode == "join_with_token":
-            return self.allocator_service.join_queue_with_token(self.db, **kwargs)
+            return self.allocator_service.join_queue_with_token(db=self.db, **kwargs)
         raise ValueError(f"Unsupported queue allocation mode: {allocation_mode}")
 
     def enqueue(self, **_: Any) -> QueueSnapshot:

--- a/backend/tests/characterization/test_queue_allocator_characterization.py
+++ b/backend/tests/characterization/test_queue_allocator_characterization.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.models.online_queue import DailyQueue, OnlineQueueEntry, QueueToken
+from app.services.force_majeure_service import ForceMajeureService
+from app.services.queue_service import QueueBusinessService, queue_service
+
+
+def _create_daily_queue_and_token(db_session, test_doctor, token_value: str) -> tuple[DailyQueue, QueueToken]:
+    daily_queue = DailyQueue(
+        day=date.today(),
+        specialist_id=test_doctor.id,
+        queue_tag="cardiology_common",
+        active=True,
+    )
+    db_session.add(daily_queue)
+    db_session.commit()
+    db_session.refresh(daily_queue)
+
+    local_now = datetime.now(ZoneInfo("Asia/Tashkent")).replace(tzinfo=None)
+    token = QueueToken(
+        token=token_value,
+        day=date.today(),
+        specialist_id=test_doctor.id,
+        department="cardiology",
+        expires_at=local_now + timedelta(hours=2),
+        active=True,
+    )
+    db_session.add(token)
+    db_session.commit()
+    db_session.refresh(token)
+    return daily_queue, token
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_online_join_characterization_service_path_assigns_waiting_online_entry(
+    db_session,
+    test_doctor,
+    monkeypatch,
+):
+    monkeypatch.setattr(QueueBusinessService, "ONLINE_QUEUE_START_TIME", time(0, 0))
+    daily_queue, token = _create_daily_queue_and_token(
+        db_session,
+        test_doctor,
+        token_value="characterization-online-join",
+    )
+
+    join_result = queue_service.join_queue_with_token(
+        db_session,
+        token_str=token.token,
+        patient_name="Characterization Patient",
+        phone="+998901111111",
+        source="online",
+    )
+
+    assert join_result["duplicate"] is False
+    assert join_result["entry"].number >= 1
+
+    entry = (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.queue_id == daily_queue.id)
+        .one()
+    )
+    assert entry.number == join_result["entry"].number
+    assert entry.source == "online"
+    assert entry.status == "waiting"
+    assert entry.queue_time is not None
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_qr_session_join_characterization_assigns_waiting_entry(
+    client,
+    db_session,
+    test_doctor,
+    monkeypatch,
+):
+    monkeypatch.setattr(QueueBusinessService, "ONLINE_QUEUE_START_TIME", time(0, 0))
+    daily_queue, token = _create_daily_queue_and_token(
+        db_session,
+        test_doctor,
+        token_value="characterization-qr-session",
+    )
+
+    start_response = client.post("/api/v1/queue/join/start", json={"token": token.token})
+    assert start_response.status_code == 200
+    session_token = start_response.json()["session_token"]
+
+    complete_response = client.post(
+        "/api/v1/queue/join/complete",
+        json={
+            "session_token": session_token,
+            "patient_name": "QR Session Patient",
+            "phone": "+998902222222",
+        },
+    )
+    assert complete_response.status_code == 200
+    payload = complete_response.json()
+    assert payload["success"] is True
+    assert payload["queue_number"] >= 1
+
+    entry = (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.queue_id == daily_queue.id)
+        .one()
+    )
+    assert entry.number == payload["queue_number"]
+    assert entry.source == "online"
+    assert entry.status == "waiting"
+    assert entry.queue_time is not None
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_telegram_join_characterization_reuses_existing_waiting_entry(
+    db_session,
+    test_doctor,
+    monkeypatch,
+):
+    monkeypatch.setattr(QueueBusinessService, "ONLINE_QUEUE_START_TIME", time(0, 0))
+    daily_queue, token = _create_daily_queue_and_token(
+        db_session,
+        test_doctor,
+        token_value="characterization-telegram-join",
+    )
+
+    first = queue_service.join_queue_with_token(
+        db_session,
+        token_str=token.token,
+        patient_name="Telegram Patient",
+        telegram_id=123456789,
+        source="online",
+    )
+    second = queue_service.join_queue_with_token(
+        db_session,
+        token_str=token.token,
+        patient_name="Telegram Patient",
+        telegram_id=123456789,
+        source="online",
+    )
+
+    assert first["duplicate"] is False
+    assert second["duplicate"] is True
+    assert first["entry"].id == second["entry"].id
+    assert first["entry"].number == second["entry"].number
+    assert first["entry"].queue_time == second["entry"].queue_time
+    assert first["entry"].status == "waiting"
+    assert first["entry"].source == "online"
+
+    entries = (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.queue_id == daily_queue.id)
+        .all()
+    )
+    assert len(entries) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_registrar_batch_characterization_preserves_desk_source_and_waiting_status(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    cardio_user,
+    test_service,
+):
+    response = client.post(
+        "/api/v1/registrar-integration/queue/entries/batch",
+        headers=registrar_auth_headers,
+        json={
+            "patient_id": test_patient.id,
+            "source": "desk",
+            "services": [
+                {
+                    "specialist_id": cardio_user.id,
+                    "service_id": test_service.id,
+                    "quantity": 1,
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert len(payload["entries"]) == 1
+    assert payload["entries"][0]["number"] >= 1
+    assert payload["entries"][0]["queue_time"]
+
+    entry = (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.patient_id == test_patient.id)
+        .order_by(OnlineQueueEntry.id.desc())
+        .first()
+    )
+    assert entry is not None
+    assert entry.number == payload["entries"][0]["number"]
+    assert entry.source == "desk"
+    assert entry.status == "waiting"
+    assert entry.queue_time is not None
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_force_majeure_transfer_characterization_preserves_current_allocator_behavior(
+    db_session,
+    test_doctor,
+    test_patient,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "app.services.force_majeure_service.get_fcm_service",
+        lambda: object(),
+    )
+
+    today_queue = DailyQueue(
+        day=date.today(),
+        specialist_id=test_doctor.id,
+        queue_tag="cardiology_common",
+        active=True,
+    )
+    tomorrow_queue = DailyQueue(
+        day=date.today() + timedelta(days=1),
+        specialist_id=test_doctor.id,
+        queue_tag="cardiology_common",
+        active=True,
+    )
+    db_session.add_all([today_queue, tomorrow_queue])
+    db_session.commit()
+    db_session.refresh(today_queue)
+    db_session.refresh(tomorrow_queue)
+
+    source_entry = OnlineQueueEntry(
+        queue_id=today_queue.id,
+        number=1,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        source="online",
+        status="waiting",
+        queue_time=datetime.utcnow(),
+    )
+    existing_waiting = OnlineQueueEntry(
+        queue_id=tomorrow_queue.id,
+        number=4,
+        patient_id=None,
+        patient_name="Existing Waiting",
+        source="desk",
+        status="waiting",
+        queue_time=datetime.utcnow(),
+    )
+    existing_cancelled = OnlineQueueEntry(
+        queue_id=tomorrow_queue.id,
+        number=99,
+        patient_id=None,
+        patient_name="Existing Cancelled",
+        source="desk",
+        status="cancelled",
+        queue_time=datetime.utcnow(),
+    )
+    db_session.add_all([source_entry, existing_waiting, existing_cancelled])
+    db_session.commit()
+    db_session.refresh(source_entry)
+
+    service = ForceMajeureService(db_session)
+    result = service.transfer_entries_to_tomorrow(
+        entries=[source_entry],
+        specialist_id=test_doctor.id,
+        reason="Characterization transfer",
+        performed_by_id=1,
+        send_notifications=False,
+    )
+
+    assert result["success"] is True
+    assert result["transferred"] == 1
+
+    transferred_entry = (
+        db_session.query(OnlineQueueEntry)
+        .filter(
+            OnlineQueueEntry.queue_id == tomorrow_queue.id,
+            OnlineQueueEntry.source == "force_majeure_transfer",
+            OnlineQueueEntry.patient_id == test_patient.id,
+        )
+        .one()
+    )
+    assert transferred_entry.number == 5
+    assert transferred_entry.status == "waiting"
+    assert transferred_entry.priority == ForceMajeureService.TRANSFER_PRIORITY
+    assert transferred_entry.queue_time is not None
+
+    db_session.refresh(source_entry)
+    assert source_entry.status == "cancelled"

--- a/backend/tests/characterization/test_queue_allocator_characterization.py
+++ b/backend/tests/characterization/test_queue_allocator_characterization.py
@@ -167,7 +167,7 @@ def test_registrar_batch_characterization_preserves_desk_source_and_waiting_stat
     db_session,
     registrar_auth_headers,
     test_patient,
-    cardio_user,
+    test_doctor,
     test_service,
 ):
     response = client.post(
@@ -178,7 +178,7 @@ def test_registrar_batch_characterization_preserves_desk_source_and_waiting_stat
             "source": "desk",
             "services": [
                 {
-                    "specialist_id": cardio_user.id,
+                    "specialist_id": test_doctor.id,
                     "service_id": test_service.id,
                     "quantity": 1,
                 }

--- a/backend/tests/characterization/test_queue_allocator_concurrency.py
+++ b/backend/tests/characterization/test_queue_allocator_concurrency.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import threading
+import uuid
+from datetime import date
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.orm import sessionmaker
+
+from app.models.clinic import Doctor
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.user import User
+from app.services.queue_service import queue_service
+
+
+def _make_concurrency_queue(test_db, suffix: str) -> tuple[int, str, int, int]:
+    SessionLocal = sessionmaker(bind=test_db, autocommit=False, autoflush=False)
+    session = SessionLocal()
+    try:
+        user = User(
+            username=f"concurrency_user_{suffix}",
+            email=f"concurrency_{suffix}@test.local",
+            full_name=f"Concurrency {suffix}",
+            hashed_password="hashed",
+            role="Doctor",
+            is_active=True,
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        doctor = Doctor(
+            user_id=user.id,
+            specialty="cardiology",
+            active=True,
+        )
+        session.add(doctor)
+        session.commit()
+        session.refresh(doctor)
+
+        queue = DailyQueue(
+            day=date.today(),
+            specialist_id=doctor.id,
+            queue_tag=f"cardiology_{suffix}",
+            active=True,
+        )
+        session.add(queue)
+        session.commit()
+        session.refresh(queue)
+
+        first_entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=1,
+            patient_name="Baseline",
+            source="online",
+            status="waiting",
+        )
+        session.add(first_entry)
+        session.commit()
+        return queue.id, queue.queue_tag, doctor.id, user.id
+    finally:
+        session.close()
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_parallel_allocator_read_paths_observe_same_next_number_candidate(test_db):
+    queue_id, queue_tag, doctor_id, user_id = _make_concurrency_queue(
+        test_db,
+        suffix=uuid.uuid4().hex[:8],
+    )
+    SessionLocal = sessionmaker(bind=test_db, autocommit=False, autoflush=False)
+    barrier = threading.Barrier(2)
+    results: list[int] = []
+    lock = threading.Lock()
+
+    def service_worker() -> None:
+        session = SessionLocal()
+        try:
+            queue = session.query(DailyQueue).filter(DailyQueue.id == queue_id).one()
+            barrier.wait()
+            number = queue_service.get_next_queue_number(
+                session,
+                daily_queue=queue,
+                queue_tag=queue_tag,
+            )
+            with lock:
+                results.append(number)
+        finally:
+            session.close()
+
+    def sql_worker() -> None:
+        session = SessionLocal()
+        try:
+            barrier.wait()
+            number = session.execute(
+                text(
+                    "SELECT COALESCE(MAX(number), 0) + 1 FROM queue_entries WHERE queue_id = :qid"
+                ),
+                {"qid": queue_id},
+            ).scalar_one()
+            with lock:
+                results.append(number)
+        finally:
+            session.close()
+
+    try:
+        threads = [
+            threading.Thread(target=service_worker),
+            threading.Thread(target=sql_worker),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert sorted(results) == [2, 2]
+    finally:
+        cleanup = SessionLocal()
+        try:
+            cleanup.query(OnlineQueueEntry).filter(OnlineQueueEntry.queue_id == queue_id).delete()
+            cleanup.query(DailyQueue).filter(DailyQueue.id == queue_id).delete()
+            cleanup.query(Doctor).filter(Doctor.id == doctor_id).delete()
+            cleanup.query(User).filter(User.id == user_id).delete()
+            cleanup.commit()
+        finally:
+            cleanup.close()
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_parallel_duplicate_join_read_phase_can_observe_no_existing_entry(test_db):
+    queue_id, _queue_tag, doctor_id, user_id = _make_concurrency_queue(
+        test_db,
+        suffix=uuid.uuid4().hex[:8],
+    )
+    SessionLocal = sessionmaker(bind=test_db, autocommit=False, autoflush=False)
+    barrier = threading.Barrier(2)
+    results: list[bool] = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        session = SessionLocal()
+        try:
+            queue = session.query(DailyQueue).filter(DailyQueue.id == queue_id).one()
+            barrier.wait()
+            existing_entry, _reason = queue_service.check_uniqueness(
+                session,
+                queue,
+                phone="+998903333333",
+                source="online",
+            )
+            with lock:
+                results.append(existing_entry is None)
+        finally:
+            session.close()
+
+    try:
+        threads = [threading.Thread(target=worker), threading.Thread(target=worker)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert results == [True, True]
+    finally:
+        cleanup = SessionLocal()
+        try:
+            cleanup.query(OnlineQueueEntry).filter(OnlineQueueEntry.queue_id == queue_id).delete()
+            cleanup.query(DailyQueue).filter(DailyQueue.id == queue_id).delete()
+            cleanup.query(Doctor).filter(Doctor.id == doctor_id).delete()
+            cleanup.query(User).filter(User.id == user_id).delete()
+            cleanup.commit()
+        finally:
+            cleanup.close()

--- a/backend/tests/unit/test_queue_allocator_boundary.py
+++ b/backend/tests/unit/test_queue_allocator_boundary.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from app.services.queue_domain_service import QueueDomainService
+
+
+@pytest.mark.unit
+def test_allocate_ticket_create_entry_delegates_to_legacy_allocator() -> None:
+    allocator = Mock()
+    expected_entry = SimpleNamespace(
+        id=10,
+        queue_id=20,
+        number=3,
+        status="waiting",
+        source="desk",
+        queue_time=datetime(2026, 3, 7, 9, 0, 0),
+    )
+    allocator.create_queue_entry.return_value = expected_entry
+
+    service = QueueDomainService(
+        db="db-session",
+        read_repository=Mock(),
+        allocator_service=allocator,
+    )
+
+    result = service.allocate_ticket(
+        allocation_mode="create_entry",
+        daily_queue=SimpleNamespace(id=20),
+        patient_id=1,
+        patient_name="Test Patient",
+        source="desk",
+        queue_time=expected_entry.queue_time,
+        commit=False,
+    )
+
+    assert result is expected_entry
+    allocator.create_queue_entry.assert_called_once()
+    assert allocator.create_queue_entry.call_args.args[0] == "db-session"
+    assert allocator.create_queue_entry.call_args.kwargs["patient_id"] == 1
+    assert allocator.create_queue_entry.call_args.kwargs["source"] == "desk"
+    assert allocator.create_queue_entry.call_args.kwargs["commit"] is False
+
+
+@pytest.mark.unit
+def test_allocate_ticket_join_with_token_preserves_legacy_duplicate_result() -> None:
+    allocator = Mock()
+    expected = {
+        "entry": SimpleNamespace(id=11, number=7, status="waiting", source="online"),
+        "duplicate": True,
+        "duplicate_reason": "телефону +998900000000",
+        "queue_length_before": 1,
+        "estimated_wait_minutes": 15,
+    }
+    allocator.join_queue_with_token.return_value = expected
+
+    service = QueueDomainService(
+        db="db-session",
+        read_repository=Mock(),
+        allocator_service=allocator,
+    )
+
+    result = service.allocate_ticket(
+        allocation_mode="join_with_token",
+        token_str="qr-token",
+        patient_name="Test Patient",
+        phone="+998900000000",
+        source="online",
+    )
+
+    assert result == expected
+    allocator.join_queue_with_token.assert_called_once()
+    assert allocator.join_queue_with_token.call_args.args[0] == "db-session"
+    assert allocator.join_queue_with_token.call_args.kwargs["token_str"] == "qr-token"
+    assert allocator.join_queue_with_token.call_args.kwargs["source"] == "online"
+
+
+@pytest.mark.unit
+def test_allocate_ticket_raises_for_unsupported_mode() -> None:
+    service = QueueDomainService(
+        db="db-session",
+        read_repository=Mock(),
+        allocator_service=Mock(),
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        service.allocate_ticket(allocation_mode="unsupported")
+
+    assert "Unsupported allocation_mode" in str(exc_info.value)

--- a/backend/tests/unit/test_queue_allocator_boundary.py
+++ b/backend/tests/unit/test_queue_allocator_boundary.py
@@ -90,4 +90,4 @@ def test_allocate_ticket_raises_for_unsupported_mode() -> None:
     with pytest.raises(ValueError) as exc_info:
         service.allocate_ticket(allocation_mode="unsupported")
 
-    assert "Unsupported allocation_mode" in str(exc_info.value)
+    assert "Unsupported queue allocation mode" in str(exc_info.value)

--- a/backend/tests/unit/test_queue_allocator_boundary.py
+++ b/backend/tests/unit/test_queue_allocator_boundary.py
@@ -40,7 +40,7 @@ def test_allocate_ticket_create_entry_delegates_to_legacy_allocator() -> None:
 
     assert result is expected_entry
     allocator.create_queue_entry.assert_called_once()
-    assert allocator.create_queue_entry.call_args.args[0] == "db-session"
+    assert allocator.create_queue_entry.call_args.kwargs["db"] == "db-session"
     assert allocator.create_queue_entry.call_args.kwargs["patient_id"] == 1
     assert allocator.create_queue_entry.call_args.kwargs["source"] == "desk"
     assert allocator.create_queue_entry.call_args.kwargs["commit"] is False
@@ -74,7 +74,7 @@ def test_allocate_ticket_join_with_token_preserves_legacy_duplicate_result() -> 
 
     assert result == expected
     allocator.join_queue_with_token.assert_called_once()
-    assert allocator.join_queue_with_token.call_args.args[0] == "db-session"
+    assert allocator.join_queue_with_token.call_args.kwargs["db"] == "db-session"
     assert allocator.join_queue_with_token.call_args.kwargs["token_str"] == "qr-token"
     assert allocator.join_queue_with_token.call_args.kwargs["source"] == "online"
 

--- a/docs/architecture/W2C_ALLOCATOR_CALL_SITES.md
+++ b/docs/architecture/W2C_ALLOCATOR_CALL_SITES.md
@@ -1,0 +1,64 @@
+# Wave 2C Allocator Call Sites
+
+Date: 2026-03-07
+Mode: analysis-first, docs-only
+Scope: current runtime and legacy allocator call sites
+
+## Purpose
+
+This document records every allocator-adjacent call site that matters for Wave
+2C allocator migration.
+
+It is the baseline for introducing a compatibility boundary without changing the
+current numbering algorithm or duplicate policy.
+
+## Call Site Map
+
+| File | Function / handler | Allocator logic used | Risk level | Migration priority |
+|---|---|---|---|---|
+| `backend/app/services/queue_service.py` | `create_queue_entry()` | Calls `get_next_queue_number()` when `number is None` or `auto_number=True` | Medium | P1 |
+| `backend/app/services/queue_service.py` | `join_queue_with_token()` | Uses duplicate check + `create_queue_entry(auto_number=True)` | Medium | P1 |
+| `backend/app/services/queue_service.py` | `get_next_queue_number()` | SSOT-style `max(number) + 1` allocator | Medium | P1 |
+| `backend/app/services/morning_assignment.py` | `_assign_single_queue()` | Delegates to `queue_service.create_queue_entry(auto_number=True)` | Medium | P2 |
+| `backend/app/api/v1/endpoints/registrar_integration.py` | `create_queue_entries_batch()` | Duplicate check in router, then `queue_service.create_queue_entry(auto_number=True)` | High | P2 |
+| `backend/app/services/queue_batch_service.py` | `create_entries()` | Delegates to `queue_service.create_queue_entry()` | Medium | P2 |
+| `backend/app/services/visit_confirmation_service.py` | confirmation queue creation | Calls `get_next_queue_number()` first, then `create_queue_entry(number=...)` | High | P2 |
+| `backend/app/api/v1/endpoints/registrar_wizard.py` | queue creation branches | Calls `get_next_queue_number()` and then `create_queue_entry()` or direct model creation | High | P3 |
+| `backend/app/services/registrar_wizard_api_service.py` | queue creation branches | Calls `get_next_queue_number()` and then `create_queue_entry()` or direct model creation | High | P3 |
+| `backend/app/crud/online_queue.py` | online join helpers | Calls `get_next_queue_number()` then creates `OnlineQueueEntry(number=...)` directly | High | P3 |
+| `backend/app/api/v1/endpoints/queue.py` | deprecated `/queue/join` | Calls `queue_service.join_queue_with_token()` | Medium | P2 |
+| `backend/app/api/v1/endpoints/online_queue_new.py` | online join | Calls `queue_service.join_queue_with_token()` | Medium | P2 |
+| `backend/app/services/qr_queue_service.py` | `complete_join_session*()` | Calls `queue_service.join_queue_with_token()` | Medium | P2 |
+| `backend/app/api/v1/endpoints/qr_queue.py` | `full_update_online_entry()` branches | Direct SQL `SELECT COALESCE(MAX(number), 0) + 1` in some branches; `get_next_queue_number()` in another | Very High | P4 |
+| `backend/app/services/qr_queue_api_service.py` | service-layer mirror of `full_update_online_entry()` | Same mixed direct-SQL and service allocator split | Very High | P4 |
+| `backend/app/services/force_majeure_service.py` | `_get_next_queue_number()` and `transfer_entries_to_tomorrow()` | Separate transfer allocator ignoring `cancelled` rows | High | P4 |
+| `backend/app/services/online_queue.py` | `issue_next_ticket()` | Legacy `OnlineDay` / `last_ticket` counter | Very High | P5 |
+| `backend/app/api/v1/endpoints/online_queue.py` | legacy queue endpoints | Delegates to `issue_next_ticket()` | Very High | P5 |
+| `backend/app/services/online_queue_api_service.py` | legacy service-layer endpoints | Delegates to `issue_next_ticket()` | Very High | P5 |
+| `backend/app/crud/queue.py` | `next_ticket_and_insert_entry()` | Stale legacy ticket counter path | Very High | P5 |
+
+## Migration Priority Legend
+
+- `P1`: canonical allocator owner path
+- `P2`: compatibility-boundary candidates that already rely on SSOT queue models
+- `P3`: split-flow callers that still separate number allocation from row creation
+- `P4`: high-risk mixed or exceptional allocators
+- `P5`: legacy-only allocators outside first migration pass
+
+## Immediate Phase 2 Outcome
+
+Wave 2C Phase 2 introduces a public boundary in `QueueDomainService`, but this
+document intentionally keeps most production callers unchanged.
+
+That means:
+
+- call sites are now mapped
+- behavior is characterized with tests
+- only the compatibility boundary is added
+- direct SQL and legacy allocators remain in place for now
+
+## Explicit Non-Finding
+
+`doctor_integration.py` was checked during this pass. No direct allocator call
+site was found there in the current runtime. Its queue complexity is currently
+about lifecycle/status orchestration rather than ticket assignment.

--- a/docs/architecture/W2C_ALLOCATOR_COMPATIBILITY_LAYER.md
+++ b/docs/architecture/W2C_ALLOCATOR_COMPATIBILITY_LAYER.md
@@ -1,0 +1,80 @@
+# Wave 2C Allocator Compatibility Layer
+
+Date: 2026-03-07
+Mode: behavior-preserving execution
+
+## Purpose
+
+This document explains the compatibility boundary introduced in Wave 2C Phase 2.
+
+The new public boundary is:
+
+- `QueueDomainService.allocate_ticket()`
+
+This is a facade only. It does not introduce a new numbering algorithm.
+
+## Delegation Rules
+
+`QueueDomainService.allocate_ticket()` currently supports two delegation modes:
+
+### `allocation_mode="create_entry"`
+
+Delegates to:
+
+- `queue_service.create_queue_entry(self.db, **kwargs)`
+
+Use this for current SSOT-style callers that already create queue rows through
+the queue service.
+
+### `allocation_mode="join_with_token"`
+
+Delegates to:
+
+- `queue_service.join_queue_with_token(self.db, **kwargs)`
+
+Use this for current online/QR join flows that already rely on token validation,
+duplicate checks, and queue-time-window checks inside `queue_service`.
+
+## What The Compatibility Layer Does Not Cover Yet
+
+The boundary does **not** yet absorb:
+
+- direct SQL allocators in `qr_queue.py`
+- mixed allocator logic in `qr_queue_api_service.py`
+- transfer allocator in `force_majeure_service.py`
+- legacy `OnlineDay` / `issue_next_ticket()` paths
+- stale `crud/queue.py` ticket path
+
+Those paths remain external migration targets.
+
+## Where The Boundary Is Used Today
+
+At the end of Phase 2, the boundary is used in:
+
+- characterization tests
+- boundary unit tests
+
+It is **not yet wired into production call sites**.
+
+This is intentional. The goal of Phase 2 is to establish the public boundary
+without changing runtime behavior.
+
+## Why This Shape Is Safe
+
+The boundary is safe because:
+
+- it reuses the existing `queue_service` implementation
+- it does not change numbering logic
+- it does not change duplicate-policy enforcement
+- it does not change `queue_time` semantics
+- it does not move direct SQL allocators yet
+
+## Migration Use
+
+This layer is the first execution seam for later phases.
+
+Future migration should replace production callers gradually:
+
+1. caller keeps current behavior
+2. caller switches from direct `queue_service` use to `QueueDomainService.allocate_ticket()`
+3. only later does the internal allocator implementation change

--- a/docs/architecture/W2C_ALLOCATOR_MIGRATION_STRATEGY.md
+++ b/docs/architecture/W2C_ALLOCATOR_MIGRATION_STRATEGY.md
@@ -1,7 +1,7 @@
 # Wave 2C Allocator Migration Strategy
 
 Date: 2026-03-07
-Mode: analysis-first, docs-only
+Mode: behavior-preserving execution
 
 ## Purpose
 
@@ -37,18 +37,19 @@ Migration must follow this order:
 
 ## Recommended Migration Phases
 
-### Phase A: Contract + characterization
+### Phase 1: Contract + characterization
 
-- done in Phase 1.5 and 1.6 docs
-- add characterization tests before code movement
+- completed in Phase 1.5 and 1.6 docs
+- characterization tests added before behavior changes
 
-### Phase B: Introduce domain owner without changing callers
+### Phase 2: Introduce compatibility boundary
 
-- `QueueDomainService.allocate_ticket()` exists as compatibility boundary
-- current `queue_service` becomes an internal collaborator
-- no router path changes yet
+- `QueueDomainService.allocate_ticket()` exists as the public boundary
+- current `queue_service` remains the internal implementation
+- no production caller migration yet
+- direct SQL and legacy allocators remain untouched
 
-### Phase C: Migrate low-complexity writers
+### Phase 3: Gradually migrate callers
 
 Preferred early caller families:
 
@@ -56,21 +57,21 @@ Preferred early caller families:
 - registrar batch path
 - confirmation path that already relies on SSOT queue models
 
-### Phase D: Migrate complex mutation families
-
 Later only:
 
 - QR full-update / add-service path
 - force-majeure transfer path
 - doctor/registrar queue lifecycle flows if allocator coupling appears
 
-### Phase E: Legacy isolation or retirement
+### Phase 4: Remove legacy allocators
 
+- direct SQL allocator branches in `qr_queue.py`
+- legacy registrar count-based allocator
 - `OnlineDay`
 - `appointments.py` legacy counters
 - stale `crud/queue.py`
 
-This phase should not be mixed into the first allocator migration.
+This phase should not be mixed into the first compatibility-boundary rollout.
 
 ## Migration Guardrails
 

--- a/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
+++ b/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
@@ -1,7 +1,7 @@
 # Wave 2C Queue Domain Service Proposal
 
-Date: 2026-03-06
-Mode: analysis-first
+Date: 2026-03-07
+Mode: analysis-first, updated with Phase 2 compatibility boundary
 
 ## Goal
 
@@ -257,6 +257,9 @@ Currently implemented:
 - `get_queue_snapshot_by_specialist_day(specialist_id=..., day=...)`
 - `list_queue_cabinet_info(day=..., specialist_id=..., cabinet_number=...)`
 - `get_queue_cabinet_info(queue_id=...)`
+- `get_queue_limits_status(day=..., specialty=...)`
+- `get_queue_groups_payload()`
+- `get_service_code_mappings_payload()`
 
 Skeleton-only methods that intentionally still raise `NotImplementedError`:
 
@@ -272,3 +275,30 @@ This is intentional for Phase 1:
 - read-only queue slices can adopt the service now
 - mutation flows stay in legacy paths until the state machine and transaction rules
   are migrated explicitly
+
+## Phase 2 Compatibility Boundary Status
+
+Implemented in Wave 2C Phase 2:
+
+- `allocate_ticket(allocation_mode="create_entry", **kwargs)`
+- `allocate_ticket(allocation_mode="join_with_token", **kwargs)`
+
+Current behavior:
+
+- the method is a facade only
+- it delegates to the existing `queue_service`
+- it does not change numbering logic
+- it does not change duplicate-policy enforcement
+- it does not change `queue_time` semantics
+
+Current limitation:
+
+- production callers are not yet repointed to this boundary
+- direct SQL allocators and legacy `OnlineDay` flows remain outside it
+- migration risk is reduced by characterization tests, not by runtime unification yet
+
+Notes for the narrowed `W2C-MS-004` slice:
+
+- only queue metadata reads moved under `QueueDomainService`
+- static taxonomy definitions still live in `app/services/service_mapping.py`
+- no queue numbering, duplicate, lifecycle, or QR-window behavior changed


### PR DESCRIPTION
﻿## Summary

Replacement for stale PR #69 after parent allocation-contract PR #68 was superseded by merged replacement PR #256.

Preserves the useful Wave 2C Phase 2 allocator compatibility boundary on current main without carrying stale parent commits.

## Contract Impact

- Endpoint: no public endpoint changes.
- Request shape: unchanged for public HTTP routes.
- Response shape: unchanged for public HTTP routes.
- Status codes: unchanged.
- Frontend consumer: unchanged.
- Canonical surface: `QueueDomainService.allocate_ticket(allocation_mode="create_entry" | "join_with_token", **kwargs)`.
- Compatibility path or alias: `create_entry` delegates to `queue_service.create_queue_entry()`; `join_with_token` delegates to `queue_service.join_queue_with_token()`; no public route alias is added.
- Contract proof: `backend/tests/unit/test_queue_allocator_boundary.py`, allocator characterization tests, local compile proof, PR body gate, and fresh GitHub CI.

## RBAC / Permissions

- Roles allowed: unchanged; no public endpoint role surface is added or changed.
- Roles denied: unchanged; no public endpoint role surface is added or changed.
- Positive auth proof: not applicable because no public endpoint permission is changed; existing endpoint tests/CI remain the proof for caller paths.
- Negative auth proof: not applicable because this replacement adds an internal service facade and characterization tests, not a new route or role surface.
- Legacy role normalization: not touched.

## Notification / Realtime

- Event type or websocket channel: not applicable because this replacement does not emit notifications or websocket events.
- Payload version / ack behavior: not applicable because no realtime payload contract changes.
- Read/unread or delivery semantics: not applicable because no inbox/read/delivery path changes.
- Reconnect/resync proof: not applicable because no websocket lifecycle path changes.

## Frontend Resilience

- Empty data proof: not applicable because no frontend loader or UI state is changed.
- Partial data proof: not applicable because no frontend payload consumer is changed.
- Forbidden secondary path behavior: not applicable because no frontend or auth secondary path is changed.
- Missing draft/resource behavior: not applicable because no draft/resource UI path is changed.
- Stale route/deep-link behavior: not applicable because no route/deep-link behavior is changed.

## Scope Gate

- Allowed paths: `backend/app/services/queue_domain_service.py`; allocator characterization/unit tests; W2C allocator docs listed in this PR.
- Denied paths: public endpoint behavior migrations; RBAC/frontend/notification/realtime changes; migrations/schema changes; queue fairness rewrites; allocator semantic rewrites; stale parent commits from old PR #69.
- Migration/docs/test impact: one internal queue-domain facade extension, three test files, and four allocator docs/status files.
- Rollback note: revert this replacement PR; no migration or external contract rollback is required.

Allowed path set:
- `backend/app/services/queue_domain_service.py`
- `backend/tests/characterization/test_queue_allocator_characterization.py`
- `backend/tests/characterization/test_queue_allocator_concurrency.py`
- `backend/tests/unit/test_queue_allocator_boundary.py`
- `docs/architecture/W2C_ALLOCATOR_CALL_SITES.md`
- `docs/architecture/W2C_ALLOCATOR_COMPATIBILITY_LAYER.md`
- `docs/architecture/W2C_ALLOCATOR_MIGRATION_STRATEGY.md`
- `docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md`

Compatibility review:
- Direct merge of #69 is unsafe because its old base was superseded by #256.
- Current main already has a narrower `allocate_ticket(create_entry)` facade; this replacement only extends it to the #69 compatibility boundary while preserving current main queue metadata methods.

## Validation

- Targeted tests or smoke run: exact allowlist check; `git diff --check HEAD`; targeted Python compile for touched runtime/tests; PR body gate.
- Result: local allowlist/diff/compile checks passed; PR body gate passes with this body; fresh GitHub CI required before merge decision.
- Not checked: local pytest was not run because the fresh temp clone is used for surgical replacement and CI is the authoritative full test runner.
