### PR TITLE
docs: redact postgresql guide password examples

### DIFF
--- a/docs/POSTGRESQL_PRODUCTION_GUIDE.md
+++ b/docs/POSTGRESQL_PRODUCTION_GUIDE.md
@@ -31,7 +31,7 @@ sudo systemctl enable postgresql
 docker run -d \
   --name clinic-postgres \
   -e POSTGRES_USER=clinic_user \
-  -e POSTGRES_PASSWORD=secure_password \
+  -e POSTGRES_PASSWORD=<set_POSTGRES_PASSWORD> \
   -e POSTGRES_DB=clinic_db \
   -p 5432:5432 \
   -v clinic_data:/var/lib/postgresql/data \
@@ -260,7 +260,7 @@ LIMIT 10;
 ```python
 from sqlalchemy import create_engine
 
-DATABASE_URL = "postgresql://clinic_user:password@localhost:5432/clinic_db"
+DATABASE_URL = "postgresql://clinic_user:<db_password>@localhost:5432/clinic_db"
 engine = create_engine(DATABASE_URL)
 
 with engine.connect() as conn:


### PR DESCRIPTION
﻿## Summary

- Replaces the literal `POSTGRES_PASSWORD=secure_password` Docker example with an explicit placeholder.
- Replaces the Python `clinic_user:password@...` sample connection string with a placeholder password token.

## Contract Impact

not applicable - docs-only PostgreSQL guide redaction; no API, websocket, event, frontend route, request, response, status code, or compatibility contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `docs/POSTGRESQL_PRODUCTION_GUIDE.md`
- Denied paths: runtime backend code, ops runtime files, frontend code, endpoint/service deletions or renames, generated artifacts, evidence logs
- Migration/docs/test impact: docs-only redaction of sample database credentials
- Rollback note: revert the single docs commit if placeholder wording needs to change

## Validation

- Targeted tests or smoke run: `git diff --check`; static scan for `POSTGRES_PASSWORD=secure_password` and `clinic_user:password@` in `docs/POSTGRESQL_PRODUCTION_GUIDE.md`
- Result: passed locally
- Not checked: full backend/frontend test suites, because this is a docs-only credential-example redaction
