### PR TITLE
fix(queue): hide queue limits error details

### DIFF
--- a/.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md
+++ b/.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md
@@ -13,6 +13,49 @@ Workflow: `/aif-plan` -> `/aif-improve @.ai-factory/PLAN.md` -> `/aif-implement 
 - Runtime code changed: yes
 - Secrets inspected or printed: no
 
+## Task 26 Slice Queue Limits Evidence
+
+Execution mode:
+
+- selected mode: `gate_known_root_cause`, continued as narrow override
+- reason: mounted queue limits endpoint leaked raw exception text through public HTTP 500 details
+- risky domain: yes, queue limits and staff workflow
+- root cause known: yes
+- command: `python scripts\agent_gate.py "Task 26 sanitize mounted queue limits endpoint raw public exception leakage without changing queue limit route contracts roles domain behavior or success payloads" --known-root-cause "backend/app/api/v1/endpoints/queue_limits.py"`
+
+Gate result:
+
+- The gate returned frontend routing files alongside the confirmed backend root-cause file.
+- Per `AGENTS.md`, execution continued as a narrow override limited to `backend/app/api/v1/endpoints/queue_limits.py` plus this recovery log.
+
+Changed behavior:
+
+- Replaced raw public HTTP 500 details that included exception text with generic `Internal server error`.
+- Added structured endpoint logging with action name plus exception class only.
+- Preserved route paths, role dependencies, domain 404 behavior, success payload shapes, and service/repository behavior.
+- Added explicit `HTTPException` passthrough so endpoint-local HTTP errors are not masked as generic 500.
+
+Validation run:
+
+- `python -m py_compile backend\app\api\v1\endpoints\queue_limits.py`
+  - result: passed
+- `python -m ruff check backend\app\api\v1\endpoints\queue_limits.py`
+  - result: passed
+- `python -m black --check backend\app\api\v1\endpoints\queue_limits.py`
+  - result: passed
+- static leakage scan for raw exception details/logging in the file
+  - result: no matches
+- direct endpoint smoke with marker exception
+  - result: passed; HTTP 500 returned `Internal server error`, marker text did not leak to response or logs, and `DOCTOR_NOT_FOUND` stayed HTTP 404
+- `python -m pytest backend\tests\architecture\test_w2c_queue_boundaries.py backend\tests\unit\test_queue_limits_api_service.py backend\tests\unit\test_queue_domain_service.py backend\tests\unit\test_service_repository_boundary.py -q --tb=short --disable-warnings`
+  - result: 69 passed, 1 warning
+- `npm.cmd --prefix frontend run build`
+  - result: passed from `C:\final` because the isolated worktree does not have `frontend\node_modules`; warnings are existing Vite dynamic/static import and large chunk warnings
+
+Scope note:
+
+- Task 26 remains open. This slice only hardens the mounted queue limits endpoint and does not claim all backend runtime leakage is gone.
+
 ## Task 26 Slice Wait-Time Analytics Evidence
 
 Post-merge recovery note:

--- a/backend/app/api/v1/endpoints/queue_limits.py
+++ b/backend/app/api/v1/endpoints/queue_limits.py
@@ -2,8 +2,9 @@
 API для управления лимитами онлайн-очередей
 """
 
+import logging
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional
+from typing import NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
@@ -14,7 +15,21 @@ from app.models.user import User
 from app.services.queue_domain_service import QueueDomainService
 from app.services.queue_limits_api_service import QueueLimitsApiService
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+
+def _raise_queue_limits_internal_error(action: str, exc: Exception) -> NoReturn:
+    logger.error(
+        "Queue limits endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Internal server error",
+    ) from exc
 
 
 # ===================== PYDANTIC МОДЕЛИ =====================
@@ -33,9 +48,9 @@ class QueueLimitUpdate(BaseModel):
     """Обновление лимитов"""
 
     specialty: str = Field(..., description="Специальность")
-    max_per_day: Optional[int] = Field(None, ge=1, le=100)
-    start_number: Optional[int] = Field(None, ge=1, le=999)
-    enabled: Optional[bool] = Field(None)
+    max_per_day: int | None = Field(None, ge=1, le=100)
+    start_number: int | None = Field(None, ge=1, le=999)
+    enabled: bool | None = Field(None)
 
 
 class DoctorQueueLimit(BaseModel):
@@ -57,7 +72,7 @@ class QueueLimitResponse(BaseModel):
     enabled: bool
     current_usage: int
     doctors_count: int
-    last_updated: Optional[datetime]
+    last_updated: datetime | None
 
 
 class QueueStatusResponse(BaseModel):
@@ -66,7 +81,7 @@ class QueueStatusResponse(BaseModel):
     doctor_id: int
     doctor_name: str
     specialty: str
-    cabinet: Optional[str]
+    cabinet: str | None
     day: date
     current_entries: int
     max_entries: int
@@ -78,9 +93,9 @@ class QueueStatusResponse(BaseModel):
 # ===================== ПОЛУЧЕНИЕ НАСТРОЕК ЛИМИТОВ =====================
 
 
-@router.get("/queue-limits", response_model=List[QueueLimitResponse])
+@router.get("/queue-limits", response_model=list[QueueLimitResponse])
 def get_queue_limits(
-    specialty: Optional[str] = Query(None, description="Фильтр по специальности"),
+    specialty: str | None = Query(None, description="Фильтр по специальности"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar")),
 ):
@@ -91,11 +106,10 @@ def get_queue_limits(
         result = QueueLimitsApiService(db).get_queue_limits(specialty=specialty)
         return [QueueLimitResponse(**item) for item in result]
 
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения лимитов: {str(e)}",
-        ) from e
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_queue_limits_internal_error("get_queue_limits", exc)
 
 
 # ===================== ОБНОВЛЕНИЕ ЛИМИТОВ =====================
@@ -103,7 +117,7 @@ def get_queue_limits(
 
 @router.put("/queue-limits")
 def update_queue_limits(
-    limits: List[QueueLimitUpdate],
+    limits: list[QueueLimitUpdate],
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -116,20 +130,19 @@ def update_queue_limits(
             current_user_id=current_user.id,
         )
 
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления лимитов: {str(e)}",
-        ) from e
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_queue_limits_internal_error("update_queue_limits", exc)
 
 
 # ===================== СТАТУС ОЧЕРЕДЕЙ С ЛИМИТАМИ =====================
 
 
-@router.get("/queue-status", response_model=List[QueueStatusResponse])
+@router.get("/queue-status", response_model=list[QueueStatusResponse])
 def get_queue_status_with_limits(
-    day: Optional[date] = Query(None, description="Дата (по умолчанию сегодня)"),
-    specialty: Optional[str] = Query(None, description="Фильтр по специальности"),
+    day: date | None = Query(None, description="Дата (по умолчанию сегодня)"),
+    specialty: str | None = Query(None, description="Фильтр по специальности"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar")),
 ):
@@ -146,11 +159,10 @@ def get_queue_status_with_limits(
         )
         return [QueueStatusResponse(**item) for item in result]
 
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статуса очередей: {str(e)}",
-        ) from e
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_queue_limits_internal_error("get_queue_status_with_limits", exc)
 
 
 # ===================== ИНДИВИДУАЛЬНЫЕ ЛИМИТЫ ДЛЯ ВРАЧЕЙ =====================
@@ -168,7 +180,7 @@ def set_doctor_queue_limit(
     try:
         return QueueLimitsApiService(db).set_doctor_queue_limit(limit_data=limit_data)
     except ValueError as exc:
-        if str(exc) == "DOCTOR_NOT_FOUND":
+        if exc.args and exc.args[0] == "DOCTOR_NOT_FOUND":
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Врач не найден",
@@ -176,12 +188,9 @@ def set_doctor_queue_limit(
         raise
     except HTTPException:
         raise
-    except Exception as e:
+    except Exception as exc:
         QueueLimitsApiService(db).rollback()
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка установки лимита: {str(e)}",
-        ) from e
+        _raise_queue_limits_internal_error("set_doctor_queue_limit", exc)
 
 
 # ===================== СБРОС ЛИМИТОВ =====================
@@ -189,7 +198,7 @@ def set_doctor_queue_limit(
 
 @router.post("/reset-queue-limits")
 def reset_queue_limits(
-    specialty: Optional[str] = Query(
+    specialty: str | None = Query(
         None, description="Сбросить лимиты для конкретной специальности"
     ),
     db: Session = Depends(get_db),
@@ -204,8 +213,7 @@ def reset_queue_limits(
             current_user_id=current_user.id,
         )
 
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка сброса лимитов: {str(e)}",
-        ) from e
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _raise_queue_limits_internal_error("reset_queue_limits", exc)


### PR DESCRIPTION
﻿## Summary

- Hide raw unexpected exception details from mounted queue limits API responses.
- Keep queue limit routes, role dependencies, domain 404 behavior, and success payloads unchanged.
- Record resume-friendly Task 26 evidence in the AI Factory recovery log.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/queue_limits.py`, mounted through the existing `/api/v1/admin` router surface.
- Request shape: unchanged authenticated admin/registrar requests; no request bodies or query parameters were renamed or removed.
- Response shape: success responses unchanged; unexpected server failures now return generic `{"detail":"Internal server error"}` instead of raw exception text.
- Status codes: existing success statuses unchanged; explicit `HTTPException` passthrough and `DOCTOR_NOT_FOUND` HTTP 404 behavior preserved; unexpected exceptions remain HTTP 500 with generic detail.
- Frontend consumer: existing admin/registrar queue limit and queue status consumers continue using the same routes and response contracts.
- Compatibility path or alias: no route path, prefix, alias, or compatibility redirect changed.
- Contract proof: targeted queue service/API tests passed and direct marker endpoint smoke proved generic 500 plus preserved doctor-not-found 404.

## RBAC / Permissions

- Roles allowed: unchanged; Admin can update, set, and reset limits; Admin and Registrar can read queue limits/status.
- Roles denied: unchanged; no role dependency or permission matrix was edited.
- Positive auth proof: source diff preserves existing `require_roles("Admin")` and `require_roles("Admin", "Registrar")`; targeted queue tests passed.
- Negative auth proof: no public route was added, no dependency was weakened, and denied-role behavior remains owned by unchanged `require_roles` guards.

## Notification / Realtime

- Event type or websocket channel: not applicable because this slice does not touch notification, websocket, chat, or realtime code.
- Payload version / ack behavior: not applicable because this slice does not emit notification or realtime payloads.
- Read/unread or delivery semantics: not applicable because this slice does not change delivery state or notification storage.
- Reconnect/resync proof: not applicable because this slice does not change websocket reconnect or resync behavior.

## Frontend Resilience

- Empty data proof: unchanged; no frontend component, route, or empty-state behavior was edited.
- Partial data proof: unchanged; success payload contract and Pydantic response models remain compatible with existing consumers.
- Forbidden secondary path behavior: unchanged; role guards and route paths were not modified.
- Missing draft/resource behavior: not applicable because queue limits do not create or reopen draft resources in this slice.
- Stale route/deep-link behavior: unchanged; no frontend route or deep-link handling was edited.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/queue_limits.py` and `.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md`.
- Denied paths: services, repositories, schemas, database migrations, frontend routes/components, auth/RBAC dependencies, and generated artifacts.
- Migration/docs/test impact: no migration and no test source changes; recovery log updated with validation evidence.
- Rollback note: revert commit `9406bc94` to restore previous endpoint error details and recovery-log state.

## Validation

- Targeted tests or smoke run: `py_compile`, `ruff`, `black --check`, static leakage scan, direct marker endpoint smoke, targeted queue pytest suite, and `npm.cmd --prefix frontend run build` from `C:\final` because the isolated worktree lacks `frontend\node_modules`.
- Result: passed; targeted pytest result was 69 passed with 1 warning, frontend build passed with existing Vite dynamic/static import and large chunk warnings.
- Not checked: full backend suite, browser role smoke, and live database/API server smoke were not run for this one-file endpoint-hardening slice.
