### PR TITLE
fix: require full emr cutover confirmation

### DIFF
--- a/backend/scripts/run_emr_cutover.py
+++ b/backend/scripts/run_emr_cutover.py
@@ -193,6 +193,11 @@ def _ops_command(mode: str, *, pretty: bool, limit: int | None) -> list[str]:
 
 def main() -> int:
     args = _parse_args()
+    if os.getenv("CONFIRM_RUN_EMR_CUTOVER") != "1":
+        raise RuntimeError(
+            "Refusing to run full EMR cutover workflow. "
+            "Set CONFIRM_RUN_EMR_CUTOVER=1 only for an explicit operator-approved cutover run."
+        )
     backend_root = _backend_root()
     env = os.environ.copy()
     _load_dotenv_defaults(env)


### PR DESCRIPTION
﻿## Summary
- Require `CONFIRM_RUN_EMR_CUTOVER=1` before the full EMR cutover workflow wrapper can run.
- Stop accidental execution before backup, Alembic upgrade, dry-run, live run, or final verification steps begin.
- Keep the existing workflow behavior unchanged after explicit operator confirmation.

## Contract Impact
not applicable - operator helper guard only, no API or runtime contract changed.

## RBAC / Permissions
not applicable - no auth, role, route guard, or permission behavior changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed.

## Scope Gate
- Allowed paths: `backend/scripts/run_emr_cutover.py`.
- Denied paths: backend EMR services, frontend, ops, workflows, generated outputs, evidence logs.
- Migration/docs/test impact: guard added to the cutover workflow wrapper; no database migration or EMR service code changed.
- Rollback note: reverting would allow accidental full EMR cutover workflow invocation without an explicit confirmation environment variable.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/scripts/run_emr_cutover.py`; `git diff --check`; static scan for `CONFIRM_RUN_EMR_CUTOVER`; negative wrapper smoke without confirmation.
- Result: passed; no-confirm run exits with `RuntimeError` before backup, Alembic, or live cutover steps.
- Not checked: actual EMR cutover execution, because this PR verifies only the safety guard.
