### PR TITLE
chore(db): retire legacy server startup smoke

### DIFF
--- a/backend/test_server_startup.py
+++ b/backend/test_server_startup.py
@@ -1,146 +1,33 @@
 #!/usr/bin/env python3
+"""Retired legacy server-startup smoke helper.
+
+This root script used to force a local SQLite DATABASE_URL and permissive
+development flags before importing the application. That bypassed the
+PostgreSQL + Alembic runtime contract and could hide startup drift.
 """
-Тест для проверки запуска сервера
-"""
-import os
+
+from __future__ import annotations
+
 import sys
-import traceback
 
-# Устанавливаем переменные окружения
-os.environ["DATABASE_URL"] = "sqlite:///./clinic.db"
-os.environ["CORS_DISABLE"] = "1"
-os.environ["WS_DEV_ALLOW"] = "1"
 
-def test_imports():
-    """Тестируем импорты основных модулей"""
-    print("🔍 Тестируем импорты...")
-    
-    try:
-        print("  - Импорт app.main...")
-        from app.main import app
-        print("  ✅ app.main импортирован успешно")
-        
-        print("  - Импорт app.db.session...")
-        from app.db.session import engine, SessionLocal
-        print("  ✅ app.db.session импортирован успешно")
-        
-        print("  - Импорт app.api.v1.api...")
-        from app.api.v1.api import api_router
-        print("  ✅ app.api.v1.api импортирован успешно")
-        
-        print("  - Импорт app.api.v1.endpoints.health...")
-        from app.api.v1.endpoints.health import router as health_router
-        print("  ✅ app.api.v1.endpoints.health импортирован успешно")
-        
-        return True
-        
-    except Exception as e:
-        print(f"  ❌ Ошибка импорта: {e}")
-        traceback.print_exc()
-        return False
+MESSAGE = """
+backend/test_server_startup.py is retired.
 
-def test_database_connection():
-    """Тестируем подключение к базе данных"""
-    print("\n🔍 Тестируем подключение к БД...")
-    
-    try:
-        from app.db.session import engine
-        from sqlalchemy import text
-        
-        with engine.connect() as conn:
-            result = conn.execute(text("SELECT 1"))
-            print("  ✅ Подключение к БД успешно")
-            return True
-            
-    except Exception as e:
-        print(f"  ❌ Ошибка подключения к БД: {e}")
-        traceback.print_exc()
-        return False
+Do not validate backend startup by forcing a local SQLite database URL or
+permissive CORS/WebSocket development flags. Use the canonical test suite or
+start the backend with a configured PostgreSQL DATABASE_URL instead:
 
-def test_health_endpoint():
-    """Тестируем health endpoint"""
-    print("\n🔍 Тестируем health endpoint...")
-    
-    try:
-        from app.api.v1.endpoints.health import get_health
-        
-        result = get_health()
-        print(f"  ✅ Health endpoint работает: {result}")
-        return True
-        
-    except Exception as e:
-        print(f"  ❌ Ошибка health endpoint: {e}")
-        traceback.print_exc()
-        return False
+  cd backend
+  python -m pytest tests/unit
+  python -m uvicorn app.main:app --host 127.0.0.1 --port 18000
+""".strip()
 
-def test_app_creation():
-    """Тестируем создание FastAPI приложения"""
-    print("\n🔍 Тестируем создание FastAPI приложения...")
-    
-    try:
-        from app.main import app
-        
-        # Проверяем, что приложение создано
-        if hasattr(app, 'router'):
-            print("  ✅ FastAPI приложение создано успешно")
-            print(f"  📊 Количество маршрутов: {len(app.router.routes)}")
-            return True
-        else:
-            print("  ❌ FastAPI приложение не создано корректно")
-            return False
-            
-    except Exception as e:
-        print(f"  ❌ Ошибка создания приложения: {e}")
-        traceback.print_exc()
-        return False
 
-def main():
-    """Основная функция тестирования"""
-    print("🚀 Запуск тестов сервера...")
-    print("=" * 50)
-    
-    # Диагностика окружения
-    print("🔍 Диагностика окружения:")
-    print(f"  Python version: {sys.version}")
-    print(f"  Current working directory: {os.getcwd()}")
-    print(f"  PYTHONPATH: {os.environ.get('PYTHONPATH', 'не установлен')}")
-    print(f"  DATABASE_URL: {os.environ.get('DATABASE_URL', 'не установлен')}")
-    print(f"  CORS_DISABLE: {os.environ.get('CORS_DISABLE', 'не установлен')}")
-    print(f"  WS_DEV_ALLOW: {os.environ.get('WS_DEV_ALLOW', 'не установлен')}")
-    
-    tests = [
-        test_imports,
-        test_database_connection,
-        test_health_endpoint,
-        test_app_creation
-    ]
-    
-    passed = 0
-    total = len(tests)
-    
-    for test in tests:
-        try:
-            print(f"\n🔍 Запуск теста: {test.__name__}")
-            if test():
-                passed += 1
-                print(f"✅ Тест {test.__name__} прошел успешно")
-            else:
-                print(f"❌ Тест {test.__name__} не прошел")
-        except Exception as e:
-            print(f"❌ Тест {test.__name__} упал с ошибкой: {e}")
-            print("Детали ошибки:")
-            traceback.print_exc()
-    
-    print("\n" + "=" * 50)
-    print(f"📊 Результаты: {passed}/{total} тестов прошли")
-    
-    if passed == total:
-        print("✅ Все тесты прошли успешно!")
-        return 0
-    else:
-        print("❌ Некоторые тесты не прошли")
-        print("🔍 Рекомендуется проверить логи выше для диагностики")
-        return 1
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary
- Retire `backend/test_server_startup.py`, a legacy root smoke script that forced local SQLite and permissive development flags before importing the backend.
- Replace it with fail-fast guidance to use canonical pytest checks or start FastAPI against a configured PostgreSQL `DATABASE_URL`.

## Contract Impact
- Canonical surface: no runtime API surface changed; this PR only replaces one root manual smoke helper with a retired wrapper.
- Request shape: not applicable because no HTTP request body, query parameter, or header contract changed.
- Response shape: not applicable because no API response schema or payload changed.
- Status codes: not applicable because no FastAPI endpoint or exception/status-code path changed.
- Frontend consumer: not applicable because no frontend call site, route, panel, or API client changed.
- Compatibility path or alias: not applicable because no route alias, compatibility endpoint, redirect, or legacy API path changed.
- Contract proof: diff is limited to `backend/test_server_startup.py`; targeted scans confirmed the file no longer contains active SQLite, `clinic.db`, permissive CORS/WS env assignments, `os.environ`, `create_all`, or `create_engine` startup bypass markers.

## RBAC / Permissions
- Roles allowed: not applicable; this script is not an authenticated runtime operation.
- Roles denied: not applicable; no permission matrix or denial behavior changed.
- Positive auth proof: not applicable; no auth guard, token creation, role check, or login path changed.
- Negative auth proof: not applicable; no authorization failure path changed.

## Notification / Realtime
- Event type or websocket channel: not applicable; no notification, WebSocket, queue realtime, Telegram, or messaging channel changed.
- Payload version / ack behavior: not applicable; no realtime payload, acknowledgement, or event version changed.
- Read/unread or delivery semantics: not applicable; no notification delivery or read state changed.
- Reconnect/resync proof: not applicable; no reconnect, resync, subscription, or websocket lifecycle behavior changed.

## Frontend Resilience
- Empty data proof: not applicable; no frontend data rendering path changed.
- Partial data proof: not applicable; no frontend partial-response handling changed.
- Forbidden secondary path behavior: not applicable; no forbidden/secondary frontend route or fallback changed.
- Missing draft/resource behavior: not applicable; no draft/resource loading path changed.
- Stale route/deep-link behavior: not applicable; no route registry, navigation, or deep-link behavior changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\test_server_startup.py`; `git diff --check`; targeted `rg` scan for `sqlite`, `clinic.db`, `CORS_DISABLE`, `WS_DEV_ALLOW`, `os.environ`, `create_all`, and `create_engine` in `backend/test_server_startup.py`.
- Result: py_compile passed; diff hygiene passed with only Git line-ending warning; targeted scan returned no findings.
- Not checked: full backend/frontend suites locally, because this PR changes only one retired manual smoke helper; GitHub CI covers repo-wide gates.

## Scope Gate
- Allowed paths: `backend/test_server_startup.py`.
- Denied paths: canonical backend app/routers/services, Alembic migrations, database models, frontend app code, ops compose/Docker entrypoints, generated artifacts, evidence logs, and unrelated legacy helpers.
- Migration/docs/test impact: no migration or automated test contract changed; this removes a stale local startup smoke that bypassed PostgreSQL + Alembic.
- Rollback note: revert this PR to restore the previous helper behavior, though that would also restore SQLite startup bypass risk.
