### PR TITLE
🎨 Palette: Add aria-busy to loading states of complex UI components

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-12 - Missing aria-busy on Complex Loading States
+**Learning:** While buttons effectively communicated their loading states via `aria-busy`, larger container components in the design system (Tables, Lists, Stat Cards) with custom loading skeletons or empty states completely lacked this attribute. This creates a confusing experience for screen reader users who aren't notified when these regions are processing or waiting for data.
+**Action:** Always add `aria-busy="true"` (or `aria-busy={loading}`) to the root container of complex UI components that handle asynchronous data loading, especially when rendering custom loading skeletons or empty states instead of standard UI elements.

--- a/frontend/src/components/ui/macos/MacOSList.jsx
+++ b/frontend/src/components/ui/macos/MacOSList.jsx
@@ -168,7 +168,7 @@ const MacOSList = ({
 
   if (loading) {
     return (
-      <div className={className} style={listStyle}>
+      <div className={className} style={listStyle} aria-busy="true">
         {renderLoadingState()}
       </div>);
 
@@ -176,14 +176,14 @@ const MacOSList = ({
 
   if (!items || items.length === 0) {
     return (
-      <div className={className} style={listStyle}>
+      <div className={className} style={listStyle} aria-busy={loading}>
         {renderEmptyState()}
       </div>);
 
   }
 
   return (
-    <div className={className} style={listStyle}>
+    <div className={className} style={listStyle} aria-busy={loading}>
       {items.map((item, index) => {
         const isSelected = selectedIndex === index;
         const isInteractive = selectable || Boolean(onItemClick);

--- a/frontend/src/components/ui/macos/MacOSMetricCard.jsx
+++ b/frontend/src/components/ui/macos/MacOSMetricCard.jsx
@@ -200,7 +200,7 @@ const MacOSMetricCard = ({
   };
 
   const renderLoading = () =>
-  <div style={cardStyle}>
+  <div style={cardStyle} aria-busy="true">
       <div style={headerStyle}>
         <div style={{
         width: '60%',
@@ -261,7 +261,8 @@ const MacOSMetricCard = ({
         onMouseLeave={handleMouseLeave}
         onKeyDown={handleKeyDown}
         role="button"
-        tabIndex={0}>
+        tabIndex={0}
+        aria-busy={loading}>
         
         {content}
       </div>);
@@ -269,7 +270,7 @@ const MacOSMetricCard = ({
   }
 
   return (
-    <div className={className} style={cardStyle}>
+    <div className={className} style={cardStyle} aria-busy={loading}>
       {content}
     </div>);
 

--- a/frontend/src/components/ui/macos/MacOSStatCard.jsx
+++ b/frontend/src/components/ui/macos/MacOSStatCard.jsx
@@ -188,7 +188,7 @@ const MacOSStatCard = ({
   };
 
   const renderLoading = () => (
-    <div style={cardStyle}>
+    <div style={cardStyle} aria-busy="true">
       <div style={headerStyle}>
         <div style={{ 
           width: '60%', 
@@ -251,6 +251,7 @@ const MacOSStatCard = ({
         onKeyDown={handleKeyDown}
         role="button"
         tabIndex={0}
+        aria-busy={loading}
       >
         {content}
       </div>
@@ -258,7 +259,7 @@ const MacOSStatCard = ({
   }
 
   return (
-    <div className={className} style={cardStyle}>
+    <div className={className} style={cardStyle} aria-busy={loading}>
       {content}
     </div>
   );

--- a/frontend/src/components/ui/macos/MacOSTable.jsx
+++ b/frontend/src/components/ui/macos/MacOSTable.jsx
@@ -217,7 +217,7 @@ const MacOSTable = ({
 
   if (loading) {
     return (
-      <div style={{ overflowX: 'auto' }}>
+      <div style={{ overflowX: 'auto' }} aria-busy="true">
         <table className={className} style={tableStyle}>
           <thead>
             <tr>
@@ -242,7 +242,7 @@ const MacOSTable = ({
   // ✅ Если переданы children, рендерим их напрямую (legacy режим)
   if (children) {
     return (
-      <div style={{ overflowX: 'auto' }}>
+      <div style={{ overflowX: 'auto' }} aria-busy={loading}>
         <table className={className} style={tableStyle}>
           {children}
         </table>
@@ -252,7 +252,7 @@ const MacOSTable = ({
 
   if (!data || data.length === 0) {
     return (
-      <div style={{ overflowX: 'auto' }}>
+      <div style={{ overflowX: 'auto' }} aria-busy={loading}>
         <table className={className} style={tableStyle}>
           <thead>
             <tr>
@@ -275,7 +275,7 @@ const MacOSTable = ({
   }
 
   return (
-    <div style={{ overflowX: 'auto' }}>
+    <div style={{ overflowX: 'auto' }} aria-busy={loading}>
       <table className={className} style={tableStyle}>
         <thead>
           <tr>


### PR DESCRIPTION
﻿## Summary

- Add `aria-busy` coverage to MacOS table, list, metric card, and stat card loading regions.
- Keep the UI component APIs and visual loading states unchanged.
- Add the Palette learning note for this accessibility pattern in `.Jules/palette.md`.

## Contract Impact

- Canonical surface: frontend UI components under `frontend/src/components/ui/macos/*`.
- Request shape: not applicable because no backend API request, route, schema, or frontend data-fetch contract changed.
- Response shape: not applicable because no backend response payload or frontend data shape changed.
- Status codes: not applicable because no HTTP endpoint behavior changed.
- Frontend consumer: existing consumers keep the same component props; rendered loading regions now expose `aria-busy` while loading.
- Compatibility path or alias: not applicable because no route path, alias, or compatibility redirect changed.
- Contract proof: PR diff changes only ARIA attributes on existing loading/root wrappers and a Palette note; frontend CI passed.

## RBAC / Permissions

- Roles allowed: not applicable because this PR does not change auth, RBAC dependencies, or protected route checks.
- Roles denied: not applicable because this PR does not change permission checks or role guards.
- Positive auth proof: not applicable because no authorization boundary changed.
- Negative auth proof: not applicable because no authorization boundary changed.

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR does not touch notification, websocket, chat, or realtime code.
- Payload version / ack behavior: not applicable because no notification or realtime payload changed.
- Read/unread or delivery semantics: not applicable because no delivery state or notification storage changed.
- Reconnect/resync proof: not applicable because no websocket reconnect or resync path changed.

## Frontend Resilience

- Empty data proof: unchanged; empty/loading placeholders continue rendering through the existing component logic.
- Partial data proof: unchanged; the PR adds accessibility attributes without changing item rendering or data fallback behavior.
- Forbidden secondary path behavior: not applicable because no protected route or secondary navigation path changed.
- Missing draft/resource behavior: not applicable because these generic UI components do not create or reopen draft resources.
- Stale route/deep-link behavior: not applicable because no routing or deep-link handling changed.

## Scope Gate

- Allowed paths: `.Jules/palette.md`, `frontend/src/components/ui/macos/MacOSList.jsx`, `frontend/src/components/ui/macos/MacOSMetricCard.jsx`, `frontend/src/components/ui/macos/MacOSStatCard.jsx`, `frontend/src/components/ui/macos/MacOSTable.jsx`.
- Denied paths: backend code, migrations, auth/RBAC, routing, deployment configs, generated output.
- Migration/docs/test impact: no migration or test source changes; `.Jules/palette.md` records the accessibility learning note.
- Rollback note: revert PR #647 to remove the added `aria-busy` attributes and Palette note.

## Validation

- Targeted tests or smoke run: existing PR checks already passed for frontend tests, backend tests, docs generation, CodeQL, GitGuardian, security scan, quality, frontend-backend parity, context boundary, and CI Scope; PR body was updated to satisfy the review gate template.
- Result: all non-template checks were already green before this body-only update; the next PR Review Quality Gate run should validate the new body.
- Not checked: manual screen-reader smoke was not run locally in this environment.
