### PR TITLE
chore(db): retire legacy sqlite data helpers

### DIFF
--- a/backend/fix_ecg_code.py
+++ b/backend/fix_ecg_code.py
@@ -1,32 +1,30 @@
-"""Update ЭКГ service code from ECG01 to K10"""
-import sys
-import os
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+#!/usr/bin/env python3
+"""Retired legacy ECG service-code helper.
 
-from sqlalchemy import create_engine, text
+Service catalog changes are owned by migrations, seed data, or supported admin
+flows. This root helper no longer mutates a local SQLite database directly.
+"""
 
-# Connect to database
-db_path = os.path.join(os.path.dirname(__file__), 'app', 'clinic.db')
-engine = create_engine(f'sqlite:///{db_path}')
+from __future__ import annotations
 
-with engine.connect() as conn:
-    # Update ЭКГ service code
-    result = conn.execute(text("""
-        UPDATE services 
-        SET service_code='K10', category_code='K' 
-        WHERE name='ЭКГ' OR service_code='ECG01'
-    """))
-    conn.commit()
-    print(f"Updated {result.rowcount} rows")
-    
-    # Show result
-    result = conn.execute(text("""
-        SELECT id, name, code, service_code, category_code 
-        FROM services 
-        WHERE name LIKE '%ЭКГ%' OR name LIKE '%ЭхоКГ%'
-    """))
-    print("\nServices with ЭКГ/ЭхоКГ:")
-    for row in result:
-        print(f"  ID={row[0]}, name={row[1]}, code={row[2]}, service_code={row[3]}, category_code={row[4]}")
 
-print("\nDone!")
+MESSAGE = """
+backend/fix_ecg_code.py is retired.
+
+Do not update ECG service codes through a direct SQLite UPDATE. Apply catalog
+changes through the canonical migration, seed, or admin-service path instead.
+
+For schema changes:
+
+  cd backend
+  alembic upgrade head
+""".strip()
+
+
+def main() -> int:
+    print(MESSAGE)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/reset_departments_table.py
+++ b/backend/reset_departments_table.py
@@ -1,51 +1,31 @@
+#!/usr/bin/env python3
+"""Retired legacy departments table reset helper.
+
+Department schema is owned by Alembic migrations. This root helper no longer
+drops or recreates local SQLite tables, because that can destroy data, hide
+schema drift, and bypass the PostgreSQL + Alembic source of truth.
 """
-Скрипт для удаления старой таблицы departments и создания новой с правильной структурой
-"""
-import sqlite3
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
-from app.db.base_class import Base
-from app.models.department import Department
+from __future__ import annotations
 
-# Подключение к БД
-DB_PATH = "./clinic.db"
 
-def reset_departments_table():
-    """Удалить старую таблицу и создать новую"""
+MESSAGE = """
+backend/reset_departments_table.py is retired.
 
-    print("[*] Удаление старой таблицы departments...")
+Do not reset departments through direct SQLite table drops or metadata table
+creation. Apply schema changes through Alembic migrations instead:
 
-    # Используем sqlite3 для удаления таблицы
-    try:
-        conn = sqlite3.connect(DB_PATH)
-        cursor = conn.cursor()
-        cursor.execute("DROP TABLE IF EXISTS departments")
-        conn.commit()
-        conn.close()
-        print("[OK] Старая таблица departments удалена")
-    except Exception as e:
-        print(f"[ERROR] Ошибка при удалении таблицы: {e}")
-        return False
+  cd backend
+  alembic upgrade head
 
-    # Создаем новую таблицу через SQLAlchemy
-    print("\n[*] Создание новой таблицы departments...")
-    try:
-        engine = create_engine(f"sqlite:///{DB_PATH}", echo=True)
-        Base.metadata.create_all(bind=engine, tables=[Department.__table__])
-        print("[OK] Новая таблица departments создана")
-        return True
-    except Exception as e:
-        print(f"[ERROR] Ошибка при создании таблицы: {e}")
-        return False
+Use supported seed or admin flows for department data corrections.
+""".strip()
+
+
+def main() -> int:
+    print(MESSAGE)
+    return 2
+
 
 if __name__ == "__main__":
-    print("=" * 60)
-    print("RESET DEPARTMENTS TABLE")
-    print("=" * 60)
-
-    if reset_departments_table():
-        print("\n[OK] Таблица успешно пересоздана")
-        print("Теперь можно запустить: python init_departments.py")
-    else:
-        print("\n[ERROR] Не удалось пересоздать таблицу")
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary
- Retire `backend/fix_ecg_code.py` so it no longer mutates a local SQLite `clinic.db` service catalog directly.
- Retire `backend/reset_departments_table.py` so it no longer drops/recreates departments outside Alembic.
- Point operators to Alembic migrations and supported seed/admin flows instead of SQLite-first data/schema patches.

## Contract Impact
- Canonical surface: no runtime API surface changed; this PR only replaces two root legacy helper scripts with fail-fast guidance.
- Request shape: not applicable because no HTTP request body, query parameter, or header contract changed.
- Response shape: not applicable because no API response schema or payload changed.
- Status codes: not applicable because no FastAPI endpoint or exception/status-code path changed.
- Frontend consumer: not applicable because no frontend call site, route, panel, or API client changed.
- Compatibility path or alias: not applicable because no route alias, compatibility endpoint, redirect, or legacy API path changed.
- Contract proof: diff is limited to `backend/fix_ecg_code.py` and `backend/reset_departments_table.py`; targeted scans confirmed both files no longer contain `sqlite3.connect`, `clinic.db`, `sqlite:///`, or `create_all(`.

## RBAC / Permissions
- Roles allowed: not applicable; these scripts are local helper entry points, not authenticated runtime operations.
- Roles denied: not applicable; no permission matrix or denial behavior changed.
- Positive auth proof: not applicable; no auth guard, token creation, role check, or login path changed.
- Negative auth proof: not applicable; no authorization failure path changed.

## Notification / Realtime
- Event type or websocket channel: not applicable; no notification, WebSocket, queue realtime, Telegram, or messaging channel changed.
- Payload version / ack behavior: not applicable; no realtime payload, acknowledgement, or event version changed.
- Read/unread or delivery semantics: not applicable; no notification delivery or read state changed.
- Reconnect/resync proof: not applicable; no reconnect, resync, subscription, or websocket lifecycle behavior changed.

## Frontend Resilience
- Empty data proof: not applicable; no frontend data rendering path changed.
- Partial data proof: not applicable; no frontend partial-response handling changed.
- Forbidden secondary path behavior: not applicable; no forbidden/secondary frontend route or fallback changed.
- Missing draft/resource behavior: not applicable; no draft/resource loading path changed.
- Stale route/deep-link behavior: not applicable; no route registry, navigation, or deep-link behavior changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\fix_ecg_code.py backend\reset_departments_table.py`; `git diff --check origin/main...HEAD`; targeted `rg --fixed-strings` scans for `sqlite3.connect` and `clinic.db`; `python -m pytest backend\tests\unit\test_no_legacy_ports_in_active_text.py -q`.
- Result: py_compile passed; diff hygiene passed; targeted scans returned no findings; focused unit guard passed with 8 tests.
- Not checked: full backend/frontend suites locally, because this PR changes only two retired root helper scripts; GitHub CI covers repo-wide gates.

## Scope Gate
- Allowed paths: `backend/fix_ecg_code.py`, `backend/reset_departments_table.py`.
- Denied paths: canonical backend app/routers/services, Alembic migrations, database models, frontend app code, ops compose/Docker entrypoints, generated artifacts, evidence logs, and unrelated legacy helpers.
- Migration/docs/test impact: no migration or automated test contract changed; this PR removes direct SQLite schema/data mutation behavior from two root helpers.
- Rollback note: revert this PR to restore the previous helper behavior, though that would also restore direct SQLite mutation and Alembic-bypass risk.
