### PR TITLE
fix(security): hide admin providers error details

### DIFF
--- a/backend/app/api/v1/endpoints/admin_providers.py
+++ b/backend/app/api/v1/endpoints/admin_providers.py
@@ -1,6 +1,7 @@
 # app/api/v1/endpoints/admin_providers.py
 from __future__ import annotations
 
+import logging
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -22,6 +23,21 @@ from app.schemas.payment_webhook import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+ADMIN_PROVIDERS_PUBLIC_ERROR = "Internal server error"
+ADMIN_PROVIDERS_BULK_ITEM_ERROR = "Provider update failed"
+
+
+def _admin_providers_http_error(exc: Exception) -> HTTPException:
+    logger.warning(
+        "Admin providers endpoint failed error_type=%s",
+        type(exc).__name__,
+    )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=ADMIN_PROVIDERS_PUBLIC_ERROR,
+    )
 
 
 @router.get(
@@ -40,10 +56,7 @@ def list_providers(
         providers = get_all_providers(db, skip=offset, limit=limit)
         return providers
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения провайдеров: {str(e)}",
-        )
+        raise _admin_providers_http_error(e) from e
 
 
 @router.get(
@@ -68,10 +81,7 @@ def get_provider(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения провайдера: {str(e)}",
-        )
+        raise _admin_providers_http_error(e) from e
 
 
 @router.post(
@@ -101,10 +111,7 @@ def create_new_provider(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания провайдера: {str(e)}",
-        )
+        raise _admin_providers_http_error(e) from e
 
 
 @router.put(
@@ -144,10 +151,7 @@ def update_existing_provider(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления провайдера: {str(e)}",
-        )
+        raise _admin_providers_http_error(e) from e
 
 
 @router.delete("/admin/providers/{provider_id}", summary="Удаление провайдера")
@@ -180,10 +184,7 @@ def delete_existing_provider(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка удаления провайдера: {str(e)}",
-        )
+        raise _admin_providers_http_error(e) from e
 
 
 @router.get(
@@ -220,10 +221,7 @@ def test_provider_connection(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка тестирования провайдера: {str(e)}",
-        )
+        raise _admin_providers_http_error(e) from e
 
 
 @router.get("/admin/providers/{provider_id}/stats", summary="Статистика провайдера")
@@ -261,10 +259,7 @@ def get_provider_stats(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
-        )
+        raise _admin_providers_http_error(e) from e
 
 
 @router.post("/admin/providers/bulk-update", summary="Массовое обновление провайдеров")
@@ -314,7 +309,18 @@ def bulk_update_providers(
                 )
 
             except Exception as e:
-                results.append({"id": provider_id, "success": False, "error": str(e)})
+                logger.warning(
+                    "Admin providers bulk update item failed provider_id=%s error_type=%s",
+                    provider_id,
+                    type(e).__name__,
+                )
+                results.append(
+                    {
+                        "id": provider_id,
+                        "success": False,
+                        "error": ADMIN_PROVIDERS_BULK_ITEM_ERROR,
+                    }
+                )
 
         return {
             "success": True,
@@ -323,7 +329,4 @@ def bulk_update_providers(
         }
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка массового обновления: {str(e)}",
-        )
+        raise _admin_providers_http_error(e) from e


### PR DESCRIPTION
﻿## Summary

- Replace raw public `500` exception details in admin providers endpoints with a stable generic message.
- Add a shared endpoint helper that logs only the exception type for internal provider-management failures.
- Sanitize per-item bulk-update failures so `results[]` no longer exposes raw backend exception text.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/admin_providers.py` admin provider list/get/create/update/delete/test/stats/bulk-update endpoints.
- Request shape: unchanged.
- Response shape: unchanged for success, explicit `400`, and explicit `404` responses; unexpected internal failures now return `Internal server error`. Bulk-update still returns per-item `id`/`success`, but failed items now use a stable `Provider update failed` message instead of raw exception text.
- Status codes: unchanged for success, validation/not-found, and `500` internal failures.
- Frontend consumer: unchanged because no frontend code or provider success payload shape changed.
- Compatibility path or alias: unchanged; no routing, prefix, or alias changed.
- Contract proof: `python -m py_compile backend\app\api\v1\endpoints\admin_providers.py` passed and static scans confirmed raw `str(e)` sinks were removed from public `500` and bulk-item error payloads.

## RBAC / Permissions

- Roles allowed: unchanged existing `require_roles("Admin")` guards.
- Roles denied: unchanged because no auth dependency or permission check changed.
- Positive auth proof: not applicable because this slice changes only internal error reporting.
- Negative auth proof: not applicable because denied-role behavior was not changed.

## Notification / Realtime

- Notification behavior: unchanged; no websocket, Telegram, notification, or realtime delivery path changed.
- Realtime behavior: unchanged.
- Event type or websocket channel: none changed.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable because no realtime path changed.

## Frontend Resilience

- Empty data proof: not applicable because no frontend rendering path changed.
- Partial data proof: not applicable because no frontend rendering path changed.
- Forbidden secondary path behavior: not applicable because no auth/request path changed.
- Missing draft/resource behavior: not applicable because no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable because no route or deep-link changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_providers.py` only.
- Denied paths: frontend, services, migrations, generated artifacts, and unrelated endpoint modules.
- Migration/docs/test impact: no migration or docs change; no new test file added for this narrow endpoint hardening slice.
- Rollback note: revert commit `0fe62d3b` to restore the previous raw provider error details.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\admin_providers.py`; `rg -n 'str\(e\)|detail=f.*\{.*e.*\}|"error": str\(e\)' backend/app/api/v1/endpoints/admin_providers.py`; `git diff --word-diff=color -- backend/app/api/v1/endpoints/admin_providers.py`.
- Result: compile passed; static scan returned only expected explicit `400/404` provider messages and no raw exception interpolation in public `500` or bulk-item error payloads; word diff confirmed a narrow one-file logic change.
- Not checked: `git diff --check` on this legacy CRLF-tracked file reported Windows line-ending false positives on added lines, so it was not used as a pass criterion; full backend suite and browser/admin provider smoke were not run for this one-file slice.
