### PR TITLE
fix(security): redact PayMe auth diagnostics

### DIFF
--- a/backend/app/services/payment_providers/payme.py
+++ b/backend/app/services/payment_providers/payme.py
@@ -295,7 +295,17 @@ class PayMeProvider(BasePaymentProvider):
 
             # Проверяем формат Basic Auth
             if not auth_header.startswith("Basic "):
-                self.log_error("validate_webhook_signature", "Invalid Authorization header format", {"header": auth_header[:20]})
+                self.log_error(
+                    "validate_webhook_signature",
+                    "Invalid Authorization header format",
+                    {
+                        "header_present": bool(auth_header),
+                        "header_scheme": (
+                            auth_header.split(" ", 1)[0] if auth_header else None
+                        ),
+                        "header_length": len(auth_header or ""),
+                    },
+                )
                 return False
 
             # Декодируем base64
@@ -304,7 +314,14 @@ class PayMeProvider(BasePaymentProvider):
 
             # Проверяем формат "Paycom:secret_key"
             if not decoded.startswith("Paycom:"):
-                self.log_error("validate_webhook_signature", "Invalid Basic Auth format", {"decoded": decoded[:20]})
+                self.log_error(
+                    "validate_webhook_signature",
+                    "Invalid Basic Auth format",
+                    {
+                        "decoded_present": bool(decoded),
+                        "decoded_length": len(decoded or ""),
+                    },
+                )
                 return False
 
             # Извлекаем secret_key из заголовка
@@ -319,7 +336,14 @@ class PayMeProvider(BasePaymentProvider):
             return True
 
         except Exception as e:
-            self.log_error("validate_webhook_signature", str(e), {"auth_header": auth_header[:20] if auth_header else None})
+            self.log_error(
+                "validate_webhook_signature",
+                str(e),
+                {
+                    "auth_header_present": bool(auth_header),
+                    "auth_header_length": len(auth_header or ""),
+                },
+            )
             return False
 
     def _generate_auth_header(self) -> str:


### PR DESCRIPTION
## Summary
- Redacts PayMe webhook authentication diagnostics so Basic Auth headers and decoded values are never partially logged.
- Keeps validation behavior unchanged: missing/invalid format/secret mismatch still return `False`.
- Logs only safe metadata such as presence, scheme, and length.

## Contract Impact
- Canonical surface: `backend/app/services/payment_providers/payme.py`.
- Request shape: unchanged; PayMe webhook auth header parsing still expects `Basic base64(Paycom:secret_key)`.
- Response shape: unchanged; `validate_webhook_signature` still returns boolean.
- Status codes: unchanged; this provider does not map HTTP status codes directly.
- Frontend consumer: unchanged.
- Compatibility path or alias: unchanged.
- Contract proof: provider module compiles and payment provider/settings unit tests pass locally.

## RBAC / Permissions
- Roles allowed: unchanged; webhook authentication still requires matching PayMe secret key.
- Roles denied: unchanged; invalid/missing/mismatched credentials still return `False`.
- Positive auth proof: provider/settings tests passed and successful validation branch is not altered.
- Negative auth proof: marker scan on `backend/app/services/payment_providers/payme.py` returned no `auth_header[:20]` or `decoded[:20]` matches.

## Notification / Realtime
- Event type or websocket channel: unchanged; no realtime code touched.
- Payload version / ack behavior: unchanged; payment provider validation return contract is unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no websocket or reconnect path touched.

## Frontend Resilience
- Empty data proof: frontend app behavior untouched; no UI component or empty-state data path changed.
- Partial data proof: frontend app behavior untouched; no DTO/serializer or partial-data rendering path changed.
- Forbidden secondary path behavior: no auth guard, secondary route, or forbidden-state UI changed.
- Missing draft/resource behavior: no draft/resource screen or loader changed.
- Stale route/deep-link behavior: no router or deep-link handling changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\\app\\services\\payment_providers\\payme.py`; marker scan on `backend/app/services/payment_providers/payme.py`; `python -m pytest backend\\tests\\unit\\test_payment_provider_manager_factory.py backend\\tests\\unit\\test_payment_settings_service.py` with `DATABASE_URL=sqlite:///./test_payme_unit.db` and `ALLOW_SQLITE_DATABASE_URL=1`; `git diff --check -- backend\\app\\services\\payment_providers\\payme.py`.
- Result: all local validation passed; pytest reported 8 passed; marker scan returned no auth-header or decoded-prefix matches in the touched file.
- Not checked: live PayMe provider webhook smoke was not run because it requires provider credentials and external/payment side effects.

## Scope Gate
- Gate result: known-root-cause narrow override for `backend/app/services/payment_providers/payme.py`.
- Allowed paths: `backend/app/services/payment_providers/payme.py`.
- Denied paths: payment webhook service, endpoint files, frontend, ops, generated/evidence artifacts.
- Migration/docs/test impact: no migration; no docs; no test files changed.
- Rollback note: revert this PR to restore prior diagnostics, though that would reintroduce Basic Auth prefix exposure in logs.
