### PR TITLE
QA: add PR review lifecycle scripts and docs

### DIFF
--- a/docs/runbooks/PR_REVIEW_ADOPTION_LOG.md
+++ b/docs/runbooks/PR_REVIEW_ADOPTION_LOG.md
@@ -1,0 +1,150 @@
+# PR Review Adoption Log
+
+Use this log with `docs/runbooks/PR_REVIEW_PRACTICE_TRACK.md`.
+
+This is not a release gate. It is a lightweight weekly record of what the team practiced, what repeated, and what should become a rule, test, or checklist improvement.
+
+## How To Use
+
+- Add one entry per week or per reviewed risky PR.
+- Keep entries factual and short.
+- Link the PR, branch, or local evidence when available.
+- Record `none` when no gap was observed.
+- If the same gap repeats twice, propose a candidate project rule instead of growing the checklist.
+
+Helper command:
+
+```powershell
+python scripts/add_pr_review_adoption_entry.py `
+  --focus "PR #123 registrar services" `
+  --track "Contract / RBAC" `
+  --evidence "PR body, diff, targeted tests" `
+  --gate-result passed `
+  --gap "none" `
+  --prevention "targeted contract proof added" `
+  --next-action "watch next registrar API PR"
+```
+
+Add `--write` only after reviewing the generated entry. The helper inserts new entries at the top of the `Log` section.
+
+## Entry Template
+
+```markdown
+## YYYY-MM-DD - <PR or focus>
+
+- Track: Contract / RBAC / Notification / Realtime / Frontend resilience / Scope / Release readiness
+- Evidence reviewed: <PR link, branch, runbook, smoke log, or diff>
+- Gate result: passed / failed / partial / not run
+- Repeated gap observed: <specific gap or none>
+- Prevention added: <test, checklist, doc, workflow, or none>
+- Next action: <smallest next step>
+```
+
+## Metrics Snapshot
+
+| Metric | Current count | Notes |
+|---|---:|---|
+| Contract drift caught during review | 0 | Start counting when the gate is applied to live PRs. |
+| RBAC issue caught before merge | 0 | Count endpoint or route-surface permission gaps. |
+| Realtime/read-state drift caught before merge | 0 | Count websocket/read/unread convergence gaps. |
+| PR scope issue caught before merge | 0 | Count unrelated files or unclear allowed path sets. |
+| CI/env repeat caught before merge | 0 | Count lockfile, port, Postgres/SQLite, CORS, or migration drift. |
+
+## Log
+
+## 2026-05-02 - PR #83 registrar wizard duplicate gate
+
+- Track: Contract / Scope gate adoption
+- Evidence reviewed: PR body updated via authenticated gh with Contract Impact, RBAC / Permissions, Notification / Realtime, Frontend Resilience, Scope Gate, and Validation sections
+- Gate result: passed
+- Repeated gap observed: older runtime-risk duplicate gate PR body had Summary and Testing only
+- Prevention added: PR #83 now documents duplicate-claim contract, active statuses, RBAC non-impact, scope, rollback, and validation proof
+- Next action: Continue high-risk bodies with PR #80 and PR #79
+## 2026-05-02 - PR #85 wizard allocator seam extraction
+
+- Track: Contract / Scope gate adoption
+- Evidence reviewed: PR body updated via authenticated gh with Contract Impact, RBAC / Permissions, Notification / Realtime, Frontend Resilience, Scope Gate, and Validation sections
+- Gate result: passed
+- Repeated gap observed: older runtime-risk wizard seam PR body had Summary and Testing only
+- Prevention added: PR #85 now documents wizard seam contract, RBAC non-impact, scope, rollback, and validation proof
+- Next action: Continue high-risk bodies with PR #83
+## 2026-05-02 - PR #88 wizard create-branch handoff extraction
+
+- Track: Contract / Scope gate adoption
+- Evidence reviewed: PR body updated via authenticated gh with Contract Impact, RBAC / Permissions, Notification / Realtime, Frontend Resilience, Scope Gate, and Validation sections
+- Gate result: passed
+- Repeated gap observed: older runtime-risk wizard extraction PR body had Summary and Validation only
+- Prevention added: PR #88 now documents extracted handoff contract, RBAC non-impact, scope, rollback, and validation proof
+- Next action: Continue high-risk bodies with PR #85 and PR #83
+## 2026-05-02 - Open PR body gate sweep
+
+- Track: PR Scope And Release Readiness
+- Evidence reviewed: Unauthenticated GitHub REST sweep over 43 open PR bodies using validate_pr_body
+- Gate result: partial
+- Repeated gap observed: 5 open PR bodies passed (#93,#92,#91,#90,#89); 38 still miss required quality gate sections
+- Prevention added: Sweep identifies remaining old-format PRs before review/merge
+- Next action: Prioritize #88, #85, #83, #80, #79, #74, #70, #66, #65, #64, #63 as runtime-risk bodies
+## 2026-05-02 - PR #89 wizard boundary readiness recheck
+
+- Track: Scope gate adoption
+- Evidence reviewed: PR body updated on GitHub with docs-only gate sections and explicit no-impact reasons
+- Gate result: passed
+- Repeated gap observed: older docs-only readiness PR body had Summary and Validation only
+- Prevention added: PR #89 now documents no contract/RBAC/runtime impact and docs-only allowed scope
+- Next action: Run open PR gate sweep to find any remaining body gaps
+## 2026-05-02 - PR #91 registrar allocator follow-up inventory
+
+- Track: Scope gate adoption
+- Evidence reviewed: PR body updated on GitHub with docs-only gate sections and explicit no-impact reasons
+- Gate result: passed
+- Repeated gap observed: older docs-only PR body had Summary and Notes only
+- Prevention added: PR #91 now documents no contract/RBAC/runtime impact and docs-only allowed scope
+- Next action: Consider PR #89 docs-only readiness body next
+## 2026-05-02 - PR #92 registrar batch create-action characterization
+
+- Track: Contract / Scope gate adoption
+- Evidence reviewed: PR body updated on GitHub with gate sections and explicit characterization-only not-applicable reasons
+- Gate result: passed
+- Repeated gap observed: older characterization PR body had Summary and Notes only
+- Prevention added: PR #92 now documents no contract/RBAC/runtime impact and allowed docs/test scope
+- Next action: Apply docs-only gate body to PR #91
+## 2026-05-02 - PR #90 Wave 2C wizard seam migration
+
+- Track: Contract / RBAC / Scope gate adoption
+- Evidence reviewed: PR body updated on GitHub with Contract Impact, RBAC / Permissions, Notification / Realtime, Frontend Resilience, Scope Gate, and Validation sections
+- Gate result: passed
+- Repeated gap observed: older risky queue allocator PR body had Summary and Validation only
+- Prevention added: PR #90 now carries explicit queue allocator contract, RBAC non-impact, scope, rollback, and validation proof
+- Next action: Apply lighter docs/test-only gate bodies to PR #92 and PR #91
+## 2026-05-02 - PR #93 fix: restore registrar batch create-action path
+
+- Track: Contract / RBAC / Scope gate adoption
+- Evidence reviewed: PR body updated on GitHub with Contract Impact, RBAC / Permissions, Notification / Realtime, Frontend Resilience, Scope Gate, and Validation sections
+- Gate result: passed
+- Repeated gap observed: older PR body was missing the required review gate sections
+- Prevention added: PR #93 now carries explicit contract, RBAC non-impact, scope, rollback, and validation proof
+- Next action: Use the same template on the next open risky registrar/queue PR
+## 2026-05-02 - PR #93 fix: restore registrar batch create-action path
+
+- Track: Contract / RBAC / Scope gate adoption
+- Evidence reviewed: Real PR body from https://github.com/drsapaev/final/pull/93; runner passed internal checks but failed live PR body
+- Gate result: failed
+- Repeated gap observed: PR body only has Summary and Testing; missing Contract Impact, RBAC / Permissions, Notification / Realtime, Frontend Resilience, Scope Gate, and Validation sections
+- Prevention added: Gate blocks review without explicit contract/auth/scope proof for risky registrar queue path
+- Next action: Update PR #93 body with required gate sections or mark specific not-applicable reasons
+## 2026-05-02 - PR review quality gate workflow checkout
+
+- Track: PR Scope And Release Readiness
+- Evidence reviewed: Workflow reviewed; base SHA checkout replaced with PR code checkout; gate runner passed
+- Gate result: passed
+- Repeated gap observed: CI could validate stale base-branch gate code instead of PR-side runner/tests
+- Prevention added: Workflow now checks out PR code before running gate
+- Next action: Apply gate to next real PR body
+## 2026-05-02 - PR review gate bootstrap
+
+- Track: Scope / Release readiness
+- Evidence reviewed: local docs/process implementation of PR review gate, samples, checker, tests, and workflow.
+- Gate result: passed locally via `python scripts/run_pr_review_gate_checks.py --body-file docs/runbooks/pr-review-samples/runtime-contract-pr.md`.
+- Repeated gap observed: weak `not applicable` fields in a runtime sample were caught by the checker before documentation was finalized.
+- Prevention added: checker field validation, sample PR bodies, unit tests, unified local/CI runner, and hidden PR template guidance.
+- Next action: apply the runner to a real PR body or diff and record the first live adoption entry.

--- a/docs/runbooks/PR_REVIEW_SAMPLE_BODIES.md
+++ b/docs/runbooks/PR_REVIEW_SAMPLE_BODIES.md
@@ -1,0 +1,40 @@
+# PR Review Sample Bodies
+
+Use these examples when filling `.github/pull_request_template.md` or when testing the local PR review gate.
+
+The sample files are intentionally valid PR bodies, not explanatory docs. You can pass them directly to the checker:
+
+```powershell
+python scripts/run_pr_review_gate_checks.py
+python scripts/check_pr_review_template.py --body-file docs\runbooks\pr-review-samples\docs-only-pr.md
+python scripts/check_pr_review_template.py --body-file docs\runbooks\pr-review-samples\runtime-contract-pr.md
+```
+
+The dedicated PR gate workflow runs `scripts/run_pr_review_gate_checks.py`, which also validates these samples. A future checker/template change must keep the examples current.
+
+## Docs-Only Or Process PR
+
+Use `docs/runbooks/pr-review-samples/docs-only-pr.md` when the PR changes only documentation, templates, or process files.
+
+Expected pattern:
+- Runtime sections use `not applicable` with a specific reason.
+- Scope Gate names allowed and denied paths.
+- Validation explains what was checked and what was intentionally not checked.
+
+## Runtime Contract PR
+
+Use `docs/runbooks/pr-review-samples/runtime-contract-pr.md` when the PR changes an endpoint, payload shape, frontend consumer, or role-sensitive surface.
+
+Expected pattern:
+- Contract Impact names the canonical surface and frontend consumer.
+- RBAC / Permissions includes positive and negative auth proof.
+- Frontend Resilience states empty, partial, and fallback behavior.
+- Validation names targeted tests or smoke proof.
+
+## Reviewer Use
+
+When a PR body is unclear, compare it to the closest sample:
+
+- If the PR is docs-only, it should look like the docs-only sample and avoid runtime proof.
+- If the PR changes runtime behavior, it should look like the runtime contract sample and include proof fields.
+- If the PR is risky but neither sample fits, keep the template sections and fill each one with the closest concrete proof.

--- a/docs/runbooks/pr-review-samples/docs-only-pr.md
+++ b/docs/runbooks/pr-review-samples/docs-only-pr.md
@@ -1,0 +1,33 @@
+## Summary
+
+- Add or update documentation/process guidance.
+- No runtime behavior, API contract, migration, or user-facing flow changed.
+
+## Contract Impact
+
+not applicable - documentation/process only, no API, websocket, event, or frontend consumer contract changed.
+
+## RBAC / Permissions
+
+not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.
+
+## Notification / Realtime
+
+not applicable - no notification, websocket, chat, or realtime behavior changed.
+
+## Frontend Resilience
+
+not applicable - no user-facing panel or frontend data flow changed.
+
+## Scope Gate
+
+- Allowed paths: docs/**, .github/**, scripts/check_pr_review_template.py when the PR is gate-related
+- Denied paths: backend runtime, frontend runtime, migrations, generated output
+- Migration/docs/test impact: docs/process only; no migration expected
+- Rollback note: revert the docs/process changes
+
+## Validation
+
+- Targeted tests or smoke run: local PR review body checker when the PR changes the template or gate
+- Result: passed
+- Not checked: runtime app behavior, because no runtime files changed

--- a/docs/runbooks/pr-review-samples/runtime-contract-pr.md
+++ b/docs/runbooks/pr-review-samples/runtime-contract-pr.md
@@ -1,0 +1,46 @@
+## Summary
+
+- Update a backend endpoint and its frontend consumer.
+- Preserve documented compatibility behavior for existing callers.
+
+## Contract Impact
+
+- Canonical surface: GET /api/v1/registrar/services
+- Request shape: authenticated request, no request body
+- Response shape: grouped service dictionary keyed by canonical service group
+- Status codes: 200 for allowed users, 401 unauthenticated, 403 forbidden role
+- Frontend consumer: registrar service selector
+- Compatibility path or alias: legacy code-prefix fallback remains compatibility only
+- Contract proof: targeted backend contract test and frontend consumer mapping test
+
+## RBAC / Permissions
+
+- Roles allowed: admin, registrar
+- Roles denied: doctor, patient
+- Positive auth proof: registrar token returns 200
+- Negative auth proof: patient token returns 403
+
+## Notification / Realtime
+
+not applicable - no notification, websocket, chat, or realtime behavior changed.
+
+## Frontend Resilience
+
+- Empty data proof: empty group renders stable empty selector state
+- Partial data proof: missing optional description does not crash the selector
+- Forbidden secondary path behavior: not applicable, no secondary path used
+- Missing draft/resource behavior: not applicable, service selector does not create or reopen drafts/resources
+- Stale route/deep-link behavior: not applicable, service selector does not read deep-link route state
+
+## Scope Gate
+
+- Allowed paths: backend registrar endpoint, frontend registrar consumer, targeted regression tests
+- Denied paths: unrelated admin panels, migrations, generated output
+- Migration/docs/test impact: no migration; targeted tests updated
+- Rollback note: revert endpoint, consumer, and targeted tests
+
+## Validation
+
+- Targeted tests or smoke run: backend contract regression and frontend consumer mapping test
+- Result: passed
+- Not checked: full browser panel smoke

--- a/scripts/add_pr_review_adoption_entry.py
+++ b/scripts/add_pr_review_adoption_entry.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Format or append a PR review adoption log entry."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LOG_PATH = REPO_ROOT / "docs" / "runbooks" / "PR_REVIEW_ADOPTION_LOG.md"
+LOG_HEADING = "## Log"
+VALID_RESULTS = ("passed", "failed", "partial", "not run")
+
+
+@dataclass(frozen=True)
+class AdoptionEntry:
+    entry_date: str
+    focus: str
+    track: str
+    evidence: str
+    gate_result: str
+    repeated_gap: str
+    prevention: str
+    next_action: str
+
+
+def format_entry(entry: AdoptionEntry) -> str:
+    return "\n".join(
+        [
+            f"## {entry.entry_date} - {entry.focus}",
+            "",
+            f"- Track: {entry.track}",
+            f"- Evidence reviewed: {entry.evidence}",
+            f"- Gate result: {entry.gate_result}",
+            f"- Repeated gap observed: {entry.repeated_gap}",
+            f"- Prevention added: {entry.prevention}",
+            f"- Next action: {entry.next_action}",
+            "",
+        ]
+    )
+
+
+def append_entry(log_text: str, entry_text: str) -> str:
+    if LOG_HEADING not in log_text:
+        raise ValueError(f"Could not find `{LOG_HEADING}` heading in adoption log.")
+
+    marker = f"{LOG_HEADING}\n"
+    before, after = log_text.split(marker, 1)
+    existing_log = after.lstrip("\n")
+    return f"{before}{marker}\n{entry_text}{existing_log}"
+
+
+def _required_text(value: str, field_name: str) -> str:
+    value = value.strip()
+    if not value:
+        raise SystemExit(f"{field_name} cannot be empty.")
+    return value
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create a PR review adoption log entry. By default prints the entry; "
+            "use --write to append it to the log."
+        )
+    )
+    parser.add_argument("--date", default=date.today().isoformat(), help="Entry date.")
+    parser.add_argument("--focus", required=True, help="PR, branch, or focus label.")
+    parser.add_argument("--track", required=True, help="Skill track name.")
+    parser.add_argument("--evidence", required=True, help="Evidence reviewed.")
+    parser.add_argument(
+        "--gate-result",
+        required=True,
+        choices=VALID_RESULTS,
+        help="Gate result.",
+    )
+    parser.add_argument("--gap", required=True, help="Repeated gap observed, or none.")
+    parser.add_argument("--prevention", required=True, help="Prevention added, or none.")
+    parser.add_argument("--next-action", required=True, help="Smallest next action.")
+    parser.add_argument(
+        "--log-file",
+        default=str(DEFAULT_LOG_PATH),
+        help="Adoption log file to update when --write is set.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Append the entry to the adoption log instead of only printing it.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    entry = AdoptionEntry(
+        entry_date=_required_text(args.date, "--date"),
+        focus=_required_text(args.focus, "--focus"),
+        track=_required_text(args.track, "--track"),
+        evidence=_required_text(args.evidence, "--evidence"),
+        gate_result=_required_text(args.gate_result, "--gate-result"),
+        repeated_gap=_required_text(args.gap, "--gap"),
+        prevention=_required_text(args.prevention, "--prevention"),
+        next_action=_required_text(args.next_action, "--next-action"),
+    )
+    entry_text = format_entry(entry)
+
+    if not args.write:
+        print(entry_text, end="")
+        return 0
+
+    log_path = Path(args.log_file)
+    log_text = log_path.read_text(encoding="utf-8")
+    log_path.write_text(append_entry(log_text, entry_text), encoding="utf-8")
+    print(f"Appended adoption entry to {log_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_pr_review_template.py
+++ b/scripts/check_pr_review_template.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Validate that a pull request body fills the review quality gate template."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+
+
+REQUIRED_SECTIONS = (
+    "Summary",
+    "Contract Impact",
+    "RBAC / Permissions",
+    "Notification / Realtime",
+    "Frontend Resilience",
+    "Scope Gate",
+    "Validation",
+)
+
+REQUIRED_FIELDS_BY_SECTION = {
+    "Contract Impact": (
+        "Canonical surface",
+        "Request shape",
+        "Response shape",
+        "Status codes",
+        "Frontend consumer",
+        "Compatibility path or alias",
+        "Contract proof",
+    ),
+    "RBAC / Permissions": (
+        "Roles allowed",
+        "Roles denied",
+        "Positive auth proof",
+        "Negative auth proof",
+    ),
+    "Notification / Realtime": (
+        "Event type or websocket channel",
+        "Payload version / ack behavior",
+        "Read/unread or delivery semantics",
+        "Reconnect/resync proof",
+    ),
+    "Frontend Resilience": (
+        "Empty data proof",
+        "Partial data proof",
+        "Forbidden secondary path behavior",
+        "Missing draft/resource behavior",
+        "Stale route/deep-link behavior",
+    ),
+    "Scope Gate": (
+        "Allowed paths",
+        "Denied paths",
+        "Migration/docs/test impact",
+        "Rollback note",
+    ),
+    "Validation": (
+        "Targeted tests or smoke run",
+        "Result",
+        "Not checked",
+    ),
+}
+
+PLACEHOLDER_PATTERNS = (
+    r"describe the change in 2-4 bullets",
+    r"canonical surface:\s*$",
+    r"request shape:\s*$",
+    r"response shape:\s*$",
+    r"status codes:\s*$",
+    r"frontend consumer:\s*$",
+    r"compatibility path or alias:\s*$",
+    r"contract proof:\s*$",
+    r"roles allowed:\s*$",
+    r"roles denied:\s*$",
+    r"positive auth proof:\s*$",
+    r"negative auth proof:\s*$",
+    r"targeted tests or smoke run:\s*$",
+    r"result:\s*$",
+)
+
+FIELD_RE = re.compile(r"^[ \t]*-[ \t]*([^:\n]+):[ \t]*(.*?)[ \t]*$", re.MULTILINE)
+HEADING_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+UTF8_BOM = "\ufeff"
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    errors: list[str]
+    warnings: list[str]
+
+
+def _read_body(args: argparse.Namespace) -> str:
+    if args.body_env:
+        return os.environ.get(args.body_env, "")
+    if args.body_file:
+        with open(args.body_file, "r", encoding="utf-8") as handle:
+            return handle.read()
+    return sys.stdin.read()
+
+
+def _extract_sections(body: str) -> dict[str, str]:
+    matches = list(HEADING_RE.finditer(body))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        title = match.group(1).strip()
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        sections[title] = body[start:end].strip()
+    return sections
+
+
+def _strip_html_comments(text: str) -> str:
+    return HTML_COMMENT_RE.sub("", text)
+
+
+def _strip_utf8_bom(text: str) -> str:
+    return text.lstrip(UTF8_BOM)
+
+
+def _strip_guidance_lines(text: str) -> str:
+    text = _strip_html_comments(text)
+    kept: list[str] = []
+    for line in text.splitlines():
+        normalized = line.strip().lower()
+        if normalized.startswith("if no "):
+            continue
+        if normalized.startswith("see `docs/runbooks/pr_review_quality_gates.md`"):
+            continue
+        kept.append(line)
+    return "\n".join(kept).strip()
+
+
+def _has_meaningful_text(text: str) -> bool:
+    cleaned = _strip_guidance_lines(text)
+    if not cleaned:
+        return False
+
+    lowered = cleaned.lower()
+    if "not applicable" in lowered:
+        return True
+
+    placeholder_hits = 0
+    for pattern in PLACEHOLDER_PATTERNS:
+        if re.search(pattern, lowered, flags=re.MULTILINE):
+            placeholder_hits += 1
+
+    field_values = [value.strip() for _, value in FIELD_RE.findall(cleaned)]
+    non_empty_values = [value for value in field_values if value and value.lower() != "n/a"]
+
+    if field_values:
+        return bool(non_empty_values)
+
+    return placeholder_hits == 0 and len(cleaned.split()) >= 4
+
+
+def _has_not_applicable_reason(text: str) -> bool:
+    cleaned = _strip_guidance_lines(text).strip()
+    match = re.search(r"\bnot applicable\b\s*(?:[-:;,]|\sbecause\b)\s*(.+)", cleaned, re.I)
+    if not match:
+        return False
+    reason = match.group(1).strip()
+    return len(reason.split()) >= 3
+
+
+def _missing_required_field_answers(section: str, text: str) -> list[str]:
+    required_fields = REQUIRED_FIELDS_BY_SECTION.get(section, ())
+    if not required_fields:
+        return []
+
+    cleaned = _strip_guidance_lines(text)
+    field_pairs = FIELD_RE.findall(cleaned)
+    if not field_pairs and _has_not_applicable_reason(cleaned):
+        return []
+
+    fields = {name.strip().lower(): value.strip() for name, value in field_pairs}
+    missing: list[str] = []
+
+    for field in required_fields:
+        value = fields.get(field.lower(), "")
+        if not value or value.lower() == "n/a":
+            missing.append(field)
+            continue
+        if value.lower() == "not applicable" or (
+            value.lower().startswith("not applicable") and not _has_not_applicable_reason(value)
+        ):
+            missing.append(field)
+
+    return missing
+
+
+def validate_pr_body(body: str) -> ValidationResult:
+    errors: list[str] = []
+    warnings: list[str] = []
+    body = _strip_utf8_bom(body)
+    body = _strip_html_comments(body)
+
+    if not body.strip():
+        return ValidationResult(
+            errors=["PR body is empty. Fill the review quality gate template."],
+            warnings=[],
+        )
+
+    sections = _extract_sections(body)
+    for required in REQUIRED_SECTIONS:
+        if required not in sections:
+            errors.append(f"Missing required section: ## {required}")
+            continue
+        if not _has_meaningful_text(sections[required]):
+            errors.append(
+                f"Section ## {required} still looks empty. Fill it or write "
+                "`not applicable` with a short reason."
+            )
+            continue
+        missing_fields = _missing_required_field_answers(required, sections[required])
+        if missing_fields:
+            errors.append(
+                f"Section ## {required} has unanswered required fields: "
+                + ", ".join(missing_fields)
+            )
+
+    if "not applicable" in body.lower():
+        warnings.append(
+            "`not applicable` is accepted, but reviewers should confirm the reason is specific."
+        )
+
+    return ValidationResult(errors=errors, warnings=warnings)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate PR review quality gate template completion."
+    )
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--body-file", help="Path to a markdown file containing PR body.")
+    source.add_argument("--body-env", help="Environment variable containing PR body text.")
+    args = parser.parse_args()
+
+    body = _read_body(args)
+    result = validate_pr_body(body)
+
+    for warning in result.warnings:
+        print(f"warning: {warning}")
+
+    if result.errors:
+        print("PR review quality gate failed:")
+        for error in result.errors:
+            print(f"- {error}")
+        return 1
+
+    print("PR review quality gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/recommend_pr_lifecycle.py
+++ b/scripts/recommend_pr_lifecycle.py
@@ -1,0 +1,330 @@
+"""Recommend PR lifecycle labels and review order from PR metadata.
+
+This script is intentionally conservative: it does not merge, close, or edit a
+PR. It emits a machine-readable label list plus a Markdown comment that a
+workflow can post back to the PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+try:
+    from scripts.check_pr_review_template import validate_pr_body
+except ModuleNotFoundError:  # pragma: no cover - supports direct script execution
+    from check_pr_review_template import validate_pr_body
+
+
+DEFAULT_MAIN_BRANCHES = {"main", "master"}
+COMMENT_MARKER = "<!-- pr-lifecycle-recommendation -->"
+
+KNOWN_LIFECYCLE_LABELS = [
+    "pr-gate:passed",
+    "pr-gate:failed",
+    "decision:safe-to-merge-candidate",
+    "decision:needs-review",
+    "decision:needs-tests",
+    "decision:merge-after-parent",
+    "decision:stale-or-superseded",
+    "decision:should-close-candidate",
+    "risk:runtime",
+    "risk:docs-only",
+    "risk:tests-only",
+    "risk:deps",
+    "risk:unknown",
+    "domain:contract",
+    "domain:rbac",
+    "domain:realtime",
+    "domain:notifications",
+    "domain:queue",
+    "domain:registrar",
+]
+
+
+@dataclass(frozen=True)
+class PullRequestContext:
+    number: int | None
+    title: str
+    body: str
+    base_ref: str
+    head_ref: str
+    html_url: str
+    is_draft: bool
+    mergeable: str | None
+    files: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Recommendation:
+    decisions: tuple[str, ...]
+    risk_labels: tuple[str, ...]
+    domain_labels: tuple[str, ...]
+    gate_passed: bool
+    gate_errors: tuple[str, ...]
+    reasons: tuple[str, ...]
+    next_actions: tuple[str, ...]
+
+    @property
+    def labels(self) -> tuple[str, ...]:
+        gate_label = "pr-gate:passed" if self.gate_passed else "pr-gate:failed"
+        decision_labels = tuple(f"decision:{decision}" for decision in self.decisions)
+        return (gate_label, *decision_labels, *self.risk_labels, *self.domain_labels)
+
+
+def _read_json(path: str | None) -> dict:
+    if not path:
+        return {}
+    return json.loads(Path(path).read_text(encoding="utf-8-sig"))
+
+
+def _collect_files(files_json: dict) -> tuple[str, ...]:
+    files = files_json.get("files", [])
+    paths: list[str] = []
+    for item in files:
+        if isinstance(item, str):
+            paths.append(item)
+        elif isinstance(item, dict) and item.get("path"):
+            paths.append(str(item["path"]))
+    return tuple(paths)
+
+
+def _event_to_context(event: dict, files: tuple[str, ...]) -> PullRequestContext:
+    pr = event.get("pull_request") or event
+    base = pr.get("base") or {}
+    head = pr.get("head") or {}
+    return PullRequestContext(
+        number=pr.get("number"),
+        title=pr.get("title") or "",
+        body=pr.get("body") or "",
+        base_ref=base.get("ref") or pr.get("baseRefName") or "",
+        head_ref=head.get("ref") or pr.get("headRefName") or "",
+        html_url=pr.get("html_url") or pr.get("url") or "",
+        is_draft=bool(pr.get("draft")),
+        mergeable=pr.get("mergeable"),
+        files=files,
+    )
+
+
+def _all_match(paths: Iterable[str], prefixes: tuple[str, ...], suffixes: tuple[str, ...]) -> bool:
+    normalized = tuple(path.replace("\\", "/") for path in paths)
+    if not normalized:
+        return False
+    return all(path.startswith(prefixes) or path.endswith(suffixes) for path in normalized)
+
+
+def _any_file(paths: Iterable[str], prefixes: tuple[str, ...], names: tuple[str, ...]) -> bool:
+    for raw_path in paths:
+        path = raw_path.replace("\\", "/")
+        leaf = path.rsplit("/", 1)[-1]
+        if path.startswith(prefixes) or leaf in names:
+            return True
+    return False
+
+
+def _contains_any(haystack: str, needles: tuple[str, ...]) -> bool:
+    value = haystack.lower()
+    return any(needle in value for needle in needles)
+
+
+def classify_risk(ctx: PullRequestContext) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    files = ctx.files
+    text = " ".join((ctx.title, ctx.body, " ".join(files))).lower()
+
+    docs_only = _all_match(files, ("docs/", ".github/ISSUE_TEMPLATE/"), (".md", ".mdx", ".txt"))
+    tests_only = not docs_only and _all_match(
+        files,
+        ("test", "tests/", "backend/tests/", "frontend/src/__tests__/"),
+        (".md", ".mdx"),
+    )
+    deps = _contains_any(ctx.title, ("deps(", "dependency", "lockfile")) or _any_file(
+        files,
+        tuple(),
+        (
+            "package.json",
+            "package-lock.json",
+            "pnpm-lock.yaml",
+            "yarn.lock",
+            "requirements.txt",
+            "requirements-dev.txt",
+            "pyproject.toml",
+            "poetry.lock",
+        ),
+    )
+    runtime = _any_file(
+        files,
+        (
+            "backend/app/",
+            "frontend/src/",
+            "alembic/",
+            "ops/",
+            ".github/workflows/",
+        ),
+        tuple(),
+    )
+
+    risk_labels: list[str] = []
+    if runtime:
+        risk_labels.append("risk:runtime")
+    if docs_only:
+        risk_labels.append("risk:docs-only")
+    if tests_only:
+        risk_labels.append("risk:tests-only")
+    if deps:
+        risk_labels.append("risk:deps")
+    if not risk_labels:
+        risk_labels.append("risk:unknown")
+
+    domain_map = {
+        "domain:contract": ("contract", "endpoint", "payload", "api", "websocket", "ws"),
+        "domain:rbac": ("rbac", "role", "permission", "403", "auth"),
+        "domain:realtime": ("websocket", "ws", "realtime", "unread", "read-state", "chat"),
+        "domain:notifications": ("notification", "telegram", "inbox", "quiet hours"),
+        "domain:queue": ("queue", "allocator", "diagnostic", "queue_time"),
+        "domain:registrar": ("registrar", "wizard", "batch create", "morning assignment"),
+    }
+    domain_labels = tuple(label for label, needles in domain_map.items() if _contains_any(text, needles))
+
+    return tuple(dict.fromkeys(risk_labels)), domain_labels
+
+
+def recommend(ctx: PullRequestContext) -> Recommendation:
+    validation = validate_pr_body(ctx.body)
+    gate_passed = not validation.errors
+    risk_labels, domain_labels = classify_risk(ctx)
+    base_is_main = ctx.base_ref in DEFAULT_MAIN_BRANCHES
+    runtime_or_deps = "risk:runtime" in risk_labels or "risk:deps" in risk_labels
+    docs_or_tests_only = "risk:docs-only" in risk_labels or "risk:tests-only" in risk_labels
+
+    decisions: list[str] = []
+    reasons: list[str] = []
+    next_actions: list[str] = []
+
+    if not base_is_main:
+        decisions.append("merge-after-parent")
+        reasons.append(f"Base branch is `{ctx.base_ref}`, so this PR is stacked behind a parent branch.")
+        next_actions.append(f"Merge only after `{ctx.base_ref}` lands or is explicitly superseded.")
+
+    if ctx.is_draft:
+        decisions.append("needs-review")
+        reasons.append("PR is draft, so it should not be considered merge-ready yet.")
+        next_actions.append("Mark ready for review only after the author confirms the scope.")
+
+    if not gate_passed:
+        decisions.append("needs-review")
+        reasons.append("PR body does not satisfy the review quality gate.")
+        next_actions.append("Fill the required gate sections before review/merge decision.")
+
+    if runtime_or_deps and not gate_passed:
+        decisions.append("needs-tests")
+        reasons.append("Runtime/dependency change lacks complete validation proof in the PR body.")
+        next_actions.append("Add targeted test, smoke, or explicit not-run rationale.")
+
+    if not decisions and runtime_or_deps:
+        decisions.append("needs-review")
+        reasons.append("Runtime/dependency change passed the body gate but still needs human code review.")
+        next_actions.append("Review contract/RBAC/runtime impact and wait for required CI checks.")
+
+    if not decisions and docs_or_tests_only:
+        decisions.append("safe-to-merge-candidate")
+        reasons.append("Docs/tests-only change passed the body gate and is not stacked behind another branch.")
+        next_actions.append("Confirm CI status and merge if reviewers agree.")
+
+    if not decisions:
+        decisions.append("needs-review")
+        reasons.append("Risk classification is not specific enough for automatic safe-to-merge recommendation.")
+        next_actions.append("Reviewer should classify scope before merge decision.")
+
+    return Recommendation(
+        decisions=tuple(dict.fromkeys(decisions)),
+        risk_labels=risk_labels,
+        domain_labels=domain_labels,
+        gate_passed=gate_passed,
+        gate_errors=tuple(validation.errors),
+        reasons=tuple(dict.fromkeys(reasons)),
+        next_actions=tuple(dict.fromkeys(next_actions)),
+    )
+
+
+def render_comment(ctx: PullRequestContext, rec: Recommendation) -> str:
+    decision_text = ", ".join(rec.decisions)
+    risk_text = ", ".join(label.removeprefix("risk:") for label in rec.risk_labels)
+    domain_text = ", ".join(label.removeprefix("domain:") for label in rec.domain_labels) or "none detected"
+    gate_text = "passed" if rec.gate_passed else "failed"
+    pr_label = f"PR #{ctx.number}" if ctx.number else "PR"
+
+    lines = [
+        COMMENT_MARKER,
+        "## PR lifecycle recommendation",
+        "",
+        f"- PR: {pr_label}",
+        f"- Decision: `{decision_text}`",
+        f"- Risk lane: `{risk_text}`",
+        f"- Domains: `{domain_text}`",
+        f"- Body gate: `{gate_text}`",
+        f"- Base/head: `{ctx.base_ref}` <- `{ctx.head_ref}`",
+        "",
+        "### Why",
+    ]
+    lines.extend(f"- {reason}" for reason in rec.reasons)
+    lines.extend(["", "### Next action"])
+    lines.extend(f"- {action}" for action in rec.next_actions)
+
+    if rec.gate_errors:
+        lines.extend(["", "### Body gate gaps"])
+        lines.extend(f"- {error}" for error in rec.gate_errors[:8])
+        if len(rec.gate_errors) > 8:
+            lines.append(f"- ...and {len(rec.gate_errors) - 8} more.")
+
+    lines.extend(
+        [
+            "",
+            "### Manual merge decision options",
+            "- `safe to merge`: only after CI and reviewer approval.",
+            "- `needs review`: default for runtime, contract, RBAC, queue, realtime, or unclear scope.",
+            "- `needs tests`: required when validation proof is missing or too broad.",
+            "- `stale / superseded`: use when a newer PR replaces this branch.",
+            "- `should close`: use only after confirming no useful current work remains.",
+            "- `merge only after parent PR`: use for stacked branches or non-main base branches.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_lines(path: str | None, lines: Iterable[str]) -> None:
+    if not path:
+        return
+    Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event-file", required=True, help="GitHub event JSON path")
+    parser.add_argument("--files-json", required=True, help="JSON from `gh pr view --json files`")
+    parser.add_argument("--output-comment", required=True, help="Markdown comment output path")
+    parser.add_argument("--output-labels", required=True, help="Labels output path, one label per line")
+    parser.add_argument(
+        "--output-known-labels",
+        help="Optional known lifecycle labels output path for workflow cleanup",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    event = _read_json(args.event_file)
+    files_json = _read_json(args.files_json)
+    ctx = _event_to_context(event, _collect_files(files_json))
+    rec = recommend(ctx)
+
+    Path(args.output_comment).write_text(render_comment(ctx, rec), encoding="utf-8")
+    write_lines(args.output_labels, rec.labels)
+    write_lines(args.output_known_labels, KNOWN_LIFECYCLE_LABELS)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_pr_review_gate_checks.py
+++ b/scripts/run_pr_review_gate_checks.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Run all lightweight PR review gate checks with stdlib Python only."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SAMPLE_BODY_FILES = (
+    REPO_ROOT / "docs" / "runbooks" / "pr-review-samples" / "docs-only-pr.md",
+    REPO_ROOT / "docs" / "runbooks" / "pr-review-samples" / "runtime-contract-pr.md",
+)
+
+
+def _ensure_repo_imports() -> None:
+    repo_root_text = str(REPO_ROOT)
+    if repo_root_text not in sys.path:
+        sys.path.insert(0, repo_root_text)
+
+
+def _run_unit_tests() -> bool:
+    _ensure_repo_imports()
+    suite = unittest.defaultTestLoader.loadTestsFromNames(
+        [
+            "test_check_pr_review_template",
+            "test_add_pr_review_adoption_entry",
+        ]
+    )
+    result = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
+    return result.wasSuccessful()
+
+
+def _validate_body(label: str, body: str) -> bool:
+    _ensure_repo_imports()
+    from scripts.check_pr_review_template import validate_pr_body
+
+    print(f"\nValidating {label}...")
+    result = validate_pr_body(body)
+    for warning in result.warnings:
+        print(f"warning: {warning}")
+
+    if result.errors:
+        print(f"{label} failed:")
+        for error in result.errors:
+            print(f"- {error}")
+        return False
+
+    print(f"{label} passed.")
+    return True
+
+
+def _validate_sample_bodies() -> bool:
+    ok = True
+    for sample_path in SAMPLE_BODY_FILES:
+        if not sample_path.exists():
+            print(f"missing sample body: {sample_path}")
+            ok = False
+            continue
+        ok = _validate_body(
+            str(sample_path.relative_to(REPO_ROOT)),
+            sample_path.read_text(encoding="utf-8"),
+        ) and ok
+    return ok
+
+
+def _read_pr_body(args: argparse.Namespace) -> tuple[str, str] | None:
+    if args.body_env:
+        return f"env:{args.body_env}", os.environ.get(args.body_env, "")
+    if args.body_file:
+        path = Path(args.body_file)
+        return str(path), path.read_text(encoding="utf-8")
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run PR review gate unit tests, samples, and optional PR body validation."
+    )
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--body-file", help="Path to a markdown file containing PR body.")
+    source.add_argument("--body-env", help="Environment variable containing PR body text.")
+    args = parser.parse_args()
+
+    ok = True
+    print("Running PR review gate unit tests...")
+    ok = _run_unit_tests() and ok
+
+    print("\nValidating documented sample PR bodies...")
+    ok = _validate_sample_bodies() and ok
+
+    pr_body = _read_pr_body(args)
+    if pr_body:
+        label, body = pr_body
+        ok = _validate_body(label, body) and ok
+    else:
+        print("\nNo live PR body provided; skipped live PR body validation.")
+
+    if not ok:
+        print("\nPR review gate checks failed.")
+        return 1
+
+    print("\nPR review gate checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test_add_pr_review_adoption_entry.py
+++ b/test_add_pr_review_adoption_entry.py
@@ -1,0 +1,54 @@
+import unittest
+
+from scripts.add_pr_review_adoption_entry import AdoptionEntry, append_entry, format_entry
+
+
+class AdoptionEntryTests(unittest.TestCase):
+    def test_format_entry_matches_adoption_log_shape(self):
+        entry = AdoptionEntry(
+            entry_date="2026-05-02",
+            focus="Example PR",
+            track="Contract / Scope",
+            evidence="PR body and diff",
+            gate_result="passed",
+            repeated_gap="none",
+            prevention="none",
+            next_action="record next live adoption entry",
+        )
+
+        self.assertEqual(
+            format_entry(entry),
+            "\n".join(
+                [
+                    "## 2026-05-02 - Example PR",
+                    "",
+                    "- Track: Contract / Scope",
+                    "- Evidence reviewed: PR body and diff",
+                    "- Gate result: passed",
+                    "- Repeated gap observed: none",
+                    "- Prevention added: none",
+                    "- Next action: record next live adoption entry",
+                    "",
+                ]
+            ),
+        )
+
+    def test_append_entry_places_new_entry_first_under_log_heading(self):
+        log_text = "# Adoption\n\n## Log\n\n## 2026-05-01 - Old Entry\n\n- Track: Scope\n"
+        entry_text = "## 2026-05-02 - New Entry\n\n- Track: Contract\n\n"
+
+        updated = append_entry(log_text, entry_text)
+
+        self.assertIn("## Log\n\n## 2026-05-02 - New Entry", updated)
+        self.assertLess(
+            updated.index("## 2026-05-02 - New Entry"),
+            updated.index("## 2026-05-01 - Old Entry"),
+        )
+
+    def test_append_entry_requires_log_heading(self):
+        with self.assertRaises(ValueError):
+            append_entry("# Adoption\n", "## 2026-05-02 - Entry\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_check_pr_review_template.py
+++ b/test_check_pr_review_template.py
@@ -1,0 +1,248 @@
+import unittest
+
+from scripts.check_pr_review_template import validate_pr_body
+
+
+VALID_DOCS_ONLY_BODY = """
+## Summary
+
+- Add docs-only PR review process gate.
+- No runtime behavior changed.
+
+## Contract Impact
+
+not applicable - docs/process only, no API or frontend consumer contract changed.
+
+## RBAC / Permissions
+
+not applicable - no route, endpoint, guard, or auth-sensitive behavior changed.
+
+## Notification / Realtime
+
+not applicable - no event, websocket, chat, or realtime behavior changed.
+
+## Frontend Resilience
+
+not applicable - no user-facing panel or frontend data flow changed.
+
+## Scope Gate
+
+- Allowed paths: docs/runbooks/**
+- Denied paths: backend runtime, frontend runtime, migrations
+- Migration/docs/test impact: docs only
+- Rollback note: revert the docs changes
+
+## Validation
+
+- Targeted tests or smoke run: PR body gate script
+- Result: passed
+- Not checked: runtime app behavior
+"""
+
+
+VALID_RUNTIME_BODY = """
+## Summary
+
+- Add a registrar service payload mapping regression.
+- Keep legacy aliases documented.
+
+## Contract Impact
+
+- Canonical surface: GET /api/v1/registrar/services
+- Request shape: authenticated request, no body
+- Response shape: grouped service dictionary
+- Status codes: 200, 401, 403
+- Frontend consumer: registrar service selector
+- Compatibility path or alias: legacy code-prefix fallback remains compatibility only
+- Contract proof: backend contract test and frontend consumer test
+
+## RBAC / Permissions
+
+- Roles allowed: registrar, admin
+- Roles denied: doctor, patient
+- Positive auth proof: registrar token returns 200
+- Negative auth proof: patient token returns 403
+
+## Notification / Realtime
+
+not applicable - no event, websocket, chat, or realtime behavior changed.
+
+## Frontend Resilience
+
+- Empty data proof: empty group renders empty selector state
+- Partial data proof: missing optional description does not crash
+- Forbidden secondary path behavior: not applicable, no secondary path used
+- Missing draft/resource behavior: not applicable, no draft/resource path changed
+- Stale route/deep-link behavior: not applicable, no route state changed
+
+## Scope Gate
+
+- Allowed paths: backend registrar endpoint, frontend registrar consumer, targeted tests
+- Denied paths: unrelated admin panels, migrations
+- Migration/docs/test impact: no migration; targeted tests added
+- Rollback note: revert endpoint and consumer changes
+
+## Validation
+
+- Targeted tests or smoke run: pytest targeted backend/frontend regression tests
+- Result: passed
+- Not checked: full browser panel smoke
+"""
+
+
+class PRReviewTemplateValidationTests(unittest.TestCase):
+    def test_rejects_empty_body(self):
+        result = validate_pr_body("")
+
+        self.assertEqual(
+            result.errors,
+            ["PR body is empty. Fill the review quality gate template."],
+        )
+
+    def test_rejects_missing_required_section(self):
+        body = VALID_DOCS_ONLY_BODY.replace("## Validation", "## Evidence")
+
+        result = validate_pr_body(body)
+
+        self.assertIn("Missing required section: ## Validation", result.errors)
+
+    def test_rejects_unfilled_template_placeholders(self):
+        body = """
+## Summary
+
+Describe the change in 2-4 bullets.
+
+## Contract Impact
+
+- Canonical surface:
+
+## RBAC / Permissions
+
+- Roles allowed:
+
+## Notification / Realtime
+
+- Event type or websocket channel:
+
+## Frontend Resilience
+
+- Empty data proof:
+
+## Scope Gate
+
+- Allowed paths:
+
+## Validation
+
+- Targeted tests or smoke run:
+"""
+
+        result = validate_pr_body(body)
+
+        self.assertEqual(len(result.errors), 7)
+        self.assertTrue(any("## Contract Impact" in error for error in result.errors))
+
+    def test_html_comments_do_not_count_as_section_answers(self):
+        body = VALID_DOCS_ONLY_BODY.replace(
+            "- Add docs-only PR review process gate.\n- No runtime behavior changed.",
+            "<!-- Author guidance only; this is not an answer. -->",
+        )
+
+        result = validate_pr_body(body)
+
+        self.assertTrue(any("## Summary" in error for error in result.errors))
+
+    def test_accepts_body_with_utf8_bom_prefix(self):
+        result = validate_pr_body("\ufeff" + VALID_DOCS_ONLY_BODY)
+
+        self.assertEqual(result.errors, [])
+
+    def test_rejects_partially_filled_required_fields(self):
+        body = """
+## Summary
+
+- Add a partially documented runtime change.
+
+## Contract Impact
+
+- Canonical surface: GET /api/v1/example
+- Request shape:
+- Response shape:
+- Status codes:
+- Frontend consumer:
+- Compatibility path or alias:
+- Contract proof:
+
+## RBAC / Permissions
+
+not applicable - no route, endpoint, guard, or auth-sensitive behavior changed.
+
+## Notification / Realtime
+
+not applicable - no event, websocket, chat, or realtime behavior changed.
+
+## Frontend Resilience
+
+not applicable - no user-facing panel or frontend data flow changed.
+
+## Scope Gate
+
+- Allowed paths: backend/app/api/example.py
+- Denied paths:
+- Migration/docs/test impact:
+- Rollback note:
+
+## Validation
+
+- Targeted tests or smoke run: validator smoke
+- Result: passed
+- Not checked: runtime app behavior
+"""
+
+        result = validate_pr_body(body)
+
+        self.assertTrue(any("## Contract Impact" in error for error in result.errors))
+        self.assertTrue(any("Request shape" in error for error in result.errors))
+        self.assertTrue(any("## Scope Gate" in error for error in result.errors))
+        self.assertTrue(any("Denied paths" in error for error in result.errors))
+
+    def test_rejects_not_applicable_without_specific_reason(self):
+        body = VALID_DOCS_ONLY_BODY.replace(
+            "not applicable - docs/process only, no API or frontend consumer contract changed.",
+            "not applicable",
+        )
+
+        result = validate_pr_body(body)
+
+        self.assertTrue(any("## Contract Impact" in error for error in result.errors))
+
+    def test_field_level_not_applicable_does_not_fill_entire_section(self):
+        body = VALID_RUNTIME_BODY.replace(
+            "- Partial data proof: missing optional description does not crash",
+            "- Partial data proof:",
+        )
+
+        result = validate_pr_body(body)
+
+        self.assertTrue(any("## Frontend Resilience" in error for error in result.errors))
+        self.assertTrue(any("Partial data proof" in error for error in result.errors))
+
+    def test_accepts_docs_only_body_with_specific_not_applicable_reasons(self):
+        result = validate_pr_body(VALID_DOCS_ONLY_BODY)
+
+        self.assertEqual(result.errors, [])
+        self.assertEqual(
+            result.warnings,
+            [
+                "`not applicable` is accepted, but reviewers should confirm the reason is specific."
+            ],
+        )
+
+    def test_accepts_runtime_body_with_review_proof_fields(self):
+        result = validate_pr_body(VALID_RUNTIME_BODY)
+
+        self.assertEqual(result.errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the local PR review/lifecycle automation base without enabling GitHub write-capable workflows.

## Scope

- Add PR review body validator and local gate runner.
- Add lifecycle recommendation script for local/workflow use.
- Add adoption-log helper and unit coverage.
- Add sample PR bodies and review adoption docs.

This is PR-2A split from the larger local lifecycle patch. It intentionally excludes GitHub workflow activation, GH_TOKEN usage, runtime/backend/ops/frontend changes, endpoint/service cleanup, deletion/rename waves, and generated/evidence artifacts.

## Risk

Low. This PR adds local scripts, tests, and documentation only. It does not enable workflow write behavior and does not modify runtime code.

## Validation

- git diff --check: passed
- Safety scan for generated/evidence/runtime/workflow scope: passed
- python -m unittest test_check_pr_review_template.py test_add_pr_review_adoption_entry.py: passed
- python scripts/run_pr_review_gate_checks.py: passed