### PR TITLE
fix(security): hide wait-time analytics error details

### DIFF
--- a/backend/app/api/v1/endpoints/wait_time_analytics.py
+++ b/backend/app/api/v1/endpoints/wait_time_analytics.py
@@ -4,7 +4,7 @@ API endpoints для аналитики времени ожидания
 
 import logging
 from datetime import date, datetime, timedelta
-from typing import List, Optional
+from typing import List, NoReturn, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
@@ -17,6 +17,19 @@ from app.services.wait_time_analytics_service import get_wait_time_analytics_ser
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def raise_wait_time_internal_error(action: str, exc: Exception) -> NoReturn:
+    logger.error(
+        "Wait-time analytics endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Internal server error",
+    ) from exc
+
 
 # ===================== PYDANTIC СХЕМЫ =====================
 
@@ -111,11 +124,7 @@ async def get_wait_time_analytics(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка получения аналитики времени ожидания: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения аналитики: {str(e)}",
-        )
+        raise_wait_time_internal_error("get_wait_time_analytics", e)
 
 
 @router.get("/real-time-wait-estimates", response_model=RealTimeWaitEstimateResponse)
@@ -132,13 +141,7 @@ async def get_real_time_wait_estimates(
         return RealTimeWaitEstimateResponse(**estimates)
 
     except Exception as e:
-        logger.error(
-            f"Ошибка получения оценок времени ожидания в реальном времени: {e}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения оценок: {str(e)}",
-        )
+        raise_wait_time_internal_error("get_real_time_wait_estimates", e)
 
 
 @router.get("/service-wait-analytics", response_model=ServiceWaitAnalyticsResponse)
@@ -182,11 +185,7 @@ async def get_service_wait_analytics(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка получения аналитики времени ожидания по услугам: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения аналитики: {str(e)}",
-        )
+        raise_wait_time_internal_error("get_service_wait_analytics", e)
 
 
 @router.get("/wait-time-summary")
@@ -229,11 +228,7 @@ async def get_wait_time_summary(
         return summary
 
     except Exception as e:
-        logger.error(f"Ошибка получения сводки времени ожидания: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения сводки: {str(e)}",
-        )
+        raise_wait_time_internal_error("get_wait_time_summary", e)
 
 
 @router.get("/wait-time-comparison")
@@ -321,11 +316,7 @@ async def get_wait_time_comparison(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка сравнения времени ожидания: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка сравнения: {str(e)}",
-        )
+        raise_wait_time_internal_error("get_wait_time_comparison", e)
 
 
 @router.get("/wait-time-heatmap")
@@ -404,11 +395,7 @@ async def get_wait_time_heatmap(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Ошибка получения тепловой карты времени ожидания: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения тепловой карты: {str(e)}",
-        )
+        raise_wait_time_internal_error("get_wait_time_heatmap", e)
 
 
 # ===================== ВСПОМОГАТЕЛЬНЫЕ ФУНКЦИИ =====================


### PR DESCRIPTION
## Summary
- Hide raw exception text from mounted `/api/v1/analytics/wait-time/*` public HTTP 500 responses.
- Replace f-string exception logs with structured action name plus exception class only.
- Preserve wait-time analytics routes, auth guards, validation errors, and success response shapes.
- Update the recovery status log with the Task 26 wait-time analytics slice evidence.

## Contract Impact
- Canonical surface: mounted backend wait-time analytics routes from `backend/app/api/v1/endpoints/wait_time_analytics.py` under `/api/v1/analytics/wait-time/*`.
- Request shape: unchanged; existing query parameters for date ranges, department, doctor, services, days, and comparison settings are preserved.
- Response shape: unchanged for successful analytics responses; internal 500 failures now return generic `Internal server error` instead of raw exception text.
- Status codes: success codes unchanged; explicit bad-date validation remains HTTP 400; unexpected internal failures remain HTTP 500 without raw exception text.
- Frontend consumer: no frontend file changed; existing analytics consumers keep the same route and payload contracts.
- Compatibility path or alias: no compatibility path or alias changed.
- Contract proof: py_compile, ruff, black, static leakage scan, direct endpoint smoke, security middleware tests, and frontend build passed.

## RBAC / Permissions
- Roles allowed: unchanged from existing `require_roles([Admin, Registrar, Doctor])` guards.
- Roles denied: unchanged; this slice does not alter role dependencies or permission logic.
- Positive auth proof: direct smoke passed an allowed `Admin`/`Doctor` style user object through endpoint calls.
- Negative auth proof: security middleware regression suite passed and the diff leaves every `require_roles([Admin, Registrar, Doctor])` dependency intact.

## Notification / Realtime
not applicable - no notification, webhook, websocket, realtime event, read/unread, ack, reconnect, or resync behavior changed in this backend endpoint cleanup.

## Frontend Resilience
- Empty data proof: not applicable - no frontend rendering or empty analytics state changed.
- Partial data proof: not applicable - no frontend partial-data behavior changed.
- Forbidden secondary path behavior: not applicable - this slice does not alter route guards or secondary frontend paths.
- Missing draft/resource behavior: not applicable - wait-time analytics does not create, reopen, or persist drafts/resources in this endpoint file.
- Stale route/deep-link behavior: not applicable - no frontend routes or deep links changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/wait_time_analytics.py` and `.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md`.
- Denied paths: frontend route files, backend services, schemas, repositories, migrations, generated artifacts, and unrelated docs.
- Migration/docs/test impact: no migration; no runtime docs changed; recovery status log updated; targeted smoke and existing security/frontend build checks run.
- Rollback note: revert this PR to restore previous wait-time analytics endpoint error/logging behavior and status-log entry.

## Validation
- Targeted tests or smoke run: py_compile, ruff, black, static leakage scan, direct async endpoint smoke, security middleware tests, CRLF-aware diff check, and frontend production build.
- Result: passed locally; frontend build retained existing Vite dynamic/static import and large chunk warnings.
- Not checked: full manual browser analytics workflow and live analytics data correctness against a populated database.