### PR TITLE
[codex] QA: redact VPS smoke failure payloads

### DIFF
--- a/ops/vps/scripts/smoke_fresh_install.py
+++ b/ops/vps/scripts/smoke_fresh_install.py
@@ -21,6 +21,37 @@ from clinic_lifecycle_common import (
 )
 
 
+SENSITIVE_KEYS = {
+    "access_token",
+    "activation_key",
+    "authorization",
+    "password",
+    "refresh_token",
+    "secret",
+    "token",
+}
+
+
+def _redact_sensitive(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted = {}
+        for key, item in value.items():
+            if str(key).lower() in SENSITIVE_KEYS:
+                redacted[key] = "***"
+            else:
+                redacted[key] = _redact_sensitive(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_sensitive(item) for item in value]
+    return value
+
+
+def _safe_payload(value: Any) -> Any:
+    if isinstance(value, (dict, list)):
+        return _redact_sensitive(value)
+    return value
+
+
 def _run_health_check(expected_initialized: bool) -> None:
     helper = Path(__file__).resolve().parent / "health_check.py"
     env = os.environ.copy()
@@ -101,9 +132,9 @@ def _post_setup_initialize(payload: dict[str, Any]) -> dict[str, Any]:
         payload=payload,
     )
     if status != 200 or not isinstance(response, dict):
-        fail(f"setup initialize failed: HTTP {status} {raw}")
+        fail(f"setup initialize failed: HTTP {status} {_safe_payload(response or raw)}")
     if not response.get("initialized"):
-        fail(f"setup initialize returned unexpected payload: {response}")
+        fail(f"setup initialize returned unexpected payload: {_safe_payload(response)}")
     return response
 
 
@@ -129,9 +160,9 @@ def _maybe_login(payload: dict[str, Any]) -> None:
         payload={"username": username, "password": password, "remember_me": False},
     )
     if status != 200 or not isinstance(response, dict):
-        fail(f"Login smoke failed: HTTP {status} {raw}")
+        fail(f"Login smoke failed: HTTP {status} {_safe_payload(response or raw)}")
     if not response.get("access_token"):
-        fail(f"Login smoke returned no access token: {response}")
+        fail(f"Login smoke returned no access token: {_safe_payload(response)}")
 
 
 def main() -> int:
@@ -143,7 +174,10 @@ def main() -> int:
         f"{backend_url()}/api/v1/setup/status",
     )
     if status_status != 200 or not isinstance(status_payload, dict):
-        fail(f"setup/status check before install failed: HTTP {status_status} {status_raw}")
+        fail(
+            "setup/status check before install failed: "
+            f"HTTP {status_status} {_safe_payload(status_payload or status_raw)}"
+        )
     if bool(status_payload.get("initialized")):
         fail("Fresh install smoke expected an uninitialized deployment before setup")
 

--- a/ops/vps/scripts/smoke_post_update.py
+++ b/ops/vps/scripts/smoke_post_update.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 from clinic_lifecycle_common import (
     app_root,
@@ -14,6 +15,37 @@ from clinic_lifecycle_common import (
     pass_message,
     run_command,
 )
+
+
+SENSITIVE_KEYS = {
+    "access_token",
+    "activation_key",
+    "authorization",
+    "password",
+    "refresh_token",
+    "secret",
+    "token",
+}
+
+
+def _redact_sensitive(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted = {}
+        for key, item in value.items():
+            if str(key).lower() in SENSITIVE_KEYS:
+                redacted[key] = "***"
+            else:
+                redacted[key] = _redact_sensitive(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_sensitive(item) for item in value]
+    return value
+
+
+def _safe_payload(value: Any) -> Any:
+    if isinstance(value, (dict, list)):
+        return _redact_sensitive(value)
+    return value
 
 
 def _run_health_check(expected_initialized: bool) -> None:
@@ -67,9 +99,9 @@ def _maybe_login() -> None:
         payload={"username": username, "password": password, "remember_me": False},
     )
     if status != 200 or not isinstance(payload, dict):
-        fail(f"Login smoke failed: HTTP {status} {raw}")
+        fail(f"Login smoke failed: HTTP {status} {_safe_payload(payload or raw)}")
     if not payload.get("access_token"):
-        fail(f"Login smoke returned no access token: {payload}")
+        fail(f"Login smoke returned no access token: {_safe_payload(payload)}")
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

- Adds VPS smoke payload redaction for setup/login failure paths.
- Redacts sensitive keys before logging smoke failure payloads.
- Keeps smoke request flow unchanged.

## Contract Impact

- Canonical surface: VPS operator smoke scripts only; no application API, WebSocket, frontend route, or runtime contract surface changes.
- Request shape: Not applicable because this PR does not change smoke request payloads or application request payloads.
- Response shape: Not applicable because this PR only changes how failure payloads are rendered in operator logs.
- Status codes: Not applicable because no endpoint behavior changes.
- Frontend consumer: Not applicable because no frontend runtime consumer changes.
- Compatibility path or alias: Not applicable because no compatibility route, alias, or legacy path is changed.
- Contract proof: Changed files are limited to two ops/vps smoke scripts; no backend endpoint, frontend, workflow, or deletion/rename paths are included.

## RBAC / Permissions

- Roles allowed: Not applicable because application RBAC roles are not changed.
- Roles denied: Not applicable because application RBAC deny paths are not changed.
- Positive auth proof: Login smoke flow remains the same; only failure payload output is redacted.
- Negative auth proof: Scope excludes backend runtime auth/RBAC files and frontend auth flows.

## Notification / Realtime

- Event type or websocket channel: Not applicable because no notification, inbox, Telegram, or WebSocket event is changed.
- Payload version / ack behavior: Not applicable because no realtime payload contract is changed.
- Read/unread or delivery semantics: Not applicable because no read state or delivery path is changed.
- Reconnect/resync proof: Not applicable because no reconnect or resync behavior is changed.

## Frontend Resilience

- Empty data proof: Not applicable because no frontend data surface is changed.
- Partial data proof: Not applicable because no frontend data surface is changed.
- Forbidden secondary path behavior: Not applicable because no frontend authorization fallback path is changed.
- Missing draft/resource behavior: Not applicable because no frontend draft/resource loader is changed.
- Stale route/deep-link behavior: Not applicable because no frontend routing or deep-link behavior is changed.

## Scope Gate

- Allowed paths: ops/vps/scripts/smoke_fresh_install.py; ops/vps/scripts/smoke_post_update.py.
- Denied paths: backend/**, frontend/**, .github/workflows/**, docs/**, generated/evidence artifacts, output/**, test-results/**, storage/**, endpoint/service deletion or rename waves.
- Migration/docs/test impact: No migrations or runtime docs changed; validation is focused on script compilation and targeted redaction smoke.
- Rollback note: Revert this PR to restore previous smoke failure payload rendering without touching application runtime code.

## Validation

- Targeted tests or smoke run: git diff --check; python -m py_compile for both files; targeted smoke payload redaction test.
- Result: Passed locally before push.
- Not checked: Real VPS smoke execution against a live deployment was not run in this temp branch.