### PR TITLE
fix(security): sanitize printable window html

### DIFF
--- a/frontend/src/utils/printWindow.js
+++ b/frontend/src/utils/printWindow.js
@@ -1,10 +1,18 @@
+import DOMPurify from 'dompurify';
+
+export const sanitizePrintableHtml = (html) => DOMPurify.sanitize(String(html ?? ''), {
+  WHOLE_DOCUMENT: true,
+  ADD_TAGS: ['html', 'head', 'body', 'style'],
+  ADD_ATTR: ['style', 'class', 'id', 'role', 'aria-label', 'colspan', 'rowspan']
+});
+
 export const finalizePrintableWindow = (printWindow, html, logger) => {
   if (!printWindow) {
     return false;
   }
 
   printWindow.document.open();
-  printWindow.document.write(html);
+  printWindow.document.write(sanitizePrintableHtml(html));
   printWindow.document.close();
 
   let finalized = false;


### PR DESCRIPTION
## Summary
- Sanitizes printable popup HTML before writing it into the new window document.
- Uses DOMPurify at the shared print-window boundary so existing print callers keep their current API.
- Preserves printable document markup while stripping executable HTML such as scripts and inline handlers.

## Contract Impact
- Canonical surface: `frontend/src/utils/printWindow.js` exports `openPrintableWindow`, `finalizePrintableWindow`, and now `sanitizePrintableHtml`.
- Request shape: unchanged; callers still pass `{ html, features, logger, onOpenFailure }` or `(printWindow, html, logger)`.
- Response shape: unchanged; helpers still return boolean success/failure.
- Status codes: not applicable - this is client-side print rendering, not an HTTP API.
- Frontend consumer: existing print callers continue importing the same utility functions.
- Compatibility path or alias: not applicable - no route or alias changes.
- Contract proof: `npm.cmd run build` succeeded after adding DOMPurify sanitization.

## RBAC / Permissions
- Roles allowed: unchanged; print access remains controlled by existing caller screens.
- Roles denied: unchanged; no permission checks were added or removed.
- Positive auth proof: not applicable - auth is enforced before caller screens render print actions.
- Negative auth proof: not applicable - no route or endpoint authorization changed.

## Notification / Realtime
not applicable - printing does not emit notifications, websocket events, queue events, or realtime updates.

## Frontend Resilience
- Empty data proof: `sanitizePrintableHtml(null)` and `sanitizePrintableHtml(undefined)` coerce to an empty-safe string path through `String(html ?? '')`.
- Partial data proof: existing printable partial markup is still accepted and sanitized as HTML.
- Forbidden secondary path behavior: executable tags and inline handlers are stripped before `document.write`.
- Missing draft/resource behavior: unchanged; popup open failure handling still calls `onOpenFailure` and returns false.
- Stale route/deep-link behavior: not applicable - this utility is not route-bound.

## Scope Gate
- Allowed paths: `frontend/src/utils/printWindow.js`.
- Denied paths: caller components and separate test files were not edited.
- Migration/docs/test impact: no migration or docs impact; test-file edit was not allowed by gate, so build validation was used.
- Rollback note: revert commit `f0d92e0b` to restore the previous raw `document.write(html)` behavior if needed.

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run build`; `git diff --check -- frontend\src\utils\printWindow.js`.
- Result: passed.
- Not checked: full frontend test suite; persistent unit test file was not added because the gate did not allow editing a test file in this slice; CodeQL alert closure is pending GitHub analysis on this PR branch and then on `main` after merge.