### PR TITLE
fix(security): hide authentication endpoint error details

### DIFF
--- a/backend/app/api/v1/endpoints/authentication.py
+++ b/backend/app/api/v1/endpoints/authentication.py
@@ -379,7 +379,7 @@ async def update_user_profile(
 
 
 @router.get("/sessions", response_model=SessionListResponse)
-async def get_user_sessions(
+async def get_paginated_user_sessions(
     page: int = Query(1, ge=1),
     per_page: int = Query(20, ge=1, le=100),
     db: Session = Depends(get_db),
@@ -425,7 +425,7 @@ async def get_user_sessions(
 
 
 @router.delete("/sessions/{session_id}")
-async def revoke_session(
+async def delete_user_session(
     session_id: int,
     request_data: SessionRevokeRequest,
     db: Session = Depends(get_db),
@@ -601,7 +601,7 @@ async def get_current_session(
 
 
 @router.get("/sessions", include_in_schema=False)
-async def get_user_sessions(
+async def get_active_user_sessions(
     active_only: bool = Query(True, description="Только активные сессии"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -633,7 +633,7 @@ async def get_user_sessions(
 
 
 @router.post("/sessions/{session_id}/revoke")
-async def revoke_session(
+async def revoke_user_session(
     session_id: int,
     reason: str = Query("manual", description="Причина отзыва сессии"),
     current_user: User = Depends(get_current_user),

--- a/backend/app/api/v1/endpoints/authentication.py
+++ b/backend/app/api/v1/endpoints/authentication.py
@@ -4,44 +4,22 @@ API endpoints для системы аутентификации
 
 import json
 import logging
-from datetime import datetime, timedelta
-from typing import List, Optional
+from typing import NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
-from app.db.session import get_db
-from app.models.user import User
-from app.services.authentication_service import (
-    get_authentication_service,
-)
-from app.services.authentication_api_service import (
-    AuthenticationApiDomainError,
-    AuthenticationApiService,
-)
-from app.services.user_management_service import get_user_management_service
-
-logger = logging.getLogger(__name__)
 from app.crud.authentication import (
-    email_verification_token,
-    login_attempt,
-    password_reset_token,
-    refresh_token,
-    security_event,
-    user,
     user_activity,
     user_session,
 )
+from app.db.session import get_db
+from app.models.user import User
 from app.schemas.authentication import (
-    AuthErrorResponse,
-    AuthStatsResponse,
     AuthStatusResponse,
     AuthSuccessResponse,
-    DeviceInfoResponse,
     EmailVerificationConfirmRequest,
-    EmailVerificationRequest,
-    LoginAttemptResponse,
     LoginRequest,
     LoginResponse,
     LogoutRequest,
@@ -49,26 +27,26 @@ from app.schemas.authentication import (
     PasswordChangeRequest,
     PasswordResetConfirmRequest,
     PasswordResetRequest,
-    PasswordStrengthResponse,
     RefreshTokenRequest,
     RefreshTokenResponse,
-    SecurityEventListResponse,
-    SecurityEventResolveRequest,
-    SecurityEventResponse,
     SessionListResponse,
     SessionRevokeRequest,
-    TokenValidationResponse,
     UserActivityResponse,
-    UserCreateRequest,
-    UserDeleteRequest,
-    UserListResponse,
     UserProfileResponse,
     UserProfileUpdateRequest,
     UserSessionResponse,
-    UserUpdateRequest,
 )
+from app.services.authentication_api_service import (
+    AuthenticationApiDomainError,
+    AuthenticationApiService,
+)
+from app.services.authentication_service import (
+    get_authentication_service,
+)
+from app.services.user_management_service import get_user_management_service
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 def get_client_info(request: Request) -> tuple[str, str]:
@@ -76,6 +54,18 @@ def get_client_info(request: Request) -> tuple[str, str]:
     ip_address = request.client.host if request.client else "unknown"
     user_agent = request.headers.get("user-agent", "unknown")
     return ip_address, user_agent
+
+
+def raise_authentication_internal_error(action: str, exc: Exception) -> NoReturn:
+    logger.error(
+        "Authentication endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Internal server error",
+    ) from exc
 
 
 @router.post("/login", response_model=LoginResponse)
@@ -137,14 +127,7 @@ async def login(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(
-            "Authentication login endpoint failed",
-            extra={"exception_type": type(e).__name__},
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Ошибка входа",
-        )
+        raise_authentication_internal_error("login", e)
 
 
 @router.post("/refresh", response_model=RefreshTokenResponse)
@@ -171,10 +154,7 @@ async def refresh_access_token(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления токена: {str(e)}",
-        )
+        raise_authentication_internal_error("refresh_access_token", e)
 
 
 @router.post("/logout", response_model=LogoutResponse)
@@ -204,10 +184,7 @@ async def logout(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка выхода: {str(e)}",
-        )
+        raise_authentication_internal_error("logout", e)
 
 
 @router.post("/password-reset", response_model=AuthSuccessResponse)
@@ -240,10 +217,7 @@ async def request_password_reset(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка запроса сброса пароля: {str(e)}",
-        )
+        raise_authentication_internal_error("request_password_reset", e)
 
 
 @router.post("/password-reset/confirm", response_model=AuthSuccessResponse)
@@ -267,10 +241,7 @@ async def confirm_password_reset(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка сброса пароля: {str(e)}",
-        )
+        raise_authentication_internal_error("confirm_password_reset", e)
 
 
 @router.post("/password-change", response_model=AuthSuccessResponse)
@@ -299,10 +270,7 @@ async def change_password(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка смены пароля: {str(e)}",
-        )
+        raise_authentication_internal_error("change_password", e)
 
 
 @router.post("/email-verification", response_model=AuthSuccessResponse)
@@ -334,10 +302,7 @@ async def request_email_verification(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка запроса верификации email: {str(e)}",
-        )
+        raise_authentication_internal_error("request_email_verification", e)
 
 
 @router.post("/email-verification/confirm", response_model=AuthSuccessResponse)
@@ -359,10 +324,7 @@ async def confirm_email_verification(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка верификации email: {str(e)}",
-        )
+        raise_authentication_internal_error("confirm_email_verification", e)
 
 
 @router.get("/profile", response_model=UserProfileResponse)
@@ -385,10 +347,7 @@ async def get_user_profile(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения профиля: {str(e)}",
-        )
+        raise_authentication_internal_error("get_user_profile", e)
 
 
 @router.put("/profile", response_model=UserProfileResponse)
@@ -416,10 +375,7 @@ async def update_user_profile(
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except Exception as e:
         api_service.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления профиля: {str(e)}",
-        ) from e
+        raise_authentication_internal_error("update_user_profile", e)
 
 
 @router.get("/sessions", response_model=SessionListResponse)
@@ -465,10 +421,7 @@ async def get_user_sessions(
         )
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения сессий: {str(e)}",
-        )
+        raise_authentication_internal_error("get_user_sessions", e)
 
 
 @router.delete("/sessions/{session_id}")
@@ -498,13 +451,10 @@ async def revoke_session(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отзыва сессии: {str(e)}",
-        )
+        raise_authentication_internal_error("revoke_session", e)
 
 
-@router.get("/activity", response_model=List[UserActivityResponse])
+@router.get("/activity", response_model=list[UserActivityResponse])
 async def get_user_activity(
     limit: int = Query(50, ge=1, le=200),
     db: Session = Depends(get_db),
@@ -532,10 +482,7 @@ async def get_user_activity(
         return activity_responses
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения активности: {str(e)}",
-        )
+        raise_authentication_internal_error("get_user_activity", e)
 
 
 @router.get("/status", response_model=AuthStatusResponse)
@@ -584,10 +531,7 @@ async def get_auth_status(
         )
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статуса: {str(e)}",
-        )
+        raise_authentication_internal_error("get_auth_status", e)
 
 
 @router.get("/health")

--- a/backend/app/api/v1/endpoints/authentication.py
+++ b/backend/app/api/v1/endpoints/authentication.py
@@ -593,7 +593,11 @@ async def get_current_session(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error getting current session: {e}")
+        logger.error(
+            "Authentication endpoint failed action=%s error_type=%s",
+            "get current session",
+            type(e).__name__,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Ошибка получения текущей сессии",
@@ -625,7 +629,11 @@ async def get_active_user_sessions(
         }
 
     except Exception as e:
-        logger.error(f"Error getting user sessions: {e}")
+        logger.error(
+            "Authentication endpoint failed action=%s error_type=%s",
+            "get active user sessions",
+            type(e).__name__,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Ошибка получения сессий пользователя",
@@ -667,7 +675,11 @@ async def revoke_user_session(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error revoking session {session_id}: {e}")
+        logger.error(
+            "Authentication endpoint failed action=%s error_type=%s",
+            "revoke session",
+            type(e).__name__,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Ошибка отзыва сессии",
@@ -707,7 +719,11 @@ async def revoke_all_sessions(
         }
 
     except Exception as e:
-        logger.error(f"Error revoking all sessions: {e}")
+        logger.error(
+            "Authentication endpoint failed action=%s error_type=%s",
+            "revoke all sessions",
+            type(e).__name__,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Ошибка отзыва всех сессий",
@@ -739,7 +755,11 @@ async def cleanup_expired_sessions(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error cleaning up expired sessions: {e}")
+        logger.error(
+            "Authentication endpoint failed action=%s error_type=%s",
+            "cleanup expired sessions",
+            type(e).__name__,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Ошибка очистки истекших сессий",
@@ -780,7 +800,11 @@ async def get_session_info(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error getting session info {session_id}: {e}")
+        logger.error(
+            "Authentication endpoint failed action=%s error_type=%s",
+            "get session info",
+            type(e).__name__,
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Ошибка получения информации о сессии",


### PR DESCRIPTION
## Summary
- Hides raw exception text from canonical authentication endpoint HTTP 500 responses.
- Replaces raw authentication session logger f-strings with structured action/error_type logging that avoids token, session id, credential, and raw exception detail leakage.
- Keeps route paths, request/response schemas, explicit HTTPException behavior, and 2FA login contract unchanged.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/authentication.py` REST endpoints under `/api/v1/authentication`.
- Request shape: unchanged for login, refresh, logout, profile, sessions, activity, status, and health endpoints.
- Response shape: success responses and explicit domain/auth errors are unchanged; unexpected internal failures now use a generic HTTP 500 detail.
- Status codes: unchanged for success, explicit 400/401/404/403 behavior, and internal 500 failures.
- Frontend consumer: canonical login and 2FA response fields are preserved; no frontend files were touched.
- Compatibility path or alias: unchanged; this PR does not alter fallback auth routers or route mounting.
- Contract proof: targeted auth/2FA tests passed locally and direct smoke preserved an explicit refresh-token 401 while hiding an unexpected raw RuntimeError marker.

## RBAC / Permissions
- Roles allowed: unchanged; existing `get_current_user` dependencies and service-level checks remain in place.
- Roles denied: unchanged; this PR does not relax any auth dependency, RBAC branch, or session ownership check.
- Positive auth proof: `tests/test_2fa_enforcement.py` and `tests/test_auth_profile_api.py` passed locally.
- Negative auth proof: direct smoke confirmed an explicit failed refresh remains HTTP 401 and no unexpected access token path is introduced.

## Notification / Realtime
- Event type or websocket channel: not applicable - authentication endpoint error formatting does not emit notifications, websocket events, chat messages, or realtime channels.
- Payload version / ack behavior: not applicable - no notification/realtime payload contract or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable - no delivery state, read marker, or notification persistence is touched.
- Reconnect/resync proof: not applicable - no websocket or realtime resync path is involved in this backend-only error-handling slice.

## Frontend Resilience
- Empty data proof: not applicable - no frontend data rendering path changed; auth success/error response shapes remain compatible.
- Partial data proof: not applicable - no frontend partial-data state or optional rendering branch changed.
- Forbidden secondary path behavior: not applicable - auth/RBAC denial paths keep their existing HTTPException details and no secondary route was added.
- Missing draft/resource behavior: not applicable - this PR does not create, reopen, or load draft/resource entities.
- Stale route/deep-link behavior: not applicable - no React route, redirect, or deep-link behavior changed.

## Scope Gate
- Plan item: `.ai-factory/PLAN.md` Task 26, remaining backend raw public/log error leakage outside payment webhook.
- Execution mode: gate_known_root_cause followed by narrow_override for `backend/app/api/v1/endpoints/authentication.py` only.
- Allowed paths: `backend/app/api/v1/endpoints/authentication.py`.
- Denied paths: frontend, migrations, payment, Telegram, docs, tests, and unrelated backend endpoints.
- Migration/docs/test impact: no migration; no docs change; tests used as validation only.
- Rollback note: revert this PR merge to restore the prior authentication endpoint logging/error details.

## Validation
- Targeted tests or smoke run: `py_compile`, `black --check`, `ruff check`, static `rg` leakage scan, `tests/test_2fa_enforcement.py`, `tests/test_auth_profile_api.py`, and direct async smoke for generic 500 plus preserved explicit 401.
- Result: passed locally; GitHub CI was rerun after this body update.
- Not checked: full manual browser login/2FA, staging deployment, and full production-like auth provider integration.