### PR TITLE
docs(ai): record telegram migration gate misroute

### DIFF
--- a/ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md
+++ b/ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md
@@ -3341,3 +3341,42 @@ Continue recovery through `/aif-implement @.ai-factory/PLAN.md`, Task 25: prove 
 - current stack sufficient: partial
 - would LightRAG likely help here: yes
 - Better retrieval should connect Alembic proof tasks to `backend/alembic/env.py`, migration revision files, testing/deployment docs, and local contour blockers.
+
+## Task 94 - Telegram staff link token migration gate misroute
+
+### User task
+Continue the Telegram bot implementation loop and close the storage gap after the
+`TelegramStaffLinkToken` model shape landed on `main`.
+
+### Gate result
+- mode: execute
+- handoff required: yes
+- handoff used: yes, with narrow override
+- gate_misroute: yes
+- override_used: yes
+- known_root_cause_file: backend/app/models/telegram_config.py
+
+### What handoff solved well
+- It preserved the rule that Telegram integration and database ownership are risky domains.
+- It stopped runtime handler/storage-write enablement while staff token storage is incomplete.
+
+### Missing relationship mapping
+- The gate mapped a missing Alembic migration task to Docker/runtime packaging files.
+- The known-root-cause retry included the SQLAlchemy model but still omitted the required new migration file under `backend/alembic/versions/`.
+- This left the model shape on `main` without an approved migration patch path.
+
+### Manual reconstruction needed
+- Manually inspected `backend/app/models/telegram_config.py`, `backend/alembic/versions/0024_tg_user_lang_bcp47.py`, and `origin/main` history.
+- Manually confirmed the next safe slice should create `0025_telegram_staff_link_tokens.py` after revision `0024_tg_user_lang_bcp47`.
+
+### Signals observed
+- multi-hop gap: yes
+- ownership ambiguity: yes
+- manual graph reconstruction: yes
+- gate_misroute: yes
+- override_used: yes
+
+### Short verdict
+- current stack sufficient: no for this schema slice
+- would LightRAG likely help here: yes
+- Better retrieval should connect new SQLAlchemy table models to Alembic migration creation, revision chain ownership, and migration validation targets.


### PR DESCRIPTION
## Summary
- Record the Telegram staff link token migration gate misroute in the LightRAG/dev-brain evidence log.
- Capture that the model shape landed on `main` while the gate still omitted the required Alembic migration path.
- Preserve the next safe slice recommendation: create `0025_telegram_staff_link_tokens.py` after `0024_tg_user_lang_bcp47`.

## Contract Impact

- Canonical surface: dev-brain evidence document only.
- Request shape: not applicable, no runtime request shape changed.
- Response shape: not applicable, no runtime response shape changed.
- Status codes: not applicable, no endpoint behavior changed.
- Frontend consumer: not applicable, no frontend consumer changed.
- Compatibility path or alias: not applicable, no compatibility route or alias changed.
- Contract proof: documentation diff only; no runtime contract changed.

## RBAC / Permissions

- Roles allowed: not applicable, no permission behavior changed.
- Roles denied: not applicable, no permission behavior changed.
- Positive auth proof: not applicable, docs-only evidence update.
- Negative auth proof: not applicable, docs-only evidence update.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no frontend rendering changed.
- Partial data proof: not applicable, no frontend data path changed.
- Forbidden secondary path behavior: not applicable, no frontend secondary path changed.
- Missing draft/resource behavior: not applicable, no draft/resource behavior changed.
- Stale route/deep-link behavior: not applicable, no route/deep-link behavior changed.

## Scope Gate

- Allowed paths: `ai/langgraph/EVIDENCE_LIGHTRAG_READINESS.md`.
- Denied paths: runtime code, migrations, frontend code, generated output.
- Migration/docs/test impact: docs/evidence only; no migration created in this PR.
- Rollback note: revert the evidence entry if the recorded gate observation is superseded.

## Validation

- Targeted tests or smoke run: `git diff --check`.
- Result: passed with existing line-ending warnings.
- Not checked: application tests were not run because this is docs/evidence only.