### PR TITLE
fix: require alembic postgres docker startup

### DIFF
--- a/backend/Dockerfile.staging
+++ b/backend/Dockerfile.staging
@@ -21,6 +21,6 @@ RUN chmod +x /entrypoint.sh
 
 ENV PYTHONPATH=/app
 
-EXPOSE 8000
+EXPOSE 18000
 
 CMD ["/bin/bash", "/entrypoint.sh"]

--- a/backend/docker/entrypoint.staging.sh
+++ b/backend/docker/entrypoint.staging.sh
@@ -2,41 +2,34 @@
 set -euo pipefail
 
 : "${HOST:=0.0.0.0}"
-: "${PORT:=8000}"
+: "${PORT:=18000}"
 : "${APP_MODULE:=app.main:app}"
 : "${WORKERS:=1}"
 : "${RELOAD:=0}"
-: "${DATABASE_URL:=sqlite:////data/app.db}"
+: "${DATABASE_URL:?DATABASE_URL must be set to a PostgreSQL connection string}"
 : "${ENSURE_ADMIN:=1}"
-: "${RUN_ALEMBIC_ON_START:=0}"
+: "${RUN_ALEMBIC_ON_START:=1}"
 
 mkdir -p /data
 export DATABASE_URL
 
+case "${DATABASE_URL,,}" in
+  sqlite:*)
+    echo "[entrypoint] Refusing SQLite DATABASE_URL. PostgreSQL + Alembic are the schema source of truth." >&2
+    exit 1
+    ;;
+esac
+
 if [[ "${RUN_ALEMBIC_ON_START}" == "1" ]]; then
   echo "[entrypoint] Running alembic upgrade head..."
   alembic upgrade head
+else
+  echo "[entrypoint] Alembic migration skipped because RUN_ALEMBIC_ON_START=${RUN_ALEMBIC_ON_START}"
 fi
-
-echo "[entrypoint] Creating database tables..."
-python -c "
-import sys
-sys.path.insert(0, '.')
-from app.db.base import Base
-from app.db.session import engine
-try:
-    Base.metadata.create_all(bind=engine)
-    print('✅ Database tables created successfully')
-except Exception as e:
-    print(f'⚠️ Error creating tables: {e}')
-    import traceback
-    traceback.print_exc()
-    sys.exit(1)
-"
 
 if [[ "${ENSURE_ADMIN}" == "1" ]]; then
   echo "[entrypoint] Ensuring admin user..."
-  python app/scripts/ensure_admin.py || echo "⚠️ Warning: Could not ensure admin user"
+  python app/scripts/ensure_admin.py || echo "[entrypoint] Warning: Could not ensure admin user"
 fi
 
 echo "[entrypoint] Starting Uvicorn ${APP_MODULE} on ${HOST}:${PORT} (workers=${WORKERS}, reload=${RELOAD})"

--- a/ops/backend.Dockerfile
+++ b/ops/backend.Dockerfile
@@ -28,7 +28,7 @@ RUN chmod +x /entrypoint.sh
 
 ENV PYTHONPATH=/app
 
-EXPOSE 8000
+EXPOSE 18000
 
 FROM base AS runtime
 CMD ["/bin/bash", "/entrypoint.sh"]

--- a/ops/backend.entrypoint.sh
+++ b/ops/backend.entrypoint.sh
@@ -3,41 +3,34 @@ set -euo pipefail
 
 # --- Defaults ---
 : "${HOST:=0.0.0.0}"
-: "${PORT:=8000}"
+: "${PORT:=18000}"
 : "${APP_MODULE:=app.main:app}"
 : "${WORKERS:=1}"
 : "${RELOAD:=0}"
-: "${DATABASE_URL:=sqlite:////data/app.db}"
+: "${DATABASE_URL:?DATABASE_URL must be set to a PostgreSQL connection string}"
 : "${ENSURE_ADMIN:=1}"
-: "${RUN_ALEMBIC_ON_START:=0}"
+: "${RUN_ALEMBIC_ON_START:=1}"
 
 mkdir -p /data
 export DATABASE_URL
 
+case "${DATABASE_URL,,}" in
+  sqlite:*)
+    echo "[entrypoint] Refusing SQLite DATABASE_URL. PostgreSQL + Alembic are the schema source of truth." >&2
+    exit 1
+    ;;
+esac
+
 if [[ "${RUN_ALEMBIC_ON_START}" == "1" ]]; then
   echo "[entrypoint] Running alembic upgrade head..."
   alembic upgrade head
+else
+  echo "[entrypoint] Alembic migration skipped because RUN_ALEMBIC_ON_START=${RUN_ALEMBIC_ON_START}"
 fi
-
-echo "[entrypoint] Creating database tables..."
-python -c "
-import sys
-sys.path.insert(0, '.')
-from app.db.base import Base
-from app.db.session import engine
-try:
-    Base.metadata.create_all(bind=engine)
-    print('✅ Database tables created successfully')
-except Exception as e:
-    print(f'⚠️ Error creating tables: {e}')
-    import traceback
-    traceback.print_exc()
-    sys.exit(1)
-"
 
 if [[ "${ENSURE_ADMIN}" == "1" ]]; then
   echo "[entrypoint] Ensuring admin user..."
-  python app/scripts/ensure_admin.py || echo "⚠️ Warning: Could not ensure admin user"
+  python app/scripts/ensure_admin.py || echo "[entrypoint] Warning: Could not ensure admin user"
 fi
 
 echo "[entrypoint] Starting Uvicorn ${APP_MODULE} on ${HOST}:${PORT} (workers=${WORKERS}, reload=${RELOAD})"


### PR DESCRIPTION
﻿## Summary

- Removes SQLite fallback startup from active backend Docker entrypoints.
- Removes `Base.metadata.create_all()` startup table creation so Alembic remains the schema source of truth.
- Switches backend Docker defaults/EXPOSE from 8000 to canonical 18000 and runs Alembic by default.

## Contract Impact

not applicable - no API, websocket, request, response, status-code, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, route, or frontend data flow changed.

## Scope Gate

- Allowed paths: ops/backend.entrypoint.sh; backend/docker/entrypoint.staging.sh; ops/backend.Dockerfile; backend/Dockerfile.staging
- Denied paths: compose files, env samples, backend app code, frontend, migrations, generated artifacts, ops scripts outside entrypoints
- Migration/docs/test impact: no migration or docs changes; startup now requires DATABASE_URL and refuses SQLite runtime
- Rollback note: revert this commit to restore prior Docker startup behavior

## Validation

- Targeted tests or smoke run: bash -n ops/backend.entrypoint.sh; bash -n backend/docker/entrypoint.staging.sh; git diff --check; static scan for DATABASE_URL requirement, Alembic default, SQLite refusal, and removed create_all/Base.metadata fallback
- Result: bash syntax checks passed; diff check passed with only LF-to-CRLF warnings; static scan found required guard lines and no create_all/Base.metadata/old SQLite fallback in touched entrypoints
- Not checked: docker compose config/build locally because Docker CLI is not installed in this environment
