### PR TITLE
fix(security): hide registrar integration error details

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -122,6 +122,21 @@ def _resolve_payment_truth(
 
     return ("paid", None) if legacy_paid_at else ("pending", None)
 
+
+def _raise_registrar_internal_error(action: str, exc: Exception) -> None:
+    if isinstance(exc, HTTPException):
+        raise exc
+
+    logger.exception(
+        "registrar_integration: unexpected error during %s (%s)",
+        action,
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Internal server error",
+    )
+
 # ===================== ОТДЕЛЕНИЯ ДЛЯ РЕГИСТРАТУРЫ =====================
 
 
@@ -478,7 +493,7 @@ def create_queue_profile(
     except Exception as e:
         logger.error(f"Error creating queue profile: {e}")
         db.rollback()
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_registrar_internal_error("create queue profile", e)
 
 
 @router.put("/queues/profiles/{profile_key}")
@@ -533,7 +548,7 @@ def update_queue_profile(
     except Exception as e:
         logger.error(f"Error updating queue profile: {e}")
         db.rollback()
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_registrar_internal_error("update queue profile", e)
 
 
 @router.delete("/queues/profiles/{profile_key}")
@@ -570,7 +585,7 @@ def delete_queue_profile(
     except Exception as e:
         logger.error(f"Error deleting queue profile: {e}")
         db.rollback()
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_registrar_internal_error("delete queue profile", e)
 
 
 @router.post("/queues/profiles/reorder")
@@ -606,7 +621,7 @@ def reorder_queue_profiles(
     except Exception as e:
         logger.error(f"Error reordering queue profiles: {e}")
         db.rollback()
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_registrar_internal_error("reorder queue profiles", e)
 
 
 # ===================== СПРАВОЧНИК УСЛУГ (СТАРЫЙ) =====================


### PR DESCRIPTION
## Summary

- Hide raw unexpected exception details in active registrar queue-profile 500 responses.
- Preserve explicit `HTTPException` behavior for validation and 404/400 paths.
- Keep registrar service mirror and broader f-string cleanup out of this narrow slice.

## Contract Impact

- Canonical surface: active registrar integration router queue-profile mutation endpoints: `POST /api/v1/queues/profiles`, `PUT /api/v1/queues/profiles/{profile_key}`, `DELETE /api/v1/queues/profiles/{profile_key}`, `POST /api/v1/queues/profiles/reorder`.
- Request shape: unchanged authenticated requests and request bodies.
- Response shape: success payloads unchanged; unexpected internal 500 detail is now the stable string `Internal server error` instead of raw exception text.
- Status codes: explicit 400/404 behavior unchanged; unexpected failures remain 500.
- Frontend consumer: existing queue-profile/registrar consumers; no frontend files changed.
- Compatibility path or alias: no route alias or compatibility path changed.
- Contract proof: active router compiles, targeted registrar tests pass, and raw `status_code=500, detail=str(e)` scan has no matches in the active router.

## RBAC / Permissions

- Roles allowed: unchanged Admin-only guards on queue-profile mutation endpoints via existing `require_roles(Admin)`.
- Roles denied: unchanged non-Admin behavior; this patch does not alter dependencies or role checks.
- Positive auth proof: diff confirms existing `require_roles(Admin)` guards remain on touched handlers, and targeted registrar import/contract tests passed.
- Negative auth proof: not re-smoked with live tokens because auth code was not touched; denied-role behavior remains owned by the unchanged dependency.

## Notification / Realtime

- Event type or websocket channel: not applicable - this patch does not touch notifications, websocket channels, or realtime events.
- Payload version / ack behavior: not applicable - no event payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read state changed.
- Reconnect/resync proof: not applicable - no realtime reconnect or resync path changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path or empty-state handling changed.
- Partial data proof: not applicable - no frontend data mapping or optional field handling changed.
- Forbidden secondary path behavior: not applicable - no secondary frontend path was touched.
- Missing draft/resource behavior: not applicable - no draft or resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/registrar_integration.py` active router only.
- Denied paths: `backend/app/services/registrar_integration_api_service.py`, broader f-string cleanup, frontend, ops, migrations, generated artifacts, and LightRAG evidence logs.
- Migration/docs/test impact: no migration; no docs file change; targeted tests run against registrar serialization, appointments, service grouping, and service boundary.
- Rollback note: revert this single commit to restore previous raw 500 detail behavior for the four queue-profile handlers.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\registrar_integration.py`; `git diff --check`; `rg -n 'status_code=500, detail=str\(e\)' backend\app\api\v1\endpoints\registrar_integration.py`; `pytest backend\tests\unit\test_registrar_time_serialization.py backend\tests\integration\test_registrar_all_appointments.py backend\tests\integration\test_registrar_services_grouping.py backend\tests\unit\test_service_repository_boundary.py -q`.
- Result: compile passed; diff check passed; raw 500 detail scan returned no matches for the active router; targeted pytest passed with 59 passed and 1 warning.
- Not checked: full backend suite, frontend suite, browser smoke, and full `ruff --select I,F401`; the touched file has pre-existing import-order/unused-import findings outside this patch.