### PR TITLE
refactor(ui): use app state primitives in audit page

### DIFF
--- a/frontend/src/pages/Audit.jsx
+++ b/frontend/src/pages/Audit.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, useCallback } from 'react';
 import RoleGate from '../components/RoleGate.jsx';
 import { api } from '../api/client.js';
+import { AppEmpty, AppError, AppLoading } from '../components/ui/macos';
 
 /**
  * Аудит: список последних действий пользователей.
@@ -41,6 +42,8 @@ export default function Audit() {
     );
   }, [q, rows]);
 
+  const stateCellStyle = { minHeight: '96px', padding: '16px' };
+
   return (
     <div>
       <RoleGate roles={['Admin']}>
@@ -56,7 +59,13 @@ export default function Audit() {
             <button className="legacy-button" onClick={load} disabled={busy}>{busy ? 'Загрузка' : 'Обновить'}</button>
           </div>
 
-          {err && <div className="legacy-error">{String(err)}</div>}
+          {err && (
+            <AppError
+              title="Ошибка загрузки аудита"
+              description={String(err)}
+              style={{ marginBottom: 12 }}
+            />
+          )}
 
           <div className="legacy-table-wrap">
             <table className="legacy-table">
@@ -70,18 +79,40 @@ export default function Audit() {
                 </tr>
               </thead>
               <tbody>
-                {filtered.map((a, i) =>
-                <tr key={a.id || i}>
-                    <td>{a.created_at || a.time || '—'}</td>
-                    <td>{a.user || a.username || a.actor_user_id || '—'}</td>
-                    <td>{a.action || '—'}</td>
-                    <td>{a.entity || a.table || a.entity_type || '—'}</td>
-                    <td><code style={{ fontSize: 12 }}>{a.details ? JSON.stringify(a.details) : a.payload ? JSON.stringify(a.payload) : '—'}</code></td>
+                {busy && rows.length === 0 ? (
+                  <tr>
+                    <td colSpan={5}>
+                      <AppLoading
+                        title="Загрузка аудита"
+                        size="sm"
+                        style={stateCellStyle}
+                      />
+                    </td>
                   </tr>
+                ) : (
+                  <>
+                    {filtered.map((a, i) =>
+                    <tr key={a.id || i}>
+                        <td>{a.created_at || a.time || '—'}</td>
+                        <td>{a.user || a.username || a.actor_user_id || '—'}</td>
+                        <td>{a.action || '—'}</td>
+                        <td>{a.entity || a.table || a.entity_type || '—'}</td>
+                        <td><code style={{ fontSize: 12 }}>{a.details ? JSON.stringify(a.details) : a.payload ? JSON.stringify(a.payload) : '—'}</code></td>
+                      </tr>
+                    )}
+                    {filtered.length === 0 && (
+                      <tr>
+                        <td colSpan={5}>
+                          <AppEmpty
+                            title="Нет записей"
+                            description={q ? 'По текущему поиску записи не найдены.' : 'Журнал аудита пока пуст.'}
+                            style={stateCellStyle}
+                          />
+                        </td>
+                      </tr>
+                    )}
+                  </>
                 )}
-                {filtered.length === 0 &&
-                <tr><td colSpan={5}>Нет записей</td></tr>
-                }
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Summary
- Migrates the Audit page's local loading, error, and empty states to the canonical macOS AppState primitives.
- Keeps the audit table, filters, refresh behavior, and API request semantics unchanged.

## Contract Impact
- Canonical surface: `frontend/src/pages/Audit.jsx` visual state rendering only; canonical primitives are imported from `frontend/src/components/ui/macos`.
- Request shape: unchanged; existing `api.get('/audit', { params: { limit } })` call is preserved.
- Response shape: unchanged; existing array normalization and row rendering fields are preserved.
- Status codes: unchanged; this PR does not touch backend status handling or interceptors.
- Frontend consumer: existing Admin audit page rendered through the current routing setup.
- Compatibility path or alias: unchanged; no route path, legacy redirect, or alias was edited.
- Contract proof: local diff changes only `Audit.jsx`; `npm.cmd run test:run` and `npm.cmd run build` passed.

## RBAC / Permissions
- Roles allowed: unchanged; existing `RoleGate roles={['Admin']}` remains in place.
- Roles denied: unchanged; non-Admin behavior remains controlled by the existing `RoleGate` and route guards.
- Positive auth proof: inspected the patch and preserved the Admin `RoleGate` wrapper.
- Negative auth proof: no route guard, role registry, auth store, or permission file changed.

## Notification / Realtime
- Event type or websocket channel: not applicable because this page-state migration does not use notifications or websocket channels.
- Payload version / ack behavior: not applicable because no realtime payloads or acknowledgements are touched.
- Read/unread or delivery semantics: not applicable because audit page state rendering has no notification delivery semantics.
- Reconnect/resync proof: not applicable because no websocket, reconnect, or resync logic changed.

## Frontend Resilience
- Empty data proof: `AppEmpty` now renders when `filtered.length === 0` after loading, inside the existing table `colSpan={5}` row.
- Partial data proof: existing row fallback expressions for time, user, action, entity, and details remain unchanged.
- Forbidden secondary path behavior: existing Admin-only `RoleGate` remains unchanged; no secondary path was added.
- Missing draft/resource behavior: not applicable because Audit has no draft/resource workflow; empty audit data is handled by `AppEmpty`.
- Stale route/deep-link behavior: route registry and deep-link behavior were not changed.

## Scope Gate
- Allowed paths: `frontend/src/pages/Audit.jsx` only.
- Denied paths: backend, routing, role panels, auth, payment, queue, EMR, lab, sidebar, login, landing, and health page were not changed.
- Migration/docs/test impact: exactly one runtime page was migrated; no docs or tests were modified.
- Rollback note: revert commit `2f821ee9` or restore `frontend/src/pages/Audit.jsx` to the previous local state blocks.

## Validation
- Targeted tests or smoke run: `git diff --check`; `npm.cmd run lint:check`; `npm.cmd run test:run`; `npm.cmd run build`.
- Result: all local validation passed; lint passed with existing warnings; tests passed 63 files / 302 tests; build passed with existing Vite chunk warnings.
- Not checked: manual browser smoke was not run because this was a small one-page state-rendering pilot and local build/tests passed.