### PR TITLE
ci(vercel): tolerate missing git metadata in ignore command

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "installCommand": "npm --prefix frontend ci",
   "framework": "vite",
   "outputDirectory": "frontend/dist",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- frontend vercel.json .vercelignore",
+  "ignoreCommand": "test -d .git && git diff --quiet HEAD^ HEAD -- frontend vercel.json .vercelignore",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
﻿## Summary

- Make Vercel `ignoreCommand` tolerate deployments where `.vercelignore` has removed `.git` before the ignore command runs.
- Preserve the existing path-based skip behavior when `.git` metadata is available.
- Fix observed Vercel failure on #523 where `git diff --quiet HEAD^ HEAD -- frontend vercel.json .vercelignore` ran outside a git repository.

## Contract Impact

- Canonical surface: unchanged because only Vercel deployment configuration changed.
- Request shape: unchanged because no API request contract changed.
- Response shape: unchanged because no API response contract changed.
- Status codes: unchanged because no endpoint implementation changed.
- Frontend consumer: unchanged because no frontend source changed.
- Compatibility path or alias: unchanged because no route alias changed.
- Contract proof: `vercel.json` parse check and diff review only.

## RBAC / Permissions

- Roles allowed: unchanged because no authorization code changed.
- Roles denied: unchanged because no authorization code changed.
- Positive auth proof: unchanged because no auth flow changed.
- Negative auth proof: unchanged because no permission path changed.

## Notification / Realtime

- Event type or websocket channel: unchanged because no realtime channel changed.
- Payload version / ack behavior: unchanged because no event payload changed.
- Read/unread or delivery semantics: unchanged because no delivery behavior changed.
- Reconnect/resync proof: unchanged because no websocket behavior changed.

## Frontend Resilience

- Empty data proof: unchanged because no frontend data state changed.
- Partial data proof: unchanged because no frontend data flow changed.
- Forbidden secondary path behavior: unchanged because no frontend route changed.
- Missing draft/resource behavior: unchanged because no draft handling changed.
- Stale route/deep-link behavior: unchanged because no route behavior changed.

## Scope Gate

- Allowed paths: `vercel.json`.
- Denied paths: runtime code, frontend source, backend source, tests, migrations, artifact cleanup files, and `.vercelignore`.
- Migration/docs/test impact: no migrations, docs, or test source changed.
- Rollback note: revert this PR to restore the old ignore command behavior.

## Validation

- Targeted tests or smoke run: `git diff --check`; `node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8')); console.log('vercel.json valid')"`; Vercel failure log inspection from deployment `dpl_6Rq5sJT224F8CznH5vjqYXHxHRJk`.
- Result: diff check passed; `vercel.json` parses; Vercel logs showed failure came from `git diff` running after `.git` had been removed by `.vercelignore`.
- Not checked: runtime app behavior because only deployment ignore configuration changed.
