### PR TITLE
test: align load profile default backend port

### DIFF
--- a/ops/load/clinic_core.js
+++ b/ops/load/clinic_core.js
@@ -26,7 +26,7 @@ export const options = {
   summaryTrendStats: ["avg", "min", "med", "max", "p(90)", "p(95)", "p(99)"],
 };
 
-const BASE_URL = __ENV.BASE_URL || "http://127.0.0.1:8000";
+const BASE_URL = __ENV.BASE_URL || "http://127.0.0.1:18000";
 
 const DEFAULT_ENDPOINTS = [
   "/api/v1/status",


### PR DESCRIPTION
﻿## Summary

- Align the k6 clinic load profile default backend origin with the canonical local backend port `18000`.
- Keep `BASE_URL` override behavior unchanged for custom load-test targets.

## Contract Impact

not applicable - load-test default target only, no API request or response contract changed.

## RBAC / Permissions

not applicable - load-test default target only, no route guard or role behavior changed.

## Notification / Realtime

not applicable - load-test default target only, no websocket, notification, or realtime behavior changed.

## Frontend Resilience

not applicable - load-test default target only, no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `ops/load/clinic_core.js`.
- Denied paths: compose files, Dockerfiles, backend, frontend, generated outputs, evidence logs.
- Migration/docs/test impact: load-smoke helper default only; no migration or runtime code changed.
- Rollback note: revert this commit to restore the previous k6 default target.

## Validation

- Targeted tests or smoke run: `git diff --check`; static scan for `127.0.0.1:18000` and absence of `127.0.0.1:8000` in `ops/load/clinic_core.js`.
- Result: passed; only the expected PowerShell LF->CRLF warning appeared for the touched JavaScript file.
- Not checked: k6 execution, because k6 is not configured in this local environment and this patch changes only the default URL literal.
