### PR TITLE
fix(payments): preserve visit target in Payme webhooks

### DIFF
--- a/backend/app/services/payment_webhook.py
+++ b/backend/app/services/payment_webhook.py
@@ -51,7 +51,7 @@ class PaymentWebhookService:
         visit_id = PaymentWebhookService._optional_int(
             PaymentWebhookService._account_value(account, "visit_id")
         )
-        if appointment_id is None:
+        if appointment_id is None and visit_id is None:
             appointment_id = PaymentWebhookService._optional_int(
                 PaymentWebhookService._account_value(account, "order_id")
             )

--- a/backend/tests/unit/test_payment_webhook_service.py
+++ b/backend/tests/unit/test_payment_webhook_service.py
@@ -73,6 +73,7 @@ class TestPaymentWebhookService:
             ({"appointment_id": "123"}, 123, None),
             ({"order_id": "456"}, 456, None),
             ({"visit_id": "789"}, None, 789),
+            ({"visit_id": "789", "order_id": "456"}, None, 789),
         ],
     )
     def test_payme_webhook_extracts_dict_account_targets(


### PR DESCRIPTION
## Summary
- Fixes Payme webhook account target extraction when both `visit_id` and `order_id` are present.
- Preserves the visit target instead of also treating `order_id` as an appointment target.
- Adds a regression case for the mixed `visit_id` + `order_id` payload.

## Contract Impact
- Canonical surface: `backend/app/services/payment_webhook.py` and its unit test.
- Request shape: unchanged; Payme account payload shape is not changed.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged.
- Compatibility path or alias: unchanged.
- Contract proof: targeted payment webhook service unit tests pass locally.

## RBAC / Permissions
- Roles allowed: unchanged; no auth or permission checks are modified.
- Roles denied: unchanged; no denied-role branch is modified.
- Positive auth proof: webhook extraction helper does not own RBAC; targeted payment webhook unit coverage passed and auth/signature calls remain outside the changed branch.
- Negative auth proof: no auth/RBAC branches changed; regression coverage confirms only account-target selection changes for mixed Payme account payloads.

## Notification / Realtime
- Event type or websocket channel: unchanged; no notification/realtime code touched.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: payment webhook account extraction only; no websocket or reconnect path touched.

## Frontend Resilience
- Empty data proof: frontend untouched; no UI data source or empty-state component changed.
- Partial data proof: frontend untouched; no DTO/serializer or partial-data rendering path changed.
- Forbidden secondary path behavior: frontend untouched; no auth guard, secondary route, or forbidden-state UI changed.
- Missing draft/resource behavior: frontend untouched; no draft/resource screen or loader changed.
- Stale route/deep-link behavior: frontend untouched; no router or deep-link handling changed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/services/payment_webhook.py backend/tests/unit/test_payment_webhook_service.py`; `python -m pytest backend/tests/unit/test_payment_webhook_service.py`; `git diff --check -- backend/app/services/payment_webhook.py backend/tests/unit/test_payment_webhook_service.py`.
- Result: passed locally; pytest reported `7 passed`.
- Not checked: live Payme provider/webhook delivery because this PR only changes deterministic local account target extraction.

## Scope Gate
- Gate result: known-root-cause narrow override for `backend/app/services/payment_webhook.py`, plus separate narrow gate for `backend/tests/unit/test_payment_webhook_service.py`.
- Allowed paths: `backend/app/services/payment_webhook.py`, `backend/tests/unit/test_payment_webhook_service.py`.
- Denied paths: payment endpoints, frontend, ops, generated/evidence artifacts.
- Migration/docs/test impact: no migration; no docs; one focused unit test case added.
- Rollback note: revert this PR to restore prior extraction behavior, though that would again map `order_id` to appointment even when `visit_id` is present.
