### PR TITLE
fix(security): remove default admin password from login UI

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -34,7 +34,7 @@ const translations = {
     loggingIn: 'Входим...',
     forgotPassword: 'Забыли пароль?',
     backToHome: 'На главную',
-    note: 'По умолчанию админ создаётся скриптом create_admin.py (admin/admin).',
+    note: 'Администратор создаётся через защищённую настройку. Пароль не хранится и не показывается в интерфейсе.',
     flagUrl: 'https://flagcdn.com/w80/ru.png'
   },
   UZ: {
@@ -47,7 +47,7 @@ const translations = {
     loggingIn: 'Kirilmoqda...',
     forgotPassword: 'Parolni unutdingizmi?',
     backToHome: 'Bosh sahifaga',
-    note: 'Odatiy holda admin create_admin.py skripti bilan yaratiladi (admin/admin).',
+    note: 'Administrator xavfsiz sozlash orqali yaratiladi. Parol interfeysda saqlanmaydi va ko\'rsatilmaydi.',
     flagUrl: 'https://flagcdn.com/w80/uz.png'
   },
   EN: {
@@ -60,7 +60,7 @@ const translations = {
     loggingIn: 'Signing in...',
     forgotPassword: 'Forgot password?',
     backToHome: 'Back to Home',
-    note: 'By default, admin is created by create_admin.py script (admin/admin).',
+    note: 'Admin access is configured during secure setup. Passwords are not stored or shown in the UI.',
     flagUrl: 'https://flagcdn.com/w80/gb.png'
   }
 };
@@ -70,7 +70,7 @@ export default function Login() {
 
   const [selectedRoleKey, setSelectedRoleKey] = useState('admin');
   const [username, setUsername] = useState('admin@example.com');
-  const [password, setPassword] = useState('admin');
+  const [password, setPassword] = useState('');
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
   const [language, setLanguage] = useState('RU');


### PR DESCRIPTION
## Summary

- Remove the visible default admin password hint from Login.jsx helper text.
- Stop pre-filling the login password field with a default password.
- Keep the default admin role and username selection unchanged for operator convenience.

## Contract Impact

- Canonical surface: frontend/src/pages/Login.jsx only.
- Request shape: not changed - login API request payload shape is unchanged.
- Response shape: not changed - login API response handling is unchanged.
- Status codes: not changed - no backend HTTP handler changed.
- Frontend consumer: login page users now type the password instead of receiving a default password hint/prefill.
- Compatibility path or alias: not applicable - no route alias changed.
- Contract proof: diff is limited to Login.jsx helper copy and initial password state.

## RBAC / Permissions

- Roles allowed: not applicable - app RBAC rules are unchanged.
- Roles denied: not applicable - app RBAC rules are unchanged.
- Positive auth proof: not applicable - no login endpoint behavior changed.
- Negative auth proof: marker scan confirms Login.jsx no longer contains admin/admin, create_admin.py, or password admin prefill.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification or websocket path changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - delivery state is untouched.
- Reconnect/resync proof: not applicable - no realtime client/server behavior changed.

## Frontend Resilience

- Empty data proof: password initial state is empty and remains controlled by React.
- Partial data proof: username/role default remains present while password is blank.
- Forbidden secondary path behavior: not applicable - auth error handling is unchanged.
- Missing draft/resource behavior: not applicable - no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable - no route changed.

## Scope Gate

- Allowed paths: frontend/src/pages/Login.jsx.
- Denied paths: LoginFormStyled.jsx, frontend API client, backend auth, database, ops configs, generated artifacts, evidence logs.
- Migration/docs/test impact: no migration needed; targeted Login accessibility tests still pass.
- Rollback note: revert this PR to restore old visible default credential hint/prefill, which is not recommended.

## Validation

- Targeted tests or smoke run: npm.cmd run lint:check -- --quiet; npm.cmd run test:run -- src/pages/__tests__/Login.accessibility.test.jsx; rg marker scan for admin/admin/create_admin.py/password admin prefill in Login.jsx and frontend/src; git diff --check.
- Result: all targeted validation passed locally.
- Not checked: live browser login was not run because this PR changes only helper copy and initial password state.