### PR TITLE
feat(telegram): report staff bot token readiness

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import hmac
 import logging
+import os
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, NoReturn, Optional
@@ -32,6 +33,14 @@ logger = logging.getLogger(__name__)
 STAFF_LINK_TOKEN_PREFIX = "stl"
 STAFF_LINK_TOKEN_HASH_PREFIX = "staff_link_token:"
 STAFF_LINK_TOKEN_SEPARATOR = "_"
+STAFF_BOT_TOKEN_ENV_KEYS = (
+    "TELEGRAM_STAFF_BOT_TOKEN",
+    "STAFF_TELEGRAM_BOT_TOKEN",
+)
+STAFF_BOT_TOKEN_SETTING_KEYS = (
+    "staff_bot_token",
+    "telegram_staff_bot_token",
+)
 
 STAFF_BOT_SUPPORTED_ROLES = [
     "registrar",
@@ -132,11 +141,14 @@ STAFF_BOT_GUARDRAILS = [
 STAFF_BOT_TOKEN_CONTRACT = {
     "contract_version": "staff-token-v1",
     "enabled": False,
-    "runtime_read_enabled": False,
+    "runtime_read_enabled": True,
     "required_before_enablement": True,
     "scope": "dedicated_staff_bot",
     "must_not_share_patient_bot_token": True,
     "secret_source": "environment_or_secret_store",
+    "env_keys": list(STAFF_BOT_TOKEN_ENV_KEYS),
+    "setting_keys": list(STAFF_BOT_TOKEN_SETTING_KEYS),
+    "token_returned_to_frontend": False,
     "required_server_checks": [
         "separate_staff_bot_token_configured",
         "token_not_logged",
@@ -827,8 +839,17 @@ def _build_staff_role_menu_enablement_contract(
     }
 
 
-def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
+def _build_staff_bot_status(
+    webhook_set: bool, staff_bot_token_status: Dict[str, Any] | None = None
+) -> Dict[str, Any]:
     role_menus = _build_staff_role_menus_summary()
+    token_status = staff_bot_token_status or {
+        "configured": False,
+        "ready": False,
+        "source": "not_configured",
+        "source_key": None,
+    }
+    token_contract = _build_staff_bot_token_contract(token_status)
     return {
         "version": "linking-runtime",
         "contract_version": "staff-menu-read-only-v1",
@@ -849,7 +870,7 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
                 "one_time_signed_staff_token",
             ],
         },
-        "token_contract": STAFF_BOT_TOKEN_CONTRACT,
+        "token_contract": token_contract,
         "linking_contract": STAFF_BOT_LINKING_CONTRACT,
         "linking_runtime_contract": STAFF_BOT_LINKING_RUNTIME_CONTRACT,
         "link_token_validation_contract": STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT,
@@ -876,7 +897,11 @@ def _build_staff_bot_status(webhook_set: bool) -> Dict[str, Any]:
         ),
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
-        "next_slice": "dedicated_staff_bot_token_runtime_config",
+        "next_slice": (
+            "staff_read_only_menu_runtime_enablement"
+            if token_contract["ready"]
+            else "dedicated_staff_bot_token_runtime_config"
+        ),
     }
 
 
@@ -910,6 +935,10 @@ class TelegramWebhookRequest(BaseModel):
     webhook_url: Optional[str] = None
 
 
+def _has_secret_value(value: Any) -> bool:
+    return bool(str(value or "").strip())
+
+
 def _get_configured_bot_token(db: Session) -> str | None:
     config = crud_telegram.get_telegram_config(db)
     if config and config.bot_token:
@@ -917,6 +946,108 @@ def _get_configured_bot_token(db: Session) -> str | None:
 
     bot_token_setting = crud_clinic.get_setting_by_key(db, "bot_token")
     return getattr(bot_token_setting, "value", None) if bot_token_setting else None
+
+
+def _build_staff_bot_token_status(
+    *,
+    token_value: Any,
+    source: str,
+    source_key: str,
+    patient_bot_token: str | None,
+) -> Dict[str, Any]:
+    token_text = str(token_value or "").strip()
+    patient_token_text = str(patient_bot_token or "").strip()
+    token_present = bool(token_text)
+    patient_bot_token_reused = bool(
+        token_present and patient_token_text and token_text == patient_token_text
+    )
+    ready = token_present and not patient_bot_token_reused
+    return {
+        "configured": token_present,
+        "ready": ready,
+        "source": source,
+        "source_key": source_key,
+        "separate_staff_bot_token_configured": ready,
+        "patient_bot_token_reused": patient_bot_token_reused,
+    }
+
+
+def _get_staff_bot_token_runtime_status(
+    db: Session, patient_bot_token: str | None = None
+) -> Dict[str, Any]:
+    for env_key in STAFF_BOT_TOKEN_ENV_KEYS:
+        token_value = os.getenv(env_key)
+        if _has_secret_value(token_value):
+            return _build_staff_bot_token_status(
+                token_value=token_value,
+                source="environment",
+                source_key=env_key,
+                patient_bot_token=patient_bot_token,
+            )
+
+    for setting_key in STAFF_BOT_TOKEN_SETTING_KEYS:
+        setting = crud_clinic.get_setting_by_key(db, setting_key)
+        token_value = getattr(setting, "value", None)
+        if _has_secret_value(token_value):
+            return _build_staff_bot_token_status(
+                token_value=token_value,
+                source="clinic_settings",
+                source_key=setting_key,
+                patient_bot_token=patient_bot_token,
+            )
+
+    return {
+        "configured": False,
+        "ready": False,
+        "source": "not_configured",
+        "source_key": None,
+        "separate_staff_bot_token_configured": False,
+        "patient_bot_token_reused": False,
+    }
+
+
+def _build_staff_bot_token_contract(token_status: Dict[str, Any]) -> Dict[str, Any]:
+    configured = bool(token_status.get("configured"))
+    ready = bool(token_status.get("ready"))
+    blocked_by = []
+    if not configured:
+        blocked_by.append("dedicated_staff_bot_token")
+    elif not ready:
+        blocked_by.append("separate_staff_bot_token_configured")
+    return {
+        **STAFF_BOT_TOKEN_CONTRACT,
+        "enabled": ready,
+        "runtime_read_enabled": True,
+        "configured": configured,
+        "ready": ready,
+        "separate_staff_bot_token_configured": ready,
+        "token_returned_to_frontend": False,
+        "patient_bot_token_reused": bool(token_status.get("patient_bot_token_reused")),
+        "patient_bot_transport_unchanged": True,
+        "source": token_status.get("source") or "not_configured",
+        "source_key": token_status.get("source_key"),
+        "accepted_env_keys": list(STAFF_BOT_TOKEN_ENV_KEYS),
+        "accepted_setting_keys": list(STAFF_BOT_TOKEN_SETTING_KEYS),
+        "runtime_blocked_by": blocked_by,
+        "checks": [
+            {
+                "key": "dedicated_staff_bot_token",
+                "ready": configured,
+            },
+            {
+                "key": "separate_staff_bot_token_configured",
+                "ready": ready,
+            },
+            {
+                "key": "token_not_returned_to_frontend",
+                "ready": True,
+            },
+            {
+                "key": "patient_bot_transport_unchanged",
+                "ready": True,
+            },
+        ],
+    }
 
 
 def _get_configured_bot_username(db: Session) -> str | None:
@@ -1269,6 +1400,9 @@ def get_telegram_integration_status(
         config = crud_telegram.get_telegram_config(db)
         bot_token = _get_configured_bot_token(db)
         bot_username = _get_configured_bot_username(db)
+        staff_bot_token_status = _get_staff_bot_token_runtime_status(
+            db, patient_bot_token=bot_token
+        )
         telegram_users = crud_telegram.get_telegram_users(
             db, active_only=False, limit=100000
         )
@@ -1397,7 +1531,7 @@ def get_telegram_integration_status(
                 "results_delivery": "telegram_pdf",
                 "max_pdf_reports_per_request": 3,
             },
-            "staff_bot": _build_staff_bot_status(webhook_set),
+            "staff_bot": _build_staff_bot_status(webhook_set, staff_bot_token_status),
             "transition_path": (
                 "Set webhook when a public HTTPS backend URL is available; "
                 "stop polling before webhook is enabled."

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.v1.endpoints import admin_telegram
+from app.models.clinic import ClinicSettings
+
+
+@pytest.mark.unit
+class TestTelegramStaffBotTokenRuntimeConfig:
+    def _clear_staff_bot_token_sources(self, monkeypatch):
+        for env_key in admin_telegram.STAFF_BOT_TOKEN_ENV_KEYS:
+            monkeypatch.delenv(env_key, raising=False)
+        monkeypatch.setattr(
+            admin_telegram,
+            "settings",
+            SimpleNamespace(model_config={}),
+        )
+
+    def test_reads_env_without_exposing_secret(self, monkeypatch, db_session):
+        secret_value = "999999:staff-secret"
+        self._clear_staff_bot_token_sources(monkeypatch)
+        monkeypatch.setenv("TELEGRAM_STAFF_BOT_TOKEN", secret_value)
+
+        token_status = admin_telegram._get_staff_bot_token_runtime_status(db_session)
+        status = admin_telegram._build_staff_bot_status(
+            webhook_set=False,
+            staff_bot_token_status=token_status,
+        )
+
+        contract = status["token_contract"]
+        assert contract["configured"] is True
+        assert contract["runtime_read_enabled"] is True
+        assert contract["source"] == "environment"
+        assert contract["source_key"] == "TELEGRAM_STAFF_BOT_TOKEN"
+        assert contract["token_returned_to_frontend"] is False
+        assert contract["patient_bot_token_reused"] is False
+        assert status["next_slice"] == "staff_read_only_menu_runtime_enablement"
+        assert secret_value not in str(status)
+
+    def test_reads_legacy_env_without_secret_leak(self, monkeypatch, db_session):
+        secret_value = "777777:legacy-staff-secret"
+        self._clear_staff_bot_token_sources(monkeypatch)
+        monkeypatch.setenv("STAFF_TELEGRAM_BOT_TOKEN", secret_value)
+
+        token_status = admin_telegram._get_staff_bot_token_runtime_status(
+            db_session,
+            patient_bot_token="patient-token",
+        )
+        status = admin_telegram._build_staff_bot_status(
+            webhook_set=False,
+            staff_bot_token_status=token_status,
+        )
+
+        contract = status["token_contract"]
+        assert contract["configured"] is True
+        assert contract["ready"] is True
+        assert contract["source"] == "environment"
+        assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
+        assert contract["enabled"] is True
+        assert contract["runtime_blocked_by"] == []
+        assert status["next_slice"] == "staff_read_only_menu_runtime_enablement"
+        assert secret_value not in str(status)
+        assert "patient-token" not in str(status)
+
+    def test_reads_clinic_setting_without_secret_leak(self, monkeypatch, db_session):
+        secret_value = "888888:staff-setting-secret"
+        self._clear_staff_bot_token_sources(monkeypatch)
+        db_session.add(
+            ClinicSettings(
+                key="telegram_staff_bot_token",
+                value=secret_value,
+                category="telegram",
+            )
+        )
+        db_session.commit()
+
+        token_status = admin_telegram._get_staff_bot_token_runtime_status(db_session)
+        status = admin_telegram._build_staff_bot_status(
+            webhook_set=False,
+            staff_bot_token_status=token_status,
+        )
+
+        contract = status["token_contract"]
+        assert contract["configured"] is True
+        assert contract["source"] == "clinic_settings"
+        assert contract["source_key"] == "telegram_staff_bot_token"
+        assert contract["separate_staff_bot_token_configured"] is True
+        assert secret_value not in str(status)
+
+    def test_blocks_patient_bot_token_reuse(self, monkeypatch, db_session):
+        secret_value = "666666:shared-token"
+        self._clear_staff_bot_token_sources(monkeypatch)
+        monkeypatch.setenv("TELEGRAM_STAFF_BOT_TOKEN", secret_value)
+
+        token_status = admin_telegram._get_staff_bot_token_runtime_status(
+            db_session,
+            patient_bot_token=secret_value,
+        )
+        status = admin_telegram._build_staff_bot_status(
+            webhook_set=False,
+            staff_bot_token_status=token_status,
+        )
+
+        contract = status["token_contract"]
+        assert contract["configured"] is True
+        assert contract["ready"] is False
+        assert contract["enabled"] is False
+        assert contract["separate_staff_bot_token_configured"] is False
+        assert contract["patient_bot_token_reused"] is True
+        assert "separate_staff_bot_token_configured" in contract["runtime_blocked_by"]
+        assert status["next_slice"] == "dedicated_staff_bot_token_runtime_config"
+        assert secret_value not in str(status)

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -183,6 +183,22 @@ const TelegramManager = () => {
   }, 0);
   const staffRoleSummary = staffRoles.length ? staffRoles.join(', ') : 'none';
   const staffTokenContract = staffBot.token_contract || {};
+  const staffTokenReady = Boolean(staffTokenContract.ready || staffTokenContract.enabled);
+  const staffTokenBlockedBy = Array.isArray(staffTokenContract.runtime_blocked_by)
+    ? staffTokenContract.runtime_blocked_by
+    : [];
+  const staffTokenSource = staffTokenContract.source_key
+    ? `${staffTokenContract.source || 'source'}: ${staffTokenContract.source_key}`
+    : staffTokenContract.source || 'not_configured';
+  let staffTokenIssue = 'separate token configured';
+  if (staffTokenContract.patient_bot_token_reused) {
+    staffTokenIssue = 'patient token reused';
+  } else if (staffTokenBlockedBy.length) {
+    staffTokenIssue = `blocked: ${staffTokenBlockedBy.join(', ')}`;
+  }
+  const staffTokenSecretVisibility = staffTokenContract.token_returned_to_frontend
+    ? 'secret exposed to frontend'
+    : 'secret hidden from frontend';
   const staffLinkingContract = staffBot.linking_contract || staffBot.role_linking || {};
   const staffLinkingMethods = Array.isArray(staffLinkingContract.accepted_methods) ?
   staffLinkingContract.accepted_methods :
@@ -328,14 +344,14 @@ const TelegramManager = () => {
                   <ListItemText
                     primary="Staff token separation"
                     secondary={staffTokenContract.contract_version ?
-                    `scope: ${staffTokenContract.scope || 'staff'}; runtime read: ${staffTokenContract.runtime_read_enabled ? 'enabled' : 'disabled'}` :
+                    `${staffTokenSource}; ${staffTokenIssue}; ${staffTokenSecretVisibility}` :
                     'Dedicated staff bot token contract не опубликован'} />
 
                   <Badge
-                    variant={staffTokenContract.runtime_read_enabled ? 'success' : 'warning'}
+                    variant={staffTokenReady ? 'success' : 'warning'}
                     size="small">
 
-                    {staffTokenContract.required_before_enablement ? 'Required' : 'Planned'}
+                    {staffTokenReady ? 'Ready' : 'Required'}
                   </Badge>
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
## Summary
- Reports dedicated Telegram staff bot token runtime readiness in the admin integration status payload without returning the token value.
- Reads staff bot readiness from explicit process env keys and clinic settings keys, and blocks readiness when the value matches the patient bot token.
- Updates the Telegram manager staff token row to show source, blocker/readiness, and secret-hidden status without adding any staff bot action controls.
- Adds focused unit coverage for env, legacy env, clinic setting, no-secret-leak, and patient-token reuse behavior.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/telegram/integration-status` `staff_bot.token_contract` in `backend/app/api/v1/endpoints/admin_telegram.py`.
- Request shape: unchanged; no new query params, body fields, or headers.
- Response shape: `staff_bot.token_contract` now includes readiness fields such as `configured`, `ready`, `source`, `source_key`, `runtime_blocked_by`, `patient_bot_token_reused`, accepted env/setting keys, and secret redaction flags.
- Status codes: unchanged; existing success/error behavior remains in the integration-status endpoint.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads the expanded token contract for display-only status.
- Compatibility path or alias: no route alias or legacy endpoint change; existing callers can keep reading the previous `staff_bot.token_contract` object.
- Contract proof: token values are used only for comparison/readiness and are never inserted into the returned contract; patient-token reuse keeps `ready` and `enabled` false.

## RBAC / Permissions
- Roles allowed: unchanged; existing admin integration-status access remains controlled by the endpoint dependency.
- Roles denied: unchanged; no new role, permission, or bypass path is introduced.
- Positive auth proof: the change runs inside the existing admin endpoint and only enriches the already authorized status payload.
- Negative auth proof: no new public endpoint, command handler, or staff action path was added.

## Notification / Realtime
- Event type or websocket channel: not applicable - this status-only change emits no event and opens no websocket channel.
- Payload version / ack behavior: not applicable - no notification payload or acknowledgement behavior changes.
- Read/unread or delivery semantics: not applicable - no message delivery, unread counter, or notification state is touched.
- Reconnect/resync proof: not applicable - no realtime subscription or reconnect path is involved.

## Frontend Resilience
- Empty data proof: missing `staff_bot` or `token_contract` still falls back to existing empty objects and shows the contract-not-published fallback.
- Partial data proof: missing source/blocker arrays are normalized to `not_configured` and an empty blocker list before display.
- Forbidden secondary path behavior: no secondary action path was added; the row remains display-only.
- Missing draft/resource behavior: not applicable - the Telegram manager does not create drafts or resource-specific records in this slice.
- Stale route/deep-link behavior: not applicable - no route, navigation, or deep-link contract was changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`; `frontend/src/components/TelegramManager.jsx`; `backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py`.
- Denied paths: no config model, migration, Telegram webhook command handler, patient bot token transport, generated artifact, or broad test rewrites.
- Migration/docs/test impact: no migration or docs change; focused unit coverage was added in a new narrow test file.
- Rollback note: revert this PR to restore the static staff token contract and previous Telegram manager display copy.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `git diff --check`; `python -m pytest backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py -q`; `python -m pytest backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py backend/tests/unit/test_telegram_bot_management_api_service.py -q`; `cd frontend && npm.cmd run build`.
- Result: all passed locally; frontend build completed with existing chunk-size/dynamic-import warnings.
- Not checked: live Telegram API/webhook runtime and browser visual smoke were not run because this slice is status-contract/display only.
