### PR TITLE
[codex] Require env passwords for role e2e specs

### DIFF
--- a/frontend/e2e/payment-system.spec.js
+++ b/frontend/e2e/payment-system.spec.js
@@ -1,11 +1,21 @@
 import { test, expect } from '@playwright/test';
 
+const CASHIER_USERNAME = process.env.QA_CASHIER_USERNAME || 'cashier@clinic.com';
+
+function requiredCashierPassword() {
+  const password = process.env.QA_CASHIER_PASSWORD;
+  if (!password) {
+    throw new Error('Set QA_CASHIER_PASSWORD to run payment system e2e tests.');
+  }
+  return password;
+}
+
 test.describe('Payment System Tests', () => {
   test.beforeEach(async ({ page }) => {
     // Логинимся как кассир
     await page.goto('/login');
-    await page.fill('input[type="text"]', 'cashier@clinic.com');
-    await page.fill('input[type="password"]', 'cashier123');
+    await page.fill('input[type="text"]', CASHIER_USERNAME);
+    await page.fill('input[type="password"]', requiredCashierPassword());
     await page.click('button[type="submit"]');
     
     // Ждем загрузки панели кассира

--- a/frontend/e2e/print-system.spec.js
+++ b/frontend/e2e/print-system.spec.js
@@ -1,11 +1,21 @@
 import { test, expect } from '@playwright/test';
 
+const DOCTOR_USERNAME = process.env.QA_DOCTOR_USERNAME || 'doctor@clinic.com';
+
+function requiredDoctorPassword() {
+  const password = process.env.QA_DOCTOR_PASSWORD;
+  if (!password) {
+    throw new Error('Set QA_DOCTOR_PASSWORD to run print system e2e tests.');
+  }
+  return password;
+}
+
 test.describe('Print System Tests', () => {
   test.beforeEach(async ({ page }) => {
     // Логинимся как врач
     await page.goto('/login');
-    await page.fill('input[type="text"]', 'doctor@clinic.com');
-    await page.fill('input[type="password"]', 'doctor123');
+    await page.fill('input[type="text"]', DOCTOR_USERNAME);
+    await page.fill('input[type="password"]', requiredDoctorPassword());
     await page.click('button[type="submit"]');
     
     // Ждем загрузки панели врача

--- a/frontend/e2e/queue-system.spec.js
+++ b/frontend/e2e/queue-system.spec.js
@@ -1,11 +1,21 @@
 import { test, expect } from '@playwright/test';
 
+const REGISTRAR_USERNAME = process.env.QA_REGISTRAR_USERNAME || 'registrar@clinic.com';
+
+function requiredRegistrarPassword() {
+  const password = process.env.QA_REGISTRAR_PASSWORD;
+  if (!password) {
+    throw new Error('Set QA_REGISTRAR_PASSWORD to run queue system e2e tests.');
+  }
+  return password;
+}
+
 test.describe('Queue System Tests', () => {
   test.beforeEach(async ({ page }) => {
     // Логинимся как регистратор
     await page.goto('/login');
-    await page.fill('input[type="text"]', 'registrar@clinic.com');
-    await page.fill('input[type="password"]', 'registrar123');
+    await page.fill('input[type="text"]', REGISTRAR_USERNAME);
+    await page.fill('input[type="password"]', requiredRegistrarPassword());
     await page.click('button[type="submit"]');
     
     // Ждем загрузки панели регистратора


### PR DESCRIPTION
﻿## Summary

- Require Playwright queue/payment/print role passwords from QA_*_PASSWORD environment variables instead of embedded demo passwords.
- Keep role usernames configurable with QA_*_USERNAME while preserving the existing default email usernames.
- Align these role e2e specs with the existing admin e2e pattern that fails fast when the required QA password is not provided.

## Contract Impact

- Canonical surface: frontend Playwright e2e login setup only.
- Request shape: unchanged browser login form fill sequence.
- Response shape: not applicable - no API response contract changed.
- Status codes: not applicable - no backend endpoint behavior changed.
- Frontend consumer: queue, payment, and print Playwright specs.
- Compatibility path or alias: default usernames remain unchanged; password literals are removed.
- Contract proof: frontend production build and focused password literal scan passed.

## RBAC / Permissions

- Roles allowed: registrar, cashier, doctor test accounts when the matching QA password env var is supplied.
- Roles denied: unchanged; this PR does not change runtime RBAC guards.
- Positive auth proof: not checked live, because e2e credentials are intentionally environment-provided and not embedded.
- Negative auth proof: not checked live, because no auth guard behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, login setup only.
- Partial data proof: not applicable, no data rendering path changed.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: not applicable, no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable, no route state handling changed.

## Scope Gate

- Allowed paths: frontend/e2e/queue-system.spec.js, frontend/e2e/payment-system.spec.js, frontend/e2e/print-system.spec.js
- Denied paths: backend runtime, frontend runtime, migrations, generated output, unrelated e2e specs
- Migration/docs/test impact: no migration; e2e test login setup now needs QA_REGISTRAR_PASSWORD, QA_CASHIER_PASSWORD, and QA_DOCTOR_PASSWORD when these specs run
- Rollback note: revert the three e2e spec changes

## Validation

- Targeted tests or smoke run: cd frontend; npm.cmd run build; git diff --check; focused rg scan for registrar123/doctor123/cashier123 in the touched e2e files
- Result: passed; focused rg returned no matches for the removed password literals
- Not checked: live Playwright login, because real QA role passwords are intentionally not stored in the repository
