### PR TITLE
ci(vercel): restore PR frontend previews

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,14 @@
   "installCommand": "npm --prefix frontend ci",
   "framework": "vite",
   "outputDirectory": "frontend/dist",
+  "git": {
+    "deploymentEnabled": {
+      "**": false,
+      "main": true,
+      "preview/**": true,
+      "ci/**": true
+    }
+  },
   "ignoreCommand": "if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then git diff --quiet HEAD^ HEAD -- frontend vercel.json .vercelignore; code=$?; if [ $code -gt 1 ]; then exit 1; fi; exit $code; fi; exit 1",
   "rewrites": [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -3,13 +3,6 @@
   "installCommand": "npm --prefix frontend ci",
   "framework": "vite",
   "outputDirectory": "frontend/dist",
-  "git": {
-    "deploymentEnabled": {
-      "**": false,
-      "main": true,
-      "preview/**": true
-    }
-  },
   "ignoreCommand": "if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then git diff --quiet HEAD^ HEAD -- frontend vercel.json .vercelignore; code=$?; if [ $code -gt 1 ]; then exit 1; fi; exit $code; fi; exit 1",
   "rewrites": [
     {


### PR DESCRIPTION
## Summary
- Keep the Vercel branch deployment allowlist in `vercel.json` instead of enabling deployments for every PR/feature branch.
- Add `ci/**` to the existing `main` and `preview/**` allowlist so controlled CI/frontend preview branches can produce Vercel previews.
- Keep the existing frontend/config-only `ignoreCommand` as a secondary guard inside allowed branches.

## Contract Impact
not applicable - CI/deployment configuration only, no API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions
not applicable - no route, endpoint, guard, role helper, token scope, or auth-sensitive runtime behavior changed.

## Notification / Realtime
not applicable - no notification, websocket, chat, queue, delivery, or realtime behavior changed.

## Frontend Resilience
not applicable - no frontend runtime code or user-facing state changed; only Vercel preview branch eligibility changed.

## Scope Gate
- Allowed paths: `vercel.json`
- Denied paths: backend runtime, frontend runtime, migrations, tests, generated output, secrets
- Migration/docs/test impact: Vercel Git deployment config only; no migration expected
- Rollback note: remove the `ci/**` deployment allowlist entry if controlled CI preview branches create too much Vercel volume

## Validation
- Targeted tests or smoke run: JSON parse for `vercel.json`; `git diff --check`; static diff inspection that `git.deploymentEnabled` remains present and only `ci/**` is added to the allowlist
- Result: passed locally; `git diff --check` reported only the existing Windows line-ending warning for `vercel.json`
- Not checked: Vercel cloud deployment execution after this follow-up commit; GitHub/Vercel checks should re-run on the updated PR branch

## Follow-ups
- If normal arbitrary PR branches need Vercel previews without build-slot churn, configure Vercel monorepo skip-unaffected-projects in the Vercel project settings instead of removing the branch gate in repo config.
