### PR TITLE
docs(security): redact API documentation password examples

### DIFF
--- a/backend/app/api/v1/endpoints/api_documentation.py
+++ b/backend/app/api/v1/endpoints/api_documentation.py
@@ -36,7 +36,7 @@ async def get_detailed_endpoints_documentation(
                             "password": {
                                 "type": "string",
                                 "required": True,
-                                "example": "admin123",
+                                "example": "REPLACE_WITH_ADMIN_PASSWORD",
                             },
                         },
                     },
@@ -144,7 +144,7 @@ async def get_detailed_endpoints_documentation(
                             "password": {
                                 "type": "string",
                                 "required": True,
-                                "example": "password123",
+                                "example": "REPLACE_WITH_USER_PASSWORD",
                             },
                             "role": {
                                 "type": "string",
@@ -569,13 +569,13 @@ async def get_api_examples(
     examples = {
         "authentication_examples": {
             "login": {
-                "curl": "curl -X POST 'http://localhost:18000/api/v1/auth/login' -H 'Content-Type: application/x-www-form-urlencoded' -d 'username=admin&password=admin123'",
+                "curl": "curl -X POST 'http://localhost:18000/api/v1/auth/login' -H 'Content-Type: application/x-www-form-urlencoded' -d 'username=admin&password=REPLACE_WITH_ADMIN_PASSWORD'",
                 "python": """
 import requests
 
 response = requests.post(
     'http://localhost:18000/api/v1/auth/login',
-    data={'username': 'admin', 'password': 'admin123'}
+    data={'username': 'admin', 'password': 'REPLACE_WITH_ADMIN_PASSWORD'}
 )
 token = response.json()['access_token']
                 """,
@@ -585,7 +585,7 @@ const response = await fetch('http://localhost:18000/api/v1/auth/login', {
     headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: 'username=admin&password=admin123'
+    body: 'username=admin&password=REPLACE_WITH_ADMIN_PASSWORD'
 });
 const data = await response.json();
 const token = data.access_token;

--- a/backend/app/api/v1/endpoints/docs.py
+++ b/backend/app/api/v1/endpoints/docs.py
@@ -44,7 +44,7 @@ async def get_api_docs():
             <div class="example">
                 {
                     "username": "admin",
-                    "password": "admin123"
+                    "password": "REPLACE_WITH_ADMIN_PASSWORD"
                 }
             </div>
         </div>

--- a/backend/app/services/api_documentation_api_service.py
+++ b/backend/app/services/api_documentation_api_service.py
@@ -35,7 +35,7 @@ async def get_detailed_endpoints_documentation(
                             "password": {
                                 "type": "string",
                                 "required": True,
-                                "example": "admin123",
+                                "example": "REPLACE_WITH_ADMIN_PASSWORD",
                             },
                         },
                     },
@@ -143,7 +143,7 @@ async def get_detailed_endpoints_documentation(
                             "password": {
                                 "type": "string",
                                 "required": True,
-                                "example": "password123",
+                                "example": "REPLACE_WITH_USER_PASSWORD",
                             },
                             "role": {
                                 "type": "string",
@@ -568,13 +568,13 @@ async def get_api_examples(
     examples = {
         "authentication_examples": {
             "login": {
-                "curl": "curl -X POST 'http://localhost:18000/api/v1/auth/login' -H 'Content-Type: application/x-www-form-urlencoded' -d 'username=admin&password=admin123'",
+                "curl": "curl -X POST 'http://localhost:18000/api/v1/auth/login' -H 'Content-Type: application/x-www-form-urlencoded' -d 'username=admin&password=REPLACE_WITH_ADMIN_PASSWORD'",
                 "python": """
 import requests
 
 response = requests.post(
     'http://localhost:18000/api/v1/auth/login',
-    data={'username': 'admin', 'password': 'admin123'}
+    data={'username': 'admin', 'password': 'REPLACE_WITH_ADMIN_PASSWORD'}
 )
 token = response.json()['access_token']
                 """,
@@ -584,7 +584,7 @@ const response = await fetch('http://localhost:18000/api/v1/auth/login', {
     headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: 'username=admin&password=admin123'
+    body: 'username=admin&password=REPLACE_WITH_ADMIN_PASSWORD'
 });
 const data = await response.json();
 const token = data.access_token;

--- a/backend/app/services/docs_api_service.py
+++ b/backend/app/services/docs_api_service.py
@@ -44,7 +44,7 @@ async def get_api_docs():
             <div class="example">
                 {
                     "username": "admin",
-                    "password": "admin123"
+                    "password": "REPLACE_WITH_ADMIN_PASSWORD"
                 }
             </div>
         </div>


### PR DESCRIPTION
﻿## What changed
Redacts concrete password examples from API documentation endpoint/service mirrors.

## Why
This PR was opened from the verified backup namespace after local branch preservation work. It represents committed local work that was not in origin/main and did not have a normal cloud branch anymore.

## Scope guardrails
- Base branch: main
- Head branch: $(@{Head=codex/backup-20260512-0554/codex/redact-api-documentation-password-examples; Title=docs(security): redact API documentation password examples; Summary=Redacts concrete password examples from API documentation endpoint/service mirrors.; Validation=Reviewed diff against origin/main; no runtime tests run for this backup PR.}.Head)
- Draft PR for review before merge
- No backend contracts, migrations, route architecture, or domain invariants were changed by this PR creation step

## Validation
Reviewed diff against origin/main; no runtime tests run for this backup PR.

## Notes
This PR was created from a backup branch. Please review the diff before marking ready for review.
