### PR TITLE
fix(security): redact appointment payment failure logs

### DIFF
--- a/backend/app/services/visit_payment_integration.py
+++ b/backend/app/services/visit_payment_integration.py
@@ -446,9 +446,8 @@ class VisitPaymentIntegrationService:
 
         except Exception as e:
             logger.warning(
-                "Appointment payment processing failed appointment_id=%s webhook_id=%s error_type=%s",
-                appointment_id,
-                getattr(webhook, "id", None),
+                "Appointment payment processing failed has_webhook=%s error_type=%s",
+                webhook is not None,
                 type(e).__name__,
             )
             return False, "Ошибка обработки платежа для записи"


### PR DESCRIPTION
﻿## Summary

- remove `appointment_id` and `webhook_id` from appointment-payment failure logs in `VisitPaymentIntegrationService`
- keep the log diagnostically useful by recording only `error_type` and a boolean `has_webhook` flag

## Contract Impact

not applicable - this patch only redacts internal service logging and does not change request/response payloads, tuple shapes, or API status mapping.

## RBAC / Permissions

not applicable - no auth, role, or permission logic changed.

## Notification / Realtime

not applicable - no websocket, notification, or realtime path changed.

## Frontend Resilience

not applicable - no frontend code or client data flow changed.

## Scope Gate

- Allowed paths: `backend/app/services/visit_payment_integration.py`
- Denied paths: repositories, endpoints, frontend files, docs, migrations, and other payment provider files
- Migration/docs/test impact: no migrations or docs changed; validation used `py_compile`, the existing visit-payment unit tests, and an inline exception-path harness
- Rollback note: revert commit `429c8d8a` to restore the previous logging fields

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/services/visit_payment_integration.py`; `pytest backend/tests/unit/test_visit_payment_integration_service.py -q` with test-only env (`TESTING=1`, SQLite `DATABASE_URL`, `SECRET_KEY`); inline Python harness forcing the exception path and asserting `logger.warning` receives only `has_webhook` and `error_type`; `rg -n "Appointment payment processing failed|appointment_id=%s webhook_id=%s|has_webhook=%s" backend/app/services/visit_payment_integration.py`
- Result: `py_compile` passed; unit tests passed (`5 passed`); inline harness passed and confirmed the warning call no longer contains raw identifiers; grep confirmed the new log template is `has_webhook=%s error_type=%s`
- Not checked: full backend suite and live payment provider/webhook flows were not run because this is a one-line logging redaction slice
