### PR TITLE
refactor(queue): replace wizard create branch handoff

### DIFF
--- a/backend/app/services/morning_assignment.py
+++ b/backend/app/services/morning_assignment.py
@@ -4,7 +4,9 @@
 """
 
 import logging
+from dataclasses import dataclass
 from datetime import date, datetime
+from typing import Any
 
 from sqlalchemy import and_
 from sqlalchemy.orm import Session
@@ -42,6 +44,29 @@ WIZARD_DUPLICATE_ACTIVE_STATUSES = (
 
 class MorningAssignmentClaimError(ValueError):
     """Raised when a wizard-family queue claim cannot be resolved safely."""
+
+
+@dataclass(frozen=True)
+class MorningAssignmentCreateBranchHandoff:
+    """Wizard-local handoff for the create-entry branch."""
+
+    queue_tag: str
+    daily_queue: DailyQueue
+    create_entry_kwargs: dict[str, Any]
+
+    def build_assigned_payload(self, *, number: int) -> dict[str, Any]:
+        return {
+            "queue_tag": self.queue_tag,
+            "queue_id": self.daily_queue.id,
+            "number": number,
+            "status": "assigned",
+        }
+
+
+@dataclass(frozen=True)
+class MorningAssignmentPreparedQueueAssignment:
+    assignment: dict[str, Any] | None = None
+    create_handoff: MorningAssignmentCreateBranchHandoff | None = None
 
 
 class MorningAssignmentService:
@@ -359,6 +384,48 @@ class MorningAssignmentService:
         *,
         source: str = "morning_assignment",
     ) -> dict[str, any] | None:
+        """Assign one queue number through the explicit wizard create-branch handoff."""
+
+        prepared_assignment = self.prepare_wizard_queue_assignment(
+            visit,
+            queue_tag,
+            target_date,
+            source=source,
+        )
+        if prepared_assignment is None:
+            return None
+
+        if prepared_assignment.assignment is not None:
+            return prepared_assignment.assignment
+
+        create_handoff = prepared_assignment.create_handoff
+        if create_handoff is None:
+            return None
+
+        queue_entry = queue_service.create_queue_entry(
+            self.db,
+            **create_handoff.create_entry_kwargs,
+        )
+
+        service_codes_for_entry = create_handoff.create_entry_kwargs.get("service_codes", [])
+        logger.info(
+            "Assigned number %s in queue %s for patient %s through SSOT, services: %s",
+            queue_entry.number,
+            queue_tag,
+            visit.patient_id,
+            service_codes_for_entry,
+        )
+
+        return create_handoff.build_assigned_payload(number=queue_entry.number)
+
+    def prepare_wizard_queue_assignment(
+        self,
+        visit: Visit,
+        queue_tag: str,
+        target_date: date,
+        *,
+        source: str = "morning_assignment",
+    ) -> MorningAssignmentPreparedQueueAssignment | None:
         """Присваивает номер в конкретной очереди"""
 
         # Определяем врача для очереди
@@ -473,12 +540,14 @@ class MorningAssignmentService:
 
         if existing_entry:
             logger.info(f"Patient {visit.patient_id} already has active queue entry for {queue_tag}")
-            return {
-                "queue_tag": queue_tag,
-                "queue_id": daily_queue.id,
-                "number": existing_entry.number,
-                "status": "existing",
-            }
+            return MorningAssignmentPreparedQueueAssignment(
+                assignment={
+                    "queue_tag": queue_tag,
+                    "queue_id": daily_queue.id,
+                    "number": existing_entry.number,
+                    "status": "existing",
+                }
+            )
         # ✅ ИСПРАВЛЕНО: Используем SSOT queue_service для создания записи
         # Получаем информацию о пациенте для передачи в create_queue_entry
         patient = self.db.query(Patient).filter(Patient.id == visit.patient_id).first()
@@ -539,32 +608,26 @@ class MorningAssignmentService:
                         })
 
         # ✅ ИСПРАВЛЕНО: Используем SSOT метод для создания записи С услугами
-        queue_entry = queue_service.create_queue_entry(
-            self.db,
-            daily_queue=daily_queue,
-            patient_id=visit.patient_id,
-            patient_name=patient_name,
-            phone=phone,
-            visit_id=visit.id,
-            source=source,  # Источник: зависит от сценария (desk / morning_assignment / confirmation)
-            status="waiting",
-            queue_time=queue_time,  # Бизнес-время регистрации
-            services=services_for_entry,  # ⭐ ДОБАВЛЕНО: услуги с кодами
-            service_codes=service_codes_for_entry,  # ⭐ ДОБАВЛЕНО: коды услуг
-            auto_number=True,  # Автоматически присваиваем номер
-            commit=False,  # Не коммитим сразу, коммит будет в run_morning_assignment
+        return MorningAssignmentPreparedQueueAssignment(
+            create_handoff=MorningAssignmentCreateBranchHandoff(
+                queue_tag=queue_tag,
+                daily_queue=daily_queue,
+                create_entry_kwargs={
+                    "daily_queue": daily_queue,
+                    "patient_id": visit.patient_id,
+                    "patient_name": patient_name,
+                    "phone": phone,
+                    "visit_id": visit.id,
+                    "source": source,
+                    "status": "waiting",
+                    "queue_time": queue_time,
+                    "services": services_for_entry,
+                    "service_codes": service_codes_for_entry,
+                    "auto_number": True,
+                    "commit": False,
+                },
+            )
         )
-
-        logger.info(
-            f"Присвоен номер {queue_entry.number} в очереди {queue_tag} для пациента {visit.patient_id} (через SSOT), услуги: {service_codes_for_entry}"
-        )
-
-        return {
-            "queue_tag": queue_tag,
-            "queue_id": daily_queue.id,
-            "number": queue_entry.number,
-            "status": "assigned",
-        }
 
     def _resolve_existing_queue_claim_or_raise(
         self,

--- a/backend/app/services/registrar_wizard_queue_assignment_service.py
+++ b/backend/app/services/registrar_wizard_queue_assignment_service.py
@@ -8,7 +8,12 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from app.models.visit import Visit
-from app.services.morning_assignment import MorningAssignmentService
+from app.services.morning_assignment import (
+    MorningAssignmentCreateBranchHandoff,
+    MorningAssignmentPreparedQueueAssignment,
+    MorningAssignmentService,
+)
+from app.services.queue_service import queue_service
 
 logger = logging.getLogger(__name__)
 
@@ -22,10 +27,18 @@ class RegistrarWizardQueueAssignmentService:
         *,
         assignment_service_factory: Callable[[Session], MorningAssignmentService]
         | None = None,
+        create_entry_allocator: Callable[
+            [MorningAssignmentCreateBranchHandoff],
+            Any,
+        ]
+        | None = None,
     ) -> None:
         self.db = db
         self._assignment_service_factory = (
             assignment_service_factory or (lambda session: MorningAssignmentService(session))
+        )
+        self._create_entry_allocator = (
+            create_entry_allocator or self._allocate_create_branch_handoff
         )
 
     def assign_same_day_queue_numbers(
@@ -43,7 +56,8 @@ class RegistrarWizardQueueAssignmentService:
                 continue
 
             try:
-                queue_assignments = assignment_service._assign_queues_for_visit(
+                queue_assignments = self._assign_same_day_queues_for_visit(
+                    assignment_service,
                     visit,
                     target_day,
                     source=source,
@@ -74,3 +88,76 @@ class RegistrarWizardQueueAssignmentService:
                 continue
 
         return queue_numbers
+
+    def _assign_same_day_queues_for_visit(
+        self,
+        assignment_service: MorningAssignmentService,
+        visit: Visit,
+        target_day: date,
+        *,
+        source: str,
+    ) -> list[dict[str, Any]]:
+        unique_queue_tags = assignment_service._get_visit_queue_tags(visit)
+        if not unique_queue_tags:
+            logger.warning("Визит %d: нет queue_tag в услугах", visit.id)
+            return []
+
+        queue_assignments: list[dict[str, Any]] = []
+        for queue_tag in unique_queue_tags:
+            try:
+                prepared_assignment = assignment_service.prepare_wizard_queue_assignment(
+                    visit,
+                    queue_tag,
+                    target_day,
+                    source=source,
+                )
+                assignment = self._materialize_prepared_assignment(prepared_assignment)
+                if assignment:
+                    queue_assignments.append(assignment)
+            except Exception as exc:
+                logger.error(
+                    "Ошибка присвоения очереди %s для визита %d: %s",
+                    queue_tag,
+                    visit.id,
+                    str(exc),
+                    exc_info=True,
+                )
+                self._rollback_session()
+
+        return queue_assignments
+
+    def _materialize_prepared_assignment(
+        self,
+        prepared_assignment: MorningAssignmentPreparedQueueAssignment | None,
+    ) -> dict[str, Any] | None:
+        if prepared_assignment is None:
+            return None
+
+        if prepared_assignment.assignment is not None:
+            return prepared_assignment.assignment
+
+        create_handoff = prepared_assignment.create_handoff
+        if create_handoff is None:
+            return None
+
+        queue_entry = self._create_entry_allocator(create_handoff)
+        return create_handoff.build_assigned_payload(number=queue_entry.number)
+
+    def _allocate_create_branch_handoff(
+        self,
+        handoff: MorningAssignmentCreateBranchHandoff,
+    ) -> Any:
+        return queue_service.create_queue_entry(
+            self.db,
+            **handoff.create_entry_kwargs,
+        )
+
+    def _rollback_session(self) -> None:
+        rollback = getattr(self.db, "rollback", None)
+        if not callable(rollback):
+            return
+
+        try:
+            rollback()
+        except Exception as rollback_error:
+            logger.error("Ошибка при rollback wizard queue assignment: %s", rollback_error)

--- a/backend/tests/unit/test_wizard_allocator_extraction.py
+++ b/backend/tests/unit/test_wizard_allocator_extraction.py
@@ -5,6 +5,7 @@ from datetime import date, timedelta
 
 import pytest
 
+from app.services.morning_assignment import MorningAssignmentPreparedQueueAssignment
 from app.services.registrar_wizard_queue_assignment_service import (
     RegistrarWizardQueueAssignmentService,
 )
@@ -18,16 +19,21 @@ class _FakeVisit:
 
 
 class _FakeAssignmentService:
-    def __init__(self, responses, errors=None):
-        self.responses = responses
+    def __init__(self, queue_tags, prepared_assignments, errors=None):
+        self.queue_tags = queue_tags
+        self.prepared_assignments = prepared_assignments
         self.errors = errors or {}
         self.calls = []
 
-    def _assign_queues_for_visit(self, visit, target_day, *, source):
-        self.calls.append((visit.id, target_day, source))
-        if visit.id in self.errors:
-            raise self.errors[visit.id]
-        return self.responses.get(visit.id, [])
+    def _get_visit_queue_tags(self, visit):
+        return self.queue_tags.get(visit.id, set())
+
+    def prepare_wizard_queue_assignment(self, visit, queue_tag, target_day, *, source):
+        self.calls.append((visit.id, queue_tag, target_day, source))
+        key = (visit.id, queue_tag)
+        if key in self.errors:
+            raise self.errors[key]
+        return self.prepared_assignments.get(key)
 
 
 @pytest.mark.unit
@@ -35,7 +41,12 @@ def test_assign_same_day_queue_numbers_uses_extracted_wizard_seam():
     today = date.today()
     visit = _FakeVisit(id=101, visit_date=today)
     fake_assignment_service = _FakeAssignmentService(
-        responses={101: [{"queue_tag": "cardiology_common", "number": 17, "queue_id": 5}]}
+        queue_tags={101: {"cardiology_common"}},
+        prepared_assignments={
+            (101, "cardiology_common"): MorningAssignmentPreparedQueueAssignment(
+                assignment={"queue_tag": "cardiology_common", "number": 17, "queue_id": 5}
+            )
+        },
     )
 
     service = RegistrarWizardQueueAssignmentService(
@@ -53,7 +64,7 @@ def test_assign_same_day_queue_numbers_uses_extracted_wizard_seam():
         101: [{"queue_tag": "cardiology_common", "number": 17, "queue_id": 5}]
     }
     assert visit.status == "open"
-    assert fake_assignment_service.calls == [(101, today, "desk")]
+    assert fake_assignment_service.calls == [(101, "cardiology_common", today, "desk")]
 
 
 @pytest.mark.unit
@@ -63,8 +74,9 @@ def test_assign_same_day_queue_numbers_preserves_safe_behavior_for_empty_and_fai
     same_day_visit = _FakeVisit(id=202, visit_date=today)
     failed_visit = _FakeVisit(id=203, visit_date=today)
     fake_assignment_service = _FakeAssignmentService(
-        responses={202: []},
-        errors={203: RuntimeError("allocation failed")},
+        queue_tags={202: {"cardiology_common"}, 203: {"cardiology_common"}},
+        prepared_assignments={},
+        errors={(203, "cardiology_common"): RuntimeError("allocation failed")},
     )
 
     service = RegistrarWizardQueueAssignmentService(
@@ -83,6 +95,6 @@ def test_assign_same_day_queue_numbers_preserves_safe_behavior_for_empty_and_fai
     assert same_day_visit.status == "confirmed"
     assert failed_visit.status == "confirmed"
     assert fake_assignment_service.calls == [
-        (202, today, "desk"),
-        (203, today, "desk"),
+        (202, "cardiology_common", today, "desk"),
+        (203, "cardiology_common", today, "desk"),
     ]

--- a/backend/tests/unit/test_wizard_create_branch_extraction.py
+++ b/backend/tests/unit/test_wizard_create_branch_extraction.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.morning_assignment import (
+    MorningAssignmentCreateBranchHandoff,
+    MorningAssignmentPreparedQueueAssignment,
+)
+from app.services.registrar_wizard_queue_assignment_service import (
+    RegistrarWizardQueueAssignmentService,
+)
+
+
+class _FakeVisit:
+    def __init__(self, *, visit_id: int, visit_date: date, status: str = "confirmed") -> None:
+        self.id = visit_id
+        self.visit_date = visit_date
+        self.status = status
+
+
+class _FakeAssignmentService:
+    def __init__(self, prepared_assignments):
+        self.prepared_assignments = prepared_assignments
+        self.calls = []
+
+    def _get_visit_queue_tags(self, visit):
+        return {"cardiology_common"}
+
+    def prepare_wizard_queue_assignment(self, visit, queue_tag, target_day, *, source):
+        self.calls.append((visit.id, queue_tag, target_day, source))
+        return self.prepared_assignments[(visit.id, queue_tag)]
+
+
+@pytest.mark.unit
+def test_assign_same_day_queue_numbers_uses_explicit_create_branch_handoff():
+    today = date.today()
+    visit = _FakeVisit(visit_id=301, visit_date=today)
+    create_handoff = MorningAssignmentCreateBranchHandoff(
+        queue_tag="cardiology_common",
+        daily_queue=SimpleNamespace(id=9),
+        create_entry_kwargs={
+            "daily_queue": SimpleNamespace(id=9),
+            "patient_id": 77,
+            "patient_name": "Wizard Patient",
+            "phone": "+998901112233",
+            "visit_id": 301,
+            "source": "desk",
+            "status": "waiting",
+            "queue_time": object(),
+            "services": [{"id": 1, "code": "K01", "name": "Consult", "price": 100000.0}],
+            "service_codes": ["K01"],
+            "auto_number": True,
+            "commit": False,
+        },
+    )
+    fake_assignment_service = _FakeAssignmentService(
+        {
+            (301, "cardiology_common"): MorningAssignmentPreparedQueueAssignment(
+                create_handoff=create_handoff
+            )
+        }
+    )
+    captured_handoffs = []
+
+    service = RegistrarWizardQueueAssignmentService(
+        db=object(),
+        assignment_service_factory=lambda _: fake_assignment_service,
+        create_entry_allocator=lambda handoff: (
+            captured_handoffs.append(handoff) or SimpleNamespace(number=23)
+        ),
+    )
+
+    queue_numbers = service.assign_same_day_queue_numbers(
+        [visit],
+        target_day=today,
+        source="desk",
+    )
+
+    assert queue_numbers == {
+        301: [
+            {
+                "queue_tag": "cardiology_common",
+                "queue_id": 9,
+                "number": 23,
+                "status": "assigned",
+            }
+        ]
+    }
+    assert visit.status == "open"
+    assert fake_assignment_service.calls == [(301, "cardiology_common", today, "desk")]
+    assert captured_handoffs == [create_handoff]

--- a/docs/architecture/W2C_WIZARD_CREATE_BRANCH_EXTRACTION.md
+++ b/docs/architecture/W2C_WIZARD_CREATE_BRANCH_EXTRACTION.md
@@ -1,0 +1,28 @@
+# Wave 2C Wizard Create Branch Extraction
+
+Date: 2026-05-06
+Mode: runtime replacement for stale PR #88
+
+## Current-Main Contract
+
+The mounted wizard queue path keeps shared queue-claim resolution in `MorningAssignmentService`, but makes the create-entry branch explicit for `RegistrarWizardQueueAssignmentService`.
+
+Flow:
+
+1. `RegistrarWizardQueueAssignmentService.assign_same_day_queue_numbers(...)` filters same-day confirmed visits.
+2. It asks `MorningAssignmentService._get_visit_queue_tags(...)` for queue buckets.
+3. It calls `MorningAssignmentService.prepare_wizard_queue_assignment(...)` for each bucket.
+4. Existing active entries return an immediate reuse payload.
+5. New entries return `MorningAssignmentCreateBranchHandoff`.
+6. The wizard service materializes that handoff through `queue_service.create_queue_entry(...)`.
+
+## Preserved Behavior
+
+- Duplicate/reuse lookup remains in the shared morning-assignment claim logic.
+- Number allocation still comes from `queue_service.create_queue_entry(...)`.
+- `queue_time`, `services`, `service_codes`, `source`, and `commit=False` are preserved in the handoff kwargs.
+- Future-day and non-confirmed visits are still skipped by the wizard service.
+
+## Compatibility Note
+
+This replacement does not carry the old stacked parent context. It only preserves the create-branch seam that is compatible with current `main`.

--- a/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_WIZARD_CREATE_BRANCH.md
+++ b/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_WIZARD_CREATE_BRANCH.md
@@ -1,0 +1,16 @@
+# Wave 2C Next Execution Unit After Wizard Create Branch
+
+Date: 2026-05-06
+
+## Recommended Next Step
+
+After this create-branch extraction, the next smallest runtime step is a focused compatibility test for the mounted registrar cart path.
+
+The test should prove:
+
+- same-day confirmed visits are assigned through `RegistrarWizardQueueAssignmentService`
+- existing active queue entries are reused
+- create handoff preserves `queue_time`, services, service codes, and `source`
+- ambiguous active queue claims still raise through shared resolution logic
+
+Do not combine this with queue numbering redesign or frontend workflow changes.

--- a/docs/status/W2C_WIZARD_ALLOCATOR_SURFACE.md
+++ b/docs/status/W2C_WIZARD_ALLOCATOR_SURFACE.md
@@ -1,0 +1,24 @@
+# Wave 2C Wizard Allocator Surface
+
+Date: 2026-05-06
+Mode: replacement status
+
+## Shared Surface
+
+- `MorningAssignmentService._get_visit_queue_tags(...)`
+- `MorningAssignmentService.prepare_wizard_queue_assignment(...)`
+- `MorningAssignmentService._resolve_existing_queue_claim_or_raise(...)`
+
+These keep queue-tag selection, active-entry reuse, and ambiguity handling in one place.
+
+## Wizard-Local Surface
+
+- `RegistrarWizardQueueAssignmentService._assign_same_day_queues_for_visit(...)`
+- `RegistrarWizardQueueAssignmentService._materialize_prepared_assignment(...)`
+- `RegistrarWizardQueueAssignmentService._allocate_create_branch_handoff(...)`
+
+These make create-entry materialization explicit without duplicating claim resolution.
+
+## Legacy Allocator
+
+`queue_service.create_queue_entry(...)` remains the numbering allocator. This PR does not replace numbering policy or queue fairness behavior.

--- a/docs/status/W2C_WIZARD_CREATE_BRANCH_EXTRACTION_PLAN.md
+++ b/docs/status/W2C_WIZARD_CREATE_BRANCH_EXTRACTION_PLAN.md
@@ -1,0 +1,18 @@
+# Wave 2C Wizard Create Branch Extraction Plan
+
+Date: 2026-05-06
+
+## Slice
+
+1. Add prepared assignment dataclasses to `MorningAssignmentService`.
+2. Refactor `_assign_single_queue(...)` to materialize a prepared assignment.
+3. Let `RegistrarWizardQueueAssignmentService` materialize create handoffs explicitly.
+4. Add unit coverage for reuse payload and create-handoff paths.
+
+## Denied Scope
+
+- frontend changes
+- migrations
+- CI changes
+- queue numbering redesign
+- billing/invoice orchestration

--- a/docs/status/W2C_WIZARD_CREATE_BRANCH_EXTRACTION_STATUS.md
+++ b/docs/status/W2C_WIZARD_CREATE_BRANCH_EXTRACTION_STATUS.md
@@ -1,0 +1,16 @@
+# Wave 2C Wizard Create Branch Extraction Status
+
+Date: 2026-05-06
+Status: replacement PR created from current main
+
+## Completed In This Slice
+
+- Current-main compatible create-branch handoff added.
+- Wizard service now calls prepared assignment instead of hidden direct `_assign_queues_for_visit(...)` delegation.
+- Unit tests characterize both existing assignment and create-handoff materialization.
+
+## Validation Target
+
+- `python -m py_compile backend/app/services/morning_assignment.py backend/app/services/registrar_wizard_queue_assignment_service.py backend/tests/unit/test_wizard_allocator_extraction.py backend/tests/unit/test_wizard_create_branch_extraction.py`
+- PR body gate
+- fresh PR CI


### PR DESCRIPTION
## Summary

Runtime replacement for stale PR #88 from current `main`. It preserves the useful wizard create-branch extraction without carrying the old stacked parent context: shared queue-tag claim resolution stays in `MorningAssignmentService`, while `RegistrarWizardQueueAssignmentService` now materializes an explicit `MorningAssignmentCreateBranchHandoff` for create-entry allocation.

## Contract Impact

- Canonical surface: backend wizard same-day queue assignment service and shared morning assignment queue-claim resolution.
- Request shape: no API request shape change; this is service-layer refactor only.
- Response shape: no API response shape change; assigned queue payload still returns `queue_tag`, `queue_id`, `number`, and `status`.
- Status codes: no endpoint/status-code changes.
- Compatibility path or alias: old direct `_assign_queues_for_visit(...)` delegation is replaced by prepared assignment handoff; legacy `queue_service.create_queue_entry(...)` remains the allocator.
- Contract proof: exact staged allowlist, `git diff --cached --check`, `py_compile` for touched runtime/tests, and fresh PR CI.
- Frontend consumer: no frontend consumer changes; registrar workflow should observe the same queue assignment payload.

## RBAC / Permissions

- Roles allowed: unchanged because no endpoint/router/dependency permission checks are touched.
- Roles denied: unchanged because no endpoint/router/dependency permission checks are touched.
- Positive auth proof: not applicable because this service-layer refactor does not change authorization gates.
- Negative auth proof: not applicable because this service-layer refactor does not change authorization gates.
- Legacy role normalization: not touched.

## Notification / Realtime

- Event type or websocket channel: not applicable because no notification or websocket event is added or changed.
- Payload version / ack behavior: not applicable because no realtime payload changes.
- Read/unread or delivery semantics: not applicable because no inbox/chat/notification delivery path changes.
- Reconnect/resync proof: not applicable because this PR does not touch websocket reconnect or resync behavior.

## Frontend Resilience

- Empty data proof: unchanged; no frontend or API empty-state behavior is changed.
- Partial data proof: unchanged; no frontend partial-data loader is changed.
- Forbidden secondary path behavior: unchanged; no frontend/API authorization path is changed.
- Missing draft/resource behavior: unchanged; no EMR/draft/resource flow is changed.
- Stale route/deep-link behavior: unchanged; no routing changes.

## Scope Gate

- Allowed paths: `backend/app/services/morning_assignment.py`, `backend/app/services/registrar_wizard_queue_assignment_service.py`, `backend/tests/unit/test_wizard_allocator_extraction.py`, `backend/tests/unit/test_wizard_create_branch_extraction.py`, `docs/architecture/W2C_WIZARD_CREATE_BRANCH_EXTRACTION.md`, `docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_WIZARD_CREATE_BRANCH.md`, `docs/status/W2C_WIZARD_ALLOCATOR_SURFACE.md`, `docs/status/W2C_WIZARD_CREATE_BRANCH_EXTRACTION_PLAN.md`, `docs/status/W2C_WIZARD_CREATE_BRANCH_EXTRACTION_STATUS.md`.
- Denied paths: frontend runtime, API routers, migrations, CI, generated artifacts, unrelated docs, and current `W2C_WIZARD_BOUNDARY_READINESS_V3.md`.
- Migration/docs/test impact: no migrations; adds focused unit characterization and docs for the create-branch seam.
- Rollback note: revert this PR to restore the previous direct `_assign_queues_for_visit(...)` delegation from `RegistrarWizardQueueAssignmentService` to `MorningAssignmentService`.

## Validation

- Targeted tests or smoke run: `git diff --cached --check`; `python -m py_compile backend/app/services/morning_assignment.py backend/app/services/registrar_wizard_queue_assignment_service.py backend/tests/unit/test_wizard_allocator_extraction.py backend/tests/unit/test_wizard_create_branch_extraction.py`; `python C:\final\scripts\run_pr_review_gate_checks.py --body-file PR_BODY.md`.
- Result: passing locally before PR creation.
- Not checked: local pytest/full suites not run; fresh PR CI is the repository validation target for backend/unit coverage.