### PR TITLE
fix(security): hide analytics error details

### DIFF
--- a/backend/app/api/v1/endpoints/analytics.py
+++ b/backend/app/api/v1/endpoints/analytics.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -11,6 +12,9 @@ from app.services.analytics_simple_api_service import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+ANALYTICS_PUBLIC_ERROR = "Internal server error"
 
 
 def _build_payment_provider_payload(
@@ -82,8 +86,13 @@ async def get_trends_analytics(
         # Используем SSOT для получения трендов
         return AnalyticsService.get_trends(db, days)
     except Exception as e:
+        logger.warning(
+            "Analytics trends endpoint failed error_type=%s",
+            type(e).__name__,
+        )
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения трендов: {str(e)}"
+            status_code=500,
+            detail=ANALYTICS_PUBLIC_ERROR,
         ) from e
 
 


### PR DESCRIPTION
﻿## Summary

- Replace the raw public `500` exception detail in analytics trends with a stable generic message.
- Log only exception type for internal diagnostics.
- Preserve existing success payload and analytics service behavior.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/analytics.py` `GET /trends` endpoint.
- Request shape: unchanged.
- Response shape: unchanged for success; unexpected internal failures now return `Internal server error`.
- Status codes: unchanged for success and internal failure; internal failure remains `500`.
- Frontend consumer: unchanged because no frontend code or success payload shape changed.
- Compatibility path or alias: unchanged; no routing, alias, or prefix changed.
- Contract proof: static search confirmed the raw `str(e)` sink was removed from this endpoint module.

## RBAC / Permissions

- Roles allowed: unchanged existing `require_roles(["admin", "doctor", "nurse"])` guard.
- Roles denied: unchanged because no auth dependency or permission check changed.
- Positive auth proof: not applicable because this slice changes only internal error reporting.
- Negative auth proof: not applicable because denied/unauthenticated behavior was not changed.

## Notification / Realtime

- Notification behavior: unchanged; no websocket, queue notification, Telegram, or realtime delivery path changed.
- Realtime behavior: unchanged.
- Event type or websocket channel: none changed.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable because no realtime path changed.

## Frontend Resilience

- Empty data proof: not applicable because no frontend rendering path changed.
- Partial data proof: not applicable because no frontend rendering path changed.
- Forbidden secondary path behavior: not applicable because no secondary frontend request path changed.
- Missing draft/resource behavior: not applicable because no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable because no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/analytics.py` only.
- Denied paths: frontend, services, migrations, generated artifacts, and unrelated endpoint modules.
- Migration/docs/test impact: no migration or docs change; no new test file added for this narrow endpoint hardening slice.
- Rollback note: revert commit `2596e4da` to restore the previous analytics trends raw error detail.

## Validation

- Targeted tests or smoke run: `python scripts\agent_gate.py "Sanitize public raw exception detail in analytics trends endpoint" --known-root-cause "backend/app/api/v1/endpoints/analytics.py"`; `python -m py_compile backend/app/api/v1/endpoints/analytics.py`; `git diff --check -- backend/app/api/v1/endpoints/analytics.py`; `rg -n "str\(e\)|str\(exc\)|detail=f.*\{.*e.*\}|detail=f.*\{.*exc.*\}|detail=str\(e\)|detail=str\(exc\)" backend/app/api/v1/endpoints/analytics.py`.
- Result: gate returned narrow override for the single known file; compile passed; diff check passed; static leak search returned no raw exception sinks.
- Not checked: full backend suite and browser/analytics UI smoke were not run locally for this one-file slice; GitHub CI is expected to cover broader repository gates.
