### PR TITLE
docs(security): redact JWT-shaped examples

### DIFF
--- a/PROBLEMS_RESOLVED_REPORT.md
+++ b/PROBLEMS_RESOLVED_REPORT.md
@@ -61,7 +61,7 @@ curl -X POST -d "username=admin&password=<redacted-demo-password>&grant_type=pas
   http://localhost:18000/api/v1/auth/login
 
 # Возвращает JWT токен
-{"access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...","token_type":"bearer"}
+{"access_token":"<jwt-access-token>","token_type":"bearer"}
 ```
 
 ---

--- a/backend/app/api/v1/endpoints/api_documentation.py
+++ b/backend/app/api/v1/endpoints/api_documentation.py
@@ -44,7 +44,7 @@ async def get_detailed_endpoints_documentation(
                         "200": {
                             "description": "Успешная аутентификация",
                             "example": {
-                                "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+                                "access_token": "<jwt-access-token>",
                                 "token_type": "bearer",
                             },
                         },
@@ -66,7 +66,7 @@ async def get_detailed_endpoints_documentation(
                         "200": {
                             "description": "Токен обновлен",
                             "example": {
-                                "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+                                "access_token": "<jwt-access-token>",
                                 "token_type": "bearer",
                             },
                         }
@@ -750,7 +750,7 @@ async def get_authentication_documentation():
         },
         "token_format": {
             "header": "Authorization: Bearer <access_token>",
-            "example": "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+            "example": "Authorization: Bearer <jwt-access-token>",
         },
         "token_expiration": {"access_token": "24 часа", "refresh_token": "7 дней"},
         "roles": {

--- a/backend/app/services/api_documentation_api_service.py
+++ b/backend/app/services/api_documentation_api_service.py
@@ -43,7 +43,7 @@ async def get_detailed_endpoints_documentation(
                         "200": {
                             "description": "Успешная аутентификация",
                             "example": {
-                                "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+                                "access_token": "<jwt-access-token>",
                                 "token_type": "bearer",
                             },
                         },
@@ -65,7 +65,7 @@ async def get_detailed_endpoints_documentation(
                         "200": {
                             "description": "Токен обновлен",
                             "example": {
-                                "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+                                "access_token": "<jwt-access-token>",
                                 "token_type": "bearer",
                             },
                         }
@@ -749,7 +749,7 @@ async def get_authentication_documentation():
         },
         "token_format": {
             "header": "Authorization: Bearer <access_token>",
-            "example": "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+            "example": "Authorization: Bearer <jwt-access-token>",
         },
         "token_expiration": {"access_token": "24 часа", "refresh_token": "7 дней"},
         "roles": {


### PR DESCRIPTION
﻿## Summary

- Replace JWT-shaped example strings in the active API documentation endpoint/service with neutral `<jwt-access-token>` placeholders.
- Redact one historical markdown report response example that looked like a JWT even though it was truncated.

## Contract Impact

- Canonical surface: API documentation/example payload text only.
- Request shape: unchanged.
- Response shape: unchanged structurally; example token value is now a placeholder instead of a JWT-shaped string.
- Status codes: unchanged.
- Frontend consumer: unchanged; no frontend code changed.
- Compatibility path or alias: unchanged.
- Contract proof: `python -m py_compile backend\app\api\v1\endpoints\api_documentation.py backend\app\services\api_documentation_api_service.py` passed.

## RBAC / Permissions

- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: not applicable - docs/example value cleanup only.
- Negative auth proof: not applicable - no auth enforcement logic changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, delivery, ack, reconnect, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, frontend data flow, empty/partial/forbidden state, draft handling, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/api_documentation.py`, `backend/app/services/api_documentation_api_service.py`, `PROBLEMS_RESOLVED_REPORT.md`.
- Denied paths: auth runtime, token generation/validation, frontend runtime, migrations, env/config files, generated output, evidence logs.
- Migration/docs/test impact: docs/example text only; no migration expected.
- Rollback note: revert the placeholder text changes if the old JWT-shaped examples are intentionally required.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\api_documentation.py backend\app\services\api_documentation_api_service.py`; `git diff --check -- ...`; `rg -n -S "eyJ[A-Za-z0-9_-]{20,}"` over the three touched files.
- Result: compile passed; diff whitespace check passed; targeted JWT-shaped scan returned no matches in touched files.
- Not checked: full backend/frontend suites, because this PR changes only documentation/example strings.
