### PR TITLE
[codex] Use env credentials in legacy auth smokes

### DIFF
--- a/backend/test_cicd_simple.py
+++ b/backend/test_cicd_simple.py
@@ -5,6 +5,7 @@
 """
 
 import json
+import os
 import time
 import urllib.parse
 import urllib.request
@@ -12,6 +13,8 @@ from datetime import datetime
 
 # Конфигурация
 BASE_URL = "http://127.0.0.1:18000"
+AUTH_USERNAME = os.getenv("QA_ADMIN_USERNAME", "admin")
+AUTH_PASSWORD = os.getenv("QA_ADMIN_PASSWORD", "invalid-qa-admin-password")
 
 
 def test_health_endpoint():
@@ -111,7 +114,7 @@ def test_auth_endpoint():
     try:
         # Тестовые данные для входа
         auth_data = urllib.parse.urlencode(
-            {"username": "admin", "password": "admin123"}
+            {"username": AUTH_USERNAME, "password": AUTH_PASSWORD}
         ).encode("utf-8")
 
         req = urllib.request.Request(

--- a/backend/test_role_routing.py
+++ b/backend/test_role_routing.py
@@ -3,11 +3,55 @@
 Запускать после каждого изменения в системе авторизации
 """
 
+import os
 import sys
 
 import requests
 
 BASE_URL = "http://127.0.0.1:18000"
+
+ROLE_PASSWORD_ENV_VARS = [
+    ("admin", "QA_ADMIN_PASSWORD", "Admin"),
+    ("registrar", "QA_REGISTRAR_PASSWORD", "Registrar"),
+    ("lab", "QA_LAB_PASSWORD", "Lab"),
+    ("doctor", "QA_DOCTOR_PASSWORD", "Doctor"),
+    ("cashier", "QA_CASHIER_PASSWORD", "Cashier"),
+    ("cardio", "QA_CARDIO_PASSWORD", "cardio"),
+    ("derma", "QA_DERMA_PASSWORD", "derma"),
+    ("dentist", "QA_DENTIST_PASSWORD", "dentist"),
+]
+
+
+def load_role_credentials():
+    credentials = []
+    missing = []
+
+    for username, env_name, expected_role in ROLE_PASSWORD_ENV_VARS:
+        password = os.getenv(env_name)
+        if password:
+            credentials.append((username, password, expected_role))
+        else:
+            missing.append(env_name)
+
+    if missing:
+        print(
+            "ERROR: set required QA role password env vars before running this "
+            f"manual smoke: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        return None
+
+    return credentials
+
+
+def load_admin_password():
+    password = os.getenv("QA_ADMIN_PASSWORD")
+    if not password:
+        print(
+            "ERROR: set QA_ADMIN_PASSWORD before running admin API access smoke.",
+            file=sys.stderr,
+        )
+    return password
 
 
 def test_user_login_and_role(username, password, expected_role, expected_redirect=None):
@@ -75,16 +119,9 @@ def test_all_critical_users():
     print("=" * 60)
 
     # Критические пользователи и их ожидаемые роли
-    critical_users = [
-        ("admin", "admin123", "Admin"),
-        ("registrar", "registrar123", "Registrar"),
-        ("lab", "lab123", "Lab"),
-        ("doctor", "doctor123", "Doctor"),
-        ("cashier", "cashier123", "Cashier"),
-        ("cardio", "cardio123", "cardio"),
-        ("derma", "derma123", "derma"),
-        ("dentist", "dentist123", "dentist"),
-    ]
+    critical_users = load_role_credentials()
+    if critical_users is None:
+        return False
 
     results = []
     for username, password, expected_role in critical_users:
@@ -118,7 +155,11 @@ def test_api_endpoints_access():
     print("=" * 60)
 
     # Получаем токен админа
-    login_data = {"username": "admin", "password": "admin123", "grant_type": "password"}
+    admin_password = load_admin_password()
+    if not admin_password:
+        return False
+
+    login_data = {"username": "admin", "password": admin_password, "grant_type": "password"}
     response = requests.post(f"{BASE_URL}/api/v1/authentication/login", json=login_data)
     if response.status_code != 200:
         print("ОШИБКА: Не удалось получить токен админа")


### PR DESCRIPTION
﻿## Summary
- Replace the final hardcoded `admin123` literals in referenced legacy manual auth smoke scripts with env-driven credentials.
- `backend/test_role_routing.py` now requires explicit QA role password env vars for real role proof.
- `backend/test_cicd_simple.py` uses `QA_ADMIN_USERNAME`/`QA_ADMIN_PASSWORD`, falling back to an invalid placeholder so endpoint availability can still return the expected 401 without embedding a real password.

## Contract Impact
- Canonical surface: not applicable - referenced root-level manual scripts only; no FastAPI route, OpenAPI, request, response, or frontend contract changed.
- Request shape: not applicable - runtime clients unchanged; manual script auth payload now reads from env.
- Response shape: not applicable - no runtime API response changed.
- Status codes: not applicable - endpoint behavior unchanged; `test_cicd_simple.py` still treats 200 or 401 as endpoint availability proof.
- Frontend consumer: not applicable - no frontend app code changed.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: `python -m py_compile` passed and repo-wide `admin123` scan returned no matches.

## RBAC / Permissions
- Roles allowed: not applicable - no app authorization rules changed.
- Roles denied: not applicable - no app authorization rules changed.
- Positive auth proof: manual `test_role_routing.py` can still prove role logins when QA role password env vars are set.
- Negative auth proof: `test_cicd_simple.py` can still receive 401 with the invalid fallback, proving endpoint availability without a hardcoded password.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: not applicable - no frontend data flow changed.
- Partial data proof: not applicable - no frontend data flow changed.
- Forbidden secondary path behavior: not applicable - no frontend or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - no draft or resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/test_role_routing.py`, `backend/test_cicd_simple.py`.
- Denied paths: canonical `backend/tests`, runtime routers, app services, frontend app code, ops, docs, migrations, generated output.
- Migration/docs/test impact: no migration; docs unchanged; canonical pytest suite unchanged; referenced manual scripts now use explicit env credentials.
- Rollback note: revert this commit to restore prior manual script behavior, though hardcoded passwords should not be reintroduced.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\\test_role_routing.py backend\\test_cicd_simple.py`; `rg -n "admin123" backend frontend docs scripts .github`; `git diff --check`.
- Result: passed locally; touched files compile, repo-wide `admin123` scan returned no matches, and diff check passed.
- Not checked: live browser/login smoke not run because this PR changes only referenced manual smoke credential sourcing, not runtime auth behavior.
