### PR TITLE
fix(billing): route Payme webhooks by account target

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -158,13 +158,18 @@ def require_roles(*roles: Any):
         if "registrar" in allowed_roles_lower and "receptionist" not in allowed_roles_lower:
             allowed_roles_lower.append("receptionist")
 
-        # ✅ DEBUG LOG: Explicitly log the mismatch
-        print(f"DEBUG: Checking roles for user {current_user.id} ({current_user.username})")
-        print(f"DEBUG: User Role: '{role_label}', Normalized: '{role_normalized}'")
-        print(f"DEBUG: Required Roles: {normalized_roles}, Normalized: {allowed_roles_lower}")
+        logger.debug(
+            "RBAC role check evaluated",
+            extra={
+                "required_role_count": len(normalized_roles),
+                "allowed_role_count": len(allowed_roles_lower),
+                "user_role": role_label or None,
+                "normalized_user_role": role_normalized or None,
+                "request_available": request is not None,
+            },
+        )
 
         if role_normalized not in allowed_roles_lower and role_lower not in allowed_roles_lower:
-            print(f"DEBUG: ACCESS DENIED for user {current_user.username}")
             # ✅ AUDIT LOG: Логируем попытку несанкционированного доступа
             from app.core.audit import log_critical_change
 
@@ -187,16 +192,27 @@ def require_roles(*roles: Any):
                 # ✅ FIX: Если request недоступен, логируем с предупреждением
                 audit_logger = logging.getLogger(__name__)
                 audit_logger.warning(
-                    f"SECURITY: require_roles: request context unavailable for user_id={current_user.id}, "
-                    f"roles={roles}, user_role={role}. Audit log may be incomplete."
+                    "ACCESS_DENIED audit request context unavailable",
+                    extra={
+                        "required_role_count": len(normalized_roles),
+                        "user_role": role_label or None,
+                    },
                 )
 
-            # ✅ DEBUG LOG: Explicitly log the mismatch
+            # Keep operational security logs non-identifying; the audit log below
+            # stores actor/resource context through the dedicated audit channel.
             audit_logger = logging.getLogger(__name__)
             audit_logger.error(
-                f"ACCESS DENIED DEBUG: User={current_user.username} (ID={current_user.id}), "
-                f"RoleInDB='{role}' (normalized='{role_lower}'), "
-                f"Required='{roles}' (normalized='{allowed_roles_lower}')"
+                "RBAC role check denied",
+                extra={
+                    "required_roles": list(normalized_roles),
+                    "allowed_roles": allowed_roles_lower,
+                    "user_role": role_label or None,
+                    "normalized_user_role": role_normalized or None,
+                    "resource_type": resource_type or "unknown",
+                    "resource_id_present": resource_id is not None,
+                    "request_available": request is not None,
+                },
             )
 
             # ✅ FIX: Всегда логируем 403, даже если request недоступен (для безопасности)
@@ -220,7 +236,11 @@ def require_roles(*roles: Any):
             except Exception as e:
                 # ✅ FIX: Если логирование не удалось, все равно выбрасываем 403
                 audit_logger = logging.getLogger(__name__)
-                audit_logger.error(f"Failed to log ACCESS_DENIED audit: {e}", exc_info=True)
+                audit_logger.error(
+                    "Failed to log ACCESS_DENIED audit",
+                    extra={"exception_type": type(e).__name__},
+                    exc_info=True,
+                )
 
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/app/services/payment_webhook.py
+++ b/backend/app/services/payment_webhook.py
@@ -24,7 +24,38 @@ logger = logging.getLogger(__name__)
 
 
 class PaymentWebhookService:
-    """Сервис для обработки вебхуков оплат"""
+    """Payment webhook processing service."""
+
+    @staticmethod
+    def _optional_int(value: Any) -> int | None:
+        if value in (None, ""):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _account_value(account: Any, key: str) -> Any:
+        if isinstance(account, dict):
+            return account.get(key)
+        return getattr(account, key, None)
+
+    @staticmethod
+    def _extract_payme_account_targets(
+        account: Any,
+    ) -> tuple[int | None, int | None]:
+        appointment_id = PaymentWebhookService._optional_int(
+            PaymentWebhookService._account_value(account, "appointment_id")
+        )
+        visit_id = PaymentWebhookService._optional_int(
+            PaymentWebhookService._account_value(account, "visit_id")
+        )
+        if appointment_id is None:
+            appointment_id = PaymentWebhookService._optional_int(
+                PaymentWebhookService._account_value(account, "order_id")
+            )
+        return appointment_id, visit_id
 
     @staticmethod
     def verify_payme_signature(
@@ -138,17 +169,20 @@ class PaymentWebhookService:
                     visit_id = None
 
                     if hasattr(webhook_data, "account") and webhook_data.account:
-                        # Пытаемся найти appointment_id или visit_id в account данных
-                        if hasattr(webhook_data.account, "appointment_id"):
-                            appointment_id = int(webhook_data.account.appointment_id)
-                        elif hasattr(webhook_data.account, "visit_id"):
-                            visit_id = int(webhook_data.account.visit_id)
-                        elif hasattr(webhook_data.account, "order_id"):
-                            # Если есть order_id, пытаемся интерпретировать как appointment_id
-                            try:
-                                appointment_id = int(webhook_data.account.order_id)
-                            except (ValueError, TypeError):
-                                pass
+                        appointment_id, visit_id = (
+                            PaymentWebhookService._extract_payme_account_targets(
+                                webhook_data.account
+                            )
+                        )
+                        logger.info(
+                            "[FIX:PAYME_ACCOUNT_TARGETS] Extracted Payme account targets",
+                            extra={
+                                "payment_provider": "payme",
+                                "webhook_record_id": webhook.id,
+                                "has_appointment_target": appointment_id is not None,
+                                "has_visit_target": visit_id is not None,
+                            },
+                        )
 
                     # Приоритет: сначала ищем appointment_id, потом visit_id
                     if appointment_id:

--- a/backend/tests/unit/test_payment_webhook_service.py
+++ b/backend/tests/unit/test_payment_webhook_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -66,3 +66,74 @@ class TestPaymentWebhookService:
         assert summary["transactions"]["total"] == 20
         assert summary["transactions"]["successful"] == 2
         assert summary["transactions"]["failed"] == 1
+
+    @pytest.mark.parametrize(
+        ("account", "expected_appointment_id", "expected_visit_id"),
+        [
+            ({"appointment_id": "123"}, 123, None),
+            ({"order_id": "456"}, 456, None),
+            ({"visit_id": "789"}, None, 789),
+        ],
+    )
+    def test_payme_webhook_extracts_dict_account_targets(
+        self,
+        db_session,
+        account,
+        expected_appointment_id,
+        expected_visit_id,
+    ):
+        webhook = SimpleNamespace(id=99)
+        repository = SimpleNamespace(
+            get_provider_by_code=Mock(return_value=SimpleNamespace(secret_key="secret")),
+            get_webhook_by_webhook_id=Mock(return_value=None),
+            create_webhook=Mock(return_value=webhook),
+            create_transaction=Mock(return_value=SimpleNamespace(id=100)),
+            update_webhook=Mock(return_value=webhook),
+        )
+        data = {
+            "id": "payme-tx-1",
+            "state": 2,
+            "amount": 250000,
+            "account": account,
+        }
+
+        with (
+            patch(
+                "app.services.payment_webhook.PaymentWebhookProcessingRepository",
+                return_value=repository,
+            ),
+            patch.object(
+                PaymentWebhookService, "verify_payme_signature", return_value=True
+            ),
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_appointment",
+                return_value=(True, "appointment paid"),
+            ) as process_appointment,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_existing_visit",
+                return_value=(True, "visit paid"),
+            ) as process_visit,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.create_appointment_from_payment",
+                return_value=(True, "created", 501),
+            ) as create_appointment,
+        ):
+            success, message, result_webhook = PaymentWebhookService.process_payme_webhook(
+                db_session, data, "signature"
+            )
+
+        assert success is True
+        assert message == "Webhook processed successfully"
+        assert result_webhook is webhook
+        create_appointment.assert_not_called()
+
+        if expected_appointment_id is not None:
+            process_appointment.assert_called_once_with(
+                db_session, expected_appointment_id, webhook
+            )
+            process_visit.assert_not_called()
+        else:
+            process_visit.assert_called_once_with(
+                db_session, expected_visit_id, webhook
+            )
+            process_appointment.assert_not_called()


### PR DESCRIPTION
﻿## What changed
Adds a clean billing/security slice for Payme webhook target routing with unit coverage changes.

## Why
This PR was opened from the verified backup namespace after local branch preservation work. It represents committed local work that was not in origin/main and did not have a normal cloud branch anymore.

## Scope guardrails
- Base branch: main
- Head branch: $(@{Head=codex/backup-20260512-0554/codex/recovery-task26-core-security-clean; Title=fix(billing): route Payme webhooks by account target; Summary=Adds a clean billing/security slice for Payme webhook target routing with unit coverage changes.; Validation=Reviewed diff against origin/main; payment webhook unit tests not run yet.}.Head)
- Draft PR for review before merge
- No backend contracts, migrations, route architecture, or domain invariants were changed by this PR creation step

## Validation
Reviewed diff against origin/main; payment webhook unit tests not run yet.

## Notes
This PR was created from a backup branch. Please review the diff before marking ready for review.
