### PR TITLE
fix(security): hide emr export error details

### DIFF
--- a/backend/app/api/v1/endpoints/emr_export.py
+++ b/backend/app/api/v1/endpoints/emr_export.py
@@ -3,7 +3,8 @@ API endpoints для экспорта и импорта EMR данных
 """
 
 import io
-from typing import List, Optional
+import logging
+from typing import List, NoReturn, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
@@ -15,6 +16,18 @@ from app.schemas.emr import EMRBase, EMRUpdate
 from app.services.emr_export_service import EMRExportService
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+EMR_EXPORT_PUBLIC_ERROR = "Internal server error"
+
+
+def _raise_emr_export_internal_error(operation: str, exc: Exception) -> NoReturn:
+    logger.warning(
+        "EMR export endpoint failed operation=%s error_type=%s",
+        operation,
+        type(exc).__name__,
+    )
+    raise HTTPException(status_code=500, detail=EMR_EXPORT_PUBLIC_ERROR) from exc
 
 
 @router.get("/formats")
@@ -30,9 +43,7 @@ async def get_export_formats(current_user: User = Depends(get_current_user)):
             "message": "Список форматов экспорта получен",
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения форматов: {str(e)}"
-        )
+        _raise_emr_export_internal_error("get_export_formats", e)
 
 
 @router.get("/formats/import")
@@ -48,9 +59,7 @@ async def get_import_formats(current_user: User = Depends(get_current_user)):
             "message": "Список форматов импорта получен",
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения форматов: {str(e)}"
-        )
+        _raise_emr_export_internal_error("get_import_formats", e)
 
 
 @router.post("/export/json")
@@ -78,7 +87,7 @@ async def export_emr_to_json(
             "message": "EMR успешно экспортирован в JSON",
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка экспорта в JSON: {str(e)}")
+        _raise_emr_export_internal_error("export_emr_to_json", e)
 
 
 @router.post("/export/xml")
@@ -101,7 +110,7 @@ async def export_emr_to_xml(
             headers={"Content-Disposition": "attachment; filename=emr_export.xml"},
         )
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка экспорта в XML: {str(e)}")
+        _raise_emr_export_internal_error("export_emr_to_xml", e)
 
 
 @router.post("/export/csv")
@@ -124,7 +133,7 @@ async def export_emr_to_csv(
             headers={"Content-Disposition": "attachment; filename=emr_export.csv"},
         )
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка экспорта в CSV: {str(e)}")
+        _raise_emr_export_internal_error("export_emr_to_csv", e)
 
 
 @router.post("/export/zip")
@@ -147,7 +156,7 @@ async def export_emr_to_zip(
             headers={"Content-Disposition": "attachment; filename=emr_export.zip"},
         )
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка экспорта в ZIP: {str(e)}")
+        _raise_emr_export_internal_error("export_emr_to_zip", e)
 
 
 @router.post("/import/json")
@@ -166,7 +175,7 @@ async def import_emr_from_json(
             "message": "EMR успешно импортирован из JSON",
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка импорта из JSON: {str(e)}")
+        _raise_emr_export_internal_error("import_emr_from_json", e)
 
 
 @router.post("/import/xml")
@@ -185,7 +194,7 @@ async def import_emr_from_xml(
             "message": "EMR успешно импортирован из XML",
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка импорта из XML: {str(e)}")
+        _raise_emr_export_internal_error("import_emr_from_xml", e)
 
 
 @router.post("/import/zip")
@@ -204,7 +213,7 @@ async def import_emr_from_zip(
             "message": "EMR успешно импортирован из ZIP",
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка импорта из ZIP: {str(e)}")
+        _raise_emr_export_internal_error("import_emr_from_zip", e)
 
 
 @router.post("/validate")
@@ -227,7 +236,7 @@ async def validate_import_data(
             "message": "Валидация данных выполнена",
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка валидации: {str(e)}")
+        _raise_emr_export_internal_error("validate_import_data", e)
 
 
 @router.post("/estimate-size")
@@ -250,7 +259,7 @@ async def estimate_export_size(
             "message": "Размер экспорта оценен",
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка оценки размера: {str(e)}")
+        _raise_emr_export_internal_error("estimate_export_size", e)
 
 
 @router.get("/templates/export")
@@ -302,9 +311,7 @@ async def get_export_templates(current_user: User = Depends(get_current_user)):
             "message": "Шаблоны экспорта получены",
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения шаблонов: {str(e)}"
-        )
+        _raise_emr_export_internal_error("get_export_templates", e)
 
 
 @router.get("/statistics")
@@ -327,6 +334,4 @@ async def get_export_statistics(current_user: User = Depends(get_current_user)):
             "message": "Статистика экспорта/импорта получена",
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения статистики: {str(e)}"
-        )
+        _raise_emr_export_internal_error("get_export_statistics", e)


### PR DESCRIPTION
## Summary

- Replace EMR export/import endpoint public 500 details with a stable generic message.
- Stop exposing raw exception text from EMR export, import, validation, template, and statistics failure paths.
- Preserve EMR export route mount, auth dependency, success payloads, download headers, and format-specific behavior.

## Contract Impact

- Canonical surface: `/api/v1/emr/export/*` endpoints implemented in `backend/app/api/v1/endpoints/emr_export.py`.
- Request shape: unchanged authenticated endpoint requests and existing body/query parameters.
- Response shape: unchanged success payloads and response headers; public internal failure details now use `Internal server error` instead of raw exception text.
- Status codes: unchanged for success and internal failure paths.
- Frontend consumer: unchanged existing EMR export/import consumers; no frontend files changed.
- Compatibility path or alias: not applicable because this slice does not add, remove, or redirect routes or aliases.
- Contract proof: compile/static checks plus endpoint-level smoke prove a service exception now returns a generic 500 detail without changing success-path response structures.

## RBAC / Permissions

- Roles allowed: unchanged existing `get_current_user` authentication dependency and downstream access behavior.
- Roles denied: unchanged because no role guards, auth dependencies, or permission checks were edited.
- Positive auth proof: not applicable because this slice does not alter successful auth behavior or authorization wiring.
- Negative auth proof: not applicable because this slice does not alter denied-role behavior or authorization wiring.

## Notification / Realtime

- Event type or websocket channel: not applicable because no notification, Telegram, websocket, or realtime event surface changed.
- Payload version / ack behavior: not applicable because no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable because this endpoint slice does not touch delivery or read-state semantics.
- Reconnect/resync proof: not applicable because no websocket reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged because no frontend rendering, empty state, or export/import response collection shape changed.
- Partial data proof: unchanged because no frontend parsing or partial-data handling changed.
- Forbidden secondary path behavior: not applicable because no secondary frontend path or forbidden route behavior changed.
- Missing draft/resource behavior: not applicable because this slice does not create, reopen, or recover drafts/resources.
- Stale route/deep-link behavior: not applicable because no route registry, alias, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/emr_export.py` only.
- Denied paths: frontend files, route mounting, migrations, auth dependencies, EMR export service implementation, generated output, and unrelated endpoint modules.
- Migration/docs/test impact: no migration required; no docs required for this narrow security hardening; no dedicated EMR export endpoint test file was found, so validation used compile/static/endpoint smoke.
- Rollback note: revert commit `5b85c0e4` to restore the previous raw exception detail behavior if needed.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/emr_export.py`; static search for raw `detail=f...str(e)` / `detail=str(e)` patterns in `backend/app/api/v1/endpoints/emr_export.py`; endpoint-level smoke that monkeypatches `EMRExportService.export_emr_to_json` to raise and asserts a generic 500 detail.
- Result: compile passed; static search returned no matches; endpoint-level marker-redaction smoke passed.
- Not checked: no dedicated EMR export endpoint test file was found; local frontend build/audit was not run because this backend-only slice does not touch frontend files and the gate's frontend package targets were a known misroute for this confirmed root-cause patch.