### PR TITLE
fix(dermatology): sanitize thumbnail logging

### DIFF
--- a/backend/app/api/v1/endpoints/dermatology_photos.py
+++ b/backend/app/api/v1/endpoints/dermatology_photos.py
@@ -87,10 +87,7 @@ async def upload_photos(
                     img.save(thumbnail_path, "JPEG", quality=85)
             except Exception as exc:
                 logger.warning(
-                    "Dermatology photo thumbnail generation failed "
-                    "patient_id=%s user_id=%s error_type=%s",
-                    patient_id,
-                    getattr(current_user, "id", None),
+                    "Dermatology photo thumbnail generation failed error_type=%s",
                     type(exc).__name__,
                 )
                 thumbnail_path = None

--- a/backend/app/api/v1/endpoints/dermatology_photos.py
+++ b/backend/app/api/v1/endpoints/dermatology_photos.py
@@ -3,6 +3,7 @@ API endpoints для работы с фото в дерматологии
 Основа: passport.md стр. 1789-2063
 """
 
+import logging
 import os
 import uuid
 from datetime import datetime
@@ -19,6 +20,7 @@ from app.models.dermatology_photos import DermatologyPhoto
 from app.models.user import User
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 # Настройки для загрузки фото
 UPLOAD_DIR = "uploads/dermatology"
@@ -83,8 +85,14 @@ async def upload_photos(
                 with Image.open(file_path) as img:
                     img.thumbnail(THUMBNAIL_SIZE, Image.Resampling.LANCZOS)
                     img.save(thumbnail_path, "JPEG", quality=85)
-            except Exception as e:
-                print(f"Ошибка создания миниатюры: {e}")
+            except Exception as exc:
+                logger.warning(
+                    "Dermatology photo thumbnail generation failed "
+                    "patient_id=%s user_id=%s error_type=%s",
+                    patient_id,
+                    getattr(current_user, "id", None),
+                    type(exc).__name__,
+                )
                 thumbnail_path = None
 
             # Сохраняем в БД


### PR DESCRIPTION
## Summary

- Replace the raw thumbnail-generation `print(...)` in the dermatology photo endpoint with structured logger output.
- Avoid logging raw exception text while preserving thumbnail failure tolerance.
- Preserve upload behavior: thumbnail generation failure still sets `thumbnail_path` to `None` and continues.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/dermatology_photos.py` dermatology photo upload endpoint module.
- Request shape: unchanged multipart upload fields (`files`, `patient_id`, `category`, optional `patient_name`, optional `notes`).
- Response shape: unchanged successful response fields and thumbnail URL behavior.
- Status codes: unchanged endpoint-level behavior; thumbnail generation failure remains non-fatal.
- Frontend consumer: not applicable - no frontend code or response field changed.
- Compatibility path or alias: unchanged; endpoint mounting was not changed.
- Contract proof: endpoint import smoke plus static check; behavior change is limited to logging in the thumbnail exception path.

## RBAC / Permissions

- Roles allowed: unchanged existing `require_roles(Admin, Doctor, derma)` dependency.
- Roles denied: unchanged existing endpoint-level dependency behavior.
- Positive auth proof: not applicable - auth dependency was not changed.
- Negative auth proof: not applicable - auth dependency was not changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend behavior changed.
- Partial data proof: not applicable - thumbnail failure still returns `thumbnail_url: null` through existing behavior.
- Forbidden secondary path behavior: not applicable - no route or permission behavior changed.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no route behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/dermatology_photos.py` only.
- Denied paths: file validation, storage paths, DB writes, endpoint mounting, public response shape, role checks, service-layer duplicate cleanup, migrations, generated output.
- Migration/docs/test impact: no migration; docs unchanged; targeted local smoke/static checks used for this logging slice.
- Rollback note: revert commit `b637dcdf` to restore previous thumbnail stderr/stdout print behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\\app\\api\\v1\\endpoints\\dermatology_photos.py`; static `rg` for removed `print(` and old thumbnail warning text; endpoint import smoke with SQLite test env and no stdout/stderr; `git diff --check`.
- Result: passed locally.
- Not checked: full dermatology photo upload browser/API flow and service-layer duplicate cleanup; those remain separate slices because this patch only removes the raw endpoint thumbnail print.