### PR TITLE
test(security): sanitize websocket auth smoke

### DIFF
--- a/backend/ws_test_auth.py
+++ b/backend/ws_test_auth.py
@@ -5,11 +5,17 @@
 import asyncio
 import json
 import os
+import sys
 import urllib.parse
 import urllib.request
 from datetime import datetime
 
 import websockets
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
 BASE_URL = os.getenv("QA_BACKEND_BASE_URL", "http://127.0.0.1:18000")
 WS_BASE_URL = os.getenv("QA_BACKEND_WS_URL", "ws://127.0.0.1:18000")
@@ -45,6 +51,8 @@ async def get_auth_token():
             else:
                 print(f"❌ Ошибка получения токена: {response.status}")
                 return None
+    except RuntimeError:
+        raise
     except Exception as e:
         print(f"❌ Ошибка запроса токена: {e}")
         return None
@@ -83,7 +91,7 @@ async def test_ws_queue_auth(token):
                 print(f"⚠️ Неожиданный тип сообщения: {data}")
 
     except Exception as e:
-        print(f"❌ Ошибка подключения: {e}")
+        print(f"Connection error: {type(e).__name__}")
 
 
 async def test_broadcast_trigger():
@@ -140,10 +148,14 @@ async def main():
     print("=" * 60)
 
     # Получаем токен
-    token = await get_auth_token()
+    try:
+        token = await get_auth_token()
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}")
+        return 2
     if not token:
         print("❌ Не удалось получить токен аутентификации")
-        return
+        return 1
 
     print("🔑 Токен получен; значение не печатается")
 
@@ -155,7 +167,8 @@ async def main():
 
     print("\n" + "=" * 60)
     print("✅ WebSocket тестирование с аутентификацией завершено")
+    return 0
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    raise SystemExit(asyncio.run(main()))

--- a/backend/ws_test_auth.py
+++ b/backend/ws_test_auth.py
@@ -4,21 +4,36 @@
 """
 import asyncio
 import json
+import os
 import urllib.parse
 import urllib.request
 from datetime import datetime
 
 import websockets
 
+BASE_URL = os.getenv("QA_BACKEND_BASE_URL", "http://127.0.0.1:18000")
+WS_BASE_URL = os.getenv("QA_BACKEND_WS_URL", "ws://127.0.0.1:18000")
+AUTH_USERNAME = os.getenv("QA_ADMIN_USERNAME", "admin")
+
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Set {name} to run backend websocket smoke scripts.")
+    return value
+
 
 async def get_auth_token():
     """Получаем JWT токен для аутентификации"""
     try:
         data = urllib.parse.urlencode(
-            {"username": "admin", "password": "admin"}
+            {
+                "username": AUTH_USERNAME,
+                "password": required_env("QA_ADMIN_PASSWORD"),
+            }
         ).encode()
         req = urllib.request.Request(
-"http://127.0.0.1:18000/api/v1/login",
+            f"{BASE_URL}/api/v1/login",
             data=data,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
@@ -39,9 +54,7 @@ async def test_ws_queue_auth(token):
     """Тест WebSocket очереди с аутентификацией"""
     print("\n🔌 Тестирую /ws/queue с аутентификацией...")
     try:
-        uri = (
-"ws://127.0.0.1:18000/ws/queue?department=ENT&date=2025-08-28&token=" + token
-        )
+        uri = f"{WS_BASE_URL}/ws/queue?department=ENT&date=2025-08-28&token={token}"
         headers = {"Origin": "http://localhost:5173"}
         async with websockets.connect(uri, additional_headers=headers) as ws:
             # Получаем приветственное сообщение
@@ -88,7 +101,7 @@ async def test_broadcast_trigger():
         # Открываем день (должно вызвать broadcast)
         print("📅 Открываю день для ENT...")
         req = urllib.request.Request(
-"http://127.0.0.1:18000/api/v1/appointments/open?department=ENT&date=2025-08-28&start_number=1",
+            f"{BASE_URL}/api/v1/appointments/open?department=ENT&date=2025-08-28&start_number=1",
             headers=headers,
             method="POST",
         )
@@ -107,7 +120,7 @@ async def test_broadcast_trigger():
         # Выдаём следующий талон (должно вызвать broadcast)
         print("🎫 Выдаю следующий талон...")
         req = urllib.request.Request(
-"http://127.0.0.1:18000/api/v1/next-ticket?department=ENT&date=2025-08-28",
+            f"{BASE_URL}/api/v1/next-ticket?department=ENT&date=2025-08-28",
             headers=headers,
             method="POST",
         )
@@ -132,7 +145,7 @@ async def main():
         print("❌ Не удалось получить токен аутентификации")
         return
 
-    print(f"🔑 Токен получен: {token[:20]}...")
+    print("🔑 Токен получен; значение не печатается")
 
     # Тестируем WebSocket с аутентификацией
     await test_ws_queue_auth(token)


### PR DESCRIPTION
## Summary
- Removes the hardcoded `admin/admin` credential from the root websocket auth smoke script.
- Requires `QA_ADMIN_PASSWORD` before the helper can request a token.
- Stops printing token prefixes and token-bearing websocket connection errors in local smoke output.
- Returns nonzero exit codes for missing credentials or token acquisition failure.

## Contract Impact
- Canonical surface: root backend smoke helper `backend/ws_test_auth.py` only.
- Request shape: unchanged for real backend APIs; helper still sends OAuth form data when explicit credentials are provided.
- Response shape: unchanged.
- Status codes: unchanged for backend runtime; helper process exit codes are now explicit (`2` for missing env, `1` for token failure).
- Frontend consumer: unchanged.
- Compatibility path or alias: helper keeps its path and now requires explicit local credentials.
- Contract proof: script compiles, missing `QA_ADMIN_PASSWORD` exits locally with code `2`, and marker scan found no hardcoded admin password or token-prefix print in the touched file.

## RBAC / Permissions
- Roles allowed: unchanged; helper still uses whichever admin username/password the operator provides.
- Roles denied: unchanged.
- Positive auth proof: not run against live backend in this PR because no backend credentials/server were used.
- Negative auth proof: missing `QA_ADMIN_PASSWORD` exits before any login request with code `2`.

## Notification / Realtime
- Event type or websocket channel: websocket queue smoke path unchanged (`/ws/queue`).
- Payload version / ack behavior: unchanged; no server websocket handler or payload model changed.
- Read/unread or delivery semantics: unchanged; queue realtime semantics are outside this helper-only diff.
- Reconnect/resync proof: not run because this PR only sanitizes the local smoke helper and does not change websocket runtime.

## Frontend Resilience
- Empty data proof: frontend untouched; no UI data source or empty-state component changed.
- Partial data proof: frontend untouched; no DTO/serializer or partial-data rendering path changed.
- Forbidden secondary path behavior: frontend untouched; no auth guard, secondary route, or forbidden-state UI changed.
- Missing draft/resource behavior: frontend untouched; no draft/resource screen or loader changed.
- Stale route/deep-link behavior: frontend untouched; no router or deep-link handling changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/ws_test_auth.py`; missing-env smoke with `QA_ADMIN_PASSWORD` removed; marker scan for hardcoded admin password, legacy port 8000, and token-prefix output; `git diff --check -- backend/ws_test_auth.py`; `python -m pytest backend\tests\unit\test_no_legacy_ports_in_active_text.py`.
- Result: passed locally; missing-env smoke exited with expected code `2`; legacy guard test reported `9 passed`.
- Not checked: live websocket smoke against a running backend; no backend server credentials were used.

## Scope Gate
- Allowed paths: `backend/ws_test_auth.py`.
- Denied paths: backend runtime routers/services, frontend, ops, generated/evidence artifacts.
- Migration/docs/test impact: no migration; root helper only.
- Rollback note: revert this PR to restore old local smoke behavior, though that would reintroduce default password handling and token output risk.