### PR TITLE
fix(security): hide legacy json login error details

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -158,9 +158,13 @@ async def json_login(request_data: JSONLoginRequest, db=Depends(get_db)) -> Any:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Exception in JSON login: {e}")
+    except Exception as exc:
+        logger.warning(
+            "Legacy JSON login endpoint failed operation=%s error_type=%s",
+            "json_login",
+            type(exc).__name__,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка входа: {str(e)}",
-        )
+            detail="Internal server error",
+        ) from exc

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -6,11 +6,12 @@ This implementation is defensive: it supports get_db() returning either an
 AsyncSession (async DB) or a sync Session/sessionmaker. The DB calls are
 dispatched either by awaiting (async) or via run_in_threadpool (sync).
 """
+
 from __future__ import annotations
 
 import logging
 import secrets
-from typing import Any, Dict
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
@@ -99,7 +100,7 @@ class JSONLoginResponse(BaseModel):
 
     access_token: str
     token_type: str = "bearer"
-    user: Dict[str, Any]
+    user: dict[str, Any]
 
 
 class CSRFTokenResponse(BaseModel):


### PR DESCRIPTION
## Summary

- Hide raw exception text from the legacy JSON login internal `500` response.
- Keep existing domain/auth failure responses unchanged.
- Log only the operation name and exception type for unexpected JSON login failures.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/auth.py` legacy `/json-login` endpoint.
- Request shape: unchanged.
- Response shape: unchanged for successful login and `AuthApiDomainError` failures; unexpected internal failures now return `Internal server error` instead of raw exception text.
- Status codes: unchanged; unexpected internal failure remains `500`.
- Frontend consumer: unchanged because successful login payload and auth-domain errors were not changed.
- Compatibility path or alias: unchanged; no route, prefix, or alias changed.
- Contract proof: static search confirmed the previous raw `detail=f...{str(e)}` sink and raw exception log string were removed from `auth.py`.

## RBAC / Permissions

- Roles allowed: unchanged; login endpoint remains unauthenticated by design.
- Roles denied: unchanged; no permission dependency or credential validation path changed.
- Positive auth proof: successful login flow still delegates to `AuthApiService(db).json_login_payload`.
- Negative auth proof: invalid credential/domain errors still use `AuthApiDomainError` status/detail without changing semantics.

## Notification / Realtime

- Notification behavior: unchanged; no notification, Telegram, websocket, or realtime code touched.
- Realtime behavior: unchanged.
- Event type or websocket channel: none changed.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no realtime path changed.

## Frontend Resilience

- Empty data proof: no frontend rendering path changed.
- Partial data proof: no frontend rendering path changed.
- Forbidden secondary path behavior: no secondary frontend request path changed.
- Missing draft/resource behavior: no draft/resource flow changed.
- Stale route/deep-link behavior: no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/auth.py` only.
- Denied paths: fallback auth endpoints, frontend, services, migrations, generated artifacts, and unrelated modules.
- Migration/docs/test impact: no migration or docs change; no new test file added for this one-file error-detail hardening slice.
- Rollback note: revert commit `007c039d` to restore previous raw JSON-login internal error detail behavior.

## Validation

- Targeted tests or smoke run: agent gate with known root cause for `auth.py`; `python -m py_compile backend\app\api\v1\endpoints\auth.py`; `git diff --check -- backend/app/api/v1/endpoints/auth.py`; targeted raw detail/log leak scan with `rg` in `auth.py`.
- Result: gate returned narrow override for `auth.py`; compile passed; diff check passed with only a line-ending warning; static leak search returned no matches.
- Not checked: full backend suite and browser login smoke were not run locally for this one-file slice; GitHub CI is expected to cover broader repository gates.