### PR TITLE
feat(telegram): add staff read-only domain aggregates

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -142,7 +142,13 @@ STAFF_BOT_GUARDRAILS = [
     "explicit_confirmation_for_state_changes",
     "no_queue_fairness_mutation_without_domain_service",
 ]
-STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS = ["staff_readiness"]
+STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS = [
+    "staff_readiness",
+    "queue_overview",
+    "payment_status",
+    "ready_reports",
+    "daily_summary",
+]
 
 STAFF_BOT_TOKEN_CONTRACT = {
     "contract_version": "staff-token-v1",
@@ -577,18 +583,14 @@ STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
     "domain_data_commands_status": "partial",
     "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
     "pending_domain_data_command_keys": [
-        "queue_overview",
         "next_patient",
-        "payment_status",
         "today_schedule",
         "emr_reminders",
         "unpaid_invoices",
         "paid_invoices",
         "reconciliation_alerts",
-        "ready_reports",
         "pending_reports",
         "delivery_status",
-        "daily_summary",
         "integration_errors",
         "revenue_summary",
     ],

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from typing import Any, Dict, NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.api.deps import require_roles
@@ -86,6 +87,19 @@ TELEGRAM_STAFF_ACTION_DENIED_MESSAGE = (
     "State-changing staff actions require confirmation in the clinic app. "
     "Telegram execution is disabled."
 )
+STAFF_COMMAND_DOMAIN_ITEM_KEYS = {
+    "/queue": ("queue_overview",),
+    "/payments": (
+        "payment_status",
+        "unpaid_invoices",
+        "paid_invoices",
+        "reconciliation_alerts",
+        "revenue_summary",
+    ),
+    "/reports": ("ready_reports", "integration_errors"),
+    "/schedule": ("today_schedule",),
+    "/summary": ("daily_summary", "revenue_summary"),
+}
 TELEGRAM_SHARE_CONTACT_MESSAGE = (
     "Чтобы привязать Telegram к карте пациента, нажмите кнопку "
     "\"Поделиться номером\". Номер должен совпадать с номером в регистратуре."
@@ -899,6 +913,171 @@ def _staff_menu_item_for_text(
     return None
 
 
+def _staff_menu_item_for_command(
+    role_menu: Dict[str, Any], command: str
+) -> Dict[str, Any] | None:
+    allowed_keys = set(STAFF_COMMAND_DOMAIN_ITEM_KEYS.get(command, ()))
+    if not allowed_keys:
+        return None
+    for item in role_menu.get("items", []):
+        if str(item.get("key") or "").strip().lower() in allowed_keys:
+            return item
+    return None
+
+
+def _today_start() -> datetime:
+    return datetime.combine(date.today(), datetime.min.time())
+
+
+def _status_counts(rows: list[tuple[Any, Any]]) -> Dict[str, int]:
+    return {str(status or "unknown"): int(count or 0) for status, count in rows}
+
+
+def _format_money(amount: Any) -> str:
+    value = amount if isinstance(amount, Decimal) else Decimal(str(amount or 0))
+    return f"{value.quantize(Decimal('0.01'))} UZS"
+
+
+def _queue_status_counts(db: Session) -> Dict[str, int]:
+    rows = (
+        db.query(OnlineQueueEntry.status, func.count(OnlineQueueEntry.id))
+        .join(DailyQueue, OnlineQueueEntry.queue_id == DailyQueue.id)
+        .filter(DailyQueue.day == date.today())
+        .group_by(OnlineQueueEntry.status)
+        .all()
+    )
+    return _status_counts(rows)
+
+
+def _payment_status_rows(db: Session) -> list[tuple[str, int, Decimal]]:
+    return [
+        (str(status or "unknown"), int(count or 0), amount or Decimal("0"))
+        for status, count, amount in (
+            db.query(
+                Payment.status,
+                func.count(Payment.id),
+                func.coalesce(func.sum(Payment.amount), 0),
+            )
+            .filter(Payment.created_at >= _today_start())
+            .group_by(Payment.status)
+            .all()
+        )
+    ]
+
+
+def _lab_status_counts(db: Session) -> Dict[str, int]:
+    rows = (
+        db.query(LabReportInstance.status, func.count(LabReportInstance.id))
+        .filter(LabReportInstance.created_at >= _today_start())
+        .group_by(LabReportInstance.status)
+        .all()
+    )
+    return _status_counts(rows)
+
+
+def _staff_queue_overview_message(db: Session) -> str:
+    counts = _queue_status_counts(db)
+    total = sum(counts.values())
+    active = sum(
+        count for status, count in counts.items() if status not in QUEUE_TERMINAL_STATUSES
+    )
+    in_progress = sum(
+        counts.get(status, 0) for status in ("called", "in_service", "diagnostics")
+    )
+    return "\n".join(
+        [
+            "Queue overview",
+            f"Date: {date.today().isoformat()}",
+            f"Total entries: {total}",
+            f"Active entries: {active}",
+            f"Waiting: {counts.get('waiting', 0)}",
+            f"Called/in service: {in_progress}",
+            "Mode: read-only aggregate snapshot",
+        ]
+    )
+
+
+def _staff_payment_status_message(db: Session) -> str:
+    rows = _payment_status_rows(db)
+    total_count = sum(count for _status, count, _amount in rows)
+    paid_total = sum(
+        (amount for status, _count, amount in rows if status in PAYMENT_PAID_STATUSES),
+        Decimal("0"),
+    )
+    pending_total = sum(
+        (amount for status, _count, amount in rows if status in PAYMENT_PENDING_STATUSES),
+        Decimal("0"),
+    )
+    pending_count = sum(
+        count for status, count, _amount in rows if status in PAYMENT_PENDING_STATUSES
+    )
+    return "\n".join(
+        [
+            "Payment status",
+            f"Date: {date.today().isoformat()}",
+            f"Payments today: {total_count}",
+            f"Pending payments: {pending_count}",
+            f"Paid total: {_format_money(paid_total)}",
+            f"Pending total: {_format_money(pending_total)}",
+            "Mode: read-only aggregate snapshot",
+        ]
+    )
+
+
+def _staff_lab_reports_message(db: Session) -> str:
+    counts = _lab_status_counts(db)
+    ready = sum(
+        counts.get(status, 0)
+        for status in {"READY", "FINALIZED", "PRINTED"} | LAB_REPORT_READY_STATUSES
+    )
+    total = sum(counts.values())
+    return "\n".join(
+        [
+            "Lab report status",
+            f"Date: {date.today().isoformat()}",
+            f"Reports today: {total}",
+            f"Ready reports: {ready}",
+            f"Pending reports: {max(total - ready, 0)}",
+            "Mode: read-only aggregate snapshot",
+        ]
+    )
+
+
+def _staff_daily_summary_message(db: Session) -> str:
+    queue_counts = _queue_status_counts(db)
+    payment_rows = _payment_status_rows(db)
+    lab_counts = _lab_status_counts(db)
+    visits_today = (
+        db.query(func.count(Visit.id))
+        .filter(Visit.visit_date == date.today())
+        .scalar()
+        or 0
+    )
+    paid_total = sum(
+        (
+            amount
+            for status, _count, amount in payment_rows
+            if status in PAYMENT_PAID_STATUSES
+        ),
+        Decimal("0"),
+    )
+    ready_reports = sum(
+        lab_counts.get(status, 0)
+        for status in {"READY", "FINALIZED", "PRINTED"} | LAB_REPORT_READY_STATUSES
+    )
+    return "\n".join(
+        [
+            "Daily clinic summary",
+            f"Date: {date.today().isoformat()}",
+            f"Visits scheduled: {int(visits_today)}",
+            f"Queue entries: {sum(queue_counts.values())}",
+            f"Paid today: {_format_money(paid_total)}",
+            f"Ready lab reports: {ready_reports}",
+            "Mode: read-only aggregate snapshot",
+        ]
+    )
+
+
 def _staff_readiness_message(db: Session) -> str:
     patient_bot_token = _get_configured_bot_token(db)
     token_status = _get_staff_bot_token_runtime_status(
@@ -923,7 +1102,7 @@ def _staff_readiness_message(db: Session) -> str:
                 if command_contract.get("registration_enabled")
                 else "Read-only commands: blocked"
             ),
-            "Live data: staff_readiness only",
+            "Live data: limited read-only aggregates",
             "State-changing actions: disabled",
         ]
     )
@@ -937,6 +1116,14 @@ def _staff_read_only_domain_data_message(
         return None
     if item_key == "staff_readiness":
         return _staff_readiness_message(db)
+    if item_key == "queue_overview":
+        return _staff_queue_overview_message(db)
+    if item_key == "payment_status":
+        return _staff_payment_status_message(db)
+    if item_key == "ready_reports":
+        return _staff_lab_reports_message(db)
+    if item_key == "daily_summary":
+        return _staff_daily_summary_message(db)
     return None
 
 
@@ -1098,7 +1285,30 @@ async def _handle_staff_read_only_menu(
         return True
 
     menu_item = _staff_menu_item_for_text(role_menu, text)
+    if not menu_item and command in read_only_commands:
+        menu_item = _staff_menu_item_for_command(role_menu, command)
+
     command_key = command if command in read_only_commands else "staff_menu_item"
+    if command in read_only_commands and not menu_item:
+        _record_staff_command_audit(
+            db,
+            chat_id=chat_id,
+            request_id=request_id,
+            actor_user_id=int(user.id),
+            telegram_user_id=getattr(_telegram_user, "id", None),
+            role=_normalize_staff_role(getattr(user, "role", None)),
+            command_key=command_key,
+            result="denied",
+            reason="role_not_allowed",
+        )
+        db.commit()
+        await bot_service._send_message(
+            chat_id,
+            TELEGRAM_STAFF_MENU_FORBIDDEN_MESSAGE,
+            menu,
+        )
+        return True
+
     domain_data_message = _staff_read_only_domain_data_message(db, menu_item)
     _record_staff_command_audit(
         db,

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -220,7 +220,11 @@ class TestTelegramBotManagementApiService:
         assert role_menu_enablement["domain_data_commands_enabled"] is True
         assert role_menu_enablement["domain_data_commands_status"] == "partial"
         assert role_menu_enablement["domain_data_command_keys"] == [
-            "staff_readiness"
+            "staff_readiness",
+            "queue_overview",
+            "payment_status",
+            "ready_reports",
+            "daily_summary",
         ]
 
     @pytest.mark.parametrize(

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -83,9 +83,9 @@ class TestTelegramStaffReadOnlyMenuRuntime:
 
     @pytest.mark.asyncio
     async def test_staff_read_only_command_does_not_execute_patient_queue(
-        self, db_session, admin_user
+        self, db_session, registrar_user
     ):
-        _link_staff_chat(db_session, chat_id=7202, user_id=admin_user.id)
+        _link_staff_chat(db_session, chat_id=7202, user_id=registrar_user.id)
         fake_service = FakeTelegramBotService()
         update = {
             "update_id": 202,
@@ -103,17 +103,18 @@ class TestTelegramStaffReadOnlyMenuRuntime:
 
         assert handled is True
         fake_service._send_message.assert_awaited_once()
-        assert (
-            fake_service._send_message.await_args.args[1]
-            == telegram_webhook.TELEGRAM_STAFF_MENU_PLACEHOLDER_MESSAGE
-        )
+        text = fake_service._send_message.await_args.args[1]
+        assert "Queue overview" in text
+        assert "Mode: read-only aggregate snapshot" in text
+        assert "7202" not in text
         audit_log = (
             db_session.query(AuditLog)
             .filter(AuditLog.action == "staff_command_received")
             .one()
         )
-        assert audit_log.actor_user_id == admin_user.id
+        assert audit_log.actor_user_id == registrar_user.id
         assert audit_log.payload["command_key"] == "/queue"
+        assert audit_log.payload["menu_item_key"] == "queue_overview"
         assert audit_log.payload["read_only"] is True
         assert audit_log.payload["state_changing_action"] is False
 
@@ -141,7 +142,7 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         fake_service._send_message.assert_awaited_once()
         text = fake_service._send_message.await_args.args[1]
         assert "Staff bot readiness" in text
-        assert "Live data: staff_readiness only" in text
+        assert "Live data: limited read-only aggregates" in text
         assert "State-changing actions: disabled" in text
         assert "7205" not in text
         audit_log = (


### PR DESCRIPTION
## Summary

- Expands staff Telegram read-only domain data from readiness-only to safe aggregate snapshots.
- Adds role-scoped `/queue`, `/payments`, `/reports`, and `/summary` routing to existing staff menu items without exposing patient-level details.
- Keeps state-changing staff actions denied and keeps doctor-specific schedule data as a pending scoped path.

## Contract Impact

- Canonical surface: staff Telegram read-only menu runtime in `backend/app/api/v1/endpoints/telegram_webhook.py` and staff bot status contract in `admin_telegram.py`.
- Request shape: no HTTP request shape change; Telegram staff text commands and menu item labels continue through the existing webhook update shape.
- Response shape: Telegram replies now return aggregate text snapshots for enabled menu keys: `staff_readiness`, `queue_overview`, `payment_status`, `ready_reports`, and `daily_summary`.
- Status codes: no HTTP status behavior changed for admin endpoints or webhook endpoint registration.
- Frontend consumer: TelegramManager continues to read `domain_data_commands_enabled`, `domain_data_commands_status`, and `domain_data_command_keys` from the existing staff status payload.
- Compatibility path or alias: patient bot `/queue` and `/payments` handlers remain unchanged; staff commands are intercepted before patient routing only for linked staff accounts.
- Contract proof: focused staff menu test covers `/queue` for a linked registrar and asserts a read-only aggregate snapshot plus redacted audit payload.

## RBAC / Permissions

- Roles allowed: linked staff accounts only; registrar receives `queue_overview`, cashier/registrar payment paths map only to allowed role menu items, lab receives `ready_reports`, and admin/owner receive `daily_summary` where present in their role menu.
- Roles denied: unlinked accounts and roles without a matching menu item receive existing staff forbidden/unlinked behavior.
- Positive auth proof: `_linked_staff_for_chat` must resolve an active application user and role menu before aggregate data is sent.
- Negative auth proof: a read-only command with no role menu item writes a denied audit row with `reason=role_not_allowed` and does not return domain data.

## Notification / Realtime

- Event type or websocket channel: not applicable - Telegram command replies are direct bot messages and no app notification/websocket event is introduced.
- Payload version / ack behavior: Telegram receives plain text aggregate snapshots; no webhook acknowledgment shape changes.
- Read/unread or delivery semantics: not applicable - no unread counters, notification deliveries, or persisted chat delivery state are created.
- Reconnect/resync proof: not applicable - each command performs a fresh read-only aggregate query when invoked.

## Frontend Resilience

- Empty data proof: zero-row aggregate queries render stable zero-count Telegram messages.
- Partial data proof: only enabled command keys are advertised in the status contract while pending keys remain listed separately.
- Forbidden secondary path behavior: unsupported role/command combinations receive the existing forbidden staff message.
- Missing draft/resource behavior: not applicable - this slice does not create drafts/resources or add frontend persisted state.
- Stale route/deep-link behavior: not applicable - no route or deep-link changes were made.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/app/api/v1/endpoints/telegram_webhook.py`, and focused Telegram staff tests.
- Denied paths: queue mutation services, payment mutation services, lab mutation services, EMR, migrations, frontend runtime code, generated artifacts, and secrets/settings files.
- Migration/docs/test impact: no migration or docs change; focused staff Telegram tests updated for the expanded aggregate command contract.
- Rollback note: revert this PR to return staff domain commands to readiness-only/placeholder behavior while keeping earlier staff link, menu, audit, guard, and command registration slices.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; `python -m pytest backend\tests\unit\test_telegram_staff_read_only_menu_runtime.py backend\tests\unit\test_telegram_bot_management_api_service.py -q`; `git diff --check HEAD~1..HEAD`; `npm.cmd run build` in `frontend`.
- Result: passed locally on fresh `origin/main`; pytest reported 25 passed with 1 warning and Vite build completed with existing chunk/dynamic-import warnings.
- Not checked: live Telegram webhook invocation against a real staff bot, browser UI smoke, doctor-specific scoped schedule mapping, and full end-to-end suite.