### PR TITLE
Chore: update Telegram staff next runtime slice

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -450,7 +450,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         "role_menus": _build_staff_role_menus_summary(),
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
-        "next_slice": "staff_server_side_authorization_contract",
+        "next_slice": "staff_role_linking_runtime",
     }
 
 
@@ -903,6 +903,7 @@ def get_telegram_integration_status(
                 "dedicated_staff_bot_token_readiness_contract",
                 "staff_read_only_menu_contract",
                 "staff_role_linking_contract",
+                "staff_role_linking_runtime",
                 "staff_server_side_authorization_contract",
                 "staff_command_registration_contract",
                 "staff_state_change_confirmation_contract",


### PR DESCRIPTION
## Summary
- Updates Telegram staff bot planning status so `next_slice` points to `staff_role_linking_runtime` after the server-side authorization contract is published.
- Adds `staff_role_linking_runtime` to `planned_functions` so the next slice value is discoverable in the same status payload.
- Does not enable staff bot runtime, linking, commands, state-changing actions, or audit writer.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/integration-status`, implemented in `backend/app/api/v1/endpoints/admin_telegram.py`.
- Request shape: unchanged; no new query parameters, body fields, or endpoint route changes.
- Response shape: changes only planning metadata: `staff_bot.next_slice` and `planned_functions`; existing contracts and runtime flags remain unchanged.
- Status codes: unchanged; existing success/error behavior remains the same.
- Frontend consumer: TelegramManager can display the existing status payload; no frontend change is required.
- Compatibility path or alias: no route alias or compatibility endpoint changes.
- Contract proof: `py_compile` passed for Telegram endpoints and frontend build passed against the existing consumer.

## RBAC / Permissions
- Roles allowed: unchanged existing Admin-only integration status endpoint access.
- Roles denied: unchanged for non-Admin roles through existing dependencies.
- Positive auth proof: the same authorized status endpoint returns the metadata update.
- Negative auth proof: no new route, webhook handler, Telegram command, or secondary access path is added.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py` only.
- Denied paths: no changes to webhook, polling worker, frontend, staff linking runtime, commands, audit writer, queue, payment, EMR, or migrations.
- Migration/docs/test impact: no migration or docs required; validation is compile/build smoke for the status contract.
- Rollback note: restore `next_slice` to `staff_server_side_authorization_contract` and remove `staff_role_linking_runtime` from `planned_functions`.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend && npm.cmd run build`.
- Result: passed. Frontend build completed with existing Vite dynamic-import and chunk-size warnings only.
- Not checked: no live Telegram polling/webhook smoke and no browser UI smoke because this PR changes only planning metadata.

## Notification / Realtime
- Event type or websocket channel: none; no realtime event, websocket channel, or notification path changed.
- Payload version / ack behavior: no payload version or ack behavior changes.
- Read/unread or delivery semantics: none; no Telegram messages or notifications are sent.
- Reconnect/resync proof: existing admin status refetch returns the updated metadata.

## Frontend Resilience
- Empty data proof: no frontend rendering change; existing empty/fallback behavior remains unchanged.
- Partial data proof: no required frontend field is added; clients that ignore `next_slice` keep working.
- Forbidden secondary path behavior: no route or permission behavior changed.
- Missing draft/resource behavior: no draft/resource lookup added.
- Stale route/deep-link behavior: no route, deep link, QR, or Telegram start-token behavior changed.