### PR TITLE
QA: harden local backend operator scripts

### DIFF
--- a/backend/kill_port_18000.ps1
+++ b/backend/kill_port_18000.ps1
@@ -1,29 +1,47 @@
-# Скрипт для остановки всех процессов на порту 18000
-Write-Host "[*] Поиск процессов на порту 18000..." -ForegroundColor Cyan
+param(
+    [switch]$ForcePortOwner
+)
 
-$connections = Get-NetTCPConnection -LocalPort 18000 -ErrorAction SilentlyContinue
+$port = 18000
+$allowKill = $ForcePortOwner -or ($env:CONFIRM_KILL_PORT_18000_OWNER -eq "1")
 
-if ($connections) {
-    $pids = $connections | Select-Object -ExpandProperty OwningProcess -Unique
+Write-Host "[*] Searching for listeners on port $port..." -ForegroundColor Cyan
 
-    foreach ($processId in $pids) {
-        try {
-            $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
-            if ($process) {
-                Write-Host "[!] Остановка процесса: $($process.ProcessName) (PID: $processId)" -ForegroundColor Yellow
-                Stop-Process -Id $processId -Force
-                Write-Host "[OK] Процесс PID $processId остановлен" -ForegroundColor Green
-            }
-        }
-        catch {
-            Write-Host "[ERROR] Не удалось остановить процесс PID $processId" -ForegroundColor Red
-        }
+$connections = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
+
+if (-not $connections) {
+    Write-Host "[OK] Port $port is free." -ForegroundColor Green
+    exit 0
+}
+
+$pids = $connections | Select-Object -ExpandProperty OwningProcess -Unique
+
+foreach ($processId in $pids) {
+    $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
+    if (-not $process) {
+        continue
     }
 
-    Start-Sleep -Seconds 1
-    Write-Host ""
-    Write-Host "[OK] Порт 18000 освобожден!" -ForegroundColor Green
+    Write-Host "[WARN] Port owner: $($process.ProcessName) (PID: $processId)" -ForegroundColor Yellow
+    if (-not $allowKill) {
+        Write-Host "Refusing to stop PID $processId without -ForcePortOwner or CONFIRM_KILL_PORT_18000_OWNER=1" -ForegroundColor Red
+        continue
+    }
+
+    try {
+        Stop-Process -Id $processId -Force
+        Write-Host "[OK] Stopped PID $processId." -ForegroundColor Green
+    }
+    catch {
+        Write-Host "[ERROR] Failed to stop PID $processId." -ForegroundColor Red
+    }
 }
-else {
-    Write-Host "[OK] Порт 18000 свободен" -ForegroundColor Green
+
+Start-Sleep -Seconds 1
+$remaining = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
+if ($remaining) {
+    Write-Host "[WARN] Port $port is still busy." -ForegroundColor Yellow
+    exit 1
 }
+
+Write-Host "[OK] Port $port is free." -ForegroundColor Green

--- a/backend/reset_database.ps1
+++ b/backend/reset_database.ps1
@@ -1,74 +1,17 @@
-# Database Reset Script for FK Policy Hardening
-# This script drops all tables and recreates them with correct FK constraints
-# WARNING: ALL DATA WILL BE DELETED
+# Deprecated database reset helper.
+# PostgreSQL + Alembic are the database source of truth for this project.
 
 Write-Host "========================================" -ForegroundColor Yellow
-Write-Host "DATABASE RESET SCRIPT" -ForegroundColor Yellow
+Write-Host "DEPRECATED DATABASE RESET SCRIPT" -ForegroundColor Yellow
 Write-Host "========================================" -ForegroundColor Yellow
 Write-Host ""
-Write-Host "WARNING: This will DELETE ALL DATA in the database!" -ForegroundColor Red
+Write-Host "This legacy helper no longer deletes local SQLite files." -ForegroundColor Red
+Write-Host "Runtime databases must be managed through PostgreSQL procedures and Alembic migrations." -ForegroundColor Yellow
 Write-Host ""
-
-$confirm = Read-Host "Type 'RESET' to confirm database reset"
-if ($confirm -ne "RESET") {
-    Write-Host "Reset cancelled." -ForegroundColor Green
-    exit 0
-}
-
+Write-Host "For schema updates, run:" -ForegroundColor Cyan
+Write-Host "  alembic upgrade head"
 Write-Host ""
-Write-Host "Step 1: Creating backup..." -ForegroundColor Cyan
-$timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
-$backupPath = "clinic.db.backup_pre_reset_$timestamp"
-if (Test-Path "clinic.db") {
-    Copy-Item "clinic.db" $backupPath -ErrorAction SilentlyContinue
-    Write-Host "Backup created: $backupPath" -ForegroundColor Green
-} else {
-    Write-Host "No existing database found, skipping backup." -ForegroundColor Yellow
-}
-
+Write-Host "For destructive PostgreSQL reset or data recovery, use an explicit runbook/backup procedure." -ForegroundColor Cyan
+Write-Host "Do not use SQLite file deletion as a runtime reset path." -ForegroundColor Cyan
 Write-Host ""
-Write-Host "Step 2: Deleting database files..." -ForegroundColor Cyan
-Remove-Item "clinic.db" -ErrorAction SilentlyContinue
-Remove-Item "clinic.db-journal" -ErrorAction SilentlyContinue
-Remove-Item "clinic.db-wal" -ErrorAction SilentlyContinue
-Remove-Item "clinic.db-shm" -ErrorAction SilentlyContinue
-Write-Host "Database files deleted." -ForegroundColor Green
-
-Write-Host ""
-Write-Host "Step 3: Running Alembic migrations..." -ForegroundColor Cyan
-alembic upgrade head
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "ERROR: Migration failed!" -ForegroundColor Red
-    exit 1
-}
-Write-Host "Migrations applied successfully." -ForegroundColor Green
-
-Write-Host ""
-Write-Host "Step 4: Verifying FK enforcement..." -ForegroundColor Cyan
-python verify_fk_enforcement.py
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "ERROR: FK enforcement verification failed!" -ForegroundColor Red
-    exit 1
-}
-Write-Host "FK enforcement verified." -ForegroundColor Green
-
-Write-Host ""
-Write-Host "Step 5: Checking for orphaned records..." -ForegroundColor Cyan
-python app/scripts/audit_foreign_keys.py
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "WARNING: Audit script returned errors (may be expected for empty DB)" -ForegroundColor Yellow
-}
-
-Write-Host ""
-Write-Host "========================================" -ForegroundColor Green
-Write-Host "DATABASE RESET COMPLETE" -ForegroundColor Green
-Write-Host "========================================" -ForegroundColor Green
-Write-Host ""
-Write-Host "Database is now clean with correct FK constraints:" -ForegroundColor Green
-Write-Host "  - All FKs have explicit ondelete policies" -ForegroundColor Green
-Write-Host "  - FK enforcement is enabled (PRAGMA foreign_keys = 1)" -ForegroundColor Green
-Write-Host "  - No orphaned records possible by design" -ForegroundColor Green
-Write-Host ""
-Write-Host "Backup location: $backupPath" -ForegroundColor Cyan
-Write-Host ""
-
+exit 2

--- a/backend/reset_database_auto.ps1
+++ b/backend/reset_database_auto.ps1
@@ -1,104 +1,17 @@
-# Database Reset Script for FK Policy Hardening (AUTO MODE)
-# This script drops all tables and recreates them with correct FK constraints
-# WARNING: ALL DATA WILL BE DELETED
-# AUTO MODE: No confirmation required
+# Deprecated automatic database reset helper.
+# PostgreSQL + Alembic are the database source of truth for this project.
 
 Write-Host "========================================" -ForegroundColor Yellow
-Write-Host "DATABASE RESET SCRIPT (AUTO MODE)" -ForegroundColor Yellow
+Write-Host "DEPRECATED AUTO DATABASE RESET SCRIPT" -ForegroundColor Yellow
 Write-Host "========================================" -ForegroundColor Yellow
 Write-Host ""
-Write-Host "WARNING: This will DELETE ALL DATA in the database!" -ForegroundColor Red
-Write-Host "AUTO MODE: Proceeding without confirmation..." -ForegroundColor Yellow
+Write-Host "Automatic SQLite file deletion is disabled." -ForegroundColor Red
+Write-Host "CONFIRM_LEGACY_SQLITE_RESET is intentionally ignored by this script." -ForegroundColor Yellow
 Write-Host ""
-
-Write-Host "Step 1: Creating backup..." -ForegroundColor Cyan
-$timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
-$backupPath = "clinic.db.backup_pre_reset_$timestamp"
-if (Test-Path "clinic.db") {
-    try {
-        Copy-Item "clinic.db" $backupPath -ErrorAction Stop
-        Write-Host "Backup created: $backupPath" -ForegroundColor Green
-    } catch {
-        Write-Host "WARNING: Failed to create backup: $_" -ForegroundColor Yellow
-        Write-Host "Continuing anyway..." -ForegroundColor Yellow
-    }
-} else {
-    Write-Host "No existing database found, skipping backup." -ForegroundColor Yellow
-}
-
+Write-Host "For schema updates, run:" -ForegroundColor Cyan
+Write-Host "  alembic upgrade head"
 Write-Host ""
-Write-Host "Step 2: Deleting database files..." -ForegroundColor Cyan
-$deleted = $false
-if (Test-Path "clinic.db") {
-    Remove-Item "clinic.db" -ErrorAction SilentlyContinue
-    $deleted = $true
-}
-Remove-Item "clinic.db-journal" -ErrorAction SilentlyContinue
-Remove-Item "clinic.db-wal" -ErrorAction SilentlyContinue
-Remove-Item "clinic.db-shm" -ErrorAction SilentlyContinue
-if ($deleted) {
-    Write-Host "Database files deleted." -ForegroundColor Green
-} else {
-    Write-Host "No database files to delete." -ForegroundColor Yellow
-}
-
+Write-Host "For destructive PostgreSQL reset or data recovery, use an explicit runbook/backup procedure." -ForegroundColor Cyan
+Write-Host "Do not use SQLite file deletion as a runtime reset path." -ForegroundColor Cyan
 Write-Host ""
-Write-Host "Step 3: Running Alembic migrations..." -ForegroundColor Cyan
-try {
-    alembic upgrade head
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "ERROR: Migration failed with exit code $LASTEXITCODE" -ForegroundColor Red
-        exit 1
-    }
-    Write-Host "Migrations applied successfully." -ForegroundColor Green
-} catch {
-    Write-Host "ERROR: Migration failed with exception: $_" -ForegroundColor Red
-    exit 1
-}
-
-Write-Host ""
-Write-Host "Step 4: Verifying FK enforcement..." -ForegroundColor Cyan
-try {
-    python verify_fk_enforcement.py
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "ERROR: FK enforcement verification failed with exit code $LASTEXITCODE" -ForegroundColor Red
-        exit 1
-    }
-    Write-Host "FK enforcement verified." -ForegroundColor Green
-} catch {
-    Write-Host "ERROR: FK enforcement verification failed with exception: $_" -ForegroundColor Red
-    exit 1
-}
-
-Write-Host ""
-Write-Host "Step 5: Checking for orphaned records..." -ForegroundColor Cyan
-try {
-    if (Test-Path "app/scripts/audit_foreign_keys.py") {
-        python app/scripts/audit_foreign_keys.py
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "WARNING: Audit script returned errors (may be expected for empty DB)" -ForegroundColor Yellow
-        } else {
-            Write-Host "Audit completed successfully." -ForegroundColor Green
-        }
-    } else {
-        Write-Host "WARNING: audit_foreign_keys.py not found, skipping audit." -ForegroundColor Yellow
-    }
-} catch {
-    Write-Host "WARNING: Audit script failed: $_" -ForegroundColor Yellow
-}
-
-Write-Host ""
-Write-Host "========================================" -ForegroundColor Green
-Write-Host "DATABASE RESET COMPLETE" -ForegroundColor Green
-Write-Host "========================================" -ForegroundColor Green
-Write-Host ""
-Write-Host "Database is now clean with correct FK constraints:" -ForegroundColor Green
-Write-Host "  - All FKs have explicit ondelete policies" -ForegroundColor Green
-Write-Host "  - FK enforcement is enabled (PRAGMA foreign_keys = 1)" -ForegroundColor Green
-Write-Host "  - No orphaned records possible by design" -ForegroundColor Green
-Write-Host ""
-if (Test-Path $backupPath) {
-    Write-Host "Backup location: $backupPath" -ForegroundColor Cyan
-}
-Write-Host ""
-
+exit 2

--- a/backend/restart_backend.ps1
+++ b/backend/restart_backend.ps1
@@ -1,26 +1,44 @@
-# Restart backend server
-Write-Host "🔄 Restarting backend server..." -ForegroundColor Yellow
+param(
+    [switch]$ForceUvicornProcesses
+)
 
-# Kill existing python processes running uvicorn
-Write-Host "🛑 Stopping existing backend processes..." -ForegroundColor Yellow
-Get-Process | Where-Object {$_.ProcessName -eq "python" -and $_.CommandLine -like "*uvicorn*"} | Stop-Process -Force -ErrorAction SilentlyContinue
+$backendRoot = "C:\final\backend"
+$allowUnownedStop = $ForceUvicornProcesses -or ($env:CONFIRM_RESTART_BACKEND_STOP_UNOWNED_UVICORN -eq "1")
 
-# Wait a moment
+Write-Host "Restarting backend server..." -ForegroundColor Yellow
+Write-Host "Stopping existing project backend processes..." -ForegroundColor Yellow
+
+$uvicornProcesses = Get-CimInstance Win32_Process -Filter "Name = 'python.exe'" -ErrorAction SilentlyContinue | Where-Object {
+    $_.CommandLine -like "*uvicorn*"
+}
+
+foreach ($proc in $uvicornProcesses) {
+    $commandLine = [string]$proc.CommandLine
+    $executablePath = [string]$proc.ExecutablePath
+    $ownedByProject = $commandLine -like "*$backendRoot*" -or $executablePath -like "C:\final*"
+
+    if (-not $ownedByProject -and -not $allowUnownedStop) {
+        Write-Host "Refusing to stop unowned uvicorn process PID $($proc.ProcessId). Use -ForceUvicornProcesses or CONFIRM_RESTART_BACKEND_STOP_UNOWNED_UVICORN=1." -ForegroundColor Red
+        continue
+    }
+
+    Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue
+    Write-Host "Stopped uvicorn process PID $($proc.ProcessId)." -ForegroundColor Green
+}
+
 Start-Sleep -Seconds 2
 
-# Start new backend process
-Write-Host "🚀 Starting backend server..." -ForegroundColor Green
-Set-Location "c:\final\backend"
+Write-Host "Starting backend server..." -ForegroundColor Green
+Set-Location $backendRoot
 
-# Start uvicorn in a new window
-Start-Process powershell -ArgumentList "-NoExit", "-Command", "cd c:\final\backend; uvicorn app.main:app --reload --host 0.0.0.0 --port 18000"
+Start-Process powershell -ArgumentList "-NoExit", "-Command", "cd C:\final\backend; uvicorn app.main:app --reload --host 0.0.0.0 --port 18000"
 
-Write-Host "✅ Backend server started in new window!" -ForegroundColor Green
-Write-Host "⏳ Waiting 5 seconds for server to initialize..." -ForegroundColor Yellow
+Write-Host "Backend server started in a new PowerShell window." -ForegroundColor Green
+Write-Host "Waiting 5 seconds for server to initialize..." -ForegroundColor Yellow
 Start-Sleep -Seconds 5
 
-# Verify
-Write-Host "🔍 Verifying backend..." -ForegroundColor Yellow
+Write-Host "Verifying backend..." -ForegroundColor Yellow
 python verify_fix.py
 
-Write-Host "`n✅ Done! Check the new PowerShell window for backend logs." -ForegroundColor Green
+Write-Host ""
+Write-Host "Done. Check the new PowerShell window for backend logs." -ForegroundColor Green

--- a/backend/smart_restart.ps1
+++ b/backend/smart_restart.ps1
@@ -1,16 +1,22 @@
-# Умный скрипт перезапуска с проверкой порта
-Write-Host "=" * 80 -ForegroundColor Cyan
-Write-Host "🏥 CLINIC MANAGEMENT SYSTEM - УМНЫЙ ПЕРЕЗАПУСК" -ForegroundColor Cyan
-Write-Host "=" * 80 -ForegroundColor Cyan
+param(
+    [switch]$ForcePortOwners
+)
+
+Write-Host ("=" * 80) -ForegroundColor Cyan
+Write-Host "CLINIC MANAGEMENT SYSTEM - SMART BACKEND RESTART" -ForegroundColor Cyan
+Write-Host ("=" * 80) -ForegroundColor Cyan
 Write-Host ""
 
-# Шаг 1: Остановка процессов
-Write-Host "Шаг 1: Остановка процессов Python..." -ForegroundColor Yellow
-& "$PSScriptRoot\stop_all_python.ps1"
+Write-Host "Step 1: stopping project Python processes..." -ForegroundColor Yellow
+if ($ForcePortOwners) {
+    & "$PSScriptRoot\stop_all_python.ps1" -ForcePortOwners
+}
+else {
+    & "$PSScriptRoot\stop_all_python.ps1"
+}
 
-# Шаг 2: Проверка порта
 Write-Host ""
-Write-Host "Шаг 2: Проверка доступности порта 18000..." -ForegroundColor Yellow
+Write-Host "Step 2: checking port 18000..." -ForegroundColor Yellow
 
 $maxAttempts = 5
 $attempt = 0
@@ -19,55 +25,51 @@ $portFree = $false
 while ($attempt -lt $maxAttempts -and -not $portFree) {
     $attempt++
     $check = netstat -ano | Select-String ":18000.*LISTENING"
-    
+
     if (-not $check) {
         $portFree = $true
-        Write-Host "✅ Порт 18000 свободен!" -ForegroundColor Green
+        Write-Host "[OK] Port 18000 is free." -ForegroundColor Green
     }
     else {
-        Write-Host "⏳ Попытка $attempt/$maxAttempts - порт все еще занят, ожидание..." -ForegroundColor Yellow
-        
-        # Пытаемся убить процесс еще раз
-        $check | ForEach-Object {
-            $line = $_.Line
-            $processId = ($line -split '\s+')[-1]
-            Write-Host "   Останавливаем процесс PID: $processId"
-            taskkill /PID $processId /F 2>$null
+        Write-Host "Attempt $attempt/${maxAttempts}: port 18000 is still busy." -ForegroundColor Yellow
+
+        if (-not $ForcePortOwners -and $env:CONFIRM_STOP_ALL_PYTHON_PORT_OWNERS -ne "1") {
+            Write-Host "Refusing unmanaged port-owner kill without -ForcePortOwners or CONFIRM_STOP_ALL_PYTHON_PORT_OWNERS=1." -ForegroundColor Red
         }
-        
+        else {
+            $check | ForEach-Object {
+                $line = $_.Line
+                $processId = ($line -split '\s+')[-1]
+                Write-Host "Killing unmanaged port owner PID: $processId"
+                taskkill /PID $processId /F 2>$null
+            }
+        }
+
         Start-Sleep -Seconds 2
     }
 }
 
-# Шаг 3: Выбор порта и запуск
 Write-Host ""
 if ($portFree) {
-    Write-Host "Шаг 3: Запуск сервера на порту 18000..." -ForegroundColor Yellow
+    Write-Host "Step 3: starting backend on port 18000..." -ForegroundColor Yellow
     Write-Host ""
     & "c:\final\.venv\Scripts\python.exe" "$PSScriptRoot\start_server.py"
 }
 else {
-    Write-Host "=" * 80 -ForegroundColor Red
-    Write-Host "⚠️ ВНИМАНИЕ: Не удалось освободить порт 18000!" -ForegroundColor Red
-    Write-Host "=" * 80 -ForegroundColor Red
+    Write-Host ("=" * 80) -ForegroundColor Red
+    Write-Host "[WARN] Could not free port 18000." -ForegroundColor Red
+    Write-Host ("=" * 80) -ForegroundColor Red
     Write-Host ""
-    Write-Host "Варианты решения:" -ForegroundColor Yellow
+    Write-Host "Options:" -ForegroundColor Yellow
+    Write-Host "1. Close the owning process manually." -ForegroundColor Cyan
+    Write-Host "2. Rerun with -ForcePortOwners or CONFIRM_STOP_ALL_PYTHON_PORT_OWNERS=1." -ForegroundColor Cyan
+    Write-Host "3. Start on alternate port 8001." -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "1. Запустить на альтернативном порту 8001:" -ForegroundColor Cyan
-    Write-Host "   python start_server_port8001.py" -ForegroundColor White
-    Write-Host ""
-    Write-Host "2. Закрыть процессы вручную через Диспетчер задач:" -ForegroundColor Cyan
-    Write-Host "   - Нажмите Ctrl+Shift+Esc" -ForegroundColor White
-    Write-Host "   - Найдите процессы python.exe" -ForegroundColor White
-    Write-Host "   - Завершите их" -ForegroundColor White
-    Write-Host ""
-    Write-Host "3. Перезагрузить компьютер" -ForegroundColor Cyan
-    Write-Host ""
-    
-    $response = Read-Host "Запустить на порту 8001? (y/n)"
-    if ($response -eq 'y' -or $response -eq 'Y') {
+
+    $response = Read-Host "Start on port 8001? (y/n)"
+    if ($response -eq "y" -or $response -eq "Y") {
         Write-Host ""
-        Write-Host "Запуск на порту 8001..." -ForegroundColor Green
+        Write-Host "Starting on port 8001..." -ForegroundColor Green
         & "c:\final\.venv\Scripts\python.exe" "$PSScriptRoot\start_server_port8001.py"
     }
 }

--- a/backend/start_server_fixed.bat
+++ b/backend/start_server_fixed.bat
@@ -4,7 +4,7 @@ call "C:\final\.venv\Scripts\activate.bat"
 set WS_DEV_ALLOW=1
 set CORS_DISABLE=0
 set CORS_ALLOW_ALL=0
-set CORS_ORIGINS=http://localhost:5173,http://localhost:5174,http://127.0.0.1:5173,http://127.0.0.1:5174
+set CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 set BACKEND_HOST=0.0.0.0
 set BACKEND_PORT=18000
 python run_server.py

--- a/backend/stop_all_python.ps1
+++ b/backend/stop_all_python.ps1
@@ -1,72 +1,79 @@
-# Простой и надежный скрипт для остановки всех процессов Python в проекте
-Write-Host "=" * 60
-Write-Host "🛑 Остановка всех процессов Python в проекте..." -ForegroundColor Yellow
-Write-Host "=" * 60
+param(
+    [switch]$ForcePortOwners
+)
+
+Write-Host ("=" * 60)
+Write-Host "Stopping project Python processes..." -ForegroundColor Yellow
+Write-Host ("=" * 60)
 
 $stopped = 0
+$allowPortOwnerKill = $ForcePortOwners -or ($env:CONFIRM_STOP_ALL_PYTHON_PORT_OWNERS -eq "1")
 
-# Метод 1: Через Get-Process
 Get-Process python -ErrorAction SilentlyContinue | Where-Object {
-    $_.Path -like '*final*'
+    $_.Path -like "*final*"
 } | ForEach-Object {
-    Write-Host "Останавливаем: $($_.ProcessName) (PID: $($_.Id))" -ForegroundColor Cyan
-    Write-Host "  Путь: $($_.Path)"
+    Write-Host "Stopping project process: $($_.ProcessName) (PID: $($_.Id))" -ForegroundColor Cyan
+    Write-Host "  Path: $($_.Path)"
     Stop-Process -Id $_.Id -Force
     $stopped++
 }
 
 if ($stopped -gt 0) {
     Write-Host ""
-    Write-Host "✅ Остановлено процессов: $stopped" -ForegroundColor Green
+    Write-Host "[OK] Stopped project Python processes: $stopped" -ForegroundColor Green
     Start-Sleep -Seconds 2
 }
 else {
-    Write-Host "ℹ️ Процессы Python не найдены" -ForegroundColor Gray
+    Write-Host "[INFO] No project Python processes found." -ForegroundColor Gray
 }
 
-# Метод 2: Проверка порта 18000 через netstat
 Write-Host ""
-Write-Host "Проверка порта 18000..." -ForegroundColor Yellow
+Write-Host "Checking port 18000..." -ForegroundColor Yellow
 $netstat = netstat -ano | Select-String ":18000.*LISTENING"
 
 if ($netstat) {
-    Write-Host "⚠️ Порт 18000 все еще занят, принудительная очистка..." -ForegroundColor Yellow
+    Write-Host "[WARN] Port 18000 is still busy." -ForegroundColor Yellow
     $netstat | ForEach-Object {
         $line = $_.Line
         $processId = ($line -split '\s+')[-1]
-        Write-Host "Останавливаем процесс PID: $processId"
+        if (-not $allowPortOwnerKill) {
+            Write-Host "Refusing to kill unmanaged port owner PID $processId without -ForcePortOwners or CONFIRM_STOP_ALL_PYTHON_PORT_OWNERS=1" -ForegroundColor Red
+            return
+        }
+        Write-Host "Killing unmanaged port owner PID: $processId"
         taskkill /PID $processId /F 2>$null
     }
-    
-    # Даем время на освобождение порта
-    Write-Host "Ожидание освобождения порта..." -ForegroundColor Yellow
+
+    Write-Host "Waiting for port release..." -ForegroundColor Yellow
     Start-Sleep -Seconds 3
-    
-    # Повторная проверка и очистка
+
     $netstat2 = netstat -ano | Select-String ":18000.*LISTENING"
     if ($netstat2) {
-        Write-Host "Повторная попытка очистки порта..." -ForegroundColor Yellow
+        Write-Host "Second port cleanup attempt..." -ForegroundColor Yellow
         $netstat2 | ForEach-Object {
             $line = $_.Line
             $processId = ($line -split '\s+')[-1]
+            if (-not $allowPortOwnerKill) {
+                Write-Host "Refusing second unmanaged port-owner kill for PID $processId without explicit confirmation" -ForegroundColor Red
+                return
+            }
             taskkill /PID $processId /F 2>$null
         }
         Start-Sleep -Seconds 2
     }
 }
 
-# Финальная проверка
 $finalCheck = netstat -ano | Select-String ":18000.*LISTENING"
 if (-not $finalCheck) {
     Write-Host ""
-    Write-Host "=" * 60
-    Write-Host "✅ Порт 18000 свободен и готов к использованию!" -ForegroundColor Green
-    Write-Host "=" * 60
+    Write-Host ("=" * 60)
+    Write-Host "[OK] Port 18000 is free and ready." -ForegroundColor Green
+    Write-Host ("=" * 60)
 }
 else {
     Write-Host ""
-    Write-Host "=" * 60
-    Write-Host "⚠️ ВНИМАНИЕ: Порт 18000 все еще занят!" -ForegroundColor Red
-    Write-Host "Попробуйте закрыть процессы вручную через Диспетчер задач" -ForegroundColor Yellow
-    Write-Host "=" * 60
+    Write-Host ("=" * 60)
+    Write-Host "[WARN] Port 18000 is still busy." -ForegroundColor Red
+    Write-Host "Close the owning process manually or rerun with explicit confirmation." -ForegroundColor Yellow
+    Write-Host ("=" * 60)
 }


### PR DESCRIPTION
## Summary

Hardens local Windows/backend operator scripts so they stop assuming destructive SQLite reset flows or unmanaged process termination.

## Scope

- Add explicit confirmation gates before killing unmanaged port owners or uvicorn processes.
- Retire legacy SQLite reset scripts instead of deleting runtime DB files.
- Tighten local backend restart/stop behavior to project-owned processes first.
- Narrow local dev CORS defaults in `start_server_fixed.bat`.

## Contract Impact

- Canonical surface: Not applicable; this PR changes local operator scripts only.
- Request shape: Not applicable; no API request contract changes.
- Response shape: Not applicable; no API response contract changes.
- Status codes: Not applicable; no route handler behavior changed.
- Frontend consumer: Not applicable; no frontend consumer depends on these scripts as a typed contract.
- Compatibility path or alias: Not applicable; no route alias or compatibility path changed.
- Contract proof: Script-only diff plus parser and deprecation/refusal smoke validation; no HTTP/WS contract in scope.

## RBAC / Permissions

- Roles allowed: Not applicable; these scripts are run manually by operators/developers outside app RBAC.
- Roles denied: Not applicable; no runtime role matrix changed.
- Positive auth proof: Not applicable; no auth-protected API/UI surface changed.
- Negative auth proof: Not applicable; no auth-protected API/UI surface changed.

## Notification / Realtime

- Event type or websocket channel: Not applicable; no notification or websocket flow changed.
- Payload version / ack behavior: Not applicable; no realtime payload changed.
- Read/unread or delivery semantics: Not applicable; no inbox/delivery path changed.
- Reconnect/resync proof: Not applicable; no realtime client behavior changed.

## Frontend Resilience

- Empty data proof: Not applicable; no frontend state is in scope.
- Partial data proof: Not applicable; no frontend state is in scope.
- Forbidden secondary path behavior: Not applicable; no frontend fetch path changed.
- Missing draft/resource behavior: Not applicable; no frontend draft/resource path changed.
- Stale route/deep-link behavior: Not applicable; no route/deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/kill_port_18000.ps1`, `backend/reset_database.ps1`, `backend/reset_database_auto.ps1`, `backend/restart_backend.ps1`, `backend/smart_restart.ps1`, `backend/start_server_fixed.bat`, `backend/stop_all_python.ps1`
- Denied paths: `backend/app/api/v1/endpoints/**`, `backend/app/services/**`, `backend/tests/**`, `frontend/**`, `.github/**`, `ops/**`, generated/evidence artifacts, deletion/rename wave
- Migration/docs/test impact: No migrations or docs changed. No new tests added. Validation uses parser checks plus safe deprecation/refusal smokes only.
- Rollback note: Revert this commit to restore previous local operator script behavior if a local workflow still depends on forceful unmanaged process stop or SQLite file reset semantics.

## Risk

Low. This PR affects only local operator scripts. It intentionally makes destructive or broad stop/reset behavior stricter.

## Validation

- Targeted tests or smoke run: `git diff --check`; PowerShell parser checks for touched `.ps1` files; safe execution smokes for `reset_database.ps1`, `reset_database_auto.ps1`, and `kill_port_18000.ps1`
- Result: Passed. `git diff --check` passed with only non-blocking Windows `LF -> CRLF` warnings, PowerShell parser checks returned zero errors, deprecated reset scripts exited with code `2`, and `kill_port_18000.ps1` completed safely without forced termination.
- Not checked: `restart_backend.ps1`, `smart_restart.ps1`, `stop_all_python.ps1`, and `start_server_fixed.bat` were not executed because they can stop/start local processes; validation for those files was limited to static diff review and parser/hygiene checks.
