### PR TITLE
fix(security): hide admin display error details

### DIFF
--- a/backend/app/api/v1/endpoints/admin_display.py
+++ b/backend/app/api/v1/endpoints/admin_display.py
@@ -26,6 +26,19 @@ from app.schemas.display_config import DisplayBoardUpdate
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+ADMIN_DISPLAY_PUBLIC_ERROR = "Internal server error"
+
+
+def _admin_display_http_error(exc: Exception) -> HTTPException:
+    logger.warning(
+        "Admin display endpoint failed error_type=%s",
+        type(exc).__name__,
+    )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=ADMIN_DISPLAY_PUBLIC_ERROR,
+    )
+
 
 def _iso(value: datetime | None) -> str | None:
     return value.isoformat() if value else None
@@ -130,10 +143,7 @@ def get_display_boards(
         )
         return [_serialize_board(board) for board in boards]
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения списка табло: {str(e)}",
-        )
+        raise _admin_display_http_error(e) from e
 
 
 @router.get("/display/boards/{board_id}")
@@ -156,10 +166,7 @@ def get_display_board(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения табло: {str(e)}",
-        )
+        raise _admin_display_http_error(e) from e
 
 
 @router.put("/display/boards/{board_id}")
@@ -190,11 +197,10 @@ def update_display_board(
             "board_id": board_id,
             "board": _serialize_board(updated_board),
         }
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления табло: {str(e)}",
-        )
+        raise _admin_display_http_error(e) from e
 
 
 # ===================== БАННЕРЫ =====================
@@ -212,10 +218,7 @@ def get_display_banners(
         # Пока возвращаем заглушку
         return []
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения баннеров: {str(e)}",
-        )
+        raise _admin_display_http_error(e) from e
 
 
 @router.post("/display/boards/{board_id}/banners")
@@ -230,10 +233,7 @@ def create_display_banner(
         # Здесь будет реальная логика создания баннера
         return {"success": True, "message": "Баннер создан", "banner_id": 1}
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания баннера: {str(e)}",
-        )
+        raise _admin_display_http_error(e) from e
 
 
 @router.post("/display/upload-banner")
@@ -282,10 +282,7 @@ def upload_banner_image(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка загрузки баннера: {str(e)}",
-        )
+        raise _admin_display_http_error(e) from e
 
 
 # ===================== ТЕМЫ =====================
@@ -308,10 +305,7 @@ def get_display_themes(
         return [_serialize_theme(theme) for theme in themes]
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения тем: {str(e)}",
-        )
+        raise _admin_display_http_error(e) from e
 
 
 # ===================== ТЕСТИРОВАНИЕ ТАБЛО =====================
@@ -356,10 +350,7 @@ def test_display_board(
             return {"success": True, "message": f"Тест типа {test_type} выполнен"}
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка тестирования табло: {str(e)}",
-        )
+        raise _admin_display_http_error(e) from e
 
 
 # ===================== СТАТИСТИКА ТАБЛО =====================
@@ -400,7 +391,4 @@ def get_display_stats(
             "by_board": by_board,
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики табло: {str(e)}",
-        )
+        raise _admin_display_http_error(e) from e


### PR DESCRIPTION
﻿## Summary

- Replace admin display public 500 exception details with a stable generic message.
- Log only the exception type for internal admin display failures.
- Preserve explicit 400/404 validation responses and existing display board/theme/banner success contracts.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/admin_display.py` admin display endpoints.
- Request shape: unchanged.
- Response shape: unchanged for success and explicit validation/not-found responses; public 500 error bodies now use `Internal server error` instead of raw exception text.
- Status codes: unchanged for success, 400 validation, 404 not found, and 500 internal failures.
- Frontend consumer: unchanged because no frontend files, route contracts, or success payloads changed.
- Compatibility path or alias: unchanged; no routing, prefix, or alias behavior changed.
- Contract proof: compile, diff hygiene, and static scans passed locally; explicit `HTTPException` branches remain re-raised.

## RBAC / Permissions

- Roles allowed: unchanged existing `require_roles("Admin")` guards.
- Roles denied: unchanged because no role guards, auth dependencies, or permission checks were edited.
- Positive auth proof: not checked locally because this slice changes only internal 500 error handling.
- Negative auth proof: not applicable because denied-role behavior was not changed.

## Notification / Realtime

- Event type or websocket channel: not applicable because no notification, Telegram, websocket, or realtime event surface changed.
- Payload version / ack behavior: not applicable because no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable because this endpoint slice does not touch delivery or read-state semantics.
- Reconnect/resync proof: not applicable because no websocket reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged; no frontend files or success response shapes changed.
- Partial data proof: not applicable because no frontend parsing or partial-data handling changed.
- Forbidden secondary path behavior: not applicable because no secondary frontend path or forbidden route behavior changed.
- Missing draft/resource behavior: not applicable because this slice does not create, reopen, or recover drafts/resources.
- Stale route/deep-link behavior: not applicable because no route registry, alias, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_display.py` only.
- Denied paths: frontend files, route mounting, migrations, RBAC dependencies, service implementations, generated output, and unrelated endpoint modules.
- Migration/docs/test impact: no migration required; no docs required for this narrow security hardening; targeted compile/static checks used as validation.
- Rollback note: revert commit `b8deb2bf` to restore the previous raw exception detail behavior if needed.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/admin_display.py`; `git diff --check`; `Select-String` static search for old `str(e)`, `detail=f"`, and raw exception logging patterns in `backend/app/api/v1/endpoints/admin_display.py`.
- Result: compile passed; diff check passed; static scan found no `str(e)` 500-detail patterns and only the expected explicit 404 `detail=f"...board_id..."` messages remained.
- Not checked: full backend suite and browser/admin display smoke were not run locally for this one-file error-handling slice; GitHub CI will run broader automated checks.
