### PR TITLE
fix(security): redact FCM token display

### DIFF
--- a/frontend/src/components/admin/FCMManager.jsx
+++ b/frontend/src/components/admin/FCMManager.jsx
@@ -27,6 +27,13 @@ import { api } from '../../api/client';
 import { toast } from 'react-toastify';
 
 import logger from '../../utils/logger';
+const formatFcmTokenStatus = (user) => {
+  const fallbackLength = typeof user.fcm_token === 'string' ? user.fcm_token.length : 0;
+  const tokenLength = Number.isFinite(user.fcm_token_length) ? user.fcm_token_length : fallbackLength;
+
+  return tokenLength > 0 ? `скрыт (${tokenLength} символов)` : 'не зарегистрирован';
+};
+
 const FCMManager = () => {
   const [loading, setLoading] = useState(false);
   const [fcmStatus, setFcmStatus] = useState(null);
@@ -546,7 +553,7 @@ const FCMManager = () => {
                 color: 'var(--mac-text-secondary)',
                 margin: '0 0 4px 0'
               }}>
-                    Токен: {user.fcm_token}
+                    FCM токен: {formatFcmTokenStatus(user)}
                   </p>
                   {user.last_login &&
               <p style={{


### PR DESCRIPTION
## Summary

- Stop the admin FCM manager from rendering `user.fcm_token` directly.
- Display only a Russian defensive status: `????? (<length> ????????)` or `?? ???????????????` in the users-with-tokens list.
- Preserve the `/fcm/user-tokens` fetch flow and existing notification management UI behavior.

## Contract Impact

- Canonical surface: `/fcm/user-tokens` remains the backend source for this panel.
- Request shape: unchanged.
- Response shape: unchanged; frontend now consumes `fcm_token_length` when present and falls back to local length without rendering the token value.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/components/admin/FCMManager.jsx` no longer displays a raw FCM token if legacy data includes one.
- Compatibility path or alias: unchanged.
- Contract proof: backend canonical and mirror endpoints already return `[redacted]` plus `fcm_token_length`; frontend marker scan confirms the old `user.fcm_token` render is gone.

## RBAC / Permissions

- Roles allowed: unchanged; this panel still relies on the existing admin route/API access controls.
- Roles denied: unchanged.
- Positive auth proof: not checked locally; no auth guard changed.
- Negative auth proof: not checked locally; no auth guard changed.

## Notification / Realtime

- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable - this is display redaction in the admin FCM manager, not delivery logic.

## Frontend Resilience

- Empty data proof: unchanged existing empty-state path when no users have registered FCM tokens.
- Partial data proof: formatter handles missing `fcm_token_length` and missing `fcm_token` without rendering secrets.
- Forbidden secondary path behavior: unchanged.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate

- Allowed paths: `frontend/src/components/admin/FCMManager.jsx`.
- Denied paths: backend API behavior, routing, auth guards, notification delivery services, generated/evidence artifacts.
- Migration/docs/test impact: no database migrations, docs, or automated tests changed.
- Rollback note: revert commit `bec57bb4` to restore previous FCM token display behavior.

## Validation

- Targeted tests or smoke run: `cd C:\final\frontend; npm.cmd run lint:check -- src/components/admin/FCMManager.jsx`; `cd C:\final\frontend; npm.cmd run build`; `git diff --check -- frontend\src\components\admin\FCMManager.jsx`; marker scan for old raw `user.fcm_token` display.
- Result: lint:check completed with 0 errors and existing warnings elsewhere; frontend build passed; diff check passed; old raw token render marker was not found.
- Not checked: browser smoke of the admin FCM panel, because this slice only changes defensive display formatting.
