### PR TITLE
docs: redact telegram token placeholders

### DIFF
--- a/docs/TELEGRAM_PWA_GUIDE.md
+++ b/docs/TELEGRAM_PWA_GUIDE.md
@@ -19,10 +19,10 @@
 2. **Установка токена:**
    ```bash
    # В .env файле
-   TELEGRAM_BOT_TOKEN=your-bot-token-here
+   TELEGRAM_BOT_TOKEN=
    
    # Или в переменных окружения
-   export TELEGRAM_BOT_TOKEN="your-bot-token"
+   export TELEGRAM_BOT_TOKEN=""
    ```
 
 ### Функции бота
@@ -225,7 +225,7 @@ await registration.showNotification('Заголовок', {
 
 1. **Переменные окружения:**
    ```bash
-   TELEGRAM_BOT_TOKEN=your-bot-token
+   TELEGRAM_BOT_TOKEN=
    FRONTEND_URL=https://your-domain.com
    ```
 


### PR DESCRIPTION
﻿## Summary

- Redacts sample Telegram bot token placeholders from the Telegram/PWA guide.
- Leaves the guide instructive while requiring real token values to come from local environment configuration.

## Contract Impact

not applicable - docs-only Telegram token example redaction; no API, websocket, event, frontend route, request, response, status code, or compatibility contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `docs/TELEGRAM_PWA_GUIDE.md`
- Denied paths: Telegram runtime endpoints, frontend Telegram manager code, backend code, endpoint/service deletions or renames, generated artifacts, evidence logs
- Migration/docs/test impact: docs-only redaction of sample Telegram token values
- Rollback note: revert the single docs commit if token placeholder wording should be phrased differently

## Validation

- Targeted tests or smoke run: `git diff --check`; static scan for `your-bot-token-here` and `your-bot-token` in `docs/TELEGRAM_PWA_GUIDE.md`
- Result: passed locally
- Not checked: full backend/frontend test suites, because this is a docs-only token placeholder redaction
