### PR TITLE
fix(security): hide dynamic pricing error details

### DIFF
--- a/.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md
+++ b/.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md
@@ -7,11 +7,55 @@ Workflow: `/aif-plan` -> `/aif-improve @.ai-factory/PLAN.md` -> `/aif-implement 
 ## Current Status
 
 - Current task: Task 26 - remaining backend raw print/public error leakage
-- Last completed slice: Task 26 queue cabinet management endpoint leakage cleanup
+- Last completed slice: Task 26 dynamic pricing endpoint leakage cleanup
 - Next task: continue Task 26 with the next one-file mounted runtime leakage slice
 - Blocker state: none for the current slice; Task 26 remains open as a multi-slice audit
 - Runtime code changed: yes
 - Secrets inspected or printed: no
+
+## Task 26 Slice Dynamic Pricing Evidence
+
+Execution mode:
+
+- selected mode: `gate_known_root_cause`, continued as narrow override
+- reason: mounted dynamic pricing endpoint leaked raw exception text through public HTTP error details
+- risky domain: yes, billing/pricing-adjacent workflow
+- root cause known: yes
+- command: `python scripts\agent_gate.py "Task 26 sanitize mounted dynamic pricing endpoint raw public exception leakage without changing pricing route contracts roles domain behavior or success payloads" --known-root-cause "backend/app/api/v1/endpoints/dynamic_pricing.py"`
+
+Gate result:
+
+- The gate returned frontend routing files alongside the confirmed backend root-cause file.
+- Per `AGENTS.md`, execution stayed narrowed to `backend/app/api/v1/endpoints/dynamic_pricing.py` plus this recovery log.
+
+Changed behavior:
+
+- Replaced raw public HTTP 500 details that included exception text with generic `Internal server error`.
+- Replaced remaining raw public HTTP 400 `str(e)` details with generic `Invalid dynamic pricing request`.
+- Added structured endpoint logging with action name plus exception class only.
+- Preserved route paths, auth dependencies, status-code classes, success payload shapes, and service/repository behavior.
+- Applied mechanical pyupgrade annotation fixes in the same file because the required `ruff check` failed on existing `typing.List`/`Optional`/`Dict` usage after the endpoint file was selected for validation.
+
+Validation run:
+
+- `python -m py_compile backend\app\api\v1\endpoints\dynamic_pricing.py`
+  - result: passed
+- `python -m ruff check backend\app\api\v1\endpoints\dynamic_pricing.py`
+  - result: passed after same-file mechanical annotation fixes
+- `python -m black --check backend\app\api\v1\endpoints\dynamic_pricing.py`
+  - result: passed
+- static leakage scan for raw exception details/logging in the file
+  - result: no matches
+- direct endpoint smoke with marker exception
+  - result: passed; HTTP 400 returned `Invalid dynamic pricing request`, HTTP 500 returned `Internal server error`, and marker text did not leak to response or logs
+- `python -m pytest backend\tests\integration\test_dynamic_pricing_api.py backend\tests\unit\test_dynamic_pricing_api_service.py backend\tests\unit\test_service_repository_boundary.py -q --tb=short --disable-warnings`
+  - result: 57 passed, 1 warning
+- `npm.cmd --prefix frontend run build`
+  - result: passed with existing Vite dynamic/static import and large chunk warnings
+
+Scope note:
+
+- Task 26 remains open. This slice only hardens the mounted dynamic pricing endpoint and does not claim all backend runtime leakage is gone.
 
 ## Task 26 Slice Queue Limits Evidence
 

--- a/backend/app/api/v1/endpoints/dynamic_pricing.py
+++ b/backend/app/api/v1/endpoints/dynamic_pricing.py
@@ -2,10 +2,11 @@
 API endpoints для динамического ценообразования и пакетных услуг
 """
 
+import logging
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, NoReturn
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
@@ -19,107 +20,135 @@ from app.services.dynamic_pricing_api_service import (
 
 router = APIRouter()
 
+logger = logging.getLogger(__name__)
+
+
+def _raise_dynamic_pricing_internal_error(action: str, exc: Exception) -> NoReturn:
+    if isinstance(exc, HTTPException):
+        raise exc
+    logger.error(
+        "Dynamic pricing endpoint failed action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Internal server error",
+    ) from exc
+
+
+def _raise_dynamic_pricing_bad_request(action: str, exc: Exception) -> NoReturn:
+    logger.warning(
+        "Dynamic pricing request rejected action=%s error_type=%s",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Invalid dynamic pricing request",
+    ) from exc
+
 
 # === Pydantic схемы ===
 
 
 class PricingRuleCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
-    description: Optional[str] = None
+    description: str | None = None
     rule_type: PricingRuleType
     discount_type: DiscountType
     discount_value: float = Field(..., gt=0)
-    start_date: Optional[datetime] = None
-    end_date: Optional[datetime] = None
-    start_time: Optional[str] = Field(
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    start_time: str | None = Field(
         None, pattern=r"^([01]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
     )
-    end_time: Optional[str] = Field(
+    end_time: str | None = Field(
         None, pattern=r"^([01]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
     )
-    days_of_week: Optional[str] = Field(None, pattern=r"^[1-7](,[1-7])*$")
+    days_of_week: str | None = Field(None, pattern=r"^[1-7](,[1-7])*$")
     min_quantity: int = Field(1, ge=1)
-    max_quantity: Optional[int] = Field(None, ge=1)
-    min_amount: Optional[float] = Field(None, ge=0)
+    max_quantity: int | None = Field(None, ge=1)
+    min_amount: float | None = Field(None, ge=0)
     priority: int = Field(0, ge=0)
-    max_uses: Optional[int] = Field(None, ge=1)
-    service_ids: List[int] = Field(..., min_length=1)
+    max_uses: int | None = Field(None, ge=1)
+    service_ids: list[int] = Field(..., min_length=1)
 
 
 class PricingRuleUpdate(BaseModel):
-    name: Optional[str] = Field(None, min_length=1, max_length=255)
-    description: Optional[str] = None
-    is_active: Optional[bool] = None
-    discount_value: Optional[float] = Field(None, gt=0)
-    start_date: Optional[datetime] = None
-    end_date: Optional[datetime] = None
-    start_time: Optional[str] = Field(
+    name: str | None = Field(None, min_length=1, max_length=255)
+    description: str | None = None
+    is_active: bool | None = None
+    discount_value: float | None = Field(None, gt=0)
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    start_time: str | None = Field(
         None, pattern=r"^([01]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
     )
-    end_time: Optional[str] = Field(
+    end_time: str | None = Field(
         None, pattern=r"^([01]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
     )
-    days_of_week: Optional[str] = Field(None, pattern=r"^[1-7](,[1-7])*$")
-    min_quantity: Optional[int] = Field(None, ge=1)
-    max_quantity: Optional[int] = Field(None, ge=1)
-    min_amount: Optional[float] = Field(None, ge=0)
-    priority: Optional[int] = Field(None, ge=0)
-    max_uses: Optional[int] = Field(None, ge=1)
+    days_of_week: str | None = Field(None, pattern=r"^[1-7](,[1-7])*$")
+    min_quantity: int | None = Field(None, ge=1)
+    max_quantity: int | None = Field(None, ge=1)
+    min_amount: float | None = Field(None, ge=0)
+    priority: int | None = Field(None, ge=0)
+    max_uses: int | None = Field(None, ge=1)
 
 
 class ServicePackageCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
-    description: Optional[str] = None
-    service_ids: List[int] = Field(..., min_length=2)
+    description: str | None = None
+    service_ids: list[int] = Field(..., min_length=2)
     package_price: float = Field(..., gt=0)
-    valid_from: Optional[datetime] = None
-    valid_to: Optional[datetime] = None
-    max_purchases: Optional[int] = Field(None, ge=1)
-    per_patient_limit: Optional[int] = Field(None, ge=1)
+    valid_from: datetime | None = None
+    valid_to: datetime | None = None
+    max_purchases: int | None = Field(None, ge=1)
+    per_patient_limit: int | None = Field(None, ge=1)
 
 
 class ServicePackageUpdate(BaseModel):
-    name: Optional[str] = Field(None, min_length=1, max_length=255)
-    description: Optional[str] = None
-    is_active: Optional[bool] = None
-    package_price: Optional[float] = Field(None, gt=0)
-    valid_from: Optional[datetime] = None
-    valid_to: Optional[datetime] = None
-    max_purchases: Optional[int] = Field(None, ge=1)
-    per_patient_limit: Optional[int] = Field(None, ge=1)
+    name: str | None = Field(None, min_length=1, max_length=255)
+    description: str | None = None
+    is_active: bool | None = None
+    package_price: float | None = Field(None, gt=0)
+    valid_from: datetime | None = None
+    valid_to: datetime | None = None
+    max_purchases: int | None = Field(None, ge=1)
+    per_patient_limit: int | None = Field(None, ge=1)
 
 
 class PriceCalculationRequest(BaseModel):
-    services: List[Dict[str, Any]] = Field(..., min_length=1)
-    patient_id: Optional[int] = None
-    appointment_time: Optional[datetime] = None
+    services: list[dict[str, Any]] = Field(..., min_length=1)
+    patient_id: int | None = None
+    appointment_time: datetime | None = None
 
 
 class PackagePurchaseRequest(BaseModel):
     package_id: int
     patient_id: int
-    visit_id: Optional[int] = None
-    appointment_id: Optional[int] = None
+    visit_id: int | None = None
+    appointment_id: int | None = None
 
 
 class PricingRuleResponse(BaseModel):
     id: int
     name: str
-    description: Optional[str]
+    description: str | None
     rule_type: str
     discount_type: str
     discount_value: float
     is_active: bool
-    start_date: Optional[datetime]
-    end_date: Optional[datetime]
-    start_time: Optional[str]
-    end_time: Optional[str]
-    days_of_week: Optional[str]
+    start_date: datetime | None
+    end_date: datetime | None
+    start_time: str | None
+    end_time: str | None
+    days_of_week: str | None
     min_quantity: int
-    max_quantity: Optional[int]
-    min_amount: Optional[float]
+    max_quantity: int | None
+    min_amount: float | None
     priority: int
-    max_uses: Optional[int]
+    max_uses: int | None
     current_uses: int
     created_at: datetime
 
@@ -129,17 +158,17 @@ class PricingRuleResponse(BaseModel):
 class ServicePackageResponse(BaseModel):
     id: int
     name: str
-    description: Optional[str]
+    description: str | None
     is_active: bool
     package_price: float
-    original_price: Optional[float]
-    savings_amount: Optional[float]
-    savings_percentage: Optional[float]
-    valid_from: Optional[datetime]
-    valid_to: Optional[datetime]
-    max_purchases: Optional[int]
+    original_price: float | None
+    savings_amount: float | None
+    savings_percentage: float | None
+    valid_from: datetime | None
+    valid_to: datetime | None
+    max_purchases: int | None
     current_purchases: int
-    per_patient_limit: Optional[int]
+    per_patient_limit: int | None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
@@ -169,15 +198,15 @@ def create_pricing_rule(
         )
     except Exception as e:
         service.rollback()
-        raise HTTPException(status_code=400, detail=str(e))
+        _raise_dynamic_pricing_bad_request("create_pricing_rule", e)
 
 
-@router.get("/pricing-rules", response_model=List[PricingRuleResponse])
+@router.get("/pricing-rules", response_model=list[PricingRuleResponse])
 def get_pricing_rules(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    rule_type: Optional[PricingRuleType] = None,
-    is_active: Optional[bool] = None,
+    rule_type: PricingRuleType | None = None,
+    is_active: bool | None = None,
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.get_current_user),
 ):
@@ -221,7 +250,7 @@ def update_pricing_rule(
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except Exception as e:
         service.rollback()
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_dynamic_pricing_internal_error("update_pricing_rule", e)
 
 
 @router.delete("/pricing-rules/{rule_id}")
@@ -238,7 +267,7 @@ def delete_pricing_rule(
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except Exception as e:
         service.rollback()
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_dynamic_pricing_internal_error("delete_pricing_rule", e)
 
 
 @router.post("/calculate-price")
@@ -256,7 +285,7 @@ def calculate_price(
             appointment_time=request.appointment_time,
         )
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        _raise_dynamic_pricing_bad_request("calculate_price", e)
 
 
 @router.post("/service-packages", response_model=ServicePackageResponse)
@@ -274,15 +303,15 @@ def create_service_package(
         )
     except Exception as e:
         service.rollback()
-        raise HTTPException(status_code=400, detail=str(e))
+        _raise_dynamic_pricing_bad_request("create_service_package", e)
 
 
-@router.get("/service-packages", response_model=List[ServicePackageResponse])
+@router.get("/service-packages", response_model=list[ServicePackageResponse])
 def get_service_packages(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    is_active: Optional[bool] = None,
-    patient_id: Optional[int] = None,
+    is_active: bool | None = None,
+    patient_id: int | None = None,
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.get_current_user),
 ):
@@ -326,7 +355,7 @@ def update_service_package(
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except Exception as e:
         service.rollback()
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_dynamic_pricing_internal_error("update_service_package", e)
 
 
 @router.delete("/service-packages/{package_id}")
@@ -343,7 +372,7 @@ def delete_service_package(
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except Exception as e:
         service.rollback()
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_dynamic_pricing_internal_error("delete_service_package", e)
 
 
 @router.post("/purchase-package")
@@ -372,9 +401,9 @@ def purchase_package(
             "expires_at": purchase.expires_at,
         }
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        _raise_dynamic_pricing_bad_request("purchase_package_validation", e)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_dynamic_pricing_internal_error("purchase_package", e)
 
 
 @router.post("/update-dynamic-prices")
@@ -387,13 +416,13 @@ def update_dynamic_prices(
     try:
         return service.update_dynamic_prices()
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_dynamic_pricing_internal_error("update_dynamic_prices", e)
 
 
 @router.get("/pricing-analytics")
 def get_pricing_analytics(
-    start_date: Optional[datetime] = Query(None),
-    end_date: Optional[datetime] = Query(None),
+    start_date: datetime | None = Query(None),
+    end_date: datetime | None = Query(None),
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.get_current_user),
 ):
@@ -402,7 +431,7 @@ def get_pricing_analytics(
     try:
         return service.get_pricing_analytics(start_date=start_date, end_date=end_date)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_dynamic_pricing_internal_error("get_pricing_analytics", e)
 
 
 @router.get("/price-history/{service_id}")


### PR DESCRIPTION
﻿## Summary

- Hide raw exception details from dynamic pricing public error responses.
- Keep dynamic-pricing route paths, request payloads, success payloads, auth dependency, and service/repository calls unchanged.
- Record Task 26 dynamic-pricing evidence in the AI Factory recovery log.

## Contract Impact

- Canonical surface: existing `/api/v1/dynamic-pricing/*` routes in `backend/app/api/v1/endpoints/dynamic_pricing.py`.
- Request shape: unchanged for all touched routes.
- Response shape: success payloads unchanged; unexpected 500 responses now return `detail="Internal server error"`; selected legacy 400 catch-all responses now return `detail="Invalid dynamic pricing request"` instead of raw exception text.
- Status codes: domain `DynamicPricingApiDomainError` status codes are preserved; existing legacy 400 catch-all handlers remain HTTP 400; unexpected exceptions remain HTTP 500.
- Frontend consumer: no frontend code changed; callers still receive the same success contracts and status-code classes.
- Compatibility path or alias: no route paths, prefixes, aliases, or compatibility redirects changed.
- Contract proof: py_compile, full ruff, black, raw-detail scan, marker endpoint smoke, targeted dynamic-pricing pytest, and frontend build passed locally.

## RBAC / Permissions

- Roles allowed: unchanged; existing `deps.get_current_user` dependency stays in place.
- Roles denied: unchanged; no auth dependency or permission rule changed.
- Positive auth proof: source diff preserves existing `deps.get_current_user` dependencies and targeted integration test login path passed.
- Negative auth proof: no public route was added, no dependency was weakened, and protected route behavior remains owned by unchanged auth dependencies.

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR does not touch notification, websocket, chat, or realtime code.
- Payload version / ack behavior: not applicable because no realtime payload changed.
- Read/unread or delivery semantics: not applicable because no delivery state or notification storage changed.
- Reconnect/resync proof: not applicable because no websocket reconnect or resync path changed.

## Frontend Resilience

- Empty data proof: not applicable because no frontend rendering path changed.
- Partial data proof: not applicable because no frontend data mapping changed.
- Forbidden secondary path behavior: unchanged; auth dependency and route registration were not edited.
- Missing draft/resource behavior: not applicable because dynamic pricing package purchase does not create draft resources in this endpoint slice.
- Stale route/deep-link behavior: not applicable because no route or deep-link handling changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/dynamic_pricing.py` and `.ai-factory/logs/RECOVERY_IMPLEMENTATION_STATUS.md`.
- Denied paths: pricing services, repositories, frontend source, ops, migrations, generated output, and deployment configs.
- Migration/docs/test impact: no migrations or test source changes; recovery log updated with validation evidence.
- Rollback note: revert commit `ac4d0f4a` to restore previous public exception details and recovery-log state.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/dynamic_pricing.py`; `python -m ruff check backend/app/api/v1/endpoints/dynamic_pricing.py`; `python -m black --check backend/app/api/v1/endpoints/dynamic_pricing.py`; raw-detail `rg` scan; marker endpoint smoke; `python -m pytest backend/tests/integration/test_dynamic_pricing_api.py backend/tests/unit/test_dynamic_pricing_api_service.py backend/tests/unit/test_service_repository_boundary.py -q --tb=short --disable-warnings`; `npm.cmd --prefix frontend run build`.
- Result: passed locally; targeted pytest result `57 passed, 1 warning`; frontend build passed with existing Vite dynamic/static import and large chunk warnings.
- Not checked: full backend suite, full frontend unit suite, and browser role smoke.
