### PR TITLE
fix(security): hide 2fa sms email error details

### DIFF
--- a/backend/app/api/v1/endpoints/two_factor_sms_email.py
+++ b/backend/app/api/v1/endpoints/two_factor_sms_email.py
@@ -5,7 +5,8 @@ API endpoints для SMS/Email двухфакторной аутентифика
 import random
 import string
 from datetime import datetime, timedelta
-from typing import Optional
+import logging
+from typing import NoReturn, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
@@ -18,6 +19,25 @@ from app.services.sms_providers import get_sms_manager, SMSProviderType
 from app.services.two_factor_service import get_two_factor_service, TwoFactorService
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+def get_safe_two_factor_method(method: str) -> str:
+    return method if method in {"sms", "email"} else "unknown"
+
+
+def raise_two_factor_sms_internal_error(
+    action: str, public_detail: str, exc: Exception
+) -> NoReturn:
+    logger.warning(
+        "2FA SMS/email endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=public_detail,
+    )
 
 
 @router.post("/send-code")
@@ -63,9 +83,14 @@ async def send_verification_code(
         )
 
         if not result["success"]:
+            safe_method = get_safe_two_factor_method(method)
+            logger.warning(
+                "2FA SMS/email provider send failed method=%s",
+                safe_method,
+            )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Ошибка отправки {method.upper()}: {result.get('error', 'Unknown error')}",
+                detail=f"Ошибка отправки {safe_method.upper()}",
             )
 
         return {
@@ -78,10 +103,7 @@ async def send_verification_code(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки кода: {str(e)}",
-        )
+        raise_two_factor_sms_internal_error("send-code", "Ошибка отправки кода", e)
 
 
 @router.post("/verify-code")
@@ -123,10 +145,7 @@ async def verify_verification_code(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка проверки кода: {str(e)}",
-        )
+        raise_two_factor_sms_internal_error("verify-code", "Ошибка проверки кода", e)
 
 
 @router.get("/verification-status")
@@ -146,9 +165,8 @@ async def get_verification_status(
         return status
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статуса: {str(e)}",
+        raise_two_factor_sms_internal_error(
+            "verification-status", "Ошибка получения статуса", e
         )
 
 
@@ -223,9 +241,8 @@ async def resend_verification_code(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка повторной отправки: {str(e)}",
+        raise_two_factor_sms_internal_error(
+            "resend-code", "Ошибка повторной отправки", e
         )
 
 
@@ -277,9 +294,8 @@ async def get_security_logs(
         return {"logs": logs, "total": len(logs), "limit": limit, "offset": offset}
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения журнала: {str(e)}",
+        raise_two_factor_sms_internal_error(
+            "security-logs", "Ошибка получения журнала", e
         )
 
 
@@ -296,7 +312,6 @@ async def get_recovery_methods(
         return {"methods": methods}
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения методов восстановления: {str(e)}",
+        raise_two_factor_sms_internal_error(
+            "recovery-methods", "Ошибка получения методов восстановления", e
         )


### PR DESCRIPTION
## Summary
- Sanitize 2FA SMS/email endpoint internal exception details before they reach public HTTP responses.
- Remove provider raw error text from send-code failures.
- Add structured non-sensitive warning logs with action, error class, and normalized method only.

## Contract Impact
- Canonical surface: POST /api/v1/2fa/send-code, POST /api/v1/2fa/verify-code, GET /api/v1/2fa/verification-status, POST /api/v1/2fa/resend-code, GET /api/v1/2fa/security-logs, GET /api/v1/2fa/recovery-methods.
- Request shape: unchanged authenticated requests with the same query parameters.
- Response shape: unchanged success payloads; failure detail text is intentionally generic on internal/provider errors.
- Status codes: unchanged for documented success, bad request, rate limit, and internal error paths.
- Frontend consumer: existing 2FA SMS/email UI/API clients continue to consume the same endpoint shapes.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: targeted endpoint smoke covered service exception and provider failure redaction without changing endpoint shape.

## RBAC / Permissions
- Roles allowed: unchanged - existing get_current_user authenticated-user dependency remains the guard.
- Roles denied: unchanged - unauthenticated requests remain denied by the existing dependency path; no role matrix was changed.
- Positive auth proof: targeted endpoint smoke exercised the redaction paths with authenticated dependency context.
- Negative auth proof: not applicable - no auth dependency, role guard, or permission decision changed in this PR.

## Notification / Realtime
- Event type or websocket channel: not applicable - no websocket, realtime event, or channel changed.
- Payload version / ack behavior: not applicable - no event payload or ack contract changed.
- Read/unread or delivery semantics: unchanged SMS/email delivery path; only provider/internal failure text is redacted.
- Reconnect/resync proof: not applicable - no realtime reconnect or resync behavior exists in this patch.

## Frontend Resilience
- Empty data proof: not applicable - no frontend data list or empty state changed.
- Partial data proof: not applicable - no frontend partial data rendering changed.
- Forbidden secondary path behavior: not applicable - no secondary frontend route or forbidden path changed.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link behavior changed.

## Scope Gate
- Allowed paths: backend/app/api/v1/endpoints/two_factor_sms_email.py.
- Denied paths: frontend runtime, migrations, payment, queue, Telegram, generated output, and unrelated 2FA modules.
- Migration/docs/test impact: no migration; no docs change; validation is targeted compile, redaction search, smoke, and diff check.
- Rollback note: revert the single endpoint file change to restore previous public error text behavior.

## Validation
- Targeted tests or smoke run: python -m py_compile backend\\app\\api\\v1\\endpoints\\two_factor_sms_email.py; rg no-match for raw str(e)/provider error patterns in two_factor_sms_email.py; direct endpoint smoke for service exception and provider failure redaction; git diff --check.
- Result: Local compile, redaction search, direct endpoint smoke, and diff check passed before publish; GitHub checks are being watched after the PR body fix.
- Not checked: Live SMS/email provider delivery with production credentials, full browser E2E, production deploy.