### PR TITLE
fix: guard reset all passwords helper

### DIFF
--- a/backend/reset_all_passwords.py
+++ b/backend/reset_all_passwords.py
@@ -3,33 +3,74 @@
 Скрипт для сброса паролей всех пользователей
 """
 
-from app.core.security import get_password_hash
-from app.db.session import SessionLocal
-from app.models.user import User
+from __future__ import annotations
+
+import os
+
+
+USERS = (
+    "admin",
+    "registrar",
+    "lab",
+    "doctor",
+    "cashier",
+    "cardio",
+    "derma",
+    "dentist",
+)
+
+TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
+
+
+def _require_confirmation() -> None:
+    value = os.getenv("CONFIRM_RESET_ALL_PASSWORDS", "").strip().lower()
+    if value not in TRUTHY_ENV_VALUES:
+        raise RuntimeError(
+            "Set CONFIRM_RESET_ALL_PASSWORDS=1 before resetting all user passwords."
+        )
+
+
+def _require_postgres_database_url() -> None:
+    database_url = os.getenv("DATABASE_URL", "").strip()
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set before resetting user passwords.")
+    if database_url.lower().startswith("sqlite"):
+        raise RuntimeError("reset_all_passwords.py requires a PostgreSQL DATABASE_URL.")
+
+
+def _password_env_names(username: str) -> list[str]:
+    names = [f"RESET_ALL_{username.upper()}_PASSWORD"]
+    if username == "admin":
+        names.insert(0, "ADMIN_PASSWORD")
+    return names
+
+
+def _required_password(username: str) -> str:
+    for env_name in _password_env_names(username):
+        password = os.getenv(env_name, "").strip()
+        if password:
+            return password
+    expected = " or ".join(_password_env_names(username))
+    raise RuntimeError(f"Set {expected} before resetting user '{username}'.")
 
 
 def reset_all_passwords():
     """Сброс паролей всех пользователей согласно документации"""
+    _require_confirmation()
+    _require_postgres_database_url()
+    passwords = {username: _required_password(username) for username in USERS}
+
+    from app.core.security import get_password_hash
+    from app.db.session import SessionLocal
+    from app.models.user import User
+
     db = SessionLocal()
     try:
-        # Пользователи и их пароли согласно ROLES_AND_ROUTING.md
-        users_data = [
-            ("admin", "admin123"),
-            ("registrar", "registrar123"),
-            ("lab", "lab123"),
-            ("doctor", "doctor123"),
-            ("cashier", "cashier123"),
-            ("cardio", "cardio123"),
-            ("derma", "derma123"),
-            ("dentist", "dentist123"),
-        ]
-
-        for username, password in users_data:
+        for username in USERS:
             user = db.query(User).filter(User.username == username).first()
             if user:
-                # Устанавливаем новый пароль
-                user.hashed_password = get_password_hash(password)
-                print(f"OK: Пароль для {username} сброшен на {password}")
+                user.hashed_password = get_password_hash(passwords[username])
+                print(f"OK: Пароль для {username} сброшен")
             else:
                 print(f"ERROR: Пользователь {username} не найден")
 
@@ -39,6 +80,7 @@ def reset_all_passwords():
     except Exception as e:
         print(f"ERROR: Ошибка при сбросе паролей: {e}")
         db.rollback()
+        raise
     finally:
         db.close()
 


### PR DESCRIPTION
﻿## Summary

- Require `CONFIRM_RESET_ALL_PASSWORDS=1` before the helper can mutate users.
- Require a non-SQLite `DATABASE_URL` before resetting passwords.
- Replace hardcoded role passwords with explicit env-provided secrets such as `ADMIN_PASSWORD` and `RESET_ALL_<ROLE>_PASSWORD`.
- Stop printing password values and re-raise failures so script errors produce a failing exit.

## Contract Impact

not applicable - standalone backend maintenance helper only, no API request or response contract changed.

## RBAC / Permissions

not applicable - standalone maintenance helper only, no route guard or runtime role permission changed.

## Notification / Realtime

not applicable - standalone maintenance helper only, no websocket, notification, or realtime behavior changed.

## Frontend Resilience

not applicable - backend maintenance helper only, no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/reset_all_passwords.py`.
- Denied paths: backend app runtime config, DB session, setup scripts, frontend, ops, generated outputs, evidence logs.
- Migration/docs/test impact: helper safety hardening only; no migration or runtime application code changed.
- Rollback note: revert this commit to restore the previous helper behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/reset_all_passwords.py`; `git diff --check`; direct import/guard smoke for confirmation, SQLite rejection, missing password rejection, and env password resolution; static scan for old hardcoded passwords and printed password wording.
- Result: passed.
- Not checked: live password reset against a database, because that would mutate real user rows and this PR intentionally validates guard behavior without DB writes.
