### PR TITLE
fix(security): hide admin doctors error details

### DIFF
--- a/backend/app/api/v1/endpoints/admin_doctors.py
+++ b/backend/app/api/v1/endpoints/admin_doctors.py
@@ -1,5 +1,6 @@
 """API endpoints для управления врачами в админ панели."""
 
+import logging
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -23,11 +24,26 @@ from app.schemas.clinic import (
 from app.services.admin_doctors_stats_service import AdminDoctorsStatsService
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+ADMIN_DOCTORS_PUBLIC_ERROR = "Internal server error"
 
 DOCTOR_ROLE_VALUES = {
     str(role.value) if hasattr(role, "value") else str(role)
     for role in DOCTOR_ROLES
 }
+
+
+def _admin_doctors_http_error(exc: Exception, operation: str) -> HTTPException:
+    logger.warning(
+        "Admin doctors endpoint failed operation=%s error_type=%s",
+        operation,
+        type(exc).__name__,
+    )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=ADMIN_DOCTORS_PUBLIC_ERROR,
+    )
 
 
 def _validate_doctor_user(db: Session, user_id: int) -> User:
@@ -107,10 +123,7 @@ def get_doctors(
             doctors = [d for d in doctors if d.specialty == specialty]
         return [_serialize_doctor(db, doctor) for doctor in doctors]
     except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения списка врачей: {exc}",
-        ) from exc
+        raise _admin_doctors_http_error(exc, "get_doctors") from exc
 
 
 @router.get("/doctors/available-users", response_model=List[DoctorUserOption])
@@ -198,10 +211,7 @@ def create_doctor(
     except HTTPException:
         raise
     except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания врача: {exc}",
-        ) from exc
+        raise _admin_doctors_http_error(exc, "create_doctor") from exc
 
 
 @router.put("/doctors/{doctor_id}", response_model=DoctorOut)
@@ -240,10 +250,7 @@ def update_doctor(
     except HTTPException:
         raise
     except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления врача: {exc}",
-        ) from exc
+        raise _admin_doctors_http_error(exc, "update_doctor") from exc
 
 
 @router.delete("/doctors/{doctor_id}")
@@ -264,10 +271,7 @@ def delete_doctor(
     except HTTPException:
         raise
     except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка удаления врача: {exc}",
-        ) from exc
+        raise _admin_doctors_http_error(exc, "delete_doctor") from exc
 
 
 @router.get("/doctors/{doctor_id}/schedule", response_model=List[ScheduleOut])
@@ -306,10 +310,7 @@ def update_doctor_schedule(
     except HTTPException:
         raise
     except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления расписания: {exc}",
-        ) from exc
+        raise _admin_doctors_http_error(exc, "update_doctor_schedule") from exc
 
 
 @router.post("/doctors/{doctor_id}/schedule", response_model=ScheduleOut)
@@ -332,10 +333,7 @@ def create_schedule(
     except HTTPException:
         raise
     except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания расписания: {exc}",
-        ) from exc
+        raise _admin_doctors_http_error(exc, "create_schedule") from exc
 
 
 @router.get("/specialties")
@@ -347,10 +345,7 @@ def get_specialties(
     try:
         return AdminDoctorsStatsService(db).get_specialties()
     except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения специальностей: {exc}",
-        ) from exc
+        raise _admin_doctors_http_error(exc, "get_specialties") from exc
 
 
 @router.get("/doctors/stats")
@@ -362,7 +357,4 @@ def get_doctors_stats(
     try:
         return AdminDoctorsStatsService(db).get_doctors_stats()
     except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики врачей: {exc}",
-        ) from exc
+        raise _admin_doctors_http_error(exc, "get_doctors_stats") from exc


### PR DESCRIPTION
﻿## Summary

- Replace raw public `500` exception details in admin doctors endpoints with a stable generic message.
- Log only operation name and exception type for internal admin doctors failures.
- Preserve existing success payloads and explicit `400` / `404` responses.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/admin_doctors.py` doctors list/detail, create/update/delete, schedule, specialties, and stats endpoints.
- Request shape: unchanged.
- Response shape: unchanged for success, explicit `400`, and explicit `404`; unexpected internal failures now return `Internal server error`.
- Status codes: unchanged for success, validation/not-found, and `500` internal failures.
- Frontend consumer: unchanged because no frontend code or success payload shape changed.
- Compatibility path or alias: unchanged; no routing, alias, or prefix changed.
- Contract proof: static search confirmed raw `exc` details were removed from public `500` responses in this endpoint module.

## RBAC / Permissions

- Roles allowed: unchanged existing `require_roles("Admin")` guards.
- Roles denied: unchanged because no auth dependency or permission check changed.
- Positive auth proof: not applicable because this slice changes only internal error reporting.
- Negative auth proof: not applicable because denied-role behavior was not changed.

## Notification / Realtime

- Notification behavior: unchanged; no websocket, queue notification, Telegram, or realtime delivery path changed.
- Realtime behavior: unchanged.
- Event type or websocket channel: none changed.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable because no realtime path changed.

## Frontend Resilience

- Empty data proof: not applicable because no frontend rendering path changed.
- Partial data proof: not applicable because no frontend rendering path changed.
- Forbidden secondary path behavior: not applicable because no secondary frontend request path changed.
- Missing draft/resource behavior: not applicable because no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable because no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_doctors.py` only.
- Denied paths: frontend, services, migrations, generated artifacts, and unrelated endpoint modules.
- Migration/docs/test impact: no migration or docs change; no new test file added for this narrow endpoint hardening slice.
- Rollback note: revert commit `61378b98` to restore the previous admin doctors raw error details.

## Validation

- Targeted tests or smoke run: `python scripts\agent_gate.py "Sanitize public raw exception details in admin doctors endpoints" --known-root-cause "backend/app/api/v1/endpoints/admin_doctors.py"`; `python -m py_compile backend/app/api/v1/endpoints/admin_doctors.py`; `git diff --check -- backend/app/api/v1/endpoints/admin_doctors.py`; `rg -n "str\(e\)|str\(exc\)|detail=f.*\{.*exc.*\}|detail=f.*\{.*e.*\}|error_message=str\(e\)" backend/app/api/v1/endpoints/admin_doctors.py`.
- Result: gate returned narrow override for the single known file; compile passed; diff check passed; static leak search returned only the expected explicit `404` detail for missing user ID and no raw exception sinks.
- Not checked: full backend suite and browser/admin doctors smoke were not run locally for this one-file slice; GitHub CI is expected to cover broader repository gates.
