### PR TITLE
fix(security): harden file shares webhooks and imports

### DIFF
--- a/backend/app/api/v1/endpoints/file_system.py
+++ b/backend/app/api/v1/endpoints/file_system.py
@@ -53,6 +53,34 @@ from app.utils.file_validator import validate_upload_file
 
 router = APIRouter()
 
+IMPORT_ARCHIVE_READ_CHUNK_BYTES = 1024 * 1024
+
+
+async def _read_limited_import_archive(file: UploadFile, max_bytes: int) -> bytes:
+    chunks: list[bytes] = []
+    total_size = 0
+
+    while True:
+        chunk = await file.read(IMPORT_ARCHIVE_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+
+        total_size += len(chunk)
+        if total_size > max_bytes:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail="Import archive is too large",
+            )
+        chunks.append(chunk)
+
+    if total_size == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Import archive is empty",
+        )
+
+    return b"".join(chunks)
+
 
 @router.post("/upload", response_model=FileOut)
 async def upload_file(
@@ -82,7 +110,7 @@ async def upload_file(
         if not is_valid:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"File validation failed: {error_msg}"
+                detail=f"File validation failed: {error_msg}",
             )
 
         # Парсим теги
@@ -402,7 +430,7 @@ async def update_file(
 
         # ✅ AUDIT LOG: Сохраняем старые данные перед обновлением
         old_data, _ = extract_model_changes(db_file, None)
-        
+
         # Обновляем файл
         updated_file = file.update(db, db_obj=db_file, obj_in=update_data)
         FileSystemApiService(db).finalize_file_update_audit(
@@ -442,7 +470,7 @@ async def replace_file_content(
     """
     try:
         service = get_file_system_service()
-        
+
         # Заменяем содержимое файла (создает версию автоматически)
         updated_file = service.replace_file_content(
             db, file_id, file, current_user.id, change_description
@@ -458,9 +486,9 @@ async def replace_file_content(
                 f"(хеш: {updated_file.file_hash[:8]}...)"
             ),
         )
-        
+
         return FileOut.from_orm(updated_file)
-        
+
     except HTTPException:
         raise
     except Exception as e:
@@ -483,16 +511,17 @@ async def delete_file(
     try:
         # ✅ Получаем файл перед удалением для логирования
         from app.crud.file_system import file as file_crud
+
         db_file = file_crud.get(db, id=file_id)
         if not db_file:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Файл не найден"
             )
-        
+
         # Сохраняем данные для аудита перед удалением
         old_data, _ = extract_model_changes(db_file, None)
         filename = db_file.filename
-        
+
         # ✅ FIX: Выполняем удаление ПЕРЕД логированием аудита
         service = get_file_system_service()
         success = service.delete_file(db, file_id, current_user.id)
@@ -634,7 +663,10 @@ async def import_files(
     """Импортировать файлы из архива"""
     try:
         # Читаем содержимое файла
-        file_content = await file.read()
+        service = get_file_system_service()
+        file_content = await _read_limited_import_archive(
+            file, service.max_import_archive_size
+        )
 
         # Определяем формат архива
         file_format = "zip"  # По умолчанию ZIP
@@ -644,6 +676,12 @@ async def import_files(
             elif file.filename.endswith('.tar'):
                 file_format = "tar"
 
+        if file_format != "zip":
+            raise HTTPException(
+                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                detail="Only ZIP imports are supported",
+            )
+
         # Создаем запрос на импорт
         import_request = FileImportRequest(
             import_data=file_content,
@@ -652,7 +690,6 @@ async def import_files(
             overwrite_existing=overwrite_existing,
         )
 
-        service = get_file_system_service()
         result = await service.import_files(db, import_request, current_user.id)
 
         return FileImportResponse(**result)

--- a/backend/app/schemas/webhook.py
+++ b/backend/app/schemas/webhook.py
@@ -6,8 +6,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, HttpUrl, field_validator
-from pydantic import ConfigDict
+from pydantic import BaseModel, ConfigDict, HttpUrl, field_validator
+
+from app.utils.url_security import validate_public_http_url
 
 # ===================== БАЗОВЫЕ СХЕМЫ =====================
 
@@ -123,7 +124,10 @@ class WebhookBase(BaseModel):
 class WebhookCreate(WebhookBase):
     """Схема для создания webhook'а"""
 
-    pass
+    @field_validator('url', mode='before')
+    @classmethod
+    def validate_url(cls, v: Any) -> str:
+        return validate_public_http_url(str(v))
 
 
 class WebhookUpdate(BaseModel):
@@ -141,6 +145,13 @@ class WebhookUpdate(BaseModel):
     filters: dict[str, Any] | None = None
     status: WebhookStatusEnum | None = None
     is_active: bool | None = None
+
+    @field_validator('url', mode='before')
+    @classmethod
+    def validate_url(cls, v: Any) -> str | None:
+        if v is None:
+            return None
+        return validate_public_http_url(str(v))
 
 
 class WebhookInDB(WebhookBase):

--- a/backend/app/services/file_system_service.py
+++ b/backend/app/services/file_system_service.py
@@ -12,7 +12,7 @@ import shutil
 import tempfile
 import zipfile
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from fastapi import HTTPException, UploadFile, status
@@ -54,6 +54,13 @@ class FileSystemService:
         self.base_storage_path = os.getenv("FILE_STORAGE_PATH", "storage/files")
         self.temp_storage_path = os.getenv("TEMP_STORAGE_PATH", "storage/temp")
         self.max_file_size = int(os.getenv("MAX_FILE_SIZE", 100 * 1024 * 1024))  # 100MB
+        self.max_import_archive_size = int(
+            os.getenv("MAX_IMPORT_ARCHIVE_SIZE", self.max_file_size)
+        )
+        self.max_import_uncompressed_size = int(
+            os.getenv("MAX_IMPORT_UNCOMPRESSED_SIZE", self.max_file_size * 5)
+        )
+        self.max_import_files = int(os.getenv("MAX_IMPORT_FILES", 1000))
         self.allowed_extensions = {
             FileType.DOCUMENT: ['.pdf', '.doc', '.docx', '.txt', '.rtf', '.odt'],
             FileType.IMAGE: ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.webp'],
@@ -107,6 +114,85 @@ class FileSystemService:
     def _generate_file_hash(self, file_content: bytes) -> str:
         """Генерировать SHA-256 хеш файла"""
         return hashlib.sha256(file_content).hexdigest()
+
+    @staticmethod
+    def _share_is_not_expired(share: Any) -> bool:
+        expires_at = getattr(share, "expires_at", None)
+        if expires_at is None:
+            return True
+        now = (
+            datetime.now(expires_at.tzinfo) if expires_at.tzinfo else datetime.utcnow()
+        )
+        return expires_at > now
+
+    @staticmethod
+    def _zip_info_is_symlink(info: zipfile.ZipInfo) -> bool:
+        return ((info.external_attr >> 16) & 0o170000) == 0o120000
+
+    @staticmethod
+    def _safe_zip_member_parts(member_name: str) -> tuple[str, ...]:
+        normalized_name = member_name.replace("\\", "/")
+        member_path = PurePosixPath(normalized_name)
+        if (
+            member_path.is_absolute()
+            or not member_path.parts
+            or any(part in {"", ".", ".."} for part in member_path.parts)
+            or any(":" in part for part in member_path.parts)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Archive contains an unsafe file path",
+            )
+        return member_path.parts
+
+    def _safe_extract_zip(self, zipf: zipfile.ZipFile, extracted_path: str) -> None:
+        root_path = Path(extracted_path).resolve()
+        root_path.mkdir(parents=True, exist_ok=True)
+
+        total_uncompressed_size = 0
+        extracted_files = 0
+
+        for info in zipf.infolist():
+            member_parts = self._safe_zip_member_parts(info.filename)
+            target_path = root_path.joinpath(*member_parts).resolve()
+            if not target_path.is_relative_to(root_path):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Archive contains an unsafe file path",
+                )
+
+            if self._zip_info_is_symlink(info):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Archive contains a symbolic link",
+                )
+
+            if info.is_dir():
+                target_path.mkdir(parents=True, exist_ok=True)
+                continue
+
+            extracted_files += 1
+            if extracted_files > self.max_import_files:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail="Archive contains too many files",
+                )
+            if info.file_size > self.max_file_size:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail="Archive member is too large",
+                )
+
+            total_uncompressed_size += info.file_size
+            if total_uncompressed_size > self.max_import_uncompressed_size:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail="Archive uncompressed size is too large",
+                )
+
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            with zipf.open(info) as source, target_path.open("wb") as target:
+                shutil.copyfileobj(source, target, length=1024 * 1024)
 
     def _generate_file_path(self, filename: str, file_hash: str) -> str:
         """Генерировать путь для сохранения файла"""
@@ -175,10 +261,16 @@ class FileSystemService:
 
             # ✅ CERTIFICATION: Всегда генерируем file_path для нового файла
             # Используем существующий путь только если файл физически существует
-            if existing_file and existing_file.file_path and os.path.exists(existing_file.file_path):
+            if (
+                existing_file
+                and existing_file.file_path
+                and os.path.exists(existing_file.file_path)
+            ):
                 # Дедупликация: используем существующий файл
                 file_path = existing_file.file_path
-                logger.info(f"Используется существующий файл по хешу: {file_hash[:8]}... (путь: {file_path})")
+                logger.info(
+                    f"Используется существующий файл по хешу: {file_hash[:8]}... (путь: {file_path})"
+                )
             else:
                 # Генерируем путь для нового файла
                 file_path = self._generate_file_path(upload_file.filename, file_hash)
@@ -192,7 +284,9 @@ class FileSystemService:
                 logger.info(f"Создан новый файл: {file_path}")
 
             # ✅ CERTIFICATION: file_path всегда установлен перед созданием FileCreate
-            assert file_path is not None and file_path != "", "file_path должен быть установлен"
+            assert (
+                file_path is not None and file_path != ""
+            ), "file_path должен быть установлен"
 
             # Преобразуем file_type из FileType (модель) в FileTypeEnum (схема), если нужно
             file_type_value = file_data.file_type
@@ -290,10 +384,8 @@ class FileSystemService:
         # Проверяем совместное использование
         shares = file_share.get_file_shares(db, file_id=file_obj.id)
         for share in shares:
-            if share.shared_with_user_id == user_id or (
-                share.access_token
-                and share.expires_at
-                and share.expires_at > datetime.utcnow()
+            if share.shared_with_user_id == user_id and self._share_is_not_expired(
+                share
             ):
                 return True
 
@@ -407,15 +499,19 @@ class FileSystemService:
         old_version_data = {
             "file_path": db_file.file_path,
             "file_size": db_file.file_size,
-            "file_hash": db_file.file_hash or "",  # ✅ Обязательный хеш для версии (может быть пустым для старых файлов)
-            "change_description": change_description or "Автоматическая версия перед заменой содержимого",
+            "file_hash": db_file.file_hash
+            or "",  # ✅ Обязательный хеш для версии (может быть пустым для старых файлов)
+            "change_description": change_description
+            or "Автоматическая версия перед заменой содержимого",
         }
         file_version.create(
             db, file_id=file_id, version_data=old_version_data, created_by=user_id
         )
 
         # Генерируем путь для нового файла
-        new_file_path = self._generate_file_path(new_file.filename or db_file.filename, new_hash)
+        new_file_path = self._generate_file_path(
+            new_file.filename or db_file.filename, new_hash
+        )
 
         # Создаем директорию если нужно
         os.makedirs(os.path.dirname(new_file_path), exist_ok=True)
@@ -440,7 +536,9 @@ class FileSystemService:
 
         # Обновляем квоту (разница в размере)
         size_delta = new_size - old_size
-        file_quota.update_usage(db, user_id=user_id, size_delta=size_delta, files_delta=0)
+        file_quota.update_usage(
+            db, user_id=user_id, size_delta=size_delta, files_delta=0
+        )
 
         # Логируем замену
         file_access_log.create(
@@ -562,8 +660,19 @@ class FileSystemService:
 
         try:
             # Извлекаем архив
+            if import_request.format != "zip":
+                raise HTTPException(
+                    status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                    detail="Only ZIP imports are supported",
+                )
+            if len(import_request.import_data) > self.max_import_archive_size:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail="Import archive is too large",
+                )
+
             with zipfile.ZipFile(io.BytesIO(import_request.import_data), 'r') as zipf:
-                zipf.extractall(extracted_path)
+                self._safe_extract_zip(zipf, extracted_path)
 
             processed_files = 0
             errors = []
@@ -615,6 +724,13 @@ class FileSystemService:
                 "success": len(errors) == 0,
             }
 
+        except HTTPException:
+            raise
+        except zipfile.BadZipFile as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid ZIP archive",
+            ) from e
         except Exception as e:
             logger.error(f"Ошибка импорта файлов: {e}")
             raise HTTPException(

--- a/backend/app/services/webhook_service.py
+++ b/backend/app/services/webhook_service.py
@@ -23,6 +23,7 @@ from app.models.webhook import (
     WebhookEventType,
     WebhookStatus,
 )
+from app.utils.url_security import validate_public_http_url
 
 logger = logging.getLogger(__name__)
 
@@ -52,10 +53,11 @@ class WebhookService:
     ) -> Webhook:
         """Создает новый webhook"""
         try:
+            safe_url = validate_public_http_url(url)
             webhook = Webhook(
                 name=name,
                 description=description,
-                url=url,
+                url=safe_url,
                 events=events,
                 headers=headers or {},
                 secret=secret,
@@ -290,8 +292,9 @@ class WebhookService:
             call.status = WebhookCallStatus.PENDING
 
             # Выполняем HTTP запрос
+            safe_url = validate_public_http_url(webhook.url)
             async with httpx.AsyncClient(timeout=webhook.timeout) as client:
-                response = await client.post(webhook.url, json=payload, headers=headers)
+                response = await client.post(safe_url, json=payload, headers=headers)
 
             # Рассчитываем время выполнения
             duration_ms = int((time.time() - start_time) * 1000)

--- a/backend/app/utils/url_security.py
+++ b/backend/app/utils/url_security.py
@@ -1,0 +1,41 @@
+"""
+Helpers for validating user-configured outbound URLs.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+ALLOWED_PUBLIC_HTTP_SCHEMES = {"http", "https"}
+
+
+def _is_blocked_ip(address: str) -> bool:
+    ip = ipaddress.ip_address(address)
+    return ip.is_multicast or not ip.is_global
+
+
+def validate_public_http_url(raw_url: str) -> str:
+    """Return a normalized public HTTP(S) URL or raise ValueError."""
+    parsed = urlparse(str(raw_url))
+    if parsed.scheme.lower() not in ALLOWED_PUBLIC_HTTP_SCHEMES:
+        raise ValueError("URL scheme must be http or https")
+    if not parsed.hostname:
+        raise ValueError("URL host is required")
+    if parsed.username or parsed.password:
+        raise ValueError("URL credentials are not allowed")
+
+    hostname = parsed.hostname.strip().rstrip(".")
+    if not hostname:
+        raise ValueError("URL host is required")
+
+    try:
+        addresses = {info[4][0] for info in socket.getaddrinfo(hostname, parsed.port)}
+    except socket.gaierror as exc:
+        raise ValueError("URL host cannot be resolved") from exc
+
+    if not addresses or any(_is_blocked_ip(address) for address in addresses):
+        raise ValueError("URL host is not allowed")
+
+    return parsed.geturl()

--- a/backend/tests/unit/test_codex_security_fixes.py
+++ b/backend/tests/unit/test_codex_security_fixes.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import io
+import zipfile
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.schemas.file_system import FilePermissionEnum
+from app.schemas.webhook import WebhookCreate, WebhookEventTypeEnum, WebhookUpdate
+from app.services import file_system_service as file_system_module
+from app.services.file_system_service import FileSystemService
+from app.utils import url_security
+from app.utils.url_security import validate_public_http_url
+
+
+def _service(tmp_path, monkeypatch) -> FileSystemService:
+    monkeypatch.setenv("FILE_STORAGE_PATH", str(tmp_path / "files"))
+    monkeypatch.setenv("TEMP_STORAGE_PATH", str(tmp_path / "temp"))
+    return FileSystemService()
+
+
+def _file(permission: FilePermissionEnum = FilePermissionEnum.PRIVATE):
+    return SimpleNamespace(id=42, owner_id=1, permission=permission)
+
+
+def test_share_token_presence_does_not_grant_other_users_access(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    active_token_share_for_someone_else = SimpleNamespace(
+        shared_with_user_id=99,
+        access_token="active-token",
+        expires_at=datetime.utcnow() + timedelta(hours=1),
+    )
+    monkeypatch.setattr(
+        file_system_module.file_share,
+        "get_file_shares",
+        lambda db, file_id: [active_token_share_for_someone_else],
+    )
+
+    assert service._check_file_access(object(), _file(), user_id=2) is False
+
+
+def test_direct_unexpired_share_still_grants_access(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    direct_share = SimpleNamespace(
+        shared_with_user_id=2,
+        access_token="token-for-a-link",
+        expires_at=datetime.utcnow() + timedelta(hours=1),
+    )
+    monkeypatch.setattr(
+        file_system_module.file_share,
+        "get_file_shares",
+        lambda db, file_id: [direct_share],
+    )
+
+    assert service._check_file_access(object(), _file(), user_id=2) is True
+
+
+def test_expired_direct_share_does_not_grant_access(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    expired_direct_share = SimpleNamespace(
+        shared_with_user_id=2,
+        access_token="expired-token",
+        expires_at=datetime.utcnow() - timedelta(seconds=1),
+    )
+    monkeypatch.setattr(
+        file_system_module.file_share,
+        "get_file_shares",
+        lambda db, file_id: [expired_direct_share],
+    )
+
+    assert service._check_file_access(object(), _file(), user_id=2) is False
+
+
+def test_webhook_schema_rejects_private_network_urls(monkeypatch):
+    monkeypatch.setattr(
+        url_security.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [(None, None, None, None, ("127.0.0.1", 443))],
+    )
+
+    with pytest.raises(ValueError, match="URL host is not allowed"):
+        WebhookCreate(
+            name="internal",
+            url="https://example.test/hook",
+            events=[WebhookEventTypeEnum.PATIENT_CREATED],
+        )
+
+
+def test_webhook_schema_accepts_public_urls(monkeypatch):
+    monkeypatch.setattr(
+        url_security.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [(None, None, None, None, ("93.184.216.34", 443))],
+    )
+
+    webhook = WebhookCreate(
+        name="external",
+        url="https://example.test/hook",
+        events=[WebhookEventTypeEnum.PATIENT_CREATED],
+    )
+    update = WebhookUpdate(url="https://example.test/updated")
+
+    assert str(webhook.url).startswith("https://example.test/")
+    assert str(update.url).startswith("https://example.test/")
+
+
+def test_public_url_validator_rejects_credentials(monkeypatch):
+    monkeypatch.setattr(
+        url_security.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [(None, None, None, None, ("93.184.216.34", 443))],
+    )
+
+    with pytest.raises(ValueError, match="credentials"):
+        validate_public_http_url("https://user:pass@example.test/hook")
+
+
+def test_safe_zip_extract_rejects_path_traversal(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as zipf:
+        zipf.writestr("../evil.txt", "owned")
+    archive.seek(0)
+
+    with zipfile.ZipFile(archive) as zipf, pytest.raises(HTTPException) as exc:
+        service._safe_extract_zip(zipf, str(tmp_path / "extract"))
+
+    assert exc.value.status_code == 400
+
+
+def test_safe_zip_extract_rejects_uncompressed_size_limit(tmp_path, monkeypatch):
+    service = _service(tmp_path, monkeypatch)
+    service.max_import_uncompressed_size = 10
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as zipf:
+        zipf.writestr("large.txt", "x" * 11)
+    archive.seek(0)
+
+    with zipfile.ZipFile(archive) as zipf, pytest.raises(HTTPException) as exc:
+        service._safe_extract_zip(zipf, str(tmp_path / "extract"))
+
+    assert exc.value.status_code == 413


### PR DESCRIPTION
## Summary

- Fix file share access checks so active share tokens no longer grant access to unrelated authenticated users.
- Add public HTTP(S) URL validation for user-configured webhook create/update paths and legacy dispatch-time webhook URLs.
- Harden ZIP file imports with archive size, member count, uncompressed size, path traversal, and symlink checks.

## Contract Impact

- Canonical surface: GET /api/v1/files/{file_id}, GET /api/v1/files/{file_id}/download, POST /api/v1/files/import, webhook create/update/dispatch URL handling.
- Request shape: file metadata/download requests are unchanged; ZIP import still uses multipart upload; webhook create/update still submit URL fields.
- Response shape: unchanged for successful allowed file access and webhook responses; unsafe imports/webhook URLs now fail validation instead of proceeding.
- Status codes: unauthorized file share access remains not-found/no-access; oversized imports return 413; non-ZIP imports return 415; unsafe webhook URLs return validation errors or failed dispatch records.
- Frontend consumer: not applicable - no frontend code changed.
- Compatibility path or alias: existing explicit user shares still work; token-link behavior must be implemented through a token-presenting path rather than normal authenticated file lookup.
- Contract proof: targeted regression tests plus existing file security tests passed locally and backend tests passed in CI.

## RBAC / Permissions

- Roles allowed: existing file and webhook route role declarations are unchanged.
- Roles denied: unrelated authenticated users are denied access to files unless they own the file, are explicitly shared, or the file is public.
- Positive auth proof: direct unexpired file share regression test passes.
- Negative auth proof: active access token for another user no longer grants file access; expired direct share no longer grants file access.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: backend file-system endpoint/service, webhook schema/service, shared URL validator, targeted security tests.
- Denied paths: frontend code, database migrations, deploy workflows, unrelated runtime behavior.
- Migration/docs/test impact: no migration; targeted regression tests added.
- Rollback note: revert this PR to restore previous file share, webhook URL, and ZIP import behavior.

## Validation

- Targeted tests or smoke run: `DATABASE_URL=sqlite:///./test_security_fixes.db TESTING=1 python -m pytest tests/unit/test_codex_security_fixes.py -q`; `DATABASE_URL=sqlite:///./test_file_security_existing.db TESTING=1 python -m pytest tests/test_file_security.py -q`; `python -m compileall -q app tests/unit/test_codex_security_fixes.py`; `git diff --check`; `black --check` for changed formatted files; `ruff --select I,F` for changed/new security files.
- Result: local focused tests passed; CI backend tests, security scan, formatting, frontend tests, role-system check, and lifecycle recommendation passed.
- Not checked: full live DB or production webhook dispatch, because this PR only validates code paths and unit-level security invariants.