### PR TITLE
fix: harden foreign key audit helper

### DIFF
--- a/backend/app/scripts/audit_foreign_keys.py
+++ b/backend/app/scripts/audit_foreign_keys.py
@@ -1,34 +1,32 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Аудит целостности внешних ключей и поиск orphaned records.
-Проверяет все FK связи в базе данных и выводит отчет.
-"""
+"""Audit foreign keys and orphaned records for the configured database."""
 from __future__ import annotations
 
 import os
 import sys
-from typing import Dict, List, Tuple
+from pathlib import Path
+from typing import Any, Dict, List
 
 import sqlalchemy as sa
 from sqlalchemy import inspect, text
 from sqlalchemy.engine import make_url
 
-# Добавляем путь к приложению
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(BACKEND_DIR))
+
 
 def get_database_url() -> str:
-    url = os.getenv("DATABASE_URL", "").strip()
-    if url:
-        return url
+    url = os.getenv("DATABASE_URL")
+    if url and url.strip():
+        return url.strip()
 
     settings_error = None
     try:
         from app.core.config import settings
 
-        configured = getattr(settings, "DATABASE_URL", None)
-        if configured:
-            return str(configured).strip()
+        settings_url = getattr(settings, "DATABASE_URL", None)
+        if settings_url:
+            return str(settings_url).strip()
     except Exception as exc:
         settings_error = exc
 
@@ -67,9 +65,8 @@ def display_database_url(url: str) -> str:
     return make_url(url).render_as_string(hide_password=True)
 
 
-
-def get_foreign_keys(conn, table_name: str) -> List[Dict]:
-    """Получить все внешние ключи для таблицы"""
+def get_foreign_keys(conn, table_name: str) -> List[Dict[str, Any]]:
+    """Return foreign keys for one table, or an empty list if inspection fails."""
     inspector = inspect(conn)
     try:
         return inspector.get_foreign_keys(table_name)
@@ -77,37 +74,48 @@ def get_foreign_keys(conn, table_name: str) -> List[Dict]:
         return []
 
 
-def check_orphaned_records(conn, child_table: str, fk_column: str, parent_table: str, parent_pk: str = "id") -> int:
-    """Проверить количество orphaned записей"""
+def check_orphaned_records(
+    conn,
+    child_table: str,
+    fk_column: str,
+    parent_table: str,
+    parent_pk: str = "id",
+) -> int:
+    """Return the orphaned-row count for one FK relationship."""
     try:
-        query = text(f"""
+        query = text(
+            f"""
             SELECT COUNT(*) as count
             FROM "{child_table}" c
             LEFT JOIN "{parent_table}" p ON c."{fk_column}" = p."{parent_pk}"
             WHERE c."{fk_column}" IS NOT NULL AND p."{parent_pk}" IS NULL
-        """)
+            """
+        )
         result = conn.execute(query).fetchone()
         return result[0] if result else 0
-    except Exception as e:
-        print(f"  ⚠️  Ошибка проверки {child_table}.{fk_column} -> {parent_table}.{parent_pk}: {e}")
+    except Exception as exc:
+        print(
+            "  [WARNING] Could not check "
+            f"{child_table}.{fk_column} -> {parent_table}.{parent_pk}: {exc}"
+        )
         return -1
 
 
-def audit_all_foreign_keys(conn) -> Dict[str, any]:
-    """Аудит всех внешних ключей в базе данных"""
+def audit_all_foreign_keys(conn) -> Dict[str, Any]:
+    """Audit all FK relationships and orphaned records in the database."""
     inspector = inspect(conn)
     tables = inspector.get_table_names()
 
-    results = {
+    results: Dict[str, Any] = {
         "total_tables": len(tables),
         "tables_with_fks": 0,
         "total_fks": 0,
         "orphaned_records": [],
-        "errors": []
+        "errors": [],
     }
 
     print("=" * 80)
-    print("АУДИТ ВНЕШНИХ КЛЮЧЕЙ И ORPHANED RECORDS")
+    print("FOREIGN KEY AND ORPHANED RECORD AUDIT")
     print("=" * 80)
     print()
 
@@ -119,9 +127,8 @@ def audit_all_foreign_keys(conn) -> Dict[str, any]:
         results["tables_with_fks"] += 1
         results["total_fks"] += len(fks)
 
-        print(f"📋 Таблица: {table}")
+        print(f"Table: {table}")
         for fk in fks:
-            fk_name = fk.get("name", "unnamed")
             constrained_columns = fk.get("constrained_columns", [])
             referred_table = fk.get("referred_table", "")
             referred_columns = fk.get("referred_columns", [])
@@ -132,36 +139,58 @@ def audit_all_foreign_keys(conn) -> Dict[str, any]:
             fk_column = constrained_columns[0]
             parent_pk = referred_columns[0] if referred_columns else "id"
 
-            print(f"  🔗 FK: {fk_column} -> {referred_table}.{parent_pk}")
+            print(f"  FK: {fk_column} -> {referred_table}.{parent_pk}")
 
-            # Проверяем orphaned records
-            orphan_count = check_orphaned_records(conn, table, fk_column, referred_table, parent_pk)
+            orphan_count = check_orphaned_records(
+                conn,
+                table,
+                fk_column,
+                referred_table,
+                parent_pk,
+            )
 
             if orphan_count > 0:
-                results["orphaned_records"].append({
-                    "table": table,
-                    "column": fk_column,
-                    "parent_table": referred_table,
-                    "parent_pk": parent_pk,
-                    "count": orphan_count
-                })
-                print(f"    ❌ Найдено {orphan_count} orphaned записей!")
+                results["orphaned_records"].append(
+                    {
+                        "table": table,
+                        "column": fk_column,
+                        "parent_table": referred_table,
+                        "parent_pk": parent_pk,
+                        "count": orphan_count,
+                    }
+                )
+                print(f"    [ERROR] Found {orphan_count} orphaned records")
             elif orphan_count == 0:
-                print(f"    ✅ Нет orphaned записей")
+                print("    [OK] No orphaned records")
             else:
-                results["errors"].append({
-                    "table": table,
-                    "column": fk_column,
-                    "error": "Check failed"
-                })
+                results["errors"].append(
+                    {
+                        "table": table,
+                        "column": fk_column,
+                        "error": "Check failed",
+                    }
+                )
 
         print()
 
     return results
 
 
-def main():
-    """Основная функция"""
+def enable_sqlite_foreign_keys(conn, url: str) -> None:
+    if not is_sqlite_database_url(url):
+        return
+
+    conn.execute(text("PRAGMA foreign_keys=ON"))
+    print("[OK] Foreign key enforcement enabled for SQLite\n")
+
+    fk_status = conn.execute(text("PRAGMA foreign_keys")).fetchone()
+    if fk_status and fk_status[0]:
+        print("[OK] Foreign keys are enabled in SQLite\n")
+    else:
+        print("[WARNING] Foreign keys are not enabled in SQLite\n")
+
+
+def main() -> int:
     url = normalize_sync_database_url(get_database_url())
     enforce_database_url_policy(url)
     print(f"Database URL: {display_database_url(url)}")
@@ -169,45 +198,34 @@ def main():
     engine = sa.create_engine(url, future=True)
 
     with engine.connect() as conn:
-        # ✅ SECURITY: Включаем проверку FK для SQLite
-        if url.startswith("sqlite"):
-            conn.execute(text("PRAGMA foreign_keys=ON"))
-            print("✅ Foreign key enforcement включен для SQLite\n")
-
-        # Проверяем, включены ли FK
-        if url.startswith("sqlite"):
-            fk_status = conn.execute(text("PRAGMA foreign_keys")).fetchone()
-            if fk_status and fk_status[0]:
-                print("✅ Foreign keys включены в SQLite\n")
-            else:
-                print("⚠️  WARNING: Foreign keys НЕ включены в SQLite!\n")
-
-        # Выполняем аудит
+        enable_sqlite_foreign_keys(conn, url)
         results = audit_all_foreign_keys(conn)
 
-    # Выводим итоговый отчет
     print("=" * 80)
-    print("ИТОГОВЫЙ ОТЧЕТ")
+    print("SUMMARY")
     print("=" * 80)
-    print(f"Всего таблиц: {results['total_tables']}")
-    print(f"Таблиц с FK: {results['tables_with_fks']}")
-    print(f"Всего FK: {results['total_fks']}")
-    print(f"Orphaned записей найдено: {len(results['orphaned_records'])}")
-    print(f"Ошибок: {len(results['errors'])}")
+    print(f"Total tables: {results['total_tables']}")
+    print(f"Tables with FK: {results['tables_with_fks']}")
+    print(f"Total FK: {results['total_fks']}")
+    print(f"Orphaned relationship findings: {len(results['orphaned_records'])}")
+    print(f"Errors: {len(results['errors'])}")
     print()
 
-    if results['orphaned_records']:
-        print("⚠️  ORPHANED RECORDS НАЙДЕНЫ:")
-        for orphan in results['orphaned_records']:
-            print(f"  - {orphan['table']}.{orphan['column']} -> {orphan['parent_table']}.{orphan['parent_pk']}: {orphan['count']} записей")
+    if results["orphaned_records"]:
+        print("[WARNING] Orphaned records found:")
+        for orphan in results["orphaned_records"]:
+            print(
+                f"  - {orphan['table']}.{orphan['column']} -> "
+                f"{orphan['parent_table']}.{orphan['parent_pk']}: "
+                f"{orphan['count']} records"
+            )
         print()
-        print("Рекомендация: Исправьте orphaned записи перед включением FK enforcement.")
+        print("Recommendation: fix orphaned records before enabling FK enforcement.")
         return 1
-    else:
-        print("✅ Orphaned records не найдены. FK enforcement можно безопасно включить.")
-        return 0
+
+    print("[OK] No orphaned records found.")
+    return 0
 
 
 if __name__ == "__main__":
     sys.exit(main())
-


### PR DESCRIPTION
﻿## Summary
- Replace mojibake output/docstrings in the FK/orphan audit helper with ASCII-safe audit messages.
- Keep the script on explicit `DATABASE_URL` and PostgreSQL-first policy while preserving the existing explicit SQLite opt-in for legacy/tools/tests.
- Split SQLite FK enabling/status reporting into a small helper and tighten typing for FK audit results.

## Contract Impact
not applicable - maintenance helper script only, no API or runtime contract changed.

## RBAC / Permissions
not applicable - no auth, role, route guard, or permission behavior changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed.

## Scope Gate
- Allowed paths: `backend/app/scripts/audit_foreign_keys.py`.
- Denied paths: migrations, models, runtime DB config, frontend dependency files, ops, workflows, generated outputs, evidence logs.
- Migration/docs/test impact: maintenance helper only; no Alembic migration or runtime database code changed.
- Rollback note: reverting would restore mojibake helper output and the less isolated SQLite FK status logic.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/scripts/audit_foreign_keys.py`; `git diff --check`; static scan for removed mojibake markers and expected FK/SQLite policy strings.
- Result: passed for compile, diff check, and static scan.
- Not checked: runtime SQLite smoke, because this sparse local worktree does not have `sqlalchemy` importable; GitHub backend CI remains the runtime dependency check.
