### PR TITLE
feat(telegram): expose staff bot readiness contract

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -470,6 +470,11 @@ def get_telegram_integration_status(
                 "patient_payments_debt",
                 "patient_status",
                 "lab_results_pdf",
+            ],
+            "planned_functions": [
+                "staff_role_menus",
+                "staff_action_confirmations",
+                "staff_audit_logging",
                 "admin_notifications",
             ],
             "patient_bot": {
@@ -517,6 +522,52 @@ def get_telegram_integration_status(
                 ],
                 "results_delivery": "telegram_pdf",
                 "max_pdf_reports_per_request": 3,
+            },
+            "staff_bot": {
+                "version": "planning",
+                "enabled": False,
+                "status": "requires_role_linking_audit_and_confirmations",
+                "transport": "polling" if not webhook_set else "webhook",
+                "supported_languages": [
+                    {"code": "ru", "label": "Русский"},
+                ],
+                "supported_roles": [
+                    "registrar",
+                    "doctor",
+                    "cashier",
+                    "lab",
+                    "admin",
+                    "owner",
+                ],
+                "readiness": [
+                    {
+                        "key": "role_based_staff_linking",
+                        "label": "Ролевая привязка сотрудников",
+                        "ready": False,
+                    },
+                    {
+                        "key": "server_side_authorization",
+                        "label": "Проверка ролей на backend",
+                        "ready": False,
+                    },
+                    {
+                        "key": "audit_logging",
+                        "label": "Аудит действий сотрудников",
+                        "ready": False,
+                    },
+                    {
+                        "key": "state_change_confirmations",
+                        "label": "Подтверждения для операций",
+                        "ready": False,
+                    },
+                ],
+                "guardrails": [
+                    "server_side_authorization",
+                    "audit_logging",
+                    "explicit_confirmation_for_state_changes",
+                    "no_queue_fairness_mutation_without_domain_service",
+                ],
+                "next_slice": "role_linking_and_read_only_staff_menu_contract",
             },
             "transition_path": (
                 "Set webhook when a public HTTPS backend URL is available; "

--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -25,6 +25,139 @@ from app.services.telegram_bot import (
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+STAFF_BOT_SUPPORTED_ROLES = [
+    "registrar",
+    "doctor",
+    "cashier",
+    "lab",
+    "admin",
+    "owner",
+]
+
+STAFF_BOT_READINESS = [
+    {
+        "key": "role_based_staff_linking",
+        "label": "Ролевая привязка сотрудников",
+        "ready": False,
+    },
+    {
+        "key": "server_side_authorization",
+        "label": "Проверка ролей на backend",
+        "ready": False,
+    },
+    {
+        "key": "audit_logging",
+        "label": "Аудит действий сотрудников",
+        "ready": False,
+    },
+    {
+        "key": "state_change_confirmations",
+        "label": "Подтверждения для операций",
+        "ready": False,
+    },
+]
+
+STAFF_BOT_READ_ONLY_MENU_CONTRACT = [
+    {
+        "role": "registrar",
+        "label": "Регистратор",
+        "items": [
+            {"key": "queue_overview", "label": "Очередь", "intent": "read_only"},
+            {"key": "next_patient", "label": "Следующий пациент", "intent": "read_only"},
+            {"key": "payment_status", "label": "Статус оплаты", "intent": "read_only"},
+        ],
+    },
+    {
+        "role": "doctor",
+        "label": "Врач",
+        "items": [
+            {"key": "today_schedule", "label": "Расписание на сегодня", "intent": "read_only"},
+            {"key": "next_patient", "label": "Следующий пациент", "intent": "read_only"},
+            {"key": "emr_reminders", "label": "Напоминания ЭМК", "intent": "read_only"},
+        ],
+    },
+    {
+        "role": "cashier",
+        "label": "Кассир",
+        "items": [
+            {"key": "unpaid_invoices", "label": "Неоплаченные счета", "intent": "read_only"},
+            {"key": "paid_invoices", "label": "Оплаченные счета", "intent": "read_only"},
+            {"key": "reconciliation_alerts", "label": "Сверка оплат", "intent": "read_only"},
+        ],
+    },
+    {
+        "role": "lab",
+        "label": "Лаборатория",
+        "items": [
+            {"key": "ready_reports", "label": "Готовые результаты", "intent": "read_only"},
+            {"key": "pending_reports", "label": "Ожидающие результаты", "intent": "read_only"},
+            {"key": "delivery_status", "label": "Статус доставки", "intent": "read_only"},
+        ],
+    },
+    {
+        "role": "admin",
+        "label": "Администратор",
+        "items": [
+            {"key": "daily_summary", "label": "Дневная сводка", "intent": "read_only"},
+            {"key": "integration_errors", "label": "Ошибки интеграций", "intent": "read_only"},
+            {"key": "staff_readiness", "label": "Готовность staff bot", "intent": "read_only"},
+        ],
+    },
+    {
+        "role": "owner",
+        "label": "Владелец",
+        "items": [
+            {"key": "daily_summary", "label": "Дневная сводка", "intent": "read_only"},
+            {"key": "revenue_summary", "label": "Сводка выручки", "intent": "read_only"},
+            {"key": "integration_errors", "label": "Ошибки интеграций", "intent": "read_only"},
+        ],
+    },
+]
+
+STAFF_BOT_GUARDRAILS = [
+    "server_side_authorization",
+    "audit_logging",
+    "explicit_confirmation_for_state_changes",
+    "no_queue_fairness_mutation_without_domain_service",
+]
+
+
+def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
+    return {
+        "version": "planning",
+        "contract_version": "staff-menu-read-only-v1",
+        "enabled": False,
+        "contract_published": True,
+        "status": "requires_role_linking_audit_and_confirmations",
+        "transport": "polling" if not webhook_set else "webhook",
+        "supported_languages": [
+            {"code": "ru", "label": "Русский"},
+        ],
+        "supported_roles": STAFF_BOT_SUPPORTED_ROLES,
+        "role_linking": {
+            "enabled": False,
+            "required_before_enablement": True,
+            "accepted_methods": [
+                "admin_verified_staff_link",
+                "one_time_signed_staff_token",
+            ],
+        },
+        "authorization": {
+            "source": "application_rbac",
+            "server_side_required": True,
+            "ready": False,
+        },
+        "audit": {
+            "required": True,
+            "ready": False,
+        },
+        "state_changing_actions_enabled": False,
+        "readiness": STAFF_BOT_READINESS,
+        "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
+        "guardrails": STAFF_BOT_GUARDRAILS,
+        "next_slice": "role_linking_and_read_only_staff_menu_contract",
+    }
+
 
 def raise_admin_telegram_error(
     action: str,
@@ -472,6 +605,7 @@ def get_telegram_integration_status(
                 "lab_results_pdf",
             ],
             "planned_functions": [
+                "staff_read_only_menu_contract",
                 "staff_role_menus",
                 "staff_action_confirmations",
                 "staff_audit_logging",
@@ -523,52 +657,7 @@ def get_telegram_integration_status(
                 "results_delivery": "telegram_pdf",
                 "max_pdf_reports_per_request": 3,
             },
-            "staff_bot": {
-                "version": "planning",
-                "enabled": False,
-                "status": "requires_role_linking_audit_and_confirmations",
-                "transport": "polling" if not webhook_set else "webhook",
-                "supported_languages": [
-                    {"code": "ru", "label": "Русский"},
-                ],
-                "supported_roles": [
-                    "registrar",
-                    "doctor",
-                    "cashier",
-                    "lab",
-                    "admin",
-                    "owner",
-                ],
-                "readiness": [
-                    {
-                        "key": "role_based_staff_linking",
-                        "label": "Ролевая привязка сотрудников",
-                        "ready": False,
-                    },
-                    {
-                        "key": "server_side_authorization",
-                        "label": "Проверка ролей на backend",
-                        "ready": False,
-                    },
-                    {
-                        "key": "audit_logging",
-                        "label": "Аудит действий сотрудников",
-                        "ready": False,
-                    },
-                    {
-                        "key": "state_change_confirmations",
-                        "label": "Подтверждения для операций",
-                        "ready": False,
-                    },
-                ],
-                "guardrails": [
-                    "server_side_authorization",
-                    "audit_logging",
-                    "explicit_confirmation_for_state_changes",
-                    "no_queue_fairness_mutation_without_domain_service",
-                ],
-                "next_slice": "role_linking_and_read_only_staff_menu_contract",
-            },
+            "staff_bot": _build_staff_bot_status(webhook_set),
             "transition_path": (
                 "Set webhook when a public HTTPS backend URL is available; "
                 "stop polling before webhook is enabled."

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -170,6 +170,10 @@ const TelegramManager = () => {
   const enabledPatientFeatures = patientBotFeatures.filter((feature) => feature?.enabled);
   const patientBotCommands = Array.isArray(patientBot.commands) ? patientBot.commands : [];
   const patientBotLanguages = Array.isArray(patientBot.supported_languages) ? patientBot.supported_languages : [];
+  const staffBot = botStatus?.staff_bot || {};
+  const staffBotReadiness = Array.isArray(staffBot.readiness) ? staffBot.readiness : [];
+  const readyStaffControls = staffBotReadiness.filter((item) => item?.ready);
+  const staffRoles = Array.isArray(staffBot.supported_roles) ? staffBot.supported_roles : [];
 
   return (
     <Box sx={{ p: 3 }}>
@@ -317,6 +321,34 @@ const TelegramManager = () => {
                     secondary={patientBotCommands.length ?
                     patientBotCommands.map((item) => item.command).join(' ') :
                     'Нет данных'} />
+
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <MessageSquare />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={`Staff bot ${staffBot.version || 'planning'}`}
+                    secondary={staffBot.enabled ?
+                    'Готов к ролевым действиям' :
+                    'План: роли, audit и подтверждения до включения'} />
+
+                  <Badge
+                    variant={staffBot.enabled ? 'success' : 'warning'}
+                    size="small">
+
+                    {staffBot.enabled ? 'Готов' : 'План'}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <CheckCircle />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff guardrails"
+                    secondary={staffBotReadiness.length ?
+                    `${readyStaffControls.length}/${staffBotReadiness.length} готово; роли: ${staffRoles.join(', ')}` :
+                    'Требуется отдельный staff/admin contract'} />
 
                 </ListItem>
                 <ListItem>

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -101,7 +101,9 @@ const TelegramManager = () => {
         transition_path: integrationData.transition_path,
         webhook_error: integrationData.webhook_error,
         patient_bot: integrationData.patient_bot || null,
+        staff_bot: integrationData.staff_bot || null,
         supported_functions: Array.isArray(integrationData.supported_functions) ? integrationData.supported_functions : [],
+        planned_functions: Array.isArray(integrationData.planned_functions) ? integrationData.planned_functions : [],
         configured: Boolean(integrationData.configured ?? statusData.configured),
         raw: { status: statusData, integration: integrationData }
       });
@@ -174,6 +176,12 @@ const TelegramManager = () => {
   const staffBotReadiness = Array.isArray(staffBot.readiness) ? staffBot.readiness : [];
   const readyStaffControls = staffBotReadiness.filter((item) => item?.ready);
   const staffRoles = Array.isArray(staffBot.supported_roles) ? staffBot.supported_roles : [];
+  const staffMenuContract = Array.isArray(staffBot.read_only_menu_contract) ? staffBot.read_only_menu_contract : [];
+  const staffMenuItemCount = staffMenuContract.reduce((count, role) => {
+    const items = Array.isArray(role?.items) ? role.items : [];
+    return count + items.length;
+  }, 0);
+  const staffRoleSummary = staffRoles.length ? staffRoles.join(', ') : 'none';
 
   return (
     <Box sx={{ p: 3 }}>
@@ -347,9 +355,26 @@ const TelegramManager = () => {
                   <ListItemText
                     primary="Staff guardrails"
                     secondary={staffBotReadiness.length ?
-                    `${readyStaffControls.length}/${staffBotReadiness.length} готово; роли: ${staffRoles.join(', ')}` :
+                    `${readyStaffControls.length}/${staffBotReadiness.length} готово; роли: ${staffRoleSummary}` :
                     'Требуется отдельный staff/admin contract'} />
 
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <Settings />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff menu contract"
+                    secondary={staffMenuContract.length ?
+                    `${staffMenuContract.length} ролей, ${staffMenuItemCount} read-only пунктов; действия: выключены` :
+                    'Read-only contract не опубликован'} />
+
+                  <Badge
+                    variant={staffBot.state_changing_actions_enabled ? 'error' : 'warning'}
+                    size="small">
+
+                    {staffBot.state_changing_actions_enabled ? 'Actions' : 'Read-only'}
+                  </Badge>
                 </ListItem>
                 <ListItem>
                   <ListItemIcon>


### PR DESCRIPTION
## Summary

- Expose a read-only staff bot readiness/status contract from the Admin Telegram integration endpoint.
- Add the staff read-only menu contract for registrar, doctor, cashier, lab, admin, and owner roles.
- Surface the staff bot contract in the Admin Telegram manager without enabling state-changing Telegram actions.

## Contract Impact

- Canonical surface: GET /api/v1/admin/telegram/integration-status
- Request shape: authenticated Admin request, no request body
- Response shape: existing integration status object plus `staff_bot.contract_version`, `role_linking`, `authorization`, `audit`, `state_changing_actions_enabled`, and `read_only_menu_contract`
- Status codes: unchanged from existing Admin integration status endpoint behavior
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` Admin Telegram status panel
- Compatibility path or alias: existing patient bot and integration status fields remain present; no existing response field was removed or renamed
- Contract proof: `py_compile` for Telegram endpoints and frontend production build for the consumer

## RBAC / Permissions

- Roles allowed: Admin, unchanged existing endpoint guard via `require_roles(Admin)`
- Roles denied: non-Admin roles remain denied by the existing endpoint guard
- Positive auth proof: endpoint guard is unchanged and existing Admin consumer continues to build against the response shape
- Negative auth proof: no new public endpoint or staff action path was added; non-Admin behavior remains covered by the existing guard

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime event behavior changed
- Payload version / ack behavior: not applicable - no outbound notification payload or acknowledgement path changed
- Read/unread or delivery semantics: not applicable - no inbox, read state, Telegram delivery, or retry semantics changed
- Reconnect/resync proof: not applicable - no websocket reconnect or resync behavior changed

## Frontend Resilience

- Empty data proof: missing `staff_bot` normalizes to `null` and renders fallback copy for the staff contract rows
- Partial data proof: `readiness`, `supported_roles`, and `read_only_menu_contract` are read only after `Array.isArray` checks
- Forbidden secondary path behavior: not applicable - this slice does not add a secondary path or forbidden recovery flow
- Missing draft/resource behavior: not applicable - this screen does not create or reopen drafts/resources for the staff bot contract
- Stale route/deep-link behavior: not applicable - no route, deep link, or navigation behavior changed

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/app/api/v1/endpoints/telegram_webhook.py`, `frontend/src/components/TelegramManager.jsx`
- Denied paths: migrations, models, services, Telegram send/webhook dispatch logic, generated output, unrelated frontend routes
- Migration/docs/test impact: no migration; no docs file changed; validation used targeted compile/build checks for this read-only contract slice
- Rollback note: revert commits `780eb8a3` and `1d23fc8d` or revert the two touched runtime files to remove the staff status contract display

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `npm.cmd run build` in `frontend`; `git diff --check`
- Result: passed locally; frontend build reported existing Vite warnings about mixed static/dynamic `errorHandler.js` imports and large chunks
- Not checked: live Admin Telegram browser smoke, real Telegram API call, and backend integration test were not run because this slice only publishes a read-only status contract and adds no state-changing path