### PR TITLE
feat(telegram): register staff read-only commands

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -357,8 +357,16 @@ STAFF_BOT_AUTHORIZATION_CONTRACT = {
 STAFF_BOT_COMMAND_REGISTRATION_CONTRACT = {
     "contract_version": "staff-commands-v1",
     "registration_enabled": False,
-    "registration_endpoint_published": False,
+    "registration_endpoint_published": True,
+    "runtime_registration_enabled": True,
+    "registration_endpoint": "POST /api/v1/admin/telegram/register-staff-commands",
+    "runtime_handler": "register_staff_bot_commands",
+    "telegram_api_method": "setMyCommands",
     "bot_scope": "staff_bot_only",
+    "registered_command_scope": "read_only_staff_commands_only",
+    "patient_bot_token_allowed": False,
+    "uses_dedicated_staff_bot_token": True,
+    "token_returned_to_frontend": False,
     "commands": [
         {
             "command": "/staff",
@@ -396,6 +404,7 @@ STAFF_BOT_COMMAND_REGISTRATION_CONTRACT = {
             "intent": "read_only",
         },
     ],
+    "read_only_commands_registered": False,
     "enablement_gate": [
         "dedicated_staff_bot_token",
         "role_based_staff_linking",
@@ -880,6 +889,9 @@ def _build_staff_bot_status(
         "source_key": None,
     }
     token_contract = _build_staff_bot_token_contract(token_status)
+    command_registration_contract = _build_staff_command_registration_contract(
+        token_contract
+    )
     return {
         "version": "linking-runtime",
         "contract_version": "staff-menu-read-only-v1",
@@ -907,7 +919,7 @@ def _build_staff_bot_status(
         "link_token_validation_contract": STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT,
         "link_token_storage_contract": STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT,
         "authorization_contract": STAFF_BOT_AUTHORIZATION_CONTRACT,
-        "command_registration_contract": STAFF_BOT_COMMAND_REGISTRATION_CONTRACT,
+        "command_registration_contract": command_registration_contract,
         "confirmation_contract": STAFF_BOT_CONFIRMATION_CONTRACT,
         "audit_contract": STAFF_BOT_AUDIT_CONTRACT,
         "authorization": {
@@ -949,7 +961,7 @@ def _build_staff_bot_status(
         "next_slice": (
             "dedicated_staff_bot_token_runtime_config"
             if not token_contract["ready"]
-            else "staff_command_registration_runtime"
+            else "staff_read_only_domain_data_runtime"
         ),
     }
 
@@ -1055,6 +1067,24 @@ def _get_staff_bot_token_runtime_status(
     }
 
 
+def _get_configured_staff_bot_token(
+    db: Session, patient_bot_token: str | None = None
+) -> str | None:
+    patient_token_text = str(patient_bot_token or "").strip()
+    for env_key in STAFF_BOT_TOKEN_ENV_KEYS:
+        token_text = str(os.getenv(env_key) or "").strip()
+        if token_text and token_text != patient_token_text:
+            return token_text
+
+    for setting_key in STAFF_BOT_TOKEN_SETTING_KEYS:
+        setting = crud_clinic.get_setting_by_key(db, setting_key)
+        token_text = str(getattr(setting, "value", None) or "").strip()
+        if token_text and token_text != patient_token_text:
+            return token_text
+
+    return None
+
+
 def _build_staff_bot_token_contract(token_status: Dict[str, Any]) -> Dict[str, Any]:
     configured = bool(token_status.get("configured"))
     ready = bool(token_status.get("ready"))
@@ -1096,6 +1126,44 @@ def _build_staff_bot_token_contract(token_status: Dict[str, Any]) -> Dict[str, A
                 "ready": True,
             },
         ],
+    }
+
+
+def _staff_bot_read_only_command_payload() -> list[Dict[str, str]]:
+    commands = []
+    for item in STAFF_BOT_COMMAND_REGISTRATION_CONTRACT.get("commands", []):
+        if item.get("intent") != "read_only":
+            continue
+        command = str(item.get("command") or "").strip().lstrip("/")
+        description = str(item.get("label") or command).strip()
+        if command:
+            commands.append(
+                {
+                    "command": command,
+                    "description": description[:256],
+                }
+            )
+    return commands
+
+
+def _build_staff_command_registration_contract(
+    token_contract: Dict[str, Any],
+) -> Dict[str, Any]:
+    token_ready = bool(token_contract.get("ready"))
+    return {
+        **STAFF_BOT_COMMAND_REGISTRATION_CONTRACT,
+        "registration_enabled": token_ready,
+        "runtime_registration_enabled": True,
+        "registration_endpoint_published": True,
+        "read_only_command_registration_available": token_ready,
+        "read_only_commands_registered": False,
+        "registered_command_scope": "read_only_staff_commands_only",
+        "patient_bot_token_allowed": False,
+        "state_changing_commands_registered": False,
+        "runtime_blocked_by": (
+            [] if token_ready else list(token_contract["runtime_blocked_by"])
+        ),
+        "telegram_payload_commands": _staff_bot_read_only_command_payload(),
     }
 
 
@@ -1309,6 +1377,64 @@ async def register_patient_bot_commands(
         raise_admin_telegram_error(
             "register-patient-commands",
             "Telegram patient bot command registration failed",
+            e,
+        )
+
+
+@router.post("/telegram/register-staff-commands")
+async def register_staff_bot_commands(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_roles("Admin")),
+):
+    """Register read-only staff bot commands with a dedicated staff bot token."""
+    try:
+        patient_bot_token = _get_configured_bot_token(db)
+        token_status = _get_staff_bot_token_runtime_status(
+            db, patient_bot_token=patient_bot_token
+        )
+        staff_bot_token = _get_configured_staff_bot_token(
+            db, patient_bot_token=patient_bot_token
+        )
+        if not staff_bot_token or not token_status.get("ready"):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "message": "Dedicated staff bot token is not configured",
+                    "source": token_status.get("source"),
+                    "source_key": token_status.get("source_key"),
+                    "patient_bot_token_reused": bool(
+                        token_status.get("patient_bot_token_reused")
+                    ),
+                },
+            )
+
+        commands = _staff_bot_read_only_command_payload()
+        bot_service = await get_telegram_bot_service()
+        ok, error = await bot_service.set_staff_bot_commands(
+            staff_bot_token, commands=commands
+        )
+        if not ok:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail={
+                    "message": "Telegram staff bot commands were not registered",
+                    "error": error,
+                },
+            )
+
+        return {
+            "success": True,
+            "message": "Telegram staff bot read-only commands registered",
+            "registered_commands": [item["command"] for item in commands],
+            "state_changing_commands_registered": False,
+            "token_returned_to_frontend": False,
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise_admin_telegram_error(
+            "register-staff-commands",
+            "Telegram staff bot command registration failed",
             e,
         )
 

--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -39,6 +39,15 @@ PATIENT_BOT_COMMANDS_UZ = [
     {"command": "profile", "description": "Mening holatim"},
     {"command": "help", "description": "Yordam"},
 ]
+STAFF_BOT_COMMANDS_DEFAULT = [
+    {"command": "staff", "description": "Staff status"},
+    {"command": "queue", "description": "Role queue"},
+    {"command": "schedule", "description": "Schedule"},
+    {"command": "payments", "description": "Payment statuses"},
+    {"command": "reports", "description": "Report readiness"},
+    {"command": "summary", "description": "Operational summary"},
+    {"command": "help", "description": "Staff help"},
+]
 
 
 class TelegramBotService:
@@ -512,17 +521,14 @@ class TelegramBotService:
         message_id = (payload.get("result") or {}).get("message_id")
         return True, int(message_id) if message_id is not None else None, None
 
-    async def set_patient_bot_commands(self) -> tuple[bool, str | None]:
-        """Register patient bot command menu in Telegram."""
-        if not self.bot_token:
+    async def _set_bot_commands(
+        self, bot_token: str | None, payloads: list[dict[str, Any]]
+    ) -> tuple[bool, str | None]:
+        if not bot_token:
             logger.error("Bot token is not configured for Telegram command registration")
             return False, "bot_token_not_configured"
 
-        url = f"https://api.telegram.org/bot{self.bot_token}/setMyCommands"
-        payloads = [
-            {"commands": PATIENT_BOT_COMMANDS_RU},
-            {"commands": PATIENT_BOT_COMMANDS_UZ, "language_code": "uz"},
-        ]
+        url = f"https://api.telegram.org/bot{bot_token}/setMyCommands"
         for payload in payloads:
             try:
                 response = requests.post(url, json=payload, timeout=10)
@@ -551,6 +557,27 @@ class TelegramBotService:
                 return False, "telegram_api_error"
 
         return True, None
+
+    async def set_patient_bot_commands(self) -> tuple[bool, str | None]:
+        """Register patient bot command menu in Telegram."""
+        return await self._set_bot_commands(
+            self.bot_token,
+            [
+                {"commands": PATIENT_BOT_COMMANDS_RU},
+                {"commands": PATIENT_BOT_COMMANDS_UZ, "language_code": "uz"},
+            ],
+        )
+
+    async def set_staff_bot_commands(
+        self,
+        staff_bot_token: str | None,
+        commands: list[dict[str, str]] | None = None,
+    ) -> tuple[bool, str | None]:
+        """Register read-only staff bot commands with the dedicated staff bot."""
+        return await self._set_bot_commands(
+            staff_bot_token,
+            [{"commands": commands or STAFF_BOT_COMMANDS_DEFAULT}],
+        )
 
     async def _answer_callback_query(self, callback_query_id: str, text: str = ""):
         """Ответ на callback запрос"""

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.api.v1.endpoints import admin_telegram
 from app.models.clinic import ClinicSettings
+from app.services import telegram_bot
 
 
 @pytest.mark.unit
@@ -37,7 +38,14 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "TELEGRAM_STAFF_BOT_TOKEN"
         assert contract["token_returned_to_frontend"] is False
         assert contract["patient_bot_token_reused"] is False
-        assert status["next_slice"] == "staff_command_registration_runtime"
+        assert status["next_slice"] == "staff_read_only_domain_data_runtime"
+        assert (
+            status["command_registration_contract"]["registration_enabled"] is True
+        )
+        assert (
+            status["command_registration_contract"]["state_changing_commands_registered"]
+            is False
+        )
         assert secret_value not in str(status)
 
     def test_reads_legacy_env_without_secret_leak(self, monkeypatch, db_session):
@@ -61,7 +69,10 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_command_registration_runtime"
+        assert status["next_slice"] == "staff_read_only_domain_data_runtime"
+        assert (
+            status["command_registration_contract"]["registration_enabled"] is True
+        )
         assert secret_value not in str(status)
         assert "patient-token" not in str(status)
 
@@ -113,3 +124,50 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert "separate_staff_bot_token_configured" in contract["runtime_blocked_by"]
         assert status["next_slice"] == "dedicated_staff_bot_token_runtime_config"
         assert secret_value not in str(status)
+
+    @pytest.mark.asyncio
+    async def test_register_staff_commands_uses_read_only_payload_without_secret(
+        self, monkeypatch, db_session
+    ):
+        secret_value = "999999:staff-secret"
+        calls = []
+        self._clear_staff_bot_token_sources(monkeypatch)
+        monkeypatch.setenv("TELEGRAM_STAFF_BOT_TOKEN", secret_value)
+
+        class FakeResponse:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {"ok": True}
+
+        def fake_post(url, json, timeout):
+            calls.append({"url": url, "json": json, "timeout": timeout})
+            return FakeResponse()
+
+        monkeypatch.setattr(telegram_bot.requests, "post", fake_post)
+
+        result = await admin_telegram.register_staff_bot_commands(
+            db_session,
+            SimpleNamespace(id=1),
+        )
+
+        registered = result["registered_commands"]
+        assert result["success"] is True
+        assert result["state_changing_commands_registered"] is False
+        assert result["token_returned_to_frontend"] is False
+        assert registered == [
+            "staff",
+            "queue",
+            "schedule",
+            "payments",
+            "reports",
+            "summary",
+            "help",
+        ]
+        assert "refund" not in registered
+        assert "call" not in registered
+        assert secret_value not in str(result)
+        assert calls[0]["json"]["commands"] == (
+            admin_telegram._staff_bot_read_only_command_payload()
+        )

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -62,6 +62,7 @@ const TelegramManager = () => {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [registeringCommands, setRegisteringCommands] = useState(false);
+  const [registeringStaffCommands, setRegisteringStaffCommands] = useState(false);
   const [showTemplateDialog, setShowTemplateDialog] = useState(false);
   const [templateForm, setTemplateForm] = useState({
     name: '',
@@ -150,6 +151,26 @@ const TelegramManager = () => {
     }
   };
 
+  const registerStaffCommands = async () => {
+    try {
+      setError('');
+      setSuccess('');
+      setRegisteringStaffCommands(true);
+      const response = await api.post('/admin/telegram/register-staff-commands');
+      const commands = Array.isArray(response?.data?.registered_commands) ?
+      response.data.registered_commands.join(', ') :
+      'read-only staff commands';
+      setSuccess(`Staff-команды зарегистрированы: ${commands}`);
+      await loadTelegramData();
+    } catch (e) {
+      const detail = e?.response?.data?.detail;
+      const message = typeof detail === 'string' ? detail : detail?.message || detail?.error;
+      setError(message || e?.message || 'Не удалось зарегистрировать staff-команды Telegram');
+    } finally {
+      setRegisteringStaffCommands(false);
+    }
+  };
+
   if (loading) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" sx={{ minHeight: '400px' }}>
@@ -221,6 +242,11 @@ const TelegramManager = () => {
   const staffCommandNames = staffCommandList.
   map((item) => item?.command).
   filter(Boolean);
+  const staffCommandEndpointReady = Boolean(
+    staffCommandContract.registration_endpoint_published ||
+    staffCommandContract.runtime_registration_enabled
+  );
+  const staffCommandRegistrationEnabled = Boolean(staffCommandContract.registration_enabled);
   const staffConfirmationContract = staffBot.confirmation_contract || {};
   const staffConfirmationRuntime = staffBot.confirmations || {};
   const staffConfirmationOperations = Array.isArray(staffConfirmationContract.operations) ?
@@ -591,14 +617,14 @@ const TelegramManager = () => {
                   <ListItemText
                     primary="Staff command registration"
                     secondary={staffCommandNames.length ?
-                    `${staffCommandNames.join(' ')}; registration: ${staffCommandContract.registration_enabled ? 'enabled' : 'disabled until staff gates'}` :
+                    `${staffCommandNames.join(' ')}; registration: ${staffCommandRegistrationEnabled ? 'ready' : 'blocked until staff token'}; endpoint: ${staffCommandEndpointReady ? 'published' : 'planned'}` :
                     'Staff command contract не опубликован'} />
 
                   <Badge
-                    variant={staffCommandContract.registration_enabled ? 'success' : 'warning'}
+                    variant={staffCommandRegistrationEnabled ? 'success' : 'warning'}
                     size="small">
 
-                    {staffCommandContract.registration_enabled ? 'Enabled' : 'Planned'}
+                    {staffCommandRegistrationEnabled ? 'Ready' : staffCommandEndpointReady ? 'Endpoint' : 'Planned'}
                   </Badge>
                 </ListItem>
                 <ListItem>
@@ -684,6 +710,15 @@ const TelegramManager = () => {
                   style={{ paddingTop: 12, paddingBottom: 12 }}>
                   <CheckCircle size={16} />
                   {registeringCommands ? 'Регистрация команд...' : 'Зарегистрировать команды'}
+                </Button>
+                <Button
+                  fullWidth
+                  variant="outlined"
+                  disabled={!staffCommandRegistrationEnabled || registeringStaffCommands}
+                  onClick={registerStaffCommands}
+                  style={{ paddingTop: 12, paddingBottom: 12 }}>
+                  <CheckCircle size={16} />
+                  {registeringStaffCommands ? 'Регистрация staff-команд...' : 'Зарегистрировать staff-команды'}
                 </Button>
                 <Button
                   fullWidth


### PR DESCRIPTION
﻿## Summary

- Adds admin-triggered registration for staff bot read-only commands using the dedicated staff bot token only.
- Reuses the Telegram service `setMyCommands` path and keeps patient bot command registration unchanged.
- Keeps state-changing staff commands unregistered and advances the staff bot status next slice to read-only domain data runtime once the staff token is ready.
- Surfaces staff command registration readiness and a staff command registration action in TelegramManager.

## Contract Impact

- Canonical surface: `POST /api/v1/admin/telegram/register-staff-commands`, staff bot command registration contract, and TelegramManager quick action/status row.
- Request shape: no request body is required; the endpoint reads the dedicated staff bot token from accepted env/settings sources and rejects missing or patient-token-reused configurations.
- Response shape: success responses include `success`, `message`, `registered_commands`, `state_changing_commands_registered: false`, and `token_returned_to_frontend: false`; error responses include structured `detail.message` and `detail.error`/token source context.
- Status codes: 200 on Telegram API success, 400 when the dedicated staff token is missing or reused, 502 when Telegram command registration fails, existing auth failure behavior unchanged.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads `registration_enabled`/endpoint flags and calls `/admin/telegram/register-staff-commands` only when the staff command contract is ready.
- Compatibility path or alias: patient command registration remains on `/admin/telegram/register-patient-commands`; staff read-only menu and state-change denial runtime remain unchanged.
- Contract proof: focused tests assert the staff endpoint sends only read-only commands, excludes `/refund` and `/call`, does not return the token, and keeps state-changing command registration false.

## RBAC / Permissions

- Roles allowed: Admin via the existing `require_roles("Admin")` dependency on the new endpoint.
- Roles denied: non-admin users remain denied by the shared admin Telegram endpoint role dependency.
- Positive auth proof: route declaration uses the same Admin dependency as existing Telegram admin actions, and the focused endpoint test exercises the Admin-only function path with a staff token.
- Negative auth proof: no state-changing commands are registered; tests assert denied command names such as `refund` and `call` are absent from the registration payload.

## Notification / Realtime

- Event type or websocket channel: not applicable - no websocket, notification, or realtime event is emitted.
- Payload version / ack behavior: not applicable - Telegram Bot API command registration is a one-shot admin action, not a delivery ack flow.
- Read/unread or delivery semantics: not applicable - no notification state is introduced.
- Reconnect/resync proof: not applicable - no realtime subscription or reconnect path is changed.

## Frontend Resilience

- Empty data proof: missing command contract still renders the existing contract-not-published fallback.
- Partial data proof: missing endpoint/registration flags resolve to false booleans and keep the staff registration action disabled.
- Forbidden secondary path behavior: registration errors surface backend `detail.message`/`detail.error` in the existing TelegramManager error channel.
- Missing draft/resource behavior: not applicable - no draft/resource workflow is introduced.
- Stale route/deep-link behavior: not applicable - no route params or deep-link state are consumed.

## Scope Gate

- Allowed paths: `backend/app/services/telegram_bot.py`, `backend/app/api/v1/endpoints/admin_telegram.py`, `frontend/src/components/TelegramManager.jsx`, and focused staff bot token runtime tests.
- Denied paths: migrations, Telegram webhook mutation behavior, queue/payment/EMR/lab services, generated output, secrets/settings files, and state-changing Bot API command registration.
- Migration/docs/test impact: no migration or docs changed; focused test coverage added for the staff command registration runtime and status next slice.
- Rollback note: revert commit `0572800b` to return staff command registration to status-only planning and remove the admin trigger.

## Validation

- Targeted tests or smoke run: `python scripts\agent_gate.py "Telegram staff command registration runtime: add admin-triggered registration for read-only staff bot commands using dedicated staff bot token only, keep state-changing commands unregistered and surface status in TelegramManager" --known-root-cause "backend/app/services/telegram_bot.py"`; `python -m py_compile backend\app\services\telegram_bot.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; `python -m pytest backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py backend\tests\unit\test_telegram_bot_management_api_service.py backend\tests\unit\test_telegram_webhook_security.py -q`; `git diff --check`; `npm.cmd run build`.
- Result: gate returned narrow override with known-root-cause recovery; local py_compile passed; 47 focused backend tests passed; diff check passed; frontend build passed with existing Vite chunk/dynamic-import warnings.
- Not checked: live Telegram Bot API registration against a real staff bot token, non-admin HTTP auth smoke, and browser E2E.
