### PR TITLE
fix(security): escape html validator helper

### DIFF
--- a/backend/app/schemas/validators.py
+++ b/backend/app/schemas/validators.py
@@ -4,6 +4,7 @@
 Этот модуль содержит переиспользуемые валидаторы для обеспечения
 бизнес-логики на уровне данных.
 """
+import html
 import re
 from datetime import date, datetime, timedelta
 
@@ -216,11 +217,5 @@ def sanitize_html(v: str | None) -> str | None:
         Очищенная строка
     """
     if v is not None:
-        # Удаляем script и style теги с их содержимым
-        v = re.sub(r'<script[^>]*>.*?</script>', '', v, flags=re.IGNORECASE | re.DOTALL)
-        v = re.sub(r'<style[^>]*>.*?</style>', '', v, flags=re.IGNORECASE | re.DOTALL)
-        # Удаляем on* атрибуты (onclick, onload, etc.)
-        v = re.sub(r'\s+on\w+\s*=\s*["\'][^"\']*["\']', '', v, flags=re.IGNORECASE)
-        # Удаляем javascript: URLs
-        v = re.sub(r'javascript:', '', v, flags=re.IGNORECASE)
+        v = html.escape(v, quote=True)
     return v


### PR DESCRIPTION
﻿## Summary

- replace the regex-based `sanitize_html` helper with `html.escape(..., quote=True)` so malformed script tags cannot bypass a brittle custom filter
- keep the change isolated to `backend/app/schemas/validators.py`; current repository search shows `sanitize_html` has no live callers outside its own definition

## Contract Impact

not applicable - this helper currently has no live callers and the patch does not change any route, schema payload, or external contract.

## RBAC / Permissions

not applicable - no auth, role, or permission logic changed.

## Notification / Realtime

not applicable - no notification, websocket, or realtime path changed.

## Frontend Resilience

not applicable - no frontend code or client data flow changed.

## Scope Gate

- Allowed paths: `backend/app/schemas/validators.py`
- Denied paths: endpoints, services, frontend files, docs, migrations, and test files
- Migration/docs/test impact: no migrations or docs changed; validation used `py_compile`, a focused inline harness, and repo search proof instead of adding a new test file for an unused helper
- Rollback note: revert commit `f6b78792` to restore the old regex-based helper

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/schemas/validators.py`; inline Python harness covering `</script >`, inline event handlers, and `javascript:` payloads; `rg -n "sanitize_html\(|html.escape|<script\[\^>\]\*|javascript:" backend/app/schemas/validators.py` and repo search for `sanitize_html(` callers
- Result: `py_compile` passed; harness passed and confirmed dangerous markup is escaped into plain text; grep confirmed `html.escape` is the only sanitization path left in the helper and repo search found no live callers beyond the helper definition
- Not checked: fresh GitHub CodeQL analysis has not run yet; no broader backend suite was run because the helper is currently unused and the change is constrained to one file
