### PR TITLE
fix(ui): polish admin empty state accessibility

### DIFF
--- a/frontend/src/components/admin/EmptyState.jsx
+++ b/frontend/src/components/admin/EmptyState.jsx
@@ -28,7 +28,7 @@ const EmptyState = ({
   const stateRole = type === 'error' ? 'alert' : 'status';
 
   const getIcon = () => {
-    if (CustomIcon) return <CustomIcon className="w-12 h-12" aria-hidden="true" />;
+    if (CustomIcon) return <CustomIcon className="w-12 h-12" aria-hidden="true" focusable="false" />;
 
     const iconMap = {
       default: FileText,
@@ -44,7 +44,7 @@ const EmptyState = ({
     };
 
     const Icon = iconMap[type] || iconMap.default;
-    return <Icon className="w-12 h-12" aria-hidden="true" />;
+    return <Icon className="w-12 h-12" aria-hidden="true" focusable="false" />;
   };
 
   const getColor = () => {
@@ -100,7 +100,7 @@ const EmptyState = ({
         </p>
         
         {action &&
-        <div className="flex gap-3 justify-center">
+        <div className="flex gap-3 justify-center" role="group" aria-labelledby={titleId}>
             {action}
           </div>
         }


### PR DESCRIPTION
Plan summary:
- Continue the low-risk admin utility/display-only accessibility stack with a one-file admin EmptyState polish.
- Preserve existing empty/error state structure, copy, actions, and AdminPanel usage.

Selected fix:
- Mark decorative empty/error SVG icons as non-focusable while keeping them hidden from assistive tech.
- Expose the optional EmptyState action area as a grouped control region labelled by the existing state title.

Why it is safe:
- The patch only changes accessibility metadata in frontend/src/components/admin/EmptyState.jsx.
- Existing title/description/action rendering, state role selection, AdminPanel usage, routes, APIs, roles, and domain semantics are unchanged.

Files changed:
- frontend/src/components/admin/EmptyState.jsx

Validation results:
- git diff --check: passed; existing CRLF warnings only on unrelated dirty files.
- cd frontend; npm.cmd run lint:check: passed with 0 errors and 65 existing warnings.
- cd frontend; npm.cmd run build: passed with existing Vite dynamic import/chunk warnings.
- cd frontend; npm.cmd run test:run: passed, 63 files / 305 tests; expected stderr warnings observed.

Intentionally not changed:
- No backend files, package files, route runtime, auth/RBAC, queue, payment, EMR, lab, file upload, or patient-data semantics.
- No AdminPanel runtime flow, data loading, empty/error copy, action callbacks, or API behavior changes.
- No live browser smoke was run.

Next 3 recommended PRs:
1. Another isolated admin display utility accessibility slice with a single file and no callbacks changed.
2. A low-risk admin table empty/error state copy/accessibility slice where data semantics are clear.
3. Pause for review/merge order if the stacked accessibility PR queue is getting too tall.