### PR TITLE
chore(security): clean 2FA endpoint error handling

### DIFF
--- a/backend/app/api/v1/endpoints/two_factor_auth.py
+++ b/backend/app/api/v1/endpoints/two_factor_auth.py
@@ -2,11 +2,11 @@
 API endpoints для двухфакторной аутентификации (2FA)
 """
 
-from datetime import datetime, timedelta
 import logging
-from typing import List, NoReturn, Optional
+from datetime import datetime, timedelta
+from typing import NoReturn
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
@@ -15,16 +15,13 @@ from app.crud.two_factor_auth import (
     two_factor_backup_code,
     two_factor_device,
     two_factor_recovery,
-    two_factor_session,
 )
 from app.db.session import get_db
 from app.models.user import User
-from app.schemas.authentication import LoginResponse
 from app.schemas.two_factor_auth import (
     TwoFactorBackupCodesResponse,
     TwoFactorDeviceListResponse,
     TwoFactorDisableRequest,
-    TwoFactorErrorResponse,
     TwoFactorRecoveryRequest,
     TwoFactorRecoveryResponse,
     TwoFactorSetupRequest,
@@ -35,8 +32,8 @@ from app.schemas.two_factor_auth import (
     TwoFactorVerifyResponse,
 )
 from app.services.authentication_service import get_authentication_service
-from app.services.two_factor_service import get_two_factor_service, TwoFactorService
 from app.services.two_factor_auth_api_service import TwoFactorAuthApiService
+from app.services.two_factor_service import get_two_factor_service
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -50,7 +47,7 @@ def raise_two_factor_internal_error(action: str, exc: Exception) -> NoReturn:
     )
     raise HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        detail=f"Error {action}",
+        detail="Internal server error",
     )
 
 
@@ -164,11 +161,12 @@ async def verify_two_factor(
             )
 
         # ✅ CERTIFICATION: Получаем пользователя из access_token или pending_2fa_token
-        user: Optional[User] = None
-        
+        user: User | None = None
+
         # Пробуем получить из access_token (если передан в заголовке)
         try:
             from fastapi.security import HTTPBearer
+
             security = HTTPBearer(auto_error=False)
             token_result = await security(request)
             if token_result and token_result.credentials:
@@ -178,13 +176,13 @@ async def verify_two_factor(
                     pass  # Не JWT токен, пробуем pending_2fa_token
         except Exception:
             pass
-        
+
         # Если access_token не сработал, пробуем pending_2fa_token
         if not user and request_data.pending_2fa_token:
             user = TwoFactorAuthApiService(db).get_user_from_pending_token(
                 request_data.pending_2fa_token
             )
-        
+
         if not user:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
@@ -207,9 +205,7 @@ async def verify_two_factor(
             # Получаем количество оставшихся backup кодов
             backup_codes_remaining = None
             if request_data.backup_code:
-                two_factor_auth_obj = two_factor_auth.get_by_user_id(
-                    db, user.id
-                )
+                two_factor_auth_obj = two_factor_auth.get_by_user_id(db, user.id)
                 if two_factor_auth_obj:
                     backup_codes_remaining = two_factor_backup_code.get_unused_count(
                         db, two_factor_auth_obj.id
@@ -315,7 +311,7 @@ async def request_two_factor_recovery(
                 detail="2FA configuration not found",
             )
 
-        recovery = two_factor_recovery.create(
+        two_factor_recovery.create(
             db,
             obj_in={
                 "two_factor_auth_id": two_factor_auth_obj.id,
@@ -435,7 +431,9 @@ async def regenerate_backup_codes(
         raise_two_factor_internal_error("regenerating backup codes", e)
 
 
-@router.get("/devices", response_model=TwoFactorDeviceListResponse, include_in_schema=False)
+@router.get(
+    "/devices", response_model=TwoFactorDeviceListResponse, include_in_schema=False
+)
 async def get_trusted_devices(
     db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
 ):


### PR DESCRIPTION
## Summary
- Clean up the already-merged 2FA endpoint raw-error handling in `backend/app/api/v1/endpoints/two_factor_auth.py`.
- Keep unexpected 2FA failures generic for callers and remove lint/format issues.
- Preserve explicit validation/auth `HTTPException` paths and existing routes.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/two_factor_auth.py` 2FA REST endpoints under the existing router.
- Request shape: unchanged; no request model, parameter, header, or body field changes.
- Response shape: unchanged for success and explicit validation errors; unexpected 500 detail remains generic.
- Status codes: unchanged for success and explicit `HTTPException` paths; unexpected internal failures remain HTTP 500.
- Frontend consumer: unchanged; no frontend files, API client methods, or route consumers were touched.
- Compatibility path or alias: unchanged; no route alias, legacy path, or redirect behavior changed.
- Contract proof: targeted smoke verified explicit 400 `HTTPException` is preserved while unexpected service failure returns generic HTTP 500.

## RBAC / Permissions
- Roles allowed: unchanged; existing `get_current_user` dependency behavior remains the authority for protected endpoints.
- Roles denied: unchanged; this PR does not alter role checks, auth dependencies, or permission gates.
- Positive auth proof: targeted smoke exercises the protected setup path up to the existing already-enabled 400 behavior.
- Negative auth proof: not broadened in this cleanup; no RBAC/auth dependency code was changed.

## Notification / Realtime
Not applicable: this PR does not touch notifications, Telegram, websocket, queue, broadcast, retry, or realtime delivery code.

## Frontend Resilience
Not applicable: backend-only cleanup; no frontend state, loading/error UI, route, retry, or rendering behavior changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/two_factor_auth.py` only.
- Denied paths: frontend, migrations, docs, generated artifacts, runtime output, agent config, and unrelated backend endpoints.
- Migration/docs/test impact: no migration or docs change required; validation is targeted to the single backend endpoint file.
- Rollback note: revert commit `9de5cf19` or the PR merge commit to restore the previous cleanup state.

## Validation
- Targeted tests or smoke run: `py_compile`, `black --check`, `ruff check`, raw-error grep, and targeted 2FA smoke with a secret marker.
- Result: local checks passed; GitHub checks are passing except this PR body gate before this body update.
- Not checked: full manual browser login/2FA flow and staging deployment were not run for this backend-only cleanup.