### PR TITLE
feat(telegram): add staff linking crud helpers

### DIFF
--- a/backend/app/crud/telegram_config.py
+++ b/backend/app/crud/telegram_config.py
@@ -130,6 +130,17 @@ def get_telegram_user_by_chat_id(db: Session, chat_id: int) -> TelegramUser | No
     return db.query(TelegramUser).filter(TelegramUser.chat_id == chat_id).first()
 
 
+def get_telegram_user_by_linked_user_id(
+    db: Session, linked_user_id: int
+) -> TelegramUser | None:
+    """Get a Telegram account linked to an application user."""
+    return (
+        db.query(TelegramUser)
+        .filter(TelegramUser.user_id == linked_user_id)
+        .first()
+    )
+
+
 def get_telegram_users(
     db: Session, active_only: bool = True, skip: int = 0, limit: int = 100
 ) -> list[TelegramUser]:
@@ -175,6 +186,23 @@ def link_patient_to_telegram(
     user = get_telegram_user_by_chat_id(db, chat_id)
     if user:
         user.patient_id = patient_id
+        db.commit()
+        db.refresh(user)
+        return user
+    return None
+
+
+def link_staff_user_to_telegram(
+    db: Session, chat_id: int, linked_user_id: int
+) -> TelegramUser | None:
+    """Link an application staff user to an existing Telegram account.
+
+    Role authorization and one-time link-token validation must happen before
+    this helper is called. This function only writes telegram_users.user_id.
+    """
+    user = get_telegram_user_by_chat_id(db, chat_id)
+    if user:
+        user.user_id = linked_user_id
         db.commit()
         db.refresh(user)
         return user


### PR DESCRIPTION
## Summary

- Add a TelegramUser lookup by linked application user id.
- Add a staff Telegram linking helper that writes only `telegram_users.user_id`.
- Keep role authorization and one-time link-token validation outside CRUD for the next runtime slice.

## Contract Impact

- Canonical surface: backend Telegram CRUD helpers in `backend/app/crud/telegram_config.py`.
- Request shape: not applicable - no HTTP API, webhook payload, or frontend API contract changed.
- Response shape: not applicable - no external response contract changed.
- Status codes: not applicable - no endpoint behavior changed.
- Frontend consumer: not applicable - no frontend consumer changed in this PR.
- Compatibility path or alias: existing patient Telegram linking remains unchanged; staff helper uses existing `telegram_users.user_id`.
- Contract proof: `py_compile` for Telegram CRUD/webhook/admin endpoint modules and frontend build smoke.

## RBAC / Permissions

- Roles allowed: not applicable - no staff command or endpoint is enabled by this PR.
- Roles denied: not applicable - authorization remains a caller responsibility before invoking the helper.
- Positive auth proof: not checked because no auth surface changed.
- Negative auth proof: not checked because no auth surface changed.

## Notification / Realtime

not applicable - no Telegram message sending, websocket, notification template, polling, or webhook dispatch behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed.
- Partial data proof: not applicable - no frontend rendering path changed.
- Forbidden secondary path behavior: not applicable - no frontend route or fallback path changed.
- Missing draft/resource behavior: not applicable - no draft/resource UI changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link handling changed.

## Scope Gate

- Allowed paths: `backend/app/crud/telegram_config.py` only for the committed patch.
- Denied paths: staff bot command handling, webhook routing, frontend UI, migrations, generated output, and unrelated Telegram patient flows.
- Migration/docs/test impact: no migration needed because `telegram_users.user_id` already exists; no docs changed; no new tests added because the helper is not wired into a user-visible flow yet.
- Rollback note: revert commit `887b14a4` to remove the staff-linking helper functions.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/crud/telegram_config.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `npm.cmd run build`.
- Result: passed locally in `C:\final-worktrees\telegram-staff-linking-runtime`; frontend build completed with existing chunk-size/dynamic-import warnings only.
- Not checked: full backend pytest suite, live Telegram polling/webhook flow, staff link-token validation, and staff command authorization runtime.