### PR TITLE
feat(telegram): publish staff authorization contract

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -178,6 +178,45 @@ STAFF_BOT_LINKING_CONTRACT = {
     "state_changing_actions_allowed_after_link": False,
 }
 
+STAFF_BOT_AUTHORIZATION_CONTRACT = {
+    "contract_version": "staff-authorization-v1",
+    "enabled": False,
+    "source": "application_rbac",
+    "server_side_required": True,
+    "default_decision": "deny",
+    "role_checks": [
+        {
+            "role": "registrar",
+            "allowed_intents": ["queue_read", "patient_lookup_read", "payment_status_read"],
+        },
+        {
+            "role": "doctor",
+            "allowed_intents": ["schedule_read", "next_patient_read", "emr_reminder_read"],
+        },
+        {
+            "role": "cashier",
+            "allowed_intents": ["invoice_read", "payment_reconciliation_read"],
+        },
+        {
+            "role": "lab",
+            "allowed_intents": ["report_status_read", "result_delivery_status_read"],
+        },
+        {
+            "role": "admin",
+            "allowed_intents": ["operations_summary_read", "integration_error_read"],
+        },
+        {
+            "role": "owner",
+            "allowed_intents": ["operations_summary_read", "revenue_summary_read"],
+        },
+    ],
+    "denied_behavior": [
+        "send_generic_forbidden_message",
+        "do_not_execute_domain_action",
+        "write_audit_denied_event_when_audit_enabled",
+    ],
+}
+
 STAFF_BOT_COMMAND_REGISTRATION_CONTRACT = {
     "contract_version": "staff-commands-v1",
     "registration_enabled": False,
@@ -368,6 +407,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         },
         "token_contract": STAFF_BOT_TOKEN_CONTRACT,
         "linking_contract": STAFF_BOT_LINKING_CONTRACT,
+        "authorization_contract": STAFF_BOT_AUTHORIZATION_CONTRACT,
         "command_registration_contract": STAFF_BOT_COMMAND_REGISTRATION_CONTRACT,
         "confirmation_contract": STAFF_BOT_CONFIRMATION_CONTRACT,
         "audit_contract": STAFF_BOT_AUDIT_CONTRACT,
@@ -384,7 +424,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         "readiness": STAFF_BOT_READINESS,
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
-        "next_slice": "dedicated_staff_bot_token_readiness_contract",
+        "next_slice": "staff_server_side_authorization_contract",
     }
 
 
@@ -837,6 +877,7 @@ def get_telegram_integration_status(
                 "dedicated_staff_bot_token_readiness_contract",
                 "staff_read_only_menu_contract",
                 "staff_role_linking_contract",
+                "staff_server_side_authorization_contract",
                 "staff_command_registration_contract",
                 "staff_state_change_confirmation_contract",
                 "staff_audit_logging_contract",

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -190,6 +190,10 @@ const TelegramManager = () => {
   const staffLinkingMethodNames = staffLinkingMethods.
   map((method) => method?.label || method?.key || method).
   filter(Boolean);
+  const staffAuthorizationContract = staffBot.authorization_contract || staffBot.authorization || {};
+  const staffAuthorizationRoles = Array.isArray(staffAuthorizationContract.role_checks) ?
+  staffAuthorizationContract.role_checks :
+  [];
   const staffCommandContract = staffBot.command_registration_contract || staffBot.command_contract || {};
   const staffCommandList = Array.isArray(staffCommandContract.commands) ?
   staffCommandContract.commands :
@@ -414,6 +418,23 @@ const TelegramManager = () => {
                     size="small">
 
                     {staffLinkingContract.enabled ? 'Enabled' : 'Planned'}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <CheckCircle />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff authorization"
+                    secondary={staffAuthorizationRoles.length ?
+                    `${staffAuthorizationRoles.length} role checks; default: ${staffAuthorizationContract.default_decision || 'deny'}` :
+                    'Authorization contract не опубликован'} />
+
+                  <Badge
+                    variant={staffAuthorizationContract.enabled ? 'success' : 'warning'}
+                    size="small">
+
+                    {staffAuthorizationContract.server_side_required ? 'Required' : 'Planned'}
                   </Badge>
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
## Summary
- Publishes a read-only staff bot server-side authorization contract in the admin Telegram integration status.
- Defines default-deny RBAC metadata, role-to-intent checks, and denied behavior before staff bot enablement.
- Shows authorization readiness in `TelegramManager` without changing RBAC dependencies, role models, or Telegram handlers.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/integration-status` response field `staff_bot.authorization_contract`.
- Request shape: Unchanged; no new request body, query params, command payload, or endpoint.
- Response shape: Adds `contract_version`, `enabled`, `source`, `server_side_required`, `default_decision`, `role_checks`, and `denied_behavior` under `staff_bot.authorization_contract`.
- Status codes: Unchanged; existing integration-status success/error behavior remains in place.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads the optional authorization contract and renders a planned staff authorization row.
- Compatibility path or alias: The frontend falls back to existing `staffBot.authorization`; missing role checks render fallback copy.
- Contract proof: `py_compile` passed for the admin endpoint and webhook endpoint; frontend production build passed with the optional consumer.

## RBAC / Permissions
- Roles allowed: Existing Admin-only dependency on the admin Telegram integration status endpoint remains unchanged; staff role intent metadata is not enforcement code.
- Roles denied: Non-Admin users remain denied by the existing `require_roles("Admin")` guard; staff default decision is contract metadata only.
- Positive auth proof: No RBAC code changed; the existing Admin path still returns the status payload.
- Negative auth proof: No denied-role path changed; authorization remains owned by existing dependencies and future staff handlers.

## Notification / Realtime
- Event type or websocket channel: No notification event or websocket channel is introduced by this contract-only slice.
- Payload version / ack behavior: Not applicable because no Telegram callback, authorization decision handler, or mutation acknowledgment is implemented.
- Read/unread or delivery semantics: Not applicable because no Telegram message is sent, queued, marked read, or delivered.
- Reconnect/resync proof: Existing admin refresh reloads integration status; no realtime resync behavior was changed.

## Frontend Resilience
- Empty data proof: Missing `authorization_contract` and missing role checks render the fallback "Authorization contract не опубликован" text.
- Partial data proof: Missing `role_checks` normalizes to an empty array; missing default decision falls back to `deny`.
- Forbidden secondary path behavior: No new secondary action or authorization-test button was added, so forbidden behavior is unchanged.
- Missing draft/resource behavior: Missing authorization metadata is handled as optional display state.
- Stale route/deep-link behavior: No route, callback data, or deep-link was added or changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `frontend/src/components/TelegramManager.jsx`.
- Denied paths: No edits to `backend/app/api/v1/endpoints/telegram_webhook.py`, auth dependencies, role models, permission services, Telegram services, command handlers, migrations, or queue/payment/EMR/lab/schedule domain services.
- Migration/docs/test impact: No database migration or docs update required; validation used the gate-targeted compile and frontend build checks.
- Rollback note: Revert this commit to remove the staff authorization contract from the status response and UI row.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend; npm.cmd run build`.
- Result: Passed; frontend build reported the existing mixed import/chunk-size Vite warnings only.
- Not checked: Live staff authorization decisions were not run because this slice intentionally does not add handlers or change RBAC enforcement.