### PR TITLE
ci: allow sqlite for maintenance health checks

### DIFF
--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -167,6 +167,7 @@ jobs:
         shell: bash
         env:
           DATABASE_URL: sqlite:///./maintenance-health.sqlite3
+          ALLOW_SQLITE_DATABASE_URL: '1'
           CORS_DISABLE: '1'
           WS_DEV_ALLOW: '1'
         run: |


### PR DESCRIPTION
## Summary

- Add `ALLOW_SQLITE_DATABASE_URL=1` to the backend health step in the manual weekly maintenance workflow.
- This matches the backend runtime guard error from the first manual report run and keeps the check sqlite-only, test-scoped, and free of live DB requirements.

## Contract Impact

not applicable - workflow env only; no API, websocket, event, database schema, or frontend consumer contract changed.

## RBAC / Permissions

- Workflow permissions remain `contents: read` only.
- Roles allowed: not applicable - no app route, endpoint, role helper, or auth-sensitive runtime behavior changed.
- Roles denied: not applicable - no app authorization path changed.
- Positive auth proof: not applicable - workflow does not call app auth paths.
- Negative auth proof: not applicable - workflow does not call app auth paths.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime channel, issue, PR comment, or messaging behavior changed.

## Frontend Resilience

not applicable - no frontend files or user-facing behavior changed.

## Scope Gate

- Allowed paths: `.github/workflows/weekly-maintenance.yml` only.
- Denied paths: runtime backend/frontend code, migrations, Dependabot config, lifecycle scripts, generated output, deploy configuration.
- Migration/docs/test impact: no migration; maintenance workflow test env correction only.
- Rollback note: remove the `ALLOW_SQLITE_DATABASE_URL` env line.

## Validation

- Targeted tests or smoke run: YAML parse; `git diff --check`; static grep for forbidden write/deploy/secret patterns; first manual workflow artifact review.
- Result: local static checks passed. First manual workflow run succeeded, but backend health artifacts showed expected SQLite runtime guard failures until this env correction.
- Not checked: second manual `workflow_dispatch` after merge; it will be run before PR-4D schedule.

## Safety Review

- Trigger remains `workflow_dispatch` only; no schedule in this PR.
- Permissions remain `contents: read` only.
- No GH_TOKEN write usage, issue creation, PR creation, push, merge, close, branch deletion, production deploy, environment, or secrets usage.