### PR TITLE
fix(security): hide mcp endpoint error details

### DIFF
--- a/.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md
+++ b/.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md
@@ -6,10 +6,10 @@ Workflow: `/aif-plan` -> `/aif-improve @.ai-factory/PLAN.md` -> `/aif-implement 
 
 ## Current Status
 
-- Current task: implementation plan tasks completed
-- Last completed task: Task 21 - Align docs and AIF context
-- Next task: `/aif-verify --strict`
-- Blocker state: none for plan implementation; verification still required
+- Current task: Task 26 - remaining backend raw print/public error leakage
+- Last completed slice: Task 26 MCP endpoint leakage cleanup
+- Next task: continue Task 26 with the next one-file mounted runtime leakage slice
+- Blocker state: none for the current slice; Task 26 remains open as a multi-slice audit
 - Runtime code changed: yes
 - Secrets inspected or printed: no
 
@@ -1417,6 +1417,52 @@ Validation run:
 LightRAG evidence note:
 
 - No new LightRAG readiness entry was appended for this routine narrow gate slice; no gate misroute or retrieval regression was observed.
+
+## Task 26 Slice MCP Endpoint Evidence
+
+Execution mode:
+
+- selected mode: `gate`, then `gate_known_root_cause` with `backend/app/api/v1/endpoints/mcp.py`
+- reason: mounted MCP/AI clinical endpoint leaked raw exception text in public HTTP 500 details and f-string exception logs
+- risky domain: yes, AI/clinical support endpoint
+- root cause known: selected after the broad Task 26 gate stopped without a first-touch file and repository search identified `mcp.py`
+- command: `python scripts\agent_gate.py "Task 26 sanitize mounted MCP endpoint raw public exception leakage and f-string exception logging without changing AI clinical suggestion behavior auth guards routes or success payloads" --known-root-cause "backend/app/api/v1/endpoints/mcp.py"`
+
+Initial boundaries:
+
+- canonical anchor: `backend/app/api/v1/endpoints/mcp.py`
+- first-touch files: `backend/app/api/v1/endpoints/mcp.py`
+- validation target: compile, ruff, black, static leakage scan, direct endpoint smoke
+- stop condition watched first: any required edit outside `mcp.py` or any change to routes, auth guards, success payload shapes, or AI clinical decision boundaries
+
+Changed behavior:
+
+- Replaced raw public `detail=str(e)` HTTP 500 responses with a generic `Internal server error`.
+- Replaced f-string exception logs with structured action name plus exception class only.
+- Removed raw exception text from ICD-10 fallback response messages while preserving the existing non-500 fallback shape.
+- Preserved explicit `HTTPException` guard behavior for role/file/JSON validation paths so intended 403/400 responses are not converted to generic 500 responses.
+- Applied same-file ruff mechanical typing fixes so changed-file lint stays clean.
+
+Validation run:
+
+- `python -m py_compile backend\app\api\v1\endpoints\mcp.py`
+  - result: passed
+- `python -m ruff check backend\app\api\v1\endpoints\mcp.py`
+  - result: passed
+- `python -m black --check backend\app\api\v1\endpoints\mcp.py`
+  - result: passed
+- `rg -n "str\(e\)|str\(exc\)|str\(mcp_error\)|detail=str\(|logger\.error\(f|logger\.warning\(f|print\(" backend\app\api\v1\endpoints\mcp.py`
+  - result: no matches
+- direct async endpoint smoke with monkeypatched MCP managers raising a marker exception
+  - result: passed; HTTP 500 returned `Internal server error`, marker text did not leak to response or logs, ICD-10 fallback message did not include the marker, and a role guard still returned HTTP 403
+- `python -m pytest backend\tests\test_security_middleware.py -q --tb=short --disable-warnings`
+  - result: 24 passed, 1 warning
+- `git diff --check`
+  - result: passed; Git printed line-ending normalization warnings only
+
+Scope note:
+
+- Task 26 remains open. This slice hardens only the mounted MCP endpoint and does not claim all backend runtime leakage is gone.
 
 ## Task 26 Current Slice Evidence (2026-05-12 - EMR AI endpoint)
 

--- a/backend/app/api/v1/endpoints/mcp.py
+++ b/backend/app/api/v1/endpoints/mcp.py
@@ -5,7 +5,7 @@ MCP (Model Context Protocol) API endpoints
 import base64
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, NoReturn
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel
@@ -19,13 +19,30 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def log_mcp_service_unavailable(action: str, exc: Exception) -> None:
+    logger.warning(
+        "MCP service unavailable action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+
+
+def raise_mcp_internal_error(action: str, exc: Exception) -> NoReturn:
+    logger.error(
+        "MCP endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(status_code=500, detail="Internal server error") from exc
+
+
 # === MCP Management Endpoints ===
 
 
 @router.get("/status")
 async def get_mcp_status(
     current_user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Получить статус MCP системы"""
     try:
         mcp_manager = await get_mcp_manager()
@@ -35,14 +52,13 @@ async def get_mcp_status(
             "capabilities": await mcp_manager.get_capabilities(),
         }
     except Exception as e:
-        logger.error(f"Error getting MCP status: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("get_mcp_status", e)
 
 
 @router.get("/health")
 async def mcp_health_check(
     current_user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Проверка здоровья MCP серверов"""
     try:
         mcp_manager = await get_mcp_manager()
@@ -52,14 +68,13 @@ async def mcp_health_check(
         else:
             return {"overall": "unhealthy", "error": "MCP client not initialized"}
     except Exception as e:
-        logger.error(f"Error checking MCP health: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_health_check", e)
 
 
 @router.get("/metrics")
 async def get_mcp_metrics(
-    server: Optional[str] = None, current_user: User = Depends(get_current_user)
-) -> Dict[str, Any]:
+    server: str | None = None, current_user: User = Depends(get_current_user)
+) -> dict[str, Any]:
     """Получить метрики MCP"""
     try:
         mcp_manager = await get_mcp_manager()
@@ -67,14 +82,13 @@ async def get_mcp_metrics(
             return mcp_manager.get_server_metrics(server)
         return mcp_manager.get_metrics()
     except Exception as e:
-        logger.error(f"Error getting MCP metrics: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("get_mcp_metrics", e)
 
 
 @router.get("/circuit-breaker")
 async def get_circuit_breaker_status(
     current_user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Получить статус circuit breaker для всех серверов"""
     try:
         mcp_manager = await get_mcp_manager()
@@ -87,14 +101,13 @@ async def get_circuit_breaker_status(
             },
         }
     except Exception as e:
-        logger.error(f"Error getting circuit breaker status: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("get_circuit_breaker_status", e)
 
 
 @router.post("/reset-metrics")
 async def reset_mcp_metrics(
     current_user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Сбросить метрики MCP (только для админов)"""
     try:
         if current_user.role not in ["admin", "Admin"]:
@@ -103,9 +116,10 @@ async def reset_mcp_metrics(
         mcp_manager = await get_mcp_manager()
         await mcp_manager.reset_metrics()
         return {"status": "success", "message": "Metrics reset successfully"}
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error resetting MCP metrics: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("reset_mcp_metrics", e)
 
 
 # === Complaint Analysis via MCP ===
@@ -115,16 +129,16 @@ class MCPComplaintRequest(BaseModel):
     """Запрос на анализ жалоб через MCP"""
 
     complaint: str
-    patient_age: Optional[int] = None
-    patient_gender: Optional[str] = None
+    patient_age: int | None = None
+    patient_gender: str | None = None
     urgency_assessment: bool = True
-    provider: Optional[str] = None
+    provider: str | None = None
 
 
 @router.post("/complaint/analyze")
 async def mcp_analyze_complaint(
     request: MCPComplaintRequest, current_user: User = Depends(get_current_user)
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Анализ жалоб через MCP"""
     try:
         # Расширенный список разрешенных ролей
@@ -172,15 +186,16 @@ async def mcp_analyze_complaint(
 
         return result
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error in MCP complaint analysis: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_analyze_complaint", e)
 
 
 @router.post("/complaint/validate")
 async def mcp_validate_complaint(
     complaint: str, current_user: User = Depends(get_current_user)
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Валидация жалоб через MCP"""
     try:
         mcp_manager = await get_mcp_manager()
@@ -194,14 +209,13 @@ async def mcp_validate_complaint(
         return result
 
     except Exception as e:
-        logger.error(f"Error in MCP complaint validation: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_validate_complaint", e)
 
 
 @router.get("/complaint/templates")
 async def mcp_get_complaint_templates(
-    specialty: Optional[str] = None, current_user: User = Depends(get_current_user)
-) -> Dict[str, Any]:
+    specialty: str | None = None, current_user: User = Depends(get_current_user)
+) -> dict[str, Any]:
     """Получить шаблоны жалоб через MCP"""
     try:
         mcp_manager = await get_mcp_manager()
@@ -215,8 +229,7 @@ async def mcp_get_complaint_templates(
         return result
 
     except Exception as e:
-        logger.error(f"Error getting complaint templates: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_get_complaint_templates", e)
 
 
 # === ICD-10 via MCP ===
@@ -225,17 +238,17 @@ async def mcp_get_complaint_templates(
 class MCPICD10Request(BaseModel):
     """Запрос на работу с МКБ-10 через MCP"""
 
-    symptoms: List[str]
-    diagnosis: Optional[str] = None
-    specialty: Optional[str] = None
-    provider: Optional[str] = None
+    symptoms: list[str]
+    diagnosis: str | None = None
+    specialty: str | None = None
+    provider: str | None = None
     max_suggestions: int = 5
 
 
 @router.post("/icd10/suggest")
 async def mcp_suggest_icd10(
     request: MCPICD10Request, current_user: User = Depends(get_current_user)
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Подсказки МКБ-10 через MCP"""
     try:
         # Расширенный список разрешенных ролей
@@ -327,21 +340,21 @@ async def mcp_suggest_icd10(
 
         except Exception as mcp_error:
             # Если ошибка при обращении к MCP, возвращаем корректный ответ вместо 500
-            logger.warning(f"MCP ICD-10 service error: {str(mcp_error)}")
+            log_mcp_service_unavailable("mcp_suggest_icd10_service", mcp_error)
             return {
                 "suggestions": [],
-                "message": f"Сервис подбора МКБ-10 временно недоступен: {str(mcp_error)}",
+                "message": "Сервис подбора МКБ-10 временно недоступен",
                 "success": False,
             }
 
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error in MCP ICD-10 suggestions: {str(e)}")
+        log_mcp_service_unavailable("mcp_suggest_icd10", e)
         # Возвращаем корректный ответ вместо 500
         return {
             "suggestions": [],
-            "message": f"Ошибка при подборе кодов МКБ-10: {str(e)}",
+            "message": "Сервис подбора МКБ-10 временно недоступен",
             "success": False,
         }
 
@@ -349,10 +362,10 @@ async def mcp_suggest_icd10(
 @router.post("/icd10/validate")
 async def mcp_validate_icd10(
     code: str,
-    symptoms: Optional[List[str]] = None,
-    diagnosis: Optional[str] = None,
+    symptoms: list[str] | None = None,
+    diagnosis: str | None = None,
     current_user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Валидация кода МКБ-10 через MCP"""
     try:
         mcp_manager = await get_mcp_manager()
@@ -366,17 +379,16 @@ async def mcp_validate_icd10(
         return result
 
     except Exception as e:
-        logger.error(f"Error in MCP ICD-10 validation: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_validate_icd10", e)
 
 
 @router.get("/icd10/search")
 async def mcp_search_icd10(
     query: str,
-    category: Optional[str] = None,
+    category: str | None = None,
     limit: int = 10,
     current_user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Поиск кодов МКБ-10 через MCP"""
     try:
         mcp_manager = await get_mcp_manager()
@@ -390,8 +402,7 @@ async def mcp_search_icd10(
         return result
 
     except Exception as e:
-        logger.error(f"Error in MCP ICD-10 search: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_search_icd10", e)
 
 
 # === Lab Analysis via MCP ===
@@ -400,17 +411,17 @@ async def mcp_search_icd10(
 class MCPLabRequest(BaseModel):
     """Запрос на анализ лабораторных данных через MCP"""
 
-    results: List[Dict[str, Any]]
-    patient_age: Optional[int] = None
-    patient_gender: Optional[str] = None
-    provider: Optional[str] = None
+    results: list[dict[str, Any]]
+    patient_age: int | None = None
+    patient_gender: str | None = None
+    provider: str | None = None
     include_recommendations: bool = True
 
 
 @router.post("/lab/interpret")
 async def mcp_interpret_lab_results(
     request: MCPLabRequest, current_user: User = Depends(get_current_user)
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Интерпретация лабораторных результатов через MCP"""
     try:
         if current_user.role not in ["doctor", "lab", "admin", "Admin"]:
@@ -437,15 +448,16 @@ async def mcp_interpret_lab_results(
 
         return result
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error in MCP lab interpretation: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_interpret_lab_results", e)
 
 
 @router.post("/lab/check-critical")
 async def mcp_check_critical_values(
-    results: List[Dict[str, Any]], current_user: User = Depends(get_current_user)
-) -> Dict[str, Any]:
+    results: list[dict[str, Any]], current_user: User = Depends(get_current_user)
+) -> dict[str, Any]:
     """Проверка критических значений через MCP"""
     try:
         mcp_manager = await get_mcp_manager()
@@ -459,16 +471,15 @@ async def mcp_check_critical_values(
         return result
 
     except Exception as e:
-        logger.error(f"Error checking critical values: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_check_critical_values", e)
 
 
 @router.get("/lab/normal-ranges")
 async def mcp_get_normal_ranges(
-    test_name: Optional[str] = None,
-    patient_gender: Optional[str] = None,
+    test_name: str | None = None,
+    patient_gender: str | None = None,
     current_user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Получить нормальные диапазоны через MCP"""
     try:
         mcp_manager = await get_mcp_manager()
@@ -482,8 +493,7 @@ async def mcp_get_normal_ranges(
         return result
 
     except Exception as e:
-        logger.error(f"Error getting normal ranges: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_get_normal_ranges", e)
 
 
 # === Medical Imaging via MCP ===
@@ -493,11 +503,11 @@ async def mcp_get_normal_ranges(
 async def mcp_analyze_image(
     image: UploadFile = File(...),
     image_type: str = Form(...),
-    modality: Optional[str] = Form(None),
-    clinical_context: Optional[str] = Form(None),
-    provider: Optional[str] = Form(None),
+    modality: str | None = Form(None),
+    clinical_context: str | None = Form(None),
+    provider: str | None = Form(None),
     current_user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Анализ медицинского изображения через MCP"""
     try:
         if current_user.role not in ["doctor", "admin", "Admin"]:
@@ -528,19 +538,20 @@ async def mcp_analyze_image(
 
         return result
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error in MCP image analysis: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_analyze_image", e)
 
 
 @router.post("/imaging/skin-lesion")
 async def mcp_analyze_skin_lesion(
     image: UploadFile = File(...),
-    lesion_info: Optional[str] = Form(None),
-    patient_history: Optional[str] = Form(None),
-    provider: Optional[str] = Form(None),
+    lesion_info: str | None = Form(None),
+    patient_history: str | None = Form(None),
+    provider: str | None = Form(None),
     current_user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Анализ кожных образований через MCP"""
     try:
         if current_user.role not in ["doctor", "admin", "Admin"]:
@@ -569,17 +580,18 @@ async def mcp_analyze_skin_lesion(
 
         return result
 
+    except HTTPException:
+        raise
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="Неверный формат JSON данных")
     except Exception as e:
-        logger.error(f"Error in MCP skin lesion analysis: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_analyze_skin_lesion", e)
 
 
 @router.get("/imaging/types")
 async def mcp_get_imaging_types(
-    category: Optional[str] = None, current_user: User = Depends(get_current_user)
-) -> Dict[str, Any]:
+    category: str | None = None, current_user: User = Depends(get_current_user)
+) -> dict[str, Any]:
     """Получить типы медицинских изображений через MCP"""
     try:
         mcp_manager = await get_mcp_manager()
@@ -593,8 +605,7 @@ async def mcp_get_imaging_types(
         return result
 
     except Exception as e:
-        logger.error(f"Error getting imaging types: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_get_imaging_types", e)
 
 
 # === Batch Processing ===
@@ -603,14 +614,14 @@ async def mcp_get_imaging_types(
 class MCPBatchRequest(BaseModel):
     """Запрос на пакетную обработку через MCP"""
 
-    requests: List[Dict[str, Any]]
+    requests: list[dict[str, Any]]
     parallel: bool = True
 
 
 @router.post("/batch")
 async def mcp_batch_process(
     request: MCPBatchRequest, current_user: User = Depends(get_current_user)
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Пакетная обработка запросов через MCP"""
     try:
         if current_user.role not in ["doctor", "admin", "Admin"]:
@@ -624,9 +635,10 @@ async def mcp_batch_process(
 
         return results
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error in MCP batch processing: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_batch_process", e)
 
 
 # === Server Capabilities ===
@@ -634,8 +646,8 @@ async def mcp_batch_process(
 
 @router.get("/capabilities")
 async def mcp_get_capabilities(
-    server: Optional[str] = None, current_user: User = Depends(get_current_user)
-) -> Dict[str, Any]:
+    server: str | None = None, current_user: User = Depends(get_current_user)
+) -> dict[str, Any]:
     """Получить возможности MCP серверов"""
     try:
         mcp_manager = await get_mcp_manager()
@@ -646,5 +658,4 @@ async def mcp_get_capabilities(
             return {"status": "error", "error": "MCP client not initialized"}
 
     except Exception as e:
-        logger.error(f"Error getting MCP capabilities: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_mcp_internal_error("mcp_get_capabilities", e)


### PR DESCRIPTION
## Summary
- Hide raw exception text from mounted `/api/v1/mcp` public HTTP 500 responses.
- Replace f-string exception logs with structured action name plus exception class only.
- Keep ICD-10 suggestion fallback response shape while removing raw exception text from the visible message.
- Update the recovery status log with the Task 26 MCP slice evidence.

## Contract Impact
- Canonical surface: mounted backend MCP routes under `/api/v1/mcp/*`, with first-touch code in `backend/app/api/v1/endpoints/mcp.py`.
- Request shape: unchanged; existing authenticated requests, query params, JSON bodies, and upload form fields are preserved.
- Response shape: unchanged for successful responses; internal 500 failures now use generic `Internal server error`; ICD-10 unavailable fallback keeps `{suggestions, message, success}`.
- Status codes: success codes unchanged; explicit 400/403 `HTTPException` paths are preserved; generic internal failures remain HTTP 500 without raw exception text.
- Frontend consumer: no frontend file changed; any existing MCP consumers keep the same routes and success payload contracts.
- Compatibility path or alias: no compatibility route or alias changed.
- Contract proof: py_compile, ruff, black, static leakage scan, direct endpoint smoke, and security middleware tests passed.

## RBAC / Permissions
- Roles allowed: unchanged from existing MCP endpoint checks, including existing admin/doctor/lab-style MCP role checks where present.
- Roles denied: unchanged from existing MCP endpoint checks; denied role paths still raise explicit HTTP 403.
- Positive auth proof: direct smoke used an allowed `doctor` role for ICD-10 fallback and preserved the existing response shape.
- Negative auth proof: direct smoke used a denied `Registrar` role for `/batch` and confirmed HTTP 403 is preserved.

## Notification / Realtime
not applicable - no notification, webhook, websocket, realtime event, read/unread, ack, reconnect, or resync behavior changed in this backend endpoint cleanup.

## Frontend Resilience
- Empty data proof: not applicable - no frontend rendering or data-list behavior changed.
- Partial data proof: not applicable - no frontend partial-data rendering behavior changed.
- Forbidden secondary path behavior: direct smoke confirms a forbidden MCP role path still returns HTTP 403 instead of generic 500.
- Missing draft/resource behavior: not applicable - this slice does not create, reopen, or persist drafts/resources.
- Stale route/deep-link behavior: not applicable - no frontend routes or deep links changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/mcp.py` and `.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md`.
- Denied paths: other backend endpoints/services, frontend files, migrations, generated artifacts, and unrelated docs.
- Migration/docs/test impact: no migration; no runtime docs changed; recovery status log updated; targeted smoke and existing security middleware tests run.
- Rollback note: revert this PR to restore the previous MCP endpoint error/logging behavior and status-log entry.

## Validation
- Targeted tests or smoke run: py_compile, ruff, black, static leakage scan, direct async endpoint smoke, security middleware tests, and `git diff --check`.
- Result: passed locally; earlier GitHub runtime checks passed before this PR body template correction.
- Not checked: full manual browser MCP workflow and external MCP provider availability.