### PR TITLE
fix(auth): sanitize rbac debug logging

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -158,13 +158,18 @@ def require_roles(*roles: Any):
         if "registrar" in allowed_roles_lower and "receptionist" not in allowed_roles_lower:
             allowed_roles_lower.append("receptionist")
 
-        # ✅ DEBUG LOG: Explicitly log the mismatch
-        print(f"DEBUG: Checking roles for user {current_user.id} ({current_user.username})")
-        print(f"DEBUG: User Role: '{role_label}', Normalized: '{role_normalized}'")
-        print(f"DEBUG: Required Roles: {normalized_roles}, Normalized: {allowed_roles_lower}")
+        logger.debug(
+            "RBAC role check evaluated",
+            extra={
+                "required_role_count": len(normalized_roles),
+                "allowed_role_count": len(allowed_roles_lower),
+                "user_role": role_label or None,
+                "normalized_user_role": role_normalized or None,
+                "request_available": request is not None,
+            },
+        )
 
         if role_normalized not in allowed_roles_lower and role_lower not in allowed_roles_lower:
-            print(f"DEBUG: ACCESS DENIED for user {current_user.username}")
             # ✅ AUDIT LOG: Логируем попытку несанкционированного доступа
             from app.core.audit import log_critical_change
 
@@ -187,16 +192,27 @@ def require_roles(*roles: Any):
                 # ✅ FIX: Если request недоступен, логируем с предупреждением
                 audit_logger = logging.getLogger(__name__)
                 audit_logger.warning(
-                    f"SECURITY: require_roles: request context unavailable for user_id={current_user.id}, "
-                    f"roles={roles}, user_role={role}. Audit log may be incomplete."
+                    "ACCESS_DENIED audit request context unavailable",
+                    extra={
+                        "required_role_count": len(normalized_roles),
+                        "user_role": role_label or None,
+                    },
                 )
 
-            # ✅ DEBUG LOG: Explicitly log the mismatch
+            # Keep operational security logs non-identifying; the audit log below
+            # stores actor/resource context through the dedicated audit channel.
             audit_logger = logging.getLogger(__name__)
             audit_logger.error(
-                f"ACCESS DENIED DEBUG: User={current_user.username} (ID={current_user.id}), "
-                f"RoleInDB='{role}' (normalized='{role_lower}'), "
-                f"Required='{roles}' (normalized='{allowed_roles_lower}')"
+                "RBAC role check denied",
+                extra={
+                    "required_roles": list(normalized_roles),
+                    "allowed_roles": allowed_roles_lower,
+                    "user_role": role_label or None,
+                    "normalized_user_role": role_normalized or None,
+                    "resource_type": resource_type or "unknown",
+                    "resource_id_present": resource_id is not None,
+                    "request_available": request is not None,
+                },
             )
 
             # ✅ FIX: Всегда логируем 403, даже если request недоступен (для безопасности)
@@ -220,7 +236,11 @@ def require_roles(*roles: Any):
             except Exception as e:
                 # ✅ FIX: Если логирование не удалось, все равно выбрасываем 403
                 audit_logger = logging.getLogger(__name__)
-                audit_logger.error(f"Failed to log ACCESS_DENIED audit: {e}", exc_info=True)
+                audit_logger.error(
+                    "Failed to log ACCESS_DENIED audit",
+                    extra={"exception_type": type(e).__name__},
+                    exc_info=True,
+                )
 
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,


### PR DESCRIPTION
## Summary
- Continues `.ai-factory/PLAN.md` Task 26 through `/aif-implement` with one narrow backend security/logging slice.
- Removes raw `print(...)` diagnostics from the shared RBAC `require_roles` path.
- Replaces username/user-id debug leakage in ordinary runtime logs with structured non-identifying metadata while preserving the existing ACCESS_DENIED audit event.

## Contract Impact
- Canonical surface: `app.core.security.require_roles(...)` dependency factory used by protected backend endpoints.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged; unauthorized role checks still raise HTTP 403.
- Frontend consumer: unchanged; existing protected screens continue receiving the same 403 behavior.
- Compatibility path or alias: unchanged; `app.api.deps.require_roles` remains the compatibility alias to this SSOT helper.
- Contract proof: targeted RBAC normalization unit test and RBAC matrix integration test passed locally.

## RBAC / Permissions
- Roles allowed: unchanged; existing allowed roles, superuser bypass, and registrar/receptionist compatibility are preserved.
- Roles denied: unchanged; disallowed roles still receive HTTP 403 and ACCESS_DENIED audit logging.
- Positive auth proof: `backend\tests\unit\test_require_roles_normalization.py` passed, including nested-role and enum-role allow cases.
- Negative auth proof: `backend\tests\integration\test_rbac_matrix.py` passed, including forbidden-role and 403 audit-log cases.

## Notification / Realtime
- Event type or websocket channel: not applicable because this change does not touch notification, WebSocket, Telegram, or realtime code.
- Payload version / ack behavior: not applicable because no event payloads or acknowledgement paths changed.
- Read/unread or delivery semantics: not applicable because delivery state is untouched.
- Reconnect/resync proof: not applicable because no realtime connection behavior changed.

## Frontend Resilience
- Empty data proof: not applicable because no frontend data rendering changed.
- Partial data proof: not applicable because no frontend API/data states changed.
- Forbidden secondary path behavior: covered by RBAC matrix; forbidden backend paths still return 403.
- Missing draft/resource behavior: not applicable because no draft/resource UI path changed.
- Stale route/deep-link behavior: not applicable because routing and frontend files are untouched.

## Scope Gate
- Allowed paths: `backend/app/core/security.py` only.
- Denied paths: no frontend, schema, migration, API route registration, payment, Telegram, EMR, or queue files changed.
- Migration/docs/test impact: no migration needed; tests were run as validation only and were not edited; Task 26 remains pending for further slices.
- Rollback note: revert commit `ba75eec3` to restore previous runtime logging behavior; authorization behavior should not need rollback because logic is unchanged.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\core\security.py`; static `rg` check for removed print/debug strings; `python -m pytest backend\tests\unit\test_require_roles_normalization.py -q --tb=short --disable-warnings`; `python -m pytest backend\tests\integration\test_rbac_matrix.py -q --tb=short --disable-warnings`; `git diff --check`.
- Result: compile passed; static search returned no matches; unit RBAC normalization passed with 2 passed and 1 warning; RBAC matrix passed with 19 passed and 1 warning; diff check passed with only the existing Windows LF/CRLF warning.
- Not checked: full backend suite, frontend build, browser smoke, external deployment, and disposable PostgreSQL migration proof were not run because this is a single-file RBAC logging slice.