### PR TITLE
docs: align online queue v2 registrar route

### DIFF
--- a/docs/ONLINE_QUEUE_SYSTEM_V2.md
+++ b/docs/ONLINE_QUEUE_SYSTEM_V2.md
@@ -636,7 +636,7 @@ class QueueToken(Base):
 | Компонент | Путь | Описание |
 |-----------|------|----------|
 | `QueueJoin.jsx` | `/queue/join` | QR-регистрация |
-| `RegistrarPanel.jsx` | `/registrar-panel` | Панель регистратора |
+| `RegistrarPanel.jsx` | `/registrar` | Панель регистратора |
 | `ModernQueueManager.jsx` | — | Управление очередью |
 
 ### Компоненты


### PR DESCRIPTION
﻿## Summary

- Updates the online queue V2 guide table to show the canonical registrar UI route as `/registrar`.
- Leaves the runtime legacy redirect untouched; this is documentation alignment only.

## Contract Impact

not applicable - docs-only route reference alignment; no API, websocket, event, frontend route, request, response, status code, or compatibility contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `docs/ONLINE_QUEUE_SYSTEM_V2.md`
- Denied paths: runtime frontend routing code, backend code, endpoint/service deletions or renames, generated artifacts, evidence logs
- Migration/docs/test impact: docs-only correction to match `frontend/src/routing/routeRegistry.js`
- Rollback note: revert the single docs commit if the V2 guide should intentionally document the legacy redirect instead

## Validation

- Targeted tests or smoke run: `git diff --check`; static scan for the stale `RegistrarPanel.jsx` `/registrar-panel` table row; canonical route proof from `frontend/src/routing/routeRegistry.js`
- Result: passed locally
- Not checked: full backend/frontend test suites, because this is a docs-only route reference correction
