### PR TITLE
fix(security): hide password reset error details

### DIFF
--- a/backend/app/api/v1/endpoints/password_reset.py
+++ b/backend/app/api/v1/endpoints/password_reset.py
@@ -2,9 +2,10 @@
 API endpoints для восстановления паролей
 """
 
+import logging
 import re
 from datetime import datetime
-from typing import Optional
+from typing import NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, field_validator, model_validator
@@ -16,17 +17,30 @@ from app.models.user import User
 from app.services.password_reset_service import get_password_reset_service
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+def raise_password_reset_internal_error(action: str, exc: Exception) -> NoReturn:
+    logger.error(
+        "Password reset endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Internal server error",
+    ) from exc
 
 
 class PasswordResetInitiateRequest(BaseModel):
     """Запрос на инициацию сброса пароля"""
 
-    phone: Optional[str] = None
-    email: Optional[str] = None
+    phone: str | None = None
+    email: str | None = None
 
     @field_validator('phone')
     @classmethod
-    def validate_phone(cls, v: Optional[str]) -> Optional[str]:
+    def validate_phone(cls, v: str | None) -> str | None:
         if v is None:
             return v
         phone = re.sub(r'[^\d+]', '', v)
@@ -36,7 +50,7 @@ class PasswordResetInitiateRequest(BaseModel):
 
     @field_validator('email')
     @classmethod
-    def validate_email(cls, v: Optional[str]) -> Optional[str]:
+    def validate_email(cls, v: str | None) -> str | None:
         if v is None:
             return v
         if not re.match(r'^[^\s@]+@[^\s@]+\.[^\s@]+$', v):
@@ -127,10 +141,7 @@ async def initiate_password_reset(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка инициации сброса пароля: {str(e)}",
-        )
+        raise_password_reset_internal_error("initiate_password_reset", e)
 
 
 @router.post("/verify-phone")
@@ -177,10 +188,7 @@ async def verify_phone_for_reset(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка верификации телефона: {str(e)}",
-        )
+        raise_password_reset_internal_error("verify_phone_for_reset", e)
 
 
 @router.post("/confirm")
@@ -215,10 +223,7 @@ async def confirm_password_reset(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка подтверждения сброса пароля: {str(e)}",
-        )
+        raise_password_reset_internal_error("confirm_password_reset", e)
 
 
 @router.get("/validate-token")
@@ -252,10 +257,7 @@ async def validate_reset_token(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка проверки токена: {str(e)}",
-        )
+        raise_password_reset_internal_error("validate_reset_token", e)
 
 
 @router.get("/statistics")
@@ -271,7 +273,4 @@ async def get_password_reset_statistics(
         return {"statistics": stats, "timestamp": datetime.now().isoformat()}
 
     except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
-        )
+        raise_password_reset_internal_error("get_password_reset_statistics", e)


### PR DESCRIPTION
## Summary
- Hides raw exception text from mounted `/api/v1/password-reset` unexpected HTTP 500 responses.
- Adds structured password-reset endpoint logging with `action` and `error_type` only, avoiding phone, email, reset token, password, and raw exception detail leakage.
- Keeps explicit service/domain HTTPException behavior unchanged, including rate limit, send failure, token not found/expired/used, and validation errors.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/password_reset.py` mounted under `/api/v1/password-reset`.
- Request shape: unchanged for initiate, verify-phone, confirm, validate-token, and statistics endpoints.
- Response shape: success responses and explicit service/domain errors are unchanged; unexpected internal failures now use generic HTTP 500 detail.
- Status codes: unchanged for success, explicit 400/404/409/410/429/502 behavior, and internal 500 failures.
- Frontend consumer: no frontend files changed; existing reset screens should receive compatible success and explicit failure responses, with less detailed unexpected 500 text.
- Compatibility path or alias: unchanged; no route paths, prefixes, tags, middleware, or auth router aliases changed.
- Contract proof: targeted security middleware tests passed locally and direct smoke preserved explicit TOKEN_NOT_FOUND 404 while hiding an unexpected RuntimeError marker.

## RBAC / Permissions
- Roles allowed: unchanged; public reset initiation/verification/confirmation behavior and Admin/SuperAdmin statistics guard remain as-is.
- Roles denied: unchanged; this PR does not alter `require_roles([Admin, SuperAdmin])` for password reset statistics.
- Positive auth proof: direct smoke exercised public reset initiation and explicit token-validation error behavior; `tests/test_security_middleware.py` passed locally.
- Negative auth proof: direct smoke preserved explicit missing-token HTTP 404 and did not introduce any token/password success path.

## Notification / Realtime
- Event type or websocket channel: not applicable - password reset HTTP error formatting does not emit notifications, websocket events, chat messages, or realtime channels.
- Payload version / ack behavior: not applicable - no notification/realtime payload contract or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable - no delivery state, read marker, or notification persistence is touched.
- Reconnect/resync proof: not applicable - no websocket or realtime resync path is involved in this backend-only password-reset slice.

## Frontend Resilience
- Empty data proof: not applicable - no frontend data rendering path changed; password reset response shapes remain compatible.
- Partial data proof: not applicable - no frontend partial-data state or optional rendering branch changed.
- Forbidden secondary path behavior: unchanged - statistics endpoint role guard is untouched and no secondary path was added.
- Missing draft/resource behavior: not applicable - this PR does not create, reopen, or load draft/resource entities.
- Stale route/deep-link behavior: not applicable - no React route, redirect, or deep-link behavior changed.

## Scope Gate
- Plan item: `.ai-factory/PLAN.md` Task 26, remaining backend raw public/log error leakage outside payment webhook.
- Execution mode: gate_known_root_cause followed by narrow_override for `backend/app/api/v1/endpoints/password_reset.py` only.
- Allowed paths: `backend/app/api/v1/endpoints/password_reset.py`.
- Denied paths: frontend, migrations, payment, Telegram, docs, tests, password reset service, middleware, and unrelated backend endpoints.
- Migration/docs/test impact: no migration; no docs change; tests used as validation only.
- Rollback note: revert this PR merge to restore the prior password-reset endpoint error details.

## Validation
- Targeted tests or smoke run: `py_compile`, `black --check`, `ruff check`, static `rg` leakage scan, `tests/test_security_middleware.py`, and direct async smoke for generic 500 plus preserved explicit 404.
- Result: passed locally; GitHub CI pending after this body update.
- Not checked: full manual browser forgot-password flow, email/SMS provider delivery, staging deployment, and production rate-limit backend behavior.