### PR TITLE
feat(telegram): expose staff readiness read-only data

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -142,6 +142,7 @@ STAFF_BOT_GUARDRAILS = [
     "explicit_confirmation_for_state_changes",
     "no_queue_fairness_mutation_without_domain_service",
 ]
+STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS = ["staff_readiness"]
 
 STAFF_BOT_TOKEN_CONTRACT = {
     "contract_version": "staff-token-v1",
@@ -572,7 +573,25 @@ STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
     "required_before_enablement": True,
     "state_changing_menu_items_enabled": False,
     "runtime_handler": "_handle_staff_read_only_menu",
-    "domain_data_commands_enabled": False,
+    "domain_data_commands_enabled": True,
+    "domain_data_commands_status": "partial",
+    "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
+    "pending_domain_data_command_keys": [
+        "queue_overview",
+        "next_patient",
+        "payment_status",
+        "today_schedule",
+        "emr_reminders",
+        "unpaid_invoices",
+        "paid_invoices",
+        "reconciliation_alerts",
+        "ready_reports",
+        "pending_reports",
+        "delivery_status",
+        "daily_summary",
+        "integration_errors",
+        "revenue_summary",
+    ],
     "state_changing_actions_enabled": False,
     "allowed_until_enabled": [
         "read_status_contract",
@@ -858,11 +877,12 @@ def _build_staff_role_menus_summary() -> Dict[str, Any]:
         "role_count": len(menu_roles),
         "item_count": menu_item_count,
         "handler": "_handle_staff_read_only_menu",
-        "domain_data_commands_enabled": False,
+        "domain_data_commands_enabled": True,
+        "domain_data_commands_status": "partial",
+        "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
         "state_changing_actions_enabled": False,
         "blocked_until": [
-            "audit_logging",
-            "state_change_confirmations",
+            "role_specific_domain_read_models",
         ],
     }
 
@@ -961,7 +981,7 @@ def _build_staff_bot_status(
         "next_slice": (
             "dedicated_staff_bot_token_runtime_config"
             if not token_contract["ready"]
-            else "staff_read_only_domain_data_runtime"
+            else "staff_read_only_queue_summary_runtime"
         ),
     }
 

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -16,9 +16,13 @@ from app.api.deps import require_roles
 from app.api.v1.endpoints.admin_telegram import (
     STAFF_BOT_COMMAND_REGISTRATION_CONTRACT,
     STAFF_BOT_CONFIRMATION_CONTRACT,
+    STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS,
     STAFF_BOT_READ_ONLY_MENU_CONTRACT,
     STAFF_LINK_TOKEN_PREFIX,
     STAFF_LINK_TOKEN_SEPARATOR,
+    _build_staff_bot_status,
+    _get_configured_bot_token,
+    _get_staff_bot_token_runtime_status,
     _normalize_staff_role,
     validate_staff_link_start_token,
 )
@@ -877,6 +881,9 @@ def _staff_read_only_item_labels() -> set[str]:
             label = str(item.get("label") or "").strip().lower()
             if label:
                 labels.add(label)
+            key = str(item.get("key") or "").strip().lower()
+            if key:
+                labels.add(key)
     return labels
 
 
@@ -889,6 +896,47 @@ def _staff_menu_item_for_text(
         key = str(item.get("key") or "").strip().lower()
         if normalized_text in {label, key}:
             return item
+    return None
+
+
+def _staff_readiness_message(db: Session) -> str:
+    patient_bot_token = _get_configured_bot_token(db)
+    token_status = _get_staff_bot_token_runtime_status(
+        db, patient_bot_token=patient_bot_token
+    )
+    staff_status = _build_staff_bot_status(
+        webhook_set=False,
+        staff_bot_token_status=token_status,
+    )
+    readiness = staff_status.get("readiness", [])
+    ready_count = sum(1 for item in readiness if item.get("ready"))
+    command_contract = staff_status.get("command_registration_contract", {})
+    token_contract = staff_status.get("token_contract", {})
+    return "\n".join(
+        [
+            "Staff bot readiness",
+            f"Ready gates: {ready_count}/{len(readiness)}",
+            f"Dedicated token: {'ready' if token_contract.get('ready') else 'required'}",
+            "Read-only menu: enabled",
+            (
+                "Read-only commands: ready"
+                if command_contract.get("registration_enabled")
+                else "Read-only commands: blocked"
+            ),
+            "Live data: staff_readiness only",
+            "State-changing actions: disabled",
+        ]
+    )
+
+
+def _staff_read_only_domain_data_message(
+    db: Session, menu_item: Dict[str, Any] | None
+) -> str | None:
+    item_key = str((menu_item or {}).get("key") or "").strip()
+    if item_key not in STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS:
+        return None
+    if item_key == "staff_readiness":
+        return _staff_readiness_message(db)
     return None
 
 
@@ -1051,6 +1099,7 @@ async def _handle_staff_read_only_menu(
 
     menu_item = _staff_menu_item_for_text(role_menu, text)
     command_key = command if command in read_only_commands else "staff_menu_item"
+    domain_data_message = _staff_read_only_domain_data_message(db, menu_item)
     _record_staff_command_audit(
         db,
         chat_id=chat_id,
@@ -1064,7 +1113,7 @@ async def _handle_staff_read_only_menu(
     db.commit()
     await bot_service._send_message(
         chat_id,
-        TELEGRAM_STAFF_MENU_PLACEHOLDER_MESSAGE,
+        domain_data_message or TELEGRAM_STAFF_MENU_PLACEHOLDER_MESSAGE,
         menu,
     )
     return True

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -217,7 +217,11 @@ class TestTelegramBotManagementApiService:
         assert role_menu_enablement["enabled"] is True
         assert role_menu_enablement["runtime_menu_enabled"] is True
         assert role_menu_enablement["state_changing_menu_items_enabled"] is False
-        assert role_menu_enablement["domain_data_commands_enabled"] is False
+        assert role_menu_enablement["domain_data_commands_enabled"] is True
+        assert role_menu_enablement["domain_data_commands_status"] == "partial"
+        assert role_menu_enablement["domain_data_command_keys"] == [
+            "staff_readiness"
+        ]
 
     @pytest.mark.parametrize(
         ("webhook_set", "expected_transport"),

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -38,7 +38,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "TELEGRAM_STAFF_BOT_TOKEN"
         assert contract["token_returned_to_frontend"] is False
         assert contract["patient_bot_token_reused"] is False
-        assert status["next_slice"] == "staff_read_only_domain_data_runtime"
+        assert status["next_slice"] == "staff_read_only_queue_summary_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )
@@ -69,7 +69,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_read_only_domain_data_runtime"
+        assert status["next_slice"] == "staff_read_only_queue_summary_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -118,6 +118,42 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         assert audit_log.payload["state_changing_action"] is False
 
     @pytest.mark.asyncio
+    async def test_staff_readiness_menu_item_returns_safe_live_status(
+        self, db_session, admin_user
+    ):
+        _link_staff_chat(db_session, chat_id=7205, user_id=admin_user.id)
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 205,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7205},
+                "from": {"id": 7205},
+                "text": "staff_readiness",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        text = fake_service._send_message.await_args.args[1]
+        assert "Staff bot readiness" in text
+        assert "Live data: staff_readiness only" in text
+        assert "State-changing actions: disabled" in text
+        assert "7205" not in text
+        audit_log = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_command_received")
+            .one()
+        )
+        assert audit_log.payload["menu_item_key"] == "staff_readiness"
+        assert audit_log.payload["read_only"] is True
+        assert audit_log.payload["state_changing_action"] is False
+
+    @pytest.mark.asyncio
     async def test_staff_state_change_command_is_denied_without_domain_mutation(
         self, db_session, admin_user
     ):

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -291,6 +291,12 @@ const TelegramManager = () => {
   const staffRoleMenuDomainDataEnabled = Boolean(
     staffRoleMenuEnablementContract.domain_data_commands_enabled
   );
+  const staffRoleMenuDomainDataStatus =
+  staffRoleMenuEnablementContract.domain_data_commands_status ||
+  (staffRoleMenuDomainDataEnabled ? 'enabled' : 'app only');
+  const staffRoleMenuDomainDataKeys = Array.isArray(staffRoleMenuEnablementContract.domain_data_command_keys) ?
+  staffRoleMenuEnablementContract.domain_data_command_keys :
+  [];
   const staffRoleMenuEnablementRoleCount = typeof staffRoleMenuEnablementContract.role_count === 'number' ?
   staffRoleMenuEnablementContract.role_count :
   staffMenuContract.length;
@@ -600,7 +606,7 @@ const TelegramManager = () => {
                   <ListItemText
                     primary="Staff role menu enablement"
                     secondary={staffRoleMenuEnablementContract.contract_version ?
-                    `${staffRoleMenuEnablementRoleCount} roles, ${staffRoleMenuEnablementItemCount} items; runtime menu: ${staffRoleMenuRuntimeEnabled ? 'enabled' : 'disabled'}; live data: ${staffRoleMenuDomainDataEnabled ? 'enabled' : 'app only'}` :
+                    `${staffRoleMenuEnablementRoleCount} roles, ${staffRoleMenuEnablementItemCount} items; runtime menu: ${staffRoleMenuRuntimeEnabled ? 'enabled' : 'disabled'}; live data: ${staffRoleMenuDomainDataStatus}${staffRoleMenuDomainDataKeys.length ? ` (${staffRoleMenuDomainDataKeys.join(', ')})` : ''}` :
                     'Role menu enablement contract not published'} />
 
                   <Badge


### PR DESCRIPTION
﻿## Summary

- Adds the first staff read-only live-data response for the `staff_readiness` menu item.
- Keeps the slice limited to staff bot readiness metadata; no patient, queue, payment, EMR, or lab data is read.
- Marks staff role menu domain data as partial and advances the next slice to queue summary runtime when the staff token is ready.
- Updates TelegramManager to show partial live-data status and the enabled command key.

## Contract Impact

- Canonical surface: staff read-only menu runtime, `staff_bot.role_menu_enablement_contract`, and TelegramManager staff role menu status row.
- Request shape: unchanged Telegram text/menu input; the existing `staff_readiness` menu item key is now recognized as a read-only live-data request.
- Response shape: Telegram replies for `staff_readiness` now include a short readiness summary with ready gate count, token readiness, read-only command readiness, partial live-data status, and state-changing actions disabled.
- Status codes: unchanged; this is inside existing Telegram update handling, not a new HTTP route.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` reads `domain_data_commands_status` and `domain_data_command_keys` defensively.
- Compatibility path or alias: other read-only menu items continue returning the placeholder; staff state-changing commands remain deny-only and disabled.
- Contract proof: focused unit tests assert `staff_readiness` returns safe live status, writes read-only audit, omits chat id, and does not mark state-changing action.

## RBAC / Permissions

- Roles allowed: linked Admin staff can use the existing admin menu item `staff_readiness`.
- Roles denied: unlinked users and unsupported staff roles keep the existing denied/forbidden staff menu behavior.
- Positive auth proof: focused test links an Admin user to Telegram and receives the readiness response.
- Negative auth proof: existing focused tests still assert unlinked staff requests are denied and `/refund` remains deny-only without domain mutation.

## Notification / Realtime

- Event type or websocket channel: not applicable - no websocket, notification, or realtime event is emitted.
- Payload version / ack behavior: not applicable - Telegram response is a direct read-only message, not an acked notification flow.
- Read/unread or delivery semantics: not applicable - no notification delivery state is introduced.
- Reconnect/resync proof: not applicable - no realtime subscription or reconnect path is changed.

## Frontend Resilience

- Empty data proof: missing role menu enablement contract still renders the existing fallback.
- Partial data proof: missing `domain_data_commands_status` falls back to enabled/app-only text; missing command keys render without crashing.
- Forbidden secondary path behavior: unsupported/forbidden staff menu behavior remains backend-controlled by the existing role menu checks.
- Missing draft/resource behavior: not applicable - no draft/resource workflow is introduced.
- Stale route/deep-link behavior: not applicable - no route params or deep-link state are consumed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/app/api/v1/endpoints/telegram_webhook.py`, `frontend/src/components/TelegramManager.jsx`, and focused Telegram staff menu/status tests.
- Denied paths: queue/payment/EMR/lab services, patient data queries, migrations, generated output, secrets/settings files, and state-changing Telegram actions.
- Migration/docs/test impact: no migration or docs changed; focused test coverage added for the `staff_readiness` live-data response.
- Rollback note: revert commit `95ef70a8` to return all staff read-only menu item selections to the placeholder response.

## Validation

- Targeted tests or smoke run: `python scripts\agent_gate.py "Telegram staff read-only domain data runtime: implement only the admin staff_readiness read-only menu item with no patient/queue/payment/EMR data, keep state-changing actions disabled and surface partial live-data status" --known-root-cause "backend/app/api/v1/endpoints/telegram_webhook.py"`; `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; `python -m pytest backend\tests\unit\test_telegram_staff_read_only_menu_runtime.py backend\tests\unit\test_telegram_bot_management_api_service.py backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py -q`; `git diff --check`; `npm.cmd run build`.
- Result: gate ok; local py_compile passed; 30 focused backend tests passed; diff check passed; frontend build passed with existing Vite chunk/dynamic-import warnings.
- Not checked: live Telegram delivery, browser E2E, and any queue/payment/EMR/lab read model.
