### PR TITLE
fix: harden cascade audit helper

### DIFF
--- a/backend/app/scripts/audit_cascade_deletes.py
+++ b/backend/app/scripts/audit_cascade_deletes.py
@@ -1,35 +1,61 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Аудит cascade delete стратегий в моделях
-
-✅ SECURITY: Проверяет все FK связи и их cascade поведение
-"""
+"""Audit cascade-delete strategies for configured database constraints."""
 from __future__ import annotations
 
 import os
 import sys
-from typing import Dict, List, Tuple
+from pathlib import Path
+from typing import Dict, List
 
 import sqlalchemy as sa
 from sqlalchemy import inspect
 from sqlalchemy.engine import make_url
 
-# Добавляем путь к приложению
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(BACKEND_DIR))
+
+
+CRITICAL_RELATIONSHIPS = {
+    ("users", "refresh_tokens", "user_id"): "CASCADE",
+    ("users", "user_sessions", "user_id"): "CASCADE",
+    ("users", "password_reset_tokens", "user_id"): "CASCADE",
+    ("users", "email_verification_tokens", "user_id"): "CASCADE",
+    ("users", "login_attempts", "user_id"): "CASCADE",
+    ("users", "user_activities", "user_id"): "CASCADE",
+    ("users", "security_events", "user_id"): "CASCADE",
+    ("visits", "visit_services", "visit_id"): "CASCADE",
+    ("visits", "prescriptions", "visit_id"): "CASCADE",
+    ("visits", "emr", "visit_id"): "SET NULL",
+    ("payments", "payment_transactions", "payment_id"): "CASCADE",
+    ("payments", "payment_webhooks", "payment_id"): "SET NULL",
+    ("departments", "department_services", "department_id"): "CASCADE",
+    ("departments", "department_queue_settings", "department_id"): "CASCADE",
+    ("departments", "department_registration_settings", "department_id"): "CASCADE",
+    ("files", "file_versions", "file_id"): "CASCADE",
+    ("files", "file_shares", "file_id"): "CASCADE",
+    ("daily_queues", "online_queue_entries", "queue_id"): "CASCADE",
+}
+
+PRESERVE_RELATIONSHIPS = {
+    ("patients", "visits", "patient_id"): "SET NULL",
+    ("patients", "appointments", "patient_id"): "SET NULL",
+    ("users", "visits", "doctor_id"): "SET NULL",
+    ("users", "appointments", "doctor_id"): "SET NULL",
+}
+
 
 def get_database_url() -> str:
-    url = os.getenv("DATABASE_URL", "").strip()
-    if url:
-        return url
+    url = os.getenv("DATABASE_URL")
+    if url and url.strip():
+        return url.strip()
 
     settings_error = None
     try:
         from app.core.config import settings
 
-        configured = getattr(settings, "DATABASE_URL", None)
-        if configured:
-            return str(configured).strip()
+        settings_url = getattr(settings, "DATABASE_URL", None)
+        if settings_url:
+            return str(settings_url).strip()
     except Exception as exc:
         settings_error = exc
 
@@ -68,9 +94,8 @@ def display_database_url(url: str) -> str:
     return make_url(url).render_as_string(hide_password=True)
 
 
-
 def audit_cascade_strategies(conn) -> Dict[str, List[Dict]]:
-    """Аудит всех cascade стратегий в базе данных"""
+    """Audit cascade strategies in database foreign key metadata."""
     inspector = inspect(conn)
     tables = inspector.get_table_names()
 
@@ -82,155 +107,112 @@ def audit_cascade_strategies(conn) -> Dict[str, List[Dict]]:
     }
 
     print("=" * 80)
-    print("АУДИТ CASCADE DELETE СТРАТЕГИЙ")
+    print("CASCADE DELETE STRATEGY AUDIT")
     print("=" * 80)
     print()
-
-    # Критические связи, которые должны иметь cascade
-    critical_relationships = {
-        # User -> related entities (should cascade)
-        ("users", "refresh_tokens", "user_id"): "CASCADE",
-        ("users", "user_sessions", "user_id"): "CASCADE",
-        ("users", "password_reset_tokens", "user_id"): "CASCADE",
-        ("users", "email_verification_tokens", "user_id"): "CASCADE",
-        ("users", "login_attempts", "user_id"): "CASCADE",
-        ("users", "user_activities", "user_id"): "CASCADE",
-        ("users", "security_events", "user_id"): "CASCADE",
-
-        # Visit -> related entities
-        ("visits", "visit_services", "visit_id"): "CASCADE",
-        ("visits", "prescriptions", "visit_id"): "CASCADE",
-        ("visits", "emr", "visit_id"): "SET NULL",  # EMR should be preserved
-
-        # Payment -> related entities
-        ("payments", "payment_transactions", "payment_id"): "CASCADE",
-        ("payments", "payment_webhooks", "payment_id"): "SET NULL",  # Webhooks should be preserved for audit
-
-        # Department -> related entities
-        ("departments", "department_services", "department_id"): "CASCADE",
-        ("departments", "department_queue_settings", "department_id"): "CASCADE",
-        ("departments", "department_registration_settings", "department_id"): "CASCADE",
-
-        # File -> related entities
-        ("files", "file_versions", "file_id"): "CASCADE",
-        ("files", "file_shares", "file_id"): "CASCADE",
-
-        # Online Queue -> related entities
-        ("daily_queues", "online_queue_entries", "queue_id"): "CASCADE",
-    }
-
-    # Связи, которые НЕ должны иметь cascade (для сохранения данных)
-    preserve_relationships = {
-        ("patients", "visits", "patient_id"): "SET NULL",  # Visits should be preserved
-        ("patients", "appointments", "patient_id"): "SET NULL",  # Appointments should be preserved
-        ("users", "visits", "doctor_id"): "SET NULL",  # Visits should be preserved
-        ("users", "appointments", "doctor_id"): "SET NULL",  # Appointments should be preserved
-    }
 
     for table in tables:
         try:
             fks = inspector.get_foreign_keys(table)
+        except Exception as exc:
+            print(f"[WARNING] Could not inspect table {table}: {exc}")
+            continue
 
-            for fk in fks:
-                constrained_table = table
-                constrained_columns = fk.get("constrained_columns", [])
-                referred_table = fk.get("referred_table", "")
-                referred_columns = fk.get("referred_columns", [])
-                fk_name = fk.get("name", "unnamed")
+        for fk in fks:
+            constrained_columns = fk.get("constrained_columns", [])
+            referred_table = fk.get("referred_table", "")
+            fk_name = fk.get("name", "unnamed")
 
-                if not constrained_columns or not referred_table:
-                    continue
+            if not constrained_columns or not referred_table:
+                continue
 
-                constrained_col = constrained_columns[0]
-                key = (referred_table, constrained_table, constrained_col)
+            constrained_col = constrained_columns[0]
+            key = (referred_table, table, constrained_col)
+            ondelete = fk.get("options", {}).get("ondelete")
 
-                # Проверяем ondelete
-                ondelete = fk.get("options", {}).get("ondelete")
+            expected_cascade = CRITICAL_RELATIONSHIPS.get(key)
+            should_preserve = PRESERVE_RELATIONSHIPS.get(key)
 
-                # Проверяем критичность связи
-                expected_cascade = critical_relationships.get(key)
-                should_preserve = preserve_relationships.get(key)
-
-                if expected_cascade:
-                    if ondelete != expected_cascade:
-                        results["inconsistent_cascade"].append({
-                            "table": constrained_table,
+            if expected_cascade:
+                if ondelete != expected_cascade:
+                    results["inconsistent_cascade"].append(
+                        {
+                            "table": table,
                             "column": constrained_col,
                             "parent_table": referred_table,
                             "current": ondelete or "NONE",
                             "expected": expected_cascade,
                             "fk_name": fk_name,
-                        })
-                        print(f"[WARNING] {constrained_table}.{constrained_col} -> {referred_table}")
-                        print(f"     Текущий: {ondelete or 'NONE'}, Ожидается: {expected_cascade}")
-                    else:
-                        results["safe_cascade"].append({
-                            "table": constrained_table,
+                        }
+                    )
+                    print(f"[WARNING] {table}.{constrained_col} -> {referred_table}")
+                    print(f"     Current: {ondelete or 'NONE'}, expected: {expected_cascade}")
+                else:
+                    results["safe_cascade"].append(
+                        {
+                            "table": table,
                             "column": constrained_col,
                             "parent_table": referred_table,
                             "cascade": ondelete,
-                        })
-                        print(f"[OK] {constrained_table}.{constrained_col} -> {referred_table}: {ondelete}")
+                        }
+                    )
+                    print(f"[OK] {table}.{constrained_col} -> {referred_table}: {ondelete}")
 
-                elif should_preserve:
-                    if ondelete and ondelete != "SET NULL":
-                        results["orphan_risk"].append({
-                            "table": constrained_table,
+            elif should_preserve:
+                if ondelete and ondelete != "SET NULL":
+                    results["orphan_risk"].append(
+                        {
+                            "table": table,
                             "column": constrained_col,
                             "parent_table": referred_table,
                             "current": ondelete,
                             "recommended": "SET NULL",
                             "reason": "Data should be preserved",
-                        })
-                        print(f"[WARNING] {constrained_table}.{constrained_col} -> {referred_table}")
-                        print(f"     Текущий: {ondelete}, Рекомендуется: SET NULL (данные должны сохраняться)")
+                        }
+                    )
+                    print(f"[WARNING] {table}.{constrained_col} -> {referred_table}")
+                    print(f"     Current: {ondelete}, recommended: SET NULL")
 
-                # Проверяем отсутствие cascade для важных связей
-                elif not ondelete and referred_table in ["users", "patients", "visits", "payments"]:
-                    results["missing_cascade"].append({
-                        "table": constrained_table,
+            elif not ondelete and referred_table in {"users", "patients", "visits", "payments"}:
+                results["missing_cascade"].append(
+                    {
+                        "table": table,
                         "column": constrained_col,
                         "parent_table": referred_table,
                         "fk_name": fk_name,
-                    })
-                    print(f"[ERROR] {constrained_table}.{constrained_col} -> {referred_table}: НЕТ CASCADE")
-
-        except Exception as e:
-                        print(f"[WARNING] Ошибка проверки таблицы {table}: {e}")
+                    }
+                )
+                print(f"[ERROR] {table}.{constrained_col} -> {referred_table}: no cascade")
 
     return results
 
 
-def main():
-    """Основная функция"""
+def main() -> int:
     url = normalize_sync_database_url(get_database_url())
     enforce_database_url_policy(url)
     print(f"Database URL: {display_database_url(url)}")
 
     engine = sa.create_engine(url, future=True)
-
     with engine.connect() as conn:
         results = audit_cascade_strategies(conn)
 
-    # Выводим итоговый отчет
     print()
     print("=" * 80)
-    print("ИТОГОВЫЙ ОТЧЕТ")
+    print("SUMMARY")
     print("=" * 80)
-    print(f"[OK] Правильные cascade: {len(results['safe_cascade'])}")
-    print(f"[WARNING] Несоответствия: {len(results['inconsistent_cascade'])}")
-    print(f"[ERROR] Отсутствующие cascade: {len(results['missing_cascade'])}")
-    print(f"[WARNING] Риск потери данных: {len(results['orphan_risk'])}")
+    print(f"[OK] Safe cascade policies: {len(results['safe_cascade'])}")
+    print(f"[WARNING] Inconsistent policies: {len(results['inconsistent_cascade'])}")
+    print(f"[ERROR] Missing cascade policies: {len(results['missing_cascade'])}")
+    print(f"[WARNING] Data preservation risks: {len(results['orphan_risk'])}")
     print()
 
     if results["inconsistent_cascade"] or results["missing_cascade"]:
-        print("[WARNING] ОБНАРУЖЕНЫ ПРОБЛЕМЫ С CASCADE DELETE!")
+        print("[WARNING] Cascade delete issues found.")
         return 1
-    else:
-        print("[OK] Все cascade стратегии корректны")
-        return 0
+
+    print("[OK] Cascade delete strategies are consistent.")
+    return 0
 
 
 if __name__ == "__main__":
     sys.exit(main())
-


### PR DESCRIPTION
﻿## Summary
- Replace mojibake output/docstrings in the cascade-delete audit helper with ASCII-safe audit messages.
- Move expected cascade/preserve relationship maps to module constants without changing the expected policy values.
- Keep explicit `DATABASE_URL` handling and the SQLite opt-in guard aligned with PostgreSQL + Alembic as the schema source of truth.

## Contract Impact
not applicable - maintenance helper script only, no API, route, schema, or runtime database contract changed.

## RBAC / Permissions
not applicable - no auth, role, route guard, or permission behavior changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed.

## Scope Gate
- Allowed paths: `backend/app/scripts/audit_cascade_deletes.py`.
- Denied paths: migrations, models, runtime DB config, frontend dependency files, ops, workflows, generated outputs, evidence logs.
- Migration/docs/test impact: maintenance helper only; no Alembic migration or runtime cascade policy changed.
- Rollback note: reverting would restore mojibake helper output and the less isolated cascade audit maps.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/scripts/audit_cascade_deletes.py`; `git diff --check`; static scan for removed mojibake markers and expected cascade/SQLite policy strings; line-length scan.
- Result: passed for compile, diff check, static scan, and line-length scan.
- Not checked: live database audit execution, because this PR intentionally avoids connecting to a runtime database; GitHub backend CI remains the dependency/import check.
