### PR TITLE
ci: make Dependabot rollout safe

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "12:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     reviewers:
       - "drsapaev"
     assignees:
@@ -45,6 +45,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # Frontend npm dependencies
   - package-ecosystem: "npm"
@@ -53,7 +56,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "13:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     reviewers:
       - "drsapaev"
     assignees:
@@ -72,6 +75,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # Обновление GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/pr-review-quality-gate.yml
+++ b/.github/workflows/pr-review-quality-gate.yml
@@ -28,5 +28,6 @@ jobs:
       - name: Run PR review quality gate
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           python scripts/run_pr_review_gate_checks.py --body-env PR_BODY

--- a/scripts/run_pr_review_gate_checks.py
+++ b/scripts/run_pr_review_gate_checks.py
@@ -15,6 +15,7 @@ SAMPLE_BODY_FILES = (
     REPO_ROOT / "docs" / "runbooks" / "pr-review-samples" / "docs-only-pr.md",
     REPO_ROOT / "docs" / "runbooks" / "pr-review-samples" / "runtime-contract-pr.md",
 )
+DEPENDABOT_AUTHORS = {"app/dependabot", "dependabot[bot]"}
 
 
 def _ensure_repo_imports() -> None:
@@ -29,6 +30,7 @@ def _run_unit_tests() -> bool:
         [
             "test_check_pr_review_template",
             "test_add_pr_review_adoption_entry",
+            "test_run_pr_review_gate_checks",
         ]
     )
     result = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
@@ -77,6 +79,18 @@ def _read_pr_body(args: argparse.Namespace) -> tuple[str, str] | None:
     return None
 
 
+def _read_pr_author(args: argparse.Namespace) -> str:
+    if args.author:
+        return args.author
+    if args.author_env:
+        return os.environ.get(args.author_env, "")
+    return os.environ.get("PR_AUTHOR", "")
+
+
+def _is_dependabot_author(author: str) -> bool:
+    return author.strip().lower() in DEPENDABOT_AUTHORS
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Run PR review gate unit tests, samples, and optional PR body validation."
@@ -84,6 +98,8 @@ def main() -> int:
     source = parser.add_mutually_exclusive_group()
     source.add_argument("--body-file", help="Path to a markdown file containing PR body.")
     source.add_argument("--body-env", help="Environment variable containing PR body text.")
+    parser.add_argument("--author", help="Pull request author login.")
+    parser.add_argument("--author-env", help="Environment variable containing the PR author login.")
     args = parser.parse_args()
 
     ok = True
@@ -96,7 +112,14 @@ def main() -> int:
     pr_body = _read_pr_body(args)
     if pr_body:
         label, body = pr_body
-        ok = _validate_body(label, body) and ok
+        author = _read_pr_author(args)
+        if _is_dependabot_author(author):
+            print(
+                f"\nSkipping live PR body validation for Dependabot author `{author}`; "
+                "Dependabot bodies are generated release notes, not the human review template."
+            )
+        else:
+            ok = _validate_body(label, body) and ok
     else:
         print("\nNo live PR body provided; skipped live PR body validation.")
 

--- a/test_run_pr_review_gate_checks.py
+++ b/test_run_pr_review_gate_checks.py
@@ -1,0 +1,26 @@
+import unittest
+from argparse import Namespace
+from unittest.mock import patch
+
+from scripts.run_pr_review_gate_checks import _is_dependabot_author, _read_pr_author
+
+
+class PRReviewGateRunnerTests(unittest.TestCase):
+    def test_accepts_dependabot_pull_request_author(self):
+        self.assertTrue(_is_dependabot_author("dependabot[bot]"))
+
+    def test_accepts_gh_cli_dependabot_author(self):
+        self.assertTrue(_is_dependabot_author("app/dependabot"))
+
+    def test_rejects_regular_author(self):
+        self.assertFalse(_is_dependabot_author("drsapaev"))
+
+    def test_reads_default_pr_author_environment(self):
+        args = Namespace(author=None, author_env=None)
+
+        with patch.dict("os.environ", {"PR_AUTHOR": "dependabot[bot]"}):
+            self.assertEqual(_read_pr_author(args), "dependabot[bot]")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Skip live PR body template validation only for Dependabot-authored PRs, because Dependabot bodies are generated release notes.
- Keep human PR body validation unchanged, including the existing unit/sample gate.
- Lower npm Dependabot open PR limits and ignore npm semver-major updates to stop the noisy major-update rollout from PR-4A.

## Contract Impact

not applicable - CI and Dependabot policy only, no API or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no event, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: .github/dependabot.yml, .github/workflows/pr-review-quality-gate.yml, scripts/run_pr_review_gate_checks.py, test_run_pr_review_gate_checks.py
- Denied paths: runtime backend, runtime frontend, migrations, production deploy configuration
- Migration/docs/test impact: no migration; one targeted stdlib unittest file added
- Rollback note: revert this PR to restore strict live PR body validation for Dependabot and previous npm Dependabot volume

## Validation

- Targeted tests or smoke run: python scripts/run_pr_review_gate_checks.py --body-file docs/runbooks/pr-review-samples/docs-only-pr.md --author drsapaev
- Targeted tests or smoke run: generated Dependabot-style body with --author dependabot[bot] passes by skipping only live body validation
- Targeted tests or smoke run: same generated body with --author drsapaev fails as expected on missing template sections
- Targeted tests or smoke run: YAML parse for .github/dependabot.yml and .github/workflows/pr-review-quality-gate.yml plus duplicate package-ecosystem/directory check
- Targeted tests or smoke run: git diff --check
- Result: passed
- Not checked: full GitHub Actions matrix before PR creation; checks will run on this PR