### PR TITLE
docs: redact windows runbook database password

### DIFF
--- a/docs/runbooks/CLINIC_WINDOWS_PILOT_HOST_RUNBOOK.md
+++ b/docs/runbooks/CLINIC_WINDOWS_PILOT_HOST_RUNBOOK.md
@@ -100,7 +100,7 @@ The wrapper will:
 
 Expected proof lines:
 - `RESTORE_BACKUP_FILE=...`
-- `RESTORE_DATABASE_URL=postgresql+psycopg://clinic:clinicpwd@127.0.0.1:55433/clinicdb_restore`
+- `RESTORE_DATABASE_URL=postgresql+psycopg://clinic:<redacted>@127.0.0.1:55433/clinicdb_restore`
 - `RESTORE_BACKEND_URL=http://127.0.0.1:18001`
 - `RESTORE_PUBLIC_URL=http://127.0.0.1:18081`
 - `PASS: restore_rehearsal completed successfully`


### PR DESCRIPTION
﻿## Summary

- Redacts the literal `clinicpwd` password from the Windows pilot host restore rehearsal database URL example.

## Contract Impact

not applicable - docs-only runbook redaction; no API, websocket, event, frontend route, request, response, status code, or compatibility contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `docs/runbooks/CLINIC_WINDOWS_PILOT_HOST_RUNBOOK.md`
- Denied paths: runtime backend code, ops runtime files, frontend code, endpoint/service deletions or renames, generated artifacts, evidence logs
- Migration/docs/test impact: docs-only redaction of a restore rehearsal credential example
- Rollback note: revert the single docs commit if the placeholder wording needs to change

## Validation

- Targeted tests or smoke run: `git diff --check`; static scan for `clinic:clinicpwd@` in `docs/runbooks/CLINIC_WINDOWS_PILOT_HOST_RUNBOOK.md`
- Result: passed locally
- Not checked: full backend/frontend test suites, because this is a docs-only credential-example redaction
