### PR TITLE
fix(ui): repair payment cancel support action

### DIFF
--- a/frontend/src/pages/PaymentCancel.jsx
+++ b/frontend/src/pages/PaymentCancel.jsx
@@ -1,7 +1,10 @@
 
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Box, Card, CardContent, Typography, Button, Alert } from '../components/ui/macos';
-import { XCircle as CancelIcon, Home as HomeIcon, RefreshCw as RetryIcon, Headset as SupportIcon } from 'lucide-react';
+import { XCircle as CancelIcon, Home as HomeIcon, Headset as SupportIcon } from 'lucide-react';
+
+const SUPPORT_TELEGRAM_HANDLE = '@clinic_support';
+const SUPPORT_TELEGRAM_URL = 'https://t.me/clinic_support';
 
 const PaymentCancel = () => {
   const navigate = useNavigate();
@@ -12,18 +15,14 @@ const PaymentCancel = () => {
   const reason = searchParams.get('reason');
   const error = searchParams.get('error');
 
-  const handleRetryPayment = () => {
-    // Возвращаемся к оплате или на страницу с услугами
-    if (paymentId) {
-      navigate(`/payment/retry?payment_id=${paymentId}`);
-    } else {
-      navigate('/cashier');
-    }
+  const handleCashierPayment = () => {
+    // Возвращаемся в существующий кассовый маршрут без несуществующего retry-route.
+    navigate('/cashier');
   };
 
   const handleContactSupport = () => {
-    // Переход к контактам или открытие чата поддержки
-    navigate('/support');
+    // Открываем существующий официальный Telegram-канал поддержки из landing/contact copy.
+    window.location.assign(SUPPORT_TELEGRAM_URL);
   };
 
   const getReason = () => {
@@ -36,7 +35,7 @@ const PaymentCancel = () => {
       'provider_error': 'Ошибка платежной системы'
     };
 
-    return reasons[reason] || 'Платеж был отменен';
+    return reasons[reason] || 'Платеж был отменен или не подтвержден';
   };
 
   return (
@@ -46,7 +45,7 @@ const PaymentCancel = () => {
         <CardContent style={{ textAlign: 'center', padding: '32px 16px' }}>
           <CancelIcon style={{ fontSize: 80, color: 'var(--mac-warning)', marginBottom: 8 }} />
           <Typography variant="h4" color="warning" gutterBottom>
-            Платеж отменен
+            Платеж не завершен
           </Typography>
           <Typography variant="h6" color="textSecondary">
             {getReason()}
@@ -104,7 +103,7 @@ const PaymentCancel = () => {
               • Попробуйте использовать другой способ оплаты
             </Typography>
             <Typography variant="body1" paragraph>
-              • Обратитесь в службу поддержки при повторных ошибках
+              • Обратитесь в клинику через официальный канал поддержки при повторных ошибках
             </Typography>
           </Box>
         </CardContent>
@@ -117,10 +116,9 @@ const PaymentCancel = () => {
             Доступные действия
           </Typography>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 12, marginTop: 8 }}>
-            <Button onClick={handleRetryPayment}><RetryIcon style={{ marginRight: 8 }} />Повторить оплату</Button>
-            <Button variant="outline" onClick={handleContactSupport}><SupportIcon style={{ marginRight: 8 }} />Связаться с поддержкой</Button>
+            <Button onClick={handleCashierPayment}>К оплате в кассе</Button>
+            <Button variant="outline" onClick={handleContactSupport}><SupportIcon style={{ marginRight: 8 }} />Связаться в Telegram</Button>
             <Button variant="outline" onClick={() => navigate('/')}><HomeIcon style={{ marginRight: 8 }} />На главную</Button>
-            <Button variant="outline" onClick={() => navigate('/cashier')}>К оплате в кассе</Button>
           </div>
         </CardContent>
       </Card>
@@ -128,10 +126,10 @@ const PaymentCancel = () => {
       {/* Контактная информация */}
       <Box style={{ marginTop: 16, textAlign: 'center' }}>
         <Typography variant="body2" color="textSecondary" paragraph>
-          Служба поддержки: +998 (71) 123-45-67
+          Официальный канал поддержки: {SUPPORT_TELEGRAM_HANDLE}
         </Typography>
         <Typography variant="body2" color="textSecondary">
-          Email: support@clinic.uz
+          Контакты клиники также доступны на главной странице.
         </Typography>
       </Box>
     </Box>);


### PR DESCRIPTION
## Summary
- Replace PaymentCancel's broken /support navigation with the existing Telegram support channel.
- Remove the visible retry action that pointed at the unregistered /payment/retry route.
- Keep cancel-page query parameter rendering and payment semantics intact.

## Contract Impact
not applicable - no backend API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions
not applicable - no route guard, role helper, endpoint permission, role list, or auth business rule changed.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: missing payment_id still renders the cancel page with safe home/cashier/support actions.
- Partial data proof: optional payment_id and error details still render only when present.
- Forbidden secondary path behavior: /cashier remains an existing protected route and uses existing route guards.
- Missing draft/resource behavior: not applicable - the page does not create or mutate resources.
- Stale route/deep-link behavior: /payment/cancel keeps the same public callback route and query-param handling.

## Scope Gate
- Allowed paths: frontend/src/pages/PaymentCancel.jsx.
- Denied paths: backend runtime code, payment API/business logic, route architecture, PaymentSuccess, auth, login, queue, sidebar, landing content, patient, EMR, lab, unrelated pages.
- Migration/docs/test impact: no migration/docs/test changes; existing full frontend validation run.
- Rollback note: revert commit b42cb2fc to restore the prior PaymentCancel actions.

## Validation
- Targeted tests or smoke run: cd frontend && npm run lint:check; cd frontend && npm run test:run; cd frontend && npm run build; git diff --check.
- Result: passed locally before opening the PR.
- Not checked: manual browser smoke against a live payment cancel callback.