### PR TITLE
fix(security): hide cardio error details

### DIFF
--- a/backend/app/api/v1/endpoints/cardio.py
+++ b/backend/app/api/v1/endpoints/cardio.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, NoReturn, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import desc
@@ -17,6 +17,16 @@ router = APIRouter(prefix="/cardio", tags=["cardio"])
 logger = logging.getLogger(__name__)
 
 CARDIO_ROLES = ("Admin", "Doctor", "cardio", "cardiology", "cardiologist", "Cardiologist")
+CARDIO_PUBLIC_ERROR = "Internal server error"
+
+
+def _raise_cardio_internal_error(operation: str, exc: Exception) -> NoReturn:
+    logger.warning(
+        "[cardio] endpoint failed operation=%s error_type=%s",
+        operation,
+        type(exc).__name__,
+    )
+    raise HTTPException(status_code=500, detail=CARDIO_PUBLIC_ERROR) from exc
 
 
 @router.get("/ecg", summary="ЭКГ исследования")
@@ -32,7 +42,7 @@ async def get_ecg_results(
     try:
         return []
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка получения ЭКГ: {str(e)}")
+        _raise_cardio_internal_error("get_ecg_results", e)
 
 
 @router.post("/ecg", summary="Создать ЭКГ исследование")
@@ -47,7 +57,7 @@ async def create_ecg(
     try:
         return {"message": "ЭКГ исследование создано", "id": 1}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка создания ЭКГ: {str(e)}")
+        _raise_cardio_internal_error("create_ecg", e)
 
 
 @router.get(
@@ -86,14 +96,7 @@ async def get_blood_tests(
         )
         return tests
     except SQLAlchemyError as e:
-        logger.exception(
-            "[cardio.blood-tests] failed to list tests user_id=%s patient_id=%s",
-            getattr(user, "id", None),
-            patient_id,
-        )
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения анализов крови: {str(e)}"
-        )
+        _raise_cardio_internal_error("get_blood_tests", e)
 
 
 @router.post(
@@ -155,15 +158,7 @@ async def create_blood_test(
         raise
     except SQLAlchemyError as e:
         db.rollback()
-        logger.exception(
-            "[cardio.blood-tests] failed to create test user_id=%s patient_id=%s visit_id=%s",
-            getattr(user, "id", None),
-            blood_test_data.patient_id,
-            blood_test_data.visit_id,
-        )
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка создания анализа крови: {str(e)}"
-        )
+        _raise_cardio_internal_error("create_blood_test", e)
 
 
 @router.get("/risk-assessment", summary="Оценка рисков")
@@ -178,6 +173,4 @@ async def get_risk_assessment(
     try:
         return {"message": "Модуль оценки рисков будет доступен в следующей версии"}
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения оценки рисков: {str(e)}"
-        )
+        _raise_cardio_internal_error("get_risk_assessment", e)


### PR DESCRIPTION
## Summary

- Replace cardio endpoint public 500 exception details with a stable generic message.
- Stop logging raw exception text from cardio endpoint failure paths.
- Preserve cardio route prefix, role guards, ECG placeholder responses, blood-test success contracts, and explicit 400/404 validation behavior.

## Contract Impact

- Canonical surface: `/api/v1/cardio/*` endpoints implemented in `backend/app/api/v1/endpoints/cardio.py`.
- Request shape: unchanged authenticated endpoint requests and existing query/body parameters.
- Response shape: unchanged success payloads; public 500 error bodies now use `Internal server error` instead of raw exception text.
- Status codes: unchanged for success, 400 validation, 404 not found, and 500 internal failures.
- Frontend consumer: unchanged existing cardio consumers; no frontend files changed.
- Compatibility path or alias: not applicable because this slice does not add, remove, or redirect routes or aliases.
- Contract proof: targeted cardio integration tests plus compile/static/smoke checks prove the endpoint still loads and existing cardio API behavior remains intact.

## RBAC / Permissions

- Roles allowed: unchanged `CARDIO_ROLES` and existing `deps.require_roles(*CARDIO_ROLES)` guards.
- Roles denied: unchanged because no role guards, auth dependencies, or permission checks were edited.
- Positive auth proof: `backend/tests/integration/test_cardio_api.py` passed, including cardiologist-role access coverage.
- Negative auth proof: not applicable because this slice does not alter denied-role behavior or auth dependencies.

## Notification / Realtime

- Event type or websocket channel: not applicable because no notification, Telegram, websocket, or realtime event surface changed.
- Payload version / ack behavior: not applicable because no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable because this endpoint slice does not touch delivery or read-state semantics.
- Reconnect/resync proof: not applicable because no websocket reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged ECG placeholder and cardio API response shapes; no frontend empty-state code changed.
- Partial data proof: not applicable because no frontend parsing or partial-data handling changed.
- Forbidden secondary path behavior: not applicable because no secondary frontend path or forbidden route behavior changed.
- Missing draft/resource behavior: not applicable because this slice does not create, reopen, or recover drafts/resources.
- Stale route/deep-link behavior: not applicable because no route registry, alias, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/cardio.py` only.
- Denied paths: frontend files, route mounting, migrations, RBAC dependencies, service implementations, generated output, and unrelated endpoint modules.
- Migration/docs/test impact: no migration required; no docs required for this narrow security hardening; existing cardio integration tests used as validation.
- Rollback note: revert commit `4ab195a1` to restore the previous raw exception detail/logging behavior if needed.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/cardio.py`; `rg` static search for raw `detail=str(e)` / `detail=f...str(e)` / raw exception logging patterns in `cardio.py`; marker-redaction smoke for `_raise_cardio_internal_error`; `ALLOW_SQLITE_DATABASE_URL=1 DATABASE_URL=sqlite:///./test_cardio_task26.db python -m pytest backend/tests/integration/test_cardio_api.py -q --tb=short --disable-warnings`.
- Result: compile passed; static search returned no matches; marker-redaction smoke passed; cardio integration tests passed with `3 passed, 1 warning`.
- Not checked: local `frontend/npm run build` could not start in the clean worktree because frontend dependencies were not installed (`vite` not found); GitHub CI is expected to install dependencies and run frontend checks.