### PR TITLE
fix(security): hide file system error details

### DIFF
--- a/backend/app/api/v1/endpoints/file_system.py
+++ b/backend/app/api/v1/endpoints/file_system.py
@@ -3,11 +3,12 @@ API endpoints для файловой системы
 """
 
 import io
+import logging
 import os
 import shutil
 import tempfile
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, NoReturn, Optional
 
 from fastapi import (
     APIRouter,
@@ -52,8 +53,21 @@ from app.services.file_system_service import get_file_system_service
 from app.utils.file_validator import validate_upload_file
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 IMPORT_ARCHIVE_READ_CHUNK_BYTES = 1024 * 1024
+
+
+def raise_file_system_internal_error(action: str, exc: Exception) -> NoReturn:
+    logger.error(
+        "File system endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Internal server error",
+    ) from exc
 
 
 async def _read_limited_import_archive(file: UploadFile, max_bytes: int) -> bytes:
@@ -150,10 +164,7 @@ async def upload_file(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка загрузки файла: {str(e)}",
-        )
+        raise_file_system_internal_error("upload_file", e)
 
 
 @router.get("/statistics", response_model=FileStats)
@@ -171,10 +182,7 @@ async def get_file_statistics(
         return FileStats(**stats)
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
-        )
+        raise_file_system_internal_error("get_file_statistics", e)
 
 
 @router.get("/{file_id}", response_model=FileOut)
@@ -201,10 +209,7 @@ async def get_file(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения файла: {str(e)}",
-        )
+        raise_file_system_internal_error("get_file", e)
 
 
 @router.get("/{file_id}/download")
@@ -231,10 +236,7 @@ async def download_file(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка скачивания файла: {str(e)}",
-        )
+        raise_file_system_internal_error("download_file", e)
 
 
 @router.get("/{file_id}/preview")
@@ -276,10 +278,7 @@ async def preview_file(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка предварительного просмотра: {str(e)}",
-        )
+        raise_file_system_internal_error("preview_file", e)
 
 
 @router.post("/search", response_model=FileSearchResponse)
@@ -308,10 +307,7 @@ async def search_files(
         )
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка поиска файлов: {str(e)}",
-        )
+        raise_file_system_internal_error("search_files", e)
 
 
 @router.get("/", response_model=FileList)
@@ -373,10 +369,7 @@ async def get_files(
         )
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения списка файлов: {str(e)}",
-        )
+        raise_file_system_internal_error("get_files", e)
 
 
 @router.put("/{file_id}", response_model=FileOut)
@@ -447,10 +440,7 @@ async def update_file(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления файла: {str(e)}",
-        )
+        raise_file_system_internal_error("update_file", e)
 
 
 @router.put("/{file_id}/content", response_model=FileOut)
@@ -492,10 +482,7 @@ async def replace_file_content(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка замены содержимого файла: {str(e)}",
-        )
+        raise_file_system_internal_error("replace_file_content", e)
 
 
 @router.delete("/{file_id}")
@@ -545,10 +532,7 @@ async def delete_file(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка удаления файла: {str(e)}",
-        )
+        raise_file_system_internal_error("delete_file", e)
 
 
 @router.post("/{file_id}/share", response_model=FileShareOut)
@@ -572,10 +556,7 @@ async def create_file_share(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания совместного использования: {str(e)}",
-        )
+        raise_file_system_internal_error("create_file_share", e)
 
 
 @router.get("/{file_id}/shares", response_model=List[FileShareOut])
@@ -605,10 +586,7 @@ async def get_file_shares(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения совместных использований: {str(e)}",
-        )
+        raise_file_system_internal_error("get_file_shares", e)
 
 
 @router.post("/export", response_model=FileExportResponse)
@@ -644,10 +622,7 @@ async def export_files(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка экспорта файлов: {str(e)}",
-        )
+        raise_file_system_internal_error("export_files", e)
 
 
 @router.post("/import", response_model=FileImportResponse)
@@ -697,10 +672,7 @@ async def import_files(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка импорта файлов: {str(e)}",
-        )
+        raise_file_system_internal_error("import_files", e)
 
 
 @router.post("/cleanup")
@@ -719,7 +691,4 @@ async def cleanup_files(
         }
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка очистки файлов: {str(e)}",
-        )
+        raise_file_system_internal_error("cleanup_files", e)


### PR DESCRIPTION
## Summary
- Hides raw exception text from mounted `/api/v1/files` unexpected HTTP 500 responses.
- Adds structured file-system endpoint logging with `action` and `error_type` only, avoiding filename, patient, token, payload, and raw exception detail leakage.
- Keeps explicit validation/domain HTTPException behavior unchanged, including file validation failures and existing 400/403/404 paths.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/file_system.py` mounted under `/api/v1/files`.
- Request shape: unchanged for upload, statistics, get/download/preview, search/list, update/replace, delete, share, export/import, and cleanup endpoints.
- Response shape: success responses and explicit validation/domain errors are unchanged; unexpected internal failures now use generic HTTP 500 detail.
- Status codes: unchanged for success, explicit 400/403/404/413/415 behavior, and internal 500 failures.
- Frontend consumer: no frontend files changed; existing consumers receive compatible success and explicit error responses, with less detailed unexpected 500 text.
- Compatibility path or alias: unchanged; no route paths, prefixes, tags, or router mounting changed.
- Contract proof: targeted file security tests passed locally and direct smoke preserved explicit 404 while hiding an unexpected RuntimeError marker.

## RBAC / Permissions
- Roles allowed: unchanged; existing `require_roles` dependencies remain in place for Admin, Doctor, Nurse, Receptionist, and Patient paths.
- Roles denied: unchanged; this PR does not modify role lists or access-control branches.
- Positive auth proof: `tests/test_file_security.py` passed locally, including authorized Doctor upload/replace flows.
- Negative auth proof: `tests/test_file_security.py` passed locally, including Patient upload denial; direct smoke preserved explicit missing-file 404.

## Notification / Realtime
- Event type or websocket channel: not applicable - file-system HTTP error formatting does not emit notifications, websocket events, chat messages, or realtime channels.
- Payload version / ack behavior: not applicable - no notification/realtime payload contract or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable - no delivery state, read marker, or notification persistence is touched.
- Reconnect/resync proof: not applicable - no websocket or realtime resync path is involved in this backend-only file endpoint slice.

## Frontend Resilience
- Empty data proof: not applicable - no frontend data rendering path changed; list/stat/search response shapes remain compatible.
- Partial data proof: not applicable - no frontend partial-data state or optional rendering branch changed.
- Forbidden secondary path behavior: not applicable - existing 403 role behavior is untouched and covered by file-security tests.
- Missing draft/resource behavior: not applicable - this PR does not create, reopen, or load draft/resource entities.
- Stale route/deep-link behavior: not applicable - no React route, redirect, or deep-link behavior changed.

## Scope Gate
- Plan item: `.ai-factory/PLAN.md` Task 26, remaining backend raw public/log error leakage outside payment webhook.
- Execution mode: gate_known_root_cause followed by narrow_override for `backend/app/api/v1/endpoints/file_system.py` only.
- Allowed paths: `backend/app/api/v1/endpoints/file_system.py`.
- Denied paths: frontend, migrations, payment, Telegram, docs, tests, and unrelated backend endpoints/services.
- Migration/docs/test impact: no migration; no docs change; tests used as validation only.
- Rollback note: revert this PR merge to restore the prior file-system endpoint error details.

## Validation
- Targeted tests or smoke run: `py_compile`, `black --check`, `ruff check`, static `rg` leakage scan, `tests/test_file_security.py`, and direct async smoke for generic 500 plus preserved explicit 404.
- Result: passed locally; GitHub CI pending.
- Not checked: full manual browser file upload/download flow, staging deployment, and object-storage/provider integrations.