### PR TITLE
feat(telegram): add patient notification consent

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -82,6 +82,18 @@ TELEGRAM_LANGUAGE_MENU = {
     "resize_keyboard": True,
     "one_time_keyboard": True,
 }
+TELEGRAM_NOTIFICATION_CONSENT_MENUS = {
+    TELEGRAM_LANGUAGE_RU: {
+        "keyboard": [[{"text": "Разрешить уведомления"}, {"text": "Без уведомлений"}]],
+        "resize_keyboard": True,
+        "one_time_keyboard": True,
+    },
+    TELEGRAM_LANGUAGE_UZ: {
+        "keyboard": [[{"text": "Xabarnomalarga roziman"}, {"text": "Xabarnomasiz"}]],
+        "resize_keyboard": True,
+        "one_time_keyboard": True,
+    },
+}
 TELEGRAM_MAIN_MENUS = {
     TELEGRAM_LANGUAGE_RU: TELEGRAM_MAIN_MENU,
     TELEGRAM_LANGUAGE_UZ: {
@@ -167,6 +179,22 @@ TELEGRAM_LOCALIZED_TEXTS = {
             "Bot orqali Telegramni bemor kartasiga bog'lash, klinika xabarnomalarini olish "
             "va natijalar tayyor bo'lganda ularni ochish mumkin."
         ),
+    },
+    "notification_consent": {
+        TELEGRAM_LANGUAGE_RU: (
+            "Разрешить Telegram-уведомления от клиники: напоминания, очередь, оплаты и готовые результаты?"
+        ),
+        TELEGRAM_LANGUAGE_UZ: (
+            "Klinikadan Telegram xabarnomalarini olishga rozimisiz: eslatmalar, navbat, to'lovlar va tayyor natijalar?"
+        ),
+    },
+    "notifications_enabled": {
+        TELEGRAM_LANGUAGE_RU: "Уведомления включены.",
+        TELEGRAM_LANGUAGE_UZ: "Xabarnomalar yoqildi.",
+    },
+    "notifications_disabled": {
+        TELEGRAM_LANGUAGE_RU: "Уведомления отключены. Их можно включить позже через клинику.",
+        TELEGRAM_LANGUAGE_UZ: "Xabarnomalar o'chirildi. Ularni keyin klinika orqali yoqish mumkin.",
     },
     "help": {
         TELEGRAM_LANGUAGE_RU: (
@@ -269,6 +297,13 @@ def _localized_main_menu(language_code: Any) -> Dict[str, Any]:
     )
 
 
+def _localized_notification_consent_menu(language_code: Any) -> Dict[str, Any]:
+    return TELEGRAM_NOTIFICATION_CONSENT_MENUS.get(
+        _normalize_patient_language(language_code),
+        TELEGRAM_NOTIFICATION_CONSENT_MENUS[TELEGRAM_LANGUAGE_RU],
+    )
+
+
 def _telegram_chat_language(db: Session, chat_id: int) -> str:
     telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, chat_id)
     return _normalize_patient_language(getattr(telegram_user, "language_code", None))
@@ -287,6 +322,7 @@ def _upsert_ticket_qr_telegram_user(
     message: Dict[str, Any],
     patient_id: int | None = None,
     language_code: str | None = None,
+    notifications_enabled: bool | None = None,
 ) -> None:
     chat = message.get("chat") or {}
     from_user = message.get("from") or {}
@@ -311,6 +347,10 @@ def _upsert_ticket_qr_telegram_user(
         )
     if patient_id is not None:
         payload["patient_id"] = patient_id
+    if notifications_enabled is not None:
+        payload["notifications_enabled"] = notifications_enabled
+        payload["appointment_reminders"] = notifications_enabled
+        payload["lab_notifications"] = notifications_enabled
 
     if telegram_user:
         for field, value in payload.items():
@@ -319,13 +359,16 @@ def _upsert_ticket_qr_telegram_user(
         db.flush()
         return
 
+    create_notifications_enabled = payload.pop("notifications_enabled", True)
+    create_appointment_reminders = payload.pop("appointment_reminders", True)
+    create_lab_notifications = payload.pop("lab_notifications", True)
     db.add(
         TelegramUser(
             **payload,
             chat_id=int(chat_id),
-            notifications_enabled=True,
-            appointment_reminders=True,
-            lab_notifications=True,
+            notifications_enabled=create_notifications_enabled,
+            appointment_reminders=create_appointment_reminders,
+            lab_notifications=create_lab_notifications,
         )
     )
     db.flush()
@@ -881,6 +924,36 @@ async def _send_clinic_welcome(
     )
 
 
+async def _send_notification_consent(
+    bot_service, chat_id: int, language_code: str = TELEGRAM_LANGUAGE_RU
+) -> None:
+    await bot_service._send_message(
+        chat_id,
+        _localized_text("notification_consent", language_code),
+        _localized_notification_consent_menu(language_code),
+    )
+
+
+async def _set_notification_consent(
+    db: Session, bot_service, chat_id: int, enabled: bool
+) -> None:
+    telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, chat_id)
+    language = _normalize_patient_language(getattr(telegram_user, "language_code", None))
+    if telegram_user:
+        telegram_user.notifications_enabled = enabled
+        telegram_user.appointment_reminders = enabled
+        telegram_user.lab_notifications = enabled
+        telegram_user.last_activity = datetime.utcnow()
+        db.commit()
+
+    result_key = "notifications_enabled" if enabled else "notifications_disabled"
+    await bot_service._send_message(
+        chat_id,
+        _localized_text(result_key, language),
+        _localized_main_menu(language),
+    )
+
+
 async def _handle_contact_link(
     message: Dict[str, Any], db: Session, bot_service
 ) -> bool:
@@ -947,13 +1020,18 @@ async def _handle_clinic_bot_update(
 
     async def language_handler(chat_id: int, language_code: str) -> None:
         message = _message_from_update(update)
-        _upsert_ticket_qr_telegram_user(db, message, language_code=language_code)
+        _upsert_ticket_qr_telegram_user(
+            db,
+            message,
+            language_code=language_code,
+            notifications_enabled=False,
+        )
         db.commit()
         logger.info(
             "Telegram patient bot language selected",
             extra={"language_code": _normalize_patient_language(language_code)},
         )
-        await _send_clinic_welcome(bot_service, chat_id, language_code)
+        await _send_notification_consent(bot_service, chat_id, language_code)
 
     async def help_handler(chat_id: int) -> None:
         language = _telegram_chat_language(db, chat_id)
@@ -988,6 +1066,12 @@ async def _handle_clinic_bot_update(
             _telegram_chat_menu(db, chat_id),
         )
 
+    async def enable_notifications_handler(chat_id: int) -> None:
+        await _set_notification_consent(db, bot_service, chat_id, True)
+
+    async def disable_notifications_handler(chat_id: int) -> None:
+        await _set_notification_consent(db, bot_service, chat_id, False)
+
     async def russian_language_handler(chat_id: int) -> None:
         await language_handler(chat_id, TELEGRAM_LANGUAGE_RU)
 
@@ -1012,6 +1096,10 @@ async def _handle_clinic_bot_update(
         "o'zbekcha": uzbek_language_handler,
         "ozbekcha": uzbek_language_handler,
         "uzbekcha": uzbek_language_handler,
+        "разрешить уведомления": enable_notifications_handler,
+        "без уведомлений": disable_notifications_handler,
+        "xabarnomalarga roziman": enable_notifications_handler,
+        "xabarnomasiz": disable_notifications_handler,
         "yordam": help_handler,
         "mening navbatim": queue_handler,
         "to'lovlar va qarz": payments_handler,

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -270,6 +270,87 @@ class TestTelegramWebhookSecurity:
             .one()
         )
         assert telegram_user.language_code == "uz-Latn"
+        assert telegram_user.notifications_enabled is False
+        assert telegram_user.appointment_reminders is False
+        assert telegram_user.lab_notifications is False
+        assert "rozimisiz" in fake_service._send_message.await_args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_notification_consent_accept_enables_patient_notifications(
+        self, db_session
+    ):
+        telegram_user = TelegramUser(
+            chat_id=7007,
+            username="patient_chat",
+            first_name="Patient",
+            language_code="uz-Latn",
+            notifications_enabled=False,
+            appointment_reminders=False,
+            lab_notifications=False,
+            active=True,
+            blocked=False,
+        )
+        db_session.add(telegram_user)
+        db_session.commit()
+        fake_service = FakeTelegramBotService(active=True)
+        update = {
+            "update_id": 103,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7007},
+                "from": {"id": 111},
+                "text": "Xabarnomalarga roziman",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        db_session.refresh(telegram_user)
+        assert telegram_user.notifications_enabled is True
+        assert telegram_user.appointment_reminders is True
+        assert telegram_user.lab_notifications is True
+        assert fake_service._send_message.await_args.args[1] == "Xabarnomalar yoqildi."
+
+    @pytest.mark.asyncio
+    async def test_notification_consent_decline_disables_patient_notifications(
+        self, db_session
+    ):
+        telegram_user = TelegramUser(
+            chat_id=7008,
+            username="patient_chat",
+            first_name="Patient",
+            language_code="ru",
+            notifications_enabled=True,
+            appointment_reminders=True,
+            lab_notifications=True,
+            active=True,
+            blocked=False,
+        )
+        db_session.add(telegram_user)
+        db_session.commit()
+        fake_service = FakeTelegramBotService(active=True)
+        update = {
+            "update_id": 104,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7008},
+                "from": {"id": 111},
+                "text": "Без уведомлений",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        db_session.refresh(telegram_user)
+        assert telegram_user.notifications_enabled is False
+        assert telegram_user.appointment_reminders is False
+        assert telegram_user.lab_notifications is False
 
     def test_queue_message_reports_linked_patient_position_and_cabinet(
         self, db_session, test_patient, test_daily_queue, test_queue_entry


### PR DESCRIPTION
﻿## Summary

- Add bilingual patient notification consent after Telegram language selection.
- Store consent in existing `TelegramUser.notifications_enabled`, `appointment_reminders`, and `lab_notifications` flags.
- Keep patient bot menu available after accept/decline without adding new tables or frontend routes.

## Contract Impact

- Canonical surface: Telegram patient bot `/start` onboarding and text handlers in `telegram_webhook.py`.
- Request shape: Telegram Update payload unchanged; patients can send localized consent button text after choosing language.
- Response shape: language choice now returns a localized notification consent prompt before the main menu.
- Status codes: webhook endpoint status behavior unchanged.
- Frontend consumer: no frontend consumer changed; Telegram Manager build still verified by frontend production build.
- Compatibility path or alias: existing `/queue`, `/payments`, `/results`, `/profile`, contact linking, and QR/start-token handlers remain unchanged.
- Contract proof: targeted Telegram webhook unit tests, py_compile, and frontend production build.

## RBAC / Permissions

- Roles allowed: Telegram chat owner can choose notification consent for their own Telegram account.
- Roles denied: spoofed contacts remain denied; no staff/admin permissions are introduced.
- Positive auth proof: tests cover Uzbek consent accept and language-choice storage.
- Negative auth proof: tests cover consent decline and existing spoofed-contact rejection still passes.

## Notification / Realtime

- Event type or websocket channel: Telegram bot message flow only; no websocket channel changed.
- Payload version / ack behavior: Bot API update payload and webhook acknowledgement behavior unchanged.
- Read/unread or delivery semantics: consent toggles existing notification flags; no read/unread delivery state added.
- Reconnect/resync proof: no polling/webhook transport changes; targeted webhook tests and compile checks pass.

## Frontend Resilience

not applicable - no frontend user-facing panel, route, or data rendering changed in this slice.

## Scope Gate

- Allowed paths: Telegram webhook onboarding/handlers and targeted Telegram webhook unit tests.
- Denied paths: migrations, queue fairness, payments logic, EMR/lab report business rules, frontend panels, generated output, bot tokens, and real patient data.
- Migration/docs/test impact: no migration; targeted tests updated.
- Rollback note: revert commit `dd57608e` to restore immediate main-menu behavior after language selection.

## Validation

- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend\tests\unit\test_telegram_webhook_security.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; `python -m pytest backend\tests\unit\test_telegram_webhook_security.py -q`; `npm.cmd run build` in `frontend`.
- Result: passed; pytest reported 16 passed and frontend build completed with existing Vite chunk/dynamic-import warnings.
- Not checked: full backend suite, live Telegram Bot API polling, and webhook deployment.
