### PR TITLE
fix(security): require explicit smoke admin usernames

### DIFF
--- a/backend/app/services/api_documentation_api_service.py
+++ b/backend/app/services/api_documentation_api_service.py
@@ -30,7 +30,7 @@ async def get_detailed_endpoints_documentation(
                             "username": {
                                 "type": "string",
                                 "required": True,
-                                "example": "admin",
+                                "example": "YOUR_ADMIN_USERNAME",
                             },
                             "password": {
                                 "type": "string",
@@ -98,7 +98,7 @@ async def get_detailed_endpoints_documentation(
                             "example": [
                                 {
                                     "id": 1,
-                                    "username": "admin",
+                                    "username": "YOUR_ADMIN_USERNAME",
                                     "email": "admin@clinic.com",
                                     "role": "Admin",
                                     "is_active": True,
@@ -116,7 +116,7 @@ async def get_detailed_endpoints_documentation(
                             "description": "Информация о пользователе",
                             "example": {
                                 "id": 1,
-                                "username": "admin",
+                                "username": "YOUR_ADMIN_USERNAME",
                                 "email": "admin@clinic.com",
                                 "role": "Admin",
                                 "is_active": True,
@@ -568,13 +568,13 @@ async def get_api_examples(
     examples = {
         "authentication_examples": {
             "login": {
-                "curl": "curl -X POST 'http://localhost:18000/api/v1/auth/login' -H 'Content-Type: application/x-www-form-urlencoded' -d 'username=admin&password=REPLACE_WITH_ADMIN_PASSWORD'",
+                "curl": "curl -X POST 'http://localhost:18000/api/v1/auth/login' -H 'Content-Type: application/x-www-form-urlencoded' -d 'username=YOUR_ADMIN_USERNAME&password=REPLACE_WITH_ADMIN_PASSWORD'",
                 "python": """
 import requests
 
 response = requests.post(
     'http://localhost:18000/api/v1/auth/login',
-    data={'username': 'admin', 'password': 'REPLACE_WITH_ADMIN_PASSWORD'}
+    data={'username': 'YOUR_ADMIN_USERNAME', 'password': 'REPLACE_WITH_ADMIN_PASSWORD'}
 )
 token = response.json()['access_token']
                 """,
@@ -584,7 +584,7 @@ const response = await fetch('http://localhost:18000/api/v1/auth/login', {
     headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: 'username=admin&password=REPLACE_WITH_ADMIN_PASSWORD'
+    body: 'username=YOUR_ADMIN_USERNAME&password=REPLACE_WITH_ADMIN_PASSWORD'
 });
 const data = await response.json();
 const token = data.access_token;

--- a/backend/test_cicd_simple.py
+++ b/backend/test_cicd_simple.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 # Конфигурация
 BASE_URL = "http://127.0.0.1:18000"
-AUTH_USERNAME = os.getenv("QA_ADMIN_USERNAME", "admin")
+AUTH_USERNAME = os.getenv("QA_ADMIN_USERNAME", "qa-smoke-user")
 AUTH_PASSWORD = os.getenv("QA_ADMIN_PASSWORD", "invalid-qa-admin-password")
 
 

--- a/backend/test_time_restrictions.py
+++ b/backend/test_time_restrictions.py
@@ -9,7 +9,7 @@ import os
 from datetime import datetime
 
 BASE_URL = os.getenv("QA_BACKEND_BASE_URL", "http://localhost:18000")
-AUTH_USERNAME = os.getenv("QA_ADMIN_USERNAME", "admin")
+AUTH_USERNAME_ENV = "QA_ADMIN_USERNAME"
 
 
 def required_env(name):
@@ -26,7 +26,7 @@ def test_time_restrictions():
     
     # Получаем токен авторизации
     login_data = {
-        "username": AUTH_USERNAME,
+        "username": required_env(AUTH_USERNAME_ENV),
         "password": required_env("QA_ADMIN_PASSWORD"),
     }
     login_response = requests.post(f"{BASE_URL}/api/v1/authentication/login", data=login_data)

--- a/backend/ws_test_auth.py
+++ b/backend/ws_test_auth.py
@@ -19,7 +19,7 @@ if hasattr(sys.stderr, "reconfigure"):
 
 BASE_URL = os.getenv("QA_BACKEND_BASE_URL", "http://127.0.0.1:18000")
 WS_BASE_URL = os.getenv("QA_BACKEND_WS_URL", "ws://127.0.0.1:18000")
-AUTH_USERNAME = os.getenv("QA_ADMIN_USERNAME", "admin")
+AUTH_USERNAME_ENV = "QA_ADMIN_USERNAME"
 
 
 def required_env(name: str) -> str:
@@ -34,7 +34,7 @@ async def get_auth_token():
     try:
         data = urllib.parse.urlencode(
             {
-                "username": AUTH_USERNAME,
+                "username": required_env(AUTH_USERNAME_ENV),
                 "password": required_env("QA_ADMIN_PASSWORD"),
             }
         ).encode()

--- a/backend/ws_test_final.py
+++ b/backend/ws_test_final.py
@@ -13,7 +13,7 @@ import websockets
 
 BASE_URL = os.getenv("QA_BACKEND_BASE_URL", "http://127.0.0.1:18000")
 WS_BASE_URL = os.getenv("QA_BACKEND_WS_URL", "ws://127.0.0.1:18000")
-AUTH_USERNAME = os.getenv("QA_ADMIN_USERNAME", "admin")
+AUTH_USERNAME_ENV = "QA_ADMIN_USERNAME"
 
 
 def required_env(name: str) -> str:
@@ -28,7 +28,7 @@ async def get_auth_token():
     try:
         data = urllib.parse.urlencode(
             {
-                "username": AUTH_USERNAME,
+                "username": required_env(AUTH_USERNAME_ENV),
                 "password": required_env("QA_ADMIN_PASSWORD"),
             }
         ).encode()

--- a/backend/ws_test_improved.py
+++ b/backend/ws_test_improved.py
@@ -13,7 +13,7 @@ import websockets
 
 BASE_URL = os.getenv("QA_BACKEND_BASE_URL", "http://127.0.0.1:18000")
 WS_BASE_URL = os.getenv("QA_BACKEND_WS_URL", "ws://127.0.0.1:18000")
-AUTH_USERNAME = os.getenv("QA_ADMIN_USERNAME", "admin")
+AUTH_USERNAME_ENV = "QA_ADMIN_USERNAME"
 
 
 def required_env(name: str) -> str:
@@ -28,7 +28,7 @@ async def get_auth_token():
     try:
         data = urllib.parse.urlencode(
             {
-                "username": AUTH_USERNAME,
+                "username": required_env(AUTH_USERNAME_ENV),
                 "password": required_env("QA_ADMIN_PASSWORD"),
             }
         ).encode()


### PR DESCRIPTION
﻿## Summary

- Replace hard-coded admin username examples in the backend API documentation service mirror with `YOUR_ADMIN_USERNAME` placeholders.
- Remove implicit `QA_ADMIN_USERNAME=admin` fallbacks from WebSocket and QR smoke helpers that perform real authentication.
- Keep the simplified CI smoke helper runnable without credentials by using a non-privileged placeholder username for the expected 401-compatible login probe.

## Contract Impact

- Canonical surface: backend API documentation service example payloads and manual backend smoke helper credential setup only.
- Request shape: unchanged; smoke helpers still send the same login form fields when explicit environment values are present.
- Response shape: unchanged; no backend endpoint response model changed.
- Status codes: unchanged; no backend route logic changed.
- Frontend consumer: not applicable - no frontend files or browser-facing data consumers changed.
- Compatibility path or alias: not applicable - no route alias, redirect, or compatibility endpoint changed.
- Contract proof: `python -m py_compile` on touched Python files and targeted credential-string scan passed.

## RBAC / Permissions

- Roles allowed: unchanged; no RBAC checks or role mappings changed.
- Roles denied: unchanged; no permission denial logic changed.
- Positive auth proof: not run - this PR only changes manual helper credential defaults, and no live QA admin credentials are available in the repo.
- Negative auth proof: simplified CI smoke still uses a non-privileged placeholder username when no env is provided, preserving its 401-compatible login probe.

## Notification / Realtime

not applicable - realtime runtime is unchanged; only manual WebSocket smoke helper credential sourcing changed before token acquisition.

## Frontend Resilience

not applicable - no frontend component, route, data loader, or browser-facing fallback behavior changed.

## Scope Gate

- Allowed paths: backend API documentation service mirror and backend manual smoke helper scripts touched in this PR.
- Denied paths: runtime auth implementation, canonical routers, migrations, frontend runtime, ops config, generated output, and evidence artifacts.
- Migration/docs/test impact: no migration; docs-service examples now use placeholders; validation is compile and targeted string scanning.
- Rollback note: revert the PR commits to restore previous helper defaults and documentation examples.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\services\api_documentation_api_service.py backend\ws_test_improved.py backend\ws_test_final.py backend\ws_test_auth.py backend\test_cicd_simple.py backend\test_time_restrictions.py`; `git diff --check`; targeted `rg` scan for `username=admin`, `QA_ADMIN_USERNAME=admin`, and `AUTH_USERNAME = os.getenv("QA_ADMIN_USERNAME", "admin")` in touched files.
- Result: passed locally.
- Not checked: live login/WebSocket/QR smoke against a running backend, because this change intentionally avoids requiring or exposing real QA admin credentials.
