### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -10,6 +10,13 @@ on:
     - cron: '0 2 * * *'  # Ежедневно в 2:00
   workflow_dispatch:  # Ручной запуск
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
+
 env:
   PYTHON_VERSION: '3.11.10'
   NODE_VERSION: '20'
@@ -449,6 +456,7 @@ jobs:
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
     
     - name: 📦 Установка зависимостей
       run: |
@@ -458,11 +466,8 @@ jobs:
     - name: 🔍 Линтинг frontend
       run: |
         cd frontend
-        if npm run lint:check; then
-          echo "✅ Frontend lint passed"
-        else
-          echo "::warning::Frontend lint has legacy violations and is non-blocking in this phase. Frontend tests/build remain blocking."
-        fi
+        npm run lint:check
+        echo "✅ Frontend lint passed"
     
     - name: 🧪 Тесты frontend
       run: |
@@ -581,6 +586,7 @@ jobs:
       with:
         name: coverage-report
         path: backend/htmlcov/
+        retention-days: 7
         if-no-files-found: warn
 
   # --- Архитектурные boundary тесты ---
@@ -729,6 +735,7 @@ jobs:
           docs/reports/FRONTEND_BACKEND_PARITY_REPORT.md
           docs/reports/FRONTEND_UX_CORRECTNESS_SCORECARD.md
           docs/reports/frontend_ux_correctness_scorecard.json
+        retention-days: 14
         if-no-files-found: error
 
   # --- Security сканирование ---
@@ -817,6 +824,7 @@ jobs:
       with:
         name: security-reports
         path: backend/security-reports/
+        retention-days: 14
         if-no-files-found: warn
 
   # --- Docker сборка ---
@@ -856,8 +864,8 @@ jobs:
         file: ./ops/backend.Dockerfile
         push: false
         tags: clinic-backend:latest
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=clinic-backend
+        cache-to: type=gha,mode=min,scope=clinic-backend,ignore-error=true
         build-args: |
           BUILDKIT_INLINE_CACHE=1
     
@@ -868,8 +876,8 @@ jobs:
         file: ./ops/frontend.Dockerfile
         push: false
         tags: clinic-frontend:latest
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=clinic-frontend
+        cache-to: type=gha,mode=min,scope=clinic-frontend,ignore-error=true
         build-args: |
           BUILDKIT_INLINE_CACHE=1
 
@@ -1309,6 +1317,7 @@ jobs:
           artifacts/load/load-regression-report.md
           artifacts/load/load-regression-report.json
           artifacts/load/profiles/**
+        retention-days: 14
         if-no-files-found: warn
 
     - name: 🛑 Stop API
@@ -1491,10 +1500,11 @@ jobs:
 
     - name: 📤 Upload ZAP artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: zap-nightly-report
         path: zap-report/
+        retention-days: 14
         if-no-files-found: warn
 
     - name: 🛑 Stop API
@@ -1649,10 +1659,11 @@ jobs:
       with:
         name: api-docs
         path: backend/openapi.json
+        retention-days: 14
 
-  # --- Deploy Staging ---
+  # --- Staging readiness report (no live deploy) ---
   deploy-staging:
-    name: 🚀 Deploy Staging
+    name: Staging readiness report
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [docker, security, docs, integration]
@@ -1661,17 +1672,17 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     
-    - name: 🚀 Deploy to Staging
+    - name: Staging readiness summary
       run: |
-        echo "🚀 Развертывание в staging окружение"
+        echo "🚀 Staging readiness report (no live deployment)"
         echo "✅ Все проверки пройдены"
         echo "📦 Docker образы собраны"
         echo "🔒 Security сканирование завершено"
         echo "🔗 Интеграционные тесты пройдены"
 
-  # --- Deploy Production ---
+  # --- Production readiness report (no live deploy) ---
   deploy-production:
-    name: 🌟 Deploy Production
+    name: Production readiness report
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [docker, security, docs, integration]
@@ -1682,9 +1693,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     
-    - name: 🌟 Deploy to Production
+    - name: Production readiness summary
       run: |
-        echo "🌟 Развертывание в production окружение"
+        echo "🌟 Production readiness report (no live deployment)"
         echo "✅ Все проверки пройдены"
         echo "📦 Docker образы собраны"
         echo "🔒 Security сканирование завершено"

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -1,4 +1,4 @@
-name: 🎨 Автоматическое форматирование кода
+name: Code formatting report
 
 on:
   workflow_dispatch:  # Только ручной запуск
@@ -7,9 +7,16 @@ on:
       - 'backend/**/*.py'
       - 'frontend/**/*.{js,jsx,ts,tsx}'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   format-backend:
-    name: 🐍 Форматирование Python кода
+    name: Python formatting report
     runs-on: ubuntu-latest
     
     steps:
@@ -27,33 +34,19 @@ jobs:
         pip install --upgrade pip
         pip install black isort
     
-    - name: 🎨 Форматирование кода
+    - name: 🎨 Отчет о форматировании кода
       run: |
         cd backend
-        echo "🎨 Применяем black форматирование..."
-        black . --line-length 88
-        
-        echo "📦 Применяем isort сортировку импортов..."
-        isort . --profile black
-        
-        echo "✅ Форматирование завершено"
-    
-    - name: 📤 Коммит изменений
-      run: |
-        cd backend
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        
-        if [ -n "$(git status --porcelain)" ]; then
-          echo "⚠️ Найдены изменения форматирования, но автопуш отключен"
-          git status --porcelain
-          echo "✅ Форматирование выполнено (без коммита)"
-        else
-          echo "ℹ️ Нет изменений для коммита"
-        fi
+        echo "🎨 Проверяем black форматирование..."
+        black . --line-length 88 --check --diff || echo "::warning::Python formatting drift detected; report-only workflow."
+
+        echo "📦 Проверяем isort сортировку импортов..."
+        isort . --profile black --check-only --diff || echo "::warning::Python import ordering drift detected; report-only workflow."
+
+        echo "✅ Python formatting report completed without modifying files"
 
   format-frontend:
-    name: 🎨 Форматирование Frontend кода
+    name: Frontend lint report
     runs-on: ubuntu-latest
     
     steps:
@@ -64,33 +57,15 @@ jobs:
       with:
         node-version: '20'
         cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
     
     - name: 📦 Установка зависимостей
       run: |
         cd frontend
         npm ci
     
-    - name: 🎨 Форматирование кода
+    - name: 🔍 Отчет frontend lint
       run: |
         cd frontend
-        echo "🎨 Применяем Prettier форматирование..."
-        npm run format || echo "⚠️ Prettier не настроен"
-        
-        echo "🔍 Применяем ESLint исправления..."
-        npm run lint:fix || echo "⚠️ ESLint не настроен"
-        
-        echo "✅ Форматирование завершено"
-    
-    - name: 📤 Коммит изменений
-      run: |
-        cd frontend
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        
-        if [ -n "$(git status --porcelain)" ]; then
-          echo "⚠️ Найдены изменения форматирования frontend, но автопуш отключен"
-          git status --porcelain
-          echo "✅ Frontend форматирование выполнено (без коммита)"
-        else
-          echo "ℹ️ Нет изменений для коммита"
-        fi
+        npm run lint:check || echo "::warning::Frontend lint drift detected; report-only workflow."
+        echo "✅ Frontend lint report completed without modifying files"

--- a/.github/workflows/load-testing.yml
+++ b/.github/workflows/load-testing.yml
@@ -10,6 +10,13 @@ on:
   #   branches: [main]  # Только после успешного CI/CD на main
   workflow_dispatch:  # Только ручной запуск
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   load-testing:
     name: ⚡ Нагрузочное тестирование
@@ -374,6 +381,7 @@ jobs:
       with:
         name: performance-report
         path: performance-report.md
+        retention-days: 14
         if-no-files-found: warn
         
     - name: 🛑 Остановка сервера

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -6,6 +6,13 @@ on:
   #   - cron: '0 */6 * * *'  # Каждые 6 часов для стабильности
   workflow_dispatch:  # Только ручной запуск
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   system-monitoring:
     name: 📊 Мониторинг системы
@@ -212,6 +219,8 @@ jobs:
       with:
         name: monitoring-report
         path: monitoring-report.md
+        retention-days: 14
+        if-no-files-found: warn
         
     - name: 📧 Уведомление о статусе
       run: |

--- a/.github/workflows/pr-lifecycle-recommendation.yml
+++ b/.github/workflows/pr-lifecycle-recommendation.yml
@@ -15,6 +15,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   recommend:
     name: Recommend PR lifecycle state

--- a/.github/workflows/pr-review-quality-gate.yml
+++ b/.github/workflows/pr-review-quality-gate.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-review-quality-gate:
     name: PR Review Quality Gate

--- a/.github/workflows/role-system-check.yml
+++ b/.github/workflows/role-system-check.yml
@@ -13,6 +13,13 @@ on:
       - "backend/app/core/role_validation.py"
       - "backend/tests/integration/test_rbac_matrix.py"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
+
 jobs:
   role-system-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,6 +8,13 @@ on:
   schedule:
     - cron: '0 3 * * *'  # Каждый день в 3:00 UTC
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
+
 jobs:
   security-scan:
     name: 🔒 Сканирование безопасности
@@ -52,6 +59,7 @@ jobs:
           backend/safety-report.json
           backend/pip-audit-report.json
           backend/bandit-report.json
+        retention-days: 14
         
     - name: 📊 Анализ результатов
       run: |

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   maintenance-report:
     name: Maintenance health report


### PR DESCRIPTION
﻿## Summary

- Harden GitHub Actions workflow policy without changing runtime application code.
- Add explicit least-privilege permissions and concurrency controls.
- Make Docker cache export less brittle and formatter workflow report-only/non-mutating.
- Clarify echo-only deploy jobs as readiness reports.

## Contract Impact

not applicable - workflow policy only, no API, websocket, event, request/response, or frontend consumer contract changed.

## RBAC / Permissions

- Roles allowed: not applicable - no application route, endpoint, or role helper changed.
- Roles denied: not applicable - no application auth decision changed.
- Positive auth proof: GitHub workflow token permissions are explicit; workflows that only read repository contents use `contents: read`.
- Negative auth proof: static grep found no `contents: write`, `pull_request_target`, auto-merge, auto-close, branch delete, or workflow push behavior added.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime delivery behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, frontend data flow, route, draft/resource state, or browser behavior changed.

## Scope Gate

- Allowed paths: `.github/workflows/**` only.
- Denied paths: backend runtime, frontend runtime, migrations, generated output, production secrets, deployment scripts outside workflow readiness labels.
- Migration/docs/test impact: no migration; workflow-only validation and PR body gate update.
- Rollback note: revert commit `a39122a1` or this PR to restore prior workflow policy.

## Validation

- Targeted tests or smoke run: YAML parse for all workflow files; `git diff --check`; static workflow grep; `npm --prefix frontend ci`; `npm --prefix frontend run lint:check`; PR checks for CodeQL, frontend, backend, docs, quality, parity, lifecycle, security scan.
- Result: local checks passed; frontend lint passed with warnings only; cloud checks passed except the PR body gate before this template fix.
- Not checked: full post-merge push-only Docker/readiness jobs, because this PR is not a push to `main`; backend black/isort backlog remains report-only by design.
