### PR TITLE
test(security): sanitize root manual smoke helpers

### DIFF
--- a/backend/test_cart_error_debug.py
+++ b/backend/test_cart_error_debug.py
@@ -29,7 +29,7 @@ try:
     )
     if response.status_code == 200:
         token = response.json()["access_token"]
-        print(f"✅ Токен получен: {token[:20]}...")
+        print("✅ Токен получен; значение не печатается")
     else:
         print(f"❌ Ошибка авторизации: {response.status_code}")
         print(response.text)

--- a/backend/test_cicd_simple.py
+++ b/backend/test_cicd_simple.py
@@ -131,7 +131,7 @@ def test_auth_endpoint():
             print(f"✅ /api/v1/auth/login работает (код: {response.getcode()})")
             if response.getcode() == 200:
                 data = json.loads(response.read().decode())
-                print(f"   Токен получен: {data.get('access_token', 'N/A')[:20]}...")
+                print("   Токен получен; значение не печатается")
             else:
                 print("   Неправильные данные для входа (ожидаемо)")
             return True

--- a/backend/test_queue_batch_manual.py
+++ b/backend/test_queue_batch_manual.py
@@ -10,14 +10,22 @@ Requirements:
     - В БД должны быть пользователи: admin или registrar
     - В БД должны быть пациенты, услуги, специалисты
 """
-import requests
 import json
+import os
 from datetime import date
 
+import requests
+
 # Configuration
-API_BASE = "http://localhost:18000/api/v1"
-USERNAME = "admin"  # Или "registrar"
-PASSWORD = "admin"  # Замените на реальный пароль
+API_BASE = os.getenv("QA_BACKEND_API_BASE_URL", "http://localhost:18000/api/v1")
+USERNAME = os.getenv("QA_QUEUE_BATCH_USERNAME", "admin")
+
+
+def required_env(name):
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Set {name} to run the queue batch manual helper.")
+    return value
 
 
 class Colors:
@@ -58,13 +66,13 @@ def login():
 
     response = requests.post(
         f"{API_BASE}/authentication/login",
-        json={"username": USERNAME, "password": PASSWORD}
+        json={"username": USERNAME, "password": required_env("QA_QUEUE_BATCH_PASSWORD")}
     )
 
     if response.status_code == 200:
         data = response.json()
         token = data.get("access_token")
-        print_success(f"Авторизация успешна! Token: {token[:20]}...")
+        print_success("Авторизация успешна! Token value is not printed")
         return token
     else:
         print_error(f"Ошибка авторизации: {response.status_code}")

--- a/backend/test_registration_creation.py
+++ b/backend/test_registration_creation.py
@@ -31,7 +31,7 @@ def get_auth_token():
     
     if response.status_code == 200:
         token_data = response.json()
-        print(f"✅ Токен получен: {token_data['access_token'][:50]}...")
+        print("✅ Токен получен; значение не печатается")
         return token_data['access_token']
     else:
         print(f"❌ Ошибка получения токена: {response.status_code}")

--- a/backend/test_time_restrictions.py
+++ b/backend/test_time_restrictions.py
@@ -5,9 +5,18 @@
 
 import requests
 import json
+import os
 from datetime import datetime
 
-BASE_URL = "http://localhost:18000"
+BASE_URL = os.getenv("QA_BACKEND_BASE_URL", "http://localhost:18000")
+AUTH_USERNAME = os.getenv("QA_ADMIN_USERNAME", "admin")
+
+
+def required_env(name):
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Set {name} to run the QR time restrictions helper.")
+    return value
 
 def test_time_restrictions():
     """Тестирует временные ограничения QR системы"""
@@ -16,7 +25,10 @@ def test_time_restrictions():
     print("=" * 60)
     
     # Получаем токен авторизации
-    login_data = {"username": "admin", "password": "admin"}
+    login_data = {
+        "username": AUTH_USERNAME,
+        "password": required_env("QA_ADMIN_PASSWORD"),
+    }
     login_response = requests.post(f"{BASE_URL}/api/v1/authentication/login", data=login_data)
     
     if login_response.status_code != 200:
@@ -47,7 +59,7 @@ def test_time_restrictions():
         return
     
     qr_token = qr_response.json()["token"]
-    print(f"✅ QR токен сгенерирован: {qr_token}")
+    print("✅ QR токен сгенерирован; значение не печатается")
     
     # Проверяем информацию о токене
     token_info_response = requests.get(f"{BASE_URL}/api/v1/qr-tokens/{qr_token}/info")
@@ -82,7 +94,7 @@ def test_time_restrictions():
     if session_response.status_code == 200:
         session_data = session_response.json()
         print(f"✅ Сессия присоединения начата:")
-        print(f"   - Токен сессии: {session_data['session_token'][:20]}...")
+        print("   - Токен сессии: значение не печатается")
         print(f"   - Истекает: {session_data['expires_at']}")
         
         # Пытаемся завершить присоединение


### PR DESCRIPTION
## Summary
- Stops root manual smoke helpers from printing JWT, QR, and session token values.
- Removes remaining default admin credentials from queue/time-restriction/CORS smoke helpers.
- Keeps these as explicit local helper scripts without touching backend runtime code.
- Marks the root CORS smoke helper as non-pytest test content so it is not accidentally collected as a live-backend test.

## Contract Impact
- Canonical surface: root backend/manual smoke helper scripts only.
- Request shape: unchanged for backend runtime APIs; helper login payloads still target existing endpoints with explicit env credentials or safe dummy CORS credentials.
- Response shape: unchanged.
- Status codes: unchanged for backend runtime; helper process behavior only changes around missing local credentials, sanitized output, and CORS helper exit status.
- Frontend consumer: unchanged because no frontend files or browser routes are touched.
- Compatibility path or alias: helper paths remain the same; credentials now come from env where needed.
- Contract proof: all touched helper scripts compile and marker scans found no token-prefix output or `admin/admin` default in touched files.

## RBAC / Permissions
- Roles allowed: unchanged; helpers use explicitly supplied admin/registrar smoke credentials where auth is needed.
- Roles denied: unchanged.
- Positive auth proof: not run against live backend because no smoke credentials were used.
- Negative auth proof: missing helper passwords fail before successful token-dependent smoke flow; CORS helper uses non-admin dummy credentials by default and treats `401` as acceptable for CORS header proof.

## Notification / Realtime
- Event type or websocket channel: unchanged; no runtime realtime channel code is touched.
- Payload version / ack behavior: unchanged because only root helper output and credential sourcing changed.
- Read/unread or delivery semantics: unchanged; no notification persistence or delivery state code is touched.
- Reconnect/resync proof: not run because these helpers do not implement reconnect/resync behavior.

## Frontend Resilience
- Empty data proof: not changed because this PR touches only root/backend helper scripts and no frontend data rendering path.
- Partial data proof: not changed because no frontend DTO, serializer, loader, or component was modified.
- Forbidden secondary path behavior: not changed because no frontend route guard or browser auth path was modified.
- Missing draft/resource behavior: not changed because no draft/resource UI or backend resource endpoint was modified.
- Stale route/deep-link behavior: not changed because frontend routing and deep-link handling are outside this PR.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/test_cart_error_debug.py backend/test_cicd_simple.py backend/test_queue_batch_manual.py backend/test_registration_creation.py backend/test_time_restrictions.py test_cors.py`; marker scans for token-prefix output and `admin/admin`; `python -m pytest --collect-only -q test_cors.py`; `git diff --check origin/main...HEAD`.
- Result: passed locally; `test_cors.py` collect-only reported no tests collected as expected for a manual helper.
- Not checked: live backend smoke flows; no local credentials were used.

## Scope Gate
- Allowed paths: `backend/test_cart_error_debug.py`, `backend/test_cicd_simple.py`, `backend/test_queue_batch_manual.py`, `backend/test_registration_creation.py`, `backend/test_time_restrictions.py`, `test_cors.py`.
- Denied paths: backend runtime, frontend, ops, generated/evidence artifacts, MCP browser helper files.
- Migration/docs/test impact: no migration; root manual helpers only.
- Rollback note: revert this PR to restore previous helper output, though that would reintroduce token leakage and default credentials in local smoke scripts.