### PR TITLE
QA: harden SQLite runtime guard paths

### DIFF
--- a/backend/app/scripts/ensure_admin.py
+++ b/backend/app/scripts/ensure_admin.py
@@ -35,21 +35,27 @@ def ensure_admin() -> dict:
     password = os.getenv("ADMIN_PASSWORD", "admin")  # ⚠️ DEV ONLY: используйте сильный пароль в продакшене!
     email = os.getenv("ADMIN_EMAIL", "admin@example.com").strip()
     full_name = os.getenv("ADMIN_FULL_NAME", "Administrator").strip()
-    allow_initialized = os.getenv("ENSURE_ADMIN_ALLOW_INITIALIZED", "").strip().lower() in {
+    allow_initialized = os.getenv(INITIALIZED_OVERRIDE_ENV, "").strip().lower() in {
         "1",
         "true",
         "yes",
     }
+    confirm_initialized_override = (
+        os.getenv(INITIALIZED_OVERRIDE_CONFIRM_ENV, "").strip().lower()
+        in {"1", "true", "yes"}
+    )
 
     with SessionLocal() as db:  # type: ignore # type: Session
-        if SetupService(db).is_initialized() and not allow_initialized:
-            return {
-                "skipped": True,
-                "reason": (
-                    "initialized_instance_requires_explicit_ops_override; "
-                    "set ENSURE_ADMIN_ALLOW_INITIALIZED=1 for controlled recovery"
-                ),
-            }
+        if SetupService(db).is_initialized():
+            if not allow_initialized or not confirm_initialized_override:
+                return {
+                    "skipped": True,
+                    "reason": (
+                        "initialized_instance_requires_explicit_ops_override; "
+                        f"set {INITIALIZED_OVERRIDE_ENV}=1 and "
+                        f"{INITIALIZED_OVERRIDE_CONFIRM_ENV}=1 for controlled recovery"
+                    ),
+                }
 
         # Check by username first
         row = (

--- a/backend/app/scripts/ensure_admin.py
+++ b/backend/app/scripts/ensure_admin.py
@@ -18,6 +18,9 @@ from app.db.session import SessionLocal  # noqa: E402
 from app.models.user import User  # type: ignore[attr-defined]  # noqa: E402
 from app.services.setup_service import SetupService  # noqa: E402
 
+INITIALIZED_OVERRIDE_ENV = "ENSURE_ADMIN_ALLOW_INITIALIZED"
+INITIALIZED_OVERRIDE_CONFIRM_ENV = "ENSURE_ADMIN_CONFIRM_INITIALIZED_OVERRIDE"
+
 
 def _hash_or_plain(pw: str) -> str:
     """Вернуть bcrypt-хэш, если passlib доступен, иначе исходную строку (для dev)."""

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -15,6 +15,40 @@ from sqlalchemy.orm import Session
 logger = logging.getLogger(__name__)
 
 
+def _is_sqlite_url(url: str) -> bool:
+    return url.lower().startswith(("sqlite://", "sqlite+"))
+
+
+def _allow_sqlite_database_url() -> bool:
+    raw = os.getenv("ALLOW_SQLITE_DATABASE_URL", "")
+    if raw.strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return os.getenv("TESTING", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _validate_database_url(url: str) -> None:
+    if _is_sqlite_url(url) and not _allow_sqlite_database_url():
+        logger.error(
+            "Refusing SQLite DATABASE_URL for backup operation without explicit legacy/test opt-in"
+        )
+        raise RuntimeError(
+            "SQLite DATABASE_URL is disabled for backup operations. "
+            "Use PostgreSQL as the schema source of truth, or set "
+            "ALLOW_SQLITE_DATABASE_URL=1 only for explicit legacy tools/tests."
+        )
+
+
+def _get_database_url() -> str:
+    from app.core.config import settings
+
+    db_url = getattr(settings, "DATABASE_URL", "")
+    if not db_url:
+        raise ValueError("DATABASE_URL must be configured before backup operations.")
+    url = str(db_url)
+    _validate_database_url(url)
+    return url
+
+
 class BackupService:
     """Service for automated database backups"""
 
@@ -39,8 +73,7 @@ class BackupService:
         """
         try:
             # Get database URL
-            from app.core.config import settings
-            db_url = getattr(settings, "DATABASE_URL", "sqlite:///./clinic.db")
+            db_url = _get_database_url()
 
             timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
             backup_filename = f"backup_{backup_type}_{timestamp}.db"
@@ -205,8 +238,7 @@ class BackupService:
             safety_backup = self.create_backup("before_restore")
 
             # Get database URL
-            from app.core.config import settings
-            db_url = getattr(settings, "DATABASE_URL", "sqlite:///./clinic.db")
+            db_url = _get_database_url()
 
             # Decompress if needed
             if backup_path.suffix == ".gz":

--- a/backend/app/services/monitoring_service.py
+++ b/backend/app/services/monitoring_service.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import os
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -15,6 +16,38 @@ from sqlalchemy import create_engine, text
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
+
+
+def _is_sqlite_url(url: str) -> bool:
+    return url.lower().startswith(("sqlite://", "sqlite+"))
+
+
+def _allow_sqlite_database_url() -> bool:
+    raw = os.getenv("ALLOW_SQLITE_DATABASE_URL", "")
+    if raw.strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return os.getenv("TESTING", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _validate_database_url(url: str) -> None:
+    if _is_sqlite_url(url) and not _allow_sqlite_database_url():
+        logger.error(
+            "Refusing SQLite DATABASE_URL for monitoring metrics without explicit legacy/test opt-in"
+        )
+        raise RuntimeError(
+            "SQLite DATABASE_URL is disabled for monitoring metrics. "
+            "Use PostgreSQL as the schema source of truth, or set "
+            "ALLOW_SQLITE_DATABASE_URL=1 only for explicit legacy tools/tests."
+        )
+
+
+def _get_database_url() -> str:
+    db_url = settings.DATABASE_URL
+    if not db_url:
+        raise ValueError("DATABASE_URL must be configured before monitoring metrics.")
+    url = str(db_url)
+    _validate_database_url(url)
+    return url
 
 
 class MonitoringService:
@@ -123,16 +156,17 @@ class MonitoringService:
     def _get_database_metrics(self) -> dict[str, Any]:
         """Получает метрики базы данных"""
         try:
-            engine = create_engine(settings.DATABASE_URL)
+            db_url = _get_database_url()
+            engine = create_engine(db_url)
 
             with engine.connect() as conn:
                 # Количество активных соединений
-                if "sqlite" in settings.DATABASE_URL:
+                if _is_sqlite_url(db_url):
                     # Для SQLite соединения не актуальны
                     active_connections = 1
 
                     # Размер БД
-                    db_file = settings.DATABASE_URL.replace("sqlite:///", "")
+                    db_file = db_url.replace("sqlite:///", "").replace("sqlite+aiosqlite://", "")
                     db_size = (
                         Path(db_file).stat().st_size if Path(db_file).exists() else 0
                     )
@@ -256,7 +290,8 @@ class MonitoringService:
             # Время отклика БД
             start_time = time.time()
             try:
-                engine = create_engine(settings.DATABASE_URL)
+                db_url = _get_database_url()
+                engine = create_engine(db_url)
                 with engine.connect() as conn:
                     conn.execute(text("SELECT 1"))
                 db_response_time = time.time() - start_time

--- a/backend/tests/unit/test_sqlite_runtime_guards.py
+++ b/backend/tests/unit/test_sqlite_runtime_guards.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services import backup_service, monitoring_service
+
+
+@pytest.mark.parametrize(
+    "module, message",
+    [
+        (backup_service, "backup operations"),
+        (monitoring_service, "monitoring metrics"),
+    ],
+)
+def test_active_services_reject_sqlite_database_url_without_opt_in(
+    monkeypatch: pytest.MonkeyPatch, module, message: str
+) -> None:
+    monkeypatch.delenv("ALLOW_SQLITE_DATABASE_URL", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+
+    with pytest.raises(RuntimeError, match=message):
+        module._validate_database_url("sqlite:///clinic.db")
+
+
+@pytest.mark.parametrize("module", [backup_service, monitoring_service])
+def test_active_services_allow_sqlite_only_with_explicit_legacy_opt_in(
+    monkeypatch: pytest.MonkeyPatch, module
+) -> None:
+    monkeypatch.setenv("ALLOW_SQLITE_DATABASE_URL", "1")
+    monkeypatch.delenv("TESTING", raising=False)
+
+    module._validate_database_url("sqlite:///clinic.db")


### PR DESCRIPTION
## Summary

Runtime/Ops/QA hardening slice split from a larger local QA patch.

## Scope

- Harden admin helper password handling.
- Add SQLite runtime guard coverage.
- Reject SQLite `DATABASE_URL` for active backup/monitoring service paths unless explicit legacy/test opt-in is set.
- Keep PR surgical: no frontend, no endpoint/service deletion wave, no PR lifecycle automation, no generated artifacts.

Scope note: this PR was split from a larger local patch and intentionally excludes lifecycle automation, deletion/rename waves, generated/evidence artifacts, frontend changes, and unrelated staged/unstaged work.

## Risk

Low-to-medium. The PR changes active backup/monitoring runtime behavior for SQLite database URLs. This is intentional: PostgreSQL remains the runtime source of truth, while SQLite requires explicit `ALLOW_SQLITE_DATABASE_URL=1` or test opt-in.

## Validation

- `git diff --check`: passed
- Safety scan for generated/evidence artifacts: passed
- Secret/env scan: no production secret detected
- SQLite/stale port/CORS scan: passed
- `py_compile`: passed
- Config/import smoke: passed
- `backend/tests/unit/test_sqlite_runtime_guards.py`: 4 passed