### PR TITLE
fix(db): require postgres for orphan cleanup helper

### DIFF
--- a/backend/cleanup_orphaned_records.py
+++ b/backend/cleanup_orphaned_records.py
@@ -5,6 +5,7 @@
 import os
 import sys
 from sqlalchemy import create_engine, text, inspect
+from sqlalchemy.engine import make_url
 from sqlalchemy.orm import sessionmaker
 
 # Add backend to sys.path
@@ -12,21 +13,43 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 from app.core.config import get_settings
 
+
+def _is_sqlite_url(url: str) -> bool:
+    return url.lower().startswith(("sqlite://", "sqlite+"))
+
+
+def _safe_database_url_for_log(url: str) -> str:
+    try:
+        return make_url(url).render_as_string(hide_password=True)
+    except Exception:
+        return "<invalid database url>"
+
+
 def get_db_url():
     try:
         settings = get_settings()
-        return settings.DATABASE_URL
-    except Exception:
-        return "sqlite:///./clinic.db"
+    except Exception as exc:
+        raise RuntimeError(
+            "DATABASE_URL must be configured before orphan cleanup."
+        ) from exc
+
+    db_url = str(getattr(settings, "DATABASE_URL", "") or "").strip()
+    if not db_url:
+        raise RuntimeError("DATABASE_URL must be configured before orphan cleanup.")
+    if _is_sqlite_url(db_url):
+        raise RuntimeError(
+            "SQLite DATABASE_URL is disabled for orphan cleanup. "
+            "Use PostgreSQL as the database source of truth; use explicit "
+            "legacy migration/recovery tools for SQLite snapshots."
+        )
+    return db_url
 
 DATABASE_URL = get_db_url()
-if DATABASE_URL.startswith("sqlite+aiosqlite://"):
-    DATABASE_URL = DATABASE_URL.replace("sqlite+aiosqlite://", "sqlite://", 1)
 
 print("=" * 80)
 print("CLEANUP ORPHANED RECORDS")
 print("=" * 80)
-print(f"Database URL: {DATABASE_URL}\n")
+print(f"Database URL: {_safe_database_url_for_log(DATABASE_URL)}\n")
 
 # Orphaned records cleanup strategies
 CLEANUP_STRATEGIES = {
@@ -235,12 +258,7 @@ def verify_cleanup(engine):
 
 def main():
     engine = create_engine(DATABASE_URL, future=True)
-    
-    # Ensure FK enforcement is enabled
-    with engine.connect() as conn:
-        conn.execute(text("PRAGMA foreign_keys=ON"))
-        conn.commit()
-    
+
     # Cleanup orphaned records
     cleanup_orphaned_records(engine)
     

--- a/backend/tests/unit/test_no_legacy_ports_in_active_text.py
+++ b/backend/tests/unit/test_no_legacy_ports_in_active_text.py
@@ -391,3 +391,16 @@ def test_diagnose_ci_uses_only_isolated_temporary_sqlite():
     assert "ALLOW_SQLITE_DATABASE_URL" in content
     assert "CONFIRM_DIAGNOSE_CI_TEMP_SQLITE" in content
     assert "clinic.db" not in content
+
+
+def test_orphan_cleanup_requires_postgres_without_sqlite_fallback():
+    repo_root = Path(__file__).resolve().parents[3]
+    content = (repo_root / "backend/cleanup_orphaned_records.py").read_text(
+        encoding="utf-8", errors="ignore"
+    )
+
+    assert "DATABASE_URL must be configured before orphan cleanup." in content
+    assert "SQLite DATABASE_URL is disabled for orphan cleanup." in content
+    assert "sqlite:///./clinic.db" not in content
+    assert "clinic.db" not in content
+    assert "PRAGMA foreign_keys=ON" not in content


### PR DESCRIPTION
﻿## Summary
- Remove the silent `sqlite:///./clinic.db` fallback from `backend/cleanup_orphaned_records.py`.
- Require an explicit configured non-SQLite `DATABASE_URL` before orphan cleanup can run.
- Mask the database URL in helper output and remove the SQLite-only `PRAGMA foreign_keys=ON` call.
- Add a focused guard to prevent reintroducing this SQLite fallback.

## Contract Impact
- Canonical surface: no runtime API surface changed; this PR only hardens a root operational database cleanup helper and one text guard test.
- Request shape: not applicable because no HTTP request body, query parameter, or header contract changed.
- Response shape: not applicable because no API response schema or payload changed.
- Status codes: not applicable because no FastAPI endpoint or exception/status-code path changed.
- Frontend consumer: not applicable because no frontend call site, route, panel, or API client changed.
- Compatibility path or alias: not applicable because no route alias, compatibility endpoint, redirect, or legacy API path changed.
- Contract proof: diff is limited to `backend/cleanup_orphaned_records.py` and `backend/tests/unit/test_no_legacy_ports_in_active_text.py`; targeted scans confirmed the helper no longer contains `clinic.db`, `sqlite:///./clinic.db`, `sqlite+aiosqlite://`, or `PRAGMA foreign_keys=ON`.

## RBAC / Permissions
- Roles allowed: not applicable; this helper is not an authenticated runtime operation.
- Roles denied: not applicable; no permission matrix or denial behavior changed.
- Positive auth proof: not applicable; no auth guard, token creation, role check, or login path changed.
- Negative auth proof: not applicable; no authorization failure path changed.

## Notification / Realtime
- Event type or websocket channel: not applicable; no notification, WebSocket, queue realtime, Telegram, or messaging channel changed.
- Payload version / ack behavior: not applicable; no realtime payload, acknowledgement, or event version changed.
- Read/unread or delivery semantics: not applicable; no notification delivery or read state changed.
- Reconnect/resync proof: not applicable; no reconnect, resync, subscription, or websocket lifecycle behavior changed.

## Frontend Resilience
- Empty data proof: not applicable; no frontend data rendering path changed.
- Partial data proof: not applicable; no frontend partial-response handling changed.
- Forbidden secondary path behavior: not applicable; no forbidden/secondary frontend route or fallback changed.
- Missing draft/resource behavior: not applicable; no draft/resource loading path changed.
- Stale route/deep-link behavior: not applicable; no route registry, navigation, or deep-link behavior changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\cleanup_orphaned_records.py`; `python -m pytest backend\tests\unit\test_no_legacy_ports_in_active_text.py -q`; `python -m pytest backend\tests\unit\test_sqlite_runtime_guards.py backend\tests\unit\test_no_legacy_ports_in_active_text.py -q`; `git diff --check`; targeted `rg --fixed-strings` scans for `clinic.db`, `sqlite:///./clinic.db`, `sqlite+aiosqlite://`, and `PRAGMA foreign_keys=ON` in `backend/cleanup_orphaned_records.py`.
- Result: py_compile passed; focused guard passed with 9 tests; combined sqlite guard run passed with 13 tests; diff hygiene passed with only Git line-ending warnings; targeted helper scans returned no findings.
- Not checked: full backend/frontend suites locally, because this PR changes only one root operational helper and one focused text guard; GitHub CI covers repo-wide gates.

## Scope Gate
- Allowed paths: `backend/cleanup_orphaned_records.py`, `backend/tests/unit/test_no_legacy_ports_in_active_text.py`.
- Denied paths: canonical backend app/routers/services, Alembic migrations, database models, frontend app code, ops compose/Docker entrypoints, generated artifacts, evidence logs, and unrelated legacy helpers.
- Migration/docs/test impact: no migration or runtime API test contract changed; the helper now fails fast unless configured for PostgreSQL, preserving PostgreSQL + Alembic as the source of truth.
- Rollback note: revert this PR to restore previous helper behavior, though that would also restore silent SQLite fallback and SQLite-only PRAGMA risk.
