### PR TITLE
fix(security): hide report endpoint error details

### DIFF
--- a/backend/app/api/v1/endpoints/reports.py
+++ b/backend/app/api/v1/endpoints/reports.py
@@ -4,7 +4,7 @@ API endpoints для системы отчетов
 
 import logging
 from datetime import date, datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, NoReturn, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -18,6 +18,21 @@ from app.services.reporting_service import get_reporting_service, ReportingServi
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def raise_report_internal_error(
+    action: str, public_detail: str, exc: Exception
+) -> NoReturn:
+    logger.warning(
+        "Report endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(status_code=500, detail=public_detail)
+
+
+def log_report_service_error(report_type: str) -> None:
+    logger.warning("Report service returned error report_type=%s", report_type)
 
 
 # ===================== PYDANTIC MODELS =====================
@@ -112,12 +127,13 @@ async def generate_patient_report(
         )
 
         if "error" in result:
+            log_report_service_error("patient_report")
             return ReportResponse(
                 success=False,
                 report_type="patient_report",
                 generated_at=datetime.now().isoformat(),
                 format=request.format,
-                error=result["error"],
+                error="Ошибка генерации отчета по пациентам",
             )
 
         return ReportResponse(
@@ -132,8 +148,9 @@ async def generate_patient_report(
         )
 
     except Exception as e:
-        logger.error(f"Ошибка генерации отчета по пациентам: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_report_internal_error(
+            "patient-report", "Ошибка генерации отчета по пациентам", e
+        )
 
 
 @router.post("/appointments", response_model=ReportResponse)
@@ -156,12 +173,13 @@ async def generate_appointments_report(
         )
 
         if "error" in result:
+            log_report_service_error("appointments_report")
             return ReportResponse(
                 success=False,
                 report_type="appointments_report",
                 generated_at=datetime.now().isoformat(),
                 format=request.format,
-                error=result["error"],
+                error="Ошибка генерации отчета по записям",
             )
 
         return ReportResponse(
@@ -176,8 +194,9 @@ async def generate_appointments_report(
         )
 
     except Exception as e:
-        logger.error(f"Ошибка генерации отчета по записям: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_report_internal_error(
+            "appointments-report", "Ошибка генерации отчета по записям", e
+        )
 
 
 @router.post("/financial", response_model=ReportResponse)
@@ -199,12 +218,13 @@ async def generate_financial_report(
         )
 
         if "error" in result:
+            log_report_service_error("financial_report")
             return ReportResponse(
                 success=False,
                 report_type="financial_report",
                 generated_at=datetime.now().isoformat(),
                 format=request.format,
-                error=result["error"],
+                error="Ошибка генерации финансового отчета",
             )
 
         return ReportResponse(
@@ -219,8 +239,9 @@ async def generate_financial_report(
         )
 
     except Exception as e:
-        logger.error(f"Ошибка генерации финансового отчета: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_report_internal_error(
+            "financial-report", "Ошибка генерации финансового отчета", e
+        )
 
 
 @router.get("/daily-summary")
@@ -238,13 +259,19 @@ async def get_daily_summary(
         result = reporting_service.generate_daily_summary(target_date)
 
         if "error" in result:
-            raise HTTPException(status_code=500, detail=result["error"])
+            log_report_service_error("daily_summary")
+            raise HTTPException(
+                status_code=500, detail="Ошибка получения ежедневной сводки"
+            )
 
         return result
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Ошибка получения ежедневной сводки: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_report_internal_error(
+            "daily-summary", "Ошибка получения ежедневной сводки", e
+        )
 
 
 @router.get("/available-reports")
@@ -262,8 +289,9 @@ async def get_available_reports(
         return {"success": True, "reports": reporting_service.get_available_reports()}
 
     except Exception as e:
-        logger.error(f"Ошибка получения списка отчетов: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_report_internal_error(
+            "available-reports", "Ошибка получения списка отчетов", e
+        )
 
 
 @router.post("/cleanup")
@@ -287,8 +315,7 @@ async def cleanup_old_reports(
         }
 
     except Exception as e:
-        logger.error(f"Ошибка очистки старых отчетов: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_report_internal_error("cleanup", "Ошибка очистки старых отчетов", e)
 
 
 @router.get("/files")
@@ -328,5 +355,6 @@ async def list_report_files(
         return {"success": True, "files": files, "total_count": len(files)}
 
     except Exception as e:
-        logger.error(f"Ошибка получения списка файлов отчетов: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_report_internal_error(
+            "report-files", "Ошибка получения списка файлов отчетов", e
+        )


### PR DESCRIPTION
## Summary

- Sanitize raw report endpoint exception details before public HTTP 500 responses.
- Replace raw report service error payloads with generic report response errors.
- Keep non-sensitive logs with report action and exception class only.

## Contract Impact

- Canonical surface: `/api/v1/reports/*` endpoints implemented by `backend/app/api/v1/endpoints/reports.py`.
- Request shape: unchanged.
- Response shape: success payloads unchanged; error payloads now use generic public messages instead of raw exception text.
- Status codes: unchanged for the edited paths.
- Frontend consumer: not changed.
- Compatibility path or alias: not applicable - no route, alias, or prefix changed.
- Contract proof: direct endpoint smoke verifies internal exception text is not returned in the HTTP 500 detail.

## RBAC / Permissions

- Roles allowed: unchanged; existing report endpoint dependencies and role guards are preserved.
- Roles denied: unchanged.
- Positive auth proof: not checked in this slice; no auth dependency or role mapping changed.
- Negative auth proof: not checked in this slice; no auth dependency or role mapping changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, Telegram, SMS, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing frontend panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/reports.py` only.
- Denied paths: report generation services, frontend runtime, migrations, generated output, unrelated endpoint modules.
- Migration/docs/test impact: no migration; no docs change; targeted local smoke and static checks only.
- Rollback note: revert this endpoint-only commit to restore previous raw error propagation.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\reports.py`; static `rg` no-match for raw `detail=str(e)`, `logger.error(f...)`, and `result[error]` public patterns; direct endpoint smoke for report service exception redaction; `git diff --check`.
- Result: passed locally.
- Not checked: full backend test suite, browser smoke, and live report generation against a real database.