### PR TITLE
chore(db): retire root sqlite diagnostic helpers

### DIFF
--- a/backend/test_cart_error.py
+++ b/backend/test_cart_error.py
@@ -1,34 +1,33 @@
+#!/usr/bin/env python3
+"""Retired legacy cart diagnostic helper.
+
+This root script used to open a local file-backed database directly while
+debugging registrar cart failures. Cart behavior is now validated through the
+canonical FastAPI test suite and the configured PostgreSQL/Alembic runtime.
 """
-Тест для воспроизведения ошибки 500 в /registrar/cart
-"""
+
+from __future__ import annotations
+
 import sys
-sys.path.insert(0, '.')
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from app.crud import clinic as crud_clinic
 
-# Создаем сессию БД
-engine = create_engine("sqlite:///./clinic.db", echo=False)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-db = SessionLocal()
+MESSAGE = """
+backend/test_cart_error.py is retired.
 
-try:
-    print("[*] Тестирование get_queue_settings...")
+Do not diagnose registrar cart behavior by opening a local file-backed
+database. Use the canonical API/integration tests against the configured
+runtime instead:
 
-    # Вызываем функцию, которая вызывается в create_cart_appointments
-    queue_settings = crud_clinic.get_queue_settings(db)
+  cd backend
+  python -m pytest tests/integration/test_admin_finance_transactions.py
+  python -m pytest tests/unit/test_service_repository_boundary.py
+""".strip()
 
-    print("[OK] Функция выполнена успешно!")
-    print(f"     Результат: {queue_settings}")
 
-except Exception as e:
-    print(f"[ERROR] Ошибка при выполнении:")
-    print(f"        Тип: {type(e).__name__}")
-    print(f"        Сообщение: {str(e)}")
-    import traceback
-    print("\n[TRACEBACK]")
-    traceback.print_exc()
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
-finally:
-    db.close()
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/test_cart_function_direct.py
+++ b/backend/test_cart_function_direct.py
@@ -1,101 +1,33 @@
+#!/usr/bin/env python3
+"""Retired legacy direct cart-function diagnostic helper.
+
+This root script used to import a registrar endpoint function directly and bind
+it to a local file-backed database session. That bypassed the API contract,
+dependency injection, RBAC, and the PostgreSQL/Alembic runtime source of truth.
 """
-Test cart creation function directly to see Python error
-"""
+
+from __future__ import annotations
+
 import sys
-sys.path.insert(0, '.')
 
-from decimal import Decimal
-from datetime import date
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
-# Create DB session
-engine = create_engine("sqlite:///./clinic.db", echo=False)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-db = SessionLocal()
+MESSAGE = """
+backend/test_cart_function_direct.py is retired.
 
-try:
-    # Import the endpoint function
-    print("[*] Importing endpoint...")
-    from app.api.v1.endpoints.registrar_wizard import create_cart_appointments, CartRequest, VisitRequest, ServiceItemRequest
-    print("[OK] Endpoint imported successfully")
+Do not call registrar cart endpoint functions directly against a local
+file-backed database. Use canonical API/integration coverage against the
+configured runtime instead:
 
-    # Get a patient
-    from app.models.patient import Patient
-    patient = db.query(Patient).first()
-    if not patient:
-        print("[ERROR] No patients found")
-        sys.exit(1)
-    print(f"[OK] Using patient ID: {patient.id}")
+  cd backend
+  python -m pytest tests/integration/test_admin_finance_transactions.py
+  python -m pytest tests/integration/test_e2e_clinic.py
+""".strip()
 
-    # Get a service
-    from app.models.service import Service
-    service = db.query(Service).first()
-    if not service:
-        print("[ERROR] No services found")
-        sys.exit(1)
-    print(f"[OK] Using service ID: {service.id} ({service.name})")
 
-    # Get current user (registrar)
-    from app.models.user import User
-    user = db.query(User).filter(User.username == "registrar").first()
-    if not user:
-        print("[ERROR] Registrar user not found")
-        sys.exit(1)
-    print(f"[OK] Using user: {user.username}")
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
-    # Create cart request
-    print("\n[*] Creating cart request...")
-    cart_data = CartRequest(
-        patient_id=patient.id,
-        discount_mode="none",
-        payment_method="cash",
-        notes="Test cart",
-        visits=[
-            VisitRequest(
-                department="general",
-                visit_date=date.today(),
-                visit_time="10:00",
-                doctor_id=None,
-                services=[
-                    ServiceItemRequest(
-                        service_id=service.id,
-                        quantity=1,
-                        custom_price=None
-                    )
-                ]
-            )
-        ]
-    )
-    print("[OK] Cart request created")
 
-    # Call the endpoint function directly
-    print("\n[*] Calling create_cart_appointments...")
-    try:
-        result = create_cart_appointments(
-            cart_data=cart_data,
-            db=db,
-            current_user=user
-        )
-        print(f"\n[OK] Success!")
-        print(f"     Invoice ID: {result.invoice_id}")
-        print(f"     Visit IDs: {result.visit_ids}")
-        print(f"     Total amount: {result.total_amount}")
-        print(f"     Message: {result.message}")
-    except Exception as e:
-        print(f"\n[ERROR] Function call failed:")
-        print(f"        Type: {type(e).__name__}")
-        print(f"        Message: {str(e)}")
-        import traceback
-        print("\n[TRACEBACK]")
-        traceback.print_exc()
-
-except Exception as e:
-    print(f"\n[ERROR] Import or setup failed:")
-    print(f"        Type: {type(e).__name__}")
-    print(f"        Message: {str(e)}")
-    import traceback
-    print("\n[TRACEBACK]")
-    traceback.print_exc()
-finally:
-    db.close()
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/test_payment_webhooks.py
+++ b/backend/test_payment_webhooks.py
@@ -1,112 +1,34 @@
 #!/usr/bin/env python3
+"""Retired legacy payment-webhook smoke helper.
+
+This root script used to force a local file-backed test database, create
+ad-hoc tables with SQLAlchemy metadata, and probe stale webhook routes. That
+bypassed the PostgreSQL + Alembic runtime contract and could hide payment route
+drift.
 """
-Тестирование вебхуков оплаты
-"""
-import asyncio
-import os
+
+from __future__ import annotations
+
 import sys
-from datetime import datetime
-
-import httpx
-
-# Добавляем путь к проекту
-sys.path.insert(0, '.')
-
-# Настройка переменных окружения
-os.environ.setdefault('DATABASE_URL', 'sqlite:///./test_clinic.db')
-os.environ.setdefault('CORS_DISABLE', '1')
-os.environ.setdefault('WS_DEV_ALLOW', '1')
-
-# Импортируем после настройки окружения
-from app.db.base import Base
-from app.db.session import engine
-
-BASE_URL = "http://127.0.0.1:18000"
 
 
-async def test_payment_webhooks():
-    """Тестирование создания и обработки вебхуков"""
-    print("🧪 Тестирование вебхуков оплаты...")
+MESSAGE = """
+backend/test_payment_webhooks.py is retired.
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        # Проверяем health endpoint
-        try:
-            response = await client.get(f"{BASE_URL}/api/v1/health")
-            if response.status_code != 200:
-                print(f"❌ Health check failed: {response.status_code}")
-                return False
-            print("✅ Health check пройден")
-        except Exception as e:
-            print(f"❌ Не удалось подключиться к серверу: {e}")
-            return False
+Do not validate payment webhooks by forcing a local file-backed database or
+creating schema from SQLAlchemy metadata. Use canonical payment webhook tests
+against the configured PostgreSQL/Alembic environment instead:
 
-        # Тестируем создание вебхука
-        webhook_data = {
-            "payment_id": "test_payment_001",
-            "amount": 100000,
-            "status": "completed",
-            "timestamp": datetime.now().isoformat(),
-        }
-
-        try:
-            # Пытаемся создать вебхук через API
-            response = await client.post(
-                f"{BASE_URL}/api/v1/webhooks/payment", json=webhook_data
-            )
-
-            if response.status_code in [200, 201]:
-                print("✅ Вебхук успешно создан")
-            elif response.status_code == 404:
-                print("⚠️ Endpoint вебхуков не найден (404), но это некритично")
-            else:
-                print(f"⚠️ Неожиданный статус: {response.status_code}")
-
-        except Exception as e:
-            print(f"⚠️ Ошибка при создании вебхука: {e}")
-            # Не критично, продолжаем тесты
-
-        # Проверяем базовые эндпоинты
-        endpoints_to_test = [
-            "/api/v1/status",
-            "/api/v1/queue/stats",
-            "/api/v1/appointments/stats",
-        ]
-
-        for endpoint in endpoints_to_test:
-            try:
-                response = await client.get(f"{BASE_URL}{endpoint}")
-                if response.status_code == 200:
-                    print(f"✅ {endpoint}: OK")
-                else:
-                    print(f"⚠️ {endpoint}: {response.status_code}")
-            except Exception as e:
-                print(f"⚠️ {endpoint}: {e}")
-
-    print("🎉 Тестирование вебхуков завершено!")
-    return True
+  cd backend
+  python -m pytest tests/integration/test_notification_catalog_slice2_online_payments.py
+  python -m pytest tests/unit/test_service_repository_boundary.py
+""".strip()
 
 
-def main():
-    """Основная функция"""
-    try:
-        # Создаём таблицы если их нет
-        Base.metadata.create_all(bind=engine)
-        print("✅ База данных готова")
-
-        # Запускаем тесты
-        result = asyncio.run(test_payment_webhooks())
-
-        if not result:
-            print("❌ Тесты не прошли")
-            sys.exit(1)
-
-        print("✅ Все тесты пройдены")
-        sys.exit(0)
-
-    except Exception as e:
-        print(f"❌ Критическая ошибка: {e}")
-        sys.exit(1)
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Retire three root-level legacy diagnostic helpers that used direct local database setup or stale smoke behavior.
- Replace them with fail-fast messages that point maintainers to canonical pytest coverage.
- Keep runtime API, routers, models, migrations, and frontend untouched.

## Contract Impact

- Canonical surface: no public API contract changes; only root-level manual helper scripts changed.
- Request shape: not applicable - no request payloads or API handlers changed.
- Response shape: not applicable - no response schemas changed.
- Status codes: not applicable - no route behavior changed.
- Frontend consumer: not applicable - frontend code is untouched.
- Compatibility path or alias: not applicable - retired local-only diagnostics now exit before doing work.
- Contract proof: targeted grep confirms removed direct sqlite/create_all markers from the touched helpers.

## RBAC / Permissions

- Roles allowed: not applicable - no RBAC-protected runtime path changed.
- Roles denied: not applicable - no permission matrix changed.
- Positive auth proof: not applicable - no authenticated endpoint changed.
- Negative auth proof: not applicable - no authenticated endpoint changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification or websocket behavior changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no notification state changed.
- Reconnect/resync proof: not applicable - no websocket reconnect path changed.

## Frontend Resilience

- Empty data proof: not applicable - frontend code is untouched.
- Partial data proof: not applicable - frontend code is untouched.
- Forbidden secondary path behavior: not applicable - frontend code is untouched.
- Missing draft/resource behavior: not applicable - frontend code is untouched.
- Stale route/deep-link behavior: not applicable - frontend code is untouched.

## Scope Gate

- Allowed paths: backend/test_cart_error.py, backend/test_cart_function_direct.py, backend/test_payment_webhooks.py.
- Denied paths: backend app runtime, routers, migrations, ops, frontend, generated artifacts, evidence logs.
- Migration/docs/test impact: no migration needed; touched scripts now direct users to existing canonical pytest coverage.
- Rollback note: revert this commit to restore the legacy local diagnostics, though that would also restore direct local DB behavior.

## Validation

- Targeted tests or smoke run: python -m py_compile backend\\test_cart_error.py backend\\test_cart_function_direct.py backend\\test_payment_webhooks.py; each retired helper verified to exit with code 2; rg safety scan for sqlite/create_all/clinic.db markers in touched files; python -m pytest backend\\tests\\unit\\test_no_legacy_ports_in_active_text.py; git diff --check; default password/JWT scan outside backend/tests.
- Result: all targeted validation passed; rg marker scan returned no matches.
- Not checked: full backend suite, frontend suite, browser smoke.