### PR TITLE
docs(api): redact password examples in API docs

### DIFF
--- a/backend/app/api/v1/endpoints/api_documentation.py
+++ b/backend/app/api/v1/endpoints/api_documentation.py
@@ -36,7 +36,7 @@ async def get_detailed_endpoints_documentation(
                             "password": {
                                 "type": "string",
                                 "required": True,
-                                "example": "admin123",
+                                "example": "REPLACE_WITH_ADMIN_PASSWORD",
                             },
                         },
                     },
@@ -144,7 +144,7 @@ async def get_detailed_endpoints_documentation(
                             "password": {
                                 "type": "string",
                                 "required": True,
-                                "example": "password123",
+                                "example": "REPLACE_WITH_USER_PASSWORD",
                             },
                             "role": {
                                 "type": "string",
@@ -569,13 +569,13 @@ async def get_api_examples(
     examples = {
         "authentication_examples": {
             "login": {
-                "curl": "curl -X POST 'http://localhost:18000/api/v1/auth/login' -H 'Content-Type: application/x-www-form-urlencoded' -d 'username=admin&password=admin123'",
+                "curl": "curl -X POST 'http://localhost:18000/api/v1/auth/login' -H 'Content-Type: application/x-www-form-urlencoded' -d 'username=admin&password=REPLACE_WITH_ADMIN_PASSWORD'",
                 "python": """
 import requests
 
 response = requests.post(
     'http://localhost:18000/api/v1/auth/login',
-    data={'username': 'admin', 'password': 'admin123'}
+    data={'username': 'admin', 'password': 'REPLACE_WITH_ADMIN_PASSWORD'}
 )
 token = response.json()['access_token']
                 """,
@@ -585,7 +585,7 @@ const response = await fetch('http://localhost:18000/api/v1/auth/login', {
     headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: 'username=admin&password=admin123'
+    body: 'username=admin&password=REPLACE_WITH_ADMIN_PASSWORD'
 });
 const data = await response.json();
 const token = data.access_token;

--- a/backend/app/api/v1/endpoints/docs.py
+++ b/backend/app/api/v1/endpoints/docs.py
@@ -44,7 +44,7 @@ async def get_api_docs():
             <div class="example">
                 {
                     "username": "admin",
-                    "password": "admin123"
+                    "password": "REPLACE_WITH_ADMIN_PASSWORD"
                 }
             </div>
         </div>

--- a/backend/app/services/api_documentation_api_service.py
+++ b/backend/app/services/api_documentation_api_service.py
@@ -35,7 +35,7 @@ async def get_detailed_endpoints_documentation(
                             "password": {
                                 "type": "string",
                                 "required": True,
-                                "example": "admin123",
+                                "example": "REPLACE_WITH_ADMIN_PASSWORD",
                             },
                         },
                     },
@@ -143,7 +143,7 @@ async def get_detailed_endpoints_documentation(
                             "password": {
                                 "type": "string",
                                 "required": True,
-                                "example": "password123",
+                                "example": "REPLACE_WITH_USER_PASSWORD",
                             },
                             "role": {
                                 "type": "string",
@@ -568,13 +568,13 @@ async def get_api_examples(
     examples = {
         "authentication_examples": {
             "login": {
-                "curl": "curl -X POST 'http://localhost:18000/api/v1/auth/login' -H 'Content-Type: application/x-www-form-urlencoded' -d 'username=admin&password=admin123'",
+                "curl": "curl -X POST 'http://localhost:18000/api/v1/auth/login' -H 'Content-Type: application/x-www-form-urlencoded' -d 'username=admin&password=REPLACE_WITH_ADMIN_PASSWORD'",
                 "python": """
 import requests
 
 response = requests.post(
     'http://localhost:18000/api/v1/auth/login',
-    data={'username': 'admin', 'password': 'admin123'}
+    data={'username': 'admin', 'password': 'REPLACE_WITH_ADMIN_PASSWORD'}
 )
 token = response.json()['access_token']
                 """,
@@ -584,7 +584,7 @@ const response = await fetch('http://localhost:18000/api/v1/auth/login', {
     headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: 'username=admin&password=admin123'
+    body: 'username=admin&password=REPLACE_WITH_ADMIN_PASSWORD'
 });
 const data = await response.json();
 const token = data.access_token;

--- a/backend/app/services/docs_api_service.py
+++ b/backend/app/services/docs_api_service.py
@@ -44,7 +44,7 @@ async def get_api_docs():
             <div class="example">
                 {
                     "username": "admin",
-                    "password": "admin123"
+                    "password": "REPLACE_WITH_ADMIN_PASSWORD"
                 }
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Replaces hard-coded demo passwords in runtime-visible API documentation examples with explicit placeholder values.
- Updates both active documentation routers and their unreferenced service mirror copies without deleting legacy files.
- Keeps request shapes, routes, authentication behavior, and examples structure unchanged.

## Contract Impact
- Canonical surface: `/api/v1/docs/api-docs`, `/api/v1/documentation/documentation/endpoints`, and `/api/v1/documentation/examples` documentation responses.
- Request shape: unchanged because endpoint parameters and payload examples still use the same `username` / `password` fields.
- Response shape: unchanged except example password string values now use `REPLACE_WITH_ADMIN_PASSWORD` or `REPLACE_WITH_USER_PASSWORD`.
- Status codes: unchanged because no route logic, dependencies, or exceptions changed.
- Frontend consumer: unchanged; this is documentation/example content only.
- Compatibility path or alias: unchanged; no router registration, prefix, alias, or import path changed.
- Contract proof: touched modules compile and the touched docs files no longer contain `admin123` or `password123`.

## RBAC / Permissions
- Roles allowed: unchanged; docs endpoint dependencies are not modified.
- Roles denied: unchanged.
- Positive auth proof: not applicable because this PR does not change authentication checks or role gates.
- Negative auth proof: not applicable because forbidden-role behavior is untouched.

## Notification / Realtime
- Event type or websocket channel: not applicable because this PR does not touch notification or websocket code.
- Payload version / ack behavior: not applicable because no realtime payload or acknowledgement contract changed.
- Read/unread or delivery semantics: not applicable because notification delivery state is untouched.
- Reconnect/resync proof: not applicable because realtime connection behavior is untouched.

## Frontend Resilience
- Empty data proof: not applicable because no frontend rendering or data-loading path changed.
- Partial data proof: not applicable because no frontend API/data state changed.
- Forbidden secondary path behavior: unchanged because no route guard or frontend forbidden path changed.
- Missing draft/resource behavior: not applicable because this PR does not touch draft/resource UI flows.
- Stale route/deep-link behavior: unchanged because routing files are untouched.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/api_documentation.py`, `backend/app/api/v1/endpoints/docs.py`, `backend/app/services/api_documentation_api_service.py`, `backend/app/services/docs_api_service.py`.
- Denied paths: no auth implementation, password hashing, user seed data, migrations, frontend, ops, generated output, or test artifacts changed.
- Migration/docs/test impact: no migration needed; this is a documentation-example redaction only.
- Rollback note: revert this branch to restore the previous example strings, though real runtime credentials are not changed either way.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\api_documentation.py backend\app\api\v1\endpoints\docs.py backend\app\services\api_documentation_api_service.py backend\app\services\docs_api_service.py`; `rg admin123|password123` on the four touched files; `git diff --check origin/main...HEAD`.
- Result: compile passed; redaction scan returned no matches in the four touched files; diff check passed.
- Not checked: full backend suite, frontend build, browser smoke, and deployment smoke were not run because this PR changes only static documentation/example strings.