### PR TITLE
chore: ignore local qa artifacts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell entrypoints run inside Linux containers and must keep LF endings.
+/.gitattributes text eol=lf
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 *.pyd
 *.sqlite3
 .venv/
+.venv.wsl.bak/
 env/
 venv/
 *.sqlite3
@@ -34,8 +35,11 @@ alembic/**/__pycache__/
 
 # Coverage/test
 .coverage
+coverage.xml
+frontend/coverage/
 htmlcov/
 pytest_cache/
+frontend/eslint-*.json
 NUL
 nul
 
@@ -55,6 +59,9 @@ backend/.secret_key
 # Test logs
 pytest_*.txt
 *_log*.txt
+backend/routes.json
+backend/cascade_audit_*.txt
+backend/fk_audit_*.txt
 *.db
 *.sqlite
 clinic.db
@@ -95,7 +102,35 @@ wf_page*.html
 !.ai-factory/landing/runs/.gitkeep
 
 # Local staging/runtime artifacts
+.playwright-cli/
+output/
+frontend/output/
+ops/meta/
+output/**/.playwright-cli/
+backend/storage/files/
+storage/files/
 output/staging/
+output/**/*.pid
+output/playwright/start-*.cmd
+output/playwright/inspect_*.ps1
+output/playwright/inspect_*.py
+output/playwright/verify_*.mjs
+output/playwright/verify_*.py
+output/*-recon.mjs
+output/*-live-check.mjs
+output/browser_row_actions_smoke.cjs
+job_*.html
+run_*.html
 staging-postgres-55432/
 frontend/playwright-report/
 frontend/test-results/
+test-results/
+frontend/vite.config.js.timestamp-*.mjs
+frontend/lint_report*.txt
+frontend/temp_*.js
+temp_token.json
+temp_old.jsx
+test_auth.json
+tree_F.txt
+mcp_test_report.json
+mcp_test_results_complaint.json


### PR DESCRIPTION
﻿## Summary
- Add repo hygiene ignores for local QA, Playwright, coverage, route-snapshot, output, and temporary MCP/auth artifacts.
- Add `.gitattributes` so Linux shell entrypoints keep LF endings.

## Contract Impact
not applicable - repository hygiene only, no API or runtime contract changed.

## RBAC / Permissions
not applicable - no auth, role, route guard, or permission behavior changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed; only local generated artifact patterns are ignored.

## Scope Gate
- Allowed paths: `.gitignore`, `.gitattributes`.
- Denied paths: backend runtime, frontend source, workflows, ops scripts, generated outputs, evidence logs, service/endpoint deletion wave.
- Migration/docs/test impact: none; this prevents local generated files from entering future diffs.
- Rollback note: reverting would allow these local QA/output artifacts to appear in `git status` again.

## Validation
- Targeted tests or smoke run: `git diff --cached --check`; `git check-attr -a -- .gitattributes ops/backend.entrypoint.sh .gitignore`; static scan for the new ignore patterns.
- Result: passed; `.sh` files resolve to `text eol=lf`, and all targeted ignore patterns are present.
- Not checked: application runtime tests, because this PR changes only Git metadata and ignore policy.
