### PR TITLE
QA: harden service catalog seed script

### DIFF
--- a/backend/seed_services.py
+++ b/backend/seed_services.py
@@ -8,16 +8,26 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
-from app.db.session import _get_db_url_from_env_or_settings
-from app.models.clinic import ServiceCategory
-from app.models.service import Service
 import logging
 
 # Настройка логирования
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+def require_seed_services_confirmation():
+    if os.getenv("CONFIRM_SEED_SERVICES") != "1":
+        raise RuntimeError(
+            "Refusing to seed services. "
+            "Set CONFIRM_SEED_SERVICES=1 only for an explicit catalog seed run."
+        )
+
+def require_postgres_database_url(database_url: str) -> str:
+    database_url = database_url.strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before seeding services.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError("seed_services.py requires a PostgreSQL DATABASE_URL.")
+    return database_url
 
 def seed_service_categories():
     """Создание категорий услуг"""
@@ -890,9 +900,19 @@ def seed_services():
 
 def main():
     """Основная функция инициализации"""
+    require_seed_services_confirmation()
+
+    from sqlalchemy import create_engine, inspect
+    from sqlalchemy.orm import sessionmaker
+
+    from app.core.config import settings
+
     try:
         # Создаем подключение к базе данных
-        db_url = _get_db_url_from_env_or_settings()
+        db_url = require_postgres_database_url(str(settings.DATABASE_URL))
+        from app.models.clinic import ServiceCategory
+        from app.models.service import Service
+
         engine = create_engine(db_url)
         SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
         
@@ -900,18 +920,18 @@ def main():
             logger.info("🚀 Начинаем инициализацию справочника услуг...")
             
             # Проверяем существование таблиц
-            with engine.connect() as conn:
-                # Проверяем таблицу service_categories
-                result = conn.execute(text("SELECT name FROM sqlite_master WHERE type='table' AND name='service_categories'"))
-                if not result.fetchone():
-                    logger.error("❌ Таблица service_categories не найдена. Запустите миграции.")
-                    return False
-                
-                # Проверяем таблицу services
-                result = conn.execute(text("SELECT name FROM sqlite_master WHERE type='table' AND name='services'"))
-                if not result.fetchone():
-                    logger.error("❌ Таблица services не найдена. Запустите миграции.")
-                    return False
+            inspector = inspect(engine)
+            # Проверяем таблицу service_categories
+            result = inspector.has_table("service_categories")
+            if not result:
+                logger.error("❌ Таблица service_categories не найдена. Запустите миграции.")
+                return False
+
+            # Проверяем таблицу services
+            result = inspector.has_table("services")
+            if not result:
+                logger.error("❌ Таблица services не найдена. Запустите миграции.")
+                return False
             
             # Создаем категории услуг
             logger.info("📂 Создаем категории услуг...")


### PR DESCRIPTION
## Summary

Hardens `backend/seed_services.py` so service catalog seeding requires explicit confirmation and a PostgreSQL `DATABASE_URL`.

## Scope

- Add `CONFIRM_SEED_SERVICES=1` guard before any mutating catalog seed run.
- Require a non-empty PostgreSQL `DATABASE_URL`.
- Replace SQLite-specific table existence checks with dialect-safe SQLAlchemy inspector checks.

## Contract Impact

- Canonical surface: Not applicable; this PR changes only the operator-run script `backend/seed_services.py` and does not touch HTTP or WebSocket surfaces.
- Request shape: Not applicable; there is no request payload because no API entrypoint changes.
- Response shape: Not applicable; there is no API response contract in this slice.
- Status codes: Not applicable; no route handler behavior changes.
- Frontend consumer: Not applicable; no frontend consumer reads this script output as a typed contract.
- Compatibility path or alias: Not applicable; no route alias, legacy endpoint, or compatibility path changes.
- Contract proof: Script diff only; validation is limited to refusal smoke and compile checks because there is no API or WS contract in scope.

## RBAC / Permissions

- Roles allowed: Not applicable; this script is run manually by an operator or developer, not through application RBAC.
- Roles denied: Not applicable; there is no application role gate in this script path.
- Positive auth proof: Not applicable; no auth-protected endpoint or UI surface changed.
- Negative auth proof: Not applicable; no auth-protected endpoint or UI surface changed.

## Notification / Realtime

- Event type or websocket channel: Not applicable; this slice does not publish events or use WebSocket channels.
- Payload version / ack behavior: Not applicable; no realtime payload is emitted.
- Read/unread or delivery semantics: Not applicable; no inbox or delivery path exists here.
- Reconnect/resync proof: Not applicable; no realtime client behavior changed.

## Frontend Resilience

- Empty data proof: Not applicable; there is no frontend state in scope.
- Partial data proof: Not applicable; there is no frontend state in scope.
- Forbidden secondary path behavior: Not applicable; no frontend secondary fetch path exists here.
- Missing draft/resource behavior: Not applicable; no frontend draft or resource loading path changed.
- Stale route/deep-link behavior: Not applicable; no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/seed_services.py`
- Denied paths: `backend/app/api/v1/endpoints/**`, `backend/app/services/**`, other backend scripts, `frontend/**`, `.github/**`, `ops/**`, generated/evidence artifacts, deletion/rename wave
- Migration/docs/test impact: No migration or docs changes. No new test files. Validation uses targeted compile and refusal smoke only.
- Rollback note: Revert this commit to restore previous seed behavior if the confirm or PostgreSQL-only guard proves too strict for a required environment.

## Risk

Low. This is a script-only hardening change. The intended behavior is stricter refusal unless the operator explicitly confirms the seed run and targets PostgreSQL.

## Validation

- Targeted tests or smoke run: `git diff --check -- backend/seed_services.py`; `python -m py_compile backend/seed_services.py`; refusal smoke without `CONFIRM_SEED_SERVICES`
- Result: Passed. Diff hygiene passed with only a non-blocking Windows LF->CRLF working-copy warning, `py_compile` passed, and the script refused to run without explicit confirmation.
- Not checked: No live database seed execution was run, no end-to-end catalog verification was run, and no broader backend suite was run for this single-file script hardening slice.
