### PR TITLE
ci: use current trusted PR gate validator

### DIFF
--- a/.github/workflows/pr-review-quality-gate.yml
+++ b/.github/workflows/pr-review-quality-gate.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout trusted base validator
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary

- Update the PR review quality gate checkout to use the repository default branch instead of the stale pull request base SHA.
- Keep the validator trusted while allowing long-lived Dependabot PRs to pick up the current Dependabot-aware gate after main advances.
- No permissions, merge, close, push, issue, or deploy behavior is added.

## Contract Impact

not applicable - CI workflow checkout target only, no API or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no event, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: .github/workflows/pr-review-quality-gate.yml
- Denied paths: Dependabot config, lifecycle scripts, runtime backend/frontend, migrations
- Migration/docs/test impact: no migration; workflow-only change
- Rollback note: revert this PR to pin the validator checkout back to the PR base SHA

## Validation

- Targeted tests or smoke run: YAML parse for .github/workflows/pr-review-quality-gate.yml
- Targeted tests or smoke run: git diff --check
- Result: passed
- Not checked: old Dependabot PR reruns after merge; they need a post-merge synchronize/rebase event