### PR TITLE
fix(ui): polish unified notifications tab accessibility

### DIFF
--- a/frontend/src/components/admin/UnifiedNotifications.jsx
+++ b/frontend/src/components/admin/UnifiedNotifications.jsx
@@ -18,7 +18,7 @@ const AdminTabs = ({ tabs, activeTab, onTabChange }) => {
   };
 
   return (
-    <div style={{
+    <div role="tablist" aria-label="Notification sections" style={{
       display: 'flex',
       gap: '4px',
       padding: '8px',
@@ -30,6 +30,11 @@ const AdminTabs = ({ tabs, activeTab, onTabChange }) => {
       {tabs.map((tab) =>
       <button
         key={tab.id}
+        id={`notifications-tab-${tab.id}`}
+        type="button"
+        role="tab"
+        aria-selected={activeTab === tab.id}
+        aria-controls={`notifications-panel-${tab.id}`}
         onClick={() => onTabChange(tab.id)}
         style={{
           padding: '8px 16px',
@@ -101,7 +106,12 @@ const UnifiedNotifications = () => {
         activeTab={activeTab}
         onTabChange={setActiveTab} />
       
-      <div style={{ flex: 1, overflow: 'auto' }}>
+      <div
+        id={`notifications-panel-${activeTab}`}
+        role="tabpanel"
+        aria-labelledby={`notifications-tab-${activeTab}`}
+        style={{ flex: 1, overflow: 'auto' }}
+      >
         {renderContent()}
       </div>
     </div>);


### PR DESCRIPTION
Summary: Adds low-risk accessibility semantics to the local UnifiedNotifications admin tabs only: the tab strip now exposes tablist/tab/tabpanel relationships, selected tab state, stable controls, and explicit button types. Safety: Preserves section-to-tab mapping, activeTab state, FCMManager/RegistrarNotificationManager rendering, notification API behavior, AdminPanel routing, RBAC, and all notification workflows. Files changed: frontend/src/components/admin/UnifiedNotifications.jsx. Validation: git diff --check; npm.cmd run lint:check; npm.cmd run build; npm.cmd run test:run. Intentionally not changed: backend, routes, app-shell navigation, role panels, FCM/registrar notification endpoints, queue/payment/EMR/lab behavior, package files, tests, and unrelated local backend/ticket-print/ops files.