### PR TITLE
fix(billing): route Payme webhooks by account targets

### DIFF
--- a/backend/app/services/payment_webhook.py
+++ b/backend/app/services/payment_webhook.py
@@ -24,7 +24,38 @@ logger = logging.getLogger(__name__)
 
 
 class PaymentWebhookService:
-    """Сервис для обработки вебхуков оплат"""
+    """Payment webhook processing service."""
+
+    @staticmethod
+    def _optional_int(value: Any) -> int | None:
+        if value in (None, ""):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _account_value(account: Any, key: str) -> Any:
+        if isinstance(account, dict):
+            return account.get(key)
+        return getattr(account, key, None)
+
+    @staticmethod
+    def _extract_payme_account_targets(
+        account: Any,
+    ) -> tuple[int | None, int | None]:
+        appointment_id = PaymentWebhookService._optional_int(
+            PaymentWebhookService._account_value(account, "appointment_id")
+        )
+        visit_id = PaymentWebhookService._optional_int(
+            PaymentWebhookService._account_value(account, "visit_id")
+        )
+        if appointment_id is None:
+            appointment_id = PaymentWebhookService._optional_int(
+                PaymentWebhookService._account_value(account, "order_id")
+            )
+        return appointment_id, visit_id
 
     @staticmethod
     def verify_payme_signature(
@@ -138,17 +169,20 @@ class PaymentWebhookService:
                     visit_id = None
 
                     if hasattr(webhook_data, "account") and webhook_data.account:
-                        # Пытаемся найти appointment_id или visit_id в account данных
-                        if hasattr(webhook_data.account, "appointment_id"):
-                            appointment_id = int(webhook_data.account.appointment_id)
-                        elif hasattr(webhook_data.account, "visit_id"):
-                            visit_id = int(webhook_data.account.visit_id)
-                        elif hasattr(webhook_data.account, "order_id"):
-                            # Если есть order_id, пытаемся интерпретировать как appointment_id
-                            try:
-                                appointment_id = int(webhook_data.account.order_id)
-                            except (ValueError, TypeError):
-                                pass
+                        appointment_id, visit_id = (
+                            PaymentWebhookService._extract_payme_account_targets(
+                                webhook_data.account
+                            )
+                        )
+                        logger.info(
+                            "payment_webhook_payme_account_targets_extracted",
+                            extra={
+                                "payment_provider": "payme",
+                                "webhook_record_id": webhook.id,
+                                "has_appointment_target": appointment_id is not None,
+                                "has_visit_target": visit_id is not None,
+                            },
+                        )
 
                     # Приоритет: сначала ищем appointment_id, потом visit_id
                     if appointment_id:

--- a/backend/tests/unit/test_payment_webhook_service.py
+++ b/backend/tests/unit/test_payment_webhook_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -66,3 +66,74 @@ class TestPaymentWebhookService:
         assert summary["transactions"]["total"] == 20
         assert summary["transactions"]["successful"] == 2
         assert summary["transactions"]["failed"] == 1
+
+    @pytest.mark.parametrize(
+        ("account", "expected_appointment_id", "expected_visit_id"),
+        [
+            ({"appointment_id": "123"}, 123, None),
+            ({"order_id": "456"}, 456, None),
+            ({"visit_id": "789"}, None, 789),
+        ],
+    )
+    def test_payme_webhook_extracts_dict_account_targets(
+        self,
+        db_session,
+        account,
+        expected_appointment_id,
+        expected_visit_id,
+    ):
+        webhook = SimpleNamespace(id=99)
+        repository = SimpleNamespace(
+            get_provider_by_code=Mock(return_value=SimpleNamespace(secret_key="secret")),
+            get_webhook_by_webhook_id=Mock(return_value=None),
+            create_webhook=Mock(return_value=webhook),
+            create_transaction=Mock(return_value=SimpleNamespace(id=100)),
+            update_webhook=Mock(return_value=webhook),
+        )
+        data = {
+            "id": "payme-tx-1",
+            "state": 2,
+            "amount": 250000,
+            "account": account,
+        }
+
+        with (
+            patch(
+                "app.services.payment_webhook.PaymentWebhookProcessingRepository",
+                return_value=repository,
+            ),
+            patch.object(
+                PaymentWebhookService, "verify_payme_signature", return_value=True
+            ),
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_appointment",
+                return_value=(True, "appointment paid"),
+            ) as process_appointment,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_existing_visit",
+                return_value=(True, "visit paid"),
+            ) as process_visit,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.create_appointment_from_payment",
+                return_value=(True, "created", 501),
+            ) as create_appointment,
+        ):
+            success, message, result_webhook = PaymentWebhookService.process_payme_webhook(
+                db_session, data, "signature"
+            )
+
+        assert success is True
+        assert message == "Webhook processed successfully"
+        assert result_webhook is webhook
+        create_appointment.assert_not_called()
+
+        if expected_appointment_id is not None:
+            process_appointment.assert_called_once_with(
+                db_session, expected_appointment_id, webhook
+            )
+            process_visit.assert_not_called()
+        else:
+            process_visit.assert_called_once_with(
+                db_session, expected_visit_id, webhook
+            )
+            process_appointment.assert_not_called()


### PR DESCRIPTION
## Summary
- Repackages PR #382 as a billing-only QA slice after RBAC logging was merged separately in #381.
- Fixes Payme webhook routing so successful payments can target `account.appointment_id`, `account.order_id`, or `account.visit_id` from dict-shaped Payme account payloads.
- Adds focused unit coverage for dict account targets without changing Click, provider lookup, signature verification, or transaction creation contracts.

## Contract Impact
- Canonical surface: `app.services.payment_webhook.PaymentWebhookService.process_payme_webhook(...)`.
- Request shape: unchanged; Payme webhook payload still accepts the existing `account` object.
- Response shape: unchanged; service still returns `(success, message, webhook)`.
- Status codes: unchanged; endpoint behavior remains governed by the existing router/service caller.
- Frontend consumer: unchanged; this is a backend webhook-processing fix and no frontend routes/screens are touched.
- Compatibility path or alias: unchanged; no API route registration, webhook URL, or provider alias changed.
- Contract proof: focused Payme webhook unit tests pass locally.

## RBAC / Permissions
- Roles allowed: unchanged; payment webhook processing auth/permissions are not modified in this slice.
- Roles denied: unchanged.
- Positive auth proof: not applicable because this PR does not touch authenticated user-role checks.
- Negative auth proof: not applicable because this PR does not touch forbidden-role paths.

## Notification / Realtime
- Event type or websocket channel: not applicable because this PR does not create, publish, subscribe to, or rename any realtime notification event or websocket channel.
- Payload version / ack behavior: not applicable because this PR only extracts Payme account target IDs inside synchronous webhook processing and does not change any event payload or acknowledgement contract.
- Read/unread or delivery semantics: not applicable because payment webhook processing does not update notification read state, delivery state, or message delivery queues in this slice.
- Reconnect/resync proof: not applicable because this PR does not change realtime connection, reconnect, or resync behavior.

## Frontend Resilience
- Empty data proof: not applicable because no frontend rendering changed and no frontend API response shape is changed.
- Partial data proof: not applicable because no frontend API/data state changed; the new handling is server-side account target extraction.
- Forbidden secondary path behavior: not applicable because no frontend or RBAC path changed.
- Missing draft/resource behavior: not applicable because this PR does not touch draft flows, resource loading, or frontend missing-resource fallbacks.
- Stale route/deep-link behavior: not applicable because routing files are untouched.

## Scope Gate
- Allowed paths: `backend/app/services/payment_webhook.py`, `backend/tests/unit/test_payment_webhook_service.py`.
- Denied paths: no frontend, migrations, API route registration, auth/RBAC, Telegram, EMR, queue, or ops files changed in this branch.
- Migration/docs/test impact: no migration needed; one focused unit test file updated to cover the Payme dict-account routing contract.
- Rollback note: revert commit `7a5e9217` to restore previous Payme account-target extraction behavior.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\services\payment_webhook.py`; `git diff --check origin/main...HEAD`; `python -m pytest backend\tests\unit\test_payment_webhook_service.py -q --tb=short --disable-warnings`.
- Result: compile passed; diff check passed; Payme webhook unit tests passed with 6 passed and 1 warning.
- Not checked: full backend suite, frontend build, browser smoke, external Payme sandbox callback, and deployment smoke were not run because this PR is a two-file focused service/test slice.