### PR TITLE
deps: add npm Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,60 @@ updates:
       - "dependencies"
       - "python"
       
+  # Root npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "12:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "drsapaev"
+    assignees:
+      - "drsapaev"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "root"
+    groups:
+      root-npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Frontend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "13:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "drsapaev"
+    assignees:
+      - "drsapaev"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "frontend"
+    groups:
+      frontend-npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   # Обновление GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Add Dependabot npm version-update coverage for the repository root.
- Add Dependabot npm version-update coverage for `/frontend`.
- Group root/frontend npm minor and patch updates while leaving major updates as separate PRs.
- Keep the safe automation rollout limited to Dependabot configuration only.

## Contract Impact
not applicable - this changes only Dependabot repository automation config, not application APIs, websocket events, request payloads, or response payloads.

## RBAC / Permissions
not applicable - this changes only Dependabot update configuration and does not alter routes, endpoint guards, roles, or auth-sensitive behavior.

## Notification / Realtime
not applicable - this changes only dependency update scheduling and does not alter notifications, websocket channels, delivery semantics, or resync behavior.

## Frontend Resilience
not applicable - this changes no user-facing frontend panel, state handling, data flow, route, or component behavior.

## Scope Gate
- Allowed paths: `.github/dependabot.yml` only.
- Denied paths: workflows, lifecycle scripts, runtime/backend/frontend source, tests, deployment config, and PR/issue automation behavior.
- Migration/docs/test impact: no migration or docs changes; configuration-only validation was performed.
- Rollback note: revert this PR to remove npm Dependabot coverage for `/` and `/frontend`.

## Validation
- Targeted tests or smoke run: YAML parse with PyYAML from a temp dependency target; duplicate `package-ecosystem + directory` check; npm group config review; `git diff --check`.
- Result: passed. Entries are `pip:/backend`, `npm:/`, `npm:/frontend`, `github-actions:/`, and `docker:/ops`; npm groups contain only `minor` and `patch` update types.
- Not checked: live Dependabot execution after merge, because Dependabot runs from GitHub after configuration lands on the default branch.