### PR TITLE
fix(security): hide appointment error details

### DIFF
--- a/backend/app/api/v1/endpoints/appointments.py
+++ b/backend/app/api/v1/endpoints/appointments.py
@@ -21,6 +21,19 @@ from app.services.service_mapping import get_service_code
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/appointments", tags=["appointments"])
+APPOINTMENTS_PUBLIC_ERROR = "Internal server error"
+
+
+def _appointments_http_error(exc: Exception, operation: str) -> HTTPException:
+    logger.warning(
+        "Appointments endpoint failed operation=%s error_type=%s",
+        operation,
+        type(exc).__name__,
+    )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=APPOINTMENTS_PUBLIC_ERROR,
+    )
 
 
 # Схема для ответа pending-payments
@@ -446,13 +459,7 @@ async def get_pending_payments(
         return result
 
     except Exception as e:
-        import traceback
-
-        traceback.print_exc()
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения записей: {str(e)}",
-        )
+        raise _appointments_http_error(e, "list_appointments") from e
 
 
 @router.get("/{appointment_id}", response_model=appointment_schemas.Appointment)
@@ -1095,10 +1102,4 @@ async def get_pending_payments(
         return json_result
 
     except Exception as e:
-        import logging
-
-        logging.error(f"Error in get_pending_payments: {str(e)}", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка при получении записей, ожидающих оплаты: {str(e)}",
-        )
+        raise _appointments_http_error(e, "get_pending_payments") from e


### PR DESCRIPTION
## Summary

- Hide raw exception text from appointments list internal `500` responses.
- Hide raw exception text from pending-payment appointments internal `500` responses.
- Replace ad hoc traceback/inline logging with endpoint-local operation/type logging.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/appointments.py` appointments list and pending-payment flows.
- Request shape: unchanged.
- Response shape: unchanged for successful responses; unexpected internal failures now return `Internal server error` instead of raw exception text.
- Status codes: unchanged; unexpected internal failures remain `500`.
- Frontend consumer: unchanged because successful payloads and route contracts were not changed.
- Compatibility path or alias: unchanged; no route, prefix, alias, or response model changed.
- Contract proof: static search confirmed the previous raw appointment `detail=f...{str(e)}` sinks and ad hoc traceback/logging patterns were removed from `appointments.py`.

## RBAC / Permissions

- Roles allowed: unchanged existing appointment endpoint dependencies.
- Roles denied: unchanged because no auth dependency or permission check changed.
- Positive auth proof: no successful appointment retrieval/payment-list path was altered.
- Negative auth proof: denied/unauthenticated behavior is unchanged; only unexpected internal error detail text changed.

## Notification / Realtime

- Notification behavior: unchanged; no notification, Telegram, websocket, or realtime delivery path changed.
- Realtime behavior: unchanged.
- Event type or websocket channel: none changed.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no realtime path changed.

## Frontend Resilience

- Empty data proof: no frontend rendering path changed.
- Partial data proof: no frontend rendering path changed.
- Forbidden secondary path behavior: no secondary frontend request path changed.
- Missing draft/resource behavior: no draft/resource flow changed.
- Stale route/deep-link behavior: no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/appointments.py` only.
- Denied paths: frontend, services, migrations, generated artifacts, schemas, auth endpoints, and unrelated endpoint modules.
- Migration/docs/test impact: no migration or docs change; no new test file added for this narrow error-detail hardening slice.
- Rollback note: revert commit `8f8bc816` to restore previous raw appointment internal error detail behavior.

## Validation

- Targeted tests or smoke run: agent gate with known root cause for `appointments.py`; `python -m py_compile backend\app\api\v1\endpoints\appointments.py`; `git diff --check HEAD~1..HEAD -- backend/app/api/v1/endpoints/appointments.py`; targeted raw detail/traceback leak scan with `rg` in `appointments.py`.
- Result: gate returned narrow override for `appointments.py`; compile passed; diff check passed; static leak search returned no matches; clean worktree diff contains only `appointments.py`.
- Not checked: full backend suite and browser appointment UI smoke were not run locally for this one-file slice; GitHub CI is expected to cover broader repository gates.