### PR TITLE
[codex] QA: harden database audit and orphan repair scripts

### DIFF
--- a/backend/app/scripts/audit_cascade_deletes.py
+++ b/backend/app/scripts/audit_cascade_deletes.py
@@ -13,9 +13,60 @@ from typing import Dict, List, Tuple
 
 import sqlalchemy as sa
 from sqlalchemy import inspect
+from sqlalchemy.engine import make_url
 
 # Добавляем путь к приложению
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+def get_database_url() -> str:
+    url = os.getenv("DATABASE_URL", "").strip()
+    if url:
+        return url
+
+    settings_error = None
+    try:
+        from app.core.config import settings
+
+        configured = getattr(settings, "DATABASE_URL", None)
+        if configured:
+            return str(configured).strip()
+    except Exception as exc:
+        settings_error = exc
+
+    raise SystemExit(
+        "DATABASE_URL is required; refusing to audit a fallback database"
+    ) from settings_error
+
+
+def normalize_sync_database_url(url: str) -> str:
+    if url.startswith("sqlite+aiosqlite://"):
+        return url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+    return url
+
+
+def is_sqlite_database_url(url: str) -> bool:
+    return make_url(url).drivername.startswith("sqlite")
+
+
+def allow_sqlite_database_url() -> bool:
+    raw = os.getenv("ALLOW_SQLITE_DATABASE_URL", "")
+    if raw.strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return os.getenv("TESTING", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def enforce_database_url_policy(url: str) -> None:
+    if is_sqlite_database_url(url) and not allow_sqlite_database_url():
+        raise SystemExit(
+            "SQLite DATABASE_URL is disabled for audit_cascade_deletes.py. "
+            "Use PostgreSQL as the schema source of truth, or set "
+            "ALLOW_SQLITE_DATABASE_URL=1 only for explicit legacy tools/tests."
+        )
+
+
+def display_database_url(url: str) -> str:
+    return make_url(url).render_as_string(hide_password=True)
+
 
 
 def audit_cascade_strategies(conn) -> Dict[str, List[Dict]]:
@@ -152,21 +203,9 @@ def audit_cascade_strategies(conn) -> Dict[str, List[Dict]]:
 
 def main():
     """Основная функция"""
-    url = os.getenv("DATABASE_URL")
-    if not url:
-        try:
-            from app.core.config import settings
-            url = getattr(settings, "DATABASE_URL", None)
-        except Exception:
-            pass
-
-    if not url:
-        url = "sqlite:///./clinic.db"
-        print(f"⚠️  DATABASE_URL не установлен, используем: {url}", file=sys.stderr)
-
-    # Нормализуем SQLite URL
-    if url.startswith("sqlite+aiosqlite://"):
-        url = url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+    url = normalize_sync_database_url(get_database_url())
+    enforce_database_url_policy(url)
+    print(f"Database URL: {display_database_url(url)}")
 
     engine = sa.create_engine(url, future=True)
 

--- a/backend/app/scripts/audit_data.py
+++ b/backend/app/scripts/audit_data.py
@@ -29,6 +29,29 @@ PAIRS = [
     ("audit_trail", "user_id", "users", "id"),
 ]
 
+def _is_sqlite_url(url: str) -> bool:
+    return url.lower().startswith(("sqlite://", "sqlite+"))
+
+
+def _allow_sqlite_database_url() -> bool:
+    raw = os.getenv("ALLOW_SQLITE_DATABASE_URL", "")
+    if raw.strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return os.getenv("TESTING", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _required_database_url() -> str:
+    url = os.getenv("DATABASE_URL", "").strip()
+    if not url:
+        raise SystemExit("DATABASE_URL is not set")
+    if _is_sqlite_url(url) and not _allow_sqlite_database_url():
+        raise SystemExit(
+            "SQLite DATABASE_URL is disabled for audit_data.py. "
+            "Use PostgreSQL as the schema source of truth, or set "
+            "ALLOW_SQLITE_DATABASE_URL=1 only for explicit legacy tools/tests."
+        )
+    return url
+
 
 def table_has(inspector, table: str, col: str) -> bool:
     return table in inspector.get_table_names() and any(
@@ -52,9 +75,10 @@ def count_orphans(conn, child_t, child_c, parent_t, parent_c="id"):
 
 
 def main():
-    url = os.getenv("DATABASE_URL")
-    if not url:
-        print("DATABASE_URL is not set", file=sys.stderr)
+    try:
+        url = _required_database_url()
+    except SystemExit as exc:
+        print(str(exc), file=sys.stderr)
         sys.exit(2)
     engine = sa.create_engine(url, future=True)
     out_dir = os.path.join(os.path.dirname(__file__), "out")

--- a/backend/app/scripts/audit_foreign_keys.py
+++ b/backend/app/scripts/audit_foreign_keys.py
@@ -12,9 +12,60 @@ from typing import Dict, List, Tuple
 
 import sqlalchemy as sa
 from sqlalchemy import inspect, text
+from sqlalchemy.engine import make_url
 
 # Добавляем путь к приложению
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+def get_database_url() -> str:
+    url = os.getenv("DATABASE_URL", "").strip()
+    if url:
+        return url
+
+    settings_error = None
+    try:
+        from app.core.config import settings
+
+        configured = getattr(settings, "DATABASE_URL", None)
+        if configured:
+            return str(configured).strip()
+    except Exception as exc:
+        settings_error = exc
+
+    raise SystemExit(
+        "DATABASE_URL is required; refusing to audit a fallback database"
+    ) from settings_error
+
+
+def normalize_sync_database_url(url: str) -> str:
+    if url.startswith("sqlite+aiosqlite://"):
+        return url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+    return url
+
+
+def is_sqlite_database_url(url: str) -> bool:
+    return make_url(url).drivername.startswith("sqlite")
+
+
+def allow_sqlite_database_url() -> bool:
+    raw = os.getenv("ALLOW_SQLITE_DATABASE_URL", "")
+    if raw.strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return os.getenv("TESTING", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def enforce_database_url_policy(url: str) -> None:
+    if is_sqlite_database_url(url) and not allow_sqlite_database_url():
+        raise SystemExit(
+            "SQLite DATABASE_URL is disabled for audit_foreign_keys.py. "
+            "Use PostgreSQL as the schema source of truth, or set "
+            "ALLOW_SQLITE_DATABASE_URL=1 only for explicit legacy tools/tests."
+        )
+
+
+def display_database_url(url: str) -> str:
+    return make_url(url).render_as_string(hide_password=True)
+
 
 
 def get_foreign_keys(conn, table_name: str) -> List[Dict]:
@@ -111,22 +162,9 @@ def audit_all_foreign_keys(conn) -> Dict[str, any]:
 
 def main():
     """Основная функция"""
-    url = os.getenv("DATABASE_URL")
-    if not url:
-        # Пробуем получить из настроек
-        try:
-            from app.core.config import settings
-            url = getattr(settings, "DATABASE_URL", None)
-        except Exception:
-            pass
-
-    if not url:
-        url = "sqlite:///./clinic.db"
-        print(f"⚠️  DATABASE_URL не установлен, используем: {url}", file=sys.stderr)
-
-    # Нормализуем SQLite URL
-    if url.startswith("sqlite+aiosqlite://"):
-        url = url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+    url = normalize_sync_database_url(get_database_url())
+    enforce_database_url_policy(url)
+    print(f"Database URL: {display_database_url(url)}")
 
     engine = sa.create_engine(url, future=True)
 

--- a/backend/app/scripts/fix_orphans.py
+++ b/backend/app/scripts/fix_orphans.py
@@ -12,11 +12,43 @@ import sqlalchemy as sa
 
 SQLS = []
 
+def _is_sqlite_url(url: str) -> bool:
+    return url.lower().startswith(("sqlite://", "sqlite+"))
+
+
+def _allow_sqlite_database_url() -> bool:
+    raw = os.getenv("ALLOW_SQLITE_DATABASE_URL", "")
+    if raw.strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return os.getenv("TESTING", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _required_database_url() -> str:
+    url = os.getenv("DATABASE_URL", "").strip()
+    if not url:
+        raise SystemExit("DATABASE_URL is not set")
+    if _is_sqlite_url(url) and not _allow_sqlite_database_url():
+        raise SystemExit(
+            "SQLite DATABASE_URL is disabled for fix_orphans.py. "
+            "Use PostgreSQL as the schema source of truth, or set "
+            "ALLOW_SQLITE_DATABASE_URL=1 only for explicit legacy tools/tests."
+        )
+    return url
+
+
+def _require_fix_orphans_confirmation() -> None:
+    if os.getenv("CONFIRM_FIX_ORPHANS") != "1":
+        raise SystemExit(
+            "Refusing to run manual orphan repair without CONFIRM_FIX_ORPHANS=1."
+        )
+
 
 def main():
-    url = os.getenv("DATABASE_URL")
-    if not url:
-        print("DATABASE_URL is not set", file=sys.stderr)
+    try:
+        _require_fix_orphans_confirmation()
+        url = _required_database_url()
+    except SystemExit as exc:
+        print(str(exc), file=sys.stderr)
         sys.exit(2)
     engine = sa.create_engine(url, future=True)
     applied = 0


### PR DESCRIPTION
## Summary

- Harden database audit scripts so they refuse SQLite by default and require an explicit PostgreSQL source of truth.
- Require explicit confirmation before running manual orphan repair.

## Contract Impact

- Canonical surface: backend local audit/repair scripts only (`audit_cascade_deletes.py`, `audit_data.py`, `audit_foreign_keys.py`, `fix_orphans.py`)
- Request shape: environment-driven script execution using `DATABASE_URL`, plus `CONFIRM_FIX_ORPHANS=1` for manual orphan repair
- Response shape: stdout/stderr script messages only; no API or websocket payload changes
- Status codes: process exit `0` on success, refusal exits for missing/forbidden configuration, no HTTP status changes
- Frontend consumer: not applicable - no frontend consumer or API caller changed
- Compatibility path or alias: not applicable - no route alias, legacy endpoint, or compatibility API path involved
- Contract proof: targeted local refusal smokes for SQLite and missing confirm, plus script compile validation

## RBAC / Permissions

- Roles allowed: not applicable - no runtime RBAC or endpoint auth changes
- Roles denied: not applicable - no runtime RBAC or endpoint auth changes
- Positive auth proof: not applicable - script hardening only
- Negative auth proof: not applicable - script hardening only

## Notification / Realtime

not applicable - no notification, websocket, chat, read-state, reconnect, or delivery behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend surface changed
- Partial data proof: not applicable - no frontend surface changed
- Forbidden secondary path behavior: not applicable - no frontend or fallback path changed
- Missing draft/resource behavior: not applicable - no draft/resource workflow changed
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed

## Scope Gate

- Allowed paths: `backend/app/scripts/audit_cascade_deletes.py`, `backend/app/scripts/audit_data.py`, `backend/app/scripts/audit_foreign_keys.py`, `backend/app/scripts/fix_orphans.py`
- Denied paths: `backend/app/api/v1/endpoints/**`, `backend/app/services/**`, `frontend/**`, `.github/**`, `ops/**`, `output/**`, `test-results/**`, `storage/**`, `ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md`
- Migration/docs/test impact: no migration and no docs changes; targeted compile and refusal smokes only
- Rollback note: revert this PR to restore previous script behavior if these guardrails need to be relaxed

## Risk

Medium-low. This touches operator/audit scripts only. The intended behavior is stricter database-source guardrails and explicit confirmation for manual orphan repair.

## Validation

- Targeted tests or smoke run: `git diff --check`; repo-venv `py_compile` for all 4 scripts; SQLite refusal smoke for `audit_cascade_deletes.py`, `audit_data.py`, and `audit_foreign_keys.py`; confirm refusal smoke for `fix_orphans.py`; SQLite refusal smoke for `fix_orphans.py` after explicit confirm
- Result: passed locally in temp repo
- Not checked: full backend suite, live Postgres execution against a real database, browser-level flows

## Notes

This slice was reconstructed on top of fresh `origin/main` after patch drift, so the final diff is larger than the original staged hunk, but scope remains limited to the four audit/repair scripts above.