### PR TITLE
fix(queue): sanitize broadcast logging

### DIFF
--- a/backend/app/services/online_queue.py
+++ b/backend/app/services/online_queue.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as _dt
+import logging
 from dataclasses import dataclass
 
 from sqlalchemy import select
@@ -11,6 +12,8 @@ from app.models.online import (
     OnlineDay,  # type: ignore[attr-defined]  # DEPRECATED: use DailyQueue instead
 )
 from app.models.setting import Setting  # type: ignore[attr-defined]
+
+logger = logging.getLogger(__name__)
 
 # ============================================================================
 # DEPRECATED SERVICE: Legacy department-based queue system
@@ -191,28 +194,34 @@ def _broadcast(dep: str, d: str, stats: DayStats) -> None:
         },
     }
     # room format должен совпадать с ws/queue_ws.py
-    print(f"🔔 Broadcasting to room: {dep}::{d}")
-    print(f"🔔 Payload: {payload}")
+    logger.info(
+        "Queue broadcast requested department=%s date=%s waiting=%s serving=%s done=%s",
+        dep,
+        d,
+        stats.waiting,
+        stats.serving,
+        stats.done,
+    )
 
     mgr = _ws_manager()
     if mgr:
         try:
-            print(f"🔔 WSManager получен: {type(mgr)}")
-            print(f"🔔 Комнаты в WSManager: {list(mgr.rooms.keys())}")
-            print(f"🔔 Целевая комната: {dep}::{d}")
+            room_count = len(getattr(mgr, "rooms", {}) or {})
+            logger.debug("Queue WS manager available room_count=%s", room_count)
 
             # broadcast - синхронная функция, не нужно create_task
             mgr.broadcast(f"{dep}::{d}", payload)
-            print("🔔 Broadcast sent successfully")
+            logger.debug("Queue broadcast sent")
         except Exception as e:
-            print(f"❌ Broadcast error: {e}")
-            import traceback
-
-            traceback.print_exc()
+            logger.warning(
+                "Queue broadcast failed (%s)",
+                type(e).__name__,
+                exc_info=True,
+            )
             # не роняем транзакции/запрос, если рассылка не удалась
             pass
     else:
-        print("⚠️ WSManager not available for broadcast")
+        logger.debug("Queue WS manager unavailable; broadcast skipped")
 
 
 def issue_next_ticket(


### PR DESCRIPTION
## Summary

- Sanitizes legacy online queue broadcast logging in backend/app/services/online_queue.py.
- Replaces raw print diagnostics for room, payload, WS room list, traceback, and raw exception text with structured non-sensitive logger calls.
- Preserves the existing queue.update payload shape and synchronous mgr.broadcast(room, payload) behavior.

## Contract Impact

- Canonical surface: legacy online queue broadcast helper backend/app/services/online_queue.py::_broadcast.
- Request shape: not applicable - no HTTP request contract changed.
- Response shape: unchanged; broadcast payload sent to WebSocket manager is unchanged.
- Status codes: not applicable - no endpoint status behavior changed.
- Frontend consumer: queue/display WebSocket consumers receive the same queue.update payload.
- Compatibility path or alias: existing legacy online queue service remains compatibility-only for current callers.
- Contract proof: direct _broadcast smoke asserted the same room and payload fields are passed to the manager.

## RBAC / Permissions

- Roles allowed: unchanged; this patch does not alter route dependencies or permission checks.
- Roles denied: unchanged; this patch does not alter route dependencies or permission checks.
- Positive auth proof: not applicable - no auth path changed.
- Negative auth proof: not applicable - no auth path changed.

## Notification / Realtime

- Event type or websocket channel: queue.update broadcast to the existing legacy queue room format remains unchanged.
- Payload version / ack behavior: no payload version exists in this helper; the payload keys and no-ack synchronous broadcast behavior are unchanged.
- Read/unread or delivery semantics: not applicable - queue broadcasts do not use read/unread notification state.
- Reconnect/resync proof: not checked in browser; this patch does not alter room naming or reconnect/resync code paths.

## Frontend Resilience

- Empty data proof: not applicable, no frontend rendering changed.
- Partial data proof: not applicable, no frontend rendering changed.
- Forbidden secondary path behavior: not applicable, no frontend route changed.
- Missing draft/resource behavior: not applicable, no draft/resource UI changed.
- Stale route/deep-link behavior: not applicable, no route handling changed.

## Scope Gate

- Allowed paths: backend/app/services/online_queue.py only.
- Denied paths: queue fairness logic, queue_time, queue models, queue_service.py, WebSocket manager implementation, frontend files, migrations, generated output.
- Migration/docs/test impact: no migration; no docs change; existing queue-time test and direct smoke used as validation.
- Rollback note: revert commit 6464793b to restore previous queue broadcast logging.

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/services/online_queue.py; static rg check for removed raw leakage patterns; direct _broadcast smoke with a fake manager; python -m pytest backend/tests/unit/test_queue_time_window.py -q --tb=short --disable-warnings; git diff --check.
- Result: py_compile passed; static rg returned no risky leakage matches; direct smoke passed; 2 queue time tests passed; git diff --check passed.
- Not checked: full backend suite, browser WebSocket smoke, frontend build because this was a one-file queue logging-only slice.