### PR TITLE
fix(ui): clarify equipment empty state copy

### DIFF
--- a/frontend/src/components/admin/EquipmentManagement.jsx
+++ b/frontend/src/components/admin/EquipmentManagement.jsx
@@ -218,6 +218,11 @@ const EquipmentManagement = () => {
     const matchesBranch = branchFilter === 'all' || item.branch_id === parseInt(branchFilter);
     return matchesSearch && matchesStatus && matchesType && matchesBranch;
   });
+  const hasEquipmentFilters = searchTerm.trim() !== '' || statusFilter !== 'all' || typeFilter !== 'all' || branchFilter !== 'all';
+  const equipmentEmptyTitle = hasEquipmentFilters ? 'Оборудование по фильтрам не найдено' : 'Оборудование ещё не добавлено';
+  const equipmentEmptyDescription = hasEquipmentFilters ?
+  'Измените поиск, статус, тип или филиал, чтобы увидеть другое оборудование.' :
+  'Добавьте первую единицу оборудования, чтобы вести учет техники по филиалам.';
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '24px', overflow: 'hidden' }}>
@@ -678,11 +683,11 @@ const EquipmentManagement = () => {
       filteredEquipment.length === 0 ?
       <MacOSEmptyState
         icon={Wrench}
-        title="Оборудование не найдено"
-        description="Добавьте первое оборудование или измените фильтры поиска"
+        title={equipmentEmptyTitle}
+        description={equipmentEmptyDescription}
         action={
         <MacOSButton onClick={() => setShowAddForm(true)} variant="primary">
-              <Plus aria-hidden="true" style={{ width: '16px', height: '16px', marginRight: '8px' }} />
+              <Plus aria-hidden="true" focusable="false" style={{ width: '16px', height: '16px', marginRight: '8px' }} />
               Добавить оборудование
             </MacOSButton>
         } /> :


### PR DESCRIPTION
## Summary

- Clarify EquipmentManagement empty-state copy for true-empty versus filtered-empty states.
- Mark the decorative empty-state action icon as non-focusable while preserving current equipment management behavior.
- Keep this as a one-component admin utility UI copy/accessibility slice.

## Contract Impact

- Canonical surface: frontend admin EquipmentManagement empty-state UI only.
- Request shape: not applicable - no frontend API request shape changed.
- Response shape: not applicable - no backend response or data contract changed.
- Status codes: not applicable - no HTTP status behavior changed.
- Frontend consumer: frontend/src/components/admin/EquipmentManagement.jsx.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: existing lint, build, test run, and origin/main diff check.

## RBAC / Permissions

- Roles allowed: not applicable - existing Admin panel access remains unchanged.
- Roles denied: not applicable - no authorization rule or guard changed.
- Positive auth proof: not applicable - no auth-sensitive API or route changed.
- Negative auth proof: not applicable - no denied-path behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, polling, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: true-empty and filtered-empty states now present distinct operator copy.
- Partial data proof: existing equipment filtering/list rendering remains unchanged and does not require new fields.
- Forbidden secondary path behavior: not applicable - no secondary path or forbidden fallback changed.
- Missing draft/resource behavior: not applicable - component does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no route state or deep-link handling changed.

## Scope Gate

- Allowed paths: frontend/src/components/admin/EquipmentManagement.jsx.
- Denied paths: backend, package files, route runtime, AdminPanel, equipment CRUD/API contracts, branch association logic, queue, payment, EMR, lab, patient data.
- Migration/docs/test impact: no migration; no docs update; existing frontend lint/build/test validation used.
- Rollback note: revert the EquipmentManagement copy/accessibility commit.

## Validation

- Targeted tests or smoke run: git diff --check; npm.cmd --prefix frontend run lint:check; npm.cmd --prefix frontend run build; npm.cmd --prefix frontend run test:run; git diff --check origin/main...HEAD.
- Result: passed with existing warnings only where noted in the PR body.
- Not checked: live browser smoke was not run.