### PR TITLE
fix(queue): show missing token error on bare join route

### DIFF
--- a/frontend/src/pages/QueueJoin.jsx
+++ b/frontend/src/pages/QueueJoin.jsx
@@ -94,6 +94,8 @@ const formatSpecialistLabel = (specialist) => {
     .join(' • ');
 };
 
+const MISSING_QUEUE_TOKEN_MESSAGE = 'QR-код не найден. Откройте ссылку из клиники или отсканируйте QR-код заново.';
+
 const QueueJoin = () => {
   const { token: paramToken } = useParams();
   const [searchParams] = useSearchParams();
@@ -203,8 +205,12 @@ const QueueJoin = () => {
   }, []);
 
   useEffect(() => {
+    if (!token) {
+      setIsSpecialistsLoading(false);
+      return;
+    }
     loadSpecialists();
-  }, [loadSpecialists]);
+  }, [loadSpecialists, token]);
 
   // ✅ Функции объявлены до использования в useEffect
   const startJoinSession = useCallback(async () => {
@@ -228,6 +234,12 @@ const QueueJoin = () => {
   }, [getApiErrorMessage, token]);
 
   const loadTokenInfo = useCallback(async () => {
+    if (!token) {
+      setError(MISSING_QUEUE_TOKEN_MESSAGE);
+      setStep('error');
+      return;
+    }
+
     try {
       setStep('loading');
       const tokenInfo = await fetchQrTokenInfo(token);
@@ -271,14 +283,20 @@ const QueueJoin = () => {
 
   // Загрузка информации о токене при монтировании
   useEffect(() => {
-    if (token) {
-      // ✅ Пытаемся восстановить session_token из localStorage
-      const savedSessionToken = localStorage.getItem(`queue_session_${token}`);
-      if (savedSessionToken) {
-        setSessionToken(savedSessionToken);
-      }
-      loadTokenInfo();
+    if (!token) {
+      setSessionToken(null);
+      setQueueInfo(null);
+      setError(MISSING_QUEUE_TOKEN_MESSAGE);
+      setStep('error');
+      return;
     }
+
+    // ✅ Пытаемся восстановить session_token из localStorage
+    const savedSessionToken = localStorage.getItem(`queue_session_${token}`);
+    if (savedSessionToken) {
+      setSessionToken(savedSessionToken);
+    }
+    loadTokenInfo();
   }, [token, loadTokenInfo]);
 
   // Обратный отсчет до открытия очереди

--- a/frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx
+++ b/frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx
@@ -59,6 +59,16 @@ function renderQueueJoin(token = 'test-token') {
   );
 }
 
+function renderBareQueueJoin() {
+  return render(
+    <MemoryRouter initialEntries={['/queue/join']}>
+      <Routes>
+        <Route path="/queue/join" element={<QueueJoin />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 describe('QueueJoin Accessibility & UX', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -75,6 +85,16 @@ describe('QueueJoin Accessibility & UX', () => {
     window.localStorage.clear = vi.fn(() => {
       storage.clear();
     });
+  });
+
+  it('shows a missing token error for the bare join route without calling queue APIs', async () => {
+    renderBareQueueJoin();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/QR-код не найден/i);
+    expect(queueApiMocks.fetchQrTokenInfo).not.toHaveBeenCalled();
+    expect(queueApiMocks.startQueueJoinSession).not.toHaveBeenCalled();
+    expect(queueApiMocks.fetchPublicQueueProfiles).not.toHaveBeenCalled();
+    expect(queueApiMocks.fetchAvailableSpecialists).not.toHaveBeenCalled();
   });
 
   it('exposes labeled required fields and announces validation errors', async () => {


### PR DESCRIPTION
﻿## Summary

- Show a recoverable missing-token error when the public `/queue/join` route is opened without a QR token.
- Avoid calling public queue APIs when no token is available.
- Add a regression test for the bare join route while keeping the tokenized `/queue/join/:token` flow unchanged.

## Contract Impact

- Canonical surface: `frontend/src/pages/QueueJoin.jsx` and `frontend/src/routing/routeRegistry.js` public queue routes.
- Request shape: unchanged - no backend request payloads changed.
- Response shape: unchanged - no backend response parsing changed for tokenized queue links.
- Status codes: unchanged - no backend endpoint behavior changed.
- Frontend consumer: public queue join page now renders an explicit error for `/queue/join` without token instead of staying in loading state.
- Compatibility path or alias: unchanged - existing `/queue/join` and `/queue/join/:token` routes remain registered.
- Contract proof: targeted QueueJoin regression test, route contract test, and production build passed locally.

## RBAC / Permissions

- Roles allowed: unchanged - queue join remains a public route.
- Roles denied: unchanged - no auth guard, role helper, or backend permission branch changed.
- Positive auth proof: not run because the route is public and this slice does not edit authenticated flows.
- Negative auth proof: not run because no forbidden/allowed role logic changed.

## Notification / Realtime

not applicable - no notification, websocket, queue event delivery, reconnect, Telegram, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: bare `/queue/join` now shows `QR-код не найден...` instead of indefinite loading.
- Partial data proof: unchanged for tokenized links; the existing QR token API flow still loads token info before rendering queue data.
- Forbidden secondary path behavior: unchanged - no navigation guard or forbidden route branch changed.
- Missing draft/resource behavior: missing QR token is handled as a user-visible error state.
- Stale route/deep-link behavior: `/queue/join/:token` and `?token=` paths still resolve through the existing token lookup logic.

## Scope Gate

- Allowed paths: `frontend/src/pages/QueueJoin.jsx`, `frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx`.
- Denied paths: backend queue APIs, route registry, queue fairness logic, specialist mapping, auth/RBAC, generated output, and unrelated UI audit changes from PR #389.
- Migration/docs/test impact: no migration or docs change; adds one focused frontend regression test.
- Rollback note: revert this PR to restore the previous bare-route loading behavior.

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/pages/__tests__/QueueJoin.accessibility.test.jsx`; `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js`; `npm.cmd run build`; `git diff --check`.
- Result: passed locally. QueueJoin test reported 6 tests passed; route contract reported 13 tests passed; build completed with existing Vite chunk/dynamic-import warnings only.
- Not checked: live browser QR scan flow; CI will rerun repository gates.
