### PR TITLE
fix(backend): require database URL in alternate start helpers

### DIFF
--- a/backend/start_server_port8001.py
+++ b/backend/start_server_port8001.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 import uvicorn
+from sqlalchemy.engine import make_url
 
 # Настраиваем логирование
 logging.basicConfig(
@@ -23,27 +24,48 @@ for logger_name in ["uvicorn", "uvicorn.access", "uvicorn.error", "fastapi", "cl
 current_dir = os.path.dirname(os.path.abspath(__file__))
 
 # Устанавливаем правильные переменные окружения
-os.environ["DATABASE_URL"] = "sqlite:///./clinic.db"
 os.environ["PYTHONPATH"] = current_dir
 
 # Добавляем путь к проекту
 sys.path.insert(0, current_dir)
 
+
+def require_database_url() -> str:
+    database_url = os.environ.get("DATABASE_URL", "").strip()
+    if not database_url:
+        from app.core.config import get_settings
+
+        database_url = str(get_settings().DATABASE_URL or "").strip()
+
+    if not database_url:
+        raise RuntimeError(
+            "DATABASE_URL is required; refusing to start the backend with a fallback database"
+        )
+
+    os.environ["DATABASE_URL"] = database_url
+    return database_url
+
+
+def display_database_url(database_url: str) -> str:
+    return make_url(database_url).render_as_string(hide_password=True)
+
+
 if __name__ == "__main__":
     PORT = 8001
-    
+    DATABASE_URL = require_database_url()
+
     print("=" * 80)
     print("🚀 Запуск сервера на альтернативном порту")
     print("=" * 80)
     print(f"📁 Рабочая директория: {os.getcwd()}")
-    print(f"🗄️ База данных: {os.environ['DATABASE_URL']}")
+    print(f"🗄️ База данных: {display_database_url(DATABASE_URL)}")
     print(f"🌐 Порт: {PORT}")
     print("=" * 80)
     print()
     print("⚠️  ВАЖНО: Обновите frontend для работы с портом 8001!")
     print(f"   В файле frontend/.env установите: VITE_API_URL=http://localhost:{PORT}")
     print("=" * 80)
-    
+
     uvicorn.run(
         "app.main:app",
         host="0.0.0.0",

--- a/backend/start_server_verbose.py
+++ b/backend/start_server_verbose.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     print(f"🐍 Python path: {os.environ['PYTHONPATH']}")
     print(f"🌐 Порт: {PORT}")
     print("=" * 80)
-    
+
     # Конфигурация uvicorn с МАКСИМАЛЬНЫМ логированием
     uvicorn.run(
         "app.main:app",

--- a/backend/start_server_verbose.py
+++ b/backend/start_server_verbose.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 import uvicorn
+from sqlalchemy.engine import make_url
 
 # Настраиваем логирование ДО импорта приложения
 logging.basicConfig(
@@ -27,20 +28,34 @@ for logger_name in ["uvicorn", "uvicorn.access", "uvicorn.error", "fastapi", "cl
 current_dir = os.path.dirname(os.path.abspath(__file__))
 
 # Устанавливаем правильные переменные окружения
-os.environ["DATABASE_URL"] = "sqlite:///./clinic.db"
 os.environ["PYTHONPATH"] = current_dir
 
 # Добавляем путь к проекту
 sys.path.insert(0, current_dir)
 
+
+def require_database_url() -> str:
+    database_url = os.environ.get("DATABASE_URL", "").strip()
+    if not database_url:
+        raise RuntimeError(
+            "DATABASE_URL is required; refusing to start the backend with a fallback database"
+        )
+    return database_url
+
+
+def display_database_url(database_url: str) -> str:
+    return make_url(database_url).render_as_string(hide_password=True)
+
+
 if __name__ == "__main__":
     PORT = int(os.environ.get("BACKEND_PORT", "18000"))
+    DATABASE_URL = require_database_url()
 
     print("=" * 80)
     print("🚀 ЗАПУСК СЕРВЕРА С ПОЛНЫМ ЛОГИРОВАНИЕМ")
     print("=" * 80)
     print(f"📁 Рабочая директория: {os.getcwd()}")
-    print(f"🗄️ База данных: {os.environ['DATABASE_URL']}")
+    print(f"🗄️ База данных: {display_database_url(DATABASE_URL)}")
     print(f"🐍 Python path: {os.environ['PYTHONPATH']}")
     print(f"🌐 Порт: {PORT}")
     print("=" * 80)


### PR DESCRIPTION
﻿## Summary
- Remove SQLite fallback assignment from `backend/start_server_verbose.py`.
- Remove SQLite fallback assignment from `backend/start_server_port8001.py`.
- Require an explicit configured database URL and print it with the password masked.

## Contract Impact
- Canonical surface: no runtime API surface changed; this PR only hardens alternate/manual backend startup helper scripts.
- Request shape: not applicable because no HTTP route, request body, query parameter, or header contract changed.
- Response shape: not applicable because no HTTP response schema or payload changed.
- Status codes: not applicable because no FastAPI endpoint or exception/status-code path changed.
- Frontend consumer: not applicable because no frontend call site, route, panel, or API client changed.
- Compatibility path or alias: not applicable because no route alias, compatibility endpoint, redirect, or legacy API path changed.
- Contract proof: `python -m py_compile backend\start_server_verbose.py backend\start_server_port8001.py`; targeted scans confirmed the touched helpers no longer contain SQLite fallback markers, `clinic.db`, `create_all(`, legacy `:8000`, permissive CORS, or change-me defaults.

## RBAC / Permissions
- Roles allowed: not applicable; startup helper configuration only, no authenticated runtime operation changed.
- Roles denied: not applicable; no permission matrix or denial behavior changed.
- Positive auth proof: not applicable; no auth guard, token creation, role check, or login path changed.
- Negative auth proof: not applicable; no authorization failure path changed.

## Notification / Realtime
- Event type or websocket channel: not applicable; no notification, WebSocket, queue realtime, Telegram, or messaging channel changed.
- Payload version / ack behavior: not applicable; no realtime payload, acknowledgement, or event version changed.
- Read/unread or delivery semantics: not applicable; no notification delivery or read state changed.
- Reconnect/resync proof: not applicable; no reconnect, resync, subscription, or websocket lifecycle behavior changed.

## Frontend Resilience
- Empty data proof: not applicable; no frontend data rendering path changed.
- Partial data proof: not applicable; no frontend partial-response handling changed.
- Forbidden secondary path behavior: not applicable; no forbidden/secondary frontend route or fallback changed.
- Missing draft/resource behavior: not applicable; no draft/resource loading path changed.
- Stale route/deep-link behavior: not applicable; no route registry, navigation, or deep-link behavior changed.

## Validation
- Targeted tests or smoke run: `git diff --check origin/main...HEAD`; `python -m py_compile backend\start_server_verbose.py backend\start_server_port8001.py`; targeted `rg --fixed-strings` scans for `clinic.db`, `sqlite:///`, `create_all(`, `localhost:8000`, `:8000`, `CORS_ALLOW_ALL`, `change-me`, and `changeme` in both touched helpers.
- Result: diff hygiene passed; py_compile passed; targeted scans returned no findings in the two touched helpers; GitHub backend, frontend, parity, security, CodeQL, formatting, context-boundary, and docs checks are green.
- Not checked: full suites were not rerun locally after the PR body edit because no source files changed; Vercel deployment is rate-limited externally and unrelated to this backend helper change.

## Scope Gate
- Allowed paths: `backend/start_server_verbose.py`, `backend/start_server_port8001.py`.
- Denied paths: canonical backend app/routers/services, Alembic migrations, database models, frontend app code, ops compose/Docker entrypoints, generated artifacts, and evidence logs.
- Migration/docs/test impact: no migration, docs, or automated test contract changed; manual alternate backend startup helpers now fail fast instead of silently selecting SQLite.
- Rollback note: revert this PR to restore previous helper behavior, though that would also restore the silent SQLite fallback startup risk.
