### PR TITLE
fix: disable payment provider defaults

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -113,6 +113,25 @@ class Settings(BaseSettings):
     CELERY_BROKER_URL: str = Field(default="redis://localhost:6379/0")
     CELERY_RESULT_BACKEND: str = Field(default="redis://localhost:6379/0")
 
+    # --- Payment providers ---
+    CLICK_ENABLED: bool = Field(default=False, description="Enable Click payments")
+    CLICK_SERVICE_ID: str | None = Field(default=None, description="Click service id")
+    CLICK_MERCHANT_ID: str | None = Field(default=None, description="Click merchant id")
+    CLICK_SECRET_KEY: str | None = Field(default=None, description="Click secret key")
+    CLICK_BASE_URL: str = Field(default="https://api.click.uz/v2")
+
+    PAYME_ENABLED: bool = Field(default=False, description="Enable PayMe payments")
+    PAYME_MERCHANT_ID: str | None = Field(default=None, description="PayMe merchant id")
+    PAYME_SECRET_KEY: str | None = Field(default=None, description="PayMe secret key")
+    PAYME_BASE_URL: str = Field(default="https://checkout.paycom.uz")
+    PAYME_API_URL: str = Field(default="https://api.paycom.uz")
+
+    KASPI_ENABLED: bool = Field(default=False, description="Enable Kaspi payments")
+    KASPI_MERCHANT_ID: str | None = Field(default=None, description="Kaspi merchant id")
+    KASPI_SECRET_KEY: str | None = Field(default=None, description="Kaspi secret key")
+    KASPI_BASE_URL: str = Field(default="https://kaspi.kz/pay")
+    KASPI_API_URL: str = Field(default="https://api.kaspi.kz/pay/v1")
+
     # --- App meta ---
     APP_NAME: str = "Clinic Manager"
     APP_VERSION: str = "0.9.0"

--- a/backend/tests/integration/test_e2e_clinic.py
+++ b/backend/tests/integration/test_e2e_clinic.py
@@ -86,10 +86,18 @@ def _create_payme_auth_header(secret_key: str) -> str:
 
 
 @pytest.fixture
-def payme_secret_key():
+def payme_secret_key(monkeypatch):
     """Возвращает PayMe secret key для тестов из настроек, чтобы совпадал с провайдером"""
+    from app.services.payment_provider_manager_factory import reset_payment_manager_for_tests
+
+    test_secret_key = "test_secret"
     settings = get_settings()
-    return getattr(settings, "PAYME_SECRET_KEY", "test_secret")
+    monkeypatch.setattr(settings, "PAYME_ENABLED", True)
+    monkeypatch.setattr(settings, "PAYME_MERCHANT_ID", "test_merchant")
+    monkeypatch.setattr(settings, "PAYME_SECRET_KEY", test_secret_key)
+    reset_payment_manager_for_tests()
+    yield test_secret_key
+    reset_payment_manager_for_tests()
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/test_payment_init_e2e.py
+++ b/backend/tests/integration/test_payment_init_e2e.py
@@ -10,6 +10,27 @@ import pytest
 from app.models.payment import Payment
 
 
+@pytest.fixture(autouse=True)
+def configured_payment_providers(monkeypatch):
+    from app.core.config import get_settings
+    from app.services.payment_provider_manager_factory import reset_payment_manager_for_tests
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "CLICK_ENABLED", True)
+    monkeypatch.setattr(settings, "CLICK_SERVICE_ID", "test_service")
+    monkeypatch.setattr(settings, "CLICK_MERCHANT_ID", "test_merchant")
+    monkeypatch.setattr(settings, "CLICK_SECRET_KEY", "test_secret")
+    monkeypatch.setattr(settings, "PAYME_ENABLED", True)
+    monkeypatch.setattr(settings, "PAYME_MERCHANT_ID", "test_merchant")
+    monkeypatch.setattr(settings, "PAYME_SECRET_KEY", "test_secret")
+    monkeypatch.setattr(settings, "KASPI_ENABLED", True)
+    monkeypatch.setattr(settings, "KASPI_MERCHANT_ID", "test_merchant")
+    monkeypatch.setattr(settings, "KASPI_SECRET_KEY", "test_secret")
+    reset_payment_manager_for_tests()
+    yield
+    reset_payment_manager_for_tests()
+
+
 @pytest.mark.integration
 @pytest.mark.e2e
 class TestPaymentInitE2E:


### PR DESCRIPTION
﻿## Summary

- Adds explicit Settings fields for Click, PayMe, and Kaspi provider configuration.
- Defaults payment providers to disabled with no merchant/service/test credential fallback values in Settings.
- Updates payment integration tests to explicitly enable test providers instead of depending on runtime fallback defaults.

## Contract Impact

not applicable - no API, websocket, event, request, response, status-code, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or permission behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, route, or frontend data flow changed.

## Scope Gate

- Allowed paths: backend/app/core/config.py; backend/tests/integration/test_e2e_clinic.py; backend/tests/integration/test_payment_init_e2e.py
- Denied paths: payment flow logic, database migrations, frontend, ops, workflows, docs, generated artifacts
- Migration/docs/test impact: no migration or docs changes; payment integration tests now explicitly configure test providers
- Rollback note: revert this single commit to restore previous Settings/test behavior

## Validation

- Targeted tests or smoke run: python -m py_compile backend\app\core\config.py backend\tests\integration\test_e2e_clinic.py backend\tests\integration\test_payment_init_e2e.py; git diff --check; Settings import/default check with backend venv and explicit SECRET_KEY; pytest tests\integration\test_payment_init_e2e.py tests\integration\test_e2e_clinic.py::test_e2e_clinic_flow -q with TESTING=1, ALLOW_SQLITE_DATABASE_URL=1, DATABASE_URL=sqlite:///./test_ci_local.db
- Result: py_compile passed; diff check passed with only LF-to-CRLF warnings; Settings check printed False/None defaults for Click, PayMe, and Kaspi; targeted payment tests passed (5 passed)
- Not checked: full backend suite locally; GitHub CI is the broad validation for this PR
