### PR TITLE
feat(telegram): expose staff emr reminder snapshot

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -147,6 +147,7 @@ STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS = [
     "queue_overview",
     "next_patient",
     "today_schedule",
+    "emr_reminders",
     "payment_status",
     "ready_reports",
     "daily_summary",
@@ -585,7 +586,6 @@ STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
     "domain_data_commands_status": "partial",
     "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
     "pending_domain_data_command_keys": [
-        "emr_reminders",
         "unpaid_invoices",
         "paid_invoices",
         "reconciliation_alerts",

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -462,6 +462,15 @@ TELEGRAM_SEND_PUBLIC_ERROR = "Ошибка отправки сообщения"
 TELEGRAM_BOT_INFO_PUBLIC_MESSAGE = "Ошибка получения информации о боте"
 QUEUE_TERMINAL_STATUSES = {"served", "incomplete", "no_show", "cancelled"}
 QUEUE_WAITING_STATUSES = {"waiting"}
+EMR_CLOSED_VISIT_STATUSES = {
+    "closed",
+    "completed",
+    "served",
+    "done",
+    "cancelled",
+    "canceled",
+    "no_show",
+}
 QUEUE_TAG_LABELS = {
     "ecg": "ЭКГ",
     "cardiology_common": "Кардиология",
@@ -1097,6 +1106,34 @@ def _staff_today_schedule_message(db: Session, user: User | None = None) -> str:
     )
 
 
+def _staff_emr_reminders_message(db: Session, user: User | None = None) -> str:
+    counts = _visit_status_counts(db, user)
+    normalized_counts = {
+        str(status or "unknown").lower(): count for status, count in counts.items()
+    }
+    total = sum(counts.values())
+    closed = sum(
+        normalized_counts.get(status, 0) for status in EMR_CLOSED_VISIT_STATUSES
+    )
+    needs_closure = max(total - closed, 0)
+    in_progress = sum(
+        normalized_counts.get(status, 0)
+        for status in ("in_progress", "in_visit", "called")
+    )
+    open_visits = max(needs_closure - in_progress, 0)
+    return "\n".join(
+        [
+            "EMR reminders",
+            f"Date: {date.today().isoformat()}",
+            f"Visits needing EMR closure: {needs_closure}",
+            f"Open visits: {open_visits}",
+            f"In progress: {in_progress}",
+            f"Closed/cancelled: {closed}",
+            "Mode: read-only EMR reminder snapshot",
+        ]
+    )
+
+
 def _staff_payment_status_message(db: Session) -> str:
     rows = _payment_status_rows(db)
     total_count = sum(count for _status, count, _amount in rows)
@@ -1222,6 +1259,8 @@ def _staff_read_only_domain_data_message(
         return _staff_next_patient_message(db)
     if item_key == "today_schedule":
         return _staff_today_schedule_message(db, user)
+    if item_key == "emr_reminders":
+        return _staff_emr_reminders_message(db, user)
     if item_key == "payment_status":
         return _staff_payment_status_message(db)
     if item_key == "ready_reports":

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -224,6 +224,7 @@ class TestTelegramBotManagementApiService:
             "queue_overview",
             "next_patient",
             "today_schedule",
+            "emr_reminders",
             "payment_status",
             "ready_reports",
             "daily_summary",

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -42,9 +42,9 @@ class TestTelegramStaffBotTokenRuntimeConfig:
             status["role_menu_enablement_contract"][
                 "pending_domain_data_command_keys"
             ][0]
-            == "emr_reminders"
+            == "unpaid_invoices"
         )
-        assert status["next_slice"] == "staff_read_only_emr_reminders_runtime"
+        assert status["next_slice"] == "staff_read_only_unpaid_invoices_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )
@@ -75,7 +75,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_read_only_emr_reminders_runtime"
+        assert status["next_slice"] == "staff_read_only_unpaid_invoices_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -324,6 +324,85 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         assert audit_log.payload["state_changing_action"] is False
 
     @pytest.mark.asyncio
+    async def test_staff_emr_reminders_menu_item_returns_safe_aggregate(
+        self, db_session, test_doctor_user, test_doctor, test_patient
+    ):
+        _link_staff_chat(db_session, chat_id=7208, user_id=test_doctor_user.id)
+        test_doctor.user_id = test_doctor_user.id
+        db_session.flush()
+        db_session.add_all(
+            [
+                Visit(
+                    patient_id=test_patient.id,
+                    doctor_id=test_doctor.id,
+                    visit_date=date.today(),
+                    visit_time="09:00",
+                    status="open",
+                ),
+                Visit(
+                    patient_id=test_patient.id,
+                    doctor_id=test_doctor.id,
+                    visit_date=date.today(),
+                    visit_time="10:00",
+                    status="in_progress",
+                ),
+                Visit(
+                    patient_id=test_patient.id,
+                    doctor_id=test_doctor.id,
+                    visit_date=date.today(),
+                    visit_time="11:00",
+                    status="closed",
+                ),
+                Visit(
+                    patient_id=test_patient.id,
+                    doctor_id=None,
+                    visit_date=date.today(),
+                    visit_time="12:00",
+                    status="open",
+                ),
+            ]
+        )
+        db_session.commit()
+
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 208,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7208},
+                "from": {"id": 7208},
+                "text": "emr_reminders",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        text = fake_service._send_message.await_args.args[1]
+        assert "EMR reminders" in text
+        assert "Visits needing EMR closure: 2" in text
+        assert "Open visits: 1" in text
+        assert "In progress: 1" in text
+        assert "Closed/cancelled: 1" in text
+        assert "Mode: read-only EMR reminder snapshot" in text
+        assert test_patient.first_name not in text
+        if test_patient.phone:
+            assert test_patient.phone not in text
+        assert "7208" not in text
+        audit_log = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_command_received")
+            .one()
+        )
+        assert audit_log.payload["command_key"] == "staff_menu_item"
+        assert audit_log.payload["menu_item_key"] == "emr_reminders"
+        assert audit_log.payload["read_only"] is True
+        assert audit_log.payload["state_changing_action"] is False
+
+    @pytest.mark.asyncio
     async def test_staff_state_change_command_is_denied_without_domain_mutation(
         self, db_session, admin_user
     ):


### PR DESCRIPTION
## Summary
- Enable the staff bot `emr_reminders` read-only domain-data key.
- Return aggregate counts for visits needing EMR closure without diagnoses, EMR text, patient names, phones, or raw IDs.
- Scope doctor reminders to the linked active `Doctor.user_id` row and advance `next_slice` to `staff_read_only_unpaid_invoices_runtime`.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/admin_telegram.py` staff bot status and `backend/app/api/v1/endpoints/telegram_webhook.py` staff read-only Telegram runtime.
- Request shape: unchanged; linked doctor staff users can use the existing `emr_reminders` menu key.
- Response shape: `emr_reminders` now returns aggregate EMR reminder counts; status `domain_data_command_keys` includes `emr_reminders`, and `pending_domain_data_command_keys` now starts with `unpaid_invoices`.
- Status codes: unchanged.
- Frontend consumer: unchanged admin Telegram manager status consumer.
- Compatibility path or alias: no route, command, or alias added.
- Contract proof: focused Telegram staff runtime/status unit tests assert the aggregate response and next-slice status.

## RBAC / Permissions
- Roles allowed: unchanged; `emr_reminders` remains exposed through the existing doctor role menu.
- Roles denied: unchanged; existing staff menu denial path remains in place.
- Positive auth proof: linked doctor staff chat receives only aggregate reminders for that linked doctor's visits.
- Negative auth proof: test data includes a same-day visit outside the linked doctor scope and it is excluded from the reminder counts.

## Notification / Realtime

not applicable - no notification, websocket, delivery acknowledgement, or realtime resync behavior changed beyond the existing Telegram reply path.

## Frontend Resilience
- Empty data proof: zero matching visits renders stable aggregate counts.
- Partial data proof: unknown/open visit statuses are counted as needing closure without exposing details.
- Forbidden secondary path behavior: unchanged existing staff role denial handles forbidden menu access.
- Missing draft/resource behavior: not applicable, no draft or resource flow changed.
- Stale route/deep-link behavior: not applicable, no frontend route or deep-link state changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/app/api/v1/endpoints/telegram_webhook.py`, focused Telegram staff unit tests.
- Denied paths: frontend manager, migrations, EMR mutation handlers, visit mutation handlers, patient detail rendering.
- Migration/docs/test impact: no migration or docs update; focused unit tests updated.
- Rollback note: revert this PR to return `emr_reminders` to placeholder behavior and mark it pending again.
- Gate note: `agent_gate.py` initially included frontend and missed focused tests; retry included tests but retained frontend as generic Telegram ownership. Patch stayed backend-only and used the requested validation including frontend build.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\\app\\api\\v1\\endpoints\\admin_telegram.py backend\\app\\api\\v1\\endpoints\\telegram_webhook.py backend\\tests\\unit\\test_telegram_staff_read_only_menu_runtime.py backend\\tests\\unit\\test_telegram_staff_bot_token_runtime_config.py backend\\tests\\unit\\test_telegram_bot_management_api_service.py`; `python -m pytest backend\\tests\\unit\\test_telegram_staff_read_only_menu_runtime.py backend\\tests\\unit\\test_telegram_staff_bot_token_runtime_config.py backend\\tests\\unit\\test_telegram_bot_management_api_service.py -q`; `git diff --check origin/main...HEAD`; `cd frontend && npm.cmd run build`.
- Result: passed; 33 focused backend tests passed with the existing pytest warning; frontend build passed with existing chunk-size/dynamic-import warnings.
- Not checked: full backend suite and browser smoke were not run for this backend-only Telegram read-only slice.