### PR TITLE
fix(ui): add AI sidebar disclaimer

### DIFF
--- a/frontend/src/components/ui/macos/Sidebar.jsx
+++ b/frontend/src/components/ui/macos/Sidebar.jsx
@@ -119,6 +119,8 @@ const Sidebar = React.forwardRef(({
       <nav className="mac-sidebar-nav" style={navStyles}>
         {items.map((item) => {
           const isActive = activeItem === item.id;
+          const itemAriaLabel = item.ariaLabel || item.tooltip || item.label;
+          const itemTitle = item.tooltip || item.title || (isCollapsed ? item.label : undefined);
           const itemStyles = {
             display: 'flex',
             alignItems: 'center',
@@ -148,11 +150,11 @@ const Sidebar = React.forwardRef(({
           return (
             <button
               key={item.id}
-              aria-label={item.label}
+              aria-label={itemAriaLabel}
               className={`mac-sidebar-item ${isActive ? 'mac-sidebar-item--active' : ''}`}
               style={itemStyles}
               onClick={handleItemClick}
-              title={isCollapsed ? item.label : undefined}>
+              title={itemTitle}>
 
               {item.icon &&
               <Icon

--- a/frontend/src/routing/__tests__/routeContract.test.js
+++ b/frontend/src/routing/__tests__/routeContract.test.js
@@ -1,13 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { renderRouteDocsMarkdown } from '../routeDocsSnapshot.js';
 import { resolveSetupRedirect } from '../routeGuards.jsx';
-import { ROUTE_REGISTRY } from '../routeRegistry.js';
+import { ROUTE_REGISTRY, SIDEBAR_PRESETS } from '../routeRegistry.js';
 import {
   getCompatibilityRedirects,
   getInternalDemoRoutes,
   getLegacyRedirectTarget,
   getRoleHomeRoute,
   getRouteDocsSnapshot,
+  getRouteChromeState,
   isInternalDemoEnabled,
   isRouteAccessibleToProfile,
 } from '../routeSelectors.js';
@@ -23,6 +24,15 @@ const PRODUCTION_ROLE_HOMES = {
   dentist: '/doctor/dentistry',
   patient: '/patient',
 };
+
+const AI_SIDEBAR_BADGE = 'Черновик · не медицинское заключение';
+const AI_SIDEBAR_ACCESSIBLE_COPY = /черновик, не диагноз, не медицинское заключение/i;
+
+function assertAiSidebarDisclaimer(item) {
+  expect(item.badge).toBe(AI_SIDEBAR_BADGE);
+  expect(item.tooltip).toMatch(AI_SIDEBAR_ACCESSIBLE_COPY);
+  expect(item.ariaLabel).toMatch(AI_SIDEBAR_ACCESSIBLE_COPY);
+}
 
 describe('route contract invariants', () => {
   it('keeps route ids unique and canonical paths singular', () => {
@@ -93,6 +103,23 @@ describe('route contract invariants', () => {
     getCompatibilityRedirects().forEach((redirect) => {
       expect(canonicalPaths.has(redirect.aliasPath)).toBe(false);
     });
+  });
+
+  it('labels AI sidebar navigation as draft support, not a diagnosis', () => {
+    const presetAiItems = Object.values(SIDEBAR_PRESETS)
+      .flatMap((preset) => preset.items || [])
+      .filter((item) => item.id === 'ai' || item.id === 'ai-assistant');
+
+    expect(presetAiItems).toHaveLength(4);
+    presetAiItems.forEach(assertAiSidebarDisclaimer);
+
+    const adminAiRoute = ROUTE_REGISTRY.find((route) => route.id === 'admin-ai-settings');
+    assertAiSidebarDisclaimer(adminAiRoute.nav);
+
+    const adminChrome = getRouteChromeState('/admin/ai-settings', '', { role: 'Admin' });
+    const adminAiItem = adminChrome.sidebarItems.find((item) => item.id === 'admin-ai-settings');
+
+    assertAiSidebarDisclaimer(adminAiItem);
   });
 });
 

--- a/frontend/src/routing/routeRegistry.js
+++ b/frontend/src/routing/routeRegistry.js
@@ -22,6 +22,14 @@ export const ROLE_HOME_PRIORITY = [
   'patient',
 ];
 
+const AI_SIDEBAR_DISCLAIMER = 'Черновик · не медицинское заключение';
+const AI_SIDEBAR_ACCESSIBLE_LABEL = 'AI-помощник: черновик, не диагноз, не медицинское заключение';
+const AI_SIDEBAR_DISCLAIMER_META = {
+  badge: AI_SIDEBAR_DISCLAIMER,
+  tooltip: AI_SIDEBAR_ACCESSIBLE_LABEL,
+  ariaLabel: AI_SIDEBAR_ACCESSIBLE_LABEL,
+};
+
 export const SIDEBAR_PRESETS = {
   admin: {
     navigation: 'path',
@@ -55,7 +63,7 @@ export const SIDEBAR_PRESETS = {
       { id: 'dashboard', label: 'Обзор', icon: 'chart.bar' },
       { id: 'patients', label: 'Пациенты', icon: 'person.2' },
       { id: 'appointments', label: 'Записи', icon: 'calendar' },
-      { id: 'ai', label: 'AI-помощник', icon: 'brain' },
+      { id: 'ai', label: 'AI-помощник', icon: 'brain', ...AI_SIDEBAR_DISCLAIMER_META },
       { id: 'reports', label: 'Отчёты', icon: 'doc.text' },
     ],
   },
@@ -101,7 +109,7 @@ export const SIDEBAR_PRESETS = {
       { id: 'visit', label: 'Приём', icon: 'heart' },
       { id: 'ecg', label: 'ЭКГ', icon: 'waveform.path.ecg' },
       { id: 'blood', label: 'Анализы крови', icon: 'testtube.2' },
-      { id: 'ai', label: 'AI-помощник', icon: 'brain' },
+      { id: 'ai', label: 'AI-помощник', icon: 'brain', ...AI_SIDEBAR_DISCLAIMER_META },
       { id: 'services', label: 'Услуги', icon: 'stethoscope' },
       { id: 'history', label: 'История', icon: 'doc.text' },
     ],
@@ -118,7 +126,7 @@ export const SIDEBAR_PRESETS = {
       { id: 'photos', label: 'Фото', icon: 'camera' },
       { id: 'skin', label: 'Осмотр кожи', icon: 'eye' },
       { id: 'cosmetic', label: 'Косметология', icon: 'sparkles' },
-      { id: 'ai', label: 'AI-помощник', icon: 'brain' },
+      { id: 'ai', label: 'AI-помощник', icon: 'brain', ...AI_SIDEBAR_DISCLAIMER_META },
       { id: 'services', label: 'Услуги', icon: 'scissors' },
       { id: 'history', label: 'История', icon: 'doc.text' },
     ],
@@ -140,7 +148,7 @@ export const SIDEBAR_PRESETS = {
       { id: 'dental-chart', label: 'Зубная карта', icon: 'smile' },
       { id: 'treatment-plans', label: 'Планы лечения', icon: 'list' },
       { id: 'prosthetics', label: 'Протезирование', icon: 'smile' },
-      { id: 'ai-assistant', label: 'AI-помощник', icon: 'brain' },
+      { id: 'ai-assistant', label: 'AI-помощник', icon: 'brain', ...AI_SIDEBAR_DISCLAIMER_META },
     ],
   },
 };
@@ -729,7 +737,7 @@ export const ROUTE_REGISTRY = [
     auth: 'role-scoped',
     roles: ['Admin'],
     entry: 'direct',
-    nav: nav({ label: 'AI Инструменты', icon: 'brain', section: 'Система', order: 20, sidebar: true }),
+    nav: nav({ label: 'AI Инструменты', icon: 'brain', section: 'Система', order: 20, sidebar: true, ...AI_SIDEBAR_DISCLAIMER_META }),
     title: 'Admin AI Settings',
     owner: 'admin.ai',
     component: 'AdminPanel',

--- a/frontend/src/routing/routeSelectors.js
+++ b/frontend/src/routing/routeSelectors.js
@@ -184,6 +184,9 @@ export function getAdminNavSections(profile, options = {}) {
       to: route.path,
       label: route.nav?.label || route.title,
       icon: route.nav?.icon || 'circle',
+      badge: route.nav?.badge,
+      tooltip: route.nav?.tooltip,
+      ariaLabel: route.nav?.ariaLabel,
       route,
     };
 
@@ -233,6 +236,9 @@ export function getRouteChromeState(pathname, search = '', profile = null) {
       id: navRoute.id,
       label: navRoute.nav?.label || navRoute.title,
       icon: navRoute.nav?.icon || 'circle',
+      badge: navRoute.nav?.badge,
+      tooltip: navRoute.nav?.tooltip,
+      ariaLabel: navRoute.nav?.ariaLabel,
       to: navRoute.path,
     }));
   }
@@ -241,6 +247,9 @@ export function getRouteChromeState(pathname, search = '', profile = null) {
       id: navRoute.id,
       label: navRoute.nav?.label || navRoute.title,
       icon: navRoute.nav?.icon || 'circle',
+      badge: navRoute.nav?.badge,
+      tooltip: navRoute.nav?.tooltip,
+      ariaLabel: navRoute.nav?.ariaLabel,
       to: navRoute.path,
     }));
   }


### PR DESCRIPTION
## Summary

- Add AI sidebar disclaimer metadata to every AI-related sidebar/nav item found in the route registry.
- Pass disclaimer badge, tooltip, and aria label metadata through sidebar selectors.
- Teach the macOS sidebar to use item tooltip/aria label metadata without changing navigation behavior.

## Contract Impact

not applicable - no backend API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route guard, role helper, endpoint permission, role list, or auth business rule changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - sidebar items are static route metadata and do not depend on remote data.
- Partial data proof: Sidebar falls back to the existing item label when tooltip or aria label metadata is absent.
- Forbidden secondary path behavior: route access and guards are unchanged; only nav microcopy metadata is added.
- Missing draft/resource behavior: not applicable - AI sidebar nav does not create or reopen drafts/resources in this PR.
- Stale route/deep-link behavior: route paths, query tabs, and active item ids are unchanged.

## Scope Gate

- Allowed paths: frontend/src/routing/routeRegistry.js, frontend/src/routing/routeSelectors.js, frontend/src/components/ui/macos/Sidebar.jsx, frontend/src/routing/__tests__/routeContract.test.js.
- Denied paths: backend runtime code, EMR/AI business logic, route paths, route guards, role SSOT, payment/login/queue/landing/patient/lab/unrelated panels.
- Migration/docs/test impact: no migration or docs change; route contract test updated for AI sidebar disclaimer coverage.
- Rollback note: revert commit 12dca3a1 to remove the disclaimer metadata, selector passthrough, sidebar aria/title support, and test coverage.

## Validation

- Targeted tests or smoke run: `cd frontend && npm run test:run -- src/routing/__tests__/routeContract.test.js`; `cd frontend && npm run lint:check`; `cd frontend && npm run test:run`; `cd frontend && npm run build`; `git diff --check`.
- Result: passed locally before opening the PR.
- Not checked: manual browser sidebar smoke with a logged-in AI-enabled role.