### PR TITLE
fix(security): prevent json upload path traversal

### DIFF
--- a/backend/app/api/v1/endpoints/file_upload_json.py
+++ b/backend/app/api/v1/endpoints/file_upload_json.py
@@ -61,7 +61,8 @@ async def upload_file_json(
         file_hash = hashlib.sha256(content).hexdigest()
 
         # Создаем имя файла
-        safe_filename = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{request.filename}"
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+        safe_filename = f"{timestamp}_{file_hash[:16]}"
 
         # Сохраняем файл
         upload_dir = "uploads"

--- a/backend/app/services/file_upload_json_api_service.py
+++ b/backend/app/services/file_upload_json_api_service.py
@@ -66,7 +66,8 @@ async def upload_file_json(
         file_hash = hashlib.sha256(content).hexdigest()
 
         # Создаем имя файла
-        safe_filename = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{request.filename}"
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+        safe_filename = f"{timestamp}_{file_hash[:16]}"
 
         # Сохраняем файл
         upload_dir = "uploads"


### PR DESCRIPTION
﻿## Summary
- Stop JSON upload storage paths from including user-controlled `request.filename`.
- Use timestamp plus SHA-256 content hash prefix for the stored filename in both the canonical endpoint and mirrored service path.
- Preserve response fields, including `original_filename`, `file_size`, `file_hash`, and `file_path` shape.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/file_upload_json.py` and mirror `backend/app/services/file_upload_json_api_service.py`.
- Request shape: Existing JSON upload request fields are unchanged.
- Response shape: Existing response keys are unchanged; `filename` remains a server-generated storage name.
- Status codes: Existing 400 base64 failure and 500 upload failure behavior unchanged.
- Frontend consumer: Existing `/files/upload-json` consumers keep receiving the same response keys.
- Compatibility path or alias: Service mirror updated with the same storage filename invariant.
- Contract proof: `python -m py_compile backend\app\api\v1\endpoints\file_upload_json.py backend\app\services\file_upload_json_api_service.py` passed.

## RBAC / Permissions
- Roles allowed: Existing authenticated-user dependency remains unchanged.
- Roles denied: Existing unauthenticated denial remains owned by `get_current_user`; not modified.
- Positive auth proof: Not checked; no auth dependency changed.
- Negative auth proof: Not checked; no auth dependency changed.

## Notification / Realtime
- Event type or websocket channel: Not applicable; upload endpoint emits no realtime event in this change.
- Payload version / ack behavior: Not applicable; no notification payload changed.
- Read/unread or delivery semantics: Not applicable; no delivery state changed.
- Reconnect/resync proof: Not applicable; no websocket or resync path changed.

## Frontend Resilience
- Empty data proof: Not checked; backend-only path traversal fix.
- Partial data proof: Not checked; backend-only path traversal fix.
- Forbidden secondary path behavior: Storage path no longer uses `request.filename`, so `../` and absolute path fragments remain only in `original_filename` response metadata.
- Missing draft/resource behavior: Not applicable; no draft/resource flow changed.
- Stale route/deep-link behavior: Not applicable; no routing changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/file_upload_json.py`; `backend/app/services/file_upload_json_api_service.py` after separate gate for the mirror.
- Denied paths: Other upload handlers, file-system services, frontend, migrations, and generated artifacts were not changed.
- Migration/docs/test impact: No migration required; no persistent tests added because gate validation target was py_compile for the two first-touch slices.
- Rollback note: Revert this PR to restore the previous behavior that embedded `request.filename` in the stored path.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\file_upload_json.py backend\app\services\file_upload_json_api_service.py`; `git diff --check HEAD~1..HEAD`; `rg` confirmed `request.filename` remains only in `original_filename` response fields.
- Result: All passed.
- Not checked: Full backend suite and live upload request were not run; no local database or auth runtime was needed for the path construction fix.
