### PR TITLE
feat(telegram): publish staff role menu status

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -384,6 +384,26 @@ STAFF_BOT_AUDIT_CONTRACT = {
     ],
 }
 
+STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
+    "contract_version": "staff-role-menu-enablement-v1",
+    "enabled": False,
+    "runtime_menu_enabled": False,
+    "read_only_contract_published": True,
+    "required_before_enablement": True,
+    "state_changing_menu_items_enabled": False,
+    "allowed_until_enabled": [
+        "read_status_contract",
+        "read_only_menu_preview",
+    ],
+    "required_server_checks": [
+        "dedicated_staff_bot_token",
+        "role_based_staff_linking",
+        "server_side_authorization",
+        "audit_logging",
+        "state_change_confirmations",
+    ],
+}
+
 
 def _build_staff_role_menus_summary() -> Dict[str, Any]:
     menu_roles = [
@@ -410,7 +430,19 @@ def _build_staff_role_menus_summary() -> Dict[str, Any]:
     }
 
 
+def _build_staff_role_menu_enablement_contract(
+    role_menus: Dict[str, Any],
+) -> Dict[str, Any]:
+    return {
+        **STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT,
+        "roles_covered": role_menus["roles"],
+        "role_count": role_menus["role_count"],
+        "menu_item_count": role_menus["item_count"],
+    }
+
+
 def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
+    role_menus = _build_staff_role_menus_summary()
     return {
         "version": "planning",
         "contract_version": "staff-menu-read-only-v1",
@@ -447,7 +479,10 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         },
         "state_changing_actions_enabled": False,
         "readiness": STAFF_BOT_READINESS,
-        "role_menus": _build_staff_role_menus_summary(),
+        "role_menus": role_menus,
+        "role_menu_enablement_contract": (
+            _build_staff_role_menu_enablement_contract(role_menus)
+        ),
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
         "next_slice": "staff_role_linking_runtime",
@@ -902,6 +937,7 @@ def get_telegram_integration_status(
             "planned_functions": [
                 "dedicated_staff_bot_token_readiness_contract",
                 "staff_read_only_menu_contract",
+                "staff_role_menu_enablement_status",
                 "staff_role_linking_contract",
                 "staff_role_linking_runtime",
                 "staff_server_side_authorization_contract",

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -218,6 +218,13 @@ const TelegramManager = () => {
   const staffAuditEvents = Array.isArray(staffAuditContract.event_types) ?
   staffAuditContract.event_types :
   [];
+  const staffRoleMenuEnablementContract = staffBot.role_menu_enablement_contract || {};
+  const staffRoleMenuEnablementRoleCount = typeof staffRoleMenuEnablementContract.role_count === 'number' ?
+  staffRoleMenuEnablementContract.role_count :
+  staffMenuContract.length;
+  const staffRoleMenuEnablementItemCount = typeof staffRoleMenuEnablementContract.menu_item_count === 'number' ?
+  staffRoleMenuEnablementContract.menu_item_count :
+  staffMenuItemCount;
 
   return (
     <Box sx={{ p: 3 }}>
@@ -461,6 +468,23 @@ const TelegramManager = () => {
                     size="small">
 
                     {staffBot.state_changing_actions_enabled ? 'Actions' : 'Read-only'}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <Settings />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff role menu enablement"
+                    secondary={staffRoleMenuEnablementContract.contract_version ?
+                    `${staffRoleMenuEnablementRoleCount} roles, ${staffRoleMenuEnablementItemCount} items; runtime menu: ${staffRoleMenuEnablementContract.runtime_menu_enabled ? 'enabled' : 'disabled'}` :
+                    'Role menu enablement contract not published'} />
+
+                  <Badge
+                    variant={staffRoleMenuEnablementContract.runtime_menu_enabled ? 'success' : 'warning'}
+                    size="small">
+
+                    {staffRoleMenuEnablementContract.required_before_enablement ? 'Required' : 'Planned'}
                   </Badge>
                 </ListItem>
                 <ListItem>

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -150,15 +150,6 @@ const TelegramManager = () => {
     }
   };
 
-  const resetForm = () => {
-    setTemplateForm({
-      name: '',
-      message_type: 'text',
-      content: '',
-      is_active: true
-    });
-  };
-
   if (loading) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" sx={{ minHeight: '400px' }}>


### PR DESCRIPTION
## Summary
- Publishes a read-only staff role menu enablement contract in the Telegram admin status payload.
- Reuses the existing staff read-only menu summary counts for role coverage and item count.
- Adds one Telegram manager status row so Admin can see role-menu runtime enablement is still disabled.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/status` staff_bot metadata from `backend/app/api/v1/endpoints/admin_telegram.py`.
- Request shape: unchanged; the status request still accepts the existing admin-authenticated GET with no new query or body fields.
- Response shape: adds `staff_bot.role_menu_enablement_contract` with version, enabled flags, server checks, roles covered, role_count, and menu_item_count.
- Status codes: unchanged; successful status remains 200 and existing HTTPException handling remains unchanged.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads `staffBot.role_menu_enablement_contract` defensively and falls back to existing menu counts.
- Compatibility path or alias: existing `staff_bot.role_menus` and `staff_bot.read_only_menu_contract` remain unchanged for current consumers.
- Contract proof: `py_compile` passed for Telegram endpoints and `frontend` production build passed after the contract/UI change.

## RBAC / Permissions
- Roles allowed: unchanged existing Admin Telegram status access; this PR adds no staff bot command access.
- Roles denied: unchanged existing route protection denies non-admin/unauthorized callers through the existing auth layer.
- Positive auth proof: not applicable because this PR does not change auth code; compile/build confirm the status surface still loads.
- Negative auth proof: not applicable because this PR does not change auth code or add a callable staff command path.

## Notification / Realtime
- Event type or websocket channel: not applicable because no Telegram messages, websocket events, or notification channels are emitted.
- Payload version / ack behavior: not applicable because this is status metadata only and has no delivery ack path.
- Read/unread or delivery semantics: not applicable because the PR does not create notification records or delivery state.
- Reconnect/resync proof: not applicable because no realtime stream or reconnect behavior changes.

## Frontend Resilience
- Empty data proof: UI falls back to `Role menu enablement contract not published` if the new object is missing.
- Partial data proof: role and item counts fall back to the existing read-only menu contract summary when numeric fields are absent.
- Forbidden secondary path behavior: unchanged; this PR adds no secondary route or action path.
- Missing draft/resource behavior: unchanged; no draft/resource fetch is introduced.
- Stale route/deep-link behavior: unchanged; TelegramManager route semantics are not modified.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `frontend/src/components/TelegramManager.jsx`.
- Denied paths: runtime Telegram handlers, webhook behavior, CRUD helpers, migrations, and unrelated UI screens were not changed.
- Migration/docs/test impact: no migration required; validation is compile plus frontend build for this contract-only slice.
- Rollback note: revert this commit to remove the new status field and Admin row without changing existing staff menu metadata.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend; npm.cmd run build`.
- Result: passed; Vite repeated existing warnings about mixed dynamic/static `errorHandler.js` import and large chunks.
- Not checked: full backend test suite, browser smoke, and live Telegram integration were not run because this slice does not enable runtime handlers.