### PR TITLE
docs(db): use Postgres in department report

### DIFF
--- a/DEPARTMENTS_COMPLETE_IMPLEMENTATION_REPORT.md
+++ b/DEPARTMENTS_COMPLETE_IMPLEMENTATION_REPORT.md
@@ -226,9 +226,7 @@ alembic revision --autogenerate -m "add departments table"
 alembic upgrade head
 
 # Вариант 2: Пересоздать таблицу вручную
-python -c "from sqlalchemy import create_engine; \
-engine = create_engine('sqlite:///./clinic.db'); \
-with engine.begin() as conn: conn.execute('DROP TABLE IF EXISTS departments')"
+psql "$DATABASE_URL" -c "DROP TABLE IF EXISTS departments"
 
 python init_departments.py
 ```


### PR DESCRIPTION
﻿## Summary

- Replace a stale SQLite table-reset example in the departments implementation report with a PostgreSQL `psql "$DATABASE_URL"` command.
- Keep the historical report aligned with the repo rule that PostgreSQL + Alembic are the database source of truth.

## Contract Impact

not applicable - documentation-only cleanup; no API, websocket, event, frontend consumer, request/response shape, status code, compatibility path, or contract surface changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, permission mapping, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, delivery, ack, reconnect, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, frontend data flow, empty/partial/forbidden state, draft handling, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `DEPARTMENTS_COMPLETE_IMPLEMENTATION_REPORT.md`.
- Denied paths: backend runtime, frontend runtime, migrations, generated output, evidence logs, env/config files.
- Migration/docs/test impact: docs-only update of one stale database command example; no migration expected.
- Rollback note: revert the single documentation change if this report must preserve the historical SQLite command verbatim.

## Validation

- Targeted tests or smoke run: `python -m pytest backend\tests\unit\test_no_legacy_ports_in_active_text.py` and `git diff --check -- DEPARTMENTS_COMPLETE_IMPLEMENTATION_REPORT.md`.
- Result: pytest guard passed with 9 passed; diff whitespace check passed; follow-up `rg` finds `sqlite:///./clinic.db` only in the intentional guard assertion.
- Not checked: runtime app behavior, because no runtime files changed.
