### PR TITLE
fix(security): hide medical equipment error details

### DIFF
--- a/backend/app/api/v1/endpoints/medical_equipment.py
+++ b/backend/app/api/v1/endpoints/medical_equipment.py
@@ -24,6 +24,16 @@ from app.services.medical_equipment_service import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+MEDICAL_EQUIPMENT_PUBLIC_ERROR = "Internal server error"
+
+
+def _medical_equipment_http_error(operation: str, exc: Exception) -> HTTPException:
+    logger.warning(
+        "Medical equipment endpoint failed operation=%s error_type=%s",
+        operation,
+        type(exc).__name__,
+    )
+    return HTTPException(status_code=500, detail=MEDICAL_EQUIPMENT_PUBLIC_ERROR)
 
 
 # Pydantic Models for Requests and Responses
@@ -135,8 +145,7 @@ async def get_all_devices(
             "total_count": len(devices_response),
         }
     except Exception as e:
-        logger.error(f"Ошибка получения устройств: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("get_all_devices", e) from e
 
 
 @router.get("/devices/{device_id}")
@@ -176,8 +185,7 @@ async def get_device(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка получения устройства {device_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("get_device", e) from e
 
 
 @router.get("/devices/type/{device_type}")
@@ -231,8 +239,7 @@ async def get_devices_by_type(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка получения устройств типа {device_type}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("get_devices_by_type", e) from e
 
 
 # ===================== ПОДКЛЮЧЕНИЕ И УПРАВЛЕНИЕ =====================
@@ -266,8 +273,7 @@ async def connect_device(
                 "device_id": device_id,
             }
     except Exception as e:
-        logger.error(f"Ошибка подключения к устройству {device_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("connect_device", e) from e
 
 
 @router.post("/devices/{device_id}/disconnect")
@@ -298,8 +304,7 @@ async def disconnect_device(
                 "device_id": device_id,
             }
     except Exception as e:
-        logger.error(f"Ошибка отключения от устройства {device_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("disconnect_device", e) from e
 
 
 @router.get("/devices/{device_id}/status")
@@ -326,8 +331,7 @@ async def get_device_status(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка получения статуса устройства {device_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("get_device_status", e) from e
 
 
 # ===================== ИЗМЕРЕНИЯ =====================
@@ -368,8 +372,7 @@ async def take_measurement(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка выполнения измерения: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("take_measurement", e) from e
 
 
 @router.get("/measurements")
@@ -445,8 +448,7 @@ async def get_measurements(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка получения измерений: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("get_measurements", e) from e
 
 
 # ===================== КАЛИБРОВКА И ДИАГНОСТИКА =====================
@@ -481,8 +483,7 @@ async def calibrate_device(
                 "device_id": device_id,
             }
     except Exception as e:
-        logger.error(f"Ошибка калибровки устройства {device_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("calibrate_device", e) from e
 
 
 @router.post("/devices/{device_id}/diagnostics", response_model=DiagnosticsResponse)
@@ -509,8 +510,7 @@ async def run_device_diagnostics(
             error=results.get("error"),
         )
     except Exception as e:
-        logger.error(f"Ошибка диагностики устройства {device_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("run_device_diagnostics", e) from e
 
 
 # ===================== КОНФИГУРАЦИЯ =====================
@@ -557,8 +557,7 @@ async def update_device_config(
                 "device_id": device_id,
             }
     except Exception as e:
-        logger.error(f"Ошибка обновления конфигурации устройства {device_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("update_device_config", e) from e
 
 
 # ===================== СТАТИСТИКА =====================
@@ -584,8 +583,7 @@ async def get_device_statistics(
             measurements_this_week=stats["measurements_this_week"],
         )
     except Exception as e:
-        logger.error(f"Ошибка получения статистики устройства {device_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("get_device_statistics", e) from e
 
 
 @router.get("/statistics/overview")
@@ -635,8 +633,7 @@ async def get_equipment_overview(
             },
         }
     except Exception as e:
-        logger.error(f"Ошибка получения общей статистики оборудования: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("get_equipment_overview", e) from e
 
 
 # ===================== ЭКСПОРТ =====================
@@ -694,8 +691,7 @@ async def export_measurements(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка экспорта измерений: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("export_measurements", e) from e
 
 
 # ===================== БЫСТРЫЕ ДЕЙСТВИЯ =====================
@@ -771,8 +767,7 @@ async def quick_measurement(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка быстрого измерения: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _medical_equipment_http_error("quick_measurement", e) from e
 
 
 # ===================== ИНФОРМАЦИЯ О СИСТЕМЕ =====================


### PR DESCRIPTION
## Summary

- Replace medical-equipment public 500 exception details with stable generic messages.
- Stop logging raw exception text from medical-equipment endpoint exception handlers.
- Preserve successful device, measurement, diagnostics, config, statistics, and export response contracts.

## Contract Impact

- Canonical surface: `/api/v1/medical-equipment/*` endpoints implemented in `backend/app/api/v1/endpoints/medical_equipment.py`.
- Request shape: unchanged authenticated endpoint requests and existing query/body parameters.
- Response shape: unchanged success payloads; public 500 error bodies now use generic safe detail strings instead of raw exception text.
- Status codes: unchanged for success, 400 validation, 404 not found, and 500 internal failures.
- Frontend consumer: unchanged existing medical-equipment consumers; no frontend files changed.
- Compatibility path or alias: not applicable because this slice does not add, remove, or redirect routes or aliases.
- Contract proof: `python -m py_compile` plus static search confirmed the endpoint module keeps contracts while removing raw exception leak patterns.

## RBAC / Permissions

- Roles allowed: unchanged because existing endpoint dependencies and service authorization flow were not edited.
- Roles denied: unchanged because no role guards, dependency injection, or permission checks were changed.
- Positive auth proof: not applicable because this slice does not alter auth behavior; compile/static checks confirm only endpoint error handling/logging changed.
- Negative auth proof: not applicable because this slice does not alter auth behavior; no denied-role behavior was changed.

## Notification / Realtime

- Event type or websocket channel: not applicable because no notification, Telegram, websocket, or realtime event surface changed.
- Payload version / ack behavior: not applicable because no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable because this endpoint slice does not touch delivery or read-state semantics.
- Reconnect/resync proof: not applicable because no websocket reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable because no frontend rendering, empty state, or response collection shape changed.
- Partial data proof: not applicable because no frontend parsing or partial-data handling changed.
- Forbidden secondary path behavior: not applicable because no secondary frontend path or forbidden route behavior changed.
- Missing draft/resource behavior: not applicable because this slice does not create, reopen, or recover drafts/resources.
- Stale route/deep-link behavior: not applicable because no route registry, alias, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/medical_equipment.py` only.
- Denied paths: frontend files, migrations, route mounting, RBAC dependencies, service implementations, generated output, and unrelated endpoint modules.
- Migration/docs/test impact: no migration required; no docs required for this narrow security hardening; validation is compile/static proof for the touched endpoint.
- Rollback note: revert commit `d621894e` to restore the previous raw exception detail/logging behavior if needed.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/medical_equipment.py`; static search for raw `detail=str(e)` and raw exception interpolation patterns in `backend/app/api/v1/endpoints/medical_equipment.py`.
- Result: local compile and static checks passed before PR creation; CI is being re-run after this PR body update.
- Not checked: full backend test suite and manual device integration flow were not run because the slice does not change device service success paths.