### PR TITLE
docs(security): use placeholder admin examples in API docs

### DIFF
--- a/backend/app/api/v1/endpoints/api_documentation.py
+++ b/backend/app/api/v1/endpoints/api_documentation.py
@@ -31,7 +31,7 @@ async def get_detailed_endpoints_documentation(
                             "username": {
                                 "type": "string",
                                 "required": True,
-                                "example": "admin",
+                                "example": "YOUR_ADMIN_USERNAME",
                             },
                             "password": {
                                 "type": "string",
@@ -99,8 +99,8 @@ async def get_detailed_endpoints_documentation(
                             "example": [
                                 {
                                     "id": 1,
-                                    "username": "admin",
-                                    "email": "admin@clinic.com",
+                                    "username": "YOUR_ADMIN_USERNAME",
+                                    "email": "operator@example.com",
                                     "role": "Admin",
                                     "is_active": True,
                                     "created_at": "2025-01-29T10:00:00Z",
@@ -117,8 +117,8 @@ async def get_detailed_endpoints_documentation(
                             "description": "Информация о пользователе",
                             "example": {
                                 "id": 1,
-                                "username": "admin",
-                                "email": "admin@clinic.com",
+                                "username": "YOUR_ADMIN_USERNAME",
+                                "email": "operator@example.com",
                                 "role": "Admin",
                                 "is_active": True,
                             },

--- a/backend/app/api/v1/endpoints/docs.py
+++ b/backend/app/api/v1/endpoints/docs.py
@@ -43,7 +43,7 @@ async def get_api_docs():
             <div class="description">Вход в систему</div>
             <div class="example">
                 {
-                    "username": "admin",
+                    "username": "YOUR_ADMIN_USERNAME",
                     "password": "REPLACE_WITH_ADMIN_PASSWORD"
                 }
             </div>
@@ -234,7 +234,7 @@ async def get_api_schema():
             "title": "Clinic Management System API",
             "description": "API для системы управления клиникой",
             "version": "1.0.0",
-            "contact": {"name": "Clinic Management Team", "email": "admin@clinic.com"},
+            "contact": {"name": "Clinic Management Team", "email": "support@example.com"},
         },
         "servers": [
             {"url": "http://localhost:18000", "description": "Development server"}

--- a/backend/app/services/api_documentation_api_service.py
+++ b/backend/app/services/api_documentation_api_service.py
@@ -99,7 +99,7 @@ async def get_detailed_endpoints_documentation(
                                 {
                                     "id": 1,
                                     "username": "YOUR_ADMIN_USERNAME",
-                                    "email": "admin@clinic.com",
+                                    "email": "operator@example.com",
                                     "role": "Admin",
                                     "is_active": True,
                                     "created_at": "2025-01-29T10:00:00Z",
@@ -117,7 +117,7 @@ async def get_detailed_endpoints_documentation(
                             "example": {
                                 "id": 1,
                                 "username": "YOUR_ADMIN_USERNAME",
-                                "email": "admin@clinic.com",
+                                "email": "operator@example.com",
                                 "role": "Admin",
                                 "is_active": True,
                             },

--- a/backend/app/services/docs_api_service.py
+++ b/backend/app/services/docs_api_service.py
@@ -43,7 +43,7 @@ async def get_api_docs():
             <div class="description">Вход в систему</div>
             <div class="example">
                 {
-                    "username": "admin",
+                    "username": "YOUR_ADMIN_USERNAME",
                     "password": "REPLACE_WITH_ADMIN_PASSWORD"
                 }
             </div>
@@ -234,7 +234,7 @@ async def get_api_schema():
             "title": "Clinic Management System API",
             "description": "API для системы управления клиникой",
             "version": "1.0.0",
-            "contact": {"name": "Clinic Management Team", "email": "admin@clinic.com"},
+            "contact": {"name": "Clinic Management Team", "email": "support@example.com"},
         },
         "servers": [
             {"url": "http://localhost:18000", "description": "Development server"}


### PR DESCRIPTION
﻿## Summary

- Replace hard-coded admin username examples in runtime-served backend API documentation with `YOUR_ADMIN_USERNAME` placeholders.
- Replace sample admin contact/user emails with neutral example addresses.
- Keep endpoint paths, schemas, and auth requirements unchanged.

## Contract Impact

- Canonical surface: API documentation endpoints and matching service mirror example strings only.
- Request shape: unchanged; no request parser, dependency, or endpoint input changed.
- Response shape: documentation/example values changed from concrete admin identities to placeholders; structural shape remains unchanged.
- Status codes: unchanged; no route logic changed.
- Frontend consumer: not applicable - no frontend code or frontend API consumer changed.
- Compatibility path or alias: not applicable - no route alias, redirect, or compatibility path changed.
- Contract proof: touched Python files compile and targeted scans no longer find `username=admin`, `"username": "admin"`, or `admin@clinic.com` in the touched docs files.

## RBAC / Permissions

- Roles allowed: unchanged; no auth dependency or allowed-role list changed.
- Roles denied: unchanged; no deny path changed.
- Positive auth proof: not run because the PR changes documentation example literals only.
- Negative auth proof: not run because no auth/runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, push, Telegram, or realtime behavior changed.

## Frontend Resilience

not applicable - no frontend component, route, loader, or browser fallback behavior changed.

## Scope Gate

- Allowed paths: backend API documentation endpoints and their service mirror files.
- Denied paths: auth runtime, RBAC helpers, migrations, frontend runtime, ops config, generated output, and evidence artifacts.
- Migration/docs/test impact: docs/example-string cleanup only; no migration needed.
- Rollback note: revert this PR to restore previous API documentation example values.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\docs.py backend\app\services\docs_api_service.py backend\app\api\v1\endpoints\api_documentation.py backend\app\services\api_documentation_api_service.py`; `git diff --check`; targeted `rg` scans for `username=admin`, `"username": "admin"`, and `admin@clinic.com` in touched files.
- Result: passed locally.
- Not checked: browser/API docs smoke, because the change is limited to static example strings and does not alter route logic.
