### PR TITLE
fix(security): redact QR mirror token logs

### DIFF
--- a/backend/app/services/qr_queue_api_service.py
+++ b/backend/app/services/qr_queue_api_service.py
@@ -505,8 +505,9 @@ def start_join_session(
             raise ValueError(str(exc)) from exc
 
         logger.info(
-            "[start_join_session] Запрос на начало сессии с токеном: %s...",
-            request.token[:20],
+            "[start_join_session] Запрос на начало сессии: token_present=%s, token_length=%d",
+            bool(request.token),
+            len(request.token or ""),
         )
         result = service.start_join_session(
             token=request.token,
@@ -515,17 +516,19 @@ def start_join_session(
         )
 
         logger.info(
-            "[start_join_session] Сессия успешно создана: %s...",
-            result.get('session_token', '')[:20],
+            "[start_join_session] Сессия успешно создана: session_token_present=%s, session_token_length=%d",
+            bool(result.get("session_token")),
+            len(result.get("session_token") or ""),
         )
         return JoinSessionStartResponse(**result)
 
     except ValueError as e:
         error_msg = str(e)
         logger.warning(
-            "[start_join_session] ValueError: %s, Токен: %s...",
+            "[start_join_session] ValueError: %s, token_present=%s, token_length=%d",
             error_msg,
-            request.token[:20],
+            bool(request.token),
+            len(request.token or ""),
         )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=error_msg)
     except Exception as e:
@@ -552,11 +555,12 @@ def complete_join_session(
 
     try:
         logger.info(
-            "[complete_join_session] Начало обработки запроса: session_token=%s, patient_name=%s, phone=%s, specialist_ids=%s",
-            request.session_token,
-            request.patient_name,
-            request.phone,
-            request.specialist_ids,
+            "[complete_join_session] Начало обработки запроса: session_token_present=%s, session_token_length=%d, patient_name_present=%s, phone_present=%s, specialist_count=%d",
+            bool(request.session_token),
+            len(request.session_token or ""),
+            bool(request.patient_name),
+            bool(request.phone),
+            len(request.specialist_ids or []),
         )
 
         # Если передан список specialist_ids - множественное присоединение


### PR DESCRIPTION
## Summary

- Sanitize QR queue service-router mirror logs that exposed QR/session token prefixes.
- Align the mirror diagnostics with the canonical active QR endpoint format: presence and length only.
- Redact the complete-session start log so it no longer prints full `session_token`, patient name, or phone values.

## Contract Impact

- Canonical surface: no active route file changed; this slice only updates `backend/app/services/qr_queue_api_service.py`, which has zero current app/test references in the pre-change scan.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged; no frontend files changed.
- Compatibility path or alias: no route registration, alias, or router include changed.
- Contract proof: `git grep -n "qr_queue_api_service" -- backend/app backend/tests ':!backend/.venv'` returned no references before this slice; targeted QR queue tests still pass.

## RBAC / Permissions

- Roles allowed: unchanged; existing role dependencies in the mirror file were not edited.
- Roles denied: unchanged; no denial path or permission predicate was edited.
- Positive auth proof: covered indirectly by unchanged targeted QR queue behavior tests; no active route auth contract changed.
- Negative auth proof: not run because this PR only changes logging statements in an unreferenced mirror helper and does not alter auth guards.

## Notification / Realtime

- Event type or websocket channel: unchanged; no realtime event, broadcast channel, or queue notification path changed.
- Payload version / ack behavior: unchanged; only log message arguments changed from token values to presence/length metadata.
- Read/unread or delivery semantics: unchanged; no delivery state code changed.
- Reconnect/resync proof: not run because this slice does not touch websocket connection or reconnect code.

## Frontend Resilience

not applicable - no frontend code changed.

## Scope Gate

- Allowed paths: `backend/app/services/qr_queue_api_service.py`.
- Denied paths: active QR endpoint file, QR service logic, frontend source, ops configs, generated/evidence artifacts.
- Migration/docs/test impact: no database migrations, docs, or tests changed.
- Rollback note: revert commit `c8a77cb0` to restore the previous mirror log messages.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\\app\\services\\qr_queue_api_service.py`; `rg -n "token\\[:20\\]|access_token.*\\[:20\\]|access_token.*\\[:50\\]|session_token.*\\[:20\\]|Token: .*\\[:20\\]|QR ?????.*\\{qr_token\\}|decoded\\[:20\\]|auth_header\\[:20\\]|substring\\(0,\\s*30\\)" backend frontend test_mcp_api_auth.py test_cors.py mcp_test.html --glob '!backend/.venv/**' --glob '!**/__pycache__/**' --glob '!frontend/node_modules/**' --glob '!frontend/coverage/**' --glob '!frontend/playwright-report/**' --glob '!frontend/test-results/**'`; `git diff --check -- backend\\app\\services\\qr_queue_api_service.py`; `python -m pytest backend\\tests\\integration\\test_qr_queue_join.py backend\\tests\\unit\\test_qr_queue_service_allocator_boundary.py`.
- Result: py_compile passed; token-prefix marker scan returned no matches; diff check passed; QR targeted tests passed with 4 passed and 1 warning.
- Not checked: browser smoke, because this slice changes only logs in an unreferenced backend mirror helper and no active UI route.
