### PR TITLE
test(security): require env password for appointments smoke

### DIFF
--- a/check_appointments_api.py
+++ b/check_appointments_api.py
@@ -3,12 +3,17 @@
 Проверка данных записей из API
 """
 
-import requests
 import json
+import os
+
+import requests
 
 BASE_URL = "http://localhost:18000/api/v1"
 USERNAME = "registrar"
-PASSWORD = "registrar123"
+PASSWORD_ENV = "QA_REGISTRAR_PASSWORD"
+PASSWORD = os.environ.get(PASSWORD_ENV, "").strip()
+if not PASSWORD:
+    raise SystemExit(f"Set {PASSWORD_ENV} before running this smoke script.")
 
 def get_auth_token():
     """Получаем токен аутентификации"""


### PR DESCRIPTION
## Summary

- Require `QA_REGISTRAR_PASSWORD` before running the root appointments API smoke script.
- Remove the tracked `registrar123` literal from `check_appointments_api.py`.
- Leave backend auth/runtime behavior unchanged.

## Contract Impact

not applicable - root smoke helper only; no API, router, service, schema, request, response, status-code, frontend-consumer, or compatibility contract changed.

## RBAC / Permissions

not applicable - no role definitions, permission checks, auth guards, users, credentials, or enforcement behavior changed.

## Notification / Realtime

not applicable - no notification, WebSocket, realtime, Telegram, or messaging behavior changed.

## Frontend Resilience

not applicable - no frontend application code, route, panel, data flow, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `check_appointments_api.py`
- Denied paths: backend runtime auth code, backend tests, migrations, frontend app code, generated artifacts, seed/migration scripts
- Migration/docs/test impact: root smoke script only; no migration, docs, or test contract changed
- Rollback note: revert this commit to restore the previous local smoke-script credential behavior

## Validation

- Targeted tests or smoke run: `python -m py_compile check_appointments_api.py`; `rg -n registrar123 check_appointments_api.py`; CRLF-aware `git diff --check`
- Result: py_compile passed; literal scan returned no matches; diff hygiene passed
- Not checked: full backend/frontend suites, because this PR changes only a manual root smoke script