### PR TITLE
fix(security): redact FCM token listing response

### DIFF
--- a/backend/app/api/v1/endpoints/fcm_notifications.py
+++ b/backend/app/api/v1/endpoints/fcm_notifications.py
@@ -404,9 +404,8 @@ async def get_user_fcm_tokens(
                     "user_id": user.id,
                     "username": user.username,
                     "full_name": user.full_name,
-                    "fcm_token": (
-                        user.fcm_token[:20] + "..." if user.fcm_token else None
-                    ),
+                    "fcm_token": "[redacted]" if user.fcm_token else None,
+                    "fcm_token_length": len(user.fcm_token or ""),
                     "device_type": user.device_type,
                     "push_enabled": user.push_notifications_enabled,
                     "last_login": (


### PR DESCRIPTION
## Summary
- Redacts the active FCM user-token listing endpoint so FCM token prefixes are no longer returned.
- Preserves the `fcm_token` field with `[redacted]` when a token exists and adds `fcm_token_length` for safe diagnostics.
- Leaves FCM registration, sending, and notification behavior unchanged.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/fcm_notifications.py`.
- Request shape: unchanged for `/fcm/user-tokens`.
- Response shape: `fcm_token` remains present but is redacted; `fcm_token_length` is added for diagnostics.
- Status codes: unchanged.
- Frontend consumer: unchanged in this slice; no frontend code touched.
- Compatibility path or alias: unchanged.
- Contract proof: endpoint module compiles and FCM/settings tests pass locally.

## RBAC / Permissions
- Roles allowed: unchanged; endpoint remains guarded by `Admin` and `SuperAdmin`.
- Roles denied: unchanged; no dependency or role check changed.
- Positive auth proof: RBAC dependency call remains `require_roles(["Admin", "SuperAdmin"])`; `backend/tests/test_settings.py` passed.
- Negative auth proof: marker scan on `backend/app/api/v1/endpoints/fcm_notifications.py` returned no `fcm_token[:20]` or token-prefix match.

## Notification / Realtime
- Event type or websocket channel: unchanged; no realtime channel touched.
- Payload version / ack behavior: unchanged for notification send paths; only admin token-list diagnostics are redacted.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no websocket or reconnect path touched.

## Frontend Resilience
- Empty data proof: frontend app behavior untouched; no UI component or empty-state data path changed.
- Partial data proof: endpoint still returns per-user token presence plus safe length; no frontend partial-data path touched.
- Forbidden secondary path behavior: backend RBAC dependency remains unchanged; no frontend forbidden UI touched.
- Missing draft/resource behavior: no draft/resource path touched.
- Stale route/deep-link behavior: no router or deep-link handling changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\\app\\api\\v1\\endpoints\\fcm_notifications.py`; marker scan on `backend/app/api/v1/endpoints/fcm_notifications.py`; `python -m pytest backend\\tests\\test_settings.py`; `git diff --check -- backend\\app\\api\\v1\\endpoints\\fcm_notifications.py`.
- Result: all local validation passed; pytest reported 15 passed; marker scan returned no matches in the touched endpoint file.
- Not checked: live `/fcm/user-tokens` browser/API smoke was not run because this PR changes response redaction only and preserves route/RBAC wiring.

## Scope Gate
- Gate result: known-root-cause narrow override for `backend/app/api/v1/endpoints/fcm_notifications.py`.
- Allowed paths: `backend/app/api/v1/endpoints/fcm_notifications.py`.
- Denied paths: service mirrors, Firebase service, frontend, generated/evidence artifacts.
- Migration/docs/test impact: no migration; no docs; no test files changed.
- Rollback note: revert this PR to restore previous diagnostics, though that would reintroduce FCM token prefix exposure.
