### PR TITLE
[codex] Centralize backend admin test password

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,7 @@
 """
 
 import os
+import secrets
 import tempfile
 from datetime import date, datetime
 
@@ -21,6 +22,8 @@ from app.db.base_class import Base
 
 # Ensure app boots in test mode before importing app.main.
 os.environ.setdefault("TESTING", "1")
+
+TEST_ADMIN_PASSWORD = os.getenv("TEST_ADMIN_PASSWORD") or secrets.token_urlsafe(24)
 
 from app.main import app
 
@@ -139,7 +142,7 @@ def client(db_session):
 
 
 @pytest.fixture(scope="function")
-def admin_user(db_session):
+def admin_user(db_session, admin_password):
     """Создает тестового администратора"""
     # Переиспользуем пользователя, если он уже создан (из-за уникального username)
     user = db_session.query(User).filter(User.username == "test_admin").first()
@@ -150,7 +153,7 @@ def admin_user(db_session):
         username="test_admin",
         email="admin@test.com",
         full_name="Test Admin",
-        hashed_password=get_password_hash("admin123"),
+        hashed_password=get_password_hash(admin_password),
         role="Admin",
         is_active=True,
         is_superuser=True,
@@ -159,6 +162,11 @@ def admin_user(db_session):
     db_session.commit()
     db_session.refresh(user)
     return user
+
+
+@pytest.fixture(scope="session")
+def admin_password():
+    return TEST_ADMIN_PASSWORD
 
 
 @pytest.fixture(scope="function")
@@ -375,11 +383,11 @@ def test_queue_entry(db_session, test_daily_queue, test_patient, test_visit):
 
 
 @pytest.fixture(scope="function")
-def auth_headers(client, admin_user):
+def auth_headers(client, admin_user, admin_password):
     """Создает заголовки авторизации для администратора"""
     response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     assert response.status_code == 200
     token = response.json()["access_token"]

--- a/backend/tests/integration/test_activation_api.py
+++ b/backend/tests/integration/test_activation_api.py
@@ -3,18 +3,18 @@ from __future__ import annotations
 import pytest
 
 
-def _login_admin(client, admin_user):
+def _login_admin(client, admin_user, admin_password):
     response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     assert response.status_code == 200, response.text
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
 
 
 @pytest.mark.integration
-def test_activation_issue_list_revoke_roundtrip(client, admin_user):
-    headers = _login_admin(client, admin_user)
+def test_activation_issue_list_revoke_roundtrip(client, admin_user, admin_password):
+    headers = _login_admin(client, admin_user, admin_password)
 
     issue_response = client.post(
         "/api/v1/activation/issue",

--- a/backend/tests/integration/test_admin_display_settings.py
+++ b/backend/tests/integration/test_admin_display_settings.py
@@ -3,18 +3,18 @@ from __future__ import annotations
 import pytest
 
 
-def _login_admin(client, admin_user):
+def _login_admin(client, admin_user, admin_password):
     response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     assert response.status_code == 200, response.text
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
 
 
 @pytest.mark.integration
-def test_admin_display_settings_roundtrip(client, admin_user):
-    headers = _login_admin(client, admin_user)
+def test_admin_display_settings_roundtrip(client, admin_user, admin_password):
+    headers = _login_admin(client, admin_user, admin_password)
 
     boards_response = client.get("/api/v1/admin/display/boards", headers=headers)
     assert boards_response.status_code == 200, boards_response.text

--- a/backend/tests/integration/test_admin_finance_transactions.py
+++ b/backend/tests/integration/test_admin_finance_transactions.py
@@ -6,10 +6,10 @@ from app.models.clinic import Doctor
 from app.models.patient import Patient
 
 
-def _login_admin(client, admin_user):
+def _login_admin(client, admin_user, admin_password):
     response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     assert response.status_code == 200, response.text
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
@@ -30,6 +30,7 @@ def test_admin_finance_transactions_crud_roundtrip(
     db_session,
     admin_user,
     test_doctor_user,
+    admin_password,
 ):
     patient = Patient(
         first_name="Тест",
@@ -51,7 +52,7 @@ def test_admin_finance_transactions_crud_roundtrip(
     db_session.refresh(patient)
     db_session.refresh(doctor)
 
-    headers = _login_admin(client, admin_user)
+    headers = _login_admin(client, admin_user, admin_password)
 
     create_response = client.post(
         "/api/v1/admin/finance/transactions",

--- a/backend/tests/integration/test_admin_service_code_prefix_consistency.py
+++ b/backend/tests/integration/test_admin_service_code_prefix_consistency.py
@@ -4,10 +4,10 @@ from app.models.clinic import ServiceCategory
 from app.models.service import Service
 
 
-def _login_admin(client, admin_user):
+def _login_admin(client, admin_user, admin_password):
     login_response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     assert login_response.status_code == 200, login_response.text
     return {"Authorization": f"Bearer {login_response.json()['access_token']}"}
@@ -18,6 +18,7 @@ def test_service_create_rejects_prefix_mismatch_for_selected_category(
     client,
     db_session,
     admin_user,
+    admin_password,
 ):
     lab_category = ServiceCategory(
         code="adm-06-lab-prefix",
@@ -29,7 +30,7 @@ def test_service_create_rejects_prefix_mismatch_for_selected_category(
     db_session.commit()
     db_session.refresh(lab_category)
 
-    headers = _login_admin(client, admin_user)
+    headers = _login_admin(client, admin_user, admin_password)
     response = client.post(
         "/api/v1/services",
         json={
@@ -58,6 +59,7 @@ def test_service_create_accepts_allowed_prefixes_for_procedures(
     client,
     db_session,
     admin_user,
+    admin_password,
 ):
     procedures_category = ServiceCategory(
         code="adm-06-proc-prefix",
@@ -69,7 +71,7 @@ def test_service_create_accepts_allowed_prefixes_for_procedures(
     db_session.commit()
     db_session.refresh(procedures_category)
 
-    headers = _login_admin(client, admin_user)
+    headers = _login_admin(client, admin_user, admin_password)
     response = client.post(
         "/api/v1/services",
         json={

--- a/backend/tests/integration/test_analytics_contracts.py
+++ b/backend/tests/integration/test_analytics_contracts.py
@@ -9,10 +9,10 @@ from app.models.user import User
 
 
 @pytest.fixture
-def admin_token(client: TestClient, admin_user: User) -> str:
+def admin_token(client: TestClient, admin_user: User, admin_password: str) -> str:
     response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     assert response.status_code == 200
     return response.json()["access_token"]

--- a/backend/tests/integration/test_clinic_management_admin_access.py
+++ b/backend/tests/integration/test_clinic_management_admin_access.py
@@ -1,10 +1,10 @@
 import pytest
 
 
-def _login_admin(client, admin_user):
+def _login_admin(client, admin_user, admin_password):
     response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     assert response.status_code == 200, response.text
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
@@ -14,8 +14,9 @@ def _login_admin(client, admin_user):
 def test_clinic_management_stats_and_health_are_admin_accessible(
     client,
     admin_user,
+    admin_password,
 ):
-    headers = _login_admin(client, admin_user)
+    headers = _login_admin(client, admin_user, admin_password)
 
     stats_response = client.get("/api/v1/clinic/stats", headers=headers)
     assert stats_response.status_code == 200, stats_response.text
@@ -33,6 +34,7 @@ def test_clinic_management_stats_and_health_are_admin_accessible(
 def test_clinic_management_stats_and_health_do_not_use_request_state_auth_chain(
     client,
     admin_user,
+    admin_password,
     monkeypatch,
 ):
     import app.api.deps as deps_module
@@ -45,7 +47,7 @@ def test_clinic_management_stats_and_health_do_not_use_request_state_auth_chain(
     monkeypatch.setattr(deps_module, "require_authentication", _legacy_auth_chain_called)
     monkeypatch.setattr(deps_module, "get_current_user_from_request", _legacy_auth_chain_called)
 
-    headers = _login_admin(client, admin_user)
+    headers = _login_admin(client, admin_user, admin_password)
 
     stats_response = client.get("/api/v1/clinic/stats", headers=headers)
     assert stats_response.status_code == 200, stats_response.text

--- a/backend/tests/integration/test_dynamic_pricing_api.py
+++ b/backend/tests/integration/test_dynamic_pricing_api.py
@@ -8,10 +8,10 @@ from app.models.dynamic_pricing import PricingRule, PricingRuleService, ServiceP
 from app.models.service import Service
 
 
-def _login_admin(client, admin_user):
+def _login_admin(client, admin_user, admin_password):
     login_response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     assert login_response.status_code == 200, login_response.text
     return {"Authorization": f"Bearer {login_response.json()['access_token']}"}
@@ -22,6 +22,7 @@ def test_dynamic_pricing_rule_delete_cleans_linked_rows(
     client,
     db_session,
     admin_user,
+    admin_password,
 ):
     service = Service(
         code="DP-DEL-001",
@@ -35,7 +36,7 @@ def test_dynamic_pricing_rule_delete_cleans_linked_rows(
     db_session.commit()
     db_session.refresh(service)
 
-    headers = _login_admin(client, admin_user)
+    headers = _login_admin(client, admin_user, admin_password)
     create_response = client.post(
         "/api/v1/dynamic-pricing/pricing-rules",
         json={

--- a/backend/tests/integration/test_patient_documents_api.py
+++ b/backend/tests/integration/test_patient_documents_api.py
@@ -4,12 +4,16 @@ import pytest
 
 
 @pytest.mark.integration
-def test_create_patient_accepts_document_type_and_number_pair(client, admin_user):
+def test_create_patient_accepts_document_type_and_number_pair(
+    client,
+    admin_user,
+    admin_password,
+):
     login_response = client.post(
         "/api/v1/authentication/login",
         json={
             "username": admin_user.username,
-            "password": "admin123",
+            "password": admin_password,
         },
     )
     assert login_response.status_code == 200, login_response.text

--- a/backend/tests/integration/test_rbac_matrix.py
+++ b/backend/tests/integration/test_rbac_matrix.py
@@ -23,11 +23,11 @@ from app.core.security import get_password_hash
 # ===================== FIXTURES =====================
 
 @pytest.fixture
-def admin_token(client: TestClient, admin_user: User) -> str:
+def admin_token(client: TestClient, admin_user: User, admin_password: str) -> str:
     """Токен администратора"""
     response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     assert response.status_code == 200
     return response.json()["access_token"]
@@ -403,7 +403,13 @@ class TestAuditLog403:
 class TestRegressionRBAC:
     """Smoke-тесты для проверки регрессий"""
 
-    def test_superadmin_bypasses_all_checks(self, client: TestClient, admin_user: User, db_session: Session):
+    def test_superadmin_bypasses_all_checks(
+        self,
+        client: TestClient,
+        admin_user: User,
+        db_session: Session,
+        admin_password: str,
+    ):
         """SuperAdmin обходит все проверки (is_superuser=True)"""
         # Устанавливаем is_superuser=True
         admin_user.is_superuser = True
@@ -412,7 +418,7 @@ class TestRegressionRBAC:
         # Получаем токен
         response = client.post(
             "/api/v1/authentication/login",
-            json={"username": admin_user.username, "password": "admin123"},
+            json={"username": admin_user.username, "password": admin_password},
         )
         assert response.status_code == 200
         token = response.json()["access_token"]

--- a/backend/tests/integration/test_registrar_services_grouping.py
+++ b/backend/tests/integration/test_registrar_services_grouping.py
@@ -11,6 +11,7 @@ def test_registrar_services_prefers_explicit_lab_routing_over_code_fallback(
     client,
     db_session,
     admin_user,
+    admin_password,
 ):
     lab_category = ServiceCategory(
         code="lab-adm-06",
@@ -41,7 +42,7 @@ def test_registrar_services_prefers_explicit_lab_routing_over_code_fallback(
 
     login_response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     assert login_response.status_code == 200, login_response.text
 

--- a/backend/tests/test_2fa_enforcement.py
+++ b/backend/tests/test_2fa_enforcement.py
@@ -25,7 +25,7 @@ def enforce_2fa_requirement(monkeypatch):
 
 
 @pytest.fixture
-def admin_user_without_2fa(db_session: Session) -> User:
+def admin_user_without_2fa(db_session: Session, admin_password: str) -> User:
     """Создает тестового админа БЕЗ настроенной 2FA"""
     # Проверяем, не существует ли уже пользователь
     existing = db_session.query(User).filter(User.username == "test_admin_2fa").first()
@@ -42,7 +42,7 @@ def admin_user_without_2fa(db_session: Session) -> User:
         username="test_admin_2fa",
         email="admin2fa@test.com",
         full_name="Test Admin 2FA",
-        hashed_password=get_password_hash("admin123"),
+        hashed_password=get_password_hash(admin_password),
         role="Admin",
         is_active=True,
         is_superuser=False,
@@ -179,7 +179,7 @@ class Test2FAEnforcement:
             assert "access_token" not in response.text
 
     def test_canonical_login_does_not_issue_access_token_before_otp(
-        self, client: TestClient, admin_user_with_2fa: tuple[User, str]
+        self, client: TestClient, admin_user_with_2fa: tuple[User, str], admin_password: str
     ):
         """The 2FA-aware login step returns only a pending 2FA token before OTP."""
         admin_user, _secret = admin_user_with_2fa
@@ -188,7 +188,7 @@ class Test2FAEnforcement:
             "/api/v1/authentication/login",
             json={
                 "username": admin_user.username,
-                "password": "admin123",
+                "password": admin_password,
             },
         )
 
@@ -200,14 +200,14 @@ class Test2FAEnforcement:
         assert data.get("refresh_token") is None
 
     def test_admin_cannot_login_without_2fa(
-        self, client: TestClient, admin_user_without_2fa: User
+        self, client: TestClient, admin_user_without_2fa: User, admin_password: str
     ):
         """Admin НЕ может войти без настройки 2FA"""
         response = client.post(
             "/api/v1/authentication/login",
             json={
                 "username": admin_user_without_2fa.username,
-                "password": "admin123",
+                "password": admin_password,
             },
         )
 
@@ -240,7 +240,7 @@ class Test2FAEnforcement:
             f"Message should mention 2FA setup requirement. Detail: {detail}"
 
     def test_admin_can_login_with_correct_otp(
-        self, client: TestClient, admin_user_with_2fa: tuple[User, str]
+        self, client: TestClient, admin_user_with_2fa: tuple[User, str], admin_password: str
     ):
         """Admin может войти с правильным OTP после настройки 2FA"""
         admin_user, secret = admin_user_with_2fa
@@ -254,7 +254,7 @@ class Test2FAEnforcement:
             "/api/v1/authentication/login",
             json={
                 "username": admin_user.username,
-                "password": "admin123",
+                "password": admin_password,
             },
         )
         assert login_response.status_code == 200
@@ -280,7 +280,7 @@ class Test2FAEnforcement:
         assert "access_token" in verify_data, "access_token should be returned after 2FA verification"
 
     def test_admin_cannot_login_with_incorrect_otp(
-        self, client: TestClient, admin_user_with_2fa: tuple[User, str]
+        self, client: TestClient, admin_user_with_2fa: tuple[User, str], admin_password: str
     ):
         """Admin НЕ может войти с неправильным OTP"""
         admin_user, secret = admin_user_with_2fa
@@ -290,7 +290,7 @@ class Test2FAEnforcement:
             "/api/v1/authentication/login",
             json={
                 "username": admin_user.username,
-                "password": "admin123",
+                "password": admin_password,
             },
         )
         assert login_response.status_code == 200

--- a/backend/tests/test_audit_logs.py
+++ b/backend/tests/test_audit_logs.py
@@ -19,12 +19,12 @@ from app.models.user import User
 from app.models.visit import Visit
 
 
-def test_audit_log_create_patient(client: TestClient, db: Session, admin_user: User):
+def test_audit_log_create_patient(client: TestClient, db: Session, admin_user: User, admin_password: str):
     """Тест: создание пациента должно логироваться"""
     # Получаем токен
     response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     token = response.json()["access_token"]
 
@@ -63,12 +63,12 @@ def test_audit_log_create_patient(client: TestClient, db: Session, admin_user: U
     assert audit_log.ip_address is not None
 
 
-def test_audit_log_update_patient(client: TestClient, db: Session, admin_user: User, test_patient: Patient):
+def test_audit_log_update_patient(client: TestClient, db: Session, admin_user: User, test_patient: Patient, admin_password: str):
     """Тест: обновление пациента должно логироваться"""
     # Получаем токен
     response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     token = response.json()["access_token"]
 
@@ -101,12 +101,12 @@ def test_audit_log_update_patient(client: TestClient, db: Session, admin_user: U
     assert audit_log.diff_hash is not None
 
 
-def test_audit_log_delete_patient(client: TestClient, db: Session, admin_user: User, test_patient: Patient):
+def test_audit_log_delete_patient(client: TestClient, db: Session, admin_user: User, test_patient: Patient, admin_password: str):
     """Тест: удаление пациента должно логироваться"""
     # Получаем токен
     response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     token = response.json()["access_token"]
 
@@ -133,12 +133,12 @@ def test_audit_log_delete_patient(client: TestClient, db: Session, admin_user: U
     assert audit_log.old_values is not None
 
 
-def test_audit_log_create_payment_init(client: TestClient, db: Session, admin_user: User, test_patient: Patient):
+def test_audit_log_create_payment_init(client: TestClient, db: Session, admin_user: User, test_patient: Patient, admin_password: str):
     """Тест: инициализация платежа через /payments/init должна логироваться"""
     # Логин админа
     response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     token = response.json()["access_token"]
 
@@ -227,12 +227,12 @@ def test_log_critical_change_non_critical_table(db: Session, admin_user: User):
     assert result is None, "Не критичные таблицы не должны логироваться"
 
 
-def test_audit_log_request_id(client: TestClient, db: Session, admin_user: User):
+def test_audit_log_request_id(client: TestClient, db: Session, admin_user: User, admin_password: str):
     """Тест: каждый запрос должен иметь уникальный request_id"""
     # Получаем токен
     response = client.post(
         "/api/v1/authentication/login",
-        json={"username": admin_user.username, "password": "admin123"},
+        json={"username": admin_user.username, "password": admin_password},
     )
     token = response.json()["access_token"]
 


### PR DESCRIPTION
## Summary

- Centralize the backend pytest admin password in `backend/tests/conftest.py`.
- Generate the default test admin password per test session instead of storing `admin123` in fixtures.
- Update backend pytest login helpers/tests to consume the shared `admin_password` fixture.
- Keep runtime code, root legacy smoke scripts, and reports out of this PR.

## Contract Impact

- Canonical surface: backend pytest fixtures and backend pytest login helpers only.
- Request shape: not applicable - no public HTTP request contract changed.
- Response shape: not applicable - no API response payload contract changed.
- Status codes: not applicable - route status-code behavior is unchanged; targeted auth tests still pass.
- Frontend consumer: not applicable - no frontend runtime consumer changed.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: targeted backend pytest suite covering auth, RBAC, audit logs, analytics, activation, and admin integration paths passed.

## RBAC / Permissions

- Roles allowed: unchanged; tests still cover admin, registrar, doctor, cashier, patient paths.
- Roles denied: unchanged; targeted RBAC negative tests still pass.
- Positive auth proof: admin login/token tests passed using the centralized fixture password.
- Negative auth proof: 2FA enforcement and RBAC denied-path tests passed after removing `admin123` from backend pytest files.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed.
- Partial data proof: not applicable - no frontend partial-data path changed.
- Forbidden secondary path behavior: not applicable - no frontend secondary path changed.
- Missing draft/resource behavior: not applicable - no draft/resource behavior changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/tests/conftest.py`, two backend pytest modules, and selected `backend/tests/integration/*` pytest files.
- Denied paths: runtime backend app code, root legacy `backend/test_*.py` scripts, reports, frontend, generated output, and `QA-analise` mass diff.
- Migration/docs/test impact: test-only fixture update; no migration; no docs update.
- Rollback note: revert commit `0a07d6c5` to restore the previous pytest literal credential behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile` on the 13 touched pytest files; targeted `rg` for `admin123` in `backend/tests`; `git diff --check`; `python -m pytest tests\test_audit_logs.py tests\test_2fa_enforcement.py tests\integration\test_admin_service_code_prefix_consistency.py tests\integration\test_admin_display_settings.py tests\integration\test_admin_finance_transactions.py tests\integration\test_activation_api.py tests\integration\test_clinic_management_admin_access.py tests\integration\test_dynamic_pricing_api.py tests\integration\test_analytics_contracts.py tests\integration\test_patient_documents_api.py tests\integration\test_registrar_services_grouping.py tests\integration\test_rbac_matrix.py`.
- Result: local checks passed; targeted pytest result was `58 passed, 1 warning` after rebasing on fresh `origin/main`.
- Not checked: full backend suite and root legacy smoke scripts, because this PR is intentionally limited to canonical `backend/tests` pytest fixtures.