### PR TITLE
feat(telegram): localize queue summary

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -316,6 +316,46 @@ TELEGRAM_LOCALIZED_TEXTS = {
             "Onlayn to'lov hozircha ulanmagan. To'lov uchun kassaga murojaat qiling."
         ),
     },
+    "queue_empty": {
+        TELEGRAM_LANGUAGE_RU: (
+            "Telegram привязан к пациенту: {patient}.\n"
+            "{visit_summary}\n\n"
+            "На сегодня активной очереди нет."
+        ),
+        TELEGRAM_LANGUAGE_UZ: (
+            "Telegram bemorga bog'langan: {patient}.\n"
+            "{visit_summary}\n\n"
+            "Bugun faol navbat yo'q."
+        ),
+    },
+    "queue_patient": {
+        TELEGRAM_LANGUAGE_RU: "Пациент: {patient}",
+        TELEGRAM_LANGUAGE_UZ: "Bemor: {patient}",
+    },
+    "queue_title": {
+        TELEGRAM_LANGUAGE_RU: "Ваша очередь на сегодня:",
+        TELEGRAM_LANGUAGE_UZ: "Bugungi navbatingiz:",
+    },
+    "queue_status": {
+        TELEGRAM_LANGUAGE_RU: "статус: {status}",
+        TELEGRAM_LANGUAGE_UZ: "holat: {status}",
+    },
+    "queue_position": {
+        TELEGRAM_LANGUAGE_RU: "позиция: {position}",
+        TELEGRAM_LANGUAGE_UZ: "navbatdagi o'rin: {position}",
+    },
+    "queue_cabinet": {
+        TELEGRAM_LANGUAGE_RU: "Кабинет {cabinet}",
+        TELEGRAM_LANGUAGE_UZ: "{cabinet}-xona",
+    },
+    "queue_more": {
+        TELEGRAM_LANGUAGE_RU: "Еще записей: {count}",
+        TELEGRAM_LANGUAGE_UZ: "Yana yozuvlar: {count}",
+    },
+    "queue_default_name": {
+        TELEGRAM_LANGUAGE_RU: "Очередь",
+        TELEGRAM_LANGUAGE_UZ: "Navbat",
+    },
 }
 TELEGRAM_WEBHOOK_PUBLIC_ERROR = "Ошибка обработки webhook"
 TELEGRAM_SEND_PUBLIC_ERROR = "Ошибка отправки сообщения"
@@ -340,6 +380,31 @@ QUEUE_STATUS_LABELS = {
     "incomplete": "не завершен",
     "no_show": "не явился",
     "cancelled": "отменен",
+}
+QUEUE_TAG_LABELS_BY_LANGUAGE = {
+    TELEGRAM_LANGUAGE_RU: QUEUE_TAG_LABELS,
+    TELEGRAM_LANGUAGE_UZ: {
+        "ecg": "EKG",
+        "cardiology_common": "Kardiologiya",
+        "dermatology": "Dermatologiya",
+        "stomatology": "Stomatologiya",
+        "cosmetology": "Kosmetologiya",
+        "lab": "Laboratoriya",
+        "general": "Umumiy navbat",
+    },
+}
+QUEUE_STATUS_LABELS_BY_LANGUAGE = {
+    TELEGRAM_LANGUAGE_RU: QUEUE_STATUS_LABELS,
+    TELEGRAM_LANGUAGE_UZ: {
+        "waiting": "kutmoqda",
+        "called": "chaqirilgan",
+        "in_service": "qabulda",
+        "diagnostics": "diagnostikada",
+        "served": "yakunlangan",
+        "incomplete": "yakunlanmagan",
+        "no_show": "kelmagan",
+        "cancelled": "bekor qilingan",
+    },
 }
 PAYMENT_PAID_STATUSES = {"paid", "completed"}
 PAYMENT_PENDING_STATUSES = {"pending", "processing"}
@@ -647,25 +712,43 @@ def _queue_entry_position(db: Session, entry: OnlineQueueEntry) -> int | None:
     return None
 
 
-def _queue_entry_name(entry: OnlineQueueEntry) -> str:
+def _queue_entry_name(
+    entry: OnlineQueueEntry, language_code: str = TELEGRAM_LANGUAGE_RU
+) -> str:
     queue = getattr(entry, "queue", None)
     queue_tag = getattr(queue, "queue_tag", None)
     if queue_tag:
-        return QUEUE_TAG_LABELS.get(queue_tag, queue_tag)
+        language = _normalize_patient_language(language_code)
+        labels = QUEUE_TAG_LABELS_BY_LANGUAGE.get(language, QUEUE_TAG_LABELS)
+        return labels.get(queue_tag) or QUEUE_TAG_LABELS.get(queue_tag, queue_tag)
 
     services = entry.services or []
     if services:
         first_service = services[0] or {}
-        return str(first_service.get("name") or first_service.get("title") or "Очередь")
-    return "Очередь"
+        return str(
+            first_service.get("name")
+            or first_service.get("title")
+            or _localized_text("queue_default_name", language_code)
+        )
+    return _localized_text("queue_default_name", language_code)
 
 
-def _queue_entry_cabinet(entry: OnlineQueueEntry) -> str | None:
+def _queue_status_label(status: str, language_code: str = TELEGRAM_LANGUAGE_RU) -> str:
+    language = _normalize_patient_language(language_code)
+    labels = QUEUE_STATUS_LABELS_BY_LANGUAGE.get(language, QUEUE_STATUS_LABELS)
+    return labels.get(status) or QUEUE_STATUS_LABELS.get(status, status)
+
+
+def _queue_entry_cabinet(
+    entry: OnlineQueueEntry, language_code: str = TELEGRAM_LANGUAGE_RU
+) -> str | None:
     queue = getattr(entry, "queue", None)
     cabinet_number = getattr(queue, "cabinet_number", None)
     if not cabinet_number:
         return None
-    return f"Кабинет {_html_text(cabinet_number)}"
+    return _localized_text("queue_cabinet", language_code).format(
+        cabinet=_html_text(cabinet_number)
+    )
 
 
 def _clinic_queue_message(db: Session, chat_id: int) -> str:
@@ -673,35 +756,44 @@ def _clinic_queue_message(db: Session, chat_id: int) -> str:
     if not telegram_user or not telegram_user.patient_id:
         return _telegram_chat_text(db, chat_id, "needs_link")
 
+    language = _telegram_chat_language(db, chat_id)
+    patient_name = _html_text(_patient_display_name(patient))
     entries = _patient_today_queue_entries(db, telegram_user.patient_id)
     if not entries:
-        return (
-            f"Telegram привязан к пациенту: {_html_text(_patient_display_name(patient))}.\n"
-            f"{_html_text(_recent_visit_summary(db, telegram_user.patient_id))}\n\n"
-            "На сегодня активной очереди нет."
+        return _localized_text("queue_empty", language).format(
+            patient=patient_name,
+            visit_summary=_html_text(
+                _recent_visit_summary(db, telegram_user.patient_id, language)
+            ),
         )
 
     lines = [
-        f"Пациент: {_html_text(_patient_display_name(patient))}",
-        "Ваша очередь на сегодня:",
+        _localized_text("queue_patient", language).format(patient=patient_name),
+        _localized_text("queue_title", language),
     ]
     for entry in entries[:5]:
-        status_label = QUEUE_STATUS_LABELS.get(entry.status, entry.status)
+        status_label = _queue_status_label(entry.status, language)
         position = _queue_entry_position(db, entry)
-        cabinet = _queue_entry_cabinet(entry)
+        cabinet = _queue_entry_cabinet(entry, language)
         details = [
             f"№{entry.number}",
-            _html_text(_queue_entry_name(entry)),
-            f"статус: {_html_text(status_label)}",
+            _html_text(_queue_entry_name(entry, language)),
+            _localized_text("queue_status", language).format(
+                status=_html_text(status_label)
+            ),
         ]
         if position:
-            details.append(f"позиция: {position}")
+            details.append(
+                _localized_text("queue_position", language).format(position=position)
+            )
         if cabinet:
             details.append(cabinet)
         lines.append(" • ".join(details))
 
     if len(entries) > 5:
-        lines.append(f"Еще записей: {len(entries) - 5}")
+        lines.append(
+            _localized_text("queue_more", language).format(count=len(entries) - 5)
+        )
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary

- Localize the clinic Telegram queue summary for Russian and Uzbek patient chat languages.
- Add localized queue labels for empty queue, queue status, queue position, cabinet, overflow count, and default queue names.
- Keep the change isolated to the existing clinic Telegram webhook message composition path.

## Contract Impact

- Canonical surface: backend/app/api/v1/endpoints/telegram_webhook.py clinic Telegram queue message helpers.
- Request shape: unchanged - Telegram webhook update payload parsing is not changed.
- Response shape: changed only for outbound patient-facing Telegram queue text; Russian default remains equivalent and Uzbek chat language now receives localized text.
- Status codes: unchanged - no HTTP status behavior changed.
- Frontend consumer: not applicable - no frontend consumer reads this message shape.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: py_compile passed for admin_telegram.py and telegram_webhook.py; frontend build passed; PR checks will run required gate and CI.

## RBAC / Permissions

- Roles allowed: not applicable - patient Telegram chat linkage and authorization checks remain unchanged.
- Roles denied: not applicable - no authorization rule or guard changed.
- Positive auth proof: existing linked-patient Telegram path remains the only queue message path.
- Negative auth proof: unlinked chat still returns the existing needs-link message path.

## Notification / Realtime

- Event type or websocket channel: Telegram clinic bot queue summary reply text only; no websocket channel or app notification event changed.
- Payload version / ack behavior: not applicable - no Telegram update acknowledgement or payload version changed.
- Read/unread or delivery semantics: not applicable - no TelegramMessage rows or unread state changed.
- Reconnect/resync proof: not applicable - no reconnect, polling, websocket, or resync behavior changed.

## Frontend Resilience

- Empty data proof: empty queue response is localized and still includes patient plus recent visit summary context.
- Partial data proof: queue entries without tags, services, cabinet, or known status fall back to existing raw labels or localized default queue text.
- Forbidden secondary path behavior: not applicable - no secondary frontend path or forbidden fallback changed.
- Missing draft/resource behavior: not applicable - no draft or resource creation path changed.
- Stale route/deep-link behavior: not applicable - no route state or deep-link handling changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/telegram_webhook.py.
- Denied paths: frontend runtime, Telegram manager UI, admin Telegram endpoints, payment behavior, queue persistence, websocket delivery, database migrations, RBAC rules, EMR, lab, patient data models.
- Migration/docs/test impact: no migration; no docs update; existing backend py_compile and frontend build validation used.
- Rollback note: revert the queue localization commit.

## Validation

- Targeted tests or smoke run: agent_gate.py with known root cause; git diff --check; python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py; npm.cmd --prefix frontend run build.
- Result: passed; frontend build passed with existing Vite dynamic import/chunk warnings.
- Not checked: targeted pytest backend/tests/unit/test_telegram_webhook_security.py could not run locally because the bundled Python runtime does not include pytest.