### PR TITLE
feat(telegram): publish staff linking contract

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -121,6 +121,39 @@ STAFF_BOT_GUARDRAILS = [
     "no_queue_fairness_mutation_without_domain_service",
 ]
 
+STAFF_BOT_LINKING_CONTRACT = {
+    "contract_version": "staff-linking-v1",
+    "enabled": False,
+    "required_before_enablement": True,
+    "identity_rule": "telegram_user_id_is_not_application_identity",
+    "accepted_methods": [
+        {
+            "key": "admin_verified_staff_link",
+            "label": "Администратор подтверждает сотрудника",
+            "status": "planned",
+        },
+        {
+            "key": "one_time_signed_staff_token",
+            "label": "Одноразовый подписанный токен",
+            "status": "planned",
+        },
+    ],
+    "required_server_checks": [
+        "active_application_user",
+        "allowed_staff_role",
+        "telegram_user_not_linked_to_another_staff_user",
+        "token_not_expired",
+        "token_not_reused",
+    ],
+    "enablement_gate": [
+        "role_based_staff_linking",
+        "server_side_authorization",
+        "audit_logging",
+        "state_change_confirmations",
+    ],
+    "state_changing_actions_allowed_after_link": False,
+}
+
 
 def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
     return {
@@ -142,6 +175,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
                 "one_time_signed_staff_token",
             ],
         },
+        "linking_contract": STAFF_BOT_LINKING_CONTRACT,
         "authorization": {
             "source": "application_rbac",
             "server_side_required": True,
@@ -606,6 +640,7 @@ def get_telegram_integration_status(
             ],
             "planned_functions": [
                 "staff_read_only_menu_contract",
+                "staff_role_linking_contract",
                 "staff_role_menus",
                 "staff_action_confirmations",
                 "staff_audit_logging",

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -182,6 +182,13 @@ const TelegramManager = () => {
     return count + items.length;
   }, 0);
   const staffRoleSummary = staffRoles.length ? staffRoles.join(', ') : 'none';
+  const staffLinkingContract = staffBot.linking_contract || staffBot.role_linking || {};
+  const staffLinkingMethods = Array.isArray(staffLinkingContract.accepted_methods) ?
+  staffLinkingContract.accepted_methods :
+  [];
+  const staffLinkingMethodNames = staffLinkingMethods.
+  map((method) => method?.label || method?.key || method).
+  filter(Boolean);
 
   return (
     <Box sx={{ p: 3 }}>
@@ -358,6 +365,23 @@ const TelegramManager = () => {
                     `${readyStaffControls.length}/${staffBotReadiness.length} готово; роли: ${staffRoleSummary}` :
                     'Требуется отдельный staff/admin contract'} />
 
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <CheckCircle />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff linking foundation"
+                    secondary={staffLinkingMethodNames.length ?
+                    `${staffLinkingMethodNames.join(', ')}; до включения: ${staffLinkingContract.required_before_enablement ? 'обязательно' : 'не требуется'}` :
+                    'Контракт привязки сотрудников не опубликован'} />
+
+                  <Badge
+                    variant={staffLinkingContract.enabled ? 'success' : 'warning'}
+                    size="small">
+
+                    {staffLinkingContract.enabled ? 'Enabled' : 'Planned'}
+                  </Badge>
                 </ListItem>
                 <ListItem>
                   <ListItemIcon>


### PR DESCRIPTION
## Summary

- Publish the staff bot linking foundation contract in the Admin Telegram integration status response.
- Document accepted staff linking methods, required server checks, enablement gate, and disabled state-changing behavior.
- Surface the staff linking foundation in the Admin Telegram manager with safe fallback rendering.

## Contract Impact

- Canonical surface: GET /api/v1/admin/telegram/integration-status
- Request shape: authenticated Admin request, no request body
- Response shape: existing integration status object plus `staff_bot.linking_contract` with contract version, accepted methods, required server checks, enablement gate, and disabled action flag
- Status codes: unchanged from existing Admin integration status endpoint behavior
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` Admin Telegram status panel
- Compatibility path or alias: existing `staff_bot.role_linking` remains present; the new `linking_contract` is additive
- Contract proof: `py_compile` for Telegram endpoints and frontend production build for the consumer

## RBAC / Permissions

- Roles allowed: Admin, unchanged existing endpoint guard via `require_roles("Admin")`
- Roles denied: non-Admin roles remain denied by the existing endpoint guard
- Positive auth proof: endpoint guard is unchanged and existing Admin consumer continues to build against the additive response shape
- Negative auth proof: no new public endpoint, staff command handler, or staff action path was added

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime event behavior changed
- Payload version / ack behavior: not applicable - no outbound notification payload or acknowledgement path changed
- Read/unread or delivery semantics: not applicable - no inbox, read state, Telegram delivery, or retry semantics changed
- Reconnect/resync proof: not applicable - no websocket reconnect or resync behavior changed

## Frontend Resilience

- Empty data proof: missing `linking_contract` falls back to existing `role_linking` or an empty object
- Partial data proof: `accepted_methods` is read only after `Array.isArray` checks and method labels fall back to keys/plain values
- Forbidden secondary path behavior: not applicable - this slice does not add a secondary path or forbidden recovery flow
- Missing draft/resource behavior: not applicable - this screen does not create or reopen drafts/resources for staff linking
- Stale route/deep-link behavior: not applicable - no route, deep link, or navigation behavior changed

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/app/api/v1/endpoints/telegram_webhook.py`, `frontend/src/components/TelegramManager.jsx`
- Denied paths: migrations, models, services, Telegram send/webhook dispatch logic, generated output, unrelated frontend routes
- Migration/docs/test impact: no migration; no docs file changed; validation used targeted compile/build checks for this additive read-only contract slice
- Rollback note: revert commit `24c97e97` or revert the two touched runtime files to remove the staff linking foundation display

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `npm.cmd run build` in `frontend`; `git diff --check`
- Result: passed locally; frontend build reported existing Vite warnings about mixed static/dynamic `errorHandler.js` imports and large chunks
- Not checked: live Admin Telegram browser smoke, real Telegram API call, and backend integration test were not run because this slice only publishes an additive read-only status contract and adds no state-changing path
