### PR TITLE
ci: schedule weekly maintenance report

### DIFF
--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -1,6 +1,9 @@
 name: Weekly Maintenance Report
 
 on:
+  schedule:
+    # Weekly Monday 03:30 Asia/Tashkent (Sunday 22:30 UTC).
+    - cron: '30 22 * * 0'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Enable the weekly schedule for `weekly-maintenance.yml` after the manual workflow was merged, corrected, and successfully run.
- Keep `workflow_dispatch` for manual reruns.
- Schedule is Monday 03:30 Asia/Tashkent, expressed as Sunday 22:30 UTC.

## Contract Impact

not applicable - workflow trigger only; no API, websocket, event, database schema, or frontend consumer contract changed.

## RBAC / Permissions

- Workflow permissions remain `contents: read` only.
- Roles allowed: not applicable - no app route, endpoint, role helper, or auth-sensitive runtime behavior changed.
- Roles denied: not applicable - no app authorization path changed.
- Positive auth proof: not applicable - workflow does not call app auth paths.
- Negative auth proof: not applicable - workflow does not call app auth paths.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime channel, issue, PR comment, or messaging behavior changed.

## Frontend Resilience

not applicable - no frontend files or user-facing behavior changed.

## Scope Gate

- Allowed paths: `.github/workflows/weekly-maintenance.yml` only.
- Denied paths: runtime backend/frontend code, migrations, Dependabot config, lifecycle scripts, generated output, deploy configuration.
- Migration/docs/test impact: no migration; trigger-only workflow update.
- Rollback note: remove the `schedule` block and keep `workflow_dispatch`.

## Validation

- Targeted tests or smoke run: YAML parse; `git diff --check`; trigger review; static grep for forbidden write/deploy/secret patterns; manual workflow run `25588367718` artifact review.
- Result: passed. Manual run succeeded; checks were ok except `root npm audit` reported existing dependency advisories as intended report-only output.
- Not checked: actual scheduled execution, because it will run at the next weekly cron time after merge.

## Schedule Review

- Added cron: `30 22 * * 0`.
- UTC meaning: Sunday 22:30 UTC.
- Local meaning: Monday 03:30 Asia/Tashkent.
- Only trigger change: added `schedule`; preserved `workflow_dispatch`.

## Safety Review

- Permissions remain `contents: read` only.
- No GH_TOKEN write usage, issue creation, PR creation, push, merge, close, branch deletion, production deploy, environment, or secrets usage.