### PR TITLE
feat(telegram): expose staff today schedule snapshot

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -146,6 +146,7 @@ STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS = [
     "staff_readiness",
     "queue_overview",
     "next_patient",
+    "today_schedule",
     "payment_status",
     "ready_reports",
     "daily_summary",
@@ -584,7 +585,6 @@ STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
     "domain_data_commands_status": "partial",
     "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
     "pending_domain_data_command_keys": [
-        "today_schedule",
         "emr_reminders",
         "unpaid_invoices",
         "paid_invoices",

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -975,6 +975,16 @@ def _lab_status_counts(db: Session) -> Dict[str, int]:
     return _status_counts(rows)
 
 
+def _visit_status_counts(db: Session) -> Dict[str, int]:
+    rows = (
+        db.query(Visit.status, func.count(Visit.id))
+        .filter(Visit.visit_date == date.today())
+        .group_by(Visit.status)
+        .all()
+    )
+    return _status_counts(rows)
+
+
 def _staff_queue_overview_message(db: Session) -> str:
     counts = _queue_status_counts(db)
     total = sum(counts.values())
@@ -1042,6 +1052,38 @@ def _staff_next_patient_message(db: Session) -> str:
         details.append(f"Position: {position}")
     details.append("Mode: read-only queue snapshot")
     return "\n".join(details)
+
+
+def _staff_today_schedule_message(db: Session) -> str:
+    counts = _visit_status_counts(db)
+    normalized_counts = {
+        str(status or "unknown").lower(): count for status, count in counts.items()
+    }
+    total = sum(counts.values())
+    in_progress = sum(
+        normalized_counts.get(status, 0)
+        for status in ("in_progress", "in_visit", "called")
+    )
+    completed = sum(
+        normalized_counts.get(status, 0)
+        for status in ("completed", "served", "done")
+    )
+    cancelled = sum(
+        normalized_counts.get(status, 0)
+        for status in ("cancelled", "canceled", "no_show")
+    )
+    open_visits = max(total - in_progress - completed - cancelled, 0)
+    return "\n".join(
+        [
+            "Today's schedule",
+            f"Date: {date.today().isoformat()}",
+            f"Visits today: {total}",
+            f"Open visits: {open_visits}",
+            f"In progress: {in_progress}",
+            f"Completed/cancelled: {completed + cancelled}",
+            "Mode: read-only schedule snapshot",
+        ]
+    )
 
 
 def _staff_payment_status_message(db: Session) -> str:
@@ -1167,6 +1209,8 @@ def _staff_read_only_domain_data_message(
         return _staff_queue_overview_message(db)
     if item_key == "next_patient":
         return _staff_next_patient_message(db)
+    if item_key == "today_schedule":
+        return _staff_today_schedule_message(db)
     if item_key == "payment_status":
         return _staff_payment_status_message(db)
     if item_key == "ready_reports":

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -30,6 +30,7 @@ from app.api.v1.endpoints.admin_telegram import (
 from app.crud import audit as crud_audit
 from app.crud import telegram_config as crud_telegram
 from app.db.session import get_db
+from app.models.clinic import Doctor
 from app.models.lab import LabReportInstance
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.patient import Patient
@@ -975,13 +976,23 @@ def _lab_status_counts(db: Session) -> Dict[str, int]:
     return _status_counts(rows)
 
 
-def _visit_status_counts(db: Session) -> Dict[str, int]:
-    rows = (
-        db.query(Visit.status, func.count(Visit.id))
-        .filter(Visit.visit_date == date.today())
-        .group_by(Visit.status)
-        .all()
+def _visit_status_counts(db: Session, user: User | None = None) -> Dict[str, int]:
+    query = db.query(Visit.status, func.count(Visit.id)).filter(
+        Visit.visit_date == date.today()
     )
+    if _normalize_staff_role(getattr(user, "role", None)) == "doctor":
+        doctor = (
+            db.query(Doctor)
+            .filter(
+                Doctor.user_id == getattr(user, "id", None),
+                Doctor.active.is_(True),
+            )
+            .first()
+        )
+        if not doctor:
+            return {}
+        query = query.filter(Visit.doctor_id == doctor.id)
+    rows = query.group_by(Visit.status).all()
     return _status_counts(rows)
 
 
@@ -1054,8 +1065,8 @@ def _staff_next_patient_message(db: Session) -> str:
     return "\n".join(details)
 
 
-def _staff_today_schedule_message(db: Session) -> str:
-    counts = _visit_status_counts(db)
+def _staff_today_schedule_message(db: Session, user: User | None = None) -> str:
+    counts = _visit_status_counts(db, user)
     normalized_counts = {
         str(status or "unknown").lower(): count for status, count in counts.items()
     }
@@ -1198,7 +1209,7 @@ def _staff_readiness_message(db: Session) -> str:
 
 
 def _staff_read_only_domain_data_message(
-    db: Session, menu_item: Dict[str, Any] | None
+    db: Session, menu_item: Dict[str, Any] | None, user: User | None = None
 ) -> str | None:
     item_key = str((menu_item or {}).get("key") or "").strip()
     if item_key not in STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS:
@@ -1210,7 +1221,7 @@ def _staff_read_only_domain_data_message(
     if item_key == "next_patient":
         return _staff_next_patient_message(db)
     if item_key == "today_schedule":
-        return _staff_today_schedule_message(db)
+        return _staff_today_schedule_message(db, user)
     if item_key == "payment_status":
         return _staff_payment_status_message(db)
     if item_key == "ready_reports":
@@ -1402,7 +1413,7 @@ async def _handle_staff_read_only_menu(
         )
         return True
 
-    domain_data_message = _staff_read_only_domain_data_message(db, menu_item)
+    domain_data_message = _staff_read_only_domain_data_message(db, menu_item, user)
     _record_staff_command_audit(
         db,
         chat_id=chat_id,

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -223,6 +223,7 @@ class TestTelegramBotManagementApiService:
             "staff_readiness",
             "queue_overview",
             "next_patient",
+            "today_schedule",
             "payment_status",
             "ready_reports",
             "daily_summary",

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -42,9 +42,9 @@ class TestTelegramStaffBotTokenRuntimeConfig:
             status["role_menu_enablement_contract"][
                 "pending_domain_data_command_keys"
             ][0]
-            == "today_schedule"
+            == "emr_reminders"
         )
-        assert status["next_slice"] == "staff_read_only_today_schedule_runtime"
+        assert status["next_slice"] == "staff_read_only_emr_reminders_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )
@@ -75,7 +75,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_read_only_today_schedule_runtime"
+        assert status["next_slice"] == "staff_read_only_emr_reminders_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -242,6 +242,8 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         self, db_session, test_doctor_user, test_doctor, test_patient
     ):
         _link_staff_chat(db_session, chat_id=7207, user_id=test_doctor_user.id)
+        test_doctor.user_id = test_doctor_user.id
+        db_session.flush()
         db_session.add_all(
             [
                 Visit(
@@ -270,6 +272,13 @@ class TestTelegramStaffReadOnlyMenuRuntime:
                     doctor_id=test_doctor.id,
                     visit_date=date.today() - timedelta(days=1),
                     visit_time="12:00",
+                    status="open",
+                ),
+                Visit(
+                    patient_id=test_patient.id,
+                    doctor_id=None,
+                    visit_date=date.today(),
+                    visit_time="13:00",
                     status="open",
                 ),
             ]

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -9,6 +9,7 @@ from app.api.v1.endpoints import telegram_webhook
 from app.models.audit import AuditLog
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.telegram_config import TelegramUser
+from app.models.visit import Visit
 
 
 class FakeTelegramBotService:
@@ -233,6 +234,83 @@ class TestTelegramStaffReadOnlyMenuRuntime:
             .one()
         )
         assert audit_log.payload["menu_item_key"] == "next_patient"
+        assert audit_log.payload["read_only"] is True
+        assert audit_log.payload["state_changing_action"] is False
+
+    @pytest.mark.asyncio
+    async def test_staff_today_schedule_command_returns_read_only_visit_snapshot(
+        self, db_session, test_doctor_user, test_doctor, test_patient
+    ):
+        _link_staff_chat(db_session, chat_id=7207, user_id=test_doctor_user.id)
+        db_session.add_all(
+            [
+                Visit(
+                    patient_id=test_patient.id,
+                    doctor_id=test_doctor.id,
+                    visit_date=date.today(),
+                    visit_time="09:00",
+                    status="open",
+                ),
+                Visit(
+                    patient_id=test_patient.id,
+                    doctor_id=test_doctor.id,
+                    visit_date=date.today(),
+                    visit_time="10:00",
+                    status="in_progress",
+                ),
+                Visit(
+                    patient_id=test_patient.id,
+                    doctor_id=test_doctor.id,
+                    visit_date=date.today(),
+                    visit_time="11:00",
+                    status="completed",
+                ),
+                Visit(
+                    patient_id=test_patient.id,
+                    doctor_id=test_doctor.id,
+                    visit_date=date.today() - timedelta(days=1),
+                    visit_time="12:00",
+                    status="open",
+                ),
+            ]
+        )
+        db_session.commit()
+
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 207,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7207},
+                "from": {"id": 7207},
+                "text": "/schedule",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        text = fake_service._send_message.await_args.args[1]
+        assert "Today's schedule" in text
+        assert "Visits today: 3" in text
+        assert "Open visits: 1" in text
+        assert "In progress: 1" in text
+        assert "Completed/cancelled: 1" in text
+        assert "Mode: read-only schedule snapshot" in text
+        assert test_patient.first_name not in text
+        if test_patient.phone:
+            assert test_patient.phone not in text
+        assert "7207" not in text
+        audit_log = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_command_received")
+            .one()
+        )
+        assert audit_log.payload["command_key"] == "/schedule"
+        assert audit_log.payload["menu_item_key"] == "today_schedule"
         assert audit_log.payload["read_only"] is True
         assert audit_log.payload["state_changing_action"] is False
 


### PR DESCRIPTION
## Summary
- Enable the staff bot `today_schedule` read-only domain-data key.
- Return aggregate visit counts for today's schedule without patient names, phones, IDs, or medical details.
- Scope doctor-role schedule snapshots to the linked `Doctor.user_id` record and advance `next_slice` to `staff_read_only_emr_reminders_runtime`.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/admin_telegram.py` staff bot status and `backend/app/api/v1/endpoints/telegram_webhook.py` staff read-only Telegram runtime.
- Request shape: unchanged; linked staff users can use the existing `/schedule` command or `today_schedule` menu key.
- Response shape: `today_schedule` now returns a read-only aggregate schedule snapshot; status `domain_data_command_keys` includes `today_schedule`, and `pending_domain_data_command_keys` now starts with `emr_reminders`.
- Status codes: unchanged.
- Frontend consumer: unchanged admin Telegram manager status consumer.
- Compatibility path or alias: no route, command, or alias added.
- Contract proof: focused Telegram staff runtime/status unit tests assert the command response and next-slice status.

## RBAC / Permissions
- Roles allowed: unchanged; `today_schedule` remains exposed through the existing doctor role menu.
- Roles denied: unchanged; existing staff menu role-denial path remains in place.
- Positive auth proof: linked doctor staff chat receives only aggregate counts for that linked doctor's schedule.
- Negative auth proof: test data includes a same-day visit outside the linked doctor scope and it is excluded from the aggregate count.

## Notification / Realtime

not applicable - no notification, websocket, delivery acknowledgement, or realtime resync behavior changed beyond the existing Telegram reply path.

## Frontend Resilience
- Empty data proof: zero matching visits renders stable aggregate counts instead of patient-level rows.
- Partial data proof: unknown visit statuses are included in total/open arithmetic without exposing details.
- Forbidden secondary path behavior: unchanged existing staff role denial handles forbidden menu access.
- Missing draft/resource behavior: not applicable, no draft or resource flow changed.
- Stale route/deep-link behavior: not applicable, no frontend route or deep-link state changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/app/api/v1/endpoints/telegram_webhook.py`, focused Telegram staff unit tests.
- Denied paths: frontend manager, migrations, visit mutation handlers, queue mutation handlers, patient detail rendering.
- Migration/docs/test impact: no migration or docs update; focused unit tests updated.
- Rollback note: revert this PR to return `today_schedule` to placeholder behavior and mark it pending again.
- Gate note: `agent_gate.py` initially included frontend and missed the focused tests; one retry included tests but still kept frontend as generic Telegram ownership. The final patch stayed backend-only and used the requested validation target including frontend build.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\\app\\api\\v1\\endpoints\\admin_telegram.py backend\\app\\api\\v1\\endpoints\\telegram_webhook.py backend\\tests\\unit\\test_telegram_staff_read_only_menu_runtime.py backend\\tests\\unit\\test_telegram_staff_bot_token_runtime_config.py backend\\tests\\unit\\test_telegram_bot_management_api_service.py`; `python -m pytest backend\\tests\\unit\\test_telegram_staff_read_only_menu_runtime.py backend\\tests\\unit\\test_telegram_staff_bot_token_runtime_config.py backend\\tests\\unit\\test_telegram_bot_management_api_service.py -q`; `git diff --check`; `cd frontend && npm.cmd run build`.
- Result: passed; 32 focused backend tests passed with the existing pytest warning; frontend build passed with existing chunk-size/dynamic-import warnings.
- Not checked: full backend suite and browser smoke were not run for this backend-only Telegram read-only slice.