### PR TITLE
fix(ui): use AppEmpty in cloud printing

### DIFF
--- a/frontend/src/components/admin/CloudPrintingManager.jsx
+++ b/frontend/src/components/admin/CloudPrintingManager.jsx
@@ -6,8 +6,7 @@ import {
   MacOSInput,
   MacOSSelect,
   MacOSTextarea,
-
-  MacOSEmptyState,
+  AppEmpty,
 
   MacOSModal } from
 '../ui/macos';
@@ -320,7 +319,7 @@ const CloudPrintingManager = () => {
       </div>
 
       {list.length === 0 && !loading &&
-      <MacOSEmptyState
+      <AppEmpty
         icon={Printer}
         title={emptyTitle}
         description="Добавьте принтеры или проверьте подключение к облачным сервисам" />


### PR DESCRIPTION
## Summary
- Replaces the direct `MacOSEmptyState` in the cloud printing printer grid with canonical `AppEmpty`.
- Keeps the existing empty title/copy and printer icon behavior.
- Leaves printer loading, API calls, print/test actions, tabs, modal behavior, forms, and toast behavior unchanged.

## Why this is safe
- One runtime file changed: `frontend/src/components/admin/CloudPrintingManager.jsx`.
- Preserves existing endpoints and calls for `/cloud-printing/printers`, `/print/printers`, `/cloud-printing/statistics`, `/print/printers/:id/test`, `/cloud-printing/test/...`, `/cloud-printing/print`, and `/cloud-printing/print/medical`.
- Does not touch backend code, route runtime, auth/RBAC, queue, payment, EMR, lab, file upload, patient data, package files, or CI.

## Validation
- `git diff --check`
- `cd frontend && npm.cmd run lint:check`
- `cd frontend && npm.cmd run test:run`
- `cd frontend && npm.cmd run build`

## Stack
- Base: `ux-admin-section-appstate`
- Previous PR: #709

## Not changed
- Printer API fallback and payloads.
- Test print actions and print document flows.
- Active tab logic.
- Selected printer modal behavior.
- Toast behavior and form submission behavior.
- No live browser smoke was run.