### PR TITLE
fix(security): redact QR queue endpoint tokens in logs

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -501,8 +501,9 @@ def start_join_session(
             raise ValueError(str(exc)) from exc
 
         logger.info(
-            "[start_join_session] Запрос на начало сессии с токеном: %s...",
-            request.token[:20],
+            "[start_join_session] Запрос на начало сессии: token_present=%s, token_length=%d",
+            bool(request.token),
+            len(request.token or ""),
         )
         result = service.start_join_session(
             token=request.token,
@@ -511,17 +512,19 @@ def start_join_session(
         )
         
         logger.info(
-            "[start_join_session] Сессия успешно создана: %s...",
-            result.get('session_token', '')[:20],
+            "[start_join_session] Сессия успешно создана: session_token_present=%s, session_token_length=%d",
+            bool(result.get("session_token")),
+            len(result.get("session_token") or ""),
         )
         return JoinSessionStartResponse(**result)
         
     except ValueError as e:
         error_msg = str(e)
         logger.warning(
-            "[start_join_session] ValueError: %s, Токен: %s...",
+            "[start_join_session] ValueError: %s, token_present=%s, token_length=%d",
             error_msg,
-            request.token[:20],
+            bool(request.token),
+            len(request.token or ""),
         )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=error_msg)
     except Exception as e:
@@ -548,11 +551,12 @@ def complete_join_session(
 
     try:
         logger.info(
-            "[complete_join_session] Начало обработки запроса: session_token=%s, patient_name=%s, phone=%s, specialist_ids=%s",
-            request.session_token,
-            request.patient_name,
-            request.phone,
-            request.specialist_ids,
+            "[complete_join_session] Начало обработки запроса: session_token_present=%s, session_token_length=%d, patient_name_present=%s, phone_present=%s, specialist_count=%d",
+            bool(request.session_token),
+            len(request.session_token or ""),
+            bool(request.patient_name),
+            bool(request.phone),
+            len(request.specialist_ids or []),
         )
 
         # Если передан список specialist_ids - множественное присоединение


### PR DESCRIPTION
## Summary
- Redacts QR queue endpoint logs so QR tokens and join-session tokens are never logged, even as prefixes.
- Keeps request/response behavior unchanged; logs now record only presence and length metadata.
- Also avoids logging patient name and phone in the touched join-complete start log by replacing them with presence booleans.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/qr_queue.py`.
- Request shape: unchanged for `/queue/join/start` and `/queue/join/complete`.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged.
- Compatibility path or alias: unchanged.
- Contract proof: QR join integration/unit tests pass locally.

## RBAC / Permissions
- Roles allowed: unchanged; public QR join flow authorization/validation logic is untouched.
- Roles denied: unchanged.
- Positive auth proof: `backend/tests/integration/test_qr_queue_join.py` passed.
- Negative auth proof: token-prefix marker scan on the touched endpoint returned no matches.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable; no realtime code touched.

## Frontend Resilience
- Empty data proof: frontend app behavior untouched; no UI component or empty-state data path changed.
- Partial data proof: frontend app behavior untouched; no DTO/serializer or partial-data rendering path changed.
- Forbidden secondary path behavior: frontend app behavior untouched; no auth guard, secondary route, or forbidden-state UI changed.
- Missing draft/resource behavior: frontend app behavior untouched; no draft/resource screen or loader changed.
- Stale route/deep-link behavior: frontend app behavior untouched; no router or deep-link handling changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\\app\\api\\v1\\endpoints\\qr_queue.py`; token-prefix marker scan on `backend/app/api/v1/endpoints/qr_queue.py`; `python -m pytest backend\\tests\\integration\\test_qr_queue_join.py backend\\tests\\unit\\test_qr_queue_service_allocator_boundary.py`; `npm.cmd run build` in `frontend`; `git diff --check`.
- Result: all local validation passed; pytest reported 4 passed; token-prefix marker scan returned no matches in the touched endpoint.
- Not checked: live browser QR join flow was not run because this PR changes backend log formatting only and preserves request/response contracts.

## Scope Gate
- Gate result: initial route-owner misroute, then known-root-cause narrow override for `backend/app/api/v1/endpoints/qr_queue.py`.
- Allowed paths: `backend/app/api/v1/endpoints/qr_queue.py`.
- Denied paths: service mirrors, frontend routing, generated/evidence artifacts.
- Migration/docs/test impact: no migration; no docs; no test files changed.
- Rollback note: revert this PR to restore prior log formatting, though that would reintroduce token/PII logging in this endpoint.
