### PR TITLE
QA: harden legacy mutator and migration scripts

### DIFF
--- a/backend/app/scripts/add_planned_date.py
+++ b/backend/app/scripts/add_planned_date.py
@@ -1,29 +1,22 @@
-# app/scripts/add_planned_date.py
+#!/usr/bin/env python3
+"""Retired legacy planned-date schema mutator."""
 
-import os
-import sqlite3
+from __future__ import annotations
 
-DB_PATH = "clinic.db"
+import sys
 
-if not os.path.exists(DB_PATH):
-    print("❌ База данных clinic.db не найдена")
-    exit(1)
+MESSAGE = """
+add_planned_date.py is retired.
 
-db = sqlite3.connect(DB_PATH)
-cur = db.cursor()
+Schema changes are owned by Alembic migrations against the current PostgreSQL
+runtime. Do not mutate a local database file from this script.
+""".strip()
 
-# Получаем все колонки таблицы visits
-cur.execute("PRAGMA table_info(visits);")
-columns = [col[1] for col in cur.fetchall()]
 
-if "planned_date" in columns:
-    print("ℹ️ Колонка planned_date уже существует")
-else:
-    cur.execute("ALTER TABLE visits ADD COLUMN planned_date DATE;")
-    cur.execute(
-        "UPDATE visits SET planned_date = DATE('now') WHERE planned_date IS NULL;"
-    )
-    print("✅ Колонка planned_date успешно добавлена и заполнена")
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
-db.commit()
-db.close()
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/scripts/init_payment_providers.py
+++ b/backend/app/scripts/init_payment_providers.py
@@ -8,13 +8,23 @@ import sys
 # Добавляем путь к приложению
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from app.crud.payment_webhook import create_provider
-from app.db.session import get_db
-from app.schemas.payment_webhook import PaymentProviderCreate
+
+def _require_init_payment_providers_confirmation() -> None:
+    if os.getenv("CONFIRM_INIT_PAYMENT_PROVIDERS") != "1":
+        raise SystemExit(
+            "Refusing to initialize payment providers without "
+            "CONFIRM_INIT_PAYMENT_PROVIDERS=1."
+        )
 
 
 def init_payment_providers():
     """Инициализируем провайдеров платежей"""
+    _require_init_payment_providers_confirmation()
+
+    from app.crud.payment_webhook import create_provider
+    from app.db.session import get_db
+    from app.schemas.payment_webhook import PaymentProviderCreate
+
     print("🚀 Инициализация провайдеров платежей...")
 
     db = next(get_db())

--- a/backend/app/scripts/migrate_sqlite_to_postgres.py
+++ b/backend/app/scripts/migrate_sqlite_to_postgres.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sqlite3
 from collections import defaultdict, deque
 from dataclasses import dataclass
@@ -725,6 +726,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _require_live_migration_confirmation(*, dry_run: bool) -> None:
+    if dry_run:
+        return
+    if os.getenv("CONFIRM_SQLITE_TO_POSTGRES_MIGRATION") != "1":
+        raise SystemExit(
+            "Refusing to run live SQLite to PostgreSQL migration without "
+            "CONFIRM_SQLITE_TO_POSTGRES_MIGRATION=1. Use --dry-run for a read-only plan."
+        )
+
+
 def _mask_engine_url(engine: Engine) -> str:
     rendered = str(engine.url)
     password = engine.url.password
@@ -736,6 +747,7 @@ def _mask_engine_url(engine: Engine) -> str:
 def main() -> int:
     parser = _build_arg_parser()
     args = parser.parse_args()
+    _require_live_migration_confirmation(dry_run=args.dry_run)
 
     if args.target_url:
         target_engine = create_engine(args.target_url)

--- a/backend/app/scripts/migrate_users_to_postgres.py
+++ b/backend/app/scripts/migrate_users_to_postgres.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -9,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from sqlalchemy import Engine, create_engine, text
+from sqlalchemy.engine import make_url
 
 logger = logging.getLogger(__name__)
 
@@ -332,6 +334,23 @@ def _resolve_target_url(explicit_target_url: str | None) -> str:
     return get_settings().DATABASE_URL
 
 
+def _mask_url_string(url: str) -> str:
+    try:
+        return make_url(url).render_as_string(hide_password=True)
+    except Exception:
+        return "<unparseable target url>"
+
+
+def _require_live_migration_confirmation(*, dry_run: bool) -> None:
+    if dry_run:
+        return
+    if os.getenv("CONFIRM_USERS_SQLITE_TO_POSTGRES_MIGRATION") != "1":
+        raise SystemExit(
+            "Refusing to run live users SQLite to PostgreSQL migration without "
+            "CONFIRM_USERS_SQLITE_TO_POSTGRES_MIGRATION=1. Use --dry-run for a read-only plan."
+        )
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Migrate users from legacy SQLite clinic.db into PostgreSQL users table.",
@@ -370,10 +389,11 @@ def main() -> int:
         )
 
     target_url = _resolve_target_url(args.target_url)
+    _require_live_migration_confirmation(dry_run=args.dry_run)
     logger.info(
         "[FIX:USER-MIGRATION] Starting migration source=%s target=%s dry_run=%s",
         source_path,
-        target_url,
+        _mask_url_string(target_url),
         args.dry_run,
     )
     target_engine = create_engine(target_url)


### PR DESCRIPTION
## Summary

- Retire a legacy SQLite schema mutator that should no longer own schema changes.
- Add explicit confirmation gates before mutating payment-provider and SQLite-to-PostgreSQL migration flows.
- Mask target database URL values in users migration logs.

## Contract Impact

- Canonical surface: No API or websocket contract change; scope is local/backend helper and migration scripts only.
- Request shape: N/A. No HTTP or WS request payload changes.
- Response shape: N/A. No HTTP or WS response payload changes.
- Status codes: N/A. No route handler behavior changes.
- Frontend consumer: None. No frontend caller or consumer is affected.
- Compatibility path or alias: N/A. No alias, route, or compatibility path is introduced.
- Contract proof: Script-only diff review plus refusal smokes confirmed no app contract surface changed.

## RBAC / Permissions

- Roles allowed: N/A. These scripts remain operator/developer invoked utilities outside runtime RBAC surfaces.
- Roles denied: N/A. No runtime role matrix or route permission behavior changes.
- Positive auth proof: N/A. No application auth path changed.
- Negative auth proof: N/A. No application auth path changed.

## Notification / Realtime

- Event type or websocket channel: N/A. No notification or websocket surface changed.
- Payload version / ack behavior: N/A. No event payloads or ack semantics changed.
- Read/unread or delivery semantics: N/A. No inbox, delivery, or read-state behavior changed.
- Reconnect/resync proof: N/A. No realtime flow changed.

## Frontend Resilience

- Empty data proof: N/A. No frontend code changed.
- Partial data proof: N/A. No frontend code changed.
- Forbidden secondary path behavior: N/A. No frontend or API route behavior changed.
- Missing draft/resource behavior: N/A. No frontend code changed.
- Stale route/deep-link behavior: N/A. No frontend code changed.

## Scope Gate

- Allowed paths: `backend/app/scripts/add_planned_date.py`, `backend/app/scripts/init_payment_providers.py`, `backend/app/scripts/migrate_sqlite_to_postgres.py`, `backend/app/scripts/migrate_users_to_postgres.py`.
- Denied paths: `backend/app/api/v1/endpoints/**`, `backend/app/services/**`, `frontend/**`, `.github/**`, `ops/**`, generated/evidence artifacts, deletion/rename wave.
- Migration/docs/test impact: No Alembic migration or runtime docs changes. Validation is limited to script compile and refusal/retired smokes.
- Rollback note: Revert this commit to restore prior script behavior if these stricter guards block an urgent legacy workflow.

## Validation

- Targeted tests or smoke run: `git diff --check`; `python -m py_compile` for the 4 touched scripts; retired/refusal smokes for `add_planned_date.py`, `init_payment_providers.py`, `migrate_sqlite_to_postgres.py`, and `migrate_users_to_postgres.py --source <tempfile>`.
- Result: Passed. The retired script exits with status `2`; the other three refuse live mutation without the required `CONFIRM_*` environment variable.
- Not checked: No live PostgreSQL migration execution, no end-to-end payment provider initialization, and no broad backend/frontend suite in this slice.