### PR TITLE
fix(security): hide monitoring error details

### DIFF
--- a/backend/app/api/v1/endpoints/monitoring.py
+++ b/backend/app/api/v1/endpoints/monitoring.py
@@ -7,11 +7,25 @@ Provides endpoints for:
 - System health details
 """
 
+import logging
+
 from fastapi import APIRouter, Depends
 
-from app.api.deps import get_current_active_user, require_roles
+from app.api.deps import require_roles
 
 router = APIRouter(prefix="/monitoring", tags=["monitoring"])
+logger = logging.getLogger(__name__)
+
+MONITORING_PUBLIC_ERROR = "Monitoring data unavailable"
+
+
+def _monitoring_public_error(operation: str, exc: Exception) -> dict:
+    logger.warning(
+        "Monitoring endpoint failed operation=%s error_type=%s",
+        operation,
+        type(exc).__name__,
+    )
+    return {"error": MONITORING_PUBLIC_ERROR}
 
 
 @router.get("/query-stats", dependencies=[Depends(require_roles(["Admin"]))])
@@ -22,27 +36,28 @@ def get_query_stats():
     """
     try:
         from app.core.query_optimizer import QueryOptimizer
+
         return {
             "summary": QueryOptimizer.get_stats_summary(),
-            "slow_queries": QueryOptimizer.get_slow_queries(limit=20)
+            "slow_queries": QueryOptimizer.get_slow_queries(limit=20),
         }
     except ImportError:
         return {"error": "Query monitoring not available"}
     except Exception as e:
-        return {"error": str(e)}
+        return _monitoring_public_error("get_query_stats", e)
 
 
 @router.get("/alerts", dependencies=[Depends(require_roles(["Admin"]))])
 def get_alerts(hours: int = 24):
     """
     Get recent alerts.
-    
+
     Args:
         hours: Number of hours to look back (default 24)
     """
     try:
         from app.core.alerts import alert_manager
-        
+
         alerts = alert_manager.get_recent_alerts(hours=hours)
         return {
             "count": len(alerts),
@@ -53,16 +68,16 @@ def get_alerts(hours: int = 24):
                     "message": a.message,
                     "timestamp": a.timestamp.isoformat(),
                     "resolved": a.resolved,
-                    "details": a.details
+                    "details": a.details,
                 }
                 for a in alerts
             ],
-            "stats": alert_manager.get_alert_stats()
+            "stats": alert_manager.get_alert_stats(),
         }
     except ImportError:
         return {"error": "Alert system not available"}
     except Exception as e:
-        return {"error": str(e)}
+        return _monitoring_public_error("get_alerts", e)
 
 
 @router.get("/missing-indexes", dependencies=[Depends(require_roles(["Admin"]))])
@@ -71,17 +86,20 @@ def get_missing_indexes():
     Check for missing recommended database indexes.
     """
     try:
-        from app.core.query_optimizer import check_missing_indexes, generate_index_migration
+        from app.core.query_optimizer import (
+            check_missing_indexes,
+            generate_index_migration,
+        )
         from app.db.session import engine
-        
+
         missing = check_missing_indexes(engine)
         return {
             "missing_count": len(missing),
             "missing_indexes": missing,
-            "migration_script": generate_index_migration(missing) if missing else None
+            "migration_script": generate_index_migration(missing) if missing else None,
         }
     except Exception as e:
-        return {"error": str(e)}
+        return _monitoring_public_error("get_missing_indexes", e)
 
 
 @router.post("/reset-query-stats", dependencies=[Depends(require_roles(["Admin"]))])
@@ -89,6 +107,7 @@ def reset_query_stats():
     """Reset query statistics"""
     try:
         from app.core.query_optimizer import QueryOptimizer
+
         QueryOptimizer.reset_stats()
         return {"status": "ok", "message": "Query statistics reset"}
     except ImportError:


### PR DESCRIPTION
﻿## Summary

- Hides raw exception text returned by monitoring endpoints on unexpected failures.
- Adds a small monitoring endpoint helper that logs only operation and exception type.
- Preserves existing ImportError unavailable messages and successful response payloads.

## Contract Impact

- Canonical surface: `/api/v1/monitoring/query-stats`, `/api/v1/monitoring/alerts`, `/api/v1/monitoring/missing-indexes` via `backend/app/api/v1/endpoints/monitoring.py`.
- Request shape: unchanged.
- Response shape: unchanged JSON object shape for failure (`{"error": "..."}`); unexpected internal errors now use generic `Monitoring data unavailable` instead of raw exception details.
- Status codes: unchanged by this slice; existing functions still return JSON bodies directly.
- Frontend consumer: not changed.
- Compatibility path or alias: not applicable - no route path or alias changes.
- Contract proof: targeted smoke monkeypatched the monitoring dependencies to raise a marker exception and asserted the marker was absent from response bodies and logs.

## RBAC / Permissions

- Roles allowed: unchanged; endpoints remain guarded by `require_roles(["Admin"])`.
- Roles denied: unchanged.
- Positive auth proof: not checked locally; route dependency was not modified.
- Negative auth proof: not checked locally; route dependency was not modified.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/monitoring.py`.
- Denied paths: no backend route registry, schema, migration, frontend, or docs changes.
- Migration/docs/test impact: no migration; no docs/test file changes for this narrow security patch.
- Rollback note: revert commit `f8054080` if the generic monitoring failure message must be backed out.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/monitoring.py`; `python -m black --check backend/app/api/v1/endpoints/monitoring.py`; `python -m ruff check backend/app/api/v1/endpoints/monitoring.py`; `git diff --check`; targeted Python smoke for query stats, alerts, and missing indexes exception paths.
- Result: all passed; smoke returned only `{"error": "Monitoring data unavailable"}` and logs did not contain the secret marker.
- Not checked: full backend suite and browser UI; this patch is backend monitoring error sanitization only.
