### PR TITLE
fix(security): hide admin telegram error details

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -3,9 +3,10 @@ API endpoints для управления Telegram в админ панели
 """
 
 import asyncio
+import logging
 import secrets
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, NoReturn, Optional
 
 import requests
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
@@ -17,6 +18,33 @@ from app.crud import clinic as crud_clinic, telegram_config as crud_telegram
 from app.models.user import User
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+def raise_admin_telegram_error(
+    action: str,
+    public_detail: str,
+    exc: Exception,
+    status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR,
+) -> NoReturn:
+    logger.warning(
+        "Admin Telegram endpoint failed action=%s status_code=%s error_type=%s",
+        action,
+        status_code,
+        type(exc).__name__,
+    )
+    raise HTTPException(status_code=status_code, detail=public_detail)
+
+
+def webhook_info_error_response(
+    action: str, public_error: str, exc: Exception
+) -> Dict[str, Any]:
+    logger.warning(
+        "Admin Telegram webhook info failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    return {"webhook_set": False, "error": public_error}
 
 
 class TelegramWebhookRequest(BaseModel):
@@ -58,9 +86,10 @@ def get_telegram_settings(
 
         return result
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения настроек Telegram: {str(e)}",
+        raise_admin_telegram_error(
+            "settings-read",
+            "Ошибка получения настроек Telegram",
+            e,
         )
 
 
@@ -83,9 +112,10 @@ def update_telegram_settings(
             "updated_count": len(updated_settings),
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления настроек Telegram: {str(e)}",
+        raise_admin_telegram_error(
+            "settings-update",
+            "Ошибка обновления настроек Telegram",
+            e,
         )
 
 
@@ -144,16 +174,19 @@ def test_telegram_bot(
             raise Exception(f"HTTP {response.status_code}: {response.text}")
 
     except requests.RequestException as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Ошибка подключения к Telegram API: {str(e)}",
+        raise_admin_telegram_error(
+            "test-bot-request",
+            "Ошибка подключения к Telegram API",
+            e,
+            status.HTTP_400_BAD_REQUEST,
         )
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка тестирования бота: {str(e)}",
+        raise_admin_telegram_error(
+            "test-bot",
+            "Ошибка тестирования бота",
+            e,
         )
 
 
@@ -222,16 +255,19 @@ def set_telegram_webhook(
             raise Exception(f"HTTP {response.status_code}: {response.text}")
 
     except requests.RequestException as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Ошибка установки webhook: {str(e)}",
+        raise_admin_telegram_error(
+            "set-webhook-request",
+            "Ошибка установки webhook",
+            e,
+            status.HTTP_400_BAD_REQUEST,
         )
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка установки webhook: {str(e)}",
+        raise_admin_telegram_error(
+            "set-webhook",
+            "Ошибка установки webhook",
+            e,
         )
 
 
@@ -267,9 +303,17 @@ def get_telegram_webhook_info(
             raise Exception(f"HTTP {response.status_code}")
 
     except requests.RequestException as e:
-        return {"webhook_set": False, "error": f"Ошибка подключения: {str(e)}"}
+        return webhook_info_error_response(
+            "webhook-info-request",
+            "Ошибка подключения",
+            e,
+        )
     except Exception as e:
-        return {"webhook_set": False, "error": str(e)}
+        return webhook_info_error_response(
+            "webhook-info",
+            "Ошибка получения информации о webhook",
+            e,
+        )
 
 
 # ===================== ШАБЛОНЫ СООБЩЕНИЙ =====================
@@ -366,9 +410,10 @@ def get_telegram_templates(
         return result
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения шаблонов: {str(e)}",
+        raise_admin_telegram_error(
+            "templates",
+            "Ошибка получения шаблонов",
+            e,
         )
 
 
@@ -415,16 +460,19 @@ def send_test_message(
             raise Exception(f"HTTP {response.status_code}: {response.text}")
 
     except requests.RequestException as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Ошибка отправки сообщения: {str(e)}",
+        raise_admin_telegram_error(
+            "send-test-message-request",
+            "Ошибка отправки сообщения",
+            e,
+            status.HTTP_400_BAD_REQUEST,
         )
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки тестового сообщения: {str(e)}",
+        raise_admin_telegram_error(
+            "send-test-message",
+            "Ошибка отправки тестового сообщения",
+            e,
         )
 
 
@@ -451,9 +499,10 @@ def get_telegram_stats(
             "period_end": datetime.utcnow(),
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики Telegram: {str(e)}",
+        raise_admin_telegram_error(
+            "stats",
+            "Ошибка получения статистики Telegram",
+            e,
         )
 
 
@@ -473,9 +522,10 @@ def get_telegram_users(
         # Пока возвращаем заглушку
         return []
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения пользователей Telegram: {str(e)}",
+        raise_admin_telegram_error(
+            "users",
+            "Ошибка получения пользователей Telegram",
+            e,
         )
 
 
@@ -512,7 +562,8 @@ def send_broadcast_message(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки сообщения: {str(e)}",
+        raise_admin_telegram_error(
+            "broadcast",
+            "Ошибка отправки сообщения",
+            e,
         )


### PR DESCRIPTION
## Summary

- Sanitize raw admin Telegram endpoint exception details before public HTTP/JSON error responses.
- Avoid leaking Telegram request/provider exception text, including bot-token-bearing URLs, through admin-facing failures.
- Keep non-sensitive structured warning logs with endpoint action, status code, and exception class only.

## Contract Impact

- Canonical surface: `/api/v1/admin/telegram/*` endpoints implemented by `backend/app/api/v1/endpoints/admin_telegram.py`.
- Request shape: unchanged.
- Response shape: success payloads unchanged; error payloads now use generic public messages instead of raw exception text.
- Status codes: unchanged for edited HTTPException paths; webhook-info still returns its existing JSON shape with `webhook_set: false` on failures.
- Frontend consumer: unchanged; no frontend code changed.
- Compatibility path or alias: none; no route, alias, or prefix changed.
- Contract proof: direct endpoint smoke verifies internal DB/request exception text and fake bot token are not returned or logged.

## RBAC / Permissions

- Roles allowed: unchanged; existing Admin/SuperAdmin role dependencies are preserved.
- Roles denied: unchanged.
- Positive auth proof: not applicable - no auth dependency or role mapping changed.
- Negative auth proof: not applicable - no auth dependency or role mapping changed.

## Notification / Realtime

- Notification behavior: unchanged; no Telegram send success path, webhook success path, template, broadcast, websocket, chat, or realtime delivery behavior changed.
- Realtime behavior: unchanged; this PR only sanitizes admin HTTP/JSON failure details.
- Event type or websocket channel: none changed; no event names, websocket channels, or broadcast destinations are edited.
- Payload version / ack behavior: unchanged; success payloads and webhook-info JSON shape stay the same, and only failure detail text is sanitized.
- Read/unread or delivery semantics: unchanged; no message delivery state, read marker, unread counter, or notification persistence path is edited.
- Reconnect/resync proof: not applicable to this endpoint-only error-detail change; no websocket or realtime resync path is touched.
- Secret handling proof: direct smoke used a fake bot token in a request exception and verified it was not exposed in public detail or log message.

## Frontend Resilience

- Empty data proof: not applicable - no frontend code, route, or rendered data state changed.
- Partial data proof: not applicable - no frontend rendering or partial-response behavior changed.
- Forbidden secondary path behavior: not applicable - no secondary frontend path or permission UI changed.
- Missing draft/resource behavior: not applicable - admin Telegram endpoints do not create or reopen frontend drafts/resources.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py` only for edits; `telegram_webhook.py` and frontend build were validation-only per gate.
- Denied paths: Telegram webhook runtime, frontend runtime, migrations, generated output, unrelated endpoint modules.
- Migration/docs/test impact: no migration; no docs change; targeted local smoke/static checks plus frontend build only.
- Rollback note: revert this endpoint-only commit to restore previous raw admin Telegram error propagation.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; static `rg` no-match for raw `str(e)`/`str(exc)` public error patterns in `admin_telegram.py`; direct endpoint smoke for DB exception and Telegram request-token redaction; `git diff --check`; `npm ci`; `npm run build` in `frontend/`.
- Result: passed locally. Frontend build completed with existing Vite warnings about dynamic/static `errorHandler.js` import and large chunks.
- Not checked: live Telegram API/webhook calls, full backend suite, and browser smoke.