### PR TITLE
chore(db): retire legacy schema helper stubs

### DIFF
--- a/backend/create_file_system_tables.py
+++ b/backend/create_file_system_tables.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Retired legacy file-system schema helper."""
+
+from __future__ import annotations
+
+import sys
+
+
+MESSAGE = """
+create_file_system_tables.py is retired.
+
+This legacy helper wrote a local database directly, created file-system schema
+outside Alembic, and seeded storage/folder/quota data. Use Alembic migrations
+for schema changes and the approved file-system settings or seed workflow for
+runtime data.
+""".strip()
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/create_services_tables_manually.py
+++ b/backend/create_services_tables_manually.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Retired legacy services schema helper."""
+
+from __future__ import annotations
+
+import sys
+
+
+MESSAGE = """
+create_services_tables_manually.py is retired.
+
+This legacy helper created services schema in a local database outside Alembic.
+Use Alembic migrations for service schema changes and seed_services.py for the
+approved service catalog seed workflow.
+""".strip()
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/deep_db_fix.py
+++ b/backend/deep_db_fix.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Retired legacy service data repair helper."""
+
+from __future__ import annotations
+
+import sys
+
+
+MESSAGE = """
+deep_db_fix.py is retired.
+
+This legacy helper edited local database files directly and changed service
+codes outside the approved schema and seed workflows. Use Alembic migrations or
+the canonical service seed/update workflow for service data changes.
+""".strip()
+
+
+def main() -> int:
+    print(MESSAGE, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add retired stubs for three legacy database helper entrypoints that are absent on main.
- Each stub exits with code 2 and points maintainers to Alembic or the approved seed workflow instead of direct schema/data edits.

## Contract Impact
not applicable - legacy helper entrypoint retirement only; no API route, request body, response body, status code, frontend consumer, compatibility alias, or contract surface changes.

## RBAC / Permissions
not applicable - no application permission checks or user-facing authorization behavior changed.

## Notification / Realtime
not applicable - no notification events, websocket channels, polling, delivery guarantees, ordering, or retry behavior changed.

## Frontend Resilience
not applicable - no frontend files or UI states changed.

## Scope Gate
- Allowed paths: backend/create_file_system_tables.py, backend/create_services_tables_manually.py, backend/deep_db_fix.py
- Denied paths: runtime database session behavior, Alembic migrations, seed data, production database access, frontend changes, and the broader AI Factory backup branch
- Migration/docs/test impact: no migration or runtime test impact; these are refusal stubs for retired manual helpers
- Rollback note: delete the three added stub files if callers should receive missing-file behavior again

## Validation
- Targeted tests or smoke run: python -m py_compile for all three helper stubs; each helper executed and asserted to exit 2 with a retired message; git diff --check for the three paths
- Result: passed
- Not checked: full backend suite and database integration were not run because the slice adds only refusal stubs and does not touch runtime DB code