### PR TITLE
fix(security): hide enhanced telegram webhook error details

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook_enhanced.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook_enhanced.py
@@ -3,7 +3,7 @@
 """
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
@@ -17,6 +17,7 @@ from app.services.telegram_bot_enhanced import get_enhanced_telegram_bot
 router = APIRouter()
 logger = logging.getLogger(__name__)
 WEBHOOK_SECRET_HEADER = "x-telegram-bot-api-secret-token"
+TELEGRAM_ENHANCED_PUBLIC_ERROR = "Internal server error"
 
 
 def _validate_webhook_secret(request: Request, db: Session) -> None:
@@ -36,6 +37,32 @@ def _validate_webhook_secret(request: Request, db: Session) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid Telegram webhook secret",
         )
+
+
+def _raise_telegram_enhanced_internal_error(
+    operation: str, exc: Exception
+) -> NoReturn:
+    logger.warning(
+        "Enhanced Telegram webhook endpoint failed operation=%s error_type=%s",
+        operation,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=TELEGRAM_ENHANCED_PUBLIC_ERROR,
+    ) from exc
+
+
+def _telegram_enhanced_test_failure(exc: Exception) -> Dict[str, Any]:
+    logger.warning(
+        "Enhanced Telegram webhook endpoint failed operation=test_webhook error_type=%s",
+        type(exc).__name__,
+    )
+    return {
+        "status": "error",
+        "message": TELEGRAM_ENHANCED_PUBLIC_ERROR,
+        "processed_data": None,
+    }
 
 
 @router.post("/webhook/enhanced")
@@ -61,8 +88,7 @@ async def telegram_webhook_enhanced(request: Request, db: Session = Depends(get_
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка обработки webhook: {e}")
-        raise HTTPException(status_code=500, detail="Internal server error")
+        _raise_telegram_enhanced_internal_error("telegram_webhook_enhanced", e)
 
 
 @router.get("/webhook/info")
@@ -93,8 +119,7 @@ async def webhook_info(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка получения информации о webhook: {e}")
-        raise HTTPException(status_code=500, detail="Internal server error")
+        _raise_telegram_enhanced_internal_error("webhook_info", e)
 
 
 @router.post("/webhook/test")
@@ -122,5 +147,4 @@ async def test_webhook(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка тестирования webhook: {e}")
-        return {"status": "error", "message": str(e), "processed_data": test_data}
+        return _telegram_enhanced_test_failure(e)


### PR DESCRIPTION
﻿## Summary
- Hardened `telegram_webhook_enhanced.py` so enhanced Telegram endpoint failures no longer log raw exception text.
- Sanitized `/webhook/test` failure output so it no longer reflects raw `str(e)` or caller-provided `test_data` back to the client.
- Preserved webhook secret validation, admin role checks, route prefixes, and success payload shapes.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/telegram_webhook_enhanced.py` mounted under `/api/v1/telegram/*`.
- Request shape: unchanged for `/webhook/enhanced`, `/webhook/info`, and `/webhook/test`.
- Response shape: success payloads are unchanged; failure payloads now use `Internal server error`, and `/webhook/test` failure returns `processed_data: null` instead of echoing the submitted payload.
- Status codes: `/webhook/enhanced` and `/webhook/info` internal failures remain HTTP 500; `/webhook/test` keeps its existing JSON error response style.
- Frontend consumer: no frontend files changed; Telegram manager/admin consumers keep the same success contract.
- Compatibility path or alias: no route aliases, prefixes, or router mounts changed.
- Contract proof: diff is limited to the enhanced Telegram webhook endpoint, with compile, static leak search, direct marker-redaction smoke, and frontend build validation.

## RBAC / Permissions
- Roles allowed: unchanged; `/webhook/info` and `/webhook/test` still require `require_roles("Admin")`, and `/webhook/enhanced` still uses the Telegram secret-token gate.
- Roles denied: unchanged; non-admin callers and invalid webhook secrets continue through the existing denial paths.
- Positive auth proof: edited admin handlers still declare `current_user: User = Depends(require_roles("Admin"))`, and the webhook handler still calls `_validate_webhook_secret(...)`.
- Negative auth proof: not checked with a dedicated enhanced-webhook RBAC test because this slice did not edit RBAC dependencies or secret validation logic.

## Notification / Realtime
- Event type or websocket channel: not applicable because this PR changes only enhanced Telegram HTTP endpoint error handling and does not alter websocket channels.
- Payload version / ack behavior: the successful Telegram acknowledgement `{"status": "ok"}` remains unchanged.
- Read/unread or delivery semantics: not applicable because no notification delivery state, read state, or retry queue behavior changed.
- Reconnect/resync proof: not applicable because these HTTP handlers do not own a reconnectable realtime session.

## Frontend Resilience
- Empty data proof: not applicable because no frontend rendering or empty-state path changed.
- Partial data proof: not applicable because successful frontend-facing Telegram response shapes are unchanged.
- Forbidden secondary path behavior: not applicable because route guards and navigation were not edited.
- Missing draft/resource behavior: not applicable because this PR does not touch drafts, resources, or loading fallback UI.
- Stale route/deep-link behavior: not applicable because no route aliases or deep links changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook_enhanced.py`.
- Denied paths: other Telegram routers, bot services, frontend Telegram manager, auth/RBAC config, migrations, and deployment files.
- Migration/docs/test impact: no migration and no committed test-file changes; frontend `node_modules`/`dist` and Python cache files were local ignored validation artifacts only.
- Rollback note: revert commit `a3aa3b4d` to restore the previous enhanced Telegram failure logging and `/webhook/test` failure echo behavior.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\telegram_webhook_enhanced.py`; `python -m py_compile backend\app\api\v1\endpoints\telegram_webhook_enhanced.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; static `rg` leak search; direct async marker-redaction smoke for `/webhook/enhanced` and `/webhook/test`; `npm.cmd ci --no-audit --no-fund`; `npm.cmd run build` from `frontend/`.
- Result: passed; compile succeeded, static leak search returned no matches, smoke proved marker and payload text are not returned or logged, and frontend build completed with existing chunk-size/dynamic-import warnings.
- Not checked: full backend pytest suite and dedicated enhanced Telegram RBAC tests were not run in this narrow backend-only slice.
