### PR TITLE
fix(security): hide roles endpoint error details

### DIFF
--- a/backend/app/api/v1/endpoints/roles.py
+++ b/backend/app/api/v1/endpoints/roles.py
@@ -2,7 +2,7 @@
 API endpoints for Role management
 """
 import logging
-from typing import Optional
+from typing import NoReturn, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
@@ -22,6 +22,19 @@ from app.services.roles_api_service import RolesApiDomainError, RolesApiService
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+ROLES_PUBLIC_ERROR = "Internal server error"
+
+
+def _raise_roles_internal_error(operation: str, exc: Exception) -> NoReturn:
+    logger.warning(
+        "Roles endpoint failed operation=%s error_type=%s",
+        operation,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=ROLES_PUBLIC_ERROR,
+    ) from exc
 
 
 @router.get("/", response_model=RoleListResponse)
@@ -47,11 +60,7 @@ async def get_roles(
             total=len(roles)
         )
     except Exception as e:
-        logger.error(f"Error fetching roles: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения списка ролей: {str(e)}"
-        )
+        _raise_roles_internal_error("get_roles", e)
 
 
 @router.get("/options", response_model=RoleOptionsListResponse)
@@ -84,11 +93,7 @@ async def get_role_options(
         
         return RoleOptionsListResponse(options=options)
     except Exception as e:
-        logger.error(f"Error fetching role options: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения списка ролей: {str(e)}"
-        )
+        _raise_roles_internal_error("get_role_options", e)
 
 
 @router.get("/{role_id}", response_model=RoleResponse)
@@ -129,11 +134,7 @@ async def create_role(
     except RolesApiDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except Exception as e:
-        logger.error(f"Error creating role: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания роли: {str(e)}"
-        )
+        _raise_roles_internal_error("create_role", e)
 
 
 @router.put("/{role_id}", response_model=RoleResponse)
@@ -165,11 +166,7 @@ async def update_role(
     except RolesApiDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except Exception as e:
-        logger.error(f"Error updating role: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления роли: {str(e)}"
-        )
+        _raise_roles_internal_error("update_role", e)
 
 
 @router.delete("/{role_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -196,8 +193,4 @@ async def delete_role(
     except RolesApiDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except Exception as e:
-        logger.error(f"Error deleting role: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка удаления роли: {str(e)}"
-        )
+        _raise_roles_internal_error("delete_role", e)


### PR DESCRIPTION
﻿## Summary
- Hardened the roles endpoint so internal exception text no longer reaches public HTTP 500 responses.
- Replaced raw f-string exception logging with structured warning logs that keep only operation name and exception class.
- Preserved role service domain errors, admin checks, route prefixes, and success response schemas.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/roles.py` mounted as the backend roles API surface.
- Request shape: unchanged for role list, options, create, update, and delete handlers.
- Response shape: success payloads and `RolesApiDomainError` payloads are unchanged; unexpected internal failures now return `Internal server error` instead of exception text.
- Status codes: internal failures remain HTTP 500; existing 403 admin guards and domain error status codes are unchanged.
- Frontend consumer: no frontend files changed; role management consumers keep the same success contract.
- Compatibility path or alias: no route prefix, alias, or router mount changed in this slice.
- Contract proof: diff is limited to `roles.py`, with compile, static leak search, direct marker-redaction smoke, targeted service tests, and frontend build validation.

## RBAC / Permissions
- Roles allowed: unchanged; read handlers still require `get_current_user`, while create/update/delete still require `current_user.role == "Admin"`.
- Roles denied: unchanged; non-admin create/update/delete attempts still fail with the existing HTTP 403 guard before service execution.
- Positive auth proof: edited handlers still declare the same auth dependencies and admin checks.
- Negative auth proof: direct smoke verified a non-admin create-role call still returns HTTP 403; no route-level RBAC test file was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable because roles endpoints are synchronous HTTP CRUD handlers and do not emit realtime events.
- Payload version / ack behavior: not applicable because no notification or acknowledgement payload changed.
- Read/unread or delivery semantics: not applicable because roles endpoints do not own notification delivery state.
- Reconnect/resync proof: not applicable because this slice does not involve websocket or reconnectable sessions.

## Frontend Resilience
- Empty data proof: not applicable because no frontend empty-state rendering changed.
- Partial data proof: not applicable because frontend-facing success response shapes are unchanged.
- Forbidden secondary path behavior: not applicable because route guards and navigation paths were not edited.
- Missing draft/resource behavior: not applicable because this PR does not touch drafts, resources, or loading fallback UI.
- Stale route/deep-link behavior: not applicable because no route aliases or deep-link handlers changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/roles.py`.
- Denied paths: role service/repository logic, frontend route registry/selectors, auth config, migrations, and deployment files.
- Migration/docs/test impact: no migration and no committed test-file changes; frontend `node_modules`/`dist`, Python caches, and local `.secret_key` were ignored validation artifacts only.
- Rollback note: revert commit `6c7846ab` to restore previous roles endpoint public error-detail behavior.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\roles.py`; static `rg` leak search; direct async marker-redaction smoke across list/options/create/update/delete plus non-admin create guard; `python -m pytest backend\tests\unit\test_roles_api_service.py -q --tb=short --disable-warnings` with local SQLite env; `npm.cmd ci --no-audit --no-fund`; `npm.cmd run build` from `frontend/`.
- Result: passed; compile succeeded, static leak search returned no matches, marker text did not leak through details/logs, targeted roles service tests passed (2 passed), and frontend build completed with existing chunk-size/dynamic-import warnings.
- Not checked: full backend pytest suite and browser smoke were not run in this narrow backend-only slice.
