### PR TITLE
fix(security): route registrar invoice providers through manager

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -15,7 +15,6 @@ from sqlalchemy import String, func, literal
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
-from app.core.config import settings as app_settings
 from app.crud import clinic as crud_clinic, online_queue as crud_queue
 from app.models.clinic import ClinicSettings, Doctor
 from app.models.doctor_price_override import DoctorPriceOverride
@@ -29,6 +28,7 @@ from app.services.registrar_wizard_queue_assignment_service import (
     RegistrarWizardQueueAssignmentService,
 )
 from app.services.notifications import notification_sender_service
+from app.services.payment_provider_manager_factory import get_payment_manager
 from app.services.queue_service import queue_service
 from app.services.queue_session import get_or_create_session_id
 from app.services.service_mapping import get_service_code, normalize_service_code
@@ -506,6 +506,9 @@ class InvoicePaymentResponse(BaseModel):
     error_message: Optional[str] = None
 
 
+SUPPORTED_INVOICE_PAYMENT_PROVIDERS = {"click", "payme"}
+
+
 @router.post("/registrar/invoice/init-payment", response_model=InvoicePaymentResponse)
 def init_invoice_payment(
     payment_req: InvoicePaymentRequest,
@@ -531,64 +534,16 @@ def init_invoice_payment(
             )
 
         # Инициализируем провайдер платежей
-        if payment_req.provider == "click":
-            if not app_settings.CLICK_ENABLED:
-                return InvoicePaymentResponse(
-                    success=False,
-                    error_message="Payment provider click is not configured",
-                )
-
-            from app.services.payment_providers.click import ClickProvider
-
-            # Конфигурация Click (в реальном проекте из настроек)
-            provider_config = {
-                "service_id": app_settings.CLICK_SERVICE_ID,
-                "merchant_id": app_settings.CLICK_MERCHANT_ID,
-                "secret_key": app_settings.CLICK_SECRET_KEY,
-                "base_url": app_settings.CLICK_BASE_URL,
-            }
-
-            try:
-                provider = ClickProvider(provider_config)
-            except ValueError:
-                return InvoicePaymentResponse(
-                    success=False,
-                    error_message="Payment provider click is not configured",
-                )
-
-        elif payment_req.provider == "payme":
-            if not app_settings.PAYME_ENABLED:
-                return InvoicePaymentResponse(
-                    success=False,
-                    error_message="Payment provider payme is not configured",
-                )
-
-            from app.services.payment_providers.payme import PayMeProvider
-
-            # Конфигурация PayMe (в реальном проекте из настроек)
-            provider_config = {
-                "merchant_id": app_settings.PAYME_MERCHANT_ID,
-                "secret_key": app_settings.PAYME_SECRET_KEY,
-                "base_url": app_settings.PAYME_BASE_URL,
-                "api_url": app_settings.PAYME_API_URL,
-            }
-
-            try:
-                provider = PayMeProvider(provider_config)
-            except ValueError:
-                return InvoicePaymentResponse(
-                    success=False,
-                    error_message="Payment provider payme is not configured",
-                )
-
-        else:
+        provider_name = payment_req.provider.lower()
+        if provider_name not in SUPPORTED_INVOICE_PAYMENT_PROVIDERS:
             return InvoicePaymentResponse(
                 success=False,
                 error_message=f"Провайдер {payment_req.provider} не поддерживается",
             )
 
         # Создаём платёж
-        result = provider.create_payment(
+        result = get_payment_manager().create_payment(
+            provider_name=provider_name,
             amount=invoice.total_amount,
             currency=invoice.currency,
             order_id=f"invoice_{invoice.id}",
@@ -600,8 +555,8 @@ def init_invoice_payment(
         if result.success:
             # Обновляем invoice
             invoice.provider_payment_id = result.payment_id
-            invoice.payment_method = payment_req.provider
-            invoice.provider = payment_req.provider
+            invoice.payment_method = provider_name
+            invoice.provider = provider_name
             invoice.status = "processing"
             invoice.provider_data = result.provider_data
             db.commit()
@@ -652,40 +607,12 @@ def check_invoice_status(
 
         # Проверяем статус у провайдера
         if invoice.provider_payment_id and invoice.provider:
-            provider = None
+            provider_name = invoice.provider.lower()
 
-            if invoice.provider == "click" and app_settings.CLICK_ENABLED:
-                from app.services.payment_providers.click import ClickProvider
-
-                provider_config = {
-                    "service_id": app_settings.CLICK_SERVICE_ID,
-                    "merchant_id": app_settings.CLICK_MERCHANT_ID,
-                    "secret_key": app_settings.CLICK_SECRET_KEY,
-                    "base_url": app_settings.CLICK_BASE_URL,
-                }
-
-                try:
-                    provider = ClickProvider(provider_config)
-                except ValueError:
-                    provider = None
-
-            elif invoice.provider == "payme" and app_settings.PAYME_ENABLED:
-                from app.services.payment_providers.payme import PayMeProvider
-
-                provider_config = {
-                    "merchant_id": app_settings.PAYME_MERCHANT_ID,
-                    "secret_key": app_settings.PAYME_SECRET_KEY,
-                    "base_url": app_settings.PAYME_BASE_URL,
-                    "api_url": app_settings.PAYME_API_URL,
-                }
-
-                try:
-                    provider = PayMeProvider(provider_config)
-                except ValueError:
-                    provider = None
-
-            if provider:
-                result = provider.check_payment_status(invoice.provider_payment_id)
+            if provider_name in SUPPORTED_INVOICE_PAYMENT_PROVIDERS:
+                result = get_payment_manager().check_payment_status(
+                    provider_name, invoice.provider_payment_id
+                )
 
                 if result.success:
                     # Обновляем статус invoice


### PR DESCRIPTION
## Summary
- Replaces direct Click/PayMe provider construction in registrar invoice endpoints with the shared payment provider manager.
- Normalizes invoice provider names before create/status sync.
- Keeps the existing registrar route contracts and response shape.

## Contract Impact
- Canonical surface: POST /api/v1/registrar/invoice/init-payment and GET /api/v1/registrar/invoice/{invoice_id}/status.
- Request shape: unchanged; init still accepts InvoicePaymentRequest and status still uses invoice_id path parameter.
- Response shape: unchanged; init still returns InvoicePaymentResponse and status still returns the existing invoice status dictionary.
- Status codes: unchanged; existing 400/404/500 HTTP behavior remains, and unsupported providers still return success=false in the response body.
- Frontend consumer: registrar invoice payment flow; no frontend file changed.
- Compatibility path or alias: not applicable because this slice does not add, remove, or rename any route alias or compatibility path.
- Contract proof: py_compile passed locally, architecture import-boundary test passed locally, and PR CI contract/parity checks are passing except the PR body review gate being fixed here.

## RBAC / Permissions
- Roles allowed: existing Admin and Registrar dependencies are preserved.
- Roles denied: all roles outside the existing Admin/Registrar guard remain denied by require_roles.
- Positive auth proof: not checked locally because this slice did not change auth dependencies; CI backend tests passed on the branch.
- Negative auth proof: not checked locally because this slice did not change auth dependencies; no RBAC code path was edited.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification, websocket, Telegram, or realtime event is changed.
- Payload version / ack behavior: not applicable because no realtime payload or acknowledgement behavior is changed.
- Read/unread or delivery semantics: not applicable because this slice does not touch delivery state or unread counters.
- Reconnect/resync proof: not applicable because this slice does not touch reconnect, resync, or websocket behavior.

## Frontend Resilience
- Empty data proof: not applicable because no frontend rendering or data-empty state changed.
- Partial data proof: not applicable because no frontend partial-data behavior changed.
- Forbidden secondary path behavior: not applicable because this backend-only slice does not add a secondary frontend path.
- Missing draft/resource behavior: not applicable because this slice does not create or reopen frontend drafts/resources.
- Stale route/deep-link behavior: not applicable because no route, deep-link, or route registry behavior changed.

## Scope Gate
- Allowed paths: backend/app/api/v1/endpoints/registrar_wizard.py only.
- Denied paths: frontend routes, payment provider implementations, migrations, generated output, and unrelated registrar cart error handling.
- Migration/docs/test impact: no migration; no docs file changed; targeted local payment-manager and import-boundary tests ran.
- Rollback note: revert commit 1a9d3068 to restore direct provider construction in registrar_wizard.py.

## Validation
- Targeted tests or smoke run: python -m py_compile backend/app/api/v1/endpoints/registrar_wizard.py; pytest backend/tests/unit/test_payment_provider_manager_factory.py -q --tb=short; pytest backend/tests/architecture/test_interoperability_import_boundaries.py -q --tb=short.
- Result: local targeted checks passed; CI checks passed except the PR body review gate, which this body update addresses.
- Not checked: full backend suite, live Click/PayMe sandbox calls, and end-to-end registrar payment flow.