### PR TITLE
test(security): sanitize CORS smoke helper

### DIFF
--- a/test_cors.py
+++ b/test_cors.py
@@ -1,19 +1,40 @@
 """
 Тест CORS для MCP API
 """
+import os
+import sys
+
 import requests
-import json
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+BASE_URL = os.getenv("QA_BACKEND_API_BASE_URL", "http://localhost:18000/api/v1")
+CORS_ORIGIN = os.getenv("QA_CORS_ORIGIN", "http://localhost:8080")
+__test__ = False
+
+
+def cors_login_payload():
+    return {
+        "username": os.getenv("QA_CORS_USERNAME", "cors_smoke_user"),
+        "password": os.getenv("QA_CORS_PASSWORD", "not-a-real-password"),
+    }
+
 
 def test_cors():
     """Тест CORS настроек"""
     print("🔍 Тестирование CORS настроек...")
-    
+    preflight_ok = False
+    post_ok = False
+
     # Тест OPTIONS запроса (preflight)
     try:
         response = requests.options(
-            "http://localhost:18000/api/v1/auth/minimal-login",
+            f"{BASE_URL}/auth/minimal-login",
             headers={
-                'Origin': 'http://localhost:8080',
+                'Origin': CORS_ORIGIN,
                 'Access-Control-Request-Method': 'POST',
                 'Access-Control-Request-Headers': 'Content-Type'
             }
@@ -24,9 +45,10 @@ def test_cors():
         for header, value in response.headers.items():
             if 'access-control' in header.lower():
                 print(f"  {header}: {value}")
-        
+
         if response.status_code == 200:
             print("✅ CORS preflight работает")
+            preflight_ok = True
         else:
             print(f"❌ CORS preflight ошибка: {response.status_code}")
             
@@ -36,10 +58,10 @@ def test_cors():
     # Тест обычного запроса
     try:
         response = requests.post(
-            "http://localhost:18000/api/v1/auth/minimal-login",
-            json={"username": "admin", "password": "admin"},
+            f"{BASE_URL}/auth/minimal-login",
+            json=cors_login_payload(),
             headers={
-                'Origin': 'http://localhost:8080',
+                'Origin': CORS_ORIGIN,
                 'Content-Type': 'application/json'
             }
         )
@@ -52,11 +74,15 @@ def test_cors():
         
         if response.status_code in [200, 401]:  # 401 - нормально для неверных данных
             print("✅ CORS запрос работает")
+            post_ok = True
         else:
             print(f"❌ CORS запрос ошибка: {response.status_code}")
-            
+
     except Exception as e:
         print(f"❌ Ошибка CORS запроса: {e}")
 
+    return preflight_ok and post_ok
+
+
 if __name__ == "__main__":
-    test_cors()
+    raise SystemExit(0 if test_cors() else 1)


### PR DESCRIPTION
## Summary
- Removes hardcoded `admin/admin` from the root CORS smoke helper.
- Moves helper credentials and CORS origin to environment-backed values.
- Marks the helper as non-pytest test content and returns a process exit code for manual runs.

## Contract Impact
- Canonical surface: root helper `test_cors.py` only.
- Request shape: unchanged for backend runtime; helper still targets `/api/v1/auth/minimal-login` with JSON credentials.
- Response shape: unchanged.
- Status codes: unchanged for backend runtime; helper now exits nonzero if the CORS smoke fails.
- Frontend consumer: unchanged because no frontend files or browser routes are touched.
- Compatibility path or alias: helper path remains the same; local smoke inputs now come from env.
- Contract proof: script compiles, import smoke confirms `__test__ = False`, and marker scans found no `admin/admin` or legacy `:8000` origin in the touched file.

## RBAC / Permissions
- Roles allowed: unchanged; helper uses explicit smoke credentials from env or an intentionally invalid placeholder for 401 proof.
- Roles denied: unchanged.
- Positive auth proof: not run against live backend because no smoke credentials were used.
- Negative auth proof: default helper password is `not-a-real-password`, so it does not encode a real admin credential.

## Notification / Realtime
- Event type or websocket channel: unchanged; no notification or websocket code is touched.
- Payload version / ack behavior: unchanged because only a local HTTP CORS helper changed.
- Read/unread or delivery semantics: unchanged; no notification persistence or delivery state code is touched.
- Reconnect/resync proof: not applicable because this helper does not use realtime connections.

## Frontend Resilience
- Empty data proof: not changed because this PR touches only a root backend helper and no frontend data rendering path.
- Partial data proof: not changed because no frontend DTO, serializer, loader, or component was modified.
- Forbidden secondary path behavior: not changed because no frontend route guard or browser auth path was modified.
- Missing draft/resource behavior: not changed because no draft/resource UI or backend resource endpoint was modified.
- Stale route/deep-link behavior: not changed because frontend routing and deep-link handling are outside this PR.

## Validation
- Targeted tests or smoke run: `python -m py_compile test_cors.py`; import smoke for `__test__ = False`; marker scan for `admin/admin` and legacy `:8000`; `git diff --check origin/main...HEAD`.
- Result: passed locally. `pytest --collect-only -q test_cors.py` reported no collected tests, as intended for this manual helper.
- Not checked: live CORS smoke against a running backend; no local credentials were used.

## Scope Gate
- Allowed paths: `test_cors.py`.
- Denied paths: backend runtime, frontend, ops, generated/evidence artifacts, other root smoke helpers.
- Migration/docs/test impact: no migration; root manual helper only.
- Rollback note: revert this PR to restore old helper behavior, though that would reintroduce default admin credentials and accidental pytest collection risk.
