### PR TITLE
fix(ui): polish macos empty state accessibility

### DIFF
--- a/frontend/src/components/ui/macos/MacOSEmptyState.jsx
+++ b/frontend/src/components/ui/macos/MacOSEmptyState.jsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import PropTypes from 'prop-types';
 const MacOSEmptyState = ({
   icon: Icon,
@@ -9,6 +10,9 @@ const MacOSEmptyState = ({
   className,
   style
 }) => {
+  const descriptionId = useId();
+  const hasDescription = Boolean(description);
+
   const sizeStyles = {
     sm: {
       padding: '24px',
@@ -96,13 +100,20 @@ const MacOSEmptyState = ({
   };
 
   return (
-    <div className={className} style={containerStyle}>
-      {Icon && <Icon style={iconStyle} />}
-      
+    <div
+      className={className}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-describedby={hasDescription ? descriptionId : undefined}
+      style={containerStyle}
+    >
+      {Icon && <Icon aria-hidden="true" focusable="false" style={iconStyle} />}
+
       <h3 style={titleStyle}>{title}</h3>
-      
-      {description && (
-        <p style={descriptionStyle}>{description}</p>
+
+      {hasDescription && (
+        <p id={descriptionId} style={descriptionStyle}>{description}</p>
       )}
       
       {action && (


### PR DESCRIPTION
Summary:
- Adds accessible live-region semantics to the canonical MacOSEmptyState primitive.
- Hides decorative empty-state icons from assistive tech and associates descriptions with aria-describedby.
- Preserves visual styling, component props, routes, APIs, and domain behavior.

Validation:
- git diff --check
- cd frontend; npm.cmd run lint:check (0 errors, 65 existing warnings)
- cd frontend; npm.cmd run test:run -- src/components/ui/macos/__tests__/AppState.test.jsx
- cd frontend; npm.cmd run test:run
- cd frontend; npm.cmd run build

Intentionally not changed:
- No backend, package, route runtime, auth/RBAC, queue, payment, EMR, lab, file upload, or patient-data files changed.