### PR TITLE
fix: require live emr cutover confirmation

### DIFF
--- a/backend/scripts/emr_cutover_ops.py
+++ b/backend/scripts/emr_cutover_ops.py
@@ -40,6 +40,11 @@ def main() -> int:
     args = _parse_args()
 
     if args.mode == "live":
+        if os.getenv("CONFIRM_EMR_CUTOVER_LIVE") != "1":
+            raise RuntimeError(
+                "Refusing to run live EMR cutover. "
+                "Set CONFIRM_EMR_CUTOVER_LIVE=1 only for an explicit cutover run."
+            )
         os.environ["EMR_LEGACY_WRITE_FREEZE"] = "1"
 
     _configure_path()


### PR DESCRIPTION
﻿## Summary
- Require `CONFIRM_EMR_CUTOVER_LIVE=1` before `backend/scripts/emr_cutover_ops.py live` can run.
- Keep `verify` and `dry-run` modes unchanged.
- Preserve the existing `EMR_LEGACY_WRITE_FREEZE=1` behavior after explicit live confirmation.

## Contract Impact
not applicable - operator helper guard only, no API or runtime contract changed.

## RBAC / Permissions
not applicable - no auth, role, route guard, or permission behavior changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed.

## Scope Gate
- Allowed paths: `backend/scripts/emr_cutover_ops.py`.
- Denied paths: `backend/scripts/run_emr_cutover.py` for this slice, backend runtime EMR services, frontend, ops, workflows, generated outputs, evidence logs.
- Migration/docs/test impact: guard added to the cutover helper; no database migration or EMR service code changed.
- Rollback note: reverting would allow accidental live EMR cutover invocation without an explicit confirmation environment variable.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/scripts/emr_cutover_ops.py`; `git diff --check`; static scan for `CONFIRM_EMR_CUTOVER_LIVE`; negative live-mode smoke without confirmation.
- Result: passed; no-confirm live run exits with `RuntimeError` before importing DB/service code.
- Not checked: actual EMR cutover execution, because this PR verifies only the safety guard.
