### PR TITLE
fix(security): redact morning assignment patient logs

### DIFF
--- a/backend/app/services/morning_assignment.py
+++ b/backend/app/services/morning_assignment.py
@@ -409,10 +409,9 @@ class MorningAssignmentService:
 
         service_codes_for_entry = create_handoff.create_entry_kwargs.get("service_codes", [])
         logger.info(
-            "Assigned number %s in queue %s for patient %s through SSOT, services: %s",
+            "Assigned number %s in queue %s through SSOT, services: %s",
             queue_entry.number,
             queue_tag,
-            visit.patient_id,
             service_codes_for_entry,
         )
 
@@ -539,7 +538,10 @@ class MorningAssignmentService:
             )
 
         if existing_entry:
-            logger.info(f"Patient {visit.patient_id} already has active queue entry for {queue_tag}")
+            logger.info(
+                "Active queue entry already exists for queue %s",
+                queue_tag,
+            )
             return MorningAssignmentPreparedQueueAssignment(
                 assignment={
                     "queue_tag": queue_tag,
@@ -664,7 +666,7 @@ class MorningAssignmentService:
         if len(active_entries) > 1:
             raise MorningAssignmentClaimError(
                 "Ambiguous active queue entry for "
-                f"queue_tag={queue_tag} and patient_id={patient_id}"
+                f"queue_tag={queue_tag}"
             )
 
         if len(active_entries) == 1:
@@ -673,14 +675,14 @@ class MorningAssignmentService:
             if matched_queue is None:
                 raise MorningAssignmentClaimError(
                     "Could not safely match active queue entry for "
-                    f"queue_tag={queue_tag} and patient_id={patient_id}"
+                    f"queue_tag={queue_tag}"
                 )
             return matched_queue, active_entries[0]
 
         if len(active_queues) > 1:
             raise MorningAssignmentClaimError(
                 "Ambiguous active queue for "
-                f"queue_tag={queue_tag} and patient_id={patient_id}"
+                f"queue_tag={queue_tag}"
             )
 
         return active_queues[0], None

--- a/backend/tests/unit/test_morning_assignment_logging.py
+++ b/backend/tests/unit/test_morning_assignment_logging.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import unittest
+
+
+SOURCE_PATH = (
+    Path(__file__).resolve().parents[2] / "app" / "services" / "morning_assignment.py"
+)
+SOURCE_TEXT = SOURCE_PATH.read_text(encoding="utf-8")
+SOURCE_TREE = ast.parse(SOURCE_TEXT)
+
+
+def _logger_info_calls() -> list[ast.Call]:
+    calls: list[ast.Call] = []
+    for node in ast.walk(SOURCE_TREE):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "info":
+            continue
+        if not isinstance(node.func.value, ast.Name):
+            continue
+        if node.func.value.id != "logger":
+            continue
+        calls.append(node)
+    return calls
+
+
+def _string_arg(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _contains_patient_id(node: ast.AST) -> bool:
+    return any(
+        isinstance(child, ast.Attribute) and child.attr == "patient_id"
+        for child in ast.walk(node)
+    )
+
+
+def _find_info_call(message: str) -> ast.Call:
+    for call in _logger_info_calls():
+        if call.args and _string_arg(call.args[0]) == message:
+            return call
+    raise AssertionError(f"logger.info call not found for message: {message}")
+
+
+class MorningAssignmentLoggingTest(unittest.TestCase):
+    def test_assignment_log_redacts_patient_id(self) -> None:
+        message = "Assigned number %s in queue %s through SSOT, services: %s"
+        call = _find_info_call(message)
+
+        self.assertEqual(len(call.args), 4)
+        self.assertFalse(any(_contains_patient_id(arg) for arg in call.args[1:]))
+        self.assertNotIn("for patient %s", SOURCE_TEXT)
+
+    def test_existing_entry_log_redacts_patient_id(self) -> None:
+        message = "Active queue entry already exists for queue %s"
+        call = _find_info_call(message)
+
+        self.assertEqual(len(call.args), 2)
+        self.assertFalse(any(_contains_patient_id(arg) for arg in call.args[1:]))
+        self.assertNotIn("already has active queue entry", SOURCE_TEXT)
+
+    def test_claim_error_messages_redact_patient_id(self) -> None:
+        self.assertNotIn("and patient_id={patient_id}", SOURCE_TEXT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Remove patient identifiers from morning assignment queue logs flagged by CodeQL alerts #129 and #130.
- Redact patient identifiers from nearby MorningAssignmentClaimError messages on the same queue claim path.
- Add a focused source-level regression check for the redacted log and error message templates.

## Contract Impact

- Canonical surface: backend/app/services/morning_assignment.py queue assignment service logging and internal claim error messages.
- Request shape: unchanged.
- Response shape: unchanged for successful assignment flows.
- Status codes: unchanged; this slice does not touch endpoint status handling.
- Frontend consumer: unchanged because no frontend code or payload shape changed.
- Compatibility path or alias: unchanged; no routing, prefix, or alias changed.
- Contract proof: diff touches only logging/error-message strings and a focused unit test.

## RBAC / Permissions

- Roles allowed: unchanged because no auth dependency or permission path changed.
- Roles denied: unchanged because no auth dependency or permission path changed.
- Positive auth proof: not applicable; service logging only.
- Negative auth proof: not applicable; service logging only.

## Notification / Realtime

- Notification behavior: unchanged; no websocket, Telegram, notification, or realtime delivery path changed.
- Realtime behavior: unchanged.
- Event type or websocket channel: none changed.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable because no realtime path changed.

## Frontend Resilience

- Empty data proof: not applicable because no frontend rendering path changed.
- Partial data proof: not applicable because no frontend rendering path changed.
- Forbidden secondary path behavior: not applicable because no auth/request path changed.
- Missing draft/resource behavior: not applicable because no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable because no route or deep-link changed.

## Scope Gate

- Allowed paths: backend/app/services/morning_assignment.py and backend/tests/unit/test_morning_assignment_logging.py.
- Denied paths: endpoints, queue services, migrations, generated artifacts, and unrelated modules.
- Migration/docs/test impact: no migration or docs change; adds one focused unit test.
- Rollback note: revert commit 3831ed70 to restore previous morning assignment log/error detail text.

## Validation

- Targeted tests or smoke run: agent_gate.py with known root cause; bundled Python py_compile for backend/app/services/morning_assignment.py and backend/tests/unit/test_morning_assignment_logging.py; bundled Python unittest backend.tests.unit.test_morning_assignment_logging; git diff --check; static Select-String for old patient-id log/error patterns.
- Result: gate returned narrow override; compile passed; unittest ran 3 tests and passed; diff check passed; static search returned no old patient-id patterns.
- Not checked: full backend suite locally; GitHub CI should cover broader repository gates.