### PR TITLE
ci(vercel): skip previews for non-frontend changes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "installCommand": "npm --prefix frontend ci",
   "framework": "vite",
   "outputDirectory": "frontend/dist",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- frontend vercel.json .vercelignore",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary

- Add a Vercel `ignoreCommand` so preview deployments run only when frontend or Vercel deployment config changes.
- Backend/docs/security-only PRs should no longer consume Vercel preview build quota.
- Keep GitHub CI gates and production deploy policy unchanged.

## Contract Impact

not applicable - no API, websocket, event, frontend runtime consumer, or data contract changed; this only changes Vercel deployment selection.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed; Vercel preview selection only.

## Scope Gate

- Allowed paths: vercel.json
- Denied paths: backend runtime, frontend runtime, migrations, generated output, GitHub workflow gates
- Migration/docs/test impact: no migration; deployment preview filtering only
- Rollback note: revert the `ignoreCommand` line in `vercel.json`

## Validation

- Targeted tests or smoke run: ConvertFrom-Json parse of `vercel.json`; `git diff --check -- vercel.json`; `git diff --quiet HEAD^ HEAD -- frontend vercel.json .vercelignore` simulation on this commit
- Result: passed locally; this PR correctly triggers Vercel because it changes `vercel.json`
- Not checked: actual Vercel preview build, because Vercel is currently rate-limited for the project