### PR TITLE
QA: harden backend helper guard scripts

### DIFF
--- a/backend/scripts/cleanup_non_example_users.py
+++ b/backend/scripts/cleanup_non_example_users.py
@@ -1,12 +1,13 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
+import os
 import sys
 from typing import List, Dict
 
 import requests
 
 
-BASE_URL = "http://127.0.0.1:8003/api/v1"
+BASE_URL = os.getenv("BACKEND_API_BASE_URL", "http://127.0.0.1:18000/api/v1").rstrip("/")
 
 # Критические системные пользователи, которых нельзя трогать
 CRITICAL_USERNAMES = {
@@ -21,15 +22,31 @@ CRITICAL_USERNAMES = {
 }
 
 
-def login_admin(username: str = "admin", password: str = "admin123") -> str:
+def _required_admin_password() -> str:
+    password = os.getenv("ADMIN_PASSWORD", "").strip()
+    if not password:
+        raise RuntimeError("Set ADMIN_PASSWORD before cleaning up users.")
+    return password
+
+
+def _require_cleanup_confirmation(action: str) -> None:
+    expected = f"CONFIRM_CLEANUP_NON_EXAMPLE_USERS_{action.upper()}"
+    if os.getenv(expected) != "1":
+        raise RuntimeError(
+            f"Refusing to {action} non-example users. "
+            f"Set {expected}=1 only for an explicit admin cleanup run."
+        )
+
+
+def login_admin(username: str = "admin", admin_password: str | None = None) -> str:
+    admin_password = admin_password or _required_admin_password()
     resp = requests.post(
         f"{BASE_URL}/authentication/login",
-        json={"username": username, "password": password},
+        json={"username": username, "password": admin_password},
         timeout=15,
     )
     resp.raise_for_status()
     data = resp.json()
-    print(f"LOGIN_RESPONSE: {data}")
     token = data.get("access_token")
     if not token:
         raise RuntimeError(f"No access_token in login response: {data}")
@@ -76,7 +93,7 @@ def bulk_action(token: str, user_ids: List[int], action: str) -> Dict:
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
     body = {"action": action, "user_ids": user_ids}
     print(f"BULK_ACTION: URL={BASE_URL}/users/users/bulk-action")
-    print(f"BULK_ACTION: headers={headers}")
+    print("BULK_ACTION: Authorization header is set")
     print(f"BULK_ACTION: body={body}")
     r = requests.post(
         f"{BASE_URL}/users/users/bulk-action",
@@ -106,6 +123,7 @@ def main():
         sys.exit(2)
 
     action = sys.argv[1]
+    _require_cleanup_confirmation(action)
     token = login_admin()
     users = fetch_all_users(token)
     ids = select_non_example_ids(users)

--- a/backend/scripts/ensure_admin_async.py
+++ b/backend/scripts/ensure_admin_async.py
@@ -1,42 +1,26 @@
+#!/usr/bin/env python3
+"""Retired async admin bootstrap helper."""
+
 from __future__ import annotations
 
-import asyncio
+import sys
 
-from sqlalchemy import select
+MESSAGE = """
+scripts/ensure_admin_async.py is retired.
 
-# Универсальные импорты сессии
-try:
-    from app.db.session import async_session as SessionMaker  # type: ignore
-except Exception:
-    from app.db.session import SessionLocal as SessionMaker  # type: ignore
+This legacy helper created the bootstrap admin with a built-in credential.
+Admin bootstrap belongs to the canonical Postgres/Alembic path:
 
-from app.core.security import get_password_hash
-from app.models.user import User
+  python -m app.scripts.ensure_admin
 
-USERNAME = "admin"
-PASSWORD = "admin"
-EMAIL = "admin@example.com"
+Set ADMIN_PASSWORD before creating the bootstrap admin.
+""".strip()
 
 
-async def main():
-    async with SessionMaker() as session:  # type: ignore
-        res = await session.execute(select(User).where(User.username == USERNAME))
-        user = res.scalars().first()
-        if user:
-            print("✅ Admin already exists.")
-            return
-        user = User(
-            username=USERNAME,
-            email=EMAIL,
-            full_name="Administrator",
-            is_active=True,
-            is_superuser=True,
-            hashed_password=get_password_hash(PASSWORD),
-        )
-        session.add(user)
-        await session.commit()
-        print("✅ Admin user created:", USERNAME, "/", PASSWORD)
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    raise SystemExit(main())

--- a/backend/scripts/inspect_today_visits.py
+++ b/backend/scripts/inspect_today_visits.py
@@ -10,7 +10,16 @@ import sqlite3
 from datetime import date
 
 
+def require_diagnostic_db_read() -> None:
+  if os.getenv("ALLOW_LEGACY_SQLITE_DIAGNOSTIC_READ") != "1":
+    raise SystemExit(
+      "Refusing to read legacy SQLite diagnostic database. "
+      "Set ALLOW_LEGACY_SQLITE_DIAGNOSTIC_READ=1 only for an explicit local legacy SQLite diagnostic run."
+    )
+
+
 def main() -> None:
+  require_diagnostic_db_read()
   db_path = os.path.abspath("clinic.db")
   print(f"DB_PATH: {db_path}")
 

--- a/backend/scripts/reset_critical_passwords.py
+++ b/backend/scripts/reset_critical_passwords.py
@@ -1,33 +1,74 @@
-#!/usr/bin/env python3
+﻿#!/usr/bin/env python3
 """
-Reset or create critical users with documented passwords/roles.
+Reset or create critical users with explicit environment-provided passwords/roles.
 
 Docs reference:
 - ROLES_AND_ROUTING.md
 """
 from __future__ import annotations
 
-from app.core.security import get_password_hash
-from app.db.session import SessionLocal
-from app.models.user import User
+import os
 
 
 USERS = [
-    ("admin", "admin123", "Admin"),
-    ("registrar", "registrar123", "Registrar"),
-    ("lab", "lab123", "Lab"),
-    ("doctor", "doctor123", "Doctor"),
-    ("cashier", "cashier123", "Cashier"),
-    ("cardio", "cardio123", "cardio"),
-    ("derma", "derma123", "derma"),
-    ("dentist", "dentist123", "dentist"),
+    ("admin", "Admin"),
+    ("registrar", "Registrar"),
+    ("lab", "Lab"),
+    ("doctor", "Doctor"),
+    ("cashier", "Cashier"),
+    ("cardio", "cardio"),
+    ("derma", "derma"),
+    ("dentist", "dentist"),
 ]
 
 
+def _require_confirmation() -> None:
+    value = os.getenv("CONFIRM_RESET_CRITICAL_PASSWORDS", "").strip().lower()
+    if value not in {"1", "true", "yes", "on"}:
+        raise RuntimeError(
+            "Set CONFIRM_RESET_CRITICAL_PASSWORDS=1 before ensuring critical users."
+        )
+
+
+def _require_postgres_database_url() -> None:
+    database_url = os.getenv("DATABASE_URL", "").strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before ensuring critical users.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError(
+            "reset_critical_passwords.py requires a PostgreSQL DATABASE_URL."
+        )
+
+
+def _password_env_names(username: str) -> list[str]:
+    names = [f"RESET_CRITICAL_{username.upper()}_PASSWORD"]
+    if username == "admin":
+        names.insert(0, "ADMIN_PASSWORD")
+    return names
+
+
+def _required_password(username: str) -> str:
+    for env_name in _password_env_names(username):
+        password = os.getenv(env_name, "").strip()
+        if password:
+            return password
+    expected = " or ".join(_password_env_names(username))
+    raise RuntimeError(f"Set {expected} before ensuring user '{username}'.")
+
+
 def main() -> None:
+    _require_confirmation()
+    _require_postgres_database_url()
+
+    from app.core.security import get_password_hash
+    from app.db.session import SessionLocal
+    from app.models.user import User
+
     db = SessionLocal()
     try:
-        for username, password, role in USERS:
+        passwords = {username: _required_password(username) for username, _role in USERS}
+        for username, role in USERS:
+            password = passwords[username]
             user = db.query(User).filter(User.username == username).first()
             if user:
                 user.hashed_password = get_password_hash(password)


### PR DESCRIPTION
## Summary

Hardens a small backend helper-scripts batch by retiring a legacy admin bootstrap path, adding explicit confirmations for destructive local scripts, and requiring opt-in for legacy SQLite diagnostics.

## Scope

- Retire `backend/scripts/ensure_admin_async.py` instead of keeping a built-in bootstrap admin credential path.
- Require explicit confirmation and env-provided admin password before bulk cleanup of non-example users.
- Require explicit opt-in before reading legacy local SQLite visit diagnostics.
- Require explicit confirmation, PostgreSQL `DATABASE_URL`, and env-provided passwords before resetting critical users.

This PR intentionally excludes `backend/app/**`, endpoint/service cleanup, frontend changes, workflow changes, generated artifacts, and the deletion/rename wave.

## Contract Impact

- Canonical surface: not applicable because this slice changes only local helper scripts under `backend/scripts/**`, not runtime API routes or contracts.
- Request shape: not applicable because no HTTP request payload shape changes are introduced.
- Response shape: not applicable because no HTTP response payload shape changes are introduced.
- Status codes: not applicable because no runtime endpoint behavior is changed.
- Frontend consumer: not applicable because no frontend route, component, or API consumer is touched.
- Compatibility path or alias: not applicable because no endpoint aliases, redirects, or legacy compatibility paths are changed.
- Contract proof: local scope review confirmed only helper-script guardrails in `backend/scripts/**`; no `backend/app/api/**` files are in scope.

## RBAC / Permissions

- Roles allowed: not applicable because runtime route-level RBAC behavior is unchanged.
- Roles denied: not applicable because runtime route-level RBAC behavior is unchanged.
- Positive auth proof: not applicable because no endpoint auth path changed; this PR only hardens local helper scripts.
- Negative auth proof: not applicable because no endpoint auth path changed; `cleanup_non_example_users.py` now additionally refuses without explicit confirmation and `ADMIN_PASSWORD`.

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR does not touch notifications, websockets, or event producers.
- Payload version / ack behavior: not applicable because no event payloads or ack semantics are changed.
- Read/unread or delivery semantics: not applicable because no inbox, read-state, or delivery path is touched.
- Reconnect/resync proof: not applicable because no realtime flow is touched.

## Frontend Resilience

- Empty data proof: not applicable because no frontend UI or data-loading path is changed.
- Partial data proof: not applicable because no frontend UI or data-loading path is changed.
- Forbidden secondary path behavior: not applicable because no frontend route or fallback behavior is changed.
- Missing draft/resource behavior: not applicable because no frontend draft/resource flow is changed.
- Stale route/deep-link behavior: not applicable because no frontend routing behavior is changed.

## Scope Gate

Included:
- `backend/scripts/cleanup_non_example_users.py`
- `backend/scripts/ensure_admin_async.py`
- `backend/scripts/inspect_today_visits.py`
- `backend/scripts/reset_critical_passwords.py`

Excluded:
- `backend/app/**`
- `backend/app/services/**`
- `backend/app/api/v1/endpoints/**`
- frontend/workflows/docs unrelated to this helper slice
- generated/evidence artifacts
- deletion/rename wave
- Allowed paths: `backend/scripts/cleanup_non_example_users.py`, `backend/scripts/ensure_admin_async.py`, `backend/scripts/inspect_today_visits.py`, `backend/scripts/reset_critical_passwords.py`
- Denied paths: any `backend/app/**`, `frontend/**`, `.github/**`, `ops/**`, generated/evidence paths, and deletion/rename-wave files
- Migration/docs/test impact: no migrations or runtime docs changed; validation is limited to targeted helper-script compile/refusal checks
- Rollback note: revert this PR to restore previous helper-script behavior if the stricter guardrails block an expected operator flow

## Risk

Low to medium. These scripts are operator/developer helpers, not application runtime paths. The main behavior change is stricter refusal-by-default for destructive or legacy helper flows.

## Validation

- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/scripts/cleanup_non_example_users.py backend/scripts/ensure_admin_async.py backend/scripts/inspect_today_visits.py backend/scripts/reset_critical_passwords.py`; `python backend/scripts/ensure_admin_async.py`; `python backend/scripts/inspect_today_visits.py`; `C:\final\backend\.venv\Scripts\python.exe backend/scripts/cleanup_non_example_users.py deactivate`; `C:\final\backend\.venv\Scripts\python.exe backend/scripts/reset_critical_passwords.py`
- Result: passed; compile succeeded, retired/refusal paths triggered as expected, and no scope drift beyond the 4 helper scripts was introduced
- Not checked: no full backend suite, no browser smoke, and no runtime API/RBAC flow testing because this slice does not modify runtime application paths
