### PR TITLE
fix(auth): sanitize simple fallback login logging

### DIFF
--- a/backend/app/services/simple_auth_api_service.py
+++ b/backend/app/services/simple_auth_api_service.py
@@ -1,6 +1,7 @@
 """
 Упрощенный endpoint авторизации без сложных зависимостей
 """
+import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict
 
@@ -15,6 +16,7 @@ from app.models.user import User
 from app.repositories.simple_auth_api_repository import SimpleAuthApiRepository
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 
@@ -45,7 +47,15 @@ async def simple_login(
     Упрощенный вход в систему без сложных зависимостей
     """
     try:
-        print(f"DEBUG: Simple login called with username={request_data.username}")
+        logger.debug(
+            "Simple fallback login requested",
+            extra={
+                "login_identifier_kind": (
+                    "email" if "@" in request_data.username else "username"
+                ),
+                "remember_me": bool(request_data.remember_me),
+            },
+        )
 
         # Ищем пользователя по username или email
         user = _repo(db).query(User).filter(
@@ -54,27 +64,37 @@ async def simple_login(
         ).first()
 
         if not user:
-            print(f"DEBUG: User not found for username={request_data.username}")
+            logger.info(
+                "Simple fallback login rejected",
+                extra={"reason": "user_not_found"},
+            )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Неверные учетные данные"
             )
 
-        print(f"DEBUG: User found: ID={user.id}, Username={user.username}, IsActive={user.is_active}")
+        logger.debug(
+            "Simple fallback login user loaded",
+            extra={"is_active": bool(user.is_active), "role": user.role},
+        )
 
         if not user.is_active:
-            print(f"DEBUG: User is inactive")
+            logger.info(
+                "Simple fallback login rejected",
+                extra={"reason": "inactive_user", "role": user.role},
+            )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Пользователь деактивирован"
             )
 
-        print(f"DEBUG: Verifying password...")
         password_valid = verify_password(request_data.password, user.hashed_password)
-        print(f"DEBUG: Password verification result: {password_valid}")
 
         if not password_valid:
-            print(f"DEBUG: Invalid password")
+            logger.info(
+                "Simple fallback login rejected",
+                extra={"reason": "invalid_password", "role": user.role},
+            )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Неверные учетные данные"
@@ -89,7 +109,10 @@ async def simple_login(
 
         expires_in = int(expires_delta.total_seconds())
 
-        print(f"DEBUG: Token created successfully, expires in {expires_in} seconds")
+        logger.info(
+            "Simple fallback login succeeded",
+            extra={"role": user.role, "expires_in": expires_in},
+        )
 
         # Формируем данные пользователя
         user_data = {
@@ -102,8 +125,6 @@ async def simple_login(
             "is_superuser": user.is_superuser
         }
 
-        print(f"DEBUG: Successful authentication for user {user.username}")
-
         return SimpleLoginResponse(
             access_token=access_token,
             token_type="bearer",
@@ -114,12 +135,14 @@ async def simple_login(
     except HTTPException:
         raise
     except Exception as e:
-        print(f"DEBUG: Exception in simple login: {e}")
-        import traceback
-        print(f"DEBUG: Traceback: {traceback.format_exc()}")
+        logger.error(
+            "Simple fallback login failed",
+            extra={"exception_type": type(e).__name__},
+            exc_info=True,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка входа: {str(e)}"
+            detail="Ошибка входа"
         )
 
 


### PR DESCRIPTION
## Summary
- Continues `.ai-factory/PLAN.md` Task 26 through `/aif-implement` with one narrow backend auth/logging slice.
- Removes raw `print(...)` diagnostics from `backend/app/services/simple_auth_api_service.py`.
- Replaces username/password-result/token debug leakage with structured non-sensitive logging.
- Replaces the simple fallback login public HTTP 500 detail that included raw `str(e)` with a generic login error.

## Contract Impact
- Canonical surface: fallback `POST /api/v1/auth/simple-login` implementation in `backend/app/services/simple_auth_api_service.py` when fallback auth is explicitly enabled.
- Request shape: unchanged; `username`, `password`, and `remember_me` are unchanged.
- Response shape: unchanged; successful responses still include `access_token`, `token_type`, `expires_in`, and `user`.
- Status codes: unchanged for known auth failures; unexpected server errors remain HTTP 500 with safer public detail.
- Frontend consumer: unchanged; canonical frontend login stays on the 2FA-aware flow and does not depend on this fallback endpoint.
- Compatibility path or alias: unchanged; fallback auth remains controlled by existing route/config behavior.
- Contract proof: compile, static leakage search, fallback/auth service tests, repository-boundary test, and 2FA enforcement tests passed locally.

## RBAC / Permissions
- Roles allowed: unchanged; this patch does not alter role checks or route guards.
- Roles denied: unchanged; this patch does not alter denied-role behavior.
- Positive auth proof: `backend\tests\unit\test_auth_fallback_service.py` passed locally.
- Negative auth proof: `backend\tests\test_2fa_enforcement.py` passed locally, preserving fallback-disabled and canonical 2FA expectations.

## Notification / Realtime
- Event type or websocket channel: not applicable because this change does not touch notification, WebSocket, Telegram, or realtime code.
- Payload version / ack behavior: not applicable because no event payloads or acknowledgement paths changed.
- Read/unread or delivery semantics: not applicable because delivery state is untouched.
- Reconnect/resync proof: not applicable because no realtime connection behavior changed.

## Frontend Resilience
- Empty data proof: not applicable because no frontend data rendering changed.
- Partial data proof: not applicable because no frontend API/data states changed.
- Forbidden secondary path behavior: not applicable because no frontend route or role UI path changed.
- Missing draft/resource behavior: not applicable because no draft/resource UI path changed.
- Stale route/deep-link behavior: not applicable because routing and frontend files are untouched.

## Scope Gate
- Allowed paths: `backend/app/services/simple_auth_api_service.py` only.
- Denied paths: no frontend, schema, migration, API route registration, payment, Telegram, EMR, queue, or adjacent minimal-auth files changed.
- Migration/docs/test impact: no migration needed; tests were run as validation only and were not edited; Task 26 remains pending for additional independent backend leakage slices.
- Rollback note: revert commit `44346bc6` to restore previous simple fallback auth logging behavior; auth/token behavior should not need rollback because business logic is unchanged.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\services\simple_auth_api_service.py`; static `rg` search for removed `print`, `traceback`, `DEBUG`, and raw `str(e)` patterns; `python -m pytest backend\tests\test_2fa_enforcement.py -q --tb=short --disable-warnings`; `python -m pytest backend\tests\unit\test_service_repository_boundary.py::test_simple_auth_service_avoids_direct_session_calls -q --tb=short --disable-warnings`; `python -m pytest backend\tests\unit\test_auth_fallback_service.py -q --tb=short --disable-warnings`; `git diff --check`.
- Result: compile passed; static search returned no matches; 2FA enforcement tests passed with 7 passed and 2 warnings; repository-boundary test passed with 1 passed and 1 warning; auth fallback service tests passed with 2 passed and 2 warnings; diff check passed.
- Not checked: full backend suite, frontend build, browser smoke, external deployment, and disposable PostgreSQL migration proof were not run because this is a single-file fallback-auth logging slice.