### PR TITLE
test(frontend): accept local doctor queue origin

### DIFF
--- a/frontend/src/components/doctor/__tests__/DoctorQueuePanel.test.jsx
+++ b/frontend/src/components/doctor/__tests__/DoctorQueuePanel.test.jsx
@@ -151,13 +151,15 @@ describe('DoctorQueuePanel', () => {
     const requestedUrls = fetchMock.mock.calls.map(([url]) => String(url));
 
     expect(requestedUrls).toEqual([
-      'http://localhost:18000/api/v1/doctor/my-info',
-      'http://localhost:18000/api/v1/doctor/cardiology/queue/today',
+      expect.stringMatching(/^http:\/\/(?:localhost|127\.0\.0\.1):18000\/api\/v1\/doctor\/my-info$/),
+      expect.stringMatching(/^http:\/\/(?:localhost|127\.0\.0\.1):18000\/api\/v1\/doctor\/cardiology\/queue\/today$/),
     ]);
     expect(requestedUrls.some((url) => url.includes(':8000'))).toBe(false);
     expect(loggerInfo).toHaveBeenCalledWith(
       '[FIX:DOCTOR_QUEUE_PANEL] Loading doctor info from canonical API origin',
-      expect.objectContaining({ url: 'http://localhost:18000/api/v1/doctor/my-info' }),
+      expect.objectContaining({
+        url: expect.stringMatching(/^http:\/\/(?:localhost|127\.0\.0\.1):18000\/api\/v1\/doctor\/my-info$/),
+      }),
     );
   });
 });


### PR DESCRIPTION
## Summary

- Makes the DoctorQueuePanel canonical-origin guard accept both `localhost` and `127.0.0.1` on backend port `18000`.
- Keeps the guard rejecting legacy backend port `8000`.
- Test contract only; no runtime code changes.

## Contract Impact

- Canonical surface: DoctorQueuePanel Vitest canonical backend origin guard.
- Request shape: no runtime request shape changed; test still observes fetch calls to doctor queue endpoints.
- Response shape: no response shape changed; existing mocked doctor info and queue payloads remain unchanged.
- Status codes: no status-code contract changed; mocked successful responses remain `ok: true`.
- Frontend consumer: DoctorQueuePanel test consumer of `buildApiUrl` output.
- Compatibility path or alias: local loopback host may be `localhost` or `127.0.0.1`; legacy `:8000` remains rejected.
- Contract proof: targeted DoctorQueuePanel Vitest plus full frontend Vitest suite passed locally; GitHub frontend/parity checks passed.

## RBAC / Permissions

not applicable - this PR changes only a Vitest expectation and does not touch authentication, authorization, roles, or permission checks.

## Notification / Realtime

not applicable - this PR does not touch websocket, notification, chat, polling, or realtime code paths.

## Frontend Resilience

not applicable - no user-facing panel behavior or frontend data flow changed; this is a test-only local-origin expectation update.

## Scope Gate

- Allowed paths: `frontend/src/components/doctor/__tests__/DoctorQueuePanel.test.jsx`.
- Denied paths: production frontend code, backend code, ops files, generated output, artifact cleanup PR #414.
- Migration/docs/test impact: no migration or docs; one targeted frontend test expectation updated.
- Rollback note: revert commit `39c1e850` to restore the previous exact-host expectation.

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/components/doctor/__tests__/DoctorQueuePanel.test.jsx`; `npm.cmd run test:run`; `npm.cmd run build`.
- Result: targeted DoctorQueuePanel Vitest passed; full frontend Vitest passed 61 files / 293 tests; frontend build passed; GitHub frontend, backend, quality, security, and parity checks passed.
- Not checked: browser smoke not run because runtime code and UI behavior are unchanged.