### PR TITLE
[codex] fix UI audit state and accessibility issues

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import './styles/dark-theme-visibility-fix.css';
 import './styles/global-fixes.css';
 import './theme/macos-tokens.css';
 import './styles/macos.css';
+import './styles/header-new.css';
 import 'react-toastify/dist/ReactToastify.css';
 import { MacOSThemeProvider } from './theme/macosTheme.jsx';
 import { bootstrapStoredColorScheme } from './theme/colorScheme.js';
@@ -142,7 +143,7 @@ function AppShell({ children }) {
   return (
     <div className="app-shell" style={macOSWrapStyle} data-route-id={chrome.route?.id || 'unknown'}>
       {!chrome.hideHeader && (
-        <div style={{ padding: '12px', backgroundColor: 'transparent', width: '100vw' }}>
+        <div style={{ padding: '12px', backgroundColor: 'transparent', width: '100%', maxWidth: '100%' }}>
           <HeaderNew />
         </div>
       )}
@@ -155,7 +156,8 @@ function AppShell({ children }) {
           gap: '16px',
           flex: 1,
           minHeight: 0,
-          width: '100vw',
+          width: '100%',
+          maxWidth: '100%',
           overflowX: 'hidden',
           overflowY: 'auto',
           padding: chrome.hideHeader ? '0' : '0 0 16px 0',

--- a/frontend/src/components/search/GlobalSearchBar.jsx
+++ b/frontend/src/components/search/GlobalSearchBar.jsx
@@ -221,6 +221,16 @@ export default function GlobalSearchBar({ className = '' }) {
   };
 
   const hasResults = results.patients.length > 0 || results.visits.length > 0 || results.labResults.length > 0;
+  const listboxId = 'global-search-results';
+  const activeOptionId = selectedIndex >= 0 ? `global-search-option-${selectedIndex}` : undefined;
+  const searchStatus = isLoading
+    ? 'Поиск...'
+    : query.length < 2
+      ? 'Начните ввод, минимум 2 символа'
+      : hasResults
+        ? 'Результаты поиска доступны'
+        : 'Ничего не найдено';
+
   const handleResultItemKeyDown = (event, onActivate) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
@@ -340,6 +350,17 @@ export default function GlobalSearchBar({ className = '' }) {
       padding: '20px',
       textAlign: 'center',
       color: 'var(--mac-text-tertiary, #64748b)'
+    },
+    srOnly: {
+      position: 'absolute',
+      width: '1px',
+      height: '1px',
+      padding: 0,
+      margin: '-1px',
+      overflow: 'hidden',
+      clip: 'rect(0, 0, 0, 0)',
+      whiteSpace: 'nowrap',
+      border: 0
     }
   };
 
@@ -357,13 +378,25 @@ export default function GlobalSearchBar({ className = '' }) {
           onFocus={() => setIsOpen(true)}
           onKeyDown={handleKeyDown}
           placeholder="Поиск пациентов, визитов..."
+          aria-label="Глобальный поиск пациентов, визитов и анализов"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          aria-activedescendant={activeOptionId}
           style={styles.input} />
-        
+
                 <span style={styles.shortcut}>⌘K</span>
+                <span style={styles.srOnly} role="status" aria-live="polite">{searchStatus}</span>
             </div>
 
             {isOpen && ReactDOM.createPortal(
-        <div style={styles.dropdown} ref={dropdownRef}>
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label="Результаты глобального поиска"
+          style={styles.dropdown}
+          ref={dropdownRef}>
                     {isLoading &&
           <div style={styles.loading}>Поиск...</div>
           }
@@ -384,16 +417,19 @@ export default function GlobalSearchBar({ className = '' }) {
                                     <div style={styles.sectionTitle}>Пациенты</div>
                                     {results.patients.map((p) => {
                 flatIndex++;
-                const isSelected = flatIndex === selectedIndex;
+                const itemIndex = flatIndex;
+                const isSelected = itemIndex === selectedIndex;
                 return (
                   <div
                     key={`patient-${p.id}`}
-                    role="button"
+                    id={`global-search-option-${itemIndex}`}
+                    role="option"
+                    aria-selected={isSelected}
                     tabIndex={0}
                     style={{ ...styles.item, ...(isSelected ? styles.itemSelected : {}) }}
                     onClick={() => handleItemClick('patient', p)}
                     onKeyDown={(event) => handleResultItemKeyDown(event, () => handleItemClick('patient', p))}
-                    onMouseEnter={() => setSelectedIndex(flatIndex)}>
+                    onMouseEnter={() => setSelectedIndex(itemIndex)}>
                     
                                                 <span style={styles.itemIcon}>👤</span>
                                                 <div style={styles.itemContent}>
@@ -416,16 +452,19 @@ export default function GlobalSearchBar({ className = '' }) {
                                     <div style={styles.sectionTitle}>Визиты</div>
                                     {results.visits.map((v) => {
                 flatIndex++;
-                const isSelected = flatIndex === selectedIndex;
+                const itemIndex = flatIndex;
+                const isSelected = itemIndex === selectedIndex;
                 return (
                   <div
                     key={`visit-${v.id}`}
-                    role="button"
+                    id={`global-search-option-${itemIndex}`}
+                    role="option"
+                    aria-selected={isSelected}
                     tabIndex={0}
                     style={{ ...styles.item, ...(isSelected ? styles.itemSelected : {}) }}
                     onClick={() => handleItemClick('visit', v)}
                     onKeyDown={(event) => handleResultItemKeyDown(event, () => handleItemClick('visit', v))}
-                    onMouseEnter={() => setSelectedIndex(flatIndex)}>
+                    onMouseEnter={() => setSelectedIndex(itemIndex)}>
                     
                                                 <span style={styles.itemIcon}>📋</span>
                                                 <div style={styles.itemContent}>
@@ -448,17 +487,20 @@ export default function GlobalSearchBar({ className = '' }) {
                                     <div style={styles.sectionTitle}>Анализы</div>
                                     {results.labResults.map((l) => {
                 flatIndex++;
-                const isSelected = flatIndex === selectedIndex;
+                const itemIndex = flatIndex;
+                const isSelected = itemIndex === selectedIndex;
                 const statusIcon = l.status === 'done' ? '🟢' : l.status === 'in_progress' ? '🟡' : '⚪';
                 return (
                   <div
                     key={`lab-${l.id}`}
-                    role="button"
+                    id={`global-search-option-${itemIndex}`}
+                    role="option"
+                    aria-selected={isSelected}
                     tabIndex={0}
                     style={{ ...styles.item, ...(isSelected ? styles.itemSelected : {}) }}
                     onClick={() => handleItemClick('lab', l)}
                     onKeyDown={(event) => handleResultItemKeyDown(event, () => handleItemClick('lab', l))}
-                    onMouseEnter={() => setSelectedIndex(flatIndex)}>
+                    onMouseEnter={() => setSelectedIndex(itemIndex)}>
                     
                                                 <span style={styles.itemIcon}>{statusIcon}</span>
                                                 <div style={styles.itemContent}>

--- a/frontend/src/pages/Health.jsx
+++ b/frontend/src/pages/Health.jsx
@@ -36,46 +36,109 @@ export default function Health() {
     return () => { mounted = false; };
   }, [isAdmin]);
 
+  const styles = {
+    page: {
+      minHeight: '100vh',
+      background: 'var(--mac-gradient-window)',
+      color: 'var(--mac-text-primary)',
+      padding: '24px 16px',
+    },
+    main: {
+      maxWidth: '960px',
+      margin: '0 auto',
+    },
+    title: {
+      fontSize: '28px',
+      fontWeight: 700,
+      lineHeight: 1.2,
+      margin: 0,
+    },
+    meta: {
+      color: 'var(--mac-text-secondary)',
+      fontSize: '14px',
+      margin: '8px 0 20px',
+    },
+    section: {
+      background: 'var(--mac-card-bg)',
+      border: '1px solid var(--mac-card-border, var(--mac-border))',
+      borderRadius: '16px',
+      boxShadow: 'var(--mac-main-shell-shadow)',
+      padding: '18px',
+      marginBottom: '18px',
+    },
+    sectionTitle: {
+      fontSize: '18px',
+      fontWeight: 650,
+      margin: '0 0 12px',
+    },
+    pre: {
+      margin: 0,
+      padding: '14px',
+      overflow: 'auto',
+      borderRadius: '12px',
+      border: '1px solid var(--mac-border)',
+      background: 'var(--mac-bg-primary)',
+      color: 'var(--mac-text-primary)',
+      fontSize: '13px',
+      lineHeight: 1.5,
+      maxHeight: '56vh',
+    },
+    muted: {
+      color: 'var(--mac-text-secondary)',
+      fontSize: '14px',
+      lineHeight: 1.5,
+    },
+    alert: {
+      color: 'var(--mac-error, #b42318)',
+      background: 'color-mix(in srgb, var(--mac-error, #ff3b30), transparent 90%)',
+      border: '1px solid color-mix(in srgb, var(--mac-error, #ff3b30), transparent 60%)',
+      borderRadius: '12px',
+      padding: '12px',
+      marginBottom: '18px',
+      fontSize: '14px',
+    },
+  };
+
   return (
-    <div>
-      <main className="p-4 max-w-5xl mx-auto">
-        <h1 className="text-2xl font-semibold mb-2">Состояние приложения</h1>
-        <div className="text-sm text-gray-600 mb-4">
+    <div style={styles.page}>
+      <main style={styles.main}>
+        <h1 style={styles.title}>Состояние приложения</h1>
+        <div style={styles.meta}>
           API base: <code>{getApiBase()}</code>
         </div>
 
         {err && (
-          <div className="text-sm text-red-700 bg-red-50 border border-red-200 rounded p-2 mb-4">
+          <div style={styles.alert} role="alert">
             {err}
           </div>
         )}
 
-        <section className="mb-6">
-          <h2 className="text-lg font-medium mb-2">Health</h2>
+        <section style={styles.section} aria-labelledby="health-status-title">
+          <h2 id="health-status-title" style={styles.sectionTitle}>Health</h2>
           {loading ? (
-            <div>Проверка состояния сервера…</div>
+            <div style={styles.muted} role="status" aria-live="polite">Проверка состояния сервера...</div>
           ) : health ? (
-            <pre className="text-sm bg-gray-50 border border-gray-200 rounded p-3 overflow-auto">
+            <pre style={styles.pre}>
               {typeof health === 'string' ? health : JSON.stringify(health, null, 2)}
             </pre>
           ) : (
-            <div className="text-sm text-gray-700">
+            <div style={styles.muted}>
               Спец-эндпоинт health не обнаружен в OpenAPI. Это нормально.
             </div>
           )}
         </section>
 
         {isAdmin && (
-          <section>
-            <h2 className="text-lg font-medium mb-2">Статус активации</h2>
+          <section style={styles.section} aria-labelledby="activation-status-title">
+            <h2 id="activation-status-title" style={styles.sectionTitle}>Статус активации</h2>
             {loading ? (
-              <div>Загрузка статуса…</div>
+              <div style={styles.muted} role="status" aria-live="polite">Загрузка статуса...</div>
             ) : act ? (
-              <pre className="text-sm bg-gray-50 border border-gray-200 rounded p-3 overflow-auto">
+              <pre style={styles.pre}>
                 {typeof act === 'string' ? act : JSON.stringify(act, null, 2)}
               </pre>
             ) : (
-              <div className="text-sm text-gray-700">
+              <div style={styles.muted}>
                 Эндпоинт статуса активации отсутствует в OpenAPI. Всё в порядке.
               </div>
             )}
@@ -85,4 +148,3 @@ export default function Health() {
     </div>
   );
 }
-

--- a/frontend/src/pages/Landing.css
+++ b/frontend/src/pages/Landing.css
@@ -264,14 +264,14 @@ body.landing-body {
 .landing-section-heading h2,
 .landing-final-copy h2 {
   margin: 0;
-  letter-spacing: -0.035em;
+  letter-spacing: 0;
 }
 
 .landing-hero-card h1 {
-  margin-top: 18px;
-  max-width: 12ch;
-  font-size: clamp(2.6rem, 4.8vw, 4.9rem);
-  line-height: 0.96;
+  margin-top: 16px;
+  max-width: 16ch;
+  font-size: clamp(2.2rem, 3.6vw, 3.8rem);
+  line-height: 1.04;
 }
 
 .landing-hero-description,
@@ -290,7 +290,7 @@ body.landing-body {
 .landing-cta-row {
   gap: 14px;
   flex-wrap: wrap;
-  margin-top: 30px;
+  margin-top: 24px;
 }
 
 .landing-primary-cta,
@@ -937,7 +937,7 @@ body.landing-body {
   .landing-section-heading h2,
   .landing-final-copy h2 {
     max-width: none;
-    font-size: clamp(2rem, 11vw, 3rem);
+    font-size: clamp(1.9rem, 8vw, 2.45rem);
   }
 
   .landing-metric-strip,

--- a/frontend/src/pages/QueueJoin.jsx
+++ b/frontend/src/pages/QueueJoin.jsx
@@ -94,6 +94,8 @@ const formatSpecialistLabel = (specialist) => {
     .join(' • ');
 };
 
+const MISSING_QUEUE_TOKEN_MESSAGE = 'QR-код не найден. Откройте ссылку из клиники или отсканируйте QR-код заново.';
+
 const QueueJoin = () => {
   const { token: paramToken } = useParams();
   const [searchParams] = useSearchParams();
@@ -203,8 +205,12 @@ const QueueJoin = () => {
   }, []);
 
   useEffect(() => {
+    if (!token) {
+      setIsSpecialistsLoading(false);
+      return;
+    }
     loadSpecialists();
-  }, [loadSpecialists]);
+  }, [loadSpecialists, token]);
 
   // ✅ Функции объявлены до использования в useEffect
   const startJoinSession = useCallback(async () => {
@@ -228,6 +234,12 @@ const QueueJoin = () => {
   }, [getApiErrorMessage, token]);
 
   const loadTokenInfo = useCallback(async () => {
+    if (!token) {
+      setError(MISSING_QUEUE_TOKEN_MESSAGE);
+      setStep('error');
+      return;
+    }
+
     try {
       setStep('loading');
       const tokenInfo = await fetchQrTokenInfo(token);
@@ -271,14 +283,20 @@ const QueueJoin = () => {
 
   // Загрузка информации о токене при монтировании
   useEffect(() => {
-    if (token) {
-      // ✅ Пытаемся восстановить session_token из localStorage
-      const savedSessionToken = localStorage.getItem(`queue_session_${token}`);
-      if (savedSessionToken) {
-        setSessionToken(savedSessionToken);
-      }
-      loadTokenInfo();
+    if (!token) {
+      setSessionToken(null);
+      setQueueInfo(null);
+      setError(MISSING_QUEUE_TOKEN_MESSAGE);
+      setStep('error');
+      return;
     }
+
+    // ✅ Пытаемся восстановить session_token из localStorage
+    const savedSessionToken = localStorage.getItem(`queue_session_${token}`);
+    if (savedSessionToken) {
+      setSessionToken(savedSessionToken);
+    }
+    loadTokenInfo();
   }, [token, loadTokenInfo]);
 
   // Обратный отсчет до открытия очереди

--- a/frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx
+++ b/frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx
@@ -59,6 +59,16 @@ function renderQueueJoin(token = 'test-token') {
   );
 }
 
+function renderBareQueueJoin() {
+  return render(
+    <MemoryRouter initialEntries={['/queue/join']}>
+      <Routes>
+        <Route path="/queue/join" element={<QueueJoin />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 describe('QueueJoin Accessibility & UX', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -75,6 +85,16 @@ describe('QueueJoin Accessibility & UX', () => {
     window.localStorage.clear = vi.fn(() => {
       storage.clear();
     });
+  });
+
+  it('shows a missing token error for the bare join route without calling queue APIs', async () => {
+    renderBareQueueJoin();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/QR-код не найден/i);
+    expect(queueApiMocks.fetchQrTokenInfo).not.toHaveBeenCalled();
+    expect(queueApiMocks.startQueueJoinSession).not.toHaveBeenCalled();
+    expect(queueApiMocks.fetchPublicQueueProfiles).not.toHaveBeenCalled();
+    expect(queueApiMocks.fetchAvailableSpecialists).not.toHaveBeenCalled();
   });
 
   it('exposes labeled required fields and announces validation errors', async () => {


### PR DESCRIPTION
﻿## Summary
- Fix the public queue join bare route so it shows a recoverable missing-token error instead of endless loading.
- Improve `/health` contrast with tokenized surfaces and status semantics.
- Load existing header responsive CSS, reduce app shell `100vw` overflow risk, add GlobalSearch combobox/listbox semantics, and tighten Landing hero sizing.

## Validation
- `npm.cmd run test:run -- src/pages/__tests__/QueueJoin.accessibility.test.jsx`
- `npm.cmd run build`
- `git diff --check`

## Scope
UI-only frontend patch. No backend contracts, route registry, auth, billing, EMR, lab semantics, migrations, or queue fairness logic changed.
