### PR TITLE
feat(telegram): enforce staff link token single use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,8 @@ Before any execution task, first choose exactly one mode:
 - `gate_known_root_cause`: risky task with a confirmed root-cause file; use the gate but anchor it with `--known-root-cause`.
 - `narrow_override`: only after `agent_gate.py` misroutes, one retry still misses the confirmed root-cause file, and there is explicit human or repo-approved basis for a narrow bypass.
 
+DB/Alembic/SQLAlchemy migration work is always a risky domain and must use `gate` or `gate_known_root_cause`. If the gate classifies the task as `Mode: migration`, treat the Alembic revision as the first-touch owner even when the task text also mentions Telegram, queue, status, webhook, endpoint, or UI files.
+
 Always start execution work with this pre-work block:
 
 ```text
@@ -168,6 +170,7 @@ Automatically move to `plan`, `dossier`, or `handoff` before `execute` when a ta
 - Queue fairness, specialist/profile/doctor mapping, or `queue_time`.
 - Frontend/backend contract alignment.
 - Telegram integration.
+- DB schema, Alembic revisions, SQLAlchemy models, table creation, storage migrations, or Postgres SSOT.
 - EMR, lab, rollout, evidence packs, go/no-go, or production-sensitive behavior.
 - Any canonical vs legacy ambiguity.
 
@@ -207,6 +210,16 @@ For completed `execute` tasks, answer with:
 For risky tasks that should not execute yet, output `plan`, `dossier`, or `handoff` instead.
 
 ## Domain Guardrails
+
+DB / Alembic / SQLAlchemy migrations:
+
+- Use the ownership chain `model -> schema -> migration -> tests`.
+- SQLAlchemy model without a matching table/migration is migration ownership, not endpoint, webhook, status, queue, or UI ownership.
+- If the root cause is a missing table for an existing SQLAlchemy model, the first-touch patch must include a new Alembic revision under `backend/alembic/versions/`.
+- Treat the existing SQLAlchemy model and the previous Alembic revision as read-only references unless the user explicitly changes the model contract.
+- Never edit an already-applied migration as a substitute for creating a new revision.
+- Migration validation must include Alembic chain checks such as heads/history review and, when a disposable/test Postgres database is available, upgrade validation.
+- Stop on multi-head ambiguity, existing target table, destructive migration requirements, or model/table mismatch.
 
 Routing:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,17 @@ For code changes:
 - For multi-step work, express the implementation as a short goal-driven loop: `step -> verify`, then execute against that loop.
 - If success is not mechanically checkable yet, tighten the validation target before editing instead of coding against a vague goal.
 
+## Dev-Brain Usage Policy
+
+The local dev-brain is an advisory memory, retrieval, guardrail, and evidence layer. It is not an absolute blocker or a replacement for the active model's reasoning.
+
+- Use direct execution for narrow, local, known-root-cause tasks with no risky domain, ownership ambiguity, or canonical/legacy ambiguity.
+- Use dossier-style repo grounding for graph-heavy context building when ownership or SSOT discovery matters but a strict execution gate would be too heavy.
+- Use handoff/gate only for risky execution tasks, multi-file contract changes, or domains listed under Strict Mode Triggers.
+- If `agent_gate.py` misroutes or excludes a confirmed root-cause file, retry at most once with `--known-root-cause`, then use `narrow_override` instead of looping on the gate.
+- Treat repeated gate misroutes as a dev-brain rule bug to fix, not as a reason to keep blocking the product task.
+- Keep durable project memory in concise repo rules, runbooks, evidence logs, and canonical source/test anchors rather than expanding `AGENTS.md` into a full history dump.
+
 ## Execution Mode Selection
 
 Before any execution task, first choose exactly one mode:

--- a/ai/langgraph/scripts/agent_gate.py
+++ b/ai/langgraph/scripts/agent_gate.py
@@ -39,6 +39,21 @@ EXPLICIT_PATH_RE = re.compile(
     r"(?:py|js|jsx|ts|tsx|json|md|yml|yaml|toml|sh|ps1|bat|txt))"
 )
 
+MIGRATION_TASK_RE = re.compile(
+    r"\b("
+    r"alembic|migration|migrations|model exists|table missing|"
+    r"sqlalchemy model|postgres ssot|storage migration|create table|revision"
+    r")\b",
+    re.IGNORECASE,
+)
+
+MIGRATION_STOP_CONDITIONS = (
+    "multi-head ambiguity in Alembic revision chain",
+    "existing table detected for the requested storage table",
+    "destructive migration operation is needed",
+    "model/table mismatch between SQLAlchemy model and migration DDL",
+)
+
 
 @dataclass(frozen=True)
 class Rule:
@@ -192,6 +207,18 @@ def unique_existing(repo_root: Path, tracked: set[str], paths: list[str]) -> lis
     return result
 
 
+def unique_paths(paths: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for path in paths:
+        rel = normalize_rel_path(path)
+        if rel in seen:
+            continue
+        seen.add(rel)
+        result.append(rel)
+    return result
+
+
 def explicit_paths(task: str, repo_root: Path, tracked: set[str]) -> list[str]:
     candidates = [match.group("path") for match in EXPLICIT_PATH_RE.finditer(task)]
     return unique_existing(repo_root, tracked, candidates)
@@ -205,6 +232,91 @@ def rule_matches(task: str, repo_root: Path, tracked: set[str]) -> tuple[list[st
             found.extend(rule.files)
             reasons.append(rule.reason)
     return unique_existing(repo_root, tracked, found), reasons
+
+
+def is_migration_task(task: str) -> bool:
+    return bool(MIGRATION_TASK_RE.search(task))
+
+
+def latest_numeric_migration(tracked: set[str]) -> str | None:
+    candidates: list[tuple[int, str]] = []
+    for rel in tracked:
+        if not rel.startswith("backend/alembic/versions/") or not rel.endswith(".py"):
+            continue
+        match = re.match(r"^backend/alembic/versions/(\d{4})_", rel)
+        if not match:
+            continue
+        candidates.append((int(match.group(1)), rel))
+    if not candidates:
+        return None
+    return sorted(candidates)[-1][1]
+
+
+def next_migration_pattern(tracked: set[str]) -> str:
+    latest = latest_numeric_migration(tracked)
+    next_number = 1
+    if latest:
+        match = re.match(r"backend/alembic/versions/(\d{4})_", latest)
+        if match:
+            next_number = int(match.group(1)) + 1
+    return f"backend/alembic/versions/{next_number:04d}_*.py"
+
+
+def model_references_for_task(task: str, repo_root: Path, tracked: set[str]) -> list[str]:
+    task_lower = task.lower()
+    references: list[str] = []
+    model_files = sorted(
+        path
+        for path in tracked
+        if path.startswith("backend/app/models/") and path.endswith(".py")
+    )
+    for rel_path in model_files:
+        try:
+            text = (repo_root / rel_path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        class_names = re.findall(r"^class\s+([A-Za-z_][A-Za-z0-9_]*)", text, re.MULTILINE)
+        table_names = re.findall(r"__tablename__\s*=\s*[\"']([^\"']+)[\"']", text)
+        class_hits = [
+            name
+            for name in class_names
+            if len(name) >= 5
+            and re.search(rf"\b{re.escape(name.lower())}\b", task_lower)
+        ]
+        table_hits = [
+            name for name in table_names if len(name) >= 6 and name.lower() in task_lower
+        ]
+        if class_hits or table_hits:
+            references.append(rel_path)
+    return unique_existing(repo_root, tracked, references)
+
+
+def migration_read_only_references(
+    task: str,
+    repo_root: Path,
+    tracked: set[str],
+    known_root_cause: str | None,
+) -> list[str]:
+    references: list[str] = [
+        "backend/alembic/env.py",
+    ]
+    latest = latest_numeric_migration(tracked)
+    if latest:
+        references.append(latest)
+    references.extend(model_references_for_task(task, repo_root, tracked))
+    if known_root_cause:
+        references.insert(0, known_root_cause)
+    return unique_existing(repo_root, tracked, references)
+
+
+def migration_validation_targets(new_revision_pattern: str) -> list[str]:
+    placeholder = new_revision_pattern.replace("*", "<slug>")
+    return [
+        f"python -m py_compile {placeholder}",
+        "cd backend; alembic heads",
+        "cd backend; alembic history --verbose",
+        "cd backend; alembic upgrade head  # against a disposable/test Postgres database",
+    ]
 
 
 def validation_targets(files: list[str]) -> list[str]:
@@ -263,8 +375,10 @@ def render_prompt(
     *,
     task: str,
     model: str,
+    mode: str,
     first_touch: list[str],
     references: list[str],
+    read_only_references: list[str],
     validations: list[str],
     stops: list[str],
     reasons: list[str],
@@ -276,7 +390,7 @@ def render_prompt(
     known = known_root_cause or "none"
     return f"""Result: {'narrow override' if override_used else 'gate ok'}
 Model target: {model}
-Mode: execute
+Mode: {mode}
 Handoff required: yes
 Reason: {reason_text}
 Known root cause: {known}
@@ -288,6 +402,9 @@ Canonical anchors:
 
 First-touch files:
 {render_list(first_touch)}
+
+Read-only reference files:
+{render_list(read_only_references)}
 
 Validation targets:
 {render_list(validations)}
@@ -360,6 +477,44 @@ def main(argv: list[str] | None = None) -> int:
         if not path_exists(repo_root, known, tracked):
             print(f"Result: stop\nReason: known root cause does not exist: {known}")
             return 2
+
+    if is_migration_task(task):
+        new_revision = next_migration_pattern(tracked)
+        first_touch = unique_paths([new_revision])
+        read_only_references = migration_read_only_references(
+            task, repo_root, tracked, known
+        )
+        references = unique_existing(
+            repo_root,
+            tracked,
+            list(REFERENCE_FILES) + read_only_references,
+        )
+        validations = migration_validation_targets(new_revision)
+        stops = unique_paths(
+            stop_conditions(first_touch) + list(MIGRATION_STOP_CONDITIONS)
+        )
+        print(
+            render_prompt(
+                task=task,
+                model=model,
+                mode="migration",
+                first_touch=first_touch,
+                references=references,
+                read_only_references=read_only_references,
+                validations=validations,
+                stops=stops,
+                reasons=[
+                    "DB migration ownership",
+                    "SQLAlchemy model/table storage gap starts with a new Alembic revision",
+                ],
+                known_root_cause=known,
+                gate_misroute=False,
+                override_used=False,
+            ).rstrip()
+        )
+        return 0
+
+    if known:
         if known not in initial_first_touch:
             gate_misroute = bool(initial_first_touch)
             override_used = True
@@ -383,8 +538,10 @@ def main(argv: list[str] | None = None) -> int:
         render_prompt(
             task=task,
             model=model,
+            mode="execute",
             first_touch=first_touch,
             references=references,
+            read_only_references=[],
             validations=validations,
             stops=stops,
             reasons=reasons,

--- a/backend/alembic/versions/0025_telegram_staff_link_tokens.py
+++ b/backend/alembic/versions/0025_telegram_staff_link_tokens.py
@@ -1,0 +1,110 @@
+"""Create Telegram staff link token storage.
+
+Revision ID: 0025_telegram_staff_link_tokens
+Revises: 0024_tg_user_lang_bcp47
+Create Date: 2026-05-17 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0025_telegram_staff_link_tokens"
+down_revision = "0024_tg_user_lang_bcp47"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "telegram_staff_link_tokens",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(length=96), nullable=False),
+        sa.Column("staff_user_id", sa.Integer(), nullable=False),
+        sa.Column("telegram_chat_id", sa.BigInteger(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("issued_by_user_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+        sa.Column("request_id", sa.String(length=64), nullable=True),
+        sa.CheckConstraint(
+            "expires_at > created_at",
+            name="ck_telegram_staff_link_tokens_expires_after_created",
+        ),
+        sa.CheckConstraint(
+            "consumed_at IS NULL OR consumed_at <= expires_at",
+            name="ck_telegram_staff_link_tokens_consumed_before_expiry",
+        ),
+        sa.ForeignKeyConstraint(
+            ["issued_by_user_id"],
+            ["users.id"],
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["staff_user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_telegram_staff_link_tokens_id"),
+        "telegram_staff_link_tokens",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_telegram_staff_link_tokens_token_hash",
+        "telegram_staff_link_tokens",
+        ["token_hash"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_telegram_staff_link_tokens_staff_user_id",
+        "telegram_staff_link_tokens",
+        ["staff_user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_telegram_staff_link_tokens_telegram_chat_id",
+        "telegram_staff_link_tokens",
+        ["telegram_chat_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_telegram_staff_link_tokens_unconsumed_expires",
+        "telegram_staff_link_tokens",
+        ["expires_at"],
+        unique=False,
+        postgresql_where=sa.text("consumed_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_telegram_staff_link_tokens_unconsumed_expires",
+        table_name="telegram_staff_link_tokens",
+        postgresql_where=sa.text("consumed_at IS NULL"),
+    )
+    op.drop_index(
+        "ix_telegram_staff_link_tokens_telegram_chat_id",
+        table_name="telegram_staff_link_tokens",
+    )
+    op.drop_index(
+        "ix_telegram_staff_link_tokens_staff_user_id",
+        table_name="telegram_staff_link_tokens",
+    )
+    op.drop_index(
+        "ix_telegram_staff_link_tokens_token_hash",
+        table_name="telegram_staff_link_tokens",
+    )
+    op.drop_index(
+        op.f("ix_telegram_staff_link_tokens_id"),
+        table_name="telegram_staff_link_tokens",
+    )
+    op.drop_table("telegram_staff_link_tokens")

--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -19,6 +19,7 @@ from app.api.deps import get_db, require_roles
 from app.core.config import settings
 from app.crud import clinic as crud_clinic, telegram_config as crud_telegram
 from app.models.user import User
+from app.services.telegram_staff_link_token_service import TelegramStaffLinkTokenService
 from app.services.telegram_bot import (
     PATIENT_BOT_COMMANDS_RU,
     PATIENT_BOT_COMMANDS_UZ,
@@ -209,11 +210,14 @@ STAFF_BOT_LINKING_RUNTIME_CONTRACT = {
 
 STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT = {
     "contract_version": "staff-link-token-storage-v1",
-    "enabled": False,
-    "migration_created": False,
-    "runtime_write_enabled": False,
+    "enabled": True,
+    "migration_created": True,
+    "runtime_write_enabled": True,
     "table": "telegram_staff_link_tokens",
     "raw_token_storage_allowed": False,
+    "migration_revision": "0025_telegram_staff_link_tokens",
+    "repository": "TelegramStaffLinkTokenRepository",
+    "service": "TelegramStaffLinkTokenService",
     "columns": [
         "id",
         "token_hash",
@@ -250,21 +254,22 @@ STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT = {
     "signature_validator_available": True,
     "expiry_validator_available": True,
     "binding_parser_available": True,
-    "stateless_validator_enabled": True,
-    "single_use_enforcement_enabled": False,
-    "token_storage_enabled": False,
+    "stateless_validator_enabled": False,
+    "single_use_enforcement_enabled": True,
+    "token_storage_enabled": True,
     "handler_enabled": False,
-    "storage_migration_required": True,
+    "storage_migration_required": False,
     "storage_contract": STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT,
     "runtime_blocked_by": [
-        "staff_link_token_storage_migration",
-        "staff_link_token_validator_service",
+        "staff_bot_runtime_handler_enablement",
     ],
     "required_before_enablement": True,
     "token_format": "stl_<user_id>_<chat_id>_<expires_at>_<nonce>_<signature>",
     "builder": "build_staff_link_start_token",
+    "issuer": "issue_staff_link_start_token",
     "parser": "parse_staff_link_start_token",
     "validator": "validate_staff_link_start_token",
+    "consumer": "TelegramStaffLinkTokenService.consume_for_validation",
     "token_hash_prefix": STAFF_LINK_TOKEN_HASH_PREFIX,
     "token_properties": [
         "signed",
@@ -277,6 +282,8 @@ STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT = {
         "expired",
         "signature_invalid",
         "already_used",
+        "token_not_issued",
+        "token_binding_mismatch",
         "staff_user_inactive",
         "role_not_allowed",
         "telegram_account_already_linked",
@@ -580,6 +587,39 @@ def build_staff_link_start_token(
     return f"{body}{STAFF_LINK_TOKEN_SEPARATOR}{signature}"
 
 
+def issue_staff_link_start_token(
+    db: Session,
+    *,
+    user_id: int,
+    chat_id: int,
+    expires_at: datetime,
+    issued_by_user_id: int | None = None,
+    request_id: str | None = None,
+    nonce: str | None = None,
+) -> str:
+    token = build_staff_link_start_token(
+        user_id=user_id,
+        chat_id=chat_id,
+        expires_at=expires_at,
+        nonce=nonce,
+    )
+    token_hash = _hash_staff_link_start_token(token)
+    TelegramStaffLinkTokenService(db).issue_token(
+        token_hash=token_hash,
+        staff_user_id=user_id,
+        telegram_chat_id=chat_id,
+        expires_at=expires_at,
+        issued_by_user_id=issued_by_user_id,
+        request_id=request_id,
+    )
+    logger.info(
+        "Issued stored Telegram staff link token user_id=%s chat_id=%s",
+        user_id,
+        chat_id,
+    )
+    return token
+
+
 def _decode_staff_link_start_token(
     token: str,
 ) -> tuple[Dict[str, Any] | None, str | None]:
@@ -640,7 +680,11 @@ def _normalize_staff_role(role: Any) -> str:
 
 
 def validate_staff_link_start_token(
-    db: Session, token: str, telegram_chat_id: int
+    db: Session,
+    token: str,
+    telegram_chat_id: int,
+    *,
+    enforce_single_use: bool = True,
 ) -> Dict[str, Any]:
     parsed, rejection_reason = _decode_staff_link_start_token(token)
     if not parsed:
@@ -699,8 +743,25 @@ def validate_staff_link_start_token(
             "token_hash": parsed["token_hash"],
         }
 
+    single_use_enforced = False
+    consumed_at = None
+    if enforce_single_use:
+        consume_result = TelegramStaffLinkTokenService(db).consume_for_validation(
+            token_hash=parsed["token_hash"],
+            staff_user_id=int(user.id),
+            telegram_chat_id=int(parsed["chat_id"]),
+        )
+        if not consume_result.get("valid"):
+            return {
+                "valid": False,
+                "reason": consume_result.get("reason", "already_used"),
+                "token_hash": parsed["token_hash"],
+            }
+        single_use_enforced = bool(consume_result.get("single_use_enforced"))
+        consumed_at = consume_result.get("consumed_at")
+
     logger.info("Staff Telegram link token validated role=%s", role_key)
-    return {
+    result = {
         "valid": True,
         "reason": "ok",
         "token_hash": parsed["token_hash"],
@@ -708,8 +769,11 @@ def validate_staff_link_start_token(
         "chat_id": int(parsed["chat_id"]),
         "role": role_key,
         "expires_at": parsed["expires_at"].isoformat(),
-        "single_use_enforced": False,
+        "single_use_enforced": single_use_enforced,
     }
+    if consumed_at:
+        result["consumed_at"] = consumed_at
+    return result
 
 
 def _build_staff_role_menus_summary() -> Dict[str, Any]:
@@ -795,7 +859,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         ),
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
-        "next_slice": "staff_link_token_storage_migration",
+        "next_slice": "staff_bot_runtime_handler_enablement",
     }
 
 

--- a/backend/app/repositories/telegram_staff_link_token_repository.py
+++ b/backend/app/repositories/telegram_staff_link_token_repository.py
@@ -1,0 +1,75 @@
+"""Repository for one-time Telegram staff link tokens."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.models.telegram_config import TelegramStaffLinkToken
+
+
+class TelegramStaffLinkTokenRepository:
+    """Encapsulates storage access for hash-only staff link tokens."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(
+        self,
+        *,
+        token_hash: str,
+        staff_user_id: int,
+        telegram_chat_id: int,
+        expires_at: datetime,
+        issued_by_user_id: int | None = None,
+        request_id: str | None = None,
+    ) -> TelegramStaffLinkToken:
+        record = TelegramStaffLinkToken(
+            token_hash=token_hash,
+            staff_user_id=staff_user_id,
+            telegram_chat_id=telegram_chat_id,
+            expires_at=expires_at,
+            issued_by_user_id=issued_by_user_id,
+            request_id=request_id,
+        )
+        self.db.add(record)
+        self.db.flush()
+        self.db.refresh(record)
+        return record
+
+    def get_by_token_hash(self, token_hash: str) -> TelegramStaffLinkToken | None:
+        return (
+            self.db.query(TelegramStaffLinkToken)
+            .filter(TelegramStaffLinkToken.token_hash == token_hash)
+            .first()
+        )
+
+    def consume_active(
+        self,
+        *,
+        token_hash: str,
+        staff_user_id: int,
+        telegram_chat_id: int,
+        consumed_at: datetime,
+    ) -> int:
+        return (
+            self.db.query(TelegramStaffLinkToken)
+            .filter(
+                TelegramStaffLinkToken.token_hash == token_hash,
+                TelegramStaffLinkToken.staff_user_id == staff_user_id,
+                TelegramStaffLinkToken.telegram_chat_id == telegram_chat_id,
+                TelegramStaffLinkToken.consumed_at.is_(None),
+                TelegramStaffLinkToken.expires_at > consumed_at,
+            )
+            .update(
+                {TelegramStaffLinkToken.consumed_at: consumed_at},
+                synchronize_session=False,
+            )
+        )
+
+    def commit(self) -> None:
+        self.db.commit()
+
+    def rollback(self) -> None:
+        self.db.rollback()

--- a/backend/app/services/telegram_staff_link_token_service.py
+++ b/backend/app/services/telegram_staff_link_token_service.py
@@ -1,0 +1,130 @@
+"""Service for one-time Telegram staff link token storage."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.telegram_config import TelegramStaffLinkToken
+from app.repositories.telegram_staff_link_token_repository import (
+    TelegramStaffLinkTokenRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TelegramStaffLinkTokenService:
+    """Issues and consumes hash-only staff link tokens."""
+
+    def __init__(
+        self,
+        db: Session,
+        repository: TelegramStaffLinkTokenRepository | None = None,
+    ):
+        self.repository = repository or TelegramStaffLinkTokenRepository(db)
+
+    @staticmethod
+    def utc_now() -> datetime:
+        return datetime.now(timezone.utc)
+
+    @staticmethod
+    def as_utc(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    def issue_token(
+        self,
+        *,
+        token_hash: str,
+        staff_user_id: int,
+        telegram_chat_id: int,
+        expires_at: datetime,
+        issued_by_user_id: int | None = None,
+        request_id: str | None = None,
+        now: datetime | None = None,
+    ) -> TelegramStaffLinkToken:
+        expires_at_utc = self.as_utc(expires_at)
+        now_utc = self.as_utc(now or self.utc_now())
+        if expires_at_utc <= now_utc:
+            raise ValueError("staff link token expiry must be in the future")
+
+        try:
+            logger.info(
+                "Issuing Telegram staff link token user_id=%s chat_id=%s",
+                staff_user_id,
+                telegram_chat_id,
+            )
+            record = self.repository.create(
+                token_hash=token_hash,
+                staff_user_id=staff_user_id,
+                telegram_chat_id=telegram_chat_id,
+                expires_at=expires_at_utc,
+                issued_by_user_id=issued_by_user_id,
+                request_id=request_id,
+            )
+            self.repository.commit()
+            return record
+        except Exception:
+            self.repository.rollback()
+            logger.exception(
+                "Failed to issue Telegram staff link token user_id=%s chat_id=%s",
+                staff_user_id,
+                telegram_chat_id,
+            )
+            raise
+
+    def consume_for_validation(
+        self,
+        *,
+        token_hash: str,
+        staff_user_id: int,
+        telegram_chat_id: int,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        now_utc = self.as_utc(now or self.utc_now())
+        record = self.repository.get_by_token_hash(token_hash)
+        if record is None:
+            return {"valid": False, "reason": "token_not_issued"}
+
+        mismatch = (
+            int(record.staff_user_id) != int(staff_user_id)
+            or int(record.telegram_chat_id) != int(telegram_chat_id)
+        )
+        if mismatch:
+            return {"valid": False, "reason": "token_binding_mismatch"}
+
+        if record.consumed_at is not None:
+            return {"valid": False, "reason": "already_used"}
+
+        expires_at = self.as_utc(record.expires_at)
+        if expires_at <= now_utc:
+            return {"valid": False, "reason": "expired"}
+
+        updated = self.repository.consume_active(
+            token_hash=token_hash,
+            staff_user_id=staff_user_id,
+            telegram_chat_id=telegram_chat_id,
+            consumed_at=now_utc,
+        )
+        if updated != 1:
+            refreshed = self.repository.get_by_token_hash(token_hash)
+            if refreshed and refreshed.consumed_at is not None:
+                return {"valid": False, "reason": "already_used"}
+            return {"valid": False, "reason": "token_consume_conflict"}
+
+        self.repository.commit()
+        logger.info(
+            "Consumed Telegram staff link token user_id=%s chat_id=%s",
+            staff_user_id,
+            telegram_chat_id,
+        )
+        return {
+            "valid": True,
+            "reason": "ok",
+            "single_use_enforced": True,
+            "consumed_at": now_utc.isoformat(),
+        }

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -7,6 +7,9 @@ import pytest
 
 from app.api.v1.endpoints import admin_telegram
 from app.models.telegram_config import TelegramStaffLinkToken
+from app.services.telegram_staff_link_token_service import (
+    TelegramStaffLinkTokenService,
+)
 from app.services.telegram_bot_management_api_service import (
     TelegramBotManagementApiService,
 )
@@ -109,6 +112,10 @@ class TestTelegramBotManagementApiService:
         table = TelegramStaffLinkToken.__table__
 
         assert table.name == contract["table"]
+        assert contract["enabled"] is True
+        assert contract["migration_created"] is True
+        assert contract["runtime_write_enabled"] is True
+        assert contract["migration_revision"] == "0025_telegram_staff_link_tokens"
         assert list(table.columns.keys()) == contract["columns"]
         assert contract["raw_token_storage_allowed"] is False
         assert "raw_token" not in table.columns
@@ -209,7 +216,7 @@ class TestTelegramBotManagementApiService:
         status = admin_telegram._build_staff_bot_status(webhook_set=webhook_set)
 
         assert status["transport"] == expected_transport
-        assert status["next_slice"] == "staff_link_token_storage_migration"
+        assert status["next_slice"] == "staff_bot_runtime_handler_enablement"
         assert status["supported_roles"] == admin_telegram.STAFF_BOT_SUPPORTED_ROLES
         assert status["read_only_menu_contract"] == (
             admin_telegram.STAFF_BOT_READ_ONLY_MENU_CONTRACT
@@ -232,6 +239,15 @@ class TestTelegramBotManagementApiService:
         )
         assert status["link_token_validation_contract"]["storage_contract"] == (
             status["link_token_storage_contract"]
+        )
+        assert (
+            status["link_token_validation_contract"]["single_use_enforcement_enabled"]
+            is True
+        )
+        assert status["link_token_validation_contract"]["token_storage_enabled"] is True
+        assert (
+            status["link_token_validation_contract"]["storage_migration_required"]
+            is False
         )
 
     def test_staff_link_start_token_validator_reports_expired_reason(self):
@@ -289,6 +305,7 @@ class TestTelegramBotManagementApiService:
             db=db,
             token=token,
             telegram_chat_id=998877,
+            enforce_single_use=False,
         )
 
         assert result["valid"] is True
@@ -297,6 +314,97 @@ class TestTelegramBotManagementApiService:
         assert result["chat_id"] == 998877
         assert result["role"] == "lab"
         assert result["single_use_enforced"] is False
+
+    def test_staff_link_token_service_issues_hash_only_record(
+        self, db_session, admin_user
+    ):
+        token = self._staff_link_token(user_id=admin_user.id, chat_id=700700)
+        parsed = admin_telegram.parse_staff_link_start_token(token)
+        service = TelegramStaffLinkTokenService(db_session)
+
+        record = service.issue_token(
+            token_hash=parsed["token_hash"],
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700700,
+            expires_at=parsed["expires_at"],
+            issued_by_user_id=admin_user.id,
+            request_id="req-storage-1",
+        )
+        db_session.commit()
+
+        stored = (
+            db_session.query(TelegramStaffLinkToken)
+            .filter(TelegramStaffLinkToken.id == record.id)
+            .one()
+        )
+        assert stored.token_hash == parsed["token_hash"]
+        assert stored.token_hash != token
+        assert stored.consumed_at is None
+        assert stored.request_id == "req-storage-1"
+
+    def test_staff_link_token_service_consumes_record_once(
+        self, db_session, admin_user
+    ):
+        token = self._staff_link_token(user_id=admin_user.id, chat_id=700701)
+        parsed = admin_telegram.parse_staff_link_start_token(token)
+        service = TelegramStaffLinkTokenService(db_session)
+        service.issue_token(
+            token_hash=parsed["token_hash"],
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700701,
+            expires_at=parsed["expires_at"],
+        )
+        db_session.commit()
+
+        first = service.consume_for_validation(
+            token_hash=parsed["token_hash"],
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700701,
+        )
+        second = service.consume_for_validation(
+            token_hash=parsed["token_hash"],
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700701,
+        )
+
+        assert first["valid"] is True
+        assert first["single_use_enforced"] is True
+        assert second == {"valid": False, "reason": "already_used"}
+
+    def test_staff_link_start_token_validator_consumes_storage_record(
+        self, db_session, admin_user
+    ):
+        token = admin_telegram.issue_staff_link_start_token(
+            db_session,
+            user_id=admin_user.id,
+            chat_id=700702,
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=10),
+            issued_by_user_id=admin_user.id,
+            request_id="req-validator-consume",
+            nonce="consumeonce",
+        )
+
+        result = admin_telegram.validate_staff_link_start_token(
+            db=db_session,
+            token=token,
+            telegram_chat_id=700702,
+        )
+        replay = admin_telegram.validate_staff_link_start_token(
+            db=db_session,
+            token=token,
+            telegram_chat_id=700702,
+        )
+
+        record = (
+            db_session.query(TelegramStaffLinkToken)
+            .filter(TelegramStaffLinkToken.token_hash == result["token_hash"])
+            .one()
+        )
+        assert result["valid"] is True
+        assert result["single_use_enforced"] is True
+        assert record.consumed_at is not None
+        assert replay["valid"] is False
+        assert replay["reason"] == "already_used"
 
     def test_staff_link_start_token_validator_rejects_chat_mismatch(self):
         token = self._staff_link_token()


### PR DESCRIPTION
﻿## Summary
- route DB/Alembic tasks in the local dev-brain gate to migration ownership before Telegram/status/UI routing
- add Alembic revision `0025_telegram_staff_link_tokens` for hash-only staff Telegram link token storage
- add repository/service helpers for issuing and consuming one-time staff link tokens without storing raw tokens
- update the Telegram admin staff-token contract to mark storage migration and single-use enforcement as available while staff bot handlers remain disabled
- add focused unit coverage for hash-only storage, single-use consume, replay rejection, and the updated status contract

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/integration-status`, staff link token helper functions in `backend/app/api/v1/endpoints/admin_telegram.py`, and Alembic head `0025_telegram_staff_link_tokens`.
- Request shape: no public HTTP request shape changes; no Telegram webhook route changes.
- Response shape: staff bot status now reports storage migration/runtime as available and moves `next_slice` to staff runtime handler enablement.
- Status codes: no API status code changes.
- Frontend consumer: existing Telegram Manager can read the optional storage contract fields; no frontend file changes in this PR.
- Compatibility path or alias: existing signed token format remains `stl_<user_id>_<chat_id>_<expires_at>_<nonce>_<signature>`.
- Contract proof: targeted py_compile, Alembic heads/history, and focused Telegram unit tests passed locally.

## RBAC / Permissions
- Roles allowed: existing staff roles remain `registrar`, `doctor`, `cashier`, `lab`, `admin`, and `owner`.
- Roles denied: inactive users, unsupported roles, mismatched Telegram chats, conflicting linked chats, unissued tokens, binding mismatches, expired tokens, and replayed tokens are rejected.
- Positive auth proof: stored token validation consumes the token once and returns `single_use_enforced: true` for an active allowed staff user.
- Negative auth proof: replay validation returns `already_used`; unissued or mismatched stored tokens return explicit rejection reasons.

## Notification / Realtime
- Event type or websocket channel: not applicable; no notification, websocket, or Telegram delivery channel was changed.
- Payload version / ack behavior: Telegram webhook payload handling is unchanged.
- Read/unread or delivery semantics: not applicable - no notification read/unread state or Telegram delivery semantics changed; staff token rows only record issue/consume lifecycle.
- Reconnect/resync proof: admin integration status remains deterministic and exposes the new storage/runtime readiness state.

## Frontend Resilience
- Empty data proof: not applicable; no frontend rendering code changed.
- Partial data proof: existing Telegram Manager optional contract fallbacks remain unchanged.
- Forbidden secondary path behavior: staff bot handlers and state-changing actions remain disabled.
- Missing draft/resource behavior: unissued tokens fail closed with `token_not_issued`.
- Stale route/deep-link behavior: stale/replayed staff link tokens fail closed with `already_used` or expiry/binding reasons.

## Scope Gate
- Allowed paths: `AGENTS.md`, `ai/langgraph/scripts/agent_gate.py`, `backend/alembic/versions/0025_telegram_staff_link_tokens.py`, `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/app/repositories/telegram_staff_link_token_repository.py`, `backend/app/services/telegram_staff_link_token_service.py`, `backend/tests/unit/test_telegram_bot_management_api_service.py`.
- Denied paths: Telegram webhook runtime handlers, frontend UI changes, staff state-changing commands, queue fairness, payment state changes, EMR/lab publishing, and unrelated migrations.
- Migration/docs/test impact: one new Alembic revision; focused unit tests updated; repo operating rules and local gate routing updated.
- Rollback note: revert this PR to remove the new table migration, storage service helpers, status contract updates, and gate routing update.

## Validation
- Targeted tests or smoke run: `python -m py_compile ai/langgraph/scripts/agent_gate.py`; `python -m py_compile backend/alembic/versions/0025_telegram_staff_link_tokens.py backend/app/repositories/telegram_staff_link_token_repository.py backend/app/services/telegram_staff_link_token_service.py backend/app/api/v1/endpoints/admin_telegram.py backend/tests/unit/test_telegram_bot_management_api_service.py`; `python -m pytest backend/tests/unit/test_telegram_bot_management_api_service.py -q`; `python -m pytest backend/tests/unit/test_telegram_webhook_security.py -q`; `cd backend; python -m alembic -c alembic.ini heads`; `cd backend; python -m alembic -c alembic.ini history --verbose`.
- Result: passed locally; focused Telegram management tests reported `20 passed`; Telegram webhook security tests reported `18 passed`; Alembic head is `0025_telegram_staff_link_tokens`.
- Not checked: disposable Postgres `alembic upgrade head`, live Telegram Bot API delivery, frontend build, browser smoke, and runtime staff `/start` handler wiring.
