### PR TITLE
fix(security): block SSRF in link previews

### DIFF
--- a/backend/app/api/v1/endpoints/utils.py
+++ b/backend/app/api/v1/endpoints/utils.py
@@ -1,17 +1,68 @@
 
-from fastapi import APIRouter, Query, HTTPException
+import ipaddress
+import logging
+import socket
+from urllib.parse import urljoin, urlparse
+
 import httpx
 from bs4 import BeautifulSoup
-import logging
+from fastapi import APIRouter, HTTPException, Query
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+MAX_REDIRECTS = 3
+ALLOWED_SCHEMES = {"http", "https"}
+
+
+def _is_blocked_ip(address: str) -> bool:
+    ip = ipaddress.ip_address(address)
+    return ip.is_multicast or not ip.is_global
+
+
+def _validate_public_preview_url(raw_url: str) -> str:
+    parsed = urlparse(raw_url)
+    if parsed.scheme.lower() not in ALLOWED_SCHEMES:
+        raise HTTPException(status_code=400, detail="Unsupported URL scheme")
+    if not parsed.hostname:
+        raise HTTPException(status_code=400, detail="URL host is required")
+    if parsed.username or parsed.password:
+        raise HTTPException(status_code=400, detail="URL credentials are not allowed")
+
+    hostname = parsed.hostname.strip().rstrip(".")
+    if not hostname:
+        raise HTTPException(status_code=400, detail="URL host is required")
+
+    try:
+        addresses = {info[4][0] for info in socket.getaddrinfo(hostname, parsed.port)}
+    except socket.gaierror as exc:
+        raise HTTPException(status_code=400, detail="URL host cannot be resolved") from exc
+
+    if not addresses or any(_is_blocked_ip(address) for address in addresses):
+        raise HTTPException(status_code=400, detail="URL host is not allowed")
+
+    return parsed.geturl()
+
+
+async def _fetch_public_preview(client: httpx.AsyncClient, url: str) -> httpx.Response:
+    current_url = _validate_public_preview_url(url)
+    for _ in range(MAX_REDIRECTS + 1):
+        response = await client.get(current_url, follow_redirects=False)
+        if response.is_redirect:
+            location = response.headers.get("location")
+            if not location:
+                raise HTTPException(status_code=400, detail="Invalid redirect")
+            current_url = _validate_public_preview_url(urljoin(current_url, location))
+            continue
+        return response
+    raise HTTPException(status_code=400, detail="Too many redirects")
+
 
 @router.get("/link-preview")
 async def get_link_preview(url: str = Query(..., description="The URL to preview")):
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
-            response = await client.get(url, follow_redirects=True)
+            response = await _fetch_public_preview(client, url)
             if response.status_code != 200:
                 raise HTTPException(status_code=400, detail="Could not fetch URL")
             
@@ -39,6 +90,11 @@ async def get_link_preview(url: str = Query(..., description="The URL to preview
                 "image": image,
                 "url": url
             }
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error fetching link preview for {url}: {e}")
-        return {"error": str(e)}
+        logger.warning(
+            "Error fetching link preview error_type=%s",
+            type(e).__name__,
+        )
+        raise HTTPException(status_code=400, detail="Could not fetch URL") from None

--- a/backend/app/services/utils_api_service.py
+++ b/backend/app/services/utils_api_service.py
@@ -1,5 +1,8 @@
 
+import ipaddress
 import logging
+import socket
+from urllib.parse import urljoin, urlparse
 
 import httpx
 from bs4 import BeautifulSoup
@@ -8,11 +11,58 @@ from fastapi import APIRouter, HTTPException, Query
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+MAX_REDIRECTS = 3
+ALLOWED_SCHEMES = {"http", "https"}
+
+
+def _is_blocked_ip(address: str) -> bool:
+    ip = ipaddress.ip_address(address)
+    return ip.is_multicast or not ip.is_global
+
+
+def _validate_public_preview_url(raw_url: str) -> str:
+    parsed = urlparse(raw_url)
+    if parsed.scheme.lower() not in ALLOWED_SCHEMES:
+        raise HTTPException(status_code=400, detail="Unsupported URL scheme")
+    if not parsed.hostname:
+        raise HTTPException(status_code=400, detail="URL host is required")
+    if parsed.username or parsed.password:
+        raise HTTPException(status_code=400, detail="URL credentials are not allowed")
+
+    hostname = parsed.hostname.strip().rstrip(".")
+    if not hostname:
+        raise HTTPException(status_code=400, detail="URL host is required")
+
+    try:
+        addresses = {info[4][0] for info in socket.getaddrinfo(hostname, parsed.port)}
+    except socket.gaierror as exc:
+        raise HTTPException(status_code=400, detail="URL host cannot be resolved") from exc
+
+    if not addresses or any(_is_blocked_ip(address) for address in addresses):
+        raise HTTPException(status_code=400, detail="URL host is not allowed")
+
+    return parsed.geturl()
+
+
+async def _fetch_public_preview(client: httpx.AsyncClient, url: str) -> httpx.Response:
+    current_url = _validate_public_preview_url(url)
+    for _ in range(MAX_REDIRECTS + 1):
+        response = await client.get(current_url, follow_redirects=False)
+        if response.is_redirect:
+            location = response.headers.get("location")
+            if not location:
+                raise HTTPException(status_code=400, detail="Invalid redirect")
+            current_url = _validate_public_preview_url(urljoin(current_url, location))
+            continue
+        return response
+    raise HTTPException(status_code=400, detail="Too many redirects")
+
+
 @router.get("/link-preview")
 async def get_link_preview(url: str = Query(..., description="The URL to preview")):
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
-            response = await client.get(url, follow_redirects=True)
+            response = await _fetch_public_preview(client, url)
             if response.status_code != 200:
                 raise HTTPException(status_code=400, detail="Could not fetch URL")
 
@@ -40,6 +90,11 @@ async def get_link_preview(url: str = Query(..., description="The URL to preview
                 "image": image,
                 "url": url
             }
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error fetching link preview for {url}: {e}")
-        return {"error": str(e)}
+        logger.warning(
+            "Error fetching link preview error_type=%s",
+            type(e).__name__,
+        )
+        raise HTTPException(status_code=400, detail="Could not fetch URL") from None


### PR DESCRIPTION
## Summary

- Harden `/link-preview` URL fetching against SSRF in both the active endpoint and service mirror modules.
- Allow only public `http`/`https` URLs, reject URL credentials, block multicast and all non-global resolved IPs including private, loopback, link-local, shared, reserved, and unspecified ranges, and validate every redirect target before following it.
- Replace raw exception-string responses with a generic 400 error while logging only the exception type.

## Contract Impact

- Canonical surface: `GET /api/v1/link-preview` handler and matching service mirror helper.
- Request shape: unchanged; caller still supplies the `url` query parameter.
- Response shape: success response keeps `title`, `description`, `image`, and `url`; blocked/failed fetches now raise a generic 400 instead of returning raw `{error: ...}` strings.
- Status codes: invalid, non-global, credentialed, unsupported-scheme, over-redirected, and failed preview fetches return 400.
- Frontend consumer: any link-preview consumer should continue to handle failure as an error response; no frontend code changed in this PR.
- Compatibility path or alias: no route alias or path registration changed.
- Contract proof: touched Python modules compile; local negative harness confirmed blocked localhost, loopback, metadata IP, shared `100.64.0.1`, unsupported scheme, URL credentials, and redirect-to-loopback inputs for both modules.

## RBAC / Permissions

- Roles allowed: unchanged; the endpoint auth/permission behavior is not modified in this PR.
- Roles denied: unchanged; no RBAC denial path changed.
- Positive auth proof: not run because this PR does not change route auth dependencies or roles.
- Negative auth proof: URL validation harness confirmed SSRF-style blocked targets return `HTTPException` before fetch.

## Notification / Realtime

not applicable - no notification, websocket, push, Telegram, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - success payload shape is unchanged and no frontend component changed.
- Partial data proof: not applicable - parser still tolerates missing metadata by returning empty strings.
- Forbidden secondary path behavior: blocked preview URLs now fail with 400 instead of leaking raw fetch exceptions.
- Missing draft/resource behavior: not applicable - link preview does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no route/deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/utils.py`, `backend/app/services/utils_api_service.py`.
- Denied paths: unrelated routers, auth/RBAC, database migrations, frontend runtime, ops config, generated output, and evidence artifacts.
- Migration/docs/test impact: no migration; security hardening only; validation is compile, diff check, and local blocked-URL harness.
- Rollback note: revert this PR to restore the previous direct `httpx` link-preview fetch behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/utils.py backend/app/services/utils_api_service.py`; `git diff --check -- backend/app/api/v1/endpoints/utils.py backend/app/services/utils_api_service.py`; inline Python harness against both modules for localhost, loopback, metadata IP, shared `100.64.0.1`, unsupported scheme, URL credentials, public `8.8.8.8`, and redirect-to-loopback.
- Result: passed locally.
- Not checked: live external URL preview fetch, because this PR focuses on blocking unsafe targets without depending on network availability.