### PR TITLE
[codex] Require env passwords for backend helpers

### DIFF
--- a/backend/integration_test.py
+++ b/backend/integration_test.py
@@ -7,9 +7,17 @@
 import asyncio
 import aiohttp
 import json
+import os
 import time
 from datetime import datetime
 from typing import Dict, Any, List
+
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Set {name} to run backend integration helper scripts.")
+    return value
 
 class APIIntegrationTester:
     def __init__(self, base_url: str = "http://localhost:18000"):
@@ -87,8 +95,8 @@ class APIIntegrationTester:
         
         # Пробуем создать тестового пользователя
         test_user = {
-            "email": "test@example.com",
-            "password": "testpassword123",
+            "email": os.getenv("QA_INTEGRATION_TEST_EMAIL", "test@example.com"),
+            "password": required_env("QA_INTEGRATION_TEST_PASSWORD"),
             "full_name": "Test User"
         }
         

--- a/backend/test_cart_error_debug.py
+++ b/backend/test_cart_error_debug.py
@@ -3,13 +3,21 @@
 """
 import requests
 import json
+import os
 
 BASE_URL = "http://localhost:18000"
 
+
+def required_env(name):
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Set {name} to run backend cart debug helper scripts.")
+    return value
+
 # Получаем токен
 login_data = {
-    "username": "registrar@example.com",
-    "password": "registrar123"
+    "username": os.getenv("QA_REGISTRAR_USERNAME", "registrar@example.com"),
+    "password": required_env("QA_REGISTRAR_PASSWORD")
 }
 
 print("🔐 Авторизация...")

--- a/backend/test_registration_creation.py
+++ b/backend/test_registration_creation.py
@@ -4,12 +4,19 @@
 """
 import requests
 import json
+import os
 from datetime import date
 
 # Конфигурация
 BASE_URL = "http://localhost:18000"
-REGISTRAR_USERNAME = "registrar@example.com"
-REGISTRAR_PASSWORD = "registrar123"
+REGISTRAR_USERNAME = os.getenv("QA_REGISTRAR_USERNAME", "registrar@example.com")
+
+
+def required_registrar_password():
+    password = os.getenv("QA_REGISTRAR_PASSWORD")
+    if not password:
+        raise RuntimeError("Set QA_REGISTRAR_PASSWORD to run registration creation helper scripts.")
+    return password
 
 def get_auth_token():
     """Получить токен авторизации для регистратора"""
@@ -17,7 +24,7 @@ def get_auth_token():
     
     login_data = {
         "username": REGISTRAR_USERNAME,
-        "password": REGISTRAR_PASSWORD
+        "password": required_registrar_password()
     }
     
     response = requests.post(f"{BASE_URL}/api/v1/auth/login", data=login_data)

--- a/backend/verify_fix.py
+++ b/backend/verify_fix.py
@@ -3,9 +3,17 @@ Comprehensive verification script
 """
 import requests
 import json
+import os
 import sys
 
 BASE_URL = "http://localhost:18000"
+
+
+def required_registrar_password():
+    password = os.getenv("QA_REGISTRAR_PASSWORD")
+    if not password:
+        raise RuntimeError("Set QA_REGISTRAR_PASSWORD to run backend verification helper scripts.")
+    return password
 
 def check_backend_restart():
     print("🔍 Checking if backend was restarted...")
@@ -28,7 +36,10 @@ def test_cart_creation():
         # Login
         response = requests.post(
             f"{BASE_URL}/api/v1/auth/login",
-            data={"username": "registrar@example.com", "password": "registrar123"}
+            data={
+                "username": os.getenv("QA_REGISTRAR_USERNAME", "registrar@example.com"),
+                "password": required_registrar_password()
+            }
         )
         if response.status_code != 200:
             print(f"❌ Login failed: {response.status_code}")


### PR DESCRIPTION
﻿## Summary

- Require backend manual/helper scripts to read live test passwords from environment variables instead of embedded demo passwords.
- Preserve existing helper script behavior, URLs, and default usernames while removing `registrar123` and `testpassword123` from repository code.
- Keep the slice limited to four non-runtime backend helper files allowed by the agent gate.

## Contract Impact

- Canonical surface: backend manual/helper scripts only; no FastAPI route or service contract changed.
- Request shape: unchanged login/register payload keys; password values now come from QA_REGISTRAR_PASSWORD or QA_INTEGRATION_TEST_PASSWORD.
- Response shape: not applicable - no API response contract changed.
- Status codes: not applicable - no backend endpoint behavior changed.
- Frontend consumer: not applicable - no frontend runtime consumer changed.
- Compatibility path or alias: default usernames remain unchanged; embedded password defaults are removed.
- Contract proof: Python compile check and repository password literal scan passed.

## RBAC / Permissions

- Roles allowed: unchanged; helper scripts still authenticate as their configured test users when env credentials are supplied.
- Roles denied: unchanged; this PR does not modify runtime auth or RBAC guards.
- Positive auth proof: not checked live, because live QA passwords are intentionally not stored in the repository.
- Negative auth proof: not checked live, because no auth guard behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no frontend runtime panel, data flow, route state, or browser behavior changed.

## Scope Gate

- Allowed paths: backend/integration_test.py, backend/test_cart_error_debug.py, backend/test_registration_creation.py, backend/verify_fix.py
- Denied paths: backend/app runtime, backend/tests, frontend runtime, migrations, generated output, PowerShell restart wrapper
- Migration/docs/test impact: no migration; manual helpers now require QA_REGISTRAR_PASSWORD or QA_INTEGRATION_TEST_PASSWORD when executed
- Rollback note: revert the four helper script edits

## Validation

- Targeted tests or smoke run: python -m py_compile backend/integration_test.py backend/test_cart_error_debug.py backend/test_registration_creation.py backend/verify_fix.py; git diff --check; full repository scan for registrar123/doctor123/lab123/cashier123/cardio123/derma123/dentist123/testpassword123 outside canonical tests and excluded artifacts
- Result: passed; full scan returned no matches in backend/frontend/docs/scripts/.github/ops with exclusions
- Not checked: live backend helper execution, because live QA credentials are intentionally environment-provided and not committed
