### PR TITLE
feat(telegram): add staff link token model shape

### DIFF
--- a/backend/app/models/telegram_config.py
+++ b/backend/app/models/telegram_config.py
@@ -8,14 +8,17 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
+    CheckConstraint,
     JSON,
     BigInteger,
     Boolean,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
+    text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
@@ -144,6 +147,72 @@ class TelegramUser(Base):
     # Relationships
     patient: Mapped[Patient | None] = relationship("Patient", foreign_keys=[patient_id])
     user: Mapped[User | None] = relationship("User", foreign_keys=[user_id])
+
+
+class TelegramStaffLinkToken(Base):
+    """Hash-only storage shape for one-time staff Telegram link tokens."""
+
+    __tablename__ = "telegram_staff_link_tokens"
+    __table_args__ = (
+        CheckConstraint(
+            "expires_at > created_at",
+            name="ck_telegram_staff_link_tokens_expires_after_created",
+        ),
+        CheckConstraint(
+            "consumed_at IS NULL OR consumed_at <= expires_at",
+            name="ck_telegram_staff_link_tokens_consumed_before_expiry",
+        ),
+        Index(
+            "ix_telegram_staff_link_tokens_staff_user_id",
+            "staff_user_id",
+        ),
+        Index(
+            "ix_telegram_staff_link_tokens_telegram_chat_id",
+            "telegram_chat_id",
+        ),
+        Index(
+            "ix_telegram_staff_link_tokens_unconsumed_expires",
+            "expires_at",
+            postgresql_where=text("consumed_at IS NULL"),
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    token_hash: Mapped[str] = mapped_column(
+        String(96), unique=True, nullable=False, index=True
+    )
+    staff_user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    telegram_chat_id: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    consumed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    issued_by_user_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )
+    request_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    staff_user: Mapped[User] = relationship("User", foreign_keys=[staff_user_id])
+    issued_by: Mapped[User | None] = relationship(
+        "User", foreign_keys=[issued_by_user_id]
+    )
 
 
 class TelegramMessage(Base):


### PR DESCRIPTION
## Summary
- add the canonical SQLAlchemy model shape for hash-only staff Telegram link tokens
- model the planned storage contract fields: `token_hash`, `staff_user_id`, `telegram_chat_id`, `expires_at`, `consumed_at`, `issued_by_user_id`, `created_at`, and `request_id`
- define model-level indexes and constraints for token uniqueness, staff/chat lookup, unconsumed expiry cleanup, and expiry/consumption ordering

## Contract Impact
- Canonical surface: `backend/app/models/telegram_config.py` SQLAlchemy metadata for the planned `telegram_staff_link_tokens` table.
- Request shape: no API, webhook, or frontend request shape changes.
- Response shape: no API response shape changes in this PR.
- Status codes: no API status code changes.
- Frontend consumer: none changed.
- Compatibility path or alias: existing Telegram models remain in the same canonical module; no legacy `backend/app/models/telegram.py` path is touched.
- Contract proof: model import smoke prints `telegram_staff_link_tokens`, and local compile/build checks passed.

## RBAC / Permissions
- Roles allowed: no runtime authorization path is changed.
- Roles denied: no runtime authorization path is changed.
- Positive auth proof: model uses `staff_user_id` referencing `users.id` for the future staff-owner check, but no staff action is enabled.
- Negative auth proof: no token issuance, consumption, or write path is added; runtime deny/disabled behavior remains unchanged.

## Notification / Realtime
- Event type or websocket channel: no notification, WebSocket, or Telegram delivery behavior is changed.
- Payload version / ack behavior: not changed because this PR only adds ORM metadata.
- Read/unread or delivery semantics: not changed.
- Reconnect/resync proof: no realtime subscription or resync path is changed.

## Frontend Resilience
- Empty data proof: no frontend data path is changed.
- Partial data proof: no frontend data path is changed.
- Forbidden secondary path behavior: staff token storage writes remain disabled until a separate migration/service PR.
- Missing draft/resource behavior: no table is created yet; callers still must treat storage as planned.
- Stale route/deep-link behavior: no route or deep-link behavior is changed.

## Scope Gate
- Allowed paths: `backend/app/models/telegram_config.py`.
- Denied paths: Alembic migrations, CRUD/service writes, webhook token consumption, admin status/UI changes, Docker/runtime entrypoints, and legacy `backend/app/models/telegram.py`.
- Migration/docs/test impact: no Alembic migration is created; docs are not changed; validation is compile/import/build plus CI.
- Rollback note: reverting this PR removes only the unused ORM model metadata; no database table or data exists from this PR alone.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/app/models/telegram_config.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd backend; python -c "from app.models.telegram_config import TelegramStaffLinkToken; print(TelegramStaffLinkToken.__tablename__)"`; `cd frontend; npm.cmd run build`.
- Result: passed locally; import smoke printed `telegram_staff_link_tokens`; Vite reported existing chunk-size and mixed dynamic/static import warnings for `errorHandler.js`.
- Not checked: Alembic migration/table creation, database persistence, token issuance/consumption, live Telegram Bot API, and browser E2E.
