### PR TITLE
docs(queue): replace wizard boundary readiness recheck

### DIFF
--- a/docs/architecture/W2C_WIZARD_REMAINING_BLOCKERS.md
+++ b/docs/architecture/W2C_WIZARD_REMAINING_BLOCKERS.md
@@ -1,0 +1,19 @@
+# Wave 2C Wizard Remaining Blockers
+
+Date: 2026-05-06
+Mode: docs-only replacement for stale PR #89
+Depends on: merged replacement PR #267
+
+## Remaining Coupling / Blocker Review
+
+| Blocker | Severity | Blocks migration | Narrow fix possible | Notes |
+|---|---|---:|---:|---|
+| Hidden shared allocator logic | LOW | No | Yes | Resolved for mounted wizard-family: create branch is now an explicit handoff, not a hidden inline create call. |
+| Billing coupling at allocation step | MEDIUM | No | Yes | Billing/invoice orchestration still shares the request transaction, but allocator materialization is isolated enough for a local boundary swap. |
+| Source ownership ambiguity | LOW | No | Yes | Mounted same-day wizard path carries explicit `source` through the handoff payload. |
+| Wizard-only claim ambiguity | LOW | No | Yes | Claim resolution stays in `MorningAssignmentService.prepare_wizard_queue_assignment(...)`. |
+| Visit linkage ambiguity | LOW | No | Yes | `visit_id` remains part of the handoff kwargs passed to queue-entry creation. |
+
+## Conclusion
+
+No remaining blocker currently forces another decomposition slice before wizard boundary migration.

--- a/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_WIZARD_RECHECK_V2.md
+++ b/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_WIZARD_RECHECK_V2.md
@@ -1,0 +1,25 @@
+# Wave 2C Next Execution Unit After Wizard Recheck V2
+
+Date: 2026-05-06
+Mode: docs-only replacement for stale PR #89
+
+## Decision
+
+Recommended next execution unit: `wizard boundary migration`.
+
+## Why This Step
+
+The mounted wizard-family now satisfies the prerequisites that blocked earlier passes:
+
+- queue-tag claim model is explicit
+- duplicate/reuse gate stays in shared claim resolution
+- outer wizard seam exists
+- create-branch handoff exists after #267
+- `QueueDomainService.allocate_ticket(allocation_mode="create_entry")` exists and delegates to the same legacy allocator
+
+The next narrow architectural step is therefore to replace the wizard-local create-branch materialization call with `QueueDomainService.allocate_ticket(...)` without changing billing orchestration or broader registrar behavior.
+
+## Not Chosen
+
+- `one more narrow wizard fix`: not chosen because no blocking narrow fix remains after #267.
+- `defer wizard family and move to another allocator family`: not chosen because wizard-family is now better isolated than the remaining high-risk allocator families.

--- a/docs/status/W2C_WIZARD_BOUNDARY_FEASIBILITY_V2.md
+++ b/docs/status/W2C_WIZARD_BOUNDARY_FEASIBILITY_V2.md
@@ -1,0 +1,38 @@
+# Wave 2C Wizard Boundary Feasibility V2
+
+Date: 2026-05-06
+Mode: docs-only replacement for stale PR #89
+
+## Question
+
+Can the extracted wizard-local create-branch handoff now be replaced with `QueueDomainService.allocate_ticket(...)` without changing runtime semantics?
+
+## Answer
+
+Yes, as the next narrow runtime slice.
+
+## Why
+
+Current mounted wizard-family create path is:
+
+1. build `MorningAssignmentCreateBranchHandoff`
+2. materialize it through `RegistrarWizardQueueAssignmentService._allocate_create_branch_handoff(...)`
+3. call `queue_service.create_queue_entry(self.db, **handoff.create_entry_kwargs)`
+
+Current queue-domain boundary implementation is:
+
+- `QueueDomainService.allocate_ticket(allocation_mode="create_entry", **kwargs)`
+- delegates to the same legacy `queue_service.create_queue_entry(...)`
+
+## Semantics Check
+
+- Numbering behavior: safe to preserve because the same `create_queue_entry(..., auto_number=True)` call remains underneath the boundary.
+- `queue_time` behavior: safe to preserve because `queue_time` is computed before the call and carried in the handoff kwargs.
+- Fairness ordering: safe to preserve because no ordering logic needs to move for the boundary swap.
+- Duplicate semantics: safe to preserve because duplicate/reuse logic runs before create-branch materialization.
+- Source semantics: safe to preserve because `source` already travels in the handoff payload.
+- Future-day behavior: safe to preserve because the wizard service still filters same-day confirmed visits.
+
+## Required Runtime Proof For Next PR
+
+The next runtime PR should prove that replacing `_allocate_create_branch_handoff(...)` with `QueueDomainService.allocate_ticket(...)` preserves the handoff kwargs and assigned payload.

--- a/docs/status/W2C_WIZARD_BOUNDARY_READINESS_V4.md
+++ b/docs/status/W2C_WIZARD_BOUNDARY_READINESS_V4.md
@@ -1,0 +1,27 @@
+# Wave 2C Wizard Boundary Readiness V4
+
+Date: 2026-05-06
+Mode: docs-only replacement for stale PR #89
+
+## Readiness Result
+
+Wizard boundary migration is ready for one narrow runtime PR.
+
+## Ready Because
+
+- Current `main` has an explicit wizard service seam.
+- Current `main` has `MorningAssignmentCreateBranchHandoff`.
+- Current `main` has `QueueDomainService.allocate_ticket(allocation_mode="create_entry")`.
+- The proposed boundary swap can preserve the same `create_entry_kwargs` and assigned queue payload.
+
+## Not Ready For
+
+- broad registrar cart rewrite
+- billing/invoice orchestration changes
+- frontend flow changes
+- queue numbering policy redesign
+- migration changes
+
+## Merge Guidance
+
+A future runtime PR should be marked risky until it proves parity between direct `queue_service.create_queue_entry(...)` materialization and `QueueDomainService.allocate_ticket(...)` materialization.

--- a/docs/status/W2C_WIZARD_CONTRACT_COMPLIANCE_RECHECK_V2.md
+++ b/docs/status/W2C_WIZARD_CONTRACT_COMPLIANCE_RECHECK_V2.md
@@ -1,0 +1,26 @@
+# Wave 2C Wizard Contract Compliance Recheck V2
+
+Date: 2026-05-06
+Mode: docs-only replacement for stale PR #89
+
+## Contract Surfaces
+
+| Surface | Current owner | Status |
+|---|---|---|
+| Same-day confirmed visit filtering | `RegistrarWizardQueueAssignmentService` | ready |
+| Queue-tag discovery | `MorningAssignmentService._get_visit_queue_tags(...)` | shared, explicit |
+| Duplicate/reuse claim | `MorningAssignmentService.prepare_wizard_queue_assignment(...)` | shared, explicit |
+| Create-entry handoff | `MorningAssignmentCreateBranchHandoff` | ready |
+| Create-entry materialization | `RegistrarWizardQueueAssignmentService._allocate_create_branch_handoff(...)` | next migration target |
+| Domain allocation boundary | `QueueDomainService.allocate_ticket(...)` | available |
+
+## Compliance Result
+
+The wizard family is compliant enough for a narrow boundary migration. The next PR should only replace the materialization call site and should not change claim resolution or payload assembly.
+
+## Required Proof
+
+- Existing entry path still returns status `existing`.
+- Create path still returns status `assigned` with the same `queue_tag`, `queue_id`, and `number` shape.
+- `source`, `queue_time`, `services`, `service_codes`, `visit_id`, and `commit=False` are preserved.
+- Non-confirmed and future-day visits remain skipped.

--- a/docs/status/W2C_WIZARD_SEAM_VERIFICATION_V2.md
+++ b/docs/status/W2C_WIZARD_SEAM_VERIFICATION_V2.md
@@ -1,0 +1,26 @@
+# Wave 2C Wizard Seam Verification V2
+
+Date: 2026-05-06
+Mode: docs-only replacement for stale PR #89
+
+## Verified Seams
+
+### Wizard service seam
+
+`RegistrarWizardQueueAssignmentService.assign_same_day_queue_numbers(...)` is the mounted same-day assignment seam for confirmed wizard visits.
+
+### Shared claim seam
+
+`MorningAssignmentService.prepare_wizard_queue_assignment(...)` owns shared queue-tag claim resolution and returns either an existing assignment payload or a create handoff.
+
+### Create branch seam
+
+`MorningAssignmentCreateBranchHandoff` carries the exact kwargs used to create a queue entry.
+
+### Allocation seam
+
+`RegistrarWizardQueueAssignmentService._allocate_create_branch_handoff(...)` currently delegates to `queue_service.create_queue_entry(...)` and is the narrow replacement target for `QueueDomainService.allocate_ticket(...)`.
+
+## Verification Conclusion
+
+The remaining boundary migration can be scoped to allocation materialization. Claim resolution, handoff assembly, and registrar transaction behavior should stay untouched in that next slice.


### PR DESCRIPTION
## Summary

Docs-only replacement for stale PR #89 after parent #88 was superseded by merged replacement #267. It preserves the wizard boundary readiness recheck on current `main`: create-branch handoff now exists, `QueueDomainService.allocate_ticket(allocation_mode="create_entry")` exists, and the next recommended runtime slice is a narrow wizard boundary migration.

## Contract Impact

- Canonical surface: wizard queue boundary readiness documentation only.
- Request shape: no runtime request shape change.
- Response shape: no runtime response shape change.
- Status codes: no runtime status-code change.
- Compatibility path or alias: docs identify `_allocate_create_branch_handoff(...)` as the compatibility call site that can later move to `QueueDomainService.allocate_ticket(...)`.
- Contract proof: exact docs allowlist, `git diff --cached --check`, source anchor search confirming `QueueDomainService.allocate_ticket(...)`, and fresh PR CI.
- Frontend consumer: not applicable because this PR changes docs only and no frontend consumer code.

## RBAC / Permissions

- Roles allowed: not applicable because no endpoint, dependency, role helper, or permission check changes.
- Roles denied: not applicable because no endpoint, dependency, role helper, or permission check changes.
- Positive auth proof: not applicable because this is docs-only readiness clarification.
- Negative auth proof: not applicable because this is docs-only readiness clarification.
- Legacy role normalization: not touched.

## Notification / Realtime

- Event type or websocket channel: not applicable because wizard readiness docs do not add notification or websocket events.
- Payload version / ack behavior: not applicable because no realtime payload changes.
- Read/unread or delivery semantics: not applicable because no inbox/chat/notification delivery path changes.
- Reconnect/resync proof: not applicable because this docs-only PR does not touch websocket reconnect or resync behavior.

## Frontend Resilience

- Empty data proof: not applicable because no frontend behavior changes.
- Partial data proof: not applicable because no frontend behavior changes.
- Forbidden secondary path behavior: not applicable because no frontend/API authorization path changes.
- Missing draft/resource behavior: not applicable because no EMR/draft/resource flow changes.
- Stale route/deep-link behavior: not applicable because no routing changes.

## Scope Gate

- Allowed paths: `docs/architecture/W2C_WIZARD_REMAINING_BLOCKERS.md`, `docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_WIZARD_RECHECK_V2.md`, `docs/status/W2C_WIZARD_BOUNDARY_FEASIBILITY_V2.md`, `docs/status/W2C_WIZARD_BOUNDARY_READINESS_V4.md`, `docs/status/W2C_WIZARD_CONTRACT_COMPLIANCE_RECHECK_V2.md`, `docs/status/W2C_WIZARD_SEAM_VERIFICATION_V2.md`.
- Denied paths: backend runtime, frontend runtime, tests, migrations, CI, generated artifacts, and existing wizard readiness docs not listed above.
- Migration/docs/test impact: docs-only; no migrations or tests added.
- Rollback note: revert this docs-only PR if the team decides the wizard boundary migration should not be the next runtime slice after #267.

## Validation

- Targeted tests or smoke run: exact staged allowlist, `git diff --cached --check`, source anchor search for `QueueDomainService.allocate_ticket(...)`, and `python C:\final\scripts\run_pr_review_gate_checks.py --body-file PR_BODY.md`.
- Result: passing locally before PR creation.
- Not checked: full backend/frontend suites not run locally because this is docs-only and fresh PR CI is the repository validation target.