### PR TITLE
feat(telegram): extend staff token storage and settings contracts

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -207,18 +207,55 @@ STAFF_BOT_LINKING_RUNTIME_CONTRACT = {
     "state_changing_actions_allowed_after_link": False,
 }
 
+STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT = {
+    "contract_version": "staff-link-token-storage-v1",
+    "enabled": False,
+    "migration_created": False,
+    "runtime_write_enabled": False,
+    "table": "telegram_staff_link_tokens",
+    "raw_token_storage_allowed": False,
+    "columns": [
+        "id",
+        "token_hash",
+        "staff_user_id",
+        "telegram_chat_id",
+        "expires_at",
+        "consumed_at",
+        "issued_by_user_id",
+        "created_at",
+        "request_id",
+    ],
+    "required_indexes": [
+        "unique(token_hash)",
+        "index(staff_user_id)",
+        "index(telegram_chat_id)",
+        "partial_index(expires_at) where consumed_at is null",
+    ],
+    "required_constraints": [
+        "expires_at > created_at",
+        "consumed_at is null or consumed_at <= expires_at",
+        "staff_user_id references users(id)",
+    ],
+    "retention_policy": {
+        "expired_token_ttl_days": 7,
+        "consumed_token_ttl_days": 30,
+    },
+}
+
 STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT = {
     "contract_version": "staff-link-token-validation-v1",
     "enabled": False,
-    "validator_enabled": False,
+    "validator_enabled": True,
     "runtime_helper_available": True,
     "signature_validator_available": True,
     "expiry_validator_available": True,
     "binding_parser_available": True,
+    "stateless_validator_enabled": True,
     "single_use_enforcement_enabled": False,
     "token_storage_enabled": False,
     "handler_enabled": False,
     "storage_migration_required": True,
+    "storage_contract": STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT,
     "runtime_blocked_by": [
         "staff_link_token_storage_migration",
         "staff_link_token_validator_service",
@@ -227,6 +264,7 @@ STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT = {
     "token_format": "stl_<user_id>_<chat_id>_<expires_at>_<nonce>_<signature>",
     "builder": "build_staff_link_start_token",
     "parser": "parse_staff_link_start_token",
+    "validator": "validate_staff_link_start_token",
     "token_hash_prefix": STAFF_LINK_TOKEN_HASH_PREFIX,
     "token_properties": [
         "signed",
@@ -242,6 +280,7 @@ STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT = {
         "staff_user_inactive",
         "role_not_allowed",
         "telegram_account_already_linked",
+        "staff_user_already_linked",
     ],
     "required_audit_events": [
         "staff_link_token_issued",
@@ -571,6 +610,89 @@ def parse_staff_link_start_token(token: str) -> Dict[str, Any] | None:
     }
 
 
+def _normalize_staff_role(role: Any) -> str:
+    role_key = str(role or "").strip().lower().replace("-", "_").replace(" ", "_")
+    role_aliases = {
+        "administrator": "admin",
+        "admin": "admin",
+        "owner": "owner",
+        "doctor": "doctor",
+        "cashier": "cashier",
+        "lab": "lab",
+        "lab_tech": "lab",
+        "laboratory": "lab",
+        "registrar": "registrar",
+        "receptionist": "registrar",
+    }
+    return role_aliases.get(role_key, role_key)
+
+
+def validate_staff_link_start_token(
+    db: Session, token: str, telegram_chat_id: int
+) -> Dict[str, Any]:
+    parsed = parse_staff_link_start_token(token)
+    if not parsed:
+        return {"valid": False, "reason": "signature_invalid"}
+
+    if int(parsed["chat_id"]) != int(telegram_chat_id):
+        return {
+            "valid": False,
+            "reason": "chat_mismatch",
+            "token_hash": parsed["token_hash"],
+        }
+
+    user = db.query(User).filter(User.id == parsed["user_id"]).first()
+    if not user or not user.is_active:
+        return {
+            "valid": False,
+            "reason": "staff_user_inactive",
+            "token_hash": parsed["token_hash"],
+        }
+
+    role_key = _normalize_staff_role(user.role)
+    if role_key not in STAFF_BOT_SUPPORTED_ROLES:
+        return {
+            "valid": False,
+            "reason": "role_not_allowed",
+            "role": role_key,
+            "token_hash": parsed["token_hash"],
+        }
+
+    telegram_user = crud_telegram.get_telegram_user_by_chat_id(
+        db, int(parsed["chat_id"])
+    )
+    linked_user_id = getattr(telegram_user, "user_id", None)
+    if linked_user_id and int(linked_user_id) != int(user.id):
+        return {
+            "valid": False,
+            "reason": "telegram_account_already_linked",
+            "token_hash": parsed["token_hash"],
+        }
+
+    linked_telegram_user = crud_telegram.get_telegram_user_by_linked_user_id(
+        db, int(user.id)
+    )
+    linked_chat_id = getattr(linked_telegram_user, "chat_id", None)
+    if linked_chat_id and int(linked_chat_id) != int(parsed["chat_id"]):
+        return {
+            "valid": False,
+            "reason": "staff_user_already_linked",
+            "token_hash": parsed["token_hash"],
+        }
+
+    logger.info("Staff Telegram link token validated role=%s", role_key)
+    return {
+        "valid": True,
+        "reason": "ok",
+        "token_hash": parsed["token_hash"],
+        "user_id": int(user.id),
+        "chat_id": int(parsed["chat_id"]),
+        "role": role_key,
+        "expires_at": parsed["expires_at"].isoformat(),
+        "single_use_enforced": False,
+    }
+
+
 def _build_staff_role_menus_summary() -> Dict[str, Any]:
     menu_roles = [
         role_menu["role"] for role_menu in STAFF_BOT_READ_ONLY_MENU_CONTRACT
@@ -632,6 +754,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         "linking_contract": STAFF_BOT_LINKING_CONTRACT,
         "linking_runtime_contract": STAFF_BOT_LINKING_RUNTIME_CONTRACT,
         "link_token_validation_contract": STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT,
+        "link_token_storage_contract": STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT,
         "authorization_contract": STAFF_BOT_AUTHORIZATION_CONTRACT,
         "command_registration_contract": STAFF_BOT_COMMAND_REGISTRATION_CONTRACT,
         "confirmation_contract": STAFF_BOT_CONFIRMATION_CONTRACT,
@@ -1100,6 +1223,7 @@ def get_telegram_integration_status(
                 "patient_queue",
                 "patient_payments_debt",
                 "patient_status",
+                "patient_language_notification_settings",
                 "lab_results_pdf",
             ],
             "planned_functions": [
@@ -1110,6 +1234,7 @@ def get_telegram_integration_status(
                 "staff_role_linking_runtime",
                 "staff_link_token_validation_contract",
                 "staff_link_token_validation_runtime_helper",
+                "staff_link_token_storage_migration_contract",
                 "staff_server_side_authorization_contract",
                 "staff_command_registration_contract",
                 "staff_state_change_confirmation_contract",
@@ -1133,6 +1258,7 @@ def get_telegram_integration_status(
                     {"command": "/payments", "label": "Оплаты и долг"},
                     {"command": "/results", "label": "PDF-результаты"},
                     {"command": "/profile", "label": "Мой статус"},
+                    {"command": "/settings", "label": "Язык и уведомления"},
                     {"command": "/help", "label": "Помощь"},
                 ],
                 "features": [
@@ -1159,6 +1285,11 @@ def get_telegram_integration_status(
                     {
                         "key": "lab_results_pdf",
                         "label": "PDF-результаты лаборатории",
+                        "enabled": bool(bot_token),
+                    },
+                    {
+                        "key": "patient_language_notification_settings",
+                        "label": "Настройки языка и уведомлений",
                         "enabled": bool(bot_token),
                     },
                 ],

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -70,7 +70,7 @@ TELEGRAM_MAIN_MENU = {
         [{"text": "Поделиться номером", "request_contact": True}],
         [{"text": "Моя очередь"}, {"text": "Оплаты и долг"}],
         [{"text": "Мой статус"}, {"text": "Результаты"}],
-        [{"text": "Помощь"}],
+        [{"text": "Настройки"}, {"text": "Помощь"}],
     ],
     "resize_keyboard": True,
     "one_time_keyboard": False,
@@ -101,7 +101,27 @@ TELEGRAM_MAIN_MENUS = {
             [{"text": "Telefon raqamni ulashish", "request_contact": True}],
             [{"text": "Mening navbatim"}, {"text": "To'lovlar va qarz"}],
             [{"text": "Mening holatim"}, {"text": "Natijalar"}],
-            [{"text": "Yordam"}],
+            [{"text": "Sozlamalar"}, {"text": "Yordam"}],
+        ],
+        "resize_keyboard": True,
+        "one_time_keyboard": False,
+    },
+}
+TELEGRAM_SETTINGS_MENUS = {
+    TELEGRAM_LANGUAGE_RU: {
+        "keyboard": [
+            [{"text": "Русский"}, {"text": "O'zbekcha"}],
+            [{"text": "Разрешить уведомления"}, {"text": "Без уведомлений"}],
+            [{"text": "Моя очередь"}, {"text": "Помощь"}],
+        ],
+        "resize_keyboard": True,
+        "one_time_keyboard": False,
+    },
+    TELEGRAM_LANGUAGE_UZ: {
+        "keyboard": [
+            [{"text": "Русский"}, {"text": "O'zbekcha"}],
+            [{"text": "Xabarnomalarga roziman"}, {"text": "Xabarnomasiz"}],
+            [{"text": "Mening navbatim"}, {"text": "Yordam"}],
         ],
         "resize_keyboard": True,
         "one_time_keyboard": False,
@@ -203,6 +223,7 @@ TELEGRAM_LOCALIZED_TEXTS = {
             "/queue - моя очередь\n"
             "/payments - оплаты и долг\n"
             "/profile - статус привязки\n"
+            "/settings - язык и уведомления\n"
             "/results - получить готовые PDF-результаты\n\n"
             "Для привязки можно отсканировать QR с чека или нажать "
             "\"Поделиться номером\"."
@@ -213,9 +234,18 @@ TELEGRAM_LOCALIZED_TEXTS = {
             "/queue - mening navbatim\n"
             "/payments - to'lovlar va qarz\n"
             "/profile - bog'lanish holati\n"
+            "/settings - til va xabarnomalar\n"
             "/results - tayyor PDF natijalarni olish\n\n"
             "Bog'lash uchun chekdagi QR kodni skaner qiling yoki "
             "\"Telefon raqamni ulashish\" tugmasini bosing."
+        ),
+    },
+    "settings": {
+        TELEGRAM_LANGUAGE_RU: (
+            "Настройки Telegram: выберите язык обслуживания или режим уведомлений."
+        ),
+        TELEGRAM_LANGUAGE_UZ: (
+            "Telegram sozlamalari: xizmat tilini yoki xabarnoma rejimini tanlang."
         ),
     },
     "lab_results_empty": {
@@ -478,6 +508,13 @@ def _localized_notification_consent_menu(language_code: Any) -> Dict[str, Any]:
     return TELEGRAM_NOTIFICATION_CONSENT_MENUS.get(
         _normalize_patient_language(language_code),
         TELEGRAM_NOTIFICATION_CONSENT_MENUS[TELEGRAM_LANGUAGE_RU],
+    )
+
+
+def _localized_settings_menu(language_code: Any) -> Dict[str, Any]:
+    return TELEGRAM_SETTINGS_MENUS.get(
+        _normalize_patient_language(language_code),
+        TELEGRAM_SETTINGS_MENUS[TELEGRAM_LANGUAGE_RU],
     )
 
 
@@ -1283,6 +1320,14 @@ async def _handle_clinic_bot_update(
             _localized_main_menu(language),
         )
 
+    async def settings_handler(chat_id: int) -> None:
+        language = _telegram_chat_language(db, chat_id)
+        await bot_service._send_message(
+            chat_id,
+            _localized_text("settings", language),
+            _localized_settings_menu(language),
+        )
+
     async def queue_handler(chat_id: int) -> None:
         await bot_service._send_message(
             chat_id, _clinic_queue_message(db, chat_id), _telegram_chat_menu(db, chat_id)
@@ -1326,9 +1371,11 @@ async def _handle_clinic_bot_update(
         "/payments": payments_handler,
         "/profile": profile_handler,
         "/results": results_handler,
+        "/settings": settings_handler,
     }
     text_handlers = {
         "помощь": help_handler,
+        "настройки": settings_handler,
         "моя очередь": queue_handler,
         "оплаты и долг": payments_handler,
         "мой статус": profile_handler,
@@ -1343,6 +1390,7 @@ async def _handle_clinic_bot_update(
         "xabarnomalarga roziman": enable_notifications_handler,
         "xabarnomasiz": disable_notifications_handler,
         "yordam": help_handler,
+        "sozlamalar": settings_handler,
         "mening navbatim": queue_handler,
         "to'lovlar va qarz": payments_handler,
         "mening holatim": profile_handler,

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -192,6 +192,8 @@ const TelegramManager = () => {
   filter(Boolean);
   const staffLinkingRuntimeContract = staffBot.linking_runtime_contract || {};
   const staffLinkTokenValidationContract = staffBot.link_token_validation_contract || {};
+  const staffLinkTokenStorageContract =
+  staffBot.link_token_storage_contract || staffLinkTokenValidationContract.storage_contract || {};
   const staffAuthorizationContract = staffBot.authorization_contract || staffBot.authorization || {};
   const staffAuthorizationRoles = Array.isArray(staffAuthorizationContract.role_checks) ?
   staffAuthorizationContract.role_checks :
@@ -461,6 +463,23 @@ const TelegramManager = () => {
                     size="small">
 
                     {staffLinkTokenValidationContract.runtime_helper_available ? 'Helper' : 'Planned'}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <CheckCircle />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff link token storage"
+                    secondary={staffLinkTokenStorageContract.contract_version ?
+                    `${staffLinkTokenStorageContract.table || 'token table'}; indexes: ${staffLinkTokenStorageContract.required_indexes?.length || 0}; migration: ${staffLinkTokenStorageContract.migration_created ? 'created' : 'required'}` :
+                    'Staff link token storage contract not published'} />
+
+                  <Badge
+                    variant={staffLinkTokenStorageContract.migration_created ? 'success' : 'warning'}
+                    size="small">
+
+                    {staffLinkTokenStorageContract.runtime_write_enabled ? 'Writes' : 'Planned'}
                   </Badge>
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
## Summary
- publish the planned staff link token storage contract in the Telegram admin status payload while runtime writes stay disabled
- add a stateless staff link token validator for signed, chat-bound staff tokens without enabling staff handlers or single-use storage enforcement
- expose patient `/settings` for language and notification controls in Russian and Uzbek Latin menus/status
- show the staff token storage contract in the Telegram manager UI

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/integration-status`, `staff_bot.link_token_storage_contract`, `staff_bot.link_token_validation_contract.storage_contract`, and existing Telegram webhook text command handling for `/settings`.
- Request shape: no admin API request shape changes; Telegram webhook keeps the existing update payload and now recognizes `/settings`, `Настройки`, and `Sozlamalar` text.
- Response shape: status payload adds a disabled storage contract object, validator metadata, and patient settings command/feature metadata.
- Status codes: no API status code changes; webhook success/error behavior is unchanged.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads the optional storage contract with fallbacks.
- Compatibility path or alias: existing `link_token_validation_contract` consumers keep current fields; storage metadata is also nested under `storage_contract` for compatibility.
- Contract proof: local `py_compile`, `git diff --check`, and frontend Vite build completed before opening this PR.

## RBAC / Permissions
- Roles allowed: staff token validation only recognizes configured staff roles (`admin`, `owner`, `doctor`, `cashier`, `lab`, `registrar`) and does not enable staff bot actions.
- Roles denied: inactive users, unsupported roles, mismatched chats, and already-linked conflicting Telegram/application users return rejection reasons.
- Positive auth proof: validator checks signature/expiry through the parser, then active user, normalized role, chat binding, and link conflicts before returning `valid: true`.
- Negative auth proof: validator returns explicit failure reasons such as `signature_invalid`, `chat_mismatch`, `staff_user_inactive`, `role_not_allowed`, `telegram_account_already_linked`, and `staff_user_already_linked`; runtime writes remain disabled.

## Notification / Realtime
- Event type or websocket channel: Telegram patient bot text commands only; no WebSocket or realtime channel changes.
- Payload version / ack behavior: Telegram webhook payload version is unchanged; `/settings` replies with the existing keyboard-message pattern.
- Read/unread or delivery semantics: no read/unread semantics are introduced; notification consent buttons reuse existing handlers.
- Reconnect/resync proof: integration status remains deterministic and the settings command is published in the status command list for UI/admin resync.

## Frontend Resilience
- Empty data proof: UI falls back to “Staff link token storage contract not published” when contract metadata is absent.
- Partial data proof: optional chaining/default objects keep the panel rendering when table/index fields are missing.
- Forbidden secondary path behavior: storage writes and staff handlers are still marked disabled/planned, so the UI exposes status only, not a state-changing action.
- Missing draft/resource behavior: `migration_created: false` renders as `Planned`/`required` instead of implying a usable table.
- Stale route/deep-link behavior: no frontend route changes or deep-link behavior changes.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/app/api/v1/endpoints/telegram_webhook.py`, `frontend/src/components/TelegramManager.jsx`.
- Denied paths: Alembic migrations, SQLAlchemy models, CRUD persistence, token storage writes, staff webhook token consumption, and broad Telegram routing refactors.
- Migration/docs/test impact: no migration is created in this PR; docs are not changed; validation is local compile/build plus CI.
- Rollback note: reverting this PR removes only status metadata, stateless validation helper exposure, patient settings menu entries, and the UI status row; no database data is written.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `git diff --check`; `cd frontend; npm.cmd run build`.
- Result: passed locally; Vite reported existing chunk-size and mixed dynamic/static import warnings for `errorHandler.js`.
- Not checked: Alembic migration, database persistence, single-use token consumption, live Telegram Bot API delivery, and full browser E2E.