### PR TITLE
QA: harden bootstrap and setup scripts

### DIFF
--- a/backend/create_comprehensive_test_data.py
+++ b/backend/create_comprehensive_test_data.py
@@ -23,10 +23,40 @@ from app.models.visit import Visit
 from app.models.emr import EMR
 from app.models.payment import Payment
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.core.config import settings
 from app.core.security import get_password_hash
+
+def _require_confirmation():
+    if os.getenv("CONFIRM_CREATE_COMPREHENSIVE_TEST_DATA") != "1":
+        raise RuntimeError(
+            "Refusing to create comprehensive test data. "
+            "Set CONFIRM_CREATE_COMPREHENSIVE_TEST_DATA=1 only for an explicit local seed run."
+        )
+
+
+def _require_postgres_database_url():
+    database_url = str(settings.DATABASE_URL).strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before creating comprehensive test data.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError(
+            "create_comprehensive_test_data.py requires PostgreSQL; SQLite is not allowed."
+        )
+
+def required_test_user_password():
+    password = os.getenv("COMPREHENSIVE_TEST_DATA_PASSWORD", "").strip()
+    if not password:
+        raise RuntimeError(
+            "Set COMPREHENSIVE_TEST_DATA_PASSWORD before creating test users."
+        )
+    return password
+
 
 def create_test_data():
     """Создание комплексных тестовых данных"""
+    _require_confirmation()
+    _require_postgres_database_url()
+    test_user_password = required_test_user_password()
     db = SessionLocal()
     
     try:
@@ -55,7 +85,7 @@ def create_test_data():
                     full_name=user_data["full_name"],
                     role=user_data["role"],
                     is_active=True,
-                    hashed_password=get_password_hash("test123"),
+                    hashed_password=get_password_hash(test_user_password),
                 )
                 db.add(user)
                 db.flush()

--- a/backend/create_print_templates.py
+++ b/backend/create_print_templates.py
@@ -1,12 +1,34 @@
 """
 Создание шаблонов печати в БД
 """
+import os
+
+from app.core.config import settings
 from app.db.session import SessionLocal
 from app.models.print_config import PrinterConfig, PrintTemplate
 from app.crud import print_config as crud_print
 
+def _require_confirmation():
+    if os.getenv("CONFIRM_CREATE_PRINT_TEMPLATES") != "1":
+        raise RuntimeError(
+            "Refusing to create print templates. "
+            "Set CONFIRM_CREATE_PRINT_TEMPLATES=1 only for an explicit print setup run."
+        )
+
+
+def _require_postgres_database_url():
+    database_url = str(settings.DATABASE_URL).strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before creating print templates.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError("create_print_templates.py requires PostgreSQL; SQLite is not allowed.")
+
+
 def create_templates():
     """Создать стандартные шаблоны"""
+    _require_confirmation()
+    _require_postgres_database_url()
+
     print('📄 Создание шаблонов печати в БД...')
 
     db = SessionLocal()

--- a/backend/create_test_data.py
+++ b/backend/create_test_data.py
@@ -9,10 +9,32 @@ from app.db.session import SessionLocal
 from app.models.patient import Patient
 from app.models.service import Service
 from app.models.user import User
+import os
+
+
+def require_test_data_confirmation():
+    if os.getenv("CONFIRM_CREATE_TEST_DATA") != "1":
+        raise RuntimeError(
+            "Refusing to create test data. "
+            "Set CONFIRM_CREATE_TEST_DATA=1 only for an explicit local seed run."
+        )
+
+
+def require_postgres_database_url():
+    from app.core.config import settings
+
+    database_url = str(settings.DATABASE_URL).strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before creating test data.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError("create_test_data.py requires PostgreSQL; SQLite is not allowed.")
 
 
 def create_test_data():
     """Создание тестовых данных"""
+    require_test_data_confirmation()
+    require_postgres_database_url()
+
     db = SessionLocal()
     try:
         # Создаём тестовые услуги

--- a/backend/create_test_emr_data.py
+++ b/backend/create_test_emr_data.py
@@ -17,8 +17,29 @@ from app.models.lab import LabOrder, LabResult
 from sqlalchemy import text
 
 
+def require_test_emr_data_confirmation():
+    if os.getenv("CONFIRM_CREATE_TEST_EMR_DATA") != "1":
+        raise RuntimeError(
+            "Refusing to create EMR test data. "
+            "Set CONFIRM_CREATE_TEST_EMR_DATA=1 only for an explicit local seed run."
+        )
+
+
+def require_postgres_database_url():
+    from app.core.config import settings
+
+    database_url = str(settings.DATABASE_URL).strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before creating EMR test data.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError("create_test_emr_data.py requires PostgreSQL; SQLite is not allowed.")
+
+
 def create_test_data():
     """Создать тестовые данные для EMR"""
+    require_test_emr_data_confirmation()
+    require_postgres_database_url()
+
     print("🔄 СОЗДАНИЕ ТЕСТОВЫХ ДАННЫХ ДЛЯ EMR")
     print("=" * 40)
     

--- a/backend/create_users.py
+++ b/backend/create_users.py
@@ -8,8 +8,29 @@ from app.db.session import SessionLocal
 from app.models.user import User
 
 
+def require_create_users_confirmation():
+    if os.getenv("CONFIRM_CREATE_USERS") != "1":
+        raise RuntimeError(
+            "Refusing to create users. "
+            "Set CONFIRM_CREATE_USERS=1 only for an explicit local bootstrap run."
+        )
+
+
+def require_postgres_database_url():
+    from app.core.config import settings
+
+    database_url = str(settings.DATABASE_URL).strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before creating users.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError("create_users.py requires PostgreSQL; SQLite is not allowed.")
+
+
 def create_users():
     """Создание пользователей с разными ролями"""
+    require_create_users_confirmation()
+    require_postgres_database_url()
+
     db = SessionLocal()
     try:
         # Список пользователей для создания

--- a/backend/initialize_feature_flags.py
+++ b/backend/initialize_feature_flags.py
@@ -10,8 +10,31 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from app.db.session import SessionLocal
 from app.services.feature_flags import initialize_feature_flags
 
+def require_feature_flags_confirmation():
+    if os.getenv("CONFIRM_INITIALIZE_FEATURE_FLAGS") != "1":
+        raise RuntimeError(
+            "Refusing to initialize feature flags. "
+            "Set CONFIRM_INITIALIZE_FEATURE_FLAGS=1 only for an explicit feature-flag seed run."
+        )
+
+
+def require_postgres_database_url():
+    from app.core.config import settings
+
+    database_url = str(settings.DATABASE_URL).strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before initializing feature flags.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError(
+            "initialize_feature_flags.py requires PostgreSQL; SQLite is not allowed."
+        )
+
+
 def main():
     """Инициализирует предопределенные фича-флаги"""
+    require_feature_flags_confirmation()
+    require_postgres_database_url()
+
     print("🎛️ Инициализация фича-флагов...")
     
     db = SessionLocal()

--- a/backend/seed_services_wizard.py
+++ b/backend/seed_services_wizard.py
@@ -10,8 +10,27 @@ from sqlalchemy.orm import Session
 from app.db.session import SessionLocal
 from app.models.service import Service
 from app.models.clinic import ServiceCategory
+import os
 
 # Данные из файла "Услуги и врачи в нашей клинике.txt"
+def require_seed_services_wizard_confirmation():
+    if os.getenv("CONFIRM_SEED_SERVICES_WIZARD") != "1":
+        raise RuntimeError(
+            "Refusing to seed wizard services. "
+            "Set CONFIRM_SEED_SERVICES_WIZARD=1 only for an explicit catalog seed run."
+        )
+
+
+def require_postgres_database_url() -> None:
+    from app.core.config import settings
+
+    database_url = str(settings.DATABASE_URL).strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before seeding wizard services.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError("seed_services_wizard.py requires a PostgreSQL DATABASE_URL.")
+
+
 SERVICES_DATA = [
     # ===== ЛАБОРАТОРНЫЕ АНАЛИЗЫ (L) =====
     # Общий анализ крови
@@ -116,6 +135,9 @@ CATEGORIES_DATA = [
 
 def seed_services():
     """Заполнение справочника услуг"""
+    require_seed_services_wizard_confirmation()
+    require_postgres_database_url()
+
     db = SessionLocal()
     try:
         print("🔄 Начинаем заполнение справочника услуг...")

--- a/backend/setup_ai_providers.py
+++ b/backend/setup_ai_providers.py
@@ -2,9 +2,29 @@
 Настройка стандартных AI провайдеров и промпт-шаблонов
 Основа: passport.md стр. 3325-3888
 """
+import os
+
 from app.db.session import SessionLocal
 from app.models.ai_config import AIProvider, AIPromptTemplate
 from app.crud import ai_config as crud_ai
+
+def require_ai_setup_confirmation():
+    if os.getenv("CONFIRM_SETUP_AI_PROVIDERS") != "1":
+        raise RuntimeError(
+            "Refusing to setup AI providers. "
+            "Set CONFIRM_SETUP_AI_PROVIDERS=1 only for an explicit AI catalog setup run."
+        )
+
+
+def require_postgres_database_url():
+    from app.core.config import settings
+
+    database_url = str(settings.DATABASE_URL).strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before setting up AI providers.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError("setup_ai_providers.py requires PostgreSQL; SQLite is not allowed.")
+
 
 def create_ai_providers():
     """Создать стандартных AI провайдеров"""
@@ -263,6 +283,9 @@ def create_prompt_templates():
 
 def main():
     """Основная функция настройки"""
+    require_ai_setup_confirmation()
+    require_postgres_database_url()
+
     print("🚀 НАСТРОЙКА AI СИСТЕМЫ")
     print("=" * 50)
     

--- a/backend/setup_env.py
+++ b/backend/setup_env.py
@@ -67,13 +67,13 @@ LICENSE_ALLOW_HEALTH=1
 
 # --- TELEGRAM (УВЕДОМЛЕНИЯ) ---
 # Раскомментируйте для интеграции с Telegram
-# TELEGRAM_BOT_TOKEN=your-bot-token
-# TELEGRAM_CHAT_ID=your-chat-id
+# TELEGRAM_BOT_TOKEN=
+# TELEGRAM_CHAT_ID=
 
 # --- ПЛАТЕЖИ ---
 # Раскомментируйте для интеграции с платежными системами
-# PAYME_MERCHANT_ID=your-merchant-id
-# PAYME_SECRET_KEY=your-secret-key
+# PAYME_MERCHANT_ID=
+# PAYME_SECRET_KEY=
 # PAYME_TEST_MODE=1
 """
 

--- a/backend/setup_telegram_templates.py
+++ b/backend/setup_telegram_templates.py
@@ -2,12 +2,37 @@
 Создание шаблонов сообщений Telegram
 Основа: passport.md стр. 2064-2570
 """
+import os
+
+
+def _require_setup_telegram_templates_confirmation() -> None:
+    if os.getenv("CONFIRM_SETUP_TELEGRAM_TEMPLATES") != "1":
+        raise RuntimeError(
+            "Set CONFIRM_SETUP_TELEGRAM_TEMPLATES=1 before creating Telegram config/templates."
+        )
+
+
+def _require_postgres_database_url() -> None:
+    from app.core.config import settings
+
+    database_url = str(settings.DATABASE_URL).strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before creating Telegram templates.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError(
+            "setup_telegram_templates.py requires PostgreSQL; SQLite is not allowed."
+        )
+
+
 from app.db.session import SessionLocal
 from app.models.telegram_config import TelegramConfig, TelegramTemplate
 from app.crud import telegram_config as crud_telegram
 
 def create_telegram_config():
     """Создать базовую конфигурацию Telegram"""
+    _require_setup_telegram_templates_confirmation()
+    _require_postgres_database_url()
+
     print('📱 Создание конфигурации Telegram бота...')
 
     db = SessionLocal()
@@ -239,6 +264,9 @@ def create_message_templates():
 
 def main():
     """Основная функция настройки"""
+    _require_setup_telegram_templates_confirmation()
+    _require_postgres_database_url()
+
     print("📱 НАСТРОЙКА TELEGRAM БОТА")
     print("=" * 50)
     


### PR DESCRIPTION
﻿## Summary

- Harden local bootstrap, setup, and seed scripts with explicit `CONFIRM_*` guards before mutating data or config.
- Require PostgreSQL-backed `DATABASE_URL` for these script paths instead of silently allowing SQLite-oriented runs.
- Require `COMPREHENSIVE_TEST_DATA_PASSWORD` for comprehensive test-user seeding and blank example Telegram/Payme secret placeholders in `backend/setup_env.py`.

## Contract Impact

not applicable - this PR changes standalone backend scripts only and does not change API routes, websocket events, response payloads, or frontend consumers.

## RBAC / Permissions

not applicable - no route guards, auth helpers, role matrices, or user-facing permission checks changed; these scripts are local operator/bootstrap tools gated by explicit environment confirms.

## Notification / Realtime

not applicable - no notification producer, websocket, chat, read-state, or reconnect/resync behavior changed.

## Frontend Resilience

not applicable - no frontend panels, route-state flows, empty-state handling, or forbidden secondary fetch paths changed.

## Scope Gate

- Allowed paths: `backend/create_comprehensive_test_data.py`, `backend/create_print_templates.py`, `backend/create_test_data.py`, `backend/create_test_emr_data.py`, `backend/create_users.py`, `backend/initialize_feature_flags.py`, `backend/seed_services_wizard.py`, `backend/setup_ai_providers.py`, `backend/setup_env.py`, `backend/setup_telegram_templates.py`
- Denied paths: `backend/app/api/v1/endpoints/**`, `backend/app/services/**`, frontend runtime, workflows/ops, generated artifacts, deletion/rename wave, `backend/seed_services.py`
- Migration/docs/test impact: no migration; no runtime docs change required; targeted local validation only for script hardening paths
- Rollback note: revert this script-hardening slice if it blocks intended local bootstrap/setup flows

## Validation

- Targeted tests or smoke run: `git diff --check`; `C:\final\backend\.venv\Scripts\python.exe -m py_compile` for all 10 touched files; refusal smokes without `CONFIRM_*` for bootstrap/setup scripts using the existing backend venv against the clean temp clone
- Result: passed locally; all code-related GitHub checks passed before this body-template fix, and only `PR Review Quality Gate` failed due to missing required PR sections
- Not checked: confirmed mutating runs with `CONFIRM_*` enabled against a live PostgreSQL instance, and the deferred `backend/seed_services.py` follow-up slice
