### PR TITLE
test(security): require env token for root api smoke

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1,8 +1,11 @@
-import requests
-import json
+import os
+import sys
 
-# Токен из логов
-token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMCIsInVzZXJfaWQiOjIwLCJ1c2VybmFtZSI6InJlZ2lzdHJhckBleGFtcGxlLmNvbSIsImV4cCI6MTc1OTMzMzY1OH0.kSlNwHRz0LzXZ6u4AXfLeY41zuJHXhIFqWtXEd_FLMg"
+import requests
+token = os.environ.get("REGISTRAR_API_TOKEN")
+if not token:
+    print("Set REGISTRAR_API_TOKEN to a locally generated bearer token before running this smoke script.")
+    sys.exit(2)
 
 try:
     response = requests.get(


### PR DESCRIPTION
## Summary

- Remove the hardcoded bearer JWT from the root `test_api.py` manual smoke script.
- Require `REGISTRAR_API_TOKEN` from the local operator environment before making the request.
- Fail closed with exit code 2 when the token is not provided.

## Contract Impact

not applicable - root manual smoke script only; no API, router, service, schema, frontend, request, response, or runtime contract changed.

## RBAC / Permissions

not applicable - this PR does not change auth enforcement or role permissions; it removes a tracked bearer token from a manual auth smoke path.

## Notification / Realtime

not applicable - no notification, WebSocket, realtime, Telegram, or messaging behavior changed.

## Frontend Resilience

not applicable - no frontend application code, route, panel, or data flow changed.

## Scope Gate

- Allowed paths: `test_api.py`
- Denied paths: backend runtime auth code, routers, Alembic migrations, frontend app code, ops entrypoints, generated artifacts
- Migration/docs/test impact: root legacy/manual smoke only; no migration or automated test contract changed
- Rollback note: revert this commit to restore the previous manual smoke behavior, though that would also restore the tracked JWT

## Validation

- Targeted tests or smoke run: `python -m py_compile test_api.py`; `python test_api.py` without token; `rg` scan for JWT in `test_api.py`; `git diff --check origin/main...HEAD`
- Result: py_compile passed; script exits 2 with an env-token instruction when `REGISTRAR_API_TOKEN` is absent; no JWT remains in `test_api.py`; diff hygiene passed
- Not checked: full backend/frontend suites, because this PR changes only one root manual smoke helper