### PR TITLE
chore: require restore smoke admin password

### DIFF
--- a/docs/runbooks/CLINIC_HOST_INSTALL_RUNBOOK.md
+++ b/docs/runbooks/CLINIC_HOST_INSTALL_RUNBOOK.md
@@ -55,8 +55,9 @@ Minimum values:
 ```env
 APP_ENV=production
 APP_HOST=clinic.internal.example
-DATABASE_URL=postgresql://clinic_host:clinic_host_password@127.0.0.1:5432/clinic_host
-SECRET_KEY=<unique_secret>
+DATABASE_URL=postgresql://clinic_host:<db_password>@127.0.0.1:5432/clinic_host
+# Generate a fresh value during install; do not commit or reuse examples.
+SECRET_KEY=
 BACKEND_CORS_ORIGINS=https://clinic.internal.example
 ENSURE_ADMIN=0
 ENSURE_ADMIN_ALLOW_INITIALIZED=0

--- a/ops/windows/clinic_host.ps1
+++ b/ops/windows/clinic_host.ps1
@@ -798,6 +798,8 @@ function Ensure-RestoreSmokeAdmin {
             ADMIN_USERNAME = $Username
             ADMIN_PASSWORD = $Password
             ADMIN_EMAIL = 'admin@example.com'
+            ADMIN_RESET_PASSWORD = '1'
+            ENSURE_ADMIN_ALLOW_INITIALIZED = '1'
         }
 }
 
@@ -819,7 +821,10 @@ function Invoke-RestoreRehearsal {
     $restoreBackendUrl = "http://127.0.0.1:$RestoreBackendPort"
     $restorePublicUrl = "http://127.0.0.1:$RestoreFrontendPort"
     $smokeLoginUsername = if ($env:SMOKE_LOGIN_USERNAME) { $env:SMOKE_LOGIN_USERNAME } elseif ($env:SETUP_ADMIN_USERNAME) { $env:SETUP_ADMIN_USERNAME } else { 'admin' }
-    $smokeLoginPassword = if ($env:SMOKE_LOGIN_PASSWORD) { $env:SMOKE_LOGIN_PASSWORD } elseif ($env:SETUP_ADMIN_PASSWORD) { $env:SETUP_ADMIN_PASSWORD } else { 'admin' }
+    $smokeLoginPassword = if ($env:SMOKE_LOGIN_PASSWORD) { $env:SMOKE_LOGIN_PASSWORD } elseif ($env:SETUP_ADMIN_PASSWORD) { $env:SETUP_ADMIN_PASSWORD } else { $null }
+    if (-not $smokeLoginPassword) {
+        Write-Fail 'Set SMOKE_LOGIN_PASSWORD or SETUP_ADMIN_PASSWORD before restore smoke admin seeding.'
+    }
 
     Write-Step 'Preparing isolated restore target...'
     Initialize-RestorePostgres


### PR DESCRIPTION
﻿## Summary
- require explicit SMOKE_LOGIN_PASSWORD or SETUP_ADMIN_PASSWORD before restore smoke admin seeding
- keep restore rehearsal admin reset behavior explicit for isolated smoke targets
- update clinic host install runbook to avoid reusable secret/password examples

## Contract Impact

- Canonical surface: ops restore rehearsal script and clinic host install runbook.
- Request shape: not applicable - no HTTP/API request contract changed.
- Response shape: not applicable - no HTTP/API response contract changed.
- Status codes: not applicable - no endpoint behavior changed.
- Frontend consumer: not applicable - no frontend runtime consumer changed.
- Compatibility path or alias: not applicable - no route, endpoint, or alias changed.
- Contract proof: diff inspection confirms ops/runbook-only scope; PowerShell parse validates script syntax.

## RBAC / Permissions

- Roles allowed: not applicable - no runtime route or permission guard changed.
- Roles denied: not applicable - no runtime route or permission guard changed.
- Positive auth proof: not applicable - restore smoke credential seeding only.
- Negative auth proof: not applicable - no auth-sensitive endpoint changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no event or websocket surface changed.
- Payload version / ack behavior: not applicable - no realtime payload behavior changed.
- Read/unread or delivery semantics: not applicable - no delivery state behavior changed.
- Reconnect/resync proof: not applicable - no reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no user-facing data flow changed.
- Partial data proof: not applicable - no user-facing data flow changed.
- Forbidden secondary path behavior: not applicable - no secondary request path changed.
- Missing draft/resource behavior: not applicable - no draft/resource bootstrap path changed.
- Stale route/deep-link behavior: not applicable - no route state behavior changed.

## Scope Gate

- Allowed paths: docs/runbooks/CLINIC_HOST_INSTALL_RUNBOOK.md and ops/windows/clinic_host.ps1.
- Denied paths: unrelated ops scripts, workflows, runtime backend/frontend files, generated/evidence artifacts.
- Migration/docs/test impact: docs/runbook update plus PowerShell syntax validation; no database migration.
- Rollback note: revert this branch to restore previous restore-smoke default behavior; no data rollback needed.

## Validation

- Targeted tests or smoke run: git diff --cached --check; PowerShell scriptblock parse for ops/windows/clinic_host.ps1; unsafe default scan for added admin/password/SECRET_KEY examples.
- Result: parse passed; unsafe default scan found 0 hits.
- Not checked: full restore rehearsal smoke on Windows host.
