### PR TITLE
fix: ignore ai profile token cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ backend/mypy_ci_check.txt
 run_*.final.html
 run_latest.html
 wf_page*.html
+.ai-factory/profile_tokens.json
 .ai-factory/landing/runs/*
 !.ai-factory/landing/runs/.gitkeep
 


### PR DESCRIPTION
﻿## Summary
- Ignore local `.ai-factory/profile_tokens.json` regeneration after the tracked token artifact was removed.
- Keep the change limited to repo ignore policy.

## Contract Impact
not applicable - git ignore policy only, no API or runtime contract changed.

## RBAC / Permissions
not applicable - git ignore policy only, no route guard or role behavior changed.

## Notification / Realtime
not applicable - git ignore policy only, no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - git ignore policy only, no frontend panel or data flow changed.

## Scope Gate
- Allowed paths: `.gitignore`.
- Denied paths: runtime auth code, DB migrations, frontend, ops, generated outputs, evidence logs.
- Migration/docs/test impact: ignore-rule only; no migration/runtime code changed.
- Rollback note: reverting would allow regenerated token cache files to appear in `git status` again.

## Validation
- Targeted tests or smoke run: `git diff --check`; static scan for `.ai-factory/profile_tokens.json` in `.gitignore`; `git ls-tree -r HEAD -- .ai-factory/profile_tokens.json`.
- Result: passed; ignore rule present and token artifact remains absent from tracked files.
- Not checked: secret rotation/history rewrite, because this PR only prevents re-adding the local cache file after #310 removed it.
