### PR TITLE
fix(security): hide telegram bot exception details

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_bot.py
+++ b/backend/app/api/v1/endpoints/telegram_bot.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 WEBHOOK_SECRET_HEADER = "x-telegram-bot-api-secret-token"
+INTERNAL_ERROR_DETAIL = "Internal server error"
 
 
 def _validate_webhook_secret(request: Request, db: Session) -> None:
@@ -65,8 +66,14 @@ async def telegram_webhook(request: Request, db: Session = Depends(get_db)):
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Telegram webhook error: {str(e)}")
-        return JSONResponse({"status": "error", "message": str(e)}, status_code=500)
+        logger.exception(
+            "Telegram webhook error",
+            extra={"error_class": e.__class__.__name__},
+        )
+        return JSONResponse(
+            {"status": "error", "message": INTERNAL_ERROR_DETAIL},
+            status_code=500,
+        )
 
 
 @router.post("/set-webhook")
@@ -112,8 +119,11 @@ async def set_telegram_webhook(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Set webhook error: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.exception(
+            "Set Telegram webhook error",
+            extra={"error_class": e.__class__.__name__},
+        )
+        raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)
 
 
 @router.delete("/webhook")
@@ -145,8 +155,11 @@ async def remove_telegram_webhook(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Remove webhook error: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.exception(
+            "Remove Telegram webhook error",
+            extra={"error_class": e.__class__.__name__},
+        )
+        raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)
 
 
 @router.get("/info")
@@ -187,8 +200,11 @@ async def get_bot_info(current_user: User = Depends(require_roles("Admin"))):
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Get bot info error: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.exception(
+            "Get Telegram bot info error",
+            extra={"error_class": e.__class__.__name__},
+        )
+        raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)
 
 
 @router.post("/send-notification")
@@ -219,8 +235,11 @@ async def send_telegram_notification(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Send notification error: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.exception(
+            "Send Telegram notification error",
+            extra={"error_class": e.__class__.__name__},
+        )
+        raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)
 
 
 @router.post("/send-appointment-reminder")
@@ -248,8 +267,11 @@ async def send_appointment_reminder(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Send reminder error: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.exception(
+            "Send Telegram reminder error",
+            extra={"error_class": e.__class__.__name__},
+        )
+        raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)
 
 
 @router.post("/send-lab-notification")
@@ -277,8 +299,11 @@ async def send_lab_results_notification(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Send lab notification error: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.exception(
+            "Send Telegram lab notification error",
+            extra={"error_class": e.__class__.__name__},
+        )
+        raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)
 
 
 @router.get("/stats")
@@ -304,5 +329,8 @@ async def get_telegram_stats(current_user: User = Depends(require_roles("Admin")
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Get telegram stats error: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.exception(
+            "Get Telegram stats error",
+            extra={"error_class": e.__class__.__name__},
+        )
+        raise HTTPException(status_code=500, detail=INTERNAL_ERROR_DETAIL)


### PR DESCRIPTION
﻿## Summary
- Hide raw exception text from active Telegram bot API 500 responses.
- Keep webhook secret validation, role gates, and existing success/status behavior unchanged.
- Replace public `str(e)` details with a constant generic error while logging the exception class for diagnostics.

## Contract Impact
- Canonical surface: `backend/app/api/v1/api.py` mounts `telegram_bot.router` at `/api/v1/telegram/bot`.
- Request shape: unchanged for webhook, webhook management, notification, reminder, lab notification, info, and stats routes.
- Response shape: unchanged keys for affected 500 paths; error message/detail value is sanitized to `Internal server error`.
- Status codes: unchanged; only existing 500 exception responses are sanitized.
- Frontend consumer: no frontend call shape changed; build was run to confirm no frontend contract break.
- Compatibility path or alias: no route, alias, or prefix changed.
- Contract proof: static scan confirms no `detail=str(e)` or `message=str(e)` remains in `telegram_bot.py`; py_compile passed.

## RBAC / Permissions
- Roles allowed: unchanged; existing `require_roles` dependencies remain intact.
- Roles denied: unchanged; no auth dependency, token, or permission logic was edited.
- Positive auth proof: existing route decorators/dependencies remain untouched in diff.
- Negative auth proof: no bypass path was added; validation included existing Telegram webhook security tests.

## Notification / Realtime
- Event type or websocket channel: Telegram bot send/reminder/lab notification flow names are unchanged.
- Payload version / ack behavior: webhook success ack remains `{"status":"ok"}`; 500 error body no longer exposes exception text.
- Read/unread or delivery semantics: not applicable because this patch only changes failed HTTP error disclosure.
- Reconnect/resync proof: not applicable because no websocket or retry transport behavior changed.

## Frontend Resilience
- Empty data proof: not applicable because no frontend rendering or empty-state handling changed.
- Partial data proof: not applicable because no frontend data contract fields were removed from successful responses.
- Forbidden secondary path behavior: unchanged; role guards and webhook secret failures are untouched.
- Missing draft/resource behavior: unchanged; only unexpected 500 error text changed.
- Stale route/deep-link behavior: unchanged; no route or client navigation path changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/telegram_bot.py`.
- Denied paths: no frontend files, DB migrations, docs, MCP configs, agent configs, or other Telegram files edited.
- Migration/docs/test impact: no migration or docs required; existing targeted tests and build run.
- Rollback note: revert commit `2389f068` to restore previous public raw exception behavior if needed.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/telegram_bot.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `rg -n 'detail=str\(e\)|"message": str\(e\)|logger\.error\(f' backend/app/api/v1/endpoints/telegram_bot.py`; `git diff --check`; `python -m pytest backend/tests/unit/test_telegram_webhook_security.py -q`; `cd frontend && npm.cmd run build`.
- Result: all validation passed; rg returned no matches; frontend build completed with existing Vite chunk/import warnings.
- Not checked: live Telegram API calls and end-to-end bot delivery were not run.
