### PR TITLE
🎨 Palette: Add accessible labels and tooltips to icon-only buttons

### DIFF
--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -621,10 +621,10 @@ const TelegramManager = () => {
                           </Badge>
                         </TableCell>
                         <TableCell align="right">
-                          <IconButton>
+                          <IconButton aria-label="Редактировать" title="Редактировать">
                             <Edit />
                           </IconButton>
-                          <IconButton>
+                          <IconButton aria-label="Удалить" title="Удалить">
                             <Trash2 />
                           </IconButton>
                         </TableCell>

--- a/frontend/src/components/admin/UserManagement.jsx
+++ b/frontend/src/components/admin/UserManagement.jsx
@@ -329,6 +329,8 @@ const UserManagement = () => {
     render: (_, user) =>
     <div onClick={(e) => e.stopPropagation()}>
           <IconButton
+        aria-label="Действия"
+        title="Действия"
         onClick={(e) => {
           e.stopPropagation();
           setAnchorEl(e.currentTarget);

--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -337,7 +337,7 @@ const Dashboard = ({ user }) => {
                 <Typography variant="h6">
                   Последние уведомления
                 </Typography>
-                <IconButton>
+                <IconButton aria-label="Больше действий" title="Больше действий">
                   <MoreVert />
                 </IconButton>
               </Box>

--- a/frontend/src/components/dental/ToothModal.jsx
+++ b/frontend/src/components/dental/ToothModal.jsx
@@ -250,7 +250,7 @@ const ToothModal = ({
                   <ListItem
                     key={procedure.id}
                     secondaryAction={
-                      <IconButton edge="end" onClick={() => removeProcedure(procedure.id)}>
+                      <IconButton edge="end" aria-label="Удалить" title="Удалить" onClick={() => removeProcedure(procedure.id)}>
                         <Delete />
                       </IconButton>
                     }

--- a/frontend/src/components/dental/TreatmentPlanner.jsx
+++ b/frontend/src/components/dental/TreatmentPlanner.jsx
@@ -261,7 +261,7 @@ const TreatmentPlanner = ({ visitId, onUpdate }) => {
                       }
                     />
                     <ListItemSecondaryAction>
-                      <IconButton onClick={() => handleDeleteStage(stage.id)}>
+                      <IconButton aria-label="Удалить" title="Удалить" onClick={() => handleDeleteStage(stage.id)}>
                         <Delete />
                       </IconButton>
                     </ListItemSecondaryAction>


### PR DESCRIPTION
## Summary
- Add accessible names to existing icon-only `IconButton` controls in Telegram management, admin user actions, dashboard notifications, and dental workflow lists.
- Add matching native `title` tooltips for the same icon-only actions.
- Accessibility-only metadata change; no layout, routing, API, state machine, or handler behavior changed.

## Contract Impact
- Canonical surface: not applicable - existing frontend icon-only button labels only; no endpoint, websocket, event, or frontend/backend consumer contract changed.
- Request shape: not applicable - no request or payload code changed.
- Response shape: not applicable - no response shape or data mapping changed.
- Status codes: not applicable - no API call or status handling changed.
- Frontend consumer: existing TelegramManager, UserManagement, Dashboard, ToothModal, and TreatmentPlanner controls receive accessible text only.
- Compatibility path or alias: not applicable - no route, path, alias, or compatibility behavior changed.
- Contract proof: PR diff inspection shows only `aria-label` and `title` additions on existing buttons, with handlers and data flow preserved.

## RBAC / Permissions
- Roles allowed: unchanged - existing role access and visible controls remain owned by the current screens.
- Roles denied: unchanged - no route guard, permission helper, or role denial logic changed.
- Positive auth proof: not applicable - no auth-sensitive code changed; existing authenticated screen behavior is preserved.
- Negative auth proof: not applicable - no forbidden-path, denial, or permission fallback behavior changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no event, websocket channel, chat, queue, or realtime channel changed.
- Payload version / ack behavior: not applicable - no notification payload, ack, or event version changed.
- Read/unread or delivery semantics: not applicable - dashboard notification control label changed only; delivery and read/unread state are untouched.
- Reconnect/resync proof: not applicable - no reconnect, resync, subscription, or websocket recovery logic changed.

## Frontend Resilience
- Empty data proof: not applicable - button labels do not read, fetch, or reshape empty data states.
- Partial data proof: not applicable - no partial-data rendering branch changed.
- Forbidden secondary path behavior: not applicable - no secondary or forbidden fallback path changed.
- Missing draft/resource behavior: not applicable - no draft/resource create, reopen, or missing-resource path changed.
- Stale route/deep-link behavior: not applicable - no route state, params, redirect, or deep-link behavior changed.

## Scope Gate
- Allowed paths: `frontend/src/components/TelegramManager.jsx`, `frontend/src/components/admin/UserManagement.jsx`, `frontend/src/components/dashboard/Dashboard.jsx`, `frontend/src/components/dental/ToothModal.jsx`, `frontend/src/components/dental/TreatmentPlanner.jsx`
- Denied paths: backend runtime, migrations, routing, RBAC, API clients, generated artifacts, broad UI migration, unrelated frontend cleanup
- Migration/docs/test impact: no migration; no docs or test files changed; PR body updated only to satisfy the review metadata gate.
- Rollback note: revert the single PR commit or remove the added `aria-label` and `title` props; no data or schema rollback required.

## Validation
- Targeted tests or smoke run: local PR review gate validation for this exact body; GitHub CI on PR #771 includes frontend lint, frontend unit tests, frontend build, PR Required Gate, CodeQL, and GitGuardian.
- Result: local body validation passed before updating GitHub; GitHub frontend lint, frontend unit tests, frontend build, PR Required Gate, CodeQL, and GitGuardian passed on the PR.
- Not checked: manual browser smoke not run; frontend e2e skipped by workflow; backend tests skipped because no backend code changed.

## Follow-ups
- Consider a later narrow pass to make repeated delete labels object-specific, such as deleting a dental procedure vs deleting a treatment stage, if screen-reader ambiguity appears in real workflow testing.
