### PR TITLE
chore(telegram): update staff next slice status

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -359,7 +359,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         "readiness": STAFF_BOT_READINESS,
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
-        "next_slice": "staff_audit_logging_contract",
+        "next_slice": "staff_role_menus",
     }
 
 


### PR DESCRIPTION
## Summary
- Updates the admin Telegram staff bot `next_slice` metadata after the staff audit contract was published.
- Keeps staff bot enablement, command registration, state-changing actions, and audit writer disabled.
- Points the visible next staff-bot step to `staff_role_menus`.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/admin_telegram.py`
- Request shape: unchanged.
- Response shape: `staff_bot.next_slice` value changes from a completed contract step to the next planned implementation step.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` can keep reading the same field; no UI contract shape changed.
- Compatibility path or alias: unchanged `/admin/telegram/integration-status` response object.
- Contract proof: py_compile and frontend build passed.

## RBAC / Permissions
- Roles allowed: unchanged Admin-only endpoint access.
- Roles denied: unchanged.
- Positive auth proof: no auth surface changed.
- Negative auth proof: no denied-role surface changed.

## Notification / Realtime
- Notification surface: none; this is admin status metadata only.
- Realtime impact: none; no websocket or push path is touched.
- Template keys: none.
- Delivery proof: not applicable because no Telegram message is sent by this change.
- Event type or websocket channel: none; `/admin/telegram/integration-status` is a pull-only HTTP status endpoint.
- Payload version / ack behavior: unchanged; no ack protocol exists for this metadata field.
- Read/unread or delivery semantics: unchanged; no notification delivery state is created or consumed.
- Reconnect/resync proof: unchanged; Admin UI resync remains the existing refresh/load of integration status.

## Frontend Resilience
- Loading state: unchanged.
- Error state: unchanged.
- Empty state: unchanged.
- Mobile/responsive impact: none.
- Empty data proof: existing UI already falls back when `staff_bot` or `next_slice` is absent; this only changes a present string value.
- Partial data proof: existing optional reads in `TelegramManager.jsx` remain compatible with partial `staff_bot` payloads.
- Forbidden secondary path behavior: unchanged Admin-only API path and RBAC behavior.
- Missing draft/resource behavior: unchanged; no draft/resource is loaded by this metadata value.
- Stale route/deep-link behavior: unchanged; no route, link, or navigation target changes.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`
- Denied paths: staff bot enablement, staff command registration, state-changing actions, audit writer, Telegram webhook transport, frontend behavior.
- Migration/docs/test impact: no schema/docs change; no new test needed for one metadata value.
- Rollback note: revert this commit to restore the previous `next_slice` value.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend && npm.cmd run build`.
- Result: pass; Vite build passed with existing dynamic-import/chunk-size warnings.
- Not checked: live Admin UI browser smoke.