### PR TITLE
Chore: consume Telegram staff role menu summary

### DIFF
--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -176,8 +176,17 @@ const TelegramManager = () => {
   const staffBotReadiness = Array.isArray(staffBot.readiness) ? staffBot.readiness : [];
   const readyStaffControls = staffBotReadiness.filter((item) => item?.ready);
   const staffRoles = Array.isArray(staffBot.supported_roles) ? staffBot.supported_roles : [];
-  const staffMenuContract = Array.isArray(staffBot.read_only_menu_contract) ? staffBot.read_only_menu_contract : [];
-  const staffMenuItemCount = staffMenuContract.reduce((count, role) => {
+  const staffMenuContractSource = Array.isArray(staffBot.read_only_menu_contract) ? staffBot.read_only_menu_contract : [];
+  const staffRoleMenus = staffBot.role_menus || {};
+  const staffMenuRoleCount = typeof staffRoleMenus.role_count === 'number' ?
+  staffRoleMenus.role_count :
+  staffMenuContractSource.length;
+  const staffMenuContract = staffMenuRoleCount === staffMenuContractSource.length ?
+  staffMenuContractSource :
+  Array.from({ length: staffMenuRoleCount });
+  const staffMenuItemCount = typeof staffRoleMenus.item_count === 'number' ?
+  staffRoleMenus.item_count :
+  staffMenuContractSource.reduce((count, role) => {
     const items = Array.isArray(role?.items) ? role.items : [];
     return count + items.length;
   }, 0);


### PR DESCRIPTION
## Summary
- Updates the admin TelegramManager staff menu status row to prefer `staff_bot.role_menus.role_count` and `item_count` when present.
- Preserves fallback to the existing `staff_bot.read_only_menu_contract` for older payloads.
- Does not change backend contracts, routes, RBAC, Telegram runtime, staff commands, or state-changing actions.

## Contract Impact
- Canonical surface: frontend consumer `frontend/src/components/TelegramManager.jsx` for `GET /api/v1/admin/telegram/integration-status`.
- Request shape: unchanged; no new request parameters, route changes, or API calls.
- Response shape: no backend response change; frontend optionally reads existing `staff_bot.role_menus` and falls back to `staff_bot.read_only_menu_contract`.
- Status codes: unchanged because no backend endpoint behavior changes.
- Frontend consumer: `TelegramManager` staff menu row now displays summary counts from `role_menus` when available.
- Compatibility path or alias: `/admin/integrations/telegram` and legacy redirect `/telegram-integration` remain unchanged.
- Contract proof: frontend build passed after rebase on current `origin/main`; backend `py_compile` passed for Telegram endpoints.

## RBAC / Permissions
- Roles allowed: unchanged existing Admin-only Telegram integration screen/API access.
- Roles denied: unchanged for non-Admin roles; no route guard or backend permission changes.
- Positive auth proof: this PR only changes rendering after the existing authorized API response is loaded.
- Negative auth proof: no new route, API call, Telegram command, or secondary access path is added.

## Scope Gate
- Allowed paths: `frontend/src/components/TelegramManager.jsx` only.
- Denied paths: no backend, route registry, polling worker, webhook, staff linking, audit writer, queue, payment, EMR, or migration changes.
- Migration/docs/test impact: no migration or docs required; validation is compile/build smoke for the existing contract consumer.
- Rollback note: revert the local `staffRoleMenus` count fallback block to restore the previous UI count source.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend && npm.cmd run build`.
- Result: passed. Frontend build completed with existing Vite dynamic-import and chunk-size warnings only.
- Not checked: browser visual smoke and live Telegram polling/webhook smoke were not run because this is a narrow status-row data-source change.

## Notification / Realtime
- Event type or websocket channel: none; no realtime event, websocket channel, or notification path changed.
- Payload version / ack behavior: no payload version or acknowledgement behavior changes.
- Read/unread or delivery semantics: none; no Telegram message or notification delivery behavior changes.
- Reconnect/resync proof: existing page reload/status refetch still refreshes the row; no persistent connection added.

## Frontend Resilience
- Empty data proof: if `staff_bot.role_menus` is absent, the row uses `read_only_menu_contract`; if both are absent/empty, existing empty text remains.
- Partial data proof: `role_count` and `item_count` are checked for numeric type before use, otherwise fallback data is used.
- Forbidden secondary path behavior: no route, permission, or forbidden-state behavior changed.
- Missing draft/resource behavior: no draft/resource lookup added.
- Stale route/deep-link behavior: no route, deep link, QR, or Telegram start-token behavior changed.