### PR TITLE
fix(security): hide qr queue call errors

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -713,11 +713,13 @@ async def call_next_patient(
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
-        import traceback
-        logger.error(f"Error calling next patient: {e}\n{traceback.format_exc()}")
+        logger.error(
+            "Error calling next patient",
+            extra={"error_class": e.__class__.__name__},
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка вызова пациента: {str(e)}",
+            detail="Ошибка вызова пациента",
         )
 
 


### PR DESCRIPTION
## Summary

- Remove raw traceback logging from the canonical QR queue `call_next_patient` unexpected-error path.
- Remove raw `str(e)` from the public HTTP 500 detail for the same path.
- Preserve queue state transition behavior, notifications, and existing status-code semantics.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/qr_queue.py` remains mounted under `/api/v1/queue` through `backend/app/api/v1/api.py`.
- Request shape: unchanged; no route parameters, body fields, or auth dependencies changed.
- Response shape: unchanged success response and unchanged error envelope; unexpected 500 detail is now generic.
- Status codes: unchanged; `ValueError` still maps to 400 and unexpected failures still map to 500.
- Frontend consumer: unchanged; no frontend route/API client changed.
- Compatibility path or alias: unchanged; no router mount or queue alias changed.
- Contract proof: diff is limited to the `call_next_patient` unexpected exception block; static scan no longer finds the removed traceback/raw-detail strings in canonical `qr_queue.py`.

## RBAC / Permissions

- Roles allowed: unchanged; existing Doctor/Registrar/Admin dependencies are not edited.
- Roles denied: unchanged; no auth or role check changed.
- Positive auth proof: not applicable - this patch does not change permission logic, only unexpected-error detail/log sanitization.
- Negative auth proof: not applicable - this patch does not change permission logic, only unexpected-error detail/log sanitization.

## Notification / Realtime

- Event type or websocket channel: unchanged; display and notification calls remain untouched.
- Payload version / ack behavior: unchanged; no websocket payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable - QR call-next does not change notification read/unread semantics in this patch.
- Reconnect/resync proof: not applicable - no reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend data loading changed.
- Partial data proof: not applicable - no frontend partial-data path changed.
- Forbidden secondary path behavior: unchanged; auth/role failures are not edited.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/qr_queue.py` only.
- Denied paths: queue services, queue repositories, allocator logic, queue_time/fairness logic, frontend, docs, migrations, generated artifacts, and service mirrors.
- Migration/docs/test impact: no migration or docs update; existing queue boundary tests were used for validation without test edits.
- Rollback note: revert commit `7c2a8925` to restore the previous diagnostic error detail/log behavior if a hidden operational dependency is found.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\qr_queue.py`; static `rg` scan for removed leakage strings; `git diff --check`; `TESTING=1 ALLOW_SQLITE_DATABASE_URL=1 DATABASE_URL=sqlite:///:memory: SECRET_KEY=... python -m pytest backend\tests\architecture\test_w2c_queue_boundaries.py backend\tests\unit\test_qr_queue_service_allocator_boundary.py backend\tests\integration\test_qr_queue_join.py -q --tb=short --disable-warnings`.
- Result: passed; targeted queue tests reported 11 passed, 1 warning.
- Not checked: full backend suite, browser queue operator smoke, and live display-board behavior were not run for this one-block unexpected-error sanitization slice.