### PR TITLE
test(security): sanitize websocket smoke helpers

### DIFF
--- a/backend/ws_test_final.py
+++ b/backend/ws_test_final.py
@@ -4,21 +4,36 @@
 """
 import asyncio
 import json
+import os
 import urllib.parse
 import urllib.request
 from datetime import datetime
 
 import websockets
 
+BASE_URL = os.getenv("QA_BACKEND_BASE_URL", "http://127.0.0.1:18000")
+WS_BASE_URL = os.getenv("QA_BACKEND_WS_URL", "ws://127.0.0.1:18000")
+AUTH_USERNAME = os.getenv("QA_ADMIN_USERNAME", "admin")
+
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Set {name} to run backend websocket smoke scripts.")
+    return value
+
 
 async def get_auth_token():
     """Получаем JWT токен для аутентификации"""
     try:
         data = urllib.parse.urlencode(
-            {"username": "admin", "password": "admin"}
+            {
+                "username": AUTH_USERNAME,
+                "password": required_env("QA_ADMIN_PASSWORD"),
+            }
         ).encode()
         req = urllib.request.Request(
-            "http://127.0.0.1:18000/api/v1/login",
+            f"{BASE_URL}/api/v1/login",
             data=data,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
@@ -30,6 +45,8 @@ async def get_auth_token():
             else:
                 print(f"❌ Ошибка получения токена: {response.status}")
                 return None
+    except RuntimeError:
+        raise
     except Exception as e:
         print(f"❌ Ошибка запроса токена: {e}")
         return None
@@ -41,7 +58,7 @@ async def test_ws_with_broadcast(token):
 
     # 1. Сначала подключаемся к WebSocket
     print("🔌 Подключаюсь к WebSocket...")
-    uri = "ws://127.0.0.1:18000/ws/queue?department=ENT&date=2025-08-28&token=" + token
+    uri = f"{WS_BASE_URL}/ws/queue?department=ENT&date=2025-08-28&token={token}"
     headers = {"Origin": "http://localhost:5173"}
 
     try:
@@ -66,7 +83,7 @@ async def test_ws_with_broadcast(token):
                 print("📅 Открываю день для ENT...")
                 try:
                     req = urllib.request.Request(
-                        "http://127.0.0.1:18000/api/v1/appointments/open?department=ENT&date_str=2025-08-28&start_number=1",
+                        f"{BASE_URL}/api/v1/appointments/open?department=ENT&date_str=2025-08-28&start_number=1",
                         headers={"Authorization": f"Bearer {token}"},
                         method="POST",
                     )
@@ -95,7 +112,7 @@ async def test_ws_with_broadcast(token):
                 return False
 
     except Exception as e:
-        print(f"❌ Ошибка WebSocket: {e}")
+        print(f"WebSocket error: {type(e).__name__}")
         return False
 
 
@@ -105,12 +122,16 @@ async def main():
     print("=" * 60)
 
     # Получаем токен
-    token = await get_auth_token()
+    try:
+        token = await get_auth_token()
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}")
+        return 2
     if not token:
         print("❌ Не удалось получить токен аутентификации")
-        return
+        return 1
 
-    print(f"🔑 Токен получен: {token[:20]}...")
+    print("Token received; value is not printed")
 
     # Тестируем WebSocket + Broadcast
     success = await test_ws_with_broadcast(token)
@@ -121,7 +142,8 @@ async def main():
     else:
         print("⚠️ WebSocket работает, но broadcast не доходит")
     print("✅ Финальный тест завершён")
+    return 0
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    raise SystemExit(asyncio.run(main()))

--- a/backend/ws_test_improved.py
+++ b/backend/ws_test_improved.py
@@ -4,21 +4,36 @@
 """
 import asyncio
 import json
+import os
 import urllib.parse
 import urllib.request
 from datetime import datetime
 
 import websockets
 
+BASE_URL = os.getenv("QA_BACKEND_BASE_URL", "http://127.0.0.1:18000")
+WS_BASE_URL = os.getenv("QA_BACKEND_WS_URL", "ws://127.0.0.1:18000")
+AUTH_USERNAME = os.getenv("QA_ADMIN_USERNAME", "admin")
+
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Set {name} to run backend websocket smoke scripts.")
+    return value
+
 
 async def get_auth_token():
     """Получаем JWT токен для аутентификации"""
     try:
         data = urllib.parse.urlencode(
-            {"username": "admin", "password": "admin"}
+            {
+                "username": AUTH_USERNAME,
+                "password": required_env("QA_ADMIN_PASSWORD"),
+            }
         ).encode()
         req = urllib.request.Request(
-            "http://127.0.0.1:18000/api/v1/login",
+            f"{BASE_URL}/api/v1/login",
             data=data,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
@@ -30,6 +45,8 @@ async def get_auth_token():
             else:
                 print(f"❌ Ошибка получения токена: {response.status}")
                 return None
+    except RuntimeError:
+        raise
     except Exception as e:
         print(f"❌ Ошибка запроса токена: {e}")
         return None
@@ -39,12 +56,10 @@ async def test_ws_queue_auth(token):
     """Тест WebSocket очереди с аутентификацией"""
     print("\n🔌 Тестирую /ws/queue с аутентификацией...")
     try:
-        uri = (
-            "ws://127.0.0.1:18000/ws/queue?department=ENT&date=2025-08-28&token=" + token
-        )
+        uri = f"{WS_BASE_URL}/ws/queue?department=ENT&date=2025-08-28&token={token}"
         headers = {"Origin": "http://localhost:5173"}
 
-        print(f"📡 Подключаюсь к: {uri}")
+        print("📡 Подключаюсь к /ws/queue; token is not printed")
         async with websockets.connect(uri, additional_headers=headers) as ws:
             print("🔗 WebSocket соединение установлено")
 
@@ -70,7 +85,7 @@ async def test_ws_queue_auth(token):
                 print(f"⚠️ Неожиданный тип сообщения: {data}")
 
     except Exception as e:
-        print(f"❌ Ошибка подключения: {e}")
+        print(f"Connection error: {type(e).__name__}")
 
 
 async def test_broadcast_trigger(token):
@@ -83,7 +98,7 @@ async def test_broadcast_trigger(token):
     print("📅 Открываю день для ENT...")
     try:
         req = urllib.request.Request(
-            "http://127.0.0.1:18000/api/v1/appointments/open?department=ENT&date_str=2025-08-28&start_number=1",
+            f"{BASE_URL}/api/v1/appointments/open?department=ENT&date_str=2025-08-28&start_number=1",
             headers=headers,
             method="POST",
         )
@@ -105,7 +120,7 @@ async def test_broadcast_trigger(token):
     print("\n🎫 Выдаю следующий талон...")
     try:
         req = urllib.request.Request(
-            "http://127.0.0.1:18000/api/v1/next-ticket?department=ENT&date=2025-08-28",
+            f"{BASE_URL}/api/v1/next-ticket?department=ENT&date=2025-08-28",
             headers=headers,
             method="POST",
         )
@@ -146,12 +161,16 @@ async def main():
     print("=" * 60)
 
     # Получаем токен
-    token = await get_auth_token()
+    try:
+        token = await get_auth_token()
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}")
+        return 2
     if not token:
         print("❌ Не удалось получить токен аутентификации")
-        return
+        return 1
 
-    print(f"🔑 Токен получен: {token[:20]}...")
+    print("Token received; value is not printed")
 
     # Тест 1: Простое WebSocket подключение
     await test_ws_queue_auth(token)
@@ -164,7 +183,8 @@ async def main():
 
     print("\n" + "=" * 60)
     print("✅ Улучшенный WebSocket тест завершён")
+    return 0
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
## Summary
- Removes hardcoded `admin/admin` login from `ws_test_final.py` and `ws_test_improved.py`.
- Requires `QA_ADMIN_PASSWORD` before either root websocket smoke helper can request a token.
- Stops printing token prefixes and token-bearing websocket URLs.

## Contract Impact
- Canonical surface: root backend websocket smoke helpers only.
- Request shape: unchanged for backend runtime; helpers still use the existing login and websocket smoke paths.
- Response shape: unchanged.
- Status codes: unchanged for backend runtime; helpers now return nonzero on missing credentials or token failure.
- Frontend consumer: unchanged because no frontend source files or browser routes are touched.
- Compatibility path or alias: helper paths stay the same; credential source is now environment-based.
- Contract proof: both scripts compile and marker scans found no token prefix output or hardcoded `admin/admin` in touched files.

## RBAC / Permissions
- Roles allowed: unchanged; helpers use explicitly supplied admin smoke credentials.
- Roles denied: unchanged.
- Positive auth proof: not run against live backend in this PR because no admin smoke password was used.
- Negative auth proof: missing `QA_ADMIN_PASSWORD` fails locally before login.

## Notification / Realtime
- Event type or websocket channel: `/ws/queue` smoke path unchanged.
- Payload version / ack behavior: unchanged because only local helper logging and credential sourcing changed.
- Read/unread or delivery semantics: unchanged; no notification persistence or delivery state code is touched.
- Reconnect/resync proof: not run because these helpers do not implement reconnect/resync behavior.

## Frontend Resilience
- Empty data proof: not changed because this PR touches only root backend smoke scripts and no frontend data rendering path.
- Partial data proof: not changed because no frontend DTO, serializer, loader, or component was modified.
- Forbidden secondary path behavior: not changed because no frontend route guard or browser auth path was modified.
- Missing draft/resource behavior: not changed because no draft/resource UI or backend resource endpoint was modified.
- Stale route/deep-link behavior: not changed because frontend routing and deep-link handling are outside this PR.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/ws_test_final.py backend/ws_test_improved.py`; marker scans for token-prefix output and hardcoded admin password; `git diff --check origin/main...HEAD`.
- Result: passed locally.
- Not checked: live websocket smoke; no backend server credentials were used.

## Scope Gate
- Allowed paths: `backend/ws_test_final.py`, `backend/ws_test_improved.py`.
- Denied paths: backend runtime, frontend, ops, generated/evidence artifacts, MCP helper PR #471.
- Migration/docs/test impact: no migration; root smoke helpers only.
- Rollback note: revert this PR to restore old helper behavior, though that would reintroduce default credentials and token leakage in local smoke output.
