### PR TITLE
fix(security): hide chat upload exception details

### DIFF
--- a/backend/app/services/messages_api_service.py
+++ b/backend/app/services/messages_api_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import logging
 import os
 import re
 from datetime import datetime
@@ -26,6 +27,7 @@ from app.services.notifications import notification_sender_service
 
 CHAT_UPLOAD_DIR = Path("uploads/chat")
 CHAT_STORAGE_FILENAME_RE = re.compile(r"^\d{8}_\d{6}_.+$")
+logger = logging.getLogger(__name__)
 
 
 def _safe_chat_storage_filename(filename: str) -> str:
@@ -769,7 +771,11 @@ async def upload_file_message(
     except HTTPException:
         raise
     except Exception as exc:  # noqa: BLE001
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        logger.warning(
+            "Chat file upload endpoint failed error_type=%s",
+            type(exc).__name__,
+        )
+        raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
 @router.get("/download/{filename}")


### PR DESCRIPTION
## Summary
- Hide raw exception details from the chat file upload endpoint public 500 response.
- Add a non-sensitive structured warning log with exception class only.
- Preserve existing upload behavior and existing HTTPException passthrough behavior.

## Contract Impact
- Canonical surface: `POST /api/v1/messages/upload` implemented in `backend/app/services/messages_api_service.py`.
- Request shape: unchanged multipart upload fields and auth dependency.
- Response shape: success response unchanged; unexpected 500 detail becomes generic.
- Status codes: unchanged; unexpected exceptions still return 500.
- Frontend consumer: existing chat upload UI/API clients keep the same endpoint and success shape.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: focused diff keeps the upload service call and HTTPException passthrough unchanged.

## RBAC / Permissions
- Roles allowed: unchanged existing authenticated current-user dependency remains the guard.
- Roles denied: unchanged unauthenticated requests remain denied by the existing dependency path.
- Positive auth proof: not checked - no auth dependency or permission logic changed.
- Negative auth proof: not checked - no auth dependency or permission logic changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, chat event, or realtime delivery behavior changed.
- Payload version / ack behavior: not applicable - no event payload or ack contract changed.
- Read/unread or delivery semantics: unchanged upload notification behavior inside the service layer.
- Reconnect/resync proof: not applicable - no realtime reconnect or resync behavior changed.

## Frontend Resilience
- Empty data proof: not applicable - no frontend data list or empty state changed.
- Partial data proof: not applicable - no frontend partial data rendering changed.
- Forbidden secondary path behavior: unchanged existing upload/auth behavior remains server-side.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/app/services/messages_api_service.py`.
- Denied paths: frontend runtime, migrations, payment, queue, Telegram, AI Factory config, generated output, unrelated message flows.
- Migration/docs/test impact: no migration; no docs change; targeted compile/search/diff validation only.
- Rollback note: revert this commit to restore previous raw exception detail behavior.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\\app\\services\\messages_api_service.py`; `rg` no-match for raw `detail=str(...)` and f-string logger leaks in the file; `git diff --check`.
- Result: passed.
- Not checked: full backend suite, browser chat upload flow, production upload storage.