### PR TITLE
fix(security): hide MCP test token value

### DIFF
--- a/mcp_test.html
+++ b/mcp_test.html
@@ -208,7 +208,7 @@
                     authToken = data.access_token;
                     resultDiv.className = 'result success';
                     resultDiv.style.display = 'block';
-                    resultDiv.textContent = `✅ Токен получен успешно!\n\nТокен: ${authToken.substring(0, 50)}...\n\nТеперь вы можете тестировать MCP endpoints.`;
+                    resultDiv.textContent = '✅ Токен получен успешно; значение не отображается.\n\nТеперь вы можете тестировать MCP endpoints.';
                 } else {
                     resultDiv.className = 'result error';
                     resultDiv.style.display = 'block';


### PR DESCRIPTION
## Summary
- Stops the local MCP browser helper from displaying JWT token prefixes after login.
- Keeps the token stored in memory for subsequent helper requests, but the UI no longer renders any token value.

## Contract Impact
- Canonical surface: local helper file `mcp_test.html` only.
- Request shape: unchanged; helper still calls `/api/v1/auth/minimal-login` with user-entered credentials.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged; this is not the app frontend bundle.
- Compatibility path or alias: helper file path and browser flow remain the same.
- Contract proof: marker scan found no token-prefix display, `admin/admin`, or legacy 8000 backend markers in the touched file.

## RBAC / Permissions
- Roles allowed: unchanged; helper still uses user-entered credentials.
- Roles denied: unchanged.
- Positive auth proof: not run against live backend because no smoke credentials were used.
- Negative auth proof: successful login UI no longer renders token value or token prefix.

## Notification / Realtime
- Event type or websocket channel: not changed; no realtime code is touched.
- Payload version / ack behavior: not changed.
- Read/unread or delivery semantics: not changed.
- Reconnect/resync proof: not run because this local helper does not use realtime connections.

## Frontend Resilience
- Empty data proof: app frontend untouched; no UI data source or empty-state component changed.
- Partial data proof: app frontend untouched; no DTO/serializer or partial-data rendering path changed.
- Forbidden secondary path behavior: app frontend untouched; no auth guard, secondary route, or forbidden-state UI changed.
- Missing draft/resource behavior: app frontend untouched; no draft/resource screen or loader changed.
- Stale route/deep-link behavior: app frontend untouched; no router or deep-link handling changed.

## Validation
- Targeted tests or smoke run: marker scan for `authToken.substring`, token-prefix text, `admin/admin`, and legacy 8000 backend origins; `git diff --check -- mcp_test.html`.
- Result: passed locally.
- Not checked: live browser helper flow; no backend credentials were used.

## Scope Gate
- Allowed paths: `mcp_test.html`.
- Denied paths: app frontend source, backend runtime, ops, generated/evidence artifacts.
- Migration/docs/test impact: no migration; local browser helper only.
- Rollback note: revert this PR to restore old helper behavior, though that would reintroduce token-prefix display.