### PR TITLE
fix(security): avoid sensitive dermatology thumbnail log fields

### DIFF
--- a/backend/app/api/v1/endpoints/dermatology_photos.py
+++ b/backend/app/api/v1/endpoints/dermatology_photos.py
@@ -87,10 +87,7 @@ async def upload_photos(
                     img.save(thumbnail_path, "JPEG", quality=85)
             except Exception as exc:
                 logger.warning(
-                    "Dermatology photo thumbnail generation failed "
-                    "patient_id=%s user_id=%s error_type=%s",
-                    patient_id,
-                    getattr(current_user, "id", None),
+                    "Dermatology photo thumbnail generation failed error_type=%s",
                     type(exc).__name__,
                 )
                 thumbnail_path = None

--- a/backend/app/api/v1/endpoints/dermatology_photos.py
+++ b/backend/app/api/v1/endpoints/dermatology_photos.py
@@ -3,6 +3,7 @@ API endpoints для работы с фото в дерматологии
 Основа: passport.md стр. 1789-2063
 """
 
+import logging
 import os
 import uuid
 from datetime import datetime
@@ -19,6 +20,7 @@ from app.models.dermatology_photos import DermatologyPhoto
 from app.models.user import User
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 # Настройки для загрузки фото
 UPLOAD_DIR = "uploads/dermatology"
@@ -83,8 +85,14 @@ async def upload_photos(
                 with Image.open(file_path) as img:
                     img.thumbnail(THUMBNAIL_SIZE, Image.Resampling.LANCZOS)
                     img.save(thumbnail_path, "JPEG", quality=85)
-            except Exception as e:
-                print(f"Ошибка создания миниатюры: {e}")
+            except Exception as exc:
+                logger.warning(
+                    "Dermatology photo thumbnail generation failed "
+                    "patient_id=%s user_id=%s error_type=%s",
+                    patient_id,
+                    getattr(current_user, "id", None),
+                    type(exc).__name__,
+                )
                 thumbnail_path = None
 
             # Сохраняем в БД


### PR DESCRIPTION
﻿## What changed
Reduces sensitive thumbnail-related logging in the dermatology photos endpoint.

## Why
This PR was opened from the verified backup namespace after local branch preservation work. It represents committed local work that was not in origin/main and did not have a normal cloud branch anymore.

## Scope guardrails
- Base branch: main
- Head branch: $(@{Head=codex/backup-20260512-0554/codex/recovery-task26-dermatology-endpoint-logging; Title=fix(security): avoid sensitive dermatology thumbnail log fields; Summary=Reduces sensitive thumbnail-related logging in the dermatology photos endpoint.; Validation=Reviewed diff against origin/main; targeted endpoint tests not run yet.}.Head)
- Draft PR for review before merge
- No backend contracts, migrations, route architecture, or domain invariants were changed by this PR creation step

## Validation
Reviewed diff against origin/main; targeted endpoint tests not run yet.

## Notes
This PR was created from a backup branch. Please review the diff before marking ready for review.
