### PR TITLE
chore(db): retire legacy create table helpers

### DIFF
--- a/backend/create_clinic_management_tables.py
+++ b/backend/create_clinic_management_tables.py
@@ -1,63 +1,29 @@
 #!/usr/bin/env python3
-"""
-Создание таблиц для системы управления клиникой
-"""
-import sys
-import os
+"""Retired legacy clinic-management table helper.
 
-# Добавляем путь к приложению
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+Schema creation is owned by Alembic migrations. This root helper no longer
+performs direct SQLAlchemy metadata table creation, because that can hide schema
+drift and bypass the PostgreSQL + Alembic source of truth.
+"""
 
-def create_clinic_management_tables():
-    """Создает таблицы для управления клиникой"""
-    print("🏥 СОЗДАНИЕ ТАБЛИЦ УПРАВЛЕНИЯ КЛИНИКОЙ")
-    print("=" * 50)
-    
-    try:
-        from app.db.base_class import Base
-        from app.db.session import engine
-        
-        # Импортируем все модели для создания таблиц
-        from app.models.clinic import (
-            Branch, BranchStatus, Equipment, EquipmentStatus, EquipmentType, EquipmentMaintenance,
-            License, LicenseStatus, LicenseType, LicenseActivation,
-            Backup, BackupStatus, BackupType, SystemInfo
-        )
-        
-        print("📋 Создание таблиц...")
-        
-        # Создаем все таблицы
-        Base.metadata.create_all(bind=engine)
-        
-        print("✅ Таблицы созданы успешно")
-        
-        # Проверяем созданные таблицы
-        from sqlalchemy import text
-        with engine.connect() as conn:
-            result = conn.execute(text("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE '%branch%' OR name LIKE '%equipment%' OR name LIKE '%license%' OR name LIKE '%backup%' OR name LIKE '%system_info%'"))
-            tables = [row[0] for row in result.fetchall()]
-            
-            print(f"📊 Создано таблиц: {len(tables)}")
-            for table in tables:
-                print(f"  ✅ {table}")
-        
-        print("\n🎉 СИСТЕМА УПРАВЛЕНИЯ КЛИНИКОЙ ГОТОВА!")
-        print("=" * 50)
-        print("✅ Модели БД созданы")
-        print("✅ Pydantic схемы готовы")
-        print("✅ CRUD операции реализованы")
-        print("✅ Сервисы созданы")
-        print("✅ API endpoints готовы")
-        print("✅ Таблицы БД созданы")
-        
-        return True
-        
-    except Exception as e:
-        print(f"❌ Ошибка создания таблиц: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
+from __future__ import annotations
+
+
+MESSAGE = """
+backend/create_clinic_management_tables.py is retired.
+
+Do not create clinic-management tables through direct metadata table creation.
+Apply schema changes through Alembic migrations instead:
+
+  cd backend
+  alembic upgrade head
+""".strip()
+
+
+def main() -> int:
+    print(MESSAGE)
+    return 2
+
 
 if __name__ == "__main__":
-    success = create_clinic_management_tables()
-    sys.exit(0 if success else 1)
+    raise SystemExit(main())

--- a/backend/create_emr_versions_table.py
+++ b/backend/create_emr_versions_table.py
@@ -1,34 +1,29 @@
 #!/usr/bin/env python3
+"""Retired legacy EMR versions table helper.
+
+Schema creation is owned by Alembic migrations. This root helper no longer
+performs direct SQLAlchemy metadata table creation, because that can hide schema
+drift and bypass the PostgreSQL + Alembic source of truth.
 """
-Создание таблицы для версий EMR
-"""
-import sys
-import os
 
-# Добавляем корневую директорию проекта в sys.path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), 'app')))
-
-from app.db.session import engine
-from app.models.emr_version import EMRVersion
-from app.db.base import Base
+from __future__ import annotations
 
 
-def create_emr_versions_table():
-    """Создать таблицу для версий EMR"""
-    print("🔄 СОЗДАНИЕ ТАБЛИЦЫ EMR_VERSIONS")
-    print("=" * 40)
-    
-    try:
-        # Создаем таблицу
-        Base.metadata.create_all(bind=engine, tables=[EMRVersion.__table__])
-        print("✅ Таблица emr_versions создана успешно")
-        return True
-        
-    except Exception as e:
-        print(f"❌ Ошибка создания таблицы: {e}")
-        return False
+MESSAGE = """
+backend/create_emr_versions_table.py is retired.
+
+Do not create EMR version tables through direct metadata table creation.
+Apply schema changes through Alembic migrations instead:
+
+  cd backend
+  alembic upgrade head
+""".strip()
+
+
+def main() -> int:
+    print(MESSAGE)
+    return 2
 
 
 if __name__ == "__main__":
-    success = create_emr_versions_table()
-    sys.exit(0 if success else 1)
+    raise SystemExit(main())

--- a/backend/create_user_management_tables.py
+++ b/backend/create_user_management_tables.py
@@ -1,252 +1,29 @@
 #!/usr/bin/env python3
+"""Retired legacy user-management table helper.
+
+Schema creation is owned by Alembic migrations. This root helper no longer
+performs direct SQLAlchemy metadata table creation, because that can hide schema
+drift and bypass the PostgreSQL + Alembic source of truth.
 """
-Создание таблиц для системы управления пользователями
-"""
-import sys
-import os
 
-# Добавляем путь к приложению
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from __future__ import annotations
 
-from sqlalchemy import create_engine, text
-from app.db.base_class import Base
-from app.db.session import engine
-from app.models.user_profile import (
-    UserProfile, UserPreferences, UserNotificationSettings, 
-    UserRole, UserPermission, RolePermission, UserGroup, 
-    UserGroupMember, UserAuditLog
-)
 
-def create_user_management_tables():
-    """Создает таблицы для системы управления пользователями"""
-    print("🔧 СОЗДАНИЕ ТАБЛИЦ ДЛЯ СИСТЕМЫ УПРАВЛЕНИЯ ПОЛЬЗОВАТЕЛЯМИ")
-    print("=" * 60)
-    
-    try:
-        # Создаем все таблицы
-        print("📋 Создание таблиц...")
-        Base.metadata.create_all(bind=engine)
-        print("✅ Таблицы созданы успешно")
-        
-        # Проверяем созданные таблицы
-        print("\n🔍 Проверка созданных таблиц...")
-        with engine.connect() as conn:
-            result = conn.execute(text("""
-                SELECT name FROM sqlite_master 
-                WHERE type='table' AND name LIKE 'user_%'
-                ORDER BY name
-            """))
-            tables = [row[0] for row in result.fetchall()]
-            
-            print(f"✅ Найдено таблиц: {len(tables)}")
-            for table in tables:
-                print(f"   - {table}")
-        
-        # Создаем базовые роли
-        print("\n👥 Создание базовых ролей...")
-        with engine.connect() as conn:
-            # Проверяем, есть ли уже роли
-            result = conn.execute(text("SELECT COUNT(*) FROM user_roles"))
-            role_count = result.scalar()
-            
-            if role_count == 0:
-                # Создаем базовые роли
-                roles = [
-                    ("Admin", "Администратор", "Полный доступ к системе", True),
-                    ("Doctor", "Врач", "Доступ к пациентам и записям", True),
-                    ("Nurse", "Медсестра", "Доступ к записям и расписанию", True),
-                    ("Receptionist", "Регистратор", "Доступ к записям и платежам", True),
-                    ("Patient", "Пациент", "Доступ к своему профилю", True)
-                ]
-                
-                for name, display_name, description, is_system in roles:
-                    conn.execute(text("""
-                        INSERT INTO user_roles (name, display_name, description, is_system, is_active)
-                        VALUES (:name, :display_name, :description, :is_system, :is_active)
-                    """), {
-                        "name": name,
-                        "display_name": display_name,
-                        "description": description,
-                        "is_system": is_system,
-                        "is_active": True
-                    })
-                
-                conn.commit()
-                print("✅ Базовые роли созданы")
-            else:
-                print(f"✅ Роли уже существуют ({role_count} ролей)")
-        
-        # Создаем базовые разрешения
-        print("\n🔐 Создание базовых разрешений...")
-        with engine.connect() as conn:
-            # Проверяем, есть ли уже разрешения
-            result = conn.execute(text("SELECT COUNT(*) FROM user_permissions"))
-            permission_count = result.scalar()
-            
-            if permission_count == 0:
-                # Создаем базовые разрешения
-                permissions = [
-                    ("users:read", "Просмотр пользователей", "Просмотр списка пользователей", "users"),
-                    ("users:write", "Редактирование пользователей", "Создание и редактирование пользователей", "users"),
-                    ("users:delete", "Удаление пользователей", "Удаление пользователей", "users"),
-                    ("users:bulk_action", "Массовые действия", "Выполнение массовых действий с пользователями", "users"),
-                    ("profile:read", "Просмотр профилей", "Просмотр профилей пользователей", "profile"),
-                    ("profile:write", "Редактирование профилей", "Редактирование профилей пользователей", "profile"),
-                    ("patients:read", "Просмотр пациентов", "Просмотр списка пациентов", "patients"),
-                    ("patients:write", "Редактирование пациентов", "Создание и редактирование пациентов", "patients"),
-                    ("patients:delete", "Удаление пациентов", "Удаление пациентов", "patients"),
-                    ("appointments:read", "Просмотр записей", "Просмотр записей на прием", "appointments"),
-                    ("appointments:write", "Редактирование записей", "Создание и редактирование записей", "appointments"),
-                    ("appointments:delete", "Удаление записей", "Удаление записей на прием", "appointments"),
-                    ("emr:read", "Просмотр медкарт", "Просмотр медицинских карт", "emr"),
-                    ("emr:write", "Редактирование медкарт", "Создание и редактирование медкарт", "emr"),
-                    ("emr:delete", "Удаление медкарт", "Удаление медицинских карт", "emr"),
-                    ("payments:read", "Просмотр платежей", "Просмотр платежей", "payments"),
-                    ("payments:write", "Редактирование платежей", "Создание и редактирование платежей", "payments"),
-                    ("payments:delete", "Удаление платежей", "Удаление платежей", "payments"),
-                    ("analytics:read", "Просмотр аналитики", "Просмотр аналитики и отчетов", "analytics"),
-                    ("settings:read", "Просмотр настроек", "Просмотр настроек системы", "settings"),
-                    ("settings:write", "Редактирование настроек", "Редактирование настроек системы", "settings"),
-                    ("audit:read", "Просмотр аудита", "Просмотр журнала аудита", "audit"),
-                    ("export:write", "Экспорт данных", "Экспорт данных системы", "export")
-                ]
-                
-                for name, display_name, description, category in permissions:
-                    conn.execute(text("""
-                        INSERT INTO user_permissions (name, display_name, description, category, is_system, is_active)
-                        VALUES (:name, :display_name, :description, :category, :is_system, :is_active)
-                    """), {
-                        "name": name,
-                        "display_name": display_name,
-                        "description": description,
-                        "category": category,
-                        "is_system": True,
-                        "is_active": True
-                    })
-                
-                conn.commit()
-                print("✅ Базовые разрешения созданы")
-            else:
-                print(f"✅ Разрешения уже существуют ({permission_count} разрешений)")
-        
-        # Создаем связи ролей и разрешений
-        print("\n🔗 Создание связей ролей и разрешений...")
-        with engine.connect() as conn:
-            # Проверяем, есть ли уже связи
-            result = conn.execute(text("SELECT COUNT(*) FROM role_permissions"))
-            link_count = result.scalar()
-            
-            if link_count == 0:
-                # Получаем ID ролей
-                result = conn.execute(text("SELECT id, name FROM user_roles"))
-                roles = {name: id for id, name in result.fetchall()}
-                
-                # Получаем ID разрешений
-                result = conn.execute(text("SELECT id, name FROM user_permissions"))
-                permissions = {name: id for id, name in result.fetchall()}
-                
-                # Создаем связи для роли Admin (все разрешения)
-                admin_role_id = roles.get("Admin")
-                if admin_role_id:
-                    for perm_name, perm_id in permissions.items():
-                        conn.execute(text("""
-                            INSERT INTO role_permissions (role_id, permission_id)
-                            VALUES (:role_id, :permission_id)
-                        """), {
-                            "role_id": admin_role_id,
-                            "permission_id": perm_id
-                        })
-                
-                # Создаем связи для роли Doctor
-                doctor_role_id = roles.get("Doctor")
-                if doctor_role_id:
-                    doctor_permissions = [
-                        "patients:read", "patients:write",
-                        "appointments:read", "appointments:write",
-                        "emr:read", "emr:write",
-                        "analytics:read", "profile:read", "profile:write"
-                    ]
-                    for perm_name in doctor_permissions:
-                        if perm_name in permissions:
-                            conn.execute(text("""
-                                INSERT INTO role_permissions (role_id, permission_id)
-                                VALUES (:role_id, :permission_id)
-                            """), {
-                                "role_id": doctor_role_id,
-                                "permission_id": permissions[perm_name]
-                            })
-                
-                # Создаем связи для роли Nurse
-                nurse_role_id = roles.get("Nurse")
-                if nurse_role_id:
-                    nurse_permissions = [
-                        "patients:read", "appointments:read", "emr:read", "profile:read"
-                    ]
-                    for perm_name in nurse_permissions:
-                        if perm_name in permissions:
-                            conn.execute(text("""
-                                INSERT INTO role_permissions (role_id, permission_id)
-                                VALUES (:role_id, :permission_id)
-                            """), {
-                                "role_id": nurse_role_id,
-                                "permission_id": permissions[perm_name]
-                            })
-                
-                # Создаем связи для роли Receptionist
-                receptionist_role_id = roles.get("Receptionist")
-                if receptionist_role_id:
-                    receptionist_permissions = [
-                        "patients:read", "patients:write",
-                        "appointments:read", "appointments:write",
-                        "payments:read", "payments:write",
-                        "profile:read", "profile:write"
-                    ]
-                    for perm_name in receptionist_permissions:
-                        if perm_name in permissions:
-                            conn.execute(text("""
-                                INSERT INTO role_permissions (role_id, permission_id)
-                                VALUES (:role_id, :permission_id)
-                            """), {
-                                "role_id": receptionist_role_id,
-                                "permission_id": permissions[perm_name]
-                            })
-                
-                # Создаем связи для роли Patient
-                patient_role_id = roles.get("Patient")
-                if patient_role_id:
-                    patient_permissions = [
-                        "profile:read", "profile:write",
-                        "appointments:read", "payments:read"
-                    ]
-                    for perm_name in patient_permissions:
-                        if perm_name in permissions:
-                            conn.execute(text("""
-                                INSERT INTO role_permissions (role_id, permission_id)
-                                VALUES (:role_id, :permission_id)
-                            """), {
-                                "role_id": patient_role_id,
-                                "permission_id": permissions[perm_name]
-                            })
-                
-                conn.commit()
-                print("✅ Связи ролей и разрешений созданы")
-            else:
-                print(f"✅ Связи уже существуют ({link_count} связей)")
-        
-        print("\n🎉 СИСТЕМА УПРАВЛЕНИЯ ПОЛЬЗОВАТЕЛЯМИ ГОТОВА К ИСПОЛЬЗОВАНИЮ!")
-        print("✅ Все таблицы созданы")
-        print("✅ Базовые роли настроены")
-        print("✅ Базовые разрешения настроены")
-        print("✅ Связи ролей и разрешений созданы")
-        
-        return True
-        
-    except Exception as e:
-        print(f"\n❌ ОШИБКА СОЗДАНИЯ ТАБЛИЦ: {str(e)}")
-        import traceback
-        traceback.print_exc()
-        return False
+MESSAGE = """
+backend/create_user_management_tables.py is retired.
+
+Do not create user-management tables through direct metadata table creation.
+Apply schema changes through Alembic migrations instead:
+
+  cd backend
+  alembic upgrade head
+""".strip()
+
+
+def main() -> int:
+    print(MESSAGE)
+    return 2
+
 
 if __name__ == "__main__":
-    success = create_user_management_tables()
-    sys.exit(0 if success else 1)
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Retire three unreferenced root backend table-creation helpers that performed direct metadata table creation.
- Replace executable DB mutation behavior with fail-fast guidance to Alembic.
- Leave runtime code, migrations, backend/app, tests, and ops entrypoints unchanged.

## Contract Impact

not applicable - retired root maintenance helpers only; no API, router, service, schema, request, response, status-code, frontend-consumer, or compatibility contract changed.

## RBAC / Permissions

not applicable - no role definitions, permission checks, auth guards, users, credentials, or enforcement behavior changed.

## Notification / Realtime

not applicable - no notification, WebSocket, realtime, Telegram, or messaging behavior changed.

## Frontend Resilience

not applicable - no frontend application code, route, panel, data flow, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/create_clinic_management_tables.py`, `backend/create_emr_versions_table.py`, `backend/create_user_management_tables.py`
- Denied paths: backend runtime code, Alembic migrations, backend tests, frontend app code, ops entrypoints, generated artifacts
- Migration/docs/test impact: root legacy helpers only; no migration, docs, or backend/frontend test contract changed
- Rollback note: revert this commit to restore the legacy helpers, though that would also restore direct metadata table creation behavior

## Validation

- Targeted tests or smoke run: `python -m py_compile` on the three touched scripts; targeted scan for direct table-creation markers; CRLF-aware `git diff --check`
- Result: py_compile passed; targeted marker scan returned no matches; diff hygiene passed
- Not checked: full backend/frontend suites, because this PR changes only retired root maintenance helpers