### PR TITLE
feat(telegram): add admin command registration endpoint

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -16,6 +16,11 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_db, require_roles
 from app.crud import clinic as crud_clinic, telegram_config as crud_telegram
 from app.models.user import User
+from app.services.telegram_bot import (
+    PATIENT_BOT_COMMANDS_RU,
+    PATIENT_BOT_COMMANDS_UZ,
+    get_telegram_bot_service,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -225,6 +230,51 @@ def test_telegram_bot(
         raise_admin_telegram_error(
             "test-bot",
             "Ошибка тестирования бота",
+            e,
+        )
+
+
+@router.post("/telegram/register-patient-commands")
+async def register_patient_bot_commands(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_roles("Admin")),
+):
+    """Register patient bot commands in Telegram via the configured bot token."""
+    try:
+        bot_token = _get_configured_bot_token(db)
+        if not bot_token:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Bot token is not configured",
+            )
+
+        bot_service = await get_telegram_bot_service()
+        bot_service.bot_token = bot_token
+        ok, error = await bot_service.set_patient_bot_commands()
+        if not ok:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail={
+                    "message": "Telegram patient bot commands were not registered",
+                    "error": error,
+                },
+            )
+
+        return {
+            "success": True,
+            "message": "Telegram patient bot commands registered",
+            "registered_languages": ["ru", "uz"],
+            "commands": {
+                "ru": PATIENT_BOT_COMMANDS_RU,
+                "uz": PATIENT_BOT_COMMANDS_UZ,
+            },
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise_admin_telegram_error(
+            "register-patient-commands",
+            "Telegram patient bot command registration failed",
             e,
         )
 


### PR DESCRIPTION
## Summary

- Adds an admin-only backend endpoint to register patient Telegram bot commands through the existing service helper.
- Uses the configured bot token from existing Telegram settings/config sources and does not expose the token in responses.
- Keeps polling, webhook, queue, payments, reports, and frontend UI unchanged in this slice.

## Contract Impact

- Canonical surface: POST /api/v1/admin/telegram/register-patient-commands in backend/app/api/v1/endpoints/admin_telegram.py.
- Request shape: authenticated Admin request with no body.
- Response shape: success boolean, message, registered_languages, and RU/UZ command payloads without secrets.
- Status codes: 200 on successful Telegram registration, 400 when bot token is missing, 502 when Telegram command registration fails, existing 500 wrapper for unexpected backend failures.
- Frontend consumer: not applicable - no frontend consumer changed in this backend endpoint slice.
- Compatibility path or alias: existing /admin/telegram/test-bot, /admin/telegram/set-webhook, polling, webhook, and command handlers remain unchanged.
- Contract proof: py_compile for admin Telegram endpoint and webhook, import smoke for endpoint symbol, existing Telegram webhook security unit suite.

## RBAC / Permissions

- Roles allowed: Admin via existing require_roles(Admin) dependency.
- Roles denied: unauthenticated users and non-Admin roles denied by existing admin dependency.
- Positive auth proof: route imports with the Admin dependency bound and uses configured bot token only after dependency resolution.
- Negative auth proof: missing bot token returns 400 without a Telegram request; non-Admin runtime path remains guarded by existing require_roles dependency.

## Notification / Realtime

- Event type or websocket channel: not applicable - no app notification event, websocket channel, polling update, or realtime stream changed.
- Payload version / ack behavior: outgoing Telegram setMyCommands configuration call only; no notification payload or ack contract changed.
- Read/unread or delivery semantics: not applicable - command registration does not create TelegramMessage rows or unread state.
- Reconnect/resync proof: not applicable - no webhook reconnect, polling offset, or websocket resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend panel, route, list, or data rendering changed.
- Partial data proof: not applicable - no frontend consumer reads this endpoint yet.
- Forbidden secondary path behavior: not applicable - no frontend secondary path was added.
- Missing draft/resource behavior: not applicable - no draft, report, queue, payment, or visit resource is opened.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link parsing changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/admin_telegram.py.
- Denied paths: telegram webhook behavior, Telegram service helper internals, polling worker startup, frontend UI, migrations, queue, payments, reports, generated output.
- Migration/docs/test impact: no migration or docs update; validation uses compile/import smoke and existing Telegram tests.
- Rollback note: revert commit 2c11b11f to remove the endpoint and imports.

## Validation

- Targeted tests or smoke run: git diff --check; python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py; backend import smoke for admin_telegram.register_patient_bot_commands; python -m pytest backend/tests/unit/test_telegram_webhook_security.py -q; npm.cmd run build in frontend.
- Result: all local checks passed; Telegram unit suite 17 passed with 1 warning; frontend build passed with existing Vite warnings.
- Not checked: live Telegram Bot API setMyCommands call, frontend button wiring, polling worker startup, webhook live delivery, QR queue, payments, report sending.
