### PR TITLE
docs: harden chat system setup examples

### DIFF
--- a/docs/CHAT_SYSTEM_IMPROVEMENTS.md
+++ b/docs/CHAT_SYSTEM_IMPROVEMENTS.md
@@ -128,7 +128,8 @@ Added audit logging for:
 MESSAGE_ENCRYPTION_KEY=gAAAAABg...
 
 # JWT secret (already required)
-SECRET_KEY=your-secret-key-min-32-chars
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+SECRET_KEY=
 ```
 
 ## Security Checklist
@@ -166,8 +167,7 @@ python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().d
 ```bash
 cd backend
 alembic upgrade head
-# Or manually if migration conflicts:
-python -c "import sqlite3; conn = sqlite3.connect('clinic.db'); conn.execute('ALTER TABLE messages ADD COLUMN patient_id INTEGER'); conn.commit()"
+# If migration conflicts, stop and fix the Alembic migration instead of patching SQLite manually.
 ```
 
 ### Run Retention Cleanup (Dry Run)


### PR DESCRIPTION
﻿## Summary

- Replaces the chat docs JWT secret placeholder with a blank value plus a generation command.
- Removes the manual SQLite `ALTER TABLE` fallback from the migration instructions and points readers back to Alembic.

## Contract Impact

not applicable - docs-only setup guidance hardening; no API, websocket, event, frontend route, request, response, status code, or compatibility contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `docs/CHAT_SYSTEM_IMPROVEMENTS.md`
- Denied paths: runtime backend code, ops compose/entrypoint files, frontend chat code, endpoint/service deletions or renames, generated artifacts, evidence logs
- Migration/docs/test impact: docs-only hardening of secret and migration examples
- Rollback note: revert the single docs commit if wording should be phrased differently

## Validation

- Targeted tests or smoke run: `git diff --check`; static scan for `SECRET_KEY=your-secret-key-min-32-chars` and `sqlite3.connect('clinic.db')` in `docs/CHAT_SYSTEM_IMPROVEMENTS.md`
- Result: passed locally
- Not checked: full backend/frontend test suites, because this is a docs-only setup guidance hardening
