### PR TITLE
fix: remove bom from reset critical helper

### DIFF
--- a/backend/scripts/reset_critical_passwords.py
+++ b/backend/scripts/reset_critical_passwords.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 """
 Reset or create critical users with explicit environment-provided passwords/roles.
 


### PR DESCRIPTION
﻿## Summary

- Remove the UTF-8 BOM before the shebang in `backend/scripts/reset_critical_passwords.py`.
- Keep the helper logic unchanged.

## Contract Impact

not applicable - script encoding/shebang hygiene only, no API request or response contract changed.

## RBAC / Permissions

not applicable - script encoding/shebang hygiene only, no route guard or role behavior changed.

## Notification / Realtime

not applicable - script encoding/shebang hygiene only, no websocket, notification, or realtime behavior changed.

## Frontend Resilience

not applicable - backend helper encoding cleanup only, no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/scripts/reset_critical_passwords.py`.
- Denied paths: reset logic, backend app runtime config, frontend, ops, generated outputs, evidence logs.
- Migration/docs/test impact: helper portability only; no migration or runtime application code changed.
- Rollback note: revert this commit to restore the prior file bytes.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/scripts/reset_critical_passwords.py`; `git diff --check`; byte smoke confirming the file starts with `#!` and not UTF-8 BOM.
- Result: passed.
- Not checked: live reset command execution against a database, because the helper logic was not changed.
