### PR TITLE
fix(security): redact Telegram token mask

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -52,7 +52,8 @@ def get_telegram_settings(
 
         # Скрываем токен бота в ответе
         if result["bot_token"]:
-            result["bot_token_masked"] = result["bot_token"][:10] + "***скрыт***"
+            result["bot_token_masked"] = "***скрыт***"
+            result["bot_token_length"] = len(result["bot_token"])
             result["bot_token"] = "***скрыт***"
 
         return result

--- a/backend/app/services/admin_telegram_api_service.py
+++ b/backend/app/services/admin_telegram_api_service.py
@@ -45,7 +45,8 @@ def get_telegram_settings(
 
         # Скрываем токен бота в ответе
         if result["bot_token"]:
-            result["bot_token_masked"] = result["bot_token"][:10] + "***скрыт***"
+            result["bot_token_masked"] = "***скрыт***"
+            result["bot_token_length"] = len(result["bot_token"])
             result["bot_token"] = "***скрыт***"
 
         return result


### PR DESCRIPTION
﻿## Summary

- Stop admin Telegram settings responses from returning a bot token prefix in `bot_token_masked`.
- Keep `bot_token` redacted and return only `bot_token_length` as a non-secret diagnostic.
- Apply the same behavior to the canonical endpoint and the legacy service-router mirror.

## Contract Impact

- Canonical surface: `GET /telegram/settings` in `backend/app/api/v1/endpoints/admin_telegram.py`.
- Request shape: unchanged.
- Response shape: `bot_token_masked` remains present when configured but no longer includes token prefix; `bot_token_length` is added when a token exists.
- Status codes: unchanged.
- Frontend consumer: unchanged; no frontend code currently references `bot_token_masked` directly.
- Compatibility path or alias: service-router mirror `backend/app/services/admin_telegram_api_service.py` was aligned with the canonical endpoint.
- Contract proof: exact reference scan found only the canonical and mirror `bot_token_masked` writers; marker scan confirms no `bot_token[:10]` prefix masking remains in those files.

## RBAC / Permissions

- Roles allowed: unchanged `Admin` guard.
- Roles denied: unchanged, delegated to existing `require_roles` behavior.
- Positive auth proof: not checked locally; no auth guard code changed.
- Negative auth proof: not checked locally; no auth guard code changed.

## Notification / Realtime

- Event type or websocket channel: unchanged Telegram settings behavior only.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable - no realtime delivery path changed.

## Frontend Resilience

- Empty data proof: unchanged default settings response behavior.
- Partial data proof: unchanged; redaction fields are only added when a token is configured.
- Forbidden secondary path behavior: unchanged.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/app/services/admin_telegram_api_service.py`.
- Denied paths: Telegram webhook delivery, frontend Telegram UI, auth guards, migrations, generated/evidence artifacts.
- Migration/docs/test impact: no database migrations, docs, or tests changed.
- Rollback note: revert commit `a77ec62a` to restore prior prefix masking.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\services\admin_telegram_api_service.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; `cd C:\final\frontend; npm.cmd run build`; `git diff --check`; marker scan for `bot_token[:10]` prefix masking.
- Result: py_compile passed; frontend build passed; diff check passed; no Telegram bot-token prefix masking marker remains in the touched files.
- Not checked: live Telegram API calls, because this slice only changes settings response redaction and does not touch outbound Telegram requests.
