### PR TITLE
fix(db): replace session stderr prints with logging

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import logging
 import os
-import sys
 from collections.abc import Generator
 
 from sqlalchemy import create_engine, event, text
 from sqlalchemy.engine import make_url
 from sqlalchemy.orm import Session
 from sqlalchemy.orm import sessionmaker as orm_sessionmaker
+
+logger = logging.getLogger(__name__)
 
 
 def _get_db_url_from_env_or_settings() -> str:
@@ -84,10 +86,10 @@ DATABASE_URL = _get_db_url_from_env_or_settings()
 _validate_runtime_database_url(DATABASE_URL)
 DATABASE_URL = _normalize_sqlite_to_sync(DATABASE_URL)
 
-# небольшая диагностика при импорте (в лог / stderr)
-print(
-    f"[app.db.session] Using DATABASE_URL = {_safe_database_url_for_log(DATABASE_URL)}",
-    file=sys.stderr,
+# небольшая диагностика при импорте
+logger.info(
+    "Using database URL database_url=%s",
+    _safe_database_url_for_log(DATABASE_URL),
 )
 
 # Создаём СИНХРОННЫЙ движок
@@ -106,12 +108,18 @@ def _enable_sqlite_fk(dbapi_conn, connection_record):
             cursor.execute("PRAGMA foreign_keys")
             fk_status = cursor.fetchone()
             if fk_status and fk_status[0] == 1:
-                print(f"[app.db.session] ✅ Foreign keys enabled on connection (verified: {fk_status[0]})", file=sys.stderr)
+                logger.info("SQLite foreign keys enabled on connection")
             else:
-                print(f"[app.db.session] ⚠️  WARNING: Foreign keys NOT enabled on connection (status: {fk_status})", file=sys.stderr)
+                logger.warning(
+                    "SQLite foreign keys not enabled on connection status=%s",
+                    fk_status,
+                )
             cursor.close()
-        except Exception as e:
-            print(f"[app.db.session] ❌ ERROR enabling foreign keys: {e}", file=sys.stderr)
+        except Exception as exc:
+            logger.error(
+                "SQLite foreign key setup failed error_type=%s",
+                type(exc).__name__,
+            )
             raise
 
 _is_sqlite = DATABASE_URL.startswith("sqlite")
@@ -139,7 +147,7 @@ engine = create_engine(
 # ✅ SECURITY: Register event listener for SQLite FK enforcement
 if _is_sqlite:
     event.listen(engine, "connect", _enable_sqlite_fk)
-    print("[app.db.session] Foreign key enforcement enabled for SQLite via event listener", file=sys.stderr)
+    logger.info("SQLite foreign key enforcement registered via event listener")
 
 # sync session factory
 SessionLocal = orm_sessionmaker(


### PR DESCRIPTION
## Summary

- Replace raw `stderr` prints in `app.db.session` with structured logger calls.
- Preserve database URL validation, engine construction, session factory, and SQLite foreign-key enforcement behavior.
- Avoid logging raw SQLite FK setup exception text while preserving failure propagation.

## Contract Impact

- Canonical surface: `app.db.session` import, `engine`, `SessionLocal`, and `get_db()` dependency.
- Request shape: not applicable - infrastructure/session factory only.
- Response shape: not applicable - no API payload changed.
- Status codes: not applicable - no endpoint behavior changed.
- Frontend consumer: not applicable - backend infrastructure logging only.
- Compatibility path or alias: unchanged existing `SessionLocal`, `sessionmaker`, `engine`, and `get_db` exports.
- Contract proof: import smoke and `get_db()` SQLite FK smoke confirm session creation and FK enforcement still work.

## RBAC / Permissions

- Roles allowed: unchanged - no auth or permission code changed.
- Roles denied: unchanged - no auth or permission code changed.
- Positive auth proof: not applicable - DB session infrastructure only.
- Negative auth proof: not applicable - DB session infrastructure only.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend behavior changed.
- Partial data proof: not applicable - no frontend behavior changed.
- Forbidden secondary path behavior: not applicable - no route or permission behavior changed.
- Missing draft/resource behavior: not applicable - no draft/resource behavior changed.
- Stale route/deep-link behavior: not applicable - no route behavior changed.

## Scope Gate

- Allowed paths: `backend/app/db/session.py` only.
- Denied paths: DATABASE_URL validation policy, PostgreSQL/SQLite selection, engine kwargs, session factory behavior, Alembic behavior, migrations, generated output.
- Migration/docs/test impact: no migration; docs unchanged; targeted local smoke/static checks used for this logging slice.
- Rollback note: revert commit `e2be7a8e` to restore previous stderr print diagnostics.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\\app\\db\\session.py`; static `rg` for removed `print(`, `sys.stderr`, and old stderr messages; import + `get_db()` SQLite smoke with `ALLOW_SQLITE_DATABASE_URL=1`; `git diff --check`.
- Result: passed locally; smoke confirmed no stdout/stderr output and `PRAGMA foreign_keys` returned `1`.
- Not checked: full PostgreSQL runtime boot and Alembic migration flow; those remain broader infra checks outside this single-file logging slice.