### PR TITLE
ci(vercel): harden ignore command git detection

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "installCommand": "npm --prefix frontend ci",
   "framework": "vite",
   "outputDirectory": "frontend/dist",
-  "ignoreCommand": "test -d .git && git diff --quiet HEAD^ HEAD -- frontend vercel.json .vercelignore",
+  "ignoreCommand": "if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then git diff --quiet HEAD^ HEAD -- frontend vercel.json .vercelignore; code=$?; if [ $code -gt 1 ]; then exit 1; fi; exit $code; fi; exit 1",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
﻿## Summary

- Harden Vercel `ignoreCommand` so missing or invalid git metadata exits with `1` and lets the build continue.
- Preserve the intended skip behavior when a valid git worktree exists and there are no frontend/Vercel config changes.
- Keep the change scoped to `vercel.json`; no runtime source or deployment output changed.

## Contract Impact

not applicable - deployment configuration only; no API, websocket, event, route, request/response, status code, compatibility alias, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, permission mapping, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, event payload, ack, read/unread, delivery, reconnect, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, route, deep link, draft/resource handling, or frontend data flow changed; this only prevents Vercel preview deployment failures when `.vercelignore` leaves invalid git metadata.

## Scope Gate

- Allowed paths: `vercel.json` only.
- Denied paths: runtime source, tests, workflows, `.vercelignore`, frontend/backend code, generated artifacts, and docs.
- Migration/docs/test impact: no migration, docs, or tests changed.
- Rollback note: restore the prior `ignoreCommand` if Vercel starts preserving a valid git worktree after `.vercelignore` processing and the new guard is no longer needed.

## Validation

- Targeted tests or smoke run: `node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8')); console.log('vercel.json valid')"`; `git diff --check`; invalid `.git` temp-directory simulation of `ignoreCommand`; `python scripts/run_pr_review_gate_checks.py --body-env PR_BODY`.
- Result: `vercel.json` parsed successfully; diff check passed; invalid git metadata simulation exited `1`; PR body gate passed.
- Not checked: full Vercel deployment before PR, because this change is intended to be validated by the PR deployment check.
