### PR TITLE
fix(security): hide sms service error details

### DIFF
--- a/backend/app/services/sms_providers.py
+++ b/backend/app/services/sms_providers.py
@@ -15,6 +15,20 @@ from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
+SMS_PROVIDER_AUTH_ERROR = "SMS provider authentication failed"
+SMS_PROVIDER_SEND_ERROR = "SMS provider send failed"
+SMS_PROVIDER_BALANCE_ERROR = "SMS provider balance failed"
+SMS_PROVIDER_STATUS_ERROR = "SMS provider status lookup failed"
+
+
+def _log_provider_failure(provider: str, operation: str, exc: Exception) -> None:
+    logger.warning(
+        "SMS provider operation failed provider=%s operation=%s error_type=%s",
+        provider,
+        operation,
+        type(exc).__name__,
+    )
+
 
 class SMSProviderType(str, Enum):
     """Типы SMS провайдеров"""
@@ -105,11 +119,10 @@ class EskizSMSProvider(BaseSMSProvider):
                     # Токен действует 30 дней
                     self.token_expires = datetime.now() + timedelta(days=29)
                     return self.auth_token
-                else:
-                    error_text = response.text
-                    raise Exception(f"Eskiz auth failed: {error_text}")
-            except Exception as e:
-                raise Exception(f"Eskiz auth request failed: {str(e)}")
+                raise RuntimeError(SMS_PROVIDER_AUTH_ERROR)
+            except Exception as exc:
+                _log_provider_failure("eskiz", "auth", exc)
+                raise RuntimeError(SMS_PROVIDER_AUTH_ERROR) from exc
 
     async def send_sms(self, message: SMSMessage) -> SMSResponse:
         """Отправить SMS через Eskiz"""
@@ -151,13 +164,15 @@ class EskizSMSProvider(BaseSMSProvider):
                 else:
                     return SMSResponse(
                         success=False,
-                        error=data.get("message", "Unknown error"),
+                        error=SMS_PROVIDER_SEND_ERROR,
                         provider="eskiz",
                     )
 
-        except Exception as e:
-            logger.error(f"Eskiz SMS error: {str(e)}")
-            return SMSResponse(success=False, error=str(e), provider="eskiz")
+        except Exception as exc:
+            _log_provider_failure("eskiz", "send_sms", exc)
+            return SMSResponse(
+                success=False, error=SMS_PROVIDER_SEND_ERROR, provider="eskiz"
+            )
 
     async def get_balance(self) -> dict[str, Any]:
         """Получить баланс Eskiz"""
@@ -189,8 +204,13 @@ class EskizSMSProvider(BaseSMSProvider):
                         "provider": "eskiz",
                     }
 
-        except Exception as e:
-            return {"success": False, "error": str(e), "provider": "eskiz"}
+        except Exception as exc:
+            _log_provider_failure("eskiz", "get_balance", exc)
+            return {
+                "success": False,
+                "error": SMS_PROVIDER_BALANCE_ERROR,
+                "provider": "eskiz",
+            }
 
     async def get_message_status(self, message_id: str) -> dict[str, Any]:
         """Получить статус сообщения Eskiz"""
@@ -221,8 +241,13 @@ class EskizSMSProvider(BaseSMSProvider):
                         "provider": "eskiz",
                     }
 
-        except Exception as e:
-            return {"success": False, "error": str(e), "provider": "eskiz"}
+        except Exception as exc:
+            _log_provider_failure("eskiz", "get_message_status", exc)
+            return {
+                "success": False,
+                "error": SMS_PROVIDER_STATUS_ERROR,
+                "provider": "eskiz",
+            }
 
 
 class PlayMobileSMSProvider(BaseSMSProvider):
@@ -278,13 +303,15 @@ class PlayMobileSMSProvider(BaseSMSProvider):
 
                 return SMSResponse(
                     success=False,
-                    error=data.get("error", "Unknown error"),
+                    error=SMS_PROVIDER_SEND_ERROR,
                     provider="playmobile",
                 )
 
-        except Exception as e:
-            logger.error(f"PlayMobile SMS error: {str(e)}")
-            return SMSResponse(success=False, error=str(e), provider="playmobile")
+        except Exception as exc:
+            _log_provider_failure("playmobile", "send_sms", exc)
+            return SMSResponse(
+                success=False, error=SMS_PROVIDER_SEND_ERROR, provider="playmobile"
+            )
 
     async def get_balance(self) -> dict[str, Any]:
         """Получить баланс PlayMobile"""
@@ -315,8 +342,13 @@ class PlayMobileSMSProvider(BaseSMSProvider):
                         "provider": "playmobile",
                     }
 
-        except Exception as e:
-            return {"success": False, "error": str(e), "provider": "playmobile"}
+        except Exception as exc:
+            _log_provider_failure("playmobile", "get_balance", exc)
+            return {
+                "success": False,
+                "error": SMS_PROVIDER_BALANCE_ERROR,
+                "provider": "playmobile",
+            }
 
     async def get_message_status(self, message_id: str) -> dict[str, Any]:
         """Получить статус сообщения PlayMobile"""
@@ -351,8 +383,13 @@ class PlayMobileSMSProvider(BaseSMSProvider):
                         "provider": "playmobile",
                     }
 
-        except Exception as e:
-            return {"success": False, "error": str(e), "provider": "playmobile"}
+        except Exception as exc:
+            _log_provider_failure("playmobile", "get_message_status", exc)
+            return {
+                "success": False,
+                "error": SMS_PROVIDER_STATUS_ERROR,
+                "provider": "playmobile",
+            }
 
 
 class MockSMSProvider(BaseSMSProvider):
@@ -405,8 +442,8 @@ class SMSManager:
                 if not self.default_provider:
                     self.default_provider = SMSProviderType.ESKIZ
                 logger.info("Initialized Eskiz SMS provider")
-            except Exception as e:
-                logger.error(f"Failed to initialize Eskiz provider: {str(e)}")
+            except Exception as exc:
+                _log_provider_failure("eskiz", "initialize", exc)
 
         # PlayMobile провайдер
         playmobile_key = getattr(settings, "PLAYMOBILE_API_KEY", None)
@@ -421,8 +458,8 @@ class SMSManager:
                 if not self.default_provider:
                     self.default_provider = SMSProviderType.PLAYMOBILE
                 logger.info("Initialized PlayMobile SMS provider")
-            except Exception as e:
-                logger.error(f"Failed to initialize PlayMobile provider: {str(e)}")
+            except Exception as exc:
+                _log_provider_failure("playmobile", "initialize", exc)
 
         # Mock провайдер (всегда доступен для тестирования)
         self.providers[SMSProviderType.MOCK] = MockSMSProvider()


### PR DESCRIPTION
﻿## Summary
- Sanitizes SMS provider service failures so Eskiz/PlayMobile exceptions and provider response bodies are not returned as raw error text.
- Replaces raw exception logging with safe provider/operation/error_type metadata.
- Preserves provider classes, manager API, route contracts, request payload construction, and success response behavior.

## Contract Impact
- Canonical surface: backend/app/services/sms_providers.py.
- Request shape: unchanged; SMSMessage fields and provider method signatures are unchanged.
- Response shape: unchanged; SMSResponse and dict fields are preserved while failed error text becomes generic.
- Status codes: not applicable because this service file does not set HTTP status codes.
- Frontend consumer: unchanged through existing endpoints; frontend still receives the same error fields after endpoint-level sanitization.
- Compatibility path or alias: no route, alias, or compatibility path changed.
- Contract proof: py_compile, static no-match scans, direct service smoke with fake providers/httpx, frontend build.

## RBAC / Permissions
- Roles allowed: unchanged because no endpoint dependency or permission gate changed.
- Roles denied: unchanged because this slice only changes service error text/logging.
- Positive auth proof: endpoint signatures and require_roles dependencies are untouched.
- Negative auth proof: not separately exercised because RBAC code is out of scope for this service-only slice.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or realtime event code changed.
- Payload version / ack behavior: not applicable because no websocket or notification payload changed.
- Read/unread or delivery semantics: not applicable because this slice only sanitizes SMS service errors.
- Reconnect/resync proof: not applicable because no realtime transport changed.

## Frontend Resilience
- Empty data proof: unchanged because no frontend code changed.
- Partial data proof: failed provider calls still return success=false with the same provider field and generic error text.
- Forbidden secondary path behavior: unchanged by existing endpoint RBAC dependencies.
- Missing draft/resource behavior: not applicable because no draft/resource frontend flow changed.
- Stale route/deep-link behavior: unchanged because no route code changed.

## Scope Gate
- Allowed paths: backend/app/services/sms_providers.py only.
- Denied paths: API endpoint routes, RBAC dependencies, SMS payload schemas, migrations, frontend routes, docs.
- Migration/docs/test impact: no migration or docs change; focused smoke used because existing tests do not cover provider service raw error leakage.
- Rollback note: revert commit b829597f to restore prior SMS service error text/log behavior.

## Validation
- Targeted tests or smoke run: py_compile for backend/app/services/sms_providers.py; static rg no-match for response.text, str(e), str(exc), logger.error; direct importlib smoke for Eskiz/PlayMobile auth/send/balance/status marker leakage; npm.cmd ci; npm.cmd run build.
- Result: passed locally; Vite build emitted existing dynamic import/chunk-size warnings only.
- Not checked: live Eskiz/PlayMobile credentials or real provider network calls; full backend test suite.
