### PR TITLE
fix(security): harden frontend input sanitizer

### DIFF
--- a/frontend/src/utils/sanitizer.js
+++ b/frontend/src/utils/sanitizer.js
@@ -52,8 +52,11 @@ const MEDICAL_CONFIG = {
 const STRICT_CONFIG = {
   ALLOWED_TAGS: [],
   ALLOWED_ATTR: [],
+  SAFE_FOR_TEMPLATES: true,
   KEEP_CONTENT: true
 };
+
+const BLOCKED_TEXT_PROTOCOLS = new Set(['javascript:', 'data:', 'vbscript:']);
 
 /**
  * Конфигурация для AI-сгенерированного контента
@@ -258,15 +261,10 @@ export function sanitizeInput(input, options = {}) {
     logger.warn('Input обрезан до максимальной длины:', maxLength);
   }
 
-  // Удаляем опасные HTML теги
-  sanitized = sanitized.replace(/<script[^>]*>.*?<\/script>/gi, '');
-  sanitized = sanitized.replace(/<iframe[^>]*>.*?<\/iframe>/gi, '');
-  sanitized = sanitized.replace(/<object[^>]*>.*?<\/object>/gi, '');
-  sanitized = sanitized.replace(/<embed[^>]*>/gi, '');
-
-  // Удаляем javascript: и data: протоколы
-  sanitized = sanitized.replace(/javascript:/gi, '');
-  sanitized = sanitized.replace(/data:text\/html/gi, '');
+  sanitized = sanitizeHTML(sanitized, STRICT_CONFIG);
+  sanitized = sanitized.replace(/[a-z][a-z0-9+.-]*:/gi, (protocol) =>
+    BLOCKED_TEXT_PROTOCOLS.has(protocol.toLowerCase()) ? '' : protocol
+  );
 
   return sanitized.trim();
 }


### PR DESCRIPTION
﻿## Summary

- Replace manual regex-based input stripping in `sanitizeInput()` with the shared DOMPurify strict sanitizer path.
- Enable `SAFE_FOR_TEMPLATES` for strict text sanitization and strip dangerous text protocols after HTML removal.
- Keep the existing `sanitizeInput()` API and caller behavior intact while reducing CodeQL/XSS false-negative risk.

## Contract Impact

not applicable - frontend utility hardening only; no API, websocket, event, route, request/response, status code, compatibility alias, or backend contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, permission mapping, or auth-sensitive runtime behavior changed; input sanitization remains a client-side utility concern.

## Notification / Realtime

not applicable - no notification, websocket, chat, event payload, ack, read/unread, delivery, reconnect, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: existing `sanitizeInput()` null/non-string guard still returns an empty string.
- Partial data proof: text-only input continues through the same trimming/max-length/control-character handling before DOMPurify strict sanitization.
- Forbidden secondary path behavior: scripts, HTML tags, and dangerous `javascript:`, `data:`, and `vbscript:` text protocols are stripped from the returned text.
- Missing draft/resource behavior: unchanged; this utility does not manage persisted drafts or external resources.
- Stale route/deep-link behavior: not applicable - this utility is not route-bound.

## Scope Gate

- Allowed paths: `frontend/src/utils/sanitizer.js`.
- Denied paths: caller components, backend runtime, docs, generated artifacts, output files, and unrelated frontend utilities.
- Migration/docs/test impact: no migration or docs impact; no dedicated sanitizer test file exists in this slice, so build validation was used.
- Rollback note: revert this PR to restore the prior regex stripping path for `sanitizeInput()`.

## Validation

- Targeted tests or smoke run: `python scripts/agent_gate.py "Fix frontend sanitizer CodeQL unsafe input sanitization" --known-root-cause "frontend/src/utils/sanitizer.js"`; `git diff --check`; `cd frontend; npm.cmd run build`; `python scripts/run_pr_review_gate_checks.py --body-file <body>`.
- Result: gate restricted first-touch to `frontend/src/utils/sanitizer.js`; diff check passed; frontend build passed; PR body gate passed.
- Not checked: full frontend Vitest suite, because this is a one-file sanitizer hardening slice and no dedicated sanitizer unit test exists yet.
