### PR TITLE
fix(security): hide AI and queue limit error details

### DIFF
--- a/backend/app/api/v1/endpoints/ai.py
+++ b/backend/app/api/v1/endpoints/ai.py
@@ -2,18 +2,17 @@
 AI API endpoints
 """
 
-import base64
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, NoReturn, Optional
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from pydantic import BaseModel
 
 from ....api.deps import get_current_user
 from ....core.rbac import AIPermission, require_any_ai_permission
 from ....models.user import User
-from ....services.ai import ai_manager, AIProviderType
+from ....services.ai import AIProviderType, ai_manager
 from ....services.mcp import get_mcp_manager
 
 logger = logging.getLogger(__name__)
@@ -27,6 +26,15 @@ LEGACY_AI_ACCESS = require_any_ai_permission(
 )
 
 router = APIRouter(dependencies=[Depends(LEGACY_AI_ACCESS)])
+
+
+def _raise_ai_internal_error(exc: Exception) -> NoReturn:
+    if isinstance(exc, HTTPException):
+        raise exc
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Internal server error",
+    ) from exc
 
 
 class ComplaintAnalysisRequest(BaseModel):
@@ -136,7 +144,7 @@ async def analyze_complaint(
 
     except Exception as e:
         logger.error(f"Error analyzing complaint: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/icd-suggest")
@@ -159,7 +167,7 @@ async def suggest_icd10_codes(
 
     except Exception as e:
         logger.error(f"Error suggesting ICD-10: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/lab-interpret")
@@ -188,7 +196,7 @@ async def interpret_lab_results(
 
     except Exception as e:
         logger.error(f"Error interpreting lab results: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/skin-analyze")
@@ -227,7 +235,7 @@ async def analyze_skin(
 
     except Exception as e:
         logger.error(f"Error analyzing skin: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/ecg-interpret")
@@ -261,7 +269,7 @@ async def interpret_ecg(
 
     except Exception as e:
         logger.error(f"Error interpreting ECG: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 class DifferentialDiagnosisRequest(BaseModel):
@@ -302,7 +310,7 @@ async def differential_diagnosis(
         return result
     except Exception as e:
         logger.error(f"Ошибка дифференциальной диагностики: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/symptom-analysis")
@@ -319,7 +327,7 @@ async def symptom_analysis(
         return result
     except Exception as e:
         logger.error(f"Ошибка анализа симптомов: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/clinical-decision-support")
@@ -334,7 +342,7 @@ async def clinical_decision_support(
         return result
     except Exception as e:
         logger.error(f"Ошибка поддержки клинических решений: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 class MedicalImageAnalysisRequest(BaseModel):
@@ -376,7 +384,7 @@ async def analyze_xray_image(
 
     except Exception as e:
         logger.error(f"Ошибка анализа рентгеновского снимка: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/analyze-ultrasound")
@@ -410,7 +418,7 @@ async def analyze_ultrasound_image(
 
     except Exception as e:
         logger.error(f"Ошибка анализа УЗИ изображения: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/analyze-dermatoscopy")
@@ -444,7 +452,7 @@ async def analyze_dermatoscopy_image(
 
     except Exception as e:
         logger.error(f"Ошибка анализа дерматоскопического изображения: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/analyze-medical-image")
@@ -482,7 +490,7 @@ async def analyze_medical_image_generic(
 
     except Exception as e:
         logger.error(f"Ошибка анализа медицинского изображения: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 class TreatmentPlanRequest(BaseModel):
@@ -534,7 +542,7 @@ async def generate_treatment_plan(
         return result
     except Exception as e:
         logger.error(f"Ошибка генерации плана лечения: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/optimize-medication")
@@ -553,7 +561,7 @@ async def optimize_medication_regimen(
         return result
     except Exception as e:
         logger.error(f"Ошибка оптимизации медикаментозной терапии: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/assess-treatment-effectiveness")
@@ -571,7 +579,7 @@ async def assess_treatment_effectiveness(
         return result
     except Exception as e:
         logger.error(f"Ошибка оценки эффективности лечения: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/suggest-lifestyle-modifications")
@@ -589,7 +597,7 @@ async def suggest_lifestyle_modifications(
         return result
     except Exception as e:
         logger.error(f"Ошибка генерации рекомендаций по образу жизни: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 class DrugInteractionRequest(BaseModel):
@@ -641,7 +649,7 @@ async def check_drug_interactions(
         return result
     except Exception as e:
         logger.error(f"Ошибка проверки лекарственных взаимодействий: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/analyze-drug-safety")
@@ -659,7 +667,7 @@ async def analyze_drug_safety(
         return result
     except Exception as e:
         logger.error(f"Ошибка анализа безопасности препарата: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/suggest-drug-alternatives")
@@ -677,7 +685,7 @@ async def suggest_drug_alternatives(
         return result
     except Exception as e:
         logger.error(f"Ошибка предложения альтернативных препаратов: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/calculate-drug-dosage")
@@ -695,7 +703,7 @@ async def calculate_drug_dosage(
         return result
     except Exception as e:
         logger.error(f"Ошибка расчета дозировки препарата: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 class RiskAssessmentRequest(BaseModel):
@@ -758,7 +766,7 @@ async def assess_patient_risk(
         return result
     except Exception as e:
         logger.error(f"Ошибка оценки рисков пациента: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/predict-complications")
@@ -777,7 +785,7 @@ async def predict_complications(
         return result
     except Exception as e:
         logger.error(f"Ошибка прогнозирования осложнений: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/calculate-mortality-risk")
@@ -795,7 +803,7 @@ async def calculate_mortality_risk(
         return result
     except Exception as e:
         logger.error(f"Ошибка расчета риска смертности: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/assess-surgical-risk")
@@ -813,7 +821,7 @@ async def assess_surgical_risk(
         return result
     except Exception as e:
         logger.error(f"Ошибка оценки хирургических рисков: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/predict-readmission-risk")
@@ -831,7 +839,7 @@ async def predict_readmission_risk(
         return result
     except Exception as e:
         logger.error(f"Ошибка прогнозирования риска повторной госпитализации: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 class AudioTranscriptionRequest(BaseModel):
@@ -902,7 +910,7 @@ async def transcribe_audio(
         return result
     except Exception as e:
         logger.error(f"Ошибка транскрипции аудио: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/structure-medical-text")
@@ -919,7 +927,7 @@ async def structure_medical_text(
         return result
     except Exception as e:
         logger.error(f"Ошибка структурирования текста: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/extract-medical-entities")
@@ -934,7 +942,7 @@ async def extract_medical_entities(
         return result
     except Exception as e:
         logger.error(f"Ошибка извлечения медицинских сущностей: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/generate-medical-summary")
@@ -951,7 +959,7 @@ async def generate_medical_summary(
         return result
     except Exception as e:
         logger.error(f"Ошибка генерации медицинского резюме: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/validate-medical-record")
@@ -966,7 +974,7 @@ async def validate_medical_record(
         return result
     except Exception as e:
         logger.error(f"Ошибка валидации медицинской записи: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 class ScheduleOptimizationRequest(BaseModel):
@@ -1024,7 +1032,7 @@ async def optimize_doctor_schedule(
         return result
     except Exception as e:
         logger.error(f"Ошибка оптимизации расписания врача: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/predict-appointment-duration")
@@ -1041,7 +1049,7 @@ async def predict_appointment_duration(
         return result
     except Exception as e:
         logger.error(f"Ошибка прогнозирования длительности приема: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/suggest-optimal-slots")
@@ -1059,7 +1067,7 @@ async def suggest_optimal_slots(
         return result
     except Exception as e:
         logger.error(f"Ошибка предложения оптимальных слотов: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/analyze-workload-distribution")
@@ -1076,7 +1084,7 @@ async def analyze_workload_distribution(
         return result
     except Exception as e:
         logger.error(f"Ошибка анализа распределения нагрузки: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/generate-shift-recommendations")
@@ -1093,7 +1101,7 @@ async def generate_shift_recommendations(
         return result
     except Exception as e:
         logger.error(f"Ошибка генерации рекомендаций по сменам: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 class DocumentationQualityRequest(BaseModel):
@@ -1151,7 +1159,7 @@ async def analyze_documentation_quality(
         return result
     except Exception as e:
         logger.error(f"Ошибка анализа качества документации: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/detect-documentation-gaps")
@@ -1168,7 +1176,7 @@ async def detect_documentation_gaps(
         return result
     except Exception as e:
         logger.error(f"Ошибка выявления пробелов в документации: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/suggest-documentation-improvements")
@@ -1186,7 +1194,7 @@ async def suggest_documentation_improvements(
         return result
     except Exception as e:
         logger.error(f"Ошибка предложения улучшений документации: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/validate-clinical-consistency")
@@ -1204,7 +1212,7 @@ async def validate_clinical_consistency(
         return result
     except Exception as e:
         logger.error(f"Ошибка валидации клинической согласованности: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/audit-prescription-safety")
@@ -1221,7 +1229,7 @@ async def audit_prescription_safety(
         return result
     except Exception as e:
         logger.error(f"Ошибка аудита безопасности назначений: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 class MedicalTrendsRequest(BaseModel):
@@ -1280,7 +1288,7 @@ async def analyze_medical_trends(
         return result
     except Exception as e:
         logger.error(f"Ошибка анализа медицинских трендов: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/detect-anomalies")
@@ -1297,7 +1305,7 @@ async def detect_anomalies(
         return result
     except Exception as e:
         logger.error(f"Ошибка выявления аномалий: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/predict-outcomes")
@@ -1314,7 +1322,7 @@ async def predict_outcomes(
         return result
     except Exception as e:
         logger.error(f"Ошибка прогнозирования исходов: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/generate-insights-report")
@@ -1331,7 +1339,7 @@ async def generate_insights_report(
         return result
     except Exception as e:
         logger.error(f"Ошибка генерации отчета с инсайтами: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)
 
 
 @router.post("/identify-risk-patterns")
@@ -1348,4 +1356,4 @@ async def identify_risk_patterns(
         return result
     except Exception as e:
         logger.error(f"Ошибка выявления паттернов рисков: {str(e)}")
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_ai_internal_error(e)

--- a/backend/app/api/v1/endpoints/queue_limits.py
+++ b/backend/app/api/v1/endpoints/queue_limits.py
@@ -2,8 +2,9 @@
 API для управления лимитами онлайн-очередей
 """
 
+import logging
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional
+from typing import NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
@@ -14,7 +15,21 @@ from app.models.user import User
 from app.services.queue_domain_service import QueueDomainService
 from app.services.queue_limits_api_service import QueueLimitsApiService
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+
+def _raise_queue_limits_internal_error(action: str, exc: Exception) -> NoReturn:
+    logger.error(
+        "Queue limits endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Internal server error",
+    ) from exc
 
 
 # ===================== PYDANTIC МОДЕЛИ =====================
@@ -33,9 +48,9 @@ class QueueLimitUpdate(BaseModel):
     """Обновление лимитов"""
 
     specialty: str = Field(..., description="Специальность")
-    max_per_day: Optional[int] = Field(None, ge=1, le=100)
-    start_number: Optional[int] = Field(None, ge=1, le=999)
-    enabled: Optional[bool] = Field(None)
+    max_per_day: int | None = Field(None, ge=1, le=100)
+    start_number: int | None = Field(None, ge=1, le=999)
+    enabled: bool | None = Field(None)
 
 
 class DoctorQueueLimit(BaseModel):
@@ -57,7 +72,7 @@ class QueueLimitResponse(BaseModel):
     enabled: bool
     current_usage: int
     doctors_count: int
-    last_updated: Optional[datetime]
+    last_updated: datetime | None
 
 
 class QueueStatusResponse(BaseModel):
@@ -66,7 +81,7 @@ class QueueStatusResponse(BaseModel):
     doctor_id: int
     doctor_name: str
     specialty: str
-    cabinet: Optional[str]
+    cabinet: str | None
     day: date
     current_entries: int
     max_entries: int
@@ -78,9 +93,9 @@ class QueueStatusResponse(BaseModel):
 # ===================== ПОЛУЧЕНИЕ НАСТРОЕК ЛИМИТОВ =====================
 
 
-@router.get("/queue-limits", response_model=List[QueueLimitResponse])
+@router.get("/queue-limits", response_model=list[QueueLimitResponse])
 def get_queue_limits(
-    specialty: Optional[str] = Query(None, description="Фильтр по специальности"),
+    specialty: str | None = Query(None, description="Фильтр по специальности"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar")),
 ):
@@ -91,11 +106,10 @@ def get_queue_limits(
         result = QueueLimitsApiService(db).get_queue_limits(specialty=specialty)
         return [QueueLimitResponse(**item) for item in result]
 
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения лимитов: {str(e)}",
-        ) from e
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_queue_limits_internal_error("get_queue_limits", exc)
 
 
 # ===================== ОБНОВЛЕНИЕ ЛИМИТОВ =====================
@@ -103,7 +117,7 @@ def get_queue_limits(
 
 @router.put("/queue-limits")
 def update_queue_limits(
-    limits: List[QueueLimitUpdate],
+    limits: list[QueueLimitUpdate],
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -116,20 +130,19 @@ def update_queue_limits(
             current_user_id=current_user.id,
         )
 
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления лимитов: {str(e)}",
-        ) from e
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_queue_limits_internal_error("update_queue_limits", exc)
 
 
 # ===================== СТАТУС ОЧЕРЕДЕЙ С ЛИМИТАМИ =====================
 
 
-@router.get("/queue-status", response_model=List[QueueStatusResponse])
+@router.get("/queue-status", response_model=list[QueueStatusResponse])
 def get_queue_status_with_limits(
-    day: Optional[date] = Query(None, description="Дата (по умолчанию сегодня)"),
-    specialty: Optional[str] = Query(None, description="Фильтр по специальности"),
+    day: date | None = Query(None, description="Дата (по умолчанию сегодня)"),
+    specialty: str | None = Query(None, description="Фильтр по специальности"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar")),
 ):
@@ -146,11 +159,10 @@ def get_queue_status_with_limits(
         )
         return [QueueStatusResponse(**item) for item in result]
 
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статуса очередей: {str(e)}",
-        ) from e
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_queue_limits_internal_error("get_queue_status_with_limits", exc)
 
 
 # ===================== ИНДИВИДУАЛЬНЫЕ ЛИМИТЫ ДЛЯ ВРАЧЕЙ =====================
@@ -168,7 +180,7 @@ def set_doctor_queue_limit(
     try:
         return QueueLimitsApiService(db).set_doctor_queue_limit(limit_data=limit_data)
     except ValueError as exc:
-        if str(exc) == "DOCTOR_NOT_FOUND":
+        if exc.args and exc.args[0] == "DOCTOR_NOT_FOUND":
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Врач не найден",
@@ -176,12 +188,9 @@ def set_doctor_queue_limit(
         raise
     except HTTPException:
         raise
-    except Exception as e:
+    except Exception as exc:
         QueueLimitsApiService(db).rollback()
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка установки лимита: {str(e)}",
-        ) from e
+        _raise_queue_limits_internal_error("set_doctor_queue_limit", exc)
 
 
 # ===================== СБРОС ЛИМИТОВ =====================
@@ -189,7 +198,7 @@ def set_doctor_queue_limit(
 
 @router.post("/reset-queue-limits")
 def reset_queue_limits(
-    specialty: Optional[str] = Query(
+    specialty: str | None = Query(
         None, description="Сбросить лимиты для конкретной специальности"
     ),
     db: Session = Depends(get_db),
@@ -204,8 +213,7 @@ def reset_queue_limits(
             current_user_id=current_user.id,
         )
 
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка сброса лимитов: {str(e)}",
-        ) from e
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_queue_limits_internal_error("reset_queue_limits", exc)


### PR DESCRIPTION
﻿## Summary
- Hide raw unexpected exception details from legacy AI endpoint public 500 responses.
- Hide raw queue limit endpoint public 500 details while preserving explicit HTTPException responses and doctor-not-found 404.
- Scope is limited to two backend endpoint files; EVIDENCE_LIGHTRAG_READINESS.md was not changed.

## Contract Impact
- Canonical surface: existing `/api/v1/ai/*` legacy AI routes and `/api/v1/*queue-limits*` queue limit routes.
- Request shape: unchanged for all touched routes.
- Response shape: success payloads unchanged; unexpected 500 responses now return `detail="Internal server error"` instead of raw exception text.
- Status codes: explicit HTTPException status codes are preserved; unexpected exceptions remain HTTP 500.
- Frontend consumer: no frontend code changed.
- Compatibility path or alias: no route paths or aliases changed.
- Contract proof: py_compile, raw-detail scan, and targeted queue boundary/service tests.

## RBAC / Permissions
- Roles allowed: unchanged; existing endpoint dependencies stay in place.
- Roles denied: unchanged; existing role guards stay in place.
- Positive auth proof: not applicable - no permission dependency changed.
- Negative auth proof: not applicable - no permission dependency changed.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: not applicable - no frontend rendering path changed.
- Partial data proof: not applicable - no frontend rendering path changed.
- Forbidden secondary path behavior: explicit HTTPException responses are preserved by the endpoint helpers.
- Missing draft/resource behavior: not applicable - no draft/resource workflow changed.
- Stale route/deep-link behavior: not applicable - no route/deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/ai.py`, `backend/app/api/v1/endpoints/queue_limits.py`.
- Denied paths: frontend, ops, migrations, generated output, evidence logs.
- Migration/docs/test impact: no migrations; no docs/test files changed.
- Rollback note: revert commit `513f0ee1` to restore previous public exception details.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/ai.py backend/app/api/v1/endpoints/queue_limits.py`; `python -m ruff check --select I,F401 backend/app/api/v1/endpoints/ai.py backend/app/api/v1/endpoints/queue_limits.py`; `git diff --check main..HEAD`; raw-detail `rg` scan; `python -m pytest backend/tests/architecture/test_w2c_queue_boundaries.py backend/tests/unit/test_queue_limits_api_service.py backend/tests/unit/test_service_repository_boundary.py -q`.
- Result: passed locally; pytest result `60 passed, 1 warning`.
- Not checked: full backend suite, full frontend suite, browser smoke.
