### PR TITLE
[codex] Retire root role helper scripts

### DIFF
--- a/backend/create_test_users.py
+++ b/backend/create_test_users.py
@@ -1,132 +1,26 @@
 #!/usr/bin/env python3
+"""Retired root manual test-user creation helper.
+
+This legacy helper forced a local SQLite database and used built-in demo role
+passwords. Use Alembic-backed setup plus canonical backend/tests fixtures or
+env-driven smoke helpers instead.
 """
-Создание тестовых пользователей для всех ролей
-"""
-import os
-from datetime import datetime
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from app.db.base_class import Base
-from app.models.user import User
-from app.core.security import get_password_hash
 
-os.environ["DATABASE_URL"] = "sqlite:///./clinic.db"
-os.environ["PYTHONPATH"] = "C:\\final\\backend"
+from __future__ import annotations
 
-SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./clinic.db")
-engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+import sys
 
-def create_test_users():
-    db = SessionLocal()
-    try:
-        print("🔧 СОЗДАНИЕ ТЕСТОВЫХ ПОЛЬЗОВАТЕЛЕЙ")
-        print("=================================")
-        
-        # Список пользователей для создания
-        test_users = [
-            {
-                "username": "registrar",
-                "email": "registrar@clinic.com",
-                "full_name": "Регистратор Иванов",
-                "role": "registrar",
-                "password": "registrar123"
-            },
-            {
-                "username": "lab",
-                "email": "lab@clinic.com", 
-                "full_name": "Лаборант Петров",
-                "role": "lab",
-                "password": "lab123"
-            },
-            {
-                "username": "doctor",
-                "email": "doctor@clinic.com",
-                "full_name": "Доктор Сидоров",
-                "role": "doctor", 
-                "password": "doctor123"
-            },
-            {
-                "username": "cashier",
-                "email": "cashier@clinic.com",
-                "full_name": "Кассир Козлов",
-                "role": "cashier",
-                "password": "cashier123"
-            },
-            {
-                "username": "cardio",
-                "email": "cardio@clinic.com",
-                "full_name": "Кардиолог Волков",
-                "role": "cardio",
-                "password": "cardio123"
-            },
-            {
-                "username": "derma",
-                "email": "derma@clinic.com",
-                "full_name": "Дерматолог Морозов",
-                "role": "derma",
-                "password": "derma123"
-            },
-            {
-                "username": "dentist",
-                "email": "dentist@clinic.com",
-                "full_name": "Стоматолог Лебедев",
-                "role": "dentist",
-                "password": "dentist123"
-            }
-        ]
-        
-        created_count = 0
-        updated_count = 0
-        
-        for user_data in test_users:
-            # Проверяем, существует ли пользователь
-            existing_user = db.query(User).filter(User.username == user_data["username"]).first()
-            
-            if existing_user:
-                print(f"   ℹ️ Пользователь {user_data['username']} уже существует")
-                # Обновляем пароль
-                existing_user.hashed_password = get_password_hash(user_data["password"])
-                existing_user.is_active = True
-                db.commit()
-                updated_count += 1
-            else:
-                print(f"   ➕ Создаем пользователя {user_data['username']}...")
-                new_user = User(
-                    username=user_data["username"],
-                    email=user_data["email"],
-                    full_name=user_data["full_name"],
-                    hashed_password=get_password_hash(user_data["password"]),
-                    role=user_data["role"],
-                    is_active=True,
-                    is_superuser=False,
-                    created_at=datetime.utcnow(),
-                    updated_at=datetime.utcnow()
-                )
-                db.add(new_user)
-                db.commit()
-                db.refresh(new_user)
-                created_count += 1
-                print(f"   ✅ Пользователь {user_data['username']} создан с ID: {new_user.id}")
-        
-        print(f"\n📊 ИТОГИ:")
-        print(f"   ➕ Создано новых пользователей: {created_count}")
-        print(f"   🔄 Обновлено существующих: {updated_count}")
-        print(f"   📝 Всего обработано: {created_count + updated_count}")
-        
-        # Проверяем всех пользователей
-        print(f"\n👥 СПИСОК ВСЕХ ПОЛЬЗОВАТЕЛЕЙ:")
-        all_users = db.query(User).all()
-        for user in all_users:
-            print(f"   - {user.username} ({user.role}) - {'✅' if user.is_active else '❌'}")
-        
-        print(f"\n🎉 Создание тестовых пользователей завершено успешно!")
-        
-    except Exception as e:
-        db.rollback()
-        print(f"❌ Ошибка при создании пользователей: {e}")
-    finally:
-        db.close()
+MESSAGE = (
+    "Retired root manual test-user creation helper. "
+    "Use Alembic-backed setup plus canonical backend/tests fixtures or "
+    "env-driven smoke helpers instead."
+)
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
 
 if __name__ == "__main__":
-    create_test_users()
+    raise SystemExit(main())

--- a/backend/final_verification.py
+++ b/backend/final_verification.py
@@ -1,92 +1,25 @@
+#!/usr/bin/env python3
+"""Retired root manual final verification script.
+
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
 """
-Final verification - all systems check
-"""
-import requests
-import json
 
-BASE_URL = "http://localhost:18000"
+from __future__ import annotations
 
-print("="*60)
-print("FINAL VERIFICATION - ALL SYSTEMS CHECK")
-print("="*60)
+import sys
 
-# Login as registrar
-print("\n1️⃣ Testing registrar login...")
-response = requests.post(
-    f"{BASE_URL}/api/v1/auth/login",
-    data={"username": "registrar@example.com", "password": "registrar123"}
-)
-if response.status_code == 200:
-    token = response.json()["access_token"]
-    print("✅ Login successful")
-else:
-    print(f"❌ Login failed: {response.status_code}")
-    exit(1)
-
-headers = {"Authorization": f"Bearer {token}"}
-
-# Test registrar departments endpoint
-print("\n2️⃣ Testing /registrar/departments endpoint...")
-response = requests.get(f"{BASE_URL}/api/v1/registrar/departments?active_only=true", headers=headers)
-if response.status_code == 200:
-    departments = response.json()
-    if isinstance(departments, list):
-        dept_list = departments
-    elif isinstance(departments, dict) and 'data' in departments:
-        dept_list = departments['data']
-    else:
-        dept_list = []
-    
-    print(f"✅ Departments loaded: {len(dept_list)} departments")
-    for dept in dept_list[:3]:
-        print(f"   - {dept.get('name_ru')} (key: {dept.get('key')})")
-else:
-    print(f"❌ Failed: {response.status_code}")
-    exit(1)
-
-# Test cart creation
-print("\n3️⃣ Testing cart creation...")
-cart_data = {
-    "patient_id": 1,
-    "visits": [{
-        "visit_date": "2025-11-28",
-        "visit_time": "10:00",
-        "department": "general",
-        "doctor_id": None,
-        "notes": "Final test",
-        "services": [{"service_id": 3, "quantity": 1, "custom_price": None}]
-    }],
-    "discount_mode": "none",
-    "payment_method": "cash",
-    "notes": "Final verification test"
-}
-
-response = requests.post(
-    f"{BASE_URL}/api/v1/registrar/cart",
-    json=cart_data,
-    headers={**headers, "Content-Type": "application/json"}
+MESSAGE = (
+    "Retired root manual final verification script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
 )
 
-if response.status_code == 200:
-    result = response.json()
-    print(f"✅ Cart created successfully!")
-    print(f"   Invoice ID: {result.get('invoice_id')}")
-    print(f"   Visit IDs: {result.get('visit_ids')}")
-    print(f"   Total: {result.get('total_amount')} UZS")
-else:
-    print(f"❌ Failed: {response.status_code}")
-    print(f"   Error: {response.text}")
-    exit(1)
 
-print("\n" + "="*60)
-print("🎉 ALL SYSTEMS OPERATIONAL!")
-print("="*60)
-print("\n✅ Summary:")
-print("  1. Registrar authentication: WORKING")
-print("  2. Department API (/registrar/departments): WORKING")
-print("  3. Cart creation API: WORKING")
-print("  4. Department field bug (500 error): FIXED")
-print("\n🚀 You can now:")
-print("  - Refresh the Registrar Panel (F5)")
-print("  - Create appointments without errors")
-print("  - Load dynamic departments")
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/quick_test.py
+++ b/backend/quick_test.py
@@ -1,91 +1,25 @@
 #!/usr/bin/env python3
-import requests
-import random
-from datetime import date
+"""Retired root manual quick smoke script.
 
-# Получаем токен
-token_response = requests.post("http://localhost:18000/api/v1/auth/login", data={
-    "username": "registrar@example.com",
-    "password": "registrar123"
-})
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
+"""
 
-if token_response.status_code != 200:
-    print(f"❌ Ошибка получения токена: {token_response.status_code}")
-    exit(1)
+from __future__ import annotations
 
-token = token_response.json()["access_token"]
-headers = {"Authorization": f"Bearer {token}"}
+import sys
 
-# Создаём пациента с уникальным номером
-phone = f"+998901{random.randint(100000, 999999)}"
-print(f"📞 Создаём пациента с телефоном: {phone}")
+MESSAGE = (
+    "Retired root manual quick smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
 
-patient_data = {
-    "first_name": "Тестовый",
-    "last_name": "Пациент", 
-    "middle_name": "Иванович",
-    "phone": phone,
-    "birth_date": "1990-01-01",
-    "address": "Тестовый адрес, 123"
-}
 
-patient_response = requests.post("http://localhost:18000/api/v1/patients", json=patient_data, headers=headers)
-print(f"📋 Статус создания пациента: {patient_response.status_code}")
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
-if patient_response.status_code not in [200, 201]:
-    print(f"❌ Ошибка создания пациента: {patient_response.text}")
-    exit(1)
 
-patient = patient_response.json()
-patient_id = patient["id"]
-print(f"✅ Пациент создан: ID {patient_id}")
-
-# Проверяем количество записей ДО создания визита
-queues_before = requests.get("http://localhost:18000/api/v1/registrar/queues/today", headers=headers)
-total_before = sum(len(q.get("entries", [])) for q in queues_before.json().get("queues", []))
-print(f"📊 Записей в очереди ДО: {total_before}")
-
-# Создаём визит
-print(f"🏥 Создаём визит для пациента {patient_id}...")
-
-cart_data = {
-    "patient_id": patient_id,
-    "visits": [{
-        "doctor_id": None,
-        "services": [{"service_id": 40, "quantity": 1}],
-        "visit_date": date.today().isoformat(),
-        "visit_time": None,
-        "department": "cardiology",
-        "notes": None
-    }],
-    "discount_mode": "none",
-    "payment_method": "cash",
-    "notes": "Тестовая запись через API"
-}
-
-print(f"📤 Отправляем данные визита...")
-cart_response = requests.post("http://localhost:18000/api/v1/registrar/cart", json=cart_data, headers=headers)
-print(f"📋 Статус создания визита: {cart_response.status_code}")
-
-if cart_response.status_code == 200:
-    result = cart_response.json()
-    print(f"✅ Визит создан успешно!")
-    print(f"   Visit IDs: {result.get('visit_ids')}")
-    print(f"   Invoice ID: {result.get('invoice_id')}")
-    print(f"   Сумма: {result.get('total_amount')}")
-else:
-    print(f"❌ Ошибка создания визита: {cart_response.text}")
-
-# Проверяем количество записей ПОСЛЕ создания визита
-queues_after = requests.get("http://localhost:18000/api/v1/registrar/queues/today", headers=headers)
-total_after = sum(len(q.get("entries", [])) for q in queues_after.json().get("queues", []))
-print(f"📊 Записей в очереди ПОСЛЕ: {total_after}")
-
-print(f"📈 РЕЗУЛЬТАТ: {total_after - total_before} новых записей")
-
-if cart_response.status_code == 200 and total_after > total_before:
-    print("✅ ТЕСТ ПРОЙДЕН: Визит создан и появился в очереди!")
-elif cart_response.status_code == 200 and total_after == total_before:
-    print("⚠️ ПРОБЛЕМА: Визит создан, но НЕ появился в очереди!")
-else:
-    print("❌ ТЕСТ НЕ ПРОЙДЕН: Ошибка создания визита!")
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/simple_test.py
+++ b/backend/simple_test.py
@@ -1,71 +1,25 @@
 #!/usr/bin/env python3
-import requests
-import random
-from datetime import date
+"""Retired root manual simple smoke script.
 
-print("🧪 Простой тест создания визита без очередей...")
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
+"""
 
-# Получаем токен
-token_response = requests.post("http://localhost:18000/api/v1/auth/login", data={
-    "username": "registrar@example.com",
-    "password": "registrar123"
-})
+from __future__ import annotations
 
-token = token_response.json()["access_token"]
-headers = {"Authorization": f"Bearer {token}"}
+import sys
 
-# Создаём пациента
-phone = f"+998901{random.randint(100000, 999999)}"
-patient_data = {
-    "first_name": "Простой",
-    "last_name": "Тест", 
-    "middle_name": "Иванович",
-    "phone": phone,
-    "birth_date": "1990-01-01",
-    "address": "Тестовый адрес, 123"
-}
+MESSAGE = (
+    "Retired root manual simple smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
 
-patient_response = requests.post("http://localhost:18000/api/v1/patients", json=patient_data, headers=headers)
-patient_id = patient_response.json()["id"]
-print(f"✅ Пациент создан: ID {patient_id}")
 
-# Создаём визит на ЗАВТРА (чтобы избежать присвоения очередей)
-tomorrow = date.today().replace(day=date.today().day + 1).isoformat()
-print(f"📅 Создаём визит на ЗАВТРА: {tomorrow}")
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
-cart_data = {
-    "patient_id": patient_id,
-    "visits": [{
-        "doctor_id": None,
-        "services": [{"service_id": 40, "quantity": 1}],
-        "visit_date": tomorrow,  # ЗАВТРА!
-        "visit_time": None,
-        "department": "cardiology",
-        "notes": None
-    }],
-    "discount_mode": "none",
-    "payment_method": "cash",
-    "notes": "Тестовая запись на завтра"
-}
 
-cart_response = requests.post("http://localhost:18000/api/v1/registrar/cart", json=cart_data, headers=headers)
-print(f"📋 Статус создания визита: {cart_response.status_code}")
-
-if cart_response.status_code == 200:
-    result = cart_response.json()
-    visit_id = result.get('visit_ids', [None])[0]
-    print(f"✅ Визит создан! Visit ID: {visit_id}")
-    
-    # Проверяем в базе
-    import sqlite3
-    conn = sqlite3.connect('backend/clinic.db')
-    cursor = conn.cursor()
-    cursor.execute('SELECT * FROM visits WHERE id = ?', (visit_id,))
-    visit = cursor.fetchone()
-    if visit:
-        print(f"✅ Визит найден в базе: ID {visit[0]}, Date {visit[3]}, Status {visit[8]}")
-    else:
-        print(f"❌ Визит ID {visit_id} НЕ найден в базе!")
-    conn.close()
-else:
-    print(f"❌ Ошибка: {cart_response.text}")
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/test_cart_direct.py
+++ b/backend/test_cart_direct.py
@@ -1,143 +1,25 @@
+#!/usr/bin/env python3
+"""Retired root manual cart smoke script.
+
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
 """
-Direct test of cart creation endpoint to see the actual error
-"""
+
+from __future__ import annotations
+
 import sys
-sys.path.insert(0, '.')
 
-import requests
-import json
-
-# API configuration
-API_BASE = "http://localhost:18000"
-AUTH_TOKEN = "your_token_here"  # We'll get this from login
-
-# First, login as registrar
-print("[*] Logging in as registrar...")
-login_response = requests.post(
-    f"{API_BASE}/api/v1/auth/minimal-login",
-    json={
-        "username": "registrar",
-        "password": "registrar123"
-    }
+MESSAGE = (
+    "Retired root manual cart smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
 )
 
-if login_response.status_code == 200:
-    login_data = login_response.json()
-    if "access_token" in login_data:
-        AUTH_TOKEN = login_data["access_token"]
-        print(f"[OK] Logged in successfully")
-    else:
-        print(f"[ERROR] No access_token in response: {login_data}")
-        sys.exit(1)
-else:
-    print(f"[ERROR] Login failed: {login_response.status_code}")
-    print(f"Response: {login_response.text}")
-    sys.exit(1)
 
-# Now try to create a cart
-print("\n[*] Testing cart creation...")
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
-# Get a patient to use
-patients_response = requests.get(
-    f"{API_BASE}/api/v1/patients/",
-    headers={"Authorization": f"Bearer {AUTH_TOKEN}"}
-)
 
-if patients_response.status_code != 200:
-    print(f"[ERROR] Failed to get patients: {patients_response.status_code}")
-    sys.exit(1)
-
-patients = patients_response.json()
-if not patients:
-    print("[ERROR] No patients found")
-    sys.exit(1)
-
-patient_id = patients[0]["id"]
-print(f"[OK] Using patient ID: {patient_id}")
-
-# Get a service to use
-services_response = requests.get(
-    f"{API_BASE}/api/v1/registrar/services",
-    headers={"Authorization": f"Bearer {AUTH_TOKEN}"}
-)
-
-if services_response.status_code != 200:
-    print(f"[ERROR] Failed to get services: {services_response.status_code}")
-    sys.exit(1)
-
-services = services_response.json()
-print(f"[DEBUG] Services response type: {type(services)}")
-print(f"[DEBUG] Services response: {services}")
-
-# Handle different response formats
-if isinstance(services, dict):
-    if "data" in services:
-        services_list = services["data"]
-    elif "services" in services:
-        services_list = services["services"]
-    elif "services_by_group" in services:
-        # Flatten services from all groups
-        services_list = []
-        for group_services in services["services_by_group"].values():
-            services_list.extend(group_services)
-    else:
-        services_list = list(services.values())[0] if services else []
-else:
-    services_list = services
-
-if not services_list:
-    print("[ERROR] No services found")
-    sys.exit(1)
-
-service_id = services_list[0]["id"]
-print(f"[OK] Using service ID: {service_id} ({services_list[0]['name']})")
-
-# Create cart request
-cart_request = {
-    "patient_id": patient_id,
-    "discount_mode": "none",
-    "payment_method": "cash",
-    "notes": "Test cart creation",
-    "visits": [
-        {
-            "department": "general",
-            "visit_date": "2025-11-26",
-            "visit_time": "10:00",
-            "doctor_id": None,
-            "services": [
-                {
-                    "service_id": service_id,
-                    "quantity": 1,
-                    "custom_price": None
-                }
-            ],
-            "notes": "Test visit"
-        }
-    ]
-}
-
-print(f"\n[*] Sending cart request...")
-print(json.dumps(cart_request, indent=2, ensure_ascii=False))
-
-cart_response = requests.post(
-    f"{API_BASE}/api/v1/registrar/cart",
-    headers={
-        "Authorization": f"Bearer {AUTH_TOKEN}",
-        "Content-Type": "application/json"
-    },
-    json=cart_request
-)
-
-print(f"\n[*] Response status: {cart_response.status_code}")
-print(f"[*] Response headers: {dict(cart_response.headers)}")
-print(f"\n[*] Response body:")
-try:
-    response_json = cart_response.json()
-    print(json.dumps(response_json, indent=2, ensure_ascii=False))
-except:
-    print(cart_response.text)
-
-if cart_response.status_code != 200:
-    print(f"\n[ERROR] Cart creation failed with status {cart_response.status_code}")
-else:
-    print(f"\n[OK] Cart created successfully!")
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/test_doctor_profile.py
+++ b/backend/test_doctor_profile.py
@@ -1,34 +1,25 @@
-import requests
-import json
+#!/usr/bin/env python3
+"""Retired root manual doctor profile smoke script.
 
-login_data = {
-    'username': 'doctor',
-    'password': 'doctor123',
-    'grant_type': 'password'
-}
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
+"""
 
-print('Тестируем логин с doctor...')
-response = requests.post('http://localhost:18000/api/v1/authentication/login', json=login_data)
-print(f'Статус логина: {response.status_code}')
+from __future__ import annotations
 
-if response.status_code == 200:
-    data = response.json()
-    token = data.get('access_token') or (data.get('tokens', {}).get('access_token'))
-    
-    if token:
-        print('Токен получен, проверяем профиль...')
-        headers = {'Authorization': f'Bearer {token}'}
-        profile_response = requests.get('http://localhost:18000/api/v1/authentication/profile', headers=headers)
-        print(f'Статус профиля: {profile_response.status_code}')
-        
-        if profile_response.status_code == 200:
-            profile = profile_response.json()
-            print(f'Профиль пользователя: {profile}')
-            print(f'Роль: {profile.get("role")}')
-            print(f'is_superuser: {profile.get("is_superuser")}')
-        else:
-            print(f'Ошибка профиля: {profile_response.text}')
-    else:
-        print('Токен не получен')
-else:
-    print(f'Ошибка логина: {response.text}')
+import sys
+
+MESSAGE = (
+    "Retired root manual doctor profile smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/test_login_direct.py
+++ b/backend/test_login_direct.py
@@ -1,80 +1,25 @@
 #!/usr/bin/env python3
+"""Retired root manual login smoke script.
+
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
 """
-Прямой тест login endpoint для диагностики ошибки 500
-"""
 
-import requests
-import json
+from __future__ import annotations
 
-def test_login_endpoint():
-    """Тестирование login endpoint"""
-    
-url = "http://127.0.0.1:18000/api/v1/authentication/login"
-    
-    # Тестовые данные
-    test_cases = [
-        {"username": "admin", "password": "admin"},
-        {"username": "doctor", "password": "doctor123"},
-        {"username": "registrar", "password": "registrar123"},
-    ]
-    
-    print("🔍 Тестирование login endpoint...")
-    print(f"URL: {url}")
-    print("-" * 50)
-    
-    for i, credentials in enumerate(test_cases, 1):
-        print(f"\n📝 Тест {i}: {credentials['username']}")
-        
-        try:
-            response = requests.post(
-                url,
-                json=credentials,
-                headers={"Content-Type": "application/json"},
-                timeout=10
-            )
-            
-            print(f"Status Code: {response.status_code}")
-            print(f"Headers: {dict(response.headers)}")
-            
-            if response.status_code == 200:
-                print("✅ Успешный вход!")
-                data = response.json()
-                print(f"Response: {json.dumps(data, indent=2, ensure_ascii=False)}")
-            else:
-                print(f"❌ Ошибка {response.status_code}")
-                try:
-                    error_data = response.json()
-                    print(f"Error: {json.dumps(error_data, indent=2, ensure_ascii=False)}")
-                except:
-                    print(f"Raw response: {response.text}")
-                    
-        except requests.exceptions.ConnectionError:
-            print("❌ Не удается подключиться к серверу")
-print("Убедитесь, что backend запущен на http://127.0.0.1:18000")
-            break
-        except Exception as e:
-            print(f"❌ Неожиданная ошибка: {e}")
+import sys
 
-def check_server_health():
-    """Проверка доступности сервера"""
-    
-    health_endpoints = [
-"http://127.0.0.1:18000/health",
-"http://127.0.0.1:18000/docs",
-"http://127.0.0.1:18000/api/v1/health"
-    ]
-    
-    print("🏥 Проверка доступности сервера...")
-    print("-" * 50)
-    
-    for endpoint in health_endpoints:
-        try:
-            response = requests.get(endpoint, timeout=5)
-            print(f"✅ {endpoint} - {response.status_code}")
-        except Exception as e:
-            print(f"❌ {endpoint} - {e}")
+MESSAGE = (
+    "Retired root manual login smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
 
 if __name__ == "__main__":
-    check_server_health()
-    print()
-    test_login_endpoint()
+    raise SystemExit(main())

--- a/backend/test_simple_cart.py
+++ b/backend/test_simple_cart.py
@@ -1,227 +1,25 @@
 #!/usr/bin/env python3
+"""Retired root manual simple cart smoke script.
+
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
 """
-Simple test for cart creation functionality
-Tests the /api/v1/registrar/cart endpoint
-"""
-print("SCRIPT START - Simple Cart Test")
+
+from __future__ import annotations
+
 import sys
-print(f"Python version: {sys.version}")
 
-try:
-    import sys
-    import os
-    # Add current directory to path (already in backend)
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    sys.path.insert(0, current_dir)
-    print(f"📁 Added to path: {current_dir}")
-except Exception as e:
-    print(f"Path setup failed: {e}")
-    sys.exit(1)
+MESSAGE = (
+    "Retired root manual simple cart smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
 
-try:
-    import requests
-    from datetime import date, datetime
-    print("✅ Imports successful")
-except ImportError as e:
-    print(f"❌ Import failed: {e}")
-    sys.exit(1)
 
-# Configuration
-API_BASE = "http://localhost:18000"
-AUTH_TOKEN = None
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
-def login_as_registrar():
-    """Login as registrar user"""
-    print("[LOGIN] Attempting to login as registrar...")
-    response = requests.post(
-        f"{API_BASE}/api/v1/auth/minimal-login",
-        json={
-            "username": "registrar",
-            "password": "registrar123"
-        }
-    )
-
-    if response.status_code == 200:
-        data = response.json()
-        if "access_token" in data:
-            global AUTH_TOKEN
-            AUTH_TOKEN = data["access_token"]
-            print("✅ Login successful")
-            return True
-        else:
-            print(f"❌ No access_token in response: {data}")
-            return False
-    else:
-        print(f"❌ Login failed: {response.status_code}")
-        print(f"Response: {response.text}")
-        return False
-
-def get_test_patient():
-    """Get a test patient ID"""
-    print("[PATIENT] Getting test patient...")
-    response = requests.get(
-        f"{API_BASE}/api/v1/patients/",
-        headers={"Authorization": f"Bearer {AUTH_TOKEN}"},
-        params={"limit": 1}
-    )
-
-    if response.status_code == 200:
-        patients = response.json()
-        if patients and len(patients) > 0:
-            patient_id = patients[0]["id"]
-            print(f"✅ Using patient ID: {patient_id}")
-            return patient_id
-        else:
-            print("❌ No patients found")
-            return None
-    else:
-        print(f"❌ Failed to get patients: {response.status_code}")
-        print(f"Response: {response.text}")
-        return None
-
-def get_test_services():
-    """Get test services"""
-    print("[SERVICES] Getting test services...")
-    response = requests.get(
-        f"{API_BASE}/api/v1/services/",
-        headers={"Authorization": f"Bearer {AUTH_TOKEN}"}
-    )
-
-    if response.status_code == 200:
-        services = response.json()
-        if services and len(services) > 0:
-            # Return first service
-            service = services[0]
-            print(f"✅ Using service: {service.get('name', 'Unknown')} (ID: {service.get('id')})")
-            return service
-        else:
-            print("❌ No services found")
-            return None
-    else:
-        print(f"❌ Failed to get services: {response.status_code}")
-        return None
-
-def get_test_doctor():
-    """Get a test doctor ID"""
-    print("[DOCTOR] Getting test doctor...")
-    response = requests.get(
-        f"{API_BASE}/api/v1/admin/doctors/",
-        headers={"Authorization": f"Bearer {AUTH_TOKEN}"}
-    )
-
-    if response.status_code == 200:
-        doctors = response.json()
-        if doctors and len(doctors) > 0:
-            doctor_id = doctors[0]["id"]
-            print(f"✅ Using doctor ID: {doctor_id}")
-            return doctor_id
-        else:
-            print("❌ No doctors found")
-            return None
-    else:
-        print(f"❌ Failed to get doctors: {response.status_code}")
-        return None
-
-def test_cart_creation():
-    """Test cart creation with minimal data"""
-    print("\n[CART] Testing cart creation...")
-
-    # Get test data
-    patient_id = get_test_patient()
-    if not patient_id:
-        return False
-
-    service = get_test_services()
-    if not service:
-        return False
-
-    doctor_id = get_test_doctor()
-    if not doctor_id:
-        return False
-
-    # Prepare cart data
-    tomorrow = date.today()  # Use today for testing
-
-    cart_data = {
-        "patient_id": patient_id,
-        "visits": [
-            {
-                "doctor_id": doctor_id,
-                "services": [
-                    {
-                        "service_id": service["id"],
-                        "quantity": 1
-                    }
-                ],
-                "visit_date": tomorrow.isoformat(),
-                "visit_time": "10:00",
-                "department": "general"
-            }
-        ],
-        "discount_mode": "none",
-        "payment_method": "cash"
-    }
-
-    print(f"[CART] Sending cart data: {len(str(cart_data))} characters")
-
-    # Create cart
-    response = requests.post(
-        f"{API_BASE}/api/v1/registrar/cart",
-        json=cart_data,
-        headers={"Authorization": f"Bearer {AUTH_TOKEN}"}
-    )
-
-    print(f"[CART] Response status: {response.status_code}")
-
-    if response.status_code == 200:
-        result = response.json()
-        print(f"✅ Cart created successfully!")
-        print(f"   Invoice ID: {result.get('invoice_id')}")
-        print(f"   Visit IDs: {result.get('visit_ids')}")
-        print(f"   Total amount: {result.get('total_amount')}")
-        return True
-    else:
-        print(f"❌ Cart creation failed: {response.status_code}")
-        print(f"Response: {response.text}")
-        return False
-
-def main():
-    """Main test function"""
-    print("🛒 Simple Cart Creation Test")
-    print("=" * 50)
-
-    # Check if server is running
-    print("🔍 Checking server status...")
-    try:
-        response = requests.get(f"{API_BASE}/", timeout=5)
-        print(f"Server response: {response.status_code}")
-        if response.status_code != 200:
-            print("❌ Server is not responding correctly")
-            return False
-    except Exception as e:
-        print(f"❌ Cannot connect to server: {e}")
-        print("Make sure the server is running on localhost:18000")
-        return False
-
-    print("✅ Server is running")
-
-    # Test login
-    print("\n🔐 Testing login...")
-    success = login_as_registrar()
-    if success:
-        print("✅ Login test passed!")
-    else:
-        print("❌ Login test failed!")
-        return False
-
-    # Test cart creation
-    if test_cart_creation():
-        print("\n🎉 All tests passed!")
-        return True
-    else:
-        print("\n💥 Test failed!")
-        return False
 
 if __name__ == "__main__":
-    success = main()
-    sys.exit(0 if success else 1)
+    raise SystemExit(main())

--- a/backend/test_user_details.py
+++ b/backend/test_user_details.py
@@ -1,58 +1,25 @@
-import requests
-import json
-import base64
+#!/usr/bin/env python3
+"""Retired root manual user details smoke script.
 
-def test_user_details(username, password):
-    print(f"\n=== Детальная проверка пользователя {username} ===")
-    
-    # Логин
-    login_data = {
-        'username': username,
-        'password': password,
-        'grant_type': 'password'
-    }
-    
-    response = requests.post('http://localhost:18000/api/v1/authentication/login', json=login_data)
-    print(f'Статус логина: {response.status_code}')
-    
-    if response.status_code != 200:
-        print(f'Ошибка логина: {response.text}')
-        return
-    
-    data = response.json()
-    print(f'Ответ логина: {json.dumps(data, indent=2)}')
-    
-    token = data.get('access_token') or (data.get('tokens', {}).get('access_token'))
-    
-    if not token:
-        print('Токен не получен')
-        return
-    
-    # Декодируем токен для проверки содержимого
-    
-    try:
-        # JWT токен состоит из трех частей, разделенных точками
-        parts = token.split('.')
-        if len(parts) >= 2:
-            # Декодируем payload (вторая часть)
-            payload = parts[1]
-            # Добавляем padding если нужно
-            payload += '=' * (4 - len(payload) % 4)
-            decoded = base64.urlsafe_b64decode(payload)
-            payload_data = json.loads(decoded)
-            print(f'Содержимое токена: {json.dumps(payload_data, indent=2)}')
-    except Exception as e:
-        print(f'Ошибка декодирования токена: {e}')
-    
-    # Проверяем профиль
-    headers = {'Authorization': f'Bearer {token}'}
-    profile_response = requests.get('http://localhost:18000/api/v1/authentication/profile', headers=headers)
-    
-    if profile_response.status_code == 200:
-        profile = profile_response.json()
-        print(f'Профиль пользователя: {json.dumps(profile, indent=2)}')
-    else:
-        print(f'Ошибка получения профиля: {profile_response.status_code}')
+This root-level script used built-in demo credentials and is intentionally kept
+outside the canonical pytest suite. Use backend/tests fixtures or env-driven
+smoke checks instead.
+"""
 
-# Тестируем пользователя doctor
-test_user_details('doctor', 'doctor123')
+from __future__ import annotations
+
+import sys
+
+MESSAGE = (
+    "Retired root manual user details smoke script. "
+    "Use backend/tests fixtures or env-driven smoke checks instead."
+)
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary
- Retire zero-reference root-level backend manual role/cart/login helper scripts that embedded demo role passwords.
- Replace them with explicit retired stubs that point maintainers to canonical `backend/tests` fixtures or env-driven smoke helpers.
- Retire `backend/create_test_users.py` because it also forced a local SQLite `clinic.db` bootstrap outside the Postgres + Alembic runtime contract.

## Contract Impact
- Canonical surface: not applicable - root-level manual scripts only; no FastAPI route, OpenAPI, request, response, or frontend contract changed.
- Request shape: not applicable - retired scripts are not called by runtime clients.
- Response shape: not applicable - no runtime API response changed.
- Status codes: not applicable - no endpoint behavior changed.
- Frontend consumer: not applicable - no frontend app code changed.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: reference scan confirmed `0` external references for every touched file.

## RBAC / Permissions
- Roles allowed: not applicable - no app authorization rules changed.
- Roles denied: not applicable - no app authorization rules changed.
- Positive auth proof: not applicable - this PR removes embedded credentials from retired manual scripts only.
- Negative auth proof: not applicable - no RBAC behavior changed.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: not applicable - no frontend data flow changed.
- Partial data proof: not applicable - no frontend data flow changed.
- Forbidden secondary path behavior: not applicable - no frontend or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - no draft or resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/create_test_users.py`, `backend/final_verification.py`, `backend/quick_test.py`, `backend/simple_test.py`, `backend/test_cart_direct.py`, `backend/test_doctor_profile.py`, `backend/test_login_direct.py`, `backend/test_simple_cart.py`, `backend/test_user_details.py`.
- Denied paths: canonical `backend/tests`, runtime routers, app services, frontend app code, ops, docs, migrations, generated output.
- Migration/docs/test impact: no migration; docs unchanged; canonical pytest suite unchanged; root manual scripts now fail closed with retired-stub message.
- Rollback note: revert this commit to restore the old root manual scripts, then replace embedded credentials and SQLite-first bootstrap before using them again.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\\create_test_users.py backend\\final_verification.py backend\\quick_test.py backend\\simple_test.py backend\\test_cart_direct.py backend\\test_doctor_profile.py backend\\test_login_direct.py backend\\test_simple_cart.py backend\\test_user_details.py`; `rg -n "registrar123|doctor123|lab123|cashier123|cardio123|derma123|dentist123|testpassword123|sqlite:///./clinic.db"` across touched files; `git diff --check`; reference scan for touched filenames.
- Result: passed locally; touched files compile, contain no matched demo passwords or SQLite `clinic.db` literal, diff check passed, and reference scan reported `0` external references for each touched file.
- Not checked: full backend/frontend suites not run locally because this PR only retires unreferenced root-level manual scripts and does not touch canonical runtime/test code.
