### PR TITLE
[codex] Remove admin123 helper defaults

### DIFF
--- a/backend/create_users.py
+++ b/backend/create_users.py
@@ -3,9 +3,23 @@
 Скрипт для создания пользователей с разными ролями
 """
 
-from app.core.security import get_password_hash
-from app.db.session import SessionLocal
-from app.models.user import User
+import os
+
+
+def _password_env_names(username: str) -> list[str]:
+    names = [f"CREATE_USERS_{username.upper()}_PASSWORD"]
+    if username == "admin":
+        names.insert(0, "ADMIN_PASSWORD")
+    return names
+
+
+def _required_password(username: str) -> str:
+    for env_name in _password_env_names(username):
+        password = os.getenv(env_name, "").strip()
+        if password:
+            return password
+    expected = " or ".join(_password_env_names(username))
+    raise RuntimeError(f"Set {expected} before creating user '{username}'.")
 
 
 def require_create_users_confirmation():
@@ -31,55 +45,51 @@ def create_users():
     require_create_users_confirmation()
     require_postgres_database_url()
 
+    from app.core.security import get_password_hash
+    from app.db.session import SessionLocal
+    from app.models.user import User
+
     db = SessionLocal()
     try:
         # Список пользователей для создания
         users_data = [
             {
                 "username": "admin",
-                "password": "admin123",
                 "role": "Admin",
                 "full_name": "Administrator",
             },
             {
                 "username": "registrar",
-                "password": "registrar123",
                 "role": "Registrar",
                 "full_name": "Регистратор",
             },
             {
                 "username": "doctor",
-                "password": "doctor123",
                 "role": "Doctor",
                 "full_name": "Врач",
             },
             {
                 "username": "cashier",
-                "password": "cashier123",
                 "role": "Cashier",
                 "full_name": "Кассир",
             },
             {
                 "username": "lab",
-                "password": "lab123",
                 "role": "Lab",
                 "full_name": "Лаборант",
             },
             {
                 "username": "cardio",
-                "password": "cardio123",
                 "role": "Doctor",
                 "full_name": "Кардиолог",
             },
             {
                 "username": "derma",
-                "password": "derma123",
                 "role": "Doctor",
                 "full_name": "Дерматолог",
             },
             {
                 "username": "dentist",
-                "password": "dentist123",
                 "role": "Doctor",
                 "full_name": "Стоматолог",
             },
@@ -99,15 +109,15 @@ def create_users():
                 username=user_data["username"],
                 full_name=user_data["full_name"],
                 email=f"{user_data['username']}@clinic.local",
-                hashed_password=get_password_hash(user_data["password"]),
+                hashed_password=get_password_hash(
+                    _required_password(user_data["username"])
+                ),
                 role=user_data["role"],
                 is_active=True,
             )
 
             db.add(user)
-            print(
-                f"✅ Создан пользователь {user_data['username']} с паролем {user_data['password']}"
-            )
+            print(f"✅ Создан пользователь {user_data['username']}")
 
         db.commit()
         print("\n✅ Все пользователи успешно созданы!")
@@ -115,6 +125,7 @@ def create_users():
     except Exception as e:
         print(f"❌ Ошибка при создании пользователей: {e}")
         db.rollback()
+        raise
     finally:
         db.close()
 

--- a/backend/fix_admin_password.py
+++ b/backend/fix_admin_password.py
@@ -1,57 +1,28 @@
 #!/usr/bin/env python3
-"""
-Скрипт для исправления пароля пользователя admin
-"""
+"""Retired legacy admin password repair helper."""
 
-import os
+from __future__ import annotations
+
 import sys
-from pathlib import Path
 
-# Добавляем путь к проекту
-project_root = Path(__file__).parent
-sys.path.insert(0, str(project_root))
+MESSAGE = """
+fix_admin_password.py is retired.
 
-from sqlalchemy import create_engine, text
-from app.core.config import settings
-from passlib.context import CryptContext
+This legacy helper repaired the bootstrap admin credential through a direct SQL
+path outside the canonical initialized-instance guard. Controlled admin
+password reset belongs to:
 
-# Создаем движок базы данных
-engine = create_engine(settings.DATABASE_URL, echo=False)
+  python -m app.scripts.ensure_admin
 
-# Создаем контекст для хеширования паролей (используем argon2 как в системе)
-pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
+Set ADMIN_PASSWORD, ADMIN_RESET_PASSWORD=1, ENSURE_ADMIN_ALLOW_INITIALIZED=1,
+and ENSURE_ADMIN_CONFIRM_INITIALIZED_OVERRIDE=1 for controlled recovery.
+""".strip()
 
-def get_password_hash(password: str) -> str:
-    return pwd_context.hash(password)
 
-print("🔧 Исправление пароля пользователя admin...")
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
-try:
-    with engine.connect() as conn:
-        # Обновляем пароль для admin
-        new_password_hash = get_password_hash("admin123")
-        
-        result = conn.execute(text("""
-            UPDATE users 
-            SET hashed_password = :password_hash 
-            WHERE username = 'admin'
-        """), {"password_hash": new_password_hash})
-        
-        conn.commit()
-        
-        if result.rowcount > 0:
-            print("✅ Пароль пользователя admin обновлен на 'admin123'")
-        else:
-            print("❌ Пользователь admin не найден")
-            
-        # Проверяем результат
-        result = conn.execute(text("SELECT username, email, role FROM users WHERE username = 'admin'"))
-        user = result.fetchone()
-        
-        if user:
-            print(f"👤 Пользователь: {user[0]} ({user[1]}) - {user[2]}")
-            
-except Exception as e:
-    print(f"❌ Ошибка при обновлении пароля: {e}")
 
-print("\n🎉 Исправление завершено!")
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/reset_admin_password.py
+++ b/backend/reset_admin_password.py
@@ -1,35 +1,26 @@
 #!/usr/bin/env python3
-"""
-Скрипт для сброса пароля администратора
-"""
+"""Retired legacy admin password reset helper."""
 
-from app.core.security import get_password_hash
-from app.db.session import SessionLocal
-from app.models.user import User
+from __future__ import annotations
+
+import sys
+
+MESSAGE = """
+reset_admin_password.py is retired.
+
+Controlled admin password reset belongs to the canonical bootstrap path:
+
+  python -m app.scripts.ensure_admin
+
+Set ADMIN_PASSWORD, ADMIN_RESET_PASSWORD=1, ENSURE_ADMIN_ALLOW_INITIALIZED=1,
+and ENSURE_ADMIN_CONFIRM_INITIALIZED_OVERRIDE=1 for controlled recovery.
+""".strip()
 
 
-def reset_admin_password():
-    """Сброс пароля администратора на 'admin123'"""
-    db = SessionLocal()
-    try:
-        # Ищем пользователя admin
-        admin_user = db.query(User).filter(User.username == "admin").first()
-        if admin_user:
-            # Устанавливаем новый пароль
-            new_password = "admin123"
-            admin_user.hashed_password = get_password_hash(new_password)
-            db.commit()
-            print(
-                f"✅ Пароль для пользователя '{admin_user.username}' успешно сброшен на '{new_password}'"
-            )
-        else:
-            print("❌ Пользователь 'admin' не найден")
-    except Exception as e:
-        print(f"❌ Ошибка при сбросе пароля: {e}")
-        db.rollback()
-    finally:
-        db.close()
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
 
 if __name__ == "__main__":
-    reset_admin_password()
+    raise SystemExit(main())

--- a/frontend/e2e/adm-05-passport-live.mjs
+++ b/frontend/e2e/adm-05-passport-live.mjs
@@ -12,8 +12,12 @@ if (!fs.existsSync(artifactsDir)) {
 const baseUrl = process.env.QA_BASE_URL || 'http://127.0.0.1:4176';
 const apiOrigin = process.env.QA_API_ORIGIN || 'http://127.0.0.1:18006';
 const username = process.env.QA_ADMIN_USERNAME || 'admin@example.com';
-const password = process.env.QA_ADMIN_PASSWORD || 'admin123';
+const password = process.env.QA_ADMIN_PASSWORD;
 const suffix = process.env.QA_SUFFIX || String(Date.now()).slice(-8);
+
+if (!password) {
+  throw new Error('Set QA_ADMIN_PASSWORD to run ADM-05 live e2e proof.');
+}
 
 const patient = {
   lastName: `Админов${suffix.slice(-2)}`,

--- a/frontend/e2e/admin-navigation.spec.js
+++ b/frontend/e2e/admin-navigation.spec.js
@@ -1,12 +1,21 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
 
+const ADMIN_USERNAME = process.env.QA_ADMIN_USERNAME || 'admin';
+
+function requiredAdminPassword() {
+  const password = process.env.QA_ADMIN_PASSWORD;
+  if (!password) {
+    throw new Error('Set QA_ADMIN_PASSWORD to run admin navigation e2e tests.');
+  }
+  return password;
+}
+
 test.describe('Admin navigation', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/login');
-    // Try default admin credentials
-    await page.fill('input[name="username"]', 'admin');
-    await page.fill('input[name="password"]', 'admin123');
+    await page.fill('input[name="username"]', ADMIN_USERNAME);
+    await page.fill('input[name="password"]', requiredAdminPassword());
     await page.click('button:has-text("Войти")');
     // Graceful: if login fails, navigate directly (CI may have auto-login)
     await page.waitForLoadState('networkidle');

--- a/frontend/e2e/auth-flow.spec.js
+++ b/frontend/e2e/auth-flow.spec.js
@@ -1,5 +1,15 @@
 import { test, expect } from '@playwright/test';
 
+const ADMIN_USERNAME = process.env.QA_ADMIN_USERNAME || 'admin@clinic.com';
+
+function requiredAdminPassword() {
+  const password = process.env.QA_ADMIN_PASSWORD;
+  if (!password) {
+    throw new Error('Set QA_ADMIN_PASSWORD to run admin login e2e tests.');
+  }
+  return password;
+}
+
 test.describe('Authentication Flow', () => {
   test.beforeEach(async ({ page }) => {
     // Переходим на страницу логина
@@ -34,8 +44,8 @@ test.describe('Authentication Flow', () => {
 
   test('should login successfully with valid credentials', async ({ page }) => {
     // Вводим валидные данные (тестовый пользователь)
-    await page.fill('input[type="text"]', 'admin@clinic.com');
-    await page.fill('input[type="password"]', 'admin123');
+    await page.fill('input[type="text"]', ADMIN_USERNAME);
+    await page.fill('input[type="password"]', requiredAdminPassword());
     await page.click('button[type="submit"]');
     
     // Проверяем редирект на дашборд
@@ -48,8 +58,8 @@ test.describe('Authentication Flow', () => {
 
   test('should handle role-based routing', async ({ page }) => {
     // Логинимся как админ
-    await page.fill('input[type="text"]', 'admin@clinic.com');
-    await page.fill('input[type="password"]', 'admin123');
+    await page.fill('input[type="text"]', ADMIN_USERNAME);
+    await page.fill('input[type="password"]', requiredAdminPassword());
     await page.click('button[type="submit"]');
     
     // Ждем загрузки
@@ -62,8 +72,8 @@ test.describe('Authentication Flow', () => {
 
   test('should logout successfully', async ({ page }) => {
     // Логинимся
-    await page.fill('input[type="text"]', 'admin@clinic.com');
-    await page.fill('input[type="password"]', 'admin123');
+    await page.fill('input[type="text"]', ADMIN_USERNAME);
+    await page.fill('input[type="password"]', requiredAdminPassword());
     await page.click('button[type="submit"]');
     
     // Ждем загрузки дашборда
@@ -92,8 +102,8 @@ test.describe('Authentication Flow', () => {
 
   test('should handle session expiration', async ({ page }) => {
     // Логинимся
-    await page.fill('input[type="text"]', 'admin@clinic.com');
-    await page.fill('input[type="password"]', 'admin123');
+    await page.fill('input[type="text"]', ADMIN_USERNAME);
+    await page.fill('input[type="password"]', requiredAdminPassword());
     await page.click('button[type="submit"]');
     
     // Ждем загрузки
@@ -119,14 +129,14 @@ test.describe('Authentication Flow', () => {
     if (await rememberCheckbox.count() > 0) {
       await rememberCheckbox.check();
       
-      await page.fill('input[type="text"]', 'admin@clinic.com');
-      await page.fill('input[type="password"]', 'admin123');
+      await page.fill('input[type="text"]', ADMIN_USERNAME);
+      await page.fill('input[type="password"]', requiredAdminPassword());
       await page.click('button[type="submit"]');
       
       // Проверяем что данные сохранились
       await page.goto('/login');
       const savedEmail = await page.locator('input[type="text"]').inputValue();
-      expect(savedEmail).toBe('admin@clinic.com');
+      expect(savedEmail).toBe(ADMIN_USERNAME);
     }
   });
 });

--- a/frontend/e2e/basic.spec.js
+++ b/frontend/e2e/basic.spec.js
@@ -1,6 +1,16 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
 
+const ADMIN_USERNAME = process.env.QA_ADMIN_USERNAME || 'admin';
+
+function requiredAdminPassword() {
+  const password = process.env.QA_ADMIN_PASSWORD;
+  if (!password) {
+    throw new Error('Set QA_ADMIN_PASSWORD to run admin login e2e tests.');
+  }
+  return password;
+}
+
 test.describe('Базовая функциональность клиники', () => {
   test('главная страница загружается', async ({ page }) => {
     await page.goto('/');
@@ -22,8 +32,8 @@ test.describe('Базовая функциональность клиники', 
     await page.goto('/login');
     
     // Заполняем форму логина
-    await page.fill('input[type="text"]', 'admin');
-    await page.fill('input[type="password"]', 'admin123');
+    await page.fill('input[type="text"]', ADMIN_USERNAME);
+    await page.fill('input[type="password"]', requiredAdminPassword());
     
     // Нажимаем кнопку входа
     await page.click('button[type="submit"]');
@@ -35,8 +45,8 @@ test.describe('Базовая функциональность клиники', 
   test('панель администратора доступна после входа', async ({ page }) => {
     // Логинимся
     await page.goto('/login');
-    await page.fill('input[type="text"]', 'admin');
-    await page.fill('input[type="password"]', 'admin123');
+    await page.fill('input[type="text"]', ADMIN_USERNAME);
+    await page.fill('input[type="password"]', requiredAdminPassword());
     await page.click('button[type="submit"]');
     
     // Ждем загрузки панели
@@ -49,8 +59,8 @@ test.describe('Базовая функциональность клиники', 
   test('навигация работает', async ({ page }) => {
     // Логинимся
     await page.goto('/login');
-    await page.fill('input[type="text"]', 'admin');
-    await page.fill('input[type="password"]', 'admin123');
+    await page.fill('input[type="text"]', ADMIN_USERNAME);
+    await page.fill('input[type="password"]', requiredAdminPassword());
     await page.click('button[type="submit"]');
     
     await page.waitForURL('**/dashboard', { timeout: 10000 });

--- a/frontend/e2e/messaging-rollout-proof.spec.js
+++ b/frontend/e2e/messaging-rollout-proof.spec.js
@@ -16,8 +16,8 @@ test.use({
 });
 
 const LIVE_CREDENTIALS = {
-  doctor: { username: 'doctor@example.com', password: 'doctor123', route: /\/doctor-panel(\?.*)?$/ },
-  admin: { username: 'admin', password: 'admin123', route: /\/admin(\?.*)?$/ },
+  doctor: { username: 'doctor@example.com', route: /\/doctor-panel(\?.*)?$/ },
+  admin: { username: 'admin', route: /\/admin(\?.*)?$/ },
 };
 
 function ensureArtifactsDir() {


### PR DESCRIPTION
## Summary

- Remove hardcoded `admin123` from frontend e2e admin login proofs.
- Require `QA_ADMIN_PASSWORD` for live/admin e2e login paths instead of falling back to a known password.
- Retire legacy backend direct admin password reset helpers in favor of canonical `python -m app.scripts.ensure_admin`.
- Make `backend/create_users.py` read role passwords from env and stop printing generated passwords.

## Contract Impact

- Canonical surface: backend admin bootstrap helper scripts and frontend e2e proof scripts only
- Request shape: not applicable - no public HTTP request contract changes were made.
- Response shape: not applicable - no API response payload contract changes were made.
- Status codes: not applicable - no route status-code behavior was changed.
- Frontend consumer: Playwright e2e admin login proofs now require `QA_ADMIN_PASSWORD`.
- Compatibility path or alias: legacy direct reset helpers now point operators to `python -m app.scripts.ensure_admin`.
- Contract proof: targeted grep, backend helper compile, e2e syntax checks, frontend build, and CI frontend/backend checks.

## RBAC / Permissions

- Roles allowed: not applicable - no runtime role allow-list changed.
- Roles denied: not applicable - no runtime role deny-list changed.
- Positive auth proof: existing CI backend and frontend checks passed with this branch.
- Negative auth proof: hardcoded fallback credential path no longer exists in the touched files.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no empty-data rendering path changed.
- Partial data proof: not applicable - no partial-data rendering path changed.
- Forbidden secondary path behavior: not applicable - no secondary route or forbidden fallback behavior changed.
- Missing draft/resource behavior: not applicable - no draft or resource reopening behavior changed.
- Stale route/deep-link behavior: not applicable - no route registry or deep-link behavior changed.

## Scope Gate

- Allowed paths: eight explicit gate-approved helper/e2e files in `backend/` and `frontend/e2e/`.
- Denied paths: `QA-analise` mass diff, backend runtime routes/services, generated logs, unrelated tests, and docs artifacts.
- Migration/docs/test impact: no migration; no docs update; e2e tests now require configured admin password.
- Rollback note: revert commit `244eb35d` to restore the previous helper/e2e credential behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\create_users.py backend\fix_admin_password.py backend\reset_admin_password.py`; `node --check frontend\e2e\messaging-rollout-proof.spec.js frontend\e2e\basic.spec.js frontend\e2e\auth-flow.spec.js frontend\e2e\admin-navigation.spec.js frontend\e2e\adm-05-passport-live.mjs`; `npm.cmd run build` in `frontend`; targeted grep for `admin123` in touched files.
- Result: local checks passed; CI frontend tests, backend tests, quality, security, docs, Vercel, and parity checks passed; only this PR body gate needed the template update.
- Not checked: live Playwright e2e login run, because it requires a running stack and real `QA_ADMIN_PASSWORD` secret.