### PR TITLE
fix(ui): polish admin empty state accessibility

### DIFF
--- a/frontend/src/components/admin/EmptyState.jsx
+++ b/frontend/src/components/admin/EmptyState.jsx
@@ -10,6 +10,7 @@ import {
   Plus,
   RefreshCw } from
 'lucide-react';
+import { useId } from 'react';
 import { Card } from '../ui/native';
 import PropTypes from 'prop-types';
 
@@ -22,8 +23,12 @@ const EmptyState = ({
   className = '',
   ...props
 }) => {
+  const titleId = useId();
+  const descriptionId = useId();
+  const stateRole = type === 'error' ? 'alert' : 'status';
+
   const getIcon = () => {
-    if (CustomIcon) return <CustomIcon className="w-12 h-12" />;
+    if (CustomIcon) return <CustomIcon className="w-12 h-12" aria-hidden="true" />;
 
     const iconMap = {
       default: FileText,
@@ -39,7 +44,7 @@ const EmptyState = ({
     };
 
     const Icon = iconMap[type] || iconMap.default;
-    return <Icon className="w-12 h-12" />;
+    return <Icon className="w-12 h-12" aria-hidden="true" />;
   };
 
   const getColor = () => {
@@ -56,6 +61,10 @@ const EmptyState = ({
 
   return (
     <Card
+      role={stateRole}
+      aria-live={type === 'error' ? 'assertive' : 'polite'}
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
       className={`p-8 text-center ${className}`}
       style={{
         background: 'var(--bg-primary)',
@@ -75,13 +84,15 @@ const EmptyState = ({
         </div>
         
         <h3
+          id={titleId}
           className="text-lg font-semibold mb-2"
           style={{ color: 'var(--text-primary)' }}>
-          
+
           {title}
         </h3>
-        
+
         <p
+          id={descriptionId}
           className="text-sm mb-6 max-w-md"
           style={{ color: 'var(--text-secondary)' }}>
           


### PR DESCRIPTION
Summary: Adds low-risk accessibility polish to the legacy admin EmptyState component only: state containers now expose status/alert semantics, title/description are linked with stable ids, and decorative empty-state icons are hidden from screen readers. Safety: Preserves all existing props, titles/descriptions/actions, AdminPanel call sites, visual layout, API calls, route behavior, RBAC, and domain workflows. Files changed: frontend/src/components/admin/EmptyState.jsx. Validation: git diff --check; npm.cmd run lint:check; npm.cmd run build; npm.cmd run test:run. Intentionally not changed: backend, routes, app-shell navigation, role panels, queue/payment/EMR/lab behavior, package files, tests, and unrelated local backend/ticket-print/ops files.