### PR TITLE
fix(notifications): sanitize mobile push logging

### DIFF
--- a/backend/app/services/mobile_notifications.py
+++ b/backend/app/services/mobile_notifications.py
@@ -2,6 +2,7 @@
 Сервис для мобильных уведомлений
 """
 
+import logging
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -11,6 +12,16 @@ from app.crud import notification as crud_notification
 from app.models.appointment import Appointment
 from app.models.user import User
 from app.services.fcm_service import get_fcm_service
+
+logger = logging.getLogger(__name__)
+
+
+def _log_notification_failure(action: str, exc: Exception) -> None:
+    logger.warning(
+        "Mobile notification action failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
 
 
 class MobileNotificationService:
@@ -64,7 +75,7 @@ class MobileNotificationService:
             return True
 
         except Exception as e:
-            print(f"Ошибка отправки push-уведомления: {e}")
+            _log_notification_failure("send_push_notification", e)
             return False
 
     async def send_appointment_reminder(
@@ -108,7 +119,7 @@ class MobileNotificationService:
             )
 
         except Exception as e:
-            print(f"Ошибка отправки напоминания о записи: {e}")
+            _log_notification_failure("send_appointment_reminder", e)
             return False
 
     async def send_queue_update(
@@ -128,7 +139,7 @@ class MobileNotificationService:
             return await self.send_push_notification(patient_id, title, message, data)
 
         except Exception as e:
-            print(f"Ошибка отправки обновления очереди: {e}")
+            _log_notification_failure("send_queue_update", e)
             return False
 
     async def send_lab_results(
@@ -148,7 +159,7 @@ class MobileNotificationService:
             return await self.send_push_notification(patient_id, title, message, data)
 
         except Exception as e:
-            print(f"Ошибка отправки результатов анализов: {e}")
+            _log_notification_failure("send_lab_results", e)
             return False
 
     async def send_payment_notification(
@@ -175,7 +186,7 @@ class MobileNotificationService:
             return await self.send_push_notification(patient_id, title, message, data)
 
         except Exception as e:
-            print(f"Ошибка отправки уведомления об оплате: {e}")
+            _log_notification_failure("send_payment_notification", e)
             return False
 
     async def send_appointment_confirmation(self, appointment_id: int) -> bool:
@@ -203,7 +214,7 @@ class MobileNotificationService:
             )
 
         except Exception as e:
-            print(f"Ошибка отправки подтверждения записи: {e}")
+            _log_notification_failure("send_appointment_confirmation", e)
             return False
 
     async def send_appointment_cancellation(
@@ -237,7 +248,7 @@ class MobileNotificationService:
             )
 
         except Exception as e:
-            print(f"Ошибка отправки уведомления об отмене: {e}")
+            _log_notification_failure("send_appointment_cancellation", e)
             return False
 
     async def _send_fcm_notification(
@@ -249,7 +260,10 @@ class MobileNotificationService:
     ) -> bool:
         """Отправка уведомления через FCM (заглушка)"""
         # TODO: Реальная интеграция с Firebase Cloud Messaging
-        print(f"FCM уведомление для {device_token}: {title} - {message}")
+        logger.info(
+            "FCM notification stub invoked has_data=%s",
+            bool(data),
+        )
         return True
 
     async def get_notification_history(
@@ -275,7 +289,7 @@ class MobileNotificationService:
             ]
 
         except Exception as e:
-            print(f"Ошибка получения истории уведомлений: {e}")
+            _log_notification_failure("get_notification_history", e)
             return []
 
     async def mark_notification_read(self, notification_id: int, user_id: int) -> bool:
@@ -294,7 +308,7 @@ class MobileNotificationService:
             return True
 
         except Exception as e:
-            print(f"Ошибка отметки уведомления как прочитанного: {e}")
+            _log_notification_failure("mark_notification_read", e)
             return False
 
 


### PR DESCRIPTION
## Summary

- Sanitizes mobile push notification logging in backend/app/services/mobile_notifications.py.
- Replaces raw print diagnostics that exposed device tokens, notification titles/messages, and raw exception text.
- Preserves notification persistence, FCM dispatch calls, stub return behavior, and existing True/False failure handling.

## Contract Impact

- Canonical surface: MobileNotificationService in backend/app/services/mobile_notifications.py.
- Request shape: not applicable - no HTTP request contract changed.
- Response shape: unchanged service return values for notification methods.
- Status codes: not applicable - no endpoint status behavior changed.
- Frontend consumer: not applicable - no frontend files or API responses changed.
- Compatibility path or alias: existing service entry point and get_mobile_notification_service helper remain unchanged.
- Contract proof: direct service smoke verified send_push_notification success, FCM stub success, and failure returning False.

## RBAC / Permissions

- Roles allowed: unchanged; this patch does not alter auth dependencies or role checks.
- Roles denied: unchanged; this patch does not alter auth dependencies or role checks.
- Positive auth proof: not applicable - no auth path changed.
- Negative auth proof: not applicable - no auth path changed.

## Notification / Realtime

- Event type or websocket channel: mobile push notification dispatch via FCM service; no websocket channel changed.
- Payload version / ack behavior: FCM payload title/body/data and service True/False return behavior are unchanged.
- Read/unread or delivery semantics: persisted notification fields and mark-as-read behavior are unchanged.
- Reconnect/resync proof: not applicable - mobile push notifications do not use websocket reconnect/resync paths.

## Frontend Resilience

- Empty data proof: not applicable, no frontend rendering changed.
- Partial data proof: not applicable, no frontend data rendering changed.
- Forbidden secondary path behavior: not applicable, no frontend route changed.
- Missing draft/resource behavior: not applicable, no draft/resource UI changed.
- Stale route/deep-link behavior: not applicable, no route handling changed.

## Scope Gate

- Allowed paths: backend/app/services/mobile_notifications.py only.
- Denied paths: mobile API endpoints, notification persistence schema, FCM provider implementation, frontend files, migrations, generated output.
- Migration/docs/test impact: no migration; no docs change; existing mobile API service tests and direct service smoke used as validation.
- Rollback note: revert commit cf8a3a61 to restore previous mobile push logging.

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/services/mobile_notifications.py; static rg check for removed raw leakage patterns; direct service smoke with mocked DB/FCM for success, stub, and failure; python -m pytest backend/tests/unit/test_mobile_api_service.py -q --tb=short --disable-warnings; git diff --check.
- Result: py_compile passed; static rg returned no risky leakage matches; direct smoke passed; 2 mobile API service tests passed; git diff --check passed.
- Not checked: full backend suite, live FCM delivery, browser/mobile client smoke because this was a one-file logging-only slice.