### PR TITLE
fix(ops): align staging nginx backend port

### DIFF
--- a/frontend/docker/nginx.staging.conf
+++ b/frontend/docker/nginx.staging.conf
@@ -8,7 +8,7 @@ server {
     client_max_body_size 25m;
 
     location /api/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://backend:18000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -17,7 +17,7 @@ server {
     }
 
     location /docs {
-        proxy_pass http://backend:8000/docs;
+        proxy_pass http://backend:18000/docs;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -25,7 +25,7 @@ server {
     }
 
     location /redoc {
-        proxy_pass http://backend:8000/redoc;
+        proxy_pass http://backend:18000/redoc;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -33,7 +33,7 @@ server {
     }
 
     location /openapi.json {
-        proxy_pass http://backend:8000/openapi.json;
+        proxy_pass http://backend:18000/openapi.json;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -41,7 +41,7 @@ server {
     }
 
     location /ws/ {
-        proxy_pass http://backend:8000/ws/;
+        proxy_pass http://backend:18000/ws/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
﻿## Summary

- Align staging frontend nginx proxy targets with the canonical backend container port `18000`.
- Update `/api/`, `/docs`, `/redoc`, `/openapi.json`, and `/ws/` proxy upstreams from `backend:8000` to `backend:18000`.
- Keep routes, headers, websocket upgrade handling, and frontend app source unchanged.

## Contract Impact

- Canonical surface: no API surface changed; staging nginx proxy config only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged; the deployed staging proxy now points at the backend port used by staging compose/Dockerfile/healthcheck.
- Compatibility path or alias: no alias changed.
- Contract proof: marker scan confirms `frontend/docker/nginx.staging.conf` no longer references `backend:8000` and keeps the same proxy locations.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: unchanged `/ws/` proxy location.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not checked; only upstream port alignment changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `frontend/docker/nginx.staging.conf`.
- Denied paths: backend runtime code, frontend app source, ops compose files, generated/evidence artifacts.
- Migration/docs/test impact: no database migrations, docs, or tests changed.
- Rollback note: revert commit `67de8276` to restore previous staging proxy targets.

## Validation

- Targeted tests or smoke run: `cd C:\final\frontend; npm.cmd run build`; `Select-String -Path frontend\docker\nginx.staging.conf -SimpleMatch -Pattern 'backend:8000','backend:18000'`; `git diff --check -- frontend/docker/nginx.staging.conf`; `git diff --cached --check`.
- Result: build passed; scan found only `backend:18000`; diff checks passed.
- Not checked: live staging deployment/browser smoke, because this PR only changes nginx deploy config and no staging container is running in this local slice.
