### PR TITLE
agents: add clinic frontend design skill

### DIFF
--- a/.agents/skills/clinic-frontend-design/SKILL.md
+++ b/.agents/skills/clinic-frontend-design/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: clinic-frontend-design
+description: Clinic-safe frontend UI/UX audit, planning, and improvement workflow for this medical management app. Use when working on Admin, Doctor, Registrar, Cashier, Lab, dashboard, form, table, route-view, empty/loading/error, accessibility, responsive, visual consistency, or design-system tasks in the clinic frontend.
+---
+
+# Clinic Frontend Design
+
+Use this skill for clinic frontend UI/UX work where polish must not reduce clinical usability. This is an operations system for medical staff, not a marketing site.
+
+## First Read
+
+Before advising, planning, or editing, inspect the relevant current source and the smallest useful set of project rules:
+
+- `AGENTS.md`
+- `.cursorrules`
+- `frontend/DESIGN_SYSTEM.md`
+- `frontend/THEME_SYSTEM_GUIDE.md`
+- `frontend/src/routing/routeRegistry.js` when routes or panels are involved
+- the specific role panel, component, hook, state, style, and test files for the requested screen
+- `ARCHITECTURE_RULES.md` only if it exists
+
+Prefer executable source and tests over broad historical docs when they disagree.
+
+## Priorities
+
+- Medical readability, speed, accessibility, predictable workflows, role clarity, and low cognitive load come before visual novelty.
+- Reuse existing design tokens, CSS variables, components, routing, state, and macOS-style patterns.
+- Keep Admin, Doctor, Registrar, Cashier, and Lab workflows distinct and easy to scan.
+- Improve empty, loading, error, disabled, partial-data, and forbidden states when they are part of the touched workflow.
+- Use small safe UI slices. Audit first when a flow affects auth, roles, routing, queue, payment, EMR, lab, or production-sensitive behavior.
+
+## Avoid
+
+- Do not apply a generic or unmodified `frontend-design` aesthetic.
+- Do not make marketing/landing-page layouts for operational clinic screens.
+- Do not add unusual fonts, aggressive motion, chaotic layouts, decorative complexity, gradient-orb decoration, or clever interactions that slow staff down.
+- Do not create a parallel UI framework, duplicate design tokens, or one-off styling systems.
+- Do not change backend contracts, route semantics, RBAC, queue behavior, payment behavior, EMR behavior, or lab behavior as part of a visual cleanup.
+
+## Workflow
+
+1. Identify the role, screen, workflow, user action, and risk level.
+2. Inspect current implementation and design-system anchors before suggesting changes.
+3. Diagnose concrete UI/UX issues: hierarchy, density, spacing, states, accessibility, responsiveness, workflow friction, and visual inconsistency.
+4. Propose the smallest safe improvement slice using existing components/tokens first.
+5. If implementing, touch only the approved UI slice and preserve existing contracts.
+6. Validate with the narrowest relevant checks: frontend lint/test/build, role-specific tests, browser or Playwright smoke, and visual verification when available.
+
+## Output
+
+For audits or plans, include:
+
+- UI/UX diagnosis
+- files inspected
+- safe design direction
+- exact implementation slice
+- validation commands
+- risks and stop conditions
+
+For implementation, include:
+
+- changed files
+- why the slice is safe
+- validation run and result
+- remaining risks

--- a/.agents/skills/clinic-frontend-design/agents/openai.yaml
+++ b/.agents/skills/clinic-frontend-design/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Clinic Frontend Design"
+  short_description: "Clinic-safe UI/UX audit workflow"
+  default_prompt: "Use $clinic-frontend-design to audit or improve this clinic frontend UI safely."
+
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
﻿## Summary

- Add a repo-owned Codex skill named `clinic-frontend-design` under `.agents/skills`.
- Configure Codex App metadata with `interface.*` fields and implicit invocation enabled.
- Keep Superpowers as a manual Codex plugin/workflow guard and do not vendor it into this repository.

## Contract Impact

not applicable - agent skill metadata only; no API, websocket, event, request/response, status code, frontend route, or runtime contract changed.

## RBAC / Permissions

- Roles allowed: not applicable - no application route, endpoint, auth helper, or role permission mapping changed.
- Roles denied: not applicable - no application authorization decision changed.
- Positive auth proof: the new skill instructs agents to inspect role workflows before risky UI changes.
- Negative auth proof: no backend, frontend runtime, routing, RBAC, auth, queue, payment, EMR, or lab code changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime, delivery, ack, read/unread, or reconnect behavior changed.

## Frontend Resilience

not applicable - no user-facing frontend component changed. The skill adds guidance to audit empty/loading/error/forbidden/partial-data states before future UI edits.

## Scope Gate

- Allowed paths: `.agents/skills/clinic-frontend-design/SKILL.md`, `.agents/skills/clinic-frontend-design/agents/openai.yaml`.
- Denied paths: runtime backend/frontend app code, migrations, deployment config, `.codex/skills`, `$HOME/.agents/skills`, Superpowers vendoring.
- Migration/docs/test impact: no migration; repo-level agent skill only.
- Rollback note: revert this PR to remove the clinic frontend design skill.

## Validation

- Targeted tests or smoke run: `SKILL.md` YAML frontmatter parse; `agents/openai.yaml` YAML parse and required field assertions; `rg "clinic-frontend-design" .agents`; `git diff --cached --check`; staged path review.
- Result: all local checks passed.
- Not checked: Codex restart/dry-run invocation and Superpowers plugin visibility, because those require interactive Codex UI/plugin setup outside repo code.
