### PR TITLE
docs(security): sanitize MCP test server credential hint

### DIFF
--- a/start_mcp_test_server.py
+++ b/start_mcp_test_server.py
@@ -48,7 +48,7 @@ def start_test_server():
             print("📋 ИНСТРУКЦИИ ДЛЯ ТЕСТИРОВАНИЯ:")
             print("="*60)
             print("1. Откройте http://localhost:8080/mcp_test.html в браузере")
-            print("2. Получите токен авторизации (admin/admin)")
+            print("2. Получите токен авторизации с явным тестовым паролем, например mcp_test / <QA_MCP_PASSWORD>")
             print("3. Протестируйте все MCP endpoints")
             print("4. Проверьте результаты в консоли браузера")
             print("="*60)


### PR DESCRIPTION
## Summary
- Replaces the legacy `admin/admin` browser-helper instruction with an explicit `mcp_test / <QA_MCP_PASSWORD>` hint.
- Keeps the helper behavior unchanged; this is only local testing guidance.

## Contract Impact
- Canonical surface: root helper `start_mcp_test_server.py` only.
- Request shape: unchanged; this helper only serves the local MCP test HTML.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged; no app frontend source is touched.
- Compatibility path or alias: helper path and served URL stay the same.
- Contract proof: script compiles and marker scan found no `admin/admin` or legacy 8000 backend markers in the touched file.

## RBAC / Permissions
- Roles allowed: unchanged; helper now points operators to explicit test credentials instead of default admin credentials.
- Roles denied: unchanged.
- Positive auth proof: not run against live backend because this PR changes only helper text.
- Negative auth proof: no default admin password remains in the touched helper text.

## Notification / Realtime
- Event type or websocket channel: not changed; no realtime code is touched.
- Payload version / ack behavior: not changed.
- Read/unread or delivery semantics: not changed.
- Reconnect/resync proof: not run because this is local helper text only.

## Frontend Resilience
- Empty data proof: frontend app untouched; no UI data source or empty-state component changed.
- Partial data proof: frontend app untouched; no DTO/serializer or partial-data rendering path changed.
- Forbidden secondary path behavior: frontend app untouched; no auth guard, secondary route, or forbidden-state UI changed.
- Missing draft/resource behavior: frontend app untouched; no draft/resource screen or loader changed.
- Stale route/deep-link behavior: frontend app untouched; no router or deep-link handling changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile start_mcp_test_server.py`; marker scan for `admin/admin`, hardcoded admin password, and legacy 8000 backend origins; `git diff --check -- start_mcp_test_server.py`.
- Result: passed locally.
- Not checked: live browser helper server; no backend credentials were used.

## Scope Gate
- Allowed paths: `start_mcp_test_server.py`.
- Denied paths: `mcp_test.html`, backend runtime, frontend runtime, ops, generated/evidence artifacts.
- Migration/docs/test impact: no migration; local helper instruction only.
- Rollback note: revert this PR to restore the old helper instruction, though that would reintroduce the `admin/admin` hint.