### PR TITLE
chore(cleanup): remove tracked storage artifacts

### DIFF
--- a/backend/storage/files/2025/09/ea/eaefe1be_test_file.txt
+++ b/backend/storage/files/2025/09/ea/eaefe1be_test_file.txt
@@ -1,1 +1,0 @@
-This is a test file for file system testing

--- a/backend/storage/files/2025/12/50/501d8537_new_version.txt
+++ b/backend/storage/files/2025/12/50/501d8537_new_version.txt
@@ -1,1 +1,0 @@
-New version content

--- a/backend/storage/files/2025/12/81/81b24147_file1.txt
+++ b/backend/storage/files/2025/12/81/81b24147_file1.txt
@@ -1,1 +1,0 @@
-Identical content

--- a/backend/storage/files/2025/12/97/9750ca6c_version_test.txt
+++ b/backend/storage/files/2025/12/97/9750ca6c_version_test.txt
@@ -1,1 +1,0 @@
-Version test

--- a/backend/storage/files/2025/12/99/99eabe29_test.txt
+++ b/backend/storage/files/2025/12/99/99eabe29_test.txt
@@ -1,1 +1,0 @@
-Test file content for hashing

--- a/backend/storage/files/2025/12/9a/9a380965_original.txt
+++ b/backend/storage/files/2025/12/9a/9a380965_original.txt
@@ -1,1 +1,0 @@
-Original file content

--- a/backend/storage/files/2025/12/fa/fa08765f_updated.txt
+++ b/backend/storage/files/2025/12/fa/fa08765f_updated.txt
@@ -1,1 +1,0 @@
-Updated file content

--- a/backend/storage/files/2026/02/50/501d8537_new_version.txt
+++ b/backend/storage/files/2026/02/50/501d8537_new_version.txt
@@ -1,1 +1,0 @@
-New version content

--- a/backend/storage/files/2026/02/81/81b24147_file1.txt
+++ b/backend/storage/files/2026/02/81/81b24147_file1.txt
@@ -1,1 +1,0 @@
-Identical content

--- a/backend/storage/files/2026/02/97/9750ca6c_version_test.txt
+++ b/backend/storage/files/2026/02/97/9750ca6c_version_test.txt
@@ -1,1 +1,0 @@
-Version test

--- a/backend/storage/files/2026/02/99/99eabe29_test.txt
+++ b/backend/storage/files/2026/02/99/99eabe29_test.txt
@@ -1,1 +1,0 @@
-Test file content for hashing

--- a/backend/storage/files/2026/02/9a/9a380965_original.txt
+++ b/backend/storage/files/2026/02/9a/9a380965_original.txt
@@ -1,1 +1,0 @@
-Original file content

--- a/backend/storage/files/2026/02/fa/fa08765f_updated.txt
+++ b/backend/storage/files/2026/02/fa/fa08765f_updated.txt
@@ -1,1 +1,0 @@
-Updated file content

--- a/storage/files/2026/04/50/501d8537_new_version.txt
+++ b/storage/files/2026/04/50/501d8537_new_version.txt
@@ -1,1 +1,0 @@
-New version content

--- a/storage/files/2026/04/81/81b24147_file1.txt
+++ b/storage/files/2026/04/81/81b24147_file1.txt
@@ -1,1 +1,0 @@
-Identical content

--- a/storage/files/2026/04/97/9750ca6c_version_test.txt
+++ b/storage/files/2026/04/97/9750ca6c_version_test.txt
@@ -1,1 +1,0 @@
-Version test

--- a/storage/files/2026/04/99/99eabe29_test.txt
+++ b/storage/files/2026/04/99/99eabe29_test.txt
@@ -1,1 +1,0 @@
-Test file content for hashing

--- a/storage/files/2026/04/9a/9a380965_original.txt
+++ b/storage/files/2026/04/9a/9a380965_original.txt
@@ -1,1 +1,0 @@
-Original file content

--- a/storage/files/2026/04/fa/fa08765f_updated.txt
+++ b/storage/files/2026/04/fa/fa08765f_updated.txt
@@ -1,1 +1,0 @@
-Updated file content


### PR DESCRIPTION
﻿## Summary

- Remove tracked generated upload-storage files under `backend/storage/files/` and `storage/files/`.
- `.gitignore` already ignores both storage trees, so future uploaded/generated files stay local.
- No runtime source, tests, workflows, output proof packs, docs, or storage service code changed.

## Contract Impact

not applicable - generated storage artifact cleanup only; no API, websocket, event, route, request/response, status code, compatibility alias, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, permission mapping, or auth-sensitive runtime behavior changed; only ignored generated upload files were removed from version control.

## Notification / Realtime

not applicable - no notification, websocket, chat, event payload, ack, read/unread, delivery, reconnect, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, route, deep link, draft/resource handling, or frontend data flow changed; only generated storage artifacts were removed.

## Scope Gate

- Allowed paths: `backend/storage/files/**` and `storage/files/**` tracked files only.
- Denied paths: runtime source, backend/frontend code, workflows, output proof packs, docs, artifacts, and unrelated generated files.
- Migration/docs/test impact: no migration, docs, or tests changed; `.gitignore` already ignores `backend/storage/files/` and `storage/files/`.
- Rollback note: restore the removed generated upload artifacts only if a historical local storage fixture is unexpectedly needed.

## Validation

- Targeted tests or smoke run: path-scope check for staged files; concrete filename reference scan; ignore coverage check; `git diff --check --cached`; `python scripts/run_pr_review_gate_checks.py --body-file <body>`.
- Result: staged diff contains 19 files all under allowed storage paths; concrete filename scan returned no refs; all removed paths are ignored; diff check passed; PR body gate passed.
- Not checked: runtime app behavior, because only generated ignored storage artifacts changed.
