### PR TITLE
fix(security): redact FCM mirror token response

### DIFF
--- a/backend/app/services/fcm_notifications_api_service.py
+++ b/backend/app/services/fcm_notifications_api_service.py
@@ -404,9 +404,8 @@ async def get_user_fcm_tokens(
                     "user_id": user.id,
                     "username": user.username,
                     "full_name": user.full_name,
-                    "fcm_token": (
-                        user.fcm_token[:20] + "..." if user.fcm_token else None
-                    ),
+                    "fcm_token": "[redacted]" if user.fcm_token else None,
+                    "fcm_token_length": len(user.fcm_token or ""),
                     "device_type": user.device_type,
                     "push_enabled": user.push_notifications_enabled,
                     "last_login": (


### PR DESCRIPTION
## Summary

- Redact the FCM token value returned by the unreferenced service-router mirror helper.
- Preserve diagnostic value by returning `fcm_token_length` when a token exists.
- Keep active FCM routes and canonical services unchanged.

## Contract Impact

- Canonical surface: no active route changed; this file has zero app/test references in the current backend scan.
- Request shape: unchanged.
- Response shape: token value is redacted in this legacy mirror diagnostic response, with token length retained.
- Status codes: unchanged.
- Frontend consumer: unchanged; no frontend references to this mirror were found.
- Compatibility path or alias: no route registration changed.
- Contract proof: `git grep` reference scan found no app/test references to `fcm_notifications_api_service.py` before this slice.

## RBAC / Permissions

- Roles allowed: unchanged from the existing mirror dependency wiring; no role or permission predicate was edited.
- Roles denied: unchanged from the existing mirror dependency wiring; no denial path was edited.
- Positive auth proof: not run because this mirror is unreferenced by current app/test imports and no active route registration changed.
- Negative auth proof: not run because this mirror is unreferenced by current app/test imports and no active route registration changed.

## Notification / Realtime

- Event type or websocket channel: unchanged; no FCM event type, websocket channel, or notification send path changed.
- Payload version / ack behavior: unchanged for active notification delivery; only the mirror token listing/debug response redacts the stored token value.
- Read/unread or delivery semantics: unchanged; no notification delivery state or read tracking code changed.
- Reconnect/resync proof: not run because this slice does not touch realtime connection or reconnect code.

## Frontend Resilience

not applicable - no frontend code changed.

## Scope Gate

- Allowed paths: `backend/app/services/fcm_notifications_api_service.py`.
- Denied paths: active routers, frontend source, ops configs, generated/evidence artifacts.
- Migration/docs/test impact: no migrations or docs changed.
- Rollback note: revert this commit to restore the previous mirror response shape.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\\app\\services\\fcm_notifications_api_service.py`; `rg -n "fcm_token\\[:20\\]|fcm_token.*\\.\\.\\.|token\\[:20\\]" backend\\app\\services\\fcm_notifications_api_service.py`; `git diff --check -- backend\\app\\services\\fcm_notifications_api_service.py`; `python -m pytest backend\\tests\\test_settings.py`.
- Result: py_compile passed; marker scan returned no token-prefix matches; diff check passed; settings tests passed with 15 passed and 1 warning.
- Not checked: browser smoke, because this slice changes only an unreferenced backend mirror helper and no active UI route.
