### PR TITLE
fix(security): hide analytics export error details

### DIFF
--- a/backend/app/api/v1/endpoints/analytics_export.py
+++ b/backend/app/api/v1/endpoints/analytics_export.py
@@ -2,6 +2,7 @@
 API endpoints для экспорта аналитических отчетов
 """
 
+import logging
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -21,6 +22,9 @@ from app.services.analytics_export_service import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+ANALYTICS_EXPORT_PUBLIC_ERROR = "Internal server error"
 
 
 @router.get("/formats")
@@ -34,9 +38,14 @@ async def get_export_formats(
 
         return {"formats": formats, "count": len(formats)}
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка получения форматов экспорта: {str(e)}"
+        logger.warning(
+            "Analytics export formats lookup failed error_type=%s",
+            type(e).__name__,
         )
+        raise HTTPException(
+            status_code=500,
+            detail=ANALYTICS_EXPORT_PUBLIC_ERROR,
+        ) from e
 
 
 @router.get("/kpi/export/{format}")


### PR DESCRIPTION
﻿## Summary

- Replace the raw public `500` exception detail in analytics export format discovery with a stable generic message.
- Log only exception type for internal diagnostics.
- Preserve existing success payload and supported export format behavior.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/analytics_export.py` `GET /formats` export-format endpoint.
- Request shape: unchanged.
- Response shape: unchanged for success; unexpected internal failures now return `Internal server error`.
- Status codes: unchanged for success and internal failure; internal failure remains `500`.
- Frontend consumer: unchanged because no frontend code or success payload shape changed.
- Compatibility path or alias: unchanged; no routing, alias, or prefix changed.
- Contract proof: static search confirmed the raw `str(e)` sink was removed from this endpoint module.

## RBAC / Permissions

- Roles allowed: unchanged existing authenticated-user dependency.
- Roles denied: unchanged because no auth dependency or permission check changed.
- Positive auth proof: not applicable because this slice changes only internal error reporting.
- Negative auth proof: not applicable because denied/unauthenticated behavior was not changed.

## Notification / Realtime

- Notification behavior: unchanged; no websocket, queue notification, Telegram, or realtime delivery path changed.
- Realtime behavior: unchanged.
- Event type or websocket channel: none changed.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable because no realtime path changed.

## Frontend Resilience

- Empty data proof: not applicable because no frontend rendering path changed.
- Partial data proof: not applicable because no frontend rendering path changed.
- Forbidden secondary path behavior: not applicable because no secondary frontend request path changed.
- Missing draft/resource behavior: not applicable because no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable because no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/analytics_export.py` only.
- Denied paths: frontend, services, migrations, generated artifacts, and unrelated endpoint modules.
- Migration/docs/test impact: no migration or docs change; no new test file added for this narrow endpoint hardening slice.
- Rollback note: revert commit `fa1cc952` to restore the previous analytics export raw error detail.

## Validation

- Targeted tests or smoke run: `python scripts\agent_gate.py "Sanitize public raw exception detail in analytics export endpoint" --known-root-cause "backend/app/api/v1/endpoints/analytics_export.py"`; `python -m py_compile backend/app/api/v1/endpoints/analytics_export.py`; `git diff --check -- backend/app/api/v1/endpoints/analytics_export.py`; `rg -n "str\(e\)|str\(exc\)|detail=f.*\{.*e.*\}|detail=f.*\{.*exc.*\}" backend/app/api/v1/endpoints/analytics_export.py`.
- Result: gate returned narrow override for the single known file; compile passed; diff check passed; static leak search returned no raw exception sinks.
- Not checked: full backend suite and browser/export UI smoke were not run locally for this one-file slice; GitHub CI is expected to cover broader repository gates.
