### PR TITLE
feat(telegram): publish staff link token validation

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -200,6 +200,35 @@ STAFF_BOT_LINKING_RUNTIME_CONTRACT = {
     "state_changing_actions_allowed_after_link": False,
 }
 
+STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT = {
+    "contract_version": "staff-link-token-validation-v1",
+    "enabled": False,
+    "validator_enabled": False,
+    "token_storage_enabled": False,
+    "handler_enabled": False,
+    "required_before_enablement": True,
+    "token_properties": [
+        "signed",
+        "single_use",
+        "expires_at",
+        "bound_to_application_user_id",
+        "bound_to_telegram_chat_id",
+    ],
+    "rejection_reasons": [
+        "expired",
+        "signature_invalid",
+        "already_used",
+        "staff_user_inactive",
+        "role_not_allowed",
+        "telegram_account_already_linked",
+    ],
+    "required_audit_events": [
+        "staff_link_token_issued",
+        "staff_link_token_consumed",
+        "staff_link_token_rejected",
+    ],
+}
+
 STAFF_BOT_AUTHORIZATION_CONTRACT = {
     "contract_version": "staff-authorization-v1",
     "enabled": False,
@@ -487,6 +516,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         "token_contract": STAFF_BOT_TOKEN_CONTRACT,
         "linking_contract": STAFF_BOT_LINKING_CONTRACT,
         "linking_runtime_contract": STAFF_BOT_LINKING_RUNTIME_CONTRACT,
+        "link_token_validation_contract": STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT,
         "authorization_contract": STAFF_BOT_AUTHORIZATION_CONTRACT,
         "command_registration_contract": STAFF_BOT_COMMAND_REGISTRATION_CONTRACT,
         "confirmation_contract": STAFF_BOT_CONFIRMATION_CONTRACT,
@@ -508,7 +538,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         ),
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
-        "next_slice": "staff_role_linking_token_validation",
+        "next_slice": "staff_link_token_validation_runtime",
     }
 
 
@@ -963,6 +993,7 @@ def get_telegram_integration_status(
                 "staff_role_menu_enablement_status",
                 "staff_role_linking_contract",
                 "staff_role_linking_runtime",
+                "staff_link_token_validation_contract",
                 "staff_server_side_authorization_contract",
                 "staff_command_registration_contract",
                 "staff_state_change_confirmation_contract",

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -191,6 +191,7 @@ const TelegramManager = () => {
   map((method) => method?.label || method?.key || method).
   filter(Boolean);
   const staffLinkingRuntimeContract = staffBot.linking_runtime_contract || {};
+  const staffLinkTokenValidationContract = staffBot.link_token_validation_contract || {};
   const staffAuthorizationContract = staffBot.authorization_contract || staffBot.authorization || {};
   const staffAuthorizationRoles = Array.isArray(staffAuthorizationContract.role_checks) ?
   staffAuthorizationContract.role_checks :
@@ -443,6 +444,23 @@ const TelegramManager = () => {
                     size="small">
 
                     {staffLinkingRuntimeContract.helper_available ? 'Helper' : 'Planned'}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <CheckCircle />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff link token validation"
+                    secondary={staffLinkTokenValidationContract.contract_version ?
+                    `${staffLinkTokenValidationContract.token_properties?.length || 0} token checks; validator: ${staffLinkTokenValidationContract.validator_enabled ? 'enabled' : 'disabled'}` :
+                    'Staff link token validation contract not published'} />
+
+                  <Badge
+                    variant={staffLinkTokenValidationContract.validator_enabled ? 'success' : 'warning'}
+                    size="small">
+
+                    {staffLinkTokenValidationContract.required_before_enablement ? 'Required' : 'Planned'}
                   </Badge>
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
## Summary
- Publishes a staff link token validation contract for the Telegram staff bot plan.
- Keeps validation, token storage, and webhook handlers disabled while documenting required signed single-use token properties.
- Adds a Telegram manager status row for Admin visibility into the token validation gate.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/status` staff_bot metadata from `backend/app/api/v1/endpoints/admin_telegram.py`.
- Request shape: unchanged; no new endpoint, webhook callback, command, query, or request body is introduced.
- Response shape: adds `staff_bot.link_token_validation_contract` with version, disabled flags, required token properties, rejection reasons, and audit events.
- Status codes: unchanged; existing admin Telegram status HTTP behavior remains the same.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads `staffBot.link_token_validation_contract` defensively and shows validator status.
- Compatibility path or alias: existing `staff_bot.linking_contract`, `staff_bot.linking_runtime_contract`, and staff menu fields remain unchanged.
- Contract proof: py_compile passed for Telegram endpoints and frontend production build passed.

## RBAC / Permissions
- Roles allowed: unchanged; this PR enables no staff linking command or token validator.
- Roles denied: unchanged; unauthorized staff linking remains impossible through Telegram because no handler or validator runtime is added.
- Positive auth proof: contract declares required properties and audit events before enablement, but runtime remains disabled in this slice.
- Negative auth proof: `handler_enabled=false`, `validator_enabled=false`, and `token_storage_enabled=false`; no Telegram payload can consume a staff link token through this PR.

## Notification / Realtime
- Event type or websocket channel: not applicable because this PR emits no Telegram messages, websocket events, or notification records.
- Payload version / ack behavior: not applicable because the token validation contract has no delivery/ack payload.
- Read/unread or delivery semantics: not applicable because no notification state is created or updated.
- Reconnect/resync proof: not applicable because no realtime stream or resync behavior changes.

## Frontend Resilience
- Empty data proof: UI falls back to `Staff link token validation contract not published` when the object is absent.
- Partial data proof: UI falls back to zero token checks and disabled validator state when optional fields are missing.
- Forbidden secondary path behavior: unchanged; no secondary route or staff action is added.
- Missing draft/resource behavior: unchanged; no draft/resource fetch is introduced.
- Stale route/deep-link behavior: unchanged; TelegramManager route semantics are not modified.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `frontend/src/components/TelegramManager.jsx`.
- Denied paths: Telegram webhook handlers, token persistence, migrations, CRUD runtime, command registration runtime, and unrelated UI screens were not changed.
- Migration/docs/test impact: no migration required; contract-only status metadata and UI row.
- Rollback note: revert this commit to remove the token validation contract and Admin status row.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend; npm.cmd run build`.
- Result: passed; Vite repeated existing mixed import and chunk-size warnings.
- Not checked: full backend suite, browser smoke, and live Telegram staff linking because this PR intentionally enables no runtime validator or handler.