### PR TITLE
fix(security): hide simple auth error details

### DIFF
--- a/backend/app/api/v1/endpoints/simple_auth.py
+++ b/backend/app/api/v1/endpoints/simple_auth.py
@@ -1,6 +1,7 @@
 """
 Упрощенный endpoint авторизации без сложных зависимостей
 """
+import logging
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -15,6 +16,7 @@ from app.services.auth_fallback_service import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 class SimpleLoginRequest(BaseModel):
@@ -51,9 +53,14 @@ async def simple_login(
     except AuthFallbackDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except Exception as exc:
+        logger.warning(
+            "Simple fallback login endpoint failed operation=%s error_type=%s",
+            "simple_login",
+            type(exc).__name__,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка входа: {str(exc)}",
+            detail="Internal server error",
         ) from exc
 
 

--- a/backend/app/api/v1/endpoints/simple_auth.py
+++ b/backend/app/api/v1/endpoints/simple_auth.py
@@ -1,8 +1,9 @@
 """
 Упрощенный endpoint авторизации без сложных зависимостей
 """
+
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 class SimpleLoginRequest(BaseModel):
     """Простая схема для входа"""
+
     username: str
     password: str
     remember_me: bool = False
@@ -28,17 +30,15 @@ class SimpleLoginRequest(BaseModel):
 
 class SimpleLoginResponse(BaseModel):
     """Простая схема ответа"""
+
     access_token: str
     token_type: str = "bearer"
     expires_in: int
-    user: Dict[str, Any]
+    user: dict[str, Any]
 
 
 @router.post("/simple-login", response_model=SimpleLoginResponse)
-async def simple_login(
-    request_data: SimpleLoginRequest,
-    db: Session = Depends(get_db)
-):
+async def simple_login(request_data: SimpleLoginRequest, db: Session = Depends(get_db)):
     """
     Упрощенный вход в систему без сложных зависимостей
     """
@@ -67,11 +67,10 @@ async def simple_login(
 @router.get("/me")
 async def get_current_user_simple(
     db: Session = Depends(get_db),
-    current_user: User = Depends(lambda: None)  # Временно отключено
+    current_user: User = Depends(lambda: None),  # Временно отключено
 ):
     """
     Получить информацию о текущем пользователе
     """
     # Временная заглушка
     return {"message": "Endpoint /me временно недоступен"}
-


### PR DESCRIPTION
## Summary

- Hide raw exception text from the simple fallback login internal `500` response.
- Keep existing `AuthFallbackDomainError` login failure responses unchanged.
- Log only the operation name and exception type for unexpected simple login failures.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/simple_auth.py` `/simple-login` endpoint.
- Request shape: unchanged.
- Response shape: unchanged for successful login and auth-domain failures; unexpected internal failures now return `Internal server error` instead of raw exception text.
- Status codes: unchanged; unexpected internal failure remains `500`.
- Frontend consumer: unchanged because successful login payload and auth-domain errors were not changed.
- Compatibility path or alias: unchanged; no route, prefix, or alias changed.
- Contract proof: static search confirmed the previous raw `detail=f...{str(exc)}` sink was removed from `simple_auth.py`.

## RBAC / Permissions

- Roles allowed: unchanged; fallback login endpoint remains unauthenticated by design.
- Roles denied: unchanged; no permission dependency or credential validation path changed.
- Positive auth proof: successful login flow still delegates to `AuthFallbackService(db).login_with_user_model`.
- Negative auth proof: invalid credential/domain errors still use `AuthFallbackDomainError` status/detail without changing semantics.

## Notification / Realtime

- Notification behavior: unchanged; no notification, Telegram, websocket, or realtime code touched.
- Realtime behavior: unchanged.
- Event type or websocket channel: none changed.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no realtime path changed.

## Frontend Resilience

- Empty data proof: no frontend rendering path changed.
- Partial data proof: no frontend rendering path changed.
- Forbidden secondary path behavior: no secondary frontend request path changed.
- Missing draft/resource behavior: no draft/resource flow changed.
- Stale route/deep-link behavior: no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/simple_auth.py` only.
- Denied paths: other auth endpoints, frontend, services, migrations, generated artifacts, and unrelated modules.
- Migration/docs/test impact: no migration or docs change; no new test file added for this one-file error-detail hardening slice.
- Rollback note: revert commit `f8c7aad3` to restore previous raw simple-login internal error detail behavior.

## Validation

- Targeted tests or smoke run: agent gate with known root cause for `simple_auth.py`; `python -m py_compile backend\app\api\v1\endpoints\simple_auth.py`; `git diff --check -- backend/app/api/v1/endpoints/simple_auth.py`; targeted raw detail leak scan with `rg` in `simple_auth.py`.
- Result: gate returned narrow override for `simple_auth.py`; compile passed; diff check passed; static leak search returned no matches.
- Not checked: full backend suite and browser login smoke were not run locally for this one-file slice; GitHub CI is expected to cover broader repository gates.