### PR TITLE
fix(security): harden Gemini env helper

### DIFF
--- a/setup_gemini_api.py
+++ b/setup_gemini_api.py
@@ -50,26 +50,8 @@ def setup_gemini_api():
         
         if api_key and api_key.startswith("AIza"):
             env_content = f"""# AI Provider API Keys
+# Runtime settings such as DATABASE_URL and SECRET_KEY must come from the real deployment env.
 GEMINI_API_KEY={api_key}
-
-# MCP Settings
-MCP_ENABLED=true
-MCP_LOG_REQUESTS=true
-MCP_FALLBACK_TO_DIRECT=true
-MCP_REQUEST_TIMEOUT=30
-MCP_HEALTH_CHECK_INTERVAL=60
-MCP_MAX_BATCH_SIZE=10
-
-# Database
-DATABASE_URL=sqlite:///./clinic.db
-
-# Auth
-SECRET_KEY=dev-secret-key-for-clinic-management-system-change-in-production
-ALGORITHM=HS256
-ACCESS_TOKEN_EXPIRE_MINUTES=10080
-
-# CORS
-BACKEND_CORS_ORIGINS=["http://localhost:5173","http://127.0.0.1:5173","http://localhost:8080","http://127.0.0.1:8080"]
 """
             
             with open(env_file, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
﻿## Summary

- Stop `setup_gemini_api.py` from generating a full backend runtime `.env` with SQLite fallback settings.
- Remove the hardcoded default `SECRET_KEY` and bundled CORS/MCP/runtime defaults from the helper-created file.
- Keep the helper focused on writing only `GEMINI_API_KEY`, with a note that runtime settings must come from the real deployment environment.

## Contract Impact

- Canonical surface: no API, websocket, or route surface changed.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged.
- Compatibility path or alias: unchanged.
- Contract proof: not applicable - this is a local setup helper, not runtime API code.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `setup_gemini_api.py`.
- Denied paths: backend runtime config, Docker/compose files, migrations, frontend code, generated/evidence artifacts.
- Migration/docs/test impact: no database migrations, docs, or tests changed.
- Rollback note: revert commit `167dc797` to restore the previous helper-created `.env` content.

## Validation

- Targeted tests or smoke run: `python -m py_compile setup_gemini_api.py`; `git diff --check -- setup_gemini_api.py`; marker scan for `DATABASE_URL=sqlite`, default `SECRET_KEY`, `MCP_ENABLED=true`, and `BACKEND_CORS_ORIGINS` in `setup_gemini_api.py`.
- Result: py_compile passed; diff check passed; unsafe helper-created runtime markers were not found.
- Not checked: interactive helper execution, to avoid creating or modifying a local `backend/.env` during QA cleanup.
