### PR TITLE
fix(ui): constrain app shell width

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import './styles/dark-theme-visibility-fix.css';
 import './styles/global-fixes.css';
 import './theme/macos-tokens.css';
 import './styles/macos.css';
+import './styles/header-new.css';
 import 'react-toastify/dist/ReactToastify.css';
 import { MacOSThemeProvider } from './theme/macosTheme.jsx';
 import { bootstrapStoredColorScheme } from './theme/colorScheme.js';
@@ -142,7 +143,7 @@ function AppShell({ children }) {
   return (
     <div className="app-shell" style={macOSWrapStyle} data-route-id={chrome.route?.id || 'unknown'}>
       {!chrome.hideHeader && (
-        <div style={{ padding: '12px', backgroundColor: 'transparent', width: '100vw' }}>
+        <div style={{ padding: '12px', backgroundColor: 'transparent', width: '100%', maxWidth: '100%' }}>
           <HeaderNew />
         </div>
       )}
@@ -155,7 +156,8 @@ function AppShell({ children }) {
           gap: '16px',
           flex: 1,
           minHeight: 0,
-          width: '100vw',
+          width: '100%',
+          maxWidth: '100%',
           overflowX: 'hidden',
           overflowY: 'auto',
           padding: chrome.hideHeader ? '0' : '0 0 16px 0',


### PR DESCRIPTION
﻿## Summary

- Import the existing HeaderNew stylesheet at the app shell level.
- Constrain the app shell/header wrappers to 100% width instead of 100vw to prevent horizontal overflow.
- Keep the slice limited to the #389 AppShell layout fix only.

## Contract Impact

- Canonical surface: frontend AppShell layout in frontend/src/App.jsx
- Request shape: not applicable - no API request shape changed.
- Response shape: not applicable - no API response shape changed.
- Status codes: not applicable - no backend route or status behavior changed.
- Frontend consumer: app shell wrapping HeaderNew and routed page content.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: frontend HeaderNew unit test and production build completed.

## RBAC / Permissions

- Roles allowed: not applicable - no role gate or permission changed.
- Roles denied: not applicable - no role denial behavior changed.
- Positive auth proof: not applicable - layout-only change does not touch auth.
- Negative auth proof: not applicable - layout-only change does not touch auth.

## Notification / Realtime

not applicable - no notification, websocket, chat, push, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - AppShell layout has no data state.
- Partial data proof: not applicable - AppShell layout has no partial data contract.
- Forbidden secondary path behavior: not applicable - no secondary route path changed.
- Missing draft/resource behavior: not applicable - no draft or resource loading changed.
- Stale route/deep-link behavior: not applicable - no route parsing or deep-link handling changed.

## Scope Gate

- Allowed paths: frontend/src/App.jsx only.
- Denied paths: routing registry, auth, backend, database, role panels, generated output, and stale draft #389 branch artifacts.
- Migration/docs/test impact: no migration or docs; targeted frontend test and build were run.
- Rollback note: revert this one App.jsx commit to restore previous AppShell wrapper width behavior.

## Validation

- Targeted tests or smoke run: npm.cmd run test:run -- src/components/layout/__tests__/HeaderNew.test.jsx; npm.cmd run build; git diff --check
- Result: passed - HeaderNew test 3 passed, Vite production build completed, diff whitespace check clean.
- Not checked: browser visual screenshot smoke, because this PR is a one-file layout constraint and build/test proof was sufficient for the safe slice.
