### PR TITLE
fix(security): use secure emr session ids

### DIFF
--- a/frontend/src/hooks/useEMR.js
+++ b/frontend/src/hooks/useEMR.js
@@ -14,9 +14,27 @@ import { apiClient } from '../api/client';
 import logger from '../utils/logger';
 import { buildInitialEMRData, normalizeEMRData } from '../utils/emrSpecialty';
 
+let fallbackSessionCounter = 0;
+
 // Generate client session ID for smart conflict resolution
 const generateSessionId = () => {
-    return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const browserCrypto = globalThis.crypto;
+
+    if (browserCrypto?.randomUUID) {
+        return browserCrypto.randomUUID();
+    }
+
+    if (browserCrypto?.getRandomValues) {
+        const randomBytes = new Uint8Array(16);
+        browserCrypto.getRandomValues(randomBytes);
+        randomBytes[6] = randomBytes[6] & 0x0f | 0x40;
+        randomBytes[8] = randomBytes[8] & 0x3f | 0x80;
+        const hex = Array.from(randomBytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+        return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+    }
+
+    fallbackSessionCounter += 1;
+    return `${Date.now().toString(36)}-${fallbackSessionCounter.toString(36)}`;
 };
 
 const emrCache = new Map();


### PR DESCRIPTION
﻿## Summary

- Replaces `Math.random`-based EMR client session IDs with Web Crypto IDs.
- Uses `crypto.randomUUID()` when available and `crypto.getRandomValues()` UUID formatting otherwise.
- Preserves one stable `client_session_id` per hook instance through the existing `useRef(generateSessionId())` flow.

## Contract Impact

- Canonical surface: `frontend/src/hooks/useEMR.js` payload field `client_session_id` for EMR save/sign requests.
- Request shape: unchanged string field name and type.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: EMR v2 hook consumers using `saveEMR`, `signEMR`, and conflict handling.
- Compatibility path or alias: existing fallback still returns a string if Web Crypto is unavailable.
- Contract proof: code inspection confirms payload key remains `client_session_id` and hook-level `useRef` stability is unchanged.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or permission behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: EMR load/save state handling is unchanged; only session ID generation changed.
- Partial data proof: existing `normalizeEMRData` and row-version payload behavior remains unchanged.
- Forbidden secondary path behavior: access-denied handling remains unchanged.
- Missing draft/resource behavior: 404 empty draft initialization remains unchanged.
- Stale route/deep-link behavior: not applicable - no routing behavior changed.

## Scope Gate

- Allowed paths: `frontend/src/hooks/useEMR.js`.
- Denied paths: backend EMR APIs, reducer behavior, EMR data contracts, other frontend hooks/components, generated artifacts.
- Migration/docs/test impact: no migration or docs changes.
- Rollback note: revert this PR to restore the previous `Date.now() + Math.random()` client session ID format.

## Validation

- Targeted tests or smoke run: `rg -n "Math\\.random|generateSessionId|randomUUID|getRandomValues" frontend/src/hooks/useEMR.js`; `git diff --check -- frontend/src/hooks/useEMR.js`; `cd frontend; npm.cmd run build`.
- Result: no `Math.random` remains in `useEMR.js`; diff check passed; Vite production build passed with existing chunk/dynamic-import warnings.
- Not checked: browser EMR save/sign smoke was not run; request field name/type and hook-level session stability were verified by code inspection.
