### PR TITLE
[codex] QA: harden local staging and DR ops scripts

### DIFF
--- a/ops/scripts/postgres_dr_test.ps1
+++ b/ops/scripts/postgres_dr_test.ps1
@@ -7,7 +7,8 @@ param(
     [string]$AdminPassword,
     [string]$Database = "clinicdb",
     [string]$BackupDir = "c:\final\backups\postgres",
-    [string]$BackendDir = "c:\final\backend"
+    [string]$BackendDir = "c:\final\backend",
+    [switch]$ConfirmDropDatabase
 )
 
 Set-StrictMode -Version Latest
@@ -36,12 +37,40 @@ function Resolve-PgTool {
     throw "Cannot find $ToolName in PATH or standard PostgreSQL install paths."
 }
 
+function Assert-SafeIdentifier {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Value
+    )
+
+    if ($Value -notmatch '^[A-Za-z_][A-Za-z0-9_]{0,62}$') {
+        throw "$Name must be a PostgreSQL identifier: letters, digits, underscores, max 63 chars, not starting with a digit."
+    }
+}
+
+function Escape-SqlLiteral {
+    param([Parameter(Mandatory = $true)][string]$Value)
+    return $Value.Replace("'", "''")
+}
+
+function Quote-SqlIdentifier {
+    param([Parameter(Mandatory = $true)][string]$Value)
+    return '"' + $Value.Replace('"', '""') + '"'
+}
+
 if (-not $AppPassword) {
     throw "AppPassword is required."
 }
 if (-not $AdminPassword) {
     throw "AdminPassword is required."
 }
+if (-not $ConfirmDropDatabase -and $env:CONFIRM_POSTGRES_DR_TEST -ne "1") {
+    throw "Refusing destructive DR test without explicit confirmation. Pass -ConfirmDropDatabase or set CONFIRM_POSTGRES_DR_TEST=1."
+}
+
+Assert-SafeIdentifier -Name "AppUser" -Value $AppUser
+Assert-SafeIdentifier -Name "AdminUser" -Value $AdminUser
+Assert-SafeIdentifier -Name "Database" -Value $Database
 
 $pgDump = Resolve-PgTool -ToolName "pg_dump.exe"
 $psql = Resolve-PgTool -ToolName "psql.exe"
@@ -60,13 +89,16 @@ Write-Host "Backup created: $backupFile"
 
 Write-Host "[2/5] Terminate active sessions..."
 $env:PGPASSWORD = $AdminPassword
-& $psql -w -h $PgHost -p $Port -U $AdminUser -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='$Database' AND pid<>pg_backend_pid();"
+$databaseLiteral = Escape-SqlLiteral -Value $Database
+$databaseIdentifier = Quote-SqlIdentifier -Value $Database
+$appUserIdentifier = Quote-SqlIdentifier -Value $AppUser
+& $psql -w -h $PgHost -p $Port -U $AdminUser -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='$databaseLiteral' AND pid<>pg_backend_pid();"
 
 Write-Host "[3/5] Drop database..."
-& $psql -w -h $PgHost -p $Port -U $AdminUser -d postgres -c "DROP DATABASE IF EXISTS $Database;"
+& $psql -w -h $PgHost -p $Port -U $AdminUser -d postgres -c "DROP DATABASE IF EXISTS $databaseIdentifier;"
 
 Write-Host "[4/5] Recreate database..."
-& $psql -w -h $PgHost -p $Port -U $AdminUser -d postgres -c "CREATE DATABASE $Database OWNER $AppUser;"
+& $psql -w -h $PgHost -p $Port -U $AdminUser -d postgres -c "CREATE DATABASE $databaseIdentifier OWNER $appUserIdentifier;"
 
 Write-Host "[5/5] Alembic upgrade and verification..."
 Push-Location $BackendDir

--- a/ops/scripts/run_load_profiles.py
+++ b/ops/scripts/run_load_profiles.py
@@ -104,6 +104,23 @@ def _fallback_summary(reason: str) -> dict[str, Any]:
     }
 
 
+def _is_ci() -> bool:
+    return os.getenv("GITHUB_ACTIONS", "").strip().lower() == "true" or os.getenv(
+        "CI", ""
+    ).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _require_load_profiles_confirmation() -> None:
+    if _is_ci():
+        return
+    if os.getenv("CONFIRM_RUN_LOAD_PROFILES") == "1":
+        return
+    raise RuntimeError(
+        "Refusing to run local k6 load profiles without explicit confirmation. "
+        "Set CONFIRM_RUN_LOAD_PROFILES=1 only for an intentional local load test."
+    )
+
+
 def _build_aggregate_markdown(rows: list[dict[str, Any]]) -> str:
     lines = [
         "# Load Test Regression Report",
@@ -143,10 +160,11 @@ def main() -> int:
     parser.add_argument("--config", required=True, type=Path)
     parser.add_argument("--workspace", default=Path.cwd(), type=Path)
     parser.add_argument("--artifacts-dir", required=True, type=Path)
-    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--base-url", default="http://127.0.0.1:18000")
     parser.add_argument("--docker-image", default="grafana/k6:latest")
     parser.add_argument("--api-ready", default=1, type=int)
     args = parser.parse_args()
+    _require_load_profiles_confirmation()
 
     workspace = args.workspace.resolve()
     artifacts_dir = args.artifacts_dir.resolve()

--- a/ops/scripts/start_staging_host.ps1
+++ b/ops/scripts/start_staging_host.ps1
@@ -3,13 +3,22 @@ $ErrorActionPreference = "Stop"
 function Import-EnvFile {
     param([string]$Path)
 
-    foreach ($line in Get-Content $Path) {
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Missing env file: $Path"
+    }
+
+    foreach ($line in Get-Content -LiteralPath $Path) {
         $trimmed = $line.Trim()
         if (-not $trimmed -or $trimmed.StartsWith("#") -or -not $trimmed.Contains("=")) {
             continue
         }
         $pair = $trimmed -split "=", 2
-        [System.Environment]::SetEnvironmentVariable($pair[0], $pair[1], "Process")
+        $key = $pair[0].Trim()
+        $value = $pair[1].Trim().Trim('"').Trim("'")
+        if (-not $key) {
+            continue
+        }
+        [System.Environment]::SetEnvironmentVariable($key, $value, "Process")
     }
 }
 
@@ -39,7 +48,7 @@ if (-not $publicHost) {
     "http://$publicHost`:18080,http://localhost:18080,http://127.0.0.1:18080",
     "Process"
 )
-[System.Environment]::SetEnvironmentVariable("VITE_API_BASE_URL", "http://localhost:18000", "Process")
+[System.Environment]::SetEnvironmentVariable("VITE_API_BASE_URL", "http://$publicHost`:18000", "Process")
 
 $backendPython = Join-Path $backendDir ".venv\\Scripts\\python.exe"
 if (-not (Test-Path $backendPython)) {

--- a/ops/scripts/stop_staging_host.ps1
+++ b/ops/scripts/stop_staging_host.ps1
@@ -1,13 +1,34 @@
+param(
+    [switch]$ForcePortOwners
+)
+
 $ErrorActionPreference = "Stop"
 
 $projectRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\\..")).Path
 $runtimeDir = Join-Path $projectRoot "output\\staging"
+
+function Confirm-UnmanagedPortOwnerStop {
+    param(
+        [int]$Port,
+        [int[]]$ProcessIds
+    )
+
+    if ($ForcePortOwners -or $env:CONFIRM_STOP_STAGING_PORT_OWNERS -eq "1") {
+        return
+    }
+
+    throw "Refusing to stop unmanaged listener(s) on port ${Port}: $($ProcessIds -join ', '). Pass -ForcePortOwners or set CONFIRM_STOP_STAGING_PORT_OWNERS=1 for an intentional cleanup."
+}
 
 function Stop-ListenerByPort {
     param([int]$Port)
 
     $listeners = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue |
         Select-Object -ExpandProperty OwningProcess -Unique
+
+    if ($listeners) {
+        Confirm-UnmanagedPortOwnerStop -Port $Port -ProcessIds @($listeners)
+    }
 
     foreach ($listenerPid in $listeners) {
         if ($listenerPid) {
@@ -23,7 +44,7 @@ foreach ($name in @("backend", "frontend")) {
         if ($pidValue) {
             Stop-Process -Id ([int]$pidValue) -Force -ErrorAction SilentlyContinue
         }
-        Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $pidFile -Force -ErrorAction SilentlyContinue
     }
 }
 

--- a/ops/scripts/zip_from_treeF.ps1
+++ b/ops/scripts/zip_from_treeF.ps1
@@ -5,7 +5,7 @@
 [CmdletBinding()]
 param(
   [string]$ProjectPath = "C:\final",
-  [string]$TreeFile = "C:\final\tree_F.txt",
+  [string]$TreeFile = "$ProjectPath\ops\meta\tree_F.txt",
   [string]$OutDir = "$ProjectPath\archives",
   [string]$NameSuffix = "",
   [switch]$DryRun
@@ -37,7 +37,38 @@ $ExcludeGlobs = @(
 )
 
 function Ensure-Dir([string]$p) {
-  if (-not (Test-Path $p)) { New-Item -ItemType Directory -Path $p | Out-Null }
+  if (-not (Test-Path -LiteralPath $p)) {
+    New-Item -ItemType Directory -Path $p | Out-Null
+  }
+}
+
+function Resolve-ExistingPath([string]$p) {
+  (Resolve-Path -LiteralPath $p -ErrorAction Stop).ProviderPath
+}
+
+function Assert-UnderPath([string]$ChildPath, [string]$ParentPath, [string]$Label) {
+  $child = [IO.Path]::GetFullPath($ChildPath).TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+  $parent = [IO.Path]::GetFullPath($ParentPath).TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+  $prefix = $parent + [IO.Path]::DirectorySeparatorChar
+
+  if (($child -ne $parent) -and (-not $child.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase))) {
+    Write-Error "$Label escapes allowed root: $child"; exit 1
+  }
+}
+
+function ConvertTo-SafeFileSegment([string]$Value) {
+  if ($null -eq $Value) { return "" }
+
+  $segment = $Value.Trim()
+  if ($segment -eq "") { return "" }
+
+  $segment = [Regex]::Replace($segment, '[^A-Za-z0-9._-]+', '_')
+  $segment = $segment.Trim([char[]]"._-")
+  if ($segment.Length -gt 64) {
+    $segment = $segment.Substring(0, 64).Trim([char[]]"._-")
+  }
+
+  return $segment
 }
 
 function RelPosix([string]$base, [string]$full) {
@@ -48,20 +79,25 @@ function RelPosix([string]$base, [string]$full) {
 
 function GlobToRegex([string]$glob) {
   $e = [Regex]::Escape($glob)
-  $e = $e -replace '\\\*\\\*','§DS§'
+  $e = $e -replace '\\\*\\\*','__DOUBLESTAR__'
   $e = $e -replace '\\\*','[^/]*'
-  $e = $e -replace '§DS§','.*'
+  $e = $e -replace '__DOUBLESTAR__','.*'
   '^' + $e + '$'
 }
 
 # ------------ Validate paths ------------
-if (-not (Test-Path $ProjectPath)) {
+if (-not (Test-Path -LiteralPath $ProjectPath -PathType Container)) {
   Write-Error "ProjectPath not found: $ProjectPath"; exit 1
 }
-if (-not (Test-Path $TreeFile)) {
+if (-not (Test-Path -LiteralPath $TreeFile -PathType Leaf)) {
   Write-Error "TreeFile not found: $TreeFile"; exit 1
 }
 Ensure-Dir $OutDir
+
+$ProjectPath = Resolve-ExistingPath $ProjectPath
+$TreeFile = Resolve-ExistingPath $TreeFile
+$OutDir = Resolve-ExistingPath $OutDir
+Assert-UnderPath $TreeFile $ProjectPath "TreeFile"
 
 # ------------ Parse tree_F.txt -> file list ------------
 # Expected line format like: "FILE /backend/app/main.py  [6110 bytes]"
@@ -93,6 +129,9 @@ $missingOnDisk = New-Object System.Collections.Generic.List[string]
 foreach ($rel in $fileRelPaths) {
   $rel = $rel.Trim()
   if ([string]::IsNullOrWhiteSpace($rel)) { continue }
+  if ([IO.Path]::IsPathRooted($rel) -or ($rel -match '^[A-Za-z]:') -or (($rel -split '/') -contains '..')) {
+    Write-Error "Unsafe FILE entry escapes project root: $rel"; exit 1
+  }
 
   # filter by exclude globs
   $isExcluded = $false
@@ -102,9 +141,11 @@ foreach ($rel in $fileRelPaths) {
   if ($isExcluded) { $excludedByPattern.Add($rel) | Out-Null; continue }
 
   # check existence
-  $abs = Join-Path $ProjectPath ($rel -replace '/','\')
-  if (Test-Path -LiteralPath $abs) {
-    $selected.Add($abs) | Out-Null
+  $abs = Join-Path $ProjectPath ($rel -replace '/','\\')
+  $absFull = [IO.Path]::GetFullPath($abs)
+  Assert-UnderPath $absFull $ProjectPath "FILE entry"
+  if (Test-Path -LiteralPath $absFull -PathType Leaf) {
+    $selected.Add($absFull) | Out-Null
   } else {
     $missingOnDisk.Add($rel) | Out-Null
   }
@@ -117,14 +158,25 @@ if ($selected.Count -eq 0) {
 # ------------ Name and path for zip ------------
 $Date = Get-Date -Format "yyyy-MM-dd"
 $ZipName = "clinic_project_$Date"
-if ($NameSuffix -ne "") { $ZipName += "_$NameSuffix" }
+if ($NameSuffix -ne "") {
+  $safeNameSuffix = ConvertTo-SafeFileSegment $NameSuffix
+  if ($safeNameSuffix -eq "") {
+    Write-Error "NameSuffix does not contain safe filename characters."; exit 1
+  }
+  if ($safeNameSuffix -ne $NameSuffix.Trim()) {
+    Write-Host "NameSuffix sanitized to: $safeNameSuffix"
+  }
+  $ZipName += "_$safeNameSuffix"
+}
 $ZipName += ".zip"
 $ZipPath = Join-Path $OutDir $ZipName
-if (Test-Path $ZipPath) { Remove-Item -LiteralPath $ZipPath -Force }
+$ZipPathFull = [IO.Path]::GetFullPath($ZipPath)
+Assert-UnderPath $ZipPathFull $OutDir "ZipPath"
+if (Test-Path -LiteralPath $ZipPathFull) { Remove-Item -LiteralPath $ZipPathFull -Force }
 
 # ------------ Dry run or compress ------------
 if ($DryRun) {
-  Write-Host "DRY-RUN: would zip $($selected.Count) files -> $ZipPath"
+  Write-Host "DRY-RUN: would zip $($selected.Count) files -> $ZipPathFull"
   Write-Host "Excluded by pattern: $($excludedByPattern.Count); Missing: $($missingOnDisk.Count)"
   if ($excludedByPattern.Count -gt 0) {
     Write-Host "---- excluded examples ----"
@@ -138,10 +190,10 @@ if ($DryRun) {
 }
 
 # Compress
-Compress-Archive -Path $selected -DestinationPath $ZipPath -Force
+Compress-Archive -Path $selected -DestinationPath $ZipPathFull -Force
 
 # Summary
-$sizeBytes = (Get-Item -LiteralPath $ZipPath).Length
-Write-Host "OK: zip created -> $ZipPath"
+$sizeBytes = (Get-Item -LiteralPath $ZipPathFull).Length
+Write-Host "OK: zip created -> $ZipPathFull"
 Write-Host "Included: $($selected.Count) files; Excluded: $($excludedByPattern.Count); Missing: $($missingOnDisk.Count)"
 Write-Host ("Zip size: {0:N0} bytes" -f $sizeBytes)


### PR DESCRIPTION
## Summary

- Hardens local staging and operator-facing DR/load/archive scripts.
- Adds explicit confirmations for destructive or high-impact local ops flows.
- Tightens path, env-file, and SQL identifier handling for safer local execution.

## Contract Impact

- Canonical surface: local ops helper scripts only (`ops/scripts/postgres_dr_test.ps1`, `run_load_profiles.py`, `start_staging_host.ps1`, `stop_staging_host.ps1`, `zip_from_treeF.ps1`)
- Request shape: CLI/script invocation with existing flags plus explicit operator confirmations for destructive local actions
- Response shape: stdout/stderr script messages only; no API or websocket payload changes
- Status codes: process exit success/failure only; no HTTP status changes
- Frontend consumer: not applicable - no frontend runtime consumer or API caller changed
- Compatibility path or alias: not applicable - no route alias or compatibility API path involved
- Contract proof: targeted parser/compile checks plus refusal/dry-run smokes for destructive local flows

## RBAC / Permissions

- Roles allowed: not applicable - no runtime RBAC or endpoint auth changes
- Roles denied: not applicable - no runtime RBAC or endpoint auth changes
- Positive auth proof: not applicable - local operator script hardening only
- Negative auth proof: not applicable - local operator script hardening only

## Notification / Realtime

not applicable - no notification, websocket, chat, read-state, reconnect, or delivery behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend surface changed
- Partial data proof: not applicable - no frontend surface changed
- Forbidden secondary path behavior: not applicable - no frontend or fallback path changed
- Missing draft/resource behavior: not applicable - no draft/resource workflow changed
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed

## Scope Gate

- Allowed paths: `ops/scripts/postgres_dr_test.ps1`, `ops/scripts/run_load_profiles.py`, `ops/scripts/start_staging_host.ps1`, `ops/scripts/stop_staging_host.ps1`, `ops/scripts/zip_from_treeF.ps1`
- Denied paths: `backend/**`, `frontend/**`, `.github/**`, `ops/vps/**`, `output/**`, `test-results/**`, `storage/**`, `ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md`
- Migration/docs/test impact: no migrations and no docs changes; validation is limited to compile/parser checks and targeted refusal/dry-run smokes for the touched scripts
- Rollback note: revert this PR to restore previous local script behavior if these guardrails need to be relaxed

## Risk

Medium-low. This touches local operator/staging scripts only. The intended behavior is stricter confirmation gates, safer SQL/path handling, and cleaner local staging env parsing.

## Validation

- Targeted tests or smoke run: `git diff --check`; repo-venv `py_compile` for `ops/scripts/run_load_profiles.py`; PowerShell parser checks for the 4 touched `.ps1` files; refusal smoke for `postgres_dr_test.ps1` without explicit confirmation; refusal smoke for `run_load_profiles.py` without explicit confirmation; dry-run smoke for `zip_from_treeF.ps1` with sanitized suffix; negative smoke showing `zip_from_treeF.ps1` rejects a `TreeFile` outside project root
- Result: passed locally in temp repo
- Not checked: live DR database execution, real k6 run with confirmation, actual staging host start/stop against running listeners, full repository test suites

## Notes

This slice was reconstructed on top of fresh `origin/main` after patch drift, so the final diff is based on current canonical files rather than a raw apply of the original staged patch.