### PR TITLE
docs(security): redact root auth report passwords

### DIFF
--- a/AUTHENTICATION_COMPLETE_FIX_REPORT.md
+++ b/AUTHENTICATION_COMPLETE_FIX_REPORT.md
@@ -112,7 +112,7 @@ if (err?.response?.data?.detail) {
 ```javascript
 // ✅ Добавлено:
 const username = formData.username || 'admin@example.com';
-const password = formData.password || 'admin123';
+const password = formData.password || '<redacted-demo-password>';
 
 const credentials = {
   username: username,
@@ -127,7 +127,7 @@ const credentials = {
 
 | Роль | Email | Пароль | Статус |
 |------|-------|--------|--------|
-| **Admin** | `admin@example.com` | `admin123` | ✅ |
+| **Admin** | `admin@example.com` | `[redacted demo password]` | ✅ |
 | **Registrar** | `registrar@example.com` | `registrar123` | ✅ |
 | **Lab** | `lab@example.com` | `lab123` | ✅ |
 | **Doctor** | `doctor@example.com` | `doctor123` | ✅ |

--- a/AUTHENTICATION_FIX_REPORT.md
+++ b/AUTHENTICATION_FIX_REPORT.md
@@ -133,7 +133,7 @@ const [username, setUsername] = useState('admin@example.com');
 ```python
 # Созданы пользователи для всех ролей:
 users_to_create = [
-    {"email": "admin@example.com", "password": "admin123", "role": "Admin"},
+    {"email": "admin@example.com", "password": "<redacted-demo-password>", "role": "Admin"},
     {"email": "registrar@example.com", "password": "registrar123", "role": "Registrar"},
     {"email": "lab@example.com", "password": "lab123", "role": "Lab"},
     {"email": "doctor@example.com", "password": "doctor123", "role": "Doctor"},
@@ -149,7 +149,7 @@ users_to_create = [
 ## ✅ РЕЗУЛЬТАТЫ ИСПРАВЛЕНИЯ
 
 ### Тестовые пользователи созданы для всех ролей:
-- **Admin:** `admin@example.com` / `admin123`
+- **Admin:** `admin@example.com` / `[redacted demo password]`
 - **Registrar:** `registrar@example.com` / `registrar123`
 - **Lab:** `lab@example.com` / `lab123`
 - **Doctor:** `doctor@example.com` / `doctor123`

--- a/CRITICAL_SECURITY_FIXES_COMPLETED.md
+++ b/CRITICAL_SECURITY_FIXES_COMPLETED.md
@@ -19,7 +19,7 @@
 ## 🎯 Выполненные задачи
 
 ### ✅ Task 1.1: Remove hardcoded credentials
-**Проблема:** Хардкод admin@example.com/admin123 в LoginFormStyled.jsx
+**Проблема:** Хардкод admin@example.com/[redacted demo password] в LoginFormStyled.jsx
 **Решение:**
 - Удалены дефолтные значения username/password из initial state
 - Добавлена валидация на пустые поля

--- a/FINAL_AUTHENTICATION_SUCCESS_REPORT.md
+++ b/FINAL_AUTHENTICATION_SUCCESS_REPORT.md
@@ -78,7 +78,7 @@
 
 | Роль | Email | Пароль | Статус |
 |------|-------|--------|--------|
-| **Admin** | `admin@example.com` | `admin123` | ✅ Создан |
+| **Admin** | `admin@example.com` | `[redacted demo password]` | ✅ Создан |
 | **Registrar** | `registrar@example.com` | `registrar123` | ✅ Создан |
 | **Lab** | `lab@example.com` | `lab123` | ✅ Создан |
 | **Doctor** | `doctor@example.com` | `doctor123` | ✅ Создан |

--- a/FINAL_SOLUTION_REPORT.md
+++ b/FINAL_SOLUTION_REPORT.md
@@ -94,7 +94,7 @@ npm run dev
 
 ### **Вход в систему:**
 - **Логин**: admin
-- **Пароль**: admin123
+- **Пароль**: [redacted demo password]
 
 ---
 

--- a/FRONTEND_SECURITY_FIX_PLAN.md
+++ b/FRONTEND_SECURITY_FIX_PLAN.md
@@ -60,13 +60,13 @@
 // Строки 35-36, 66-67
 const [formData, setFormData] = useState({
   username: 'admin@example.com',  // ❌ КРИТИЧНО
-  password: 'admin123',             // ❌ КРИТИЧНО
+  password: '<hardcoded-password>',  // ❌ КРИТИЧНО
   loginType: 'username'
 });
 
 // Строки 66-67 - используются как fallback
 const username = formData.username || 'admin@example.com';  // ❌
-const password = formData.password || 'admin123';            // ❌
+const password = formData.password || '<hardcoded-password>'; // ❌
 ```
 
 #### Решение
@@ -87,7 +87,7 @@ const [formData, setFormData] = useState({
 ```javascript
 // ❌ УДАЛИТЬ строки 66-67
 // const username = formData.username || 'admin@example.com';
-// const password = formData.password || 'admin123';
+// const password = formData.password || '<hardcoded-password>';
 
 // ✅ ЗАМЕНИТЬ на
 const username = formData.username;
@@ -106,7 +106,7 @@ if (!username || !password) {
 ```javascript
 // .env.development (НЕ коммитить!)
 VITE_DEV_USERNAME=admin@example.com
-VITE_DEV_PASSWORD=admin123
+VITE_DEV_PASSWORD=<set-locally>
 
 // В коде (только для разработки)
 const [formData, setFormData] = useState({

--- a/PROBLEMS_RESOLVED_REPORT.md
+++ b/PROBLEMS_RESOLVED_REPORT.md
@@ -26,7 +26,7 @@
 
 ### 3. **Аутентификация Admin** ✅ РЕШЕНО (ранее)
 - **Проблема**: Admin не мог войти в систему
-- **Решение**: Обновил пароль на `admin123`
+- **Решение**: Обновил пароль на redacted demo password
 - **Результат**: Admin успешно аутентифицируется
 
 ---
@@ -57,7 +57,7 @@
 ### **Admin пользователь** ✅ РАБОТАЕТ
 ```bash
 # Логин работает
-curl -X POST -d "username=admin&password=admin123&grant_type=password" \
+curl -X POST -d "username=admin&password=<redacted-demo-password>&grant_type=password" \
   http://localhost:18000/api/v1/auth/login
 
 # Возвращает JWT токен
@@ -102,7 +102,7 @@ npm run dev
 
 ### **4. Вход**
 - **Логин**: admin
-- **Пароль**: admin123
+- **Пароль**: [redacted demo password]
 
 ---
 

--- a/SYSTEM_FULLY_WORKING_REPORT.md
+++ b/SYSTEM_FULLY_WORKING_REPORT.md
@@ -33,7 +33,7 @@
 
 ### **Admin пользователь** ✅
 - **Логин**: admin
-- **Пароль**: admin123
+- **Пароль**: [redacted demo password]
 - **Роль**: Admin
 - **Статус**: ✅ АКТИВЕН
 - **JWT токен**: Генерируется корректно
@@ -41,7 +41,7 @@
 ### **API тестирование** ✅
 ```bash
 # Логин работает
-curl -X POST -d "username=admin&password=admin123&grant_type=password" \
+curl -X POST -d "username=admin&password=<redacted-demo-password>&grant_type=password" \
   http://localhost:18000/api/v1/auth/login
 # Возвращает: {"access_token":"...", "token_type":"bearer"}
 
@@ -59,7 +59,7 @@ curl -H "Authorization: Bearer <TOKEN>" \
 - **Проблема**: Admin не мог войти в систему
 - **Причина**: Неправильный хеш пароля
 - **Решение**: Пересоздан пароль с помощью Argon2
-- **Результат**: Admin успешно входит с паролем admin123
+- **Результат**: Admin успешно входит с redacted demo password
 
 ### 2. **Backend сервер** ✅ РАБОТАЕТ
 - **Проблема**: Возможные ошибки запуска
@@ -118,7 +118,7 @@ npm run dev
 
 ### **4. Вход в систему**
 - **Логин**: admin
-- **Пароль**: admin123
+- **Пароль**: [redacted demo password]
 - **Роль**: Admin (полный доступ)
 
 ---


### PR DESCRIPTION
﻿## Summary

- Redact remaining `admin123` examples from root authentication/security report markdown files.
- Replace the historical concrete password examples with `[redacted demo password]`, `<redacted-demo-password>`, or `<hardcoded-password>` placeholders.
- Leave runtime code, tests, scripts, environment files, and actual authentication behavior unchanged.

## Contract Impact

not applicable - documentation/report redaction only; no API route, request shape, response shape, status code, frontend consumer, compatibility alias, or contract behavior changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, token, permission, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, queue event, delivery state, reconnect, or realtime behavior changed.

## Frontend Resilience

not applicable - no frontend source, route, panel, data flow, empty state, partial data handling, or deep-link behavior changed.

## Scope Gate

- Allowed paths: the 8 root authentication/security report markdown files found by the `admin123` scan.
- Denied paths: backend runtime, frontend runtime, tests, scripts, environment files, generated output, operational proof packs, and non-report docs.
- Migration/docs/test impact: docs/report text only; no migration or test source impact.
- Rollback note: revert this commit to restore the previous historical report wording.

## Validation

- Targeted tests or smoke run: targeted `rg -n -S "admin123"` across the edited report files; full filtered `admin123` scan to confirm remaining hits are outside this docs slice; path allowlist check; `git diff --check`; PR body gate.
- Result: passed; edited report files no longer contain `admin123`.
- Not checked: backend/frontend runtime suites locally, because this PR changes only historical report markdown text; CI runs the repository gates.
