### PR TITLE
docs: redact prerelease runbook database passwords

### DIFF
--- a/docs/runbooks/CLINIC_PRE_RELEASE_EVIDENCE_PACK.md
+++ b/docs/runbooks/CLINIC_PRE_RELEASE_EVIDENCE_PACK.md
@@ -14,7 +14,7 @@
 | Host OS | Windows |
 | Pilot browser URL | `http://192.168.1.5:18080` |
 | Backend URL | `http://127.0.0.1:18000` |
-| Database URL | `postgresql+psycopg://clinic:clinicpwd@127.0.0.1:5432/clinicdb` |
+| Database URL | `postgresql+psycopg://clinic:<redacted>@127.0.0.1:5432/clinicdb` |
 | Backup dir | `C:\clinic\output\backups` |
 | Latest successful pre-update backup | `C:\clinic\output\backups\clinicdb_20260405_165644.dump` |
 | Latest successful restore rehearsal backup | `C:\clinic\output\backups\clinicdb_20260405_181100.dump` |
@@ -34,7 +34,7 @@
 
 ## Restore Rehearsal Proof
 - `PASS: restore_rehearsal completed successfully`
-- Restore target database: `postgresql+psycopg://clinic:clinicpwd@127.0.0.1:55433/clinicdb_restore`
+- Restore target database: `postgresql+psycopg://clinic:<redacted>@127.0.0.1:55433/clinicdb_restore`
 - Restore backend URL: `http://127.0.0.1:18001`
 - Restore public URL: `http://127.0.0.1:18081`
 - Restore smoke result: `PASS: smoke_post_update completed successfully`


### PR DESCRIPTION
﻿## Summary

- Redacts the literal `clinicpwd` password from the pre-release evidence pack database URL.
- Redacts the same password from the restore rehearsal database URL example.

## Contract Impact

not applicable - docs-only runbook redaction; no API, websocket, event, frontend route, request, response, status code, or compatibility contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `docs/runbooks/CLINIC_PRE_RELEASE_EVIDENCE_PACK.md`
- Denied paths: runtime backend code, ops runtime files, frontend code, endpoint/service deletions or renames, generated artifacts, evidence logs
- Migration/docs/test impact: docs-only redaction of historical runbook credential examples
- Rollback note: revert the single docs commit if the placeholder wording needs to change

## Validation

- Targeted tests or smoke run: `git diff --check`; static scan for `clinic:clinicpwd@` in `docs/runbooks/CLINIC_PRE_RELEASE_EVIDENCE_PACK.md`
- Result: passed locally
- Not checked: full backend/frontend test suites, because this is a docs-only credential-example redaction
