### PR TITLE
[codex] QA: harden admin and dev helper scripts

### DIFF
--- a/backend/app/scripts/create_admin_dev.py
+++ b/backend/app/scripts/create_admin_dev.py
@@ -1,15 +1,51 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from sqlalchemy import create_engine, MetaData, select, Table
+if TYPE_CHECKING:
+    from sqlalchemy import MetaData, Table
+
+
+def _require_create_admin_dev_confirmation() -> None:
+    if os.getenv("CONFIRM_CREATE_ADMIN_DEV") != "1":
+        raise SystemExit(
+            "Refusing to create or inspect dev admin without "
+            "CONFIRM_CREATE_ADMIN_DEV=1."
+        )
+
+
+def _required_database_url() -> str:
+    database_url = os.getenv("DATABASE_URL", "").strip()
+    if not database_url:
+        raise SystemExit("DATABASE_URL must be set before running create_admin_dev.py.")
+    if database_url.lower().startswith("sqlite"):
+        raise SystemExit("create_admin_dev.py requires a PostgreSQL DATABASE_URL.")
+    return database_url
+
+
+def _required_admin_password() -> str:
+    password = os.getenv("DEV_ADMIN_PASSWORD") or os.getenv("ADMIN_PASSWORD")
+    if not password:
+        raise SystemExit("Set DEV_ADMIN_PASSWORD or ADMIN_PASSWORD before creating a dev admin.")
+    return password
+
+
+def _password_value(column_name: str) -> str:
+    password = _required_admin_password()
+    if column_name == "hashed_password":
+        from app.core.security import get_password_hash
+
+        return get_password_hash(password)
+    return password
+
+
+_require_create_admin_dev_confirmation()
+DATABASE_URL = _required_database_url()
+
+from sqlalchemy import MetaData, Table, create_engine, select
 from sqlalchemy.orm import sessionmaker
 
-# Попытка использовать настройки проекта
-DATABASE_URL = os.getenv("DATABASE_URL") or "sqlite:///clinic.db"
-
-# Создаём engine/session на базе DATABASE_URL
 engine = create_engine(DATABASE_URL, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 
@@ -22,10 +58,8 @@ def find_users_table(meta: MetaData) -> Optional[Table]:
     for t in meta.sorted_tables:
         cols = {c.name for c in t.columns}
         if "username" in cols and ({"hashed_password", "password", "pass"} & cols):
-            # приоритет знакомых имён
             if t.name in candidate_names:
                 return t
-    # если точных не нашли — берём первую подходящую
     for t in meta.sorted_tables:
         cols = {c.name for c in t.columns}
         if "username" in cols and ({"hashed_password", "password", "pass"} & cols):
@@ -34,6 +68,12 @@ def find_users_table(meta: MetaData) -> Optional[Table]:
 
 
 def upsert_admin() -> None:
+    admin_username = os.getenv("DEV_ADMIN_USERNAME") or os.getenv("ADMIN_USERNAME", "admin")
+    admin_email = os.getenv("DEV_ADMIN_EMAIL") or os.getenv("ADMIN_EMAIL", "admin@example.com")
+    admin_full_name = os.getenv("DEV_ADMIN_FULL_NAME") or os.getenv(
+        "ADMIN_FULL_NAME", "Administrator"
+    )
+
     meta = MetaData()
     meta.reflect(bind=engine)
 
@@ -51,25 +91,23 @@ def upsert_admin() -> None:
     )
 
     with engine.begin() as conn:
-        # есть ли уже admin?
-        exists = conn.execute(select(users).where(users.c.username == "admin")).first()
+        exists = conn.execute(select(users).where(users.c.username == admin_username)).first()
         if exists:
-            print("✅ Пользователь 'admin' уже существует — оставляю как есть.")
+            print(f"✅ Пользователь '{admin_username}' уже существует — оставляю как есть.")
             return
 
-        row: Dict[str, Any] = {"username": "admin", pwd_col: "admin"}
-        # общие «здоровые» поля, если есть
-        for k, v in {
+        row: Dict[str, Any] = {"username": admin_username, pwd_col: _password_value(pwd_col)}
+        for key, value in {
             "is_active": True,
             "is_superuser": True,
-            "email": "admin@example.com",
-            "full_name": "Administrator",
+            "email": admin_email,
+            "full_name": admin_full_name,
         }.items():
-            if k in cols:
-                row[k] = v
+            if key in cols:
+                row[key] = value
 
         conn.execute(users.insert().values(**row))
-        print("✅ Создан пользователь admin/admin (без bcrypt — dev).")
+        print(f"✅ Создан dev admin '{admin_username}' с паролем из env.")
 
 
 if __name__ == "__main__":

--- a/backend/app/scripts/ensure_admin.py
+++ b/backend/app/scripts/ensure_admin.py
@@ -32,10 +32,17 @@ def _hash_or_plain(pw: str) -> str:
         return pw
 
 
+def _required_admin_password() -> str:
+    password = os.getenv("ADMIN_PASSWORD", "").strip()
+    if not password:
+        raise RuntimeError(
+            "ADMIN_PASSWORD must be set before creating or resetting the bootstrap admin user."
+        )
+    return password
+
+
 def ensure_admin() -> dict:
-    # SECURITY WARNING: В продакшене ОБЯЗАТЕЛЬНО установите ADMIN_PASSWORD через переменную окружения!
     username = os.getenv("ADMIN_USERNAME", "admin").strip()
-    password = os.getenv("ADMIN_PASSWORD", "admin")  # ⚠️ DEV ONLY: используйте сильный пароль в продакшене!
     email = os.getenv("ADMIN_EMAIL", "admin@example.com").strip()
     full_name = os.getenv("ADMIN_FULL_NAME", "Administrator").strip()
     allow_initialized = os.getenv(INITIALIZED_OVERRIDE_ENV, "").strip().lower() in {
@@ -60,12 +67,10 @@ def ensure_admin() -> dict:
                     ),
                 }
 
-        # Check by username first
         row = (
             db.execute(select(User).where(User.username == username)).scalars().first()
         )
 
-        # If not found by username, check by email
         if not row and email:
             row = (
                 db.execute(select(User).where(User.email == email)).scalars().first()
@@ -73,10 +78,14 @@ def ensure_admin() -> dict:
 
         if row:
             changed = False
-            # Only update email if it's different and doesn't conflict
             if email and row.email != email:
-                # Check if new email already exists
-                existing = db.execute(select(User).where(User.email == email, User.id != row.id)).scalars().first()
+                existing = (
+                    db.execute(
+                        select(User).where(User.email == email, User.id != row.id)
+                    )
+                    .scalars()
+                    .first()
+                )
                 if not existing:
                     row.email = email
                     changed = True
@@ -88,6 +97,7 @@ def ensure_admin() -> dict:
                 "true",
                 "yes",
             }:
+                password = _required_admin_password()
                 row.hashed_password = _hash_or_plain(password)
                 changed = True
             if row.role != "Admin":
@@ -107,13 +117,14 @@ def ensure_admin() -> dict:
                 "role": row.role,
             }
 
-        # Check if email already exists
-        existing_email = db.execute(select(User).where(User.email == email)).scalars().first()
+        existing_email = (
+            db.execute(select(User).where(User.email == email)).scalars().first()
+        )
         if existing_email:
-            # Update existing user to admin
             existing_email.username = username
             existing_email.role = "Admin"
             existing_email.is_active = True
+            password = _required_admin_password()
             existing_email.hashed_password = _hash_or_plain(password)
             existing_email.full_name = full_name
             db.commit()
@@ -126,6 +137,7 @@ def ensure_admin() -> dict:
                 "role": existing_email.role,
             }
 
+        password = _required_admin_password()
         row = User(
             username=username,
             full_name=full_name,

--- a/backend/app/scripts/ensure_roles.py
+++ b/backend/app/scripts/ensure_roles.py
@@ -1,39 +1,71 @@
 from __future__ import annotations
 
-from app.core.security import get_password_hash
-from app.db.session import SessionLocal
-from app.models.user import User
+import os
 
 USERS = [
-    ("admin", "Admin", "admin@ex.com", "admin123"),
-    ("registrar", "Registrar", "reg@ex.com", "registrar123"),
-    ("lab", "Lab", "lab@ex.com", "lab123"),
-    ("doctor", "Doctor", "doc@ex.com", "doctor123"),
-    ("cardio", "cardio", "cardio@ex.com", "cardio123"),
-    ("derma", "derma", "derma@ex.com", "derma123"),
-    ("dentist", "dentist", "dentist@ex.com", "dentist123"),
-    ("cashier", "Cashier", "cash@ex.com", "cashier123"),
+    ("admin", "Admin", "admin@ex.com"),
+    ("registrar", "Registrar", "reg@ex.com"),
+    ("lab", "Lab", "lab@ex.com"),
+    ("doctor", "Doctor", "doc@ex.com"),
+    ("cardio", "cardio", "cardio@ex.com"),
+    ("derma", "derma", "derma@ex.com"),
+    ("dentist", "dentist", "dentist@ex.com"),
+    ("cashier", "Cashier", "cash@ex.com"),
 ]
 
 
+def _require_ensure_roles_confirmation() -> None:
+    if os.getenv("CONFIRM_ENSURE_ROLES") != "1":
+        raise SystemExit(
+            "Refusing to create or update role users without CONFIRM_ENSURE_ROLES=1."
+        )
+
+
+def _password_env_names(username: str) -> list[str]:
+    names = [f"ENSURE_ROLES_{username.upper()}_PASSWORD"]
+    if username == "admin":
+        names.insert(0, "ADMIN_PASSWORD")
+    return names
+
+
+def _role_password(username: str, *, required: bool) -> str | None:
+    for env_name in _password_env_names(username):
+        password = os.getenv(env_name, "").strip()
+        if password:
+            return password
+    if required:
+        expected = " or ".join(_password_env_names(username))
+        raise RuntimeError(f"Set {expected} before creating user '{username}'.")
+    return None
+
+
 def upsert_users():
+    _require_ensure_roles_confirmation()
+
+    from app.core.security import get_password_hash
+    from app.db.session import SessionLocal
+    from app.models.user import User
+
     db = SessionLocal()
     try:
-        for username, role, email, pwd in USERS:
+        for username, role, email in USERS:
             u = db.query(User).filter(User.username == username).first()
             if not u:
                 u = User(
                     username=username,
                     role=role,
                     email=email,
-                    hashed_password=get_password_hash(pwd),
+                    hashed_password=get_password_hash(
+                        _role_password(username, required=True)
+                    ),
                 )
                 db.add(u)
             else:
                 u.role = role
                 u.email = email
-                # Всегда обновляем пароль и активируем пользователя
-                u.hashed_password = get_password_hash(pwd)
+                password = _role_password(username, required=False)
+                if password:
+                    u.hashed_password = get_password_hash(password)
                 u.is_active = True
             db.commit()
         print("ok")

--- a/backend/app/scripts/mint_dev_token.py
+++ b/backend/app/scripts/mint_dev_token.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
-from app.api.deps import create_access_token  # type: ignore
+import os
+
+
+def _require_mint_dev_token_confirmation() -> None:
+    if os.getenv("CONFIRM_MINT_DEV_TOKEN") != "1":
+        raise SystemExit(
+            "Refusing to mint and print a dev token without CONFIRM_MINT_DEV_TOKEN=1."
+        )
+
 
 if __name__ == "__main__":
+    _require_mint_dev_token_confirmation()
+
+    from app.api.deps import create_access_token  # type: ignore
+
     print(create_access_token("admin"))


### PR DESCRIPTION
## Summary

Adds explicit safety gates to admin/dev helper scripts so they stop requiring dangerous defaults or silent bootstrap behavior.

## Contract Impact

- Canonical surface: backend helper scripts under backend/app/scripts, no FastAPI route or WebSocket event changed.
- Request shape: not applicable - no HTTP request contract changed; these are operator/dev helper scripts with env-driven inputs only.
- Response shape: not applicable - no API response payload changed.
- Status codes: not applicable - no HTTP status behavior changed.
- Frontend consumer: not applicable - no frontend route, panel, or consumer changed.
- Compatibility path or alias: no route alias or legacy endpoint path changed.
- Contract proof: py_compile and helper-script refusal smoke passed; no application contract surface changed.

## RBAC / Permissions

- Roles allowed: not applicable - no application RBAC route surface changed.
- Roles denied: not applicable - no application RBAC route surface changed.
- Positive auth proof: not applicable - helper scripts do not authenticate app users through HTTP endpoints.
- Negative auth proof: not applicable - no role acceptance/denial matrix changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, inbox, Telegram, ack/read, or realtime flow changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed.
- Partial data proof: not applicable - no frontend payload rendering path changed.
- Forbidden secondary path behavior: not applicable - no frontend/backend secondary path changed.
- Missing draft/resource behavior: not applicable - no draft or resource workflow changed.
- Stale route/deep-link behavior: not applicable - no route state or deep-link behavior changed.

## Scope Gate

- Allowed paths: backend/app/scripts/create_admin_dev.py, backend/app/scripts/ensure_admin.py, backend/app/scripts/ensure_roles.py, backend/app/scripts/mint_dev_token.py.
- Denied paths: backend runtime routes/services, frontend, GitHub workflows, docs-only changes, deletion/rename waves, generated/evidence artifacts, output, test-results, storage, and dirty C:\final state.
- Migration/docs/test impact: no migration, no docs change, no app test change; validation is focused on helper-script syntax and refusal gates.
- Rollback note: revert this PR to restore previous helper-script defaults and confirmation behavior.

## Risk

Medium-low. This changes only helper scripts used for bootstrap/dev/admin operations. The main behavioral change is stricter confirmation and password requirements before privileged actions proceed.

## Validation

- Targeted tests or smoke run: git diff --check; python -m py_compile for the 4 touched helper scripts; refusal smoke without confirmation for create_admin_dev.py, ensure_roles.py, and mint_dev_token.py.
- Result: passed.
- Not checked: live database execution, full helper-script execution against a real environment, and end-to-end admin bootstrap on a running instance.

## Notes

- create_admin_dev.py was reconstructed manually on top of current main so the confirmation gate runs before optional SQLAlchemy imports; this preserves the hardening intent while staying compatible with the fresh base branch.
- ensure_admin.py kept the current main confirmation env naming and only added the remaining useful hardening: no implicit ADMIN_PASSWORD default for create/reset paths.