### PR TITLE
feat(telegram): store patient language as bcp47

### DIFF
--- a/backend/alembic/versions/0024_telegram_user_language_code_bcp47.py
+++ b/backend/alembic/versions/0024_telegram_user_language_code_bcp47.py
@@ -1,0 +1,51 @@
+"""Store Telegram user language codes as BCP 47 tags.
+
+Revision ID: 0024_telegram_user_language_code_bcp47
+Revises: 0023_ticket_print_qr_default
+Create Date: 2026-05-16 10:55:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0024_telegram_user_language_code_bcp47"
+down_revision = "0023_ticket_print_qr_default"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "telegram_users",
+        "language_code",
+        existing_type=sa.String(length=5),
+        type_=sa.String(length=16),
+        existing_nullable=False,
+    )
+    op.execute(
+        """
+        UPDATE telegram_users
+        SET language_code = 'uz-Latn'
+        WHERE lower(replace(language_code, '_', '-')) IN ('uz', 'uz-latn')
+           OR lower(replace(language_code, '_', '-')) LIKE 'uz-%'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE telegram_users
+        SET language_code = 'uz'
+        WHERE lower(replace(language_code, '_', '-')) = 'uz-latn'
+           OR lower(replace(language_code, '_', '-')) LIKE 'uz-%'
+        """
+    )
+    op.alter_column(
+        "telegram_users",
+        "language_code",
+        existing_type=sa.String(length=16),
+        type_=sa.String(length=5),
+        existing_nullable=False,
+    )

--- a/backend/alembic/versions/0024_tg_user_lang_bcp47.py
+++ b/backend/alembic/versions/0024_tg_user_lang_bcp47.py
@@ -1,6 +1,6 @@
 """Store Telegram user language codes as BCP 47 tags.
 
-Revision ID: 0024_telegram_user_language_code_bcp47
+Revision ID: 0024_tg_user_lang_bcp47
 Revises: 0023_ticket_print_qr_default
 Create Date: 2026-05-16 10:55:00.000000
 """
@@ -9,7 +9,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "0024_telegram_user_language_code_bcp47"
+revision = "0024_tg_user_lang_bcp47"
 down_revision = "0023_ticket_print_qr_default"
 branch_labels = None
 depends_on = None

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -76,7 +76,7 @@ TELEGRAM_MAIN_MENU = {
     "one_time_keyboard": False,
 }
 TELEGRAM_LANGUAGE_RU = "ru"
-TELEGRAM_LANGUAGE_UZ = "uz"  # Uzbek Latin; kept compact for current language_code column.
+TELEGRAM_LANGUAGE_UZ = "uz-Latn"
 TELEGRAM_LANGUAGE_MENU = {
     "keyboard": [[{"text": "Русский"}, {"text": "O'zbekcha"}]],
     "resize_keyboard": True,

--- a/backend/app/models/telegram_config.py
+++ b/backend/app/models/telegram_config.py
@@ -125,7 +125,7 @@ class TelegramUser(Base):
     username: Mapped[str | None] = mapped_column(String(100), nullable=True)
     first_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     last_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
-    language_code: Mapped[str] = mapped_column(String(5), default="ru", nullable=False)
+    language_code: Mapped[str] = mapped_column(String(16), default="ru", nullable=False)
 
     # Настройки уведомлений
     notifications_enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/backend/app/services/telegram_templates.py
+++ b/backend/app/services/telegram_templates.py
@@ -6,6 +6,15 @@
 from typing import Any
 
 
+def _template_language_key(language: str) -> str:
+    value = str(language or "").strip().lower().replace("_", "-")
+    if value == "uz" or value.startswith("uz-"):
+        return "uz"
+    if value == "en" or value.startswith("en-"):
+        return "en"
+    return "ru"
+
+
 class TelegramTemplatesService:
     def __init__(self):
         self.templates = self._load_default_templates()
@@ -349,7 +358,9 @@ class TelegramTemplatesService:
     ) -> dict[str, Any]:
         """Получить шаблон сообщения с подстановкой данных"""
         try:
-            template = self.templates.get(template_key, {}).get(language, {})
+            template = self.templates.get(template_key, {}).get(
+                _template_language_key(language), {}
+            )
 
             if not template:
                 # Fallback на русский язык
@@ -432,7 +443,7 @@ class TelegramTemplatesService:
         self, has_abnormalities: bool, language: str = "ru"
     ) -> str:
         """Получить текст о нарушениях в анализах"""
-        if language == "uz":
+        if _template_language_key(language) == "uz":
             return (
                 "⚠️ <b>E'tibor:</b> Natijalarda og'ishlar aniqlandi. Shifokor bilan maslahatlashingiz tavsiya etiladi."
                 if has_abnormalities

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -9,6 +9,7 @@ import pytest
 
 from app.api.v1.endpoints import telegram_webhook
 from app.services import telegram_bot
+from app.services.telegram_templates import TelegramTemplatesService
 from app.models.lab import LabReportInstance, LabReportTemplate, LabReportTemplateVersion
 from app.models.online_queue import OnlineQueueEntry
 from app.models.patient import Patient
@@ -225,6 +226,50 @@ class TestTelegramWebhookSecurity:
             .first()
             is None
         )
+
+    def test_patient_language_normalization_uses_canonical_uz_latn(self):
+        assert telegram_webhook._normalize_patient_language("uz") == "uz-Latn"
+        assert telegram_webhook._normalize_patient_language("uz_Latn") == "uz-Latn"
+        assert telegram_webhook._normalize_patient_language("uzbek") == "uz-Latn"
+        assert telegram_webhook._normalize_patient_language("ru") == "ru"
+
+    def test_legacy_templates_accept_canonical_uz_latn(self):
+        templates = TelegramTemplatesService()
+
+        template = templates.get_template(
+            "welcome",
+            "uz-Latn",
+            {"first_name": "Ali"},
+        )
+
+        assert "Programma Clinic-ga" in template["text"]
+        assert "Ali" in template["text"]
+        assert "Dobro" not in template["text"]
+
+    @pytest.mark.asyncio
+    async def test_uzbek_language_choice_stores_canonical_uz_latn(self, db_session):
+        fake_service = FakeTelegramBotService(active=True)
+        update = {
+            "update_id": 102,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7006},
+                "from": {"id": 111, "language_code": "uz"},
+                "text": "O'zbekcha",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        telegram_user = (
+            db_session.query(TelegramUser)
+            .filter(TelegramUser.chat_id == 7006)
+            .one()
+        )
+        assert telegram_user.language_code == "uz-Latn"
 
     def test_queue_message_reports_linked_patient_position_and_cabinet(
         self, db_session, test_patient, test_daily_queue, test_queue_entry


### PR DESCRIPTION
﻿## Summary

- Store patient Telegram language as canonical BCP 47-style `uz-Latn` instead of compact `uz`.
- Widen `telegram_users.language_code` and migrate existing Uzbek values to `uz-Latn`.
- Keep legacy notification templates compatible by mapping `uz-Latn` back to existing `uz` template keys.

## Contract Impact

- Canonical surface: `telegram_users.language_code`, Telegram patient bot language normalization, and Telegram notification template lookup.
- Request shape: Telegram Update payload unchanged; `/start` language choice still accepts `Русский` and `O'zbekcha`.
- Response shape: patient bot responses unchanged; stored language value for Uzbek is now `uz-Latn`.
- Status codes: webhook/admin endpoints keep existing status behavior.
- Frontend consumer: admin Telegram status/UI already advertises `ru` and `uz-Latn`; no frontend file changed in this slice.
- Compatibility path or alias: incoming `uz`, `uz_Latn`, `uz-Latn`, and Uzbek text aliases normalize to `uz-Latn`; legacy template keys continue to use `uz` internally.
- Contract proof: targeted Telegram webhook unit tests, template alias regression, py_compile, and Alembic heads check.

## RBAC / Permissions

- Roles allowed: linked patient Telegram accounts retain their existing access to their own bot data.
- Roles denied: unlinked Telegram users and spoofed contacts remain denied by existing checks.
- Positive auth proof: targeted Telegram webhook tests cover linked/user command behavior and language selection.
- Negative auth proof: spoofed contact rejection test still passes.

## Notification / Realtime

- Event type or websocket channel: Telegram bot command/message flow only; no websocket channel changed.
- Payload version / ack behavior: Bot API update payload and webhook acknowledgement behavior unchanged.
- Read/unread or delivery semantics: no read/unread state added; notification send semantics unchanged.
- Reconnect/resync proof: no polling/webhook transport changes; targeted webhook tests and compile checks pass.

## Frontend Resilience

not applicable - no frontend user-facing panel, route, or data rendering changed in this slice.

## Scope Gate

- Allowed paths: Telegram user model, Telegram webhook language normalization, Telegram template compatibility, one Alembic migration, and targeted Telegram unit tests.
- Denied paths: queue fairness, payments logic, EMR/lab report business rules, frontend panels, generated output, bot tokens, and real patient data.
- Migration/docs/test impact: adds Alembic migration `0024_tg_user_lang_bcp47`; targeted tests updated.
- Rollback note: revert commits `dea0aa3a` and `2e07352e`, then run Alembic downgrade to restore compact `uz` storage.

## Validation

- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend\app\models\telegram_config.py backend\app\api\v1\endpoints\telegram_webhook.py backend\app\services\telegram_templates.py backend\alembic\versions\0024_tg_user_lang_bcp47.py`; `python -m pytest backend\tests\unit\test_telegram_webhook_security.py -q`; `python -m alembic heads`.
- Result: passed; pytest reported 14 passed and Alembic reported single head `0024_tg_user_lang_bcp47`.
- Not checked: full backend suite, live Telegram Bot API polling, webhook deployment, and frontend build because this slice did not touch frontend runtime.
