### PR TITLE
fix(security): hide admin clinic error details

### DIFF
--- a/backend/app/api/v1/endpoints/admin_clinic.py
+++ b/backend/app/api/v1/endpoints/admin_clinic.py
@@ -2,6 +2,7 @@
 API endpoints для управления настройками клиники в админ панели
 """
 
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -28,6 +29,19 @@ from app.schemas.clinic import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+ADMIN_CLINIC_PUBLIC_ERROR = "Internal server error"
+
+
+def _admin_clinic_http_error(exc: Exception) -> HTTPException:
+    logger.warning(
+        "Admin clinic endpoint failed error_type=%s",
+        type(exc).__name__,
+    )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=ADMIN_CLINIC_PUBLIC_ERROR,
+    )
 
 # ===================== НАСТРОЙКИ КЛИНИКИ =====================
 
@@ -48,10 +62,7 @@ def get_clinic_settings(
         settings = crud_clinic.get_settings_by_category(db, category)
         return settings
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения настроек: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 @router.get("/clinic/settings/{key}", response_model=ClinicSettingsOut)
@@ -83,10 +94,7 @@ def update_clinic_settings_batch(
         )
         return updated_settings
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления настроек: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 @router.put("/clinic/settings/{key}", response_model=ClinicSettingsOut)
@@ -127,10 +135,7 @@ def create_clinic_setting(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания настройки: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 @router.get("/clinic/ticket-print-settings", response_model=TicketPrintSettingsOut)
@@ -147,10 +152,7 @@ def get_ticket_print_settings(
     try:
         return crud_clinic.get_ticket_print_settings(db)
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения настроек печати талонов: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 @router.put("/clinic/ticket-print-settings", response_model=TicketPrintSettingsOut)
@@ -167,10 +169,7 @@ def update_ticket_print_settings(
             current_user.id,
         )
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления настроек печати талонов: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 # ===================== ЗАГРУЗКА ЛОГОТИПА =====================
@@ -223,10 +222,7 @@ def upload_clinic_logo(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка загрузки логотипа: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 # ===================== НАСТРОЙКИ ОЧЕРЕДЕЙ =====================
@@ -241,10 +237,7 @@ def get_queue_settings(
         settings = crud_clinic.get_queue_settings(db)
         return settings
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения настроек очередей: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 @router.put("/queue/settings")
@@ -264,10 +257,7 @@ def update_queue_settings(
             "settings": updated_settings,
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления настроек очередей: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 @router.post("/queue/test")
@@ -314,10 +304,7 @@ def test_queue_generation(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка тестирования очереди: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 # ===================== ИНФОРМАЦИЯ О СИСТЕМЕ =====================
@@ -350,7 +337,7 @@ def get_system_info(current_user: User = Depends(require_roles("Admin"))):
         }
     except Exception as e:
         return {
-            "error": f"Не удалось получить информацию о системе: {str(e)}",
+            "error": ADMIN_CLINIC_PUBLIC_ERROR,
             "basic_info": {
                 "environment": os.getenv("ENVIRONMENT", "development"),
                 "timezone": os.getenv("TIMEZONE", "Asia/Tashkent"),
@@ -375,7 +362,4 @@ def get_service_categories(
         )
         return categories
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения категорий: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e


### PR DESCRIPTION
﻿## Summary

- Replace admin clinic public 500 exception details with a stable generic message.
- Stop exposing raw exception text from admin clinic error responses.
- Preserve successful clinic settings, ticket print settings, queue settings, logo upload, and service category paths.

## Contract Impact

- Canonical surface: admin clinic endpoints implemented in `backend/app/api/v1/endpoints/admin_clinic.py`.
- Request shape: unchanged authenticated endpoint requests and existing request bodies/query parameters.
- Response shape: unchanged success payloads; public 500 error bodies now use `Internal server error` instead of raw exception text.
- Status codes: unchanged for success and existing explicit validation/not-found paths; internal failures still return 500.
- Frontend consumer: unchanged existing admin clinic consumers; no frontend files changed.
- Compatibility path or alias: not applicable because this slice does not add, remove, or redirect routes or aliases.
- Contract proof: targeted compile/static validation proves the endpoint module still loads and the old raw-exception response patterns are absent.

## RBAC / Permissions

- Roles allowed: unchanged existing admin clinic role/auth dependencies.
- Roles denied: unchanged because no role guards, auth dependencies, or permission checks were edited.
- Positive auth proof: not checked locally because this slice only changes internal 500 error handling and did not alter auth dependencies.
- Negative auth proof: not applicable because denied-role behavior was not changed.

## Notification / Realtime

- Event type or websocket channel: not applicable because no notification, Telegram, websocket, or realtime event surface changed.
- Payload version / ack behavior: not applicable because no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable because this endpoint slice does not touch delivery or read-state semantics.
- Reconnect/resync proof: not applicable because no websocket reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable because no frontend files or response success shapes changed.
- Partial data proof: not applicable because no frontend parsing or partial-data handling changed.
- Forbidden secondary path behavior: not applicable because no secondary frontend path or forbidden route behavior changed.
- Missing draft/resource behavior: not applicable because this slice does not create, reopen, or recover drafts/resources.
- Stale route/deep-link behavior: not applicable because no route registry, alias, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_clinic.py` only.
- Denied paths: frontend files, route mounting, migrations, RBAC dependencies, service implementations, generated output, and unrelated endpoint modules.
- Migration/docs/test impact: no migration required; no docs required for this narrow security hardening; targeted compile/static checks used as validation.
- Rollback note: revert commit `92364f58` to restore the previous raw exception detail behavior if needed.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/admin_clinic.py`; `git diff --check`; `Select-String` static search for old `str(e)`, `detail=f"Ошибка`, and raw `logger.error(f...{e})` patterns in `backend/app/api/v1/endpoints/admin_clinic.py`.
- Result: compile passed; diff check passed; static search returned no old raw exception detail/logging matches.
- Not checked: full backend suite and browser smoke were not run locally for this one-file error-handling slice; GitHub CI is running the broader automated checks.
