### PR TITLE
test(security): cover admin stats error details

### DIFF
--- a/backend/tests/unit/test_admin_stats_error_mapping.py
+++ b/backend/tests/unit/test_admin_stats_error_mapping.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.endpoints.admin_stats import (
+    get_activity_chart,
+    get_admin_stats,
+    get_analytics_charts,
+    get_analytics_overview,
+    get_quick_stats,
+)
+
+
+class _BrokenDb:
+    def query(self, *args, **kwargs):
+        raise RuntimeError("sensitive internal diagnostic")
+
+
+@pytest.mark.parametrize(
+    "call_endpoint",
+    [
+        lambda db: get_admin_stats(db=db, _=object()),
+        lambda db: get_quick_stats(db=db, _=object()),
+        lambda db: get_activity_chart(days=1, db=db, _=object()),
+        lambda db: get_analytics_overview(
+            period="week",
+            department=None,
+            doctor_id=None,
+            db=db,
+            _=object(),
+        ),
+        lambda db: get_analytics_charts(
+            period="week",
+            chart_type="appointments",
+            department=None,
+            db=db,
+            _=object(),
+        ),
+    ],
+)
+def test_admin_stats_500_errors_do_not_expose_exception_text(
+    call_endpoint: Callable[[_BrokenDb], object],
+) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        call_endpoint(_BrokenDb())
+
+    assert exc_info.value.status_code == 500
+    assert "sensitive internal diagnostic" not in str(exc_info.value.detail)


### PR DESCRIPTION
## Summary

- Add targeted coverage for admin stats public 500 error details after the code fix already landed in #613.
- Verify internal DB exception text is not copied into admin stats HTTPException details.
- Keep this PR test-only after rebasing on current `main`.

## Contract Impact

- Canonical surface: admin stats handlers in `backend/app/api/v1/endpoints/admin_stats.py`.
- Request shape: unchanged; this PR adds tests only.
- Response shape: unchanged by this PR; tests assert internal diagnostic text is not exposed in 500 details.
- Status codes: unchanged by this PR; tests assert the touched failure paths remain 500.
- Frontend consumer: no frontend code changed.
- Compatibility path or alias: no route aliases changed.
- Contract proof: targeted unit test calls admin stats handlers with a DB stub that raises internal diagnostic text.

## RBAC / Permissions

- Roles allowed: unchanged; this PR adds tests only.
- Roles denied: unchanged; this PR adds tests only.
- Positive auth proof: not applicable - no auth code changed.
- Negative auth proof: not applicable - no auth code changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend or success payload behavior changed.
- Partial data proof: not applicable - no frontend or success payload behavior changed.
- Forbidden secondary path behavior: not applicable - no secondary path behavior changed.
- Missing draft/resource behavior: not applicable - admin stats endpoints do not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/tests/unit/test_admin_stats_error_mapping.py`.
- Denied paths: production endpoint code, admin dashboard frontend, RBAC dependencies, migrations, generated output.
- Migration/docs/test impact: test-only PR; no migration or docs change.
- Rollback note: remove the targeted test file.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\admin_stats.py`; `rg -n detail=f|detail=str backend\app\api\v1\endpoints\admin_stats.py backend\tests\unit\test_admin_stats_error_mapping.py`; `DATABASE_URL=<test-postgres-url> python -m pytest backend\tests\unit\test_admin_stats_error_mapping.py`.
- Result: py_compile passed; grep found no old raw detail patterns in touched files/current endpoint; targeted pytest passed with 5 tests.
- Not checked: full backend suite and live admin dashboard smoke were not run locally for this test-only PR.