### PR TITLE
fix(security): hide admin departments error details

### DIFF
--- a/backend/app/api/v1/endpoints/admin_departments.py
+++ b/backend/app/api/v1/endpoints/admin_departments.py
@@ -2,6 +2,7 @@
 CRUD endpoints для управления отделениями в админ-панели
 """
 
+import logging
 from datetime import date
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
@@ -32,6 +33,9 @@ from app.schemas.department import (
 from app.services.service_mapping import get_service_code, normalize_service_code
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+ADMIN_DEPARTMENTS_PUBLIC_ERROR = "Internal server error"
 
 
 # Pydantic schemas
@@ -1062,9 +1066,15 @@ def initialize_department(
 
     except Exception as e:
         db.rollback()
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка инициализации отделения: {str(e)}"
+        logger.warning(
+            "Admin department initialization failed department_id=%s error_type=%s",
+            department_id,
+            type(e).__name__,
         )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ADMIN_DEPARTMENTS_PUBLIC_ERROR,
+        ) from e
 
 
 # ============================================================


### PR DESCRIPTION
﻿## Summary

- Replace the raw public `500` exception detail in the admin department initialization endpoint with a stable generic message.
- Log only department id and exception type for internal diagnostics.
- Preserve existing success payloads and explicit `400` / `404` responses.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/admin_departments.py` department initialization endpoint.
- Request shape: unchanged.
- Response shape: unchanged for success and explicit `400` / `404`; unexpected internal failures now return `Internal server error`.
- Status codes: unchanged for success and not-found/validation flows; internal failure remains `500`.
- Frontend consumer: unchanged because no frontend code or success payload shape changed.
- Compatibility path or alias: unchanged; no routing, alias, or prefix changed.
- Contract proof: static search confirmed the raw `str(e)` sink was removed from the public `500` response in this endpoint module.

## RBAC / Permissions

- Roles allowed: unchanged existing `require_roles("Admin")` guard.
- Roles denied: unchanged because no auth dependency or permission check changed.
- Positive auth proof: not applicable because this slice changes only internal error reporting.
- Negative auth proof: not applicable because denied-role behavior was not changed.

## Notification / Realtime

- Notification behavior: unchanged; no websocket, queue notification, Telegram, or realtime delivery path changed.
- Realtime behavior: unchanged.
- Event type or websocket channel: none changed.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable because no realtime path changed.

## Frontend Resilience

- Empty data proof: not applicable because no frontend rendering path changed.
- Partial data proof: not applicable because no frontend rendering path changed.
- Forbidden secondary path behavior: not applicable because no secondary frontend request path changed.
- Missing draft/resource behavior: not applicable because no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable because no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_departments.py` only.
- Denied paths: frontend, services, migrations, generated artifacts, and unrelated endpoint modules.
- Migration/docs/test impact: no migration or docs change; no new test file added for this narrow endpoint hardening slice.
- Rollback note: revert commit `9cc8572c` to restore the previous admin department initialization raw error detail.

## Validation

- Targeted tests or smoke run: `python scripts\agent_gate.py "Sanitize public raw exception detail in admin departments initialization endpoint" --known-root-cause "backend/app/api/v1/endpoints/admin_departments.py"`; `python -m py_compile backend/app/api/v1/endpoints/admin_departments.py`; `git diff --check -- backend/app/api/v1/endpoints/admin_departments.py`; `rg -n "str\(e\)|str\(exc\)|detail=f.*\{.*e.*\}|detail=f.*\{.*exc.*\}" backend/app/api/v1/endpoints/admin_departments.py`.
- Result: gate returned narrow override for the single known file; compile passed; diff check passed; static leak search returned only expected explicit `404`/duplicate details and no raw internal exception sink.
- Not checked: full backend suite and browser/admin departments smoke were not run locally for this one-file slice; GitHub CI is expected to cover broader repository gates.
