### PR TITLE
[codex] QA: harden VPS release deploy guards

### DIFF
--- a/ops/vps/scripts/bootstrap_postgres.sh
+++ b/ops/vps/scripts/bootstrap_postgres.sh
@@ -10,17 +10,50 @@ DB_USER="$1"
 DB_PASSWORD="$2"
 DB_NAME="$3"
 
-sudo -u postgres psql -v ON_ERROR_STOP=1 <<SQL
-DO \$\$
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${DB_USER}') THEN
-        EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', '${DB_USER}', '${DB_PASSWORD}');
-    END IF;
-END
-\$\$;
-SQL
+validate_identifier() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "${value}" =~ ^[A-Za-z_][A-Za-z0-9_]{0,62}$ ]]; then
+    echo "${name} must be a PostgreSQL identifier: letters, digits, underscores, max 63 chars, not starting with a digit" >&2
+    exit 1
+  fi
+}
 
-if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1; then
+sql_literal() {
+  local value="$1"
+  local escaped="${value//\'/\'\'}"
+  printf "'%s'" "${escaped}"
+}
+
+if [[ "${DB_PASSWORD}" == *$'\n'* || "${DB_PASSWORD}" == *$'\r'* ]]; then
+  echo "db_password must not contain newline characters" >&2
+  exit 1
+fi
+
+validate_identifier "db_user" "${DB_USER}"
+validate_identifier "db_name" "${DB_NAME}"
+
+DB_USER_LITERAL="$(sql_literal "${DB_USER}")"
+DB_PASSWORD_LITERAL="$(sql_literal "${DB_PASSWORD}")"
+DB_NAME_LITERAL="$(sql_literal "${DB_NAME}")"
+
+ROLE_SQL="DO \$\$ "
+ROLE_SQL+="DECLARE role_name text := ${DB_USER_LITERAL}; "
+ROLE_SQL+="role_password text := ${DB_PASSWORD_LITERAL}; "
+ROLE_SQL+="BEGIN "
+ROLE_SQL+="IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN "
+ROLE_SQL+="EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', role_name, role_password); "
+ROLE_SQL+="END IF; "
+ROLE_SQL+="END \$\$;"
+
+sudo -u postgres psql -v ON_ERROR_STOP=1 -c "${ROLE_SQL}"
+
+DB_EXISTS="$(
+  sudo -u postgres psql -v ON_ERROR_STOP=1 --tuples-only --no-align \
+    -c "SELECT 1 FROM pg_database WHERE datname = ${DB_NAME_LITERAL};"
+)"
+
+if [[ "${DB_EXISTS}" != "1" ]]; then
   sudo -u postgres createdb -O "${DB_USER}" "${DB_NAME}"
 fi
 

--- a/ops/vps/scripts/build_release_artifact.py
+++ b/ops/vps/scripts/build_release_artifact.py
@@ -12,15 +12,35 @@ from pathlib import Path
 from clinic_lifecycle_common import app_root, fail, load_clinic_env, pass_message, run_command
 
 
+_REF_FORBIDDEN_CHARS = set(":\\ \t\r\n")
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
 def _safe_name(value: str) -> str:
     cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip())
     cleaned = cleaned.strip("-._")
     return cleaned or "release"
 
 
-def _git_output(args: list[str]) -> str:
-    result = run_command(["git", *args], cwd=app_root())
-    return result.stdout.strip()
+def _validate_build_ref(value: str) -> str:
+    git_ref = value.strip()
+    if not git_ref:
+        fail("Release artifact --ref must not be empty")
+    if git_ref.startswith("-") or any(char in _REF_FORBIDDEN_CHARS or ord(char) < 32 for char in git_ref):
+        fail(f"Release artifact --ref is unsafe: {git_ref}")
+    return git_ref
+
+
+def _resolve_commit(git_ref: str) -> str:
+    result = run_command(
+        ["git", "rev-parse", "--verify", "--quiet", f"{git_ref}^{{commit}}"],
+        cwd=app_root(),
+        check=False,
+    )
+    commit_sha = result.stdout.strip()
+    if result.returncode != 0 or not _COMMIT_SHA_RE.fullmatch(commit_sha):
+        fail(f"Release artifact --ref does not resolve to a commit: {git_ref}")
+    return commit_sha
 
 
 def main() -> int:
@@ -46,7 +66,8 @@ def main() -> int:
     output_dir = Path(args.output_dir).expanduser().resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    commit_sha = _git_output(["rev-parse", args.git_ref])
+    git_ref = _validate_build_ref(args.git_ref)
+    commit_sha = _resolve_commit(git_ref)
     short_sha = commit_sha[:12]
     release_name = _safe_name(args.release_name or f"clinic-release-{short_sha}")
 
@@ -56,7 +77,7 @@ def main() -> int:
         manifest_path = temp_dir / "release-manifest.json"
 
         run_command(
-            ["git", "bundle", "create", str(bundle_path), args.git_ref],
+            ["git", "bundle", "create", str(bundle_path), git_ref],
             cwd=root,
         )
 
@@ -64,7 +85,7 @@ def main() -> int:
             "format_version": 1,
             "artifact_kind": "approved_release_artifact",
             "release_name": release_name,
-            "bundle_ref": args.git_ref,
+            "bundle_ref": git_ref,
             "commit_sha": commit_sha,
             "created_at_utc": datetime.now(timezone.utc).isoformat(),
             "delivery_modes": ["github_release_asset", "offline_package"],
@@ -79,7 +100,7 @@ def main() -> int:
 
     print(f"ARTIFACT_FILE={artifact_path}", flush=True)
     print(f"ARTIFACT_RELEASE_NAME={release_name}", flush=True)
-    print(f"ARTIFACT_RELEASE_REF={args.git_ref}", flush=True)
+    print(f"ARTIFACT_RELEASE_REF={git_ref}", flush=True)
     print(f"ARTIFACT_COMMIT_SHA={commit_sha}", flush=True)
     pass_message("build_release_artifact completed successfully")
     return 0

--- a/ops/vps/scripts/check_health.sh
+++ b/ops/vps/scripts/check_health.sh
@@ -2,7 +2,18 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-export PUBLIC_URL="${1:-${PUBLIC_URL:-}}"
-export BACKEND_URL="${2:-${BACKEND_URL:-}}"
+
+if [[ $# -gt 2 ]]; then
+  echo "Usage: $0 [public_url] [backend_url]" >&2
+  exit 1
+fi
+
+if [[ $# -ge 1 && -n "${1}" ]]; then
+  export PUBLIC_URL="${1}"
+fi
+
+if [[ $# -ge 2 && -n "${2}" ]]; then
+  export BACKEND_URL="${2}"
+fi
 
 exec python3 "${SCRIPT_DIR}/health_check.py"

--- a/ops/vps/scripts/deploy_host.sh
+++ b/ops/vps/scripts/deploy_host.sh
@@ -6,6 +6,39 @@ set -euo pipefail
 : "${APP_ROOT:=/opt/clinic}"
 : "${RUN_AS_USER:=$(whoami)}"
 
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+validate_identifier() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "${value}" =~ ^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$ ]]; then
+    fail "${name} must use letters, digits, underscores, or hyphens; max 63 chars; must start with a letter or digit"
+  fi
+}
+
+validate_app_root() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "${value}" =~ ^/[A-Za-z0-9._/-]+$ ]]; then
+    fail "${name} must be an absolute Unix path using only letters, digits, dots, underscores, hyphens, and slashes"
+  fi
+}
+
+validate_host() {
+  local value="$1"
+  if [[ ! "${value}" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)(\.([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?))*$ ]]; then
+    fail "APP_HOST must be a hostname without scheme, path, port, spaces, or template metacharacters"
+  fi
+}
+
+validate_identifier "APP_ENV" "${APP_ENV}"
+validate_identifier "RUN_AS_USER" "${RUN_AS_USER}"
+validate_app_root "APP_ROOT" "${APP_ROOT}"
+validate_host "${APP_HOST}"
+
 BACKEND_DIR="${APP_ROOT}/backend"
 FRONTEND_DIR="${APP_ROOT}/frontend"
 OUTPUT_DIR="${APP_ROOT}/output/vps"

--- a/ops/vps/scripts/import_release_artifact.py
+++ b/ops/vps/scripts/import_release_artifact.py
@@ -3,11 +3,54 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
+import subprocess
 import tempfile
 import zipfile
 from pathlib import Path
 
 from clinic_lifecycle_common import app_root, fail, load_clinic_env, pass_message, run_command
+
+
+_RELEASE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_REF_FORBIDDEN_CHARS = set(":\\ \t\r\n")
+_IMPORTED_REF_NAMESPACE = "refs/clinic-releases"
+
+
+def _validate_release_name(value: str) -> str:
+    release_name = value.strip()
+    if not _RELEASE_NAME_RE.fullmatch(release_name):
+        fail(
+            "Artifact manifest has an invalid release_name. "
+            "Use 1-128 ASCII letters, digits, dots, underscores, or hyphens, starting with a letter or digit."
+        )
+    return release_name
+
+
+def _validate_ref_component(value: str, *, field_name: str) -> str:
+    ref = value.strip()
+    if not ref:
+        fail(f"Missing release artifact {field_name}")
+    if ref.startswith("-") or any(char in _REF_FORBIDDEN_CHARS or ord(char) < 32 for char in ref):
+        fail(f"Unsafe release artifact {field_name}: {ref}")
+    return ref
+
+
+def _validate_ref_prefix(value: str) -> str:
+    ref_prefix = _validate_ref_component(value.rstrip("/"), field_name="ref-prefix")
+    if ref_prefix != _IMPORTED_REF_NAMESPACE and not ref_prefix.startswith(f"{_IMPORTED_REF_NAMESPACE}/"):
+        fail(f"Imported release ref-prefix must stay under {_IMPORTED_REF_NAMESPACE}: {ref_prefix}")
+    return ref_prefix
+
+
+def _validate_imported_ref(ref: str) -> None:
+    if subprocess.run(
+        ["git", "check-ref-format", ref],
+        cwd=str(app_root()),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode != 0:
+        fail(f"Imported release ref is not a valid git ref: {ref}")
 
 
 def main() -> int:
@@ -45,14 +88,12 @@ def main() -> int:
         manifest_path = temp_dir / "release-manifest.json"
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
-        bundle_ref = str(manifest.get("bundle_ref") or "").strip()
-        release_name = str(manifest.get("release_name") or "").strip()
-        if not bundle_ref:
-            fail("Artifact manifest is missing bundle_ref")
-        if not release_name:
-            fail("Artifact manifest is missing release_name")
+        bundle_ref = _validate_ref_component(str(manifest.get("bundle_ref") or ""), field_name="bundle_ref")
+        release_name = _validate_release_name(str(manifest.get("release_name") or ""))
 
-        imported_ref = f"{args.ref_prefix.rstrip('/')}/{release_name}"
+        ref_prefix = _validate_ref_prefix(args.ref_prefix)
+        imported_ref = f"{ref_prefix}/{release_name}"
+        _validate_imported_ref(imported_ref)
         run_command(
             ["git", "fetch", "--force", str(bundle_path), f"{bundle_ref}:{imported_ref}"],
             cwd=app_root(),

--- a/ops/vps/scripts/run_cutover.sh
+++ b/ops/vps/scripts/run_cutover.sh
@@ -4,6 +4,30 @@ set -euo pipefail
 : "${APP_ENV:=staging}"
 : "${APP_ROOT:=/opt/clinic}"
 
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+validate_identifier() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "${value}" =~ ^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$ ]]; then
+    fail "${name} must use letters, digits, underscores, or hyphens; max 63 chars; must start with a letter or digit"
+  fi
+}
+
+validate_app_root() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "${value}" =~ ^/[A-Za-z0-9._/-]+$ ]]; then
+    fail "${name} must be an absolute Unix path using only letters, digits, dots, underscores, hyphens, and slashes"
+  fi
+}
+
+validate_identifier "APP_ENV" "${APP_ENV}"
+validate_app_root "APP_ROOT" "${APP_ROOT}"
+
 BACKEND_DIR="${APP_ROOT}/backend"
 BACKEND_ENV_FILE="${BACKEND_DIR}/.env.${APP_ENV}"
 

--- a/ops/vps/scripts/run_migrations.py
+++ b/ops/vps/scripts/run_migrations.py
@@ -6,6 +6,7 @@ from clinic_lifecycle_common import (
     backend_dir,
     fail,
     load_clinic_env,
+    parse_database_url,
     pass_message,
     require_env,
     run_command,
@@ -14,7 +15,7 @@ from clinic_lifecycle_common import (
 
 def main() -> int:
     load_clinic_env()
-    require_env("DATABASE_URL")
+    parse_database_url(require_env("DATABASE_URL"))
 
     cmd = backend_alembic_cmd()
     run_command(cmd + ["upgrade", "head"], cwd=backend_dir())


### PR DESCRIPTION
## Summary

Adds VPS release/deploy guard hardening for operator scripts.

## Contract Impact

- Canonical surface: VPS operator scripts under ops/vps/scripts, no FastAPI endpoint or WebSocket event changed.
- Request shape: not applicable - no HTTP request contract changed; shell/Python CLI arguments are only narrowed by validation.
- Response shape: not applicable - no API response payload changed.
- Status codes: not applicable - no HTTP status behavior changed.
- Frontend consumer: not applicable - no frontend consumer or route changed.
- Compatibility path or alias: no route aliases or legacy compatibility paths changed.
- Contract proof: py_compile, Git-blob bash syntax, and targeted release/ref validator smoke passed.

## RBAC / Permissions

- Roles allowed: not applicable - no application RBAC surface changed.
- Roles denied: not applicable - no application RBAC surface changed.
- Positive auth proof: not applicable - operator scripts do not change authenticated app routes.
- Negative auth proof: not applicable - no role acceptance/denial behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, inbox, Telegram, ack/read, or realtime delivery behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend data rendering path changed.
- Partial data proof: not applicable - no frontend payload rendering path changed.
- Forbidden secondary path behavior: not applicable - no secondary frontend/backend path changed.
- Missing draft/resource behavior: not applicable - no EMR draft or resource workflow changed.
- Stale route/deep-link behavior: not applicable - no frontend route state or deep link changed.

## Scope Gate

- Allowed paths: ops/vps/scripts/bootstrap_postgres.sh, ops/vps/scripts/build_release_artifact.py, ops/vps/scripts/check_health.sh, ops/vps/scripts/deploy_host.sh, ops/vps/scripts/import_release_artifact.py, ops/vps/scripts/run_cutover.sh, ops/vps/scripts/run_migrations.py.
- Denied paths: backend runtime, frontend, GitHub workflows, docs-only changes, endpoint/service cleanup, deletion/rename waves, generated/evidence artifacts, output, test-results, storage, and dirty C:\final state.
- Migration/docs/test impact: no Alembic migration, no docs change, no app test change; validation is focused on touched operator scripts.
- Rollback note: revert this PR to restore the previous VPS operator script validation behavior.

## Risk

Medium-low. This touches VPS operator scripts and makes input validation stricter, but does not modify application runtime code or deployment workflow structure beyond explicit guardrails.

## Validation

- Targeted tests or smoke run: git diff --check; python -m py_compile for touched Python scripts; Git-blob bash syntax for touched shell scripts; targeted release/ref validator smoke; added-line safety scan for secret logging, destructive rm, force checkout, shell eval, and SQLite fallback.
- Result: passed.
- Not checked: live VPS execution, real systemd services, real PostgreSQL bootstrap, real release artifact import on production host.

## Notes

- Direct Windows worktree bash syntax saw CRLF checkout noise, so shell syntax was validated against Git blobs using git show :path piped to bash -n.