### PR TITLE
docs: harden root env example

### DIFF
--- a/env_example.txt
+++ b/env_example.txt
@@ -22,10 +22,13 @@ MCP_HEALTH_CHECK_INTERVAL=60
 MCP_MAX_BATCH_SIZE=10
 
 # Database
-DATABASE_URL=sqlite:///./clinic.db
+# Required. PostgreSQL only; do not use SQLite for runtime.
+# Example: postgresql+psycopg://clinic:<db_password>@localhost:55432/clinicdb
+DATABASE_URL=
 
 # Auth
-SECRET_KEY=dev-secret-key-for-clinic-management-system-change-in-production
+# Required. Generate with: python -c "import secrets; print(secrets.token_urlsafe(48))"
+SECRET_KEY=
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=10080
 


### PR DESCRIPTION
﻿## Summary
- Remove the root env example's SQLite runtime default.
- Remove the root env example's committed dev-style `SECRET_KEY` placeholder.
- Leave `DATABASE_URL` and `SECRET_KEY` blank with generation/fill-in guidance and a PostgreSQL example on the canonical local port.

## Contract Impact
not applicable - documentation/example env template only; no runtime API, route, or database behavior changed.

## RBAC / Permissions
not applicable - no auth, role, route guard, or permission behavior changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed.

## Scope Gate
- Allowed paths: `env_example.txt`.
- Denied paths: Docker/compose/entrypoints, backend runtime config, migrations, frontend, ops, generated outputs, evidence logs.
- Migration/docs/test impact: example template only; no Alembic migration or runtime settings code changed.
- Rollback note: reverting would restore a SQLite runtime default and dev-style secret placeholder in the root env example.

## Validation
- Targeted tests or smoke run: `git diff --check --cached`; static scan for removed `sqlite:///`, `dev-secret-key`, `clinicpwd`, `strongpassword`, and default-secret patterns.
- Result: passed.
- Not checked: runtime startup, because this PR only changes an example env template.
