### PR TITLE
fix(security): guard print template file paths

### DIFF
--- a/backend/app/api/v1/endpoints/print_templates.py
+++ b/backend/app/api/v1/endpoints/print_templates.py
@@ -29,6 +29,67 @@ router = APIRouter()
 # Путь к шаблонам
 TEMPLATES_DIR = Path(__file__).parent.parent.parent / "templates" / "print"
 
+
+def _safe_template_type(value: str) -> str:
+    if value == "ticket":
+        return "ticket"
+    if value == "prescription":
+        return "prescription"
+    if value == "medical_certificate":
+        return "medical_certificate"
+    if value == "payment_receipt":
+        return "payment_receipt"
+    if value == "lab_results":
+        return "lab_results"
+    if value == "appointment_reminder":
+        return "appointment_reminder"
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Invalid template_type",
+    )
+
+
+def _safe_template_language(value: str) -> str:
+    if value == "ru":
+        return "ru"
+    if value == "uz":
+        return "uz"
+    if value == "en":
+        return "en"
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Invalid language",
+    )
+
+
+def _template_filename(template_type: str, language: str | None = None) -> str:
+    safe_template_type = _safe_template_type(template_type)
+    if language is None:
+        return f"{safe_template_type}.j2"
+
+    safe_language = _safe_template_language(language)
+    return f"{safe_template_type}_{safe_language}.j2"
+
+
+def _template_path(filename: str) -> Path:
+    safe_filename = os.path.basename(filename)
+    if safe_filename != filename:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid template path",
+        )
+
+    root = TEMPLATES_DIR.resolve()
+    candidate = (TEMPLATES_DIR / safe_filename).resolve()
+    if candidate.parent != root:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid template path",
+        )
+    return candidate
+
 # ===================== УПРАВЛЕНИЕ ШАБЛОНАМИ =====================
 
 
@@ -207,8 +268,8 @@ def upload_template_file(
         TEMPLATES_DIR.mkdir(parents=True, exist_ok=True)
 
         # Формируем имя файла
-        filename = f"{template_type}_{language}.j2"
-        file_path = TEMPLATES_DIR / filename
+        filename = _template_filename(template_type, language)
+        file_path = _template_path(filename)
 
         # Сохраняем файл
         content = file.file.read()
@@ -300,13 +361,13 @@ def get_default_template(
     Получить стандартный шаблон по типу
     """
     try:
-        filename = f"{template_type}_{language}.j2"
-        file_path = TEMPLATES_DIR / filename
+        filename = _template_filename(template_type, language)
+        file_path = _template_path(filename)
 
         # Если файл не найден, пробуем базовый шаблон
         if not file_path.exists():
-            filename = f"{template_type}.j2"
-            file_path = TEMPLATES_DIR / filename
+            filename = _template_filename(template_type)
+            file_path = _template_path(filename)
 
         if not file_path.exists():
             raise HTTPException(


### PR DESCRIPTION
﻿## Summary
- Restrict print template filesystem access to the endpoint's known template types and supported languages (`ru`, `uz`, `en`).
- Route upload writes and default-template reads through helpers that produce flat template filenames only.
- Add basename and resolved-path containment checks so template files cannot escape `TEMPLATES_DIR`.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/print_templates.py`.
- Request shape: Existing route and query parameter names are unchanged; unknown template types or unsupported languages now return 400 before path construction.
- Response shape: Existing successful response keys are unchanged.
- Status codes: Adds 400 for invalid `template_type` or `language`; existing 404/500 behavior remains.
- Frontend consumer: Existing consumers using documented template codes and `ru`/`uz`/`en` languages continue to work.
- Compatibility path or alias: Not applicable; no route alias changed.
- Contract proof: `python -m py_compile backend\app\api\v1\endpoints\print_templates.py` passed.

## RBAC / Permissions
- Roles allowed: Existing endpoint role dependencies are unchanged.
- Roles denied: Existing role denial remains owned by `require_roles`; not modified.
- Positive auth proof: Not checked; no auth dependency changed.
- Negative auth proof: Not checked; no auth dependency changed.

## Notification / Realtime
- Event type or websocket channel: Not applicable; no realtime path changed.
- Payload version / ack behavior: Not applicable; no notification payload changed.
- Read/unread or delivery semantics: Not applicable; no delivery state changed.
- Reconnect/resync proof: Not applicable; no websocket or resync path changed.

## Frontend Resilience
- Empty data proof: Not checked; backend-only path guard.
- Partial data proof: Helper harness verified normal `ticket`/`ru` and `medical_certificate`/`uz` components still produce expected filenames.
- Forbidden secondary path behavior: Helper harness verified `../../secret`, `../ticket`, `ru/junk`, unsupported language, custom template type, and direct `../secret.j2` path are rejected with HTTP 400.
- Missing draft/resource behavior: Not applicable; no draft/resource flow changed.
- Stale route/deep-link behavior: Not applicable; no frontend route changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/print_templates.py`.
- Denied paths: Frontend, database models, migrations, generated artifacts, and other upload handlers were not changed.
- Migration/docs/test impact: No migration or docs required; focused helper harness was run but not committed because the gate first-touch slice allowed only the endpoint file.
- Rollback note: Revert this PR to restore the previous direct filename construction from `template_type` and `language`.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\print_templates.py`; inline Python helper harness for valid and traversal components; `git diff --check -- backend\app\api\v1\endpoints\print_templates.py`.
- Result: All passed.
- Not checked: Full backend suite and live authenticated upload/read requests were not run.
