### PR TITLE
fix(security): hide admin stats error details

### DIFF
--- a/backend/app/api/v1/endpoints/admin_stats.py
+++ b/backend/app/api/v1/endpoints/admin_stats.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import logging
 from datetime import date, datetime, time, timedelta, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, NoReturn, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import and_, desc, func
@@ -15,6 +16,16 @@ from app.models.user import User
 from app.models.visit import Visit
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+def raise_admin_stats_error(action: str, public_detail: str, exc: Exception) -> NoReturn:
+    logger.warning(
+        "Admin stats endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(status_code=500, detail=public_detail)
 
 
 @router.get("/stats", summary="Общая статистика для админ-панели")
@@ -109,7 +120,11 @@ def get_admin_stats(
         }
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка получения статистики: {e}")
+        raise_admin_stats_error(
+            "stats",
+            "Ошибка получения статистики",
+            e,
+        )
 
 
 @router.get("/quick-stats", summary="Быстрая статистика для дашборда")
@@ -163,8 +178,10 @@ def get_quick_stats(
             "generatedAt": datetime.utcnow().isoformat(),
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения быстрой статистики: {e}"
+        raise_admin_stats_error(
+            "quick-stats",
+            "Ошибка получения быстрой статистики",
+            e,
         )
 
 
@@ -360,8 +377,10 @@ def get_recent_activities(
         }
 
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения последних действий: {e}"
+        raise_admin_stats_error(
+            "recent-activities",
+            "Ошибка получения последних действий",
+            e,
         )
 
 
@@ -451,8 +470,10 @@ def get_activity_chart(
         }
 
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения данных графика: {e}"
+        raise_admin_stats_error(
+            "dashboard-chart",
+            "Ошибка получения данных графика",
+            e,
         )
 
 
@@ -611,7 +632,11 @@ def get_analytics_overview(
         }
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка получения аналитики: {e}")
+        raise_admin_stats_error(
+            "analytics",
+            "Ошибка получения аналитики",
+            e,
+        )
 
 
 @router.get("/analytics/charts", summary="Данные для графиков аналитики")
@@ -703,6 +728,8 @@ def get_analytics_charts(
         }
 
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения данных графиков: {e}"
+        raise_admin_stats_error(
+            "analytics-charts",
+            "Ошибка получения данных графиков",
+            e,
         )


### PR DESCRIPTION
## Summary

- Sanitize raw admin stats endpoint exception details before public HTTP 500 responses.
- Add non-sensitive structured warning logs with endpoint action and exception class only.
- Preserve existing Admin role guards, query logic, response fields, and analytics calculations.

## Contract Impact

- Canonical surface: `/api/v1/admin/stats`, `/api/v1/admin/quick-stats`, `/api/v1/admin/recent-activities`, `/api/v1/admin/activity-chart`, `/api/v1/admin/analytics/overview`, `/api/v1/admin/analytics/charts` implemented by `backend/app/api/v1/endpoints/admin_stats.py`.
- Request shape: unchanged.
- Response shape: success payloads unchanged; HTTP 500 details now use generic public messages instead of raw exception text.
- Status codes: unchanged for the edited failure paths.
- Frontend consumer: not changed.
- Compatibility path or alias: not applicable - no route, alias, or prefix changed.
- Contract proof: direct endpoint smoke verifies internal exception text is not returned in the HTTP 500 detail.

## RBAC / Permissions

- Roles allowed: unchanged; existing `require_roles(Admin)` dependencies are preserved.
- Roles denied: unchanged.
- Positive auth proof: not checked in this slice; no auth dependency or role mapping changed.
- Negative auth proof: not checked in this slice; no auth dependency or role mapping changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, Telegram, SMS, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing frontend panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_stats.py` only.
- Denied paths: admin analytics services, frontend runtime, migrations, generated output, unrelated endpoint modules.
- Migration/docs/test impact: no migration; no docs change; targeted local smoke and static checks only.
- Rollback note: revert this endpoint-only commit to restore previous raw error propagation.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\admin_stats.py`; static `rg` no-match for raw exception interpolation in admin stats HTTPException details; direct endpoint smoke for DB exception redaction; `git diff --check`.
- Result: passed locally.
- Not checked: full backend test suite, browser smoke, and live admin dashboard queries against a real database.