### PR TITLE
docs(security): redact CI database password examples

### DIFF
--- a/CI-CD-README.md
+++ b/CI-CD-README.md
@@ -146,7 +146,7 @@ python generate_openapi.py > openapi.json
 ### Переменные окружения
 ```yaml
 PYTHON_VERSION: '3.11'
-DATABASE_URL: 'postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb'
+DATABASE_URL: 'postgresql+psycopg://clinic:<db_password>@localhost:5432/clinicdb'
 CORS_DISABLE: '1'
 WS_DEV_ALLOW: '1'
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,7 +445,7 @@ For risky tasks that should not execute yet, output `plan`, `dossier`, or `hando
 ## Environment Variables
 
 **Backend Key Variables:**
-- `DATABASE_URL` - Database connection (default: PostgreSQL via `postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb`)
+- `DATABASE_URL` - Database connection (example: PostgreSQL via `postgresql+psycopg://clinic:<db_password>@localhost:5432/clinicdb`)
 - `SECRET_KEY` - JWT secret
 - `API_V1_STR` - API prefix (default: `/api/v1`)
 - `CORS_ORIGINS` - Allowed CORS origins

--- a/README-CI-CD.md
+++ b/README-CI-CD.md
@@ -88,7 +88,7 @@
 
 ```bash
 # Основные настройки
-DATABASE_URL=postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb
+DATABASE_URL=postgresql+psycopg://clinic:<db_password>@localhost:5432/clinicdb
 CORS_DISABLE=1
 WS_DEV_ALLOW=1
 

--- a/SETUP-CI-CD.md
+++ b/SETUP-CI-CD.md
@@ -86,7 +86,7 @@
 
 ```bash
 # База данных
-DATABASE_URL=postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb
+DATABASE_URL=postgresql+psycopg://clinic:<db_password>@localhost:5432/clinicdb
 
 # CORS и WebSocket
 CORS_DISABLE=1

--- a/backend/tests/unit/test_no_legacy_ports_in_active_text.py
+++ b/backend/tests/unit/test_no_legacy_ports_in_active_text.py
@@ -42,6 +42,10 @@ SQLITE_FIRST_DOC_PATTERNS = [
     re.compile(r"clinic\.db\s+работает", re.IGNORECASE),
 ]
 
+DEFAULT_DB_CREDENTIAL_DOC_PATTERNS = [
+    re.compile(r"postgresql\+psycopg://clinic:clinicpwd@", re.IGNORECASE),
+]
+
 RETIRED_DOC_COMMAND_PATTERNS = [
     re.compile(r"\bpython\s+quick_check\.py\b", re.IGNORECASE),
     re.compile(r"\bpython\s+check_system_integrity\.py\b", re.IGNORECASE),
@@ -197,6 +201,62 @@ def test_no_sqlite_first_claims_in_active_docs():
                     matches.append(f"{path.relative_to(repo_root)}:{line_number}:{line}")
 
     assert not matches, "SQLite-first doc claims still exist:\n" + "\n".join(matches[:50])
+
+
+def test_no_default_database_passwords_in_active_docs():
+    repo_root = Path(__file__).resolve().parents[3]
+    matches: list[str] = []
+
+    scan_roots = [
+        repo_root / "backend",
+        repo_root / "docs",
+    ]
+
+    seen: set[Path] = set()
+    for scan_root in scan_roots:
+        if not scan_root.exists():
+            continue
+        for path in _collect_active_text_files(scan_root):
+            if path in seen or path.suffix.lower() != ".md":
+                continue
+            seen.add(path)
+            try:
+                content = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+
+            for pattern in DEFAULT_DB_CREDENTIAL_DOC_PATTERNS:
+                for match in pattern.finditer(content):
+                    line_number = content.count("\n", 0, match.start()) + 1
+                    line_start = content.rfind("\n", 0, match.start()) + 1
+                    line_end = content.find("\n", match.start())
+                    if line_end == -1:
+                        line_end = len(content)
+                    line = content[line_start:line_end].strip()
+                    matches.append(f"{path.relative_to(repo_root)}:{line_number}:{line}")
+
+    for path in repo_root.glob("*.md"):
+        if _is_excluded(path):
+            continue
+        try:
+            content = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+
+        for pattern in DEFAULT_DB_CREDENTIAL_DOC_PATTERNS:
+            for match in pattern.finditer(content):
+                line_number = content.count("\n", 0, match.start()) + 1
+                line_start = content.rfind("\n", 0, match.start()) + 1
+                line_end = content.find("\n", match.start())
+                if line_end == -1:
+                    line_end = len(content)
+                line = content[line_start:line_end].strip()
+                matches.append(f"{path.relative_to(repo_root)}:{line_number}:{line}")
+
+    assert not matches, (
+        "Default database passwords still exist in active docs:\n"
+        + "\n".join(matches[:50])
+    )
 
 
 def test_no_retired_backend_helper_commands_in_active_docs():


### PR DESCRIPTION
﻿## Summary

- Replace hardcoded `clinicpwd` PostgreSQL examples in active CI/operator docs with `<db_password>` placeholders.
- Clarify the CLAUDE.md database URL line as an example instead of a default credential.
- Add a unit guard that fails if `postgresql+psycopg://clinic:clinicpwd@` returns to active docs.

## Contract Impact

not applicable - docs/test-only security hygiene; no API, websocket, event, database schema, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, frontend data flow, or browser behavior changed.

## Scope Gate

- Allowed paths: CI docs, CLAUDE.md, and the existing backend hygiene unit test.
- Denied paths: backend runtime, frontend runtime, migrations, generated output, storage, and evidence artifacts.
- Migration/docs/test impact: documentation placeholders plus a regression guard only; no migration expected.
- Rollback note: revert this PR to restore the previous documentation examples and remove the guard.

## Validation

- Targeted tests or smoke run: `git diff --check`; `rg -n "clinicpwd" -g "!output/**" -g "!archives/**" -g "!storage/**" -g "!backend/storage/**" -g "!node_modules/**" -g "!frontend/dist/**" -g "!.playwright-cli/**" -g "!test-results/**" -g "!artifacts/**" -g "!backend/tests/unit/test_no_legacy_ports_in_active_text.py" .`; `$env:TESTING='1'; $env:ALLOW_SQLITE_DATABASE_URL='1'; $env:DATABASE_URL='sqlite:///:memory:'; $env:SECRET_KEY='test-secret-key-for-doc-guard-0123456789abcdef'; python -m pytest backend\tests\unit\test_no_legacy_ports_in_active_text.py`
- Result: diff check passed; active-doc `clinicpwd` scan returned no matches; targeted pytest passed with 10 tests.
- Not checked: full backend/frontend suites, because this PR changes docs and one hygiene test only.
