### PR TITLE
fix: remove payment test demo auth

### DIFF
--- a/frontend/src/pages/PaymentTest.jsx
+++ b/frontend/src/pages/PaymentTest.jsx
@@ -22,7 +22,7 @@ import CreditCardIcon from '@mui/icons-material/CreditCard';
 import ScienceIcon from '@mui/icons-material/Science';
 
 import PaymentWidget from '../components/payment/PaymentWidget';
-import { buildApiUrl, getApiOrigin, setToken, getToken } from '../api/client';
+import { getApiOrigin, setToken, getToken } from '../api/client';
 
 import logger from '../utils/logger';
 const PaymentTest = () => {
@@ -42,91 +42,12 @@ const PaymentTest = () => {
     setIsAuthenticated(!!token);
   }, []);
 
-  // Тестовая авторизация через реальный API
-  const handleTestAuth = async () => {
-    try {
-      setResult({ type: 'info', message: 'Выполняется авторизация...' });
-      
-      // Проверяем доступность backend
-      logger.log('🔍 Проверяем доступность backend...');
-      
-      // Пробуем войти с тестовыми данными (JSON формат)
-      const loginData = {
-        username: 'registrar',
-        password: 'registrar123',
-        remember_me: false
-      };
-      
-      logger.log('📤 Отправляем запрос авторизации:', {
-        url: buildApiUrl('/auth/login'),
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(loginData)
-      });
-
-      const response = await fetch(buildApiUrl('/auth/login'), {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(loginData)
-      });
-
-      logger.log('📥 Получен ответ:', {
-        status: response.status,
-        statusText: response.statusText,
-        ok: response.ok,
-        headers: Object.fromEntries(response.headers.entries())
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        const token = data.access_token;
-        
-        if (token) {
-          setToken(token);
-          setIsAuthenticated(true);
-          setResult({
-            type: 'success',
-            message: 'Авторизация выполнена успешно!'
-          });
-        } else {
-          throw new Error('Токен не получен');
-        }
-      } else {
-        let errorMessage = 'Ошибка авторизации';
-        try {
-          const errorData = await response.json();
-          if (errorData.detail) {
-            errorMessage = typeof errorData.detail === 'string' ? errorData.detail : JSON.stringify(errorData.detail);
-          } else if (errorData.message) {
-            errorMessage = errorData.message;
-          }
-        } catch {
-          errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-        }
-        throw new Error(errorMessage);
-      }
-    } catch (error) {
-      logger.error('Ошибка авторизации:', error);
-      
-      // Получаем понятное сообщение об ошибке
-      let errorMessage = 'Неизвестная ошибка';
-      if (error.message && error.message !== '[object Object]') {
-        errorMessage = error.message;
-      } else if (error.toString && error.toString() !== '[object Object]') {
-        errorMessage = error.toString();
-      }
-      
-      // Fallback: устанавливаем тестовый токен для демонстрации UI
-      const testToken = 'demo_token_for_ui_testing';
-      setToken(testToken);
-      setIsAuthenticated(true);
-      setResult({
-        type: 'warning',
-        message: `Не удалось получить реальный токен: ${errorMessage}. Установлен демо-токен для тестирования UI. Проверьте консоль для подробностей.`
-      });
-    }
+  const handleTestAuth = () => {
+    setResult({
+      type: 'info',
+      message: 'Open /login and sign in before using the internal payment test.'
+    });
+    window.location.assign('/login');
   };
 
   const handlePaymentSuccess = (paymentData) => {
@@ -234,7 +155,7 @@ const PaymentTest = () => {
                     onClick={handleTestAuth}
                     sx={{ mb: 2 }}
                   >
-                    🔐 Тестовая авторизация
+                    🔐 Открыть вход
                   </Button>
                 ) : (
                   <Box sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary
- Remove the internal payment test page auto-login with hardcoded registrar credentials.
- Remove the demo token fallback that marked the page authenticated without a real token.
- Send unauthenticated users to the real /login flow before using PaymentWidget tests.

## Contract Impact
- Canonical surface: frontend internal PaymentTest auth bootstrap behavior.
- Request shape: not applicable - no API request schema changed by this frontend-only security fix.
- Response shape: not applicable - no API response schema changed by this frontend-only security fix.
- Status codes: not applicable - no backend status-code behavior changed by this frontend-only security fix.
- Frontend consumer: PaymentTest now relies on an existing real token from the normal login flow.
- Compatibility path or alias: /payment-test remains the same page; unauthenticated bootstrap now redirects to /login.
- Contract proof: frontend build and static scan for removed hardcoded credentials and demo token fallback.

## RBAC / Permissions
- Roles allowed: unchanged; authenticated access still depends on the existing token and route guard behavior.
- Roles denied: unchanged; no guard logic or role mapping changed.
- Positive auth proof: existing token detection through getToken remains in PaymentTest and build passed.
- Negative auth proof: hardcoded registrar123 and demo_token_for_ui_testing are absent from PaymentTest after the fix.

## Notification / Realtime
- Event type or websocket channel: not applicable - no event or websocket surface changed by this security fix.
- Payload version / ack behavior: not applicable - no realtime payload behavior changed by this security fix.
- Read/unread or delivery semantics: not applicable - no delivery state behavior changed by this security fix.
- Reconnect/resync proof: not applicable - no reconnect or resync behavior changed by this security fix.

## Frontend Resilience
- Empty data proof: not applicable - payment data rendering was not changed by this security fix.
- Partial data proof: not applicable - PaymentWidget payload mapping was not changed by this security fix.
- Forbidden secondary path behavior: unauthenticated users are sent to /login instead of receiving fake auth.
- Missing draft/resource behavior: not applicable - no draft or resource bootstrap path changed by this security fix.
- Stale route/deep-link behavior: /payment-test remains stable; /login is the canonical auth route.

## Scope Gate
- Allowed paths: frontend/src/pages/PaymentTest.jsx.
- Denied paths: package.json, package-lock.json, api/client.js, payment provider runtime, artifacts, timestamp files, generated dist/node_modules.
- Migration/docs/test impact: no migration or docs changes; validation is build plus focused static scan.
- Rollback note: revert this one-file branch to restore the previous test auth shortcut, which is not recommended.

## Validation
- Targeted tests or smoke run: npm ci; npm run build; PaymentTest static scan for registrar123, demo_token_for_ui_testing, username: 'registrar', setToken(testToken), and buildApiUrl(; git diff --cached --check; artifact scan.
- Result: build passed; PaymentTest secret/fake-token scan clean; diff check clean; artifact hits 0.
- Not checked: browser click smoke was not run because this PR changes only unauthenticated bootstrap behavior and build/static proof cover the removed vulnerable path.
