### PR TITLE
chore(security): retire direct auth diagnostic

### DIFF
--- a/backend/test_auth_direct.py
+++ b/backend/test_auth_direct.py
@@ -1,43 +1,32 @@
 #!/usr/bin/env python3
-"""
-Прямое тестирование аутентификации
-"""
-import sqlite3
-import hashlib
-import secrets
+"""Retired legacy direct-auth diagnostic helper.
 
-def test_auth():
-    """Тестировать аутентификацию напрямую"""
-    conn = sqlite3.connect("clinic.db")
-    cursor = conn.cursor()
-    
-    try:
-        # Получаем данные админа
-        cursor.execute("SELECT id, username, hashed_password FROM users WHERE username = 'admin'")
-        admin = cursor.fetchone()
-        
-        if not admin:
-            print("❌ Админ не найден")
-            return False
-        
-        print(f"✅ Админ найден: ID={admin[0]}, Username={admin[1]}")
-        print(f"   Password hash: {admin[2][:20]}...")
-        
-        # Проверяем, что пароль не пустой
-        if not admin[2]:
-            print("❌ Пароль не установлен")
-            return False
-        
-        print(f"   Stored hash: {admin[2]}")
-        print(f"   Hash length: {len(admin[2])}")
-        
-        return True
-        
-    except Exception as e:
-        print(f"❌ Ошибка: {e}")
-        return False
-    finally:
-        conn.close()
+This script previously inspected user credential records directly from a local
+database file. Authentication checks must go through canonical tests and
+runtime auth contracts instead of local database introspection.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+MESSAGE = """
+backend/test_auth_direct.py is retired.
+
+Do not inspect stored credential records through local database files. Use the
+canonical auth tests and current login smoke helpers against the configured
+PostgreSQL runtime instead:
+
+  cd backend
+  python -m pytest tests/integration/test_rbac_matrix.py
+""".strip()
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
 
 if __name__ == "__main__":
-    test_auth()
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary
- Retire `backend/test_auth_direct.py`, a legacy diagnostic that inspected auth records directly from a local database file.
- Replace it with fail-fast guidance to use canonical auth tests and current login smoke helpers against configured PostgreSQL runtime.

## Contract Impact
- Canonical surface: no runtime API surface changed; this PR only replaces one root auth diagnostic helper with a retired wrapper.
- Request shape: not applicable because no HTTP request body, query parameter, or header contract changed.
- Response shape: not applicable because no API response schema or payload changed.
- Status codes: not applicable because no FastAPI endpoint or exception/status-code path changed.
- Frontend consumer: not applicable because no frontend call site, route, panel, or API client changed.
- Compatibility path or alias: not applicable because no route alias, compatibility endpoint, redirect, or legacy API path changed.
- Contract proof: diff is limited to `backend/test_auth_direct.py`; targeted scans confirmed the file no longer contains SQLite/local DB markers, direct user-table query markers, credential hash output markers, or hard-coded default credential markers.

## RBAC / Permissions
- Roles allowed: not applicable; this script is not an authenticated runtime operation.
- Roles denied: not applicable; no permission matrix or denial behavior changed.
- Positive auth proof: not applicable; no auth guard, token creation, role check, or login path changed.
- Negative auth proof: not applicable; no authorization failure path changed.

## Notification / Realtime
- Event type or websocket channel: not applicable; no notification, WebSocket, queue realtime, Telegram, or messaging channel changed.
- Payload version / ack behavior: not applicable; no realtime payload, acknowledgement, or event version changed.
- Read/unread or delivery semantics: not applicable; no notification delivery or read state changed.
- Reconnect/resync proof: not applicable; no reconnect, resync, subscription, or websocket lifecycle behavior changed.

## Frontend Resilience
- Empty data proof: not applicable; no frontend data rendering path changed.
- Partial data proof: not applicable; no frontend partial-response handling changed.
- Forbidden secondary path behavior: not applicable; no forbidden/secondary frontend route or fallback changed.
- Missing draft/resource behavior: not applicable; no draft/resource loading path changed.
- Stale route/deep-link behavior: not applicable; no route registry, navigation, or deep-link behavior changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\test_auth_direct.py`; `git diff --check`; targeted `rg` scan for `sqlite`, `clinic.db`, `sqlite3`, `hashed_password`, `password hash`, `hashlib`, `secrets`, direct users-table query markers, `admin123`, and `admin/admin` in `backend/test_auth_direct.py`.
- Result: py_compile passed; diff hygiene passed with only Git line-ending warning; targeted scan returned no findings.
- Not checked: full backend/frontend suites locally, because this PR changes only one retired auth diagnostic helper; GitHub CI covers repo-wide gates.

## Scope Gate
- Allowed paths: `backend/test_auth_direct.py`.
- Denied paths: canonical backend app/routers/services, Alembic migrations, database models, frontend app code, ops compose/Docker entrypoints, generated artifacts, evidence logs, and unrelated legacy helpers.
- Migration/docs/test impact: no migration or automated test contract changed; this removes a stale direct-auth diagnostic that bypassed runtime auth contracts.
- Rollback note: revert this PR to restore the previous helper behavior, though that would also restore direct local credential-record inspection risk.
