### PR TITLE
test(telegram): cover staff link token validator

### DIFF
--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
 
+from app.api.v1.endpoints import admin_telegram
 from app.services.telegram_bot_management_api_service import (
     TelegramBotManagementApiService,
 )
@@ -69,3 +70,85 @@ class TestTelegramBotManagementApiService:
         assert payload["total_count"] == 1
         assert payload["users"][0]["username"] == "user5"
         assert payload["users"][0]["telegram_chat_id"] == "12345"
+
+    def test_staff_link_start_token_round_trips_with_hash_only_contract(self):
+        expires_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+
+        token = admin_telegram.build_staff_link_start_token(
+            user_id=42,
+            chat_id=998877,
+            expires_at=expires_at,
+            nonce="unitnonce",
+        )
+        parsed = admin_telegram.parse_staff_link_start_token(token)
+
+        assert parsed is not None
+        assert parsed["user_id"] == 42
+        assert parsed["chat_id"] == 998877
+        assert parsed["token_hash"].startswith(
+            admin_telegram.STAFF_LINK_TOKEN_HASH_PREFIX
+        )
+
+    def test_staff_link_start_token_validator_reports_expired_reason(self):
+        token = admin_telegram.build_staff_link_start_token(
+            user_id=42,
+            chat_id=998877,
+            expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+            nonce="expirednonce",
+        )
+
+        result = admin_telegram.validate_staff_link_start_token(
+            db=object(),
+            token=token,
+            telegram_chat_id=998877,
+        )
+
+        assert result["valid"] is False
+        assert result["reason"] == "expired"
+        assert result["token_hash"].startswith(
+            admin_telegram.STAFF_LINK_TOKEN_HASH_PREFIX
+        )
+        assert admin_telegram.parse_staff_link_start_token(token) is None
+
+    def test_staff_link_start_token_validator_accepts_active_staff(
+        self, monkeypatch
+    ):
+        token = admin_telegram.build_staff_link_start_token(
+            user_id=42,
+            chat_id=998877,
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=10),
+            nonce="validnonce",
+        )
+        user = SimpleNamespace(id=42, role="Laboratory", is_active=True)
+
+        class FakeQuery:
+            def filter(self, *_args, **_kwargs):
+                return self
+
+            def first(self):
+                return user
+
+        db = SimpleNamespace(query=lambda _model: FakeQuery())
+        monkeypatch.setattr(
+            admin_telegram.crud_telegram,
+            "get_telegram_user_by_chat_id",
+            lambda _db, _chat_id: SimpleNamespace(user_id=None),
+        )
+        monkeypatch.setattr(
+            admin_telegram.crud_telegram,
+            "get_telegram_user_by_linked_user_id",
+            lambda _db, _linked_user_id: None,
+        )
+
+        result = admin_telegram.validate_staff_link_start_token(
+            db=db,
+            token=token,
+            telegram_chat_id=998877,
+        )
+
+        assert result["valid"] is True
+        assert result["reason"] == "ok"
+        assert result["user_id"] == 42
+        assert result["chat_id"] == 998877
+        assert result["role"] == "lab"
+        assert result["single_use_enforced"] is False


### PR DESCRIPTION
## Summary
- add focused unit coverage for staff Telegram link token build/parse behavior
- verify expired signed tokens return the explicit `expired` validator reason while public parsing stays closed
- verify a valid active staff token is accepted without enabling single-use storage or runtime writes

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/admin_telegram.py` staff link token helper contract, covered from `backend/tests/unit/test_telegram_bot_management_api_service.py`.
- Request shape: no API, webhook, or frontend request shape changes.
- Response shape: no production response shape changes; tests assert existing helper result fields.
- Status codes: no API status code changes.
- Frontend consumer: no frontend consumer changes.
- Compatibility path or alias: `parse_staff_link_start_token` remains closed for expired tokens while `validate_staff_link_start_token` exposes the explicit rejection reason.
- Contract proof: targeted unit tests cover hash-only token parsing, expired rejection, and valid active-staff validation.

## RBAC / Permissions
- Roles allowed: active supported staff roles continue to validate; the test covers `Laboratory` normalization to `lab`.
- Roles denied: expired tokens remain denied with `expired`; invalid/mismatched and linked-account rejections are unchanged.
- Positive auth proof: the valid-token test patches Telegram link lookups to no-conflict and asserts `valid: true`, `reason: ok`, role, user id, chat id, and `single_use_enforced: false`.
- Negative auth proof: the expired-token test asserts `valid: false`, `reason: expired`, and no storage/write path is invoked.

## Notification / Realtime
- Event type or websocket channel: no notification, WebSocket, or Telegram delivery behavior is changed.
- Payload version / ack behavior: no Telegram webhook payload or ack behavior is changed.
- Read/unread or delivery semantics: no delivery/read state is changed.
- Reconnect/resync proof: helper tests are stateless and deterministic from token/database inputs; no subscription or resync path is modified.

## Frontend Resilience
- Empty data proof: no frontend data path is changed.
- Partial data proof: no frontend data path is changed.
- Forbidden secondary path behavior: staff runtime writes and token consumption remain disabled.
- Missing draft/resource behavior: storage migration/service remain outside this PR; tests assert `single_use_enforced: false`.
- Stale route/deep-link behavior: no route or deep-link behavior is changed.

## Scope Gate
- Allowed paths: `backend/tests/unit/test_telegram_bot_management_api_service.py`.
- Denied paths: runtime Telegram handlers, admin status/UI, Alembic migrations, SQLAlchemy models, CRUD/service writes, webhook token consumption, and frontend files.
- Migration/docs/test impact: test-only PR; no migration or docs changes.
- Rollback note: reverting this PR removes only regression coverage and does not change runtime behavior.

## Validation
- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/tests/unit/test_telegram_bot_management_api_service.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `python -m pytest backend/tests/unit/test_telegram_bot_management_api_service.py -q`; `cd frontend; npm.cmd run build`.
- Result: passed locally; pytest reported 6 passed with 1 warning; Vite reported existing chunk-size and mixed dynamic/static import warnings for `errorHandler.js`.
- Not checked: live Telegram Bot API delivery, Alembic migration/table creation, runtime storage writes, token consumption, and browser E2E.
