### PR TITLE
fix(ui): polish color scheme icon accessibility

### DIFF
--- a/frontend/src/components/admin/ColorSchemeSelector.jsx
+++ b/frontend/src/components/admin/ColorSchemeSelector.jsx
@@ -64,7 +64,7 @@ function ThemePreviewCard({ scheme, isActive, onSelect }) {
       <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '12px' }}>
         <div style={{ display: 'grid', gap: '6px' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Icon aria-hidden="true" style={{ width: '18px', height: '18px' }} />
+            <Icon aria-hidden="true" focusable="false" style={{ width: '18px', height: '18px' }} />
             <span style={{ fontSize: '15px', fontWeight: 700 }}>
               {scheme.name}
             </span>
@@ -193,7 +193,7 @@ export default function ColorSchemeSelector() {
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: '10px', justifyContent: 'space-between', flexWrap: 'wrap' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-          <Palette aria-hidden="true" style={{ width: '20px', height: '20px', color: 'var(--mac-accent-blue)' }} />
+          <Palette aria-hidden="true" focusable="false" style={{ width: '20px', height: '20px', color: 'var(--mac-accent-blue)' }} />
           <div style={{ display: 'grid', gap: '4px' }}>
             <h3 id={selectorTitleId} style={{
               fontSize: 'var(--mac-font-size-lg)',
@@ -228,7 +228,7 @@ export default function ColorSchemeSelector() {
           fontSize: '12px',
         }}
         >
-          <SwatchBook aria-hidden="true" style={{ width: '14px', height: '14px', color: 'var(--mac-accent-blue)' }} />
+          <SwatchBook aria-hidden="true" focusable="false" style={{ width: '14px', height: '14px', color: 'var(--mac-accent-blue)' }} />
           Accent сейчас: <strong style={{ color: 'var(--mac-text-primary)' }}>{currentAccentLabel}</strong>
         </div>
       </div>
@@ -315,7 +315,7 @@ export default function ColorSchemeSelector() {
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: '10px', justifyContent: 'space-between' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-              <ActiveIcon aria-hidden="true" style={{ width: '18px', height: '18px' }} />
+              <ActiveIcon aria-hidden="true" focusable="false" style={{ width: '18px', height: '18px' }} />
               <div style={{ display: 'grid', gap: '2px' }}>
                 <strong>{currentScheme.name}</strong>
                 <span style={{ fontSize: '12px', opacity: 0.84 }}>{currentScheme.description}</span>


### PR DESCRIPTION
Plan summary:
- Continue the low-risk admin/settings utility accessibility stack with a one-file ColorSchemeSelector polish.
- Preserve existing color scheme selection, theme persistence, macOS theme integration, tests, routes, APIs, and user flow.

Selected fix:
- Mark decorative lucide SVG icons in the color scheme selector as non-focusable while keeping existing aria-hidden semantics.

Why it is safe:
- The patch only changes accessibility metadata in frontend/src/components/admin/ColorSchemeSelector.jsx.
- Existing setColorScheme calls, selected values, local/backend theme persistence, visual layout, labels, tests, routes, and API mocks are unchanged.

Files changed:
- frontend/src/components/admin/ColorSchemeSelector.jsx

Validation results:
- git diff --check: passed; existing CRLF warnings only on dirty worktree files.
- cd frontend; npm.cmd run lint:check: passed with 0 errors and 65 existing warnings.
- cd frontend; npm.cmd run build: passed with existing Vite dynamic import/chunk warnings.
- cd frontend; npm.cmd run test:run: passed, 63 files / 305 tests; expected stderr warnings observed.

Intentionally not changed:
- No backend files, package files, route runtime, auth/RBAC, queue, payment, EMR, lab, file upload, or patient-data semantics.
- No theme behavior, persistence behavior, color scheme catalog, settings route integration, or API behavior changes.
- No live browser smoke was run.

Next 3 recommended PRs:
1. Pause for stack review/merge if the accessibility PR stack is now tall enough.
2. Another isolated display-only admin utility where callbacks and API contracts are untouched.
3. A low-risk admin table empty/error state accessibility slice after confirming data semantics.