### PR TITLE
fix(security): use configured registrar invoice payment providers

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -28,6 +28,7 @@ from app.services.registrar_wizard_queue_assignment_service import (
     RegistrarWizardQueueAssignmentService,
 )
 from app.services.notifications import notification_sender_service
+from app.services.payment_provider_manager_factory import get_payment_manager
 from app.services.queue_service import queue_service
 from app.services.queue_session import get_or_create_session_id
 from app.services.service_mapping import get_service_code, normalize_service_code
@@ -505,6 +506,9 @@ class InvoicePaymentResponse(BaseModel):
     error_message: Optional[str] = None
 
 
+SUPPORTED_INVOICE_PAYMENT_PROVIDERS = {"click", "payme"}
+
+
 @router.post("/registrar/invoice/init-payment", response_model=InvoicePaymentResponse)
 def init_invoice_payment(
     payment_req: InvoicePaymentRequest,
@@ -530,40 +534,16 @@ def init_invoice_payment(
             )
 
         # Инициализируем провайдер платежей
-        if payment_req.provider == "click":
-            from app.services.payment_providers.click import ClickProvider
-
-            # Конфигурация Click (в реальном проекте из настроек)
-            provider_config = {
-                "service_id": "test_service",
-                "merchant_id": "test_merchant",
-                "secret_key": "test_secret",
-                "base_url": "https://api.click.uz/v2",
-            }
-
-            provider = ClickProvider(provider_config)
-
-        elif payment_req.provider == "payme":
-            from app.services.payment_providers.payme import PayMeProvider
-
-            # Конфигурация PayMe (в реальном проекте из настроек)
-            provider_config = {
-                "merchant_id": "test_merchant_payme",
-                "secret_key": "test_secret_payme",
-                "base_url": "https://checkout.paycom.uz",
-                "api_url": "https://api.paycom.uz",
-            }
-
-            provider = PayMeProvider(provider_config)
-
-        else:
+        provider_name = payment_req.provider.lower()
+        if provider_name not in SUPPORTED_INVOICE_PAYMENT_PROVIDERS:
             return InvoicePaymentResponse(
                 success=False,
                 error_message=f"Провайдер {payment_req.provider} не поддерживается",
             )
 
         # Создаём платёж
-        result = provider.create_payment(
+        result = get_payment_manager().create_payment(
+            provider_name=provider_name,
             amount=invoice.total_amount,
             currency=invoice.currency,
             order_id=f"invoice_{invoice.id}",
@@ -575,8 +555,8 @@ def init_invoice_payment(
         if result.success:
             # Обновляем invoice
             invoice.provider_payment_id = result.payment_id
-            invoice.payment_method = payment_req.provider
-            invoice.provider = payment_req.provider
+            invoice.payment_method = provider_name
+            invoice.provider = provider_name
             invoice.status = "processing"
             invoice.provider_data = result.provider_data
             db.commit()
@@ -627,34 +607,12 @@ def check_invoice_status(
 
         # Проверяем статус у провайдера
         if invoice.provider_payment_id and invoice.provider:
-            provider = None
+            provider_name = invoice.provider.lower()
 
-            if invoice.provider == "click":
-                from app.services.payment_providers.click import ClickProvider
-
-                provider_config = {
-                    "service_id": "test_service",
-                    "merchant_id": "test_merchant",
-                    "secret_key": "test_secret",
-                    "base_url": "https://api.click.uz/v2",
-                }
-
-                provider = ClickProvider(provider_config)
-
-            elif invoice.provider == "payme":
-                from app.services.payment_providers.payme import PayMeProvider
-
-                provider_config = {
-                    "merchant_id": "test_merchant_payme",
-                    "secret_key": "test_secret_payme",
-                    "base_url": "https://checkout.paycom.uz",
-                    "api_url": "https://api.paycom.uz",
-                }
-
-                provider = PayMeProvider(provider_config)
-
-            if provider:
-                result = provider.check_payment_status(invoice.provider_payment_id)
+            if provider_name in SUPPORTED_INVOICE_PAYMENT_PROVIDERS:
+                result = get_payment_manager().check_payment_status(
+                    provider_name, invoice.provider_payment_id
+                )
 
                 if result.success:
                     # Обновляем статус invoice


### PR DESCRIPTION
## Summary
- Removes hardcoded Click/PayMe test credentials from the active registrar invoice payment endpoints.
- Reuses the existing settings-backed `get_payment_manager()` path for invoice payment init and status checks.
- Keeps supported registrar invoice providers limited to `click` and `payme`.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/registrar_wizard.py` active routes `/registrar/invoice/init-payment` and `/registrar/invoice/{invoice_id}/status`.
- Request shape: unchanged `InvoicePaymentRequest` fields: `invoice_id`, `provider`, `return_url`, `cancel_url`.
- Response shape: unchanged `InvoicePaymentResponse` for init and unchanged status response dictionary for status checks.
- Status codes: unchanged explicit 404/400 paths; provider config failures still return `success=false` via central payment manager result for init.
- Frontend consumer: registrar invoice payment UI can keep sending `click` or `payme`; provider name is normalized lowercase server-side.
- Compatibility path or alias: no route aliases added or removed; no frontend route changes.
- Contract proof: `python -m py_compile backend\app\api\v1\endpoints\registrar_wizard.py` and targeted scan confirmed no hardcoded payment test credentials remain in the active endpoint.

## RBAC / Permissions
- Roles allowed: unchanged `Admin` and `Registrar` via existing `require_roles("Admin", "Registrar")` guards.
- Roles denied: unchanged, any role outside the existing guard remains denied by the existing dependency.
- Positive auth proof: code path and dependency were not changed; targeted compile proves the guarded endpoints still import and load.
- Negative auth proof: not rerun in this slice because RBAC code was not edited.

## Notification / Realtime
- Event type or websocket channel: not applicable because this payment-provider config change emits no notification or websocket event.
- Payload version / ack behavior: not applicable; no realtime payload is introduced or changed.
- Read/unread or delivery semantics: not applicable; no notification delivery semantics are touched.
- Reconnect/resync proof: not checked because no realtime channel code changed.

## Frontend Resilience
- Empty data proof: not checked; response schemas and frontend code were not changed.
- Partial data proof: central manager returns `success=false` with `error_message` when provider config is unavailable, preserving existing failure-response shape.
- Forbidden secondary path behavior: unchanged because RBAC dependencies and routes were not changed.
- Missing draft/resource behavior: unchanged existing 404 invoice-not-found path remains in place.
- Stale route/deep-link behavior: unchanged because no frontend routes or API paths changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/registrar_wizard.py` only.
- Denied paths: legacy service mirrors, provider classes, settings schema, frontend, ops, migrations, generated artifacts, and `EVIDENCE_LIGHTRAG_READINESS.md`.
- Migration/docs/test impact: no DB migration required; no docs or tests changed; validation used existing payment manager tests.
- Rollback note: revert commit `2b6d0b1d` to restore the previous direct provider construction if needed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\registrar_wizard.py`; `rg -n "test_secret|test_service|test_merchant|test_secret_payme|test_merchant_payme" backend\app\api\v1\endpoints\registrar_wizard.py`; `python -m pytest backend\tests\unit\test_payment_provider_manager_factory.py`; `git diff --check`.
- Result: py_compile passed; scan returned no matches; payment provider manager unit tests passed `2 passed`; diff check passed.
- Not checked: browser payment flow and full backend suite were not run because this slice only removes hardcoded provider config and preserves route/response shapes.