### PR TITLE
fix(security): require explicit MCP smoke password

### DIFF
--- a/test_mcp_api_auth.py
+++ b/test_mcp_api_auth.py
@@ -1,18 +1,32 @@
 """
 Тестирование MCP API с авторизацией
 """
-import requests
-import json
+import os
+import sys
 
-BASE_URL = "http://localhost:18000/api/v1"
+import requests
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+BASE_URL = os.getenv("QA_BACKEND_API_BASE_URL", "http://localhost:18000/api/v1")
+AUTH_USERNAME = os.getenv("QA_MCP_USERNAME", "mcp_test")
+__test__ = False
 
 def get_auth_token():
     """Получить токен авторизации"""
+    password = os.getenv("QA_MCP_PASSWORD")
+    if not password:
+        print("Set QA_MCP_PASSWORD before running this legacy MCP auth smoke script.")
+        return None
+
     try:
         # Попробуем получить токен через простую авторизацию
         response = requests.post(
             f"{BASE_URL}/auth/minimal-login",
-            json={"username": "admin", "password": "admin"},
+            json={"username": AUTH_USERNAME, "password": password},
             timeout=10
         )
         
@@ -214,8 +228,9 @@ def main():
         print("🔧 MCP endpoints: http://localhost:18000/api/v1/mcp/*")
     else:
         print(f"⚠️ {total_count - success_count} тестов завершились с ошибками")
-    
+
     print("=" * 60)
+    return 0 if success_count == total_count else 1
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Removes the hardcoded `admin/admin` login from the legacy MCP API auth smoke helper.
- Requires `QA_MCP_PASSWORD` before the helper can request a token.
- Defaults the helper username to `mcp_test`, matching the existing MCP test-user helpers, with `QA_MCP_USERNAME` override support.
- Marks the root smoke helper as non-pytest test content so it is not accidentally collected as a live-backend test.

## Contract Impact
- Canonical surface: root helper `test_mcp_api_auth.py` only.
- Request shape: unchanged for backend runtime; helper still posts JSON credentials to `/api/v1/auth/minimal-login` when explicit credentials are supplied.
- Response shape: unchanged.
- Status codes: unchanged for backend runtime; helper process now returns nonzero when the smoke fails.
- Frontend consumer: unchanged.
- Compatibility path or alias: helper path is unchanged; credential source is now environment-based.
- Contract proof: script compiles, no-env smoke exits with code `1`, marker scan found no hardcoded `admin/admin`, and pytest collect-only does not collect this helper as tests.

## RBAC / Permissions
- Roles allowed: unchanged; helper uses the explicitly provided MCP test user credentials.
- Roles denied: unchanged.
- Positive auth proof: not run against live backend in this PR because no MCP test password/server credentials were used.
- Negative auth proof: missing `QA_MCP_PASSWORD` fails locally before any login request.

## Notification / Realtime
- Event type or websocket channel: not changed; this PR does not touch realtime code.
- Payload version / ack behavior: not changed; no notification or websocket payload code is in scope.
- Read/unread or delivery semantics: not changed; no notification persistence path is in scope.
- Reconnect/resync proof: not run because this is a legacy MCP HTTP smoke helper only.

## Frontend Resilience
- Empty data proof: frontend untouched; no UI data source or empty-state component changed.
- Partial data proof: frontend untouched; no DTO/serializer or partial-data rendering path changed.
- Forbidden secondary path behavior: frontend untouched; no auth guard, secondary route, or forbidden-state UI changed.
- Missing draft/resource behavior: frontend untouched; no draft/resource screen or loader changed.
- Stale route/deep-link behavior: frontend untouched; no router or deep-link handling changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile test_mcp_api_auth.py`; missing-env smoke with `QA_MCP_PASSWORD` removed; marker scan for hardcoded admin password, legacy port 8000, and token-prefix output; `python -m pytest --collect-only -q test_mcp_api_auth.py`; `git diff --cached --check`.
- Result: passed locally; missing-env smoke exited with expected code `1`; pytest reported no tests collected for the helper.
- Not checked: live MCP API smoke against a running backend; no MCP test credentials were used.

## Scope Gate
- Allowed paths: `test_mcp_api_auth.py`.
- Denied paths: `test_cors.py`, `start_mcp_test_server.py`, `mcp_test.html`, backend runtime, frontend runtime, ops, generated/evidence artifacts.
- Migration/docs/test impact: no migration; root legacy smoke helper only.
- Rollback note: revert this PR to restore old helper behavior, though that would reintroduce default admin credentials in a smoke script.