### PR TITLE
feat(telegram): add patient bot commands helper

### DIFF
--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -23,6 +23,22 @@ from app.crud import (
 
 logger = logging.getLogger(__name__)
 MAX_TELEGRAM_DOCUMENT_BYTES = 20 * 1024 * 1024
+PATIENT_BOT_COMMANDS_RU = [
+    {"command": "start", "description": "Начать"},
+    {"command": "queue", "description": "Моя очередь"},
+    {"command": "payments", "description": "Оплаты и долг"},
+    {"command": "results", "description": "Результаты"},
+    {"command": "profile", "description": "Мой статус"},
+    {"command": "help", "description": "Помощь"},
+]
+PATIENT_BOT_COMMANDS_UZ = [
+    {"command": "start", "description": "Boshlash"},
+    {"command": "queue", "description": "Mening navbatim"},
+    {"command": "payments", "description": "To'lovlar va qarz"},
+    {"command": "results", "description": "Natijalar"},
+    {"command": "profile", "description": "Mening holatim"},
+    {"command": "help", "description": "Yordam"},
+]
 
 
 class TelegramBotService:
@@ -487,6 +503,46 @@ class TelegramBotService:
 
         message_id = (payload.get("result") or {}).get("message_id")
         return True, int(message_id) if message_id is not None else None, None
+
+    async def set_patient_bot_commands(self) -> tuple[bool, str | None]:
+        """Register patient bot command menu in Telegram."""
+        if not self.bot_token:
+            logger.error("Bot token is not configured for Telegram command registration")
+            return False, "bot_token_not_configured"
+
+        url = f"https://api.telegram.org/bot{self.bot_token}/setMyCommands"
+        payloads = [
+            {"commands": PATIENT_BOT_COMMANDS_RU},
+            {"commands": PATIENT_BOT_COMMANDS_UZ, "language_code": "uz"},
+        ]
+        for payload in payloads:
+            try:
+                response = requests.post(url, json=payload, timeout=10)
+            except requests.RequestException as exc:
+                logger.warning(
+                    "Telegram command registration request failed error_type=%s",
+                    type(exc).__name__,
+                )
+                return False, type(exc).__name__
+
+            if response.status_code != 200:
+                logger.warning(
+                    "Telegram command registration failed status_code=%s",
+                    response.status_code,
+                )
+                return False, f"telegram_http_{response.status_code}"
+
+            try:
+                result = response.json()
+            except ValueError:
+                logger.warning("Telegram command registration returned invalid json")
+                return False, "telegram_invalid_json"
+
+            if not result.get("ok"):
+                logger.warning("Telegram command registration returned not ok")
+                return False, "telegram_api_error"
+
+        return True, None
 
     async def _answer_callback_query(self, callback_query_id: str, text: str = ""):
         """Ответ на callback запрос"""

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -561,3 +561,38 @@ class TestTelegramWebhookSecurity:
             "application/pdf",
         )
         assert captured["timeout"] == 20
+
+    @pytest.mark.asyncio
+    async def test_telegram_bot_service_registers_patient_commands(self, monkeypatch):
+        captured = []
+
+        class FakeResponse:
+            status_code = 200
+
+            def json(self):
+                return {"ok": True, "result": True}
+
+        def fake_post(url, json, timeout):
+            captured.append({"url": url, "json": json, "timeout": timeout})
+            return FakeResponse()
+
+        monkeypatch.setattr(telegram_bot.requests, "post", fake_post)
+        service = telegram_bot.TelegramBotService()
+        service.bot_token = "bot-token"
+
+        ok, error = await service.set_patient_bot_commands()
+
+        assert ok is True
+        assert error is None
+        assert [item["json"].get("language_code") for item in captured] == [None, "uz"]
+        assert captured[0]["url"].endswith("/setMyCommands")
+        assert captured[0]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_RU
+        assert captured[1]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_UZ
+        assert {command["command"] for command in captured[0]["json"]["commands"]} == {
+            "start",
+            "queue",
+            "payments",
+            "results",
+            "profile",
+            "help",
+        }


### PR DESCRIPTION
## Summary

- Adds a Telegram Bot API helper to register the patient bot command menu.
- Registers Russian/default commands and Uzbek commands with Telegram language_code=uz.
- Keeps bot initialization side-effect free: no automatic network call from startup in this slice.

## Contract Impact

- Canonical surface: backend TelegramBotService.set_patient_bot_commands helper and Telegram Bot API setMyCommands call.
- Request shape: internal async service call with no app HTTP request body; outgoing Telegram JSON contains commands and optional language_code=uz.
- Response shape: tuple success flag and optional normalized error code.
- Status codes: no app HTTP status codes changed; Telegram HTTP 200 is required and non-200 maps to telegram_http_status.
- Frontend consumer: not applicable - no frontend consumer changed in this backend helper slice.
- Compatibility path or alias: existing command handlers and stored patient language codes stay unchanged; Telegram API receives uz for Uzbek menu registration.
- Contract proof: focused unit test asserts both command payloads, py_compile confirms service import, and existing webhook security suite passes.

## RBAC / Permissions

- Roles allowed: not applicable - internal bot configuration helper is not exposed as a patient or staff request path.
- Roles denied: not applicable - no user-facing endpoint, role check, or patient data access path was added.
- Positive auth proof: configured service with fake successful Telegram response returns success.
- Negative auth proof: token absence returns bot_token_not_configured without sending a Telegram request.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification event, websocket channel, or realtime stream changed.
- Payload version / ack behavior: Telegram setMyCommands payload only; no app notification payload or ack contract changed.
- Read/unread or delivery semantics: not applicable - command registration does not create messages or notification read state.
- Reconnect/resync proof: not applicable - no polling, webhook reconnect, or websocket resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend route, panel, list, or data rendering changed.
- Partial data proof: not applicable - no frontend consumer reads partial data from this helper.
- Forbidden secondary path behavior: not applicable - no secondary frontend path or forbidden view changed.
- Missing draft/resource behavior: not applicable - no draft, report, visit, queue, or payment resource opened in frontend.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link parser changed.

## Scope Gate

- Allowed paths: backend/app/services/telegram_bot.py and backend/tests/unit/test_telegram_webhook_security.py.
- Denied paths: admin endpoint wiring, polling worker startup, migrations, QR queue, payments, reports, frontend UI, generated output.
- Migration/docs/test impact: no migration or docs update; one focused unit test added for command registration.
- Rollback note: revert commit 4f0c7e6b to remove helper constants, method, and focused test.

## Validation

- Targeted tests or smoke run: git diff --check; python -m py_compile for Telegram service/webhook/admin files; python -m pytest backend/tests/unit/test_telegram_webhook_security.py -q; npm.cmd run build in frontend.
- Result: local checks passed: 17 backend unit tests passed with 1 warning; frontend build passed with existing Vite warnings.
- Not checked: live Telegram Bot API registration, admin endpoint wiring, polling startup, QR queue, payments, report sending, browser UI smoke.