### PR TITLE
refactor(ui): pilot shared app state primitive usage

### DIFF
--- a/frontend/src/pages/Health.jsx
+++ b/frontend/src/pages/Health.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { getApiBase } from '../api/client.js';
 import { getHealth, getActivationStatus } from '../api/index.js';
+import { AppEmpty, AppError, AppLoading } from '../components/ui/macos';
 import auth from '../stores/auth.js';
 
 export default function Health() {
@@ -83,19 +84,9 @@ export default function Health() {
       lineHeight: 1.5,
       maxHeight: '56vh',
     },
-    muted: {
-      color: 'var(--mac-text-secondary)',
-      fontSize: '14px',
-      lineHeight: 1.5,
-    },
-    alert: {
-      color: 'var(--mac-error, #b42318)',
-      background: 'color-mix(in srgb, var(--mac-error, #ff3b30), transparent 90%)',
-      border: '1px solid color-mix(in srgb, var(--mac-error, #ff3b30), transparent 60%)',
-      borderRadius: '12px',
-      padding: '12px',
-      marginBottom: '18px',
-      fontSize: '14px',
+    appState: {
+      minHeight: '120px',
+      padding: '16px',
     },
   };
 
@@ -108,23 +99,31 @@ export default function Health() {
         </div>
 
         {err && (
-          <div style={styles.alert} role="alert">
-            {err}
-          </div>
+          <AppError
+            title="Ошибка загрузки"
+            description={String(err)}
+            style={{ marginBottom: '18px' }}
+          />
         )}
 
         <section style={styles.section} aria-labelledby="health-status-title">
           <h2 id="health-status-title" style={styles.sectionTitle}>Health</h2>
           {loading ? (
-            <div style={styles.muted} role="status" aria-live="polite">Проверка состояния сервера...</div>
+            <AppLoading
+              title="Проверка состояния сервера..."
+              size="sm"
+              style={styles.appState}
+            />
           ) : health ? (
             <pre style={styles.pre}>
               {typeof health === 'string' ? health : JSON.stringify(health, null, 2)}
             </pre>
           ) : (
-            <div style={styles.muted}>
-              Спец-эндпоинт health не обнаружен в OpenAPI. Это нормально.
-            </div>
+            <AppEmpty
+              title="Health недоступен"
+              description="Спец-эндпоинт health не обнаружен в OpenAPI. Это нормально."
+              style={styles.appState}
+            />
           )}
         </section>
 
@@ -132,15 +131,21 @@ export default function Health() {
           <section style={styles.section} aria-labelledby="activation-status-title">
             <h2 id="activation-status-title" style={styles.sectionTitle}>Статус активации</h2>
             {loading ? (
-              <div style={styles.muted} role="status" aria-live="polite">Загрузка статуса...</div>
+              <AppLoading
+                title="Загрузка статуса..."
+                size="sm"
+                style={styles.appState}
+              />
             ) : act ? (
               <pre style={styles.pre}>
                 {typeof act === 'string' ? act : JSON.stringify(act, null, 2)}
               </pre>
             ) : (
-              <div style={styles.muted}>
-                Эндпоинт статуса активации отсутствует в OpenAPI. Всё в порядке.
-              </div>
+              <AppEmpty
+                title="Статус активации недоступен"
+                description="Эндпоинт статуса активации отсутствует в OpenAPI. Всё в порядке."
+                style={styles.appState}
+              />
             )}
           </section>
         )}


### PR DESCRIPTION
﻿## Summary
- Migrate the low-risk `Health.jsx` system status page to the canonical macOS app-state primitives.
- Replace local loading status divs with `AppLoading`.
- Replace the local error alert with `AppError` and missing health/activation fallback messages with `AppEmpty`.

## Contract Impact
not applicable - this PR changes only frontend rendering for the health page states; no backend API, websocket, event, data model, payload, or route contract changed.

## RBAC / Permissions
not applicable - the existing admin-only activation status visibility is preserved; no route guard, role helper, endpoint permission, role list, auth flow, or access decision changed.

## Notification / Realtime
not applicable - no notification, websocket, chat, realtime subscription, or event dispatch behavior changed.

## Frontend Resilience
- Empty data proof: missing health and activation status responses now render through `AppEmpty` with the same operational meaning.
- Partial data proof: existing `health` and `act` branches are preserved independently; no fetch or condition logic changed.
- Error proof: API load errors still use the existing error text and now render through `AppError`.
- Loading proof: the health and activation loading states now render through `AppLoading`.
- Forbidden secondary path behavior: not applicable - no routes, links, or guards changed.
- Missing draft/resource behavior: not applicable - no draft/resource workflow changed.
- Stale route/deep-link behavior: not applicable - no routes changed.

## Scope Gate
- Allowed paths: `frontend/src/pages/Health.jsx`.
- Denied paths: backend runtime code, packages/dependencies, routing, auth/RBAC, payment, queue, sidebar, login, landing, patient panel, EMR, lab, and role panels.
- Migration/docs/test impact: exactly one runtime page migrated; no tests or docs changed.
- Rollback note: revert commit `9004c891` to restore the prior local loading/error/empty markup.

## Validation
- Targeted tests or smoke run: `git diff --check`; `npm.cmd run lint:check`; `npm.cmd run test:run`; `npm.cmd run build`.
- Result: passed locally before opening the PR. Lint reported 65 existing warnings and 0 errors.
- Not checked: browser smoke, because this PR changes only state rendering and local build/tests passed.
