### PR TITLE
docs(queue): review registrar allocator follow-up

### DIFF
--- a/docs/architecture/W2C_REGISTRAR_FOLLOWUP_INVENTORY.md
+++ b/docs/architecture/W2C_REGISTRAR_FOLLOWUP_INVENTORY.md
@@ -1,0 +1,45 @@
+# Wave 2C Registrar Follow-up Inventory
+
+
+Date: 2026-05-06
+Current-main replacement for stale PR #91 after parent #90 was superseded by merged PR #269.
+## Scope
+
+This pass inventories only registrar-related backend paths that can still:
+
+- create queue entries;
+- invoke queue numbering;
+- bypass `QueueDomainService.allocate_ticket()`;
+- alter duplicate/reuse behavior for registrar-owned queue joins;
+- or change visit-to-queue linkage during registrar-driven flows.
+
+Pure read endpoints, payment-only actions, and queue status updates without allocation are out of scope for this document.
+
+`Production relevant` below means the path is mounted in [`backend/app/api/v1/api.py`](C:/final/backend/app/api/v1/api.py) through an endpoint router and is reachable in the current API surface. Unmounted `*_api_service.py` routers are treated as duplicate runtime surfaces, not production truth.
+
+## Inventory
+
+| Path | Function / flow | Mounted | Production relevant | Queue allocation | Direct legacy allocator usage | Already covered by migrated family | Recommended disposition | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `backend/app/api/v1/endpoints/registrar_integration.py` | `create_queue_entries_batch()` | Yes | Yes | Yes | No | Yes | `ALREADY_COVERED_BY_BOUNDARY` | Batch-only mounted family already migrated to `QueueDomainService.allocate_ticket()` |
+| `backend/app/api/v1/endpoints/registrar_wizard.py` | `create_cart_appointments()` same-day path | Yes | Yes | Yes | No | Yes | `ALREADY_COVERED_BY_BOUNDARY` | Mounted wizard same-day path delegates to `RegistrarWizardQueueAssignmentService` and then to boundary |
+| `backend/app/api/v1/endpoints/registrar_wizard.py` | `confirm_visit_by_registrar()` -> `_assign_queue_numbers_on_confirmation()` | Yes | Yes | Yes | No | Yes | `ALREADY_COVERED_BY_BOUNDARY` | Registrar confirmation bridge now reuses the migrated confirmation family |
+| `backend/app/services/registrar_wizard_queue_assignment_service.py` | `assign_same_day_queue_numbers()` / `_allocate_create_branch_handoff()` | Indirect helper | Yes (via mounted wizard flow) | Yes | No | Yes | `ALREADY_COVERED_BY_BOUNDARY` | Wizard-local seam materializes create branch through `QueueDomainService.allocate_ticket()` |
+| `backend/app/api/v1/endpoints/registrar_batch.py` | `batch_update_patient_entries()` with `EntryAction(action="create")` | Yes | Yes | Yes | Yes (indirect) | No | `NEEDS_SEPARATE_CHARACTERIZATION` | Mounted registrar batch-edit surface still reaches legacy-style allocation through `BatchPatientService._create_entry()` |
+| `backend/app/services/batch_patient_service.py` | `_create_entry()` | Indirect helper | Yes (via mounted registrar batch route) | Yes | Yes | No | `NEEDS_SEPARATE_CHARACTERIZATION` | Imports `QueueService` and calls `add_to_queue()`; this is outside already migrated registrar families |
+| `backend/app/api/v1/endpoints/registrar_wizard.py` | `_create_queue_entries()` | Helper only | No | Yes | Yes | No | `DEAD_OR_DUPLICATE` | Legacy helper remains in mounted file but is not referenced by current mounted wizard flow |
+| `backend/app/services/registrar_wizard_api_service.py` | `_create_queue_entries()`, cart queue assignment, confirmation queue creation | No | No | Yes | Yes | No | `DEAD_OR_DUPLICATE` | Duplicate service-router surface with manual/legacy allocation; not mounted in `api_router` |
+| `backend/app/services/registrar_integration_api_service.py` | `create_queue_entries_batch()` | No | No | Yes | Yes (via `QueueBatchService`) | No | `DEAD_OR_DUPLICATE` | Duplicate service-router surface; mounted endpoint version already migrated separately |
+| `backend/app/services/queue_batch_service.py` | `create_entries()` | Helper only | No (current runtime) | Yes | Yes | No | `DEAD_OR_DUPLICATE` | Current callers are only duplicate/unmounted service-router code |
+| `backend/app/services/registrar_batch_api_service.py` | `batch_update_patient_entries()` | No | No | Yes (via `BatchPatientService`) | Yes (indirect) | No | `DEAD_OR_DUPLICATE` | Duplicate service-router mirror of mounted `/registrar/batch` path |
+
+## Inventory Conclusion
+
+After excluding already migrated families and unmounted duplicates, one mounted registrar-related allocator path still remains outside the boundary architecture:
+
+- [`backend/app/api/v1/endpoints/registrar_batch.py`](C:/final/backend/app/api/v1/endpoints/registrar_batch.py)
+  `batch_update_patient_entries()` create-action path
+- via [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py)
+  `_create_entry()`
+
+That path is the only remaining production-relevant registrar allocator surface discovered in this pass.

--- a/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_REGISTRAR_FOLLOWUP.md
+++ b/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_REGISTRAR_FOLLOWUP.md
@@ -1,0 +1,46 @@
+# Wave 2C Next Execution Unit After Registrar Follow-up
+
+
+Date: 2026-05-06
+Current-main replacement for stale PR #91 after parent #90 was superseded by merged PR #269.
+## Decision
+
+`B) one more narrow registrar slice`
+
+## Recommended Execution Unit
+
+`Registrar batch-edit create-action characterization`
+
+## Target Scope
+
+Only:
+
+- [`backend/app/api/v1/endpoints/registrar_batch.py`](C:/final/backend/app/api/v1/endpoints/registrar_batch.py)
+  mounted `batch_update_patient_entries()` create-action path
+- [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py)
+  `_create_entry()`
+
+## Why This Is The Right Next Step
+
+- it is the only remaining production-relevant registrar allocator path outside the boundary architecture;
+- it is narrower than a broad registrar follow-up;
+- it should be characterized before any migration or correction;
+- it already shows concrete runtime drift (`QueueService` import mismatch), so moving to `qr_queue` now would leave one mounted registrar allocator path unresolved.
+
+## Not Recommended As The Next Step
+
+- `qr_queue` direct SQL characterization now:
+  premature while one mounted registrar allocator branch remains unresolved
+- `human review needed`:
+  not necessary yet, because the next missing work is technical characterization, not contract ambiguity
+- broad registrar refactor:
+  disproportionate to the remaining scope
+
+## Expected Next Slice Shape
+
+A safe next slice should:
+
+- be characterization-first;
+- verify whether `/registrar/batch` create-action is actually exercised and how it behaves;
+- add tests around `_create_entry()` and mounted create-action dispatch;
+- determine whether the path needs a narrow runtime correction before any later boundary migration or can be retired as dead UI surface.

--- a/docs/status/W2C_REGISTRAR_DIRECT_ALLOCATOR_REMAINS.md
+++ b/docs/status/W2C_REGISTRAR_DIRECT_ALLOCATOR_REMAINS.md
@@ -1,0 +1,80 @@
+# Wave 2C Registrar Direct Allocator Remains
+
+
+Date: 2026-05-06
+Current-main replacement for stale PR #91 after parent #90 was superseded by merged PR #269.
+## Verdict
+
+Registrar-related direct allocator usage still remains in one production-relevant mounted path.
+
+## Production-Relevant Remaining Path
+
+### 1. Mounted registrar batch edit/create flow
+
+- Endpoint:
+  [`backend/app/api/v1/endpoints/registrar_batch.py`](C:/final/backend/app/api/v1/endpoints/registrar_batch.py)
+  `batch_update_patient_entries()`
+- Helper:
+  [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py)
+  `_create_entry()`
+
+Current allocation path:
+
+1. mounted `/registrar/batch/patients/{patient_id}/entries/{date}` accepts a batch update;
+2. `BatchPatientService.batch_update()` dispatches `EntryAction(action="create")`;
+3. `_create_entry()` performs:
+   `from app.services.queue_service import QueueService`
+4. `_create_entry()` then calls:
+   `QueueService(self.db).add_to_queue(...)`
+
+Why this still counts as direct legacy allocator usage:
+
+- it does not use `QueueDomainService.allocate_ticket()`;
+- it does not go through any registrar-specific migrated seam;
+- it targets a legacy-style queue service API rather than the new compatibility boundary.
+
+## Why This Path Was Not Covered Earlier
+
+Previous registrar slices covered different mounted families:
+
+- confirmation bridge in `registrar_wizard.py`;
+- batch-only create path in `registrar_integration.py`;
+- wizard same-day cart path in `registrar_wizard.py`.
+
+The `/registrar/batch` create-action path belongs to a separate batch-edit surface (`UI Row ↔ API Entry`) and was therefore outside those slices.
+
+## Risk Assessment
+
+Risk level: `MEDIUM-HIGH`
+
+Why:
+
+- the path is mounted and production-relevant;
+- it bypasses the queue boundary architecture;
+- it is not characterized yet;
+- static inspection shows a concrete runtime drift signal:
+  [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py)
+  imports `QueueService`, but [`backend/app/services/queue_service.py`](C:/final/backend/app/services/queue_service.py) exports `QueueBusinessService` and `queue_service`, not `QueueService`.
+
+## Current-main Import Drift Evidence
+
+This replacement verified the drift by static inspection against current `main` after PR #269:
+
+- `backend/app/services/batch_patient_service.py` imports `QueueService`;
+- `backend/app/services/queue_service.py` exports `QueueBusinessService`, `queue_service`, and `get_queue_service()`, not `QueueService`;
+- `_create_entry()` therefore still needs characterization before any migration or retirement decision.
+
+That means the remaining mounted registrar allocator path is outside the queue boundary and has a concrete stale-import risk when the create-action branch is exercised.
+
+## Non-Production Direct Allocator Remains
+
+The following registrar-related direct allocator paths still exist, but are not current production entry points:
+
+- [`backend/app/api/v1/endpoints/registrar_wizard.py`](C:/final/backend/app/api/v1/endpoints/registrar_wizard.py)
+  `_create_queue_entries()`
+- [`backend/app/services/registrar_wizard_api_service.py`](C:/final/backend/app/services/registrar_wizard_api_service.py)
+- [`backend/app/services/registrar_integration_api_service.py`](C:/final/backend/app/services/registrar_integration_api_service.py)
+- [`backend/app/services/queue_batch_service.py`](C:/final/backend/app/services/queue_batch_service.py)
+- [`backend/app/services/registrar_batch_api_service.py`](C:/final/backend/app/services/registrar_batch_api_service.py)
+
+These should be treated as duplicate/unmounted cleanup debt, not as current registrar migration blockers.

--- a/docs/status/W2C_REGISTRAR_FOLLOWUP_CLASSIFICATION.md
+++ b/docs/status/W2C_REGISTRAR_FOLLOWUP_CLASSIFICATION.md
@@ -1,0 +1,72 @@
+# Wave 2C Registrar Follow-up Classification
+
+
+Date: 2026-05-06
+Current-main replacement for stale PR #91 after parent #90 was superseded by merged PR #269.
+## Category Map
+
+### A) `ALREADY_COVERED_BY_BOUNDARY`
+
+- [`backend/app/api/v1/endpoints/registrar_integration.py`](C:/final/backend/app/api/v1/endpoints/registrar_integration.py)
+  `create_queue_entries_batch()`
+- [`backend/app/api/v1/endpoints/registrar_wizard.py`](C:/final/backend/app/api/v1/endpoints/registrar_wizard.py)
+  `create_cart_appointments()` same-day queue path
+- [`backend/app/api/v1/endpoints/registrar_wizard.py`](C:/final/backend/app/api/v1/endpoints/registrar_wizard.py)
+  `confirm_visit_by_registrar()` bridge
+- [`backend/app/services/registrar_wizard_queue_assignment_service.py`](C:/final/backend/app/services/registrar_wizard_queue_assignment_service.py)
+  wizard queue-assignment seam
+
+Reason:
+
+- these are mounted or production-serving seams;
+- their allocator calls already pass through `QueueDomainService.allocate_ticket()`;
+- prior characterization/correction slices already stabilized their duplicate and claim semantics.
+
+### B) `DEAD_OR_DUPLICATE`
+
+- [`backend/app/api/v1/endpoints/registrar_wizard.py`](C:/final/backend/app/api/v1/endpoints/registrar_wizard.py)
+  `_create_queue_entries()`
+- [`backend/app/services/registrar_wizard_api_service.py`](C:/final/backend/app/services/registrar_wizard_api_service.py)
+  duplicate wizard router/service surface
+- [`backend/app/services/registrar_integration_api_service.py`](C:/final/backend/app/services/registrar_integration_api_service.py)
+  duplicate registrar integration router/service surface
+- [`backend/app/services/queue_batch_service.py`](C:/final/backend/app/services/queue_batch_service.py)
+  helper reachable only from duplicate/unmounted service-router code
+- [`backend/app/services/registrar_batch_api_service.py`](C:/final/backend/app/services/registrar_batch_api_service.py)
+  duplicate registrar batch router/service surface
+
+Reason:
+
+- not mounted in [`backend/app/api/v1/api.py`](C:/final/backend/app/api/v1/api.py);
+- not part of current endpoint router truth;
+- some still contain stale direct allocator logic, but they are not current production entry points.
+
+### C) `NEEDS_SEPARATE_CHARACTERIZATION`
+
+- [`backend/app/api/v1/endpoints/registrar_batch.py`](C:/final/backend/app/api/v1/endpoints/registrar_batch.py)
+  `batch_update_patient_entries()` with `EntryAction(action="create")`
+- [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py)
+  `_create_entry()`
+
+Reason:
+
+- mounted and production-relevant;
+- not covered by confirmation, registrar batch-only, or wizard-family migration slices;
+- still bypass the boundary architecture;
+- show runtime drift risk around legacy allocator import/use.
+
+### D) `DEFER_SAFE`
+
+None identified in this pass.
+
+Rationale:
+
+- every remaining registrar-related allocator path was either already migrated, obviously duplicate/unmounted, or the single mounted leftover requiring its own characterization.
+
+### E) `LEGACY_LATE_TRACK`
+
+None inside registrar-owned runtime scope.
+
+Rationale:
+
+- `qr_queue`, `OnlineDay`, and `force_majeure` remain separate allocator families, but they are outside registrar follow-up scope and should not be merged into registrar completeness accounting.

--- a/docs/status/W2C_REGISTRAR_TRACK_COMPLETENESS.md
+++ b/docs/status/W2C_REGISTRAR_TRACK_COMPLETENESS.md
@@ -1,0 +1,53 @@
+# Wave 2C Registrar Track Completeness
+
+
+Date: 2026-05-06
+Current-main replacement for stale PR #91 after parent #90 was superseded by merged PR #269.
+## Assessed Families
+
+Completed / effectively covered:
+
+- confirmation family;
+- mounted registrar batch-only create family;
+- mounted wizard same-day queue-assignment family.
+
+Still remaining:
+
+- mounted registrar batch-edit create-action path via
+  [`backend/app/api/v1/endpoints/registrar_batch.py`](C:/final/backend/app/api/v1/endpoints/registrar_batch.py)
+  and
+  [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py)
+
+Unmounted duplicates:
+
+- `registrar_wizard_api_service.py`
+- `registrar_integration_api_service.py`
+- `registrar_batch_api_service.py`
+- `queue_batch_service.py`
+- legacy helper `_create_queue_entries()` in mounted `registrar_wizard.py`
+
+## Verdict
+
+`PARTIALLY_COMPLETE_WITH_ONE_REMAINING_PATH`
+
+## Why Not `EFFECTIVELY_COMPLETE`
+
+The registrar allocator track cannot yet be marked effectively complete because one mounted production-relevant path still:
+
+- creates queue entries outside `QueueDomainService.allocate_ticket()`;
+- has not gone through characterization;
+- appears to rely on a stale `QueueService` import path.
+
+If that `/registrar/batch` create-action branch did not exist, the remaining registrar allocator surfaces would be only duplicate/unmounted code and the track could be considered effectively complete.
+
+## Why Not `NEEDS_ANOTHER_REGISTRAR_SLICE` In The Broad Sense
+
+The track does not need another broad registrar campaign.
+
+It needs exactly one narrow registrar follow-up slice focused on:
+
+- mounted `/registrar/batch` create-action behavior;
+- `BatchPatientService._create_entry()`;
+- allocator ownership and runtime truth for that branch only.
+
+So the remaining work is narrow, not a renewed broad registrar refactor.


### PR DESCRIPTION
## Summary

- Replacement for stale PR #91 after parent #90 was superseded by merged replacement PR #269.
- Preserves the registrar follow-up inventory/classification docs from #91 on current `main`.
- Updates wording for current-main evidence: remaining mounted `/registrar/batch` create-action path still needs separate characterization, while wizard same-day handoff is already behind `QueueDomainService` after #269.

## Contract Impact

not applicable - docs-only inventory/classification pass; no API route, request shape, response shape, status-code behavior, frontend consumer, compatibility alias, or runtime contract is changed.

## RBAC / Permissions

not applicable - no route guard, auth dependency, role matrix, legacy role form, or permission check changed; this PR only classifies remaining registrar allocator surfaces in docs.

## Notification / Realtime

not applicable - no notification event, websocket channel, chat flow, read/unread state, or realtime delivery behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - docs-only change; no frontend empty-state behavior changed.
- Partial data proof: not applicable - docs-only change; no frontend partial-data path changed.
- Missing draft/resource behavior: not applicable - docs-only change; no EMR draft/resource path changed.
- Forbidden secondary path behavior: not applicable - docs-only change; no secondary API fallback path changed.
- Stale route/deep-link behavior: not applicable - docs-only change; no frontend route/deep-link behavior changed.

## Scope Gate

- Allowed paths: five W2C registrar follow-up inventory/classification/status docs under `docs/architecture/` and `docs/status/`.
- Denied paths: backend runtime, backend tests, frontend runtime, migrations, auth/RBAC helpers, notification/realtime code, CI/workflows, generated artifacts.
- Migration/docs/test impact: docs only; no migration; no runtime or test code added or changed.
- Rollback note: revert the five W2C registrar follow-up docs from this PR.

## Validation

- Targeted tests or smoke run: exact staged allowlist check; `git diff --cached --check`; `python C:\final\scripts\run_pr_review_gate_checks.py --body-file <temp body>`.
- Result: local docs-only gate passes before PR creation; fresh PR CI must pass before merge decision.
- Not checked: runtime allocator behavior, mounted endpoint behavior, browser registrar smoke, staging/production smoke, and frontend runtime behavior because this replacement is docs-only.