### PR TITLE
fix(security): redact frontend token debug logs

### DIFF
--- a/frontend/src/components/payment/PaymentWidget.jsx
+++ b/frontend/src/components/payment/PaymentWidget.jsx
@@ -169,8 +169,8 @@ const PaymentWidget = ({
         endpoint,
         isTestToken,
         hasAuthHeader: !!apiClient.defaults.headers.common['Authorization'],
-        authHeader: apiClient.defaults.headers.common['Authorization'] ?
-        apiClient.defaults.headers.common['Authorization'].substring(0, 30) + '...' : 'none',
+        authHeader: apiClient.defaults.headers.common['Authorization'] ? '[redacted]' : 'none',
+        authHeaderLength: apiClient.defaults.headers.common['Authorization']?.length || 0,
         paymentRequest
       });
 

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -834,7 +834,7 @@ const RegistrarPanel = () => {
       // Загружаем врачей, услуги и настройки очередей из админ панели
       try {
         const token = tokenManager.getAccessToken();
-        logger.info('🔍 RegistrarPanel: token from localStorage:', token ? `${token.substring(0, 30)}...` : 'null');
+        logger.info('🔍 RegistrarPanel: token present:', Boolean(token));
 
         // ✅ ОПТИМИЗАЦИЯ: Загружаем все данные параллельно с Promise.allSettled
         logger.info('🚀 Загружаем данные параллельно...');


### PR DESCRIPTION
## Summary
- Redacts frontend debug logging that printed access-token / Authorization prefixes.
- `RegistrarPanel` now logs only whether a token exists.
- `PaymentWidget` keeps debug usefulness with auth-header presence and length, but no header value is rendered.

## Contract Impact
- Canonical surface: `frontend/src/pages/RegistrarPanel.jsx` and `frontend/src/components/payment/PaymentWidget.jsx`.
- Request shape: unchanged; API calls and payment request payloads are untouched.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged; only local logging payloads changed.
- Compatibility path or alias: unchanged.
- Contract proof: frontend build passed and marker scan found no token-prefix logging in the touched files.

## RBAC / Permissions
- Roles allowed: unchanged; no auth guard or role check changed.
- Roles denied: unchanged; no forbidden path changed.
- Positive auth proof: token acquisition and payment request branches remain intact; `npm.cmd run test:run -- notificationGuardrails` passed.
- Negative auth proof: marker scan for `substring(0, 30)`, `token from localStorage`, and Authorization substring logging returned no matches in touched files.

## Notification / Realtime
- Event type or websocket channel: unchanged; no notification/realtime code touched.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no websocket or realtime reconnect path touched.

## Frontend Resilience
- Empty data proof: no empty-state component changed; Registrar data loading still calls the same endpoints.
- Partial data proof: no DTO/serializer or partial-data rendering path changed; only logger arguments changed.
- Forbidden secondary path behavior: no auth guard, route guard, or forbidden-state UI changed.
- Missing draft/resource behavior: no draft/resource loader or fallback changed.
- Stale route/deep-link behavior: no router or deep-link handling changed.

## Validation
- Targeted tests or smoke run: marker scan on touched files; `npm.cmd run test:run -- notificationGuardrails`; attempted `npm.cmd run test:run -- PaymentWidget`; `npm.cmd run build`; `git diff --check -- frontend\\src\\pages\\RegistrarPanel.jsx frontend\\src\\components\\payment\\PaymentWidget.jsx`.
- Result: marker scan returned no matches; notification guardrails passed with 2 tests; build passed; `git diff --check` passed.
- Not checked: dedicated `PaymentWidget` Vitest coverage because no matching test file exists; browser payment flow was not run because this PR changes debug logging only.

## Scope Gate
- Execution mode: direct_execute.
- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`, `frontend/src/components/payment/PaymentWidget.jsx`.
- Denied paths: backend runtime, ops, generated/evidence artifacts.
- Migration/docs/test impact: no migration; no docs; no test files changed.
- Rollback note: revert this PR to restore prior debug logs, though that would reintroduce token/header prefix exposure in the browser console.
