### PR TITLE
test(security): require env passwords for root smoke scripts

### DIFF
--- a/check_api_no_auth.py
+++ b/check_api_no_auth.py
@@ -3,10 +3,16 @@
 Проверка API услуг без аутентификации
 """
 
-import requests
 import json
+import os
+
+import requests
 
 BASE_URL = "http://localhost:18000/api/v1"
+REGISTRAR_PASSWORD_ENV = "QA_REGISTRAR_PASSWORD"
+REGISTRAR_PASSWORD = os.environ.get(REGISTRAR_PASSWORD_ENV, "").strip()
+if not REGISTRAR_PASSWORD:
+    raise SystemExit(f"Set {REGISTRAR_PASSWORD_ENV} before running this smoke script.")
 
 def check_services_without_auth():
     """Проверяем API услуг без аутентификации"""
@@ -48,7 +54,7 @@ def check_minimal_login():
     
     credentials = {
         "username": "registrar",
-        "password": "registrar123"
+        "password": REGISTRAR_PASSWORD
     }
     
     try:

--- a/check_services_api.py
+++ b/check_services_api.py
@@ -3,12 +3,17 @@
 Проверка API эндпоинта /registrar/services
 """
 
-import requests
 import json
+import os
+
+import requests
 
 BASE_URL = "http://localhost:18000/api/v1"
 USERNAME = "registrar"
-PASSWORD = "registrar123"
+PASSWORD_ENV = "QA_REGISTRAR_PASSWORD"
+PASSWORD = os.environ.get(PASSWORD_ENV, "").strip()
+if not PASSWORD:
+    raise SystemExit(f"Set {PASSWORD_ENV} before running this smoke script.")
 
 def get_auth_token():
     """Получаем токен аутентификации"""

--- a/check_services_grouping.py
+++ b/check_services_grouping.py
@@ -3,12 +3,17 @@
 Проверка группировки услуг в API
 """
 
-import requests
 import json
+import os
+
+import requests
 
 BASE_URL = "http://localhost:18000/api/v1"
 USERNAME = "registrar"
-PASSWORD = "registrar123"
+PASSWORD_ENV = "QA_REGISTRAR_PASSWORD"
+PASSWORD = os.environ.get(PASSWORD_ENV, "").strip()
+if not PASSWORD:
+    raise SystemExit(f"Set {PASSWORD_ENV} before running this smoke script.")
 
 def get_auth_token():
     """Получаем токен аутентификации"""

--- a/test_access.py
+++ b/test_access.py
@@ -1,8 +1,14 @@
+import os
 import requests
 import json
 
+CARDIO_PASSWORD_ENV = "QA_CARDIO_PASSWORD"
+CARDIO_PASSWORD = os.environ.get(CARDIO_PASSWORD_ENV, "").strip()
+if not CARDIO_PASSWORD:
+    raise SystemExit(f"Set {CARDIO_PASSWORD_ENV} before running this smoke script.")
+
 # Тест аутентификации
-login_data = {'username': 'cardio@example.com', 'password': 'cardio123'}
+login_data = {'username': 'cardio@example.com', 'password': CARDIO_PASSWORD}
 response = requests.post('http://localhost:18000/api/v1/auth/minimal-login', json=login_data)
 
 if response.status_code == 200:

--- a/test_api_ecg.py
+++ b/test_api_ecg.py
@@ -1,9 +1,15 @@
 """
 Тестирование API очереди ЭКГ
 """
-import requests
 import json
+import os
+import requests
 from datetime import date
+
+REGISTRAR_PASSWORD_ENV = "QA_REGISTRAR_PASSWORD"
+REGISTRAR_PASSWORD = os.environ.get(REGISTRAR_PASSWORD_ENV, "").strip()
+if not REGISTRAR_PASSWORD:
+    raise SystemExit(f"Set {REGISTRAR_PASSWORD_ENV} before running this smoke script.")
 
 # Получаем токен из localStorage (нужно вставить вручную из браузера)
 # Или используем тестовый токен
@@ -14,7 +20,7 @@ if not token:
     # Попробуем залогиниться
     login_response = requests.post(
         "http://localhost:18000/api/v1/authentication/login",
-        json={"username": "registrar", "password": "registrar123"}
+        json={"username": "registrar", "password": REGISTRAR_PASSWORD}
     )
 
     if login_response.status_code == 200:

--- a/test_backend_roles.py
+++ b/test_backend_roles.py
@@ -1,5 +1,11 @@
+import os
 import requests
 import sqlite3
+
+CARDIO_PASSWORD_ENV = "QA_CARDIO_PASSWORD"
+CARDIO_PASSWORD = os.environ.get(CARDIO_PASSWORD_ENV, "").strip()
+if not CARDIO_PASSWORD:
+    raise SystemExit(f"Set {CARDIO_PASSWORD_ENV} before running this smoke script.")
 
 # 1. Проверяем роли в базе данных
 print("=== Роли пользователей в БД ===")
@@ -14,7 +20,7 @@ conn.close()
 print("\n=== Тест аутентификации cardio ===")
 login_response = requests.post(
     'http://localhost:18000/api/v1/auth/minimal-login',
-    json={'username': 'cardio@example.com', 'password': 'cardio123'}
+    json={'username': 'cardio@example.com', 'password': CARDIO_PASSWORD}
 )
 print(f'Login status: {login_response.status_code}')
 

--- a/test_frontend_api.py
+++ b/test_frontend_api.py
@@ -3,8 +3,15 @@
 Тестовый скрипт для диагностики проблем фронтенда
 """
 
-import requests
 import json
+import os
+
+import requests
+
+REGISTRAR_PASSWORD_ENV = "QA_REGISTRAR_PASSWORD"
+REGISTRAR_PASSWORD = os.environ.get(REGISTRAR_PASSWORD_ENV, "").strip()
+if not REGISTRAR_PASSWORD:
+    raise SystemExit(f"Set {REGISTRAR_PASSWORD_ENV} before running this smoke script.")
 
 def test_api_endpoints():
     """Тестируем все API эндпоинты, которые использует фронтенд"""
@@ -17,7 +24,11 @@ def test_api_endpoints():
     try:
         response = requests.post(
             f"{base_url}/api/v1/auth/minimal-login",
-            json={"username": "registrar@example.com", "password": "registrar123", "remember_me": False},
+            json={
+                "username": "registrar@example.com",
+                "password": REGISTRAR_PASSWORD,
+                "remember_me": False,
+            },
             timeout=5
         )
         if response.status_code == 200:

--- a/test_full_queue_icons.py
+++ b/test_full_queue_icons.py
@@ -1,10 +1,16 @@
 """
 Полный тест иконок очереди: от базы данных через API до проверки структуры данных
 """
-import requests
 import json
+import os
+import requests
 from datetime import date
 import sqlite3
+
+REGISTRAR_PASSWORD_ENV = "QA_REGISTRAR_PASSWORD"
+REGISTRAR_PASSWORD = os.environ.get(REGISTRAR_PASSWORD_ENV, "").strip()
+if not REGISTRAR_PASSWORD:
+    raise SystemExit(f"Set {REGISTRAR_PASSWORD_ENV} before running this smoke script.")
 
 print("=" * 60)
 print("ПОЛНЫЙ ТЕСТ СИСТЕМЫ ИКОНОК ОЧЕРЕДИ")
@@ -44,7 +50,7 @@ print("-" * 60)
 # Логин
 login_response = requests.post(
     "http://localhost:18000/api/v1/authentication/login",
-    json={"username": "registrar", "password": "registrar123"}
+    json={"username": "registrar", "password": REGISTRAR_PASSWORD}
 )
 
 if login_response.status_code != 200:

--- a/test_queue_badge.py
+++ b/test_queue_badge.py
@@ -1,9 +1,15 @@
 """
 Тест проверки данных для бейджей вкладок (иконка часов)
 """
-import requests
 import json
+import os
+import requests
 from datetime import date
+
+REGISTRAR_PASSWORD_ENV = "QA_REGISTRAR_PASSWORD"
+REGISTRAR_PASSWORD = os.environ.get(REGISTRAR_PASSWORD_ENV, "").strip()
+if not REGISTRAR_PASSWORD:
+    raise SystemExit(f"Set {REGISTRAR_PASSWORD_ENV} before running this smoke script.")
 
 print("=" * 60)
 print("ТЕСТ БЕЙДЖЕЙ ВКЛАДОК (ИКОНКА ЧАСОВ)")
@@ -13,7 +19,7 @@ print("=" * 60)
 print("\n🔐 Вход в систему...")
 login_response = requests.post(
     "http://localhost:18000/api/v1/authentication/login",
-    json={"username": "registrar", "password": "registrar123"}
+    json={"username": "registrar", "password": REGISTRAR_PASSWORD}
 )
 
 if login_response.status_code != 200:

--- a/test_queue_icons_api.py
+++ b/test_queue_icons_api.py
@@ -1,15 +1,21 @@
 """
 Тестирование API получения очередей с реальными номерами
 """
-import requests
 import json
+import os
+import requests
 from datetime import date
+
+REGISTRAR_PASSWORD_ENV = "QA_REGISTRAR_PASSWORD"
+REGISTRAR_PASSWORD = os.environ.get(REGISTRAR_PASSWORD_ENV, "").strip()
+if not REGISTRAR_PASSWORD:
+    raise SystemExit(f"Set {REGISTRAR_PASSWORD_ENV} before running this smoke script.")
 
 # Логин
 print("🔐 Вход в систему...")
 login_response = requests.post(
     "http://localhost:18000/api/v1/authentication/login",
-    json={"username": "registrar", "password": "registrar123"}
+    json={"username": "registrar", "password": REGISTRAR_PASSWORD}
 )
 
 if login_response.status_code != 200:

--- a/test_simple_cart.py
+++ b/test_simple_cart.py
@@ -27,6 +27,10 @@ from datetime import date, datetime
 # Configuration
 API_BASE = "http://localhost:18000"
 AUTH_TOKEN = None
+REGISTRAR_PASSWORD_ENV = "QA_REGISTRAR_PASSWORD"
+REGISTRAR_PASSWORD = os.environ.get(REGISTRAR_PASSWORD_ENV, "").strip()
+if not REGISTRAR_PASSWORD:
+    raise SystemExit(f"Set {REGISTRAR_PASSWORD_ENV} before running this smoke script.")
 
 def login_as_registrar():
     """Login as registrar user"""
@@ -35,7 +39,7 @@ def login_as_registrar():
         f"{API_BASE}/api/v1/auth/minimal-login",
         json={
             "username": "registrar",
-            "password": "registrar123"
+            "password": REGISTRAR_PASSWORD
         }
     )
 


### PR DESCRIPTION
## Summary

- Require `QA_REGISTRAR_PASSWORD` for registrar root smoke scripts that previously embedded `registrar123`.
- Require `QA_CARDIO_PASSWORD` for cardio root smoke scripts that previously embedded `cardio123`.
- Leave backend auth/runtime behavior, backend tests, migrations, and `add_missing_columns.py` unchanged.

## Contract Impact

not applicable - root smoke helpers only; no API, router, service, schema, request, response, status-code, frontend-consumer, or compatibility contract changed.

## RBAC / Permissions

not applicable - no role definitions, permission checks, auth guards, users, credentials, or enforcement behavior changed.

## Notification / Realtime

not applicable - no notification, WebSocket, realtime, Telegram, or messaging behavior changed.

## Frontend Resilience

not applicable - no frontend application code, route, panel, data flow, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `check_api_no_auth.py`, `check_services_api.py`, `check_services_grouping.py`, `test_simple_cart.py`, `test_queue_icons_api.py`, `test_queue_badge.py`, `test_full_queue_icons.py`, `test_frontend_api.py`, `test_backend_roles.py`, `test_api_ecg.py`, `test_access.py`
- Denied paths: backend runtime auth code, backend tests, migrations, frontend app code, generated artifacts, `add_missing_columns.py`
- Migration/docs/test impact: root smoke scripts only; no migration, docs, or backend/frontend test contract changed
- Rollback note: revert this commit to restore the previous local smoke-script credential behavior

## Validation

- Targeted tests or smoke run: `python -m py_compile` on all 11 touched scripts; targeted `rg -n (registrar123|cardio123)` over touched scripts; CRLF-aware `git diff --check`; repo scan outside `backend/tests` for known demo password literals
- Result: py_compile passed; targeted literal scan returned no matches in touched scripts; diff hygiene passed; broader scan now leaves only `add_missing_columns.py`
- Not checked: full backend/frontend suites, because this PR changes only manual root smoke scripts