### PR TITLE
fix(security): hide admin ai error details

### DIFF
--- a/backend/app/api/v1/endpoints/admin_ai.py
+++ b/backend/app/api/v1/endpoints/admin_ai.py
@@ -2,6 +2,7 @@
 API endpoints для управления AI в админ панели
 """
 
+import logging
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -26,6 +27,22 @@ from app.schemas.ai_config import (
 from app.services.admin_ai_service import AdminAIService
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+ADMIN_AI_PUBLIC_ERROR = "Internal server error"
+ADMIN_AI_PROVIDER_TEST_ERROR = "AI provider test failed"
+
+
+def _admin_ai_http_error(exc: Exception, operation: str) -> HTTPException:
+    logger.warning(
+        "Admin AI endpoint failed operation=%s error_type=%s",
+        operation,
+        type(exc).__name__,
+    )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=ADMIN_AI_PUBLIC_ERROR,
+    )
 
 # ===================== AI ПРОВАЙДЕРЫ =====================
 
@@ -47,10 +64,7 @@ def get_ai_providers(
 
         return providers
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения AI провайдеров: {str(e)}",
-        )
+        raise _admin_ai_http_error(e, "list_ai_providers") from e
 
 
 @router.get("/ai/providers/{provider_id}", response_model=AIProviderOut)
@@ -100,10 +114,7 @@ def create_ai_provider(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания AI провайдера: {str(e)}",
-        )
+        raise _admin_ai_http_error(e, "create_ai_provider") from e
 
 
 @router.put("/ai/providers/{provider_id}", response_model=AIProviderOut)
@@ -130,10 +141,7 @@ def update_ai_provider(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления AI провайдера: {str(e)}",
-        )
+        raise _admin_ai_http_error(e, "update_ai_provider") from e
 
 
 @router.delete("/ai/providers/{provider_id}")
@@ -155,10 +163,7 @@ def delete_ai_provider(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка удаления AI провайдера: {str(e)}",
-        )
+        raise _admin_ai_http_error(e, "delete_ai_provider") from e
 
 
 @router.post("/ai/providers/{provider_id}/test", response_model=AITestResult)
@@ -226,19 +231,23 @@ def test_ai_provider(
         raise
     except Exception as e:
         # Логируем ошибку
-        crud_ai.create_ai_usage_log(
-            db=db,
-            user_id=current_user.id,
-            provider_id=provider_id,
-            task_type="test",
-            success=False,
-            error_message=str(e),
-        )
+        try:
+            crud_ai.create_ai_usage_log(
+                db=db,
+                user_id=current_user.id,
+                provider_id=provider_id,
+                task_type="test",
+                success=False,
+                error_message=ADMIN_AI_PROVIDER_TEST_ERROR,
+            )
+        except Exception as log_exc:
+            logger.warning(
+                "Admin AI provider test failure log failed provider_id=%s error_type=%s",
+                provider_id,
+                type(log_exc).__name__,
+            )
 
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка тестирования AI провайдера: {str(e)}",
-        )
+        raise _admin_ai_http_error(e, "test_ai_provider") from e
 
 
 # ===================== СИСТЕМНЫЕ НАСТРОЙКИ =====================
@@ -253,10 +262,7 @@ def get_ai_settings(
         settings = crud_ai.get_ai_system_settings(db)
         return settings
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения настроек AI: {str(e)}",
-        )
+        raise _admin_ai_http_error(e, "get_ai_settings") from e
 
 
 @router.put("/ai/settings")
@@ -276,10 +282,7 @@ def update_ai_settings(
             "settings": updated_settings,
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления настроек AI: {str(e)}",
-        )
+        raise _admin_ai_http_error(e, "update_ai_settings") from e
 
 
 # ===================== СТАТИСТИКА =====================
@@ -300,10 +303,7 @@ def get_ai_stats(
         )
         return AIStatsResponse(**stats)
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики AI: {str(e)}",
-        )
+        raise _admin_ai_http_error(e, "get_ai_stats") from e
 
 
 @router.get("/ai/usage-logs", response_model=List[AIUsageLogOut])
@@ -327,7 +327,4 @@ def get_ai_usage_logs(
         )
         return logs
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения логов AI: {str(e)}",
-        )
+        raise _admin_ai_http_error(e, "get_ai_usage_logs") from e


### PR DESCRIPTION
﻿## Summary

- Replace raw public `500` exception details in admin AI provider/settings/stats/log endpoints with a stable generic message.
- Log only operation name and exception type for internal admin AI failures.
- Store a stable failure message for AI provider test usage logs instead of raw backend exception text.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/admin_ai.py` admin AI providers, provider test, settings, stats, and usage-log endpoints.
- Request shape: unchanged.
- Response shape: unchanged for success, explicit `400`, and explicit `404`; unexpected internal failures now return `Internal server error`.
- Status codes: unchanged for success, validation/not-found, and `500` internal failures.
- Frontend consumer: unchanged because no frontend code or success payload shape changed.
- Compatibility path or alias: unchanged; no routing, prefix, or alias changed.
- Contract proof: static search confirmed raw `str(e)` sinks were removed from public `500` responses and provider test error logging.

## RBAC / Permissions

- Roles allowed: unchanged existing `require_roles("Admin")` guards.
- Roles denied: unchanged because no auth dependency or permission check changed.
- Positive auth proof: not applicable because this slice changes only internal error reporting.
- Negative auth proof: not applicable because denied-role behavior was not changed.

## Notification / Realtime

- Notification behavior: unchanged; no websocket, Telegram, notification, or realtime delivery path changed.
- Realtime behavior: unchanged.
- Event type or websocket channel: none changed.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable because no realtime path changed.

## Frontend Resilience

- Empty data proof: not applicable because no frontend rendering path changed.
- Partial data proof: not applicable because no frontend rendering path changed.
- Forbidden secondary path behavior: not applicable because no auth/request path changed.
- Missing draft/resource behavior: not applicable because no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable because no route or deep-link changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_ai.py` only.
- Denied paths: frontend, services, migrations, generated artifacts, and unrelated endpoint modules.
- Migration/docs/test impact: no migration or docs change; no new test file added for this narrow endpoint hardening slice.
- Rollback note: revert commit `2bc5414d` to restore the previous admin AI raw error details.

## Validation

- Targeted tests or smoke run: `python scripts\agent_gate.py "Hide public internal exception details from admin AI provider/settings endpoints and avoid raw test exception text in AI usage logs without changing successful AI admin behavior" --known-root-cause "backend/app/api/v1/endpoints/admin_ai.py"`; `python -m py_compile backend/app/api/v1/endpoints/admin_ai.py`; `git diff --check`; `Select-String -Path backend\app\api\v1\endpoints\admin_ai.py -Pattern 'str\(e\)','error_message=str\(e\)','detail=f".*str\(e\)','detail=str\(e\)','"error"\s*:\s*str\(e\)'`.
- Result: gate returned narrow override for the single known file; compile passed; diff check passed; static leak search returned no raw exception sinks.
- Not checked: full backend suite and browser/admin AI smoke were not run locally for this one-file slice; GitHub CI is expected to cover the broader repository gates.
