### PR TITLE
fix(security): hide queue cabinet error details

### DIFF
--- a/.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md
+++ b/.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md
@@ -7,11 +7,93 @@ Workflow: `/aif-plan` -> `/aif-improve @.ai-factory/PLAN.md` -> `/aif-implement 
 ## Current Status
 
 - Current task: Task 26 - remaining backend raw print/public error leakage
-- Last completed slice: Task 26 MCP endpoint leakage cleanup
+- Last completed slice: Task 26 queue cabinet management endpoint leakage cleanup
 - Next task: continue Task 26 with the next one-file mounted runtime leakage slice
 - Blocker state: none for the current slice; Task 26 remains open as a multi-slice audit
 - Runtime code changed: yes
 - Secrets inspected or printed: no
+
+## Task 26 Slice Wait-Time Analytics Evidence
+
+Post-merge recovery note:
+
+- PR #672 merged commit `a5efc515670478947eb17167137d3214f8c77908`.
+- Runtime file changed: `backend/app/api/v1/endpoints/wait_time_analytics.py`.
+- The intended recovery-log note was not included in PR #672, so this section records the already-merged evidence without reopening that code slice.
+
+Execution mode:
+
+- selected mode: `gate_known_root_cause`, continued as narrow override
+- reason: mounted analytics endpoint leaked raw exception text through public HTTP 500 details and f-string exception logs
+- risky domain: yes
+- root cause known: yes
+- command: `python scripts\agent_gate.py "Task 26 sanitize mounted wait_time_analytics endpoint raw public exception leakage and f-string exception logging without changing analytics route contracts auth guards or success payloads" --known-root-cause "backend/app/api/v1/endpoints/wait_time_analytics.py"`
+
+Validation run:
+
+- `python -m py_compile backend\app\api\v1\endpoints\wait_time_analytics.py`
+  - result: passed
+- `python -m ruff check backend\app\api\v1\endpoints\wait_time_analytics.py`
+  - result: passed
+- `python -m black --check backend\app\api\v1\endpoints\wait_time_analytics.py`
+  - result: passed
+- static leakage scan for raw exception details/logging in the file
+  - result: no matches
+- direct async endpoint smoke with marker exception
+  - result: passed; HTTP 500 returned `Internal server error`, marker text did not leak to response or logs, and invalid date remained HTTP 400
+- `python -m pytest backend\tests\test_security_middleware.py -q --tb=short --disable-warnings`
+  - result: 24 passed, 1 warning
+- `npm.cmd --prefix frontend run build`
+  - result: passed with existing Vite chunk/import warnings
+- GitHub PR #672 CI
+  - result: passed; PR merged and remote branch pruned
+
+Scope note:
+
+- Task 26 remains open. This slice only hardened the mounted wait-time analytics endpoint and did not claim repo-wide leak cleanup.
+
+## Task 26 Slice Queue Cabinet Management Evidence
+
+Execution mode:
+
+- selected mode: `gate_known_root_cause`, continued as narrow override
+- reason: mounted queue cabinet endpoint leaked raw exception text through public HTTP 500 details and f-string exception logs
+- risky domain: yes, queue/cabinet routing and staff workflow
+- root cause known: yes
+- command: `python scripts\agent_gate.py "Task 26 sanitize mounted queue cabinet management endpoint raw public exception leakage and f-string exception logging without changing queue cabinet route contracts roles domain errors or success payloads" --known-root-cause "backend/app/api/v1/endpoints/queue_cabinet_management.py"`
+
+Gate result:
+
+- The gate included frontend routing files due routing ownership, even with the confirmed backend root-cause file.
+- Per `AGENTS.md`, execution continued as a narrow override limited to `backend/app/api/v1/endpoints/queue_cabinet_management.py` plus this recovery log.
+
+Changed behavior:
+
+- Replaced raw public HTTP 500 details that included exception text with generic `Internal server error`.
+- Replaced f-string exception logging with structured action name plus exception class only.
+- Preserved route paths, role dependencies, domain-error passthrough, success payload shapes, and service/repository behavior.
+- Added explicit `HTTPException` passthrough so endpoint-local validation such as bad date keeps its intended 400 response instead of being masked as generic 500.
+
+Validation run:
+
+- `python -m py_compile backend\app\api\v1\endpoints\queue_cabinet_management.py`
+  - result: passed
+- `python -m ruff check backend\app\api\v1\endpoints\queue_cabinet_management.py`
+  - result: passed
+- `python -m black --check backend\app\api\v1\endpoints\queue_cabinet_management.py`
+  - result: passed
+- static leakage scan for raw exception details/logging in the file
+  - result: no matches
+- direct endpoint smoke with marker exception
+  - result: passed; HTTP 500 returned `Internal server error`, marker text did not leak to response or logs, and bad-date remained HTTP 400
+- `python -m pytest backend\tests\architecture\test_w2c_queue_boundaries.py backend\tests\unit\test_queue_cabinet_management_api_service.py backend\tests\integration\test_admin_linkage_cleanup.py -q --tb=short --disable-warnings`
+  - result: 15 passed, 1 warning
+- `npm.cmd --prefix frontend run build`
+  - result: passed with existing Vite chunk/import warnings
+
+Scope note:
+
+- Task 26 remains open. This slice only hardens the mounted queue cabinet management endpoint and does not claim all backend runtime leakage is gone.
 
 ## Task 1 Evidence
 

--- a/backend/app/api/v1/endpoints/queue_cabinet_management.py
+++ b/backend/app/api/v1/endpoints/queue_cabinet_management.py
@@ -4,7 +4,7 @@ API endpoints для управления информацией о кабине
 
 import logging
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional
+from typing import NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
@@ -12,15 +12,27 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
 from app.models.user import User
-from app.services.queue_domain_service import QueueDomainReadError, QueueDomainService
 from app.services.queue_cabinet_management_api_service import (
     QueueCabinetManagementApiService,
     QueueCabinetManagementDomainError,
 )
+from app.services.queue_domain_service import QueueDomainReadError, QueueDomainService
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _raise_queue_cabinet_internal_error(action: str, exc: Exception) -> NoReturn:
+    logger.error(
+        "Queue cabinet management endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Internal server error",
+    ) from exc
 
 
 def _parse_day_query(day: str | None) -> date | None:
@@ -39,9 +51,9 @@ def _parse_day_query(day: str | None) -> date | None:
 
 
 class CabinetInfo(BaseModel):
-    cabinet_number: Optional[str] = None
-    cabinet_floor: Optional[int] = None
-    cabinet_building: Optional[str] = None
+    cabinet_number: str | None = None
+    cabinet_floor: int | None = None
+    cabinet_building: str | None = None
 
 
 class QueueCabinetUpdateRequest(BaseModel):
@@ -54,32 +66,32 @@ class QueueCabinetResponse(BaseModel):
     day: str
     specialist_id: int
     specialist_name: str
-    queue_tag: Optional[str]
-    cabinet_number: Optional[str]
-    doctor_cabinet: Optional[str]
-    effective_cabinet: Optional[str]
-    cabinet_floor: Optional[int]
-    cabinet_building: Optional[str]
+    queue_tag: str | None
+    cabinet_number: str | None
+    doctor_cabinet: str | None
+    effective_cabinet: str | None
+    cabinet_floor: int | None
+    cabinet_building: str | None
     entries_count: int
     active: bool
     linked_doctor_found: bool
     doctor_has_cabinet: bool
     sync_status: str
-    integrity_warnings: List[str]
+    integrity_warnings: list[str]
 
 
 class BulkCabinetUpdateRequest(BaseModel):
-    updates: List[QueueCabinetUpdateRequest]
+    updates: list[QueueCabinetUpdateRequest]
 
 
 # ===================== ПОЛУЧЕНИЕ ИНФОРМАЦИИ О КАБИНЕТАХ =====================
 
 
-@router.get("/queues/cabinet-info", response_model=List[QueueCabinetResponse])
+@router.get("/queues/cabinet-info", response_model=list[QueueCabinetResponse])
 def get_queues_cabinet_info(
-    day: Optional[str] = Query(None, description="Дата в формате YYYY-MM-DD"),
-    specialist_id: Optional[int] = Query(None, description="ID специалиста"),
-    cabinet_number: Optional[str] = Query(None, description="Номер кабинета"),
+    day: str | None = Query(None, description="Дата в формате YYYY-MM-DD"),
+    specialist_id: int | None = Query(None, description="ID специалиста"),
+    cabinet_number: str | None = Query(None, description="Номер кабинета"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar", "Doctor")),
 ):
@@ -95,12 +107,10 @@ def get_queues_cabinet_info(
         return [QueueCabinetResponse(**item) for item in payload]
     except QueueDomainReadError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
-    except Exception as e:
-        logger.error(f"Ошибка получения информации о кабинетах: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения информации о кабинетах: {str(e)}",
-        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_queue_cabinet_internal_error("get_queues_cabinet_info", exc)
 
 
 @router.get("/queues/{queue_id}/cabinet-info")
@@ -117,14 +127,10 @@ def get_queue_cabinet_info(
         return QueueCabinetResponse(**payload)
     except QueueDomainReadError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
-    except Exception as e:
-        logger.error(
-            f"Ошибка получения информации о кабинете для очереди {queue_id}: {e}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения информации о кабинете: {str(e)}",
-        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_queue_cabinet_internal_error("get_queue_cabinet_info", exc)
 
 
 # ===================== ОБНОВЛЕНИЕ ИНФОРМАЦИИ О КАБИНЕТАХ =====================
@@ -154,15 +160,11 @@ def update_queue_cabinet_info(
         )
     except QueueCabinetManagementDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception as exc:
         service.rollback()
-        logger.error(
-            f"Ошибка обновления информации о кабинете для очереди {queue_id}: {e}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления информации о кабинете: {str(e)}",
-        )
+        _raise_queue_cabinet_internal_error("update_queue_cabinet_info", exc)
 
 
 @router.put("/queues/cabinet-info/bulk")
@@ -185,13 +187,11 @@ def bulk_update_cabinet_info(
             updates=updates,
             updated_by=current_user.username,
         )
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception as exc:
         service.rollback()
-        logger.error(f"Ошибка массового обновления информации о кабинетах: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка массового обновления: {str(e)}",
-        )
+        _raise_queue_cabinet_internal_error("bulk_update_cabinet_info", exc)
 
 
 # ===================== СИНХРОНИЗАЦИЯ С ТАБЛИЦЕЙ DOCTORS =====================
@@ -199,12 +199,10 @@ def bulk_update_cabinet_info(
 
 @router.post("/queues/sync-cabinet-info")
 def sync_cabinet_info_from_doctors(
-    day: Optional[str] = Query(
+    day: str | None = Query(
         None, description="Дата для синхронизации (по умолчанию сегодня)"
     ),
-    specialist_id: Optional[int] = Query(
-        None, description="ID конкретного специалиста"
-    ),
+    specialist_id: int | None = Query(None, description="ID конкретного специалиста"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -221,13 +219,11 @@ def sync_cabinet_info_from_doctors(
         )
     except QueueCabinetManagementDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
-    except Exception as e:
+    except HTTPException:
+        raise
+    except Exception as exc:
         service.rollback()
-        logger.error(f"Ошибка синхронизации информации о кабинетах: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка синхронизации: {str(e)}",
-        )
+        _raise_queue_cabinet_internal_error("sync_cabinet_info_from_doctors", exc)
 
 
 # ===================== СТАТИСТИКА ПО КАБИНЕТАМ =====================
@@ -235,10 +231,8 @@ def sync_cabinet_info_from_doctors(
 
 @router.get("/queues/cabinet-statistics")
 def get_cabinet_statistics(
-    date_from: Optional[str] = Query(
-        None, description="Дата начала в формате YYYY-MM-DD"
-    ),
-    date_to: Optional[str] = Query(
+    date_from: str | None = Query(None, description="Дата начала в формате YYYY-MM-DD"),
+    date_to: str | None = Query(
         None, description="Дата окончания в формате YYYY-MM-DD"
     ),
     db: Session = Depends(get_db),
@@ -254,9 +248,7 @@ def get_cabinet_statistics(
         )
     except QueueCabinetManagementDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
-    except Exception as e:
-        logger.error(f"Ошибка получения статистики по кабинетам: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
-        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_queue_cabinet_internal_error("get_cabinet_statistics", exc)


### PR DESCRIPTION
﻿## Summary

- Hide raw unexpected exception details from the mounted queue cabinet management endpoint.
- Preserve route paths, role dependencies, domain errors, success payloads, and existing queue cabinet contracts.
- Update the recovery log with the current slice plus the already-merged wait-time slice evidence.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/queue_cabinet_management.py`, mounted by `backend/app/api/v1/api.py` under `/api/v1/admin`.
- Request shape: unchanged; queue id/path params, query params, and Pydantic request models are preserved.
- Response shape: success payloads and domain-error payloads are preserved; only unexpected internal 500 details now return `Internal server error`.
- Status codes: success codes unchanged; `QueueDomainReadError` and `QueueCabinetManagementDomainError` statuses are preserved; endpoint-local `HTTPException` such as bad date now passes through as intended; unexpected errors remain HTTP 500.
- Frontend consumer: existing admin/registrar/doctor queue cabinet UI/API consumers continue using the same `/api/v1/admin/queues/.../cabinet...` routes.
- Compatibility path or alias: no path, prefix, alias, or redirect changed.
- Contract proof: `python -m pytest backend\tests\architecture\test_w2c_queue_boundaries.py backend\tests\unit\test_queue_cabinet_management_api_service.py backend\tests\integration\test_admin_linkage_cleanup.py -q --tb=short --disable-warnings` passed.

## RBAC / Permissions

- Roles allowed: unchanged route dependencies, Admin/Registrar/Doctor for read endpoints, Admin/Registrar for update/statistics, Admin for sync.
- Roles denied: unchanged; no role dependency or auth dependency was edited.
- Positive auth proof: targeted integration coverage in `backend\tests\integration\test_admin_linkage_cleanup.py` continued to pass with existing authorized headers.
- Negative auth proof: route dependency source lines were preserved and no denial behavior was changed in this slice; no new public route was added.

## Notification / Realtime

not applicable - this endpoint does not publish notifications, Telegram messages, webhooks, or realtime events in this slice.

## Frontend Resilience

- Empty data proof: existing queue cabinet service unit tests continued to pass and response schema remains unchanged.
- Partial data proof: existing `test_admin_linkage_cleanup` coverage for doctor/cabinet linkage warnings continued to pass.
- Forbidden secondary path behavior: no secondary route, redirect, or forbidden page behavior changed.
- Missing draft/resource behavior: domain-error passthrough is preserved for missing/invalid queue cabinet domain resources.
- Stale route/deep-link behavior: route paths and API prefixes were not changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/queue_cabinet_management.py`, `.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md`.
- Denied paths: frontend routing files, queue domain services, repositories, schemas, migrations, DB models, role definitions, and API router prefixes.
- Migration/docs/test impact: no migration required; recovery log updated; no test source changed.
- Rollback note: revert commit `4d73bc8c` to restore previous queue cabinet error-detail behavior and recovery-log note.

## Validation

- Targeted tests or smoke run: `py_compile`, `ruff check`, `black --check`, static leakage scan, direct endpoint marker smoke, targeted queue cabinet pytest set, and `npm.cmd --prefix frontend run build`.
- Result: all passed; frontend build only emitted existing Vite import/chunk warnings.
- Not checked: full backend suite, browser UI smoke, and production deployment.
