### PR TITLE
docs: harden production security examples

### DIFF
--- a/docs/PRODUCTION_SECURITY.md
+++ b/docs/PRODUCTION_SECURITY.md
@@ -17,13 +17,14 @@
 ```bash
 # CRITICAL: Generate secure key for JWT tokens
 # python -c "import secrets; print(secrets.token_urlsafe(32))"
-SECRET_KEY=your-32-char-or-longer-secret-key
+# Paste a freshly generated value; do not commit or reuse examples.
+SECRET_KEY=
 
 # Set environment to production
 ENV=production
 
 # Database URL (use PostgreSQL in production)
-DATABASE_URL=postgresql://user:password@host:5432/clinic_db
+DATABASE_URL=postgresql://<db_user>:<db_password>@host:5432/clinic_db
 ```
 
 ### CORS Configuration
@@ -132,9 +133,10 @@ export PRODUCTION_CORS_ORIGINS="https://clinic.example.com,https://api.clinic.ex
 ```
 
 ### Behind Reverse Proxy (Nginx/Caddy)
-If your reverse proxy handles CORS, you can disable it in the application:
+Keep application CORS enabled and mirror the reverse-proxy allowlist in the application:
 ```bash
-export CORS_DISABLE=true
+export CORS_DISABLE=false
+export BACKEND_CORS_ORIGINS="https://clinic.example.com,https://api.clinic.example.com"
 ```
 
 ---
@@ -357,11 +359,12 @@ readinessProbe:
 
 ```bash
 # Core
-SECRET_KEY=6HK2DZj8qL4xPRvYnM9aS7cWfT3gJbE0uNhXiYlOpQw
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+SECRET_KEY=
 ENV=production
 
 # Database
-DATABASE_URL=postgresql://clinic:strongpassword@db.example.com:5432/clinic_prod
+DATABASE_URL=postgresql://clinic:<db_password>@db.example.com:5432/clinic_prod
 
 # Database Connection Pool
 DB_POOL_SIZE=10


### PR DESCRIPTION
﻿## Summary
- Redact committed-looking `SECRET_KEY` examples from the production security guide.
- Replace database URL examples that used `user:password` or `strongpassword` with placeholder credentials.
- Replace reverse-proxy guidance that suggested disabling app CORS with explicit allowlist mirroring guidance.

## Contract Impact
not applicable - production security documentation only; no runtime API, route, CORS, or database behavior changed.

## RBAC / Permissions
not applicable - no auth, role, route guard, or permission behavior changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed.

## Scope Gate
- Allowed paths: `docs/PRODUCTION_SECURITY.md`.
- Denied paths: runtime CORS/config code, `.gitignore`, Docker/compose/entrypoints, actual `.env` files, frontend, ops, generated outputs, evidence logs.
- Migration/docs/test impact: documentation-only hardening; no runtime setting or Alembic migration changed.
- Rollback note: reverting would restore committed-looking secret/password examples and weaker CORS reverse-proxy guidance.

## Validation
- Targeted tests or smoke run: `git diff --check`; static scan for removed `your-32-char-or-longer-secret-key`, generated-looking secret, `user:password`, `strongpassword`, and `export CORS_DISABLE=true`.
- Result: passed.
- Not checked: runtime startup, because this PR only changes production security documentation.
