### PR TITLE
fix(security): use configured registrar invoice payment providers

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -15,6 +15,7 @@ from sqlalchemy import String, func, literal
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
+from app.core.config import settings as app_settings
 from app.crud import clinic as crud_clinic, online_queue as crud_queue
 from app.models.clinic import ClinicSettings, Doctor
 from app.models.doctor_price_override import DoctorPriceOverride
@@ -531,30 +532,54 @@ def init_invoice_payment(
 
         # Инициализируем провайдер платежей
         if payment_req.provider == "click":
+            if not app_settings.CLICK_ENABLED:
+                return InvoicePaymentResponse(
+                    success=False,
+                    error_message="Payment provider click is not configured",
+                )
+
             from app.services.payment_providers.click import ClickProvider
 
             # Конфигурация Click (в реальном проекте из настроек)
             provider_config = {
-                "service_id": "test_service",
-                "merchant_id": "test_merchant",
-                "secret_key": "test_secret",
-                "base_url": "https://api.click.uz/v2",
+                "service_id": app_settings.CLICK_SERVICE_ID,
+                "merchant_id": app_settings.CLICK_MERCHANT_ID,
+                "secret_key": app_settings.CLICK_SECRET_KEY,
+                "base_url": app_settings.CLICK_BASE_URL,
             }
 
-            provider = ClickProvider(provider_config)
+            try:
+                provider = ClickProvider(provider_config)
+            except ValueError:
+                return InvoicePaymentResponse(
+                    success=False,
+                    error_message="Payment provider click is not configured",
+                )
 
         elif payment_req.provider == "payme":
+            if not app_settings.PAYME_ENABLED:
+                return InvoicePaymentResponse(
+                    success=False,
+                    error_message="Payment provider payme is not configured",
+                )
+
             from app.services.payment_providers.payme import PayMeProvider
 
             # Конфигурация PayMe (в реальном проекте из настроек)
             provider_config = {
-                "merchant_id": "test_merchant_payme",
-                "secret_key": "test_secret_payme",
-                "base_url": "https://checkout.paycom.uz",
-                "api_url": "https://api.paycom.uz",
+                "merchant_id": app_settings.PAYME_MERCHANT_ID,
+                "secret_key": app_settings.PAYME_SECRET_KEY,
+                "base_url": app_settings.PAYME_BASE_URL,
+                "api_url": app_settings.PAYME_API_URL,
             }
 
-            provider = PayMeProvider(provider_config)
+            try:
+                provider = PayMeProvider(provider_config)
+            except ValueError:
+                return InvoicePaymentResponse(
+                    success=False,
+                    error_message="Payment provider payme is not configured",
+                )
 
         else:
             return InvoicePaymentResponse(
@@ -629,29 +654,35 @@ def check_invoice_status(
         if invoice.provider_payment_id and invoice.provider:
             provider = None
 
-            if invoice.provider == "click":
+            if invoice.provider == "click" and app_settings.CLICK_ENABLED:
                 from app.services.payment_providers.click import ClickProvider
 
                 provider_config = {
-                    "service_id": "test_service",
-                    "merchant_id": "test_merchant",
-                    "secret_key": "test_secret",
-                    "base_url": "https://api.click.uz/v2",
+                    "service_id": app_settings.CLICK_SERVICE_ID,
+                    "merchant_id": app_settings.CLICK_MERCHANT_ID,
+                    "secret_key": app_settings.CLICK_SECRET_KEY,
+                    "base_url": app_settings.CLICK_BASE_URL,
                 }
 
-                provider = ClickProvider(provider_config)
+                try:
+                    provider = ClickProvider(provider_config)
+                except ValueError:
+                    provider = None
 
-            elif invoice.provider == "payme":
+            elif invoice.provider == "payme" and app_settings.PAYME_ENABLED:
                 from app.services.payment_providers.payme import PayMeProvider
 
                 provider_config = {
-                    "merchant_id": "test_merchant_payme",
-                    "secret_key": "test_secret_payme",
-                    "base_url": "https://checkout.paycom.uz",
-                    "api_url": "https://api.paycom.uz",
+                    "merchant_id": app_settings.PAYME_MERCHANT_ID,
+                    "secret_key": app_settings.PAYME_SECRET_KEY,
+                    "base_url": app_settings.PAYME_BASE_URL,
+                    "api_url": app_settings.PAYME_API_URL,
                 }
 
-                provider = PayMeProvider(provider_config)
+                try:
+                    provider = PayMeProvider(provider_config)
+                except ValueError:
+                    provider = None
 
             if provider:
                 result = provider.check_payment_status(invoice.provider_payment_id)


### PR DESCRIPTION
## Summary

- Remove hardcoded Click/PayMe test provider credentials from the active registrar wizard invoice payment flow.
- Read Click/PayMe provider config from `app.core.config.settings`.
- Return controlled `success=false` responses when invoice provider config is disabled or incomplete.

## Contract Impact

- Canonical surface: `POST /api/v1/registrar/invoice/init-payment` and `GET /api/v1/registrar/invoice/{invoice_id}/status`.
- Request shape: unchanged.
- Response shape: unchanged; init still returns `InvoicePaymentResponse`.
- Status codes: unchanged for existing HTTP errors; provider misconfiguration now returns response-level `success=false` instead of using test credentials.
- Frontend consumer: not changed.
- Compatibility path or alias: not applicable - no route alias changed.
- Contract proof: targeted backend payment provider smoke tests plus py_compile on the active registrar wizard endpoint.

## RBAC / Permissions

- Roles allowed: unchanged; `Admin` and `Registrar` through existing `require_roles(Admin, Registrar)`.
- Roles denied: unchanged by this PR.
- Positive auth proof: not checked in this PR because auth dependency wiring was not modified.
- Negative auth proof: not checked in this PR because auth dependency wiring was not modified.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend data rendering changed.
- Partial data proof: not applicable - no frontend data rendering changed.
- Forbidden secondary path behavior: not applicable - no frontend route or secondary path changed.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no frontend routing changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/registrar_wizard.py`.
- Denied paths: payment provider manager, frontend, migrations, generated output, and unreferenced service mirrors.
- Migration/docs/test impact: no migration; no docs change; no test code changed.
- Rollback note: revert this commit to restore the previous registrar wizard payment config behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\\app\\api\\v1\\endpoints\\registrar_wizard.py`; `TESTING=1 ALLOW_SQLITE_DATABASE_URL=1 DATABASE_URL=sqlite:///:memory: SECRET_KEY=test-secret-key-for-registrar-payment-0123456789abcdef python -m pytest backend\\tests\\integration\\test_payment_init_e2e.py backend\\tests\\unit\\test_payment_provider_manager_factory.py`; active endpoint grep for removed test provider defaults.
- Result: py_compile passed; targeted pytest passed with 6 passed; active endpoint grep returned no matches; `git diff --check` had no whitespace errors and only reported the existing CRLF warning for the edited file.
- Not checked: full browser registrar invoice flow and full backend suite were not run for this one-file config hardening slice.