### PR TITLE
fix(security): hide integration error details

### DIFF
--- a/backend/app/services/integrations_api_service.py
+++ b/backend/app/services/integrations_api_service.py
@@ -78,7 +78,7 @@ def _map_gateway_error(error: Exception) -> HTTPException:
         )
         return HTTPException(status_code=503, detail=detail)
 
-    return HTTPException(status_code=500, detail=str(error))
+    return HTTPException(status_code=500, detail="Internal server error")
 
 
 # ===================== ОБЩИЕ =====================

--- a/backend/tests/unit/test_integrations_api_error_mapping.py
+++ b/backend/tests/unit/test_integrations_api_error_mapping.py
@@ -65,7 +65,7 @@ def test_map_gateway_error_for_unknown_capability_uses_fallback_message() -> Non
 
 
 def test_map_gateway_error_for_generic_error_returns_500() -> None:
-    mapped = _map_gateway_error(RuntimeError("boom"))
+    mapped = _map_gateway_error(RuntimeError("boom secret-token=abc123"))
 
     assert mapped.status_code == 500
-    assert mapped.detail == "boom"
+    assert mapped.detail == "Internal server error"


### PR DESCRIPTION
## Summary

- Hide generic integration gateway exception messages behind a stable public 500 detail.
- Update the focused error-mapping unit test so secret-like exception text is not exposed.

## Contract Impact

- Canonical surface: integrations API error mapping helper used by `/api/v1/integrations/*` compatibility endpoints.
- Request shape: unchanged.
- Response shape: generic unexpected integration failures now return stable `Internal server error` detail instead of raw exception text.
- Status codes: unchanged; generic failures remain 500, integration unavailable/capability failures remain 503.
- Frontend consumer: not applicable - no frontend files or response parsing logic changed.
- Compatibility path or alias: existing `app/api/v1/endpoints/integrations.py` shim remains unchanged.
- Contract proof: targeted unit test covers generic 500 detail and existing 503 mappings.

## RBAC / Permissions

- Roles allowed: unchanged; endpoint-level `deps.require_roles(...)` checks are untouched.
- Roles denied: unchanged; no auth or RBAC code changed.
- Positive auth proof: not applicable - this patch changes only the helper returned after endpoint auth succeeds.
- Negative auth proof: not applicable - this patch does not alter authorization branches.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend state or data rendering changed.
- Partial data proof: not applicable - no frontend state or data rendering changed.
- Forbidden secondary path behavior: not applicable - no secondary path behavior changed.
- Missing draft/resource behavior: not applicable - integrations error mapping does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/services/integrations_api_service.py`, `backend/tests/unit/test_integrations_api_error_mapping.py`.
- Denied paths: endpoint routing, RBAC dependencies, frontend consumers, migrations, generated output.
- Migration/docs/test impact: no migration or docs change; targeted unit test updated.
- Rollback note: revert the helper detail change and the matching test expectation.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\services\integrations_api_service.py`; `rg -n detail=str\((error|exc|e)\) backend\app\services\integrations_api_service.py backend\tests\unit\test_integrations_api_error_mapping.py`; `DATABASE_URL=<test-postgres-url> python -m pytest backend\tests\unit\test_integrations_api_error_mapping.py`.
- Result: py_compile passed; grep found no old `detail=str(...)` pattern in the touched files; targeted pytest passed with 8 tests.
- Not checked: full backend suite and live external integration smoke were not run for this narrow helper-only change.