### PR TITLE
Chore: summarize Telegram staff role menus

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -322,6 +322,31 @@ STAFF_BOT_AUDIT_CONTRACT = {
 }
 
 
+def _build_staff_role_menus_summary() -> Dict[str, Any]:
+    menu_roles = [
+        role_menu["role"] for role_menu in STAFF_BOT_READ_ONLY_MENU_CONTRACT
+    ]
+    menu_item_count = sum(
+        len(role_menu.get("items", []))
+        for role_menu in STAFF_BOT_READ_ONLY_MENU_CONTRACT
+    )
+    return {
+        "contract_published": True,
+        "runtime_enabled": False,
+        "read_only": True,
+        "source": "read_only_menu_contract",
+        "roles": menu_roles,
+        "role_count": len(menu_roles),
+        "item_count": menu_item_count,
+        "blocked_until": [
+            "role_based_staff_linking",
+            "server_side_authorization",
+            "audit_logging",
+            "state_change_confirmations",
+        ],
+    }
+
+
 def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
     return {
         "version": "planning",
@@ -357,6 +382,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         },
         "state_changing_actions_enabled": False,
         "readiness": STAFF_BOT_READINESS,
+        "role_menus": _build_staff_role_menus_summary(),
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
         "next_slice": "staff_role_menus",


### PR DESCRIPTION
## Summary
- Adds explicit `staff_bot.role_menus` summary to the admin Telegram integration status payload.
- Summary is derived from the existing read-only staff menu contract.
- Staff bot remains disabled; no staff commands, linking, state-changing actions, or audit writer are enabled.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/integration-status`, implemented in `backend/app/api/v1/endpoints/admin_telegram.py`.
- Request shape: unchanged; authenticated Admin request with the existing DB dependency and no new query/body parameters.
- Response shape: adds optional-compatible `staff_bot.role_menus` with `contract_published`, `runtime_enabled`, `read_only`, `source`, `roles`, `role_count`, `item_count`, and `blocked_until`; existing `staff_bot.read_only_menu_contract` remains unchanged.
- Status codes: unchanged; normal success remains `200`, existing admin Telegram error handling remains unchanged.
- Frontend consumer: existing Telegram manager can continue reading `staff_bot.read_only_menu_contract`; no frontend consumer is required to read the new summary yet.
- Compatibility path or alias: no route alias or compatibility endpoint changes; old consumers can ignore the added JSON field.
- Contract proof: local `py_compile` passed for `admin_telegram.py` and `telegram_webhook.py`; frontend build passed against the unchanged consumer contract.

## RBAC / Permissions
- Roles allowed: unchanged existing `require_roles(Admin)` on `GET /api/v1/admin/telegram/integration-status`.
- Roles denied: unchanged for non-Admin roles through the existing dependency; no new staff or patient access path is added.
- Positive auth proof: this PR does not change auth code; existing Admin-only endpoint remains the only surface returning the new field.
- Negative auth proof: no alternate route, Telegram command, webhook handler, or frontend route is added for non-Admin access.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py` only.
- Denied paths: no changes to `telegram_webhook.py`, frontend manager, polling worker, staff command runtime, staff linking, audit writer, queue services, payment services, EMR, or migrations.
- Migration/docs/test impact: no database migration or docs change required; validation is compile/build smoke for the existing API contract.
- Rollback note: remove `_build_staff_role_menus_summary()` and the `staff_bot.role_menus` field to restore the previous payload exactly.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend && npm.cmd run build`.
- Result: passed. Frontend build completed with existing Vite dynamic-import and chunk-size warnings only.
- Not checked: no live Telegram bot polling/webhook smoke and no browser UI smoke because this PR only extends an existing backend status payload.

## Safety / Scope
- Telegram staff bot remains planning/read-only.
- Runtime staff bot menus are not enabled.
- State-changing staff actions remain disabled.
- The summary explicitly lists blockers: role linking, server-side authorization, audit logging, and state-change confirmations.

## Notification / Realtime
- Event type or websocket channel: none; this changes only the existing admin polling/status HTTP payload.
- Payload version / ack behavior: existing `staff_bot.contract_version` remains `staff-menu-read-only-v1`; no ack behavior changes.
- Read/unread or delivery semantics: none; no Telegram messages or notifications are sent.
- Reconnect/resync proof: existing admin status reload fetches the payload again; no realtime connection added.

## Frontend Resilience
- Empty data proof: no frontend rendering change; existing optional fallbacks still apply if `staff_bot.role_menus` is absent.
- Partial data proof: no frontend rendering change; existing `read_only_menu_contract` remains unchanged.
- Forbidden secondary path behavior: no routes or permissions changed.
- Missing draft/resource behavior: no draft/resource lookup added.
- Stale route/deep-link behavior: no route, deep link, QR, or Telegram start-token behavior changed.