### PR TITLE
feat(telegram): add staff linking runtime foundation

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -178,6 +178,28 @@ STAFF_BOT_LINKING_CONTRACT = {
     "state_changing_actions_allowed_after_link": False,
 }
 
+STAFF_BOT_LINKING_RUNTIME_CONTRACT = {
+    "contract_version": "staff-linking-runtime-v1",
+    "enabled": False,
+    "helper_available": True,
+    "runtime_handler_enabled": False,
+    "write_helper": "link_staff_user_to_telegram",
+    "lookup_helpers": [
+        "get_telegram_user_by_chat_id",
+        "get_telegram_user_by_linked_user_id",
+    ],
+    "writes": [
+        "telegram_users.user_id",
+    ],
+    "requires_prevalidated_inputs": [
+        "active_application_user",
+        "allowed_staff_role",
+        "one_time_link_token_validated",
+        "telegram_user_not_linked_to_another_staff_user",
+    ],
+    "state_changing_actions_allowed_after_link": False,
+}
+
 STAFF_BOT_AUTHORIZATION_CONTRACT = {
     "contract_version": "staff-authorization-v1",
     "enabled": False,
@@ -464,6 +486,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         },
         "token_contract": STAFF_BOT_TOKEN_CONTRACT,
         "linking_contract": STAFF_BOT_LINKING_CONTRACT,
+        "linking_runtime_contract": STAFF_BOT_LINKING_RUNTIME_CONTRACT,
         "authorization_contract": STAFF_BOT_AUTHORIZATION_CONTRACT,
         "command_registration_contract": STAFF_BOT_COMMAND_REGISTRATION_CONTRACT,
         "confirmation_contract": STAFF_BOT_CONFIRMATION_CONTRACT,
@@ -485,7 +508,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         ),
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
-        "next_slice": "staff_role_linking_runtime",
+        "next_slice": "staff_role_linking_token_validation",
     }
 
 

--- a/backend/app/crud/telegram_config.py
+++ b/backend/app/crud/telegram_config.py
@@ -130,6 +130,17 @@ def get_telegram_user_by_chat_id(db: Session, chat_id: int) -> TelegramUser | No
     return db.query(TelegramUser).filter(TelegramUser.chat_id == chat_id).first()
 
 
+def get_telegram_user_by_linked_user_id(
+    db: Session, linked_user_id: int
+) -> TelegramUser | None:
+    """Get a Telegram account linked to an application user."""
+    return (
+        db.query(TelegramUser)
+        .filter(TelegramUser.user_id == linked_user_id)
+        .first()
+    )
+
+
 def get_telegram_users(
     db: Session, active_only: bool = True, skip: int = 0, limit: int = 100
 ) -> list[TelegramUser]:
@@ -175,6 +186,23 @@ def link_patient_to_telegram(
     user = get_telegram_user_by_chat_id(db, chat_id)
     if user:
         user.patient_id = patient_id
+        db.commit()
+        db.refresh(user)
+        return user
+    return None
+
+
+def link_staff_user_to_telegram(
+    db: Session, chat_id: int, linked_user_id: int
+) -> TelegramUser | None:
+    """Link an application staff user to an existing Telegram account.
+
+    Role authorization and one-time link-token validation must happen before
+    this helper is called. This function only writes telegram_users.user_id.
+    """
+    user = get_telegram_user_by_chat_id(db, chat_id)
+    if user:
+        user.user_id = linked_user_id
         db.commit()
         db.refresh(user)
         return user

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -190,6 +190,7 @@ const TelegramManager = () => {
   const staffLinkingMethodNames = staffLinkingMethods.
   map((method) => method?.label || method?.key || method).
   filter(Boolean);
+  const staffLinkingRuntimeContract = staffBot.linking_runtime_contract || {};
   const staffAuthorizationContract = staffBot.authorization_contract || staffBot.authorization || {};
   const staffAuthorizationRoles = Array.isArray(staffAuthorizationContract.role_checks) ?
   staffAuthorizationContract.role_checks :
@@ -425,6 +426,23 @@ const TelegramManager = () => {
                     size="small">
 
                     {staffLinkingContract.enabled ? 'Enabled' : 'Planned'}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <CheckCircle />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff linking runtime"
+                    secondary={staffLinkingRuntimeContract.contract_version ?
+                    `${staffLinkingRuntimeContract.write_helper || 'link helper'}; handler: ${staffLinkingRuntimeContract.runtime_handler_enabled ? 'enabled' : 'disabled'}` :
+                    'Staff linking runtime contract not published'} />
+
+                  <Badge
+                    variant={staffLinkingRuntimeContract.runtime_handler_enabled ? 'success' : 'warning'}
+                    size="small">
+
+                    {staffLinkingRuntimeContract.helper_available ? 'Helper' : 'Planned'}
                   </Badge>
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
## Summary
- Adds CRUD helpers for looking up and linking a Telegram account to an application staff user.
- Publishes a `staff-linking-runtime-v1` status contract that marks the helper as available while keeping runtime handlers disabled.
- Adds one Telegram manager status row so Admin can see staff linking runtime is still helper-only.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/status` staff_bot metadata and `backend/app/crud/telegram_config.py` TelegramUser helpers.
- Request shape: unchanged; no new endpoint, command, webhook callback, query, or request body is introduced.
- Response shape: adds `staff_bot.linking_runtime_contract` with helper availability, handler enabled flag, helper names, write target, and required prevalidated inputs.
- Status codes: unchanged; existing admin Telegram status HTTP behavior remains the same.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads `staffBot.linking_runtime_contract` defensively and shows helper-only status.
- Compatibility path or alias: existing `staff_bot.linking_contract`, `staff_bot.role_linking`, and staff menu fields remain unchanged.
- Contract proof: py_compile passed for CRUD and Telegram endpoints; frontend production build passed.

## RBAC / Permissions
- Roles allowed: unchanged; no staff Telegram command is enabled and the helper requires prevalidated staff identity and role checks before callers may use it.
- Roles denied: unchanged; non-admin status access and unauthorized staff actions remain denied by existing layers because no caller path is added.
- Positive auth proof: contract lists required prevalidated inputs (`active_application_user`, `allowed_staff_role`, token validation, duplicate-link guard) before helper use.
- Negative auth proof: no webhook handler or command path calls the helper, so unauthorized Telegram payloads cannot trigger staff linking through this PR.

## Notification / Realtime
- Event type or websocket channel: not applicable because this PR emits no Telegram messages, websocket events, or notification records.
- Payload version / ack behavior: not applicable because helper-only linking foundation has no delivery/ack payload.
- Read/unread or delivery semantics: not applicable because no notification state is created or updated.
- Reconnect/resync proof: not applicable because no realtime stream or resync behavior changes.

## Frontend Resilience
- Empty data proof: UI falls back to `Staff linking runtime contract not published` when the new object is absent.
- Partial data proof: UI falls back to `link helper` and `disabled` when optional helper/status fields are missing.
- Forbidden secondary path behavior: unchanged; no secondary route or staff action is added.
- Missing draft/resource behavior: unchanged; no draft/resource fetch is introduced.
- Stale route/deep-link behavior: unchanged; TelegramManager route semantics are not modified.

## Scope Gate
- Allowed paths: `backend/app/crud/telegram_config.py`, `backend/app/api/v1/endpoints/admin_telegram.py`, `frontend/src/components/TelegramManager.jsx`.
- Denied paths: Telegram webhook handlers, command registration runtime, migrations, route registries, and unrelated UI screens were not changed.
- Migration/docs/test impact: no migration required; existing `telegram_users.user_id` column is reused.
- Rollback note: revert this commit to remove helper-only staff linking foundation and the Admin status row.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/crud/telegram_config.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend; npm.cmd run build`.
- Result: passed; `git diff --check` reported only a Git LF-to-CRLF notice for `backend/app/crud/telegram_config.py`; Vite repeated existing mixed import and chunk-size warnings.
- Not checked: full backend suite, browser smoke, and live Telegram staff linking because this PR intentionally adds no runtime caller or webhook handler.