### PR TITLE
fix(security): remove payment provider test fallbacks

### DIFF
--- a/backend/app/services/payment_provider_manager_factory.py
+++ b/backend/app/services/payment_provider_manager_factory.py
@@ -14,27 +14,25 @@ _payment_manager_lock = Lock()
 def _build_provider_config() -> dict[str, dict[str, object]]:
     return {
         "click": {
-            "enabled": getattr(settings, "CLICK_ENABLED", True),
-            "service_id": getattr(settings, "CLICK_SERVICE_ID", "test_service"),
-            "merchant_id": getattr(settings, "CLICK_MERCHANT_ID", "test_merchant"),
-            "secret_key": getattr(settings, "CLICK_SECRET_KEY", "test_secret"),
-            "base_url": getattr(settings, "CLICK_BASE_URL", "https://api.click.uz/v2"),
+            "enabled": settings.CLICK_ENABLED,
+            "service_id": settings.CLICK_SERVICE_ID,
+            "merchant_id": settings.CLICK_MERCHANT_ID,
+            "secret_key": settings.CLICK_SECRET_KEY,
+            "base_url": settings.CLICK_BASE_URL,
         },
         "payme": {
-            "enabled": getattr(settings, "PAYME_ENABLED", True),
-            "merchant_id": getattr(settings, "PAYME_MERCHANT_ID", "test_merchant"),
-            "secret_key": getattr(settings, "PAYME_SECRET_KEY", "test_secret"),
-            "base_url": getattr(
-                settings, "PAYME_BASE_URL", "https://checkout.paycom.uz"
-            ),
-            "api_url": getattr(settings, "PAYME_API_URL", "https://api.paycom.uz"),
+            "enabled": settings.PAYME_ENABLED,
+            "merchant_id": settings.PAYME_MERCHANT_ID,
+            "secret_key": settings.PAYME_SECRET_KEY,
+            "base_url": settings.PAYME_BASE_URL,
+            "api_url": settings.PAYME_API_URL,
         },
         "kaspi": {
-            "enabled": getattr(settings, "KASPI_ENABLED", True),
-            "merchant_id": getattr(settings, "KASPI_MERCHANT_ID", "test_merchant"),
-            "secret_key": getattr(settings, "KASPI_SECRET_KEY", "test_secret"),
-            "base_url": getattr(settings, "KASPI_BASE_URL", "https://kaspi.kz/pay"),
-            "api_url": getattr(settings, "KASPI_API_URL", "https://api.kaspi.kz/pay/v1"),
+            "enabled": settings.KASPI_ENABLED,
+            "merchant_id": settings.KASPI_MERCHANT_ID,
+            "secret_key": settings.KASPI_SECRET_KEY,
+            "base_url": settings.KASPI_BASE_URL,
+            "api_url": settings.KASPI_API_URL,
         },
     }
 


### PR DESCRIPTION
﻿## Summary

- Remove `test_service`, `test_merchant`, and `test_secret` fallback values from the canonical payment provider manager factory.
- Read provider flags, merchant IDs, service IDs, secrets, and URLs directly from `Settings`, whose defaults are already `False`/`None` for credentials and explicit URLs for provider endpoints.
- Keep the change limited to the canonical factory used by `/api/v1/payments` and provider webhook service; legacy service-router mirrors and registrar wizard test-provider snippets are not changed in this slice.

## Contract Impact

- Canonical surface: payment provider manager construction for payment APIs and provider webhook service.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged for configured providers; missing provider credentials continue to prevent provider initialization instead of falling back to test credentials.
- Frontend consumer: unchanged.
- Compatibility path or alias: not applicable; no route aliases changed.
- Contract proof: targeted factory unit test and payment init integration smoke passed locally.

## RBAC / Permissions

not applicable - no route, endpoint guard, role helper, permission mapping, or auth-sensitive access control changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, event payload, ack, read/unread, delivery, reconnect, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, route, deep link, draft/resource handling, or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/app/services/payment_provider_manager_factory.py`.
- Denied paths: payment endpoint routing, registrar wizard, legacy `payments_api_service.py`, migrations, frontend runtime, generated artifacts, and historical evidence logs.
- Migration/docs/test impact: no migration; no docs update; targeted existing tests validate the slice.
- Rollback note: revert this commit to restore previous provider config fallback behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/services/payment_provider_manager_factory.py`; `TESTING=1 ALLOW_SQLITE_DATABASE_URL=1 DATABASE_URL=sqlite:///:memory: SECRET_KEY=test-secret-key-for-payment-factory-0123456789abcdef python -m pytest backend/tests/unit/test_payment_provider_manager_factory.py`; `TESTING=1 ALLOW_SQLITE_DATABASE_URL=1 DATABASE_URL=sqlite:///:memory: SECRET_KEY=test-secret-key-for-payment-init-0123456789abcdef python -m pytest backend/tests/integration/test_payment_init_e2e.py`; `git diff --check`; `rg -n "test_secret|test_service|test_merchant|getattr\\(settings, .*PAYME|getattr\\(settings, .*CLICK|getattr\\(settings, .*KASPI" backend/app/services/payment_provider_manager_factory.py`; `python scripts/run_pr_review_gate_checks.py --body-file <body>`.
- Result: py_compile passed; factory unit tests passed with 2 passed; payment init integration smoke passed with 4 passed; diff check passed; fallback grep returned no matches in the canonical factory; PR body gate passed.
- Not checked: full backend suite and live payment provider calls, because the patch is limited to config construction and existing targeted tests cover manager creation plus payment init paths.
