### PR TITLE
feat(ui): add shared app state primitives

### DIFF
--- a/frontend/src/components/ui/macos/AppState.jsx
+++ b/frontend/src/components/ui/macos/AppState.jsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import MacOSAlert from './MacOSAlert';
+import MacOSEmptyState from './MacOSEmptyState';
+
+const fontFamily = '-apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", system-ui, sans-serif';
+
+const loadingSizes = {
+  sm: { spinner: 20, padding: '24px', title: 'var(--mac-font-size-base)', gap: '10px' },
+  small: { spinner: 20, padding: '24px', title: 'var(--mac-font-size-base)', gap: '10px' },
+  md: { spinner: 28, padding: '32px', title: 'var(--mac-font-size-lg)', gap: '12px' },
+  medium: { spinner: 28, padding: '32px', title: 'var(--mac-font-size-lg)', gap: '12px' },
+  lg: { spinner: 40, padding: '48px', title: 'var(--mac-font-size-xl)', gap: '16px' },
+  large: { spinner: 40, padding: '48px', title: 'var(--mac-font-size-xl)', gap: '16px' }
+};
+
+const getLoadingSize = (size) => loadingSizes[size] || loadingSizes.md;
+
+const normalizeIcon = (icon) => {
+  if (!React.isValidElement(icon)) {
+    return icon;
+  }
+
+  return function AppEmptyIcon(props) {
+    return React.cloneElement(icon, {
+      ...props,
+      style: {
+        ...props.style,
+        ...icon.props.style
+      }
+    });
+  };
+};
+
+export const AppLoading = React.forwardRef(({
+  title = 'Загрузка…',
+  description,
+  size = 'md',
+  ariaLabel,
+  className = '',
+  style = {}
+}, ref) => {
+  const currentSize = getLoadingSize(size);
+
+  return (
+    <section
+      ref={ref}
+      className={`mac-app-loading ${className}`.trim()}
+      role="status"
+      aria-live="polite"
+      aria-label={ariaLabel || title}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: currentSize.gap,
+        minHeight: '160px',
+        padding: currentSize.padding,
+        color: 'var(--mac-text-primary)',
+        textAlign: 'center',
+        fontFamily,
+        ...style
+      }}
+    >
+      <svg
+        aria-hidden="true"
+        className="mac-app-loading-spinner"
+        width={currentSize.spinner}
+        height={currentSize.spinner}
+        viewBox="0 0 24 24"
+        fill="none"
+        style={{
+          color: 'var(--mac-accent-blue)',
+          animation: 'mac-app-loading-spin 0.9s linear infinite'
+        }}
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="9"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeDasharray="18 18"
+          strokeLinecap="round"
+          opacity="0.9"
+        />
+      </svg>
+
+      <div>
+        <h3
+          style={{
+            margin: 0,
+            fontSize: currentSize.title,
+            fontWeight: 'var(--mac-font-weight-semibold)',
+            lineHeight: 1.3
+          }}
+        >
+          {title}
+        </h3>
+
+        {description && (
+          <p
+            style={{
+              margin: '6px 0 0',
+              maxWidth: 420,
+              color: 'var(--mac-text-secondary)',
+              fontSize: 'var(--mac-font-size-base)',
+              lineHeight: 1.5
+            }}
+          >
+            {description}
+          </p>
+        )}
+      </div>
+
+      <style>{`
+        @keyframes mac-app-loading-spin {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .mac-app-loading-spinner {
+            animation: none !important;
+          }
+        }
+      `}</style>
+    </section>
+  );
+});
+
+AppLoading.displayName = 'AppLoading';
+
+export const AppEmpty = React.forwardRef(({
+  title = 'Нет данных',
+  description = 'Здесь пока нет данных для отображения.',
+  action,
+  icon,
+  className = '',
+  style = {}
+}, ref) => (
+  <section
+    ref={ref}
+    className={`mac-app-empty ${className}`.trim()}
+    aria-label={title}
+    style={style}
+  >
+    <MacOSEmptyState
+      title={title}
+      description={description}
+      action={action}
+      icon={normalizeIcon(icon)}
+      variant="minimal"
+    />
+  </section>
+));
+
+AppEmpty.displayName = 'AppEmpty';
+
+export const AppError = React.forwardRef(({
+  title = 'Не удалось загрузить данные',
+  description = 'Проверьте соединение и попробуйте еще раз.',
+  action,
+  severity = 'error',
+  className = '',
+  style = {}
+}, ref) => (
+  <section
+    ref={ref}
+    className={`mac-app-error ${className}`.trim()}
+    style={style}
+  >
+    <MacOSAlert
+      type={severity}
+      title={title}
+      description={description}
+      action={action}
+    />
+  </section>
+));
+
+AppError.displayName = 'AppError';
+
+AppLoading.propTypes = {
+  ariaLabel: PropTypes.string,
+  className: PropTypes.string,
+  description: PropTypes.node,
+  size: PropTypes.oneOf(['sm', 'small', 'md', 'medium', 'lg', 'large']),
+  style: PropTypes.object,
+  title: PropTypes.node
+};
+
+AppEmpty.propTypes = {
+  action: PropTypes.node,
+  className: PropTypes.string,
+  description: PropTypes.node,
+  icon: PropTypes.oneOfType([PropTypes.elementType, PropTypes.node]),
+  style: PropTypes.object,
+  title: PropTypes.string
+};
+
+AppError.propTypes = {
+  action: PropTypes.node,
+  className: PropTypes.string,
+  description: PropTypes.node,
+  severity: PropTypes.oneOf(['info', 'success', 'warning', 'error']),
+  style: PropTypes.object,
+  title: PropTypes.node
+};

--- a/frontend/src/components/ui/macos/__tests__/AppState.test.jsx
+++ b/frontend/src/components/ui/macos/__tests__/AppState.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { AppEmpty, AppError, AppLoading } from '../index';
+
+describe('AppState primitives', () => {
+  it('renders AppLoading as an accessible loading status', () => {
+    render(<AppLoading description="Пожалуйста, подождите" />);
+
+    expect(screen.getByRole('status', { name: /загрузка/i })).toBeInTheDocument();
+    expect(screen.getByText('Пожалуйста, подождите')).toBeInTheDocument();
+  });
+
+  it('renders AppEmpty with neutral copy and an optional action', () => {
+    render(
+      <AppEmpty
+        title="Нет записей"
+        description="Данные появятся после загрузки."
+        action={<button type="button">Обновить</button>}
+      />,
+    );
+
+    expect(screen.getByLabelText('Нет записей')).toBeInTheDocument();
+    expect(screen.getByText('Данные появятся после загрузки.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Обновить' })).toBeInTheDocument();
+  });
+
+  it('renders AppError as a calm operational alert', () => {
+    render(
+      <AppError
+        description="Проверьте соединение."
+        action={<button type="button">Повторить</button>}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Не удалось загрузить данные');
+    expect(screen.getByRole('alert')).toHaveTextContent('Проверьте соединение.');
+    expect(screen.getByRole('button', { name: 'Повторить' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/macos/index.js
+++ b/frontend/src/components/ui/macos/index.js
@@ -25,6 +25,7 @@ export { default as MacOSMetricCard } from './MacOSMetricCard';
 export { default as MacOSList } from './MacOSList';
 
 // Utility Components
+export { AppLoading, AppEmpty, AppError } from './AppState';
 export { default as MacOSEmptyState } from './MacOSEmptyState';
 export { default as MacOSLoadingSkeleton } from './MacOSLoadingSkeleton';
 export { default as MacOSAlert } from './MacOSAlert';


### PR DESCRIPTION
﻿## Summary
- Add canonical macOS `AppLoading`, `AppEmpty`, and `AppError` primitives under `frontend/src/components/ui/macos`.
- Export the primitives from the macOS UI index for future clinic UI slices.
- Add focused component tests for accessible loading, empty, and error states without migrating runtime panels.
- Review note: this PR intentionally proves the primitives only at component/export level.

## Contract Impact
not applicable - this PR adds frontend UI primitives only; no backend API, websocket, event, data model, queue/payment/auth contract, or runtime consumer contract changes.

## RBAC / Permissions
not applicable - no route guard, role helper, endpoint permission, role list, auth flow, or access decision changed.

## Notification / Realtime
not applicable - no notification, websocket, chat, realtime subscription, or event dispatch behavior changed.

## Frontend Resilience
- Empty data proof: `AppEmpty` provides neutral default empty-state copy and supports optional action/icon for future empty panels.
- Partial data proof: not applicable - no data fetching UI was migrated in this PR.
- Error proof: `AppError` wraps the existing macOS alert pattern with calm default operational copy and optional action.
- Loading proof: `AppLoading` renders an accessible `role="status"` loading region with reduced-motion support.
- Forbidden secondary path behavior: not applicable - no routes, links, or guards changed.
- Missing draft/resource behavior: not applicable - no draft/resource workflow changed.
- Stale route/deep-link behavior: not applicable - no routes changed.

## Scope Gate
- Allowed paths: `frontend/src/components/ui/macos/AppState.jsx`, `frontend/src/components/ui/macos/index.js`, `frontend/src/components/ui/macos/__tests__/AppState.test.jsx`.
- Denied paths: backend runtime code, packages/dependencies, routing, auth/RBAC, payment, queue, sidebar, login, landing, patient panel, EMR, lab, and runtime role panels.
- Migration/docs/test impact: adds primitives and focused tests only; no runtime page/panel migration in this PR.
- Rollback note: revert commit `2b999262` to remove the primitives, index export, and tests.

## Validation
- Targeted tests or smoke run: `git diff --check`; `npm.cmd run lint:check`; `npm.cmd run test:run`; `npm.cmd run build`.
- Result: passed locally before opening the PR. Lint reported 65 existing warnings and 0 errors.
- Not checked: browser smoke, because no runtime page consumes the primitives yet.
