### PR TITLE
refactor(queue): route safe callers through allocation boundary replacement

### DIFF
--- a/backend/app/api/v1/endpoints/online_queue_new.py
+++ b/backend/app/api/v1/endpoints/online_queue_new.py
@@ -21,6 +21,7 @@ from app.schemas.online_queue import (
     QueueOpenResponse,
     QueueStatusCheck,
 )
+from app.services.queue_domain_service import QueueDomainService
 from app.services.queue_service import (
     queue_service,
     QueueConflictError,
@@ -33,6 +34,10 @@ from app.services.online_queue_new_service import (
 )
 
 router = APIRouter()
+
+
+def _queue_domain_service(db: Session) -> QueueDomainService:
+    return QueueDomainService(db)
 
 # ===================== ГЕНЕРАЦИЯ QR ТОКЕНОВ =====================
 
@@ -91,10 +96,10 @@ def join_queue(request: QueueJoinRequest, db: Session = Depends(get_db)):
     Вступление в онлайн-очередь
     Из detail.md стр. 235: POST /api/online-queue/join { token, phone?, telegram_id? } → номер
     """
-    svc = queue_service
+    svc = _queue_domain_service(db)
     try:
-        join_result = svc.join_queue_with_token(
-            db,
+        join_result = svc.allocate_ticket(
+            allocation_mode="join_with_token",
             token_str=request.token,
             patient_name=request.patient_name,
             phone=request.phone,

--- a/backend/app/services/qr_queue_service.py
+++ b/backend/app/services/qr_queue_service.py
@@ -28,6 +28,7 @@ from app.models.online_queue import (
 )
 from app.models.patient import Patient
 from app.models.user import User
+from app.services.queue_domain_service import QueueDomainService
 from app.services.queue_service import (
     QueueConflictError,
     QueueNotFoundError,
@@ -44,8 +45,13 @@ logger = logging.getLogger(__name__)
 class QRQueueService:
     """Сервис для управления QR очередями"""
 
-    def __init__(self, db: Session):
+    def __init__(
+        self,
+        db: Session,
+        queue_domain_service: QueueDomainService | None = None,
+    ):
         self.db = db
+        self.queue_domain_service = queue_domain_service or QueueDomainService(db)
 
     def _find_or_create_patient(
         self,
@@ -748,8 +754,8 @@ class QRQueueService:
             )
 
         try:
-            join_result = queue_service.join_queue_with_token(
-                self.db,
+            join_result = self.queue_domain_service.allocate_ticket(
+                allocation_mode="join_with_token",
                 token_str=qr_token.token,
                 patient_name=patient_name,
                 phone=phone,
@@ -864,8 +870,8 @@ class QRQueueService:
 
         for specialist_id in specialist_ids:
             try:
-                join_result = queue_service.join_queue_with_token(
-                    self.db,
+                join_result = self.queue_domain_service.allocate_ticket(
+                    allocation_mode="join_with_token",
                     token_str=qr_token.token,
                     patient_name=patient_name,
                     phone=phone,

--- a/backend/tests/integration/test_online_queue_new_join.py
+++ b/backend/tests/integration/test_online_queue_new_join.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.models.online_queue import DailyQueue, OnlineQueueEntry, QueueToken
+from app.services.queue_service import QueueBusinessService
+
+
+def _make_daily_queue_and_token(db_session, test_doctor, token_value: str):
+    daily_queue = DailyQueue(
+        day=date.today(),
+        specialist_id=test_doctor.id,
+        queue_tag="cardiology_common",
+        active=True,
+    )
+    db_session.add(daily_queue)
+    db_session.commit()
+    db_session.refresh(daily_queue)
+
+    local_now = datetime.now(ZoneInfo("Asia/Tashkent")).replace(tzinfo=None)
+    token = QueueToken(
+        token=token_value,
+        day=date.today(),
+        specialist_id=test_doctor.id,
+        department="cardiology",
+        expires_at=local_now + timedelta(hours=2),
+        active=True,
+    )
+    db_session.add(token)
+    db_session.commit()
+    db_session.refresh(token)
+    return daily_queue, token
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_online_queue_new_join_success_preserves_behavior(
+    client,
+    db_session,
+    test_doctor,
+    monkeypatch,
+):
+    monkeypatch.setattr(QueueBusinessService, "ONLINE_QUEUE_START_TIME", time(0, 0))
+    daily_queue, token = _make_daily_queue_and_token(
+        db_session,
+        test_doctor,
+        token_value="online-queue-new-success",
+    )
+
+    response = client.post(
+        "/api/v1/online-queue/join",
+        json={
+            "token": token.token,
+            "patient_name": "Online Queue Patient",
+            "phone": "+998906060606",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["duplicate"] is False
+    assert payload["number"] >= 1
+
+    entry = (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.queue_id == daily_queue.id)
+        .one()
+    )
+    assert entry.number == payload["number"]
+    assert entry.source == "online"
+    assert entry.status == "waiting"
+    assert entry.queue_time is not None
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_online_queue_new_join_duplicate_reuses_existing_entry(
+    client,
+    db_session,
+    test_doctor,
+    monkeypatch,
+):
+    monkeypatch.setattr(QueueBusinessService, "ONLINE_QUEUE_START_TIME", time(0, 0))
+    daily_queue, token = _make_daily_queue_and_token(
+        db_session,
+        test_doctor,
+        token_value="online-queue-new-duplicate",
+    )
+
+    first = client.post(
+        "/api/v1/online-queue/join",
+        json={
+            "token": token.token,
+            "patient_name": "Duplicate Patient",
+            "phone": "+998907070707",
+        },
+    )
+    second = client.post(
+        "/api/v1/online-queue/join",
+        json={
+            "token": token.token,
+            "patient_name": "Duplicate Patient",
+            "phone": "+998907070707",
+        },
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    first_payload = first.json()
+    second_payload = second.json()
+    assert first_payload["success"] is True
+    assert second_payload["success"] is True
+    assert first_payload["number"] == second_payload["number"]
+    assert second_payload["duplicate"] is True
+
+    entries = (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.queue_id == daily_queue.id)
+        .all()
+    )
+    assert len(entries) == 1

--- a/backend/tests/unit/test_online_queue_new_allocator_boundary.py
+++ b/backend/tests/unit/test_online_queue_new_allocator_boundary.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import app.api.v1.endpoints.online_queue_new as online_queue_new_module
+import pytest
+
+from app.services.queue_service import QueueValidationError
+
+
+@pytest.mark.unit
+def test_online_queue_join_uses_queue_domain_service_boundary(client, monkeypatch):
+    domain_service = Mock()
+    domain_service.allocate_ticket.return_value = {
+        "entry": SimpleNamespace(number=7),
+        "duplicate": False,
+        "specialist_name": "Test Specialist",
+        "cabinet": "12A",
+    }
+    monkeypatch.setattr(
+        online_queue_new_module,
+        "_queue_domain_service",
+        lambda db: domain_service,
+    )
+
+    response = client.post(
+        "/api/v1/online-queue/join",
+        json={
+            "token": "boundary-token",
+            "patient_name": "Boundary Patient",
+            "phone": "+998901010101",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["number"] == 7
+    assert payload["duplicate"] is False
+    domain_service.allocate_ticket.assert_called_once_with(
+        allocation_mode="join_with_token",
+        token_str="boundary-token",
+        patient_name="Boundary Patient",
+        phone="+998901010101",
+        telegram_id=None,
+        source="online",
+    )
+
+
+@pytest.mark.unit
+def test_online_queue_join_duplicate_response_is_preserved(client, monkeypatch):
+    domain_service = Mock()
+    domain_service.allocate_ticket.return_value = {
+        "entry": SimpleNamespace(number=5),
+        "duplicate": True,
+        "duplicate_reason": "телефону +998902020202",
+        "specialist_name": "Test Specialist",
+        "cabinet": "12A",
+    }
+    monkeypatch.setattr(
+        online_queue_new_module,
+        "_queue_domain_service",
+        lambda db: domain_service,
+    )
+
+    response = client.post(
+        "/api/v1/online-queue/join",
+        json={
+            "token": "duplicate-token",
+            "patient_name": "Duplicate Patient",
+            "phone": "+998902020202",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["number"] == 5
+    assert payload["duplicate"] is True
+    assert "телефону +998902020202" in payload["message"]
+
+
+@pytest.mark.unit
+def test_online_queue_join_validation_error_mapping_is_preserved(client, monkeypatch):
+    domain_service = Mock()
+    domain_service.allocate_ticket.side_effect = QueueValidationError("bad token")
+    monkeypatch.setattr(
+        online_queue_new_module,
+        "_queue_domain_service",
+        lambda db: domain_service,
+    )
+
+    response = client.post(
+        "/api/v1/online-queue/join",
+        json={
+            "token": "bad-token",
+            "patient_name": "Invalid Patient",
+            "phone": "+998903030303",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is False
+    assert payload["error_code"] == "VALIDATION_ERROR"
+    assert payload["message"] == "bad token"

--- a/backend/tests/unit/test_qr_queue_service_allocator_boundary.py
+++ b/backend/tests/unit/test_qr_queue_service_allocator_boundary.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from app.services.qr_queue_service import QRQueueService
+
+
+class _QueryStub:
+    def __init__(self, result):
+        self._result = result
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._result
+
+
+class _DbStub:
+    def __init__(self, results):
+        self._results = list(results)
+        self.commit = Mock()
+
+    def query(self, model):
+        return _QueryStub(self._results.pop(0))
+
+
+@pytest.mark.unit
+def test_complete_join_session_uses_queue_domain_boundary(monkeypatch):
+    session = SimpleNamespace(
+        qr_token="qr-token",
+        status="pending",
+        expires_at=datetime.utcnow() + timedelta(hours=1),
+        patient_name=None,
+        phone=None,
+        telegram_id=None,
+        queue_entry_id=None,
+        queue_number=None,
+        joined_at=None,
+    )
+    qr_token = SimpleNamespace(
+        token="qr-token",
+        specialist_id=11,
+        department="cardiology",
+    )
+    db = _DbStub([session, qr_token])
+    domain_service = Mock()
+    domain_service.allocate_ticket.return_value = {
+        "entry": SimpleNamespace(id=88, number=5),
+        "duplicate": True,
+        "queue_length_before": 2,
+        "estimated_wait_minutes": 15,
+        "specialist_name": "Dr. Boundary",
+    }
+
+    service = QRQueueService(db, queue_domain_service=domain_service)
+    monkeypatch.setattr(
+        service,
+        "_find_or_create_patient",
+        lambda patient_name, phone: SimpleNamespace(id=123),
+    )
+
+    result = service.complete_join_session(
+        session_token="session-token",
+        patient_name="Boundary Patient",
+        phone="+998904040404",
+        telegram_id=77,
+    )
+
+    assert result["success"] is True
+    assert result["queue_number"] == 5
+    assert result["queue_length"] == 2
+    assert session.status == "joined"
+    assert session.queue_entry_id == 88
+    assert session.queue_number == 5
+    db.commit.assert_called_once()
+    domain_service.allocate_ticket.assert_called_once_with(
+        allocation_mode="join_with_token",
+        token_str="qr-token",
+        patient_name="Boundary Patient",
+        phone="+998904040404",
+        telegram_id=77,
+        patient_id=123,
+        source="online",
+    )
+
+
+@pytest.mark.unit
+def test_complete_join_session_multiple_uses_queue_domain_boundary(monkeypatch):
+    session = SimpleNamespace(
+        qr_token="qr-token",
+        status="pending",
+        expires_at=datetime.utcnow() + timedelta(hours=1),
+        patient_name=None,
+        phone=None,
+        telegram_id=None,
+        queue_entry_id=None,
+        queue_number=None,
+        joined_at=None,
+    )
+    qr_token = SimpleNamespace(
+        token="qr-token",
+        department="cardiology",
+    )
+    db = _DbStub([session, qr_token])
+    domain_service = Mock()
+    domain_service.allocate_ticket.side_effect = [
+        {
+            "entry": SimpleNamespace(id=101, number=4),
+            "duplicate": True,
+            "queue_length_before": 1,
+            "estimated_wait_minutes": 10,
+            "specialist_name": "Dr. First",
+        },
+        {
+            "entry": SimpleNamespace(id=102, number=9),
+            "duplicate": True,
+            "queue_length_before": 3,
+            "estimated_wait_minutes": 25,
+            "specialist_name": "Dr. Second",
+        },
+    ]
+
+    service = QRQueueService(db, queue_domain_service=domain_service)
+    monkeypatch.setattr(
+        service,
+        "_find_or_create_patient",
+        lambda patient_name, phone: SimpleNamespace(id=456),
+    )
+
+    result = service.complete_join_session_multiple(
+        session_token="session-token",
+        specialist_ids=[11, 22],
+        patient_name="Boundary Patient",
+        phone="+998905050505",
+        telegram_id=99,
+    )
+
+    assert result["success"] is True
+    assert len(result["entries"]) == 2
+    assert result["entries"][0]["queue_number"] == 4
+    assert result["entries"][1]["queue_number"] == 9
+    assert session.status == "joined"
+    assert session.queue_entry_id == 101
+    assert session.queue_number == 4
+    db.commit.assert_called_once()
+    assert domain_service.allocate_ticket.call_count == 2
+    first_call = domain_service.allocate_ticket.call_args_list[0]
+    second_call = domain_service.allocate_ticket.call_args_list[1]
+    assert first_call.kwargs["allocation_mode"] == "join_with_token"
+    assert first_call.kwargs["specialist_id_override"] == 11
+    assert second_call.kwargs["specialist_id_override"] == 22

--- a/docs/architecture/W2C_ALLOCATOR_COMPATIBILITY_LAYER.md
+++ b/docs/architecture/W2C_ALLOCATOR_COMPATIBILITY_LAYER.md
@@ -49,15 +49,22 @@ Those paths remain external migration targets.
 
 ## Where The Boundary Is Used Today
 
-At the end of Phase 2, the boundary is used in:
+At the end of Phase 2.1, the boundary is used in:
 
 - characterization tests
 - boundary unit tests
+- `backend/app/api/v1/endpoints/online_queue_new.py::join_queue()`
+- `backend/app/services/qr_queue_service.py::complete_join_session()`
+- `backend/app/services/qr_queue_service.py::complete_join_session_multiple()`
 
-It is **not yet wired into production call sites**.
+This is a limited production rollout.
 
-This is intentional. The goal of Phase 2 is to establish the public boundary
-without changing runtime behavior.
+It is intentionally **not** yet wired into:
+
+- registrar batch writers
+- force-majeure allocator paths
+- direct SQL allocator branches
+- legacy `OnlineDay` callers
 
 ## Why This Shape Is Safe
 
@@ -78,3 +85,12 @@ Future migration should replace production callers gradually:
 1. caller keeps current behavior
 2. caller switches from direct `queue_service` use to `QueueDomainService.allocate_ticket()`
 3. only later does the internal allocator implementation change
+
+## Phase 2.1 Outcome
+
+Phase 2.1 narrows the allocator surface area without changing policy:
+
+- thin online join callers now depend on `QueueDomainService`
+- QR session completion callers now depend on `QueueDomainService`
+- numbering, duplicate detection, and queue-time logic still live in the legacy allocator
+- high-risk allocator families remain deferred

--- a/docs/architecture/W2C_ALLOCATOR_MIGRATION_STRATEGY.md
+++ b/docs/architecture/W2C_ALLOCATOR_MIGRATION_STRATEGY.md
@@ -49,13 +49,28 @@ Migration must follow this order:
 - no production caller migration yet
 - direct SQL and legacy allocators remain untouched
 
+### Phase 2.1: Safe caller migration
+
+Completed in this pass:
+
+- `backend/app/api/v1/endpoints/online_queue_new.py::join_queue()`
+- `backend/app/services/qr_queue_service.py::complete_join_session()`
+- `backend/app/services/qr_queue_service.py::complete_join_session_multiple()`
+
+Why these callers were safe:
+
+- they already delegated allocator policy to `queue_service.join_queue_with_token()`
+- they did not implement direct SQL numbering
+- they did not depend on `OnlineDay`
+- they did not own numbering or duplicate policy themselves
+
 ### Phase 3: Gradually migrate callers
 
 Preferred early caller families:
 
 - SSOT queue-service-backed online join
-- registrar batch path
-- confirmation path that already relies on SSOT queue models
+- registrar batch path only after explicit duplicate-policy review
+- confirmation path only after split allocation is collapsed safely
 
 Later only:
 
@@ -90,6 +105,7 @@ Allocator migration is feasible, but only as a staged domain migration.
 The correct first execution target is:
 
 - single-owner introduction behind `QueueDomainService`
+- followed by thin caller migration into the compatibility boundary
 
 The incorrect first execution target would be:
 

--- a/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
+++ b/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
@@ -293,9 +293,15 @@ Current behavior:
 
 Current limitation:
 
-- production callers are not yet repointed to this boundary
+- only a narrow set of production callers is repointed to this boundary
 - direct SQL allocators and legacy `OnlineDay` flows remain outside it
-- migration risk is reduced by characterization tests, not by runtime unification yet
+- migration risk is still controlled by characterization tests because the internal allocator has not changed
+
+Current production callers through `allocate_ticket()`:
+
+- `backend/app/api/v1/endpoints/online_queue_new.py::join_queue()`
+- `backend/app/services/qr_queue_service.py::complete_join_session()`
+- `backend/app/services/qr_queue_service.py::complete_join_session_multiple()`
 
 Notes for the narrowed `W2C-MS-004` slice:
 

--- a/docs/status/W2C_PHASE21_DEFERRED_CALLERS.md
+++ b/docs/status/W2C_PHASE21_DEFERRED_CALLERS.md
@@ -1,0 +1,23 @@
+# Wave 2C Phase 2.1 Deferred Callers
+
+Date: 2026-03-07
+Mode: behavior-preserving execution
+
+| File | Function | Reason deferred | Risk type | Suggested later phase |
+|---|---|---|---|---|
+| `backend/app/api/v1/endpoints/queue.py` | `join_queue()` | Legacy-prefixed route with low current signal; not part of primary QR/public join flow for this pass | Legacy/deprecated path | Review before later safe migration pass |
+| `backend/app/services/morning_assignment.py` | `_assign_single_queue()` | `morning_assignment` source semantics and visit-opening flow should be migrated only with dedicated characterization around scheduled queue population | Lifecycle/source semantics | Later safe pass or pre-2C high-risk review |
+| `backend/app/api/v1/endpoints/registrar_integration.py` | `create_queue_entries_batch()` | Registrar batch orchestration mixes allocator call with duplicate decisions and operator-visible batch behavior | Registrar orchestration / duplicate-policy sensitivity | Review before high-risk allocator migration |
+| `backend/app/services/queue_batch_service.py` | `create_entries()` | Batch writer path with broader side effects than thin join callers | Batch write semantics | Review before high-risk allocator migration |
+| `backend/app/services/visit_confirmation_service.py` | confirmation queue creation | Still splits number allocation and row creation | Split allocation flow | Queue domain refactor phase |
+| `backend/app/api/v1/endpoints/registrar_wizard.py` | queue creation branches | Mixed path; some branches still separate numbering from persistence or create rows directly | Mixed logic | High-risk allocator migration |
+| `backend/app/services/registrar_wizard_api_service.py` | queue creation branches | Same mixed allocator behavior as router counterpart | Mixed logic | High-risk allocator migration |
+| `backend/app/crud/online_queue.py` | online join helpers | Direct model creation after standalone number lookup | Direct model creation | High-risk allocator migration |
+| `backend/app/api/v1/endpoints/qr_queue.py` | `full_update_online_entry()` branches | Direct SQL allocator branches | Direct SQL / numbering semantics | Review before high-risk allocator migration |
+| `backend/app/services/qr_queue_api_service.py` | mirror allocator branches | Same mixed direct SQL + service allocator split | Direct SQL / mixed logic | Review before high-risk allocator migration |
+| `backend/app/services/force_majeure_service.py` | `_get_next_queue_number()`, `transfer_entries_to_tomorrow()` | Own transfer allocator with separate status and numbering assumptions | Exceptional flow / numbering semantics | Dedicated force-majeure review |
+| `backend/app/services/online_queue.py` | `issue_next_ticket()` | `OnlineDay` legacy counter | Legacy/OnlineDay | Legacy migration track |
+| `backend/app/api/v1/endpoints/online_queue.py` | legacy online queue endpoints | Delegates to `OnlineDay` counter semantics | Legacy/OnlineDay | Legacy migration track |
+| `backend/app/services/online_queue_api_service.py` | legacy online queue endpoints | Delegates to `OnlineDay` counter semantics | Legacy/OnlineDay | Legacy migration track |
+| `backend/app/crud/queue.py` | `next_ticket_and_insert_entry()` | Stale legacy ticket path | Legacy/stale allocator | Legacy cleanup track |
+| `backend/app/services/online_queue_new_api_service.py` | `join_queue()` and related router-like handlers | Duplicate unmounted module; unsafe to refactor blindly while mounted runtime path lives elsewhere | Shadow/dead-path ambiguity | Human review / cleanup track |

--- a/docs/status/W2C_PHASE21_EXECUTION_SUMMARY.md
+++ b/docs/status/W2C_PHASE21_EXECUTION_SUMMARY.md
@@ -1,0 +1,58 @@
+# Wave 2C Phase 2.1 Execution Summary
+
+Date: 2026-03-07
+Mode: behavior-preserving execution
+
+## Completed Caller Migrations
+
+- `backend/app/api/v1/endpoints/online_queue_new.py::join_queue()`
+- `backend/app/services/qr_queue_service.py::complete_join_session()`
+- `backend/app/services/qr_queue_service.py::complete_join_session_multiple()`
+
+## What Changed
+
+- selected callers now invoke `QueueDomainService.allocate_ticket()`
+- the boundary still delegates to legacy `queue_service` allocator logic
+- response shapes, numbering, duplicate behavior, and queue-time semantics were preserved
+
+## Evidence
+
+- targeted unit tests prove callers now use the boundary
+- integration tests prove `/api/v1/online-queue/join` behavior remains unchanged
+- existing QR join integration and allocator characterization tests remain green
+
+## Tests Run
+
+- `cd backend && pytest tests/unit/test_online_queue_new_allocator_boundary.py tests/unit/test_qr_queue_service_allocator_boundary.py tests/integration/test_online_queue_new_join.py tests/integration/test_qr_queue_join.py tests/characterization/test_queue_allocator_characterization.py -q`
+- `cd backend && pytest tests/unit/test_queue_allocator_boundary.py -q`
+- `cd backend && pytest -q`
+- `cd backend && pytest tests/test_openapi_contract.py -q`
+- `pytest backend/tests/characterization -q -c backend/pytest.ini`
+
+## Result
+
+- targeted migration tests:
+  - `14 passed`
+  - boundary-only regression check: `3 passed`
+- full backend suite:
+  - `693 passed, 3 skipped`
+- OpenAPI contract suite:
+  - `10 passed`
+- characterization suite:
+  - `7 passed`
+
+## Remaining Deferred Families
+
+See [W2C_PHASE21_DEFERRED_CALLERS.md](C:/final/docs/status/W2C_PHASE21_DEFERRED_CALLERS.md).
+
+## Next Recommendation
+
+Do not jump into high-risk allocator migration yet.
+
+Recommended next step:
+
+- one more review-gated safe pass only if a similarly thin caller family exists
+
+Otherwise:
+
+- stop and perform review before touching registrar, direct SQL, force-majeure, or `OnlineDay` allocators

--- a/docs/status/W2C_PHASE21_SAFE_CALLERS.md
+++ b/docs/status/W2C_PHASE21_SAFE_CALLERS.md
@@ -1,0 +1,33 @@
+# Wave 2C Phase 2.1 Safe Callers
+
+Date: 2026-03-07
+Mode: behavior-preserving execution
+
+## Selected Callers
+
+| File | Function | Current allocation path | Why safe | Why no behavior drift expected |
+|---|---|---|---|---|
+| `backend/app/api/v1/endpoints/online_queue_new.py` | `join_queue()` | Direct `queue_service.join_queue_with_token()` | Thin public join endpoint with no local numbering, duplicate, or queue ordering logic | `QueueDomainService.allocate_ticket(allocation_mode="join_with_token")` delegates to the same legacy allocator and preserves the same exception mapping and response shaping |
+| `backend/app/services/qr_queue_service.py` | `complete_join_session()` | Direct `queue_service.join_queue_with_token()` after session/token lookup and patient resolution | Service already treats allocator as a single call and keeps post-allocation work limited to session bookkeeping, metrics, and broadcast side effects | Boundary call preserves the same token-based allocator, duplicate handling, queue number assignment, and queue-time behavior |
+| `backend/app/services/qr_queue_service.py` | `complete_join_session_multiple()` | Loop of direct `queue_service.join_queue_with_token()` calls with `specialist_id_override` | Multi-specialist QR flow already centralizes allocation in one service and does not run direct SQL allocator logic here | Each iteration can delegate through the boundary without changing per-specialist allocation semantics, duplicate behavior, or response payload shape |
+
+## Explicitly Excluded From Phase 2.1
+
+- `backend/app/api/v1/endpoints/queue.py::join_queue()`:
+  mounted only under legacy prefix `/api/v1/queue/legacy`; low-signal deprecated path, not part of main QR/public join coverage for this phase
+- `backend/app/api/v1/endpoints/registrar_integration.py::create_queue_entries_batch()`:
+  registrar orchestration, batch semantics, and duplicate-policy nuances are above the current safe threshold
+- `backend/app/services/queue_batch_service.py::create_entries()`:
+  batch write path with broader side effects than a thin caller swap
+- `backend/app/services/visit_confirmation_service.py` confirmation queue creation:
+  still splits number allocation from row creation
+- `backend/app/api/v1/endpoints/registrar_wizard.py` and `backend/app/services/registrar_wizard_api_service.py`:
+  mixed allocator patterns and direct model creation
+- `backend/app/api/v1/endpoints/qr_queue.py` and `backend/app/services/qr_queue_api_service.py`:
+  direct SQL allocator branches
+- `backend/app/services/force_majeure_service.py`:
+  exceptional transfer allocator with its own numbering semantics
+- `backend/app/services/online_queue.py`, `backend/app/api/v1/endpoints/online_queue.py`, `backend/app/services/online_queue_api_service.py`, `backend/app/crud/queue.py`:
+  `OnlineDay` / legacy counter world
+- `backend/app/services/online_queue_new_api_service.py`:
+  unmounted duplicate router-like module; not safe to refactor blindly while `backend/app/api/v1/endpoints/online_queue_new.py` remains the runtime path

--- a/docs/status/wave2c/W2C_PHASE21_PLAN.md
+++ b/docs/status/wave2c/W2C_PHASE21_PLAN.md
@@ -1,0 +1,45 @@
+# Wave 2C Phase 2.1 Plan
+
+Date: 2026-03-07
+Mode: behavior-preserving execution
+
+## Selected Callers
+
+- `backend/app/api/v1/endpoints/online_queue_new.py::join_queue()`
+- `backend/app/services/qr_queue_service.py::complete_join_session()`
+- `backend/app/services/qr_queue_service.py::complete_join_session_multiple()`
+
+## Files Affected
+
+- `backend/app/api/v1/endpoints/online_queue_new.py`
+- `backend/app/services/qr_queue_service.py`
+- targeted tests under `backend/tests/unit/`
+- targeted integration tests for `/api/v1/online-queue/join`
+- queue migration docs and summaries
+
+## Current Path
+
+- selected callers invoke `queue_service.join_queue_with_token(...)` directly
+
+## New Path
+
+- selected callers invoke `QueueDomainService.allocate_ticket(allocation_mode="join_with_token", ...)`
+- `QueueDomainService` continues delegating to the existing legacy allocator
+
+## Required Test Coverage
+
+- unit test proving `online_queue_new.join_queue()` uses `QueueDomainService.allocate_ticket()`
+- unit tests proving `QRQueueService.complete_join_session*()` use `QueueDomainService.allocate_ticket()`
+- integration tests for `/api/v1/online-queue/join` success and duplicate reuse
+- existing QR join characterization/integration tests remain green
+- full backend suite, OpenAPI contract suite, and characterization suite
+
+## Rollback Notes
+
+- revert caller swap if any of these change:
+  - queue number assignment
+  - duplicate detection outcome
+  - response payload shape
+  - `queue_time` behavior
+  - QR join success/duplicate scenarios
+- do not extend the migration to registrar, force-majeure, or legacy allocators inside this pass


### PR DESCRIPTION
﻿## Summary

Replacement for stale PR #70 after parent allocator-boundary PR #69 was superseded by merged replacement PR #257.

Preserves the useful Wave 2C Phase 2.1 safe-caller migration on current main without carrying stale parent commits:
- routes online queue join through `QueueDomainService.allocate_ticket(allocation_mode="join_with_token")`;
- routes QR single and multiple join completion through the same queue-domain compatibility boundary;
- preserves focused tests and W2C Phase 2.1 docs/status notes.

## Contract Impact

- Endpoint: `POST /api/v1/online-queue/join`, QR queue single join completion, and QR queue multiple-specialist join completion keep existing public route behavior.
- Request shape: unchanged; token, patient, phone, Telegram, and specialist override inputs remain the same.
- Response shape: unchanged; join success, duplicate, ticket number, and queue entry response semantics are preserved.
- Status codes: unchanged; existing validation/conflict/not-found exceptions remain the error surface.
- Frontend consumer: unchanged; online queue and QR join consumers keep the same payload shape.
- Canonical surface: `QueueDomainService.allocate_ticket(allocation_mode="join_with_token", **kwargs)` for safe join callers.
- Compatibility path or alias: safe callers delegate through queue-domain compatibility boundary; legacy allocator remains `queue_service.join_queue_with_token()` behind the facade.
- Contract proof: focused online queue/QR allocator boundary tests, local compile proof, PR body gate, and fresh GitHub CI.

## RBAC / Permissions

- Roles allowed: unchanged for existing online queue and QR join flows, including public join behavior where already allowed.
- Roles denied: unchanged; no authorization helper or role matrix behavior is changed.
- Positive auth proof: existing online queue/QR join tests remain the proof surface.
- Negative auth proof: not applicable because access-control behavior is not changed.
- Legacy role normalization: not touched.

## Notification / Realtime

- Event type or websocket channel: not applicable because no notification or websocket event is changed.
- Payload version / ack behavior: not applicable because no realtime payload is added or renamed.
- Read/unread or delivery semantics: not applicable because this is backend queue allocation dispatch only.
- Reconnect/resync proof: not applicable because no realtime reconnect behavior is touched.

## Frontend Resilience

- Empty data proof: unchanged; no frontend empty-state handling is modified.
- Partial data proof: unchanged; no frontend partial-data handling is modified.
- Forbidden secondary path behavior: unchanged; no frontend secondary path is touched.
- Missing draft/resource behavior: unchanged; no draft/resource UI path is touched.
- Stale route/deep-link behavior: unchanged; no frontend route state is touched.

## Scope Gate

- Allowed paths: online queue join endpoint, QR queue service allocator calls, focused allocator boundary tests, and W2C Phase 2.1 docs/status notes.
- Denied paths: unsafe/deferred caller families, queue fairness rewrites, RBAC changes, frontend UI changes, notification/realtime changes, and migrations.
- Migration/docs/test impact: two runtime caller files, three focused test files, and W2C Phase 2.1 docs/status files; no database migration.
- Rollback note: revert this replacement PR to send safe callers back directly to `queue_service.join_queue_with_token()` if the compatibility boundary regresses join behavior.

Allowed path set:
- `backend/app/api/v1/endpoints/online_queue_new.py`
- `backend/app/services/qr_queue_service.py`
- `backend/tests/integration/test_online_queue_new_join.py`
- `backend/tests/unit/test_online_queue_new_allocator_boundary.py`
- `backend/tests/unit/test_qr_queue_service_allocator_boundary.py`
- `docs/architecture/W2C_ALLOCATOR_COMPATIBILITY_LAYER.md`
- `docs/architecture/W2C_ALLOCATOR_MIGRATION_STRATEGY.md`
- `docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md`
- `docs/status/W2C_PHASE21_DEFERRED_CALLERS.md`
- `docs/status/W2C_PHASE21_EXECUTION_SUMMARY.md`
- `docs/status/W2C_PHASE21_SAFE_CALLERS.md`
- `docs/status/wave2c/W2C_PHASE21_PLAN.md`

Compatibility review:
- Direct merge of old #70 is unsafe because its base is stale old #69, superseded by #257.
- Replacement starts from current main and preserves only the #70 useful safe-caller slice.

## Validation

- Targeted tests or smoke run: exact allowlist check; `git diff --check HEAD`; targeted Python compile for touched runtime/tests; PR body gate.
- Result: local allowlist/diff/compile checks passed; PR body gate passes with this body; fresh GitHub CI required before merge decision.
- Not checked: local pytest/browser smoke was not run; GitHub CI is the authoritative full test runner for this replacement.
