### PR TITLE
test(telegram): cover staff bot status contract

### DIFF
--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -181,6 +181,59 @@ class TestTelegramBotManagementApiService:
             in constraint_names
         )
 
+    def test_staff_bot_status_remains_disabled_until_readiness_gates(self):
+        status = admin_telegram._build_staff_bot_status(webhook_set=False)
+
+        assert status["enabled"] is False
+        assert status["state_changing_actions_enabled"] is False
+        assert status["authorization"]["ready"] is False
+        assert status["audit"]["ready"] is False
+        assert status["role_menus"]["read_only"] is True
+        assert status["role_menus"]["runtime_enabled"] is False
+
+        role_menu_enablement = status["role_menu_enablement_contract"]
+        assert role_menu_enablement["enabled"] is False
+        assert role_menu_enablement["runtime_menu_enabled"] is False
+        assert role_menu_enablement["state_changing_menu_items_enabled"] is False
+
+    @pytest.mark.parametrize(
+        ("webhook_set", "expected_transport"),
+        [
+            (False, "polling"),
+            (True, "webhook"),
+        ],
+    )
+    def test_staff_bot_status_exposes_contract_bundle_and_next_slice(
+        self, webhook_set, expected_transport
+    ):
+        status = admin_telegram._build_staff_bot_status(webhook_set=webhook_set)
+
+        assert status["transport"] == expected_transport
+        assert status["next_slice"] == "staff_link_token_storage_migration"
+        assert status["supported_roles"] == admin_telegram.STAFF_BOT_SUPPORTED_ROLES
+        assert status["read_only_menu_contract"] == (
+            admin_telegram.STAFF_BOT_READ_ONLY_MENU_CONTRACT
+        )
+
+        expected_contract_keys = {
+            "token_contract",
+            "linking_contract",
+            "linking_runtime_contract",
+            "link_token_validation_contract",
+            "link_token_storage_contract",
+            "authorization_contract",
+            "command_registration_contract",
+            "confirmation_contract",
+            "audit_contract",
+        }
+        assert expected_contract_keys <= set(status)
+        assert status["link_token_storage_contract"] == (
+            admin_telegram.STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT
+        )
+        assert status["link_token_validation_contract"]["storage_contract"] == (
+            status["link_token_storage_contract"]
+        )
+
     def test_staff_link_start_token_validator_reports_expired_reason(self):
         token = admin_telegram.build_staff_link_start_token(
             user_id=42,


### PR DESCRIPTION
## Summary

- Adds focused unit coverage for the Telegram staff bot status builder.
- Verifies staff bot status remains disabled/read-only, keeps role menu enablement off, exposes the expected contract bundle, and preserves polling/webhook transport mapping.
- Keeps runtime behavior, Alembic migrations, webhook consumption, and UI unchanged.

## Contract Impact

not applicable - test-only status-builder coverage; no API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat delivery, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: backend/tests/unit/test_telegram_bot_management_api_service.py
- Denied paths: runtime endpoint/service files, Alembic migrations, frontend UI files, generated artifacts
- Migration/docs/test impact: tests only; no migration or docs changes
- Rollback note: revert the test-only commit to remove the added staff bot status contract coverage

## Validation

- Targeted tests or smoke run: `git diff --check`; `python -m py_compile backend/tests/unit/test_telegram_bot_management_api_service.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `python -m pytest backend/tests/unit/test_telegram_bot_management_api_service.py -q`; `cd frontend; npm.cmd run build`
- Result: passed; frontend build kept the existing Vite dynamic/static import and chunk-size warnings
- Not checked: full backend suite, Alembic upgrade/downgrade, browser smoke, live Telegram API