### PR TITLE
docs(db): use Postgres in active debug guides

### DIFF
--- a/docs/DOCTOR_AUTOCOMPLETE_CHECKLIST.md
+++ b/docs/DOCTOR_AUTOCOMPLETE_CHECKLIST.md
@@ -65,8 +65,8 @@
 
 ### Backend
 ```bash
-# 1. Проверить таблицу
-sqlite3 clinic.db "SELECT COUNT(*) FROM doctor_phrase_history;"
+# 1. Проверить runtime-таблицу PostgreSQL
+psql "$DATABASE_URL" -c "SELECT COUNT(*) FROM doctor_phrase_history;"
 
 # 2. Проверить API
 curl http://localhost:18000/api/v1/emr/readiness/123

--- a/docs/REGISTRATION_DEBUG_GUIDE.md
+++ b/docs/REGISTRATION_DEBUG_GUIDE.md
@@ -23,20 +23,17 @@
 
 ### Шаг 1: Проверить данные в базе
 ```bash
-# В терминале backend:
-python -c "
-import sqlite3
-conn = sqlite3.connect('clinic.db')
-cursor = conn.cursor()
-
-# Последние 5 записей
-cursor.execute('SELECT v.id, p.last_name || \" \" || p.first_name, v.created_at, v.department FROM visits v JOIN patients p ON v.patient_id = p.id ORDER BY v.created_at DESC LIMIT 5')
-rows = cursor.fetchall()
-print('Последние записи в базе:')
-for row in rows:
-    print(f'ID: {row[0]} | {row[1]} | {row[2]} | {row[3]}')
-
-conn.close()
+# В терминале backend с DATABASE_URL на PostgreSQL:
+psql "$DATABASE_URL" -c "
+SELECT
+  v.id,
+  concat_ws(' ', p.last_name, p.first_name) AS patient_name,
+  v.created_at,
+  v.department
+FROM visits v
+JOIN patients p ON v.patient_id = p.id
+ORDER BY v.created_at DESC
+LIMIT 5;
 "
 ```
 


### PR DESCRIPTION
## Summary
- Update active diagnostic docs to validate runtime data through PostgreSQL via `DATABASE_URL` instead of direct `clinic.db` reads.
- Leave archived registration debug documentation untouched as historical context.

## Contract Impact
- Canonical surface: active documentation only: `docs/DOCTOR_AUTOCOMPLETE_CHECKLIST.md` and `docs/REGISTRATION_DEBUG_GUIDE.md`.
- Request shape: unchanged; no API request code changed.
- Response shape: unchanged; no API or frontend response data changed.
- Status codes: unchanged.
- Frontend consumer: not applicable because no frontend runtime files changed.
- Compatibility path or alias: not applicable because no routes or aliases changed.
- Contract proof: active-doc guard test passed and targeted scans confirm the edited docs no longer instruct direct `clinic.db` reads.

## RBAC / Permissions
- Roles allowed: unchanged; no RBAC implementation changed.
- Roles denied: unchanged; no permission logic changed.
- Positive auth proof: not run because this is docs-only.
- Negative auth proof: not run because this is docs-only.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification, websocket, push, Telegram, or realtime path changed.
- Payload version / ack behavior: not applicable because no realtime payload changed.
- Read/unread or delivery semantics: not applicable because no notification state changed.
- Reconnect/resync proof: not applicable because no realtime code changed.

## Frontend Resilience
- Empty data proof: not applicable because no frontend rendering changed.
- Partial data proof: not applicable because no frontend rendering changed.
- Forbidden secondary path behavior: not applicable because no frontend route/auth guard changed.
- Missing draft/resource behavior: not applicable because no frontend resource UI changed.
- Stale route/deep-link behavior: not applicable because no frontend route/deep-link handling changed.

## Scope Gate
- Allowed paths: `docs/DOCTOR_AUTOCOMPLETE_CHECKLIST.md`, `docs/REGISTRATION_DEBUG_GUIDE.md`.
- Denied paths: runtime DB/session code, migrations, backend scripts, frontend runtime, ops config, generated output, and archived docs.
- Migration/docs/test impact: no migration; active docs now point operators at PostgreSQL runtime verification.
- Rollback note: revert this commit to restore the previous doc commands.

## Validation
- Targeted tests or smoke run: `python -m pytest backend/tests/unit/test_no_legacy_ports_in_active_text.py`; targeted scans for `sqlite3 clinic.db` in the doctor checklist and `sqlite3.connect('clinic.db')` in the registration debug guide; `git diff --check HEAD~1..HEAD`.
- Result: 9 guard tests passed; targeted scans returned no matches; diff check passed.
- Not checked: live database/browser smoke, because this PR changes only active documentation commands.