### PR TITLE
feat(telegram): publish staff confirmation contract

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -206,6 +206,65 @@ STAFF_BOT_COMMAND_REGISTRATION_CONTRACT = {
     "state_changing_commands_registered": False,
 }
 
+STAFF_BOT_CONFIRMATION_CONTRACT = {
+    "contract_version": "staff-confirmations-v1",
+    "enabled": False,
+    "required_for_state_changes": True,
+    "state_changing_actions_enabled": False,
+    "confirmation_window_seconds": 120,
+    "operations": [
+        {
+            "key": "queue_call_or_skip_patient",
+            "label": "Вызвать или пропустить пациента",
+            "roles": ["registrar"],
+            "domain_service_required": "queue",
+        },
+        {
+            "key": "visit_cancel_or_move",
+            "label": "Отменить или перенести визит",
+            "roles": ["registrar", "admin"],
+            "domain_service_required": "visit",
+        },
+        {
+            "key": "payment_status_change",
+            "label": "Изменить статус оплаты",
+            "roles": ["cashier", "admin"],
+            "domain_service_required": "payment",
+        },
+        {
+            "key": "refund_issue",
+            "label": "Оформить возврат",
+            "roles": ["cashier", "admin", "owner"],
+            "domain_service_required": "payment",
+        },
+        {
+            "key": "medical_document_publish",
+            "label": "Закрыть ЭМК или опубликовать документ",
+            "roles": ["doctor", "lab", "admin"],
+            "domain_service_required": "emr_or_lab",
+        },
+        {
+            "key": "doctor_schedule_change",
+            "label": "Изменить расписание врача",
+            "roles": ["admin", "owner"],
+            "domain_service_required": "schedule",
+        },
+    ],
+    "required_server_checks": [
+        "staff_linked_to_active_application_user",
+        "role_allowed_for_operation",
+        "fresh_confirmation_token",
+        "idempotency_key_present",
+        "domain_service_authorizes_target",
+        "audit_log_write_succeeds",
+    ],
+    "telegram_payload_rules": [
+        "no_raw_internal_ids",
+        "no_plain_medical_details",
+        "short_human_readable_summary_only",
+    ],
+}
+
 
 def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
     return {
@@ -229,6 +288,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         },
         "linking_contract": STAFF_BOT_LINKING_CONTRACT,
         "command_registration_contract": STAFF_BOT_COMMAND_REGISTRATION_CONTRACT,
+        "confirmation_contract": STAFF_BOT_CONFIRMATION_CONTRACT,
         "authorization": {
             "source": "application_rbac",
             "server_side_required": True,
@@ -242,7 +302,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         "readiness": STAFF_BOT_READINESS,
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
-        "next_slice": "staff_bot_command_registration_contract",
+        "next_slice": "staff_state_change_confirmation_contract",
     }
 
 
@@ -695,6 +755,7 @@ def get_telegram_integration_status(
                 "staff_read_only_menu_contract",
                 "staff_role_linking_contract",
                 "staff_command_registration_contract",
+                "staff_state_change_confirmation_contract",
                 "staff_role_menus",
                 "staff_action_confirmations",
                 "staff_audit_logging",

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -196,6 +196,10 @@ const TelegramManager = () => {
   const staffCommandNames = staffCommandList.
   map((item) => item?.command).
   filter(Boolean);
+  const staffConfirmationContract = staffBot.confirmation_contract || {};
+  const staffConfirmationOperations = Array.isArray(staffConfirmationContract.operations) ?
+  staffConfirmationContract.operations :
+  [];
 
   return (
     <Box sx={{ p: 3 }}>
@@ -422,6 +426,23 @@ const TelegramManager = () => {
                     size="small">
 
                     {staffCommandContract.registration_enabled ? 'Enabled' : 'Planned'}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <CheckCircle />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff action confirmations"
+                    secondary={staffConfirmationOperations.length ?
+                    `${staffConfirmationOperations.length} state-changing actions require confirmation; actions: ${staffConfirmationContract.state_changing_actions_enabled ? 'enabled' : 'disabled'}` :
+                    'Confirmation contract не опубликован'} />
+
+                  <Badge
+                    variant={staffConfirmationContract.state_changing_actions_enabled ? 'error' : 'warning'}
+                    size="small">
+
+                    {staffConfirmationContract.required_for_state_changes ? 'Required' : 'Planned'}
                   </Badge>
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
## Summary
- Publishes a read-only staff bot confirmation contract in the admin Telegram integration status.
- Lists state-changing staff operations that must require explicit confirmation, server checks, idempotency, and audit readiness before enablement.
- Shows the confirmation contract in `TelegramManager` without adding Telegram handlers, mutation endpoints, or command buttons.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/integration-status` response field `staff_bot.confirmation_contract`.
- Request shape: Unchanged; no new request body, query params, command payload, or endpoint.
- Response shape: Adds `contract_version`, `enabled`, `required_for_state_changes`, `state_changing_actions_enabled`, `confirmation_window_seconds`, `operations`, `required_server_checks`, and `telegram_payload_rules` under `staff_bot.confirmation_contract`.
- Status codes: Unchanged; existing integration-status success/error behavior remains in place.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads the optional contract and renders a planned staff action confirmation row.
- Compatibility path or alias: Missing `confirmation_contract` is treated as absent optional metadata and renders fallback copy.
- Contract proof: `py_compile` passed for the admin endpoint and webhook endpoint; frontend production build passed with the optional consumer.

## RBAC / Permissions
- Roles allowed: Existing Admin-only dependency on the admin Telegram integration status endpoint remains unchanged.
- Roles denied: Non-Admin users remain denied by the existing `require_roles("Admin")` guard.
- Positive auth proof: No RBAC code changed; the existing Admin path still returns the status payload.
- Negative auth proof: No denied-role path changed; authorization remains owned by the existing dependency.

## Notification / Realtime
- Event type or websocket channel: No notification event or websocket channel is introduced by this contract-only slice.
- Payload version / ack behavior: Not applicable because no Telegram callback or mutation acknowledgment is implemented.
- Read/unread or delivery semantics: Not applicable because no Telegram message is sent, queued, marked read, or delivered.
- Reconnect/resync proof: Existing admin refresh reloads integration status; no realtime resync behavior was changed.

## Frontend Resilience
- Empty data proof: Missing `confirmation_contract` renders the fallback "Confirmation contract не опубликован" text.
- Partial data proof: Missing `operations` normalizes to an empty array; missing flags keep the badge in planned/required display state.
- Forbidden secondary path behavior: No new secondary action or state-changing button was added, so forbidden behavior is unchanged.
- Missing draft/resource behavior: Missing confirmation metadata is handled as optional display state.
- Stale route/deep-link behavior: No route, callback data, or deep-link was added or changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `frontend/src/components/TelegramManager.jsx`.
- Denied paths: No edits to `backend/app/api/v1/endpoints/telegram_webhook.py`, command handlers, bot service registration, migrations, queue/payment/EMR/lab/schedule domain services, or audit persistence.
- Migration/docs/test impact: No database migration or docs update required; validation used the gate-targeted compile and frontend build checks.
- Rollback note: Revert this commit to remove the staff confirmation contract from the status response and UI row.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend; npm.cmd run build`.
- Result: Passed; frontend build reported the existing mixed import/chunk-size Vite warnings only.
- Not checked: Live Telegram state-changing actions were not run because this slice intentionally does not implement handlers or enable actions.