### PR TITLE
fix(security): hide 2fa endpoint exception details

### DIFF
--- a/backend/app/api/v1/endpoints/two_factor_auth.py
+++ b/backend/app/api/v1/endpoints/two_factor_auth.py
@@ -3,7 +3,8 @@ API endpoints для двухфакторной аутентификации (2F
 """
 
 from datetime import datetime, timedelta
-from typing import List, Optional
+import logging
+from typing import List, NoReturn, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Request, status
 from sqlalchemy.orm import Session
@@ -38,6 +39,19 @@ from app.services.two_factor_service import get_two_factor_service, TwoFactorSer
 from app.services.two_factor_auth_api_service import TwoFactorAuthApiService
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+def raise_two_factor_internal_error(action: str, exc: Exception) -> NoReturn:
+    logger.warning(
+        "2FA endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=f"Error {action}",
+    )
 
 
 def get_client_info(request: Request) -> tuple[str, str]:
@@ -57,10 +71,7 @@ async def get_two_factor_status(
         status_data = service.get_two_factor_status(db, current_user.id)
         return TwoFactorStatusResponse(**status_data)
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error getting 2FA status: {str(e)}",
-        )
+        raise_two_factor_internal_error("getting 2FA status", e)
 
 
 @router.post("/setup", response_model=TwoFactorSetupResponse)
@@ -94,10 +105,7 @@ async def setup_two_factor_auth(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error setting up 2FA: {str(e)}",
-        )
+        raise_two_factor_internal_error("setting up 2FA", e)
 
 
 @router.post("/verify-setup", response_model=TwoFactorVerifyResponse)
@@ -128,10 +136,7 @@ async def verify_totp_setup(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error verifying TOTP setup: {str(e)}",
-        )
+        raise_two_factor_internal_error("verifying TOTP setup", e)
 
 
 @router.post("/verify", response_model=TwoFactorVerifyResponse)
@@ -241,10 +246,7 @@ async def verify_two_factor(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error verifying 2FA: {str(e)}",
-        )
+        raise_two_factor_internal_error("verifying 2FA", e)
 
 
 @router.post("/disable", response_model=TwoFactorSuccessResponse)
@@ -278,10 +280,7 @@ async def disable_two_factor_auth(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error disabling 2FA: {str(e)}",
-        )
+        raise_two_factor_internal_error("disabling 2FA", e)
 
 
 @router.post("/recovery/request", response_model=TwoFactorRecoveryResponse)
@@ -337,10 +336,7 @@ async def request_two_factor_recovery(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error requesting 2FA recovery: {str(e)}",
-        )
+        raise_two_factor_internal_error("requesting 2FA recovery", e)
 
 
 @router.post("/recovery/verify", response_model=TwoFactorVerifyResponse)
@@ -375,10 +371,7 @@ async def verify_two_factor_recovery(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error verifying 2FA recovery: {str(e)}",
-        )
+        raise_two_factor_internal_error("verifying 2FA recovery", e)
 
 
 @router.get("/backup-codes", response_model=TwoFactorBackupCodesResponse)
@@ -408,10 +401,7 @@ async def get_backup_codes(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error getting backup codes: {str(e)}",
-        )
+        raise_two_factor_internal_error("getting backup codes", e)
 
 
 @router.post("/backup-codes/regenerate", response_model=TwoFactorBackupCodesResponse)
@@ -442,10 +432,7 @@ async def regenerate_backup_codes(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error regenerating backup codes: {str(e)}",
-        )
+        raise_two_factor_internal_error("regenerating backup codes", e)
 
 
 @router.get("/devices", response_model=TwoFactorDeviceListResponse, include_in_schema=False)
@@ -458,10 +445,7 @@ async def get_trusted_devices(
         return TwoFactorDeviceListResponse(devices=devices, total=len(devices))
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error getting trusted devices: {str(e)}",
-        )
+        raise_two_factor_internal_error("getting trusted devices", e)
 
 
 @router.delete("/devices/{device_id}")
@@ -493,10 +477,7 @@ async def untrust_device(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error untrusting device: {str(e)}",
-        )
+        raise_two_factor_internal_error("untrusting device", e)
 
 
 @router.get("/health")


### PR DESCRIPTION
﻿## Summary
- Hide raw exception text from 2FA endpoint unexpected 500 responses.
- Add one endpoint-local helper that logs only action and exception type.
- Preserve all explicit `HTTPException` paths, 2FA auth flow, response models, and status codes.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/two_factor_auth.py` under existing `/api/v1/2fa` routes.
- Request shape: unchanged for status, setup, verify, disable, recovery, backup-code, and trusted-device endpoints.
- Response shape: unchanged for successful and explicit client-error paths; unexpected 500 detail no longer includes exception text.
- Status codes: unchanged; only existing unexpected 500 payload detail is sanitized.
- Frontend consumer: no frontend contract or route changed.
- Compatibility path or alias: no path, alias, or router registration changed.
- Contract proof: `py_compile` passed and static scan found no `str(e)`, traceback, or print leakage in the endpoint.

## RBAC / Permissions
- Roles allowed: unchanged; existing dependencies and current-user requirements were not edited.
- Roles denied: unchanged; no auth bypass, token parsing, or role check behavior changed.
- Positive auth proof: existing 2FA enforcement tests still pass.
- Negative auth proof: explicit `HTTPException` branches still re-raise unchanged; targeted 2FA/security tests passed.

## Notification / Realtime
- Event type or websocket channel: not applicable because this patch does not touch notifications or realtime paths.
- Payload version / ack behavior: not applicable because no event payload or ack behavior changed.
- Read/unread or delivery semantics: not applicable because no delivery state changed.
- Reconnect/resync proof: not applicable because no websocket/reconnect behavior changed.

## Frontend Resilience
- Empty data proof: not applicable because no frontend data rendering changed.
- Partial data proof: not applicable because successful response fields are unchanged.
- Forbidden secondary path behavior: unchanged; auth and explicit HTTP errors still behave as before.
- Missing draft/resource behavior: unchanged; only unexpected 500 detail text is sanitized.
- Stale route/deep-link behavior: unchanged; no frontend route changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/two_factor_auth.py`.
- Denied paths: no service, schema, frontend, migration, docs, MCP, or agent config files edited.
- Migration/docs/test impact: no migration or docs required; targeted tests run.
- Rollback note: revert commit `ee6fabe7` to restore previous exception-detail behavior.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/two_factor_auth.py`; `rg -n 'str\\(e\\)|str\\(exc\\)|traceback\\.format_exc|print\\(' backend/app/api/v1/endpoints/two_factor_auth.py`; `git diff --check`; `DATABASE_URL=sqlite:///./test_2fa_validation.db ALLOW_SQLITE_DATABASE_URL=1 python -m pytest backend/tests/test_2fa_enforcement.py backend/tests/unit/test_two_factor_auth_api_service.py -q`.
- Result: all validation passed; pytest reported 10 passed, 1 warning. Initial pytest without DATABASE_URL failed before loading tests, then passed with explicit test DB env.
- Not checked: live 2FA login against a running backend was not run.
