### PR TITLE
[codex] Retire root file upload smoke scripts

### DIFF
--- a/backend/fix_files_422.py
+++ b/backend/fix_files_422.py
@@ -1,149 +1,25 @@
 #!/usr/bin/env python3
+"""Retired root manual file upload fix script.
+
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
 """
-ИСПРАВЛЕНИЕ 422 ОШИБКИ В ФАЙЛОВОЙ СИСТЕМЕ
-"""
-import requests
-import json
 
-def test_files_endpoint():
-    """Тестирование endpoint файловой системы"""
-    print("🔧 ТЕСТИРОВАНИЕ ENDPOINT ФАЙЛОВОЙ СИСТЕМЫ")
-    print("=" * 50)
-    
-    # Получаем токен admin
-    try:
-        auth_response = requests.post(
-            "http://localhost:18000/api/v1/auth/login",
-            data={"username": "admin", "password": "admin123"},
-            timeout=10
-        )
-        
-        if auth_response.status_code != 200:
-            print(f"❌ Ошибка аутентификации: {auth_response.status_code}")
-            return
-        
-        token = auth_response.json()["access_token"]
-        headers = {"Authorization": f"Bearer {token}"}
-        
-        print("✅ Токен admin получен")
-        
-    except Exception as e:
-        print(f"❌ Ошибка получения токена: {e}")
-        return
-    
-    # Тестируем проблемный endpoint
-    endpoints_to_test = [
-        ("/files/stats", "Статистика файлов"),
-        ("/files/upload", "Загрузка файлов"),
-        ("/files", "Список файлов")
-    ]
-    
-    for endpoint, name in endpoints_to_test:
-        print(f"\n🧪 Тестируем {name}...")
-        
-        try:
-            if endpoint == "/files/upload":
-                # Для POST запроса
-                response = requests.get(
-                    f"http://localhost:18000/api/v1{endpoint}",
-                    headers=headers,
-                    timeout=10
-                )
-            else:
-                response = requests.get(
-                    f"http://localhost:18000/api/v1{endpoint}",
-                    headers=headers,
-                    timeout=10
-                )
-            
-            print(f"   📊 Статус: {response.status_code}")
-            
-            if response.status_code == 200:
-                print(f"   ✅ {name}: Работает")
-                try:
-                    data = response.json()
-                    print(f"   📝 Данные: {json.dumps(data, indent=2)[:200]}...")
-                except:
-                    print(f"   📝 Ответ: {response.text[:200]}...")
-            else:
-                print(f"   ❌ {name}: Ошибка {response.status_code}")
-                print(f"   📝 Ответ: {response.text[:200]}...")
-                
-        except Exception as e:
-            print(f"   ❌ {name}: {e}")
+from __future__ import annotations
 
-def create_simple_files_endpoint():
-    """Создание упрощенного endpoint для файловой системы"""
-    print("\n🔧 СОЗДАНИЕ УПРОЩЕННОГО ENDPOINT ФАЙЛОВОЙ СИСТЕМЫ")
-    print("=" * 60)
-    
-    simple_endpoint = '''
-from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.orm import Session
-from app.api.deps import get_db, require_roles
+import sys
 
-router = APIRouter()
+MESSAGE = (
+    "Retired root manual file upload fix script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
 
-@router.get("/stats")
-async def get_file_stats_simple(
-    current_user=Depends(require_roles(["admin"])),
-    db: Session = Depends(get_db),
-):
-    """Упрощенная статистика файлов"""
-    try:
-        # Простая статистика без сложных запросов
-        return {
-            "total_files": 0,
-            "total_size": 0,
-            "files_by_type": {},
-            "recent_uploads": [],
-            "storage_used": 0,
-            "storage_available": 1000000000  # 1GB
-        }
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка получения статистики: {str(e)}")
 
-@router.get("/")
-async def get_files_simple(
-    limit: int = Query(50, ge=1, le=100),
-    offset: int = Query(0, ge=0),
-    current_user=Depends(require_roles(["admin"])),
-    db: Session = Depends(get_db),
-):
-    """Упрощенный список файлов"""
-    try:
-        # Простой список без сложных запросов
-        return {
-            "files": [],
-            "total": 0,
-            "limit": limit,
-            "offset": offset
-        }
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка получения файлов: {str(e)}")
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
-@router.post("/upload")
-async def upload_file_simple(
-    current_user=Depends(require_roles(["admin"])),
-    db: Session = Depends(get_db),
-):
-    """Упрощенная загрузка файлов"""
-    try:
-        # Простая загрузка без сложных запросов
-        return {
-            "message": "Файл успешно загружен",
-            "file_id": 1,
-            "filename": "test.txt",
-            "size": 1024
-        }
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка загрузки файла: {str(e)}")
-'''
-    
-    print("✅ Упрощенный endpoint создан")
-    print("📝 Код для замены:")
-    print(simple_endpoint[:500] + "...")
 
 if __name__ == "__main__":
-    test_files_endpoint()
-    create_simple_files_endpoint()
+    raise SystemExit(main())

--- a/backend/test_file_endpoints.py
+++ b/backend/test_file_endpoints.py
@@ -1,74 +1,25 @@
 #!/usr/bin/env python3
-"""
-Тестирование файловых endpoints
-"""
-import requests
+"""Retired root manual file endpoint smoke script.
 
-def test_file_endpoints():
-    """Тестирование файловых endpoints"""
-    print("🚀 Тестирование файловых endpoints...")
-    
-    # Получаем токен
-    try:
-        auth_response = requests.post(
-            "http://localhost:18000/api/v1/auth/login",
-            data={"username": "admin", "password": "admin123"},
-            headers={"Content-Type": "application/x-www-form-urlencoded"}
-        )
-        
-        if auth_response.status_code != 200:
-            print(f"❌ Ошибка аутентификации: {auth_response.status_code}")
-            return
-        
-        token = auth_response.json()["access_token"]
-        print(f"✅ Токен получен")
-        
-    except Exception as e:
-        print(f"❌ Ошибка получения токена: {e}")
-        return
-    
-    headers = {"Authorization": f"Bearer {token}"}
-    
-    # Тестируем простой GET endpoint
-    print("\n📁 Тестирование GET /api/v1/files/test...")
-    try:
-        response = requests.get(
-            "http://localhost:18000/api/v1/files/test",
-            headers=headers,
-            timeout=5
-        )
-        
-        print(f"📊 Статус: {response.status_code}")
-        print(f"📄 Ответ: {response.text}")
-        
-        if response.status_code == 200:
-            print("✅ GET endpoint работает!")
-        else:
-            print(f"❌ Ошибка GET: {response.status_code}")
-            
-    except Exception as e:
-        print(f"❌ Ошибка GET: {e}")
-    
-    # Тестируем простой POST endpoint
-    print("\n📁 Тестирование POST /api/v1/files/test-upload...")
-    try:
-        response = requests.post(
-            "http://localhost:18000/api/v1/files/test-upload",
-            headers=headers,
-            timeout=5
-        )
-        
-        print(f"📊 Статус: {response.status_code}")
-        print(f"📄 Ответ: {response.text}")
-        
-        if response.status_code == 200:
-            print("✅ POST endpoint работает!")
-        else:
-            print(f"❌ Ошибка POST: {response.status_code}")
-            
-    except Exception as e:
-        print(f"❌ Ошибка POST: {e}")
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
+"""
+
+from __future__ import annotations
+
+import sys
+
+MESSAGE = (
+    "Retired root manual file endpoint smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
 
 if __name__ == "__main__":
-    test_file_endpoints()
-
+    raise SystemExit(main())

--- a/backend/test_file_system.py
+++ b/backend/test_file_system.py
@@ -1,180 +1,25 @@
 #!/usr/bin/env python3
+"""Retired root manual file system smoke script.
+
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
 """
-Тестовый скрипт для проверки файловой системы
-"""
-import requests
-import json
-import os
-from io import BytesIO
 
-# Настройки
-BASE_URL = "http://localhost:18000"
-TEST_USER = {
-    "username": "admin",
-    "password": "admin123"
-}
+from __future__ import annotations
 
-def get_auth_token():
-    """Получить токен аутентификации"""
-    try:
-        response = requests.post(f"{BASE_URL}/api/v1/auth/login", data=TEST_USER)
-        if response.status_code == 200:
-            data = response.json()
-            return data.get("access_token")
-        else:
-            print(f"❌ Ошибка аутентификации: {response.status_code} - {response.text}")
-            return None
-    except Exception as e:
-        print(f"❌ Ошибка подключения: {e}")
-        return None
+import sys
 
-def test_file_upload(token):
-    """Тестировать загрузку файла"""
-    print("\n📁 Тестирование загрузки файла...")
-    
-    # Создаем тестовый файл
-    test_content = "This is a test file for file system testing".encode('utf-8')
-    test_file = BytesIO(test_content)
-    
-    files = {
-        'file': ('test_file.txt', test_file, 'text/plain')
-    }
-    
-    data = {
-        'file_type': 'document',
-        'permission': 'private',
-        'title': 'Тестовый файл'
-    }
-    
-    headers = {'Authorization': f'Bearer {token}'}
-    
-    try:
-        response = requests.post(f"{BASE_URL}/api/v1/files/upload", files=files, data=data, headers=headers)
-        if response.status_code == 200:
-            file_data = response.json()
-            print(f"✅ Файл загружен: ID={file_data['id']}, размер={file_data['file_size']} байт")
-            return file_data['id']
-        else:
-            print(f"❌ Ошибка загрузки: {response.status_code} - {response.text}")
-            return None
-    except Exception as e:
-        print(f"❌ Ошибка: {e}")
-        return None
+MESSAGE = (
+    "Retired root manual file system smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
 
-def test_file_list(token):
-    """Тестировать получение списка файлов"""
-    print("\n📋 Тестирование получения списка файлов...")
-    
-    headers = {'Authorization': f'Bearer {token}'}
-    
-    try:
-        response = requests.get(f"{BASE_URL}/api/v1/files/", headers=headers)
-        if response.status_code == 200:
-            data = response.json()
-            print(f"✅ Получен список файлов: {data['total']} файлов")
-            return data['files']
-        else:
-            print(f"❌ Ошибка получения списка: {response.status_code} - {response.text}")
-            return []
-    except Exception as e:
-        print(f"❌ Ошибка: {e}")
-        return []
 
-def test_file_download(token, file_id):
-    """Тестировать скачивание файла"""
-    print(f"\n⬇️ Тестирование скачивания файла ID={file_id}...")
-    
-    headers = {'Authorization': f'Bearer {token}'}
-    
-    try:
-        response = requests.get(f"{BASE_URL}/api/v1/files/{file_id}/download", headers=headers)
-        if response.status_code == 200:
-            print(f"✅ Файл скачан: {len(response.content)} байт")
-            return True
-        else:
-            print(f"❌ Ошибка скачивания: {response.status_code} - {response.text}")
-            return False
-    except Exception as e:
-        print(f"❌ Ошибка: {e}")
-        return False
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
-def test_file_stats(token):
-    """Тестировать статистику файлов"""
-    print("\n📊 Тестирование статистики файлов...")
-    
-    headers = {'Authorization': f'Bearer {token}'}
-    
-    try:
-        response = requests.get(f"{BASE_URL}/api/v1/files/statistics", headers=headers)
-        if response.status_code == 200:
-            data = response.json()
-            print(f"✅ Статистика получена:")
-            print(f"   - Всего файлов: {data['total_files']}")
-            print(f"   - Общий размер: {data['total_size']} байт")
-            print(f"   - По типам: {data['files_by_type']}")
-            return True
-        else:
-            print(f"❌ Ошибка получения статистики: {response.status_code} - {response.text}")
-            return False
-    except Exception as e:
-        print(f"❌ Ошибка: {e}")
-        return False
-
-def test_file_search(token):
-    """Тестировать поиск файлов"""
-    print("\n🔍 Тестирование поиска файлов...")
-    
-    headers = {'Authorization': f'Bearer {token}'}
-    
-    search_data = {
-        "query": "тест",
-        "file_type": "document",
-        "page": 1,
-        "size": 10
-    }
-    
-    try:
-        response = requests.post(f"{BASE_URL}/api/v1/files/search", json=search_data, headers=headers)
-        if response.status_code == 200:
-            data = response.json()
-            print(f"✅ Поиск выполнен: найдено {data['total']} файлов")
-            return True
-        else:
-            print(f"❌ Ошибка поиска: {response.status_code} - {response.text}")
-            return False
-    except Exception as e:
-        print(f"❌ Ошибка: {e}")
-        return False
-
-def main():
-    """Основная функция тестирования"""
-    print("🚀 Начинаем тестирование файловой системы...")
-    
-    # Получаем токен аутентификации
-    token = get_auth_token()
-    if not token:
-        print("❌ Не удалось получить токен аутентификации")
-        return
-    
-    print(f"✅ Токен получен: {token[:20]}...")
-    
-    # Тестируем загрузку файла
-    file_id = test_file_upload(token)
-    
-    # Тестируем получение списка файлов
-    files = test_file_list(token)
-    
-    # Тестируем скачивание файла
-    if file_id:
-        test_file_download(token, file_id)
-    
-    # Тестируем статистику
-    test_file_stats(token)
-    
-    # Тестируем поиск
-    test_file_search(token)
-    
-    print("\n🎉 Тестирование файловой системы завершено!")
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/backend/test_file_upload_detailed.py
+++ b/backend/test_file_upload_detailed.py
@@ -1,92 +1,25 @@
 #!/usr/bin/env python3
-"""
-Детальное тестирование загрузки файлов
-"""
-import requests
-import json
+"""Retired root manual detailed file upload smoke script.
 
-def test_file_upload_detailed():
-    """Детальное тестирование загрузки файлов"""
-    print("🚀 Детальное тестирование загрузки файлов...")
-    
-    # Получаем токен
-    print("\n🔐 Получение токена...")
-    try:
-        auth_response = requests.post(
-            "http://localhost:18000/api/v1/auth/login",
-            data={"username": "admin", "password": "admin123"},
-            headers={"Content-Type": "application/x-www-form-urlencoded"}
-        )
-        
-        if auth_response.status_code != 200:
-            print(f"❌ Ошибка аутентификации: {auth_response.status_code}")
-            return
-        
-        token = auth_response.json()["access_token"]
-        print(f"✅ Токен получен: {token[:20]}...")
-        
-    except Exception as e:
-        print(f"❌ Ошибка получения токена: {e}")
-        return
-    
-    # Тестируем загрузку файла
-    print("\n📁 Тестирование загрузки файла...")
-    headers = {"Authorization": f"Bearer {token}"}
-    
-    # Создаем тестовый файл
-    test_content = "Это тестовый файл для загрузки"
-    files = {
-        'file': ('test.txt', test_content, 'text/plain')
-    }
-    
-    data = {
-        'title': 'Тестовый файл',
-        'description': 'Описание тестового файла',
-        'tags': '["test", "upload"]',
-        'permission': 'PRIVATE'
-    }
-    
-    try:
-        upload_response = requests.post(
-            "http://localhost:18000/api/v1/files/upload",
-            headers=headers,
-            files=files,
-            data=data
-        )
-        
-        print(f"📊 Статус загрузки: {upload_response.status_code}")
-        print(f"📄 Ответ: {upload_response.text}")
-        
-        if upload_response.status_code == 200:
-            print("✅ Файл успешно загружен!")
-            file_data = upload_response.json()
-            print(f"   ID файла: {file_data.get('id')}")
-            print(f"   Имя файла: {file_data.get('filename')}")
-            print(f"   Размер: {file_data.get('file_size')} байт")
-        else:
-            print(f"❌ Ошибка загрузки: {upload_response.status_code}")
-            
-    except Exception as e:
-        print(f"❌ Исключение при загрузке: {e}")
-    
-    # Тестируем получение списка файлов
-    print("\n📋 Тестирование получения списка файлов...")
-    try:
-        list_response = requests.get(
-            "http://localhost:18000/api/v1/files/",
-            headers=headers
-        )
-        
-        print(f"📊 Статус списка: {list_response.status_code}")
-        if list_response.status_code == 200:
-            files_data = list_response.json()
-            print(f"✅ Получен список файлов: {files_data.get('total', 0)} файлов")
-        else:
-            print(f"❌ Ошибка получения списка: {list_response.text}")
-            
-    except Exception as e:
-        print(f"❌ Исключение при получении списка: {e}")
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
+"""
+
+from __future__ import annotations
+
+import sys
+
+MESSAGE = (
+    "Retired root manual detailed file upload smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
 
 if __name__ == "__main__":
-    test_file_upload_detailed()
-
+    raise SystemExit(main())

--- a/backend/test_json_upload.py
+++ b/backend/test_json_upload.py
@@ -1,79 +1,25 @@
 #!/usr/bin/env python3
-"""
-Тестирование загрузки файлов через JSON
-"""
-import requests
-import base64
+"""Retired root manual JSON upload smoke script.
 
-def test_json_upload():
-    """Тестирование JSON загрузки"""
-    print("🚀 Тестирование загрузки файлов через JSON...")
-    
-    # Получаем токен
-    try:
-        auth_response = requests.post(
-            "http://localhost:18000/api/v1/auth/login",
-            data={"username": "admin", "password": "admin123"},
-            headers={"Content-Type": "application/x-www-form-urlencoded"}
-        )
-        
-        if auth_response.status_code != 200:
-            print(f"❌ Ошибка аутентификации: {auth_response.status_code}")
-            return
-        
-        token = auth_response.json()["access_token"]
-        print(f"✅ Токен получен")
-        
-    except Exception as e:
-        print(f"❌ Ошибка получения токена: {e}")
-        return
-    
-    # Тестируем JSON загрузку
-    print("\n📁 Тестирование JSON загрузки...")
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json"
-    }
-    
-    # Создаем тестовый файл
-    test_content = "Hello World from JSON upload!"
-    encoded_content = base64.b64encode(test_content.encode()).decode()
-    
-    data = {
-        "filename": "test_json.txt",
-        "content": encoded_content,
-        "title": "JSON тестовый файл",
-        "description": "Файл загружен через JSON API"
-    }
-    
-    try:
-        print("📤 Отправляем JSON запрос...")
-        upload_response = requests.post(
-            "http://localhost:18000/api/v1/files/upload-json",
-            headers=headers,
-            json=data,
-            timeout=10
-        )
-        
-        print(f"📊 Статус: {upload_response.status_code}")
-        print(f"📄 Ответ: {upload_response.text}")
-        
-        if upload_response.status_code == 200:
-            print("✅ Файл успешно загружен через JSON!")
-            result = upload_response.json()
-            print(f"   Имя файла: {result.get('filename')}")
-            print(f"   Размер: {result.get('file_size')} байт")
-            print(f"   Хеш: {result.get('file_hash')[:20]}...")
-        else:
-            print(f"❌ Ошибка: {upload_response.status_code}")
-            
-    except requests.exceptions.ConnectionError as e:
-        print(f"❌ Ошибка подключения: {e}")
-    except requests.exceptions.Timeout as e:
-        print(f"❌ Таймаут: {e}")
-    except Exception as e:
-        print(f"❌ Другая ошибка: {e}")
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
+"""
+
+from __future__ import annotations
+
+import sys
+
+MESSAGE = (
+    "Retired root manual JSON upload smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
 
 if __name__ == "__main__":
-    test_json_upload()
-
+    raise SystemExit(main())

--- a/backend/test_simple_upload.py
+++ b/backend/test_simple_upload.py
@@ -1,66 +1,25 @@
 #!/usr/bin/env python3
-"""
-Простое тестирование загрузки файлов
-"""
-import requests
-import io
+"""Retired root manual simple upload smoke script.
 
-def test_simple_upload():
-    """Простое тестирование загрузки"""
-    print("🚀 Простое тестирование загрузки...")
-    
-    # Получаем токен
-    try:
-        auth_response = requests.post(
-            "http://localhost:18000/api/v1/auth/login",
-            data={"username": "admin", "password": "admin123"},
-            headers={"Content-Type": "application/x-www-form-urlencoded"}
-        )
-        
-        if auth_response.status_code != 200:
-            print(f"❌ Ошибка аутентификации: {auth_response.status_code}")
-            return
-        
-        token = auth_response.json()["access_token"]
-        print(f"✅ Токен получен")
-        
-    except Exception as e:
-        print(f"❌ Ошибка получения токена: {e}")
-        return
-    
-    # Простая загрузка
-    print("\n📁 Простая загрузка файла...")
-    headers = {"Authorization": f"Bearer {token}"}
-    
-    # Создаем простой файл
-    files = {
-        'file': ('test.txt', 'Hello World', 'text/plain')
-    }
-    
-    try:
-        print("📤 Отправляем запрос...")
-        upload_response = requests.post(
-            "http://localhost:18000/api/v1/files/upload",
-            headers=headers,
-            files=files,
-            timeout=10
-        )
-        
-        print(f"📊 Статус: {upload_response.status_code}")
-        print(f"📄 Ответ: {upload_response.text[:200]}...")
-        
-        if upload_response.status_code == 200:
-            print("✅ Файл загружен!")
-        else:
-            print(f"❌ Ошибка: {upload_response.status_code}")
-            
-    except requests.exceptions.ConnectionError as e:
-        print(f"❌ Ошибка подключения: {e}")
-    except requests.exceptions.Timeout as e:
-        print(f"❌ Таймаут: {e}")
-    except Exception as e:
-        print(f"❌ Другая ошибка: {e}")
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
+"""
+
+from __future__ import annotations
+
+import sys
+
+MESSAGE = (
+    "Retired root manual simple upload smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
 
 if __name__ == "__main__":
-    test_simple_upload()
-
+    raise SystemExit(main())

--- a/backend/test_simple_upload_fixed.py
+++ b/backend/test_simple_upload_fixed.py
@@ -1,74 +1,25 @@
 #!/usr/bin/env python3
-"""
-Тестирование упрощенной загрузки файлов
-"""
-import requests
+"""Retired root manual fixed upload smoke script.
 
-def test_simple_upload_fixed():
-    """Тестирование упрощенной загрузки"""
-    print("🚀 Тестирование упрощенной загрузки файлов...")
-    
-    # Получаем токен
-    try:
-        auth_response = requests.post(
-            "http://localhost:18000/api/v1/auth/login",
-            data={"username": "admin", "password": "admin123"},
-            headers={"Content-Type": "application/x-www-form-urlencoded"}
-        )
-        
-        if auth_response.status_code != 200:
-            print(f"❌ Ошибка аутентификации: {auth_response.status_code}")
-            return
-        
-        token = auth_response.json()["access_token"]
-        print(f"✅ Токен получен")
-        
-    except Exception as e:
-        print(f"❌ Ошибка получения токена: {e}")
-        return
-    
-    # Тестируем упрощенную загрузку
-    print("\n📁 Тестирование упрощенной загрузки...")
-    headers = {"Authorization": f"Bearer {token}"}
-    
-    # Создаем простой файл
-    files = {
-        'file': ('test_simple.txt', 'Hello World from simple upload!', 'text/plain')
-    }
-    
-    data = {
-        'title': 'Простой тестовый файл'
-    }
-    
-    try:
-        print("📤 Отправляем запрос на /api/v1/files/upload-simple...")
-        upload_response = requests.post(
-            "http://localhost:18000/api/v1/files/upload-simple",
-            headers=headers,
-            files=files,
-            data=data,
-            timeout=10
-        )
-        
-        print(f"📊 Статус: {upload_response.status_code}")
-        print(f"📄 Ответ: {upload_response.text}")
-        
-        if upload_response.status_code == 200:
-            print("✅ Файл успешно загружен!")
-            result = upload_response.json()
-            print(f"   Имя файла: {result.get('filename')}")
-            print(f"   Размер: {result.get('file_size')} байт")
-            print(f"   Хеш: {result.get('file_hash')[:20]}...")
-        else:
-            print(f"❌ Ошибка: {upload_response.status_code}")
-            
-    except requests.exceptions.ConnectionError as e:
-        print(f"❌ Ошибка подключения: {e}")
-    except requests.exceptions.Timeout as e:
-        print(f"❌ Таймаут: {e}")
-    except Exception as e:
-        print(f"❌ Другая ошибка: {e}")
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
+"""
+
+from __future__ import annotations
+
+import sys
+
+MESSAGE = (
+    "Retired root manual fixed upload smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
 
 if __name__ == "__main__":
-    test_simple_upload_fixed()
-
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary
- Retire zero-reference root-level manual file/upload smoke scripts that embedded built-in admin/demo credentials.
- Replace them with explicit retired stubs that point maintainers to canonical `backend/tests` fixtures or env-driven smoke checks.
- Keep runtime file/upload API behavior and canonical pytest suite unchanged.

## Contract Impact
- Canonical surface: not applicable - root-level manual scripts only, no FastAPI route, OpenAPI, request, response, or frontend contract changed.
- Request shape: not applicable - retired scripts are not called by runtime clients.
- Response shape: not applicable - no runtime API response changed.
- Status codes: not applicable - no endpoint behavior changed.
- Frontend consumer: not applicable - no frontend code changed.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: reference scan confirmed `0` external references for every touched file.

## RBAC / Permissions
- Roles allowed: not applicable - no app authorization rules changed.
- Roles denied: not applicable - no app authorization rules changed.
- Positive auth proof: not applicable - this PR removes embedded credentials from retired manual scripts only.
- Negative auth proof: not applicable - no RBAC behavior changed.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: not applicable - no frontend data flow changed.
- Partial data proof: not applicable - no frontend data flow changed.
- Forbidden secondary path behavior: not applicable - no frontend or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - no draft or resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/fix_files_422.py`, `backend/test_file_endpoints.py`, `backend/test_file_system.py`, `backend/test_file_upload_detailed.py`, `backend/test_json_upload.py`, `backend/test_simple_upload.py`, `backend/test_simple_upload_fixed.py`.
- Denied paths: canonical `backend/tests`, runtime routers, app services, frontend app code, ops, docs, migrations, generated output.
- Migration/docs/test impact: no migration; docs unchanged; canonical pytest suite unchanged; root manual scripts now fail closed with retired-stub message.
- Rollback note: revert this commit to restore the old root manual scripts, then replace embedded credentials before using them again.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\\fix_files_422.py backend\\test_file_endpoints.py backend\\test_file_system.py backend\\test_file_upload_detailed.py backend\\test_json_upload.py backend\\test_simple_upload.py backend\\test_simple_upload_fixed.py`; `rg -n "admin123"` across touched files; `git diff --check`; reference scan for touched filenames.
- Result: passed locally; touched files compile, contain no `admin123`, diff check passed, and reference scan reported `0` external references for each touched file.
- Not checked: full backend/frontend suites not run locally because this PR only retires unreferenced root-level manual scripts and does not touch canonical runtime/test code.
