### PR TITLE
fix(security): hide ai analytics error details

### DIFF
--- a/backend/app/api/v1/endpoints/ai_analytics.py
+++ b/backend/app/api/v1/endpoints/ai_analytics.py
@@ -18,6 +18,21 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+AI_ANALYTICS_PUBLIC_ERROR = "Internal server error"
+
+
+def _ai_analytics_http_error(exc: Exception, operation: str) -> HTTPException:
+    logger.warning(
+        "AI analytics endpoint failed operation=%s error_type=%s",
+        operation,
+        type(exc).__name__,
+    )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=AI_ANALYTICS_PUBLIC_ERROR,
+    )
+
+
 # ===================== PYDANTIC СХЕМЫ =====================
 
 
@@ -119,11 +134,7 @@ async def track_ai_usage(
         return result
 
     except Exception as e:
-        logger.error(f"Ошибка отслеживания AI использования: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отслеживания: {str(e)}",
-        )
+        raise _ai_analytics_http_error(e, "track_ai_usage") from e
 
 
 @router.get("/usage-analytics", response_model=AIUsageAnalyticsResponse)
@@ -168,11 +179,7 @@ async def get_ai_usage_analytics(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка получения аналитики AI использования: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения аналитики: {str(e)}",
-        )
+        raise _ai_analytics_http_error(e, "get_ai_usage_analytics") from e
 
 
 @router.get("/learning-insights", response_model=AILearningInsightsResponse)
@@ -208,11 +215,7 @@ async def get_ai_learning_insights(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка получения инсайтов для обучения AI: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения инсайтов: {str(e)}",
-        )
+        raise _ai_analytics_http_error(e, "get_ai_learning_insights") from e
 
 
 @router.post("/optimize-models", response_model=AIOptimizationResponse)
@@ -231,7 +234,10 @@ async def optimize_ai_models(
                 result = service.optimize_ai_models()
                 logger.info(f"AI оптимизация завершена: {result}")
             except Exception as e:
-                logger.error(f"Ошибка в фоновой оптимизации AI: {e}")
+                logger.warning(
+                    "AI analytics background optimization failed error_type=%s",
+                    type(e).__name__,
+                )
 
         background_tasks.add_task(run_optimization)
 
@@ -241,11 +247,7 @@ async def optimize_ai_models(
         return AIOptimizationResponse(**optimization_result)
 
     except Exception as e:
-        logger.error(f"Ошибка оптимизации AI моделей: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка оптимизации: {str(e)}",
-        )
+        raise _ai_analytics_http_error(e, "optimize_ai_models") from e
 
 
 @router.post("/generate-training-dataset", response_model=TrainingDatasetResponse)
@@ -297,9 +299,12 @@ async def generate_training_dataset(
         )
 
         if "error" in dataset_info:
+            logger.warning(
+                "AI analytics training dataset generation returned service error"
+            )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=dataset_info["error"],
+                detail=AI_ANALYTICS_PUBLIC_ERROR,
             )
 
         return TrainingDatasetResponse(**dataset_info)
@@ -307,11 +312,7 @@ async def generate_training_dataset(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка генерации обучающего датасета: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка генерации датасета: {str(e)}",
-        )
+        raise _ai_analytics_http_error(e, "generate_training_dataset") from e
 
 
 @router.get("/usage-summary")
@@ -355,11 +356,7 @@ async def get_ai_usage_summary(
         return summary
 
     except Exception as e:
-        logger.error(f"Ошибка получения сводки AI использования: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения сводки: {str(e)}",
-        )
+        raise _ai_analytics_http_error(e, "get_ai_usage_summary") from e
 
 
 @router.get("/function-performance/{function_name}")
@@ -409,13 +406,7 @@ async def get_function_performance(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(
-            f"Ошибка получения производительности функции {function_name}: {e}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения данных: {str(e)}",
-        )
+        raise _ai_analytics_http_error(e, "get_function_performance") from e
 
 
 @router.get("/cost-analysis")
@@ -487,11 +478,7 @@ async def get_ai_cost_analysis(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка анализа затрат на AI: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка анализа затрат: {str(e)}",
-        )
+        raise _ai_analytics_http_error(e, "get_ai_cost_analysis") from e
 
 
 @router.get("/model-comparison")
@@ -554,11 +541,7 @@ async def compare_ai_models(
         return comparison_data
 
     except Exception as e:
-        logger.error(f"Ошибка сравнения AI моделей: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка сравнения моделей: {str(e)}",
-        )
+        raise _ai_analytics_http_error(e, "compare_ai_models") from e
 
 
 # ===================== ВСПОМОГАТЕЛЬНЫЕ ФУНКЦИИ =====================


### PR DESCRIPTION
﻿## Summary

- Replace raw public internal-error details in AI analytics endpoints with a stable generic message.
- Add one helper that logs only operation name and exception type.
- Prevent the training dataset endpoint from returning raw service error text as a public `500` detail.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/ai_analytics.py` AI analytics usage, insights, optimization, dataset, summary, function performance, cost analysis, and model comparison endpoints.
- Request shape: unchanged.
- Response shape: unchanged for success and explicit `400` / `404`; unexpected internal failures now return `Internal server error`.
- Status codes: unchanged for success, validation/not-found, and internal failures; internal failure remains `500`.
- Frontend consumer: unchanged because no frontend code or success payload shape changed.
- Compatibility path or alias: unchanged; no routing, alias, or prefix changed.
- Contract proof: static search confirmed raw `str(e)` sinks were removed from public internal-error responses in this endpoint module.

## RBAC / Permissions

- Roles allowed: unchanged existing `get_current_user` / `require_roles` guards.
- Roles denied: unchanged because no auth dependency or permission check changed.
- Positive auth proof: not applicable because this slice changes only internal error reporting.
- Negative auth proof: not applicable because denied/unauthenticated behavior was not changed.

## Notification / Realtime

- Notification behavior: unchanged; no websocket, queue notification, Telegram, or realtime delivery path changed.
- Realtime behavior: unchanged.
- Event type or websocket channel: none changed.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable because no realtime path changed.

## Frontend Resilience

- Empty data proof: not applicable because no frontend rendering path changed.
- Partial data proof: not applicable because no frontend rendering path changed.
- Forbidden secondary path behavior: not applicable because no secondary frontend request path changed.
- Missing draft/resource behavior: not applicable because no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable because no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/ai_analytics.py` only.
- Denied paths: frontend, services, migrations, generated artifacts, and unrelated endpoint modules.
- Migration/docs/test impact: no migration or docs change; no new test file added for this narrow endpoint hardening slice.
- Rollback note: revert commit `a53da77a` to restore the previous AI analytics raw error details.

## Validation

- Targeted tests or smoke run: `python scripts\agent_gate.py "Sanitize public raw exception details in AI analytics endpoints" --known-root-cause "backend/app/api/v1/endpoints/ai_analytics.py"`; `python -m py_compile backend/app/api/v1/endpoints/ai_analytics.py`; `rg -n "str\(e\)|str\(exc\)|detail=f.*\{.*e.*\}|detail=f.*\{.*exc.*\}|detail=str\(e\)|detail=str\(exc\)|logger\.error\(f.*\{e\}" backend/app/api/v1/endpoints/ai_analytics.py`; `git diff --stat -- backend/app/api/v1/endpoints/ai_analytics.py`.
- Result: gate returned narrow override for the single known file; compile passed; static leak search returned only expected explicit `400`/`404` details and no raw internal-error sinks; diff remained one-file scoped.
- Not checked: full backend suite and browser/AI analytics UI smoke were not run locally for this one-file slice; `git diff --check` reports CRLF false-positive trailing whitespace on added lines because this legacy file is stored as `i/crlf`, so GitHub CI is used as the broader validation gate.
