### PR TITLE
fix(telegram): distinguish expired staff link tokens

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -580,14 +580,16 @@ def build_staff_link_start_token(
     return f"{body}{STAFF_LINK_TOKEN_SEPARATOR}{signature}"
 
 
-def parse_staff_link_start_token(token: str) -> Dict[str, Any] | None:
+def _decode_staff_link_start_token(
+    token: str,
+) -> tuple[Dict[str, Any] | None, str | None]:
     parts = (token or "").split(STAFF_LINK_TOKEN_SEPARATOR)
     if len(parts) != 6 or parts[0] != STAFF_LINK_TOKEN_PREFIX:
-        return None
+        return None, "signature_invalid"
 
     body = STAFF_LINK_TOKEN_SEPARATOR.join(parts[:5])
     if not hmac.compare_digest(parts[5], _staff_link_token_signature(body)):
-        return None
+        return None, "signature_invalid"
 
     try:
         user_id = int(parts[1])
@@ -597,17 +599,27 @@ def parse_staff_link_start_token(token: str) -> Dict[str, Any] | None:
             tz=timezone.utc,
         )
     except (TypeError, ValueError, OverflowError, OSError):
-        return None
+        return None, "signature_invalid"
 
-    if user_id <= 0 or chat_id == 0 or expires_at < datetime.now(timezone.utc):
-        return None
+    if user_id <= 0 or chat_id == 0:
+        return None, "signature_invalid"
 
-    return {
+    decoded = {
         "user_id": user_id,
         "chat_id": chat_id,
         "expires_at": expires_at.replace(tzinfo=None),
         "token_hash": _hash_staff_link_start_token(token),
     }
+    if expires_at < datetime.now(timezone.utc):
+        return decoded, "expired"
+    return decoded, None
+
+
+def parse_staff_link_start_token(token: str) -> Dict[str, Any] | None:
+    decoded, rejection_reason = _decode_staff_link_start_token(token)
+    if rejection_reason:
+        return None
+    return decoded
 
 
 def _normalize_staff_role(role: Any) -> str:
@@ -630,9 +642,16 @@ def _normalize_staff_role(role: Any) -> str:
 def validate_staff_link_start_token(
     db: Session, token: str, telegram_chat_id: int
 ) -> Dict[str, Any]:
-    parsed = parse_staff_link_start_token(token)
+    parsed, rejection_reason = _decode_staff_link_start_token(token)
     if not parsed:
-        return {"valid": False, "reason": "signature_invalid"}
+        return {"valid": False, "reason": rejection_reason or "signature_invalid"}
+
+    if rejection_reason == "expired":
+        return {
+            "valid": False,
+            "reason": "expired",
+            "token_hash": parsed["token_hash"],
+        }
 
     if int(parsed["chat_id"]) != int(telegram_chat_id):
         return {


### PR DESCRIPTION
## Summary
- split staff link token decoding from public parsing so expired signed tokens can keep their token hash for rejection auditing
- return `expired` separately from `signature_invalid` in `validate_staff_link_start_token`
- keep `parse_staff_link_start_token` compatibility unchanged by returning `None` for expired/invalid tokens

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/admin_telegram.py` staff link token helper contract.
- Request shape: no request body, path, query, or Telegram webhook input shape changes.
- Response shape: validator rejection reason can now be `expired` for well-formed expired tokens; public parser return shape remains unchanged.
- Status codes: no API status code changes.
- Frontend consumer: none changed; frontend build was run to keep the admin bundle contract checked.
- Compatibility path or alias: `parse_staff_link_start_token` still returns `None` for expired or invalid tokens, preserving existing callers.
- Contract proof: local `py_compile`, `git diff --check`, and frontend Vite build passed before PR creation.

## RBAC / Permissions
- Roles allowed: unchanged; existing validator role checks still apply only after signature/expiry/chat parsing.
- Roles denied: unchanged for unsupported/inactive users and conflicting Telegram/application links.
- Positive auth proof: a non-expired signed token still flows through the same active-user, role, and link-conflict checks.
- Negative auth proof: expired signed tokens now return `expired`; malformed or bad-signature tokens still return `signature_invalid`; no runtime write is introduced.

## Notification / Realtime
- Event type or websocket channel: not applicable because this PR only changes local token validation helper behavior.
- Payload version / ack behavior: Telegram webhook payload and ack behavior are unchanged.
- Read/unread or delivery semantics: no notification delivery/read state is changed.
- Reconnect/resync proof: no subscription, polling, or resync behavior is changed.

## Frontend Resilience
- Empty data proof: no frontend data path is changed.
- Partial data proof: no frontend data path is changed.
- Forbidden secondary path behavior: staff runtime writes and handlers remain disabled.
- Missing draft/resource behavior: token storage/migration remains planned, not consumed.
- Stale route/deep-link behavior: no route or deep-link behavior is changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`.
- Denied paths: token storage writes, Alembic migrations, SQLAlchemy models, CRUD, webhook token consumption, frontend UI changes, and broad Telegram routing changes.
- Migration/docs/test impact: no migration or docs change; validation is compile/build plus CI.
- Rollback note: reverting this PR restores the previous behavior where expired signed tokens are reported through the generic invalid parse path.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd frontend; npm.cmd run build`.
- Result: passed locally; Vite reported existing chunk-size and mixed dynamic/static import warnings for `errorHandler.js`.
- Not checked: live Telegram Bot API, database persistence, single-use token consumption, and browser E2E.