### PR TITLE
feat(telegram): publish staff audit contract

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -265,6 +265,62 @@ STAFF_BOT_CONFIRMATION_CONTRACT = {
     ],
 }
 
+STAFF_BOT_AUDIT_CONTRACT = {
+    "contract_version": "staff-audit-v1",
+    "enabled": False,
+    "record_writer_enabled": False,
+    "required_before_enablement": True,
+    "event_types": [
+        {
+            "key": "staff_link_created",
+            "label": "Привязка сотрудника к Telegram",
+            "required": True,
+        },
+        {
+            "key": "staff_command_received",
+            "label": "Команда сотрудника получена",
+            "required": True,
+        },
+        {
+            "key": "staff_action_confirmation_requested",
+            "label": "Запрошено подтверждение действия",
+            "required": True,
+        },
+        {
+            "key": "staff_action_confirmed",
+            "label": "Действие подтверждено сотрудником",
+            "required": True,
+        },
+        {
+            "key": "staff_action_denied",
+            "label": "Действие запрещено серверной проверкой",
+            "required": True,
+        },
+        {
+            "key": "staff_action_failed",
+            "label": "Действие завершилось ошибкой",
+            "required": True,
+        },
+    ],
+    "required_fields": [
+        "actor_user_id",
+        "actor_role",
+        "telegram_user_id_hash",
+        "action_key",
+        "target_type",
+        "target_reference_hash",
+        "result",
+        "timestamp",
+        "request_id",
+    ],
+    "redaction_rules": [
+        "no_bot_tokens",
+        "no_raw_telegram_payload",
+        "no_plain_medical_details",
+        "no_raw_internal_identifiers_in_chat_text",
+    ],
+}
+
 
 def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
     return {
@@ -289,6 +345,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         "linking_contract": STAFF_BOT_LINKING_CONTRACT,
         "command_registration_contract": STAFF_BOT_COMMAND_REGISTRATION_CONTRACT,
         "confirmation_contract": STAFF_BOT_CONFIRMATION_CONTRACT,
+        "audit_contract": STAFF_BOT_AUDIT_CONTRACT,
         "authorization": {
             "source": "application_rbac",
             "server_side_required": True,
@@ -302,7 +359,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         "readiness": STAFF_BOT_READINESS,
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
-        "next_slice": "staff_state_change_confirmation_contract",
+        "next_slice": "staff_audit_logging_contract",
     }
 
 
@@ -756,6 +813,7 @@ def get_telegram_integration_status(
                 "staff_role_linking_contract",
                 "staff_command_registration_contract",
                 "staff_state_change_confirmation_contract",
+                "staff_audit_logging_contract",
                 "staff_role_menus",
                 "staff_action_confirmations",
                 "staff_audit_logging",

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -200,6 +200,10 @@ const TelegramManager = () => {
   const staffConfirmationOperations = Array.isArray(staffConfirmationContract.operations) ?
   staffConfirmationContract.operations :
   [];
+  const staffAuditContract = staffBot.audit_contract || {};
+  const staffAuditEvents = Array.isArray(staffAuditContract.event_types) ?
+  staffAuditContract.event_types :
+  [];
 
   return (
     <Box sx={{ p: 3 }}>
@@ -443,6 +447,23 @@ const TelegramManager = () => {
                     size="small">
 
                     {staffConfirmationContract.required_for_state_changes ? 'Required' : 'Planned'}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <CheckCircle />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff audit logging"
+                    secondary={staffAuditEvents.length ?
+                    `${staffAuditEvents.length} required events; writer: ${staffAuditContract.record_writer_enabled ? 'enabled' : 'disabled'}` :
+                    'Audit contract не опубликован'} />
+
+                  <Badge
+                    variant={staffAuditContract.record_writer_enabled ? 'success' : 'warning'}
+                    size="small">
+
+                    {staffAuditContract.required_before_enablement ? 'Required' : 'Planned'}
                   </Badge>
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
## Summary
- Publishes a read-only staff bot audit logging contract in the admin Telegram integration status.
- Defines required staff Telegram audit event types, required fields, and redaction rules before staff bot enablement.
- Shows audit readiness in `TelegramManager` without writing audit records or enabling Telegram staff actions.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/integration-status` response field `staff_bot.audit_contract`.
- Request shape: Unchanged; no new request body, query params, command payload, or endpoint.
- Response shape: Adds `contract_version`, `enabled`, `record_writer_enabled`, `required_before_enablement`, `event_types`, `required_fields`, and `redaction_rules` under `staff_bot.audit_contract`.
- Status codes: Unchanged; existing integration-status success/error behavior remains in place.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads the optional audit contract and renders a planned staff audit logging row.
- Compatibility path or alias: Missing `audit_contract` is treated as absent optional metadata and renders fallback copy.
- Contract proof: `py_compile` passed for the admin endpoint and webhook endpoint; frontend production build passed with the optional consumer.

## RBAC / Permissions
- Roles allowed: Existing Admin-only dependency on the admin Telegram integration status endpoint remains unchanged.
- Roles denied: Non-Admin users remain denied by the existing `require_roles("Admin")` guard.
- Positive auth proof: No RBAC code changed; the existing Admin path still returns the status payload.
- Negative auth proof: No denied-role path changed; authorization remains owned by the existing dependency.

## Notification / Realtime
- Event type or websocket channel: No realtime notification channel is introduced; audit event names are contract metadata only.
- Payload version / ack behavior: Not applicable because no Telegram callback, audit write acknowledgment, or mutation acknowledgment is implemented.
- Read/unread or delivery semantics: Not applicable because no Telegram message is sent, queued, marked read, or delivered.
- Reconnect/resync proof: Existing admin refresh reloads integration status; no realtime resync behavior was changed.

## Frontend Resilience
- Empty data proof: Missing `audit_contract` renders the fallback "Audit contract не опубликован" text.
- Partial data proof: Missing `event_types` normalizes to an empty array; missing writer flag keeps the badge in planned/required display state.
- Forbidden secondary path behavior: No new secondary action or audit-write button was added, so forbidden behavior is unchanged.
- Missing draft/resource behavior: Missing audit metadata is handled as optional display state.
- Stale route/deep-link behavior: No route, callback data, or deep-link was added or changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `frontend/src/components/TelegramManager.jsx`.
- Denied paths: No edits to `backend/app/api/v1/endpoints/telegram_webhook.py`, audit persistence models/services, command handlers, bot service registration, migrations, or queue/payment/EMR/lab/schedule domain services.
- Migration/docs/test impact: No database migration or docs update required; validation used the gate-targeted compile and frontend build checks.
- Rollback note: Revert this commit to remove the staff audit contract from the status response and UI row.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend; npm.cmd run build`.
- Result: Passed; frontend build reported the existing mixed import/chunk-size Vite warnings only.
- Not checked: Live audit persistence was not run because this slice intentionally does not write audit records or enable staff actions.