### PR TITLE
fix(security): redact Speed Insights URLs

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,8 +32,11 @@ import auth from './stores/auth.js';
 import { ROUTE_REGISTRY } from './routing/routeRegistry.js';
 import { ForbiddenPage, LegacyRouteRedirect, NotFoundPage, RouteAccessBoundary, UnauthorizedPage, resolveSetupRedirect } from './routing/routeGuards.jsx';
 import { getRouteChromeState } from './routing/routeSelectors.js';
+import { sanitizeSpeedInsightsEvent } from './utils/speedInsightsPrivacy.js';
 
 bootstrapStoredColorScheme();
+
+const beforeSendSpeedInsights = (event) => sanitizeSpeedInsightsEvent(event, ROUTE_REGISTRY);
 
 const CashierPanel = lazy(() => import('./pages/CashierPanel.jsx'));
 const Settings = lazy(() => import('./pages/Settings.jsx'));
@@ -296,7 +299,7 @@ export default function App() {
             draggable
             theme="colored"
           />
-          <SpeedInsights />
+          <SpeedInsights beforeSend={beforeSendSpeedInsights} />
         </AppProviders>
       </ThemeProvider>
     </MacOSThemeProvider>

--- a/frontend/src/__tests__/speedInsightsPrivacy.test.js
+++ b/frontend/src/__tests__/speedInsightsPrivacy.test.js
@@ -50,4 +50,19 @@ describe('Speed Insights privacy sanitizer', () => {
 
     expect(event.url).toBe('/unknown/patient/[redacted]/token/[redacted]/raw/[redacted]');
   });
+
+  it('fully redacts malformed URLs instead of throwing', () => {
+    const event = sanitizeSpeedInsightsEvent(
+      {
+        url: 'not a url',
+        name: 'CLS',
+      },
+      ROUTE_REGISTRY
+    );
+
+    expect(event).toEqual({
+      url: '[redacted]',
+      name: 'CLS',
+    });
+  });
 });

--- a/frontend/src/__tests__/speedInsightsPrivacy.test.js
+++ b/frontend/src/__tests__/speedInsightsPrivacy.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { ROUTE_REGISTRY } from '../routing/routeRegistry.js';
+import { sanitizeSpeedInsightsEvent } from '../utils/speedInsightsPrivacy.js';
+
+describe('Speed Insights privacy sanitizer', () => {
+  it('drops query strings and hashes that can contain patient workflow identifiers', () => {
+    const event = sanitizeSpeedInsightsEvent(
+      {
+        url: 'https://clinic.example/registrar?patientId=42&q=Aliya#payment',
+        name: 'TTFB',
+      },
+      ROUTE_REGISTRY
+    );
+
+    expect(event).toEqual({
+      url: '/registrar',
+      route: '/registrar',
+      name: 'TTFB',
+    });
+  });
+
+  it('uses canonical dynamic route templates instead of concrete ids and tokens', () => {
+    expect(
+      sanitizeSpeedInsightsEvent(
+        {
+          url: '/queue/join/public-qr-token-123',
+        },
+        ROUTE_REGISTRY
+      ).url
+    ).toBe('/queue/join/:token');
+
+    expect(
+      sanitizeSpeedInsightsEvent(
+        {
+          url: '/clinical/visits/98765',
+        },
+        ROUTE_REGISTRY
+      ).url
+    ).toBe('/clinical/visits/:id');
+  });
+
+  it('redacts unmatched numeric, uuid, and high-entropy path segments', () => {
+    const event = sanitizeSpeedInsightsEvent(
+      {
+        url: '/unknown/patient/123/token/550e8400-e29b-41d4-a716-446655440000/raw/abcdef1234567890',
+      },
+      ROUTE_REGISTRY
+    );
+
+    expect(event.url).toBe('/unknown/patient/[redacted]/token/[redacted]/raw/[redacted]');
+  });
+});

--- a/frontend/src/utils/speedInsightsPrivacy.js
+++ b/frontend/src/utils/speedInsightsPrivacy.js
@@ -1,5 +1,23 @@
 const SENSITIVE_ROUTE_SEGMENT = '[redacted]';
 const UUID_SEGMENT_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ABSOLUTE_URL_PATTERN = /^[a-z][a-z0-9+.-]*:\/\/[^/]*(\/.*)?$/i;
+
+const getPathnameFromUrl = (url) => {
+  const normalized = url.trim();
+  if (!normalized) return null;
+
+  const pathWithoutQuery = normalized.split('#')[0].split('?')[0];
+  if (pathWithoutQuery.startsWith('/')) {
+    return pathWithoutQuery || '/';
+  }
+
+  const absoluteMatch = pathWithoutQuery.match(ABSOLUTE_URL_PATTERN);
+  if (absoluteMatch) {
+    return absoluteMatch[1] || '/';
+  }
+
+  return null;
+};
 
 const isDynamicRouteMatch = (routePath, pathname) => {
   const routeParts = routePath.split('/').filter(Boolean);
@@ -32,20 +50,24 @@ export function sanitizeSpeedInsightsEvent(event, routes) {
     return event;
   }
 
-  try {
-    const parsed = new URL(event.url, 'https://clinic.local');
-    const matchedRoute = (routes || []).find((route) => isDynamicRouteMatch(route.path, parsed.pathname));
-    const safeUrl = matchedRoute?.path || redactUnmatchedPath(parsed.pathname);
+  const pathname = getPathnameFromUrl(event.url);
 
-    return {
-      ...event,
-      url: safeUrl,
-      route: matchedRoute?.path || event.route,
-    };
-  } catch {
+  if (!pathname) {
     return {
       ...event,
       url: SENSITIVE_ROUTE_SEGMENT,
     };
   }
+
+  const routeList = Array.isArray(routes) ? routes : [];
+  const matchedRoute = routeList.find(
+    (route) => typeof route?.path === 'string' && isDynamicRouteMatch(route.path, pathname)
+  );
+  const safeUrl = matchedRoute?.path || redactUnmatchedPath(pathname);
+
+  return {
+    ...event,
+    url: safeUrl,
+    route: matchedRoute?.path || event.route,
+  };
 }

--- a/frontend/src/utils/speedInsightsPrivacy.js
+++ b/frontend/src/utils/speedInsightsPrivacy.js
@@ -1,0 +1,51 @@
+const SENSITIVE_ROUTE_SEGMENT = '[redacted]';
+const UUID_SEGMENT_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const isDynamicRouteMatch = (routePath, pathname) => {
+  const routeParts = routePath.split('/').filter(Boolean);
+  const pathParts = pathname.split('/').filter(Boolean);
+
+  if (routeParts.length !== pathParts.length) {
+    return false;
+  }
+
+  return routeParts.every((part, index) => part.startsWith(':') || part === pathParts[index]);
+};
+
+const redactUnmatchedPath = (pathname) => {
+  const redacted = pathname
+    .split('/')
+    .map((part) => {
+      if (!part) return part;
+      if (/^\d+$/.test(part)) return SENSITIVE_ROUTE_SEGMENT;
+      if (UUID_SEGMENT_PATTERN.test(part)) return SENSITIVE_ROUTE_SEGMENT;
+      if (/^[A-Za-z0-9_-]{12,}$/.test(part)) return SENSITIVE_ROUTE_SEGMENT;
+      return part;
+    })
+    .join('/');
+
+  return redacted || '/';
+};
+
+export function sanitizeSpeedInsightsEvent(event, routes) {
+  if (!event || typeof event !== 'object' || typeof event.url !== 'string') {
+    return event;
+  }
+
+  try {
+    const parsed = new URL(event.url, 'https://clinic.local');
+    const matchedRoute = (routes || []).find((route) => isDynamicRouteMatch(route.path, parsed.pathname));
+    const safeUrl = matchedRoute?.path || redactUnmatchedPath(parsed.pathname);
+
+    return {
+      ...event,
+      url: safeUrl,
+      route: matchedRoute?.path || event.route,
+    };
+  } catch {
+    return {
+      ...event,
+      url: SENSITIVE_ROUTE_SEGMENT,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Redacts Vercel Speed Insights URL payloads before telemetry leaves the frontend.
- Strips query strings and hashes, maps known dynamic routes to route templates, and redacts sensitive unmatched path segments.
- Hardens sanitizer parsing so malformed URLs fail closed as `[redacted]`.

## Contract Impact
- Canonical surface: frontend Vercel Speed Insights telemetry event URL field in `frontend/src/App.jsx`.
- Request shape: not applicable - no backend request body, query contract, or API request shape changed.
- Response shape: not applicable - no backend response shape changed.
- Status codes: not applicable - no HTTP status behavior changed.
- Frontend consumer: Vercel Speed Insights receives sanitized route templates or redacted path values only.
- Compatibility path or alias: existing route registry matching is preserved; unknown paths fall back to segment redaction.
- Contract proof: focused sanitizer tests cover query/hash stripping, dynamic route templating, unmatched segment redaction, and malformed URL fail-closed behavior.

## RBAC / Permissions
- Roles allowed: not applicable - no role guard, route permission, endpoint authorization, or login behavior changed.
- Roles denied: not applicable - no role guard, route permission, endpoint authorization, or login behavior changed.
- Positive auth proof: not applicable - this telemetry sanitizer does not grant or deny access.
- Negative auth proof: not applicable - this telemetry sanitizer does not grant or deny access.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification event, websocket channel, queue event, or chat event changed.
- Payload version / ack behavior: not applicable - no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read state behavior changed.
- Reconnect/resync proof: not applicable - no websocket reconnect or resync path changed.

## Frontend Resilience
- Empty data proof: malformed or empty URL values fail closed to `[redacted]` instead of throwing.
- Partial data proof: events keep existing non-URL fields while replacing only unsafe URL data.
- Forbidden secondary path behavior: not applicable - no secondary navigation or forbidden route behavior changed.
- Missing draft/resource behavior: not applicable - no draft, visit resource, or persisted frontend resource behavior changed.
- Stale route/deep-link behavior: stale or unknown deep links are sanitized by redacting numeric, UUID, and high-entropy segments.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`, `frontend/src/utils/speedInsightsPrivacy.js`, `frontend/src/__tests__/speedInsightsPrivacy.test.js`.
- Denied paths: backend runtime, migrations, route registry rewrites, queue logic, notification/realtime code, generated output.
- Migration/docs/test impact: no migration or docs change; targeted frontend regression test added.
- Rollback note: revert the Speed Insights `beforeSend` wiring, sanitizer utility, and focused sanitizer tests.

## Validation
- Targeted tests or smoke run: `npm.cmd run test:run -- src/__tests__/speedInsightsPrivacy.test.js`; `npm.cmd run test:run`; `npm.cmd run build`.
- Result: passed locally. GitHub frontend test check passed after commit `e853ae17`.
- Not checked: live Vercel telemetry ingestion, because the change is local event sanitization and the CI environment does not send production telemetry.