### PR TITLE
fix(ui): polish icon selector accessibility

### DIFF
--- a/frontend/src/components/admin/IconSelector.jsx
+++ b/frontend/src/components/admin/IconSelector.jsx
@@ -72,9 +72,19 @@ const IconSelector = ({ value, onChange, label = 'Выберите иконку'
             event.preventDefault();
             action();
         }
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            action();
+        }
     };
     const handleTriggerKeyDown = (event) => {
         if (event.key === 'Escape') {
+            setIsOpen(false);
+        }
+    };
+    const handleDropdownKeyDown = (event) => {
+        if (event.key === 'Escape') {
+            event.stopPropagation();
             setIsOpen(false);
         }
     };
@@ -114,7 +124,7 @@ const IconSelector = ({ value, onChange, label = 'Выберите иконку'
                     <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                         {selectedIcon ? (
                             <>
-                                <selectedIcon.icon aria-hidden="true" size={20} />
+                                <selectedIcon.icon aria-hidden="true" focusable="false" size={20} />
                                 <span>{selectedIcon.label}</span>
                             </>
                         ) : (
@@ -143,7 +153,7 @@ const IconSelector = ({ value, onChange, label = 'Выберите иконку'
                             onClick={() => setIsOpen(false)}
                             onKeyDown={(event) => handleActivationKeyDown(event, () => setIsOpen(false))}
                         />
-                        <div id={dropdownId} role="dialog" aria-label={`Выбор иконки: ${label}`} style={{
+                        <div id={dropdownId} role="dialog" aria-label={`Выбор иконки: ${label}`} onKeyDown={handleDropdownKeyDown} style={{
                             position: 'absolute',
                             top: '100%',
                             left: 0,
@@ -158,7 +168,7 @@ const IconSelector = ({ value, onChange, label = 'Выберите иконку'
                             maxHeight: '300px',
                             overflowY: 'auto'
                         }}>
-                            <div style={{
+                            <div role="group" aria-label="Доступные иконки" style={{
                                 display: 'grid',
                                 gridTemplateColumns: 'repeat(3, 1fr)',
                                 gap: '8px'
@@ -205,7 +215,7 @@ const IconSelector = ({ value, onChange, label = 'Выберите иконку'
                                                 }
                                             }}
                                         >
-                                            <IconComponent aria-hidden="true" size={24} />
+                                            <IconComponent aria-hidden="true" focusable="false" size={24} />
                                             <span style={{
                                                 fontSize: '11px',
                                                 color: 'var(--mac-text-secondary)',


### PR DESCRIPTION
Plan summary:
- Continue the low-risk admin utility/display-only accessibility stack with a one-file IconSelector polish.
- Keep the slice inside the existing admin utility control and avoid DepartmentManagement form/API/routing changes.

Selected first fix:
- Add Escape close handling while the icon picker dialog is open.
- Add an accessible group name for the icon options.
- Mark decorative selected/option SVG icons as non-focusable while preserving visible labels.

Why it is safe:
- The patch only changes frontend accessibility attributes and local keyboard close behavior in IconSelector.jsx.
- Existing icon values, onChange behavior, DepartmentManagement integration, validation, APIs, payloads, routes, and roles are unchanged.

Files changed:
- frontend/src/components/admin/IconSelector.jsx

Validation results:
- git diff --check: passed; existing CRLF warnings only on unrelated dirty files.
- cd frontend; npm.cmd run lint:check: passed with 0 errors and 65 existing warnings.
- cd frontend; npm.cmd run build: passed with existing Vite dynamic import/chunk warnings.
- cd frontend; npm.cmd run test:run: passed, 63 files / 305 tests; existing expected stderr warnings observed.

Intentionally not changed:
- No backend files, package files, route runtime, auth/RBAC, queue, payment, EMR, lab, file upload, or patient-data semantics.
- No DepartmentManagement form behavior, service mapping, validation, or API payload changes.
- No live browser smoke was run.

Next 3 recommended PRs:
1. Another isolated admin utility display/accessibility slice with a single file and no form/API behavior changes.
2. A low-risk admin table empty/error state copy/accessibility slice.
3. A design-system primitive documentation/checklist update once the current stack is reviewed.