### PR TITLE
fix(security): require explicit create admin dev username

### DIFF
--- a/backend/app/scripts/create_admin_dev.py
+++ b/backend/app/scripts/create_admin_dev.py
@@ -31,6 +31,15 @@ def _required_admin_password() -> str:
     return password
 
 
+def _required_admin_username() -> str:
+    username = (os.getenv("DEV_ADMIN_USERNAME") or os.getenv("ADMIN_USERNAME") or "").strip()
+    if not username:
+        raise SystemExit(
+            "Set DEV_ADMIN_USERNAME or ADMIN_USERNAME before creating a dev admin."
+        )
+    return username
+
+
 def _password_value(column_name: str) -> str:
     password = _required_admin_password()
     if column_name == "hashed_password":
@@ -42,6 +51,7 @@ def _password_value(column_name: str) -> str:
 
 _require_create_admin_dev_confirmation()
 DATABASE_URL = _required_database_url()
+ADMIN_USERNAME = _required_admin_username()
 
 from sqlalchemy import MetaData, Table, create_engine, select
 from sqlalchemy.orm import sessionmaker
@@ -68,7 +78,7 @@ def find_users_table(meta: MetaData) -> Optional[Table]:
 
 
 def upsert_admin() -> None:
-    admin_username = os.getenv("DEV_ADMIN_USERNAME") or os.getenv("ADMIN_USERNAME", "admin")
+    admin_username = ADMIN_USERNAME
     admin_email = os.getenv("DEV_ADMIN_EMAIL") or os.getenv("ADMIN_EMAIL", "admin@example.com")
     admin_full_name = os.getenv("DEV_ADMIN_FULL_NAME") or os.getenv(
         "ADMIN_FULL_NAME", "Administrator"


### PR DESCRIPTION
﻿## Summary
- Remove the implicit `ADMIN_USERNAME=admin` fallback from `backend/app/scripts/create_admin_dev.py`.
- Require `DEV_ADMIN_USERNAME` or `ADMIN_USERNAME` before creating a dev admin.
- Validate the username before SQLAlchemy engine setup so missing-env refusal does not depend on a PostgreSQL driver being installed.

## Contract Impact
- Canonical surface: `backend/app/scripts/create_admin_dev.py` dev helper only; no FastAPI endpoint or frontend API contract changes.
- Request shape: Not applicable because this is a local helper, not an HTTP endpoint.
- Response shape: Not applicable because no app API response changes; helper now exits locally when username env is missing.
- Status codes: Not applicable because no HTTP endpoint behavior changes.
- Frontend consumer: Not applicable because no frontend code consumes this helper.
- Compatibility path or alias: Script path remains unchanged; accepted env names are `DEV_ADMIN_USERNAME` and `ADMIN_USERNAME` without an implicit fallback value.
- Contract proof: Missing-username smoke exits before SQLAlchemy driver setup and before DB reflection/upsert work.

## RBAC / Permissions
- Roles allowed: Unchanged; helper still targets dev admin bootstrap only when explicitly configured.
- Roles denied: Unchanged; no runtime RBAC policy changes.
- Positive auth proof: Not run because successful helper execution would mutate a live database credential row.
- Negative auth proof: Missing username smoke exits with `Set DEV_ADMIN_USERNAME or ADMIN_USERNAME before creating a dev admin` before DB mutation.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification, websocket, push, Telegram, or realtime path changes.
- Payload version / ack behavior: Not applicable because no realtime payload or acknowledgement behavior changes.
- Read/unread or delivery semantics: Not applicable because no notification delivery state changes.
- Reconnect/resync proof: Not applicable because no realtime reconnect or resync code changes.

## Frontend Resilience
- Empty data proof: Not applicable because no frontend data rendering changes.
- Partial data proof: Not applicable because no frontend data rendering changes.
- Forbidden secondary path behavior: Not applicable because no frontend route or auth guard changes.
- Missing draft/resource behavior: Not applicable because no frontend resource UI changes.
- Stale route/deep-link behavior: Not applicable because no frontend route or deep-link handling changes.

## Scope Gate
- Allowed paths: `backend/app/scripts/create_admin_dev.py`.
- Denied paths: Other admin helper scripts, frontend code, ops env files, database migrations, generated artifacts, and deletion/rename cleanup.
- Migration/docs/test impact: No migrations, docs, or test files are changed; validation uses compile and helper refusal smoke.
- Rollback note: Revert commit `79c72760` to restore the previous implicit `admin` fallback for this dev helper.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\scripts\create_admin_dev.py`; missing username smoke with `CONFIRM_CREATE_ADMIN_DEV=1` and non-sqlite `DATABASE_URL`; scan for old `ADMIN_USERNAME=admin` fallback; `git diff --check -- backend\app\scripts\create_admin_dev.py`.
- Result: Compile passed; missing username smoke failed fast before DB driver setup; old fallback scan returned no matches; diff check passed.
- Not checked: Successful dev admin upsert against a live DB, because this PR only changes the missing-env guard and avoids credential mutation in validation.
