### PR TITLE
fix(ui): polish unified reports tab accessibility

### DIFF
--- a/frontend/src/components/admin/UnifiedReports.jsx
+++ b/frontend/src/components/admin/UnifiedReports.jsx
@@ -25,7 +25,7 @@ const UnifiedReports = () => {
     };
 
     return (
-      <div style={{
+      <div role="tablist" aria-label="Reports sections" style={{
         display: 'flex',
         gap: '4px',
         padding: '8px',
@@ -37,6 +37,11 @@ const UnifiedReports = () => {
         {tabs.map((tab) => (
           <button
             key={tab.id}
+            id={`reports-tab-${tab.id}`}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            aria-controls={`reports-panel-${tab.id}`}
             onClick={() => onTabChange(tab.id)}
             style={{
               padding: '8px 16px',
@@ -87,7 +92,12 @@ const UnifiedReports = () => {
         activeTab={activeTab}
         onTabChange={setActiveTab}
       />
-      <div style={{ flex: 1, overflow: 'auto' }}>
+      <div
+        id={`reports-panel-${activeTab}`}
+        role="tabpanel"
+        aria-labelledby={`reports-tab-${activeTab}`}
+        style={{ flex: 1, overflow: 'auto' }}
+      >
         {renderContent()}
       </div>
     </div>


### PR DESCRIPTION
Summary: Adds low-risk accessibility semantics to the local UnifiedReports admin tabs only: the tab strip now exposes tablist/tab/tabpanel relationships, selected tab state, stable controls, and explicit button types. Safety: Preserves activeTab state, tab labels/ids, ReportManager/ReportGenerator rendering, report API behavior, AdminPanel routing, RBAC, and all report generation flows. Files changed: frontend/src/components/admin/UnifiedReports.jsx. Validation: git diff --check; npm.cmd run lint:check; npm.cmd run build; npm.cmd run test:run. Intentionally not changed: backend, routes, app-shell navigation, role panels, report endpoints, queue/payment/EMR/lab behavior, package files, tests, and unrelated local backend/ticket-print/ops files.