### PR TITLE
test(security): require explicit role smoke admin username

### DIFF
--- a/backend/test_role_routing.py
+++ b/backend/test_role_routing.py
@@ -1,6 +1,8 @@
 """
-Тесты для проверки системы ролей и маршрутизации
-Запускать после каждого изменения в системе авторизации
+Manual smoke checks for role routing and specialist API access.
+
+The script reads QA_* credential environment variables, but it must never print
+passwords, bearer tokens, response bodies, or raw exception objects.
 """
 
 import os
@@ -9,210 +11,292 @@ import sys
 import requests
 
 BASE_URL = "http://127.0.0.1:18000"
+REQUEST_TIMEOUT_SECONDS = 10
 
-ROLE_PASSWORD_ENV_VARS = [
-    ("admin", "QA_ADMIN_PASSWORD", "Admin"),
-    ("registrar", "QA_REGISTRAR_PASSWORD", "Registrar"),
-    ("lab", "QA_LAB_PASSWORD", "Lab"),
-    ("doctor", "QA_DOCTOR_PASSWORD", "Doctor"),
-    ("cashier", "QA_CASHIER_PASSWORD", "Cashier"),
-    ("cardio", "QA_CARDIO_PASSWORD", "cardio"),
-    ("derma", "QA_DERMA_PASSWORD", "derma"),
-    ("dentist", "QA_DENTIST_PASSWORD", "dentist"),
+ROLE_CHECKS = [
+    (None, "QA_ADMIN_USERNAME", "QA_ADMIN_PASSWORD", "Admin"),
+    ("registrar", None, "QA_REGISTRAR_PASSWORD", "Registrar"),
+    ("lab", None, "QA_LAB_PASSWORD", "Lab"),
+    ("doctor", None, "QA_DOCTOR_PASSWORD", "Doctor"),
+    ("cashier", None, "QA_CASHIER_PASSWORD", "Cashier"),
+    ("cardio", None, "QA_CARDIO_PASSWORD", "cardio"),
+    ("derma", None, "QA_DERMA_PASSWORD", "derma"),
+    ("dentist", None, "QA_DENTIST_PASSWORD", "dentist"),
 ]
 
 
-def load_role_credentials():
-    credentials = []
-    missing = []
+def _env_present(name):
+    return bool(os.getenv(name))
 
-    for username, env_name, expected_role in ROLE_PASSWORD_ENV_VARS:
-        password = os.getenv(env_name)
-        if password:
-            credentials.append((username, password, expected_role))
+
+def load_role_checks():
+    role_checks = []
+    missing_required_env = False
+
+    for (
+        default_username,
+        username_env_name,
+        password_env_name,
+        expected_role,
+    ) in ROLE_CHECKS:
+        username = os.getenv(username_env_name) if username_env_name else default_username
+        if username and _env_present(password_env_name):
+            role_checks.append((username, password_env_name, expected_role))
         else:
-            missing.append(env_name)
+            missing_required_env = True
 
-    if missing:
+    if missing_required_env:
         print(
-            "ERROR: set required QA role password env vars before running this "
-            f"manual smoke: {', '.join(missing)}",
+            "ERROR: set all required QA role credential env vars before "
+            "running this manual smoke.",
             file=sys.stderr,
         )
         return None
 
-    return credentials
+    return role_checks
 
 
-def load_admin_password():
-    password = os.getenv("QA_ADMIN_PASSWORD")
-    if not password:
+def load_admin_username():
+    if not os.getenv("QA_ADMIN_USERNAME") or not _env_present("QA_ADMIN_PASSWORD"):
         print(
-            "ERROR: set QA_ADMIN_PASSWORD before running admin API access smoke.",
+            "ERROR: set required QA admin credential env vars before "
+            "running admin API access smoke.",
             file=sys.stderr,
         )
-    return password
+        return None
+    return os.environ["QA_ADMIN_USERNAME"]
 
 
-def test_user_login_and_role(username, password, expected_role, expected_redirect=None):
-    """Тестирует логин пользователя и проверяет роль"""
-    print(f"Тестируем пользователя: {username}")
-
-    # Логин
+def fetch_authenticated_profile(username, password_env_name):
     login_url = f"{BASE_URL}/api/v1/authentication/login"
-    login_data = {"username": username, "password": password}
+    login_data = {
+        "username": username,
+        "password": os.environ[password_env_name],
+    }
+
+    result = {
+        "login_status": None,
+        "token_keys": [],
+        "profile_status": None,
+        "actual_role": None,
+        "error_type": None,
+    }
 
     try:
-        response = requests.post(login_url, json=login_data)
-        print(f"DEBUG: Login response status: {response.status_code}")
-        
+        response = requests.post(
+            login_url,
+            json=login_data,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        result["login_status"] = response.status_code
         if response.status_code != 200:
-            print(f"ОШИБКА: Логин не удался: {response.status_code}")
-            print(f"DEBUG: Response text: {response.text[:500]}")
-            return False
+            return result
 
         token_data = response.json()
-        print(f"DEBUG: Token data keys: {token_data.keys()}")
-        
-        # Новая система аутентификации возвращает токены в объекте tokens
+        result["token_keys"] = list(token_data.keys())
+
         token = token_data.get("access_token")
         if not token and token_data.get("tokens"):
             token = token_data["tokens"].get("access_token")
-        
         if not token:
-            print("ОШИБКА: Токен не получен")
-            print(f"DEBUG: Response data: {token_data}")
-            return False
+            return result
 
-
-        # Получение профиля
-        profile_url = f"{BASE_URL}/api/v1/authentication/profile"
-        headers = {"Authorization": f"Bearer {token}"}
-        profile_response = requests.get(profile_url, headers=headers)
-        print(f"DEBUG: Profile response status: {profile_response.status_code}")
-
+        profile_response = requests.get(
+            f"{BASE_URL}/api/v1/authentication/profile",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        result["profile_status"] = profile_response.status_code
         if profile_response.status_code != 200:
-            print(f"ОШИБКА: Профиль не получен: {profile_response.status_code}")
-            print(f"DEBUG: Profile response text: {profile_response.text[:500]}")
-            return False
+            return result
 
         profile = profile_response.json()
-        actual_role = profile.get("role")
+        result["actual_role"] = profile.get("role")
+        return result
+    except Exception as exc:
+        result["error_type"] = type(exc).__name__
+        return result
 
-        if actual_role != expected_role:
-            print(
-                f"ОШИБКА: Неправильная роль: ожидалось '{expected_role}', получено '{actual_role}'"
-            )
-            return False
 
-        print(f"OK: {username}: роль '{actual_role}' корректна")
-        return True
+def probe_admin_endpoints(admin_username):
+    login_data = {
+        "username": admin_username,
+        "password": os.environ["QA_ADMIN_PASSWORD"],
+        "grant_type": "password",
+    }
+    result = {"login_status": None, "probes": None, "error_type": None}
 
-    except Exception as e:
-        print(f"ОШИБКА: Ошибка при тестировании {username}: {e}")
+    try:
+        response = requests.post(
+            f"{BASE_URL}/api/v1/authentication/login",
+            json=login_data,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        result["login_status"] = response.status_code
+        if response.status_code != 200:
+            return result
+
+        token = response.json().get("access_token")
+        if not token:
+            return result
+
+        headers = {"Authorization": f"Bearer {token}"}
+        endpoints = [
+            ("/api/v1/cardio/ecg", "Cardio API"),
+            ("/api/v1/derma/examinations", "Derma API"),
+            ("/api/v1/dental/examinations", "Dental API"),
+            ("/api/v1/lab/tests", "Lab API"),
+        ]
+
+        probes = []
+        for endpoint, name in endpoints:
+            try:
+                endpoint_response = requests.get(
+                    f"{BASE_URL}{endpoint}",
+                    headers=headers,
+                    timeout=REQUEST_TIMEOUT_SECONDS,
+                )
+                probes.append(
+                    {
+                        "name": name,
+                        "status_code": endpoint_response.status_code,
+                        "error_type": None,
+                    }
+                )
+            except Exception as exc:
+                probes.append(
+                    {
+                        "name": name,
+                        "status_code": None,
+                        "error_type": type(exc).__name__,
+                    }
+                )
+
+        result["probes"] = probes
+        return result
+    except Exception as exc:
+        result["error_type"] = type(exc).__name__
+        return result
+
+
+def test_user_login_and_role(username, password_env_name, expected_role):
+    print(f"Testing role: {expected_role}")
+
+    auth_result = fetch_authenticated_profile(username, password_env_name)
+    if auth_result["error_type"]:
+        print(f"ERROR: role smoke failed with {auth_result['error_type']}")
         return False
+
+    print(f"DEBUG: Login response status: {auth_result['login_status']}")
+    if auth_result["login_status"] != 200:
+        print(f"ERROR: login failed: {auth_result['login_status']}")
+        print("DEBUG: Login response body is not printed")
+        return False
+
+    print(f"DEBUG: Token data keys: {auth_result['token_keys']}")
+    if not auth_result["profile_status"]:
+        print("ERROR: access token was not received")
+        print("DEBUG: Token response values are not printed")
+        return False
+
+    print(f"DEBUG: Profile response status: {auth_result['profile_status']}")
+    if auth_result["profile_status"] != 200:
+        print(f"ERROR: profile was not received: {auth_result['profile_status']}")
+        print("DEBUG: Profile response body is not printed")
+        return False
+
+    actual_role = auth_result["actual_role"]
+    if actual_role != expected_role:
+        print(f"ERROR: wrong role: expected {expected_role}, got {actual_role}")
+        return False
+
+    print(f"OK: role {actual_role} is correct")
+    return True
 
 
 def test_all_critical_users():
-    """Тестирует всех критических пользователей"""
-    print("Тестирование системы ролей и авторизации")
+    print("Testing role routing and authentication")
     print("=" * 60)
 
-    # Критические пользователи и их ожидаемые роли
-    critical_users = load_role_credentials()
+    critical_users = load_role_checks()
     if critical_users is None:
         return False
 
     results = []
-    for username, password, expected_role in critical_users:
-        result = test_user_login_and_role(username, password, expected_role)
-        results.append((username, result))
+    for username, password_env_name, expected_role in critical_users:
+        result = test_user_login_and_role(username, password_env_name, expected_role)
+        results.append((expected_role, result))
         print()
 
-    # Итоги
-    print("РЕЗУЛЬТАТЫ ТЕСТИРОВАНИЯ:")
+    print("TEST RESULTS:")
     print("=" * 60)
     passed = sum(1 for _, result in results if result)
     total = len(results)
 
-    for username, result in results:
+    for expected_role, result in results:
         status = "PASS" if result else "FAIL"
-        print(f"{status} {username}")
+        print(f"{status} {expected_role}")
 
-    print(f"\nИтого: {passed}/{total} тестов прошли успешно")
+    print(f"\nTotal: {passed}/{total} tests passed")
 
     if passed == total:
-        print("УСПЕХ: Все тесты прошли! Система ролей работает корректно.")
+        print("SUCCESS: all role-routing tests passed.")
         return True
-    else:
-        print("ВНИМАНИЕ: Есть проблемы с системой ролей!")
-        return False
+
+    print("WARNING: role-routing problems were detected.")
+    return False
 
 
 def test_api_endpoints_access():
-    """Тестирует доступ к специализированным API endpoints"""
-    print("\nТестирование доступа к API endpoints")
+    print("\nTesting specialist API endpoint access")
     print("=" * 60)
 
-    # Получаем токен админа
-    admin_password = load_admin_password()
-    if not admin_password:
+    admin_username = load_admin_username()
+    if not admin_username:
         return False
 
-    login_data = {"username": "admin", "password": admin_password, "grant_type": "password"}
-    response = requests.post(f"{BASE_URL}/api/v1/authentication/login", json=login_data)
-    if response.status_code != 200:
-        print("ОШИБКА: Не удалось получить токен админа")
+    admin_probe = probe_admin_endpoints(admin_username)
+    if admin_probe["error_type"]:
+        print(f"ERROR: admin endpoint smoke failed with {admin_probe['error_type']}")
+        return False
+    if admin_probe["login_status"] != 200 or admin_probe["probes"] is None:
+        print("ERROR: failed to get admin token")
         return False
 
-    token = response.json().get("access_token")
-    headers = {"Authorization": f"Bearer {token}"}
-
-    # Тестируем специализированные endpoints
-    endpoints = [
-        ("/api/v1/cardio/ecg", "Cardio API"),
-        ("/api/v1/derma/examinations", "Derma API"),
-        ("/api/v1/dental/examinations", "Dental API"),
-        ("/api/v1/lab/tests", "Lab API"),
-    ]
-
-    for endpoint, name in endpoints:
-        try:
-            response = requests.get(f"{BASE_URL}{endpoint}", headers=headers)
-            if response.status_code in [
-                200,
-                404,
-            ]:  # 404 тоже нормально, если нет данных
-                print(f"OK: {name}: доступен")
-            else:
-                print(f"ОШИБКА: {name}: ошибка {response.status_code}")
-        except Exception as e:
-            print(f"ОШИБКА: {name}: исключение {e}")
+    for probe in admin_probe["probes"]:
+        name = probe["name"]
+        if probe["error_type"]:
+            print(f"ERROR: {name}: exception {probe['error_type']}")
+        elif probe["status_code"] in [200, 404]:
+            print(f"OK: {name}: accessible")
+        else:
+            print(f"ERROR: {name}: status {probe['status_code']}")
 
     return True
 
 
 if __name__ == "__main__":
-    print("Запуск тестов системы ролей")
+    print("Starting role-routing smoke checks")
     print("=" * 60)
 
-    # Проверяем доступность сервера
     try:
-        response = requests.get(f"{BASE_URL}/api/v1/health")
+        response = requests.get(
+            f"{BASE_URL}/api/v1/health",
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
         if response.status_code != 200:
-            print("ОШИБКА: Сервер недоступен")
+            print("ERROR: backend server is unavailable")
             sys.exit(1)
     except Exception:
-        print("ОШИБКА: Сервер недоступен")
+        print("ERROR: backend server is unavailable")
         sys.exit(1)
 
-    # Запускаем тесты
     success1 = test_all_critical_users()
     success2 = test_api_endpoints_access()
 
     if success1 and success2:
-        print("\nУСПЕХ: ВСЕ ТЕСТЫ ПРОШЛИ УСПЕШНО!")
+        print("\nSUCCESS: all smoke checks passed.")
         sys.exit(0)
-    else:
-        print("\nВНИМАНИЕ: ЕСТЬ ПРОБЛЕМЫ В СИСТЕМЕ!")
-        sys.exit(1)
+
+    print("\nWARNING: smoke checks detected problems.")
+    sys.exit(1)


### PR DESCRIPTION
﻿## Summary

- Require `QA_ADMIN_USERNAME` alongside `QA_ADMIN_PASSWORD` in the manual role-routing smoke script.
- Remove the hard-coded admin username from the admin API access smoke login payload.
- Stop printing raw login/profile response bodies, token data, exception strings, and password-env names in this manual smoke helper.
- Keep non-admin seeded role usernames unchanged to avoid expanding bootstrap/seed scope.

## Contract Impact

- Canonical surface: manual backend role-routing smoke helper only.
- Request shape: unchanged for the backend API; the helper still sends username/password/grant_type fields when explicit env values are present.
- Response shape: unchanged; no backend endpoint response model changed.
- Status codes: unchanged; no route logic changed.
- Frontend consumer: not applicable - no frontend code or consumer behavior changed.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: helper compiles and targeted grep no longer finds the hard-coded admin login payload, old admin-password-only loader, or raw response/debug secret dumps.

## RBAC / Permissions

- Roles allowed: unchanged; no RBAC implementation changed.
- Roles denied: unchanged; no permission logic changed.
- Positive auth proof: not run because this PR changes only manual smoke credential sourcing and no live QA credentials are stored in repo.
- Negative auth proof: missing required admin credential env vars now stops the manual admin API access smoke before login.

## Notification / Realtime

not applicable - no notification, websocket, push, Telegram, or realtime behavior changed.

## Frontend Resilience

not applicable - no frontend component, route, loader, or browser fallback behavior changed.

## Scope Gate

- Allowed paths: `backend/test_role_routing.py`.
- Denied paths: runtime auth/RBAC code, seed/bootstrap scripts, migrations, frontend runtime, ops config, generated output, and evidence artifacts.
- Migration/docs/test impact: no migration; manual smoke helper behavior only.
- Rollback note: revert this PR to restore the previous admin-password-only manual smoke behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\test_role_routing.py`; `git diff --check -- backend\test_role_routing.py`; targeted `rg` scan for hard-coded admin login, old admin-password-only loader, raw response body prints, missing-env password name dumps, and raw exception `{e}` output.
- Result: passed locally.
- Not checked: live role-routing smoke against a running backend, because this change intentionally avoids requiring real QA admin credentials in the repo.
