### PR TITLE
docs: redact visit confirmation password example

### DIFF
--- a/backend/docs/api/visit_confirmation.md
+++ b/backend/docs/api/visit_confirmation.md
@@ -311,7 +311,7 @@
 # 1. Врач авторизуется
 curl -X POST "http://localhost:18000/api/v1/authentication/login" \
   -H "Content-Type: application/json" \
-  -d '{"username": "doctor", "password": "password"}'
+  -d '{"username": "doctor", "password": "<DOCTOR_PASSWORD_FROM_ENV>"}'
 
 # 2. Назначает визит
 curl -X POST "http://localhost:18000/api/v1/doctor/visits/schedule-next" \


### PR DESCRIPTION
﻿## Summary

- Redacts the hardcoded `"password": "password"` doctor login example in the visit confirmation API docs.
- Replaces it with an explicit environment-backed placeholder.

## Contract Impact

not applicable - docs-only example redaction; no API, websocket, event, frontend route, request, response, status code, or compatibility contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/docs/api/visit_confirmation.md`
- Denied paths: runtime backend code, frontend code, endpoint/service deletions or renames, generated artifacts, evidence logs
- Migration/docs/test impact: docs-only redaction of a sample credential
- Rollback note: revert the single docs commit if the placeholder wording needs to change

## Validation

- Targeted tests or smoke run: `git diff --check`; static scan for `"password": "password"` in `backend/docs/api/visit_confirmation.md`
- Result: passed locally
- Not checked: full backend/frontend test suites, because this is a docs-only one-line example redaction
