### PR TITLE
feat: add Telegram patient bot language onboarding

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -1,0 +1,262 @@
+# Telegram Bot Clinic Full Strategy
+
+> Strategic implementation plan for Telegram in the clinic platform.
+> This is a planning artifact for later backend/frontend execution slices; it does not contain secrets, bot tokens, or patient data.
+
+## Summary
+
+Telegram should be an operational layer for the clinic, not a full EMR. It should handle short notifications, simple confirmations, queue status, payment entry points, secure links, and human approval for AI-assisted workflows. Complex medical and administrative work stays in the protected web system or a future Telegram Mini App.
+
+Patient bot v1 supports two patient-facing languages:
+
+- `ru`: Russian
+- `uz-Latn`: Uzbek Latin
+
+Default language is Russian when no preference is saved. The staff/admin bot remains Russian-first in the initial strategy unless a later rollout explicitly adds staff localization.
+
+## Product Model
+
+Use two separate Telegram bots.
+
+Patient bot:
+
+- appointment and visit notifications
+- queue status and QR queue deep links
+- payment notifications and payment links
+- ready-result notifications with secure delivery policy
+- support and clinic contact actions
+- future Mini App entry points for full appointment booking, forms, payments, and patient cabinet
+
+Staff/admin bot:
+
+- registrar queue actions
+- doctor schedule and next-patient notifications
+- cashier payment alerts and reconciliation hints
+- lab result readiness alerts
+- owner/admin daily summaries, operational warnings, and integration errors
+- AI approval interface for suggestions that need human confirmation
+
+Telegram must not expose internal identifiers or medical implementation details to patients. Patient-facing text must avoid terms such as `EMR`, `visit_id`, `invoice_id`, `branch_id`, and raw database identifiers.
+
+## Patient Bot Flow
+
+`/start` onboarding:
+
+- show language choice: `Русский` and `O'zbekcha`
+- save selected language on the Telegram account or active Telegram session
+- request Telegram phone contact
+- accept the contact only when `contact.user_id` matches the sender
+- link Telegram to an existing patient profile by trusted phone or one-time signed start token
+- show notification consent
+- open the localized main menu
+
+Localized main menu:
+
+- `Моя очередь` / queue status
+- `Мои визиты` / current and upcoming visits
+- `Оплата` / current debt and payment entry points
+- `Результаты` / ready results and protected access
+- `Помощь` / clinic support
+- `Настройки` / language and notification preferences
+
+QR queue flow:
+
+- receipt or in-clinic QR opens `https://t.me/<patient_bot>?start=<one_time_signed_token>`
+- token resolves server-side to queue/visit context
+- token is short-lived and one-time-use
+- bot shows queue number, cabinet, status, position if safely calculable, and refresh/support actions
+- queue fairness and `queue_time` are never changed by status reads
+
+Payments:
+
+- Telegram shows short payment notifications and links into the approved payment flow
+- payment providers remain PayMe, Click, Apelsin, or the existing application payment layer
+- Telegram can show amount, status, and generic service label, but detailed invoices remain in the protected app
+- paid/completed payments trigger short confirmation and receipt availability notice
+
+Results:
+
+- Telegram should not send diagnoses, full medical details, or raw EMR content in plain chat
+- preferred long-term behavior is a secure link or Mini App protected view
+- if PDF delivery is enabled for a specific slice, it must be restricted to linked patients, ready/finalized reports only, with delivery logged and no PDF content stored in logs
+
+## Staff/Admin Bot Flow
+
+Role-based menus:
+
+- registrar: queue, next patient, find patient, redirect, payment status
+- doctor: schedule, next patient, open EMR, call patient, incomplete EMR reminders
+- cashier: unpaid invoices, paid invoices, refunds, payment reconciliation
+- lab: ready reports, pending reports, result notification status
+- owner/admin: daily report, revenue, doctor load, average wait, integration errors
+
+Staff actions that change operational state require explicit confirmation:
+
+- call or skip patient
+- cancel or move visit
+- change payment state
+- issue refund
+- close EMR or publish medical document
+- change doctor schedule
+
+Every staff action through Telegram must be checked against the application role system and recorded in audit logs.
+
+## Architecture
+
+Recommended backend flow:
+
+```text
+Telegram update
+-> webhook or polling transport
+-> Telegram bot service/router
+-> patient/staff linking and authorization
+-> domain services
+-> notification service
+-> Telegram adapter
+-> TelegramMessage / notification log / audit log
+```
+
+Transport rules:
+
+- polling remains valid before a public domain/server is ready
+- webhook can be added later without changing bot business logic
+- webhook and polling must call the same patient/staff bot handler
+- transport code should not contain queue, payment, EMR, or report business logic
+
+Notification architecture:
+
+- business modules emit events such as `VisitCreated`, `QueueTicketIssued`, `QueueStatusChanged`, `PatientCalled`, `PaymentCreated`, `PaymentPaid`, `LabResultReady`, `EMRCompleted`, and `ReportGenerated`
+- notification service maps events to channels and templates
+- Telegram adapter sends localized messages from stable template keys
+- SMS, email, WhatsApp, and push can be added later without rewriting domain modules
+
+Localization architecture:
+
+- patient-facing templates use stable keys and per-language text
+- supported patient languages in v1 are exactly `ru` and `uz-Latn`
+- language preference belongs to Telegram account/session and can later sync to patient profile preferences
+- if language is missing, invalid, or unsupported, use Russian
+
+Mini App architecture:
+
+- future Mini App handles rich flows: appointment booking, patient forms, payment details, patient cabinet, and protected reports
+- server validates Telegram Mini App `initData` before trusting identity
+- Mini App links must be scoped to the linked patient or authenticated staff user
+
+## Security Rules
+
+Identity and linking:
+
+- never trust Telegram `user_id` alone as a patient or staff identity
+- link through one-time signed token, verified contact phone, admin confirmation, or protected cabinet link
+- reject forwarded or spoofed contacts when Telegram `contact.user_id` does not match the sender
+
+Deep links:
+
+- contain only short opaque signed tokens
+- expire quickly, typically 5 to 15 minutes for QR/start flows
+- are one-time-use where they grant linking or sensitive access
+- never expose `patient_id`, phone, diagnosis, `doctor_id`, `invoice_id`, or other internal identifiers in open text
+
+Medical data:
+
+- plain Telegram messages must not contain full diagnoses, complaints, prescriptions, medical histories, or complete lab values
+- safe text format is: `Результаты готовы. Откройте защищенный кабинет.`
+- unsafe text format is sending clinical findings directly into chat
+
+Staff operations:
+
+- every staff action checks role permissions server-side
+- every state-changing staff action is logged with actor, action, target, timestamp, and result
+- critical actions require confirmation buttons and must be idempotent
+
+Secrets and logging:
+
+- bot tokens stay in environment/config storage, never in code, tests, logs, or docs
+- Telegram logs store message metadata and template keys, not medical document content
+- failures log error type/status, not raw payloads with personal or medical data
+
+## AI Through Telegram
+
+Telegram can be used as an approval and notification surface for AI workflows, not as an autonomous medical decision-maker.
+
+Doctor examples:
+
+- AI prepared a draft conclusion
+- doctor opens protected EMR, edits, accepts, or rejects
+- acceptance/rejection is captured as feedback for future workflow quality
+
+Admin examples:
+
+- AI notices queue overload, payment anomalies, or integration failures
+- bot sends concise alert and links to the protected dashboard
+- admin confirms actions such as notifying registrar or opening the queue view
+
+Owner examples:
+
+- daily AI summary with revenue, average wait, overloaded services, unpaid visits, and integration health
+- details remain in the dashboard, not in Telegram chat
+
+AI workflow engines such as LangGraph orchestrate steps; they do not train the model by themselves. Adaptation requires feedback loops, RAG, historical decisions, and explicit accepted/rejected outcomes.
+
+## Rollout Roadmap
+
+Phase 1: Patient bot MVP with language choice
+
+- `/start`
+- Russian and Uzbek Latin onboarding
+- contact-based linking
+- patient profile status
+- current queue status
+- current visit/payment summary
+- basic notifications
+
+Phase 2: QR queue
+
+- one-time signed QR/start token
+- queue ticket linking
+- queue number and cabinet
+- position/status refresh
+- next/called notifications
+
+Phase 3: Payments
+
+- unpaid bill notification
+- payment entry button
+- payment status update
+- receipt availability notice
+- PayMe/Click/Apelsin reconciliation alerts for staff
+
+Phase 4: Staff bot
+
+- role-based menus for registrar, doctor, cashier, lab, admin/owner
+- server-side authorization
+- audit logging
+- confirmed queue/payment/schedule actions
+
+Phase 5: Telegram Mini App
+
+- appointment booking
+- patient forms
+- patient cabinet
+- payment details
+- protected result/report viewing
+- Telegram `initData` validation
+
+Phase 6: AI assistant approval flows
+
+- doctor draft review
+- queue overload suggestions
+- payment anomaly alerts
+- owner summaries
+- feedback capture for accepted/rejected suggestions
+
+## Acceptance Criteria
+
+- Plan exists at `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`.
+- Patient bot v1 explicitly supports only Russian and Uzbek Latin.
+- The document names and integrates EMR, registrar, queue, QR queue, payments, notifications, reports, and AI.
+- Telegram is defined as an operational layer, not a medical record store.
+- Security section blocks sensitive medical data in plain Telegram messages.
+- QR/start links use one-time signed tokens and do not expose internal identifiers.
+- Roadmap can be sliced into backend, frontend, test, and rollout tasks without product decisions left open.

--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -101,7 +101,7 @@ def get_telegram_settings(
             "lab_results_notifications": True,
             "payment_notifications": True,
             "default_language": "ru",
-            "supported_languages": ["ru", "uz", "en"],
+            "supported_languages": ["ru", "uz-Latn"],
         }
 
         # Применяем сохраненные настройки
@@ -416,10 +416,58 @@ def get_telegram_integration_status(
             "supported_functions": [
                 "ticket_qr_link",
                 "contact_phone_link",
+                "patient_queue",
+                "patient_payments_debt",
                 "patient_status",
-                "results_ready_notice",
+                "lab_results_pdf",
                 "admin_notifications",
             ],
+            "patient_bot": {
+                "version": "v1",
+                "transport": "polling" if not webhook_set else "webhook",
+                "supported_languages": [
+                    {"code": "ru", "label": "Русский"},
+                    {"code": "uz-Latn", "label": "O'zbekcha"},
+                ],
+                "default_language": "ru",
+                "onboarding": "language_choice_then_contact_link",
+                "commands": [
+                    {"command": "/queue", "label": "Моя очередь"},
+                    {"command": "/payments", "label": "Оплаты и долг"},
+                    {"command": "/results", "label": "PDF-результаты"},
+                    {"command": "/profile", "label": "Мой статус"},
+                    {"command": "/help", "label": "Помощь"},
+                ],
+                "features": [
+                    {
+                        "key": "ticket_qr_link",
+                        "label": "Привязка через QR чека",
+                        "enabled": bool(bot_username),
+                    },
+                    {
+                        "key": "contact_phone_link",
+                        "label": "Привязка через номер телефона",
+                        "enabled": bool(bot_token),
+                    },
+                    {
+                        "key": "patient_queue",
+                        "label": "Очередь пациента на сегодня",
+                        "enabled": bool(bot_token),
+                    },
+                    {
+                        "key": "patient_payments_debt",
+                        "label": "Оплаты и долг по визиту",
+                        "enabled": bool(bot_token),
+                    },
+                    {
+                        "key": "lab_results_pdf",
+                        "label": "PDF-результаты лаборатории",
+                        "enabled": bool(bot_token),
+                    },
+                ],
+                "results_delivery": "telegram_pdf",
+                "max_pdf_reports_per_request": 3,
+            },
             "transition_path": (
                 "Set webhook when a public HTTPS backend URL is available; "
                 "stop polling before webhook is enabled."

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -2,8 +2,10 @@
 Webhook endpoint для обработки входящих сообщений от Telegram
 """
 
+import html
 import logging
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 from typing import Any, Dict, NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -12,10 +14,15 @@ from sqlalchemy.orm import Session
 from app.api.deps import require_roles
 from app.crud import telegram_config as crud_telegram
 from app.db.session import get_db
+from app.models.lab import LabReportInstance
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.patient import Patient
-from app.models.telegram_config import TelegramUser
+from app.models.payment import Payment, PaymentVisit
+from app.models.telegram_config import TelegramMessage, TelegramUser
 from app.models.user import User
 from app.models.visit import Visit
+from app.services.lab_report_pdf_service import lab_report_pdf_service
+from app.services.lab_reporting_service import LabReportingService
 from app.services.telegram_bot import get_telegram_bot_service
 from app.services.visit_confirmation_service import (
     TELEGRAM_TICKET_QR_PREFIX,
@@ -61,15 +68,157 @@ TELEGRAM_NEEDS_LINK_MESSAGE = (
 TELEGRAM_MAIN_MENU = {
     "keyboard": [
         [{"text": "Поделиться номером", "request_contact": True}],
+        [{"text": "Моя очередь"}, {"text": "Оплаты и долг"}],
         [{"text": "Мой статус"}, {"text": "Результаты"}],
         [{"text": "Помощь"}],
     ],
     "resize_keyboard": True,
     "one_time_keyboard": False,
 }
+TELEGRAM_LANGUAGE_RU = "ru"
+TELEGRAM_LANGUAGE_UZ = "uz"  # Uzbek Latin; kept compact for current language_code column.
+TELEGRAM_LANGUAGE_MENU = {
+    "keyboard": [[{"text": "Русский"}, {"text": "O'zbekcha"}]],
+    "resize_keyboard": True,
+    "one_time_keyboard": True,
+}
+TELEGRAM_MAIN_MENUS = {
+    TELEGRAM_LANGUAGE_RU: TELEGRAM_MAIN_MENU,
+    TELEGRAM_LANGUAGE_UZ: {
+        "keyboard": [
+            [{"text": "Telefon raqamni ulashish", "request_contact": True}],
+            [{"text": "Mening navbatim"}, {"text": "To'lovlar va qarz"}],
+            [{"text": "Mening holatim"}, {"text": "Natijalar"}],
+            [{"text": "Yordam"}],
+        ],
+        "resize_keyboard": True,
+        "one_time_keyboard": False,
+    },
+}
+TELEGRAM_LOCALIZED_TEXTS = {
+    "language_prompt": {
+        TELEGRAM_LANGUAGE_RU: "Выберите язык обслуживания.\n\nTilni tanlang.",
+        TELEGRAM_LANGUAGE_UZ: "Tilni tanlang.\n\nВыберите язык обслуживания.",
+    },
+    "ticket_qr_linked": {
+        TELEGRAM_LANGUAGE_RU: TELEGRAM_TICKET_QR_LINKED_MESSAGE,
+        TELEGRAM_LANGUAGE_UZ: (
+            "Telegram klinika cheki bilan bog'landi. "
+            "Natijalar tayyor bo'lganda bot menyusini oching."
+        ),
+    },
+    "ticket_qr_expired": {
+        TELEGRAM_LANGUAGE_RU: TELEGRAM_TICKET_QR_EXPIRED_MESSAGE,
+        TELEGRAM_LANGUAGE_UZ: (
+            "Chekdagi havola muddati tugagan yoki ishlatilgan. "
+            "Registraturaga murojaat qiling."
+        ),
+    },
+    "ticket_qr_link_failed": {
+        TELEGRAM_LANGUAGE_RU: TELEGRAM_TICKET_QR_LINK_FAILED_MESSAGE,
+        TELEGRAM_LANGUAGE_UZ: (
+            "Telegramni chek bilan bog'lab bo'lmadi. "
+            "QR kodni yana ochib ko'ring."
+        ),
+    },
+    "share_contact": {
+        TELEGRAM_LANGUAGE_RU: TELEGRAM_SHARE_CONTACT_MESSAGE,
+        TELEGRAM_LANGUAGE_UZ: (
+            "Telegramni bemor kartasi bilan bog'lash uchun "
+            "\"Telefon raqamni ulashish\" tugmasini bosing. Raqam registraturadagi raqam bilan mos bo'lishi kerak."
+        ),
+    },
+    "contact_rejected": {
+        TELEGRAM_LANGUAGE_RU: TELEGRAM_CONTACT_REJECTED_MESSAGE,
+        TELEGRAM_LANGUAGE_UZ: (
+            "Faqat o'zingizning Telegram raqamingizni yuborish mumkin. "
+            "Bot menyusidagi \"Telefon raqamni ulashish\" tugmasini bosing."
+        ),
+    },
+    "patient_not_found": {
+        TELEGRAM_LANGUAGE_RU: TELEGRAM_PATIENT_NOT_FOUND_MESSAGE,
+        TELEGRAM_LANGUAGE_UZ: (
+            "Bu raqam bilan bemor topilmadi. Raqamni registraturada tekshiring "
+            "yoki chekdagi QR kodni skaner qiling."
+        ),
+    },
+    "contact_linked": {
+        TELEGRAM_LANGUAGE_RU: TELEGRAM_CONTACT_LINKED_MESSAGE,
+        TELEGRAM_LANGUAGE_UZ: (
+            "Telegram bemor kartasi bilan bog'landi. "
+            "Endi bot klinika xabarnomalarini yubora oladi."
+        ),
+    },
+    "needs_link": {
+        TELEGRAM_LANGUAGE_RU: TELEGRAM_NEEDS_LINK_MESSAGE,
+        TELEGRAM_LANGUAGE_UZ: (
+            "Telegram hali bemorga bog'lanmagan. "
+            "Chekdagi QR kodni skaner qiling yoki menyudagi telefon tugmasi orqali raqamingizni ulashing."
+        ),
+    },
+    "welcome": {
+        TELEGRAM_LANGUAGE_RU: (
+            "Добро пожаловать в Kosmed Clinic.\n\n"
+            "Через бота можно привязать Telegram к карте пациента, получать "
+            "уведомления клиники и открывать результаты, когда они готовы."
+        ),
+        TELEGRAM_LANGUAGE_UZ: (
+            "Kosmed Clinic botiga xush kelibsiz.\n\n"
+            "Bot orqali Telegramni bemor kartasiga bog'lash, klinika xabarnomalarini olish "
+            "va natijalar tayyor bo'lganda ularni ochish mumkin."
+        ),
+    },
+    "help": {
+        TELEGRAM_LANGUAGE_RU: (
+            "Команды бота:\n"
+            "/start - главное меню\n"
+            "/queue - моя очередь\n"
+            "/payments - оплаты и долг\n"
+            "/profile - статус привязки\n"
+            "/results - получить готовые PDF-результаты\n\n"
+            "Для привязки можно отсканировать QR с чека или нажать "
+            "\"Поделиться номером\"."
+        ),
+        TELEGRAM_LANGUAGE_UZ: (
+            "Bot buyruqlari:\n"
+            "/start - asosiy menyu\n"
+            "/queue - mening navbatim\n"
+            "/payments - to'lovlar va qarz\n"
+            "/profile - bog'lanish holati\n"
+            "/results - tayyor PDF natijalarni olish\n\n"
+            "Bog'lash uchun chekdagi QR kodni skaner qiling yoki "
+            "\"Telefon raqamni ulashish\" tugmasini bosing."
+        ),
+    },
+}
 TELEGRAM_WEBHOOK_PUBLIC_ERROR = "Ошибка обработки webhook"
 TELEGRAM_SEND_PUBLIC_ERROR = "Ошибка отправки сообщения"
 TELEGRAM_BOT_INFO_PUBLIC_MESSAGE = "Ошибка получения информации о боте"
+QUEUE_TERMINAL_STATUSES = {"served", "incomplete", "no_show", "cancelled"}
+QUEUE_WAITING_STATUSES = {"waiting"}
+QUEUE_TAG_LABELS = {
+    "ecg": "ЭКГ",
+    "cardiology_common": "Кардиология",
+    "dermatology": "Дерматология",
+    "stomatology": "Стоматология",
+    "cosmetology": "Косметология",
+    "lab": "Лаборатория",
+    "general": "Общая очередь",
+}
+QUEUE_STATUS_LABELS = {
+    "waiting": "ожидает",
+    "called": "вызван",
+    "in_service": "на приеме",
+    "diagnostics": "на диагностике",
+    "served": "завершен",
+    "incomplete": "не завершен",
+    "no_show": "не явился",
+    "cancelled": "отменен",
+}
+PAYMENT_PAID_STATUSES = {"paid", "completed"}
+PAYMENT_PENDING_STATUSES = {"pending", "processing"}
+LAB_REPORT_READY_STATUSES = {"FINALIZED", "PRINTED"}
+MAX_TELEGRAM_LAB_REPORTS = 3
 
 
 def _telegram_update_summary(update: Dict[str, Any]) -> Dict[str, Any]:
@@ -101,10 +250,43 @@ def _extract_ticket_qr_start_payload(
     return payload, message
 
 
+def _normalize_patient_language(language_code: Any) -> str:
+    value = str(language_code or "").strip().lower().replace("_", "-")
+    if value in {"uz", "uz-latn", "uzbek", "o'zbekcha", "ozbekcha"} or value.startswith("uz-"):
+        return TELEGRAM_LANGUAGE_UZ
+    return TELEGRAM_LANGUAGE_RU
+
+
+def _localized_text(key: str, language_code: Any) -> str:
+    language = _normalize_patient_language(language_code)
+    values = TELEGRAM_LOCALIZED_TEXTS.get(key) or {}
+    return values.get(language) or values.get(TELEGRAM_LANGUAGE_RU) or ""
+
+
+def _localized_main_menu(language_code: Any) -> Dict[str, Any]:
+    return TELEGRAM_MAIN_MENUS.get(
+        _normalize_patient_language(language_code), TELEGRAM_MAIN_MENU
+    )
+
+
+def _telegram_chat_language(db: Session, chat_id: int) -> str:
+    telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, chat_id)
+    return _normalize_patient_language(getattr(telegram_user, "language_code", None))
+
+
+def _telegram_chat_text(db: Session, chat_id: int, key: str) -> str:
+    return _localized_text(key, _telegram_chat_language(db, chat_id))
+
+
+def _telegram_chat_menu(db: Session, chat_id: int) -> Dict[str, Any]:
+    return _localized_main_menu(_telegram_chat_language(db, chat_id))
+
+
 def _upsert_ticket_qr_telegram_user(
     db: Session,
     message: Dict[str, Any],
     patient_id: int | None = None,
+    language_code: str | None = None,
 ) -> None:
     chat = message.get("chat") or {}
     from_user = message.get("from") or {}
@@ -112,18 +294,23 @@ def _upsert_ticket_qr_telegram_user(
     if chat_id is None:
         return
 
+    telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, int(chat_id))
     payload = {
         "username": from_user.get("username"),
         "first_name": from_user.get("first_name"),
         "last_name": from_user.get("last_name"),
-        "language_code": from_user.get("language_code") or "ru",
         "active": True,
         "blocked": False,
         "last_activity": datetime.utcnow(),
     }
+    if language_code is not None:
+        payload["language_code"] = _normalize_patient_language(language_code)
+    elif not telegram_user:
+        payload["language_code"] = _normalize_patient_language(
+            from_user.get("language_code") or TELEGRAM_LANGUAGE_RU
+        )
     if patient_id is not None:
         payload["patient_id"] = patient_id
-    telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, int(chat_id))
 
     if telegram_user:
         for field, value in payload.items():
@@ -166,23 +353,27 @@ async def _handle_ticket_qr_start(update: Dict[str, Any], db: Session, bot_servi
                 "Telegram ticket QR user link failed error_type=%s",
                 type(exc).__name__,
             )
+            language = _normalize_patient_language(
+                (message.get("from") or {}).get("language_code")
+            )
             await bot_service._send_message(
                 int(chat_id),
-                TELEGRAM_TICKET_QR_LINK_FAILED_MESSAGE,
-                TELEGRAM_MAIN_MENU,
+                _localized_text("ticket_qr_link_failed", language),
+                _localized_main_menu(language),
             )
             return True
 
         await bot_service._send_message(
             int(chat_id),
-            TELEGRAM_TICKET_QR_LINKED_MESSAGE,
-            TELEGRAM_MAIN_MENU,
+            _telegram_chat_text(db, int(chat_id), "ticket_qr_linked"),
+            _telegram_chat_menu(db, int(chat_id)),
         )
     elif chat_id is not None:
+        language = _telegram_chat_language(db, int(chat_id))
         await bot_service._send_message(
             int(chat_id),
-            TELEGRAM_TICKET_QR_EXPIRED_MESSAGE,
-            TELEGRAM_MAIN_MENU,
+            _localized_text("ticket_qr_expired", language),
+            _localized_main_menu(language),
         )
 
     return True
@@ -234,22 +425,437 @@ def _recent_visit_summary(db: Session, patient_id: int) -> str:
     return f"Последний визит: #{visit.id}, {visit_date}, статус: {visit.status}."
 
 
-def _clinic_status_message(db: Session, chat_id: int) -> str:
-    telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, chat_id)
-    if not telegram_user or not telegram_user.patient_id:
-        return TELEGRAM_NEEDS_LINK_MESSAGE
+def _html_text(value: Any) -> str:
+    return html.escape(str(value or ""), quote=False)
 
+
+def _money_decimal(value: Any) -> Decimal:
+    if value is None:
+        return Decimal("0")
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return Decimal("0")
+
+
+def _format_money(value: Decimal) -> str:
+    normalized = value.quantize(Decimal("0.01"))
+    if normalized == normalized.to_integral_value():
+        return f"{int(normalized):,}".replace(",", " ")
+    return f"{normalized:,.2f}".replace(",", " ")
+
+
+def _telegram_user_for_chat(db: Session, chat_id: int) -> TelegramUser | None:
+    return crud_telegram.get_telegram_user_by_chat_id(db, chat_id)
+
+
+def _patient_for_telegram_chat(
+    db: Session, chat_id: int
+) -> tuple[TelegramUser | None, Patient | None]:
+    telegram_user = _telegram_user_for_chat(db, chat_id)
+    if not telegram_user or not telegram_user.patient_id:
+        return telegram_user, None
     patient = db.query(Patient).filter(Patient.id == telegram_user.patient_id).first()
+    return telegram_user, patient
+
+
+def _patient_today_queue_entries(db: Session, patient_id: int) -> list[OnlineQueueEntry]:
     return (
-        f"Telegram привязан к пациенту: {_patient_display_name(patient)}.\n"
-        f"{_recent_visit_summary(db, telegram_user.patient_id)}"
+        db.query(OnlineQueueEntry)
+        .join(DailyQueue, OnlineQueueEntry.queue_id == DailyQueue.id)
+        .filter(
+            OnlineQueueEntry.patient_id == patient_id,
+            DailyQueue.day == date.today(),
+            ~OnlineQueueEntry.status.in_(QUEUE_TERMINAL_STATUSES),
+        )
+        .order_by(OnlineQueueEntry.queue_time.asc(), OnlineQueueEntry.id.asc())
+        .all()
+    )
+
+
+def _queue_entry_position(db: Session, entry: OnlineQueueEntry) -> int | None:
+    if entry.status not in QUEUE_WAITING_STATUSES:
+        return None
+
+    waiting_entries = (
+        db.query(OnlineQueueEntry)
+        .filter(
+            OnlineQueueEntry.queue_id == entry.queue_id,
+            OnlineQueueEntry.status.in_(QUEUE_WAITING_STATUSES),
+        )
+        .order_by(
+            OnlineQueueEntry.priority.desc(),
+            OnlineQueueEntry.queue_time.asc(),
+            OnlineQueueEntry.id.asc(),
+        )
+        .all()
+    )
+    for position, waiting_entry in enumerate(waiting_entries, start=1):
+        if waiting_entry.id == entry.id:
+            return position
+    return None
+
+
+def _queue_entry_name(entry: OnlineQueueEntry) -> str:
+    queue = getattr(entry, "queue", None)
+    queue_tag = getattr(queue, "queue_tag", None)
+    if queue_tag:
+        return QUEUE_TAG_LABELS.get(queue_tag, queue_tag)
+
+    services = entry.services or []
+    if services:
+        first_service = services[0] or {}
+        return str(first_service.get("name") or first_service.get("title") or "Очередь")
+    return "Очередь"
+
+
+def _queue_entry_cabinet(entry: OnlineQueueEntry) -> str | None:
+    queue = getattr(entry, "queue", None)
+    cabinet_number = getattr(queue, "cabinet_number", None)
+    if not cabinet_number:
+        return None
+    return f"Кабинет {_html_text(cabinet_number)}"
+
+
+def _clinic_queue_message(db: Session, chat_id: int) -> str:
+    telegram_user, patient = _patient_for_telegram_chat(db, chat_id)
+    if not telegram_user or not telegram_user.patient_id:
+        return _telegram_chat_text(db, chat_id, "needs_link")
+
+    entries = _patient_today_queue_entries(db, telegram_user.patient_id)
+    if not entries:
+        return (
+            f"Telegram привязан к пациенту: {_html_text(_patient_display_name(patient))}.\n"
+            f"{_html_text(_recent_visit_summary(db, telegram_user.patient_id))}\n\n"
+            "На сегодня активной очереди нет."
+        )
+
+    lines = [
+        f"Пациент: {_html_text(_patient_display_name(patient))}",
+        "Ваша очередь на сегодня:",
+    ]
+    for entry in entries[:5]:
+        status_label = QUEUE_STATUS_LABELS.get(entry.status, entry.status)
+        position = _queue_entry_position(db, entry)
+        cabinet = _queue_entry_cabinet(entry)
+        details = [
+            f"№{entry.number}",
+            _html_text(_queue_entry_name(entry)),
+            f"статус: {_html_text(status_label)}",
+        ]
+        if position:
+            details.append(f"позиция: {position}")
+        if cabinet:
+            details.append(cabinet)
+        lines.append(" • ".join(details))
+
+    if len(entries) > 5:
+        lines.append(f"Еще записей: {len(entries) - 5}")
+    return "\n".join(lines)
+
+
+def _visit_services_total(visit: Visit) -> Decimal:
+    total = Decimal("0")
+    for service in getattr(visit, "services", []) or []:
+        total += _money_decimal(getattr(service, "price", None)) * _money_decimal(
+            getattr(service, "qty", 1) or 1
+        )
+    return total
+
+
+def _patient_relevant_visits(
+    db: Session, patient_id: int, entries: list[OnlineQueueEntry]
+) -> list[Visit]:
+    visit_ids = sorted({int(entry.visit_id) for entry in entries if entry.visit_id})
+    if visit_ids:
+        return (
+            db.query(Visit)
+            .filter(Visit.patient_id == patient_id, Visit.id.in_(visit_ids))
+            .order_by(Visit.created_at.desc(), Visit.id.desc())
+            .all()
+        )
+
+    visits = (
+        db.query(Visit)
+        .filter(Visit.patient_id == patient_id, Visit.visit_date == date.today())
+        .order_by(Visit.created_at.desc(), Visit.id.desc())
+        .limit(3)
+        .all()
+    )
+    if visits:
+        return visits
+
+    return (
+        db.query(Visit)
+        .filter(Visit.patient_id == patient_id, Visit.status == "open")
+        .order_by(Visit.created_at.desc(), Visit.id.desc())
+        .limit(3)
+        .all()
+    )
+
+
+def _payment_total_for_visits(
+    db: Session, visit_ids: list[int], statuses: set[str]
+) -> Decimal:
+    if not visit_ids:
+        return Decimal("0")
+
+    total = Decimal("0")
+    status_values = tuple(statuses)
+    junction_visit_ids: set[int] = set()
+    junction_rows = (
+        db.query(PaymentVisit.visit_id, PaymentVisit.amount)
+        .join(Payment, Payment.id == PaymentVisit.payment_id)
+        .filter(
+            PaymentVisit.visit_id.in_(visit_ids),
+            Payment.status.in_(status_values),
+        )
+        .all()
+    )
+    for visit_id, amount in junction_rows:
+        junction_visit_ids.add(int(visit_id))
+        total += _money_decimal(amount)
+
+    direct_payments = (
+        db.query(Payment)
+        .filter(Payment.visit_id.in_(visit_ids), Payment.status.in_(status_values))
+        .all()
+    )
+    for payment in direct_payments:
+        if int(payment.visit_id) in junction_visit_ids:
+            continue
+        total += _money_decimal(payment.amount)
+
+    return total
+
+
+def _billing_totals(
+    db: Session, patient_id: int
+) -> tuple[list[OnlineQueueEntry], list[Visit], Decimal, Decimal, Decimal, Decimal]:
+    entries = _patient_today_queue_entries(db, patient_id)
+    visits = _patient_relevant_visits(db, patient_id, entries)
+    visits_by_id = {visit.id: visit for visit in visits}
+    entry_total_by_visit: dict[int, Decimal] = {}
+    unlinked_entry_total = Decimal("0")
+
+    for entry in entries:
+        entry_total = _money_decimal(entry.total_amount)
+        if entry.visit_id:
+            current = entry_total_by_visit.get(int(entry.visit_id), Decimal("0"))
+            entry_total_by_visit[int(entry.visit_id)] = max(current, entry_total)
+        else:
+            unlinked_entry_total += entry_total
+
+    expected_total = unlinked_entry_total
+    for visit in visits:
+        queue_total = entry_total_by_visit.get(visit.id, Decimal("0"))
+        expected_total += queue_total if queue_total > 0 else _visit_services_total(visit)
+
+    visit_ids = sorted(visits_by_id)
+    paid_total = _payment_total_for_visits(db, visit_ids, PAYMENT_PAID_STATUSES)
+    pending_total = _payment_total_for_visits(db, visit_ids, PAYMENT_PENDING_STATUSES)
+    debt_total = max(expected_total - paid_total, Decimal("0"))
+    return entries, visits, expected_total, paid_total, pending_total, debt_total
+
+
+def _clinic_payments_message(db: Session, chat_id: int) -> str:
+    telegram_user, patient = _patient_for_telegram_chat(db, chat_id)
+    if not telegram_user or not telegram_user.patient_id:
+        return _telegram_chat_text(db, chat_id, "needs_link")
+
+    entries, visits, expected_total, paid_total, pending_total, debt_total = _billing_totals(
+        db, telegram_user.patient_id
+    )
+    if not entries and not visits and expected_total <= 0 and paid_total <= 0:
+        return (
+            f"Пациент: {_html_text(_patient_display_name(patient))}\n"
+            "Активных начислений и оплат пока нет."
+        )
+
+    lines = [
+        f"Пациент: {_html_text(_patient_display_name(patient))}",
+        "Оплаты и долг:",
+        f"Начислено: {_format_money(expected_total)} сум",
+        f"Оплачено: {_format_money(paid_total)} сум",
+        f"Долг: {_format_money(debt_total)} сум",
+    ]
+    if pending_total > 0:
+        lines.append(f"Ожидает подтверждения: {_format_money(pending_total)} сум")
+    if visits:
+        visit_numbers = ", ".join(f"#{visit.id}" for visit in visits[:5])
+        lines.append(f"Визит: {visit_numbers}")
+    lines.append("Онлайн-оплата пока не подключена. Для оплаты обратитесь в кассу.")
+    return "\n".join(lines)
+
+
+def _latest_ready_lab_report_instances(
+    db: Session, patient_id: int, limit: int = MAX_TELEGRAM_LAB_REPORTS
+) -> list[LabReportInstance]:
+    return (
+        db.query(LabReportInstance)
+        .filter(
+            LabReportInstance.patient_id == patient_id,
+            LabReportInstance.status.in_(LAB_REPORT_READY_STATUSES),
+        )
+        .order_by(LabReportInstance.created_at.desc(), LabReportInstance.id.desc())
+        .limit(limit)
+        .all()
+    )
+
+
+def _build_lab_report_pdf(db: Session, instance: LabReportInstance) -> tuple[str, bytes, str]:
+    service = LabReportingService(db)
+    materialized_sections = service.materialize_instance(instance)
+    critical_findings = service.summarize_critical_findings(materialized_sections)
+    report_date = instance.finalized_at or instance.created_at or datetime.utcnow()
+    pdf_bytes = lab_report_pdf_service.render_report(
+        {
+            "template_name": instance.template.name,
+            "layout_preset": instance.template_version.layout_preset,
+            "page_settings": instance.template_version.page_settings or {},
+            "branding": instance.branding_snapshot or {},
+            "patient": instance.patient_snapshot or {},
+            "signers": instance.signer_snapshot or {},
+            "sections": materialized_sections,
+            "critical_findings": critical_findings,
+            "footer_notes": instance.template_version.footer_notes,
+            "report_date": report_date.strftime("%d.%m.%Y"),
+        }
+    )
+    filename = f"kosmed-lab-report-{instance.id}.pdf"
+    caption = (
+        f"Результат анализа: {_html_text(instance.template.name)}\n"
+        f"Отчет #{instance.id} от {report_date.strftime('%d.%m.%Y')}"
+    )
+    if len(caption) > 1000:
+        caption = f"{caption[:997]}..."
+    return filename, pdf_bytes, caption
+
+
+def _log_lab_report_document_send(
+    db: Session,
+    chat_id: int,
+    instance_id: int,
+    caption: str,
+    status_value: str,
+    message_id: int | None = None,
+    error_message: str | None = None,
+) -> None:
+    try:
+        db.add(
+            TelegramMessage(
+                chat_id=chat_id,
+                message_id=message_id,
+                message_type="lab_result_pdf",
+                template_key="telegram_lab_result_pdf",
+                message_text=caption,
+                status=status_value,
+                error_message=error_message,
+                related_entity_type="lab_report_instance",
+                related_entity_id=instance_id,
+                sent_at=datetime.utcnow() if status_value == "sent" else None,
+            )
+        )
+        db.commit()
+    except Exception as exc:
+        db.rollback()
+        logger.warning(
+            "Telegram lab report document log failed error_type=%s",
+            type(exc).__name__,
+        )
+
+
+async def _send_clinic_lab_results(db: Session, bot_service, chat_id: int) -> None:
+    telegram_user, _patient = _patient_for_telegram_chat(db, chat_id)
+    if not telegram_user or not telegram_user.patient_id:
+        await bot_service._send_message(
+            chat_id,
+            _telegram_chat_text(db, chat_id, "needs_link"),
+            _telegram_chat_menu(db, chat_id),
+        )
+        return
+
+    instances = _latest_ready_lab_report_instances(db, telegram_user.patient_id)
+    if not instances:
+        await bot_service._send_message(
+            chat_id,
+            (
+                "Готовых PDF-результатов пока нет. "
+                "Когда лаборатория финализирует отчет, он появится здесь."
+            ),
+            _telegram_chat_menu(db, chat_id),
+        )
+        return
+
+    await bot_service._send_message(
+        chat_id,
+        f"Нашел готовые результаты: {len(instances)}. Отправляю PDF-файлы.",
+        _telegram_chat_menu(db, chat_id),
+    )
+    sent_count = 0
+    for instance in instances:
+        try:
+            filename, pdf_bytes, caption = _build_lab_report_pdf(db, instance)
+            send_document = getattr(bot_service, "_send_document", None)
+            if callable(send_document):
+                ok, message_id, error_message = await send_document(
+                    chat_id,
+                    filename,
+                    pdf_bytes,
+                    caption,
+                )
+            else:
+                logger.error("Telegram bot service does not support document send")
+                ok, message_id, error_message = False, None, "send_document_not_supported"
+            _log_lab_report_document_send(
+                db,
+                chat_id,
+                instance.id,
+                caption,
+                "sent" if ok else "failed",
+                message_id=message_id,
+                error_message=error_message,
+            )
+            if ok:
+                sent_count += 1
+        except Exception as exc:
+            logger.warning(
+                "Telegram lab report PDF send failed instance_id=%s error_type=%s",
+                instance.id,
+                type(exc).__name__,
+            )
+            _log_lab_report_document_send(
+                db,
+                chat_id,
+                instance.id,
+                f"Отчет #{instance.id}",
+                "failed",
+                error_message=type(exc).__name__,
+            )
+
+    if sent_count == 0:
+        await bot_service._send_message(
+            chat_id,
+            "Не удалось отправить PDF-результаты. Обратитесь в регистратуру.",
+            _telegram_chat_menu(db, chat_id),
+        )
+
+
+def _clinic_status_message(db: Session, chat_id: int) -> str:
+    telegram_user, patient = _patient_for_telegram_chat(db, chat_id)
+    if not telegram_user or not telegram_user.patient_id:
+        return _telegram_chat_text(db, chat_id, "needs_link")
+
+    return (
+        f"Telegram привязан к пациенту: {_html_text(_patient_display_name(patient))}.\n"
+        f"{_html_text(_recent_visit_summary(db, telegram_user.patient_id))}"
     )
 
 
 def _clinic_results_message(db: Session, chat_id: int) -> str:
     telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, chat_id)
     if not telegram_user or not telegram_user.patient_id:
-        return TELEGRAM_NEEDS_LINK_MESSAGE
+        return _telegram_chat_text(db, chat_id, "needs_link")
 
     return (
         "Результаты будут приходить сюда, когда лаборатория или врач отметит их "
@@ -257,15 +863,21 @@ def _clinic_results_message(db: Session, chat_id: int) -> str:
     )
 
 
-async def _send_clinic_welcome(bot_service, chat_id: int) -> None:
+async def _send_language_choice(bot_service, chat_id: int) -> None:
     await bot_service._send_message(
         chat_id,
-        (
-            "Добро пожаловать в Kosmed Clinic.\n\n"
-            "Через бота можно привязать Telegram к карте пациента, получать "
-            "уведомления клиники и открывать результаты, когда они готовы."
-        ),
-        TELEGRAM_MAIN_MENU,
+        _localized_text("language_prompt", TELEGRAM_LANGUAGE_RU),
+        TELEGRAM_LANGUAGE_MENU,
+    )
+
+
+async def _send_clinic_welcome(
+    bot_service, chat_id: int, language_code: str = TELEGRAM_LANGUAGE_RU
+) -> None:
+    await bot_service._send_message(
+        chat_id,
+        _localized_text("welcome", language_code),
+        _localized_main_menu(language_code),
     )
 
 
@@ -283,12 +895,20 @@ async def _handle_contact_link(
         return True
 
     if from_user_id is None or contact_user_id != from_user_id:
-        await bot_service._send_message(chat_id, TELEGRAM_CONTACT_REJECTED_MESSAGE, TELEGRAM_MAIN_MENU)
+        await bot_service._send_message(
+            chat_id,
+            _telegram_chat_text(db, chat_id, "contact_rejected"),
+            _telegram_chat_menu(db, chat_id),
+        )
         return True
 
     patient = _find_patient_by_phone(db, str(contact.get("phone_number") or ""))
     if not patient:
-        await bot_service._send_message(chat_id, TELEGRAM_PATIENT_NOT_FOUND_MESSAGE, TELEGRAM_MAIN_MENU)
+        await bot_service._send_message(
+            chat_id,
+            _telegram_chat_text(db, chat_id, "patient_not_found"),
+            _telegram_chat_menu(db, chat_id),
+        )
         return True
 
     try:
@@ -300,13 +920,19 @@ async def _handle_contact_link(
             "Telegram contact link failed error_type=%s",
             type(exc).__name__,
         )
-        await bot_service._send_message(chat_id, TELEGRAM_TICKET_QR_LINK_FAILED_MESSAGE, TELEGRAM_MAIN_MENU)
+        await bot_service._send_message(
+            chat_id,
+            _telegram_chat_text(db, chat_id, "ticket_qr_link_failed"),
+            _telegram_chat_menu(db, chat_id),
+        )
         return True
 
+    language = _telegram_chat_language(db, chat_id)
+    patient_label = "Bemor" if language == TELEGRAM_LANGUAGE_UZ else "Пациент"
     await bot_service._send_message(
         chat_id,
-        f"{TELEGRAM_CONTACT_LINKED_MESSAGE}\nПациент: {_patient_display_name(patient)}",
-        TELEGRAM_MAIN_MENU,
+        f"{_localized_text('contact_linked', language)}\n{patient_label}: {_patient_display_name(patient)}",
+        _localized_main_menu(language),
     )
     return True
 
@@ -314,6 +940,98 @@ async def _handle_contact_link(
 async def _handle_clinic_bot_update(
     update: Dict[str, Any], db: Session, bot_service
 ) -> bool:
+    async def start_handler(chat_id: int, message: Dict[str, Any]) -> None:
+        _upsert_ticket_qr_telegram_user(db, message)
+        db.commit()
+        await _send_language_choice(bot_service, chat_id)
+
+    async def language_handler(chat_id: int, language_code: str) -> None:
+        message = _message_from_update(update)
+        _upsert_ticket_qr_telegram_user(db, message, language_code=language_code)
+        db.commit()
+        logger.info(
+            "Telegram patient bot language selected",
+            extra={"language_code": _normalize_patient_language(language_code)},
+        )
+        await _send_clinic_welcome(bot_service, chat_id, language_code)
+
+    async def help_handler(chat_id: int) -> None:
+        language = _telegram_chat_language(db, chat_id)
+        await bot_service._send_message(
+            chat_id,
+            _localized_text("help", language),
+            _localized_main_menu(language),
+        )
+
+    async def queue_handler(chat_id: int) -> None:
+        await bot_service._send_message(
+            chat_id, _clinic_queue_message(db, chat_id), _telegram_chat_menu(db, chat_id)
+        )
+
+    async def payments_handler(chat_id: int) -> None:
+        await bot_service._send_message(
+            chat_id, _clinic_payments_message(db, chat_id), _telegram_chat_menu(db, chat_id)
+        )
+
+    async def profile_handler(chat_id: int) -> None:
+        await bot_service._send_message(
+            chat_id, _clinic_status_message(db, chat_id), _telegram_chat_menu(db, chat_id)
+        )
+
+    async def results_handler(chat_id: int) -> None:
+        await _send_clinic_lab_results(db, bot_service, chat_id)
+
+    async def share_contact_handler(chat_id: int) -> None:
+        await bot_service._send_message(
+            chat_id,
+            _telegram_chat_text(db, chat_id, "share_contact"),
+            _telegram_chat_menu(db, chat_id),
+        )
+
+    async def russian_language_handler(chat_id: int) -> None:
+        await language_handler(chat_id, TELEGRAM_LANGUAGE_RU)
+
+    async def uzbek_language_handler(chat_id: int) -> None:
+        await language_handler(chat_id, TELEGRAM_LANGUAGE_UZ)
+
+    command_handlers = {
+        "/help": help_handler,
+        "/queue": queue_handler,
+        "/payments": payments_handler,
+        "/profile": profile_handler,
+        "/results": results_handler,
+    }
+    text_handlers = {
+        "помощь": help_handler,
+        "моя очередь": queue_handler,
+        "оплаты и долг": payments_handler,
+        "мой статус": profile_handler,
+        "результаты": results_handler,
+        "поделиться номером": share_contact_handler,
+        "русский": russian_language_handler,
+        "o'zbekcha": uzbek_language_handler,
+        "ozbekcha": uzbek_language_handler,
+        "uzbekcha": uzbek_language_handler,
+        "yordam": help_handler,
+        "mening navbatim": queue_handler,
+        "to'lovlar va qarz": payments_handler,
+        "mening holatim": profile_handler,
+        "natijalar": results_handler,
+        "telefon raqamni ulashish": share_contact_handler,
+    }
+
+    dispatch = getattr(bot_service, "process_patient_bot_update", None)
+    if callable(dispatch):
+        return await dispatch(
+            update,
+            db,
+            ticket_start_handler=_handle_ticket_qr_start,
+            contact_handler=_handle_contact_link,
+            start_handler=start_handler,
+            command_handlers=command_handlers,
+            text_handlers=text_handlers,
+        )
+
     if await _handle_ticket_qr_start(update, db, bot_service):
         return True
 
@@ -330,41 +1048,13 @@ async def _handle_clinic_bot_update(
 
     text = _message_text(message)
     command = text.split(maxsplit=1)[0].split("@", 1)[0].lower() if text else ""
-    normalized_text = text.lower()
-
+    handler = command_handlers.get(command) or text_handlers.get(text.lower())
     if command == "/start":
-        _upsert_ticket_qr_telegram_user(db, message)
-        db.commit()
-        await _send_clinic_welcome(bot_service, chat_id)
+        await start_handler(chat_id, message)
         return True
-
-    if command == "/help" or normalized_text == "помощь":
-        await bot_service._send_message(
-            chat_id,
-            (
-                "Команды бота:\n"
-                "/start - главное меню\n"
-                "/profile - статус привязки\n"
-                "/results - информация о результатах\n\n"
-                "Для привязки можно отсканировать QR с чека или нажать "
-                "\"Поделиться номером\"."
-            ),
-            TELEGRAM_MAIN_MENU,
-        )
+    if handler:
+        await handler(chat_id)
         return True
-
-    if command == "/profile" or normalized_text == "мой статус":
-        await bot_service._send_message(chat_id, _clinic_status_message(db, chat_id), TELEGRAM_MAIN_MENU)
-        return True
-
-    if command == "/results" or normalized_text == "результаты":
-        await bot_service._send_message(chat_id, _clinic_results_message(db, chat_id), TELEGRAM_MAIN_MENU)
-        return True
-
-    if normalized_text == "поделиться номером":
-        await bot_service._send_message(chat_id, TELEGRAM_SHARE_CONTACT_MESSAGE, TELEGRAM_MAIN_MENU)
-        return True
-
     return False
 
 

--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -6,7 +6,7 @@ Telegram Bot сервис для клиники
 import json
 import logging
 from datetime import datetime
-from typing import Any
+from typing import Any, Awaitable, Callable, Mapping
 
 import requests
 from sqlalchemy.orm import Session
@@ -22,6 +22,7 @@ from app.crud import (
 )
 
 logger = logging.getLogger(__name__)
+MAX_TELEGRAM_DOCUMENT_BYTES = 20 * 1024 * 1024
 
 
 class TelegramBotService:
@@ -57,6 +58,48 @@ class TelegramBotService:
                 await self._handle_inline_query(update["inline_query"], db)
         except Exception as e:
             logger.error(f"Ошибка обработки webhook: {e}")
+
+    async def process_patient_bot_update(
+        self,
+        update: dict[str, Any],
+        db: Session,
+        *,
+        ticket_start_handler: Callable[..., Awaitable[bool]],
+        contact_handler: Callable[..., Awaitable[bool]],
+        start_handler: Callable[[int, dict[str, Any]], Awaitable[None]],
+        command_handlers: Mapping[str, Callable[[int], Awaitable[None]]],
+        text_handlers: Mapping[str, Callable[[int], Awaitable[None]]],
+    ) -> bool:
+        """Dispatch clinic patient bot updates above webhook/polling transports."""
+        if await ticket_start_handler(update, db, self):
+            return True
+
+        message = update.get("message") or {}
+        if not message:
+            return False
+
+        chat_id = (message.get("chat") or {}).get("id")
+        if chat_id is None:
+            return False
+        chat_id = int(chat_id)
+
+        if await contact_handler(message, db, self):
+            return True
+
+        text = str(message.get("text") or "").strip()
+        command = text.split(maxsplit=1)[0].split("@", 1)[0].lower() if text else ""
+        normalized_text = text.lower()
+
+        if command == "/start":
+            await start_handler(chat_id, message)
+            return True
+
+        handler = command_handlers.get(command) or text_handlers.get(normalized_text)
+        if handler:
+            await handler(chat_id)
+            return True
+
+        return False
 
     async def _handle_message(self, message: dict[str, Any], db: Session):
         """Обработка текстовых сообщений"""
@@ -397,6 +440,53 @@ class TelegramBotService:
         except Exception as e:
             logger.error(f"Ошибка отправки сообщения: {e}")
             return False
+
+    async def _send_document(
+        self,
+        chat_id: int,
+        filename: str,
+        document_bytes: bytes,
+        caption: str = "",
+    ) -> tuple[bool, int | None, str | None]:
+        """Send a PDF/document to Telegram without logging document contents."""
+        if not self.bot_token:
+            logger.error("Bot token is not configured for Telegram document send")
+            return False, None, "bot_token_not_configured"
+
+        if len(document_bytes) > MAX_TELEGRAM_DOCUMENT_BYTES:
+            return False, None, "document_too_large"
+
+        url = f"https://api.telegram.org/bot{self.bot_token}/sendDocument"
+        data = {"chat_id": chat_id, "caption": caption, "parse_mode": "HTML"}
+        files = {"document": (filename, document_bytes, "application/pdf")}
+        try:
+            response = requests.post(url, data=data, files=files, timeout=20)
+        except requests.RequestException as exc:
+            logger.warning(
+                "Telegram document send request failed error_type=%s",
+                type(exc).__name__,
+            )
+            return False, None, type(exc).__name__
+
+        if response.status_code != 200:
+            logger.warning(
+                "Telegram document send failed status_code=%s",
+                response.status_code,
+            )
+            return False, None, f"telegram_http_{response.status_code}"
+
+        try:
+            payload = response.json()
+        except ValueError:
+            logger.warning("Telegram document send returned invalid json")
+            return False, None, "telegram_invalid_json"
+
+        if not payload.get("ok"):
+            logger.warning("Telegram document send returned not ok")
+            return False, None, "telegram_api_error"
+
+        message_id = (payload.get("result") or {}).get("message_id")
+        return True, int(message_id) if message_id is not None else None, None
 
     async def _answer_callback_query(self, callback_query_id: str, text: str = ""):
         """Ответ на callback запрос"""

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
 from app.api.v1.endpoints import telegram_webhook
-from app.models.telegram_config import TelegramConfig
+from app.services import telegram_bot
+from app.models.lab import LabReportInstance, LabReportTemplate, LabReportTemplateVersion
+from app.models.online_queue import OnlineQueueEntry
+from app.models.patient import Patient
+from app.models.payment import Payment
+from app.models.telegram_config import TelegramConfig, TelegramMessage, TelegramUser
 
 
 class FakeTelegramBotService:
@@ -13,8 +21,55 @@ class FakeTelegramBotService:
         self.active = active
         self.initialize = AsyncMock(return_value=True)
         self.process_webhook_update = AsyncMock(return_value=None)
+        self._send_message = AsyncMock(return_value=True)
+        self._send_document = AsyncMock(return_value=(True, 77, None))
         self.bot_token = "bot-token"
         self.webhook_url = "https://example.com/webhook"
+
+
+def _link_patient_to_chat(db_session, *, chat_id: int, patient_id: int) -> TelegramUser:
+    telegram_user = TelegramUser(
+        chat_id=chat_id,
+        patient_id=patient_id,
+        username="patient_chat",
+        first_name="Patient",
+        language_code="ru",
+        notifications_enabled=True,
+        appointment_reminders=True,
+        lab_notifications=True,
+        active=True,
+        blocked=False,
+    )
+    db_session.add(telegram_user)
+    db_session.commit()
+    db_session.refresh(telegram_user)
+    return telegram_user
+
+
+def _create_lab_report_instance(
+    db_session,
+    *,
+    patient_id: int,
+    template: LabReportTemplate,
+    version: LabReportTemplateVersion,
+    status_value: str,
+    created_at: datetime,
+) -> LabReportInstance:
+    instance = LabReportInstance(
+        patient_id=patient_id,
+        template_id=template.id,
+        template_version_id=version.id,
+        status=status_value,
+        patient_snapshot={},
+        branding_snapshot={},
+        signer_snapshot={},
+        created_at=created_at,
+        finalized_at=created_at if status_value == "FINALIZED" else None,
+        printed_at=created_at if status_value == "PRINTED" else None,
+    )
+    db_session.add(instance)
+    db_session.flush()
+    return instance
 
 
 @pytest.mark.unit
@@ -137,3 +192,246 @@ class TestTelegramWebhookSecurity:
         )
 
         assert response.status_code in {401, 403}
+
+    @pytest.mark.asyncio
+    async def test_contact_spoof_is_rejected(self, db_session):
+        fake_service = FakeTelegramBotService(active=True)
+        update = {
+            "update_id": 101,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7001},
+                "from": {"id": 111},
+                "contact": {
+                    "user_id": 222,
+                    "phone_number": "+998901234567",
+                },
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        assert (
+            fake_service._send_message.await_args.args[1]
+            == telegram_webhook.TELEGRAM_CONTACT_REJECTED_MESSAGE
+        )
+        assert (
+            db_session.query(TelegramUser)
+            .filter(TelegramUser.chat_id == 7001)
+            .first()
+            is None
+        )
+
+    def test_queue_message_reports_linked_patient_position_and_cabinet(
+        self, db_session, test_patient, test_daily_queue, test_queue_entry
+    ):
+        _link_patient_to_chat(db_session, chat_id=7002, patient_id=test_patient.id)
+        now = datetime.utcnow()
+        test_daily_queue.cabinet_number = "205"
+        test_queue_entry.number = 2
+        test_queue_entry.status = "waiting"
+        test_queue_entry.queue_time = now
+        earlier_entry = OnlineQueueEntry(
+            queue_id=test_daily_queue.id,
+            number=1,
+            patient_id=None,
+            patient_name="Earlier Patient",
+            source="desk",
+            status="waiting",
+            queue_time=now - timedelta(minutes=5),
+        )
+        db_session.add(earlier_entry)
+        db_session.commit()
+
+        message = telegram_webhook._clinic_queue_message(db_session, 7002)
+
+        assert "№2" in message
+        assert "позиция: 2" in message
+        assert "Кабинет 205" in message
+        assert "Кардиология" in message
+
+    def test_payments_message_calculates_debt_from_queue_total_and_payments(
+        self, db_session, test_patient, test_visit, test_queue_entry
+    ):
+        _link_patient_to_chat(db_session, chat_id=7003, patient_id=test_patient.id)
+        test_queue_entry.visit_id = test_visit.id
+        test_queue_entry.total_amount = 120000
+        db_session.add_all(
+            [
+                Payment(
+                    visit_id=test_visit.id,
+                    amount=Decimal("50000"),
+                    status="paid",
+                    method="cash",
+                ),
+                Payment(
+                    visit_id=test_visit.id,
+                    amount=Decimal("10000"),
+                    status="pending",
+                    method="cash",
+                ),
+            ]
+        )
+        db_session.commit()
+
+        message = telegram_webhook._clinic_payments_message(db_session, 7003)
+
+        assert "Начислено: 120 000 сум" in message
+        assert "Оплачено: 50 000 сум" in message
+        assert "Долг: 70 000 сум" in message
+        assert "Ожидает подтверждения: 10 000 сум" in message
+
+    def test_ready_lab_reports_are_filtered_by_patient_status_and_limited(
+        self, db_session, test_patient
+    ):
+        other_patient = Patient(first_name="Other", last_name="Patient")
+        template = LabReportTemplate(
+            code="TG_TEST_REPORT",
+            name="Telegram Test Report",
+            family="test",
+        )
+        db_session.add_all([other_patient, template])
+        db_session.flush()
+        version = LabReportTemplateVersion(
+            template_id=template.id,
+            version_no=1,
+            status="PUBLISHED",
+            layout_preset="default",
+            page_settings={},
+            branding_overrides={},
+            signer_defaults={},
+        )
+        db_session.add(version)
+        db_session.flush()
+        base_time = datetime.utcnow()
+        ready_instances = [
+            _create_lab_report_instance(
+                db_session,
+                patient_id=test_patient.id,
+                template=template,
+                version=version,
+                status_value=status_value,
+                created_at=base_time + timedelta(minutes=index),
+            )
+            for index, status_value in enumerate(
+                ["FINALIZED", "PRINTED", "FINALIZED", "PRINTED"], start=1
+            )
+        ]
+        _create_lab_report_instance(
+            db_session,
+            patient_id=test_patient.id,
+            template=template,
+            version=version,
+            status_value="DRAFT",
+            created_at=base_time + timedelta(minutes=99),
+        )
+        _create_lab_report_instance(
+            db_session,
+            patient_id=other_patient.id,
+            template=template,
+            version=version,
+            status_value="FINALIZED",
+            created_at=base_time + timedelta(minutes=100),
+        )
+        db_session.commit()
+
+        result = telegram_webhook._latest_ready_lab_report_instances(
+            db_session, test_patient.id
+        )
+
+        assert len(result) == 3
+        assert {item.patient_id for item in result} == {test_patient.id}
+        assert {item.status for item in result} <= {"FINALIZED", "PRINTED"}
+        assert [item.id for item in result] == [
+            ready_instances[3].id,
+            ready_instances[2].id,
+            ready_instances[1].id,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_lab_results_flow_sends_pdf_through_bot_service(
+        self, db_session, test_patient, monkeypatch
+    ):
+        _link_patient_to_chat(db_session, chat_id=7004, patient_id=test_patient.id)
+        fake_service = FakeTelegramBotService(active=True)
+        fake_instance = SimpleNamespace(id=456)
+        monkeypatch.setattr(
+            telegram_webhook,
+            "_latest_ready_lab_report_instances",
+            lambda db, patient_id: [fake_instance],
+        )
+        monkeypatch.setattr(
+            telegram_webhook,
+            "_build_lab_report_pdf",
+            lambda db, instance: (
+                "result.pdf",
+                b"%PDF-1.4",
+                "Ready result",
+            ),
+        )
+
+        await telegram_webhook._send_clinic_lab_results(db_session, fake_service, 7004)
+
+        fake_service._send_document.assert_awaited_once_with(
+            7004,
+            "result.pdf",
+            b"%PDF-1.4",
+            "Ready result",
+        )
+        log = (
+            db_session.query(TelegramMessage)
+            .filter(TelegramMessage.related_entity_id == 456)
+            .one()
+        )
+        assert log.message_type == "lab_result_pdf"
+        assert log.related_entity_type == "lab_report_instance"
+        assert log.status == "sent"
+        assert log.message_id == 77
+
+    @pytest.mark.asyncio
+    async def test_telegram_bot_service_send_document_posts_pdf_bytes(self, monkeypatch):
+        captured = {}
+
+        class FakeResponse:
+            status_code = 200
+
+            def json(self):
+                return {"ok": True, "result": {"message_id": 88}}
+
+        def fake_post(url, data, files, timeout):
+            captured["url"] = url
+            captured["data"] = data
+            captured["files"] = files
+            captured["timeout"] = timeout
+            return FakeResponse()
+
+        monkeypatch.setattr(telegram_bot.requests, "post", fake_post)
+        service = telegram_bot.TelegramBotService()
+        service.bot_token = "bot-token"
+
+        ok, message_id, error = await service._send_document(
+            7005,
+            "service-result.pdf",
+            b"%PDF-1.4 service",
+            "Service result",
+        )
+
+        assert ok is True
+        assert message_id == 88
+        assert error is None
+        assert captured["url"].endswith("/sendDocument")
+        assert captured["data"] == {
+            "chat_id": 7005,
+            "caption": "Service result",
+            "parse_mode": "HTML",
+        }
+        assert captured["files"]["document"] == (
+            "service-result.pdf",
+            b"%PDF-1.4 service",
+            "application/pdf",
+        )
+        assert captured["timeout"] == 20

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -99,6 +99,8 @@ const TelegramManager = () => {
         pending_update_count: integrationData.pending_update_count,
         transition_path: integrationData.transition_path,
         webhook_error: integrationData.webhook_error,
+        patient_bot: integrationData.patient_bot || null,
+        supported_functions: Array.isArray(integrationData.supported_functions) ? integrationData.supported_functions : [],
         configured: Boolean(integrationData.configured ?? statusData.configured),
         raw: { status: statusData, integration: integrationData }
       });
@@ -141,6 +143,12 @@ const TelegramManager = () => {
       </Box>);
 
   }
+
+  const patientBot = botStatus?.patient_bot || {};
+  const patientBotFeatures = Array.isArray(patientBot.features) ? patientBot.features : [];
+  const enabledPatientFeatures = patientBotFeatures.filter((feature) => feature?.enabled);
+  const patientBotCommands = Array.isArray(patientBot.commands) ? patientBot.commands : [];
+  const patientBotLanguages = Array.isArray(patientBot.supported_languages) ? patientBot.supported_languages : [];
 
   return (
     <Box sx={{ p: 3 }}>
@@ -249,6 +257,56 @@ const TelegramManager = () => {
                   <ListItemText
                     primary="Привязка пациентов"
                     secondary={`QR: ${botStatus?.qr_linking_enabled ? 'да' : 'нет'}, телефон: ${botStatus?.contact_linking_enabled ? 'да' : 'нет'}`} />
+
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <MessageSquare />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={`Patient bot ${patientBot.version || 'v1'}`}
+                    secondary={enabledPatientFeatures.length ?
+                    enabledPatientFeatures.map((feature) => feature.label).join(', ') :
+                    'Функции пациента не активны'} />
+
+                  <Badge
+                    variant={enabledPatientFeatures.length ? 'success' : 'warning'}
+                    size="small">
+
+                    {enabledPatientFeatures.length || 0}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <Settings />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Языки пациента"
+                    secondary={patientBotLanguages.length ?
+                    patientBotLanguages.map((item) => item.label).join(', ') :
+                    'Русский'} />
+
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <Settings />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Команды пациента"
+                    secondary={patientBotCommands.length ?
+                    patientBotCommands.map((item) => item.command).join(' ') :
+                    'Нет данных'} />
+
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <Send />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Результаты"
+                    secondary={patientBot.results_delivery === 'telegram_pdf' ?
+                    `PDF в Telegram, до ${patientBot.max_pdf_reports_per_request || 3} файлов` :
+                    'Уведомление в Telegram'} />
 
                 </ListItem>
                 {botStatus?.webhook_error &&


### PR DESCRIPTION
﻿## Summary

- Add AI Factory Telegram strategy plan for the clinic system.
- Add patient bot language choice for Russian and Uzbek Latin in `/start` onboarding.
- Expose patient bot language metadata in admin Telegram status and UI.

## Contract Impact

- Canonical surface: Telegram webhook/polling patient command handler and admin Telegram status endpoint.
- Request shape: Telegram Update payload unchanged; `/start` may include an optional start token and now accepts language callback selections.
- Response shape: Telegram chat responses remain Bot API messages; admin status response adds patient language metadata for `ru` and `uz-Latn`.
- Status codes: webhook endpoint keeps existing success/error handling; admin endpoint keeps existing auth behavior.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads the admin Telegram status language metadata.
- Compatibility path or alias: existing QR/start-token and contact-linking flows remain compatible; no legacy endpoint removed.
- Contract proof: targeted Telegram webhook security/unit tests, py_compile of gate targets, and frontend production build.

## RBAC / Permissions

- Roles allowed: linked patient Telegram accounts can read their own queue/payments/results; existing admin Telegram manager access remains unchanged.
- Roles denied: unlinked Telegram users and spoofed contacts cannot access patient data; non-admin users remain denied by existing admin endpoint guards.
- Positive auth proof: existing unit tests cover linked patient scenarios and accepted own contact sharing.
- Negative auth proof: unit test coverage rejects contact substitution where `contact.user_id` does not match the sender.

## Notification / Realtime

- Event type or websocket channel: Telegram bot command/callback messages only; no websocket channel changed.
- Payload version / ack behavior: Bot API update payload remains unchanged and handlers continue to acknowledge through the existing webhook/polling path.
- Read/unread or delivery semantics: no read/unread state added; outbound Telegram messages keep existing send/log behavior.
- Reconnect/resync proof: polling/webhook imports and targeted webhook tests continue to pass; no realtime reconnect logic changed.

## Frontend Resilience

- Empty data proof: Telegram Manager renders when language metadata is absent or unavailable.
- Partial data proof: UI falls back to Russian/default labels when optional status language details are missing.
- Forbidden secondary path behavior: not applicable - this PR does not add a secondary protected frontend route.
- Missing draft/resource behavior: not applicable - no drafts or document resources are opened by the admin panel change.
- Stale route/deep-link behavior: existing Telegram QR/start-token flow remains handled by backend; no frontend route deep link changed.

## Scope Gate

- Allowed paths: `.ai-factory/plans/**`, Telegram webhook/service/admin endpoint files, targeted Telegram unit tests, and Telegram Manager UI.
- Denied paths: unrelated admin panels, migrations, queue fairness mutation, generated output, bot tokens, and real patient data.
- Migration/docs/test impact: docs plan added; no database migration in this slice; targeted tests/build updated and run.
- Rollback note: revert commit `c2d5c45e` to remove the AI Factory plan, language onboarding, admin metadata, and related tests/UI changes.

## Validation

- Targeted tests or smoke run: `pytest backend\tests\unit\test_telegram_webhook_security.py -q`; py_compile AI Factory gate targets; `npm.cmd run build`.
- Result: all targeted checks passed locally before push.
- Not checked: full backend suite, live Telegram Bot API polling, webhook deployment, and browser E2E smoke.
