### PR TITLE
docs(security): redact role auth report passwords

### DIFF
--- a/AUTHENTICATION_COMPLETE_FIX_REPORT.md
+++ b/AUTHENTICATION_COMPLETE_FIX_REPORT.md
@@ -128,13 +128,13 @@ const credentials = {
 | Роль | Email | Пароль | Статус |
 |------|-------|--------|--------|
 | **Admin** | `admin@example.com` | `[redacted demo password]` | ✅ |
-| **Registrar** | `registrar@example.com` | `registrar123` | ✅ |
-| **Lab** | `lab@example.com` | `lab123` | ✅ |
-| **Doctor** | `doctor@example.com` | `doctor123` | ✅ |
-| **Cashier** | `cashier@example.com` | `cashier123` | ✅ |
-| **Cardiologist** | `cardio@example.com` | `cardio123` | ✅ |
-| **Dermatologist** | `derma@example.com` | `derma123` | ✅ |
-| **Dentist** | `dentist@example.com` | `dentist123` | ✅ |
+| **Registrar** | `registrar@example.com` | `<set-locally>` | ✅ |
+| **Lab** | `lab@example.com` | `<set-locally>` | ✅ |
+| **Doctor** | `doctor@example.com` | `<set-locally>` | ✅ |
+| **Cashier** | `cashier@example.com` | `<set-locally>` | ✅ |
+| **Cardiologist** | `cardio@example.com` | `<set-locally>` | ✅ |
+| **Dermatologist** | `derma@example.com` | `<set-locally>` | ✅ |
+| **Dentist** | `dentist@example.com` | `<set-locally>` | ✅ |
 
 ---
 

--- a/AUTHENTICATION_FIX_REPORT.md
+++ b/AUTHENTICATION_FIX_REPORT.md
@@ -134,13 +134,13 @@ const [username, setUsername] = useState('admin@example.com');
 # Созданы пользователи для всех ролей:
 users_to_create = [
     {"email": "admin@example.com", "password": "<redacted-demo-password>", "role": "Admin"},
-    {"email": "registrar@example.com", "password": "registrar123", "role": "Registrar"},
-    {"email": "lab@example.com", "password": "lab123", "role": "Lab"},
-    {"email": "doctor@example.com", "password": "doctor123", "role": "Doctor"},
-    {"email": "cashier@example.com", "password": "cashier123", "role": "Cashier"},
-    {"email": "cardio@example.com", "password": "cardio123", "role": "cardio"},
-    {"email": "derma@example.com", "password": "derma123", "role": "derma"},
-    {"email": "dentist@example.com", "password": "dentist123", "role": "dentist"},
+    {"email": "registrar@example.com", "password": "<set-locally>", "role": "Registrar"},
+    {"email": "lab@example.com", "password": "<set-locally>", "role": "Lab"},
+    {"email": "doctor@example.com", "password": "<set-locally>", "role": "Doctor"},
+    {"email": "cashier@example.com", "password": "<set-locally>", "role": "Cashier"},
+    {"email": "cardio@example.com", "password": "<set-locally>", "role": "cardio"},
+    {"email": "derma@example.com", "password": "<set-locally>", "role": "derma"},
+    {"email": "dentist@example.com", "password": "<set-locally>", "role": "dentist"},
 ]
 ```
 
@@ -150,13 +150,13 @@ users_to_create = [
 
 ### Тестовые пользователи созданы для всех ролей:
 - **Admin:** `admin@example.com` / `[redacted demo password]`
-- **Registrar:** `registrar@example.com` / `registrar123`
-- **Lab:** `lab@example.com` / `lab123`
-- **Doctor:** `doctor@example.com` / `doctor123`
-- **Cashier:** `cashier@example.com` / `cashier123`
-- **Cardiologist:** `cardio@example.com` / `cardio123`
-- **Dermatologist:** `derma@example.com` / `derma123`
-- **Dentist:** `dentist@example.com` / `dentist123`
+- **Registrar:** `registrar@example.com` / `<set-locally>`
+- **Lab:** `lab@example.com` / `<set-locally>`
+- **Doctor:** `doctor@example.com` / `<set-locally>`
+- **Cashier:** `cashier@example.com` / `<set-locally>`
+- **Cardiologist:** `cardio@example.com` / `<set-locally>`
+- **Dermatologist:** `derma@example.com` / `<set-locally>`
+- **Dentist:** `dentist@example.com` / `<set-locally>`
 
 ### Все API endpoints исправлены:
 - ✅ `client.js` - основной API клиент

--- a/FINAL_AUTHENTICATION_SUCCESS_REPORT.md
+++ b/FINAL_AUTHENTICATION_SUCCESS_REPORT.md
@@ -79,13 +79,13 @@
 | Роль | Email | Пароль | Статус |
 |------|-------|--------|--------|
 | **Admin** | `admin@example.com` | `[redacted demo password]` | ✅ Создан |
-| **Registrar** | `registrar@example.com` | `registrar123` | ✅ Создан |
-| **Lab** | `lab@example.com` | `lab123` | ✅ Создан |
-| **Doctor** | `doctor@example.com` | `doctor123` | ✅ Создан |
-| **Cashier** | `cashier@example.com` | `cashier123` | ✅ Создан |
-| **Cardiologist** | `cardio@example.com` | `cardio123` | ✅ Создан |
-| **Dermatologist** | `derma@example.com` | `derma123` | ✅ Создан |
-| **Dentist** | `dentist@example.com` | `dentist123` | ✅ Создан |
+| **Registrar** | `registrar@example.com` | `<set-locally>` | ✅ Создан |
+| **Lab** | `lab@example.com` | `<set-locally>` | ✅ Создан |
+| **Doctor** | `doctor@example.com` | `<set-locally>` | ✅ Создан |
+| **Cashier** | `cashier@example.com` | `<set-locally>` | ✅ Создан |
+| **Cardiologist** | `cardio@example.com` | `<set-locally>` | ✅ Создан |
+| **Dermatologist** | `derma@example.com` | `<set-locally>` | ✅ Создан |
+| **Dentist** | `dentist@example.com` | `<set-locally>` | ✅ Создан |
 
 ### ✅ Исправлены серверы:
 


### PR DESCRIPTION
﻿## Summary

- Redact role demo passwords from legacy authentication report markdown files.
- Keep account-role examples and status tables intact with `<set-locally>` placeholders.
- Leave runtime code, tests, scripts, and auth behavior unchanged.

## Contract Impact

not applicable - docs-only redaction, no API/router/service/schema surface, request/response shape, status code, frontend consumer, compatibility path, or runtime contract changed.

## RBAC / Permissions

not applicable - no role definitions, permission checks, guards, users, credential values, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, Telegram, push, or realtime behavior changed.

## Frontend Resilience

not applicable - no frontend application code, route state, panel behavior, or data loading flow changed.

## Scope Gate

- Allowed paths: AUTHENTICATION_COMPLETE_FIX_REPORT.md, AUTHENTICATION_FIX_REPORT.md, FINAL_AUTHENTICATION_SUCCESS_REPORT.md.
- Denied paths: runtime auth code, backend tests, root smoke scripts, migrations, frontend app code, generated output.
- Migration/docs/test impact: docs-only report text changed; no migration or test contract changed.
- Rollback note: revert this docs-only commit to restore previous report wording if needed.

## Validation

- Targeted tests or smoke run: credential literal scan over the three edited report files, plus diff hygiene with legacy CRLF-aware whitespace settings.
- Result: targeted scan returned no matches in the edited report files, and diff hygiene passed.
- Not checked: full backend/frontend suites were not run because this is docs-only redaction.
