### PR TITLE
fix(telegram): align user language code length

### DIFF
--- a/backend/app/models/telegram.py
+++ b/backend/app/models/telegram.py
@@ -51,7 +51,7 @@ class TelegramUser(Base):
     username: Mapped[str | None] = mapped_column(String(100), nullable=True)
     first_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     last_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
-    language_code: Mapped[str] = mapped_column(String(10), default="ru")
+    language_code: Mapped[str] = mapped_column(String(16), default="ru")
     is_bot: Mapped[bool] = mapped_column(Boolean, default=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     notifications_enabled: Mapped[bool] = mapped_column(Boolean, default=True)


### PR DESCRIPTION
## Summary

- Align `TelegramUser.language_code` SQLAlchemy column metadata with the Alembic BCP47 migration.
- Preserve current patient bot language values: `ru` and `uz-Latn`.
- Remove model/schema drift after the `telegram_users.language_code` widening migration.

## Contract Impact

- Canonical surface: SQLAlchemy model metadata for `telegram_users.language_code`; Alembic migration `0024_tg_user_lang_bcp47.py` remains database source of truth.
- Request shape: not applicable - no API endpoint or request body changed.
- Response shape: not applicable - no API response serializer or payload changed.
- Status codes: not applicable - no route or exception mapping changed.
- Frontend consumer: not applicable - no frontend consumer reads this column length metadata.
- Compatibility path or alias: not applicable - no compatibility route, alias, or adapter changed.
- Contract proof: `git diff --check` and `py_compile` for the touched model passed; CI backend tests passed.

## RBAC / Permissions

- Roles allowed: not applicable - no auth guard or role policy changed.
- Roles denied: not applicable - no auth guard or role policy changed.
- Positive auth proof: not applicable - no endpoint behavior changed.
- Negative auth proof: not applicable - no endpoint behavior changed.

## Notification / Realtime

not applicable - no notification template, websocket, chat, polling, webhook, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel, frontend state, route, or data flow changed.

## Scope Gate

- Allowed paths: `backend/app/models/telegram.py` only.
- Denied paths: migrations, CRUD/service behavior, frontend UI, worker/runtime scripts, secrets, generated output.
- Migration/docs/test impact: no migration change; model metadata now matches existing migration; no docs or tests changed.
- Rollback note: revert the one-line model metadata change from `String(16)` back to the previous value.

## Validation

- Targeted tests or smoke run: `git diff --check`; `C:\Users\DrSapaev\AppData\Local\Programs\Python\Python311\python.exe -m py_compile backend/app/models/telegram.py`; GitHub CI backend tests.
- Result: local checks passed; GitHub CI backend tests passed.
- Not checked: full local backend suite and Alembic upgrade/downgrade, because this PR does not alter migrations.