### PR TITLE
test(telegram): cover staff link storage model contract

### DIFF
--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from app.api.v1.endpoints import admin_telegram
+from app.models.telegram_config import TelegramStaffLinkToken
 from app.services.telegram_bot_management_api_service import (
     TelegramBotManagementApiService,
 )
@@ -101,6 +102,83 @@ class TestTelegramBotManagementApiService:
         assert parsed["chat_id"] == 998877
         assert parsed["token_hash"].startswith(
             admin_telegram.STAFF_LINK_TOKEN_HASH_PREFIX
+        )
+
+    def test_staff_link_token_storage_contract_matches_model_columns(self):
+        contract = admin_telegram.STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT
+        table = TelegramStaffLinkToken.__table__
+
+        assert table.name == contract["table"]
+        assert list(table.columns.keys()) == contract["columns"]
+        assert contract["raw_token_storage_allowed"] is False
+        assert "raw_token" not in table.columns
+        assert "token" not in table.columns
+        assert table.c.token_hash.unique is True
+        assert table.c.token_hash.nullable is False
+        assert table.c.staff_user_id.nullable is False
+        assert table.c.telegram_chat_id.nullable is False
+        assert table.c.expires_at.nullable is False
+
+        staff_fk = next(iter(table.c.staff_user_id.foreign_keys))
+        assert staff_fk.target_fullname == "users.id"
+        assert staff_fk.ondelete == "CASCADE"
+
+    def test_staff_link_token_storage_model_has_required_indexes(self):
+        contract = admin_telegram.STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT
+        table = TelegramStaffLinkToken.__table__
+
+        assert "unique(token_hash)" in contract["required_indexes"]
+        assert "index(staff_user_id)" in contract["required_indexes"]
+        assert "index(telegram_chat_id)" in contract["required_indexes"]
+        assert (
+            "partial_index(expires_at) where consumed_at is null"
+            in contract["required_indexes"]
+        )
+
+        indexes_by_name = {index.name: index for index in table.indexes}
+        assert indexes_by_name["ix_telegram_staff_link_tokens_token_hash"].unique
+        assert [
+            column.name
+            for column in indexes_by_name[
+                "ix_telegram_staff_link_tokens_staff_user_id"
+            ].columns
+        ] == ["staff_user_id"]
+        assert [
+            column.name
+            for column in indexes_by_name[
+                "ix_telegram_staff_link_tokens_telegram_chat_id"
+            ].columns
+        ] == ["telegram_chat_id"]
+
+        partial_index = indexes_by_name[
+            "ix_telegram_staff_link_tokens_unconsumed_expires"
+        ]
+        assert [column.name for column in partial_index.columns] == ["expires_at"]
+        assert (
+            str(partial_index.dialect_options["postgresql"]["where"]).lower()
+            == "consumed_at is null"
+        )
+
+    def test_staff_link_token_storage_model_has_required_constraints(self):
+        contract = admin_telegram.STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT
+        table = TelegramStaffLinkToken.__table__
+
+        assert "expires_at > created_at" in contract["required_constraints"]
+        assert (
+            "consumed_at is null or consumed_at <= expires_at"
+            in contract["required_constraints"]
+        )
+        assert "staff_user_id references users(id)" in contract[
+            "required_constraints"
+        ]
+
+        constraint_names = {
+            constraint.name for constraint in table.constraints if constraint.name
+        }
+        assert "ck_telegram_staff_link_tokens_expires_after_created" in constraint_names
+        assert (
+            "ck_telegram_staff_link_tokens_consumed_before_expiry"
+            in constraint_names
         )
 
     def test_staff_link_start_token_validator_reports_expired_reason(self):


### PR DESCRIPTION
## Summary

- Adds focused unit coverage tying the published staff Telegram link-token storage contract to the SQLAlchemy model shape.
- Verifies hash-only storage columns, no raw token column, unique token hash storage, FK behavior, indexes, partial index, and check constraints.
- Keeps runtime behavior, Alembic migrations, webhook consumption, and UI unchanged.

## Contract Impact

not applicable - test-only model/contract coverage; no API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat delivery, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: backend/tests/unit/test_telegram_bot_management_api_service.py
- Denied paths: runtime endpoint/service files, Alembic migrations, frontend UI files, generated artifacts
- Migration/docs/test impact: tests only; no migration or docs changes
- Rollback note: revert the test-only commit to remove the added model/contract coverage

## Validation

- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/tests/unit/test_telegram_bot_management_api_service.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py backend/app/models/telegram_config.py`; `python -m pytest backend/tests/unit/test_telegram_bot_management_api_service.py -q`; `cd frontend; npm.cmd run build`
- Result: passed; frontend build kept the existing Vite dynamic/static import and chunk-size warnings
- Not checked: full backend suite, Alembic upgrade/downgrade, browser smoke, live Telegram API