### PR TITLE
[codex] QA: harden VPS backup restore safety

### DIFF
--- a/ops/vps/scripts/backup_db.py
+++ b/ops/vps/scripts/backup_db.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 from datetime import datetime
 from pathlib import Path
 
@@ -18,6 +19,12 @@ from clinic_lifecycle_common import (
     require_env,
     run_command,
 )
+
+
+def _safe_backup_stem(database_name: str) -> str:
+    stem = re.sub(r"[^A-Za-z0-9._-]+", "_", database_name.strip())
+    stem = stem.strip("._-")
+    return stem or "database"
 
 
 def main() -> int:
@@ -39,7 +46,7 @@ def main() -> int:
         backup_file.parent.mkdir(parents=True, exist_ok=True)
     else:
         timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-        backup_file = backup_dir / f"{target.name}_{timestamp}.dump"
+        backup_file = backup_dir / f"{_safe_backup_stem(target.name)}_{timestamp}.dump"
 
     cmd = [
         postgres_tool("pg_dump"),

--- a/ops/vps/scripts/clinic_lifecycle_common.py
+++ b/ops/vps/scripts/clinic_lifecycle_common.py
@@ -253,6 +253,7 @@ def run_command(
 ) -> subprocess.CompletedProcess[str]:
     printable = shlex.join(args)
     log(f"+ {printable}")
+    _require_safe_force_checkout(args, cwd)
     merged_env = os.environ.copy()
     if env:
         merged_env.update(env)
@@ -330,6 +331,25 @@ def read_json_payload(path: str | None, inline_json: str | None = None) -> dict[
     return json.loads(payload_path.read_text(encoding="utf-8"))
 
 
+def _redact_url_for_message(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return "<invalid-url>"
+
+    if not parsed.netloc or "@" not in parsed.netloc:
+        return url
+
+    host_part = parsed.hostname or ""
+    if parsed.port:
+        host_part = f"{host_part}:{parsed.port}"
+    if parsed.username:
+        safe_netloc = f"{parsed.username}:***@{host_part}"
+    else:
+        safe_netloc = f"***@{host_part}"
+    return parsed._replace(netloc=safe_netloc).geturl()
+
+
 def parse_database_url(url: str) -> DatabaseTarget:
     if not url:
         fail("DATABASE_URL is required")
@@ -340,11 +360,11 @@ def parse_database_url(url: str) -> DatabaseTarget:
     )
     parsed = urlparse(normalized)
     if parsed.scheme not in {"postgresql", "postgres"}:
-        fail(f"Unsupported database scheme in URL: {url}")
+        fail(f"Unsupported database scheme in URL: {_redact_url_for_message(url)}")
 
     name = parsed.path.lstrip("/")
     if not name:
-        fail(f"Database name is missing in URL: {url}")
+        fail(f"Database name is missing in URL: {_redact_url_for_message(url)}")
 
     return DatabaseTarget(
         url=url,
@@ -365,6 +385,50 @@ def git_head(root: Path | None = None) -> str:
         text=True,
     ).strip()
     return result
+
+
+def _git_has_tracked_changes(root: Path) -> bool:
+    worktree_dirty = subprocess.run(
+        ["git", "diff", "--quiet"],
+        cwd=str(root),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode != 0
+    index_dirty = subprocess.run(
+        ["git", "diff", "--cached", "--quiet"],
+        cwd=str(root),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode != 0
+    return worktree_dirty or index_dirty
+
+
+def _require_safe_force_checkout(args: list[str], cwd: Path | None) -> None:
+    if len(args) < 4 or args[0] != "git" or args[1] != "checkout" or args[2] != "--force":
+        return
+
+    release_ref = args[3]
+    root = (cwd or app_root()).resolve()
+    if not release_ref.strip() or any(char.isspace() for char in release_ref):
+        raise LifecycleError("Refusing forced release checkout with an empty or whitespace-containing ref")
+
+    ref_check = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{release_ref}^{{commit}}"],
+        cwd=str(root),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if ref_check.returncode != 0:
+        raise LifecycleError(f"Refusing forced release checkout because ref does not resolve to a commit: {release_ref}")
+
+    if env_bool("CONFIRM_FORCE_RELEASE_CHECKOUT", False):
+        return
+
+    if _git_has_tracked_changes(root):
+        raise LifecycleError(
+            "Refusing forced release checkout with tracked local changes. "
+            "Commit/stash the changes, or set CONFIRM_FORCE_RELEASE_CHECKOUT=1 for an intentional release operation."
+        )
 
 
 def ensure_tool(name: str) -> None:

--- a/ops/vps/scripts/restore_db.py
+++ b/ops/vps/scripts/restore_db.py
@@ -7,8 +7,10 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 from clinic_lifecycle_common import (
+    DatabaseTarget,
     backend_dir,
     fail,
     load_clinic_env,
@@ -17,6 +19,51 @@ from clinic_lifecycle_common import (
     postgres_tool,
     run_command,
 )
+
+
+def _redact_database_url(database_url: str) -> str:
+    parsed = urlsplit(database_url)
+    if not parsed.password:
+        return database_url
+
+    username = parsed.username or ""
+    hostname = parsed.hostname or ""
+    host = hostname
+    if ":" in hostname and not hostname.startswith("["):
+        host = f"[{hostname}]"
+    if parsed.port:
+        host = f"{host}:{parsed.port}"
+
+    netloc = f"{username}:***@{host}" if username else host
+    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
+
+
+def _is_same_database_target(left: DatabaseTarget, right: DatabaseTarget) -> bool:
+    return (
+        left.host.lower(),
+        left.port,
+        left.name,
+    ) == (
+        right.host.lower(),
+        right.port,
+        right.name,
+    )
+
+
+def _require_live_restore_confirmation(*, target_database_url: str) -> None:
+    runtime_database_url = os.environ.get("DATABASE_URL")
+    if runtime_database_url:
+        runtime_target = parse_database_url(runtime_database_url)
+        restore_target = parse_database_url(target_database_url)
+        if not _is_same_database_target(runtime_target, restore_target):
+            return
+    if os.environ.get("CONFIRM_RESTORE_DB") == "1":
+        return
+    fail(
+        "Refusing to restore into DATABASE_URL without explicit confirmation. "
+        "Set RESTORE_DATABASE_URL to a separate rehearsal target, or set "
+        "CONFIRM_RESTORE_DB=1 only for an intentional live database restore."
+    )
 
 
 def _prepare_restore_source(backup_file: Path) -> Path:
@@ -49,6 +96,8 @@ def main() -> int:
     target_url = args.target_database_url
     if not target_url:
         fail("RESTORE_DATABASE_URL (or DATABASE_URL) is required")
+
+    _require_live_restore_confirmation(target_database_url=target_url)
 
     target = parse_database_url(target_url)
     restore_source = _prepare_restore_source(backup_file)
@@ -93,7 +142,7 @@ def main() -> int:
             restore_source.unlink(missing_ok=True)
 
     print(f"RESTORED_BACKUP_FILE={backup_file}", flush=True)
-    print(f"RESTORE_DATABASE_URL={target_url}", flush=True)
+    print(f"RESTORE_DATABASE_URL={_redact_database_url(target_url)}", flush=True)
     pass_message(f"restore_db restored {backup_file} into {target.name}")
     return 0
 

--- a/ops/vps/scripts/run_backup_restore_rehearsal.py
+++ b/ops/vps/scripts/run_backup_restore_rehearsal.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 from clinic_lifecycle_common import (
     app_root,
@@ -12,6 +13,23 @@ from clinic_lifecycle_common import (
     pass_message,
     run_command,
 )
+
+
+def _redact_database_url(database_url: str) -> str:
+    parsed = urlsplit(database_url)
+    if not parsed.password:
+        return database_url
+
+    username = parsed.username or ""
+    hostname = parsed.hostname or ""
+    host = hostname
+    if ":" in hostname and not hostname.startswith("["):
+        host = f"[{hostname}]"
+    if parsed.port:
+        host = f"{host}:{parsed.port}"
+
+    netloc = f"{username}:***@{host}" if username else host
+    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
 
 
 def _script(name: str) -> Path:
@@ -85,7 +103,7 @@ def main() -> int:
     )
 
     print(f"RESTORE_BACKUP_FILE={backup_file}", flush=True)
-    print(f"RESTORE_DATABASE_URL={restore_database_url}", flush=True)
+    print(f"RESTORE_DATABASE_URL={_redact_database_url(restore_database_url)}", flush=True)
     print(f"RESTORE_BACKEND_URL={restore_backend_url}", flush=True)
     print(f"RESTORE_PUBLIC_URL={restore_public_url}", flush=True)
     pass_message("run_backup_restore_rehearsal completed successfully")


### PR DESCRIPTION
## Summary

- Adds VPS backup/restore and lifecycle safety hardening.
- Sanitizes generated backup filename stems.
- Redacts restore database URLs in logs/errors.
- Adds explicit restore and forced checkout guards for operator safety.

## Contract Impact

- Canonical surface: VPS operator scripts under ops/vps/scripts only; no application API, WebSocket, frontend route, or runtime contract surface changes.
- Request shape: Not applicable because this PR does not change application request payloads.
- Response shape: Not applicable because this PR does not change application response payloads.
- Status codes: Not applicable because this PR does not change HTTP endpoint behavior.
- Frontend consumer: Not applicable because this PR does not change frontend runtime consumers.
- Compatibility path or alias: Not applicable because no compatibility route, alias, or legacy path is changed.
- Contract proof: Changed files are limited to VPS operator scripts; no backend endpoint, frontend, workflow, or deletion/rename paths are included.

## RBAC / Permissions

- Roles allowed: Not applicable because application RBAC roles are not changed.
- Roles denied: Not applicable because application RBAC deny paths are not changed.
- Positive auth proof: Not applicable because these scripts are operator-run VPS tools, not app RBAC surfaces.
- Negative auth proof: Scope excludes backend runtime auth/RBAC files and frontend auth flows.

## Notification / Realtime

- Event type or websocket channel: Not applicable because no notification, inbox, Telegram, or WebSocket event is changed.
- Payload version / ack behavior: Not applicable because no realtime payload contract is changed.
- Read/unread or delivery semantics: Not applicable because no read state or delivery path is changed.
- Reconnect/resync proof: Not applicable because no reconnect or resync behavior is changed.

## Frontend Resilience

- Empty data proof: Not applicable because no frontend data surface is changed.
- Partial data proof: Not applicable because no frontend data surface is changed.
- Forbidden secondary path behavior: Not applicable because no frontend authorization fallback path is changed.
- Missing draft/resource behavior: Not applicable because no frontend draft/resource loader is changed.
- Stale route/deep-link behavior: Not applicable because no frontend routing or deep-link behavior is changed.

## Scope Gate

- Allowed paths: ops/vps/scripts/backup_db.py; ops/vps/scripts/clinic_lifecycle_common.py; ops/vps/scripts/restore_db.py; ops/vps/scripts/run_backup_restore_rehearsal.py.
- Denied paths: backend/**, frontend/**, .github/workflows/**, docs/**, generated/evidence artifacts, output/**, test-results/**, storage/**, endpoint/service deletion or rename waves.
- Migration/docs/test impact: No database migrations or runtime docs changed; validation is focused on script compilation and targeted safety smokes.
- Rollback note: Revert this PR to remove the stricter VPS operator guards without touching application runtime code.

## Validation

- Targeted tests or smoke run: git diff --check; python -m py_compile for all four files; backup filename sanitizer smoke; restore URL redaction and live DATABASE_URL guard smoke; git checkout --force guard smoke.
- Result: Passed locally before push.
- Not checked: Real VPS/systemd execution and real Postgres backup/restore were not run in this temp branch.