### PR TITLE
chore(ops): require explicit sample admin usernames

### DIFF
--- a/ops/.env.example
+++ b/ops/.env.example
@@ -54,7 +54,8 @@ FRONTEND_URL=http://localhost:5173
 # -------------------------------------------
 # Admin User (Bootstrap)
 # -------------------------------------------
-ADMIN_USERNAME=admin
+# Required. Choose an explicit first-run admin username.
+ADMIN_USERNAME=
 ADMIN_PASSWORD=
 ADMIN_EMAIL=admin@example.com
 ADMIN_FULL_NAME=Administrator

--- a/ops/staging.env.sample
+++ b/ops/staging.env.sample
@@ -8,7 +8,8 @@ SECRET_KEY=
 # Optional legacy alias. Leave empty to use SECRET_KEY.
 AUTH_SECRET=
 
-ADMIN_USERNAME=admin
+# Required. Choose an explicit first-run admin username.
+ADMIN_USERNAME=
 ADMIN_PASSWORD=
 ADMIN_EMAIL=admin@example.com
 ADMIN_FULL_NAME=Staging Administrator

--- a/ops/vps/clinic_lifecycle.env.sample
+++ b/ops/vps/clinic_lifecycle.env.sample
@@ -29,7 +29,8 @@ SETUP_BRANCH_EMAIL=
 SETUP_BRANCH_TIMEZONE=Asia/Tashkent
 SETUP_BRANCH_CAPACITY=50
 
-SETUP_ADMIN_USERNAME=admin
+# Required. Choose an explicit first-run admin username.
+SETUP_ADMIN_USERNAME=
 # Required. Use a unique first-run admin password.
 SETUP_ADMIN_PASSWORD=
 SETUP_ADMIN_FULL_NAME=Clinic Admin


### PR DESCRIPTION
## Summary
- Blank the sample bootstrap admin username fields in ops env templates.
- Add comments requiring an explicit first-run admin username instead of inheriting `admin` from examples.

## Contract Impact
- Canonical surface: ops sample env templates only; no FastAPI route, frontend route, database schema, or runtime API surface changed.
- Request shape: not applicable because no HTTP request contract changed.
- Response shape: not applicable because no HTTP response contract changed.
- Status codes: not applicable because no endpoint behavior changed.
- Frontend consumer: not applicable because no frontend code consumes these sample files at runtime.
- Compatibility path or alias: existing env variable names stay the same: `ADMIN_USERNAME` and `SETUP_ADMIN_USERNAME`.
- Contract proof: PR diff is limited to `ops/.env.example`, `ops/staging.env.sample`, and `ops/vps/clinic_lifecycle.env.sample`; local scans confirm the sample `admin` username defaults were removed.

## RBAC / Permissions
- Roles allowed: unchanged; no app role permission table or auth policy changed.
- Roles denied: unchanged; no app role permission table or auth policy changed.
- Positive auth proof: not applicable because this PR does not change login or authorization code.
- Negative auth proof: not applicable because this PR does not change login or authorization code.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification, push, websocket, Telegram, or realtime channel changed.
- Payload version / ack behavior: not applicable because no realtime payload changed.
- Read/unread or delivery semantics: not applicable because no notification state changed.
- Reconnect/resync proof: not applicable because no realtime client or server code changed.

## Frontend Resilience
- Empty data proof: not applicable because no frontend rendering/data state changed.
- Partial data proof: not applicable because no frontend rendering/data state changed.
- Forbidden secondary path behavior: not applicable because no frontend route, auth guard, or secondary path changed.
- Missing draft/resource behavior: not applicable because no draft/resource UI changed.
- Stale route/deep-link behavior: not applicable because no route/deep-link handling changed.

## Scope Gate
- Allowed paths: `ops/.env.example`, `ops/staging.env.sample`, `ops/vps/clinic_lifecycle.env.sample`.
- Denied paths: backend code, frontend code, database migrations, runtime helper fallbacks, generated artifacts, deletion/rename cleanup.
- Migration/docs/test impact: no migration impact; no executable tests required for sample-only config comments/defaults; validation uses targeted scans and diff check.
- Rollback note: revert this commit to restore the previous sample username defaults if an operator workflow explicitly depends on the examples containing `admin`.

## Validation
- Targeted tests or smoke run: `rg -n 'ADMIN_USERNAME=admin|SETUP_ADMIN_USERNAME=admin'` on touched files; broader stale-default scan for legacy admin sample values; `git diff --check -- ops/.env.example ops/staging.env.sample ops/vps/clinic_lifecycle.env.sample`.
- Result: scans returned no matches for sample admin username defaults; diff check passed.
- Not checked: no backend/frontend test suite or browser smoke because no executable app code changed.