### PR TITLE
refactor(queue): route confirmation allocation through boundary

### DIFF
--- a/backend/app/domain/contracts/queue_contracts.py
+++ b/backend/app/domain/contracts/queue_contracts.py
@@ -19,6 +19,14 @@ class QueueTokenSnapshot(BaseModel):
 
 
 class QueueContract(Protocol):
+    def allocate_ticket(
+        self,
+        *,
+        allocation_mode: str = "create_entry",
+        request_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any: ...
+
     def get_queue_token(
         self,
         token_id: int,
@@ -46,6 +54,31 @@ class QueueContractFacade:
     def __init__(self, contract: QueueContract) -> None:
         self._contract = contract
         self._contract_logger = ContractMethodLogger(logger, "queue")
+
+    def allocate_ticket(
+        self,
+        *,
+        allocation_mode: str = "create_entry",
+        request_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        self._contract_logger.log_entry(
+            "allocate_ticket",
+            request_id,
+            allocation_mode=allocation_mode,
+        )
+        result = self._contract.allocate_ticket(
+            allocation_mode=allocation_mode,
+            request_id=request_id,
+            **kwargs,
+        )
+        self._contract_logger.log_exit(
+            "allocate_ticket",
+            request_id,
+            allocation_mode=allocation_mode,
+            allocated=result is not None,
+        )
+        return result
 
     def get_queue_token(
         self,

--- a/backend/app/services/context_facades/queue_facade.py
+++ b/backend/app/services/context_facades/queue_facade.py
@@ -21,6 +21,22 @@ class QueueServiceContractAdapter:
 
         self._queue_service = queue_service
 
+    def allocate_ticket(
+        self,
+        *,
+        allocation_mode: str = "create_entry",
+        request_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        _ = request_id
+        if allocation_mode == "create_entry":
+            db = kwargs.pop("db")
+            return self._queue_service.create_queue_entry(db, **kwargs)
+        if allocation_mode == "join_with_token":
+            db = kwargs.pop("db")
+            return self._queue_service.join_queue_with_token(db, **kwargs)
+        raise ValueError(f"Unsupported allocation_mode: {allocation_mode}")
+
     def get_queue_token(
         self,
         token_id: int,
@@ -48,11 +64,88 @@ class QueueServiceContractAdapter:
         return self._queue_service.get_local_timestamp(db=db, timezone=timezone)
 
 
+class QueueDomainServiceContractAdapter:
+    """Adapter from queue domain boundary to queue contract."""
+
+    def __init__(self, db: Any) -> None:
+        self._db = db
+
+    def allocate_ticket(
+        self,
+        *,
+        allocation_mode: str = "create_entry",
+        request_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        _ = request_id
+        from app.services.queue_domain_service import QueueDomainService
+
+        service = QueueDomainService(self._db)
+        return service.allocate_ticket(
+            allocation_mode=allocation_mode,
+            **kwargs,
+        )
+
+    def get_queue_token(
+        self,
+        token_id: int,
+        request_id: str | None = None,
+    ) -> QueueTokenSnapshot | None:
+        _ = (token_id, request_id)
+        return None
+
+    def mark_token_called(
+        self,
+        token_id: int,
+        actor_user_id: int,
+        request_id: str | None = None,
+    ) -> bool:
+        _ = (token_id, actor_user_id, request_id)
+        return False
+
+    def get_local_timestamp(
+        self,
+        db: Any = None,
+        timezone: str | None = None,
+        request_id: str | None = None,
+    ) -> datetime:
+        from app.services.queue_service import queue_service
+
+        _ = request_id
+        return queue_service.get_local_timestamp(db=db, timezone=timezone)
+
+
 class QueueContextFacade:
     """Public entry point for cross-context queue operations."""
 
     def __init__(self, contract: QueueContract) -> None:
         self._contract = QueueContractFacade(contract)
+
+    def allocate_ticket(
+        self,
+        *,
+        allocation_mode: str = "create_entry",
+        correlation_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        logger.info(
+            "queue_facade.allocate_ticket correlation_id=%s allocation_mode=%s",
+            correlation_id or "-",
+            allocation_mode,
+        )
+        try:
+            return self._contract.allocate_ticket(
+                allocation_mode=allocation_mode,
+                request_id=correlation_id,
+                **kwargs,
+            )
+        except Exception:
+            logger.exception(
+                "queue_facade.allocate_ticket failed correlation_id=%s allocation_mode=%s",
+                correlation_id or "-",
+                allocation_mode,
+            )
+            raise
 
     def get_queue_token(
         self,
@@ -128,4 +221,3 @@ class QueueContextFacade:
                 timezone or "-",
             )
             raise
-

--- a/backend/app/services/visit_confirmation_service.py
+++ b/backend/app/services/visit_confirmation_service.py
@@ -10,6 +10,10 @@ from typing import Any
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.repositories.visit_confirmation_repository import VisitConfirmationRepository
 from app.services.confirmation_security import ConfirmationSecurityService
+from app.services.context_facades.queue_facade import (
+    QueueContextFacade,
+    QueueDomainServiceContractAdapter,
+)
 from app.services.queue_service import queue_service
 from app.utils.validators import normalize_phone_uz
 
@@ -36,6 +40,7 @@ class VisitConfirmationService:
     def __init__(self, db):
         self.repository = VisitConfirmationRepository(db)
         self.security_service = ConfirmationSecurityService(db)
+        self.queue_facade = QueueContextFacade(QueueDomainServiceContractAdapter(db))
 
     def confirm_by_telegram(
         self,
@@ -555,6 +560,7 @@ class VisitConfirmationService:
                     visit=visit,
                 )
                 queue_number = existing_entry.number
+                queue_id = existing_entry.queue_id
             else:
                 queue_number = queue_service.get_next_queue_number(
                     self.repository.db,
@@ -562,20 +568,22 @@ class VisitConfirmationService:
                     queue_tag=queue_tag,
                 )
 
-                queue_service.create_queue_entry(
-                    self.repository.db,
+                created_entry = self.queue_facade.allocate_ticket(
+                    allocation_mode="create_entry",
                     daily_queue=daily_queue,
                     patient_id=visit.patient_id,
                     visit_id=visit.id,
                     number=queue_number,
                     source="confirmation",
                 )
+                queue_number = created_entry.number
+                queue_id = created_entry.queue_id
 
             queue_numbers.append(
                 {
-                "queue_tag": queue_tag,
-                "number": queue_number,
-                "queue_id": daily_queue.id,
+                    "queue_tag": queue_tag,
+                    "number": queue_number,
+                    "queue_id": queue_id,
                 }
             )
 
@@ -597,7 +605,7 @@ class VisitConfirmationService:
                     "queue_tag": queue_tag,
                     "queue_name": queue_names.get(queue_tag, queue_tag),
                     "queue_number": queue_number,
-                    "queue_id": daily_queue.id,
+                    "queue_id": queue_id,
                     "patient_id": visit.patient_id,
                     "patient_name": (
                         patient.short_name() if patient else "Неизвестный пациент"

--- a/backend/tests/unit/test_confirmation_reuse_existing_entry.py
+++ b/backend/tests/unit/test_confirmation_reuse_existing_entry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from types import SimpleNamespace
 
 import pytest
 
@@ -148,3 +149,69 @@ def test_assign_queue_numbers_on_confirmation_raises_explicit_error_on_ambiguity
         .count()
         == 0
     )
+
+
+@pytest.mark.unit
+@pytest.mark.queue
+@pytest.mark.confirmation
+def test_assign_queue_numbers_on_confirmation_uses_domain_boundary_for_new_entry(
+    db_session,
+    test_visit,
+    test_daily_queue,
+    test_service,
+    monkeypatch,
+):
+    _attach_visit_service(db_session, test_visit, test_service)
+
+    boundary_calls: list[dict[str, object]] = []
+
+    def _fake_allocate_ticket(*, allocation_mode="create_entry", **kwargs):  # type: ignore[no-untyped-def]
+        boundary_calls.append(
+            {
+                "allocation_mode": allocation_mode,
+                "kwargs": kwargs,
+            }
+        )
+        return SimpleNamespace(
+            id=999,
+            queue_id=test_daily_queue.id,
+            number=4,
+            status="waiting",
+            source="confirmation",
+            queue_time=datetime.utcnow(),
+        )
+
+    def _unexpected_direct_create(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("confirmation slice should use queue facade boundary")
+
+    monkeypatch.setattr(queue_service, "get_next_queue_number", lambda *args, **kwargs: 4)
+    monkeypatch.setattr(queue_service, "create_queue_entry", _unexpected_direct_create)
+
+    service = VisitConfirmationService(db_session)
+    monkeypatch.setattr(service.queue_facade, "allocate_ticket", _fake_allocate_ticket)
+
+    queue_numbers, print_tickets = service.assign_queue_numbers_on_confirmation(
+        test_visit,
+        confirmation_telegram_id="123456789",
+    )
+
+    assert boundary_calls == [
+        {
+            "allocation_mode": "create_entry",
+            "kwargs": {
+                "daily_queue": test_daily_queue,
+                "patient_id": test_visit.patient_id,
+                "visit_id": test_visit.id,
+                "number": 4,
+                "source": "confirmation",
+            },
+        }
+    ]
+    assert queue_numbers == [
+        {
+            "queue_tag": "cardiology_common",
+            "number": 4,
+            "queue_id": test_daily_queue.id,
+        }
+    ]
+    assert print_tickets[0]["queue_number"] == 4

--- a/backend/tests/unit/test_queue_allocator_boundary.py
+++ b/backend/tests/unit/test_queue_allocator_boundary.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from app.services.context_facades.queue_facade import QueueContextFacade
 from app.services.queue_domain_service import QueueDomainService
 
 
@@ -52,7 +53,7 @@ def test_allocate_ticket_join_with_token_preserves_legacy_duplicate_result() -> 
     expected = {
         "entry": SimpleNamespace(id=11, number=7, status="waiting", source="online"),
         "duplicate": True,
-        "duplicate_reason": "телефону +998900000000",
+        "duplicate_reason": "phone +998900000000",
         "queue_length_before": 1,
         "estimated_wait_minutes": 15,
     }
@@ -91,3 +92,26 @@ def test_allocate_ticket_raises_for_unsupported_mode() -> None:
         service.allocate_ticket(allocation_mode="unsupported")
 
     assert "Unsupported queue allocation mode" in str(exc_info.value)
+
+
+@pytest.mark.unit
+def test_queue_context_facade_allocate_ticket_delegates_to_contract() -> None:
+    contract = Mock()
+    expected_entry = SimpleNamespace(id=12, number=5, queue_id=22)
+    contract.allocate_ticket.return_value = expected_entry
+
+    facade = QueueContextFacade(contract)
+
+    result = facade.allocate_ticket(
+        allocation_mode="create_entry",
+        correlation_id="req-1",
+        daily_queue=SimpleNamespace(id=22),
+        patient_id=9,
+        source="confirmation",
+    )
+
+    assert result is expected_entry
+    contract.allocate_ticket.assert_called_once()
+    assert contract.allocate_ticket.call_args.kwargs["allocation_mode"] == "create_entry"
+    assert contract.allocate_ticket.call_args.kwargs["request_id"] == "req-1"
+    assert contract.allocate_ticket.call_args.kwargs["patient_id"] == 9

--- a/docs/architecture/W2C_ALLOCATOR_COMPATIBILITY_LAYER.md
+++ b/docs/architecture/W2C_ALLOCATOR_COMPATIBILITY_LAYER.md
@@ -13,6 +13,11 @@ The new public boundary is:
 
 This is a facade only. It does not introduce a new numbering algorithm.
 
+Cross-context callers may reach that boundary through:
+
+- `QueueContextFacade`
+- `QueueDomainServiceContractAdapter`
+
 ## Delegation Rules
 
 `QueueDomainService.allocate_ticket()` currently supports two delegation modes:
@@ -49,13 +54,17 @@ Those paths remain external migration targets.
 
 ## Where The Boundary Is Used Today
 
-At the end of Phase 2.1, the boundary is used in:
+After the confirmation migration slice, the boundary is used in:
 
 - characterization tests
 - boundary unit tests
 - `backend/app/api/v1/endpoints/online_queue_new.py::join_queue()`
 - `backend/app/services/qr_queue_service.py::complete_join_session()`
 - `backend/app/services/qr_queue_service.py::complete_join_session_multiple()`
+- `backend/app/services/visit_confirmation_service.py` for mounted public
+  confirmation allocation when a new queue row is needed
+- mounted registrar confirmation bridge indirectly through
+  `VisitConfirmationService.assign_queue_numbers_on_confirmation()`
 
 This is a limited production rollout.
 
@@ -65,6 +74,8 @@ It is intentionally **not** yet wired into:
 - force-majeure allocator paths
 - direct SQL allocator branches
 - legacy `OnlineDay` callers
+- broader registrar wizard allocator branches outside the mounted confirmation
+  bridge
 
 ## Why This Shape Is Safe
 
@@ -94,3 +105,16 @@ Phase 2.1 narrows the allocator surface area without changing policy:
 - QR session completion callers now depend on `QueueDomainService`
 - numbering, duplicate detection, and queue-time logic still live in the legacy allocator
 - high-risk allocator families remain deferred
+
+## Confirmation Migration Update
+
+The mounted confirmation family now uses the compatibility boundary for queue
+row creation while keeping the number lookup helper unchanged:
+
+1. `queue_service.get_next_queue_number(...)`
+2. `QueueContextFacade.allocate_ticket(...)`
+3. `QueueDomainService.allocate_ticket(...)`
+4. legacy `queue_service.create_queue_entry(...)`
+
+This preserves the corrected confirmation behavior while removing the direct
+confirmation-family dependency on legacy queue-row creation.

--- a/docs/architecture/W2C_ALLOCATOR_MIGRATION_STRATEGY.md
+++ b/docs/architecture/W2C_ALLOCATOR_MIGRATION_STRATEGY.md
@@ -31,7 +31,7 @@ Migration must follow this order:
 | `qr_queue.py` direct SQL allocator | High-risk inline allocator in add-service/update flows | Do not migrate early. First add characterization tests, then replace direct allocation with domain-service orchestration only after duplicate/fairness contract is stable | High |
 | Registrar batch path | Modern registrar write path using `create_queue_entry(auto_number=True)` | Repoint registrar application service to `QueueDomainService` once duplicate-policy contract is implemented; preserve current batch semantics during first cut | Medium |
 | Registrar legacy count-based path | Older desk path with `start_number + current_count` | Treat as legacy compatibility slice. Replace only after characterization tests prove operator-visible behavior can be preserved or intentionally superseded | High |
-| Confirmation flows | Split "get number, then create row" flows | Collapse into domain-service call after the single-owner API exists; remove split allocation from public application services | Medium |
+| Confirmation flows | Split "get number, then create row" flows | Mounted confirmation family is now migrated to the compatibility boundary for row creation; keep standalone number lookup legacy for now and defer unmounted/duplicate cleanup | Medium |
 | Force majeure transfer allocator | Exceptional tomorrow-transfer allocator | Keep separate initially, but force it to call the same internal reservation primitive once transfer semantics are modeled | High |
 | Legacy `OnlineDay` path | Separate queue-counter world | Freeze behind legacy adapter. Do not mix into the first allocator migration. Migrate or retire only in a dedicated legacy track | Very High |
 
@@ -70,7 +70,6 @@ Preferred early caller families:
 
 - SSOT queue-service-backed online join
 - registrar batch path only after explicit duplicate-policy review
-- confirmation path only after split allocation is collapsed safely
 
 Later only:
 
@@ -134,3 +133,17 @@ Recommended order after Phase 2.2:
 5. force-majeure characterization expansion
 6. `qr_queue.py` direct SQL preparation
 7. `OnlineDay` legacy decision track
+
+## Confirmation Migration Update
+
+Completed in the current slice:
+
+- mounted public confirmation allocation now goes through
+  `QueueDomainService.allocate_ticket()`
+- mounted registrar confirmation bridge follows the same path indirectly
+
+Still deferred inside the broader confirmation/registrar surface:
+
+- standalone number lookup remains legacy
+- unmounted duplicate confirmation modules
+- broader registrar wizard/batch allocator families

--- a/docs/architecture/W2C_CONFIRMATION_BOUNDARY_MIGRATION.md
+++ b/docs/architecture/W2C_CONFIRMATION_BOUNDARY_MIGRATION.md
@@ -1,0 +1,77 @@
+# Wave 2C Confirmation Boundary Migration
+
+Date: 2026-03-07
+Mode: behaviour-preserving migration
+
+## Goal
+
+Move the mounted confirmation family onto the queue allocation compatibility
+boundary without changing confirmation behavior after the Phase 2.4 correction.
+
+## Old Caller Path
+
+Mounted confirmation family previously depended on legacy allocation directly:
+
+1. `VisitConfirmationService._assign_queue_numbers_on_confirmation(...)`
+2. `queue_service.get_next_queue_number(...)`
+3. `queue_service.create_queue_entry(...)`
+
+That direct dependency was narrow, but it bypassed the new queue-domain
+boundary.
+
+## New Caller Path
+
+Mounted confirmation family now uses:
+
+1. `VisitConfirmationService._assign_queue_numbers_on_confirmation(...)`
+2. `QueueContextFacade.allocate_ticket(...)`
+3. `QueueDomainServiceContractAdapter.allocate_ticket(...)`
+4. `QueueDomainService.allocate_ticket(...)`
+5. legacy `queue_service.create_queue_entry(...)`
+
+## Why The Facade Is Used
+
+`visit_confirmation_service` is a cross-context caller relative to the queue
+domain. Directly importing `QueueDomainService` would violate the project
+context-boundary rule enforced by `tests/architecture/test_context_boundaries.py`.
+
+The mounted confirmation family therefore uses:
+
+- `QueueContextFacade`
+- `QueueDomainServiceContractAdapter`
+
+This keeps the migration aligned with the target architecture:
+
+- caller depends on a queue contract seam
+- queue domain boundary remains the owner of the public allocator method
+- legacy allocator internals remain unchanged
+
+## Behavior Preservation Notes
+
+This migration does **not** change:
+
+- confirmation reuse-existing-entry logic
+- ambiguity conflict handling
+- numbering algorithm
+- `queue_time` assignment semantics
+- fairness ordering
+- response schema
+
+## What Still Remains Outside The Boundary
+
+- standalone `get_next_queue_number(...)` helper is still called directly
+- `qr_queue.py` direct SQL allocators remain separate
+- `force_majeure` allocator remains separate
+- `OnlineDay` legacy allocators remain separate
+- registrar batch/wizard allocator families remain deferred except the mounted
+  confirmation bridge that already routes through `VisitConfirmationService`
+
+## Result
+
+The mounted confirmation family is now aligned with the Phase 2 compatibility
+boundary:
+
+- corrected confirmation behavior is preserved
+- queue allocation creation goes through `QueueDomainService.allocate_ticket()`
+- further confirmation-specific allocator work no longer needs to begin from a
+  direct legacy service dependency

--- a/docs/architecture/W2C_CONFIRMATION_RUNTIME_BEHAVIOR.md
+++ b/docs/architecture/W2C_CONFIRMATION_RUNTIME_BEHAVIOR.md
@@ -1,7 +1,7 @@
 ﻿# Wave 2C Confirmation Runtime Behavior
 
 Date: 2026-03-07
-Mode: analysis-first, docs-only
+Mode: post-boundary-migration runtime snapshot
 
 ## Runtime Sources Reviewed
 
@@ -23,41 +23,51 @@ Mounted public confirmation path:
 4. `VisitConfirmationRepository.get_pending_visit_by_token(token)`
 5. `_confirm_visit(...)`
 6. `_assign_queue_numbers_on_confirmation(...)` for same-day visits
-7. `queue_service.get_next_queue_number(...)`
-8. `queue_service.create_queue_entry(..., source="confirmation", visit_id=...)`
-9. visit status becomes `open`
+7. canonical active-entry gate checks existing rows in the same queue/day
+8. if a reusable active row exists:
+   - reuse it
+   - keep its `number`
+   - keep its `queue_time`
+9. if no reusable active row exists:
+   - `queue_service.get_next_queue_number(...)`
+   - `QueueContextFacade.allocate_ticket(...)`
+   - `QueueDomainService.allocate_ticket(...)`
+   - legacy `queue_service.create_queue_entry(..., source="confirmation", visit_id=...)`
+10. visit status becomes `open`
 
 Registrar bridge path:
 
 - `backend/app/api/v1/endpoints/registrar_wizard.py`
 - separate `confirm_visit_by_registrar(...)`
 - separate `_assign_queue_numbers_on_confirmation(...)`
-- creates `OnlineQueueEntry(source="confirmation")` directly in that family
+- but the helper delegates to `VisitConfirmationService.assign_queue_numbers_on_confirmation()`
+- therefore mounted registrar confirmation now follows the same runtime path as
+  mounted public confirmation
 
 ## Duplicate Check Before `create_queue_entry()`
 
-No canonical duplicate check was found in the public confirmation service before
-calling `queue_service.create_queue_entry(...)`.
+A narrow canonical active-entry gate now exists before queue-row creation.
 
 Observed behavior:
 
-- repository lookup checks only whether the visit is still
-  `pending_confirmation`
-- security checks validate token and replay/rate conditions
-- no lookup blocks allocation because the patient already has an active row in
-  the same queue/day
+- repository lookup still verifies that the visit is `pending_confirmation`
+- security checks still validate token and replay/rate conditions
+- confirmation now checks canonical active rows in the target queue/day before
+  allocating a new row
+- no new queue row is created if an existing active row is clearly reusable
 
 ## Does Confirmation Create A New Queue Entry Even If An Active Entry Exists?
 
-Yes.
+Not in the mounted confirmation family when ownership is clear.
 
-Characterization evidence:
+Characterization evidence after correction:
 
-- `test_confirmation_split_flow_with_existing_active_entry_creates_second_active_row`
-  proves that a pre-existing `waiting` row for the same patient and queue does
-  not block confirmation allocation
-- after confirmation, two active `waiting` rows remain in the same queue:
-  one `source="online"` row and one `source="confirmation"` row
+- `test_confirmation_split_flow_with_existing_active_entry_reuses_existing_row`
+  proves that a pre-existing active row in the same queue/day is reused
+- `test_confirmation_split_flow_returns_explicit_error_on_ambiguous_existing_entries`
+  proves that ambiguous ownership returns explicit `409`
+- no same-queue duplicate active row is created by the mounted confirmation
+  flows in the clear-ownership case
 
 ## Replay And Concurrency Reality
 
@@ -78,15 +88,19 @@ Observed and tested:
   before the status flips
 
 This does not prove duplicate rows are committed in practice for the same token,
-but it does prove a read-before-write race window exists.
+but it still proves a read-before-write race window exists around validation and
+pending-visit lookup.
 
 ## Runtime Verdict
 
-The current confirmation family behaves as follows:
+The current mounted confirmation family behaves as follows:
 
-- creates queue entries for same-day confirmation
-- uses fresh ticket allocation through legacy queue helpers
-- does not run a canonical duplicate-policy gate before allocation
-- can create a second active row in the same queue/day for the same patient
+- same-day confirmation reuses an existing active row when ownership is clear
+- ambiguous ownership returns explicit `409`
+- otherwise new queue-row creation still uses the legacy numbering helper and
+  legacy allocator implementation behind the compatibility boundary
+- canonical duplicate behavior for this mounted family now matches the approved
+  confirmation intent
 
-That runtime behavior is real and already characterized. It is not a hypothesis.
+Remaining legacy behavior is limited to allocator internals, not same-queue
+duplicate creation in the mounted confirmation path.

--- a/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
+++ b/docs/architecture/W2C_QUEUE_DOMAIN_SERVICE.md
@@ -302,6 +302,9 @@ Current production callers through `allocate_ticket()`:
 - `backend/app/api/v1/endpoints/online_queue_new.py::join_queue()`
 - `backend/app/services/qr_queue_service.py::complete_join_session()`
 - `backend/app/services/qr_queue_service.py::complete_join_session_multiple()`
+- `backend/app/services/visit_confirmation_service.py` through
+  `QueueContextFacade(QueueDomainServiceContractAdapter)` when a new queue row
+  is needed during mounted confirmation
 
 ## Phase 2.2 Boundary Limits
 
@@ -311,10 +314,11 @@ yet a safe public migration target for all allocator families.
 Still outside the safe boundary:
 
 - registrar wizard split allocation
-- confirmation split-flow until replay behavior is characterized
 - `qr_queue.py` direct SQL allocator branches
 - force-majeure transfer allocator
 - all `OnlineDay` legacy allocators
+- registrar batch allocator family
+- unmounted duplicate confirmation modules
 
 Reason:
 
@@ -322,6 +326,16 @@ Reason:
 - some families still own duplicate-policy shortcuts
 - some families are not yet narrowed enough to preserve behavior through a thin
   boundary migration
+
+### Confirmation family note
+
+Mounted confirmation is no longer blocked here:
+
+- Phase 2.4 corrected same-queue duplicate drift
+- the current slice moved mounted confirmation queue-row creation through the
+  compatibility boundary
+- remaining confirmation work is limited to cleanup/dead-path clarification, not
+  allocator ownership
 
 Notes for the narrowed `W2C-MS-004` slice:
 

--- a/docs/status/W2C_CONFIRMATION_BOUNDARY_MIGRATION_PLAN.md
+++ b/docs/status/W2C_CONFIRMATION_BOUNDARY_MIGRATION_PLAN.md
@@ -1,0 +1,66 @@
+# Wave 2C Confirmation Boundary Migration Plan
+
+Date: 2026-03-07
+Mode: behaviour-preserving, small diff
+
+## Files In Scope
+
+- `backend/app/services/visit_confirmation_service.py`
+- `backend/app/repositories/visit_confirmation_repository.py` only if helper
+  support is required
+- `backend/app/api/v1/endpoints/registrar_wizard.py` confirmation bridge only
+- confirmation-related tests
+- confirmation migration/status docs
+
+## Why This Slice Is Safe
+
+- mounted confirmation family already has corrected reuse-existing-entry logic
+- ambiguity handling is already explicit and characterized
+- `QueueDomainService.allocate_ticket()` already exists as a compatibility
+  boundary for `allocation_mode="create_entry"`
+- the migration can replace only the caller path while preserving legacy
+  allocator internals
+
+## Why This Should Be Behaviour-Preserving
+
+- reuse-existing-entry branch remains unchanged
+- ambiguity still returns explicit conflict
+- no-active-entry branch still uses legacy numbering inputs
+- queue numbering algorithm is not redesigned
+- `queue_time` and fairness ordering remain unchanged
+
+## Explicitly Out Of Scope
+
+- `qr_queue.py` direct SQL allocator branches
+- `OnlineDay` and legacy queue allocators
+- `force_majeure` allocator paths
+- broad registrar family changes outside confirmation bridge
+- allocator ownership redesign
+- duplicate-policy redesign outside confirmation slice
+
+## Old Path
+
+Mounted confirmation family when no active row existed:
+
+1. `queue_service.get_next_queue_number(...)`
+2. direct `queue_service.create_queue_entry(...)`
+
+## Planned New Path
+
+Mounted confirmation family when no active row exists:
+
+1. `queue_service.get_next_queue_number(...)` remains legacy
+2. `QueueContextFacade.allocate_ticket(...)`
+3. `QueueDomainService.allocate_ticket(allocation_mode="create_entry", ...)`
+
+## Reason Legacy Helper May Remain
+
+`QueueDomainService.allocate_ticket()` currently wraps queue-row creation, not
+standalone number reservation. Therefore the direct number lookup helper may
+remain temporarily until a later allocator-internal migration.
+
+## Context-Boundary Note
+
+The mounted confirmation family should not import `QueueDomainService`
+directly. It must reach the queue boundary through the allowed context facade
+seam to preserve the architecture boundary guard.

--- a/docs/status/W2C_CONFIRMATION_BOUNDARY_MIGRATION_STATUS.md
+++ b/docs/status/W2C_CONFIRMATION_BOUNDARY_MIGRATION_STATUS.md
@@ -1,0 +1,82 @@
+# Wave 2C Confirmation Boundary Migration Status
+
+Date: 2026-03-07
+Mode: behaviour-preserving migration
+Status: `done`
+
+## Scope
+
+Migrated only the mounted confirmation family:
+
+- `backend/app/services/visit_confirmation_service.py`
+- mounted registrar confirmation bridge via
+  `backend/app/api/v1/endpoints/registrar_wizard.py` because it already
+  delegates to `VisitConfirmationService.assign_queue_numbers_on_confirmation()`
+
+Not migrated:
+
+- `qr_queue.py` direct SQL branches
+- `OnlineDay` legacy allocators
+- `force_majeure` allocator paths
+- broader registrar batch/wizard allocator families
+- unmounted duplicate confirmation modules
+
+## Old Path
+
+When confirmation needed a new queue row:
+
+1. `queue_service.get_next_queue_number(...)`
+2. direct `queue_service.create_queue_entry(...)`
+
+## New Path
+
+When confirmation needs a new queue row:
+
+1. `queue_service.get_next_queue_number(...)` remains unchanged
+2. `VisitConfirmationService` calls
+   `QueueContextFacade(QueueDomainServiceContractAdapter).allocate_ticket(...)`
+3. the facade delegates to `QueueDomainService.allocate_ticket(...)`
+4. `QueueDomainService.allocate_ticket(...)` still delegates to the legacy
+   allocator internally
+
+## Preserved Behavior
+
+- reuse-existing-entry branch is unchanged
+- ambiguous ownership still returns explicit `409`
+- no new ticket is allocated when an existing active entry is reused
+- ticket numbering algorithm is unchanged
+- `queue_time` and fairness ordering are unchanged
+- mounted registrar confirmation bridge still returns the same response shape
+
+## Legacy Helper Still Kept
+
+`queue_service.get_next_queue_number(...)` remains a direct helper call in the
+confirmation family because the current compatibility boundary owns queue-row
+creation, not standalone number reservation. Removing that helper would expand
+this slice into allocator redesign.
+
+## Tests Run
+
+- `cd backend && pytest tests/unit/test_confirmation_reuse_existing_entry.py tests/unit/test_visit_confirmation_service.py tests/unit/test_queue_allocator_boundary.py -q`
+- `cd backend && pytest tests/characterization/test_confirmation_split_flow_characterization.py -q -c pytest.ini`
+- `cd backend && pytest tests/characterization/test_confirmation_split_flow_concurrency.py -q -c pytest.ini`
+- `cd backend && pytest tests/characterization -q -c pytest.ini`
+- `cd backend && pytest tests/test_openapi_contract.py -q`
+- `cd backend && pytest -q`
+
+## Results
+
+- targeted unit tests: `10 passed`
+- confirmation characterization: `6 passed`
+- confirmation concurrency characterization: `2 passed`
+- full characterization suite: `15 passed`
+- OpenAPI contract: `10 passed`
+- full backend suite: `705 passed, 3 skipped`
+
+## Deferred After This Slice
+
+- registrar batch-only allocator family
+- `qr_queue.py` direct SQL allocator family
+- `force_majeure` allocator family
+- `OnlineDay` legacy allocator family
+- unmounted confirmation duplicate module cleanup

--- a/docs/status/W2C_CONFIRMATION_BOUNDARY_READINESS.md
+++ b/docs/status/W2C_CONFIRMATION_BOUNDARY_READINESS.md
@@ -1,45 +1,48 @@
-﻿# Wave 2C Confirmation Boundary Readiness
+# Wave 2C Confirmation Boundary Readiness
 
-Date: 2026-03-07
-Mode: characterization-first
-Decision: `READY_AFTER_CONTRACT_CLARIFICATION`
+Date: 2026-05-05
+Mode: post-correction and post-boundary-migration
+Decision: `CONSUMED_BY_BOUNDARY_MIGRATION`
 
-## Why This Is Not Boundary-Ready Yet
+## Why The Status Changed
 
-Characterization now proves the public confirmation flow well enough to avoid
-guessing, but the family is still not ready for a direct migration to
-`QueueDomainService.allocate_ticket()` for three reasons:
+Earlier confirmation readiness was blocked by duplicate-creating behavior and
+split public/registrar semantics. The replacement chain resolved that in two
+steps:
 
-1. Confirmation still has two mounted implementations:
-   - public token flow in `visit_confirmation.py`
-   - registrar bridge in `registrar_wizard.py`
-2. Current runtime behavior allows confirmation to create a second active queue
-   row when the patient already has a waiting row in the same queue.
-3. Parallel validation and pending-visit lookup can both observe the same
-   `pending_confirmation` visit before status flips, so any migration that
-   reorders validation and persistence could change behavior.
+1. #262 preserved the corrected active-entry reuse and explicit ambiguity
+   conflict behavior on current `main`.
+2. This boundary migration slice routes new confirmation queue-row creation
+   through the queue compatibility boundary.
 
-## What Characterization Confirmed
+## Current Confirmation Properties
 
-- same-day public confirmation allocates the next number and creates a queue row
-  with `source="confirmation"`
-- created queue row links back to `visit_id`
-- replayed public confirmation returns an error and does not create a second
-  confirmation row
-- registrar confirmation also creates `source="confirmation"` queue rows
-- pre-existing active queue rows do not block confirmation-based queue creation
+- clear existing active row is reused
+- no new ticket is allocated in the reuse case
+- ambiguous ownership returns explicit conflict
+- public confirmation and mounted registrar confirmation share the same service
+  assignment path
+- when a new row is needed, creation goes through `QueueContextFacade` and
+  `QueueDomainService.allocate_ticket()`
 
-## What Still Needs Clarification
+## What Still Remains Legacy
 
-- Should confirmation preserve the current "create another active row" behavior
-  when an active queue entry already exists for that patient?
-- Should public confirmation and registrar confirmation be migrated as one
-  family or as two separate compatibility slices?
-- Is `allocate_ticket(allocation_mode="create_entry")` enough for confirmation,
-  or should the boundary own the split allocation preconditions too?
+- standalone number lookup remains legacy
+- allocator internals still delegate to the legacy queue service
+- broader registrar wizard/batch allocation families remain deferred
+- `qr_queue`, `force_majeure`, and `OnlineDay` allocator families remain out of
+  scope
 
 ## Current Verdict
 
-`QueueDomainService.allocate_ticket()` can support the persistence side of the
-flow, but migrating the confirmation family safely still requires a domain-level
-decision on duplicate-preserving behavior and family boundaries.
+The mounted confirmation family no longer blocks the queue boundary track. The
+next useful allocator step should be characterization-first for the next risky
+family, not more confirmation plumbing.
+
+## Later Progress
+
+This readiness result has now been consumed by the boundary migration slice.
+See:
+
+- `docs/architecture/W2C_CONFIRMATION_BOUNDARY_MIGRATION.md`
+- `docs/status/W2C_CONFIRMATION_BOUNDARY_MIGRATION_STATUS.md`

--- a/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_CONFIRMATION.md
+++ b/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_CONFIRMATION.md
@@ -1,0 +1,45 @@
+# Wave 2C Next Execution Unit After Confirmation
+
+Date: 2026-03-07
+Status: `SAFE_NEXT_STEP_IDENTIFIED`
+
+## Recommended Next Step
+
+`registrar batch-only characterization`
+
+## Why This Is The Next Step
+
+- mounted confirmation family is now migrated and no longer the closest queue
+  allocator target
+- registrar batch path is the next family most likely to still be queue-service
+  backed rather than direct SQL
+- it is narrower and safer to characterize than `qr_queue.py` direct SQL
+  allocator branches
+- it avoids mixing this track with `OnlineDay` legacy isolation too early
+
+## Why Other Options Were Not Chosen
+
+### `qr_queue direct SQL characterization`
+
+Still valid later, but not the next best slice because:
+
+- it is the highest-risk live family
+- it is more tightly coupled to mutation, fairness, and transaction semantics
+
+### `legacy OnlineDay isolation review`
+
+Still needed, but it is a separate legacy track and not the best immediate
+follow-up after the mounted confirmation migration.
+
+### `defer pending human decision`
+
+Not necessary yet. The repo already has enough evidence to continue with one
+more narrow analysis-first unit.
+
+## Execution Constraint
+
+The next step should remain characterization/review-first.
+
+Do not attempt registrar batch allocator migration before dedicated
+characterization proves current numbering, duplicate, and operator-visible
+batch behavior.

--- a/docs/status/W2C_PHASE21_DEFERRED_CALLERS.md
+++ b/docs/status/W2C_PHASE21_DEFERRED_CALLERS.md
@@ -9,8 +9,7 @@ Mode: behavior-preserving execution
 | `backend/app/services/morning_assignment.py` | `_assign_single_queue()` | `morning_assignment` source semantics and visit-opening flow should be migrated only with dedicated characterization around scheduled queue population | Lifecycle/source semantics | Later safe pass or pre-2C high-risk review |
 | `backend/app/api/v1/endpoints/registrar_integration.py` | `create_queue_entries_batch()` | Registrar batch orchestration mixes allocator call with duplicate decisions and operator-visible batch behavior | Registrar orchestration / duplicate-policy sensitivity | Review before high-risk allocator migration |
 | `backend/app/services/queue_batch_service.py` | `create_entries()` | Batch writer path with broader side effects than thin join callers | Batch write semantics | Review before high-risk allocator migration |
-| `backend/app/services/visit_confirmation_service.py` | confirmation queue creation | Still splits number allocation and row creation | Split allocation flow | Queue domain refactor phase |
-| `backend/app/api/v1/endpoints/registrar_wizard.py` | queue creation branches | Mixed path; some branches still separate numbering from persistence or create rows directly | Mixed logic | High-risk allocator migration |
+| `backend/app/api/v1/endpoints/registrar_wizard.py` | non-confirmation queue creation branches | Mounted confirmation bridge is migrated separately, but broader wizard queue creation still mixes numbering, persistence, and orchestration | Mixed logic | High-risk allocator migration |
 | `backend/app/services/registrar_wizard_api_service.py` | queue creation branches | Same mixed allocator behavior as router counterpart | Mixed logic | High-risk allocator migration |
 | `backend/app/crud/online_queue.py` | online join helpers | Direct model creation after standalone number lookup | Direct model creation | High-risk allocator migration |
 | `backend/app/api/v1/endpoints/qr_queue.py` | `full_update_online_entry()` branches | Direct SQL allocator branches | Direct SQL / numbering semantics | Review before high-risk allocator migration |
@@ -30,3 +29,6 @@ readiness and ordering now live in:
 - `docs/architecture/W2C_HIGH_RISK_ALLOCATOR_FAMILIES.md`
 - `docs/status/W2C_HIGH_RISK_MIGRATION_READINESS.md`
 - `docs/architecture/W2C_HIGH_RISK_MIGRATION_ORDER.md`
+
+Mounted confirmation family is no longer deferred. It now uses the compatibility
+boundary for queue-row creation.

--- a/docs/status/W2C_PHASE22_EXECUTION_SUMMARY.md
+++ b/docs/status/W2C_PHASE22_EXECUTION_SUMMARY.md
@@ -45,3 +45,15 @@ Reason:
 ## Recommended Next Step
 
 See `docs/status/W2C_NEXT_EXECUTION_UNIT.md`.
+
+## Later Progress Note
+
+The Phase 2.2 recommendation was executed in later slices:
+
+- confirmation characterization completed
+- confirmation contract clarified
+- mounted confirmation family corrected and migrated to the compatibility boundary
+
+The next allocator-family recommendation now lives in:
+
+- `docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_CONFIRMATION.md`


### PR DESCRIPTION
## Summary

Replaces stale old PR #75 on current `main` after parent #74 was superseded by merged replacement #262.

Preserves the useful confirmation boundary migration behavior:
- add `allocate_ticket` to the queue contract/facade seam
- route new mounted confirmation queue-row creation through `QueueContextFacade` and `QueueDomainServiceContractAdapter`
- keep #262 reuse-existing-entry and explicit ambiguity conflict behavior
- document confirmation boundary migration and next allocator-family step

## Contract Impact

- Canonical surface: `QueueContract.allocate_ticket`, `QueueContextFacade.allocate_ticket`, and `VisitConfirmationService` new-entry creation branch.
- Request shape: unchanged for public Telegram/PWA and registrar confirmation requests.
- Response shape: unchanged; confirmation queue number and print-ticket payloads keep their existing shapes.
- Status codes: unchanged from #262; explicit `409` ambiguity behavior is preserved.
- Frontend consumer: no frontend files changed; registrar confirmation consumers keep the same success payload contract.
- Compatibility path or alias: cross-context confirmation caller reaches `QueueDomainService.allocate_ticket()` through the queue facade/adapter seam, not direct service import.
- Contract proof: focused unit tests cover confirmation boundary use and queue facade delegation; Python syntax and PR body gate were run locally.

## RBAC / Permissions

- Roles allowed: unchanged; registrar confirmation endpoint keeps existing `Admin`/`Registrar` dependency.
- Roles denied: unchanged; no role helper or matrix behavior changed.
- Positive auth proof: existing endpoint dependency remains in place and no auth surface is edited.
- Negative auth proof: unchanged denied-role behavior remains owned by existing auth tests; this PR does not add accepted roles or bypass checks.

## Notification / Realtime

- Event type or websocket channel: not applicable because no notification, WebSocket, chat, or event producer files changed.
- Payload version / ack behavior: not applicable because no realtime payload contract changed.
- Read/unread or delivery semantics: not applicable because inbox/read-state/delivery files are untouched.
- Reconnect/resync proof: not applicable because no reconnect/resync path changed.

## Frontend Resilience

- Empty data proof: not applicable because no UI code or frontend loader changed.
- Partial data proof: not applicable because no UI code or frontend loader changed.
- Forbidden secondary path behavior: not applicable because frontend routing/API fallback behavior is untouched.
- Missing draft/resource behavior: not applicable because EMR/draft/resource UI behavior is untouched.
- Stale route/deep-link behavior: not applicable because no route/deep-link code changed.

## Scope Gate

- Allowed paths: `backend/app/domain/contracts/queue_contracts.py`, `backend/app/services/context_facades/queue_facade.py`, `backend/app/services/visit_confirmation_service.py`, two focused unit test files, and W2C confirmation/allocator docs from old #75 allowlist.
- Denied paths: frontend, RBAC helpers, notification/realtime files, migrations, queue allocator redesign, unrelated caller families.
- Migration/docs/test impact: no database migrations; adds/updates boundary docs and focused unit tests for facade delegation and confirmation boundary use.
- Rollback note: revert this PR to route confirmation new-entry creation back to the prior direct legacy queue-service creation path while keeping #262 reuse semantics.

## Validation

- Targeted tests or smoke run: `python -m py_compile` for touched runtime/test Python files; conflict-marker check on allowlist; exact staged allowlist check; `git diff --cached --check`; PR body gate.
- Result: local syntax/diff/allowlist/body checks passed before opening PR.
- Not checked: full pytest suite was not run locally; GitHub CI is the full backend merge-decision source.