### PR TITLE
fix(ui): polish appointments empty and error states

### DIFF
--- a/frontend/src/pages/Appointments.jsx
+++ b/frontend/src/pages/Appointments.jsx
@@ -3,7 +3,7 @@ import Nav from '../components/layout/Nav.jsx';
 import RoleGate from '../components/RoleGate.jsx';
 import AppointmentFlow from '../components/AppointmentFlow.jsx';
 import EnhancedAppointmentsTable from '../components/tables/EnhancedAppointmentsTable.jsx';
-import { AppEmpty, AppError } from '../components/ui/macos';
+import { AppEmpty, AppError, Button } from '../components/ui/macos';
 import { api } from '../api/client.js';
 
 import logger from '../utils/logger';
@@ -60,6 +60,7 @@ export default function Appointments() {
       String(a.status || '').toLowerCase().includes(qq)
     );
   }, [q, rows]);
+  const isFilteredEmpty = q.trim().length > 0 && rows.length > 0 && filtered.length === 0;
 
   return (
     <div>
@@ -89,6 +90,11 @@ export default function Appointments() {
             <AppError
               title="Не удалось загрузить записи"
               description={String(err)}
+              action={
+                <Button type="button" variant="outline" size="small" onClick={load} disabled={busy} loading={busy}>
+                  Повторить
+                </Button>
+              }
             />
           )}
 
@@ -140,8 +146,12 @@ export default function Appointments() {
                   <tr>
                     <td colSpan={5}>
                       <AppEmpty
-                        title="Нет записей"
-                        description="Записи на выбранную дату появятся здесь после загрузки."
+                        title={isFilteredEmpty ? 'Записи не найдены' : 'Нет записей на выбранную дату'}
+                        description={
+                          isFilteredEmpty ?
+                            'Измените поиск по пациенту, врачу, статусу или ID, чтобы увидеть записи.' :
+                            'Если запись только что создана, обновите список.'
+                        }
                       />
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary
- Adds a retry action to the Appointments `AppError` using the existing `load` function.
- Clarifies the table empty state by distinguishing filtered-empty results from no appointments on the selected date.
- Keeps the legacy table structure, advanced table toggle, and appointment flow unchanged.

## Safety
- One runtime file changed: `frontend/src/pages/Appointments.jsx`.
- Preserves the `/appointments` date request and the existing fallback request with `d`.
- Preserves search filter semantics, table columns, `EnhancedAppointmentsTable` props, and `AppointmentFlow` callbacks.
- Does not change backend, packages, routes, roles, auth/RBAC, queue, payment, EMR, lab, or patient-data behavior.

## Validation
- `git diff --check`
- `cd frontend && npm.cmd run lint:check`
- `cd frontend && npm.cmd run test:run`
- `cd frontend && npm.cmd run build`

## Stack
Base: `ux-activation-system-load-state`
Previous: #707