### PR TITLE
feat(telegram): publish staff token contract

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -121,6 +121,30 @@ STAFF_BOT_GUARDRAILS = [
     "no_queue_fairness_mutation_without_domain_service",
 ]
 
+STAFF_BOT_TOKEN_CONTRACT = {
+    "contract_version": "staff-token-v1",
+    "enabled": False,
+    "runtime_read_enabled": False,
+    "required_before_enablement": True,
+    "scope": "dedicated_staff_bot",
+    "must_not_share_patient_bot_token": True,
+    "secret_source": "environment_or_secret_store",
+    "required_server_checks": [
+        "separate_staff_bot_token_configured",
+        "token_not_logged",
+        "token_not_returned_to_frontend",
+        "staff_webhook_or_polling_transport_selected",
+        "patient_bot_transport_unchanged",
+    ],
+    "enablement_gate": [
+        "dedicated_staff_bot_token",
+        "role_based_staff_linking",
+        "server_side_authorization",
+        "audit_logging",
+        "state_change_confirmations",
+    ],
+}
+
 STAFF_BOT_LINKING_CONTRACT = {
     "contract_version": "staff-linking-v1",
     "enabled": False,
@@ -342,6 +366,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
                 "one_time_signed_staff_token",
             ],
         },
+        "token_contract": STAFF_BOT_TOKEN_CONTRACT,
         "linking_contract": STAFF_BOT_LINKING_CONTRACT,
         "command_registration_contract": STAFF_BOT_COMMAND_REGISTRATION_CONTRACT,
         "confirmation_contract": STAFF_BOT_CONFIRMATION_CONTRACT,
@@ -359,7 +384,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         "readiness": STAFF_BOT_READINESS,
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
-        "next_slice": "staff_role_menus",
+        "next_slice": "dedicated_staff_bot_token_readiness_contract",
     }
 
 
@@ -809,6 +834,7 @@ def get_telegram_integration_status(
                 "lab_results_pdf",
             ],
             "planned_functions": [
+                "dedicated_staff_bot_token_readiness_contract",
                 "staff_read_only_menu_contract",
                 "staff_role_linking_contract",
                 "staff_command_registration_contract",

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -182,6 +182,7 @@ const TelegramManager = () => {
     return count + items.length;
   }, 0);
   const staffRoleSummary = staffRoles.length ? staffRoles.join(', ') : 'none';
+  const staffTokenContract = staffBot.token_contract || {};
   const staffLinkingContract = staffBot.linking_contract || staffBot.role_linking || {};
   const staffLinkingMethods = Array.isArray(staffLinkingContract.accepted_methods) ?
   staffLinkingContract.accepted_methods :
@@ -303,6 +304,23 @@ const TelegramManager = () => {
                     size="small">
 
                     {botStatus?.mode === 'webhook' ? 'Webhook' : 'Polling'}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <Settings />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff token separation"
+                    secondary={staffTokenContract.contract_version ?
+                    `scope: ${staffTokenContract.scope || 'staff'}; runtime read: ${staffTokenContract.runtime_read_enabled ? 'enabled' : 'disabled'}` :
+                    'Dedicated staff bot token contract не опубликован'} />
+
+                  <Badge
+                    variant={staffTokenContract.runtime_read_enabled ? 'success' : 'warning'}
+                    size="small">
+
+                    {staffTokenContract.required_before_enablement ? 'Required' : 'Planned'}
                   </Badge>
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
## Summary
- Publishes a read-only dedicated staff bot token readiness contract in the admin Telegram integration status.
- Makes staff bot enablement explicitly depend on a separate staff bot token while keeping runtime token reads disabled.
- Shows token-separation readiness in `TelegramManager` without reading secrets, adding config, or wiring a second Telegram runtime.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/integration-status` response field `staff_bot.token_contract`.
- Request shape: Unchanged; no new request body, query params, command payload, secret value, or endpoint.
- Response shape: Adds `contract_version`, `enabled`, `runtime_read_enabled`, `required_before_enablement`, `scope`, `must_not_share_patient_bot_token`, `secret_source`, `required_server_checks`, and `enablement_gate` under `staff_bot.token_contract`.
- Status codes: Unchanged; existing integration-status success/error behavior remains in place.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads the optional token contract and renders a planned staff token separation row.
- Compatibility path or alias: Missing `token_contract` is treated as absent optional metadata and renders fallback copy.
- Contract proof: `py_compile` passed for the admin endpoint and webhook endpoint; frontend production build passed with the optional consumer.

## RBAC / Permissions
- Roles allowed: Existing Admin-only dependency on the admin Telegram integration status endpoint remains unchanged.
- Roles denied: Non-Admin users remain denied by the existing `require_roles("Admin")` guard.
- Positive auth proof: No RBAC code changed; the existing Admin path still returns the status payload.
- Negative auth proof: No denied-role path changed; authorization remains owned by the existing dependency.

## Notification / Realtime
- Event type or websocket channel: No notification event or websocket channel is introduced by this contract-only slice.
- Payload version / ack behavior: Not applicable because no Telegram callback, secret validation flow, or runtime token acknowledgment is implemented.
- Read/unread or delivery semantics: Not applicable because no Telegram message is sent, queued, marked read, or delivered.
- Reconnect/resync proof: Existing admin refresh reloads integration status; no realtime resync behavior was changed.

## Frontend Resilience
- Empty data proof: Missing `token_contract` renders the fallback "Dedicated staff bot token contract не опубликован" text.
- Partial data proof: Missing `scope` falls back to `staff`; missing runtime flag keeps the badge in planned/required display state.
- Forbidden secondary path behavior: No new secondary action, token-entry form, or secret-read button was added, so forbidden behavior is unchanged.
- Missing draft/resource behavior: Missing token readiness metadata is handled as optional display state.
- Stale route/deep-link behavior: No route, callback data, or deep-link was added or changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `frontend/src/components/TelegramManager.jsx`.
- Denied paths: No edits to `backend/app/api/v1/endpoints/telegram_webhook.py`, config/core settings, secret stores, Telegram services, command handlers, migrations, or queue/payment/EMR/lab/schedule domain services.
- Migration/docs/test impact: No database migration or docs update required; validation used the gate-targeted compile and frontend build checks.
- Rollback note: Revert this commit to remove the staff token contract from the status response and UI row.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend; npm.cmd run build`.
- Result: Passed; frontend build reported the existing mixed import/chunk-size Vite warnings only.
- Not checked: Live staff bot token reads were not run because this slice intentionally does not read or require a staff token at runtime.