### PR TITLE
docs: redact confirmation security placeholders

### DIFF
--- a/backend/docs/security/confirmation_security.md
+++ b/backend/docs/security/confirmation_security.md
@@ -336,9 +336,9 @@ class CircuitBreaker:
 
 ```bash
 # Токены и ключи
-TELEGRAM_BOT_TOKEN=your_telegram_bot_token
-JWT_SECRET_KEY=your_jwt_secret_key
-ENCRYPTION_KEY=your_encryption_key
+TELEGRAM_BOT_TOKEN=
+JWT_SECRET_KEY=
+ENCRYPTION_KEY=
 
 # Настройки безопасности
 RATE_LIMIT_ENABLED=true


### PR DESCRIPTION
﻿## Summary
- Redact token/key placeholder values in the confirmation security documentation.
- Leave the environment variable names intact while making values explicitly blank.
- Avoid importing the full QA-analise markdown rewrite to keep this PR line-ending-safe and reviewable.

## Contract Impact
not applicable - security documentation only; no runtime API, route, token, or database behavior changed.

## RBAC / Permissions
not applicable - no auth, role, route guard, or permission behavior changed.

## Notification / Realtime
not applicable - no websocket, notification, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code changed.

## Scope Gate
- Allowed paths: `backend/docs/security/confirmation_security.md`.
- Denied paths: service code, actual `.env` files, broader docs, frontend, ops, generated outputs, evidence logs.
- Migration/docs/test impact: documentation-only hardening; no runtime configuration changed.
- Rollback note: reverting would restore token/key placeholder values in security docs.

## Validation
- Targeted tests or smoke run: `git diff --check`; static scan for removed `your_telegram_bot_token`, `your_jwt_secret_key`, and `your_encryption_key`.
- Result: passed.
- Not checked: runtime startup, because this PR only changes security documentation.
