### PR TITLE
ci: add actionlint metadata check

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -242,7 +242,6 @@ jobs:
       shell: bash
       env:
         WORKFLOW_CHANGED: ${{ needs.ci-scope.outputs.workflow_changed }}
-        SKILLS_CHANGED: ${{ needs.ci-scope.outputs.skills_changed }}
       run: |
         set -euo pipefail
 
@@ -251,6 +250,31 @@ jobs:
         else
           echo "workflow yaml check skipped"
         fi
+
+    - name: Lint GitHub Actions workflows
+      if: needs.ci-scope.outputs.workflow_changed == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        docker run --rm \
+          -v "${PWD}:/repo:ro" \
+          -w /repo \
+          rhysd/actionlint:1.7.12 \
+          -color \
+          -shellcheck= \
+          -pyflakes=
+
+    - name: Skip GitHub Actions workflow lint
+      if: needs.ci-scope.outputs.workflow_changed != 'true'
+      shell: bash
+      run: echo "actionlint skipped"
+
+    - name: Validate changed skill metadata
+      shell: bash
+      env:
+        SKILLS_CHANGED: ${{ needs.ci-scope.outputs.skills_changed }}
+      run: |
+        set -euo pipefail
 
         if [ "$SKILLS_CHANGED" = "true" ]; then
           python - <<'PY'


### PR DESCRIPTION
## Summary

- Add `actionlint` to the existing `metadata-checks` job for workflow changes.
- Keep the check inside the current path-aware unified CI instead of adding a duplicate generic CI workflow.
- Disable external `shellcheck`/`pyflakes` integrations for this first gate so existing script-style baseline noise does not block workflow semantic linting.

## Contract Impact

not applicable - workflow metadata only, no API, websocket, event, backend schema, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, token scope, or auth-sensitive runtime behavior changed. Workflow still uses `permissions: contents: read`.

## Notification / Realtime

not applicable - no notification, websocket, chat, queue, delivery, read/unread, reconnect, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, frontend route, data-loading state, empty state, forbidden path, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `.github/workflows/ci-cd-unified.yml`
- Denied paths: backend runtime, frontend runtime, migrations, generated output, secrets, deploy configuration outside this workflow
- Migration/docs/test impact: CI metadata-only change; no migration expected
- Rollback note: revert the workflow-only commit to remove actionlint from metadata checks

## Validation

- Targeted tests or smoke run: `git diff --check`; GitHub Actions PR run for workflow YAML parse and actionlint
- Result: local `git diff --check` passed; first GitHub run showed workflow YAML parse passed, actionlint found existing shellcheck baseline noise, so this revision disables external shellcheck/pyflakes and keeps core actionlint semantics
- Not checked: backend/frontend application test suites locally, because no runtime files changed and CI runs the required PR checks

## Follow-ups

- Consider dependency-review for lockfile-changing PRs.
- Consider a separate baseline-cleanup PR for shellcheck findings in older maintenance/load workflows.
- Keep deployment and Pages workflows out until the deployment/public-docs targets are explicitly defined.
