### PR TITLE
docs: align online queue guide registrar route

### DIFF
--- a/docs/ONLINE_QUEUE_SYSTEM_GUIDE.md
+++ b/docs/ONLINE_QUEUE_SYSTEM_GUIDE.md
@@ -673,7 +673,7 @@ class QueueToken(Base):
 | Компонент | Путь | Описание |
 |-----------|------|----------|
 | `QueueJoin.jsx` | `/queue/join` | QR-регистрация |
-| `RegistrarPanel.jsx` | `/registrar-panel` | Панель регистратора |
+| `RegistrarPanel.jsx` | `/registrar` | Панель регистратора |
 | `ModernQueueManager.jsx` | — | Управление очередью |
 
 ### Компоненты


### PR DESCRIPTION
﻿## Summary

- Updates the online queue guide table to show the canonical registrar UI route as `/registrar`.
- Leaves the runtime legacy redirect untouched; this is documentation alignment only.

## Contract Impact

not applicable - docs-only route reference alignment; no API, websocket, event, frontend route, request, response, status code, or compatibility contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `docs/ONLINE_QUEUE_SYSTEM_GUIDE.md`
- Denied paths: runtime frontend routing code, backend code, endpoint/service deletions or renames, generated artifacts, evidence logs
- Migration/docs/test impact: docs-only correction to match `frontend/src/routing/routeRegistry.js`
- Rollback note: revert the single docs commit if the queue guide should intentionally document the legacy redirect instead

## Validation

- Targeted tests or smoke run: `git diff --check`; static scan for the stale `RegistrarPanel.jsx` `/registrar-panel` table row; canonical route proof from `frontend/src/routing/routeRegistry.js`
- Result: passed locally
- Not checked: full backend/frontend test suites, because this is a docs-only route reference correction
