### PR TITLE
fix(a11y): add global search combobox semantics

### DIFF
--- a/frontend/src/components/search/GlobalSearchBar.jsx
+++ b/frontend/src/components/search/GlobalSearchBar.jsx
@@ -221,6 +221,16 @@ export default function GlobalSearchBar({ className = '' }) {
   };
 
   const hasResults = results.patients.length > 0 || results.visits.length > 0 || results.labResults.length > 0;
+  const listboxId = 'global-search-results';
+  const activeOptionId = selectedIndex >= 0 ? `global-search-option-${selectedIndex}` : undefined;
+  const searchStatus = isLoading
+    ? 'Поиск...'
+    : query.length < 2
+      ? 'Начните ввод, минимум 2 символа'
+      : hasResults
+        ? 'Результаты поиска доступны'
+        : 'Ничего не найдено';
+
   const handleResultItemKeyDown = (event, onActivate) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
@@ -340,6 +350,17 @@ export default function GlobalSearchBar({ className = '' }) {
       padding: '20px',
       textAlign: 'center',
       color: 'var(--mac-text-tertiary, #64748b)'
+    },
+    srOnly: {
+      position: 'absolute',
+      width: '1px',
+      height: '1px',
+      padding: 0,
+      margin: '-1px',
+      overflow: 'hidden',
+      clip: 'rect(0, 0, 0, 0)',
+      whiteSpace: 'nowrap',
+      border: 0
     }
   };
 
@@ -357,13 +378,25 @@ export default function GlobalSearchBar({ className = '' }) {
           onFocus={() => setIsOpen(true)}
           onKeyDown={handleKeyDown}
           placeholder="Поиск пациентов, визитов..."
+          aria-label="Глобальный поиск пациентов, визитов и анализов"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          aria-activedescendant={activeOptionId}
           style={styles.input} />
-        
+
                 <span style={styles.shortcut}>⌘K</span>
+                <span style={styles.srOnly} role="status" aria-live="polite">{searchStatus}</span>
             </div>
 
             {isOpen && ReactDOM.createPortal(
-        <div style={styles.dropdown} ref={dropdownRef}>
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label="Результаты глобального поиска"
+          style={styles.dropdown}
+          ref={dropdownRef}>
                     {isLoading &&
           <div style={styles.loading}>Поиск...</div>
           }
@@ -384,16 +417,19 @@ export default function GlobalSearchBar({ className = '' }) {
                                     <div style={styles.sectionTitle}>Пациенты</div>
                                     {results.patients.map((p) => {
                 flatIndex++;
-                const isSelected = flatIndex === selectedIndex;
+                const itemIndex = flatIndex;
+                const isSelected = itemIndex === selectedIndex;
                 return (
                   <div
                     key={`patient-${p.id}`}
-                    role="button"
+                    id={`global-search-option-${itemIndex}`}
+                    role="option"
+                    aria-selected={isSelected}
                     tabIndex={0}
                     style={{ ...styles.item, ...(isSelected ? styles.itemSelected : {}) }}
                     onClick={() => handleItemClick('patient', p)}
                     onKeyDown={(event) => handleResultItemKeyDown(event, () => handleItemClick('patient', p))}
-                    onMouseEnter={() => setSelectedIndex(flatIndex)}>
+                    onMouseEnter={() => setSelectedIndex(itemIndex)}>
                     
                                                 <span style={styles.itemIcon}>👤</span>
                                                 <div style={styles.itemContent}>
@@ -416,16 +452,19 @@ export default function GlobalSearchBar({ className = '' }) {
                                     <div style={styles.sectionTitle}>Визиты</div>
                                     {results.visits.map((v) => {
                 flatIndex++;
-                const isSelected = flatIndex === selectedIndex;
+                const itemIndex = flatIndex;
+                const isSelected = itemIndex === selectedIndex;
                 return (
                   <div
                     key={`visit-${v.id}`}
-                    role="button"
+                    id={`global-search-option-${itemIndex}`}
+                    role="option"
+                    aria-selected={isSelected}
                     tabIndex={0}
                     style={{ ...styles.item, ...(isSelected ? styles.itemSelected : {}) }}
                     onClick={() => handleItemClick('visit', v)}
                     onKeyDown={(event) => handleResultItemKeyDown(event, () => handleItemClick('visit', v))}
-                    onMouseEnter={() => setSelectedIndex(flatIndex)}>
+                    onMouseEnter={() => setSelectedIndex(itemIndex)}>
                     
                                                 <span style={styles.itemIcon}>📋</span>
                                                 <div style={styles.itemContent}>
@@ -448,17 +487,20 @@ export default function GlobalSearchBar({ className = '' }) {
                                     <div style={styles.sectionTitle}>Анализы</div>
                                     {results.labResults.map((l) => {
                 flatIndex++;
-                const isSelected = flatIndex === selectedIndex;
+                const itemIndex = flatIndex;
+                const isSelected = itemIndex === selectedIndex;
                 const statusIcon = l.status === 'done' ? '🟢' : l.status === 'in_progress' ? '🟡' : '⚪';
                 return (
                   <div
                     key={`lab-${l.id}`}
-                    role="button"
+                    id={`global-search-option-${itemIndex}`}
+                    role="option"
+                    aria-selected={isSelected}
                     tabIndex={0}
                     style={{ ...styles.item, ...(isSelected ? styles.itemSelected : {}) }}
                     onClick={() => handleItemClick('lab', l)}
                     onKeyDown={(event) => handleResultItemKeyDown(event, () => handleItemClick('lab', l))}
-                    onMouseEnter={() => setSelectedIndex(flatIndex)}>
+                    onMouseEnter={() => setSelectedIndex(itemIndex)}>
                     
                                                 <span style={styles.itemIcon}>{statusIcon}</span>
                                                 <div style={styles.itemContent}>


### PR DESCRIPTION
﻿## Summary

- Add combobox/listbox semantics to the global search input and results portal.
- Expose active search result state with `aria-activedescendant` and `aria-selected`.
- Add a polite screen-reader status message for loading, short queries, available results, and empty results without changing search API calls or navigation behavior.

## Contract Impact

- Canonical surface: `frontend/src/components/search/GlobalSearchBar.jsx`.
- Request shape: unchanged - `/global-search` and click-log request payloads are not edited.
- Response shape: unchanged - result grouping and result item handling are not edited.
- Status codes: unchanged - no backend behavior changed.
- Frontend consumer: header/global search keeps the same visual input and result actions, now with ARIA semantics for assistive tech.
- Compatibility path or alias: unchanged - no route or URL behavior changed.
- Contract proof: HeaderNew test, frontend build, and diff hygiene passed locally.

## RBAC / Permissions

- Roles allowed: unchanged - no auth, role, permission, or route guard code changed.
- Roles denied: unchanged.
- Positive auth proof: not run because this is a static frontend accessibility metadata slice.
- Negative auth proof: not run because no permission branch or protected route changed.

## Notification / Realtime

not applicable - no notification, websocket, queue event delivery, reconnect, Telegram, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: search now announces `Ничего не найдено` when no grouped results are available for a valid query.
- Partial data proof: unchanged - existing grouped patient/visit/lab rendering logic is preserved.
- Forbidden secondary path behavior: unchanged - no navigation guard or secondary path changed.
- Missing draft/resource behavior: unchanged - no draft/resource state changed.
- Stale route/deep-link behavior: unchanged - no routing behavior changed.

## Scope Gate

- Allowed paths: `frontend/src/components/search/GlobalSearchBar.jsx`.
- Denied paths: backend search API, routing, auth/RBAC, layout shell, Health page, Landing page, generated output, and other UI-audit changes from PR #389.
- Migration/docs/test impact: no migration or docs change; no test source change.
- Rollback note: revert this PR to remove the new ARIA combobox/listbox metadata while keeping existing visual search behavior.

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/components/layout/__tests__/HeaderNew.test.jsx`; `npm.cmd run build`; `git diff --check`.
- Result: passed locally. HeaderNew test reported 3 tests passed; build completed with existing Vite chunk/dynamic-import warnings only.
- Not checked: browser screen-reader smoke; CI will rerun repository gates.
