### PR TITLE
docs(security): redact password examples

### DIFF
--- a/docs/AI_MCP_QA_CHECKLIST.md
+++ b/docs/AI_MCP_QA_CHECKLIST.md
@@ -8,7 +8,7 @@
 **Backend:** http://localhost:18000  
 **Frontend:** http://localhost:5173  
 
-**Live smoke note:** backend `18000` is up; authoritative AI/MCP smoke gate is `GET /api/v1/mcp/health` (returned `overall=healthy` on `2026-03-29`). `GET /api/v1/mcp/status` is informational and may still report `healthy=false` until the cached health state refreshes. Evidence: `output/playwright/ai-mcp-health-smoke-2026-03-29.json`. Browser proof on the same stack loaded `/admin/ai-settings` and `/admin/ai-analytics` under `admin@example.com / admin123` with clean console/network evidence: `output/playwright/ai-mcp-ai-analytics-final.png`, `output/playwright/ai-mcp-ai-analytics-network.log`, `output/playwright/ai-mcp-ai-analytics-console.log`
+**Live smoke note:** backend `18000` is up; authoritative AI/MCP smoke gate is `GET /api/v1/mcp/health` (returned `overall=healthy` on `2026-03-29`). `GET /api/v1/mcp/status` is informational and may still report `healthy=false` until the cached health state refreshes. Evidence: `output/playwright/ai-mcp-health-smoke-2026-03-29.json`. Browser proof on the same stack loaded `/admin/ai-settings` and `/admin/ai-analytics` under a local admin test account with redacted credentials and clean console/network evidence: `output/playwright/ai-mcp-ai-analytics-final.png`, `output/playwright/ai-mcp-ai-analytics-network.log`, `output/playwright/ai-mcp-ai-analytics-console.log`
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -17,7 +17,7 @@ Login and get access token.
 ```json
 {
   "username": "admin",
-  "password": "admin123"
+  "password": "REPLACE_WITH_ADMIN_PASSWORD"
 }
 ```
 


### PR DESCRIPTION
## Summary
- Redacts hard-coded demo passwords from static documentation examples.
- Keeps the evidence references and API example shape intact while replacing the credential value with a placeholder.
- Does not change runtime code, tests, routes, or generated artifacts.

## Contract Impact
- Canonical surface: static docs only: `docs/API_REFERENCE.md` and `docs/AI_MCP_QA_CHECKLIST.md`.
- Request shape: unchanged because the documented login example still shows `username` and `password` fields.
- Response shape: unchanged because no API response documentation is changed.
- Status codes: not applicable because no runtime endpoint changed.
- Frontend consumer: unchanged because no frontend code or route changed.
- Compatibility path or alias: unchanged because docs only were edited.
- Contract proof: docs diff is limited to password redaction text.

## RBAC / Permissions
- Roles allowed: unchanged because no auth or RBAC code changed.
- Roles denied: unchanged.
- Positive auth proof: not applicable because this is a docs-only redaction.
- Negative auth proof: not applicable because forbidden-role behavior is untouched.

## Notification / Realtime
- Event type or websocket channel: not applicable because docs-only redaction does not touch realtime code.
- Payload version / ack behavior: not applicable because no event payloads changed.
- Read/unread or delivery semantics: not applicable because notification delivery state is untouched.
- Reconnect/resync proof: not applicable because realtime connection behavior is untouched.

## Frontend Resilience
- Empty data proof: not applicable because no frontend rendering changed.
- Partial data proof: not applicable because no frontend data state changed.
- Forbidden secondary path behavior: unchanged because no frontend routes or guards changed.
- Missing draft/resource behavior: not applicable because no draft/resource UI flow changed.
- Stale route/deep-link behavior: unchanged because routing files are untouched.

## Scope Gate
- Allowed paths: `docs/API_REFERENCE.md`, `docs/AI_MCP_QA_CHECKLIST.md`.
- Denied paths: no backend, frontend, tests, migrations, ops, generated output, or evidence artifacts changed.
- Migration/docs/test impact: no migration needed; docs-only redaction.
- Rollback note: revert commit `396ddbc7` to restore the previous static docs wording.

## Validation
- Targeted tests or smoke run: `rg admin123|password123 docs\API_REFERENCE.md docs\AI_MCP_QA_CHECKLIST.md -n`; `git diff --check`.
- Result: redaction scan returned no matches in the two touched docs; diff check passed.
- Not checked: backend tests, frontend build, browser smoke, and deployment smoke were not run because this PR is docs-only.