### PR TITLE
test: guard ci workflow database defaults

### DIFF
--- a/backend/tests/unit/test_no_legacy_ports_in_active_text.py
+++ b/backend/tests/unit/test_no_legacy_ports_in_active_text.py
@@ -259,6 +259,36 @@ def test_no_default_database_passwords_in_active_docs():
     )
 
 
+def test_no_default_database_passwords_in_active_workflows():
+    repo_root = Path(__file__).resolve().parents[3]
+    workflow_root = repo_root / ".github" / "workflows"
+    matches: list[str] = []
+
+    workflow_files = sorted(
+        list(workflow_root.glob("*.yml")) + list(workflow_root.glob("*.yaml"))
+    )
+    for path in workflow_files:
+        try:
+            content = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+
+        for pattern in DEFAULT_DB_CREDENTIAL_DOC_PATTERNS:
+            for match in pattern.finditer(content):
+                line_number = content.count("\n", 0, match.start()) + 1
+                line_start = content.rfind("\n", 0, match.start()) + 1
+                line_end = content.find("\n", match.start())
+                if line_end == -1:
+                    line_end = len(content)
+                line = content[line_start:line_end].strip()
+                matches.append(f"{path.relative_to(repo_root)}:{line_number}:{line}")
+
+    assert not matches, (
+        "Default database passwords still exist in active workflows:\n"
+        + "\n".join(matches[:50])
+    )
+
+
 def test_no_retired_backend_helper_commands_in_active_docs():
     repo_root = Path(__file__).resolve().parents[3]
     matches: list[str] = []


### PR DESCRIPTION
﻿## Summary

- Add a unit guard that scans active GitHub Actions workflow files for the retired `postgresql+psycopg://clinic:clinicpwd@` database credential pattern.
- Keep historical `.ai-factory/patches` untouched; this only protects live `.github/workflows/*.yml` and `*.yaml` files from regression.
- No runtime application code, deployment config, or workflow behavior changed.

## Contract Impact

not applicable - test-only regression guard; no API, websocket, event, route, request/response, status code, compatibility alias, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, permission mapping, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, event payload, ack, read/unread, delivery, reconnect, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, route, deep link, draft/resource handling, or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/tests/unit/test_no_legacy_ports_in_active_text.py`.
- Denied paths: backend/frontend runtime source, migrations, workflow files, generated artifacts, and historical evidence logs.
- Migration/docs/test impact: test-only guard addition; no migration or docs update expected.
- Rollback note: revert this commit to remove the workflow credential regression guard.

## Validation

- Targeted tests or smoke run: `TESTING=1 ALLOW_SQLITE_DATABASE_URL=1 DATABASE_URL=sqlite:///:memory: SECRET_KEY=test-secret-key-for-doc-guard-0123456789abcdef python -m pytest backend/tests/unit/test_no_legacy_ports_in_active_text.py`; `rg -n "postgresql\\+psycopg://clinic:clinicpwd@|clinicpwd" .github/workflows`; `git diff --check`; `python scripts/run_pr_review_gate_checks.py --body-file <body>`.
- Result: targeted pytest passed with 11 passed; workflow grep returned no matches; diff check passed; PR body gate passed.
- Not checked: full backend/frontend suites, because this PR only adds a narrow text-scan regression test.
