### PR TITLE
fix(ui): tune landing hero typography

### DIFF
--- a/frontend/src/pages/Landing.css
+++ b/frontend/src/pages/Landing.css
@@ -264,14 +264,14 @@ body.landing-body {
 .landing-section-heading h2,
 .landing-final-copy h2 {
   margin: 0;
-  letter-spacing: -0.035em;
+  letter-spacing: 0;
 }
 
 .landing-hero-card h1 {
-  margin-top: 18px;
-  max-width: 12ch;
-  font-size: clamp(2.6rem, 4.8vw, 4.9rem);
-  line-height: 0.96;
+  margin-top: 16px;
+  max-width: 16ch;
+  font-size: clamp(2.2rem, 3.6vw, 3.8rem);
+  line-height: 1.04;
 }
 
 .landing-hero-description,
@@ -290,7 +290,7 @@ body.landing-body {
 .landing-cta-row {
   gap: 14px;
   flex-wrap: wrap;
-  margin-top: 30px;
+  margin-top: 24px;
 }
 
 .landing-primary-cta,
@@ -937,7 +937,7 @@ body.landing-body {
   .landing-section-heading h2,
   .landing-final-copy h2 {
     max-width: none;
-    font-size: clamp(2rem, 11vw, 3rem);
+    font-size: clamp(1.9rem, 8vw, 2.45rem);
   }
 
   .landing-metric-strip,


### PR DESCRIPTION
﻿## Summary

- Tune landing hero heading size, width, line-height, and spacing to reduce overflow risk.
- Remove negative letter spacing from landing section headings.
- Keep this split limited to the small Landing.css typography slice from draft PR #389.

## Contract Impact

- Canonical surface: public landing page CSS typography only.
- Request shape: not applicable - no API request shape changed.
- Response shape: not applicable - no API response shape changed.
- Status codes: not applicable - no backend route behavior changed.
- Frontend consumer: landing page hero and section heading styles.
- Compatibility path or alias: not applicable - no route or alias changed.
- Contract proof: frontend production build completed.

## RBAC / Permissions

not applicable - public landing typography only, no role gate, permission, user, or auth behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, push, Telegram, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - landing typography has no data state.
- Partial data proof: not applicable - landing typography has no data contract.
- Forbidden secondary path behavior: not applicable - no secondary route path changed.
- Missing draft/resource behavior: not applicable - no draft or resource behavior changed.
- Stale route/deep-link behavior: not applicable - no routing or deep-link behavior changed.

## Scope Gate

- Allowed paths: frontend/src/pages/Landing.css only.
- Denied paths: React page logic, routing, auth, backend, database, generated output, and stale draft #389 artifacts.
- Migration/docs/test impact: no migration or docs; frontend production build and diff hygiene were run.
- Rollback note: revert this one CSS commit to restore previous landing typography.

## Validation

- Targeted tests or smoke run: npm.cmd run build; git diff --check
- Result: passed - Vite production build completed and diff whitespace check was clean.
- Not checked: browser screenshot smoke, because this is a narrow CSS typography adjustment and no logic or route behavior changed.
