### PR TITLE
docs: harden vps postgres bootstrap examples

### DIFF
--- a/ops/vps/README.md
+++ b/ops/vps/README.md
@@ -69,10 +69,11 @@ cp ops/vps/backend.env.sample backend/.env.staging
 cp ops/vps/frontend.env.sample frontend/.env.staging
 cp ops/vps/clinic_lifecycle.env.sample .env.clinic-lifecycle
 
-# edit both env files first
-# edit .env.clinic-lifecycle for smoke and rehearsal commands
+# Generate a unique DB password, then put it into backend/.env.staging
+# and .env.clinic-lifecycle DATABASE_URL before deploy.
+DB_PASSWORD="$(openssl rand -base64 24)"
 
-sudo bash ops/vps/scripts/bootstrap_postgres.sh clinic_staging clinic_staging_pwd clinic_staging
+sudo bash ops/vps/scripts/bootstrap_postgres.sh clinic_staging "$DB_PASSWORD" clinic_staging
 
 sudo APP_ENV=staging \
   APP_HOST=staging.example.com \
@@ -111,9 +112,11 @@ cd /opt/clinic
 cp ops/vps/backend.env.sample backend/.env.production
 cp ops/vps/frontend.env.sample frontend/.env.production
 
-# edit both env files first
+# Generate a unique DB password, then put it into backend/.env.production
+# DATABASE_URL before deploy.
+DB_PASSWORD="$(openssl rand -base64 24)"
 
-sudo bash ops/vps/scripts/bootstrap_postgres.sh clinic_prod change-me clinic_prod
+sudo bash ops/vps/scripts/bootstrap_postgres.sh clinic_prod "$DB_PASSWORD" clinic_prod
 
 sudo APP_ENV=production \
   APP_HOST=clinic.example.com \


### PR DESCRIPTION
﻿## Summary

- Replace documented VPS staging DB password default with generated `DB_PASSWORD`.
- Replace documented production `change-me` DB password with generated `DB_PASSWORD`.
- Clarify that the generated password must be copied into the matching backend/lifecycle `DATABASE_URL` before deploy.

## Contract Impact

not applicable - docs-only VPS rollout wording, no API or frontend/backend contract changed.

## RBAC / Permissions

not applicable - docs-only VPS rollout wording, no route guard or role behavior changed.

## Notification / Realtime

not applicable - docs-only VPS rollout wording, no websocket, notification, or realtime behavior changed.

## Frontend Resilience

not applicable - docs-only VPS rollout wording, no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `ops/vps/README.md`.
- Denied paths: VPS scripts, env samples, compose files, backend, frontend, generated outputs, evidence logs.
- Migration/docs/test impact: docs-only VPS bootstrap hardening; no migration or runtime code changed.
- Rollback note: revert this commit to restore previous VPS README examples only.

## Validation

- Targeted tests or smoke run: `git diff --check`; static scan for old `clinic_staging_pwd` and production `change-me` bootstrap example; static scan for generated `DB_PASSWORD` examples.
- Result: passed; only the expected PowerShell LF->CRLF warning appeared for the touched Markdown file.
- Not checked: live VPS bootstrap command, because this PR changes documentation only and no VPS target is attached here.
