### PR TITLE
fix: require setup env database secret

### DIFF
--- a/backend/setup_env.py
+++ b/backend/setup_env.py
@@ -22,7 +22,9 @@ APP_VERSION=0.9.0
 API_V1_STR=/api/v1
 
 # --- БАЗА ДАННЫХ ---
-DATABASE_URL=postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb
+# Required. PostgreSQL only; do not use SQLite for runtime.
+# Example: postgresql+psycopg://clinic:<db_password>@localhost:55432/clinicdb
+DATABASE_URL=
 
 # --- АУТЕНТИФИКАЦИЯ ---
 SECRET_KEY={secret_key}
@@ -54,7 +56,7 @@ REQUIRE_LICENSE=0
 LICENSE_ALLOW_HEALTH=1
 
 # --- DOCKER COMPOSE / STAGING ALTERNATIVE ---
-# DATABASE_URL=postgresql+psycopg://clinic:clinicpwd@postgres:5432/clinicdb
+# DATABASE_URL=postgresql+psycopg://clinic:<db_password>@postgres:5432/clinicdb
 
 # --- FIREBASE (PUSH УВЕДОМЛЕНИЯ) ---
 # Раскомментируйте и настройте для реальных push-уведомлений
@@ -79,10 +81,10 @@ LICENSE_ALLOW_HEALTH=1
 
     # Проверяем, существует ли уже .env
     if os.path.exists('.env'):
-        print("⚠️  Файл .env уже существует!")
+        print("WARN: Файл .env уже существует!")
         response = input("Перезаписать? (y/N): ").lower().strip()
         if response != 'y':
-            print("❌ Отменено")
+            print("CANCEL: Отменено")
             return False
     
     # Создаем .env файл
@@ -90,9 +92,9 @@ LICENSE_ALLOW_HEALTH=1
         with open('.env', 'w', encoding='utf-8') as f:
             f.write(env_content)
         
-        print("✅ Файл .env создан успешно!")
-        print(f"🔑 SECRET_KEY сгенерирован: {secret_key[:20]}...")
-        print("\n📋 Следующие шаги:")
+        print("OK: Файл .env создан успешно!")
+        print(f"KEY: SECRET_KEY сгенерирован: {secret_key[:20]}...")
+        print("\nNEXT: Следующие шаги:")
         print("1. Перезапустите backend")
         print("2. При необходимости добавьте дополнительные настройки")
         print("3. Для продакшена смените SECRET_KEY")
@@ -100,10 +102,10 @@ LICENSE_ALLOW_HEALTH=1
         return True
         
     except Exception as e:
-        print(f"❌ Ошибка создания .env: {e}")
+        print(f"ERROR: Ошибка создания .env: {e}")
         return False
 
 if __name__ == "__main__":
-    print("🚀 Настройка переменных окружения для клиники")
+    print("Настройка переменных окружения для клиники")
     print("=" * 50)
     create_env_file()


### PR DESCRIPTION
﻿## Summary

- Stop generating `.env` with the default `clinicpwd` database password.
- Leave `DATABASE_URL=` blank and document PostgreSQL-only examples with `<db_password>` placeholders.
- Replace emoji console prefixes with ASCII labels so the helper runs in default Windows PowerShell encodings.

## Contract Impact

not applicable - standalone env-generation helper only, no API request or response contract changed.

## RBAC / Permissions

not applicable - standalone env-generation helper only, no route guard or role behavior changed.

## Notification / Realtime

not applicable - standalone env-generation helper only, no websocket, notification, or realtime behavior changed.

## Frontend Resilience

not applicable - backend setup helper only, no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/setup_env.py`.
- Denied paths: compose files, env samples, backend runtime config, frontend, generated outputs, evidence logs.
- Migration/docs/test impact: setup helper template hardening only; no migration or runtime application code changed.
- Rollback note: revert this commit to restore the previous generated `.env` template and console text.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/setup_env.py`; `git diff --check`; temp-dir generated `.env` smoke without `PYTHONIOENCODING`; static scan for `clinicpwd`, emoji prefixes, blank `DATABASE_URL`, and `<db_password>` examples.
- Result: passed.
- Not checked: using the generated `.env` to boot the backend, because this PR changes only the helper template and intentionally requires the operator to fill `DATABASE_URL` first.
