### PR TITLE
ci: replace remaining ci database password defaults

### DIFF
--- a/.github/workflows/load-testing.yml
+++ b/.github/workflows/load-testing.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           POSTGRES_DB: clinicdb
           POSTGRES_USER: clinic
-          POSTGRES_PASSWORD: clinicpwd
+          POSTGRES_PASSWORD: clinic_ci_only_password
         ports:
           - 5432:5432
         options: >-
@@ -31,7 +31,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb
+      DATABASE_URL: postgresql+psycopg://clinic:clinic_ci_only_password@localhost:5432/clinicdb
       CORS_DISABLE: '1'
       WS_DEV_ALLOW: '1'
     
@@ -64,7 +64,7 @@ jobs:
     - name: 🗄️ Проверка базы данных
       run: |
         cd backend
-        export DATABASE_URL="postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb"
+        export DATABASE_URL="postgresql+psycopg://clinic:clinic_ci_only_password@localhost:5432/clinicdb"
         export CORS_DISABLE="1"
         export WS_DEV_ALLOW="1"
         
@@ -104,7 +104,7 @@ jobs:
     - name: 🚀 Запуск сервера
       run: |
         cd backend
-        export DATABASE_URL="postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb"
+        export DATABASE_URL="postgresql+psycopg://clinic:clinic_ci_only_password@localhost:5432/clinicdb"
         export CORS_DISABLE="1"
         export WS_DEV_ALLOW="1"
         
@@ -210,7 +210,7 @@ jobs:
       continue-on-error: true
       run: |
         cd backend
-        export DATABASE_URL="postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb"
+        export DATABASE_URL="postgresql+psycopg://clinic:clinic_ci_only_password@localhost:5432/clinicdb"
         export CORS_DISABLE="1"
         export WS_DEV_ALLOW="1"
         

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           POSTGRES_DB: clinicdb
           POSTGRES_USER: clinic
-          POSTGRES_PASSWORD: clinicpwd
+          POSTGRES_PASSWORD: clinic_ci_only_password
         ports:
           - 5432:5432
         options: >-
@@ -26,7 +26,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb
+      DATABASE_URL: postgresql+psycopg://clinic:clinic_ci_only_password@localhost:5432/clinicdb
       CORS_DISABLE: '1'
       WS_DEV_ALLOW: '1'
     
@@ -54,7 +54,7 @@ jobs:
     - name: 🗄️ Проверка базы данных
       run: |
         cd backend
-        export DATABASE_URL="postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb"
+        export DATABASE_URL="postgresql+psycopg://clinic:clinic_ci_only_password@localhost:5432/clinicdb"
         
         echo "🗄️ Проверяем состояние Postgres..."
         echo "📊 DATABASE_URL: $DATABASE_URL"
@@ -85,7 +85,7 @@ jobs:
     - name: 🔌 Проверка API эндпоинтов
       run: |
         cd backend
-        export DATABASE_URL="postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb"
+        export DATABASE_URL="postgresql+psycopg://clinic:clinic_ci_only_password@localhost:5432/clinicdb"
         export CORS_DISABLE="1"
         export WS_DEV_ALLOW="1"
         

--- a/.github/workflows/role-system-check.yml
+++ b/.github/workflows/role-system-check.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           POSTGRES_DB: clinicdb
           POSTGRES_USER: clinic
-          POSTGRES_PASSWORD: clinicpwd
+          POSTGRES_PASSWORD: clinic_ci_only_password
         ports:
           - 5432:5432
         options: >-
@@ -32,7 +32,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgresql+psycopg://clinic:clinicpwd@localhost:5432/clinicdb
+      DATABASE_URL: postgresql+psycopg://clinic:clinic_ci_only_password@localhost:5432/clinicdb
       CORS_DISABLE: "1"
       WS_DEV_ALLOW: "1"
       DISABLE_2FA_REQUIREMENT: "1"


### PR DESCRIPTION
﻿## Summary

- Replace the remaining CI Postgres `clinicpwd` defaults in load testing, monitoring, and role-system workflows.
- Align each workflow service password and `DATABASE_URL` to the explicit CI-only value already used by the main CI workflow.
- Keep the change limited to GitHub Actions configuration; no runtime application code changes.

## Contract Impact

not applicable - GitHub Actions database credentials only; no API, websocket, event, route, request/response, status code, compatibility alias, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, permission mapping, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, event payload, ack, read/unread, delivery, reconnect, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, route, deep link, draft/resource handling, or frontend data flow changed.

## Scope Gate

- Allowed paths: `.github/workflows/load-testing.yml`, `.github/workflows/monitoring.yml`, `.github/workflows/role-system-check.yml`.
- Denied paths: backend/frontend runtime source, migrations, secrets, docs, generated artifacts, and upload/storage directories.
- Migration/docs/test impact: none; CI configuration only.
- Rollback note: revert if these workflows intentionally need the old local test password string again.

## Validation

- Targeted tests or smoke run: `rg -n "clinicpwd" .github/workflows/load-testing.yml .github/workflows/monitoring.yml .github/workflows/role-system-check.yml`; `rg -n "clinic_ci_only_password" .github/workflows/load-testing.yml .github/workflows/monitoring.yml .github/workflows/role-system-check.yml`; `git diff --check origin/main...HEAD`; `python scripts/run_pr_review_gate_checks.py --body-file <body>`.
- Result: old `clinicpwd` string is absent from the three changed workflows; new CI-only value appears in service env and `DATABASE_URL` entries; diff check passed; PR body gate passed.
- Not checked: full GitHub Actions execution locally, because this change only updates workflow environment values.
