### PR TITLE
fix(security): require env payme helper secret

### DIFF
--- a/backend/test_admin_providers.py
+++ b/backend/test_admin_providers.py
@@ -3,6 +3,7 @@
 Тест админ-панели провайдеров оплаты
 """
 import os
+import secrets
 import sys
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -38,7 +39,7 @@ def test_providers_crud():
             code=f"test_payme_{timestamp}",
             description="Тестовый провайдер Payme",
             is_active=True,
-            secret_key="test_secret_key_123",
+            secret_key=secrets.token_urlsafe(32),
             webhook_url="https://example.com/webhook",
             api_url="https://api.payme.uz",
         )

--- a/backend/update_payme_provider.py
+++ b/backend/update_payme_provider.py
@@ -13,6 +13,15 @@ from app.db.session import get_db
 from app.schemas.payment_webhook import PaymentProviderUpdate
 
 
+def _get_required_payme_secret_key():
+    secret_key = os.getenv("PAYME_PROVIDER_SECRET_KEY") or os.getenv("PAYME_SECRET_KEY")
+    if not secret_key:
+        raise RuntimeError(
+            "Set PAYME_PROVIDER_SECRET_KEY or PAYME_SECRET_KEY before running this script."
+        )
+    return secret_key
+
+
 def update_payme_provider():
     """Обновляем провайдера Payme"""
     print("🔧 Обновление провайдера Payme")
@@ -30,16 +39,18 @@ def update_payme_provider():
             return
 
         print(f"📋 Найден провайдер: {provider.name} (ID: {provider.id})")
-        print(f"🔑 Текущий секретный ключ: {provider.secret_key or 'Не установлен'}")
+        print(
+            f"🔑 Текущий секретный ключ: {'Установлен' if provider.secret_key else 'Не установлен'}"
+        )
 
-        # Обновляем секретный ключ на тестовый
-        new_secret_key = "test_secret_key_12345"
+        # Обновляем секретный ключ из локального env
+        new_secret_key = _get_required_payme_secret_key()
         update_data = PaymentProviderUpdate(secret_key=new_secret_key)
 
         updated_provider = update_provider(db, provider.id, update_data)
         if updated_provider:
             print("✅ Провайдер обновлён!")
-            print(f"🔑 Новый секретный ключ: {updated_provider.secret_key}")
+            print("🔑 Новый секретный ключ: установлен из env")
         else:
             print("❌ Не удалось обновить провайдера")
 


### PR DESCRIPTION
## Summary
- Removes hardcoded PayMe/provider secret literals from root-level backend payment helper scripts.
- Requires `PAYME_PROVIDER_SECRET_KEY` or `PAYME_SECRET_KEY` before running `backend/update_payme_provider.py`.
- Stops printing provider secret values in the PayMe update helper and generates an ephemeral local test secret in `backend/test_admin_providers.py`.

## Contract Impact
- Canonical surface: root-level manual backend helper scripts only: `backend/update_payme_provider.py` and `backend/test_admin_providers.py`.
- Request shape: not applicable because no API request schema changes.
- Response shape: not applicable because no runtime endpoint response changes.
- Status codes: not applicable because no route handler changes.
- Frontend consumer: no frontend consumer changes.
- Compatibility path or alias: no runtime import path or route alias changes.
- Contract proof: `backend/pytest.ini` limits pytest discovery to `backend/tests`; these root helper files are not canonical runtime routes.

## RBAC / Permissions
- Roles allowed: not applicable because no RBAC dependency or route permission changed.
- Roles denied: not applicable because no authorization behavior changed.
- Positive auth proof: not checked because this is helper-script-only secret hygiene.
- Negative auth proof: not checked because no auth code changed.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket code changed.
- Payload version / ack behavior: not applicable because no realtime payload changed.
- Read/unread or delivery semantics: not applicable because notification delivery is untouched.
- Reconnect/resync proof: not checked because no realtime behavior changed.

## Frontend Resilience
- Empty data proof: not applicable because no frontend code changed.
- Partial data proof: not applicable because no frontend fetch/render behavior changed.
- Forbidden secondary path behavior: not applicable because no frontend auth path changed.
- Missing draft/resource behavior: not applicable because no frontend resource loading changed.
- Stale route/deep-link behavior: not applicable because no route changed.

## Scope Gate
- Allowed paths: `backend/update_payme_provider.py`, `backend/test_admin_providers.py`.
- Denied paths: backend runtime app, migrations, frontend, ops, generated artifacts, and `EVIDENCE_LIGHTRAG_READINESS.md`.
- Migration/docs/test impact: no migration required; no docs changed; validation uses syntax and targeted secret scans.
- Rollback note: revert commit `8b05a0ea` to restore previous helper behavior if needed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\update_payme_provider.py backend\test_admin_providers.py`; `rg -n "test_secret_key_123|test_secret_key_12345|updated_provider\.secret_key|provider\.secret_key or" backend\update_payme_provider.py backend\test_admin_providers.py`; `git diff --check`.
- Result: py_compile passed; targeted secret/log scan returned no matches; diff check passed.
- Not checked: full backend suite and browser smoke were not run because this PR only changes root-level manual helper scripts outside normal pytest discovery.