### PR TITLE
docs: add local Superpowers guard SSOT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Primary repo-level operating rules for Codex, Cursor agents, Claude Code style a
 
 Installed repo skills live in `.agents/skills`. Load skills only when the task matches their trigger, and prefer the most project-specific skill first.
 
+- Codex/Superpowers local SSOT: use `docs/runbooks/CODEX_SUPERPOWERS_GUARD.md` together with this file. The external Superpowers plugin is a manual workflow guard, not repo runtime code, and must not be vendored into this repository.
 - Skill discovery/setup: use `find-skills` only when searching for or installing new skills.
 - Clinic frontend UI/UX: `clinic-frontend-design` is mandatory first for Admin, Doctor, Registrar, Cashier, Lab, dashboard, route view, form, table, empty/loading/error, accessibility, responsive, or visual consistency work.
 - React implementation: use `vercel-react-best-practices` for performance, bundle, data-fetching, and rerender concerns; add `vercel-composition-patterns` when component APIs, contexts, providers, or boolean-prop-heavy components are involved.

--- a/docs/runbooks/CODEX_SUPERPOWERS_GUARD.md
+++ b/docs/runbooks/CODEX_SUPERPOWERS_GUARD.md
@@ -1,0 +1,152 @@
+# Codex Superpowers Guard
+
+This runbook is the repository-owned source of truth for using a Superpowers-style workflow guard in this project.
+
+It does not vendor, install, or configure the external Superpowers plugin. If the plugin is available in Codex, use it as an optional manual guard. If it is not available, follow this runbook and `AGENTS.md`.
+
+## Local SSOT
+
+Use these sources in order:
+
+1. `AGENTS.md`
+2. This runbook
+3. `.agents/skills/*/SKILL.md` for task-specific skills
+4. `ai/langgraph/scripts/agent_gate.py` when `AGENTS.md` says a gate is required
+5. The canonical source, tests, routes, migrations, contracts, or runbooks found for the task
+
+Do not treat chat history, plugin marketing pages, broad overview docs, or generated reports as stronger authority than the files above.
+
+## What Superpowers Means Here
+
+In this repository, "Superpowers" means a disciplined execution loop:
+
+1. Clarify the task mode and risk.
+2. Locate canonical anchors before editing.
+3. Define the first safe patch slice.
+4. Use the relevant skill or local gate when needed.
+5. Make a small patch.
+6. Run the narrowest useful validation.
+7. Report evidence, remaining risk, and follow-ups.
+
+This is a workflow policy, not application code.
+
+## What Is Not Repo-Owned
+
+The following are intentionally not part of this repository:
+
+- External Superpowers plugin source code
+- User-level Codex plugin installation state
+- Global files under `$HOME/.codex`
+- Global files under `$HOME/.agents`
+- Marketplace metadata or plugin cache directories
+
+Do not add those files to this repository. Do not modify shared user-level Codex settings unless the user explicitly asks for local machine setup.
+
+## Required Agent Behavior
+
+When a prompt says `Use Superpowers workflow guard`, do this before editing:
+
+```text
+Execution mode
+selected mode:
+reason:
+risky domain: yes/no
+root cause known: yes/no
+scope expectation: single-file / narrow / multi-file
+command:
+actual command to run
+or not needed for direct execute
+
+Initial boundaries
+canonical anchor:
+first-touch files:
+validation target:
+stop condition to watch first:
+```
+
+Then follow the execution mode rules in `AGENTS.md`.
+
+For `direct_execute`, the local gate is not required, but the boundaries still are.
+
+For `gate` or `gate_known_root_cause`, run:
+
+```powershell
+cd C:\final\ai\langgraph
+python scripts\agent_gate.py "<task>"
+```
+
+or:
+
+```powershell
+cd C:\final\ai\langgraph
+python scripts\agent_gate.py "<task>" --known-root-cause "<relative/path.py>"
+```
+
+If the gate cannot run, stop and report instead of improvising.
+
+## Skill Routing
+
+Use `.agents/skills` as the repo-owned skill directory.
+
+Project-specific skills take precedence over generic skills:
+
+- Clinic UI work: `clinic-frontend-design` first.
+- GitHub Actions work: `github-actions-docs` for syntax/security and `gh-fix-ci` for failing checks.
+- Security work: `code-security` first, then `semgrep` when a concrete scan or rule is needed.
+- Frontend validation: `javascript-testing-patterns`, `vitest`, `webapp-testing`, and `playwright-best-practices` as relevant.
+
+Do not use a generic frontend design workflow to override clinic readability, role clarity, accessibility, or the existing design system.
+
+## Safe Patch Contract
+
+Before the first edit, name:
+
+- Canonical anchors
+- Reference-only files
+- First-touch files
+- Narrow validation target
+- Stop condition
+
+During implementation:
+
+- Keep the first patch small.
+- Touch only the allowed first-touch files.
+- Avoid opportunistic cleanup.
+- Do not expand scope silently.
+- Preserve dirty worktree changes you did not create.
+- Do not weaken CI, permissions, RBAC, contracts, or production safety gates.
+
+## Validation Contract
+
+Prefer the narrowest validation that can prove the patch:
+
+- Docs-only: markdown/static link checks when available, `git diff --check`, and PR quality gates.
+- GitHub Actions: YAML parse, stale-reference search, `actionlint` if available, and PR checks.
+- Frontend: lint/unit/build/browser checks scoped to touched files or affected flows.
+- Backend: targeted unit/integration tests, migration checks, and contract/parity checks when relevant.
+- Security: static checks and focused exploit/regression proof when changing sensitive code.
+
+If a requested validation tool is not installed locally, say that explicitly and use the best available local substitute.
+
+## PR Evidence
+
+Every non-trivial PR should include:
+
+- Summary
+- Files changed
+- Why the scope is safe
+- Validation commands and results
+- What was intentionally not changed
+- Remaining risks
+- Follow-ups
+
+For runtime-risk PRs, also fill the required project PR review fields for contract impact, RBAC, notification/realtime, frontend resilience, and scope gate.
+
+## Acceptance Check
+
+This local SSOT is active when:
+
+- `AGENTS.md` points to this runbook.
+- Agents can follow the guard even if the external Superpowers plugin is unavailable.
+- Runtime code is not changed by the guard itself.
+- PRs using the guard show a small patch, explicit validation, and clear residual risk.


### PR DESCRIPTION
## Summary

- What: add a repo-owned local SSOT for using a Superpowers-style workflow guard.
- Why: the external Superpowers plugin is manual/user-level, so the repository needs a stable fallback policy agents can follow even when the plugin is unavailable.
- Scope: docs/instructions only; no runtime application code changed.

## What changed

- Added `docs/runbooks/CODEX_SUPERPOWERS_GUARD.md`.
- Linked the runbook from `AGENTS.md` under Skill Routing Policy.
- Defined the local SSOT order: `AGENTS.md`, the new runbook, `.agents/skills`, `agent_gate.py` when required, and canonical task sources.
- Clarified that the external Superpowers plugin is optional/manual and must not be vendored into the repo.
- Documented the required pre-edit boundary block, gate usage, skill routing, safe patch contract, validation contract, and PR evidence expectations.

## Contract Impact

- Canonical surface: Not applicable; no runtime API, route, command contract, DB schema, or generated client surface changed.
- Request shape: Not applicable; no request payload, query params, CLI runtime input, or validation schema changed.
- Response shape: Not applicable; no runtime response payload changed.
- Status codes: Not applicable; no HTTP status behavior changed.
- Frontend consumer: Not applicable; no frontend runtime consumer changed.
- Compatibility path or alias: Not applicable; no route alias, compatibility adapter, import path, or endpoint path changed.
- Contract proof: `git diff --cached --name-only` before commit showed only `AGENTS.md` and `docs/runbooks/CODEX_SUPERPOWERS_GUARD.md`.

## RBAC / Permissions

- Roles allowed: Not applicable; no app authorization or role permission matrix changed.
- Roles denied: Not applicable; no denied-role behavior changed.
- Positive auth proof: Not applicable because this is docs-only and does not touch auth/runtime code.
- Negative auth proof: Not applicable because this is docs-only and does not touch auth/runtime code.
- Repo permission proof: the runbook explicitly says not to vendor plugin code or modify user-level Codex settings unless explicitly requested.

## Notification / Realtime

- Event type or websocket channel: Not applicable; no notification, Telegram, queue, or WebSocket channel changed.
- Payload version / ack behavior: Not applicable; no realtime payload or ack semantics changed.
- Read/unread or delivery semantics: Not applicable; no delivery state behavior changed.
- Reconnect/resync proof: Not applicable because no realtime runtime code changed.

## Frontend Resilience

- Empty data proof: Not applicable; no frontend UI/data state changed.
- Partial data proof: Not applicable; no frontend runtime data handling changed.
- Forbidden secondary path behavior: Not applicable; no route/auth UI behavior changed.
- Missing draft/resource behavior: Not applicable; no draft/resource behavior changed.
- Stale route/deep-link behavior: Not applicable; no frontend routing behavior changed.

## Scope Gate

- Allowed paths: `AGENTS.md`, `docs/runbooks/CODEX_SUPERPOWERS_GUARD.md`.
- Denied paths: backend runtime code, frontend runtime code, tests, workflows, secrets, user-level Codex settings, plugin cache files, and generated artifacts.
- Migration/docs/test impact: docs/instruction update only; no migrations or application tests changed.
- Rollback note: revert commit `5081e679` to remove the runbook and AGENTS link.

## Validation

- Targeted tests or smoke run: `git diff --cached --name-only`; `git diff --cached --check`; `rg "Superpowers|CODEX_SUPERPOWERS_GUARD|local SSOT|agent_gate.py|Use Superpowers workflow guard" AGENTS.md docs/runbooks/CODEX_SUPERPOWERS_GUARD.md`.
- Result: staged diff contained only `AGENTS.md` and `docs/runbooks/CODEX_SUPERPOWERS_GUARD.md`; diff check passed; expected SSOT and guard terms are present.
- Not checked: no frontend/backend app test suites because this PR is docs-only; no local markdown linter was found or required for this scope.

## What was intentionally not changed

- Did not vendor external Superpowers plugin code.
- Did not modify `$HOME/.codex`, `$HOME/.agents`, or any user-level plugin state.
- Did not modify application runtime code.
- Did not alter CI workflows or branch protection.

## Remaining risks

- Agents still need to actually read `AGENTS.md` and the runbook; this PR documents the policy but cannot force every external tool to honor it.
- The external Superpowers plugin availability remains user-level/manual and outside repo control.

## Follow-ups

- Add a lightweight docs index entry if the project later creates a central runbook index.
- Consider a docs-only PR template note pointing agents to this runbook for non-trivial Codex tasks.