### PR TITLE
fix(ops): require explicit restore smoke username

### DIFF
--- a/ops/windows/clinic_host.ps1
+++ b/ops/windows/clinic_host.ps1
@@ -820,8 +820,11 @@ function Invoke-RestoreRehearsal {
         -Database $RestoreDatabaseName
     $restoreBackendUrl = "http://127.0.0.1:$RestoreBackendPort"
     $restorePublicUrl = "http://127.0.0.1:$RestoreFrontendPort"
-    $smokeLoginUsername = if ($env:SMOKE_LOGIN_USERNAME) { $env:SMOKE_LOGIN_USERNAME } elseif ($env:SETUP_ADMIN_USERNAME) { $env:SETUP_ADMIN_USERNAME } else { 'admin' }
+    $smokeLoginUsername = if ($env:SMOKE_LOGIN_USERNAME) { $env:SMOKE_LOGIN_USERNAME } elseif ($env:SETUP_ADMIN_USERNAME) { $env:SETUP_ADMIN_USERNAME } else { $null }
     $smokeLoginPassword = if ($env:SMOKE_LOGIN_PASSWORD) { $env:SMOKE_LOGIN_PASSWORD } elseif ($env:SETUP_ADMIN_PASSWORD) { $env:SETUP_ADMIN_PASSWORD } else { $null }
+    if (-not $smokeLoginUsername) {
+        Write-Fail 'Set SMOKE_LOGIN_USERNAME or SETUP_ADMIN_USERNAME before restore smoke admin seeding.'
+    }
     if (-not $smokeLoginPassword) {
         Write-Fail 'Set SMOKE_LOGIN_PASSWORD or SETUP_ADMIN_PASSWORD before restore smoke admin seeding.'
     }


### PR DESCRIPTION
﻿## Summary
- Remove the restore rehearsal fallback that used `admin` when no smoke username env was set.
- Require `SMOKE_LOGIN_USERNAME` or `SETUP_ADMIN_USERNAME` before restore smoke admin seeding.

## Contract Impact
- Canonical surface: `ops/windows/clinic_host.ps1` restore rehearsal ops flow only; no FastAPI endpoint or frontend API contract changes.
- Request shape: Not applicable because this is a local Windows ops script, not an HTTP endpoint.
- Response shape: Not applicable because no app API response changes; the script now fails locally when username env is missing.
- Status codes: Not applicable because no HTTP endpoint behavior changes.
- Frontend consumer: Not applicable because no frontend code consumes this script.
- Compatibility path or alias: Script path and existing env names stay unchanged; implicit fallback to `admin` is intentionally removed.
- Contract proof: The script now calls `Write-Fail` when neither `SMOKE_LOGIN_USERNAME` nor `SETUP_ADMIN_USERNAME` is set.

## RBAC / Permissions
- Roles allowed: Unchanged; restore smoke still seeds the explicitly configured admin user for rehearsal only.
- Roles denied: Unchanged; no runtime RBAC policy changes.
- Positive auth proof: Not run because restore rehearsal requires local service/database orchestration.
- Negative auth proof: Static branch proof verifies no fallback `else { 'admin' }` remains in the restore smoke username path.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification, websocket, push, Telegram, or realtime path changes.
- Payload version / ack behavior: Not applicable because no realtime payload or acknowledgement behavior changes.
- Read/unread or delivery semantics: Not applicable because no notification delivery state changes.
- Reconnect/resync proof: Not applicable because no realtime reconnect or resync code changes.

## Frontend Resilience
- Empty data proof: Not applicable because no frontend data rendering changes.
- Partial data proof: Not applicable because no frontend data rendering changes.
- Forbidden secondary path behavior: Not applicable because no frontend route or auth guard changes.
- Missing draft/resource behavior: Not applicable because no frontend resource UI changes.
- Stale route/deep-link behavior: Not applicable because no frontend route or deep-link handling changes.

## Scope Gate
- Allowed paths: `ops/windows/clinic_host.ps1`.
- Denied paths: Backend code, frontend code, env samples, database migrations, generated artifacts, and deletion/rename cleanup.
- Migration/docs/test impact: No migrations, docs, or test files are changed; validation uses PowerShell parse and targeted scan.
- Rollback note: Revert commit `527b4e2b` to restore the previous restore smoke username fallback.

## Validation
- Targeted tests or smoke run: PowerShell `[scriptblock]::Create(...)` parse check; scan for `else { 'admin' }` in `ops/windows/clinic_host.ps1`; `git diff --check origin/main...HEAD -- ops\windows\clinic_host.ps1`.
- Result: PowerShell parse passed; old fallback scan returned no matches; diff check passed.
- Not checked: Full restore rehearsal, because this PR only changes missing-env validation and avoids provisioning local restore services.
