### PR TITLE
feat(telegram): publish staff command contract

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -154,6 +154,58 @@ STAFF_BOT_LINKING_CONTRACT = {
     "state_changing_actions_allowed_after_link": False,
 }
 
+STAFF_BOT_COMMAND_REGISTRATION_CONTRACT = {
+    "contract_version": "staff-commands-v1",
+    "registration_enabled": False,
+    "registration_endpoint_published": False,
+    "bot_scope": "staff_bot_only",
+    "commands": [
+        {
+            "command": "/staff",
+            "label": "Статус сотрудника",
+            "intent": "read_only",
+        },
+        {
+            "command": "/queue",
+            "label": "Очередь по роли",
+            "intent": "read_only",
+        },
+        {
+            "command": "/schedule",
+            "label": "Расписание",
+            "intent": "read_only",
+        },
+        {
+            "command": "/payments",
+            "label": "Статусы оплат",
+            "intent": "read_only",
+        },
+        {
+            "command": "/reports",
+            "label": "Готовность результатов",
+            "intent": "read_only",
+        },
+        {
+            "command": "/summary",
+            "label": "Операционная сводка",
+            "intent": "read_only",
+        },
+        {
+            "command": "/help",
+            "label": "Помощь сотруднику",
+            "intent": "read_only",
+        },
+    ],
+    "enablement_gate": [
+        "dedicated_staff_bot_token",
+        "role_based_staff_linking",
+        "server_side_authorization",
+        "audit_logging",
+        "state_change_confirmations",
+    ],
+    "state_changing_commands_registered": False,
+}
+
 
 def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
     return {
@@ -176,6 +228,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
             ],
         },
         "linking_contract": STAFF_BOT_LINKING_CONTRACT,
+        "command_registration_contract": STAFF_BOT_COMMAND_REGISTRATION_CONTRACT,
         "authorization": {
             "source": "application_rbac",
             "server_side_required": True,
@@ -189,7 +242,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         "readiness": STAFF_BOT_READINESS,
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
-        "next_slice": "role_linking_and_read_only_staff_menu_contract",
+        "next_slice": "staff_bot_command_registration_contract",
     }
 
 
@@ -641,6 +694,7 @@ def get_telegram_integration_status(
             "planned_functions": [
                 "staff_read_only_menu_contract",
                 "staff_role_linking_contract",
+                "staff_command_registration_contract",
                 "staff_role_menus",
                 "staff_action_confirmations",
                 "staff_audit_logging",

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -189,6 +189,13 @@ const TelegramManager = () => {
   const staffLinkingMethodNames = staffLinkingMethods.
   map((method) => method?.label || method?.key || method).
   filter(Boolean);
+  const staffCommandContract = staffBot.command_registration_contract || staffBot.command_contract || {};
+  const staffCommandList = Array.isArray(staffCommandContract.commands) ?
+  staffCommandContract.commands :
+  [];
+  const staffCommandNames = staffCommandList.
+  map((item) => item?.command).
+  filter(Boolean);
 
   return (
     <Box sx={{ p: 3 }}>
@@ -398,6 +405,23 @@ const TelegramManager = () => {
                     size="small">
 
                     {staffBot.state_changing_actions_enabled ? 'Actions' : 'Read-only'}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <Settings />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff command registration"
+                    secondary={staffCommandNames.length ?
+                    `${staffCommandNames.join(' ')}; registration: ${staffCommandContract.registration_enabled ? 'enabled' : 'disabled until staff gates'}` :
+                    'Staff command contract не опубликован'} />
+
+                  <Badge
+                    variant={staffCommandContract.registration_enabled ? 'success' : 'warning'}
+                    size="small">
+
+                    {staffCommandContract.registration_enabled ? 'Enabled' : 'Planned'}
                   </Badge>
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
## Summary
- Publishes the staff bot command registration contract in the admin Telegram integration status.
- Shows the planned staff commands in `TelegramManager` without adding a registration button or webhook handlers.
- Keeps staff command registration disabled until staff bot token separation, role linking, server authorization, audit logging, and state-change confirmations are ready.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/integration-status` response field `staff_bot.command_registration_contract`.
- Request shape: Unchanged; no new request body, query params, or endpoint.
- Response shape: Adds `contract_version`, `registration_enabled`, `registration_endpoint_published`, `bot_scope`, `commands`, `enablement_gate`, and `state_changing_commands_registered` under `staff_bot.command_registration_contract`.
- Status codes: Unchanged; existing integration-status success/error behavior remains in place.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads the optional contract and renders a planned/disabled staff command registration row.
- Compatibility path or alias: The frontend also accepts `staffBot.command_contract` as a compatibility fallback; missing data renders the existing planned-state copy.
- Contract proof: `py_compile` passed for the admin endpoint and frontend production build passed with the new optional consumer.

## RBAC / Permissions
- Roles allowed: Existing Admin-only dependency on the admin Telegram integration status endpoint remains unchanged.
- Roles denied: Non-Admin users remain denied by the existing `require_roles("Admin")` guard.
- Positive auth proof: No RBAC code changed; the existing Admin path still returns the status contract.
- Negative auth proof: No auth path changed; denied-role behavior remains owned by the existing dependency.

## Notification / Realtime
- Event type or websocket channel: No notification event or websocket channel is introduced by this contract-only slice.
- Payload version / ack behavior: Not applicable because the slice only publishes readiness metadata in a read response.
- Read/unread or delivery semantics: Not applicable because no Telegram message is sent or queued.
- Reconnect/resync proof: Existing admin refresh reloads integration status; no realtime resync behavior was changed.

## Frontend Resilience
- Empty data proof: Missing `command_registration_contract` renders the fallback "Staff command contract не опубликован" text.
- Partial data proof: Missing `commands` normalizes to an empty array; missing flags keep the badge in planned state.
- Forbidden secondary path behavior: No new secondary action path was added, so forbidden behavior is unchanged.
- Missing draft/resource behavior: Missing staff bot contract data is handled as optional display state.
- Stale route/deep-link behavior: No route or deep-link was added or changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `frontend/src/components/TelegramManager.jsx`.
- Denied paths: No edits to `backend/app/api/v1/endpoints/telegram_webhook.py`, command handlers, bot service registration, migrations, or domain queue/payment/EMR code.
- Migration/docs/test impact: No database migration or docs update required; validation used the gate-targeted compile and frontend build checks.
- Rollback note: Revert this commit to remove the staff command contract from the status response and UI row.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend; npm.cmd run build`.
- Result: Passed; frontend build reported the existing mixed import/chunk-size Vite warnings only.
- Not checked: Live Telegram command registration was not run because staff registration remains intentionally disabled.