### PR TITLE
fix(ui): polish audit app states

### DIFF
--- a/frontend/src/pages/Audit.jsx
+++ b/frontend/src/pages/Audit.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, useCallback } from 'react';
 import RoleGate from '../components/RoleGate.jsx';
 import { api } from '../api/client.js';
-import { AppEmpty, AppError, AppLoading } from '../components/ui/macos';
+import { AppEmpty, AppError, AppLoading, Button } from '../components/ui/macos';
 
 /**
  * Аудит: список последних действий пользователей.
@@ -43,6 +43,20 @@ export default function Audit() {
   }, [q, rows]);
 
   const stateCellStyle = { minHeight: '96px', padding: '16px' };
+  const visuallyHiddenStyle = {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: 0,
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    border: 0
+  };
+  const limitInputId = 'audit-limit';
+  const searchInputId = 'audit-search';
+  const tableCaptionId = 'audit-table-caption';
 
   return (
     <div>
@@ -51,24 +65,66 @@ export default function Audit() {
           <h2 style={{ margin: 0 }}>Аудит</h2>
 
           <div className="legacy-toolbar">
-            <label>
+            <label htmlFor={limitInputId}>
               Порог:&nbsp;
-              <input className="legacy-input" type="number" min={10} max={1000} value={limit} onChange={(e) => setLimit(Number(e.target.value) || 100)} />
+              <input
+                id={limitInputId}
+                className="legacy-input"
+                type="number"
+                min={10}
+                max={1000}
+                value={limit}
+                onChange={(e) => setLimit(Number(e.target.value) || 100)}
+                aria-label="Количество записей аудита для загрузки"
+              />
             </label>
-            <input className="legacy-input" placeholder="Поиск по пользователю/действию/сущности" value={q} onChange={(e) => setQ(e.target.value)} style={{ minWidth: 260 }} />
-            <button className="legacy-button" onClick={load} disabled={busy}>{busy ? 'Загрузка' : 'Обновить'}</button>
+            <label htmlFor={searchInputId} style={visuallyHiddenStyle}>
+              Поиск по пользователю, действию, сущности или ID
+            </label>
+            <input
+              id={searchInputId}
+              className="legacy-input"
+              placeholder="Поиск по пользователю/действию/сущности"
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              style={{ minWidth: 260 }}
+              aria-label="Поиск по журналу аудита"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="small"
+              onClick={load}
+              disabled={busy}
+              loading={busy}
+              aria-label="Обновить журнал аудита">
+              Обновить
+            </Button>
           </div>
 
           {err && (
             <AppError
               title="Ошибка загрузки аудита"
               description={String(err)}
+              action={
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="small"
+                  onClick={load}
+                  disabled={busy}
+                  loading={busy}
+                  aria-label="Повторить загрузку журнала аудита">
+                  Повторить
+                </Button>
+              }
               style={{ marginBottom: 12 }}
             />
           )}
 
-          <div className="legacy-table-wrap">
+          <div className="legacy-table-wrap" aria-busy={busy} aria-describedby={tableCaptionId}>
             <table className="legacy-table">
+              <caption id={tableCaptionId} style={visuallyHiddenStyle}>Журнал аудита</caption>
               <thead>
                 <tr>
                   <th>Время</th>
@@ -84,6 +140,8 @@ export default function Audit() {
                     <td colSpan={5}>
                       <AppLoading
                         title="Загрузка аудита"
+                        description="Получаем последние действия пользователей."
+                        ariaLabel="Загружаем журнал аудита"
                         size="sm"
                         style={stateCellStyle}
                       />


### PR DESCRIPTION
## Summary
- Replaces the native audit refresh control with the existing macOS `Button` primitive while calling the same `load` function.
- Adds an `AppError` retry action that calls the same existing `load` flow.
- Adds stable labels for the audit limit/search controls and a hidden table caption for assistive tech.
- Adds loading description/ARIA and `aria-busy` on the audit table region.

## Why this is safe
- One runtime file changed: `frontend/src/pages/Audit.jsx`.
- Preserves existing audit endpoint semantics: `api.get('/audit', { params: { limit } })`.
- Preserves `RoleGate roles={['Admin']}`, limit state, search/filter matching, table columns, row rendering, and details/payload JSON rendering.
- Does not touch backend code, API helper files, route runtime, auth/RBAC semantics, queue, payment, EMR, lab workflows, package files, or CI.

## Validation
- `git diff --check`
- `cd frontend && npm.cmd run lint:check` - passes with existing 65 warnings
- `cd frontend && npm.cmd run test:run` - 63 files / 305 tests passed
- `cd frontend && npm.cmd run build` - passes with existing dynamic import/chunk-size warnings

## Stack
- Base: `ux-health-appstate-refresh-accessibility`
- Previous PR: #712

## Not changed
- No audit API path or query semantics changed.
- No admin route/sidebar/app-shell runtime files changed.
- No live browser smoke was run.