### PR TITLE
fix: require vps lifecycle secrets

### DIFF
--- a/ops/vps/clinic_lifecycle.env.sample
+++ b/ops/vps/clinic_lifecycle.env.sample
@@ -8,7 +8,8 @@ APP_ROOT=/opt/clinic
 APP_HOST=clinic.example.com
 BACKEND_URL=http://127.0.0.1:18000
 PUBLIC_URL=https://clinic.example.com
-DATABASE_URL=postgresql+psycopg://clinic_app:change-me@localhost:5432/clinic_app
+# Required. Use the password created by bootstrap_postgres.sh.
+DATABASE_URL=
 
 BACKUP_DIR=/opt/clinic/output/backups
 
@@ -29,7 +30,8 @@ SETUP_BRANCH_TIMEZONE=Asia/Tashkent
 SETUP_BRANCH_CAPACITY=50
 
 SETUP_ADMIN_USERNAME=admin
-SETUP_ADMIN_PASSWORD=change-me
+# Required. Use a unique first-run admin password.
+SETUP_ADMIN_PASSWORD=
 SETUP_ADMIN_FULL_NAME=Clinic Admin
 SETUP_ADMIN_EMAIL=admin@example.com
 SETUP_ACTIVATION_KEY=


### PR DESCRIPTION
﻿## Summary

- Removes `change-me` from the VPS lifecycle DATABASE_URL sample.
- Removes the default first-run admin password value from the lifecycle sample.
- Marks both fields as required so operators must provide unique secrets.

## Contract Impact

not applicable - no API, websocket, request, response, status-code, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or permission behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, route, or frontend data flow changed.

## Scope Gate

- Allowed paths: ops/vps/clinic_lifecycle.env.sample
- Denied paths: runtime code, compose files, scripts, frontend, migrations, generated artifacts, runbook docs
- Migration/docs/test impact: env sample only; no migration or code execution path changed
- Rollback note: revert this commit to restore previous sample values

## Validation

- Targeted tests or smoke run: git diff --check; static scan for `change-me`, embedded DATABASE_URL sample credential, and blank required fields
- Result: diff check passed with only LF-to-CRLF warning; `change-me` and embedded DATABASE_URL credential were not found; blank DATABASE_URL= and SETUP_ADMIN_PASSWORD= lines are present
- Not checked: VPS lifecycle runtime, because this is an env sample-only change
