### PR TITLE
chore(db): retire registrar schema patch helper

### DIFF
--- a/backend/add_registrar_fields.py
+++ b/backend/add_registrar_fields.py
@@ -1,134 +1,31 @@
 #!/usr/bin/env python3
-"""
-Скрипт для добавления новых полей в таблицы appointments и patients
-для поддержки улучшенной таблицы регистратора.
+"""Retired legacy registrar schema patch helper.
 
-Добавляемые поля:
-- appointments.visit_type (paid/repeat/free)
-- appointments.payment_type (cash/card/online) 
-- appointments.services (JSON список услуг)
-- patients.address уже есть в модели
-
-Запуск: python add_registrar_fields.py
+Registrar appointment and patient fields are owned by SQLAlchemy models and
+Alembic migrations. This helper used to mutate database schema directly and is
+kept only as a fail-fast pointer to the canonical migration flow.
 """
+
+from __future__ import annotations
 
 import sys
-import os
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from sqlalchemy import text
-from app.db.session import SessionLocal
-from app.core.config import settings
 
-def add_registrar_fields():
-    """Добавляет новые поля для регистратора"""
-    db = SessionLocal()
-    
-    try:
-        print("🔧 Добавление новых полей для регистратора...")
-        
-        # Проверяем и добавляем поля в таблицу appointments
-        print("📋 Обновление таблицы appointments...")
-        
-        # Добавляем visit_type
-        try:
-            db.execute(text("""
-                ALTER TABLE appointments 
-                ADD COLUMN visit_type VARCHAR(16) DEFAULT 'paid'
-            """))
-            print("✅ Добавлено поле visit_type")
-        except Exception as e:
-            if "already exists" in str(e) or "duplicate column" in str(e).lower():
-                print("ℹ️  Поле visit_type уже существует")
-            else:
-                print(f"❌ Ошибка добавления visit_type: {e}")
-        
-        # Добавляем payment_type
-        try:
-            db.execute(text("""
-                ALTER TABLE appointments 
-                ADD COLUMN payment_type VARCHAR(16) DEFAULT 'cash'
-            """))
-            print("✅ Добавлено поле payment_type")
-        except Exception as e:
-            if "already exists" in str(e) or "duplicate column" in str(e).lower():
-                print("ℹ️  Поле payment_type уже существует")
-            else:
-                print(f"❌ Ошибка добавления payment_type: {e}")
-        
-        # Добавляем services (JSON)
-        try:
-            db.execute(text("""
-                ALTER TABLE appointments 
-                ADD COLUMN services JSON
-            """))
-            print("✅ Добавлено поле services")
-        except Exception as e:
-            if "already exists" in str(e) or "duplicate column" in str(e).lower():
-                print("ℹ️  Поле services уже существует")
-            else:
-                print(f"❌ Ошибка добавления services: {e}")
-        
-        # Проверяем поле address в таблице patients (SQLite синтаксис)
-        print("👤 Проверка таблицы patients...")
-        try:
-            result = db.execute(text("""
-                PRAGMA table_info(patients)
-            """)).fetchall()
-            
-            address_exists = any(col[1] == 'address' for col in result)
-            
-            if address_exists:
-                print("ℹ️  Поле address в таблице patients уже существует")
-            else:
-                db.execute(text("""
-                    ALTER TABLE patients 
-                    ADD COLUMN address VARCHAR(512)
-                """))
-                print("✅ Добавлено поле address в таблицу patients")
-        except Exception as e:
-            print(f"❌ Ошибка с полем address: {e}")
-        
-        # Коммитим изменения
-        db.commit()
-        print("🎉 Все изменения успешно применены!")
-        
-        # Показываем структуру таблиц (SQLite синтаксис)
-        print("\n📊 Текущая структура таблицы appointments:")
-        result = db.execute(text("""
-            PRAGMA table_info(appointments)
-        """)).fetchall()
-        
-        for row in result:
-            print(f"  - {row[1]}: {row[2]} {'NULL' if row[3] == 0 else 'NOT NULL'} {f'DEFAULT {row[4]}' if row[4] else ''}")
-        
-        print("\n👤 Структура таблицы patients:")
-        result = db.execute(text("""
-            PRAGMA table_info(patients)
-        """)).fetchall()
-        
-        for row in result:
-            if row[1] in ['address', 'last_name', 'first_name', 'phone']:  # Показываем только ключевые поля
-                print(f"  - {row[1]}: {row[2]} {'NULL' if row[3] == 0 else 'NOT NULL'}")
-            
-    except Exception as e:
-        print(f"❌ Критическая ошибка: {e}")
-        db.rollback()
-        raise
-    finally:
-        db.close()
+MESSAGE = """
+backend/add_registrar_fields.py is retired.
+
+Do not add registrar columns with an ad-hoc schema patch helper. PostgreSQL +
+Alembic are the database source of truth. Apply the canonical migrations instead:
+
+  cd backend
+  alembic upgrade head
+""".strip()
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
 
 if __name__ == "__main__":
-    print("🚀 Запуск миграции полей регистратора...")
-    print(f"📡 База данных: {settings.DATABASE_URL}")
-    
-    try:
-        add_registrar_fields()
-        print("\n✅ Миграция завершена успешно!")
-        print("\n📝 Следующие шаги:")
-        print("1. Перезапустите backend сервер")
-        print("2. Проверьте работу таблицы в регистратуре")
-        print("3. Новые записи будут содержать все поля")
-    except Exception as e:
-        print(f"\n❌ Миграция не удалась: {e}")
-        sys.exit(1)
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Retire the legacy registrar schema patch helper that mutated appointment/patient columns outside Alembic.
- Replace direct ALTER TABLE/PRAGMA/session usage with a fail-fast pointer to alembic upgrade head.
- Keep models, migrations, routers, frontend, and ops untouched.

## Contract Impact

- Canonical surface: backend/add_registrar_fields.py only; Alembic and SQLAlchemy models remain the schema source of truth.
- Request shape: not changed - no API request payloads changed.
- Response shape: not changed - no API response schemas changed.
- Status codes: not changed - no HTTP handlers changed.
- Frontend consumer: not applicable - frontend code is untouched.
- Compatibility path or alias: legacy helper path remains present but now exits before touching database schema.
- Contract proof: refs scan found no external project references to add_registrar_fields.py beyond the file itself; model/baseline migration already include the registrar fields.

## RBAC / Permissions

- Roles allowed: not applicable - no authenticated runtime path changed.
- Roles denied: not applicable - no permission matrix changed.
- Positive auth proof: not applicable - no login or token validation flow changed.
- Negative auth proof: not applicable - no RBAC denial path changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification or websocket code changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no notification state changed.
- Reconnect/resync proof: not applicable - no websocket reconnect path changed.

## Frontend Resilience

- Empty data proof: not applicable - frontend code is untouched.
- Partial data proof: not applicable - frontend code is untouched.
- Forbidden secondary path behavior: not applicable - no frontend auth path changed.
- Missing draft/resource behavior: not applicable - no frontend resource route changed.
- Stale route/deep-link behavior: not applicable - routing code is untouched.

## Scope Gate

- Allowed paths: backend/add_registrar_fields.py.
- Denied paths: Alembic migrations, SQLAlchemy models, backend runtime routers/services, frontend, ops, generated artifacts, evidence logs.
- Migration/docs/test impact: no migration needed; the helper now points to the existing Alembic flow.
- Rollback note: revert this PR to restore the ad-hoc schema patch helper, though that would reintroduce direct DB schema mutation outside Alembic.

## Validation

- Targeted tests or smoke run: agent_gate.py with known root cause backend/add_registrar_fields.py; refs scan for add_registrar_fields.py; model/migration field scan for visit_type/payment_type/services/address; python -m py_compile backend\\add_registrar_fields.py; retired helper verified to exit with code 2; rg safety scan for PRAGMA/ALTER TABLE/settings.DATABASE_URL/SessionLocal/sqlite/create_all markers in the touched file; python -m pytest backend\\tests\\unit\\test_no_legacy_ports_in_active_text.py; git diff --check; default password/JWT scan outside backend/tests.
- Result: all targeted validation passed locally; marker scan returned no matches in the touched file.
- Not checked: full backend suite, frontend suite, browser smoke.