### PR TITLE
fix: remove jwt secret fallback

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -16,19 +16,12 @@ if "__version__" not in vars(_argon2):
     _argon2.__version__ = importlib.metadata.version("argon2-cffi")
     logger.debug("[FIX] Applied argon2 version shim for passlib compatibility")
 
-# Настройки с дефолтами
-try:
-    from app.core.config import settings  # type: ignore
+# JWT configuration is owned by app.core.config and fails closed on invalid env.
+from app.core.config import settings  # type: ignore
 
-    SECRET_KEY: str = getattr(settings, "SECRET_KEY", "dev-secret-key-change-me")
-    ALGORITHM: str = getattr(settings, "ALGORITHM", "HS256")
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = int(
-        getattr(settings, "ACCESS_TOKEN_EXPIRE_MINUTES", 60)
-    )
-except Exception:
-    SECRET_KEY = "dev-secret-key-change-me"
-    ALGORITHM = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES = 60
+SECRET_KEY: str = settings.SECRET_KEY
+ALGORITHM: str = settings.ALGORITHM
+ACCESS_TOKEN_EXPIRE_MINUTES: int = int(settings.ACCESS_TOKEN_EXPIRE_MINUTES)
 
 # Поддерживаем верификацию старых хэшей bcrypt, новые хешируем argon2
 pwd_context = CryptContext(schemes=["argon2", "bcrypt"], deprecated="auto")


### PR DESCRIPTION
﻿## Summary
- Remove the silent `dev-secret-key-change-me` fallback from `app.core.security`.
- Let JWT helpers consume validated settings from `app.core.config` so invalid/missing production config fails closed at the config owner.
- Keep token creation/verification APIs unchanged.

## Contract Impact
not applicable - public auth API shape is unchanged; only unsafe internal fallback behavior is removed.

## RBAC / Permissions
not applicable - no role, permission, route guard, or access-control mapping changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed.

## Scope Gate
- Allowed paths: `backend/app/core/security.py`.
- Denied paths: config semantics, tests/fixtures, `.gitignore`, migrations, routes, frontend, ops, generated outputs, evidence logs.
- Migration/docs/test impact: no migration; test fixture cleanup was intentionally deferred because the gate did not include it in first-touch.
- Rollback note: reverting would restore a silent default JWT secret fallback in the security helper.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/core/security.py`; `git diff --check`; static scan for removed `dev-secret-key-change-me` fallback and expected `settings.SECRET_KEY` usage.
- Result: compile, diff check, and static scan passed.
- Not checked: targeted pytest in the temp worktree, because local import failed before tests with `ModuleNotFoundError: No module named 'fastapi'`; GitHub backend CI remains the dependency-backed test proof.
