### PR TITLE
fix(files): sanitize json upload service logging

### DIFF
--- a/backend/app/services/file_upload_json_api_service.py
+++ b/backend/app/services/file_upload_json_api_service.py
@@ -4,6 +4,7 @@ Endpoint для загрузки файлов через JSON
 
 import base64
 import hashlib
+import logging
 import os
 from datetime import datetime
 
@@ -16,6 +17,7 @@ from app.db.session import get_db
 from app.models.user import User
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 class FileUploadRequest(BaseModel):
@@ -33,19 +35,32 @@ async def upload_file_json(
 ):
     """Загрузка файла через JSON (base64)"""
     try:
-        print(f"📁 Получен файл: {request.filename}")
-        print(f"👤 Пользователь: {current_user.username}")
+        logger.info(
+            "JSON file upload started user_id=%s has_title=%s has_description=%s",
+            getattr(current_user, "id", None),
+            bool(request.title),
+            bool(request.description),
+        )
 
         # Декодируем содержимое файла
         try:
             content = base64.b64decode(request.content)
-        except Exception as e:
-            raise HTTPException(
-                status_code=400, detail=f"Ошибка декодирования base64: {e}"
+        except Exception as exc:
+            logger.warning(
+                "JSON file upload base64 decode failed user_id=%s error_type=%s",
+                getattr(current_user, "id", None),
+                type(exc).__name__,
             )
+            raise HTTPException(
+                status_code=400, detail="Ошибка декодирования base64"
+            ) from None
 
         file_size = len(content)
-        print(f"📊 Размер файла: {file_size} байт")
+        logger.info(
+            "JSON file upload decoded user_id=%s file_size=%s",
+            getattr(current_user, "id", None),
+            file_size,
+        )
 
         # Создаем хеш файла
         file_hash = hashlib.sha256(content).hexdigest()
@@ -61,7 +76,11 @@ async def upload_file_json(
         with open(file_path, "wb") as f:
             f.write(content)
 
-        print(f"✅ Файл сохранен: {file_path}")
+        logger.info(
+            "JSON file upload saved user_id=%s file_size=%s",
+            getattr(current_user, "id", None),
+            file_size,
+        )
 
         return {
             "success": True,
@@ -77,7 +96,11 @@ async def upload_file_json(
 
     except HTTPException:
         raise
-    except Exception as e:
-        print(f"❌ Ошибка загрузки: {e}")
-        raise HTTPException(status_code=500, detail=f"Ошибка загрузки файла: {str(e)}")
+    except Exception as exc:
+        logger.error(
+            "JSON file upload failed user_id=%s error_type=%s",
+            getattr(current_user, "id", None),
+            type(exc).__name__,
+        )
+        raise HTTPException(status_code=500, detail="Ошибка загрузки файла") from None
 


### PR DESCRIPTION
## Summary

- Replace raw stdout prints in JSON file upload service with structured logger calls.
- Remove filename, username, file path, and raw exception text from logs.
- Return generic public upload/base64 error details while preserving successful response fields.

## Contract Impact

- Canonical surface: POST /api/v1/files/upload-json through the existing JSON upload service.
- Request shape: unchanged FileUploadRequest fields (`filename`, `content`, optional `title`, optional `description`).
- Response shape: unchanged successful response fields, including filename, original_filename, file_size, file_hash, file_path, title, and description.
- Status codes: unchanged 200 success, 400 base64 decode failure, 500 upload failure.
- Frontend consumer: not applicable - this slice only changes backend logging and public error detail text for failures.
- Compatibility path or alias: unchanged existing /files mount.
- Contract proof: direct mocked smoke covered successful upload and base64 decode failure.

## RBAC / Permissions

- Roles allowed: unchanged existing authenticated users accepted by `get_current_user`.
- Roles denied: unchanged existing authentication dependency behavior.
- Positive auth proof: not applicable - auth dependency was not changed; smoke invoked the service with an authenticated user object.
- Negative auth proof: not applicable - auth/RBAC behavior was explicitly out of scope and unchanged.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend state or payload field removal.
- Partial data proof: not applicable - optional title/description behavior is unchanged.
- Forbidden secondary path behavior: not applicable - no secondary path changed.
- Missing draft/resource behavior: not applicable - upload storage/resource semantics were not changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/services/file_upload_json_api_service.py` only.
- Denied paths: storage policy, filename construction, auth/RBAC, endpoint mounting, upload validation, migrations, generated output.
- Migration/docs/test impact: no migration; docs unchanged; targeted local smoke/static checks used for this logging slice.
- Rollback note: revert commit `2bf8a887` to restore previous logging behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\\app\\services\\file_upload_json_api_service.py`; static `rg` for removed `print(`, `str(e)`, username logging, and old raw error messages; direct mocked smoke for successful JSON upload and base64 decode failure with no stdout leakage; `git diff --check`.
- Result: passed locally.
- Not checked: full browser upload flow and production storage/security hardening; those remain separate P0 file-upload work because this slice only removes logging/public error leakage.