### PR TITLE
docs(security): redact queue-time JWT log snippets

### DIFF
--- a/Fixing New Service Queue Time.md
+++ b/Fixing New Service Queue Time.md
@@ -313,8 +313,8 @@ SELECT id, patient_name, services FROM online_queue_entry WHERE patient_id = <ID
  [INFO] 📊 После агрегации: 0 пациентов
  [INFO] 🚀 Starting initial data load (guarded)...
  [INFO] 🔧 loadIntegratedData called at: 2025-12-17T06:54:48.857Z
- [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
- [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+ [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+ [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
  [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
  [INFO] 🔔 appointments state изменился: Object
  [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
@@ -801,8 +801,8 @@ logger.js:200 [LOG] ✅ QR-запись успешно обновлена: {succ
 logger.js:209 [INFO] AppointmentWizardV2 completed successfully: {success: true, message: 'Запись успешно обновлена', entry: {…}}
 logger.js:209 [INFO] AppointmentWizardV2 closing
 logger.js:209 [INFO] 🔧 loadIntegratedData called at: 2025-12-17T06:56:17.047Z
-logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
-logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
 logger.js:200 [LOG] 🔄 API Request: GET /registrar/queues/today {params: {…}, data: undefined}
 logger.js:200 [LOG] 🔄 API Request: GET /registrar/doctors {params: undefined, data: undefined}
 logger.js:200 [LOG] 🔍 [api/client.js] Request interceptor: {url: '/registrar/queues/today', hasToken: '[REDACTED]', tokenPreview: '[REDACTED]', headers: {…}}
@@ -2323,8 +2323,8 @@ logger.js:200 [LOG] ✅ QR-запись успешно обновлена: {succ
 logger.js:209 [INFO] AppointmentWizardV2 completed successfully: {success: true, message: 'Запись успешно обновлена', entry: {…}}
 logger.js:209 [INFO] AppointmentWizardV2 closing
 logger.js:209 [INFO] 🔧 loadIntegratedData called at: 2025-12-17T06:57:50.487Z
-logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
-logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
 logger.js:200 [LOG] 🔄 API Request: GET /registrar/queues/today {params: {…}, data: undefined}
 logger.js:200 [LOG] 🔄 API Request: GET /registrar/doctors {params: undefined, data: undefined}
 logger.js:200 [LOG] 🔍 [api/client.js] Request interceptor: {url: '/registrar/queues/today', hasToken: '[REDACTED]', tokenPreview: '[REDACTED]', headers: {…}}
@@ -5102,8 +5102,8 @@ logger.js:209 [INFO] 🔍 QR-записей в фильтре: 0
 logger.js:209 [INFO] 📊 После агрегации: 0 пациентов
 logger.js:209 [INFO] 🚀 Starting initial data load (guarded)...
 logger.js:209 [INFO] 🔧 loadIntegratedData called at: 2025-12-17T07:36:09.679Z
-logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
-logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
 logger.js:209 [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
 logger.js:209 [INFO] 🔔 appointments state изменился: {count: 0, showCalendar: false, historyDate: '2025-12-17', first3: Array(0)}
 logger.js:209 [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
@@ -10241,8 +10241,8 @@ logger.js:209 [INFO] 🔍 QR-записей в фильтре: 0
 logger.js:209 [INFO] 📊 После агрегации: 0 пациентов
 logger.js:209 [INFO] 🚀 Starting initial data load (guarded)...
 logger.js:209 [INFO] 🔧 loadIntegratedData called at: 2025-12-18T03:13:36.995Z
-logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
-logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
 logger.js:209 [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
 logger.js:209 [INFO] 🔔 appointments state изменился: {count: 0, showCalendar: false, historyDate: '2025-12-18', first3: Array(0)}
 logger.js:209 [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
@@ -10408,8 +10408,8 @@ logger.js:200 [LOG] ✅ Запись создана успешно на backend:
 logger.js:209 [INFO] AppointmentWizardV2 completed successfully: {success: true, message: 'Корзина создана успешно. Присвоено номеров в очередях: 2', invoice_id: 283, visit_ids: Array(2), total_amount: '158000.0', …}
 logger.js:209 [INFO] AppointmentWizardV2 closing
 logger.js:209 [INFO] 🔧 loadIntegratedData called at: 2025-12-18T03:14:17.235Z
-logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
-logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
 logger.js:200 [LOG] 🔄 API Request: GET /registrar/queues/today {params: {…}, data: undefined}
 logger.js:200 [LOG] 🔄 API Request: GET /registrar/doctors {params: undefined, data: undefined}
 logger.js:200 [LOG] 🔍 [api/client.js] Request interceptor: {url: '/registrar/queues/today', hasToken: '[REDACTED]', tokenPreview: '[REDACTED]', headers: {…}}
@@ -10710,8 +10710,8 @@ logger.js:200 [LOG] ✅ Запись создана успешно на backend:
 logger.js:209 [INFO] AppointmentWizardV2 completed successfully: {success: true, message: 'Корзина создана успешно. Присвоено номеров в очередях: 4', invoice_id: 284, visit_ids: Array(4), total_amount: '128000.0', …}
 logger.js:209 [INFO] AppointmentWizardV2 closing
 logger.js:209 [INFO] 🔧 loadIntegratedData called at: 2025-12-18T03:16:55.162Z
-logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
-logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
 logger.js:200 [LOG] 🔄 API Request: GET /registrar/queues/today {params: {…}, data: undefined}
 logger.js:200 [LOG] 🔄 API Request: GET /registrar/doctors {params: undefined, data: undefined}
 logger.js:200 [LOG] 🔍 [api/client.js] Request interceptor: {url: '/registrar/queues/today', hasToken: '[REDACTED]', tokenPreview: '[REDACTED]', headers: {…}}
@@ -12185,8 +12185,8 @@ logger.js:209 [INFO] 🔍 QR-записей в фильтре: 0
 logger.js:209 [INFO] 📊 После агрегации: 0 пациентов
 logger.js:209 [INFO] 🚀 Starting initial data load (guarded)...
 logger.js:209 [INFO] 🔧 loadIntegratedData called at: 2025-12-18T03:44:35.947Z
-logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
-logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
 logger.js:209 [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
 logger.js:209 [INFO] 🔔 appointments state изменился: {count: 0, showCalendar: false, historyDate: '2025-12-18', first3: Array(0)}
 logger.js:209 [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
@@ -12660,8 +12660,8 @@ logger.js:209 [INFO] 🔍 QR-записей в фильтре: 0
 logger.js:209 [INFO] 📊 После агрегации: 0 пациентов
 logger.js:209 [INFO] 🚀 Starting initial data load (guarded)...
 logger.js:209 [INFO] 🔧 loadIntegratedData called at: 2025-12-18T03:49:41.147Z
-logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
-logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
 logger.js:209 [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
 logger.js:209 [INFO] 🔔 appointments state изменился: {count: 0, showCalendar: false, historyDate: '2025-12-18', first3: Array(0)}
 logger.js:209 [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
@@ -12891,8 +12891,8 @@ logger.js:209 [INFO] 🔍 QR-записей в фильтре: 0
 logger.js:209 [INFO] 📊 После агрегации: 0 пациентов
 logger.js:209 [INFO] 🚀 Starting initial data load (guarded)...
 logger.js:209 [INFO] 🔧 loadIntegratedData called at: 2025-12-18T03:54:17.858Z
-logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
-logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+logger.js:209 [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+logger.js:209 [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
 logger.js:209 [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
 logger.js:209 [INFO] 🔔 appointments state изменился: {count: 0, showCalendar: false, historyDate: '2025-12-18', first3: Array(0)}
 logger.js:209 [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
@@ -15255,8 +15255,8 @@ dispatchDiscreteEvent @ chunk-HKYTXVPL.js?v=be52e9d5:5455
  [INFO] AppointmentWizardV2 completed successfully: {success: true, message: 'Запись успешно обновлена', entry: {…}}
  [INFO] AppointmentWizardV2 closing
  [INFO] 🔧 loadIntegratedData called at: 2025-12-18T07:44:56.852Z
- [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
- [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+ [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+ [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
  [LOG] 🔄 API Request: GET /registrar/queues/today {params: {…}, data: undefined}
  [LOG] 🔄 API Request: GET /registrar/doctors {params: undefined, data: undefined}
  [LOG] 🔍 [api/client.js] Request interceptor: {url: '/registrar/queues/today', hasToken: '[REDACTED]', tokenPreview: '[REDACTED]', headers: {…}}
@@ -16047,8 +16047,8 @@ if entry.visit_id and len(new_service_ids) > 0:
  [INFO] 📊 После агрегации: 0 пациентов
  [INFO] 🚀 Starting initial data load (guarded)...
  [INFO] 🔧 loadIntegratedData called at: 2025-12-18T07:54:21.822Z
- [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
- [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+ [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+ [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
  [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
  [INFO] 🔔 appointments state изменился: Object
  [INFO] 🔄 Фильтры изменились (поиск/статус), но НЕ перезагружаем данные (дата контролируется календарём)
@@ -16434,8 +16434,8 @@ warn @ logger.js:191
  [INFO] AppointmentWizardV2 completed successfully: Object
  [INFO] AppointmentWizardV2 closing
  [INFO] 🔧 loadIntegratedData called at: 2025-12-18T07:56:05.750Z
- [INFO] 🔍 RegistrarPanel: token from localStorage: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
- [INFO] 🔍 Загружаем врачей с токеном: eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...
+ [INFO] 🔍 RegistrarPanel: token from localStorage: <redacted-jwt>
+ [INFO] 🔍 Загружаем врачей с токеном: <redacted-jwt>
  [LOG] 🔄 API Request: GET /registrar/queues/today Object
  [LOG] 🔄 API Request: GET /registrar/doctors Object
  [LOG] 🔍 [api/client.js] Request interceptor: Object


### PR DESCRIPTION
﻿## Summary

- Redact repeated JWT-shaped token prefixes from the historical queue-time markdown log.
- Leave the diagnostic narrative intact while replacing token-looking snippets with `<redacted-jwt>`.

## Contract Impact

not applicable - documentation/log redaction only; no API, websocket, event, frontend consumer, request/response shape, status code, compatibility path, or contract surface changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, permission mapping, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, delivery, ack, reconnect, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, frontend data flow, empty/partial/forbidden state, draft handling, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `Fixing New Service Queue Time.md`.
- Denied paths: backend runtime, frontend runtime, migrations, env/config files, generated output, evidence logs.
- Migration/docs/test impact: docs/log redaction only; no migration expected.
- Rollback note: revert the single markdown redaction if the historical token-shaped snippets must be restored.

## Validation

- Targeted tests or smoke run: `git diff --check -- "Fixing New Service Queue Time.md"`; `rg -n -S "eyJ[A-Za-z0-9_-]{20,}" --glob ...`; `git diff --numstat -- "Fixing New Service Queue Time.md"`.
- Result: diff whitespace check passed; JWT-shaped scan now reports only the `package-lock.json` integrity hash false positive; numstat is 26 insertions and 26 deletions in one markdown file.
- Not checked: runtime app behavior, because no runtime files changed.
