### PR TITLE
fix(emr): sanitize import version logging

### DIFF
--- a/backend/app/services/emr_export_service.py
+++ b/backend/app/services/emr_export_service.py
@@ -4,9 +4,12 @@
 
 import io
 import json
+import logging
 import zipfile
 from datetime import datetime
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class EMRExportService:
@@ -177,8 +180,10 @@ class EMRExportService:
             if 'metadata' in data:
                 format_version = data['metadata'].get('format_version', '1.0')
                 if format_version != '1.0':
-                    print(
-                        f"Предупреждение: Неподдерживаемая версия формата {format_version}"
+                    logger.warning(
+                        "Unsupported EMR import format version encountered "
+                        "format_version_type=%s",
+                        type(format_version).__name__,
                     )
 
             return emr_data


### PR DESCRIPTION
## Summary

- Replace the raw stdout warning in EMR JSON import with structured logger output.
- Avoid logging the user-controlled `format_version` value while preserving unsupported-version tolerance.
- Preserve EMR import payload behavior for supported and unsupported metadata versions.

## Contract Impact

- Canonical surface: EMR import/export service used by `/api/v1/emr/export/*` endpoints.
- Request shape: unchanged JSON import data with `metadata` and `emr` fields.
- Response shape: unchanged imported EMR dictionary returned from `import_emr_from_json`.
- Status codes: not applicable - this service slice does not change endpoint status handling.
- Frontend consumer: not applicable - no frontend code or response field changed.
- Compatibility path or alias: unchanged existing EMR export/import service usage.
- Contract proof: direct service smoke covered supported and unsupported `metadata.format_version` inputs.

## RBAC / Permissions

- Roles allowed: unchanged existing endpoint-level auth/RBAC behavior.
- Roles denied: unchanged existing endpoint-level auth/RBAC behavior.
- Positive auth proof: not applicable - this service-only logging slice did not touch dependencies or permissions.
- Negative auth proof: not applicable - auth/RBAC was explicitly out of scope and unchanged.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend behavior changed.
- Partial data proof: not applicable - EMR payload parsing behavior is unchanged.
- Forbidden secondary path behavior: not applicable - no secondary path changed.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no route behavior changed.

## Scope Gate

- Allowed paths: `backend/app/services/emr_export_service.py` only.
- Denied paths: EMR endpoint contracts, payload parsing semantics, public exception semantics, database models, migrations, generated output.
- Migration/docs/test impact: no migration; docs unchanged; targeted local smoke/static checks used for this logging slice.
- Rollback note: revert commit `fc49cc61` to restore previous stdout warning behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\\app\\services\\emr_export_service.py`; static `rg` for removed `print(` and old unsupported-version warning text; direct service smoke for supported and unsupported JSON import versions with no stdout leakage; `git diff --check`.
- Result: passed locally.
- Not checked: full browser EMR import/export flow and broader public exception sanitization; those remain separate gated EMR slices because this patch only removes the raw stdout warning.