### PR TITLE
docs: harden backend env setup guide

### DIFF
--- a/backend/env_setup_guide.md
+++ b/backend/env_setup_guide.md
@@ -33,10 +33,13 @@ APP_NAME=Clinic Manager
 APP_VERSION=0.9.0
 
 # --- БАЗА ДАННЫХ ---
-DATABASE_URL=postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb
+# PostgreSQL only. Generate/use a local DB password and fill it explicitly.
+# Example: postgresql+psycopg://clinic:<db_password>@localhost:55432/clinicdb
+DATABASE_URL=
 
 # --- АУТЕНТИФИКАЦИЯ ---
-SECRET_KEY=your-super-secret-key-change-in-production
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(48))"
+SECRET_KEY=
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=10080
 


### PR DESCRIPTION
﻿## Summary
- Remove the default `clinicpwd` database password from the backend env setup guide.
- Replace the committed `SECRET_KEY` placeholder with an explicit blank value and generation command.
- Point the local PostgreSQL example at the canonical `55432` port with a `<db_password>` placeholder.

## Contract Impact
not applicable - setup documentation only; no runtime API, route, or database behavior changed.

## RBAC / Permissions
not applicable - no auth, role, route guard, or permission behavior changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed.

## Scope Gate
- Allowed paths: `backend/env_setup_guide.md`.
- Denied paths: runtime config, `.gitignore`, Docker/compose/entrypoints, actual `.env` files, frontend, ops, generated outputs, evidence logs.
- Migration/docs/test impact: documentation-only hardening; no Alembic migration or runtime settings code changed.
- Rollback note: reverting would restore a default DB password and secret placeholder in backend setup docs.

## Validation
- Targeted tests or smoke run: `git diff --check --cached`; static scan for removed `clinicpwd`, `your-super-secret`, `dev-secret`, `sqlite:///`, `strongpassword`, and default-secret patterns.
- Result: passed.
- Not checked: runtime startup, because this PR only changes setup documentation.
