### PR TITLE
feat(telegram): localize profile status message

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -250,6 +250,26 @@ TELEGRAM_LOCALIZED_TEXTS = {
             "shu yerga keladi. Natija shoshilinch kerak bo'lsa, registraturaga murojaat qiling."
         ),
     },
+    "profile_linked": {
+        TELEGRAM_LANGUAGE_RU: (
+            "Telegram привязан к пациенту: {patient}.\n{visit_summary}"
+        ),
+        TELEGRAM_LANGUAGE_UZ: (
+            "Telegram bemorga bog'langan: {patient}.\n{visit_summary}"
+        ),
+    },
+    "recent_visit_none": {
+        TELEGRAM_LANGUAGE_RU: "Последних визитов пока нет.",
+        TELEGRAM_LANGUAGE_UZ: "Hozircha oxirgi tashriflar yo'q.",
+    },
+    "recent_visit_unknown_date": {
+        TELEGRAM_LANGUAGE_RU: "дата не указана",
+        TELEGRAM_LANGUAGE_UZ: "sana ko'rsatilmagan",
+    },
+    "recent_visit_summary": {
+        TELEGRAM_LANGUAGE_RU: "Последний визит: #{visit_id}, {visit_date}, статус: {status}.",
+        TELEGRAM_LANGUAGE_UZ: "Oxirgi tashrif: #{visit_id}, {visit_date}, holat: {status}.",
+    },
 }
 TELEGRAM_WEBHOOK_PUBLIC_ERROR = "Ошибка обработки webhook"
 TELEGRAM_SEND_PUBLIC_ERROR = "Ошибка отправки сообщения"
@@ -486,7 +506,9 @@ def _patient_display_name(patient: Patient | None) -> str:
     return patient.short_name()
 
 
-def _recent_visit_summary(db: Session, patient_id: int) -> str:
+def _recent_visit_summary(
+    db: Session, patient_id: int, language_code: str = TELEGRAM_LANGUAGE_RU
+) -> str:
     visit = (
         db.query(Visit)
         .filter(Visit.patient_id == patient_id)
@@ -494,10 +516,18 @@ def _recent_visit_summary(db: Session, patient_id: int) -> str:
         .first()
     )
     if not visit:
-        return "Последних визитов пока нет."
+        return _localized_text("recent_visit_none", language_code)
 
-    visit_date = visit.visit_date.isoformat() if visit.visit_date else "дата не указана"
-    return f"Последний визит: #{visit.id}, {visit_date}, статус: {visit.status}."
+    visit_date = (
+        visit.visit_date.isoformat()
+        if visit.visit_date
+        else _localized_text("recent_visit_unknown_date", language_code)
+    )
+    return _localized_text("recent_visit_summary", language_code).format(
+        visit_id=visit.id,
+        visit_date=visit_date,
+        status=visit.status,
+    )
 
 
 def _html_text(value: Any) -> str:
@@ -919,9 +949,12 @@ def _clinic_status_message(db: Session, chat_id: int) -> str:
     if not telegram_user or not telegram_user.patient_id:
         return _telegram_chat_text(db, chat_id, "needs_link")
 
-    return (
-        f"Telegram привязан к пациенту: {_html_text(_patient_display_name(patient))}.\n"
-        f"{_html_text(_recent_visit_summary(db, telegram_user.patient_id))}"
+    language = _telegram_chat_language(db, chat_id)
+    return _localized_text("profile_linked", language).format(
+        patient=_html_text(_patient_display_name(patient)),
+        visit_summary=_html_text(
+            _recent_visit_summary(db, telegram_user.patient_id, language)
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

- Localize patient bot `/profile` status text for Russian and Uzbek Latin (`uz-Latn`).
- Keep Telegram patient lookup/linking logic unchanged.
- Preserve the old recent-visit helper API by adding a default Russian language parameter.

## Contract Impact

- Canonical surface: backend Telegram patient bot handler in `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Request shape: not applicable - Telegram update parsing and `/profile` command matching are unchanged.
- Response shape: Telegram chat text content is localized; no HTTP API response schema changed.
- Status codes: not applicable - no HTTP route status behavior changed.
- Frontend consumer: not applicable - no frontend consumer reads these chat strings.
- Compatibility path or alias: existing `/profile` command and `Мой статус`/`Mening holatim` menu handling remain unchanged.
- Contract proof: existing Telegram webhook unit suite passed; py_compile passed; frontend build passed before rebase and py_compile passed again after rebase.

## RBAC / Permissions

- Roles allowed: linked Telegram patient remains the only profile data path.
- Roles denied: unlinked Telegram chats still receive the existing link/contact prompt.
- Positive auth proof: existing Telegram webhook unit suite passed for linked patient flows.
- Negative auth proof: existing contact spoof/webhook security tests passed in the targeted suite.

## Notification / Realtime

not applicable - no notification delivery, websocket, polling, webhook transport, or event behavior changed; only patient-facing bot message text was localized.

## Frontend Resilience

not applicable - no user-facing frontend panel, route, state, or data flow changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Denied paths: patient linking rules, queue/payment/result access rules, database models/migrations, frontend UI, polling worker, secrets, generated output.
- Migration/docs/test impact: no migration or docs changed; tests were run but not edited because the gate first-touch did not include test files.
- Rollback note: revert the localized profile/recent-visit text additions and restore the previous hardcoded `/profile` message.

## Validation

- Targeted tests or smoke run: `git diff --check`; `py_compile` for `admin_telegram.py` and `telegram_webhook.py`; `pytest backend/tests/unit/test_telegram_webhook_security.py -q`; `npm.cmd run build`; post-rebase `py_compile`.
- Result: all passed locally; frontend build used a temporary worktree `node_modules` junction and emitted existing Vite chunk/import warnings.
- Not checked: live Telegram API, full backend suite, browser UI smoke.