### PR TITLE
chore(security): retire legacy login diagnostics

### DIFF
--- a/backend/Check-LoginDiagnostics.ps1
+++ b/backend/Check-LoginDiagnostics.ps1
@@ -1,78 +1,21 @@
-# === Конфигурация ===
-$ApiRoot = "http://localhost:18000"
-$DbFilePath = "C:\final\backend\clinic.db"  # путь к SQLite-файлу (если используется)
-$EnvPath = "C:\final\backend\.env"
-$AuthFile = "C:\final\backend\app\api\v1\endpoints\auth.py"
-$DepsFile = "C:\final\backend\app\api\deps.py"
-$SessionFile = "C:\final\backend\app\db\session.py"
+<#
+Retired legacy login diagnostic helper.
 
-Write-Host "▶️  Проверка состояния проекта FastAPI..." -ForegroundColor Cyan
-Write-Host "--------------------------------------------------"
+This script previously mixed local database-file checks with a hard-coded
+login probe. That path no longer represents the PostgreSQL runtime or the
+current authentication contract.
+#>
 
-# 1. Проверка openapi.json
-Write-Host "`n[1] Проверка openapi.json..." -ForegroundColor Yellow
-try {
-  $openapi = Invoke-RestMethod -Uri "$ApiRoot/openapi.json" -TimeoutSec 3
-  if ($openapi.info.title) {
-    Write-Host "✅ OpenAPI доступен: $($openapi.info.title)" -ForegroundColor Green
-  }
-} catch {
-  Write-Host "❌ Ошибка при обращении к /openapi.json. Backend не запущен?" -ForegroundColor Red
-}
+Write-Error @"
+backend/Check-LoginDiagnostics.ps1 is retired.
 
-# 2. Проверка файла .env
-Write-Host "`n[2] Проверка .env (переменная DATABASE_URL)..." -ForegroundColor Yellow
-if (Test-Path $EnvPath) {
-  $dburl = Get-Content $EnvPath | Where-Object { $_ -match "^DATABASE_URL\s*=" }
-  if ($dburl) {
-    Write-Host "✅ Найдено: $dburl" -ForegroundColor Green
-  } else {
-    Write-Host "❌ В .env отсутствует DATABASE_URL" -ForegroundColor Red
-  }
-} else {
-  Write-Host "❌ Файл .env не найден: $EnvPath" -ForegroundColor Red
-}
+Use the canonical backend tests, configured PostgreSQL environment, and current
+auth smoke helpers instead of this legacy local login diagnostic.
 
-# 3. Проверка файла базы данных
-Write-Host "`n[3] Проверка файла БД (SQLite)..." -ForegroundColor Yellow
-if (Test-Path $DbFilePath) {
-  $size = (Get-Item $DbFilePath).Length
-  Write-Host "✅ База данных существует ($([math]::Round($size / 1KB, 1)) KB)" -ForegroundColor Green
-} else {
-  Write-Host "❌ База данных отсутствует: $DbFilePath" -ForegroundColor Red
-}
+Suggested checks:
+  cd backend
+  python -m pytest tests/unit
+  python -m pytest tests/integration/test_rbac_matrix.py
+"@
 
-# 4. Проверка доступности /login с тест-данными
-Write-Host "`n[4] Тест логина (admin/admin)..." -ForegroundColor Yellow
-try {
-  $body = "username=admin&password=admin&grant_type=password"
-  Invoke-RestMethod -Method Post -Uri "$ApiRoot/api/v1/login" `
-    -ContentType "application/x-www-form-urlencoded" `
-    -Body $body -TimeoutSec 3
-  Write-Host "✅ Логин прошёл успешно" -ForegroundColor Green
-} catch {
-  if ($_.Exception.Response.StatusCode.value__ -eq 401) {
-    Write-Host "⚠️  Неверный логин/пароль (401 Unauthorized)" -ForegroundColor Yellow
-  } elseif ($_.Exception.Response.StatusCode.value__ -eq 500) {
-    Write-Host "❌ Ошибка 500 (Internal Server Error). Проверь трассировку в uvicorn." -ForegroundColor Red
-  } else {
-    Write-Host "❌ Запрос не выполнен: $($_.Exception.Message)" -ForegroundColor Red
-  }
-}
-
-# 5. Проверка ключевых файлов
-Write-Host "`n[5] Проверка ключевых файлов auth/deps/session..." -ForegroundColor Yellow
-foreach ($file in @($AuthFile, $DepsFile, $SessionFile)) {
-  if (Test-Path $file) {
-    $line = Get-Content $file | Select-String -Pattern "def get_db|verify_password|sessionmaker"
-    if ($line) {
-      Write-Host "✅ $file содержит важные функции: $($line -join ', ')" -ForegroundColor Green
-    } else {
-      Write-Host "⚠️  $file найден, но без ключевых функций" -ForegroundColor Yellow
-    }
-  } else {
-    Write-Host "❌ Отсутствует: $file" -ForegroundColor Red
-  }
-}
-
-Write-Host "`n✅ Диагностика завершена. Если ошибка 500 осталась — покажи трассировку из uvicorn." -ForegroundColor Cyan
+exit 2


### PR DESCRIPTION
﻿## Summary
- Retire `backend/Check-LoginDiagnostics.ps1`, a legacy login diagnostic that checked a local database file and sent a hard-coded login probe.
- Replace it with fail-fast guidance to use canonical backend tests and current auth smoke helpers against configured PostgreSQL runtime.

## Contract Impact
- Canonical surface: no runtime API surface changed; this PR only replaces one root PowerShell diagnostic helper with a retired wrapper.
- Request shape: not applicable because no HTTP request body, query parameter, or header contract changed.
- Response shape: not applicable because no API response schema or payload changed.
- Status codes: not applicable because no FastAPI endpoint or exception/status-code path changed.
- Frontend consumer: not applicable because no frontend call site, route, panel, or API client changed.
- Compatibility path or alias: not applicable because no route alias, compatibility endpoint, redirect, or legacy API path changed.
- Contract proof: diff is limited to `backend/Check-LoginDiagnostics.ps1`; targeted scans confirmed the file no longer contains local SQLite path markers, hard-coded admin login probe markers, or live REST invocation code.

## RBAC / Permissions
- Roles allowed: not applicable; this script is not an authenticated runtime operation.
- Roles denied: not applicable; no permission matrix or denial behavior changed.
- Positive auth proof: not applicable; no auth guard, token creation, role check, or login path changed.
- Negative auth proof: not applicable; no authorization failure path changed.

## Notification / Realtime
- Event type or websocket channel: not applicable; no notification, WebSocket, queue realtime, Telegram, or messaging channel changed.
- Payload version / ack behavior: not applicable; no realtime payload, acknowledgement, or event version changed.
- Read/unread or delivery semantics: not applicable; no notification delivery or read state changed.
- Reconnect/resync proof: not applicable; no reconnect, resync, subscription, or websocket lifecycle behavior changed.

## Frontend Resilience
- Empty data proof: not applicable; no frontend data rendering path changed.
- Partial data proof: not applicable; no frontend partial-response handling changed.
- Forbidden secondary path behavior: not applicable; no forbidden/secondary frontend route or fallback changed.
- Missing draft/resource behavior: not applicable; no draft/resource loading path changed.
- Stale route/deep-link behavior: not applicable; no route registry, navigation, or deep-link behavior changed.

## Validation
- Targeted tests or smoke run: PowerShell parser check for `backend\Check-LoginDiagnostics.ps1`; `git diff --check`; targeted `rg` scan for `clinic.db`, `admin/admin`, `username=admin&password=admin`, `password=admin`, `sqlite`, `DbFilePath`, and `Invoke-RestMethod` in the touched file.
- Result: PowerShell parser check passed; diff hygiene passed with only Git line-ending warning; targeted scan returned no findings.
- Not checked: full backend/frontend suites locally, because this PR changes only one retired PowerShell diagnostic helper; GitHub CI covers repo-wide gates.

## Scope Gate
- Allowed paths: `backend/Check-LoginDiagnostics.ps1`.
- Denied paths: canonical backend app/routers/services, Alembic migrations, database models, frontend app code, ops compose/Docker entrypoints, generated artifacts, evidence logs, and unrelated legacy helpers.
- Migration/docs/test impact: no migration or automated test contract changed; this removes a stale diagnostic that mixed local database-file assumptions with a hard-coded login probe.
- Rollback note: revert this PR to restore the previous helper behavior, though that would also restore the local DB and hard-coded login diagnostic precedent.
