### PR TITLE
QA: harden DB validation helper scripts

### DIFF
--- a/backend/check_db.py
+++ b/backend/check_db.py
@@ -1,21 +1,61 @@
-import sqlite3
+"""Legacy SQLite queue-entry diagnostic.
+
+PostgreSQL + Alembic are the runtime source of truth. This helper is limited to
+explicit local recovery diagnostics against a legacy clinic.db file.
+"""
+
+from __future__ import annotations
+
 import json
+import os
+import sqlite3
 
-conn = sqlite3.connect('clinic.db')
-c = conn.cursor()
 
-# Check all entries for patient 377
-c.execute("SELECT id, patient_id, patient_name, queue_time, services, service_codes FROM queue_entries WHERE patient_id = 377 ORDER BY id")
-rows = c.fetchall()
-print("--- Entries for patient 377 (Тестовая Кардио) ---")
-for r in rows:
-    print(f"\nID={r[0]}, patient_id={r[1]}, name={r[2]}")
-    print(f"  queue_time={r[3]}")
-    print(f"  service_codes={r[5]}")
-    if r[4]:
-        try:
-            services = json.loads(r[4])
-            for svc in services:
-                print(f"    - {svc.get('name', 'N/A')} (code={svc.get('code', 'N/A')}, id={svc.get('service_id', 'N/A')})")
-        except:
-            print(f"  services (raw): {r[4][:200]}")
+def require_diagnostic_db_read() -> None:
+    if os.getenv("ALLOW_LEGACY_SQLITE_DIAGNOSTIC_READ") != "1":
+        raise SystemExit(
+            "Refusing to read diagnostic database state. "
+            "Set ALLOW_LEGACY_SQLITE_DIAGNOSTIC_READ=1 only for an explicit local legacy SQLite diagnostic run."
+        )
+
+
+def main() -> int:
+    require_diagnostic_db_read()
+
+    conn = sqlite3.connect("clinic.db")
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, patient_id, patient_name, queue_time, services, service_codes
+            FROM queue_entries
+            WHERE patient_id = 377
+            ORDER BY id
+            """
+        )
+        rows = cursor.fetchall()
+        print("--- Entries for patient 377 ---")
+        for row in rows:
+            print(f"\nID={row[0]}, patient_id={row[1]}, name={row[2]}")
+            print(f"  queue_time={row[3]}")
+            print(f"  service_codes={row[5]}")
+            if row[4]:
+                try:
+                    services = json.loads(row[4])
+                    for service in services:
+                        print(
+                            "    - "
+                            f"{service.get('name', 'N/A')} "
+                            f"(code={service.get('code', 'N/A')}, "
+                            f"id={service.get('service_id', 'N/A')})"
+                        )
+                except (TypeError, ValueError):
+                    print(f"  services (raw): {row[4][:200]}")
+    finally:
+        conn.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/check_services.py
+++ b/backend/check_services.py
@@ -1,17 +1,21 @@
-from app.db.session import SessionLocal
-from app.models.service import Service
+"""Retired root service diagnostic.
 
-db = SessionLocal()
-services = db.query(Service).filter(Service.name.ilike("%эхо%")).all()
-for s in services:
-    print(f"ID={s.id}, name={s.name}, code={s.code}, service_code={s.service_code}")
+This script used to open a configured database session at import time. Use
+backend/tests or a confirmed, env-driven smoke helper instead.
+"""
 
-if not services:
-    print("No services found with 'эхо'")
-    # Search for cardiology services
-    cardio_services = db.query(Service).filter(Service.department_key == "cardiology").all()
-    print(f"\nCardiology services: {len(cardio_services)}")
-    for s in cardio_services:
-        print(f"ID={s.id}, name={s.name}, code={s.code}, service_code={s.service_code}")
+from __future__ import annotations
 
-db.close()
+import sys
+
+
+def main() -> int:
+    print(
+        "backend/check_services.py is retired. "
+        "Use backend/tests or a confirmed service smoke helper instead."
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/get_services.py
+++ b/backend/get_services.py
@@ -1,27 +1,54 @@
 #!/usr/bin/env python3
+"""Env-driven services API smoke helper."""
+
+from __future__ import annotations
+
+import os
+
 import requests
 
-token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZWdpc3RyYXJAZXhhbXBsZS5jb20iLCJleHAiOjE3NTkzMTg3MjV9.8UwEEuHt2Ku4YW_657xgE9yuPDe0NyKRu1Q25Epqffs"
-headers = {"Authorization": f"Bearer {token}"}
 
-print("Получаю список услуг...")
-response = requests.get("http://localhost:18000/api/v1/services", headers=headers)
+def _required_services_smoke_token() -> str:
+    token = os.getenv("SERVICES_SMOKE_TOKEN", "").strip()
+    if not token:
+        raise SystemExit("Set SERVICES_SMOKE_TOKEN before running get_services.py.")
+    return token
 
-if response.status_code == 200:
+
+def _api_base_url() -> str:
+    return os.getenv("SERVICES_SMOKE_API_BASE_URL", "http://127.0.0.1:18000").rstrip("/")
+
+
+def main() -> int:
+    token = _required_services_smoke_token()
+    response = requests.get(
+        f"{_api_base_url()}/api/v1/services",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+
+    if response.status_code != 200:
+        print(
+            "Failed to fetch services: "
+            f"{response.status_code} - {response.text[:500]}"
+        )
+        return 1
+
     services = response.json()
-    print(f"Всего услуг: {len(services)}")
-    print("Первые 10 услуг:")
-    for i, service in enumerate(services[:10]):
-        service_id = service.get("id")
-        code = service.get("code")
-        name = service.get("name")
-        print(f"{i+1}. ID: {service_id}, Code: {code}, Name: {name}")
-    
-    # Найдем K01
-    k01_service = next((s for s in services if s.get("code") == "K01"), None)
+    print(f"Total services: {len(services)}")
+    for index, service in enumerate(services[:10], start=1):
+        print(
+            f"{index}. ID: {service.get('id')}, "
+            f"Code: {service.get('code')}, Name: {service.get('name')}"
+        )
+
+    k01_service = next((item for item in services if item.get("code") == "K01"), None)
     if k01_service:
-        print(f"\nНайдена услуга K01: ID = {k01_service['id']}")
+        print(f"K01 service id: {k01_service['id']}")
     else:
-        print("\nУслуга K01 не найдена")
-else:
-    print(f"Ошибка получения услуг: {response.status_code} - {response.text}")
+        print("K01 service was not found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/init_database.py
+++ b/backend/init_database.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-РЎРєСЂРёРїС‚ РґР»СЏ РёРЅРёС†РёР°Р»РёР·Р°С†РёРё Р±Р°Р·С‹ РґР°РЅРЅС‹С…
-РЎРѕР·РґР°РµС‚ РІСЃРµ РЅРµРѕР±С…РѕРґРёРјС‹Рµ С‚Р°Р±Р»РёС†С‹ Рё РґРѕР±Р°РІР»СЏРµС‚ Р±Р°Р·РѕРІС‹С… РїРѕР»СЊР·РѕРІР°С‚РµР»РµР№, РѕС‚РґРµР»РµРЅРёРµ Рё РІСЂР°С‡Р°.
+Скрипт для инициализации базовых данных.
+Схема должна быть создана миграциями Alembic до запуска этого seed-helper.
 """
 
 import os
@@ -9,7 +9,7 @@ import sys
 from datetime import time
 from pathlib import Path
 
-# Р”РѕР±Р°РІР»СЏРµРј РїСѓС‚СЊ Рє РїСЂРѕРµРєС‚Сѓ
+# Добавляем путь к проекту
 project_root = Path(__file__).parent
 sys.path.insert(0, str(project_root))
 
@@ -26,7 +26,6 @@ require_init_database_confirmation()
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from app.db.base import Base
 from app.models.user import User
 from app.models.role_permission import Role, Permission, UserGroup
 from app.models.authentication import RefreshToken, UserActivity, SecurityEvent, LoginAttempt
@@ -35,15 +34,36 @@ from app.models.clinic import Doctor
 from app.core.config import settings
 from passlib.context import CryptContext
 
-# РЎРѕР·РґР°РµРј РґРІРёР¶РѕРє Р±Р°Р·С‹ РґР°РЅРЅС‹С…
-engine = create_engine(settings.DATABASE_URL, echo=True)
+# Создаем движок базы данных
+def _database_url() -> str:
+    database_url = str(settings.DATABASE_URL).strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before initializing seed data.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError("init_database.py requires PostgreSQL with Alembic-applied schema.")
+    return database_url
 
-# РЎРѕР·РґР°РµРј РІСЃРµ С‚Р°Р±Р»РёС†С‹
-print("рџ—„пёЏ РЎРѕР·РґР°РЅРёРµ С‚Р°Р±Р»РёС† РІ Р±Р°Р·Рµ РґР°РЅРЅС‹С…...")
-Base.metadata.create_all(bind=engine)
 
-# РЎРѕР·РґР°РµРј РєРѕРЅС‚РµРєСЃС‚ РґР»СЏ С…РµС€РёСЂРѕРІР°РЅРёСЏ РїР°СЂРѕР»РµР№
-# РСЃРїРѕР»СЊР·СѓРµРј argon2 РєР°Рє РѕСЃРЅРѕРІРЅРѕР№ (РєР°Рє РЅР°СЃС‚СЂРѕРµРЅРѕ РІ security.py), bcrypt РєР°Рє Р·Р°РїР°СЃРЅРѕР№
+def _password_env_names(username: str) -> list[str]:
+    names = [f"INIT_DATABASE_{username.upper()}_PASSWORD"]
+    if username == "admin":
+        names.insert(0, "ADMIN_PASSWORD")
+    return names
+
+
+def _required_password(username: str) -> str:
+    for env_name in _password_env_names(username):
+        password = os.getenv(env_name, "").strip()
+        if password:
+            return password
+    expected = " or ".join(_password_env_names(username))
+    raise RuntimeError(f"Set {expected} before initializing user '{username}'.")
+
+
+engine = create_engine(_database_url(), echo=True)
+
+# Создаем контекст для хеширования паролей
+# Используем argon2 как основной (как настроено в security.py), bcrypt как запасной
 pwd_context = CryptContext(schemes=["argon2", "bcrypt"], deprecated="auto")
 
 
@@ -51,49 +71,55 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 
-# РЎРѕР·РґР°РµРј СЃРµСЃСЃРёСЋ
-print("рџ‘Ґ РЎРѕР·РґР°РЅРёРµ Р±Р°Р·РѕРІС‹С… РїРѕР»СЊР·РѕРІР°С‚РµР»РµР№...")
+# Создаем сессию
+print("👥 Создание базовых пользователей...")
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 db = SessionLocal()
 
 try:
-    # РџСЂРѕРІРµСЂСЏРµРј, РµСЃС‚СЊ Р»Рё СѓР¶Рµ РїРѕР»СЊР·РѕРІР°С‚РµР»Рё
+    # Проверяем, есть ли уже пользователи
     existing_users = db.query(User).count()
     if existing_users > 0:
-        print(f"вњ… Р’ Р±Р°Р·Рµ СѓР¶Рµ РµСЃС‚СЊ {existing_users} РїРѕР»СЊР·РѕРІР°С‚РµР»РµР№")
+        print(f"✅ В базе уже есть {existing_users} пользователей")
     else:
-        # РЎРѕР·РґР°РµРј СЂРѕР»Рё (РёСЃРїРѕР»СЊР·СѓРµРј РїСЂР°РІРёР»СЊРЅСѓСЋ РјРѕРґРµР»СЊ Role РёР· role_permission.py)
+        passwords = {
+            "admin": _required_password("admin"),
+            "doctor": _required_password("doctor"),
+            "registrar": _required_password("registrar"),
+        }
+
+        # Создаем роли (используем правильную модель Role из role_permission.py)
         admin_role = Role(
             name="Admin",
-            display_name="РђРґРјРёРЅРёСЃС‚СЂР°С‚РѕСЂ",
-            description="РђРґРјРёРЅРёСЃС‚СЂР°С‚РѕСЂ СЃРёСЃС‚РµРјС‹",
+            display_name="Администратор",
+            description="Администратор системы",
             level=100,
             is_system=True,
         )
         doctor_role = Role(
             name="Doctor",
-            display_name="Р’СЂР°С‡",
-            description="Р’СЂР°С‡",
+            display_name="Врач",
+            description="Врач",
             level=50,
             is_system=True,
         )
         registrar_role = Role(
             name="Registrar",
-            display_name="Р РµРіРёСЃС‚СЂР°С‚РѕСЂ",
-            description="Р РµРіРёСЃС‚СЂР°С‚РѕСЂ",
+            display_name="Регистратор",
+            description="Регистратор",
             level=30,
             is_system=True,
         )
 
         db.add_all([admin_role, doctor_role, registrar_role])
-        db.flush()  # РџРѕР»СѓС‡Р°РµРј ID СЂРѕР»РµР№
+        db.flush()  # Получаем ID ролей
 
-        # РЎРѕР·РґР°РµРј РїРѕР»СЊР·РѕРІР°С‚РµР»РµР№
+        # Создаем пользователей
         admin_user = User(
             username="admin",
             email="admin@clinic.local",
-            full_name="РђРґРјРёРЅРёСЃС‚СЂР°С‚РѕСЂ",
-            hashed_password=get_password_hash("admin123"),
+            full_name="Администратор",
+            hashed_password=get_password_hash(passwords["admin"]),
             role="Admin",
             is_active=True,
             is_superuser=True,
@@ -102,8 +128,8 @@ try:
         doctor_user = User(
             username="doctor",
             email="doctor@clinic.local",
-            full_name="Р”РѕРєС‚РѕСЂ РРІР°РЅРѕРІ",
-            hashed_password=get_password_hash("doctor123"),
+            full_name="Доктор Иванов",
+            hashed_password=get_password_hash(passwords["doctor"]),
             role="Doctor",
             is_active=True,
             is_superuser=False,
@@ -112,8 +138,8 @@ try:
         registrar_user = User(
             username="registrar",
             email="registrar@clinic.local",
-            full_name="Р РµРіРёСЃС‚СЂР°С‚РѕСЂ РџРµС‚СЂРѕРІР°",
-            hashed_password=get_password_hash("registrar123"),
+            full_name="Регистратор Петрова",
+            hashed_password=get_password_hash(passwords["registrar"]),
             role="Registrar",
             is_active=True,
             is_superuser=False,
@@ -121,23 +147,23 @@ try:
 
         users = [admin_user, doctor_user, registrar_user]
         db.add_all(users)
-        db.flush()  # РџРѕР»СѓС‡Р°РµРј ID РїРѕР»СЊР·РѕРІР°С‚РµР»РµР№
+        db.flush()  # Получаем ID пользователей
 
-        # РЎРѕР·РґР°РµРј РѕС‚РґРµР»РµРЅРёРµ (РєСЂРёС‚РёС‡РµСЃРєРё РІР°Р¶РЅРѕ РґР»СЏ СЂР°Р±РѕС‚С‹ QR Queue)
+        # Создаем отделение (критически важно для работы QR Queue)
         general_dept = Department(
             key="general",
-            name_ru="РћР±С‰РµРµ РѕС‚РґРµР»РµРЅРёРµ",
+            name_ru="Общее отделение",
             name_uz="Umumiy bo'lim",
             icon="folder",
             display_order=1,
             active=True,
-            description="РћР±С‰РµРµ РѕС‚РґРµР»РµРЅРёРµ РєР»РёРЅРёРєРё",
+            description="Общее отделение клиники",
         )
         db.add(general_dept)
-        db.flush()  # РџРѕР»СѓС‡Р°РµРј ID РѕС‚РґРµР»РµРЅРёСЏ
+        db.flush()  # Получаем ID отделения
 
-        # РЎРѕР·РґР°РµРј РїСЂРѕС„РёР»СЊ РІСЂР°С‡Р° (Doctor) - СЃРІСЏР·С‹РІР°РµС‚ User СЃ РѕС‚РґРµР»РµРЅРёРµРј
-        # Р­С‚Рѕ РєСЂРёС‚РёС‡РµСЃРєРё РІР°Р¶РЅРѕ РґР»СЏ СЂР°Р±РѕС‚С‹ QR Queue СЃРёСЃС‚РµРјС‹!
+        # Создаем профиль врача (Doctor) - связывает User с отделением
+        # Это критически важно для работы QR Queue системы!
         doctor = Doctor(
             user_id=doctor_user.id,
             department_id=general_dept.id,
@@ -145,30 +171,30 @@ try:
             active=True,
             start_number_online=1,
             max_online_per_day=20,
-            # РСЃРїРѕР»СЊР·СѓРµРј time() РѕР±СЉРµРєС‚ РІРјРµСЃС‚Рѕ СЃС‚СЂРѕРєРё РґР»СЏ SQLite СЃРѕРІРјРµСЃС‚РёРјРѕСЃС‚Рё
+            # Store a typed time value instead of a string.
             auto_close_time=time(9, 0),
         )
         db.add(doctor)
 
         db.commit()
 
-        print("вњ… РЎРѕР·РґР°РЅС‹ СЂРѕР»Рё:")
-        print("  - Admin (СѓСЂРѕРІРµРЅСЊ 100)")
-        print("  - Doctor (СѓСЂРѕРІРµРЅСЊ 50)")
-        print("  - Registrar (СѓСЂРѕРІРµРЅСЊ 30)")
+        print("✅ Созданы роли:")
+        print("  - Admin (уровень 100)")
+        print("  - Doctor (уровень 50)")
+        print("  - Registrar (уровень 30)")
         print()
-        print("вњ… РЎРѕР·РґР°РЅС‹ РїРѕР»СЊР·РѕРІР°С‚РµР»Рё:")
-        print("  - admin / admin123 (РђРґРјРёРЅРёСЃС‚СЂР°С‚РѕСЂ)")
-        print("  - doctor / doctor123 (Р’СЂР°С‡)")
-        print("  - registrar / registrar123 (Р РµРіРёСЃС‚СЂР°С‚РѕСЂ)")
+        print("✅ Созданы пользователи:")
+        print("  - admin (Администратор)")
+        print("  - doctor (Врач)")
+        print("  - registrar (Регистратор)")
         print()
-        print(f"вњ… РЎРѕР·РґР°РЅРѕ РѕС‚РґРµР»РµРЅРёРµ: {general_dept.name_ru} (key={general_dept.key})")
-        print(f"вњ… РЎРѕР·РґР°РЅ РїСЂРѕС„РёР»СЊ РІСЂР°С‡Р° РґР»СЏ {doctor_user.full_name} (Doctor.id={doctor.id})")
+        print(f"✅ Создано отделение: {general_dept.name_ru} (key={general_dept.key})")
+        print(f"✅ Создан профиль врача для {doctor_user.full_name} (Doctor.id={doctor.id})")
         print()
-        print("рџ’Ў РўРµРїРµСЂСЊ QR Queue СЃРёСЃС‚РµРјР° СЃРјРѕР¶РµС‚ РЅР°С…РѕРґРёС‚СЊ РѕС‡РµСЂРµРґРё РїРѕ doctor.id")
+        print("💡 Теперь QR Queue система сможет находить очереди по doctor.id")
 
 except Exception as e:
-    print(f"вќЊ РћС€РёР±РєР° РїСЂРё СЃРѕР·РґР°РЅРёРё РїРѕР»СЊР·РѕРІР°С‚РµР»РµР№: {e}")
+    print(f"❌ Ошибка при создании пользователей: {e}")
     import traceback
     traceback.print_exc()
     db.rollback()
@@ -176,4 +202,4 @@ finally:
     db.close()
 
 print()
-print("рџЋ‰ РРЅРёС†РёР°Р»РёР·Р°С†РёСЏ Р±Р°Р·С‹ РґР°РЅРЅС‹С… Р·Р°РІРµСЂС€РµРЅР°!")
+print("🎉 Инициализация базы данных завершена!")

--- a/backend/init_departments.py
+++ b/backend/init_departments.py
@@ -1,20 +1,17 @@
+"""Seed initial departments into the configured database.
+
+Schema ownership belongs to Alembic. Run `alembic upgrade head` before this
+helper; it intentionally does not create tables.
 """
-Инициализация таблицы departments с начальными данными
-"""
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from __future__ import annotations
 
-from app.db.base_class import Base
-from app.models.department import Department
+import sys
+import os
+from pathlib import Path
 
-# Создаем engine и сессию
-engine = create_engine("sqlite:///./clinic.db", echo=True)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-# Создаем таблицу
-Base.metadata.create_all(bind=engine, tables=[Department.__table__])
 
-# Начальные данные
 INITIAL_DEPARTMENTS = [
     {
         "key": "cardio",
@@ -22,7 +19,7 @@ INITIAL_DEPARTMENTS = [
         "name_uz": "Kardiologiya",
         "icon": "heart",
         "display_order": 1,
-        "active": True
+        "active": True,
     },
     {
         "key": "echokg",
@@ -30,7 +27,7 @@ INITIAL_DEPARTMENTS = [
         "name_uz": "EKG",
         "icon": "activity",
         "display_order": 2,
-        "active": True
+        "active": True,
     },
     {
         "key": "derma",
@@ -38,7 +35,7 @@ INITIAL_DEPARTMENTS = [
         "name_uz": "Dermatologiya",
         "icon": "droplet",
         "display_order": 3,
-        "active": True
+        "active": True,
     },
     {
         "key": "dental",
@@ -46,7 +43,7 @@ INITIAL_DEPARTMENTS = [
         "name_uz": "Stomatologiya",
         "icon": "smile",
         "display_order": 4,
-        "active": True
+        "active": True,
     },
     {
         "key": "lab",
@@ -54,7 +51,7 @@ INITIAL_DEPARTMENTS = [
         "name_uz": "Laboratoriya",
         "icon": "flask",
         "display_order": 5,
-        "active": True
+        "active": True,
     },
     {
         "key": "procedures",
@@ -62,39 +59,66 @@ INITIAL_DEPARTMENTS = [
         "name_uz": "Protseduralar",
         "icon": "clipboard-list",
         "display_order": 6,
-        "active": True
-    }
+        "active": True,
+    },
 ]
 
-def init_departments():
-    """Инициализация отделений"""
+
+def require_init_departments_confirmation() -> None:
+    if os.getenv("CONFIRM_INIT_DEPARTMENTS") != "1":
+        raise RuntimeError(
+            "Refusing to seed departments. "
+            "Set CONFIRM_INIT_DEPARTMENTS=1 only for an explicit catalog seed run."
+        )
+
+
+def require_postgres_database_url() -> None:
+    from app.core.config import settings
+
+    database_url = str(settings.DATABASE_URL).strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before seeding departments.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError("init_departments.py requires a PostgreSQL DATABASE_URL.")
+
+
+def init_departments() -> bool:
+    """Seed departments if the configured database has none yet."""
+    require_init_departments_confirmation()
+    require_postgres_database_url()
+
+    from app.db.session import SessionLocal
+    from app.models.department import Department
+
+    print("Seeding departments...")
     db = SessionLocal()
     try:
-        # Проверяем есть ли уже отделения
         existing_count = db.query(Department).count()
         if existing_count > 0:
-            print(f"✅ Отделения уже существуют ({existing_count} записей)")
-            return
+            print(f"Departments already exist ({existing_count} records)")
+            return True
 
-        # Создаем отделения
-        for dept_data in INITIAL_DEPARTMENTS:
-            dept = Department(**dept_data)
-            db.add(dept)
+        for department_data in INITIAL_DEPARTMENTS:
+            db.add(Department(**department_data))
 
         db.commit()
-        print(f"✅ Создано {len(INITIAL_DEPARTMENTS)} отделений")
+        print(f"Created {len(INITIAL_DEPARTMENTS)} departments")
 
-        # Выводим созданные отделения
         departments = db.query(Department).order_by(Department.display_order).all()
-        for dept in departments:
-            print(f"   {dept.display_order}. {dept.key}: {dept.name_ru} ({dept.icon})")
+        for department in departments:
+            print(
+                f"   {department.display_order}. "
+                f"{department.key}: {department.name_ru} ({department.icon})"
+            )
+        return True
 
-    except Exception as e:
-        print(f"❌ Ошибка: {e}")
+    except Exception as exc:
+        print(f"Department seed failed: {exc}")
         db.rollback()
+        return False
     finally:
         db.close()
 
+
 if __name__ == "__main__":
-    print("Инициализация таблицы departments...")
-    init_departments()
+    raise SystemExit(0 if init_departments() else 1)

--- a/backend/quick_check.py
+++ b/backend/quick_check.py
@@ -1,67 +1,24 @@
 #!/usr/bin/env python3
-"""
-Быстрая проверка системы ролей
-Запускать перед каждым коммитом: python quick_check.py
-"""
-import os
-import subprocess
+"""Retired legacy root quick-check wrapper."""
+
+from __future__ import annotations
+
 import sys
 
 
-def run_command(cmd, description):
-    """Запускает команду и возвращает результат"""
-    print(f"Проверка: {description}...")
-    try:
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-        if result.returncode == 0:
-            print(f"OK: {description}: OK")
-            return True
-        else:
-            print(f"ОШИБКА: {description}: FAILED")
-            print(f"   {result.stderr}")
-            return False
-    except Exception as e:
-        print(f"ОШИБКА: {description}: ERROR - {e}")
-        return False
+MESSAGE = """
+quick_check.py is retired.
+
+This legacy wrapper depended on a local clinic.db file and shell-invoked stale
+smoke scripts. Use targeted pytest checks or the current CI/runbook commands
+against the PostgreSQL/Alembic runtime instead.
+""".strip()
 
 
-def main():
-    """Основная функция быстрой проверки"""
-    print("Быстрая проверка системы ролей")
-    print("=" * 50)
-
-    # Проверяем, что мы в правильной директории
-    if not os.path.exists("clinic.db"):
-        print("ОШИБКА: База данных не найдена. Запустите из папки backend/")
-        sys.exit(1)
-
-    # Проверяем доступность сервера
-    if not run_command(
-        "curl -s http://127.0.0.1:18000/api/v1/health", "Проверка сервера"
-    ):
-        print("ВНИМАНИЕ: Сервер не запущен. Запустите: uvicorn app.main:app --reload")
-        sys.exit(1)
-
-    # Запускаем тесты
-    checks = [
-        ("python test_role_routing.py", "Тесты системы ролей"),
-        ("python quick_user_management_check.py", "Система управления пользователями"),
-        ("python check_system_integrity.py", "Проверка целостности"),
-    ]
-
-    all_passed = True
-    for cmd, desc in checks:
-        if not run_command(cmd, desc):
-            all_passed = False
-
-    print("\n" + "=" * 50)
-    if all_passed:
-        print("УСПЕХ: ВСЕ ПРОВЕРКИ ПРОШЛИ! Можно коммитить.")
-        sys.exit(0)
-    else:
-        print("ВНИМАНИЕ: ЕСТЬ ПРОБЛЕМЫ! Исправьте перед коммитом.")
-        sys.exit(1)
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/backend/validate_fk_policies.py
+++ b/backend/validate_fk_policies.py
@@ -1,126 +1,185 @@
-"""
-Validation script for FK policies after database reset.
-Verifies that all FK constraints have correct ondelete policies.
-"""
+"""Validate FK constraints for the configured database."""
+from __future__ import annotations
+
 import os
 import sys
-import sqlite3
 from pathlib import Path
+from typing import Any, Dict, List
 
-# Add backend to sys.path
-sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from sqlalchemy import create_engine, inspect, text
-from app.core.config import get_settings
 
-def get_db_url():
+def get_db_url() -> str:
+    from app.core.config import get_settings
+
     try:
         settings = get_settings()
-        return settings.DATABASE_URL
-    except Exception:
-        return "sqlite:///./clinic.db"
+        db_url = str(settings.DATABASE_URL or "").strip()
+    except Exception as exc:
+        raise SystemExit(
+            "DATABASE_URL is required; refusing to validate a fallback database"
+        ) from exc
 
-DATABASE_URL = get_db_url()
-if DATABASE_URL.startswith("sqlite+aiosqlite://"):
-    DATABASE_URL = DATABASE_URL.replace("sqlite+aiosqlite://", "sqlite://", 1)
+    if not db_url:
+        raise SystemExit(
+            "DATABASE_URL is required; refusing to validate a fallback database"
+        )
 
-print("=" * 80)
-print("FK POLICY VALIDATION")
-print("=" * 80)
-print(f"Database URL: {DATABASE_URL}\n")
+    return db_url
 
-def check_fk_enforcement(engine):
-    """Check that FK enforcement is enabled"""
+
+def normalize_sync_db_url(db_url: str) -> str:
+    if db_url.startswith("sqlite+aiosqlite://"):
+        return db_url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+    return db_url
+
+
+def is_sqlite_url(db_url: str) -> bool:
+    from sqlalchemy.engine import make_url
+
+    return make_url(db_url).drivername.startswith("sqlite")
+
+
+def allow_sqlite_database_url() -> bool:
+    raw = os.getenv("ALLOW_SQLITE_DATABASE_URL", "")
+    if raw.strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return os.getenv("TESTING", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def enforce_database_url_policy(db_url: str) -> None:
+    if is_sqlite_url(db_url) and not allow_sqlite_database_url():
+        raise SystemExit(
+            "SQLite DATABASE_URL is disabled for validate_fk_policies.py. "
+            "Use PostgreSQL as the schema source of truth, or set "
+            "ALLOW_SQLITE_DATABASE_URL=1 only for explicit legacy tools/tests."
+        )
+
+
+def display_db_url(db_url: str) -> str:
+    from sqlalchemy.engine import make_url
+
+    return make_url(db_url).render_as_string(hide_password=True)
+
+
+DATABASE_URL = ""
+
+
+def check_fk_enforcement(engine) -> bool:
+    """Check FK enforcement where the database exposes a runtime switch."""
+    from sqlalchemy import text
+
     print("Step 1: Checking FK enforcement...")
+
+    if not is_sqlite_url(DATABASE_URL):
+        print("  Foreign key enforcement is managed by the database engine\n")
+        return True
+
     with engine.connect() as conn:
+        conn.execute(text("PRAGMA foreign_keys=ON"))
         result = conn.execute(text("PRAGMA foreign_keys")).scalar()
         if result == 1:
-            print("  ✅ Foreign key enforcement is ENABLED\n")
+            print("  Foreign key enforcement is ENABLED\n")
             return True
-        else:
-            print(f"  ❌ Foreign key enforcement is DISABLED (status: {result})\n")
-            return False
 
-def get_all_fk_constraints(engine):
-    """Get all FK constraints from SQLite"""
+        print(f"  Foreign key enforcement is DISABLED (status: {result})\n")
+        return False
+
+
+def get_all_fk_constraints(engine) -> List[Dict[str, Any]]:
+    """Get all FK constraints through SQLAlchemy inspector."""
+    from sqlalchemy import inspect
+
     print("Step 2: Analyzing FK constraints...")
     fk_constraints = []
-    
-    with engine.connect() as conn:
-        # Get all tables
-        inspector = inspect(engine)
-        tables = inspector.get_table_names()
-        
-        for table in tables:
-            # Get FK constraints for this table
-            fks = inspector.get_foreign_keys(table)
-            for fk in fks:
-                fk_constraints.append({
-                    'table': table,
-                    'constrained_columns': fk['constrained_columns'],
-                    'referred_table': fk['referred_table'],
-                    'referred_columns': fk['referred_columns'],
-                    'name': fk.get('name', 'N/A')
-                })
-    
+
+    inspector = inspect(engine)
+    tables = inspector.get_table_names()
+
+    for table in tables:
+        fks = inspector.get_foreign_keys(table)
+        for fk in fks:
+            fk_constraints.append(
+                {
+                    "table": table,
+                    "constrained_columns": fk["constrained_columns"],
+                    "referred_table": fk["referred_table"],
+                    "referred_columns": fk["referred_columns"],
+                    "name": fk.get("name", "N/A"),
+                }
+            )
+
     print(f"  Found {len(fk_constraints)} FK constraints across {len(tables)} tables\n")
     return fk_constraints
 
-def validate_fk_policies(engine):
-    """Validate that FK policies are correctly applied"""
+
+def validate_fk_policies(engine) -> bool:
+    """Validate that FK policies are represented by schema/model contracts."""
     print("Step 3: Validating FK policies...")
-    
-    # Note: SQLite doesn't expose ondelete policy in PRAGMA, so we check via models
-    # This is a basic check - full validation requires checking models
-    print("  ⚠️  Note: SQLite doesn't expose ondelete policy in schema introspection")
-    print("  ✅ FK constraints exist (ondelete policies are enforced by SQLAlchemy models)\n")
+
+    if is_sqlite_url(DATABASE_URL):
+        print("  SQLite does not expose all ondelete policy metadata consistently")
+    else:
+        print("  FK constraints were introspected from the configured database")
+
+    print("  Full ondelete policy validation still requires model/Alembic review\n")
     return True
 
-def test_cascade_behavior(engine):
-    """Test CASCADE behavior (if possible)"""
+
+def test_cascade_behavior(engine) -> bool:
+    """Placeholder for destructive behavior tests that require fixture data."""
     print("Step 4: Testing FK behavior...")
-    print("  ⚠️  Skipping behavior tests (requires test data)")
-    print("  ✅ FK constraints are defined in models and will be enforced\n")
+    print("  Skipping behavior tests because they require controlled fixture data")
+    print("  FK constraints are defined in models and database schema\n")
     return True
 
-def main():
-    engine = create_engine(DATABASE_URL, future=True)
-    
-    # Step 1: Check FK enforcement
-    if not check_fk_enforcement(engine):
-        print("❌ VALIDATION FAILED: FK enforcement is disabled")
-        sys.exit(1)
-    
-    # Step 2: Get all FK constraints
-    fk_constraints = get_all_fk_constraints(engine)
-    
-    if len(fk_constraints) == 0:
-        print("⚠️  WARNING: No FK constraints found (database may be empty)")
-        print("  Run migrations: alembic upgrade head")
-        sys.exit(0)
-    
-    # Step 3: Validate FK policies
-    if not validate_fk_policies(engine):
-        print("❌ VALIDATION FAILED: FK policies validation failed")
-        sys.exit(1)
-    
-    # Step 4: Test behavior (optional)
-    test_cascade_behavior(engine)
-    
+
+def main() -> int:
+    from sqlalchemy import create_engine
+
+    global DATABASE_URL
+
+    DATABASE_URL = normalize_sync_db_url(get_db_url())
+    enforce_database_url_policy(DATABASE_URL)
+
     print("=" * 80)
-    print("✅ VALIDATION PASSED")
+    print("FK POLICY VALIDATION")
+    print("=" * 80)
+    print(f"Database URL: {display_db_url(DATABASE_URL)}\n")
+
+    engine = create_engine(DATABASE_URL, future=True)
+
+    if not check_fk_enforcement(engine):
+        print("VALIDATION FAILED: FK enforcement is disabled")
+        return 1
+
+    fk_constraints = get_all_fk_constraints(engine)
+
+    if len(fk_constraints) == 0:
+        print("WARNING: No FK constraints found (database may be empty)")
+        print("  Run migrations: alembic upgrade head")
+        return 0
+
+    if not validate_fk_policies(engine):
+        print("VALIDATION FAILED: FK policies validation failed")
+        return 1
+
+    test_cascade_behavior(engine)
+
+    print("=" * 80)
+    print("VALIDATION PASSED")
     print("=" * 80)
     print("\nSummary:")
-    print(f"  - FK enforcement: ENABLED")
+    print("  - FK enforcement: available for configured database")
     print(f"  - FK constraints found: {len(fk_constraints)}")
-    print(f"  - All FK policies are defined in SQLAlchemy models")
-    print(f"  - FK constraints will be enforced on database operations")
+    print("  - FK policies require model/Alembic review for full assurance")
+    print("  - FK constraints will be enforced on database operations")
     print("\nNext steps:")
     print("  1. Verify models have correct ondelete policies")
-    print("  2. Test CASCADE/SET NULL/RESTRICT behavior with test data")
+    print("  2. Test CASCADE/SET NULL/RESTRICT behavior with controlled test data")
     print("  3. Run audit_foreign_keys.py to check for orphaned records")
-    sys.exit(0)
+    return 0
+
 
 if __name__ == "__main__":
-    main()
-
+    sys.exit(main())

--- a/backend/validate_production_readiness.py
+++ b/backend/validate_production_readiness.py
@@ -1,11 +1,11 @@
-"""
-Полная автоматическая валидация базы данных перед продакшеном.
-Проверяет:
-1. FK enforcement включен
-2. Отсутствие orphaned записей
-3. Корректность FK политик
-4. Целостность схемы
-5. Готовность к продакшену
+﻿"""
+РџРѕР»РЅР°СЏ Р°РІС‚РѕРјР°С‚РёС‡РµСЃРєР°СЏ РІР°Р»РёРґР°С†РёСЏ Р±Р°Р·С‹ РґР°РЅРЅС‹С… РїРµСЂРµРґ РїСЂРѕРґР°РєС€РµРЅРѕРј.
+РџСЂРѕРІРµСЂСЏРµС‚:
+1. FK enforcement РІРєР»СЋС‡РµРЅ
+2. РћС‚СЃСѓС‚СЃС‚РІРёРµ orphaned Р·Р°РїРёСЃРµР№
+3. РљРѕСЂСЂРµРєС‚РЅРѕСЃС‚СЊ FK РїРѕР»РёС‚РёРє
+4. Р¦РµР»РѕСЃС‚РЅРѕСЃС‚СЊ СЃС…РµРјС‹
+5. Р“РѕС‚РѕРІРЅРѕСЃС‚СЊ Рє РїСЂРѕРґР°РєС€РµРЅСѓ
 """
 import os
 import sys
@@ -14,88 +14,128 @@ from pathlib import Path
 # Add backend to sys.path
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
-from sqlalchemy import create_engine, text, inspect
-from sqlalchemy.orm import sessionmaker
-
-from app.core.config import get_settings
-
 def get_db_url():
+    from app.core.config import get_settings
+
     try:
         settings = get_settings()
-        return settings.DATABASE_URL
-    except Exception:
-        return "sqlite:///./clinic.db"
+        db_url = str(settings.DATABASE_URL or "").strip()
+    except Exception as exc:
+        raise SystemExit(
+            "DATABASE_URL is required; refusing to validate a fallback database"
+        ) from exc
 
-DATABASE_URL = get_db_url()
-if DATABASE_URL.startswith("sqlite+aiosqlite://"):
-    DATABASE_URL = DATABASE_URL.replace("sqlite+aiosqlite://", "sqlite://", 1)
+    if not db_url:
+        raise SystemExit(
+            "DATABASE_URL is required; refusing to validate a fallback database"
+        )
 
-print("=" * 80)
-print("PRODUCTION READINESS VALIDATION")
-print("=" * 80)
-print(f"Database URL: {DATABASE_URL}\n")
+    return db_url
+
+
+def normalize_sync_db_url(db_url):
+    if db_url.startswith("sqlite+aiosqlite://"):
+        return db_url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+    return db_url
+
+
+def is_sqlite_url(db_url):
+    from sqlalchemy.engine import make_url
+
+    return make_url(db_url).drivername.startswith("sqlite")
+
+
+def allow_sqlite_database_url():
+    raw = os.getenv("ALLOW_SQLITE_DATABASE_URL", "")
+    if raw.strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return os.getenv("TESTING", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def enforce_database_url_policy(db_url):
+    if is_sqlite_url(db_url) and not allow_sqlite_database_url():
+        raise SystemExit(
+            "SQLite DATABASE_URL is disabled for validate_production_readiness.py. "
+            "Use PostgreSQL as the schema source of truth, or set "
+            "ALLOW_SQLITE_DATABASE_URL=1 only for explicit legacy tools/tests."
+        )
+
+
+def display_db_url(db_url):
+    from sqlalchemy.engine import make_url
+
+    return make_url(db_url).render_as_string(hide_password=True)
+
+
+DATABASE_URL = ""
 
 class ValidationResult:
     def __init__(self):
         self.passed = []
         self.failed = []
         self.warnings = []
-    
+
     def add_pass(self, message):
         self.passed.append(message)
-        print(f"  ✅ {message}")
-    
+        print(f"  вњ… {message}")
+
     def add_fail(self, message):
         self.failed.append(message)
-        print(f"  ❌ {message}")
-    
+        print(f"  вќЊ {message}")
+
     def add_warning(self, message):
         self.warnings.append(message)
-        print(f"  ⚠️  {message}")
-    
+        print(f"  вљ пёЏ  {message}")
+
     def print_summary(self):
         print("\n" + "=" * 80)
         print("VALIDATION SUMMARY")
         print("=" * 80)
-        print(f"✅ Passed: {len(self.passed)}")
-        print(f"❌ Failed: {len(self.failed)}")
-        print(f"⚠️  Warnings: {len(self.warnings)}")
+        print(f"вњ… Passed: {len(self.passed)}")
+        print(f"вќЊ Failed: {len(self.failed)}")
+        print(f"вљ пёЏ  Warnings: {len(self.warnings)}")
         print()
-        
+
         if self.failed:
             print("FAILED CHECKS:")
             for msg in self.failed:
-                print(f"  ❌ {msg}")
+                print(f"  вќЊ {msg}")
             print()
-        
+
         if self.warnings:
             print("WARNINGS:")
             for msg in self.warnings:
-                print(f"  ⚠️  {msg}")
+                print(f"  вљ пёЏ  {msg}")
             print()
-        
+
         if not self.failed:
             print("=" * 80)
-            print("✅ PRODUCTION READY")
+            print("вњ… PRODUCTION READY")
             print("=" * 80)
             print("\nDatabase is ready for production deployment.")
             return True
         else:
             print("=" * 80)
-            print("❌ NOT PRODUCTION READY")
+            print("вќЊ NOT PRODUCTION READY")
             print("=" * 80)
             print("\nPlease fix the issues above before deploying to production.")
             return False
 
 def check_fk_enforcement(engine, result):
     """Check that FK enforcement is enabled"""
+    from sqlalchemy import text
+
     print("1. Checking FK Enforcement...")
+    if not is_sqlite_url(DATABASE_URL):
+        result.add_pass("Foreign key enforcement is managed by the database engine")
+        return
+
     try:
         with engine.connect() as conn:
             # Explicitly enable FK enforcement for this connection
             conn.execute(text("PRAGMA foreign_keys=ON"))
             conn.commit()
-            
+
             # Check status
             fk_status = conn.execute(text("PRAGMA foreign_keys")).scalar()
             if fk_status == 1:
@@ -107,41 +147,45 @@ def check_fk_enforcement(engine, result):
 
 def check_orphaned_records(engine, result):
     """Check for orphaned records"""
+    from sqlalchemy import inspect, text
+    from sqlalchemy.orm import sessionmaker
+
     print("\n2. Checking for Orphaned Records...")
-    
+
     inspector = inspect(engine)
     Session = sessionmaker(bind=engine)
     session = Session()
-    
+
     total_orphaned = 0
     orphaned_tables = []
     check_errors = []
-    
+
     try:
-        # Enable FK enforcement
-        session.execute(text("PRAGMA foreign_keys=ON"))
-        session.commit()
-        
+        if is_sqlite_url(DATABASE_URL):
+            # Enable FK enforcement for SQLite validation connections.
+            session.execute(text("PRAGMA foreign_keys=ON"))
+            session.commit()
+
         tables = inspector.get_table_names()
-        
+
         for table in tables:
             fks = inspector.get_foreign_keys(table)
             for fk in fks:
                 constrained_cols = fk['constrained_columns']
                 referred_table = fk['referred_table']
                 referred_cols = fk['referred_columns']
-                
+
                 if not constrained_cols or not referred_cols:
                     continue
-                
+
                 constrained_col = constrained_cols[0]
                 referred_col = referred_cols[0]
-                
+
                 # Check if referred table exists
                 if referred_table not in tables:
                     check_errors.append(f"{table}.{constrained_col} -> {referred_table} (table not found)")
                     continue
-                
+
                 # Check for orphaned records
                 query = text(f"""
                     SELECT COUNT(*) as count
@@ -149,18 +193,18 @@ def check_orphaned_records(engine, result):
                     LEFT JOIN {referred_table} p ON c.{constrained_col} = p.{referred_col}
                     WHERE c.{constrained_col} IS NOT NULL AND p.{referred_col} IS NULL
                 """)
-                
+
                 try:
                     count_result = session.execute(query).fetchone()
                     count = count_result[0] if count_result else 0
-                    
+
                     if count > 0:
                         total_orphaned += count
                         orphaned_tables.append(f"{table}.{constrained_col} -> {referred_table}.{referred_col}: {count} records")
                 except Exception as e:
                     # Table might not exist or column might be wrong
                     check_errors.append(f"{table}.{constrained_col}: {str(e)[:100]}")
-        
+
         if total_orphaned == 0:
             result.add_pass("No orphaned records found")
         else:
@@ -169,20 +213,20 @@ def check_orphaned_records(engine, result):
                 result.add_warning(f"  {item}")
             if len(orphaned_tables) > 10:
                 result.add_warning(f"  ... and {len(orphaned_tables) - 10} more")
-        
+
         # Report check errors (non-critical)
         for error in check_errors[:5]:
             result.add_warning(f"Check error: {error}")
         if len(check_errors) > 5:
             result.add_warning(f"  ... and {len(check_errors) - 5} more check errors")
-                
+
     finally:
         session.close()
 
 def check_fk_policies(engine, result):
     """Check that FK policies are defined in models"""
     print("\n3. Checking FK Policies...")
-    
+
     # Import models to check FK definitions
     try:
         from app.models import (
@@ -191,56 +235,58 @@ def check_fk_policies(engine, result):
             clinic, visit, service, schedule, dermatology_photos,
             doctor_price_override, two_factor_auth, telegram_config
         )
-        
+
         # Count FKs with ondelete policies
         # This is a simplified check - full validation would require inspecting all models
         result.add_pass("FK policies are defined in SQLAlchemy models")
         result.add_warning("Full FK policy validation requires model inspection (manual review recommended)")
-        
+
     except Exception as e:
         result.add_warning(f"Could not import models for FK policy check: {e}")
 
 def check_schema_integrity(engine, result):
     """Check database schema integrity"""
+    from sqlalchemy import inspect
+
     print("\n4. Checking Schema Integrity...")
-    
+
     inspector = inspect(engine)
-    
+
     try:
         tables = inspector.get_table_names()
         if len(tables) == 0:
             result.add_fail("Database has no tables")
             return
-        
+
         result.add_pass(f"Database has {len(tables)} tables")
-        
+
         # Check for critical tables
         critical_tables = ['users', 'patients', 'visits', 'appointments', 'payments']
         missing_tables = [t for t in critical_tables if t not in tables]
-        
+
         if missing_tables:
             result.add_fail(f"Missing critical tables: {', '.join(missing_tables)}")
         else:
             result.add_pass("All critical tables exist")
-        
+
         # Check FK constraints
         total_fks = 0
         for table in tables:
             fks = inspector.get_foreign_keys(table)
             total_fks += len(fks)
-        
+
         if total_fks == 0:
             result.add_warning("No foreign key constraints found")
         else:
             result.add_pass(f"Found {total_fks} foreign key constraints")
-            
+
     except Exception as e:
         result.add_fail(f"Error checking schema integrity: {e}")
 
 def check_migration_status(result):
     """Check Alembic migration status"""
     print("\n5. Checking Migration Status...")
-    
+
     try:
         import subprocess
         result_alembic = subprocess.run(
@@ -249,7 +295,7 @@ def check_migration_status(result):
             text=True,
             cwd=os.path.dirname(__file__)
         )
-        
+
         if result_alembic.returncode == 0:
             output = result_alembic.stdout.strip()
             if 'head' in output.lower() or output:
@@ -258,42 +304,54 @@ def check_migration_status(result):
                 result.add_warning("Migration status unclear")
         else:
             result.add_warning(f"Could not check migration status: {result_alembic.stderr}")
-            
+
     except Exception as e:
         result.add_warning(f"Could not check migration status: {e}")
 
 def check_environment_config(result):
     """Check environment configuration"""
     print("\n6. Checking Environment Configuration...")
-    
+
     try:
         settings = get_settings()
-        
+
         # Check SECRET_KEY
         if len(settings.SECRET_KEY) >= 32:
             result.add_pass("SECRET_KEY is configured (length >= 32)")
         else:
             result.add_fail(f"SECRET_KEY is too short (length: {len(settings.SECRET_KEY)})")
-        
+
         # Check DATABASE_URL
         if settings.DATABASE_URL:
             result.add_pass("DATABASE_URL is configured")
         else:
             result.add_fail("DATABASE_URL is not configured")
-            
+
         # Check if production mode
         if hasattr(settings, 'ENV') and settings.ENV == 'production':
             result.add_warning("Running in production mode - ensure all settings are correct")
         else:
             result.add_warning("Not in production mode - verify settings before deployment")
-            
+
     except Exception as e:
         result.add_fail(f"Error checking environment configuration: {e}")
 
 def main():
+    from sqlalchemy import create_engine
+
+    global DATABASE_URL
+
+    DATABASE_URL = normalize_sync_db_url(get_db_url())
+    enforce_database_url_policy(DATABASE_URL)
+
+    print("=" * 80)
+    print("PRODUCTION READINESS VALIDATION")
+    print("=" * 80)
+    print(f"Database URL: {display_db_url(DATABASE_URL)}\n")
+
     engine = create_engine(DATABASE_URL, future=True)
     result = ValidationResult()
-    
+
     # Run all checks
     check_fk_enforcement(engine, result)
     check_orphaned_records(engine, result)
@@ -301,10 +359,10 @@ def main():
     check_schema_integrity(engine, result)
     check_migration_status(result)
     check_environment_config(result)
-    
+
     # Print summary
     is_ready = result.print_summary()
-    
+
     sys.exit(0 if is_ready else 1)
 
 if __name__ == "__main__":

--- a/backend/verify_fk_enforcement.py
+++ b/backend/verify_fk_enforcement.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-CRITICAL: Foreign Key Enforcement Verification Script
+"""Verify SQLite foreign-key enforcement for local diagnostic databases.
 
-This script verifies that foreign key constraints are properly enforced
-in the SQLite database. This is MANDATORY for medical clinic systems.
+Runtime PostgreSQL integrity is governed by the database engine, SQLAlchemy
+models, and Alembic migrations. This helper intentionally avoids pretending that
+SQLite PRAGMA checks validate non-SQLite databases.
 
 Exit codes:
-  0 = FK enforcement is working (foreign_keys = 1)
-  1 = FK enforcement is DISABLED (foreign_keys = 0) - CRITICAL ERROR
-  2 = Database connection error
-  3 = FK test violation did not fail (FK not working)
+  0 = SQLite FK enforcement works, or the configured database is non-SQLite
+  1 = SQLite FK enforcement is disabled
+  2 = configuration, connection, or verification error
+  3 = SQLite FK violation test did not fail
 """
 from __future__ import annotations
 
@@ -18,178 +17,177 @@ import os
 import sys
 from pathlib import Path
 
-# Add backend to path
 backend_dir = Path(__file__).parent
 sys.path.insert(0, str(backend_dir))
 
 try:
-    from sqlalchemy import create_engine, text
+    from sqlalchemy import create_engine, event, text
+    from sqlalchemy.engine import make_url
     from sqlalchemy.exc import IntegrityError
-except ImportError as e:
-    print(f"❌ ERROR: Failed to import SQLAlchemy: {e}", file=sys.stderr)
+except ImportError as exc:
+    print(f"ERROR: Failed to import SQLAlchemy: {exc}", file=sys.stderr)
     sys.exit(2)
 
 
 def get_database_url() -> str:
-    """Get database URL from environment or settings"""
-    # Try environment variable
+    """Read DATABASE_URL from env/settings and refuse implicit fallbacks."""
     url = os.getenv("DATABASE_URL")
-    if url:
-        return url
-    
-    # Try settings
+    if url and url.strip():
+        return url.strip()
+
+    settings_error = None
     try:
         from app.core.config import settings
-        url = getattr(settings, "DATABASE_URL", None)
-        if url:
-            return str(url)
-    except Exception:
-        pass
-    
-    # Fallback
-    return "sqlite:///./clinic.db"
+
+        settings_url = getattr(settings, "DATABASE_URL", None)
+        if settings_url:
+            return str(settings_url).strip()
+    except Exception as exc:
+        settings_error = exc
+
+    raise RuntimeError(
+        "DATABASE_URL is required; refusing to verify a fallback database"
+    ) from settings_error
 
 
-def verify_fk_enforcement() -> int:
-    """
-    Verify foreign key enforcement is working.
-    Returns exit code: 0 = success, 1 = FK disabled, 2 = connection error, 3 = FK not working
-    """
-    url = get_database_url()
-    
-    # Normalize SQLite URL
+def normalize_sync_database_url(url: str) -> str:
+    """Convert async SQLite URLs to sync URLs for this diagnostic helper."""
     if url.startswith("sqlite+aiosqlite://"):
-        url = url.replace("sqlite+aiosqlite://", "sqlite://", 1)
-    
+        return url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+    return url
+
+
+def is_sqlite_database_url(url: str) -> bool:
+    return make_url(url).drivername.startswith("sqlite")
+
+
+def display_database_url(url: str) -> str:
+    return make_url(url).render_as_string(hide_password=True)
+
+
+def require_sqlite_fk_write_test_confirmation() -> None:
+    if os.getenv("CONFIRM_VERIFY_SQLITE_FK_WRITE_TEST") != "1":
+        raise RuntimeError(
+            "Refusing to run SQLite FK write test. "
+            "It intentionally inserts a violating row to verify enforcement. "
+            "Set CONFIRM_VERIFY_SQLITE_FK_WRITE_TEST=1 only for an explicit local diagnostic run."
+        )
+
+
+def _print_header(url: str) -> None:
     print("=" * 80)
     print("FOREIGN KEY ENFORCEMENT VERIFICATION")
     print("=" * 80)
-    print(f"Database URL: {url}")
+    print(f"Database URL: {display_database_url(url)}")
     print()
-    
-    if not url.startswith("sqlite"):
-        print("⚠️  WARNING: This script is designed for SQLite.")
-        print("   Foreign key enforcement verification for other databases may differ.")
-        print()
-    
+
+
+def _enable_sqlite_fk(dbapi_conn, connection_record) -> None:
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+def verify_fk_enforcement() -> int:
+    """Return an exit code describing the FK verification result."""
     try:
-        # Create engine with FK enforcement
+        url = normalize_sync_database_url(get_database_url())
+    except Exception as exc:
+        print("=" * 80)
+        print("DATABASE CONFIGURATION ERROR")
+        print("=" * 80)
+        print(f"Error: {exc}")
+        print()
+        return 2
+
+    _print_header(url)
+
+    if not is_sqlite_database_url(url):
+        print("This helper is SQLite-specific.")
+        print("Foreign key enforcement is managed by the configured database engine.")
+        print("Use Alembic and production readiness checks for cross-database validation.")
+        print()
+        return 0
+
+    try:
+        require_sqlite_fk_write_test_confirmation()
+    except Exception as exc:
+        print(f"Error: {exc}")
+        print()
+        return 2
+
+    try:
         engine = create_engine(url, future=True, pool_pre_ping=True)
-        
-        # Add event listener for FK enforcement (same as session.py)
-        if url.startswith("sqlite"):
-            from sqlalchemy import event
-            def _enable_fk(dbapi_conn, connection_record):
-                cursor = dbapi_conn.cursor()
-                cursor.execute("PRAGMA foreign_keys=ON")
-                cursor.close()
-            event.listen(engine, "connect", _enable_fk)
-        
+        event.listen(engine, "connect", _enable_sqlite_fk)
+
         with engine.connect() as conn:
-            # Step 1: Check PRAGMA foreign_keys status
             print("Step 1: Checking PRAGMA foreign_keys status...")
-            if url.startswith("sqlite"):
-                # Ensure FK is enabled
-                conn.execute(text("PRAGMA foreign_keys=ON"))
-                result = conn.execute(text("PRAGMA foreign_keys")).scalar()
-                
-                print(f"   PRAGMA foreign_keys = {result}")
-                
-                if result != 1:
-                    print()
-                    print("=" * 80)
-                    print("❌ CRITICAL ERROR: Foreign key enforcement is DISABLED!")
-                    print("=" * 80)
-                    print(f"   PRAGMA foreign_keys returned {result} instead of 1")
-                    print("   This means foreign key constraints are NOT being enforced.")
-                    print("   This is a CRITICAL security risk for medical data integrity.")
-                    print()
-                    print("   Impact:")
-                    print("   - Orphaned records can exist in the database")
-                    print("   - Data integrity violations are not prevented")
-                    print("   - Medical records can be corrupted")
-                    print("   - Legal compliance violation")
-                    print()
-                    return 1
-                
-                print("   ✅ Foreign key enforcement is ENABLED")
-            else:
-                print("   ⚠️  Skipping PRAGMA check (not SQLite)")
-            
+            conn.execute(text("PRAGMA foreign_keys=ON"))
+            result = conn.execute(text("PRAGMA foreign_keys")).scalar()
+            print(f"   PRAGMA foreign_keys = {result}")
+
+            if result != 1:
+                print()
+                print("=" * 80)
+                print("CRITICAL ERROR: Foreign key enforcement is DISABLED!")
+                print("=" * 80)
+                print(f"   PRAGMA foreign_keys returned {result} instead of 1")
+                print("   This means foreign key constraints are NOT being enforced.")
+                print("   Medical data integrity verification failed.")
+                print()
+                return 1
+
+            print("   Foreign key enforcement is ENABLED")
             print()
-            
-            # Step 2: Test FK enforcement with actual violation attempt
+
             print("Step 2: Testing FK enforcement with violation attempt...")
             try:
-                # Try to insert a record that violates FK constraint
-                # This should FAIL if FK enforcement is working
-                test_query = text("""
-                    -- Try to insert into visits with non-existent patient_id
-                    -- This should fail if FK enforcement is working
-                    INSERT INTO visits (patient_id, status, created_at)
-                    VALUES (999999999, 'test', datetime('now'))
-                """)
-                
-                conn.execute(test_query)
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO visits (patient_id, status, created_at)
+                        VALUES (999999999, 'test', datetime('now'))
+                        """
+                    )
+                )
                 conn.commit()
-                
-                # If we get here, FK enforcement is NOT working
-                print("   ❌ CRITICAL: FK violation test did NOT fail!")
-                print("   Foreign key constraints are NOT being enforced.")
-                print("   The test insert should have failed but succeeded.")
-                print()
-                
-                # Clean up test record if it was inserted
+            except IntegrityError:
+                print("   FK violation correctly rejected.")
+                conn.rollback()
+            except Exception as exc:
+                error_msg = str(exc).lower()
+                conn.rollback()
+                if "foreign key" in error_msg or "constraint" in error_msg:
+                    print(f"   FK violation correctly rejected: {type(exc).__name__}")
+                else:
+                    print(f"   Verification could not complete: {exc}")
+                    return 2
+            else:
+                print("   CRITICAL: FK violation test did NOT fail.")
                 try:
                     conn.execute(text("DELETE FROM visits WHERE patient_id = 999999999"))
                     conn.commit()
                 except Exception:
-                    pass
-                
+                    conn.rollback()
                 return 3
-                
-            except IntegrityError as e:
-                # This is EXPECTED - FK enforcement is working!
-                print("   ✅ FK enforcement is working correctly!")
-                print(f"   Foreign key violation correctly rejected: {type(e).__name__}")
-                conn.rollback()
-            except Exception as e:
-                # Some other error - might be FK working, but check
-                error_msg = str(e).lower()
-                if "foreign key" in error_msg or "constraint" in error_msg:
-                    print("   ✅ FK enforcement is working correctly!")
-                    print(f"   Foreign key violation correctly rejected: {type(e).__name__}")
-                    conn.rollback()
-                else:
-                    print(f"   ⚠️  Unexpected error during FK test: {e}")
-                    print("   This might indicate FK is working, but verification is incomplete.")
-                    conn.rollback()
-            
+
             print()
             print("=" * 80)
-            print("✅ VERIFICATION PASSED")
+            print("VERIFICATION PASSED")
             print("=" * 80)
-            print("Foreign key enforcement is working correctly.")
-            print("The database will prevent orphaned records and data integrity violations.")
+            print("SQLite foreign key enforcement is working correctly.")
             print()
             return 0
-            
-    except Exception as e:
+
+    except Exception as exc:
         print()
         print("=" * 80)
-        print("❌ DATABASE CONNECTION ERROR")
+        print("DATABASE CONNECTION ERROR")
         print("=" * 80)
-        print(f"Error: {e}")
-        print()
-        print("Please check:")
-        print("  1. Database file exists")
-        print("  2. DATABASE_URL is correct")
-        print("  3. Database file is not locked")
+        print(f"Error: {exc}")
         print()
         return 2
 
 
 if __name__ == "__main__":
-    exit_code = verify_fk_enforcement()
-    sys.exit(exit_code)
-
+    sys.exit(verify_fk_enforcement())


### PR DESCRIPTION
## Summary

Hardens legacy root database and validation helper scripts so they no longer silently depend on SQLite-first behavior, hardcoded credentials, or unsafe mutating runs.

## Scope

- Add explicit confirmation or refusal guards to mutating/local-diagnostic scripts.
- Retire stale root wrappers that shell out to legacy checks or open DB sessions at import time.
- Replace hardcoded JWT/API smoke usage with env-driven inputs.
- Enforce PostgreSQL-first database policy for FK/readiness validators, while allowing explicit legacy SQLite opt-in for targeted diagnostics.
- Require explicit confirmation before running the SQLite FK write test.

## Contract Impact

- Canonical surface: Not applicable; this PR changes standalone backend helper scripts only.
- Request shape: Not applicable; no HTTP or WS request contract changes.
- Response shape: Not applicable; no HTTP or WS response contract changes.
- Status codes: Not applicable; no route handler behavior changed.
- Frontend consumer: Not applicable; no frontend consumer depends on these script outputs as a typed contract.
- Compatibility path or alias: Not applicable; no endpoint alias or compatibility route changed.
- Contract proof: Script-only diff plus targeted compile/refusal-smoke validation; no API contract surface in scope.

## RBAC / Permissions

- Roles allowed: Not applicable; these are operator/developer-run scripts outside app RBAC.
- Roles denied: Not applicable; no runtime role matrix changed.
- Positive auth proof: Not applicable; no auth-protected API/UI surface changed.
- Negative auth proof: Not applicable; no auth-protected API/UI surface changed.

## Notification / Realtime

- Event type or websocket channel: Not applicable; no notification or websocket flow changed.
- Payload version / ack behavior: Not applicable; no realtime payload behavior changed.
- Read/unread or delivery semantics: Not applicable; no inbox or delivery path changed.
- Reconnect/resync proof: Not applicable; no realtime client behavior changed.

## Frontend Resilience

- Empty data proof: Not applicable; no frontend state is in scope.
- Partial data proof: Not applicable; no frontend state is in scope.
- Forbidden secondary path behavior: Not applicable; no frontend fetch path changed.
- Missing draft/resource behavior: Not applicable; no frontend draft/resource loading path changed.
- Stale route/deep-link behavior: Not applicable; no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/check_db.py`, `backend/check_services.py`, `backend/get_services.py`, `backend/init_database.py`, `backend/init_departments.py`, `backend/quick_check.py`, `backend/validate_fk_policies.py`, `backend/validate_production_readiness.py`, `backend/verify_fk_enforcement.py`
- Denied paths: `backend/app/api/v1/endpoints/**`, `backend/app/services/**`, `backend/tests/**`, `frontend/**`, `.github/**`, `ops/**`, generated/evidence artifacts, deletion/rename wave
- Migration/docs/test impact: No migrations or docs changed. No new tests added. Validation uses compile checks and targeted refusal-smokes on the touched scripts.
- Rollback note: Revert this commit to restore the previous root helper behavior if a downstream workflow still depends on the legacy SQLite-first or hardcoded local script assumptions.

## Risk

Medium-low. This changes only standalone backend helper scripts, but several files are fully normalized away from unsafe legacy behavior. Runtime API code is not touched.

## Validation

- Targeted tests or smoke run: `git diff --check` on the 9 files; `python -m py_compile` on the 9 files; refusal smokes for `check_db.py`, `get_services.py`, `init_database.py`, `init_departments.py`, `quick_check.py`, `verify_fk_enforcement.py`, `validate_fk_policies.py`, `validate_production_readiness.py`
- Result: Passed. `py_compile` passed. Refusal smokes returned the expected non-zero refusal/retired exit codes. `git diff --check` passed with only non-blocking Windows LF->CRLF working-copy warnings.
- Not checked: No live PostgreSQL bootstrap run, no end-to-end service fetch with a real token, and no full backend suite were run for this script-only hardening slice.
