### PR TITLE
feat(telegram): localize payments summary

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -270,6 +270,52 @@ TELEGRAM_LOCALIZED_TEXTS = {
         TELEGRAM_LANGUAGE_RU: "Последний визит: #{visit_id}, {visit_date}, статус: {status}.",
         TELEGRAM_LANGUAGE_UZ: "Oxirgi tashrif: #{visit_id}, {visit_date}, holat: {status}.",
     },
+    "payments_empty": {
+        TELEGRAM_LANGUAGE_RU: (
+            "Пациент: {patient}\n"
+            "Активных начислений и оплат пока нет."
+        ),
+        TELEGRAM_LANGUAGE_UZ: (
+            "Bemor: {patient}\n"
+            "Hozircha faol hisob-kitoblar va to'lovlar yo'q."
+        ),
+    },
+    "payments_patient": {
+        TELEGRAM_LANGUAGE_RU: "Пациент: {patient}",
+        TELEGRAM_LANGUAGE_UZ: "Bemor: {patient}",
+    },
+    "payments_title": {
+        TELEGRAM_LANGUAGE_RU: "Оплаты и долг:",
+        TELEGRAM_LANGUAGE_UZ: "To'lovlar va qarz:",
+    },
+    "payments_billed": {
+        TELEGRAM_LANGUAGE_RU: "Начислено: {amount} сум",
+        TELEGRAM_LANGUAGE_UZ: "Hisoblangan: {amount} so'm",
+    },
+    "payments_paid": {
+        TELEGRAM_LANGUAGE_RU: "Оплачено: {amount} сум",
+        TELEGRAM_LANGUAGE_UZ: "To'langan: {amount} so'm",
+    },
+    "payments_debt": {
+        TELEGRAM_LANGUAGE_RU: "Долг: {amount} сум",
+        TELEGRAM_LANGUAGE_UZ: "Qarz: {amount} so'm",
+    },
+    "payments_pending": {
+        TELEGRAM_LANGUAGE_RU: "Ожидает подтверждения: {amount} сум",
+        TELEGRAM_LANGUAGE_UZ: "Tasdiqlanishi kutilmoqda: {amount} so'm",
+    },
+    "payments_visits": {
+        TELEGRAM_LANGUAGE_RU: "Визит: {visits}",
+        TELEGRAM_LANGUAGE_UZ: "Tashrif: {visits}",
+    },
+    "payments_online_unavailable": {
+        TELEGRAM_LANGUAGE_RU: (
+            "Онлайн-оплата пока не подключена. Для оплаты обратитесь в кассу."
+        ),
+        TELEGRAM_LANGUAGE_UZ: (
+            "Onlayn to'lov hozircha ulanmagan. To'lov uchun kassaga murojaat qiling."
+        ),
+    },
 }
 TELEGRAM_WEBHOOK_PUBLIC_ERROR = "Ошибка обработки webhook"
 TELEGRAM_SEND_PUBLIC_ERROR = "Ошибка отправки сообщения"
@@ -768,28 +814,39 @@ def _clinic_payments_message(db: Session, chat_id: int) -> str:
     if not telegram_user or not telegram_user.patient_id:
         return _telegram_chat_text(db, chat_id, "needs_link")
 
+    language = _telegram_chat_language(db, chat_id)
+    patient_name = _html_text(_patient_display_name(patient))
     entries, visits, expected_total, paid_total, pending_total, debt_total = _billing_totals(
         db, telegram_user.patient_id
     )
     if not entries and not visits and expected_total <= 0 and paid_total <= 0:
-        return (
-            f"Пациент: {_html_text(_patient_display_name(patient))}\n"
-            "Активных начислений и оплат пока нет."
-        )
+        return _localized_text("payments_empty", language).format(patient=patient_name)
 
     lines = [
-        f"Пациент: {_html_text(_patient_display_name(patient))}",
-        "Оплаты и долг:",
-        f"Начислено: {_format_money(expected_total)} сум",
-        f"Оплачено: {_format_money(paid_total)} сум",
-        f"Долг: {_format_money(debt_total)} сум",
+        _localized_text("payments_patient", language).format(patient=patient_name),
+        _localized_text("payments_title", language),
+        _localized_text("payments_billed", language).format(
+            amount=_format_money(expected_total)
+        ),
+        _localized_text("payments_paid", language).format(
+            amount=_format_money(paid_total)
+        ),
+        _localized_text("payments_debt", language).format(
+            amount=_format_money(debt_total)
+        ),
     ]
     if pending_total > 0:
-        lines.append(f"Ожидает подтверждения: {_format_money(pending_total)} сум")
+        lines.append(
+            _localized_text("payments_pending", language).format(
+                amount=_format_money(pending_total)
+            )
+        )
     if visits:
         visit_numbers = ", ".join(f"#{visit.id}" for visit in visits[:5])
-        lines.append(f"Визит: {visit_numbers}")
-    lines.append("Онлайн-оплата пока не подключена. Для оплаты обратитесь в кассу.")
+        lines.append(
+            _localized_text("payments_visits", language).format(visits=visit_numbers)
+        )
+    lines.append(_localized_text("payments_online_unavailable", language))
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary

- Localize patient bot `/payments` labels for Russian and Uzbek Latin (`uz-Latn`).
- Keep debt calculation unchanged, including `paid/completed` as paid and `pending/processing` as pending.
- Preserve existing `/payments` command and menu handling.

## Contract Impact

- Canonical surface: backend Telegram patient bot payment summary in `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Request shape: not applicable - Telegram update parsing and `/payments` command matching are unchanged.
- Response shape: Telegram chat text labels are localized; numeric totals and visit IDs are unchanged.
- Status codes: not applicable - no HTTP route status behavior changed.
- Frontend consumer: not applicable - no frontend consumer reads these chat strings.
- Compatibility path or alias: existing `/payments`, `Оплаты и долг`, and `To'lovlar va qarz` handlers remain unchanged.
- Contract proof: existing Telegram webhook unit suite passed; py_compile passed; frontend build passed.

## RBAC / Permissions

- Roles allowed: linked Telegram patient remains the only payment summary path.
- Roles denied: unlinked Telegram chats still receive the existing link/contact prompt.
- Positive auth proof: existing payments unit test passed and still validates debt totals.
- Negative auth proof: existing contact spoof/webhook security tests passed in the targeted suite.

## Notification / Realtime

not applicable - no notification delivery, websocket, polling, webhook transport, or event behavior changed; only patient-facing bot payment text was localized.

## Frontend Resilience

not applicable - no user-facing frontend panel, route, state, or data flow changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Denied paths: debt calculation logic, payment status sets, database models/migrations, frontend UI, polling worker, secrets, generated output.
- Migration/docs/test impact: no migration or docs changed; tests were run but not edited because the gate first-touch did not include test files.
- Rollback note: revert the localized payment text additions and restore the previous hardcoded `/payments` labels.

## Validation

- Targeted tests or smoke run: `git diff --check`; `py_compile` for `admin_telegram.py` and `telegram_webhook.py`; `pytest backend/tests/unit/test_telegram_webhook_security.py -q`; `npm.cmd run build`.
- Result: all passed locally; frontend build used a temporary worktree `node_modules` junction and emitted existing Vite chunk/import warnings.
- Not checked: live Telegram API, full backend suite, live payment provider flows.