### PR TITLE
fix(security): require explicit ensure admin username

### DIFF
--- a/backend/app/scripts/ensure_admin.py
+++ b/backend/app/scripts/ensure_admin.py
@@ -41,8 +41,17 @@ def _required_admin_password() -> str:
     return password
 
 
+def _required_admin_username() -> str:
+    username = os.getenv("ADMIN_USERNAME", "").strip()
+    if not username:
+        raise RuntimeError(
+            "ADMIN_USERNAME must be set before creating or resetting the bootstrap admin user."
+        )
+    return username
+
+
 def ensure_admin() -> dict:
-    username = os.getenv("ADMIN_USERNAME", "admin").strip()
+    username = _required_admin_username()
     email = os.getenv("ADMIN_EMAIL", "admin@example.com").strip()
     full_name = os.getenv("ADMIN_FULL_NAME", "Administrator").strip()
     allow_initialized = os.getenv(INITIALIZED_OVERRIDE_ENV, "").strip().lower() in {

--- a/backend/tests/unit/test_ensure_admin_script.py
+++ b/backend/tests/unit/test_ensure_admin_script.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from app.models.clinic import Branch, ClinicSettings
 
 
@@ -52,3 +54,12 @@ def test_ensure_admin_skips_initialized_instance_without_override(
 
     assert result["skipped"] is True
     assert "explicit_ops_override" in result["reason"]
+
+
+def test_ensure_admin_requires_explicit_admin_username(monkeypatch):
+    from app.scripts import ensure_admin as ensure_admin_module
+
+    monkeypatch.delenv("ADMIN_USERNAME", raising=False)
+
+    with pytest.raises(RuntimeError, match="ADMIN_USERNAME must be set"):
+        ensure_admin_module._required_admin_username()


### PR DESCRIPTION
﻿## Summary
- Remove the implicit `ADMIN_USERNAME=admin` fallback from the canonical `ensure_admin.py` helper.
- Require operators to set `ADMIN_USERNAME` before creating or resetting the bootstrap admin user.
- Add a focused unit test proving the helper fails fast when `ADMIN_USERNAME` is missing.

## Contract Impact
- Canonical surface: `backend/app/scripts/ensure_admin.py` ops helper only; no FastAPI endpoint or frontend API contract changed.
- Request shape: Not applicable because this is a local script, not an HTTP endpoint.
- Response shape: Not applicable because no app API response changed; the helper now fails fast if `ADMIN_USERNAME` is missing.
- Status codes: Not applicable because no HTTP endpoint behavior changes.
- Frontend consumer: Not applicable because no frontend code consumes this helper directly.
- Compatibility path or alias: Script path and existing env variable name `ADMIN_USERNAME` stay unchanged; implicit `admin` fallback is intentionally removed.
- Contract proof: `backend/tests/unit/test_ensure_admin_script.py` covers missing username refusal and the existing initialized-instance path with explicit username.

## RBAC / Permissions
- Roles allowed: Unchanged; helper still creates or updates only the Admin bootstrap role when explicitly configured.
- Roles denied: Unchanged; no runtime authorization policy changes.
- Positive auth proof: Existing initialized-instance unit test passes with explicit `ADMIN_USERNAME`.
- Negative auth proof: New missing `ADMIN_USERNAME` unit test raises `RuntimeError` before DB mutation.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification, websocket, push, Telegram, or realtime path changes.
- Payload version / ack behavior: Not applicable because no realtime payload or acknowledgement behavior changes.
- Read/unread or delivery semantics: Not applicable because no notification delivery state changes.
- Reconnect/resync proof: Not applicable because no realtime reconnect or resync code changes.

## Frontend Resilience
- Empty data proof: Not applicable because no frontend data rendering changes.
- Partial data proof: Not applicable because no frontend data rendering changes.
- Forbidden secondary path behavior: Not applicable because no frontend route or auth guard changes.
- Missing draft/resource behavior: Not applicable because no frontend resource UI changes.
- Stale route/deep-link behavior: Not applicable because no frontend route or deep-link handling changes.

## Scope Gate
- Allowed paths: `backend/app/scripts/ensure_admin.py`, `backend/tests/unit/test_ensure_admin_script.py`.
- Denied paths: Other admin helper scripts, frontend code, ops env files, database migrations, generated artifacts, and deletion/rename cleanup.
- Migration/docs/test impact: No migrations or docs; one focused unit test is added for the new refusal path.
- Rollback note: Revert commits `a349be63` and `95ede324` to restore the previous implicit `admin` fallback and remove the new test.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\scripts\ensure_admin.py`; `python -m pytest backend\tests\unit\test_ensure_admin_script.py -q`; scan for old `ADMIN_USERNAME=admin` fallback; `git diff --check -- backend\app\scripts\ensure_admin.py backend\tests\unit\test_ensure_admin_script.py`.
- Result: Compile passed; targeted pytest passed with `2 passed`; old fallback scan returned no matches; diff check passed.
- Not checked: Full backend suite and browser smoke, because this PR only changes a local ops helper and one focused unit test.
