### PR TITLE
fix(audio): sanitize helper error leakage

### DIFF
--- a/backend/app/utils/audio.py
+++ b/backend/app/utils/audio.py
@@ -101,12 +101,17 @@ async def get_audio_duration(content: bytes, format_name: str) -> int:
         estimated_duration = len(content) // 18000
         return min(estimated_duration, MAX_AUDIO_DURATION)
 
-    except Exception as e:
-        logger.error(f"Failed to get audio duration: {e}")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "Failed to get audio duration error_type=%s",
+            type(exc).__name__,
+        )
         raise HTTPException(
             status_code=400,
-            detail=f"Не удалось обработать аудио файл: {str(e)}"
-        )
+            detail="Не удалось обработать аудио файл"
+        ) from None
 
 
 async def compress_audio_if_needed(content: bytes, format_name: str) -> bytes:
@@ -141,13 +146,16 @@ async def compress_audio_if_needed(content: bytes, format_name: str) -> bytes:
 
         compressed = output.getvalue()
 
-        logger.info(f"Compressed audio from {len(content)} to {len(compressed)} bytes")
+        logger.info("Compressed audio successfully")
         return compressed
 
     except ImportError:
         logger.warning("pydub not installed, cannot compress audio")
         return content
 
-    except Exception as e:
-        logger.warning(f"Failed to compress audio: {e}, using original")
+    except Exception as exc:
+        logger.warning(
+            "Failed to compress audio error_type=%s; using original",
+            type(exc).__name__,
+        )
         return content


### PR DESCRIPTION
## Summary

- Sanitized audio helper error handling so decoder failures no longer expose raw exception text in public HTTP details.
- Replaced raw exception logging during duration/compression failures with structured `error_type` metadata.
- Preserved existing audio size, extension, duration, and fallback compression behavior.

## Contract Impact

- Canonical surface: `backend/app/utils/audio.py` helpers used by audio message upload handling
- Request shape: unchanged `content: bytes`, `filename: str`, and `format_name: str` helper inputs
- Response shape: unchanged return types for valid audio and compression fallback
- Status codes: unchanged 400 for invalid audio; existing explicit duration validation now remains explicit instead of being wrapped by a generic decoder failure
- Frontend consumer: not applicable - no frontend code or API client changed
- Compatibility path or alias: not applicable - no router mounting or path alias changed
- Contract proof: `py_compile`, static leakage search, and direct helper smoke for too-long and decoder-failure paths

## RBAC / Permissions

- Roles allowed: unchanged, inherited from existing callers
- Roles denied: unchanged, no authorization policy edited
- Positive auth proof: not applicable - this slice does not edit auth/RBAC behavior
- Negative auth proof: not applicable - this slice does not edit auth/RBAC behavior

## Notification / Realtime

not applicable - no notification, websocket, Telegram, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend state or rendering changed
- Partial data proof: not applicable - no frontend data consumer changed
- Forbidden secondary path behavior: not applicable - no routes or secondary paths changed
- Missing draft/resource behavior: not applicable - no draft/resource UI behavior changed
- Stale route/deep-link behavior: not applicable - no routing behavior changed

## Scope Gate

- Allowed paths: `backend/app/utils/audio.py`
- Denied paths: audio upload callers, AI transcription providers, storage behavior, route mounting, auth/RBAC, migrations, generated output
- Migration/docs/test impact: no migration; no docs change; targeted local smoke used because the helper has no dedicated test file
- Rollback note: revert the single audio helper logging/error-detail commit to restore prior behavior

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\utils\audio.py`; static search for raw `str(e)`/`str(exc)` public detail and raw f-string warning/error logs in `backend/app/utils/audio.py`; direct helper smoke for too-long audio, decoder failure, and compression failure fallback; `git diff --check`
- Result: passed locally
- Not checked: live browser audio upload flow, because this is a backend helper-only leakage slice and no app server was started