### PR TITLE
fix(security): hide admin clinic error details

### DIFF
--- a/backend/app/api/v1/endpoints/admin_clinic.py
+++ b/backend/app/api/v1/endpoints/admin_clinic.py
@@ -2,6 +2,7 @@
 API endpoints для управления настройками клиники в админ панели
 """
 
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -28,6 +29,20 @@ from app.schemas.clinic import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+ADMIN_CLINIC_PUBLIC_ERROR = "Internal server error"
+
+
+def _admin_clinic_http_error(exc: Exception) -> HTTPException:
+    logger.warning(
+        "Admin clinic endpoint failed error_type=%s",
+        type(exc).__name__,
+    )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=ADMIN_CLINIC_PUBLIC_ERROR,
+    )
 
 # ===================== НАСТРОЙКИ КЛИНИКИ =====================
 
@@ -48,10 +63,7 @@ def get_clinic_settings(
         settings = crud_clinic.get_settings_by_category(db, category)
         return settings
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения настроек: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 @router.get("/clinic/settings/{key}", response_model=ClinicSettingsOut)
@@ -83,10 +95,7 @@ def update_clinic_settings_batch(
         )
         return updated_settings
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления настроек: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 @router.put("/clinic/settings/{key}", response_model=ClinicSettingsOut)
@@ -127,10 +136,7 @@ def create_clinic_setting(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания настройки: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 @router.get("/clinic/ticket-print-settings", response_model=TicketPrintSettingsOut)
@@ -147,10 +153,7 @@ def get_ticket_print_settings(
     try:
         return crud_clinic.get_ticket_print_settings(db)
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения настроек печати талонов: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 @router.put("/clinic/ticket-print-settings", response_model=TicketPrintSettingsOut)
@@ -167,10 +170,7 @@ def update_ticket_print_settings(
             current_user.id,
         )
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления настроек печати талонов: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 # ===================== ЗАГРУЗКА ЛОГОТИПА =====================
@@ -223,10 +223,7 @@ def upload_clinic_logo(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка загрузки логотипа: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 # ===================== НАСТРОЙКИ ОЧЕРЕДЕЙ =====================
@@ -241,10 +238,7 @@ def get_queue_settings(
         settings = crud_clinic.get_queue_settings(db)
         return settings
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения настроек очередей: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 @router.put("/queue/settings")
@@ -264,10 +258,7 @@ def update_queue_settings(
             "settings": updated_settings,
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления настроек очередей: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 @router.post("/queue/test")
@@ -314,10 +305,7 @@ def test_queue_generation(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка тестирования очереди: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e
 
 
 # ===================== ИНФОРМАЦИЯ О СИСТЕМЕ =====================
@@ -349,8 +337,12 @@ def get_system_info(current_user: User = Depends(require_roles("Admin"))):
             },
         }
     except Exception as e:
+        logger.warning(
+            "Admin clinic system info endpoint failed error_type=%s",
+            type(e).__name__,
+        )
         return {
-            "error": f"Не удалось получить информацию о системе: {str(e)}",
+            "error": ADMIN_CLINIC_PUBLIC_ERROR,
             "basic_info": {
                 "environment": os.getenv("ENVIRONMENT", "development"),
                 "timezone": os.getenv("TIMEZONE", "Asia/Tashkent"),
@@ -375,7 +367,4 @@ def get_service_categories(
         )
         return categories
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения категорий: {str(e)}",
-        )
+        raise _admin_clinic_http_error(e) from e


### PR DESCRIPTION
## Summary

- Replace admin-clinic public 500 exception details with a stable generic message.
- Stop exposing raw exception text from admin clinic settings, logo, queue, system-info, and category failure paths.
- Preserve route mount, role guards, success response shapes, and explicit 400/404 validation behavior.

## Contract Impact

- Canonical surface: `/api/v1/admin/*` admin clinic endpoints implemented in `backend/app/api/v1/endpoints/admin_clinic.py`.
- Request shape: unchanged authenticated endpoint requests and existing query/body/file parameters.
- Response shape: unchanged success payloads; public internal failure details now use `Internal server error` instead of raw exception text.
- Status codes: unchanged for success, validation/not-found paths, and 500 internal failures.
- Frontend consumer: unchanged existing admin clinic consumers; no frontend files changed in this branch.
- Compatibility path or alias: not applicable because this slice does not add, remove, or redirect routes or aliases.
- Contract proof: compile/static/diff-check plus helper marker-redaction smoke prove the endpoint module loads and raw marker text is not returned in public 500 details.

## RBAC / Permissions

- Roles allowed: unchanged existing Admin-only write/admin surfaces and existing public read behavior for non-sensitive clinic settings.
- Roles denied: unchanged because no role guards, auth dependencies, or permission checks were edited.
- Positive auth proof: not applicable because this slice does not alter successful auth behavior or role dependency wiring.
- Negative auth proof: not applicable because this slice does not alter denied-role behavior or auth dependency wiring.

## Notification / Realtime

- Event type or websocket channel: not applicable because no notification, Telegram, websocket, or realtime event surface changed.
- Payload version / ack behavior: not applicable because no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable because this endpoint slice does not touch delivery or read-state semantics.
- Reconnect/resync proof: not applicable because no websocket reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged because no frontend rendering, empty state, or response collection shape changed.
- Partial data proof: unchanged because no frontend parsing or partial-data handling changed.
- Forbidden secondary path behavior: not applicable because no secondary frontend path or forbidden route behavior changed.
- Missing draft/resource behavior: not applicable because this slice does not create, reopen, or recover drafts/resources.
- Stale route/deep-link behavior: not applicable because no route registry, alias, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_clinic.py` only.
- Denied paths: frontend files, route mounting, migrations, RBAC dependencies, CRUD/service implementations, generated output, and unrelated endpoint modules.
- Migration/docs/test impact: no migration required; no docs required for this narrow security hardening; no matching admin-clinic endpoint test exists in the current tree.
- Rollback note: revert commit `8799cc29` to restore the previous raw exception detail/logging behavior if needed.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/admin_clinic.py`; `rg` static search for raw `detail=str(e)` / `detail=f...str(e)` / raw exception logging patterns in `admin_clinic.py`; `git diff --check origin/main...HEAD`; marker-redaction smoke for `_admin_clinic_http_error`.
- Result: compile passed; static search returned no matches; diff check passed; marker-redaction smoke passed.
- Not checked: no full backend suite or browser admin-panel smoke was run for this one-file endpoint error-detail hardening slice; no direct admin-clinic test file was found.