### PR TITLE
ci: add manual weekly maintenance report

### DIFF
--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -1,0 +1,270 @@
+name: Weekly Maintenance Report
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  maintenance-report:
+    name: Maintenance health report
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11.10'
+
+      - name: Prepare report files
+        shell: bash
+        run: |
+          mkdir -p maintenance-reports
+          printf "check\tstatus\texit_code\tdetails\n" > maintenance-reports/checks.tsv
+          {
+            echo "# Weekly Maintenance Report"
+            echo ""
+            echo "Manual report-only run. Failures are recorded below and in artifacts."
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Root npm health
+        shell: bash
+        run: |
+          set +e
+
+          record() {
+            local check="$1"
+            local status="$2"
+            local exit_code="$3"
+            local details="$4"
+            printf "%s\t%s\t%s\t%s\n" "$check" "$status" "$exit_code" "$details" >> maintenance-reports/checks.tsv
+          }
+
+          has_script() {
+            local script_name="$1"
+            node -e "const pkg = require('./package.json'); process.exit(pkg.scripts && pkg.scripts['${script_name}'] ? 0 : 1)"
+          }
+
+          if [ ! -f package.json ]; then
+            record "root package.json" "skipped" "0" "package.json not found"
+            exit 0
+          fi
+
+          if [ -f package-lock.json ]; then
+            npm ci > maintenance-reports/root-npm-ci.log 2>&1
+            code=$?
+            [ "$code" -eq 0 ] && status="ok" || status="failed"
+            record "root npm ci" "$status" "$code" "see root-npm-ci.log"
+
+            npm audit --audit-level=moderate --json > maintenance-reports/root-npm-audit.json 2> maintenance-reports/root-npm-audit.log
+            code=$?
+            [ "$code" -eq 0 ] && status="ok" || status="reported"
+            record "root npm audit" "$status" "$code" "see root-npm-audit.json"
+          else
+            record "root npm ci" "skipped" "0" "package-lock.json not found"
+            record "root npm audit" "skipped" "0" "package-lock.json not found"
+          fi
+
+          if (has_script test || has_script build) && node -e "const scripts = require('./package.json').scripts || {}; process.exit(Object.values(scripts).some((script) => script.includes('frontend')) ? 0 : 1)"; then
+            if [ -f frontend/package-lock.json ] && [ ! -d frontend/node_modules ]; then
+              npm --prefix frontend ci > maintenance-reports/root-delegated-frontend-npm-ci.log 2>&1
+              code=$?
+              [ "$code" -eq 0 ] && status="ok" || status="failed"
+              record "root delegated frontend npm ci" "$status" "$code" "see root-delegated-frontend-npm-ci.log"
+            fi
+          fi
+
+          if has_script test; then
+            timeout 10m npm run test > maintenance-reports/root-npm-test.log 2>&1
+            code=$?
+            [ "$code" -eq 0 ] && status="ok" || status="failed"
+            record "root npm test" "$status" "$code" "see root-npm-test.log"
+          else
+            record "root npm test" "skipped" "0" "package script test not found"
+          fi
+
+          if has_script build; then
+            timeout 10m npm run build > maintenance-reports/root-npm-build.log 2>&1
+            code=$?
+            [ "$code" -eq 0 ] && status="ok" || status="failed"
+            record "root npm build" "$status" "$code" "see root-npm-build.log"
+          else
+            record "root npm build" "skipped" "0" "package script build not found"
+          fi
+
+          exit 0
+
+      - name: Frontend npm health
+        shell: bash
+        run: |
+          set +e
+
+          record() {
+            local check="$1"
+            local status="$2"
+            local exit_code="$3"
+            local details="$4"
+            printf "%s\t%s\t%s\t%s\n" "$check" "$status" "$exit_code" "$details" >> maintenance-reports/checks.tsv
+          }
+
+          has_frontend_script() {
+            local script_name="$1"
+            node -e "const pkg = require('./frontend/package.json'); process.exit(pkg.scripts && pkg.scripts['${script_name}'] ? 0 : 1)"
+          }
+
+          if [ ! -f frontend/package.json ]; then
+            record "frontend package.json" "skipped" "0" "frontend/package.json not found"
+            exit 0
+          fi
+
+          if [ -f frontend/package-lock.json ]; then
+            npm --prefix frontend ci > maintenance-reports/frontend-npm-ci.log 2>&1
+            code=$?
+            [ "$code" -eq 0 ] && status="ok" || status="failed"
+            record "frontend npm ci" "$status" "$code" "see frontend-npm-ci.log"
+
+            npm --prefix frontend audit --audit-level=moderate --json > maintenance-reports/frontend-npm-audit.json 2> maintenance-reports/frontend-npm-audit.log
+            code=$?
+            [ "$code" -eq 0 ] && status="ok" || status="reported"
+            record "frontend npm audit" "$status" "$code" "see frontend-npm-audit.json"
+          else
+            record "frontend npm ci" "skipped" "0" "frontend/package-lock.json not found"
+            record "frontend npm audit" "skipped" "0" "frontend/package-lock.json not found"
+          fi
+
+          if has_frontend_script test; then
+            timeout 10m npm --prefix frontend run test -- --run > maintenance-reports/frontend-npm-test.log 2>&1
+            code=$?
+            [ "$code" -eq 0 ] && status="ok" || status="failed"
+            record "frontend npm test" "$status" "$code" "see frontend-npm-test.log"
+          else
+            record "frontend npm test" "skipped" "0" "frontend package script test not found"
+          fi
+
+          if has_frontend_script build; then
+            timeout 10m npm --prefix frontend run build > maintenance-reports/frontend-npm-build.log 2>&1
+            code=$?
+            [ "$code" -eq 0 ] && status="ok" || status="failed"
+            record "frontend npm build" "$status" "$code" "see frontend-npm-build.log"
+          else
+            record "frontend npm build" "skipped" "0" "frontend package script build not found"
+          fi
+
+          exit 0
+
+      - name: Backend Python health
+        shell: bash
+        env:
+          DATABASE_URL: sqlite:///./maintenance-health.sqlite3
+          CORS_DISABLE: '1'
+          WS_DEV_ALLOW: '1'
+        run: |
+          set +e
+
+          record() {
+            local check="$1"
+            local status="$2"
+            local exit_code="$3"
+            local details="$4"
+            printf "%s\t%s\t%s\t%s\n" "$check" "$status" "$exit_code" "$details" >> maintenance-reports/checks.tsv
+          }
+
+          if [ ! -d backend ]; then
+            record "backend" "skipped" "0" "backend directory not found"
+            exit 0
+          fi
+
+          python -m pip install --upgrade pip > maintenance-reports/backend-pip-upgrade.log 2>&1
+          code=$?
+          [ "$code" -eq 0 ] && status="ok" || status="failed"
+          record "backend pip upgrade" "$status" "$code" "see backend-pip-upgrade.log"
+
+          if [ -f backend/requirements.txt ]; then
+            python -m pip install -r backend/requirements.txt > maintenance-reports/backend-pip-install.log 2>&1
+            code=$?
+            [ "$code" -eq 0 ] && status="ok" || status="failed"
+            record "backend pip install" "$status" "$code" "see backend-pip-install.log"
+          else
+            record "backend pip install" "skipped" "0" "backend/requirements.txt not found"
+          fi
+
+          python -m pip install pip-audit pytest > maintenance-reports/backend-pip-tools.log 2>&1
+          code=$?
+          [ "$code" -eq 0 ] && status="ok" || status="failed"
+          record "backend maintenance tools" "$status" "$code" "see backend-pip-tools.log"
+
+          if [ -f backend/requirements.txt ]; then
+            python -m pip_audit -r backend/requirements.txt --format json --output maintenance-reports/backend-pip-audit.json > maintenance-reports/backend-pip-audit.log 2>&1
+            code=$?
+            [ "$code" -eq 0 ] && status="ok" || status="reported"
+            record "backend pip-audit" "$status" "$code" "see backend-pip-audit.json"
+          else
+            record "backend pip-audit" "skipped" "0" "backend/requirements.txt not found"
+          fi
+
+          if [ -d backend/tests/architecture ]; then
+            (cd backend && PYTHONPATH="$PWD" timeout 8m python -m pytest tests/architecture -q) > maintenance-reports/backend-pytest-architecture.log 2>&1
+            code=$?
+            [ "$code" -eq 0 ] && status="ok" || status="failed"
+            record "backend architecture pytest" "$status" "$code" "see backend-pytest-architecture.log"
+          else
+            record "backend architecture pytest" "skipped" "0" "backend/tests/architecture not found"
+          fi
+
+          if [ -d backend/tests/unit ]; then
+            (cd backend && PYTHONPATH="$PWD" timeout 8m python -m pytest tests/unit -q -m "unit and not integration and not e2e and not slow" --maxfail=1) > maintenance-reports/backend-pytest-unit.log 2>&1
+            code=$?
+            [ "$code" -eq 0 ] && status="ok" || status="failed"
+            record "backend unit pytest" "$status" "$code" "see backend-pytest-unit.log"
+          else
+            record "backend unit pytest" "skipped" "0" "backend/tests/unit not found"
+          fi
+
+          (cd backend && PYTHONPATH="$PWD" python - <<'PY'
+          import importlib
+
+          importlib.import_module("app.main")
+          print("app.main import ok")
+          PY
+          ) > maintenance-reports/backend-import-health.log 2>&1
+          code=$?
+          [ "$code" -eq 0 ] && status="ok" || status="failed"
+          record "backend import health" "$status" "$code" "see backend-import-health.log"
+
+          exit 0
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Check Results"
+            echo ""
+            echo "| Check | Status | Exit code | Details |"
+            echo "| --- | --- | --- | --- |"
+            tail -n +2 maintenance-reports/checks.tsv | while IFS=$'\t' read -r check status exit_code details; do
+              echo "| ${check} | ${status} | ${exit_code} | ${details} |"
+            done
+            echo ""
+            echo "Artifacts contain command logs and machine-readable audit output."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload maintenance artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: weekly-maintenance-report
+          path: maintenance-reports/
+          if-no-files-found: warn
+          retention-days: 14


### PR DESCRIPTION
## Summary

- Add `.github/workflows/weekly-maintenance.yml` as a manual-only maintenance health report.
- Keep automation report-only: no schedule yet, no write token permissions, no issue/PR creation, no push, no merge, no close, no branch deletion, no production deploy.
- Write results to `$GITHUB_STEP_SUMMARY` and upload `weekly-maintenance-report` artifacts with `actions/upload-artifact@v7`.

## Contract Impact

not applicable - this PR adds a manual GitHub Actions reporting workflow only; no API, websocket, event, database, or frontend consumer contract changed.

## RBAC / Permissions

- Workflow permissions: `contents: read` only.
- Roles allowed: not applicable - no app route, endpoint, role helper, or auth-sensitive runtime behavior changed.
- Roles denied: not applicable - no app authorization path changed.
- Positive auth proof: not applicable - workflow does not call app auth paths.
- Negative auth proof: not applicable - workflow does not call app auth paths.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime channel, external issue, PR comment, or messaging behavior changed.

## Frontend Resilience

not applicable - no user-facing frontend panel, route, component, data fetcher, fallback, empty state, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `.github/workflows/weekly-maintenance.yml` only.
- Denied paths: runtime backend/frontend code, migrations, Dependabot config, lifecycle scripts, generated output, deploy configuration.
- Migration/docs/test impact: no migration; new manual report workflow only.
- Rollback note: revert this workflow file to remove PR-4C.

## Validation

- Targeted tests or smoke run: YAML parse with PyYAML; `git diff --cached --check`; trigger/permissions grep; write-action grep; changed-file scope check.
- Result: passed locally before commit. PR Review Quality Gate initially failed only because this PR body was missing required template sections; body is now updated.
- Not checked: manual `workflow_dispatch`, because PR-4C must merge first before the manual run; PR-4D schedule remains intentionally out of scope.

## Safety Review

- Trigger review: `workflow_dispatch` only; no `schedule` in this PR.
- Permissions review: only `contents: read`; no `issues: write`, `pull-requests: write`, or `contents: write`.
- Write-action proof: static grep found no `git push`, `gh issue create`, `gh pr create`, `gh pr merge`, `gh pr close`, branch deletion, production deploy, environments, or secrets usage.
- Artifact version: uses `actions/upload-artifact@v7`, matching current project practice.

## Checks Covered

- Node 20 and Python 3.11.10 setup.
- Root npm: conditional `npm ci`, `npm audit`, `npm test`, and `npm build` based on package lock/scripts.
- Frontend npm: conditional `npm ci`, `npm audit`, `npm test -- --run`, and `npm build` based on lock/scripts.
- Backend Python: conditional requirements install, `pip-audit`, architecture pytest, unit pytest, and import health using sqlite-only `DATABASE_URL`.
- Dry-run behavior: missing package files, lock files, scripts, backend directory, requirements, or test directories are handled as skipped checks in the report instead of failing the workflow.