### PR TITLE
test(security): require env token for registration api smoke

### DIFF
--- a/test_registration_api.py
+++ b/test_registration_api.py
@@ -1,8 +1,12 @@
+import os
+import sys
 import requests
 import json
 
-# Токен из логов
-token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMCIsInVzZXJfaWQiOjIwLCJ1c2VybmFtZSI6InJlZ2lzdHJhckBleGFtcGxlLmNvbSIsImV4cCI6MTc1OTMzMzY1OH0.kSlNwHRz0LzXZ6u4AXfLeY41zuJHXhIFqWtXEd_FLMg"
+token = os.environ.get("REGISTRAR_API_TOKEN")
+if not token:
+    print("Set REGISTRAR_API_TOKEN to a locally generated bearer token before running this smoke script.")
+    sys.exit(2)
 
 # Тестовые данные для создания записи
 test_data = {
@@ -44,11 +48,13 @@ try:
 
     if response.status_code == 200:
         data = response.json()
-        print("✅ Запись создана успешно!"        print(f"   Visit IDs: {data.get('visit_ids', [])}")
+        print("✅ Запись создана успешно!")
+        print(f"   Visit IDs: {data.get('visit_ids', [])}")
         print(f"   Invoice ID: {data.get('invoice_id')}")
         print(f"   Total amount: {data.get('total_amount')}")
     else:
-        print("❌ Ошибка создания записи:"        print(f"   Статус: {response.status_code}")
+        print("❌ Ошибка создания записи:")
+        print(f"   Статус: {response.status_code}")
         try:
             error_data = response.json()
             print(f"   Детали: {json.dumps(error_data, indent=2, ensure_ascii=False)}")


### PR DESCRIPTION
## Summary

- Remove the hardcoded bearer JWT from the root `test_registration_api.py` manual registration smoke script.
- Require `REGISTRAR_API_TOKEN` from the local operator environment before making the registrar cart request.
- Fix two pre-existing malformed `print(...)` statements so the script compiles before runtime.

## Contract Impact

not applicable - root manual smoke script only; no API, router, service, schema, frontend, request, response, or runtime contract changed.

## RBAC / Permissions

not applicable - this PR does not change auth enforcement or role permissions; it removes a tracked bearer token from a manual registrar smoke path.

## Notification / Realtime

not applicable - no notification, WebSocket, realtime, Telegram, or messaging behavior changed.

## Frontend Resilience

not applicable - no frontend application code, route, panel, or data flow changed.

## Scope Gate

- Allowed paths: `test_registration_api.py`
- Denied paths: backend runtime auth code, routers, Alembic migrations, frontend app code, ops entrypoints, generated artifacts
- Migration/docs/test impact: root legacy/manual smoke only; no migration or automated test contract changed
- Rollback note: revert this commit to restore the previous manual smoke behavior, though that would also restore the tracked JWT and syntax issue

## Validation

- Targeted tests or smoke run: `python -m py_compile test_registration_api.py`; `python test_registration_api.py` without token; `rg` scan for JWT in `test_registration_api.py`; `git diff --check origin/main...HEAD`
- Result: py_compile passed; script exits 2 with an env-token instruction when `REGISTRAR_API_TOKEN` is absent; no JWT remains in `test_registration_api.py`; diff hygiene passed
- Not checked: full backend/frontend suites, because this PR changes only one root manual smoke helper