### PR TITLE
fix(queue): restore registrar batch create action

### DIFF
--- a/backend/app/services/batch_patient_service.py
+++ b/backend/app/services/batch_patient_service.py
@@ -15,14 +15,35 @@ from datetime import date as date_type
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
+from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.patient import Patient
+from app.models.service import Service
+from app.models.user import User
 from app.models.visit import Visit
-from app.services.service_mapping import get_service_code
+from app.services.queue_domain_service import QueueDomainService
+from app.services.queue_service import get_queue_service
+from app.services.service_mapping import (
+    get_default_service_by_specialty,
+    normalize_service_code,
+    normalize_specialty,
+)
 
 logger = logging.getLogger(__name__)
+
+_BATCH_CREATE_RESOURCE_MAPPING = {
+    "ecg": "ecg_resource",
+    "echokg": "ecg_resource",
+    "lab": "lab_resource",
+    "laboratory": "lab_resource",
+    "general": "general_resource",
+    "cardiology_common": "general_resource",
+    "dermatology": "general_resource",
+    "procedures": "general_resource",
+}
 
 
 # ============================================================================
@@ -305,22 +326,44 @@ class BatchPatientService:
         action: EntryAction
     ) -> EntryResult:
         """Создаёт новую запись"""
-        from app.services.queue_service import QueueService
-
-        # Используем существующий QueueService для создания
-        queue_service = QueueService(self.db)
-
         try:
-            result = queue_service.add_to_queue(
-                patient_id=patient_id,
-                specialty=action.specialty or "general",
-                service_id=action.service_id,
-                service_code=action.service_code,
-                source="batch_update"
+            patient = self._get_patient_or_raise(patient_id)
+            service = self._resolve_create_action_service(action)
+            queue_tag = self._resolve_create_action_queue_tag(
+                action=action,
+                service=service,
+            )
+            daily_queue = self._resolve_create_action_daily_queue(
+                action=action,
+                target_date=target_date,
+                queue_tag=queue_tag,
+                service=service,
+            )
+            service_codes = self._build_create_action_service_codes(
+                action=action,
+                service=service,
+            )
+            services_payload = self._build_create_action_services_payload(
+                service=service,
+                service_codes=service_codes,
+            )
+
+            created_entry = QueueDomainService(self.db).allocate_ticket(
+                allocation_mode="create_entry",
+                daily_queue=daily_queue,
+                patient_id=patient.id,
+                patient_name=patient.short_name(),
+                phone=patient.phone,
+                source="batch_update",
+                status="waiting",
+                services=services_payload,
+                service_codes=service_codes,
+                auto_number=True,
+                commit=False,
             )
 
             return EntryResult(
-                id=result.get("entry_id", 0),
+                id=created_entry.id,
                 status="created"
             )
         except Exception as e:
@@ -330,6 +373,234 @@ class BatchPatientService:
                 status="error",
                 error=str(e)
             )
+
+    def _get_patient_or_raise(self, patient_id: int) -> Patient:
+        patient = self.db.query(Patient).filter(Patient.id == patient_id).first()
+        if not patient:
+            raise ValueError(f"Пациент с ID {patient_id} не найден")
+        return patient
+
+    def _resolve_create_action_service(self, action: EntryAction) -> Service | None:
+        service = None
+
+        if action.service_id:
+            service = (
+                self.db.query(Service)
+                .filter(Service.id == action.service_id)
+                .first()
+            )
+
+        if service is None and action.service_code:
+            normalized_code = normalize_service_code(action.service_code)
+            candidate_codes = {
+                code
+                for code in {action.service_code, normalized_code}
+                if code
+            }
+            service = (
+                self.db.query(Service)
+                .filter(
+                    or_(
+                        Service.service_code.in_(candidate_codes),
+                        Service.code.in_(candidate_codes),
+                    )
+                )
+                .first()
+            )
+
+        if service is None and action.specialty:
+            default_service = get_default_service_by_specialty(self.db, action.specialty)
+            if default_service:
+                service = (
+                    self.db.query(Service)
+                    .filter(Service.id == default_service["id"])
+                    .first()
+                )
+
+        return service
+
+    def _resolve_create_action_queue_tag(
+        self,
+        *,
+        action: EntryAction,
+        service: Service | None,
+    ) -> str:
+        if service and service.queue_tag:
+            return service.queue_tag
+
+        normalized_specialty = normalize_specialty(action.specialty or "")
+        if normalized_specialty:
+            return normalized_specialty
+
+        raise ValueError(
+            "Не удалось определить queue_tag для create-action "
+            "(ожидались service_id, service_code или specialty)"
+        )
+
+    def _resolve_create_action_daily_queue(
+        self,
+        *,
+        action: EntryAction,
+        target_date: date_type,
+        queue_tag: str,
+        service: Service | None,
+    ) -> DailyQueue:
+        queue_service = get_queue_service()
+
+        explicit_specialist_id = action.doctor_id or getattr(service, "doctor_id", None)
+        if explicit_specialist_id:
+            return queue_service.get_or_create_daily_queue(
+                self.db,
+                day=target_date,
+                specialist_id=explicit_specialist_id,
+                queue_tag=queue_tag,
+            )
+
+        active_queues = (
+            self.db.query(DailyQueue)
+            .filter(
+                DailyQueue.day == target_date,
+                DailyQueue.queue_tag == queue_tag,
+                DailyQueue.active == True,
+            )
+            .order_by(DailyQueue.id.asc())
+            .all()
+        )
+        if len(active_queues) == 1:
+            return active_queues[0]
+        if len(active_queues) > 1:
+            raise ValueError(
+                "Неоднозначная очередь для create-action "
+                f"(queue_tag={queue_tag}, date={target_date})"
+            )
+
+        resolved_specialist_id = self._resolve_create_action_specialist_id(
+            action=action,
+            queue_tag=queue_tag,
+            service=service,
+        )
+        return queue_service.get_or_create_daily_queue(
+            self.db,
+            day=target_date,
+            specialist_id=resolved_specialist_id,
+            queue_tag=queue_tag,
+        )
+
+    def _resolve_create_action_specialist_id(
+        self,
+        *,
+        action: EntryAction,
+        queue_tag: str,
+        service: Service | None,
+    ) -> int:
+        service_doctor_ids = [
+            doctor_id
+            for (doctor_id,) in (
+                self.db.query(Service.doctor_id)
+                .filter(
+                    Service.active == True,
+                    Service.queue_tag == queue_tag,
+                    Service.doctor_id.isnot(None),
+                )
+                .distinct()
+                .all()
+            )
+            if doctor_id is not None
+        ]
+        if len(service_doctor_ids) == 1:
+            return int(service_doctor_ids[0])
+        if len(service_doctor_ids) > 1:
+            raise ValueError(
+                "Неоднозначный владелец очереди по услугам "
+                f"(queue_tag={queue_tag})"
+            )
+
+        resource_username = _BATCH_CREATE_RESOURCE_MAPPING.get(queue_tag)
+        if resource_username:
+            resource_doctor = (
+                self.db.query(Doctor)
+                .join(User, Doctor.user_id == User.id)
+                .filter(
+                    Doctor.active == True,
+                    User.username == resource_username,
+                    User.is_active == True,
+                )
+                .first()
+            )
+            if resource_doctor:
+                return int(resource_doctor.id)
+
+        specialty_candidates = {
+            candidate.lower()
+            for candidate in {
+                action.specialty or "",
+                normalize_specialty(action.specialty or ""),
+                queue_tag,
+                getattr(service, "queue_tag", "") or "",
+            }
+            if candidate
+        }
+        matching_doctors = [
+            doctor
+            for doctor in self.db.query(Doctor).filter(Doctor.active == True).all()
+            if (doctor.specialty or "").strip().lower() in specialty_candidates
+            or normalize_specialty((doctor.specialty or "").strip()) in specialty_candidates
+        ]
+
+        if len(matching_doctors) == 1:
+            return int(matching_doctors[0].id)
+        if len(matching_doctors) > 1:
+            raise ValueError(
+                "Неоднозначный врач для create-action "
+                f"(queue_tag={queue_tag}, specialty={action.specialty})"
+            )
+
+        raise ValueError(
+            "Не удалось определить владельца очереди для create-action "
+            f"(queue_tag={queue_tag})"
+        )
+
+    def _build_create_action_service_codes(
+        self,
+        *,
+        action: EntryAction,
+        service: Service | None,
+    ) -> list[str] | None:
+        if action.service_code:
+            normalized_code = normalize_service_code(action.service_code)
+            return [normalized_code] if normalized_code else [action.service_code]
+
+        if service:
+            service_code = service.service_code or service.code
+            if service_code:
+                normalized_code = normalize_service_code(service_code)
+                return [normalized_code] if normalized_code else [service_code]
+
+        return None
+
+    def _build_create_action_services_payload(
+        self,
+        *,
+        service: Service | None,
+        service_codes: list[str] | None,
+    ) -> list[dict[str, Any]] | None:
+        if not service:
+            return None
+
+        code = None
+        if service_codes:
+            code = service_codes[0]
+        elif service.service_code or service.code:
+            code = normalize_service_code(service.service_code or service.code)
+
+        return [
+            {
+                "id": service.id,
+                "code": code,
+                "name": service.name,
+                "price": float(service.price) if service.price else 0,
+            }
+        ]
 
     def _apply_common_updates(
         self,
@@ -385,12 +656,19 @@ class BatchPatientService:
 
         # Собираем данные из OnlineQueueEntry
         for entry in online_entries:
-            if entry.service_code:
-                services.append(entry.service_code)
+            legacy_service_code = getattr(entry, "service_code", None)
+            if legacy_service_code:
+                services.append(legacy_service_code)
+            elif entry.service_codes:
+                services.extend(code for code in entry.service_codes if code)
+
+            queue_tag = getattr(entry, "queue_tag", None)
+            if queue_tag is None and getattr(entry, "queue", None):
+                queue_tag = entry.queue.queue_tag
             queue_numbers.append({
                 "id": entry.id,
                 "number": entry.number,
-                "queue_tag": entry.queue_tag,
+                "queue_tag": queue_tag,
                 "status": entry.status,
                 "queue_time": entry.queue_time.isoformat() if entry.queue_time else None  # ⭐ FIX 13
             })
@@ -398,17 +676,17 @@ class BatchPatientService:
         # Собираем данные из Visit
         for visit in visits:
             if hasattr(visit, 'service') and visit.service:
-                services.append(
-                    visit.service.service_code
-                    or get_service_code(visit.service.id, self.db)
-                    or str(visit.service_id)
-                )
+                services.append(visit.service.code if hasattr(visit.service, 'code') else str(visit.service_id))
             if hasattr(visit, 'cost') and visit.cost:
                 total_cost += visit.cost
 
         return {
             "patient_id": patient_id,
-            "patient_fio": patient.fio if patient else "",
+            "patient_fio": (
+                patient.short_name()
+                if patient
+                else ""
+            ),
             "patient_phone": patient.phone if patient else "",
             "services": list(set(services)),  # Unique
             "queue_numbers": queue_numbers,

--- a/backend/tests/characterization/test_registrar_batch_create_action_characterization.py
+++ b/backend/tests/characterization/test_registrar_batch_create_action_characterization.py
@@ -5,25 +5,51 @@ from datetime import date
 import pytest
 
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.service import Service
 from app.services.batch_patient_service import (
     BatchPatientService,
     BatchUpdateRequest,
     EntryAction,
 )
+from app.services.service_mapping import normalize_service_code
+
+
+def _create_batch_service(
+    db_session,
+    *,
+    service_code: str,
+    doctor_id: int | None,
+    queue_tag: str = "cardiology",
+) -> Service:
+    service = Service(
+        code=service_code,
+        service_code=service_code,
+        name=f"Service {service_code}",
+        active=True,
+        queue_tag=queue_tag,
+        doctor_id=doctor_id,
+        requires_doctor=doctor_id is not None,
+    )
+    db_session.add(service)
+    db_session.commit()
+    db_session.refresh(service)
+    return service
 
 
 def _create_existing_entry(
     db_session,
     *,
     patient_id: int,
+    doctor_id: int,
     number: int,
+    queue_tag: str,
     status: str = "waiting",
     source: str = "desk",
 ) -> OnlineQueueEntry:
     queue = DailyQueue(
         day=date.today(),
-        specialist_id=101,
-        queue_tag="cardiology",
+        specialist_id=doctor_id,
+        queue_tag=queue_tag,
         active=True,
     )
     db_session.add(queue)
@@ -47,18 +73,20 @@ def _create_existing_entry(
 
 @pytest.mark.integration
 @pytest.mark.queue
-def test_registrar_batch_create_action_characterization_mounted_path_is_live_but_returns_400(
+def test_registrar_batch_create_action_characterization_mounted_path_creates_queue_row(
     client,
     db_session,
     registrar_auth_headers,
     test_patient,
+    test_doctor,
 ):
-    target_day = date.today().isoformat()
-    before_count = (
-        db_session.query(OnlineQueueEntry)
-        .filter(OnlineQueueEntry.patient_id == test_patient.id)
-        .count()
+    service = _create_batch_service(
+        db_session,
+        service_code="W2C-BATCH-CREATE",
+        doctor_id=test_doctor.id,
+        queue_tag="cardiology",
     )
+    target_day = date.today().isoformat()
 
     response = client.patch(
         f"/api/v1/registrar/batch/patients/{test_patient.id}/entries/{target_day}",
@@ -68,33 +96,56 @@ def test_registrar_batch_create_action_characterization_mounted_path_is_live_but
                 {
                     "action": "create",
                     "specialty": "cardiology",
-                    "service_code": "W2C-BATCH-CREATE",
+                    "service_code": service.service_code,
                 }
             ]
         },
     )
 
-    assert response.status_code == 400
-    assert response.json()["detail"] == "One or more operations failed"
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["updated_entries"][0]["status"] == "created"
 
-    after_entries = (
+    created_entries = (
         db_session.query(OnlineQueueEntry)
         .filter(OnlineQueueEntry.patient_id == test_patient.id)
+        .order_by(OnlineQueueEntry.id.asc())
         .all()
     )
-    assert len(after_entries) == before_count
-    assert not any(entry.source == "batch_update" for entry in after_entries)
+    assert len(created_entries) == 1
+    assert created_entries[0].source == "batch_update"
+    assert created_entries[0].status == "waiting"
+    assert created_entries[0].number == 1
+    assert created_entries[0].service_codes == [normalize_service_code(service.service_code)]
+    assert created_entries[0].queue_time is not None
+
+    created_queue = (
+        db_session.query(DailyQueue)
+        .filter(DailyQueue.id == created_entries[0].queue_id)
+        .first()
+    )
+    assert created_queue is not None
+    assert created_queue.specialist_id == test_doctor.id
+    assert created_queue.queue_tag == service.queue_tag
 
 
 @pytest.mark.integration
 @pytest.mark.queue
-def test_registrar_batch_create_action_characterization_reports_queue_service_import_error(
+def test_registrar_batch_create_action_characterization_service_path_returns_created_entry(
     db_session,
     test_patient,
+    test_doctor,
 ):
-    service = BatchPatientService(db_session)
+    service = _create_batch_service(
+        db_session,
+        service_code="W2C-BATCH-CREATE-SVC",
+        doctor_id=test_doctor.id,
+        queue_tag="cardiology",
+    )
+    batch_service = BatchPatientService(db_session)
 
-    result = service.batch_update(
+    result = batch_service.batch_update(
         patient_id=test_patient.id,
         target_date=date.today(),
         request=BatchUpdateRequest(
@@ -102,30 +153,47 @@ def test_registrar_batch_create_action_characterization_reports_queue_service_im
                 EntryAction(
                     action="create",
                     specialty="cardiology",
-                    service_code="W2C-BATCH-CREATE",
+                    service_code=service.service_code,
                 )
             ]
         ),
     )
 
-    assert result.success is False
+    assert result.success is True
     assert len(result.updated_entries) == 1
-    assert result.updated_entries[0].status == "error"
-    assert "cannot import name 'QueueService'" in (result.updated_entries[0].error or "")
+    assert result.updated_entries[0].status == "created"
+
+    created_entry = (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.id == result.updated_entries[0].id)
+        .first()
+    )
+    assert created_entry is not None
+    assert created_entry.source == "batch_update"
+    assert created_entry.service_codes == [normalize_service_code(service.service_code)]
 
 
 @pytest.mark.integration
 @pytest.mark.queue
-def test_registrar_batch_create_action_characterization_duplicate_scenario_still_creates_no_new_row(
+def test_registrar_batch_create_action_characterization_duplicate_scenario_creates_next_number(
     client,
     db_session,
     registrar_auth_headers,
     test_patient,
+    test_doctor,
 ):
+    service = _create_batch_service(
+        db_session,
+        service_code="W2C-BATCH-DUP",
+        doctor_id=test_doctor.id,
+        queue_tag="cardiology",
+    )
     existing_entry = _create_existing_entry(
         db_session,
         patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
         number=8,
+        queue_tag="cardiology",
         status="diagnostics",
         source="online",
     )
@@ -139,22 +207,29 @@ def test_registrar_batch_create_action_characterization_duplicate_scenario_still
                 {
                     "action": "create",
                     "specialty": "cardiology",
-                    "service_code": "W2C-BATCH-DUP",
+                    "service_code": service.service_code,
                 }
             ]
         },
     )
 
-    assert response.status_code == 400
-    assert response.json()["detail"] == "One or more operations failed"
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["updated_entries"][0]["status"] == "created"
 
     patient_entries = (
         db_session.query(OnlineQueueEntry)
         .filter(OnlineQueueEntry.patient_id == test_patient.id)
-        .order_by(OnlineQueueEntry.id.asc())
+        .order_by(OnlineQueueEntry.number.asc(), OnlineQueueEntry.id.asc())
         .all()
     )
-    assert [entry.id for entry in patient_entries] == [existing_entry.id]
-    assert patient_entries[0].number == existing_entry.number
-    assert patient_entries[0].status == existing_entry.status
-    assert patient_entries[0].source == existing_entry.source
+    assert [entry.id for entry in patient_entries] == [
+        existing_entry.id,
+        payload["updated_entries"][0]["id"],
+    ]
+    assert patient_entries[0].number == 8
+    assert patient_entries[0].status == "diagnostics"
+    assert patient_entries[1].number == 9
+    assert patient_entries[1].source == "batch_update"
+    assert patient_entries[1].service_codes == [normalize_service_code(service.service_code)]

--- a/backend/tests/unit/test_registrar_batch_create_action_fix.py
+++ b/backend/tests/unit/test_registrar_batch_create_action_fix.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+from app.models.clinic import Doctor
+from app.models.online_queue import DailyQueue
+from app.models.service import Service
+from app.models.user import User
+from app.services.batch_patient_service import BatchPatientService, EntryAction
+from app.services.queue_domain_service import QueueDomainService
+from app.services.service_mapping import normalize_service_code
+
+
+def _create_batch_service(
+    db_session,
+    *,
+    service_code: str,
+    doctor_id: int | None,
+    queue_tag: str = "cardiology",
+) -> Service:
+    service = Service(
+        code=service_code,
+        service_code=service_code,
+        name=f"Service {service_code}",
+        active=True,
+        queue_tag=queue_tag,
+        doctor_id=doctor_id,
+        requires_doctor=doctor_id is not None,
+    )
+    db_session.add(service)
+    db_session.commit()
+    db_session.refresh(service)
+    return service
+
+
+def _create_second_doctor(db_session) -> Doctor:
+    user = User(
+        username="test_cardio_second",
+        email="cardio-second@test.com",
+        full_name="Second Cardiologist",
+        hashed_password="test-hash",
+        role="Doctor",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    doctor = Doctor(
+        user_id=user.id,
+        specialty="cardiology",
+        active=True,
+    )
+    db_session.add(doctor)
+    db_session.commit()
+    db_session.refresh(doctor)
+    return doctor
+
+
+def test_create_entry_routes_through_queue_domain_service_boundary(
+    db_session,
+    test_patient,
+    test_doctor,
+    monkeypatch,
+):
+    service = _create_batch_service(
+        db_session,
+        service_code="W2C-BATCH-UNIT",
+        doctor_id=test_doctor.id,
+        queue_tag="cardiology",
+    )
+    captured: dict[str, object] = {}
+
+    def fake_allocate_ticket(self, *, allocation_mode="create_entry", **kwargs):
+        captured["allocation_mode"] = allocation_mode
+        captured.update(kwargs)
+        return SimpleNamespace(id=77, number=11)
+
+    monkeypatch.setattr(
+        QueueDomainService,
+        "allocate_ticket",
+        fake_allocate_ticket,
+    )
+
+    result = BatchPatientService(db_session)._create_entry(
+        patient_id=test_patient.id,
+        target_date=date.today(),
+        action=EntryAction(
+            action="create",
+            specialty="cardiology",
+            service_code=service.service_code,
+        ),
+    )
+
+    assert result.status == "created"
+    assert result.id == 77
+    assert captured["allocation_mode"] == "create_entry"
+    assert captured["source"] == "batch_update"
+    assert captured["status"] == "waiting"
+    assert captured["service_codes"] == [normalize_service_code(service.service_code)]
+    assert captured["commit"] is False
+    assert captured["patient_id"] == test_patient.id
+    assert captured["patient_name"] == test_patient.short_name()
+    assert captured["phone"] == test_patient.phone
+    assert captured["daily_queue"].specialist_id == test_doctor.id
+    assert captured["daily_queue"].queue_tag == "cardiology"
+
+
+def test_create_entry_returns_safe_error_when_queue_resolution_is_ambiguous(
+    db_session,
+    test_patient,
+    test_doctor,
+):
+    second_doctor = _create_second_doctor(db_session)
+    service = _create_batch_service(
+        db_session,
+        service_code="W2C-BATCH-AMB",
+        doctor_id=None,
+        queue_tag="cardiology",
+    )
+
+    db_session.add_all(
+        [
+            DailyQueue(
+                day=date.today(),
+                specialist_id=test_doctor.id,
+                queue_tag="cardiology",
+                active=True,
+            ),
+            DailyQueue(
+                day=date.today(),
+                specialist_id=second_doctor.id,
+                queue_tag="cardiology",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    result = BatchPatientService(db_session)._create_entry(
+        patient_id=test_patient.id,
+        target_date=date.today(),
+        action=EntryAction(
+            action="create",
+            specialty="cardiology",
+            service_code=service.service_code,
+        ),
+    )
+
+    assert result.status == "error"
+    assert result.id == 0
+    assert "Неоднозначная очередь" in (result.error or "")

--- a/docs/architecture/W2C_REGISTRAR_BATCH_CREATE_ACTION_RUNTIME_FIX.md
+++ b/docs/architecture/W2C_REGISTRAR_BATCH_CREATE_ACTION_RUNTIME_FIX.md
@@ -1,0 +1,76 @@
+# Wave 2C Registrar Batch Create-Action Runtime Fix
+
+
+Date: 2026-05-06
+Current-main replacement for stale PR #93 after parent #92 was superseded by merged PR #271.
+## Scope
+
+This slice fixes only the mounted `/registrar/batch` create-action runtime path:
+
+- endpoint:
+  [`backend/app/api/v1/endpoints/registrar_batch.py`](C:/final/backend/app/api/v1/endpoints/registrar_batch.py)
+- service:
+  [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py)
+
+Out of scope:
+
+- broader registrar refactor
+- `qr_queue` direct SQL family
+- `OnlineDay` legacy family
+- `force_majeure` allocator family
+- numbering redesign
+- duplicate-policy redesign outside this mounted path
+
+## Old Broken Behavior
+
+Mounted runtime used:
+
+1. `PATCH /api/v1/registrar/batch/patients/{patient_id}/entries/{date}`
+2. `BatchPatientService.batch_update()`
+3. `BatchPatientService._create_entry()`
+4. `from app.services.queue_service import QueueService`
+5. `QueueService(self.db).add_to_queue(...)`
+
+That import no longer existed, so the mounted create-action branch failed before
+queue allocation and the endpoint returned `400`.
+
+## New Working Path
+
+`BatchPatientService._create_entry()` now:
+
+1. resolves patient/service/queue_tag for this mounted create-action only
+2. resolves or creates the target `DailyQueue`
+3. calls:
+   `QueueDomainService.allocate_ticket(allocation_mode="create_entry", ...)`
+
+The new call still delegates to the legacy allocator internally, so this is a
+runtime-fix and caller-path normalization, not an allocator redesign.
+
+## Why The Fix Is Narrow
+
+- no changes to mounted endpoint shape
+- no changes to numbering algorithm
+- no changes to `queue_time` ownership
+- no changes to fairness ordering
+- no changes to `qr_queue`, `OnlineDay`, `force_majeure`, or migrated registrar families
+- no broad `batch_patient_service` rewrite beyond this broken create-action branch
+
+## Observable Behavior After Fix
+
+- mounted create-action no longer fails on `ImportError`
+- queue row creation succeeds through the supported queue boundary path
+- `source="batch_update"` is preserved
+- numbering is still produced by the legacy allocator behind
+  `QueueDomainService.allocate_ticket()`
+- duplicate behavior for this micro-family stays narrow and characterization-based:
+  an existing `diagnostics` row does not get collapsed here; a new `batch_update`
+  row receives the next number
+
+## What This Means For Queue Architecture
+
+This mounted registrar path is now covered by the queue compatibility boundary.
+It no longer bypasses supported allocation architecture through a stale
+`QueueService` import.
+
+Remaining registrar allocator debt after this slice is limited to duplicate or
+unmounted code paths, not active mounted runtime flow.

--- a/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_BATCH_CREATE_FIX.md
+++ b/docs/status/W2C_NEXT_EXECUTION_UNIT_AFTER_BATCH_CREATE_FIX.md
@@ -1,0 +1,36 @@
+# Wave 2C Next Execution Unit After Batch Create Fix
+
+
+Date: 2026-05-06
+Current-main replacement for stale PR #93 after parent #92 was superseded by merged PR #271.
+## Decision
+
+`registrar allocator track effectively complete -> move to qr_queue direct SQL family`
+
+## Why
+
+After this slice:
+
+- confirmation family is boundary-covered
+- mounted registrar batch-only family is boundary-covered
+- mounted wizard family is boundary-covered
+- mounted `/registrar/batch` create-action no longer breaks on a stale import and
+  now uses the supported queue boundary path
+
+That means no production-relevant mounted registrar allocator path remains as an
+active migration blocker.
+
+## Not Recommended Next
+
+- `one more narrow registrar follow-up`
+  not justified by current production runtime evidence
+- `human review needed`
+  not required for registrar allocator ownership at this point
+- `defer mounted batch create-action as separate legacy island`
+  no longer justified because the path is now live and boundary-covered
+
+## Recommended Track Shift
+
+The next allocator family with the highest remaining architectural risk is:
+
+- `qr_queue` direct SQL characterization / migration-prep

--- a/docs/status/W2C_REGISTRAR_BATCH_CREATE_ACTION_FIX_STATUS.md
+++ b/docs/status/W2C_REGISTRAR_BATCH_CREATE_ACTION_FIX_STATUS.md
@@ -1,0 +1,83 @@
+# Wave 2C Registrar Batch Create-Action Fix Status
+
+
+Date: 2026-05-06
+Current-main replacement for stale PR #93 after parent #92 was superseded by merged PR #271.
+## Status
+
+`done`
+
+## Scope
+
+Narrow runtime fix for the mounted `/registrar/batch` create-action branch only.
+
+In scope:
+
+- [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py)
+- characterization and unit tests for this mounted path
+
+Out of scope:
+
+- broad registrar refactor
+- allocator redesign
+- `qr_queue`
+- `OnlineDay`
+- `force_majeure`
+
+## Old Broken Behavior
+
+- mounted runtime reached `BatchPatientService._create_entry()`
+- `_create_entry()` attempted `from app.services.queue_service import QueueService`
+- import failed
+- endpoint returned `400`
+- no queue row was created
+
+## New Working Behavior
+
+- `_create_entry()` now resolves patient/service/queue context locally
+- create-action uses `QueueDomainService.allocate_ticket(allocation_mode="create_entry", ...)`
+- mounted endpoint no longer fails on the stale import
+- queue row is created through the supported boundary architecture
+
+## Files Changed
+
+- [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py)
+- [`backend/tests/characterization/test_registrar_batch_create_action_characterization.py`](C:/final/backend/tests/characterization/test_registrar_batch_create_action_characterization.py)
+- [`backend/tests/unit/test_registrar_batch_create_action_fix.py`](C:/final/backend/tests/unit/test_registrar_batch_create_action_fix.py)
+- [`docs/status/W2C_REGISTRAR_BATCH_CREATE_FIX_PLAN.md`](C:/final/docs/status/W2C_REGISTRAR_BATCH_CREATE_FIX_PLAN.md)
+- [`docs/architecture/W2C_REGISTRAR_BATCH_CREATE_ACTION_RUNTIME_FIX.md`](C:/final/docs/architecture/W2C_REGISTRAR_BATCH_CREATE_ACTION_RUNTIME_FIX.md)
+
+## Observable Semantics Preserved
+
+- mounted endpoint contract stayed intact
+- `source="batch_update"` is preserved
+- numbering still comes from the legacy allocator behind `QueueDomainService`
+- `queue_time` still comes from the legacy allocator path
+- duplicate behavior for this mounted micro-family remains characterization-based
+  and unchanged by this fix
+
+## Tests Run
+
+- `pytest backend/tests/characterization/test_registrar_batch_create_action_characterization.py -q -c backend/pytest.ini`
+- `cd backend && pytest tests/unit/test_registrar_batch_create_action_fix.py -q`
+- `cd backend && pytest tests/characterization -q -c pytest.ini`
+- `cd backend && pytest tests/test_openapi_contract.py -q`
+- `cd backend && pytest -q`
+
+## Results
+
+- create-action characterization: `3 passed`
+- create-action unit fix tests: `2 passed`
+- full characterization suite: `35 passed`
+- OpenAPI contract: `10 passed`
+- full backend suite: `743 passed, 3 skipped`
+
+## Registrar Track Impact
+
+This slice removes the last known mounted broken registrar allocator path.
+
+Result:
+
+- registrar production allocator track is now effectively complete
+- remaining registrar allocator debt is duplicate/unmounted cleanup, not a
+  mounted runtime blocker

--- a/docs/status/W2C_REGISTRAR_BATCH_CREATE_FIX_PLAN.md
+++ b/docs/status/W2C_REGISTRAR_BATCH_CREATE_FIX_PLAN.md
@@ -1,0 +1,52 @@
+# Wave 2C Registrar Batch Create-Action Fix Plan
+
+
+Date: 2026-05-06
+Current-main replacement for stale PR #93 after parent #92 was superseded by merged PR #271.
+## Old Broken Path
+
+Mounted flow:
+
+1. `PATCH /api/v1/registrar/batch/patients/{patient_id}/entries/{date}`
+2. `BatchPatientService.batch_update()`
+3. `BatchPatientService._create_entry()`
+4. `from app.services.queue_service import QueueService`
+5. `QueueService(self.db).add_to_queue(...)`
+
+Current runtime breaks at step 4 because `QueueService` is not exported from
+`backend/app/services/queue_service.py`.
+
+## Chosen Safe Replacement
+
+Replace the broken import/call with:
+
+1. local queue-resolution helper inside `BatchPatientService`
+2. `QueueDomainService.allocate_ticket(allocation_mode="create_entry", ...)`
+
+The boundary still delegates to the legacy queue allocator internally, so this
+fix restores a supported queue-row creation path without redesigning numbering.
+
+## Why This Is Behavior-Safe
+
+- scope stays inside the mounted `/registrar/batch` create-action branch;
+- no allocator redesign is introduced;
+- numbering still comes from legacy `queue_service.create_queue_entry(...)`;
+- `queue_time` still comes from the legacy allocator path;
+- response contract remains the same endpoint/response model;
+- already migrated confirmation / registrar batch-only / wizard families are
+  not touched.
+
+## What This Slice Will Not Change
+
+- no `qr_queue` direct SQL migration
+- no `OnlineDay` legacy changes
+- no `force_majeure` changes
+- no broader registrar refactor
+- no duplicate-policy redesign outside this mounted create-action path
+
+## Replacement Constraints
+
+- resolve a target `DailyQueue` only for this path
+- preserve `source="batch_update"`
+- keep transaction ownership inside `BatchPatientService.batch_update()`
+- document any remaining ambiguity explicitly instead of widening scope

--- a/docs/status/W2C_REGISTRAR_DIRECT_ALLOCATOR_REMAINS.md
+++ b/docs/status/W2C_REGISTRAR_DIRECT_ALLOCATOR_REMAINS.md
@@ -2,71 +2,44 @@
 
 
 Date: 2026-05-06
-Current-main replacement for stale PR #92 after parent #91 was superseded by merged PR #270.
+Current-main replacement for stale PR #93 after parent #92 was superseded by merged PR #271.
 ## Verdict
 
-Registrar-related direct allocator usage still remains in one production-relevant mounted path.
+No production-relevant registrar direct allocator usage remains after the narrow
+runtime fix for the mounted `/registrar/batch` create-action branch.
 
-That path is now characterization-confirmed as `LIVE_BUT_BROKEN`, not merely suspected from static inspection.
+## Former Mounted Remaining Path
 
-## Production-Relevant Remaining Path
+The previously remaining mounted registrar path was:
 
-### 1. Mounted registrar batch edit/create flow
-
-- Endpoint:
+- endpoint:
   [`backend/app/api/v1/endpoints/registrar_batch.py`](C:/final/backend/app/api/v1/endpoints/registrar_batch.py)
   `batch_update_patient_entries()`
-- Helper:
+- helper:
   [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py)
   `_create_entry()`
 
-Current allocation path:
+It used to:
 
-1. mounted `/registrar/batch/patients/{patient_id}/entries/{date}` accepts a batch update;
-2. `BatchPatientService.batch_update()` dispatches `EntryAction(action="create")`;
-3. `_create_entry()` performs:
-   `from app.services.queue_service import QueueService`
-4. `_create_entry()` then calls:
-   `QueueService(self.db).add_to_queue(...)`
+1. import a non-existent `QueueService`;
+2. fail before allocation;
+3. bypass the supported queue boundary architecture.
 
-Why this still counts as direct legacy allocator usage:
+It now:
 
-- it does not use `QueueDomainService.allocate_ticket()`;
-- it does not go through any registrar-specific migrated seam;
-- it targets a legacy-style queue service API rather than the new compatibility boundary.
+1. resolves its queue target inside `BatchPatientService`;
+2. calls `QueueDomainService.allocate_ticket(allocation_mode="create_entry", ...)`;
+3. reaches the supported boundary architecture used by the rest of the migrated
+   registrar allocator track.
 
-## Why This Path Was Not Covered Earlier
+## Production-Relevant Status
 
-Previous registrar slices covered different mounted families:
+Current verdict for registrar production runtime:
 
-- confirmation bridge in `registrar_wizard.py`;
-- batch-only create path in `registrar_integration.py`;
-- wizard same-day cart path in `registrar_wizard.py`.
-
-The `/registrar/batch` create-action path belongs to a separate batch-edit surface (`UI Row ↔ API Entry`) and was therefore outside those slices.
-
-## Risk Assessment
-
-Risk level: `MEDIUM-HIGH`
-
-Why:
-
-- the path is mounted and production-relevant;
-- it bypasses the queue boundary architecture;
-- it is characterized as live-but-broken;
-- static inspection shows a concrete runtime drift signal:
-  [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py)
-  imports `QueueService`, but [`backend/app/services/queue_service.py`](C:/final/backend/app/services/queue_service.py) exports `QueueBusinessService` and `queue_service`, not `QueueService`.
-
-## Verified Import Drift
-
-This pass verified the import directly in the backend runtime environment:
-
-```text
-ImportError: cannot import name 'QueueService' from 'app.services.queue_service'
-```
-
-That means the remaining mounted registrar allocator path is not only outside the boundary, but is now verified as broken when the create-action branch is exercised.
+- no mounted registrar path is known to bypass `QueueDomainService.allocate_ticket()`
+  while still acting as an active queue-allocation entry point;
+- no mounted registrar path is still known to depend on the broken
+  `QueueService` import.
 
 ## Non-Production Direct Allocator Remains
 

--- a/docs/status/W2C_REGISTRAR_TRACK_COMPLETENESS.md
+++ b/docs/status/W2C_REGISTRAR_TRACK_COMPLETENESS.md
@@ -2,28 +2,18 @@
 
 
 Date: 2026-05-06
-Current-main replacement for stale PR #92 after parent #91 was superseded by merged PR #270.
+Current-main replacement for stale PR #93 after parent #92 was superseded by merged PR #271.
 ## Assessed Families
 
 Completed / effectively covered:
 
 - confirmation family;
 - mounted registrar batch-only create family;
-- mounted wizard same-day queue-assignment family.
-
-Still remaining:
-
-- mounted registrar batch-edit create-action path via
+- mounted wizard same-day queue-assignment family;
+- mounted registrar batch edit/create-action path via
   [`backend/app/api/v1/endpoints/registrar_batch.py`](C:/final/backend/app/api/v1/endpoints/registrar_batch.py)
   and
-  [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py)
-
-Current status of that remaining path:
-
-- mounted and reachable;
-- characterization-confirmed;
-- currently `LIVE_BUT_BROKEN`;
-- behaves as a separate registrar legacy micro-family, not as part of the already migrated batch-only family.
+  [`backend/app/services/batch_patient_service.py`](C:/final/backend/app/services/batch_patient_service.py).
 
 Unmounted duplicates:
 
@@ -35,26 +25,31 @@ Unmounted duplicates:
 
 ## Verdict
 
-`PARTIALLY_COMPLETE_WITH_ONE_REMAINING_PATH`
+`EFFECTIVELY_COMPLETE`
 
-## Why Not `EFFECTIVELY_COMPLETE`
+## Why This Is Now `EFFECTIVELY_COMPLETE`
 
-The registrar allocator track cannot yet be marked effectively complete because one mounted production-relevant path still:
+All mounted production-relevant registrar allocator families are now either:
 
-- creates queue entries outside `QueueDomainService.allocate_ticket()`;
-- has now been characterized as live-but-broken;
-- relies on a stale `QueueService` import path.
+- corrected and routed through `QueueDomainService.allocate_ticket()`;
+- or explicitly characterized as outside the registrar allocator migration scope.
 
-If that `/registrar/batch` create-action branch did not exist, the remaining registrar allocator surfaces would be only duplicate/unmounted code and the track could be considered effectively complete.
+The former remaining `/registrar/batch` create-action branch no longer blocks the
+track because it now uses the supported boundary architecture instead of a stale
+`QueueService` import path.
 
-## Why Not `NEEDS_ANOTHER_REGISTRAR_SLICE` In The Broad Sense
+## What Still Remains
 
-The track does not need another broad registrar campaign.
+What remains is registrar-adjacent cleanup debt, not a mounted registrar
+allocator migration blocker:
 
-It needs exactly one narrow registrar follow-up slice focused on:
+- duplicate or unmounted registrar helpers
+- broader registrar workflow review if needed for non-allocator reasons
+- non-registrar allocator families such as `qr_queue`, `force_majeure`, and
+  `OnlineDay`
 
-- mounted `/registrar/batch` create-action behavior;
-- `BatchPatientService._create_entry()`;
-- a runtime fix or explicit retirement decision for that branch only.
+## Why Not `PARTIALLY_COMPLETE_WITH_ONE_REMAINING_PATH`
 
-So the remaining work is narrow, not a renewed broad registrar refactor.
+That verdict no longer applies because the only remaining mounted registrar path
+identified in the follow-up review has been fixed and boundary-covered in this
+slice.


### PR DESCRIPTION
## Summary

- Replacement for stale PR #93 after parent #92 was superseded by merged replacement PR #271.
- Restores the mounted registrar batch create-action path by replacing the broken `QueueService` construction with `QueueDomainService.allocate_ticket()`.
- Preserves targeted characterization/unit coverage and updates W2C registrar track docs for the current-main runtime fix.

## Contract Impact

- Canonical surface: mounted registrar batch create-action flow backed by `backend/app/services/batch_patient_service.py`.
- Request shape: unchanged existing batch create-action payload with optional `specialty`, `service_id`, `service_code`, and `doctor_id`.
- Response shape: unchanged service result shape; successful create returns an entry id with `status=created`, and aggregation still reports queue numbers, services, total cost, and entry count.
- Status codes: unchanged route-level behavior; this PR repairs service allocation internals under the existing endpoint.
- Compatibility path or alias: no route alias added; legacy `service_code` and newer `service_codes` aggregation paths remain supported.
- Contract proof: characterization/unit coverage in `backend/tests/characterization/test_registrar_batch_create_action_characterization.py` and `backend/tests/unit/test_registrar_batch_create_action_fix.py`.
- Frontend consumer: existing registrar batch/create-action flow; no frontend consumer code changed.

## RBAC / Permissions

- Roles allowed: unchanged; existing mounted registrar batch endpoint authorization remains in place.
- Roles denied: unchanged; no route guard, dependency, or role matrix is modified.
- Positive auth proof: existing characterization coverage exercises the registrar-auth mounted path.
- Negative auth proof: not applicable - this PR does not change auth behavior or route permission boundaries.
- Legacy role normalization: not applicable - no role normalization code changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification event or websocket channel changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no notification/read-state behavior changed.
- Reconnect/resync proof: not applicable - no websocket lifecycle behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend empty-state behavior changed.
- Partial data proof: not applicable - no frontend partial-data path changed.
- Missing draft/resource behavior: not applicable - no EMR draft/resource path changed.
- Forbidden secondary path behavior: not applicable - no secondary frontend/API fallback path changed.
- Stale route/deep-link behavior: not applicable - no frontend route/deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/services/batch_patient_service.py`, targeted backend characterization/unit tests, and W2C registrar batch create-action docs/status files listed in the PR diff.
- Denied paths: unrelated queue routes, frontend runtime, migrations, auth/RBAC helpers, notification/realtime code, CI/workflows, generated artifacts.
- Migration/docs/test impact: no migration; targeted tests preserved/added; registrar track docs updated; production runtime change limited to `BatchPatientService`.
- Rollback note: revert the service allocation change, related targeted tests, and W2C registrar status docs from this PR.

## Validation

- Targeted tests or smoke run: exact staged allowlist check; `git diff --cached --check`; `python -m py_compile backend/app/services/batch_patient_service.py backend/tests/characterization/test_registrar_batch_create_action_characterization.py backend/tests/unit/test_registrar_batch_create_action_fix.py`; `python C:\final\scripts\run_pr_review_gate_checks.py --body-file <temp body>`.
- Result: local narrow validation passes before PR creation; fresh PR CI must pass before merge decision.
- Not checked: live browser registrar panel smoke, production/staging smoke, and frontend runtime behavior because no frontend code changed.