### PR TITLE
chore(cleanup): remove tracked backend upload artifacts

### DIFF
--- a/backend/storage/files/2025/09/ea/eaefe1be_test_file.txt
+++ b/backend/storage/files/2025/09/ea/eaefe1be_test_file.txt
@@ -1,1 +1,0 @@
-This is a test file for file system testing

--- a/backend/storage/files/2025/12/50/501d8537_new_version.txt
+++ b/backend/storage/files/2025/12/50/501d8537_new_version.txt
@@ -1,1 +1,0 @@
-New version content

--- a/backend/storage/files/2025/12/81/81b24147_file1.txt
+++ b/backend/storage/files/2025/12/81/81b24147_file1.txt
@@ -1,1 +1,0 @@
-Identical content

--- a/backend/storage/files/2025/12/97/9750ca6c_version_test.txt
+++ b/backend/storage/files/2025/12/97/9750ca6c_version_test.txt
@@ -1,1 +1,0 @@
-Version test

--- a/backend/storage/files/2025/12/99/99eabe29_test.txt
+++ b/backend/storage/files/2025/12/99/99eabe29_test.txt
@@ -1,1 +1,0 @@
-Test file content for hashing

--- a/backend/storage/files/2025/12/9a/9a380965_original.txt
+++ b/backend/storage/files/2025/12/9a/9a380965_original.txt
@@ -1,1 +1,0 @@
-Original file content

--- a/backend/storage/files/2025/12/fa/fa08765f_updated.txt
+++ b/backend/storage/files/2025/12/fa/fa08765f_updated.txt
@@ -1,1 +1,0 @@
-Updated file content

--- a/backend/storage/files/2026/02/50/501d8537_new_version.txt
+++ b/backend/storage/files/2026/02/50/501d8537_new_version.txt
@@ -1,1 +1,0 @@
-New version content

--- a/backend/storage/files/2026/02/81/81b24147_file1.txt
+++ b/backend/storage/files/2026/02/81/81b24147_file1.txt
@@ -1,1 +1,0 @@
-Identical content

--- a/backend/storage/files/2026/02/97/9750ca6c_version_test.txt
+++ b/backend/storage/files/2026/02/97/9750ca6c_version_test.txt
@@ -1,1 +1,0 @@
-Version test

--- a/backend/storage/files/2026/02/99/99eabe29_test.txt
+++ b/backend/storage/files/2026/02/99/99eabe29_test.txt
@@ -1,1 +1,0 @@
-Test file content for hashing

--- a/backend/storage/files/2026/02/9a/9a380965_original.txt
+++ b/backend/storage/files/2026/02/9a/9a380965_original.txt
@@ -1,1 +1,0 @@
-Original file content

--- a/backend/storage/files/2026/02/fa/fa08765f_updated.txt
+++ b/backend/storage/files/2026/02/fa/fa08765f_updated.txt
@@ -1,1 +1,0 @@
-Updated file content


### PR DESCRIPTION
﻿## Summary

- Remove tracked backend upload test files from `backend/storage/files/**`.
- `.gitignore` already excludes `backend/storage/files/`, so generated uploads remain local going forward.
- No runtime source, tests, workflows, docs, or root storage files changed.

## Contract Impact

not applicable - generated upload artifact cleanup only; no API, websocket, event, route, request/response, status code, compatibility alias, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, permission mapping, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, event payload, ack, read/unread, delivery, reconnect, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, route, deep link, draft/resource handling, or frontend data flow changed; only tracked generated backend upload artifacts were removed.

## Scope Gate

- Allowed paths: `backend/storage/files/**` only.
- Denied paths: runtime source, tests, workflows, frontend/backend code outside generated upload storage, root `storage/files/**`, output proof packs, docs, and unrelated artifacts.
- Migration/docs/test impact: no migration, docs, or tests changed; `.gitignore` already ignores `backend/storage/files/`.
- Rollback note: restore the removed generated upload fixtures only if a historical local upload artifact is unexpectedly needed.

## Validation

- Targeted tests or smoke run: `git diff --check origin/main...HEAD`; `git check-ignore -v --no-index backend/storage/files/2025/09/ea/eaefe1be_test_file.txt backend/storage/files/2026/02/50/501d8537_new_version.txt`; `rg -n -S --glob '!backend/storage/files/**' --glob '!.git/**' "eaefe1be_test_file|501d8537_new_version|81b24147_file1|9750ca6c_version_test|99eabe29_test|9a380965_original|fa08765f_updated" .`; `python scripts/run_pr_review_gate_checks.py --body-env PR_BODY`.
- Result: diff check passed; `.gitignore:112:backend/storage/files/` covers the removed path family; external reference scan returned no matches; PR body gate passed.
- Not checked: runtime app behavior, because only generated ignored upload artifacts changed.
