### PR TITLE
fix(files): sanitize simple upload service logging

### DIFF
--- a/backend/app/services/file_upload_simple_api_service.py
+++ b/backend/app/services/file_upload_simple_api_service.py
@@ -3,6 +3,7 @@
 """
 
 import hashlib
+import logging
 import os
 from datetime import datetime
 
@@ -14,6 +15,7 @@ from app.db.session import get_db
 from app.models.user import User
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.post("/upload-simple")
@@ -25,14 +27,13 @@ async def upload_file_simple(
 ):
     """Упрощенная загрузка файла"""
     try:
-        print(f"📁 Получен файл: {file.filename}")
-        print(f"👤 Пользователь: {current_user.username}")
+        logger.info("Simple file upload started")
 
         # Читаем содержимое файла
         content = await file.read()
         file_size = len(content)
 
-        print(f"📊 Размер файла: {file_size} байт")
+        logger.info("Simple file upload content read")
 
         # Создаем хеш файла
         file_hash = hashlib.sha256(content).hexdigest()
@@ -49,7 +50,7 @@ async def upload_file_simple(
         with open(file_path, "wb") as f:
             f.write(content)
 
-        print(f"✅ Файл сохранен: {file_path}")
+        logger.info("Simple file upload saved")
 
         return {
             "success": True,
@@ -61,6 +62,6 @@ async def upload_file_simple(
             "file_path": file_path,
         }
 
-    except Exception as e:
-        print(f"❌ Ошибка загрузки: {e}")
-        raise HTTPException(status_code=500, detail=f"Ошибка загрузки файла: {str(e)}")
+    except Exception as exc:
+        logger.error("Simple file upload failed error_type=%s", type(exc).__name__)
+        raise HTTPException(status_code=500, detail="Ошибка загрузки файла") from None


### PR DESCRIPTION
## Summary

- Replaced raw `print(...)` statements in the simple file upload duplicate service with module logging.
- Removed filename, username, saved path, file size, and raw exception text from runtime logs.
- Preserved existing upload response contract and storage behavior.

## Contract Impact

- Canonical surface: `upload_file_simple` service helper in `backend/app/services/file_upload_simple_api_service.py`
- Request shape: unchanged `UploadFile`, optional `title`, injected `db`, injected `current_user`
- Response shape: unchanged success payload fields, including filename metadata and stored file path
- Status codes: unchanged success path; failure remains HTTP 500 with sanitized detail
- Frontend consumer: not applicable - no frontend code or API client changed
- Compatibility path or alias: not applicable - no router mounting or path alias changed
- Contract proof: `py_compile`, static search, and direct success/failure smoke for the helper

## RBAC / Permissions

- Roles allowed: unchanged, inherited from existing `get_current_user` dependency where routed
- Roles denied: unchanged, no authorization policy edited
- Positive auth proof: not applicable - this slice does not edit auth/RBAC behavior
- Negative auth proof: not applicable - this slice does not edit auth/RBAC behavior

## Notification / Realtime

not applicable - no notification, websocket, Telegram, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend state or rendering changed
- Partial data proof: not applicable - no frontend data consumer changed
- Forbidden secondary path behavior: not applicable - no routes or secondary paths changed
- Missing draft/resource behavior: not applicable - no draft/resource UI behavior changed
- Stale route/deep-link behavior: not applicable - no routing behavior changed

## Scope Gate

- Allowed paths: `backend/app/services/file_upload_simple_api_service.py`
- Denied paths: endpoint mounting, upload validation/security policy, storage location, auth/RBAC, migrations, generated output
- Migration/docs/test impact: no migration; no docs change; targeted local smoke used because existing behavior has no dedicated test
- Rollback note: revert the single service logging commit to restore previous logging behavior

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\services\file_upload_simple_api_service.py`; static search for removed `print(...)`, raw `str(e)`, old error detail, and sensitive logger fields; direct success/failure smoke for `upload_file_simple`; `git diff --check`
- Result: passed locally; GitHub CodeQL, GitGuardian, security scan, backend tests, frontend tests, formatting, docs, and quality/code checks passed in PR after initial run except documented external/non-code blockers
- Not checked: live browser upload flow and Vercel deployment, because this backend logging-only slice does not start the app and Vercel is rate-limited externally