### PR TITLE
fix: require staging env secrets

### DIFF
--- a/backend/staging.env.sample
+++ b/backend/staging.env.sample
@@ -3,9 +3,12 @@ APP_NAME=Clinic Manager Staging
 APP_VERSION=1.1.0-staging
 API_V1_STR=/api/v1
 
-DATABASE_URL=postgresql+psycopg://clinic_staging:clinic_staging_pwd@localhost:55432/clinic_staging
+# Required. Use a staging-only PostgreSQL password.
+# Example: postgresql+psycopg://clinic_staging:<db_password>@localhost:55432/clinic_staging
+DATABASE_URL=
 
-SECRET_KEY=change-this-staging-secret-key
+# Required. Generate with: python -c "import secrets; print(secrets.token_urlsafe(48))"
+SECRET_KEY=
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=10080
 


### PR DESCRIPTION
﻿## Summary

- Removes the committed staging database password placeholder from backend/staging.env.sample.
- Removes the committed staging SECRET_KEY placeholder value.
- Marks both values as required and documents how to generate/fill them.

## Contract Impact

not applicable - no API, websocket, request, response, status-code, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or permission behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, route, or frontend data flow changed.

## Scope Gate

- Allowed paths: backend/staging.env.sample
- Denied paths: runtime code, compose files, scripts, frontend, migrations, generated artifacts
- Migration/docs/test impact: env sample only; no migration or code execution path changed
- Rollback note: revert this commit to restore previous sample values

## Validation

- Targeted tests or smoke run: git diff --check; static scan for old staging password/SECRET_KEY placeholders and required blank fields
- Result: diff check passed with only LF-to-CRLF warning; old placeholders were not found; required DATABASE_URL= and SECRET_KEY= lines are present
- Not checked: runtime startup, because this is an env sample-only change
