### PR TITLE
fix(files): sanitize json upload logging

### DIFF
--- a/backend/app/api/v1/endpoints/file_upload_json.py
+++ b/backend/app/api/v1/endpoints/file_upload_json.py
@@ -4,6 +4,7 @@ Endpoint для загрузки файлов через JSON
 
 import base64
 import hashlib
+import logging
 import os
 from datetime import datetime
 
@@ -16,6 +17,7 @@ from app.db.session import get_db
 from app.models.user import User
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 class FileUploadRequest(BaseModel):
@@ -33,19 +35,27 @@ async def upload_file_json(
 ):
     """Загрузка файла через JSON (base64)"""
     try:
-        print(f"📁 Получен файл: {request.filename}")
-        print(f"👤 Пользователь: {current_user.username}")
+        logger.info(
+            "JSON file upload requested role=%s has_title=%s has_description=%s",
+            getattr(current_user, "role", None),
+            bool(request.title),
+            bool(request.description),
+        )
 
         # Декодируем содержимое файла
         try:
             content = base64.b64decode(request.content)
         except Exception as e:
-            raise HTTPException(
-                status_code=400, detail=f"Ошибка декодирования base64: {e}"
+            logger.warning(
+                "JSON file upload rejected during base64 decode (%s)",
+                type(e).__name__,
             )
+            raise HTTPException(
+                status_code=400, detail="Ошибка декодирования base64"
+            ) from e
 
         file_size = len(content)
-        print(f"📊 Размер файла: {file_size} байт")
+        logger.info("JSON file upload decoded size_bytes=%s", file_size)
 
         # Создаем хеш файла
         file_hash = hashlib.sha256(content).hexdigest()
@@ -61,7 +71,10 @@ async def upload_file_json(
         with open(file_path, "wb") as f:
             f.write(content)
 
-        print(f"✅ Файл сохранен: {file_path}")
+        logger.info(
+            "JSON file upload saved storage=local_uploads size_bytes=%s",
+            file_size,
+        )
 
         return {
             "success": True,
@@ -78,5 +91,9 @@ async def upload_file_json(
     except HTTPException:
         raise
     except Exception as e:
-        print(f"❌ Ошибка загрузки: {e}")
-        raise HTTPException(status_code=500, detail=f"Ошибка загрузки файла: {str(e)}")
+        logger.error(
+            "JSON file upload failed (%s)",
+            type(e).__name__,
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Ошибка загрузки файла") from e


### PR DESCRIPTION
## Summary

- Sanitizes logging in the mounted JSON file upload endpoint backend/app/api/v1/endpoints/file_upload_json.py.
- Replaces raw print diagnostics that exposed filename, username, file path, and raw exception text with structured non-sensitive logs.
- Keeps upload behavior and response shape unchanged, including existing filename/path response fields.

## Contract Impact

- Canonical surface: POST /api/v1/files/upload-json mounted from backend/app/api/v1/endpoints/file_upload_json.py.
- Request shape: unchanged JSON payload with filename, base64 content, title, and description.
- Response shape: unchanged success response fields.
- Status codes: unchanged success path; invalid base64 still returns 400; unexpected failures still return 500 with generic detail.
- Frontend consumer: not applicable - no frontend files or API client calls changed.
- Compatibility path or alias: legacy duplicate service file left untouched because it is not mounted by backend/app/api/v1/api.py.
- Contract proof: direct endpoint smoke for success and invalid base64, plus existing file security tests passed.

## RBAC / Permissions

- Roles allowed: unchanged; endpoint still depends on get_current_user.
- Roles denied: unchanged; this patch does not alter auth dependency or role logic.
- Positive auth proof: existing file security tests passed for authorized upload flows on the canonical multipart endpoint.
- Negative auth proof: existing file security tests passed for denied patient upload flow on the canonical multipart endpoint.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no frontend rendering changed.
- Partial data proof: not applicable, no frontend rendering changed.
- Forbidden secondary path behavior: not applicable, no frontend route or secondary path changed.
- Missing draft/resource behavior: not applicable, no draft/resource UI changed.
- Stale route/deep-link behavior: not applicable, no route handling changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/file_upload_json.py only.
- Denied paths: storage semantics, duplicate legacy service copy, canonical multipart upload service, migrations, frontend files, generated output.
- Migration/docs/test impact: no migration; no docs change; existing tests and direct smoke used as validation.
- Rollback note: revert commit 6dc271ee to restore previous JSON upload logging behavior.

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/api/v1/endpoints/file_upload_json.py; static rg check for removed raw leakage patterns; direct upload_file_json smoke in a temp directory for success and invalid base64; python -m pytest backend/tests/test_file_security.py -q --tb=short --disable-warnings; git diff --check.
- Result: py_compile passed; static rg returned no risky leakage matches; direct smoke passed; 5 file security tests passed; git diff --check passed.
- Not checked: full backend suite, full frontend build, browser smoke because this was a one-file backend logging/error-detail slice.