### PR TITLE
feat(telegram): enable staff read-only menu runtime

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -60,7 +60,12 @@ STAFF_BOT_READINESS = [
     {
         "key": "server_side_authorization",
         "label": "Проверка ролей на backend",
-        "ready": False,
+        "ready": True,
+    },
+    {
+        "key": "read_only_menu_runtime",
+        "label": "Read-only staff menu runtime",
+        "ready": True,
     },
     {
         "key": "audit_logging",
@@ -277,7 +282,6 @@ STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT = {
     "storage_contract": STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT,
     "runtime_blocked_by": [
         "staff_audit_logging_runtime",
-        "staff_read_only_menu_runtime_enablement",
     ],
     "required_before_enablement": True,
     "token_format": "stl_<user_id>_<chat_id>_<expires_at>_<nonce>_<signature>",
@@ -314,7 +318,8 @@ STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT = {
 
 STAFF_BOT_AUTHORIZATION_CONTRACT = {
     "contract_version": "staff-authorization-v1",
-    "enabled": False,
+    "enabled": True,
+    "runtime_read_only_enabled": True,
     "source": "application_rbac",
     "server_side_required": True,
     "default_decision": "deny",
@@ -531,14 +536,17 @@ STAFF_BOT_AUDIT_CONTRACT = {
 
 STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
     "contract_version": "staff-role-menu-enablement-v1",
-    "enabled": False,
-    "runtime_menu_enabled": False,
+    "enabled": True,
+    "runtime_menu_enabled": True,
     "read_only_contract_published": True,
     "required_before_enablement": True,
     "state_changing_menu_items_enabled": False,
+    "runtime_handler": "_handle_staff_read_only_menu",
+    "domain_data_commands_enabled": False,
+    "state_changing_actions_enabled": False,
     "allowed_until_enabled": [
         "read_status_contract",
-        "read_only_menu_preview",
+        "read_only_menu_runtime",
     ],
     "required_server_checks": [
         "dedicated_staff_bot_token",
@@ -813,15 +821,16 @@ def _build_staff_role_menus_summary() -> Dict[str, Any]:
     )
     return {
         "contract_published": True,
-        "runtime_enabled": False,
+        "runtime_enabled": True,
         "read_only": True,
         "source": "read_only_menu_contract",
         "roles": menu_roles,
         "role_count": len(menu_roles),
         "item_count": menu_item_count,
+        "handler": "_handle_staff_read_only_menu",
+        "domain_data_commands_enabled": False,
+        "state_changing_actions_enabled": False,
         "blocked_until": [
-            "role_based_staff_linking",
-            "server_side_authorization",
             "audit_logging",
             "state_change_confirmations",
         ],
@@ -855,7 +864,8 @@ def _build_staff_bot_status(
         "contract_version": "staff-menu-read-only-v1",
         "enabled": False,
         "contract_published": True,
-        "status": "staff_linking_enabled_actions_disabled",
+        "read_only_runtime_enabled": True,
+        "status": "staff_read_only_menu_enabled_actions_disabled",
         "transport": "polling" if not webhook_set else "webhook",
         "supported_languages": [
             {"code": "ru", "label": "Русский"},
@@ -882,7 +892,9 @@ def _build_staff_bot_status(
         "authorization": {
             "source": "application_rbac",
             "server_side_required": True,
-            "ready": False,
+            "ready": True,
+            "runtime_read_only_enabled": True,
+            "default_decision": "deny",
         },
         "audit": {
             "required": True,
@@ -898,9 +910,9 @@ def _build_staff_bot_status(
         "read_only_menu_contract": STAFF_BOT_READ_ONLY_MENU_CONTRACT,
         "guardrails": STAFF_BOT_GUARDRAILS,
         "next_slice": (
-            "staff_read_only_menu_runtime_enablement"
-            if token_contract["ready"]
-            else "dedicated_staff_bot_token_runtime_config"
+            "dedicated_staff_bot_token_runtime_config"
+            if not token_contract["ready"]
+            else "staff_audit_logging_runtime"
         ),
     }
 

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -14,8 +14,11 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import require_roles
 from app.api.v1.endpoints.admin_telegram import (
+    STAFF_BOT_COMMAND_REGISTRATION_CONTRACT,
+    STAFF_BOT_READ_ONLY_MENU_CONTRACT,
     STAFF_LINK_TOKEN_PREFIX,
     STAFF_LINK_TOKEN_SEPARATOR,
+    _normalize_staff_role,
     validate_staff_link_start_token,
 )
 from app.crud import audit as crud_audit
@@ -54,7 +57,7 @@ TELEGRAM_TICKET_QR_LINK_FAILED_MESSAGE = (
 )
 TELEGRAM_STAFF_LINKED_MESSAGE = (
     "Telegram привязан к учетной записи сотрудника. "
-    "Staff-команды пока не включены: действия выполняются только в приложении."
+    "Staff-команды включены в режиме просмотра: действия выполняются только в приложении."
 )
 TELEGRAM_STAFF_LINK_REJECTED_MESSAGE = (
     "Ссылка привязки сотрудника недействительна или уже использована. "
@@ -65,6 +68,15 @@ TELEGRAM_STAFF_LINK_FAILED_MESSAGE = (
     "Попробуйте открыть ссылку еще раз или обратитесь к администратору."
 )
 TELEGRAM_STAFF_LINK_REPLY_MARKUP = {"remove_keyboard": True}
+TELEGRAM_STAFF_MENU_UNLINKED_MESSAGE = (
+    "Staff Telegram menu is available only after staff account linking."
+)
+TELEGRAM_STAFF_MENU_FORBIDDEN_MESSAGE = (
+    "Staff Telegram menu is not available for this account role."
+)
+TELEGRAM_STAFF_MENU_PLACEHOLDER_MESSAGE = (
+    "Read-only staff data is not connected in Telegram yet. Use the clinic app for live data."
+)
 TELEGRAM_SHARE_CONTACT_MESSAGE = (
     "Чтобы привязать Telegram к карте пациента, нажмите кнопку "
     "\"Поделиться номером\". Номер должен совпадать с номером в регистратуре."
@@ -714,6 +726,142 @@ def _record_staff_link_audit(
     )
 
 
+def _staff_read_only_commands() -> set[str]:
+    return {
+        str(item.get("command") or "").lower()
+        for item in STAFF_BOT_COMMAND_REGISTRATION_CONTRACT.get("commands", [])
+        if item.get("intent") == "read_only" and item.get("command")
+    }
+
+
+def _staff_menu_for_role(role: Any) -> Dict[str, Any] | None:
+    role_key = _normalize_staff_role(role)
+    for role_menu in STAFF_BOT_READ_ONLY_MENU_CONTRACT:
+        if role_menu.get("role") == role_key:
+            return role_menu
+    return None
+
+
+def _staff_menu_keyboard(role_menu: Dict[str, Any]) -> Dict[str, Any]:
+    rows = [
+        [{"text": str(item.get("label") or item.get("key"))}]
+        for item in role_menu.get("items", [])
+        if item.get("intent") == "read_only"
+    ]
+    rows.append([{"text": "/staff"}, {"text": "/help"}])
+    return {
+        "keyboard": rows,
+        "resize_keyboard": True,
+        "one_time_keyboard": False,
+    }
+
+
+def _staff_menu_message(user: User, role_menu: Dict[str, Any]) -> str:
+    items = [
+        str(item.get("label") or item.get("key"))
+        for item in role_menu.get("items", [])
+        if item.get("intent") == "read_only"
+    ]
+    lines = [
+        "Staff read-only menu",
+        f"Role: {_normalize_staff_role(getattr(user, 'role', None))}",
+        "",
+        "Available:",
+    ]
+    lines.extend(f"- {item}" for item in items)
+    lines.extend(
+        [
+            "",
+            "State-changing actions are disabled in Telegram.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _staff_read_only_item_labels() -> set[str]:
+    labels: set[str] = set()
+    for role_menu in STAFF_BOT_READ_ONLY_MENU_CONTRACT:
+        for item in role_menu.get("items", []):
+            label = str(item.get("label") or "").strip().lower()
+            if label:
+                labels.add(label)
+    return labels
+
+
+def _linked_staff_for_chat(
+    db: Session, chat_id: int
+) -> tuple[TelegramUser | None, User | None, Dict[str, Any] | None]:
+    telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, chat_id)
+    if not telegram_user or not telegram_user.user_id:
+        return telegram_user, None, None
+
+    user = db.query(User).filter(User.id == telegram_user.user_id).first()
+    if not user or not getattr(user, "is_active", True):
+        return telegram_user, user, None
+
+    return telegram_user, user, _staff_menu_for_role(getattr(user, "role", None))
+
+
+async def _handle_staff_read_only_menu(
+    update: Dict[str, Any], db: Session, bot_service
+) -> bool:
+    message = _message_from_update(update)
+    if not message:
+        return False
+
+    chat_id = _message_chat_id(message)
+    if chat_id is None:
+        return False
+
+    text = _message_text(message)
+    command = text.split(maxsplit=1)[0].split("@", 1)[0].lower() if text else ""
+    normalized_text = text.lower()
+    read_only_commands = _staff_read_only_commands()
+    staff_menu_requested = (
+        command in read_only_commands
+        or command == "/start"
+        or command == "/menu"
+        or normalized_text in _staff_read_only_item_labels()
+    )
+    if not staff_menu_requested:
+        return False
+
+    _telegram_user, user, role_menu = _linked_staff_for_chat(db, chat_id)
+    if not user:
+        if command in {"/staff", "/menu"}:
+            await bot_service._send_message(
+                chat_id,
+                TELEGRAM_STAFF_MENU_UNLINKED_MESSAGE,
+                TELEGRAM_STAFF_LINK_REPLY_MARKUP,
+            )
+            return True
+        return False
+
+    if not role_menu:
+        await bot_service._send_message(
+            chat_id,
+            TELEGRAM_STAFF_MENU_FORBIDDEN_MESSAGE,
+            TELEGRAM_STAFF_LINK_REPLY_MARKUP,
+        )
+        return True
+
+    menu = _staff_menu_keyboard(role_menu)
+    if command in {"/start", "/staff", "/help", "/menu"}:
+        await bot_service._send_message(
+            chat_id,
+            _staff_menu_message(user, role_menu),
+            menu,
+        )
+        return True
+
+    await bot_service._send_message(
+        chat_id,
+        TELEGRAM_STAFF_MENU_PLACEHOLDER_MESSAGE,
+        menu,
+    )
+    return True
+
+
 async def _handle_ticket_qr_start(update: Dict[str, Any], db: Session, bot_service) -> bool:
     extracted = _extract_ticket_qr_start_payload(update)
     if not extracted:
@@ -827,10 +975,16 @@ async def _handle_staff_link_start(
         )
         db.commit()
         logger.info("Telegram staff link created role=%s", role)
+        role_menu = _staff_menu_for_role(role)
+        reply_markup = (
+            _staff_menu_keyboard(role_menu)
+            if role_menu
+            else TELEGRAM_STAFF_LINK_REPLY_MARKUP
+        )
         await bot_service._send_message(
             chat_id,
             f"{TELEGRAM_STAFF_LINKED_MESSAGE}\nРоль: {role}",
-            TELEGRAM_STAFF_LINK_REPLY_MARKUP,
+            reply_markup,
         )
         return True
     except Exception as exc:
@@ -1614,6 +1768,7 @@ async def _handle_clinic_bot_update(
             update,
             db,
             staff_start_handler=_handle_staff_link_start,
+            staff_menu_handler=_handle_staff_read_only_menu,
             ticket_start_handler=_handle_ticket_qr_start,
             contact_handler=_handle_contact_link,
             start_handler=start_handler,
@@ -1622,6 +1777,9 @@ async def _handle_clinic_bot_update(
         )
 
     if await _handle_staff_link_start(update, db, bot_service):
+        return True
+
+    if await _handle_staff_read_only_menu(update, db, bot_service):
         return True
 
     if await _handle_ticket_qr_start(update, db, bot_service):

--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -86,9 +86,13 @@ class TelegramBotService:
         start_handler: Callable[[int, dict[str, Any]], Awaitable[None]],
         command_handlers: Mapping[str, Callable[[int], Awaitable[None]]],
         text_handlers: Mapping[str, Callable[[int], Awaitable[None]]],
+        staff_menu_handler: Callable[..., Awaitable[bool]] | None = None,
     ) -> bool:
         """Dispatch clinic patient bot updates above webhook/polling transports."""
         if await staff_start_handler(update, db, self):
+            return True
+
+        if staff_menu_handler and await staff_menu_handler(update, db, self):
             return True
 
         if await ticket_start_handler(update, db, self):

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -195,16 +195,19 @@ class TestTelegramBotManagementApiService:
         assert status["state_changing_actions_enabled"] is False
         assert status["role_linking"]["enabled"] is True
         assert status["role_linking"]["runtime_handler_enabled"] is True
-        assert status["authorization"]["ready"] is False
+        assert status["authorization"]["ready"] is True
+        assert status["authorization"]["runtime_read_only_enabled"] is True
         assert status["audit"]["ready"] is False
         assert status["audit"]["linking_events_ready"] is True
         assert status["role_menus"]["read_only"] is True
-        assert status["role_menus"]["runtime_enabled"] is False
+        assert status["role_menus"]["runtime_enabled"] is True
+        assert status["role_menus"]["state_changing_actions_enabled"] is False
 
         role_menu_enablement = status["role_menu_enablement_contract"]
-        assert role_menu_enablement["enabled"] is False
-        assert role_menu_enablement["runtime_menu_enabled"] is False
+        assert role_menu_enablement["enabled"] is True
+        assert role_menu_enablement["runtime_menu_enabled"] is True
         assert role_menu_enablement["state_changing_menu_items_enabled"] is False
+        assert role_menu_enablement["domain_data_commands_enabled"] is False
 
     @pytest.mark.parametrize(
         ("webhook_set", "expected_transport"),

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -37,7 +37,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "TELEGRAM_STAFF_BOT_TOKEN"
         assert contract["token_returned_to_frontend"] is False
         assert contract["patient_bot_token_reused"] is False
-        assert status["next_slice"] == "staff_read_only_menu_runtime_enablement"
+        assert status["next_slice"] == "staff_audit_logging_runtime"
         assert secret_value not in str(status)
 
     def test_reads_legacy_env_without_secret_leak(self, monkeypatch, db_session):
@@ -61,7 +61,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_read_only_menu_runtime_enablement"
+        assert status["next_slice"] == "staff_audit_logging_runtime"
         assert secret_value not in str(status)
         assert "patient-token" not in str(status)
 

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.api.v1.endpoints import telegram_webhook
+from app.models.telegram_config import TelegramUser
+
+
+class FakeTelegramBotService:
+    def __init__(self):
+        self._send_message = AsyncMock(return_value=True)
+
+
+def _link_staff_chat(db_session, *, chat_id: int, user_id: int) -> TelegramUser:
+    telegram_user = TelegramUser(
+        chat_id=chat_id,
+        user_id=user_id,
+        username="staff_chat",
+        first_name="Staff",
+        language_code="ru",
+        notifications_enabled=False,
+        appointment_reminders=False,
+        lab_notifications=False,
+        active=True,
+        blocked=False,
+    )
+    db_session.add(telegram_user)
+    db_session.commit()
+    db_session.refresh(telegram_user)
+    return telegram_user
+
+
+@pytest.mark.unit
+class TestTelegramStaffReadOnlyMenuRuntime:
+    @pytest.mark.asyncio
+    async def test_staff_command_returns_read_only_role_menu(
+        self, db_session, admin_user
+    ):
+        _link_staff_chat(db_session, chat_id=7201, user_id=admin_user.id)
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 201,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7201},
+                "from": {"id": 7201},
+                "text": "/staff",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        chat_id, text, reply_markup = fake_service._send_message.await_args.args
+        assert chat_id == 7201
+        assert "Staff read-only menu" in text
+        assert "Role: admin" in text
+        assert "State-changing actions are disabled" in text
+        assert reply_markup["resize_keyboard"] is True
+        assert ["/staff", "/help"] == [
+            item["text"] for item in reply_markup["keyboard"][-1]
+        ]
+
+    @pytest.mark.asyncio
+    async def test_staff_read_only_command_does_not_execute_patient_queue(
+        self, db_session, admin_user
+    ):
+        _link_staff_chat(db_session, chat_id=7202, user_id=admin_user.id)
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 202,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7202},
+                "from": {"id": 7202},
+                "text": "/queue",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        assert (
+            fake_service._send_message.await_args.args[1]
+            == telegram_webhook.TELEGRAM_STAFF_MENU_PLACEHOLDER_MESSAGE
+        )
+
+    @pytest.mark.asyncio
+    async def test_unlinked_staff_menu_request_does_not_create_patient_link(
+        self, db_session
+    ):
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 203,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7203},
+                "from": {"id": 7203},
+                "text": "/staff",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once_with(
+            7203,
+            telegram_webhook.TELEGRAM_STAFF_MENU_UNLINKED_MESSAGE,
+            telegram_webhook.TELEGRAM_STAFF_LINK_REPLY_MARKUP,
+        )
+        assert (
+            db_session.query(TelegramUser)
+            .filter(TelegramUser.chat_id == 7203)
+            .first()
+            is None
+        )

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -468,10 +468,10 @@ class TestTelegramWebhookSecurity:
             fake_service._send_message.await_args.args[1]
             == f"{telegram_webhook.TELEGRAM_STAFF_LINKED_MESSAGE}\nРоль: admin"
         )
-        assert (
-            fake_service._send_message.await_args.args[2]
-            == telegram_webhook.TELEGRAM_STAFF_LINK_REPLY_MARKUP
-        )
+        reply_markup = fake_service._send_message.await_args.args[2]
+        assert "keyboard" in reply_markup
+        assert reply_markup["resize_keyboard"] is True
+        assert reply_markup["keyboard"][-1] == [{"text": "/staff"}, {"text": "/help"}]
 
     @pytest.mark.asyncio
     async def test_staff_start_token_replay_is_rejected_before_patient_onboarding(

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -230,6 +230,12 @@ const TelegramManager = () => {
   staffAuditContract.event_types :
   [];
   const staffRoleMenuEnablementContract = staffBot.role_menu_enablement_contract || {};
+  const staffRoleMenuRuntimeEnabled = Boolean(
+    staffRoleMenuEnablementContract.runtime_menu_enabled || staffBot.read_only_runtime_enabled
+  );
+  const staffRoleMenuDomainDataEnabled = Boolean(
+    staffRoleMenuEnablementContract.domain_data_commands_enabled
+  );
   const staffRoleMenuEnablementRoleCount = typeof staffRoleMenuEnablementContract.role_count === 'number' ?
   staffRoleMenuEnablementContract.role_count :
   staffMenuContract.length;
@@ -539,14 +545,14 @@ const TelegramManager = () => {
                   <ListItemText
                     primary="Staff role menu enablement"
                     secondary={staffRoleMenuEnablementContract.contract_version ?
-                    `${staffRoleMenuEnablementRoleCount} roles, ${staffRoleMenuEnablementItemCount} items; runtime menu: ${staffRoleMenuEnablementContract.runtime_menu_enabled ? 'enabled' : 'disabled'}` :
+                    `${staffRoleMenuEnablementRoleCount} roles, ${staffRoleMenuEnablementItemCount} items; runtime menu: ${staffRoleMenuRuntimeEnabled ? 'enabled' : 'disabled'}; live data: ${staffRoleMenuDomainDataEnabled ? 'enabled' : 'app only'}` :
                     'Role menu enablement contract not published'} />
 
                   <Badge
-                    variant={staffRoleMenuEnablementContract.runtime_menu_enabled ? 'success' : 'warning'}
+                    variant={staffRoleMenuRuntimeEnabled ? 'success' : 'warning'}
                     size="small">
 
-                    {staffRoleMenuEnablementContract.required_before_enablement ? 'Required' : 'Planned'}
+                    {staffRoleMenuRuntimeEnabled ? 'Enabled' : 'Required'}
                   </Badge>
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
## Summary

- Enables a safe read-only Telegram staff menu for already linked staff Telegram accounts.
- Adds `/staff`, `/menu`, read-only staff commands, and role-menu button handling before the patient pipeline.
- Keeps state-changing staff actions disabled: no queue calls/skips, payment changes, EMR changes, lab changes, or live domain data from Telegram in this slice.
- Updates admin integration status and UI to show read-only staff menu runtime enabled while audit and confirmations remain future gates.

## Contract Impact

- Canonical surface: Telegram clinic bot staff read-only menu dispatch plus the admin Telegram staff status contract.
- Request shape: Telegram webhook text updates for linked staff chats; existing admin status request remains authenticated with no request body.
- Response shape: Telegram staff menu text with reply keyboard for linked staff, unlinked staff-link prompt for unlinked chats, and admin status fields for read-only runtime/menu state.
- Status codes: no new HTTP route; existing webhook/admin endpoints keep their normal 200/handled behavior and existing auth failures.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` staff role menu enablement/status row.
- Compatibility path or alias: patient `/start`, ticket QR, patient command, and patient text handlers remain fallback paths for non-staff updates.
- Contract proof: focused staff read-only menu tests plus updated staff status/webhook security tests.

## RBAC / Permissions

- Roles allowed: linked active staff users whose normalized role exists in the published staff role menu contract.
- Roles denied: unlinked chats, inactive/unsupported staff roles, and every state-changing staff action.
- Positive auth proof: linked admin `/staff` test returns the admin staff menu with `/staff` and `/help` keyboard actions.
- Negative auth proof: unlinked `/staff` test returns the staff-link prompt and does not create a patient `TelegramUser` link.

## Notification / Realtime

- Event type or websocket channel: not applicable - no websocket, realtime event, or notification channel is emitted.
- Payload version / ack behavior: existing Telegram webhook acknowledgment behavior is unchanged; only direct chat replies are sent.
- Read/unread or delivery semantics: not applicable - no persisted notification, unread state, or delivery record is introduced.
- Reconnect/resync proof: not applicable - no realtime channel or reconnect/resync path is changed.

## Frontend Resilience

- Empty data proof: missing role menu enablement contract still renders `Role menu enablement contract not published`.
- Partial data proof: runtime/live-data booleans are derived defensively from optional `role_menu_enablement_contract` fields.
- Forbidden secondary path behavior: not applicable - the TelegramManager status row does not navigate to a secondary forbidden route.
- Missing draft/resource behavior: not applicable - this status UI does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no route params or deep-link state are consumed.

## Scope Gate

- Allowed paths: `backend/app/services/telegram_bot.py`, `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/app/api/v1/endpoints/telegram_webhook.py`, `frontend/src/components/TelegramManager.jsx`, and focused Telegram unit tests.
- Denied paths: migrations, queue/payment/EMR/lab domain services, generated output, secrets/settings files, and unrelated Telegram Bot API registration code.
- Migration/docs/test impact: no migration or docs changed; added focused staff read-only runtime test and updated affected status/security tests.
- Rollback note: revert commit `555ee256` to disable staff read-only menu runtime and restore planned-only status text.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\services\telegram_bot.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; `python -m pytest backend\tests\unit\test_telegram_staff_read_only_menu_runtime.py backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py backend\tests\unit\test_telegram_bot_management_api_service.py backend\tests\unit\test_telegram_webhook_security.py -q`; `npm.cmd run build`; `git diff --check`.
- Result: all local validation passed; GitHub checks are being re-evaluated after PR body correction.
- Not checked: real Telegram Bot API command registration, live staff domain data, and full browser E2E.