### PR TITLE
ci(vercel): limit automatic git deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,13 @@
   "installCommand": "npm --prefix frontend ci",
   "framework": "vite",
   "outputDirectory": "frontend/dist",
+  "git": {
+    "deploymentEnabled": {
+      "**": false,
+      "main": true,
+      "preview/**": true
+    }
+  },
   "ignoreCommand": "if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then git diff --quiet HEAD^ HEAD -- frontend vercel.json .vercelignore; code=$?; if [ $code -gt 1 ]; then exit 1; fi; exit $code; fi; exit 1",
   "rewrites": [
     {


### PR DESCRIPTION
## Summary
- Limits Vercel Git auto-deployments to `main` and deliberate `preview/**` branches.
- Keeps the existing `ignoreCommand` path filter so allowed branches only build when frontend or Vercel config changes.
- Reduces Vercel free quota noise during Codex cleanup PR bursts while preserving production deployment after merge to `main`.

## Contract Impact
- Canonical surface: `vercel.json` deployment policy only.
- Request shape: not applicable because no backend or frontend API request shape changes.
- Response shape: not applicable because no application response shape changes.
- Status codes: not applicable because no runtime route or handler changes.
- Frontend consumer: no frontend consumer code changes; Vercel preview availability changes only for normal `codex/*` branches.
- Compatibility path or alias: production deployment on `main` remains enabled; explicit `preview/**` branches remain available for manual previews.
- Contract proof: parsed `vercel.json` locally and verified `git.deploymentEnabled` policy shape.

## RBAC / Permissions
- Roles allowed: not applicable because this is deploy configuration, not application authorization.
- Roles denied: not applicable because no app permission behavior changes.
- Positive auth proof: not checked because no auth code changed.
- Negative auth proof: not checked because no auth code changed.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket code changes.
- Payload version / ack behavior: not applicable because no realtime payload changes.
- Read/unread or delivery semantics: not applicable because notification delivery is untouched.
- Reconnect/resync proof: not checked because no realtime behavior changed.

## Frontend Resilience
- Empty data proof: not applicable because no frontend runtime code changed.
- Partial data proof: not applicable because no data fetching or rendering changed.
- Forbidden secondary path behavior: not applicable because no route guard or app route changed.
- Missing draft/resource behavior: not applicable because no resource loading changed.
- Stale route/deep-link behavior: not applicable because no app routing changed.

## Scope Gate
- Allowed paths: `vercel.json` only.
- Denied paths: app runtime, backend, frontend source, tests, migrations, docs, generated artifacts, and `EVIDENCE_LIGHTRAG_READINESS.md`.
- Migration/docs/test impact: no DB migration; no app tests required beyond config parse/diff check for this deploy-config slice.
- Rollback note: revert commit `1039c6fb` to restore previous Vercel auto-deploy behavior.

## Validation
- Targeted tests or smoke run: parsed `vercel.json` with Node and verified `git.deploymentEnabled`; `git diff --check -- vercel.json`.
- Result: JSON parse/policy check passed; diff check passed.
- Not checked: browser smoke and backend/frontend full suites were not run locally because the PR only changes Vercel deployment filtering.

## Operational note
For a PR preview after CI is green, create or push the same commit to a deliberate `preview/<name>` branch; normal `codex/*` recovery branches will not consume Vercel deployment quota.