### PR TITLE
feat(telegram): enable staff link start handler

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -46,7 +46,7 @@ STAFF_BOT_READINESS = [
     {
         "key": "role_based_staff_linking",
         "label": "Ролевая привязка сотрудников",
-        "ready": False,
+        "ready": True,
     },
     {
         "key": "server_side_authorization",
@@ -155,7 +155,7 @@ STAFF_BOT_TOKEN_CONTRACT = {
 
 STAFF_BOT_LINKING_CONTRACT = {
     "contract_version": "staff-linking-v1",
-    "enabled": False,
+    "enabled": True,
     "required_before_enablement": True,
     "identity_rule": "telegram_user_id_is_not_application_identity",
     "accepted_methods": [
@@ -167,7 +167,7 @@ STAFF_BOT_LINKING_CONTRACT = {
         {
             "key": "one_time_signed_staff_token",
             "label": "Одноразовый подписанный токен",
-            "status": "planned",
+            "status": "runtime_enabled",
         },
     ],
     "required_server_checks": [
@@ -188,17 +188,20 @@ STAFF_BOT_LINKING_CONTRACT = {
 
 STAFF_BOT_LINKING_RUNTIME_CONTRACT = {
     "contract_version": "staff-linking-runtime-v1",
-    "enabled": False,
+    "enabled": True,
     "helper_available": True,
-    "runtime_handler_enabled": False,
-    "write_helper": "link_staff_user_to_telegram",
+    "runtime_handler_enabled": True,
+    "write_helper": "_upsert_staff_link_telegram_user",
+    "legacy_write_helper": "link_staff_user_to_telegram",
     "lookup_helpers": [
         "get_telegram_user_by_chat_id",
         "get_telegram_user_by_linked_user_id",
     ],
     "writes": [
         "telegram_users.user_id",
+        "audit_logs",
     ],
+    "runtime_handler": "_handle_staff_link_start",
     "requires_prevalidated_inputs": [
         "active_application_user",
         "allowed_staff_role",
@@ -248,7 +251,7 @@ STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT = {
 
 STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT = {
     "contract_version": "staff-link-token-validation-v1",
-    "enabled": False,
+    "enabled": True,
     "validator_enabled": True,
     "runtime_helper_available": True,
     "signature_validator_available": True,
@@ -257,11 +260,12 @@ STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT = {
     "stateless_validator_enabled": False,
     "single_use_enforcement_enabled": True,
     "token_storage_enabled": True,
-    "handler_enabled": False,
+    "handler_enabled": True,
     "storage_migration_required": False,
     "storage_contract": STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT,
     "runtime_blocked_by": [
-        "staff_bot_runtime_handler_enablement",
+        "staff_audit_logging_runtime",
+        "staff_read_only_menu_runtime_enablement",
     ],
     "required_before_enablement": True,
     "token_format": "stl_<user_id>_<chat_id>_<expires_at>_<nonce>_<signature>",
@@ -449,7 +453,18 @@ STAFF_BOT_CONFIRMATION_CONTRACT = {
 STAFF_BOT_AUDIT_CONTRACT = {
     "contract_version": "staff-audit-v1",
     "enabled": False,
-    "record_writer_enabled": False,
+    "record_writer_enabled": True,
+    "recorded_event_types": [
+        "staff_link_created",
+        "staff_link_token_rejected",
+    ],
+    "pending_event_types": [
+        "staff_command_received",
+        "staff_action_confirmation_requested",
+        "staff_action_confirmed",
+        "staff_action_denied",
+        "staff_action_failed",
+    ],
     "required_before_enablement": True,
     "event_types": [
         {
@@ -815,19 +830,20 @@ def _build_staff_role_menu_enablement_contract(
 def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
     role_menus = _build_staff_role_menus_summary()
     return {
-        "version": "planning",
+        "version": "linking-runtime",
         "contract_version": "staff-menu-read-only-v1",
         "enabled": False,
         "contract_published": True,
-        "status": "requires_role_linking_audit_and_confirmations",
+        "status": "staff_linking_enabled_actions_disabled",
         "transport": "polling" if not webhook_set else "webhook",
         "supported_languages": [
             {"code": "ru", "label": "Русский"},
         ],
         "supported_roles": STAFF_BOT_SUPPORTED_ROLES,
         "role_linking": {
-            "enabled": False,
+            "enabled": True,
             "required_before_enablement": True,
+            "runtime_handler_enabled": True,
             "accepted_methods": [
                 "admin_verified_staff_link",
                 "one_time_signed_staff_token",
@@ -850,6 +866,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         "audit": {
             "required": True,
             "ready": False,
+            "linking_events_ready": True,
         },
         "state_changing_actions_enabled": False,
         "readiness": STAFF_BOT_READINESS,
@@ -859,7 +876,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         ),
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
-        "next_slice": "staff_bot_runtime_handler_enablement",
+        "next_slice": "dedicated_staff_bot_token_runtime_config",
     }
 
 
@@ -1308,6 +1325,7 @@ def get_telegram_integration_status(
                 "patient_status",
                 "patient_language_notification_settings",
                 "lab_results_pdf",
+                "staff_link_start_token_handler",
             ],
             "planned_functions": [
                 "dedicated_staff_bot_token_readiness_contract",

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -2,6 +2,7 @@
 Webhook endpoint для обработки входящих сообщений от Telegram
 """
 
+import hashlib
 import html
 import logging
 from datetime import date, datetime
@@ -12,6 +13,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import require_roles
+from app.api.v1.endpoints.admin_telegram import (
+    STAFF_LINK_TOKEN_PREFIX,
+    STAFF_LINK_TOKEN_SEPARATOR,
+    validate_staff_link_start_token,
+)
+from app.crud import audit as crud_audit
 from app.crud import telegram_config as crud_telegram
 from app.db.session import get_db
 from app.models.lab import LabReportInstance
@@ -45,6 +52,19 @@ TELEGRAM_TICKET_QR_LINK_FAILED_MESSAGE = (
     "Не удалось привязать Telegram к чеку. "
     "Попробуйте открыть QR еще раз."
 )
+TELEGRAM_STAFF_LINKED_MESSAGE = (
+    "Telegram привязан к учетной записи сотрудника. "
+    "Staff-команды пока не включены: действия выполняются только в приложении."
+)
+TELEGRAM_STAFF_LINK_REJECTED_MESSAGE = (
+    "Ссылка привязки сотрудника недействительна или уже использована. "
+    "Запросите новую ссылку у администратора."
+)
+TELEGRAM_STAFF_LINK_FAILED_MESSAGE = (
+    "Не удалось привязать Telegram сотрудника. "
+    "Попробуйте открыть ссылку еще раз или обратитесь к администратору."
+)
+TELEGRAM_STAFF_LINK_REPLY_MARKUP = {"remove_keyboard": True}
 TELEGRAM_SHARE_CONTACT_MESSAGE = (
     "Чтобы привязать Telegram к карте пациента, нажмите кнопку "
     "\"Поделиться номером\". Номер должен совпадать с номером в регистратуре."
@@ -485,6 +505,27 @@ def _extract_ticket_qr_start_payload(
     return payload, message
 
 
+def _extract_staff_link_start_payload(
+    update: Dict[str, Any],
+) -> tuple[str, Dict[str, Any]] | None:
+    message = update.get("message") or {}
+    text = str(message.get("text") or "").strip()
+    parts = text.split(maxsplit=1)
+    if len(parts) != 2:
+        return None
+
+    command = parts[0].split("@", 1)[0].lower()
+    payload = parts[1].strip()
+    if command != "/start":
+        return None
+
+    staff_prefix = f"{STAFF_LINK_TOKEN_PREFIX}{STAFF_LINK_TOKEN_SEPARATOR}"
+    if not payload.startswith(staff_prefix):
+        return None
+
+    return payload, message
+
+
 def _normalize_patient_language(language_code: Any) -> str:
     value = str(language_code or "").strip().lower().replace("_", "-")
     if value in {"uz", "uz-latn", "uzbek", "o'zbekcha", "ozbekcha"} or value.startswith("uz-"):
@@ -588,6 +629,91 @@ def _upsert_ticket_qr_telegram_user(
     db.flush()
 
 
+def _staff_telegram_reference_hash(chat_id: int) -> str:
+    digest = hashlib.sha256(f"staff-telegram-chat:{chat_id}".encode("utf-8")).hexdigest()
+    return f"telegram_chat:{digest[:24]}"
+
+
+def _upsert_staff_link_telegram_user(
+    db: Session,
+    message: Dict[str, Any],
+    *,
+    linked_user_id: int,
+) -> TelegramUser | None:
+    chat = message.get("chat") or {}
+    from_user = message.get("from") or {}
+    chat_id = chat.get("id")
+    if chat_id is None:
+        return None
+
+    telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, int(chat_id))
+    payload = {
+        "user_id": linked_user_id,
+        "username": from_user.get("username"),
+        "first_name": from_user.get("first_name"),
+        "last_name": from_user.get("last_name"),
+        "active": True,
+        "blocked": False,
+        "last_activity": datetime.utcnow(),
+    }
+
+    if telegram_user:
+        for field, value in payload.items():
+            if hasattr(telegram_user, field):
+                setattr(telegram_user, field, value)
+        db.flush()
+        return telegram_user
+
+    telegram_user = TelegramUser(
+        **payload,
+        chat_id=int(chat_id),
+        language_code=_normalize_patient_language(
+            from_user.get("language_code") or TELEGRAM_LANGUAGE_RU
+        ),
+        notifications_enabled=False,
+        appointment_reminders=False,
+        lab_notifications=False,
+    )
+    db.add(telegram_user)
+    db.flush()
+    return telegram_user
+
+
+def _record_staff_link_audit(
+    db: Session,
+    *,
+    action: str,
+    chat_id: int,
+    request_id: str | None,
+    actor_user_id: int | None = None,
+    telegram_user_id: int | None = None,
+    role: str | None = None,
+    reason: str | None = None,
+) -> None:
+    result = "success" if action == "staff_link_created" else "rejected"
+    payload = {
+        "actor_role": role,
+        "telegram_user_id_hash": _staff_telegram_reference_hash(chat_id),
+        "action_key": action,
+        "target_type": "telegram_user",
+        "target_reference_hash": _staff_telegram_reference_hash(chat_id),
+        "result": result,
+        "timestamp": datetime.utcnow().isoformat(),
+        "request_id": request_id,
+    }
+    if reason:
+        payload["reason"] = reason
+
+    crud_audit.log(
+        db,
+        action=action,
+        entity_type="telegram_user",
+        entity_id=telegram_user_id,
+        actor_user_id=actor_user_id,
+        payload=payload,
+    )
+
+
 async def _handle_ticket_qr_start(update: Dict[str, Any], db: Session, bot_service) -> bool:
     extracted = _extract_ticket_qr_start_payload(update)
     if not extracted:
@@ -635,6 +761,90 @@ async def _handle_ticket_qr_start(update: Dict[str, Any], db: Session, bot_servi
 
     return True
 
+
+async def _handle_staff_link_start(
+    update: Dict[str, Any], db: Session, bot_service
+) -> bool:
+    extracted = _extract_staff_link_start_payload(update)
+    if not extracted:
+        return False
+
+    token, message = extracted
+    chat_id = _message_chat_id(message)
+    if chat_id is None:
+        return True
+
+    update_id = update.get("update_id")
+    request_id = f"telegram-update:{update_id}" if update_id is not None else None
+
+    try:
+        validation = validate_staff_link_start_token(
+            db, token, telegram_chat_id=chat_id
+        )
+        if not validation.get("valid"):
+            logger.info(
+                "Telegram staff link token rejected reason=%s",
+                validation.get("reason"),
+            )
+            _record_staff_link_audit(
+                db,
+                action="staff_link_token_rejected",
+                chat_id=chat_id,
+                request_id=request_id,
+                reason=str(validation.get("reason") or "invalid"),
+            )
+            db.commit()
+            await bot_service._send_message(
+                chat_id,
+                TELEGRAM_STAFF_LINK_REJECTED_MESSAGE,
+                TELEGRAM_STAFF_LINK_REPLY_MARKUP,
+            )
+            return True
+
+        linked_user = _upsert_staff_link_telegram_user(
+            db,
+            message,
+            linked_user_id=int(validation["user_id"]),
+        )
+        if not linked_user:
+            logger.warning("Telegram staff link failed because chat row was missing")
+            await bot_service._send_message(
+                chat_id,
+                TELEGRAM_STAFF_LINK_FAILED_MESSAGE,
+                TELEGRAM_STAFF_LINK_REPLY_MARKUP,
+            )
+            return True
+
+        role = validation.get("role") or "staff"
+        _record_staff_link_audit(
+            db,
+            action="staff_link_created",
+            chat_id=chat_id,
+            request_id=request_id,
+            actor_user_id=int(validation["user_id"]),
+            telegram_user_id=getattr(linked_user, "id", None),
+            role=str(role),
+        )
+        db.commit()
+        logger.info("Telegram staff link created role=%s", role)
+        await bot_service._send_message(
+            chat_id,
+            f"{TELEGRAM_STAFF_LINKED_MESSAGE}\nРоль: {role}",
+            TELEGRAM_STAFF_LINK_REPLY_MARKUP,
+        )
+        return True
+    except Exception as exc:
+        db.rollback()
+        logger.warning(
+            "Telegram staff link handler failed error_type=%s",
+            type(exc).__name__,
+        )
+        await bot_service._send_message(
+            chat_id,
+            TELEGRAM_STAFF_LINK_FAILED_MESSAGE,
+            TELEGRAM_STAFF_LINK_REPLY_MARKUP,
+        )
+        return True
 
 def _message_from_update(update: Dict[str, Any]) -> Dict[str, Any]:
     return update.get("message") or {}
@@ -1403,12 +1613,16 @@ async def _handle_clinic_bot_update(
         return await dispatch(
             update,
             db,
+            staff_start_handler=_handle_staff_link_start,
             ticket_start_handler=_handle_ticket_qr_start,
             contact_handler=_handle_contact_link,
             start_handler=start_handler,
             command_handlers=command_handlers,
             text_handlers=text_handlers,
         )
+
+    if await _handle_staff_link_start(update, db, bot_service):
+        return True
 
     if await _handle_ticket_qr_start(update, db, bot_service):
         return True

--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -80,6 +80,7 @@ class TelegramBotService:
         update: dict[str, Any],
         db: Session,
         *,
+        staff_start_handler: Callable[..., Awaitable[bool]],
         ticket_start_handler: Callable[..., Awaitable[bool]],
         contact_handler: Callable[..., Awaitable[bool]],
         start_handler: Callable[[int, dict[str, Any]], Awaitable[None]],
@@ -87,6 +88,9 @@ class TelegramBotService:
         text_handlers: Mapping[str, Callable[[int], Awaitable[None]]],
     ) -> bool:
         """Dispatch clinic patient bot updates above webhook/polling transports."""
+        if await staff_start_handler(update, db, self):
+            return True
+
         if await ticket_start_handler(update, db, self):
             return True
 

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -193,8 +193,11 @@ class TestTelegramBotManagementApiService:
 
         assert status["enabled"] is False
         assert status["state_changing_actions_enabled"] is False
+        assert status["role_linking"]["enabled"] is True
+        assert status["role_linking"]["runtime_handler_enabled"] is True
         assert status["authorization"]["ready"] is False
         assert status["audit"]["ready"] is False
+        assert status["audit"]["linking_events_ready"] is True
         assert status["role_menus"]["read_only"] is True
         assert status["role_menus"]["runtime_enabled"] is False
 
@@ -216,7 +219,7 @@ class TestTelegramBotManagementApiService:
         status = admin_telegram._build_staff_bot_status(webhook_set=webhook_set)
 
         assert status["transport"] == expected_transport
-        assert status["next_slice"] == "staff_bot_runtime_handler_enablement"
+        assert status["next_slice"] == "dedicated_staff_bot_token_runtime_config"
         assert status["supported_roles"] == admin_telegram.STAFF_BOT_SUPPORTED_ROLES
         assert status["read_only_menu_contract"] == (
             admin_telegram.STAFF_BOT_READ_ONLY_MENU_CONTRACT
@@ -240,6 +243,15 @@ class TestTelegramBotManagementApiService:
         assert status["link_token_validation_contract"]["storage_contract"] == (
             status["link_token_storage_contract"]
         )
+        assert status["linking_contract"]["enabled"] is True
+        assert (
+            status["linking_runtime_contract"]["runtime_handler"]
+            == "_handle_staff_link_start"
+        )
+        assert status["linking_runtime_contract"]["runtime_handler_enabled"] is True
+        assert "audit_logs" in status["linking_runtime_contract"]["writes"]
+        assert status["link_token_validation_contract"]["enabled"] is True
+        assert status["link_token_validation_contract"]["handler_enabled"] is True
         assert (
             status["link_token_validation_contract"]["single_use_enforcement_enabled"]
             is True
@@ -248,6 +260,12 @@ class TestTelegramBotManagementApiService:
         assert (
             status["link_token_validation_contract"]["storage_migration_required"]
             is False
+        )
+        assert status["audit_contract"]["record_writer_enabled"] is True
+        assert "staff_link_created" in status["audit_contract"]["recorded_event_types"]
+        assert (
+            "staff_link_token_rejected"
+            in status["audit_contract"]["recorded_event_types"]
         )
 
     def test_staff_link_start_token_validator_reports_expired_reason(self):

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -1,20 +1,26 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
-from app.api.v1.endpoints import telegram_webhook
+from app.api.v1.endpoints import admin_telegram, telegram_webhook
+from app.models.audit import AuditLog
 from app.services import telegram_bot
 from app.services.telegram_templates import TelegramTemplatesService
 from app.models.lab import LabReportInstance, LabReportTemplate, LabReportTemplateVersion
 from app.models.online_queue import OnlineQueueEntry
 from app.models.patient import Patient
 from app.models.payment import Payment
-from app.models.telegram_config import TelegramConfig, TelegramMessage, TelegramUser
+from app.models.telegram_config import (
+    TelegramConfig,
+    TelegramMessage,
+    TelegramStaffLinkToken,
+    TelegramUser,
+)
 
 
 class FakeTelegramBotService:
@@ -388,6 +394,224 @@ class TestTelegramWebhookSecurity:
             telegram_webhook._localized_text("settings", "uz-Latn"),
             telegram_webhook._localized_settings_menu("uz-Latn"),
         )
+
+    @pytest.mark.asyncio
+    async def test_staff_start_token_links_user_and_writes_audit(
+        self, db_session, admin_user
+    ):
+        token = admin_telegram.issue_staff_link_start_token(
+            db_session,
+            user_id=admin_user.id,
+            chat_id=7010,
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=10),
+            issued_by_user_id=admin_user.id,
+            request_id="staff-link-webhook-test",
+            nonce="staffwebhook",
+        )
+        fake_service = FakeTelegramBotService(active=True)
+        update = {
+            "update_id": 106,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7010},
+                "from": {
+                    "id": 7010,
+                    "username": "staff_chat",
+                    "first_name": "Staff",
+                    "language_code": "ru",
+                },
+                "text": f"/start {token}",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        telegram_user = (
+            db_session.query(TelegramUser)
+            .filter(TelegramUser.chat_id == 7010)
+            .one()
+        )
+        assert telegram_user.user_id == admin_user.id
+        assert telegram_user.patient_id is None
+        assert telegram_user.notifications_enabled is False
+
+        token_record = (
+            db_session.query(TelegramStaffLinkToken)
+            .filter(
+                TelegramStaffLinkToken.staff_user_id == admin_user.id,
+                TelegramStaffLinkToken.telegram_chat_id == 7010,
+            )
+            .one()
+        )
+        assert token_record.consumed_at is not None
+
+        audit_log = (
+            db_session.query(AuditLog)
+            .filter(
+                AuditLog.action == "staff_link_created",
+                AuditLog.actor_user_id == admin_user.id,
+                AuditLog.entity_id == telegram_user.id,
+            )
+            .one()
+        )
+        payload_text = str(audit_log.payload)
+        assert audit_log.payload["result"] == "success"
+        assert audit_log.payload["actor_role"] == "admin"
+        assert "telegram_chat:" in audit_log.payload["telegram_user_id_hash"]
+        assert "7010" not in payload_text
+        assert token not in payload_text
+        fake_service._send_message.assert_awaited_once()
+        assert (
+            fake_service._send_message.await_args.args[1]
+            == f"{telegram_webhook.TELEGRAM_STAFF_LINKED_MESSAGE}\nРоль: admin"
+        )
+        assert (
+            fake_service._send_message.await_args.args[2]
+            == telegram_webhook.TELEGRAM_STAFF_LINK_REPLY_MARKUP
+        )
+
+    @pytest.mark.asyncio
+    async def test_staff_start_token_replay_is_rejected_before_patient_onboarding(
+        self, db_session, admin_user
+    ):
+        token = admin_telegram.issue_staff_link_start_token(
+            db_session,
+            user_id=admin_user.id,
+            chat_id=7011,
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=10),
+            issued_by_user_id=admin_user.id,
+            nonce="staffreplay",
+        )
+        update = {
+            "update_id": 107,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7011},
+                "from": {"id": 7011, "first_name": "Staff"},
+                "text": f"/start {token}",
+            },
+        }
+
+        first_service = FakeTelegramBotService(active=True)
+        second_service = FakeTelegramBotService(active=True)
+        first = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, first_service
+        )
+        replay = await telegram_webhook._handle_clinic_bot_update(
+            {**update, "update_id": 108}, db_session, second_service
+        )
+
+        assert first is True
+        assert replay is True
+        second_service._send_message.assert_awaited_once_with(
+            7011,
+            telegram_webhook.TELEGRAM_STAFF_LINK_REJECTED_MESSAGE,
+            telegram_webhook.TELEGRAM_STAFF_LINK_REPLY_MARKUP,
+        )
+        assert second_service._send_message.await_args.args[1] != (
+            telegram_webhook._localized_text("language_prompt", "ru")
+        )
+        rejection_audit = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_link_token_rejected")
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert rejection_audit is not None
+        assert rejection_audit.payload["reason"] == "already_used"
+        assert "7011" not in str(rejection_audit.payload)
+
+    @pytest.mark.asyncio
+    async def test_invalid_staff_start_token_does_not_create_telegram_user(
+        self, db_session
+    ):
+        fake_service = FakeTelegramBotService(active=True)
+        update = {
+            "update_id": 109,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7013},
+                "from": {"id": 7013, "first_name": "Staff"},
+                "text": "/start stl_invalid",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        assert (
+            db_session.query(TelegramUser)
+            .filter(TelegramUser.chat_id == 7013)
+            .first()
+            is None
+        )
+        fake_service._send_message.assert_awaited_once_with(
+            7013,
+            telegram_webhook.TELEGRAM_STAFF_LINK_REJECTED_MESSAGE,
+            telegram_webhook.TELEGRAM_STAFF_LINK_REPLY_MARKUP,
+        )
+        rejection_audit = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_link_token_rejected")
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert rejection_audit is not None
+        assert rejection_audit.payload["reason"] == "signature_invalid"
+        assert "7013" not in str(rejection_audit.payload)
+
+    @pytest.mark.asyncio
+    async def test_patient_dispatch_routes_staff_start_before_generic_start(
+        self, db_session
+    ):
+        service = telegram_bot.TelegramBotService()
+        calls = []
+        update = {
+            "update_id": 110,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7012},
+                "from": {"id": 7012},
+                "text": "/start stl_test",
+            },
+        }
+
+        async def staff_start_handler(update_arg, db_arg, bot_arg):
+            assert update_arg is update
+            assert db_arg is db_session
+            assert bot_arg is service
+            calls.append("staff")
+            return True
+
+        async def ticket_start_handler(_update, _db, _bot):
+            calls.append("ticket")
+            return False
+
+        async def contact_handler(_message, _db, _bot):
+            calls.append("contact")
+            return False
+
+        async def start_handler(_chat_id, _message):
+            calls.append("start")
+
+        handled = await service.process_patient_bot_update(
+            update,
+            db_session,
+            staff_start_handler=staff_start_handler,
+            ticket_start_handler=ticket_start_handler,
+            contact_handler=contact_handler,
+            start_handler=start_handler,
+            command_handlers={},
+            text_handlers={},
+        )
+
+        assert handled is True
+        assert calls == ["staff"]
 
     def test_queue_message_reports_linked_patient_position_and_cabinet(
         self, db_session, test_patient, test_daily_queue, test_queue_entry


### PR DESCRIPTION
## Summary
- enable Telegram webhook handling for staff `/start stl_...` link payloads using the existing signed, single-use staff link token validator
- persist the staff Telegram link on `telegram_users.user_id` and record link/rejection audit rows without storing raw Telegram chat IDs or raw tokens in audit payloads
- route staff link payloads before patient ticket/contact/generic `/start` handling in the shared Telegram dispatcher
- update staff bot integration status contracts to report linking runtime as enabled while commands, menus, and state-changing actions remain disabled
- add focused coverage for success, replay rejection, invalid token rejection, audit redaction, and dispatcher order

## Contract Impact
- Canonical surface: Telegram webhook staff `/start` payload handling, `TelegramBotService.process_patient_bot_update`, and `GET /api/v1/admin/telegram/integration-status` staff bot contract fields.
- Request shape: Telegram webhook accepts the existing `/start stl_<user_id>_<chat_id>_<expires_at>_<nonce>_<signature>` payload format; no public HTTP request body changes.
- Response shape: admin integration status now reports staff linking runtime/handler enabled, link audit writer availability, and the next slice as dedicated staff bot token runtime config.
- Status codes: no HTTP status code changes.
- Frontend consumer: existing Telegram Manager optional contract display can show the updated handler/write-helper state; no frontend files changed.
- Compatibility path or alias: patient ticket QR `/start` payloads, contact linking, and generic `/start` onboarding remain routed after staff payload detection.
- Contract proof: py_compile, diff check, and focused Telegram webhook/management unit tests passed locally.

## RBAC / Permissions
- Roles allowed: existing supported staff roles remain `registrar`, `doctor`, `cashier`, `lab`, `admin`, and `owner` through `validate_staff_link_start_token`.
- Roles denied: inactive users, unsupported roles, mismatched Telegram chats, linked-chat conflicts, unissued tokens, expired tokens, and replayed tokens fail closed.
- Positive auth proof: staff `/start` link test consumes the stored token once, links the allowed admin user, and records a redacted `staff_link_created` audit row.
- Negative auth proof: replay and malformed `stl_` payload tests are handled before generic patient onboarding and record redacted rejection audit rows.

## Notification / Realtime
- Event type or websocket channel: not applicable; no notification, websocket, or realtime channel was added.
- Payload version / ack behavior: Telegram webhook payload parsing adds staff link detection only; patient webhook acknowledgements and Bot API send behavior are otherwise unchanged.
- Read/unread or delivery semantics: not applicable - this PR only handles staff link lifecycle messages and audit rows; it does not change notification read/unread state, message delivery state, or Telegram document/message delivery tracking.
- Reconnect/resync proof: admin integration status remains deterministic and exposes the linking runtime state for UI resync.

## Frontend Resilience
- Empty data proof: not applicable; no frontend rendering code changed.
- Partial data proof: contract fields are additive/boolean and existing Telegram Manager optional fallbacks still apply.
- Forbidden secondary path behavior: staff commands, read-only menus, and state-changing actions remain disabled after a successful link.
- Missing draft/resource behavior: malformed or unissued staff link tokens send a generic rejection message and do not create a TelegramUser row.
- Stale route/deep-link behavior: replayed staff links fail closed with `already_used` before generic `/start` onboarding.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/app/api/v1/endpoints/telegram_webhook.py`, `backend/app/services/telegram_bot.py`, `backend/tests/unit/test_telegram_webhook_security.py`, `backend/tests/unit/test_telegram_bot_management_api_service.py`.
- Denied paths: frontend UI changes, new migrations, staff command execution, queue fairness, payment state changes, EMR/lab publishing, bot token configuration, and unrelated route cleanup.
- Migration/docs/test impact: no new migration; focused unit tests updated for runtime handler and status contracts.
- Rollback note: revert this PR to disable staff `/start` runtime linking/audit and restore the staff bot status contract to runtime-handler-disabled.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/telegram_webhook.py backend/app/services/telegram_bot.py backend/app/api/v1/endpoints/admin_telegram.py`; `git diff --check`; `python -m pytest backend/tests/unit/test_telegram_webhook_security.py backend/tests/unit/test_telegram_bot_management_api_service.py -q`.
- Result: passed locally; targeted pytest reported `42 passed`.
- Not checked: live Telegram Bot API delivery, frontend build/browser smoke, full backend suite, and disposable Postgres migration upgrade because this slice has no new UI or migration.