### PR TITLE
fix(security): hide payment settings error details

### DIFF
--- a/backend/app/api/v1/endpoints/payment_settings.py
+++ b/backend/app/api/v1/endpoints/payment_settings.py
@@ -22,6 +22,8 @@ from app.services.payment_settings_service import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+PAYMENT_SETTINGS_PUBLIC_ERROR = "Внутренняя ошибка сервера"
+PAYMENT_PROVIDER_TEST_PUBLIC_ERROR = "Внутренняя ошибка тестирования провайдера"
 
 # ===================== API ENDPOINTS =====================
 
@@ -53,8 +55,11 @@ def update_payment_provider_settings(
     except PaymentSettingsDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except Exception as e:
-        logger.error(f"Ошибка сохранения настроек платежных провайдеров: {e}")
-        raise HTTPException(status_code=500, detail="Внутренняя ошибка сервера")
+        logger.warning(
+            "Payment provider settings save failed error_type=%s",
+            type(e).__name__,
+        )
+        raise HTTPException(status_code=500, detail=PAYMENT_SETTINGS_PUBLIC_ERROR)
 
 
 @router.post("/admin/test-payment-provider", response_model=TestProviderResponse)
@@ -74,9 +79,14 @@ def test_payment_provider(
         )
         return TestProviderResponse(**result)
     except Exception as e:
-        logger.error(f"Ошибка тестирования провайдера {test_request.provider}: {e}")
+        logger.warning(
+            "Payment provider test failed provider=%s error_type=%s",
+            test_request.provider,
+            type(e).__name__,
+        )
         return TestProviderResponse(
-            success=False, message=f"Внутренняя ошибка: {str(e)}"
+            success=False,
+            message=PAYMENT_PROVIDER_TEST_PUBLIC_ERROR,
         )
 
 


### PR DESCRIPTION
﻿## Summary

- Hides raw exception text from the Admin payment provider test response.
- Replaces payment settings exception logs with operation/provider plus exception type only.
- Preserves Admin-only routes, request shape, and successful provider-test responses.

## Contract Impact

- Canonical surface: `/api/v1/admin/payment-provider-settings` and `/api/v1/admin/test-payment-provider` via `backend/app/api/v1/endpoints/payment_settings.py`.
- Request shape: unchanged.
- Response shape: unchanged models; unexpected provider-test failures still return `TestProviderResponse(success=false, message=...)`, but the message is now generic.
- Status codes: unchanged by this slice.
- Frontend consumer: not changed.
- Compatibility path or alias: not applicable - no route path or alias changes.
- Contract proof: targeted smoke monkeypatched `PaymentSettingsService` to raise marker exceptions and asserted the marker was absent from HTTP details, response model JSON, and logs.

## RBAC / Permissions

- Roles allowed: unchanged; routes remain guarded by `require_roles("Admin")`.
- Roles denied: unchanged.
- Positive auth proof: not checked locally; route dependency was not modified.
- Negative auth proof: not checked locally; route dependency was not modified.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no frontend data flow changed; existing provider-test failure shape remains `success=false` plus `message`.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/payment_settings.py`.
- Denied paths: payment service internals, provider implementations, migrations, frontend, docs.
- Migration/docs/test impact: no migration; no docs/test file changes for this narrow security patch.
- Rollback note: revert commit `e60503b2` if payment provider test failures must temporarily expose raw provider diagnostics again.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/payment_settings.py`; `python -m black --check backend/app/api/v1/endpoints/payment_settings.py`; `python -m ruff check backend/app/api/v1/endpoints/payment_settings.py`; `git diff --check`; targeted Python smoke for settings-save and provider-test exception paths.
- Result: all passed; smoke confirmed the marker was absent from public response details, response model JSON, and logs.
- Not checked: full backend suite and browser UI; this patch is backend Admin payment settings error sanitization only.
