### PR TITLE
fix: remove alembic default database password

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -2,7 +2,8 @@
 
 [alembic]
 script_location = alembic
-sqlalchemy.url = postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb
+# Database URL is supplied by DATABASE_URL in alembic/env.py.
+sqlalchemy.url =
 version_table = alembic_version
 
 [loggers]


### PR DESCRIPTION
﻿## Summary
- Remove the usable default `clinic:clinicpwd` PostgreSQL URL from `backend/alembic.ini`.
- Document that Alembic receives the database URL from `DATABASE_URL` via `backend/alembic/env.py`.
- Preserve Alembic script location/version table settings.

## Contract Impact
not applicable - migration command behavior still resolves the database URL through the existing Alembic env owner; no API/runtime route contract changed.

## RBAC / Permissions
not applicable - no auth, role, route guard, or permission behavior changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed.

## Scope Gate
- Allowed paths: `backend/alembic.ini`.
- Denied paths: Docker/compose/entrypoints, migrations, models, app DB session, frontend, ops, generated outputs, evidence logs.
- Migration/docs/test impact: no migration content changed; config now refuses to provide a usable fallback DB password.
- Rollback note: reverting would restore a default database credential in Alembic config.

## Validation
- Targeted tests or smoke run: `git diff --check`; Python `configparser` parse of `backend/alembic.ini`; static scan for removed `clinicpwd` and existing `DATABASE_URL`/missing-url guard in `backend/alembic/env.py`.
- Result: passed.
- Not checked: live Alembic migration execution, because this PR intentionally avoids connecting to a runtime database.
