### PR TITLE
feat(telegram): localize lab result captions

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -240,6 +240,20 @@ TELEGRAM_LOCALIZED_TEXTS = {
             "PDF natijalarni yuborib bo'lmadi. Registraturaga murojaat qiling."
         ),
     },
+    "lab_result_document_caption": {
+        TELEGRAM_LANGUAGE_RU: (
+            "Результат анализа: {template_name}\n"
+            "Отчет #{report_id} от {report_date}"
+        ),
+        TELEGRAM_LANGUAGE_UZ: (
+            "Tahlil natijasi: {template_name}\n"
+            "Hisobot #{report_id}, sana: {report_date}"
+        ),
+    },
+    "lab_result_document_failed_caption": {
+        TELEGRAM_LANGUAGE_RU: "Отчет #{report_id}",
+        TELEGRAM_LANGUAGE_UZ: "Hisobot #{report_id}",
+    },
     "results_hint": {
         TELEGRAM_LANGUAGE_RU: (
             "Результаты будут приходить сюда, когда лаборатория или врач отметит их "
@@ -957,6 +971,21 @@ def _latest_ready_lab_report_instances(
     )
 
 
+def _lab_report_document_caption(
+    instance: LabReportInstance,
+    report_date: datetime,
+    language_code: str = TELEGRAM_LANGUAGE_RU,
+) -> str:
+    caption = _localized_text("lab_result_document_caption", language_code).format(
+        template_name=_html_text(instance.template.name),
+        report_id=instance.id,
+        report_date=report_date.strftime("%d.%m.%Y"),
+    )
+    if len(caption) > 1000:
+        return f"{caption[:997]}..."
+    return caption
+
+
 def _build_lab_report_pdf(db: Session, instance: LabReportInstance) -> tuple[str, bytes, str]:
     service = LabReportingService(db)
     materialized_sections = service.materialize_instance(instance)
@@ -977,12 +1006,9 @@ def _build_lab_report_pdf(db: Session, instance: LabReportInstance) -> tuple[str
         }
     )
     filename = f"kosmed-lab-report-{instance.id}.pdf"
-    caption = (
-        f"Результат анализа: {_html_text(instance.template.name)}\n"
-        f"Отчет #{instance.id} от {report_date.strftime('%d.%m.%Y')}"
+    caption = _lab_report_document_caption(
+        instance, report_date, TELEGRAM_LANGUAGE_RU
     )
-    if len(caption) > 1000:
-        caption = f"{caption[:997]}..."
     return filename, pdf_bytes, caption
 
 
@@ -1048,6 +1074,11 @@ async def _send_clinic_lab_results(db: Session, bot_service, chat_id: int) -> No
     for instance in instances:
         try:
             filename, pdf_bytes, caption = _build_lab_report_pdf(db, instance)
+            if language == TELEGRAM_LANGUAGE_UZ:
+                report_date = (
+                    instance.finalized_at or instance.created_at or datetime.utcnow()
+                )
+                caption = _lab_report_document_caption(instance, report_date, language)
             send_document = getattr(bot_service, "_send_document", None)
             if callable(send_document):
                 ok, message_id, error_message = await send_document(
@@ -1080,7 +1111,9 @@ async def _send_clinic_lab_results(db: Session, bot_service, chat_id: int) -> No
                 db,
                 chat_id,
                 instance.id,
-                f"Отчет #{instance.id}",
+                _localized_text(
+                    "lab_result_document_failed_caption", language
+                ).format(report_id=instance.id),
                 "failed",
                 error_message=type(exc).__name__,
             )


### PR DESCRIPTION
## Summary

- Localize Telegram lab result PDF document captions for Russian and Uzbek patient chat languages.
- Add stable localized template keys for successful and failed lab result document captions.
- Keep lab report PDF generation, ready-report filtering, patient access checks, and Telegram document transport unchanged.

## Contract Impact

- Canonical surface: backend/app/api/v1/endpoints/telegram_webhook.py clinic Telegram lab result document caption helpers.
- Request shape: unchanged - Telegram webhook update payload parsing is not changed.
- Response shape: changed only for outbound patient-facing Telegram sendDocument caption text; Russian default remains equivalent and Uzbek chat language now receives localized captions.
- Status codes: unchanged - no HTTP status behavior changed.
- Frontend consumer: not applicable - no frontend consumer reads this caption shape.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: py_compile passed for admin_telegram.py and telegram_webhook.py; frontend build passed; PR checks include backend tests and required gate.

## RBAC / Permissions

- Roles allowed: not applicable - linked patient Telegram chat access for ready lab reports remains unchanged.
- Roles denied: not applicable - no authorization rule or guard changed.
- Positive auth proof: existing linked-patient Telegram lab results path remains the only sendDocument path.
- Negative auth proof: unlinked chat still returns the existing needs-link message path and report filtering is unchanged.

## Notification / Realtime

- Event type or websocket channel: Telegram clinic bot lab result PDF sendDocument caption only; no websocket channel or app notification event changed.
- Payload version / ack behavior: not applicable - no Telegram update acknowledgement, sendDocument transport, or payload version changed.
- Read/unread or delivery semantics: unchanged - TelegramMessage logging continues without PDF content, with localized failed-caption fallback.
- Reconnect/resync proof: not applicable - no reconnect, polling, websocket, or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend empty state or empty lab-result list behavior changed.
- Partial data proof: long captions still truncate at Telegram-safe caption length; failed document logging has localized fallback caption.
- Forbidden secondary path behavior: not applicable - no secondary frontend path or forbidden fallback changed.
- Missing draft/resource behavior: not applicable - no draft or resource creation path changed.
- Stale route/deep-link behavior: not applicable - no route state or deep-link handling changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/telegram_webhook.py.
- Denied paths: lab report access rules, ready status filtering, PDF rendering service, Telegram transport service, frontend manager behavior, database migrations, RBAC rules, queue persistence, payment behavior.
- Migration/docs/test impact: no migration; no docs update; backend py_compile and frontend build validation used, CI backend tests run in PR.
- Rollback note: revert the lab caption localization commit.

## Validation

- Targeted tests or smoke run: agent_gate.py with known root cause; git diff --check; python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py; npm.cmd --prefix frontend run build.
- Result: passed; frontend build passed with existing Vite dynamic import/chunk warnings; PR backend tests passed in GitHub checks.
- Not checked: targeted pytest backend/tests/unit/test_telegram_webhook_security.py could not run locally because the bundled Python runtime does not include pytest.