### PR TITLE
fix(security): redact QR queue service token logs

### DIFF
--- a/backend/app/services/qr_queue_service.py
+++ b/backend/app/services/qr_queue_service.py
@@ -287,7 +287,9 @@ class QRQueueService:
             from app.crud import clinic as crud_clinic
 
             logger.debug(
-                f"[QRQueueService.get_qr_token_info] Запрос информации о токене: {token[:20]}..."
+                "[QRQueueService.get_qr_token_info] Запрос информации о токене: token_present=%s, token_length=%d",
+                bool(token),
+                len(token or ""),
             )
 
             # Получаем timezone для правильного сравнения
@@ -621,7 +623,9 @@ class QRQueueService:
             Данные сессии
         """
         logger.debug(
-            f"[QRQueueService.start_join_session] Начало сессии для токена: {token[:20]}..."
+            "[QRQueueService.start_join_session] Начало сессии для токена: token_present=%s, token_length=%d",
+            bool(token),
+            len(token or ""),
         )
 
         try:


### PR DESCRIPTION
## Summary
- Redacts `QRQueueService` debug logs so QR tokens are never logged, even as prefixes.
- Keeps queue lookup/session behavior unchanged; logs now record only token presence and length metadata.

## Contract Impact
- Canonical surface: `backend/app/services/qr_queue_service.py`.
- Request shape: unchanged; service method signatures and endpoint contracts are untouched.
- Response shape: unchanged.
- Status codes: unchanged; no exception mapping changed.
- Frontend consumer: unchanged.
- Compatibility path or alias: unchanged.
- Contract proof: QR join integration/unit tests pass locally.

## RBAC / Permissions
- Roles allowed: unchanged; QR token validation logic is untouched.
- Roles denied: unchanged.
- Positive auth proof: `backend/tests/integration/test_qr_queue_join.py` passed.
- Negative auth proof: token-prefix marker scan on `backend/app/services/qr_queue_service.py` returned no matches.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no realtime code touched; QR queue broadcast paths are outside this logging-only service slice.

## Frontend Resilience
- Empty data proof: frontend app behavior untouched; no UI component or empty-state data path changed.
- Partial data proof: frontend app behavior untouched; no DTO/serializer or partial-data rendering path changed.
- Forbidden secondary path behavior: frontend app behavior untouched; no auth guard, secondary route, or forbidden-state UI changed.
- Missing draft/resource behavior: frontend app behavior untouched; no draft/resource screen or loader changed.
- Stale route/deep-link behavior: frontend app behavior untouched; no router or deep-link handling changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\\app\\services\\qr_queue_service.py`; token-prefix marker scan on `backend/app/services/qr_queue_service.py`; `python -m pytest backend\\tests\\integration\\test_qr_queue_join.py backend\\tests\\unit\\test_qr_queue_service_allocator_boundary.py`; `git diff --check -- backend\\app\\services\\qr_queue_service.py`.
- Result: all local validation passed; pytest reported 4 passed; marker scan returned no matches in the touched service file.
- Not checked: live browser QR join flow was not run because this PR changes backend debug log formatting only and preserves service contracts.

## Scope Gate
- Gate result: known-root-cause narrow override for `backend/app/services/qr_queue_service.py`.
- Allowed paths: `backend/app/services/qr_queue_service.py`.
- Denied paths: endpoint files, service mirrors, frontend, generated/evidence artifacts.
- Migration/docs/test impact: no migration; no docs; no test files changed.
- Rollback note: revert this PR to restore prior debug log formatting, though that would reintroduce QR token prefix logging in the service.
