### PR TITLE
docs: fix env guide encoding and vps password example

### DIFF
--- a/docs/README_env.md
+++ b/docs/README_env.md
@@ -1,29 +1,30 @@
-# РџРµСЂРµРјРµРЅРЅС‹Рµ РѕРєСЂСѓР¶РµРЅРёСЏ (Backend/Frontend)
+# Переменные окружения (Backend/Frontend)
 
 ## Backend (`backend/.env`)
-- `ENV` вЂ” РѕРєСЂСѓР¶РµРЅРёРµ: `dev|stage|prod`.
-- `APP_NAME` / `APP_VERSION` вЂ” РјРµС‚Р°РґР°РЅРЅС‹Рµ РїСЂРёР»РѕР¶РµРЅРёСЏ.
-- `API_V1_STR` вЂ” РїСЂРµС„РёРєСЃ API (РїРѕ СѓРјРѕР»С‡Р°РЅРёСЋ `/api/v1`).
+- `ENV` — окружение: `dev|stage|prod`.
+- `APP_NAME` / `APP_VERSION` — метаданные приложения.
+- `API_V1_STR` — префикс API (по умолчанию `/api/v1`).
 - `CORS_ALLOW_ALL` - local diagnostics only. Keep it `0` in `stage|prod`; configure explicit origins with `CORS_ORIGINS`.
-- `CORS_ORIGINS` вЂ” CSV СЃРїРёСЃРѕРє РёСЃС‚РѕС‡РЅРёРєРѕРІ (РЅР°РїСЂРёРјРµСЂ, `http://localhost:5173,http://localhost:4173`).
-- `DATABASE_URL` вЂ” СЃС‚СЂРѕРєР° РїРѕРґРєР»СЋС‡РµРЅРёСЏ Рє PostgreSQL (Р»РѕРєР°Р»СЊРЅС‹Р№ РїСЂРёРјРµСЂ: `postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb`).
-- `AUTH_SECRET` / `ACCESS_TOKEN_EXPIRE_MINUTES` / `AUTH_ALGORITHM` вЂ” РїР°СЂР°РјРµС‚СЂС‹ JWT.
-- `CLINIC_LOGO_PATH` / `PDF_FOOTER_ENABLED` вЂ” РїРµС‡Р°С‚СЊ Рё PDF.
-- `PRINTER_*` вЂ” РїР°СЂР°РјРµС‚СЂС‹ ESC/POS (С‚РёРї/СЃРµС‚СЊ/USB).
-- `REQUIRE_LICENSE` вЂ” РІРєР»СЋС‡РёС‚СЊ Р»РёС†РµРЅР·РёРѕРЅРЅС‹Р№ СЂРµР¶РёРј.
-- `LICENSE_ALLOW_HEALTH` вЂ” СЂР°Р·СЂРµС€РёС‚СЊ `/api/v1/health` РґРѕ Р°РєС‚РёРІР°С†РёРё.
+- `CORS_ORIGINS` — CSV список источников (например, `http://localhost:5173,http://localhost:4173`).
+- `DATABASE_URL` — строка подключения к PostgreSQL (локальный пример: `postgresql+psycopg://clinic:<db_password>@localhost:55432/clinicdb`).
+- `AUTH_SECRET` / `ACCESS_TOKEN_EXPIRE_MINUTES` / `AUTH_ALGORITHM` — параметры JWT.
+- `CLINIC_LOGO_PATH` / `PDF_FOOTER_ENABLED` — печать и PDF.
+- `PRINTER_*` — параметры ESC/POS (тип/сеть/USB).
+- `REQUIRE_LICENSE` — включить лицензионный режим.
+- `LICENSE_ALLOW_HEALTH` — разрешить `/api/v1/health` до активации.
 
 ## Frontend (`frontend/.env`)
-- `VITE_APP_NAME` вЂ” РЅР°Р·РІР°РЅРёРµ РІ UI.
-- `VITE_API_BASE` вЂ” Р±Р°Р·РѕРІС‹Р№ Р°РґСЂРµСЃ API (РЅР°РїСЂРёРјРµСЂ, `http://localhost:18000/api/v1`).
+- `VITE_APP_NAME` — название в UI.
+- `VITE_API_BASE` — базовый адрес API (например, `http://localhost:18000/api/v1`).
 
-## Р‘С‹СЃС‚СЂС‹Р№ СЃС‚Р°СЂС‚ (Р»РѕРєР°Р»СЊРЅРѕ)
+## Быстрый старт (локально)
 ```bash
 # Backend
 cp backend/.env.example backend/.env
-# РїСЂРё РЅРµРѕР±С…РѕРґРёРјРѕСЃС‚Рё РѕС‚СЂРµРґР°РєС‚РёСЂСѓР№С‚Рµ Р·РЅР°С‡РµРЅРёСЏ
-# uvicorn app.main:app --reload --port 18000  (РёР· РєР°С‚Р°Р»РѕРіР° backend)
+# при необходимости отредактируйте значения
+# uvicorn app.main:app --reload --port 18000  (из каталога backend)
 
 # Frontend
 cp frontend/.env.example frontend/.env
-# npm install && npm run dev  (РёР· РєР°С‚Р°Р»РѕРіР° frontend)
+# npm install && npm run dev  (из каталога frontend)
+```

--- a/docs/runbooks/VPS_HOST_ROLLOUT_RUNBOOK.md
+++ b/docs/runbooks/VPS_HOST_ROLLOUT_RUNBOOK.md
@@ -75,7 +75,8 @@ Minimum edits:
 ## Bootstrap Postgres
 
 ```bash
-sudo bash ops/vps/scripts/bootstrap_postgres.sh clinic_staging change-me clinic_staging
+DB_PASSWORD="$(openssl rand -base64 24)"
+sudo bash ops/vps/scripts/bootstrap_postgres.sh clinic_staging "$DB_PASSWORD" clinic_staging
 ```
 
 ## Deploy


### PR DESCRIPTION
﻿## Summary
- Fix mojibake in `docs/README_env.md` so the environment guide is readable Russian again.
- Update the local PostgreSQL example to the canonical staging/dev port `55432` and use a placeholder password instead of `clinicpwd`.
- Replace the VPS Postgres bootstrap `change-me` example with an `openssl rand` generated `DB_PASSWORD` flow.

## Contract Impact
not applicable - documentation-only change, no API or runtime contract changed.

## RBAC / Permissions
not applicable - no auth, role, route guard, or permission behavior changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed.

## Scope Gate
- Allowed paths: `docs/README_env.md`, `docs/runbooks/VPS_HOST_ROLLOUT_RUNBOOK.md`.
- Denied paths: backend, frontend, ops scripts, workflows, generated outputs, evidence logs.
- Migration/docs/test impact: docs-only; no migration or runtime code changed.
- Rollback note: reverting would restore unreadable environment docs and the weaker placeholder password example.

## Validation
- Targeted tests or smoke run: `git diff --check`; static scan for mojibake markers and old `clinicpwd`/`change-me` examples; static scan for `localhost:55432`, `<db_password>`, and `DB_PASSWORD`.
- Result: passed; old markers are absent in touched docs and corrected examples are present.
- Not checked: application runtime tests, because this PR changes only documentation.
