### PR TITLE
fix(security): hide emr ai error details

### DIFF
--- a/.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md
+++ b/.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md
@@ -1418,6 +1418,53 @@ LightRAG evidence note:
 
 - No new LightRAG readiness entry was appended for this routine narrow gate slice; no gate misroute or retrieval regression was observed.
 
+## Task 26 Current Slice Evidence (2026-05-12 - EMR AI endpoint)
+
+Execution mode:
+
+- selected mode: `gate_known_root_cause`
+- reason: narrow Task 26 runtime leak fix in the canonical EMR AI endpoint without changing draft-only clinical behavior
+- risky domain: yes
+- root cause known: yes
+- command: `python scripts\agent_gate.py "Task 26 sanitize emr_ai endpoint public raw exception leakage without changing AI draft-only behavior route prefixes auth guards or success response shapes" --known-root-cause "backend/app/api/v1/endpoints/emr_ai.py"`
+
+Initial boundaries:
+
+- canonical anchor: `backend/app/api/v1/endpoints/emr_ai.py`
+- first-touch files: `backend/app/api/v1/endpoints/emr_ai.py`
+- validation target: compile, static no-match for public `str(e)` leakage, and direct endpoint smoke proving generic 500 redaction
+- stop condition watched first: any needed change outside `emr_ai.py` or any change to AI approval semantics, route/auth behavior, or success response shapes
+
+Gate result:
+
+- The gate response misrouted the first-touch set toward unrelated frontend routing files even with the confirmed root-cause file supplied.
+- Per `AGENTS.md`, execution continued as a narrow override limited to `backend/app/api/v1/endpoints/emr_ai.py`.
+
+Changed behavior:
+
+- Added a structured EMR AI endpoint helper that logs only the operation name and exception class for internal failures.
+- Replaced raw public HTTP 500 details that included exception text across the EMR AI suggestion/validation handlers with a generic `Internal server error` response.
+- Preserved AI draft/suggestion posture, existing `requires_doctor_confirmation` behavior, route prefixes, auth guards, and success payload shapes.
+
+Validation run:
+
+- `python -m py_compile backend\app\api\v1\endpoints\emr_ai.py`
+  - result: passed
+- `rg -n "detail=f.*str\(e\)|detail=str\(|logger\.error\(f|logger\.exception\(f|\{str\(e\)\}" backend\app\api\v1\endpoints\emr_ai.py`
+  - result: no matches
+- direct async endpoint smoke with a monkeypatched EMR AI service raising a marker exception
+  - result: passed; HTTP 500 returned `Internal server error` and the marker text did not leak
+- `git diff --check`
+  - result: passed
+
+Scope note:
+
+- Task 26 remains open. This slice only hardens one confirmed EMR AI runtime surface and does not claim the broader backend leak audit is finished.
+
+LightRAG evidence note:
+
+- A new LightRAG readiness entry was not appended for this slice; the gate misroute was handled locally under the existing narrow-override rule and did not require a separate retrieval-quality evidence update.
+
 ## Task 26 Slice A Evidence
 
 Execution mode:

--- a/backend/app/api/v1/endpoints/emr_ai.py
+++ b/backend/app/api/v1/endpoints/emr_ai.py
@@ -2,7 +2,8 @@
 API endpoints для AI функций EMR
 """
 
-from typing import Any, Dict, List, Optional
+import logging
+from typing import Any, Dict, List, NoReturn, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
@@ -13,6 +14,7 @@ from app.models.user import User
 from app.services.emr_ai_service import EMRService, get_emr_ai_service
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 EMR_AI_ACCESS = require_any_ai_permission(
     AIPermission.ADMIN_AI,
@@ -20,6 +22,17 @@ EMR_AI_ACCESS = require_any_ai_permission(
     AIPermission.SUGGEST_ICD10,
     AIPermission.ANALYZE_DOCUMENT,
 )
+
+EMR_AI_PUBLIC_ERROR = "Internal server error"
+
+
+def _raise_emr_ai_internal_error(operation: str, exc: Exception) -> NoReturn:
+    logger.warning(
+        "EMR AI endpoint failed operation=%s error_type=%s",
+        operation,
+        type(exc).__name__,
+    )
+    raise HTTPException(status_code=500, detail=EMR_AI_PUBLIC_ERROR) from exc
 
 
 def ai_safety_meta() -> Dict[str, Any]:
@@ -52,9 +65,7 @@ async def get_diagnosis_suggestions(
             **ai_safety_meta(),
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения предложений диагнозов: {str(e)}"
-        )
+        _raise_emr_ai_internal_error("get_diagnosis_suggestions", e)
 
 
 @router.post("/suggestions/treatment")
@@ -77,9 +88,7 @@ async def get_treatment_suggestions(
             **ai_safety_meta(),
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения предложений лечения: {str(e)}"
-        )
+        _raise_emr_ai_internal_error("get_treatment_suggestions", e)
 
 
 @router.post("/suggestions/icd10")
@@ -100,9 +109,7 @@ async def get_icd10_suggestions(
             **ai_safety_meta(),
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения кодов МКБ-10: {str(e)}"
-        )
+        _raise_emr_ai_internal_error("get_icd10_suggestions", e)
 
 
 @router.post("/auto-fill")
@@ -127,9 +134,7 @@ async def auto_fill_emr_fields(
             **ai_safety_meta(),
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка автозаполнения EMR: {str(e)}"
-        )
+        _raise_emr_ai_internal_error("auto_fill_emr_fields", e)
 
 
 @router.post("/validate")
@@ -150,7 +155,7 @@ async def validate_emr_data(
             return {**validation_result, **ai_safety_meta()}
         return {"result": validation_result, **ai_safety_meta()}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка валидации EMR: {str(e)}")
+        _raise_emr_ai_internal_error("validate_emr_data", e)
 
 
 @router.post("/suggestions/ai")
@@ -172,9 +177,7 @@ async def get_ai_suggestions(
             **ai_safety_meta(),
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения AI предложений: {str(e)}"
-        )
+        _raise_emr_ai_internal_error("get_ai_suggestions", e)
 
 
 @router.get("/suggestions/health")


### PR DESCRIPTION
﻿## Summary
- Hardened the canonical EMR AI HTTP endpoints so raw internal exception text no longer reaches API consumers.
- Added a structured warning helper that logs only the failing operation name and exception class.
- Recorded the slice evidence in the recovery status log so `/aif-implement @.ai-factory/PLAN.md` can resume cleanly.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/emr_ai.py` mounted at `/api/v1/emr/ai/*`.
- Request shape: unchanged for diagnosis, treatment, ICD10, auto-fill, validate, and general AI suggestion inputs.
- Response shape: success payloads are unchanged; internal-failure responses now return the generic detail `Internal server error` instead of raw exception text.
- Status codes: success codes are unchanged; protected endpoints still use existing auth/403 behavior; internal failures remain HTTP 500.
- Frontend consumer: existing doctor and specialist EMR AI consumers keep the same success payload contract; only sanitized 500 detail text changes.
- Compatibility path or alias: no route prefixes, aliases, or compatibility paths changed; `/api/v1/emr/ai/*` remains the canonical surface.
- Contract proof: diff is limited to `emr_ai.py` error handling plus a status-log entry, with compile, static leak search, and direct endpoint smoke proving the redacted 500 behavior.

## RBAC / Permissions
- Roles allowed: unchanged; the edited endpoints still require `EMR_AI_ACCESS`, which accepts users with `ADMIN_AI`, `DIAGNOSE`, `SUGGEST_ICD10`, or `ANALYZE_DOCUMENT` permission.
- Roles denied: unchanged; users without any of those AI permissions still flow through the existing `require_any_ai_permission` HTTP 403 guard.
- Positive auth proof: every edited handler in `emr_ai.py` still declares `current_user: User = Depends(EMR_AI_ACCESS)`.
- Negative auth proof: not checked because this slice did not alter RBAC wiring and no dedicated EMR AI permission test was added in this PR.

## Notification / Realtime
- Event type or websocket channel: not applicable because `emr_ai.py` exposes synchronous HTTP suggestion endpoints only and this slice did not touch websocket or event contracts.
- Payload version / ack behavior: not applicable because these endpoints do not publish notification payloads or require acknowledgement flows.
- Read/unread or delivery semantics: not applicable because no notification delivery or queueing behavior exists in this slice.
- Reconnect/resync proof: not applicable because `/api/v1/emr/ai/*` does not maintain a realtime session.

## Frontend Resilience
- Empty data proof: not applicable because no frontend files changed and this PR does not alter empty-state rendering logic.
- Partial data proof: not applicable because success payload shapes are unchanged; only server-side 500 detail text is sanitized.
- Forbidden secondary path behavior: not applicable because routing, aliases, and alternate frontend navigation paths were not edited.
- Missing draft/resource behavior: draft-only behavior remains intact because `requires_doctor_confirmation` metadata and the AI safety payload are unchanged.
- Stale route/deep-link behavior: not applicable because no route or deep-link handler changed in this backend-only slice.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/emr_ai.py`; `.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md`.
- Denied paths: all other backend AI services/routes, frontend navigation, auth, RBAC mappings, migrations, and deployment configuration.
- Migration/docs/test impact: no migration; recovery progress log updated; validation used compile, static search, and a direct async endpoint smoke.
- Rollback note: revert commits `1df6166f` and `b8c2eda5` to restore the previous EMR AI error-detail behavior and remove the matching recovery log entry.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\emr_ai.py`; `rg -n "detail=f.*str\(e\)|detail=str\(|logger\.error\(f|logger\.exception\(f|\{str\(e\)\}" backend\app\api\v1\endpoints\emr_ai.py`; direct async endpoint smoke with a monkeypatched `get_emr_ai_service` failure.
- Result: passed; compile succeeded, the static leak search returned no matches, and the smoke returned HTTP 500 with generic detail while hiding the marker exception text.
- Not checked: full backend pytest suite, frontend build, and dedicated EMR AI RBAC tests were not run in this narrow backend-only slice.
