### PR TITLE
fix(security): redact Firebase token diagnostics

### DIFF
--- a/backend/app/services/firebase_service.py
+++ b/backend/app/services/firebase_service.py
@@ -132,7 +132,11 @@ class FirebaseService:
             result = response.json()
 
             if result.get("success") == 1:
-                logger.info(f"✅ FCM notification sent to {device_token[:20]}...")
+                logger.info(
+                    "✅ FCM notification sent device_token_present=%s, device_token_length=%d",
+                    bool(device_token),
+                    len(device_token or ""),
+                )
                 return {
                     "success": True,
                     "message_id": result.get("message_id"),
@@ -199,7 +203,11 @@ class FirebaseService:
             response.raise_for_status()
             result = response.json()
 
-            logger.info(f"✅ FCM v1 notification sent to {device_token[:20]}...")
+            logger.info(
+                "✅ FCM v1 notification sent device_token_present=%s, device_token_length=%d",
+                bool(device_token),
+                len(device_token or ""),
+            )
             return {
                 "success": True,
                 "name": result.get("name"),
@@ -250,7 +258,8 @@ class FirebaseService:
             else:
                 results["failure_count"] += 1
                 results["errors"].append({
-                    "token": token[:20] + "...",
+                    "token": "[redacted]" if token else None,
+                    "token_length": len(token or ""),
                     "error": result.get("error"),
                 })
 


### PR DESCRIPTION
## Summary
- Redacts Firebase/FCM service diagnostics so device tokens are never logged, even as prefixes.
- Redacts multicast failure payload token values while preserving the `token` key and adding safe token length metadata.
- Keeps notification send/validation behavior unchanged.

## Contract Impact
- Canonical surface: `backend/app/services/firebase_service.py`.
- Request shape: unchanged; service method signatures are untouched.
- Response shape: multicast failure entries still include the `token` key, but its value is now `[redacted]`; `token_length` is added for safe diagnostics.
- Status codes: unchanged; this service does not map HTTP status codes.
- Frontend consumer: unchanged.
- Compatibility path or alias: unchanged.
- Contract proof: service compiles and settings tests covering FCM configuration pass locally.

## RBAC / Permissions
- Roles allowed: unchanged; notification authorization is enforced by caller endpoints and no permission branch is modified here.
- Roles denied: unchanged; no role checks or denial paths are edited.
- Positive auth proof: caller-owned authorization remains untouched in this service-only slice; `backend/tests/test_settings.py` passed and confirms FCM config loading still works.
- Negative auth proof: token-prefix marker scan on `backend/app/services/firebase_service.py` returned no matches.

## Notification / Realtime
- Event type or websocket channel: unchanged; FCM payload delivery path is untouched.
- Payload version / ack behavior: unchanged for outbound FCM requests; only local logs and returned diagnostic token value are redacted.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no websocket or reconnect code touched; FCM provider delivery was intentionally not invoked without credentials.

## Frontend Resilience
- Empty data proof: frontend app behavior untouched; no UI component or empty-state data path changed.
- Partial data proof: frontend app behavior untouched; no DTO/serializer or partial-data rendering path changed.
- Forbidden secondary path behavior: frontend app behavior untouched; no auth guard, secondary route, or forbidden-state UI changed.
- Missing draft/resource behavior: frontend app behavior untouched; no draft/resource screen or loader changed.
- Stale route/deep-link behavior: frontend app behavior untouched; no router or deep-link handling changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\\app\\services\\firebase_service.py`; token-prefix marker scan on `backend/app/services/firebase_service.py`; `python -m pytest backend\\tests\\test_settings.py`; `git diff --check -- backend\\app\\services\\firebase_service.py`.
- Result: all local validation passed; pytest reported 15 passed; marker scan returned no matches in the touched service file.
- Not checked: live FCM provider delivery was not run because credentials/external network side effects are outside this logging/data-redaction slice.

## Scope Gate
- Gate result: known-root-cause narrow override for `backend/app/services/firebase_service.py`.
- Allowed paths: `backend/app/services/firebase_service.py`.
- Denied paths: FCM endpoint files, service mirrors, frontend, generated/evidence artifacts.
- Migration/docs/test impact: no migration; no docs; no test files changed.
- Rollback note: revert this PR to restore prior diagnostics, though that would reintroduce device token prefix exposure.
