### PR TITLE
fix: require sqlite migration confirmation

### DIFF
--- a/backend/scripts/migrate_sqlite_to_postgres.py
+++ b/backend/scripts/migrate_sqlite_to_postgres.py
@@ -1,10 +1,23 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 
+def require_live_migration_confirmation() -> None:
+    if "--dry-run" in sys.argv:
+        return
+    if os.getenv("CONFIRM_SQLITE_TO_POSTGRES_MIGRATION") != "1":
+        raise RuntimeError(
+            "Refusing to run live SQLite-to-PostgreSQL migration. "
+            "Pass --dry-run for planning or set "
+            "CONFIRM_SQLITE_TO_POSTGRES_MIGRATION=1 for an explicit migration run."
+        )
+
+
 def main() -> int:
+    require_live_migration_confirmation()
     backend_root = Path(__file__).resolve().parents[1]
     if str(backend_root) not in sys.path:
         sys.path.insert(0, str(backend_root))


### PR DESCRIPTION
﻿## Summary
- Require `CONFIRM_SQLITE_TO_POSTGRES_MIGRATION=1` before running the SQLite-to-PostgreSQL migration wrapper in live mode.
- Preserve `--dry-run` as the planning path without requiring the live confirmation flag.
- Keep this slice limited to the migration wrapper after the gate narrowed the allowed first-touch scope.

## Contract Impact
not applicable - operator helper guard only, no API or runtime contract changed.

## RBAC / Permissions
not applicable - no auth, role, route guard, or permission behavior changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed.

## Scope Gate
- Allowed paths: `backend/scripts/migrate_sqlite_to_postgres.py`.
- Denied paths: EMR cutover scripts for this slice, Docker/ops files, backend runtime, frontend, workflows, generated outputs, evidence logs.
- Migration/docs/test impact: guard added to the migration wrapper; no database migration code changed.
- Rollback note: reverting would allow accidental live migration invocation without an explicit confirmation environment variable.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/scripts/migrate_sqlite_to_postgres.py`; `git diff --check`; static scan for `CONFIRM_SQLITE_TO_POSTGRES_MIGRATION`, `--dry-run`, and guard call; negative smoke without confirmation.
- Result: passed; no-confirm run exits with `RuntimeError` before the live migration import path.
- Not checked: actual migration execution, because the safe path here is confirming the wrapper guard only.
