### PR TITLE
fix(security): hide settings error details

### DIFF
--- a/backend/app/services/setting_api_service.py
+++ b/backend/app/services/setting_api_service.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from sqlalchemy.orm import Session
 
 from app.repositories.setting_api_repository import SettingApiRepository
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -29,4 +32,11 @@ class SettingApiService:
         try:
             return self.repository.list_by_category(category=category)
         except Exception as exc:
-            raise SettingApiDomainError(status_code=500, detail=str(exc)) from exc
+            logger.warning(
+                "Setting list query failed error_type=%s",
+                type(exc).__name__,
+            )
+            raise SettingApiDomainError(
+                status_code=500,
+                detail="Internal server error",
+            ) from exc

--- a/backend/tests/unit/test_setting_api_service.py
+++ b/backend/tests/unit/test_setting_api_service.py
@@ -18,9 +18,9 @@ class TestSettingApiService:
 
         assert result == expected
 
-    def test_get_settings_wraps_repository_error(self):
+    def test_get_settings_wraps_repository_error_without_leaking_detail(self):
         def _boom(category: str):
-            raise RuntimeError("db broken")
+            raise RuntimeError("db broken internal diagnostic")
 
         repository = SimpleNamespace(list_by_category=_boom)
         service = SettingApiService(db=None, repository=repository)
@@ -29,5 +29,5 @@ class TestSettingApiService:
             service.get_settings(category="printer")
 
         assert exc_info.value.status_code == 500
-        assert "db broken" in exc_info.value.detail
+        assert exc_info.value.detail == "Internal server error"
 


### PR DESCRIPTION
## Summary

- Hide repository exception text from the settings API service public 500 response.
- Keep server-side diagnostics as an exception type log entry without exposing the exception message.
- Update the focused unit test to prove repository diagnostics are not copied into the domain error detail.

## Contract Impact

- Canonical surface: `/api/v1/settings` service error mapping through `SettingApiService.get_settings`.
- Request shape: unchanged; `category` query parameter remains unchanged.
- Response shape: successful settings responses unchanged; unexpected repository failures now use stable `Internal server error` detail.
- Status codes: unchanged; unexpected repository failures remain 500.
- Frontend consumer: not applicable - no frontend files or response parsing logic changed.
- Compatibility path or alias: not applicable - no route aliases changed.
- Contract proof: targeted service unit test covers success path and sanitized failure path.

## RBAC / Permissions

- Roles allowed: unchanged; this endpoint had no auth/RBAC changes in this patch.
- Roles denied: unchanged; no authorization branches were edited.
- Positive auth proof: not applicable - service-only helper change, no auth dependency touched.
- Negative auth proof: not applicable - service-only helper change, no auth dependency touched.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: existing success-path unit test still returns repository rows unchanged.
- Partial data proof: not applicable - no frontend rendering or partial response behavior changed.
- Forbidden secondary path behavior: not applicable - no secondary path behavior changed.
- Missing draft/resource behavior: not applicable - settings service does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/services/setting_api_service.py`, `backend/tests/unit/test_setting_api_service.py`.
- Denied paths: endpoint routing, RBAC dependencies, frontend consumers, migrations, generated output.
- Migration/docs/test impact: no migration or docs change; targeted unit test updated.
- Rollback note: revert the service error detail/logging change and the matching test expectation.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\services\setting_api_service.py`; `rg -n detail=str\((error|exc|e)\) backend\app\services\setting_api_service.py backend\tests\unit\test_setting_api_service.py`; `DATABASE_URL=<test-postgres-url> python -m pytest backend\tests\unit\test_setting_api_service.py`.
- Result: py_compile passed; grep found no old `detail=str(...)` pattern in touched files; targeted pytest passed with 2 tests.
- Not checked: full backend suite and live `/api/v1/settings` smoke were not run for this narrow service-only change.