### PR TITLE
docs(telegram): document polling scheduled task

### DIFF
--- a/ops/windows/README.md
+++ b/ops/windows/README.md
@@ -18,3 +18,67 @@ powershell -ExecutionPolicy Bypass -File ops/windows/clinic_host.ps1 backup
 powershell -ExecutionPolicy Bypass -File ops/windows/clinic_host.ps1 import-release -ArtifactFile C:\path\to\clinic-release.zip
 powershell -ExecutionPolicy Bypass -File ops/windows/clinic_host.ps1 update -ArtifactFile C:\path\to\clinic-release.zip
 ```
+
+## Telegram polling scheduled task
+
+Before a public HTTPS domain is available, the patient Telegram bot runs through
+polling:
+
+```powershell
+cd C:\final\backend
+python -m app.scripts.telegram_polling_worker
+```
+
+On a Windows pilot host, register polling as a startup task so it comes back
+after a PC or server restart. Run PowerShell as Administrator and adjust
+`$RepoRoot` if the checkout lives somewhere else:
+
+```powershell
+$TaskName = "KosmedTelegramPollingWorker"
+$RepoRoot = "C:\final"
+$BackendDir = Join-Path $RepoRoot "backend"
+$PythonExe = (Get-Command python).Source
+
+$Action = New-ScheduledTaskAction `
+  -Execute $PythonExe `
+  -Argument "-m app.scripts.telegram_polling_worker" `
+  -WorkingDirectory $BackendDir
+
+$Trigger = New-ScheduledTaskTrigger -AtStartup
+$Settings = New-ScheduledTaskSettingsSet `
+  -StartWhenAvailable `
+  -MultipleInstances IgnoreNew `
+  -RestartCount 999 `
+  -RestartInterval (New-TimeSpan -Minutes 1) `
+  -AllowStartIfOnBatteries `
+  -DontStopIfGoingOnBatteries
+
+Register-ScheduledTask `
+  -TaskName $TaskName `
+  -Action $Action `
+  -Trigger $Trigger `
+  -Settings $Settings `
+  -Description "Runs the Kosmed Clinic Telegram bot in polling mode." `
+  -RunLevel Highest `
+  -Force
+```
+
+Useful operator commands:
+
+```powershell
+Start-ScheduledTask -TaskName "KosmedTelegramPollingWorker"
+Get-ScheduledTaskInfo -TaskName "KosmedTelegramPollingWorker"
+Stop-ScheduledTask -TaskName "KosmedTelegramPollingWorker"
+Unregister-ScheduledTask -TaskName "KosmedTelegramPollingWorker" -Confirm:$false
+```
+
+Safe smoke check before registering the task:
+
+```powershell
+cd C:\final\backend
+python -m app.scripts.telegram_polling_worker --once --max-updates 1 --keep-webhook --log-file none --pid-file none
+```
+
+Do not put the Telegram bot token in the scheduled task command. The worker reads
+the token from the application configuration/database. When a public HTTPS domain
+and server are ready, stop this task before switching the bot to webhook mode.


### PR DESCRIPTION
## Summary

- Document the Windows Scheduled Task path for running the Telegram polling worker before a public HTTPS domain is available.
- Keep the bot token out of the task command; the worker continues to read token/config from application configuration/database.
- Add safe operator commands and a dry smoke command without registering or starting any local task automatically.

## Contract Impact

- Canonical surface: ops/windows/README.md Windows host runbook for Telegram polling.
- Request shape: not applicable - docs-only change with no API request shape changed.
- Response shape: not applicable - docs-only change with no backend response changed.
- Status codes: not applicable - no HTTP status behavior changed.
- Frontend consumer: not applicable - no frontend consumer changed.
- Compatibility path or alias: existing polling command remains `python -m app.scripts.telegram_polling_worker` from `C:\final\backend`; no alias changed.
- Contract proof: git diff --check passed for the runbook diff.

## RBAC / Permissions

- Roles allowed: not applicable - no app RBAC or route permission changed.
- Roles denied: not applicable - no app denied-role behavior changed.
- Positive auth proof: not applicable - docs-only change, no authenticated runtime path changed.
- Negative auth proof: not applicable - docs-only change, no forbidden runtime path changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no app notification event, websocket channel, or realtime stream changed.
- Payload version / ack behavior: not applicable - documentation only; no Telegram payload or ack behavior changed.
- Read/unread or delivery semantics: not applicable - no TelegramMessage rows or unread state changed.
- Reconnect/resync proof: runbook notes the polling task must be stopped before switching to webhook mode; no reconnect/resync code changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend UI, list, route, or data state changed.
- Partial data proof: not applicable - no frontend data handling changed.
- Forbidden secondary path behavior: not applicable - no secondary frontend path changed.
- Missing draft/resource behavior: not applicable - no draft/resource behavior changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: ops/windows/README.md.
- Denied paths: backend service code, polling worker behavior, frontend UI, migrations, secrets, generated output.
- Migration/docs/test impact: docs-only runbook update; no migration; no runtime tests required for the doc text.
- Rollback note: revert commit bce358de to remove the scheduled task runbook section.

## Validation

- Targeted tests or smoke run: git diff --check HEAD -- ops/windows/README.md; git diff --check origin/main...HEAD -- ops/windows/README.md; local PR review gate validator.
- Result: passed.
- Not checked: live Windows Scheduled Task registration/startup, live Telegram API, production polling/webhook switching.