### PR TITLE
fix(ui): polish design validator accessibility

### DIFF
--- a/frontend/src/components/admin/DesignValidator.jsx
+++ b/frontend/src/components/admin/DesignValidator.jsx
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 const DesignValidator = ({ onValidationComplete }) => {
   const { getColor, getSpacing, getFontSize } = useTheme();
   const componentSelectId = useId();
+  const validatorTitleId = useId();
   const resultsRegionId = useId();
   const resultsTitleId = useId();
   const [isValidating, setIsValidating] = useState(false);
@@ -68,15 +69,15 @@ const DesignValidator = ({ onValidationComplete }) => {
   };
 
   return (
-    <Card padding="lg">
-      <div style={{
+    <Card padding="lg" role="region" aria-labelledby={validatorTitleId}>
+      <h2 id={validatorTitleId} style={{
         fontSize: getFontSize('lg'),
         fontWeight: '600',
-        marginBottom: getSpacing('lg'),
+        margin: `0 0 ${getSpacing('lg')} 0`,
         color: getColor('text')
       }}>
         🛠️ Валидация дизайн-системы
-      </div>
+      </h2>
 
       <div style={{ marginBottom: getSpacing('lg') }}>
         <label htmlFor={componentSelectId} style={{


### PR DESCRIPTION
Plan summary:
- Continue the low-risk admin utility/display-only accessibility stack with a one-file DesignValidator polish.
- Preserve existing validation logic, available component list, theme hook usage, callbacks, routes, APIs, and runtime behavior.

Selected fix:
- Give the DesignValidator card a labelled region landmark.
- Convert the visible title from a generic div to an h2 while preserving the existing spacing and visual styling.

Why it is safe:
- The patch only changes semantic accessibility structure in frontend/src/components/admin/DesignValidator.jsx.
- Existing validateComponent flow, selected component state, onValidationComplete callback, result rendering, and styling intent are unchanged.

Files changed:
- frontend/src/components/admin/DesignValidator.jsx

Validation results:
- git diff --check: passed; existing CRLF warnings only on dirty worktree files.
- cd frontend; npm.cmd run lint:check: passed with 0 errors and 65 existing warnings.
- cd frontend; npm.cmd run build: passed with existing Vite dynamic import/chunk warnings.
- cd frontend; npm.cmd run test:run: passed, 63 files / 305 tests; expected stderr warnings observed.

Intentionally not changed:
- No backend files, package files, route runtime, auth/RBAC, queue, payment, EMR, lab, file upload, or patient-data semantics.
- No validation algorithm, component catalog, API behavior, theme persistence, or page integration changes.
- No live browser smoke was run.

Next 3 recommended PRs:
1. Pause for stack review/merge through this PR because the accessibility stack is now fairly deep.
2. If continuing, pick only a clearly isolated display-only admin utility with no callbacks/API changes.
3. After the stack lands, consider a targeted admin table empty/error accessibility slice with explicit data-semantics review.