### PR TITLE
fix(ui): polish activation system load states

### DIFF
--- a/frontend/src/components/admin/ActivationSystem.jsx
+++ b/frontend/src/components/admin/ActivationSystem.jsx
@@ -21,7 +21,7 @@ import {
 
 
 'lucide-react';
-import { Card, Button, Badge, MacOSInput, MacOSSelect, MacOSTable, MacOSCheckbox } from '../ui/macos';
+import { AppError, AppLoading, Card, Button, Badge, MacOSInput, MacOSSelect, MacOSTable, MacOSCheckbox } from '../ui/macos';
 
 import logger from '../../utils/logger';
 import api from '../../api/client';
@@ -52,6 +52,7 @@ const ActivationSystem = () => {
   const [statusFilter, setStatusFilter] = useState('all');
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [message, setMessage] = useState({ type: '', text: '' });
+  const [loadError, setLoadError] = useState('');
 
   // Статусы активации
   const statusLabels = {
@@ -65,6 +66,7 @@ const ActivationSystem = () => {
   const loadData = useCallback(async () => {
     try {
       setLoading(true);
+      setLoadError('');
 
       const [activationsRes, statusRes] = await Promise.all([
         api.get('/activation/list', { params: { limit: 100 } }),
@@ -78,7 +80,9 @@ const ActivationSystem = () => {
 
     } catch (error) {
       logger.error('Ошибка загрузки данных активации:', error);
-      setMessage({ type: 'error', text: 'Ошибка загрузки данных активации' });
+      const errorText = 'Ошибка загрузки данных активации';
+      setLoadError(errorText);
+      setMessage({ type: 'error', text: errorText });
     } finally {
       setLoading(false);
     }
@@ -158,19 +162,32 @@ const ActivationSystem = () => {
 
     return matchesSearch && matchesStatus;
   });
+  const showInitialLoadError = loadError && activations.length === 0 && !serverStatus;
 
   if (loading) {
     return (
       <Card style={{ padding: '32px' }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <RefreshCw style={{
-            width: '20px',
-            height: '20px',
-            marginRight: '8px',
-            animation: 'spin 1s linear infinite'
-          }} />
-          <span style={{ color: 'var(--mac-text-primary)' }}>Загрузка системы активации...</span>
-        </div>
+        <AppLoading
+          title="Загрузка системы активации"
+          description="Получаем список ключей и статус сервера."
+          size="sm"
+        />
+      </Card>);
+
+  }
+
+  if (showInitialLoadError) {
+    return (
+      <Card style={{ padding: '32px' }}>
+        <AppError
+          title="Не удалось загрузить систему активации"
+          description={loadError}
+          action={
+            <Button type="button" variant="outline" onClick={loadData} disabled={loading} loading={loading}>
+              Повторить
+            </Button>
+          }
+        />
       </Card>);
 
   }


### PR DESCRIPTION
## Summary
- Replaces the ActivationSystem initial custom loading spinner with canonical `AppLoading`.
- Adds a retryable `AppError` only for the no-data initial load failure state.
- Keeps existing inline action messages for create/revoke/extend/copy flows.

## Safety
- One runtime file changed: `frontend/src/components/admin/ActivationSystem.jsx`.
- Preserves `/activation/list`, `/activation/status`, `/activation/issue`, `/activation/revoke`, and `/activation/extend` calls and payloads.
- Does not change routes, roles, auth/RBAC, activation create/revoke/extend semantics, clipboard behavior, backend, packages, queue, payment, EMR, lab, or patient-data behavior.

## Validation
- `git diff --check`
- `cd frontend && npm.cmd run lint:check`
- `cd frontend && npm.cmd run test:run`
- `cd frontend && npm.cmd run build`

## Stack
Base: `docs-appstate-candidate-checklist`
Previous: #706