### PR TITLE
test(security): require env passwords for root auth smokes

### DIFF
--- a/check_passwords.py
+++ b/check_passwords.py
@@ -13,7 +13,19 @@ def check_passwords():
     """Проверяем пароли пользователей"""
     print("🔍 Проверка паролей пользователей...")
     
-    test_passwords = ["admin", "test123", "registrar", "doctor"]
+    test_passwords = [
+        value
+        for value in (
+            os.getenv("QA_ADMIN_PASSWORD"),
+            os.getenv("QA_MCP_PASSWORD"),
+            os.getenv("QA_REGISTRAR_PASSWORD"),
+            os.getenv("QA_DOCTOR_PASSWORD"),
+        )
+        if value
+    ]
+    if not test_passwords:
+        print("Set QA_ADMIN_PASSWORD, QA_MCP_PASSWORD, QA_REGISTRAR_PASSWORD, or QA_DOCTOR_PASSWORD before running this legacy password check.")
+        return
     
     try:
         with engine.connect() as conn:
@@ -35,8 +47,10 @@ def check_passwords():
                     print(f"   Пароль '{test_password}': {'✅' if is_valid else '❌'}")
                 
                 # Попробуем создать новый хеш для тестирования
-                new_hash = get_password_hash("test123")
-                print(f"   Новый хеш для 'test123': {new_hash[:50]}...")
+                sample_password = os.getenv("QA_MCP_PASSWORD")
+                if sample_password:
+                    new_hash = get_password_hash(sample_password)
+                    print(f"   Новый хеш для QA_MCP_PASSWORD: {new_hash[:50]}...")
                 
     except Exception as e:
         print(f"❌ Ошибка: {e}")

--- a/check_passwords.py
+++ b/check_passwords.py
@@ -6,7 +6,7 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'backend'))
 
 from backend.app.db.session import engine
-from backend.app.core.security import verify_password, get_password_hash
+from backend.app.core.security import verify_password
 from sqlalchemy import text
 
 def check_passwords():
@@ -40,17 +40,11 @@ def check_passwords():
             for user_id, username, email, hashed_password in users:
                 print(f"\n👤 Пользователь: {username} (ID: {user_id})")
                 print(f"   Email: {email}")
-                print(f"   Хеш пароля: {hashed_password[:50]}...")
+                print("   Хеш пароля: <stored>")
                 
-                for test_password in test_passwords:
+                for index, test_password in enumerate(test_passwords, start=1):
                     is_valid = verify_password(test_password, hashed_password)
-                    print(f"   Пароль '{test_password}': {'✅' if is_valid else '❌'}")
-                
-                # Попробуем создать новый хеш для тестирования
-                sample_password = os.getenv("QA_MCP_PASSWORD")
-                if sample_password:
-                    new_hash = get_password_hash(sample_password)
-                    print(f"   Новый хеш для QA_MCP_PASSWORD: {new_hash[:50]}...")
+                    print(f"   QA password #{index}: {'✅' if is_valid else '❌'}")
                 
     except Exception as e:
         print(f"❌ Ошибка: {e}")

--- a/create_mcp_test_user.py
+++ b/create_mcp_test_user.py
@@ -13,6 +13,11 @@ def create_test_user():
     """Создаем тестового пользователя с известным паролем"""
     print("🔧 Создание тестового пользователя для MCP...")
     
+    password = os.getenv("QA_MCP_PASSWORD")
+    if not password:
+        print("Set QA_MCP_PASSWORD before running this legacy MCP test user helper.")
+        return
+
     try:
         with engine.connect() as conn:
             # Проверяем, есть ли уже тестовый пользователь
@@ -25,7 +30,7 @@ def create_test_user():
             if existing_user:
                 print("✅ Тестовый пользователь уже существует")
                 # Обновляем пароль
-                password_hash = get_password_hash("test123")
+                password_hash = get_password_hash(password)
                 conn.execute(text("""
                     UPDATE users 
                     SET hashed_password = :password_hash, is_active = 1
@@ -35,7 +40,7 @@ def create_test_user():
                 print("✅ Пароль обновлен")
             else:
                 # Создаем нового пользователя
-                password_hash = get_password_hash("test123")
+                password_hash = get_password_hash(password)
                 conn.execute(text("""
                     INSERT INTO users (username, email, full_name, role, is_active, is_superuser, hashed_password)
                     VALUES ('mcp_test', 'mcp_test@example.com', 'MCP Test User', 'Admin', 1, 1, :password_hash)
@@ -45,7 +50,7 @@ def create_test_user():
             
             print("\n📋 Учетные данные для тестирования:")
             print("  Username: mcp_test")
-            print("  Password: test123")
+            print("  Password: <QA_MCP_PASSWORD>")
             print("  Role: Admin")
             print("  Email: mcp_test@example.com")
             

--- a/create_mcp_test_user_backend.py
+++ b/create_mcp_test_user_backend.py
@@ -17,6 +17,11 @@ def create_test_user_in_backend_db():
     print(f"🔧 Создание тестового пользователя в backend базе данных...")
     print(f"📁 База данных: {DATABASE_URL}")
     
+    password = os.getenv("QA_MCP_PASSWORD")
+    if not password:
+        print("Set QA_MCP_PASSWORD before running this legacy MCP test user helper.")
+        return
+
     try:
         with engine.connect() as conn:
             # Проверяем, есть ли уже тестовый пользователь
@@ -29,7 +34,7 @@ def create_test_user_in_backend_db():
             if existing_user:
                 print("✅ Тестовый пользователь уже существует")
                 # Обновляем пароль
-                password_hash = get_password_hash("test123")
+                password_hash = get_password_hash(password)
                 conn.execute(text("""
                     UPDATE users 
                     SET hashed_password = :password_hash, is_active = 1
@@ -39,7 +44,7 @@ def create_test_user_in_backend_db():
                 print("✅ Пароль обновлен")
             else:
                 # Создаем нового пользователя
-                password_hash = get_password_hash("test123")
+                password_hash = get_password_hash(password)
                 conn.execute(text("""
                     INSERT INTO users (username, email, full_name, role, is_active, is_superuser, hashed_password)
                     VALUES ('mcp_test', 'mcp_test@example.com', 'MCP Test User', 'Admin', 1, 1, :password_hash)
@@ -49,7 +54,7 @@ def create_test_user_in_backend_db():
             
             print("\n📋 Учетные данные для тестирования:")
             print("  Username: mcp_test")
-            print("  Password: test123")
+            print("  Password: <QA_MCP_PASSWORD>")
             print("  Role: Admin")
             print("  Email: mcp_test@example.com")
             

--- a/create_password_hashes.py
+++ b/create_password_hashes.py
@@ -24,19 +24,18 @@ def update_passwords():
         'lab@example.com': os.getenv('QA_LAB_PASSWORD'),
         'cashier@example.com': os.getenv('QA_CASHIER_PASSWORD')
     }
-    missing = [email for email, password in passwords.items() if not password]
+    missing = [email for email, env_password in passwords.items() if not env_password]
     if missing:
         print("Set role-specific QA_*_PASSWORD environment variables before running this legacy password update helper.")
-        print(f"Missing passwords for: {', '.join(missing)}")
+        print(f"Missing env values for {len(missing)} account(s).")
         return
     
     print("🔐 Создаем хеши паролей...")
     
     db = SessionLocal()
     try:
-        for email, password in passwords.items():
-            password_hash = get_password_hash(password)
-            print(f"📧 {email}: <env password> -> {password_hash[:30]}...")
+        for email, env_password in passwords.items():
+            password_hash = get_password_hash(env_password)
             
             # Обновляем пароль в БД
             db.execute(text("UPDATE users SET hashed_password = :hash WHERE email = :email"), {
@@ -52,7 +51,7 @@ def update_passwords():
         users = result.fetchall()
         print("\n👥 Пользователи с обновленными паролями:")
         for user in users:
-            print(f"  - {user[0]}: {user[1][:30]}...")
+            print(f"  - {user[0]}: stored hash present")
             
     except Exception as e:
         print(f"❌ Ошибка при обновлении паролей: {e}")

--- a/create_password_hashes.py
+++ b/create_password_hashes.py
@@ -15,15 +15,20 @@ def update_passwords():
     
     # Создаем хеши для паролей
     passwords = {
-        'admin@example.com': 'admin123',
-        'doctor@example.com': 'doctor123', 
-        'registrar@example.com': 'registrar123',
-        'cardio@example.com': 'cardio123',
-        'derma@example.com': 'derma123',
-        'dentist@example.com': 'dentist123',
-        'lab@example.com': 'lab123',
-        'cashier@example.com': 'cashier123'
+        'admin@example.com': os.getenv('QA_ADMIN_PASSWORD'),
+        'doctor@example.com': os.getenv('QA_DOCTOR_PASSWORD'),
+        'registrar@example.com': os.getenv('QA_REGISTRAR_PASSWORD'),
+        'cardio@example.com': os.getenv('QA_CARDIO_PASSWORD'),
+        'derma@example.com': os.getenv('QA_DERMA_PASSWORD'),
+        'dentist@example.com': os.getenv('QA_DENTIST_PASSWORD'),
+        'lab@example.com': os.getenv('QA_LAB_PASSWORD'),
+        'cashier@example.com': os.getenv('QA_CASHIER_PASSWORD')
     }
+    missing = [email for email, password in passwords.items() if not password]
+    if missing:
+        print("Set role-specific QA_*_PASSWORD environment variables before running this legacy password update helper.")
+        print(f"Missing passwords for: {', '.join(missing)}")
+        return
     
     print("🔐 Создаем хеши паролей...")
     
@@ -31,7 +36,7 @@ def update_passwords():
     try:
         for email, password in passwords.items():
             password_hash = get_password_hash(password)
-            print(f"📧 {email}: {password} -> {password_hash[:30]}...")
+            print(f"📧 {email}: <env password> -> {password_hash[:30]}...")
             
             # Обновляем пароль в БД
             db.execute(text("UPDATE users SET hashed_password = :hash WHERE email = :email"), {

--- a/test_auth_debug.py
+++ b/test_auth_debug.py
@@ -24,7 +24,7 @@ def test_auth_debug():
     }
     
     print(f"URL: {url}")
-    print(f"Data: {json.dumps({**data, 'password': '<redacted>'}, indent=2)}")
+    print("Data: <redacted credentials>")
     print(f"Headers: {json.dumps(headers, indent=2)}")
     
     try:

--- a/test_auth_debug.py
+++ b/test_auth_debug.py
@@ -3,15 +3,20 @@
 """
 import requests
 import json
+import os
 
 def test_auth_debug():
     """Тест авторизации с отладкой"""
     print("🔍 Тестирование авторизации с отладкой...")
     
     url = "http://localhost:18000/api/v1/auth/minimal-login"
+    mcp_password = os.getenv("QA_MCP_PASSWORD")
+    if not mcp_password:
+        print("Set QA_MCP_PASSWORD before running this legacy auth smoke script.")
+        return None
     data = {
-        "username": "mcp_test",
-        "password": "test123"
+        "username": os.getenv("QA_MCP_USERNAME", "mcp_test"),
+        "password": mcp_password
     }
     headers = {
         "Content-Type": "application/json",
@@ -19,7 +24,7 @@ def test_auth_debug():
     }
     
     print(f"URL: {url}")
-    print(f"Data: {json.dumps(data, indent=2)}")
+    print(f"Data: {json.dumps({**data, 'password': '<redacted>'}, indent=2)}")
     print(f"Headers: {json.dumps(headers, indent=2)}")
     
     try:

--- a/test_auth_logic.py
+++ b/test_auth_logic.py
@@ -13,8 +13,11 @@ def test_auth_logic():
     """Тестируем логику авторизации"""
     print("🔍 Тестирование логики авторизации...")
     
-    username = "mcp_test"
-    password = "test123"
+    username = os.getenv("QA_MCP_USERNAME", "mcp_test")
+    password = os.getenv("QA_MCP_PASSWORD")
+    if not password:
+        print("Set QA_MCP_PASSWORD before running this legacy auth logic smoke script.")
+        return False
     
     try:
         # Используем get_db как в сервере

--- a/test_auth_simple.py
+++ b/test_auth_simple.py
@@ -3,15 +3,20 @@
 """
 import requests
 import json
+import os
 
 def test_auth():
     """Тест авторизации"""
     print("🔍 Тестирование авторизации...")
     
     try:
+        mcp_password = os.getenv("QA_MCP_PASSWORD")
+        if not mcp_password:
+            print("Set QA_MCP_PASSWORD before running this legacy auth smoke script.")
+            return None
         response = requests.post(
             "http://localhost:18000/api/v1/auth/minimal-login",
-            json={"username": "mcp_test", "password": "test123"},
+            json={"username": os.getenv("QA_MCP_USERNAME", "mcp_test"), "password": mcp_password},
             headers={
                 "Content-Type": "application/json",
                 "Origin": "http://localhost:8080"

--- a/test_backend.py
+++ b/test_backend.py
@@ -4,6 +4,7 @@
 """
 import requests
 import json
+import os
 
 def test_health():
     """Тест health endpoint"""
@@ -19,9 +20,13 @@ def test_health():
 def test_login():
     """Тест login endpoint"""
     try:
+        admin_password = os.getenv("QA_ADMIN_PASSWORD")
+        if not admin_password:
+            print("Set QA_ADMIN_PASSWORD before running this legacy auth smoke script.")
+            return False
         data = {
-            "username": "admin@example.com",
-            "password": "admin123",
+            "username": os.getenv("QA_ADMIN_USERNAME", "admin@example.com"),
+            "password": admin_password,
             "remember_me": False
         }
         
@@ -29,7 +34,7 @@ def test_login():
             "Content-Type": "application/json"
         }
         
-        print(f"Sending login request with data: {data}")
+        print(f"Sending login request with data: {dict(data, password='<redacted>')}")
         
         response = requests.post(
             "http://localhost:18000/api/v1/auth/login",

--- a/test_backend.py
+++ b/test_backend.py
@@ -34,7 +34,7 @@ def test_login():
             "Content-Type": "application/json"
         }
         
-        print(f"Sending login request with data: {dict(data, password='<redacted>')}")
+        print("Sending login request with redacted credentials")
         
         response = requests.post(
             "http://localhost:18000/api/v1/auth/login",

--- a/test_frontend_login.py
+++ b/test_frontend_login.py
@@ -5,6 +5,7 @@
 
 import httpx
 import time
+import os
 
 def test_frontend():
     """Тестируем фронтенд"""
@@ -56,9 +57,13 @@ def test_login():
     try:
         with httpx.Client() as client:
             # Тестируем логин
+            admin_password = os.getenv("QA_ADMIN_PASSWORD")
+            if not admin_password:
+                print("Set QA_ADMIN_PASSWORD before running this legacy frontend login smoke script.")
+                return
             data = {
-                "username": "admin",
-                "password": "admin123",
+                "username": os.getenv("QA_ADMIN_USERNAME", "admin"),
+                "password": admin_password,
                 "grant_type": "password"
             }
             

--- a/test_frontend_queue.py
+++ b/test_frontend_queue.py
@@ -282,7 +282,7 @@ if __name__ == "__main__":
     if success:
         print("\n🎯 РЕКОМЕНДАЦИИ:")
         print("1. Откройте http://localhost:5173/queue/join?token=test для тестирования")
-        print("2. Войдите как admin/admin123 в http://localhost:5173/login")
+        print("2. Войдите как admin/<QA_ADMIN_PASSWORD> в http://localhost:5173/login")
         print("3. Перейдите в панель регистратора для управления очередью")
         print("4. Протестируйте генерацию QR кодов и запись пациентов")
     else:

--- a/test_html_formatting.py
+++ b/test_html_formatting.py
@@ -3,18 +3,23 @@
 """
 import requests
 import json
+import os
 
 def test_html_tester_formatting():
     """Тестируем форматирование результатов"""
     print("🔍 Тестирование форматирования результатов...")
     
     base_url = "http://localhost:18000/api/v1"
+    mcp_password = os.getenv("QA_MCP_PASSWORD")
+    if not mcp_password:
+        print("Set QA_MCP_PASSWORD before running this legacy MCP smoke script.")
+        return
     
     # Получаем токен
     try:
         auth_response = requests.post(
             f"{base_url}/auth/minimal-login",
-            json={"username": "mcp_test", "password": "test123"},
+            json={"username": os.getenv("QA_MCP_USERNAME", "mcp_test"), "password": mcp_password},
             headers={"Content-Type": "application/json"}
         )
         

--- a/test_json_auth.py
+++ b/test_json_auth.py
@@ -23,7 +23,7 @@ def test_json_login():
             "Content-Type": "application/json"
         }
         
-        print(f"Sending JSON login request with data: {dict(data, password='<redacted>')}")
+        print("Sending JSON login request with redacted credentials")
         
         response = requests.post(
             "http://localhost:18000/api/v1/auth/json-login",

--- a/test_json_auth.py
+++ b/test_json_auth.py
@@ -4,13 +4,18 @@
 """
 import requests
 import json
+import os
 
 def test_json_login():
     """Тест JSON login endpoint"""
     try:
+        admin_password = os.getenv("QA_ADMIN_PASSWORD")
+        if not admin_password:
+            print("Set QA_ADMIN_PASSWORD before running this legacy auth smoke script.")
+            return False
         data = {
-            "username": "admin@example.com",
-            "password": "admin123",
+            "username": os.getenv("QA_ADMIN_USERNAME", "admin@example.com"),
+            "password": admin_password,
             "remember_me": False
         }
         
@@ -18,7 +23,7 @@ def test_json_login():
             "Content-Type": "application/json"
         }
         
-        print(f"Sending JSON login request with data: {data}")
+        print(f"Sending JSON login request with data: {dict(data, password='<redacted>')}")
         
         response = requests.post(
             "http://localhost:18000/api/v1/auth/json-login",

--- a/test_mcp_endpoints.py
+++ b/test_mcp_endpoints.py
@@ -3,12 +3,17 @@
 """
 import requests
 import json
+import os
 
 def test_mcp_endpoints():
     """Тестируем MCP endpoints"""
     print("🔍 Тестирование MCP endpoints...")
     
     base_url = "http://localhost:18000/api/v1"
+    mcp_password = os.getenv("QA_MCP_PASSWORD")
+    if not mcp_password:
+        print("Set QA_MCP_PASSWORD before running this legacy MCP smoke script.")
+        return
     
     # Сначала получаем токен
     print("🔐 Получение токена авторизации...")
@@ -16,7 +21,7 @@ def test_mcp_endpoints():
     try:
         auth_response = requests.post(
             f"{base_url}/auth/minimal-login",
-            json={"username": "mcp_test", "password": "test123"},
+            json={"username": os.getenv("QA_MCP_USERNAME", "mcp_test"), "password": mcp_password},
             headers={"Content-Type": "application/json"}
         )
         

--- a/test_minimal_auth.py
+++ b/test_minimal_auth.py
@@ -23,7 +23,7 @@ def test_minimal_login():
             "Content-Type": "application/json"
         }
         
-        print(f"Sending minimal login request with data: {dict(data, password='<redacted>')}")
+        print("Sending minimal login request with redacted credentials")
         
         response = requests.post(
             "http://localhost:18000/api/v1/auth/minimal-login",

--- a/test_minimal_auth.py
+++ b/test_minimal_auth.py
@@ -4,13 +4,18 @@
 """
 import requests
 import json
+import os
 
 def test_minimal_login():
     """Тест минимального login endpoint"""
     try:
+        admin_password = os.getenv("QA_ADMIN_PASSWORD")
+        if not admin_password:
+            print("Set QA_ADMIN_PASSWORD before running this legacy auth smoke script.")
+            return False
         data = {
-            "username": "admin@example.com",
-            "password": "admin123",
+            "username": os.getenv("QA_ADMIN_USERNAME", "admin@example.com"),
+            "password": admin_password,
             "remember_me": False
         }
         
@@ -18,7 +23,7 @@ def test_minimal_login():
             "Content-Type": "application/json"
         }
         
-        print(f"Sending minimal login request with data: {data}")
+        print(f"Sending minimal login request with data: {dict(data, password='<redacted>')}")
         
         response = requests.post(
             "http://localhost:18000/api/v1/auth/minimal-login",

--- a/test_new_auth.py
+++ b/test_new_auth.py
@@ -4,13 +4,18 @@
 """
 import requests
 import json
+import os
 
 def test_new_login():
     """Тест нового login endpoint"""
     try:
+        admin_password = os.getenv("QA_ADMIN_PASSWORD")
+        if not admin_password:
+            print("Set QA_ADMIN_PASSWORD before running this legacy auth smoke script.")
+            return False
         data = {
-            "username": "admin@example.com",
-            "password": "admin123",
+            "username": os.getenv("QA_ADMIN_USERNAME", "admin@example.com"),
+            "password": admin_password,
             "remember_me": False
         }
         
@@ -18,7 +23,7 @@ def test_new_login():
             "Content-Type": "application/json"
         }
         
-        print(f"Sending login request to /authentication/login with data: {data}")
+        print(f"Sending login request to /authentication/login with data: {dict(data, password='<redacted>')}")
         
         response = requests.post(
             "http://localhost:18000/api/v1/authentication/login",

--- a/test_new_auth.py
+++ b/test_new_auth.py
@@ -23,7 +23,7 @@ def test_new_login():
             "Content-Type": "application/json"
         }
         
-        print(f"Sending login request to /authentication/login with data: {dict(data, password='<redacted>')}")
+        print("Sending login request to /authentication/login with redacted credentials")
         
         response = requests.post(
             "http://localhost:18000/api/v1/authentication/login",

--- a/test_password_verification.py
+++ b/test_password_verification.py
@@ -32,7 +32,7 @@ def test_password_verification():
             
             print(f"👤 Пользователь: {username} (ID: {user_id})")
             print(f"   Email: {email}")
-            print(f"   Хеш пароля: {hashed_password[:50]}...")
+            print("   Хеш пароля: <stored>")
             
             # Тестируем разные пароли
             test_passwords = [
@@ -47,12 +47,12 @@ def test_password_verification():
                 print("Set QA_MCP_PASSWORD or QA_ADMIN_PASSWORD before running this legacy password verification smoke script.")
                 return
             
-            for password in test_passwords:
+            for index, password in enumerate(test_passwords, start=1):
                 try:
                     is_valid = verify_password(password, hashed_password)
-                    print(f"   Пароль '{password}': {'✅' if is_valid else '❌'}")
+                    print(f"   QA password #{index}: {'✅' if is_valid else '❌'}")
                 except Exception as e:
-                    print(f"   Пароль '{password}': ❌ Ошибка: {e}")
+                    print(f"   QA password #{index}: ❌ Ошибка: {e}")
             
             # Тестируем с пустым паролем
             try:

--- a/test_password_verification.py
+++ b/test_password_verification.py
@@ -35,7 +35,17 @@ def test_password_verification():
             print(f"   Хеш пароля: {hashed_password[:50]}...")
             
             # Тестируем разные пароли
-            test_passwords = ["test123", "admin", "password", "mcp_test"]
+            test_passwords = [
+                value
+                for value in (
+                    os.getenv("QA_MCP_PASSWORD"),
+                    os.getenv("QA_ADMIN_PASSWORD"),
+                )
+                if value
+            ]
+            if not test_passwords:
+                print("Set QA_MCP_PASSWORD or QA_ADMIN_PASSWORD before running this legacy password verification smoke script.")
+                return
             
             for password in test_passwords:
                 try:

--- a/test_payment_simple.py
+++ b/test_payment_simple.py
@@ -4,6 +4,7 @@
 """
 import requests
 import json
+import os
 from datetime import datetime
 
 BASE_URL = "http://localhost:18000/api/v1"
@@ -117,9 +118,13 @@ def test_auth_endpoint():
     
     try:
         # Пробуем правильный endpoint
+        admin_password = os.getenv("QA_ADMIN_PASSWORD")
+        if not admin_password:
+            print("Set QA_ADMIN_PASSWORD before running this legacy payment auth smoke script.")
+            return None
         response = requests.post(f"{BASE_URL}/auth/login", data={
-            "username": "admin",
-            "password": "admin123"
+            "username": os.getenv("QA_ADMIN_USERNAME", "admin"),
+            "password": admin_password
         })
         
         if response.status_code == 200:

--- a/test_simple_auth.py
+++ b/test_simple_auth.py
@@ -4,13 +4,18 @@
 """
 import requests
 import json
+import os
 
 def test_simple_login():
     """Тест простого login endpoint"""
     try:
+        admin_password = os.getenv("QA_ADMIN_PASSWORD")
+        if not admin_password:
+            print("Set QA_ADMIN_PASSWORD before running this legacy auth smoke script.")
+            return False
         data = {
-            "username": "admin@example.com",
-            "password": "admin123",
+            "username": os.getenv("QA_ADMIN_USERNAME", "admin@example.com"),
+            "password": admin_password,
             "remember_me": False
         }
         
@@ -18,7 +23,7 @@ def test_simple_login():
             "Content-Type": "application/json"
         }
         
-        print(f"Sending simple login request with data: {data}")
+        print(f"Sending simple login request with data: {dict(data, password='<redacted>')}")
         
         response = requests.post(
             "http://localhost:18000/api/v1/auth/simple-login",

--- a/test_simple_auth.py
+++ b/test_simple_auth.py
@@ -23,7 +23,7 @@ def test_simple_login():
             "Content-Type": "application/json"
         }
         
-        print(f"Sending simple login request with data: {dict(data, password='<redacted>')}")
+        print("Sending simple login request with redacted credentials")
         
         response = requests.post(
             "http://localhost:18000/api/v1/auth/simple-login",

--- a/test_simple_server.py
+++ b/test_simple_server.py
@@ -23,7 +23,7 @@ def test_simple_server():
             "Content-Type": "application/json"
         }
         
-        print(f"Sending request to simple auth server with data: {dict(data, password='<redacted>')}")
+        print("Sending request to simple auth server with redacted credentials")
         
         response = requests.post(
             "http://localhost:8001/api/v1/auth/simple",

--- a/test_simple_server.py
+++ b/test_simple_server.py
@@ -4,13 +4,18 @@
 """
 import requests
 import json
+import os
 
 def test_simple_server():
     """Тест простого сервера авторизации"""
     try:
+        admin_password = os.getenv("QA_ADMIN_PASSWORD")
+        if not admin_password:
+            print("Set QA_ADMIN_PASSWORD before running this legacy auth smoke script.")
+            return False
         data = {
-            "username": "admin@example.com",
-            "password": "admin123",
+            "username": os.getenv("QA_ADMIN_USERNAME", "admin@example.com"),
+            "password": admin_password,
             "remember_me": False
         }
         
@@ -18,7 +23,7 @@ def test_simple_server():
             "Content-Type": "application/json"
         }
         
-        print(f"Sending request to simple auth server with data: {data}")
+        print(f"Sending request to simple auth server with data: {dict(data, password='<redacted>')}")
         
         response = requests.post(
             "http://localhost:8001/api/v1/auth/simple",


### PR DESCRIPTION
﻿## Summary

- Replace hardcoded `admin123`, `test123`, and role `*123` passwords in root legacy/manual Python auth smoke helpers with explicit `QA_*_PASSWORD` environment variables.
- Keep the smoke scripts runnable with locally supplied credentials instead of checked-in defaults.
- Redact password payload logging, password/hash output, and CodeQL-sensitive secret echoes in the edited helpers.

## Contract Impact

- Canonical surface: root legacy/manual Python smoke helper files listed in this PR diff.
- Request shape: unchanged for runtime APIs; manual smoke scripts now read credentials from env before sending the same auth requests.
- Response shape: unchanged - scripts still consume the same auth responses.
- Status codes: unchanged - no backend endpoint behavior changed.
- Frontend consumer: unchanged - React frontend code is not edited; `test_frontend_login.py` and `test_frontend_queue.py` are root manual helpers only.
- Compatibility path or alias: unchanged - no route, URL alias, or endpoint mount changed.
- Contract proof: targeted default-password scan, `py_compile` for all edited Python files, diff hygiene, PR body gate, and CodeQL-sensitive logging remediation.

## RBAC / Permissions

- Roles allowed: unchanged - no runtime role or permission rule changed.
- Roles denied: unchanged - no auth deny/allow branch changed.
- Positive auth proof: not run because real local QA credentials are intentionally required by this PR.
- Negative auth proof: not run because runtime auth/RBAC behavior is untouched.

## Notification / Realtime

not applicable - no notification, websocket, queue event delivery, reconnect, Telegram, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - no React frontend empty-state code changed.
- Partial data proof: unchanged - no frontend data consumer changed.
- Forbidden secondary path behavior: unchanged - no route guard or secondary path changed.
- Missing draft/resource behavior: unchanged - manual smoke scripts now stop early when required QA env vars are missing.
- Stale route/deep-link behavior: unchanged - no routing behavior changed.

## Scope Gate

- Allowed paths: root Python legacy auth smoke/helper files in the PR diff.
- Denied paths: backend runtime auth, database migrations, frontend app code, CI workflows, generated output, and canonical backend tests with fixture credentials.
- Migration/docs/test impact: no migration or docs change; root manual smoke helper behavior changes from checked-in demo passwords to required env vars.
- Rollback note: revert this PR to restore previous manual helper password defaults and logging behavior.

## Validation

- Targeted tests or smoke run: `rg -n -S "admin123|test123|doctor123|registrar123|cardio123|derma123|dentist123|lab123|cashier123" <19 edited files>`; `python -m py_compile <19 edited files>`; `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`; PR body gate.
- Result: passed locally; targeted default-password scan returned no matches, all edited Python files compile, diff hygiene passed, and local PR body gate passed.
- Not checked: live execution of manual smoke scripts, because this PR intentionally requires real local QA credentials via env vars.
