### PR TITLE
fix(security): require explicit dev token subject

### DIFF
--- a/backend/app/scripts/mint_dev_token.py
+++ b/backend/app/scripts/mint_dev_token.py
@@ -1,18 +1,50 @@
 from __future__ import annotations
 
 import os
+from datetime import timedelta
+
+
+CONFIRM_ENV = "CONFIRM_MINT_DEV_TOKEN"
+SUBJECT_ENV = "MINT_DEV_TOKEN_SUBJECT"
+EXPIRES_ENV = "MINT_DEV_TOKEN_EXPIRES_MINUTES"
+DEFAULT_EXPIRES_MINUTES = 15
+MAX_EXPIRES_MINUTES = 60
 
 
 def _require_mint_dev_token_confirmation() -> None:
-    if os.getenv("CONFIRM_MINT_DEV_TOKEN") != "1":
+    if os.getenv(CONFIRM_ENV) != "1":
         raise SystemExit(
-            "Refusing to mint and print a dev token without CONFIRM_MINT_DEV_TOKEN=1."
+            f"Refusing to mint and print a dev token without {CONFIRM_ENV}=1."
         )
+
+
+def _required_subject() -> str:
+    subject = os.getenv(SUBJECT_ENV, "").strip()
+    if not subject:
+        raise SystemExit(
+            f"Set {SUBJECT_ENV}=<username-or-id>; refusing implicit admin token minting."
+        )
+    return subject
+
+
+def _token_expires_delta() -> timedelta:
+    raw_value = os.getenv(EXPIRES_ENV, str(DEFAULT_EXPIRES_MINUTES)).strip()
+    try:
+        minutes = int(raw_value)
+    except ValueError as exc:
+        raise SystemExit(f"{EXPIRES_ENV} must be an integer number of minutes.") from exc
+
+    if minutes < 1 or minutes > MAX_EXPIRES_MINUTES:
+        raise SystemExit(f"{EXPIRES_ENV} must be between 1 and {MAX_EXPIRES_MINUTES}.")
+
+    return timedelta(minutes=minutes)
 
 
 if __name__ == "__main__":
     _require_mint_dev_token_confirmation()
+    subject = _required_subject()
+    expires_delta = _token_expires_delta()
 
     from app.api.deps import create_access_token  # type: ignore
 
-    print(create_access_token("admin"))
+    print(create_access_token({"sub": subject}, expires_delta=expires_delta))


### PR DESCRIPTION
﻿## Summary
- Require an explicit `MINT_DEV_TOKEN_SUBJECT` before minting a dev JWT.
- Remove the implicit hardcoded `admin` subject from the helper.
- Call the canonical token helper with a dict payload and bounded short expiry.

## Contract Impact
- Canonical surface: `backend/app/scripts/mint_dev_token.py` dev helper and `backend/app/api/deps.py:create_access_token(data, expires_delta)` call contract.
- Request shape: Not applicable because this PR does not change HTTP requests or API payloads.
- Response shape: Not applicable because this PR does not change API responses; the helper still prints a token only after explicit confirmation.
- Status codes: Not applicable because no backend endpoint behavior changes.
- Frontend consumer: Not applicable because no frontend code consumes this helper.
- Compatibility path or alias: The helper remains executable at the same path but now requires explicit subject and optional bounded expiry env values.
- Contract proof: `python -m py_compile backend\app\scripts\mint_dev_token.py` passed and the helper now calls `create_access_token({"sub": subject}, expires_delta=...)`.

## RBAC / Permissions
- Roles allowed: Not applicable because application RBAC logic is unchanged; helper subject is now operator-provided.
- Roles denied: Not applicable because no runtime authorization checks are changed.
- Positive auth proof: Not applicable because no authenticated runtime endpoint is introduced or modified.
- Negative auth proof: Refusal smokes cover missing confirmation, missing subject, and invalid expiry before any token is minted.

## Notification / Realtime
- Event type or websocket channel: Not applicable because this PR does not touch notifications or websocket channels.
- Payload version / ack behavior: Not applicable because no realtime payload or acknowledgement behavior changes.
- Read/unread or delivery semantics: Not applicable because no notification delivery state changes.
- Reconnect/resync proof: Not applicable because no realtime reconnect or resync path changes.

## Frontend Resilience
- Empty data proof: Not applicable because this PR does not change UI data rendering.
- Partial data proof: Not applicable because this PR does not change UI data rendering.
- Forbidden secondary path behavior: Not applicable because no frontend auth fallback or route behavior changes.
- Missing draft/resource behavior: Not applicable because no frontend resource loading behavior changes.
- Stale route/deep-link behavior: Not applicable because no frontend routes or deep links change.

## Scope Gate
- Allowed paths: `backend/app/scripts/mint_dev_token.py` only.
- Denied paths: Runtime auth services, frontend code, ops env templates, workflows, database migrations, generated artifacts, and deletion/rename cleanup.
- Migration/docs/test impact: No migrations, docs, or test files are changed; validation uses targeted helper smokes.
- Rollback note: Revert commit `4ba8bff1` to restore the previous helper behavior.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\scripts\mint_dev_token.py`; no-env refusal smoke; `CONFIRM_MINT_DEV_TOKEN=1` without subject refusal smoke; invalid `MINT_DEV_TOKEN_EXPIRES_MINUTES=0` refusal smoke; scan for `create_access_token("admin")`; `git diff --check -- backend\app\scripts\mint_dev_token.py`.
- Result: Compile, refusal smokes, old-pattern scan, and diff check passed.
- Not checked: A successful token mint was not executed to avoid printing a live JWT into logs.
