### PR TITLE
fix: redact cardio patient ids from logs

### DIFF
--- a/backend/app/api/v1/endpoints/cardio.py
+++ b/backend/app/api/v1/endpoints/cardio.py
@@ -89,9 +89,9 @@ async def get_blood_tests(
             .all()
         )
         logger.info(
-            "[cardio.blood-tests] listed tests user_id=%s patient_id=%s count=%s",
+            "[cardio.blood-tests] listed tests user_id=%s filtered_by_patient=%s count=%s",
             getattr(user, "id", None),
-            patient_id,
+            patient_id is not None,
             len(tests),
         )
         return tests
@@ -146,9 +146,8 @@ async def create_blood_test(
         db.commit()
         db.refresh(blood_test)
         logger.info(
-            "[cardio.blood-tests] created test_id=%s patient_id=%s visit_id=%s user_id=%s",
+            "[cardio.blood-tests] created test_id=%s visit_id=%s user_id=%s",
             blood_test.id,
-            blood_test.patient_id,
             blood_test.visit_id,
             getattr(user, "id", None),
         )


### PR DESCRIPTION
﻿## Summary

- remove `patient_id` from cardio blood-test info logs so patient identifiers do not land in clear-text log storage
- keep operational logging useful by recording only `user_id`, `visit_id`, count, and whether a patient filter was applied

## Contract Impact

not applicable - endpoint request and response payloads are unchanged because this patch only redacts server-side logging.

## RBAC / Permissions

not applicable - role requirements and authorization paths are unchanged because the patch only updates log fields.

## Notification / Realtime

not applicable - the cardio endpoint does not emit websocket or notification payload changes in this patch.

## Frontend Resilience

not applicable - no frontend route, panel, draft, or client data flow changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/cardio.py`
- Denied paths: `backend/app/api/v1/endpoints/admin_clinic.py`, payment providers, frontend files, docs, migrations
- Migration/docs/test impact: no migrations or docs changed; existing cardio integration test was used for runtime validation
- Rollback note: revert commit `5c4d6bbf` to restore the previous logging strings if needed

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/cardio.py`; `pytest backend/tests/integration/test_cardio_api.py -q`; `rg -n "patient_id=%s|filtered_by_patient|created test_id=%s" backend/app/api/v1/endpoints/cardio.py`
- Result: `py_compile` passed; cardio integration tests passed (`3 passed`); grep confirmed the listing log now uses `filtered_by_patient` and the create log no longer includes `patient_id`
- Not checked: fresh CodeQL analysis on GitHub has not run yet; no broader backend suite was run because the patch is limited to one logging slice
