### PR TITLE
fix(security): guard chat download file paths

### DIFF
--- a/backend/app/services/messages_api_service.py
+++ b/backend/app/services/messages_api_service.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import os
+import re
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 from fastapi import HTTPException, UploadFile
@@ -21,6 +23,38 @@ from app.models.user import User
 from app.repositories.messages_api_repository import MessagesApiRepository
 from app.schemas.message import ConversationOut, MessageCreate, MessageOut
 from app.services.notifications import notification_sender_service
+
+CHAT_UPLOAD_DIR = Path("uploads/chat")
+CHAT_STORAGE_FILENAME_RE = re.compile(r"^\d{8}_\d{6}_.+$")
+
+
+def _safe_chat_storage_filename(filename: str) -> str:
+    if not filename or filename != filename.strip():
+        raise HTTPException(status_code=400, detail="Недопустимое имя файла")
+    if "/" in filename or "\\" in filename or os.path.basename(filename) != filename:
+        raise HTTPException(status_code=400, detail="Недопустимое имя файла")
+    if any(ord(char) < 32 for char in filename):
+        raise HTTPException(status_code=400, detail="Недопустимое имя файла")
+    if not CHAT_STORAGE_FILENAME_RE.fullmatch(filename):
+        raise HTTPException(status_code=400, detail="Недопустимое имя файла")
+    return filename
+
+
+def _find_chat_upload_file(filename: str) -> Path:
+    safe_filename = _safe_chat_storage_filename(filename)
+    upload_root = CHAT_UPLOAD_DIR.resolve()
+
+    if not upload_root.exists():
+        raise HTTPException(status_code=404, detail="Файл не найден")
+
+    for upload_path in upload_root.iterdir():
+        resolved_path = upload_path.resolve()
+        if resolved_path.parent != upload_root or not resolved_path.is_file():
+            continue
+        if upload_path.name == safe_filename:
+            return resolved_path
+
+    raise HTTPException(status_code=404, detail="Файл не найден")
 
 
 class MessagesApiService:
@@ -745,11 +779,7 @@ async def download_chat_file(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    filename = os.path.basename(filename)
-    file_path = os.path.join("uploads/chat", filename)
-    if not os.path.exists(file_path):
-        raise HTTPException(status_code=404, detail="Файл не найден")
-
+    filename = _safe_chat_storage_filename(filename)
     file_record = db.query(FileModel).filter(FileModel.filename == filename).first()
     if file_record:
         message = db.query(Message).filter(Message.file_id == file_record.id).first()
@@ -766,6 +796,7 @@ async def download_chat_file(
     ):
         raise HTTPException(status_code=403, detail="Нет доступа к этому файлу")
 
-    return FileResponse(path=file_path, filename=name or filename)
+    file_path = _find_chat_upload_file(filename)
+    return FileResponse(path=str(file_path), filename=name or file_path.name)
 
 


### PR DESCRIPTION
## Summary

- Fixes CodeQL path-injection alerts #239-#240 for chat file downloads.
- Stops building `uploads/chat` filesystem paths directly from the route `filename` parameter.
- Validates generated chat storage filenames, checks resolved containment, and serves only files found inside the chat upload directory.

## Contract Impact

- Canonical surface: `backend/app/services/messages_api_service.py` `/messages/download/{filename}` route and chat upload storage filename contract.
- Request shape: unchanged route parameter `filename`; now only generated `YYYYMMDD_HHMMSS_<original-name>` storage names are accepted.
- Response shape: unchanged `FileResponse` for authorized downloads.
- Status codes: invalid storage filenames return 400; authorized missing files return 404; unauthorized or unlinked files still return 403 before serving.
- Frontend consumer: unchanged download URL shape produced by `upload_file_message`.
- Compatibility path or alias: not applicable - no route alias changed.
- Contract proof: focused helper harness accepted a generated chat filename and rejected traversal, nested paths, non-chat names, control characters, malformed generated names, and missing safe names.

## RBAC / Permissions

- Roles allowed: unchanged authenticated sender or recipient of the message.
- Roles denied: unchanged users who are neither sender nor recipient.
- Positive auth proof: not checked - no auth dependency or permission logic changed.
- Negative auth proof: code path still raises 403 before `FileResponse` when the current user is not sender or recipient.

## Notification / Realtime

not applicable - no notification, websocket, chat event, or realtime delivery behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend panel changed.
- Partial data proof: not applicable - no frontend data rendering changed.
- Forbidden secondary path behavior: invalid path-like filenames are rejected before filesystem lookup.
- Missing draft/resource behavior: safe generated names missing from disk return 404 after authorization checks.
- Stale route/deep-link behavior: stale malformed download links fail closed with 400.

## Scope Gate

- Allowed paths: `backend/app/services/messages_api_service.py`.
- Denied paths: no frontend route files, DB schema, migrations, docs, or generated artifacts changed.
- Migration/docs/test impact: no migration needed; no test file added because the first patch slice stayed inside the service file.
- Rollback note: revert this commit to restore previous download filename handling.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\\app\\services\\messages_api_service.py`; focused inline helper harness; `git diff --check -- backend\\app\\services\\messages_api_service.py`; `cd frontend && npm.cmd run build`.
- Result: all passed. Frontend build emitted existing Vite chunk/dynamic-import warnings only.
- Not checked: full backend suite and browser-level chat download flow were not run for this narrow CodeQL slice.
