### PR TITLE
feat(telegram): expose staff unpaid invoice snapshot

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -148,6 +148,7 @@ STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS = [
     "next_patient",
     "today_schedule",
     "emr_reminders",
+    "unpaid_invoices",
     "payment_status",
     "ready_reports",
     "daily_summary",
@@ -586,7 +587,6 @@ STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
     "domain_data_commands_status": "partial",
     "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
     "pending_domain_data_command_keys": [
-        "unpaid_invoices",
         "paid_invoices",
         "reconciliation_alerts",
         "pending_reports",

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -35,6 +35,7 @@ from app.models.lab import LabReportInstance
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.patient import Patient
 from app.models.payment import Payment, PaymentVisit
+from app.models.payment_invoice import PaymentInvoice
 from app.models.telegram_config import TelegramMessage, TelegramUser
 from app.models.user import User
 from app.models.visit import Visit
@@ -517,6 +518,7 @@ QUEUE_STATUS_LABELS_BY_LANGUAGE = {
 }
 PAYMENT_PAID_STATUSES = {"paid", "completed"}
 PAYMENT_PENDING_STATUSES = {"pending", "processing"}
+UNPAID_INVOICE_STATUSES = {"pending", "processing"}
 LAB_REPORT_READY_STATUSES = {"FINALIZED", "PRINTED"}
 MAX_TELEGRAM_LAB_REPORTS = 3
 
@@ -975,6 +977,22 @@ def _payment_status_rows(db: Session) -> list[tuple[str, int, Decimal]]:
     ]
 
 
+def _payment_invoice_status_rows(db: Session) -> list[tuple[str, int, Decimal]]:
+    return [
+        (str(status or "unknown"), int(count or 0), amount or Decimal("0"))
+        for status, count, amount in (
+            db.query(
+                PaymentInvoice.status,
+                func.count(PaymentInvoice.id),
+                func.coalesce(func.sum(PaymentInvoice.total_amount), 0),
+            )
+            .filter(PaymentInvoice.created_at >= _today_start())
+            .group_by(PaymentInvoice.status)
+            .all()
+        )
+    ]
+
+
 def _lab_status_counts(db: Session) -> Dict[str, int]:
     rows = (
         db.query(LabReportInstance.status, func.count(LabReportInstance.id))
@@ -1134,6 +1152,28 @@ def _staff_emr_reminders_message(db: Session, user: User | None = None) -> str:
     )
 
 
+def _staff_unpaid_invoices_message(db: Session) -> str:
+    rows = _payment_invoice_status_rows(db)
+    total_count = sum(count for _status, count, _amount in rows)
+    unpaid_count = sum(
+        count for status, count, _amount in rows if status in UNPAID_INVOICE_STATUSES
+    )
+    unpaid_total = sum(
+        (amount for status, _count, amount in rows if status in UNPAID_INVOICE_STATUSES),
+        Decimal("0"),
+    )
+    return "\n".join(
+        [
+            "Unpaid invoices",
+            f"Date: {date.today().isoformat()}",
+            f"Invoices today: {total_count}",
+            f"Unpaid invoices: {unpaid_count}",
+            f"Unpaid total: {_format_money(unpaid_total)}",
+            "Mode: read-only invoice aggregate snapshot",
+        ]
+    )
+
+
 def _staff_payment_status_message(db: Session) -> str:
     rows = _payment_status_rows(db)
     total_count = sum(count for _status, count, _amount in rows)
@@ -1261,6 +1301,8 @@ def _staff_read_only_domain_data_message(
         return _staff_today_schedule_message(db, user)
     if item_key == "emr_reminders":
         return _staff_emr_reminders_message(db, user)
+    if item_key == "unpaid_invoices":
+        return _staff_unpaid_invoices_message(db)
     if item_key == "payment_status":
         return _staff_payment_status_message(db)
     if item_key == "ready_reports":

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -225,6 +225,7 @@ class TestTelegramBotManagementApiService:
             "next_patient",
             "today_schedule",
             "emr_reminders",
+            "unpaid_invoices",
             "payment_status",
             "ready_reports",
             "daily_summary",

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -42,9 +42,9 @@ class TestTelegramStaffBotTokenRuntimeConfig:
             status["role_menu_enablement_contract"][
                 "pending_domain_data_command_keys"
             ][0]
-            == "unpaid_invoices"
+            == "paid_invoices"
         )
-        assert status["next_slice"] == "staff_read_only_unpaid_invoices_runtime"
+        assert status["next_slice"] == "staff_read_only_paid_invoices_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )
@@ -75,7 +75,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_read_only_unpaid_invoices_runtime"
+        assert status["next_slice"] == "staff_read_only_paid_invoices_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -8,6 +8,7 @@ import pytest
 from app.api.v1.endpoints import telegram_webhook
 from app.models.audit import AuditLog
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.payment_invoice import PaymentInvoice
 from app.models.telegram_config import TelegramUser
 from app.models.visit import Visit
 
@@ -399,6 +400,80 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         )
         assert audit_log.payload["command_key"] == "staff_menu_item"
         assert audit_log.payload["menu_item_key"] == "emr_reminders"
+        assert audit_log.payload["read_only"] is True
+        assert audit_log.payload["state_changing_action"] is False
+
+    @pytest.mark.asyncio
+    async def test_staff_unpaid_invoices_menu_item_returns_safe_aggregate(
+        self, db_session, admin_user, test_patient
+    ):
+        admin_user.role = "cashier"
+        db_session.flush()
+        _link_staff_chat(db_session, chat_id=7209, user_id=admin_user.id)
+        db_session.add_all(
+            [
+                PaymentInvoice(
+                    patient_id=test_patient.id,
+                    total_amount=7000,
+                    currency="UZS",
+                    status="pending",
+                    payment_method="click",
+                    provider="click",
+                ),
+                PaymentInvoice(
+                    patient_id=test_patient.id,
+                    total_amount=5000,
+                    currency="UZS",
+                    status="processing",
+                    payment_method="payme",
+                    provider="payme",
+                ),
+                PaymentInvoice(
+                    patient_id=test_patient.id,
+                    total_amount=3000,
+                    currency="UZS",
+                    status="paid",
+                    payment_method="cash",
+                    provider=None,
+                ),
+            ]
+        )
+        db_session.commit()
+
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 209,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7209},
+                "from": {"id": 7209},
+                "text": "unpaid_invoices",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        text = fake_service._send_message.await_args.args[1]
+        assert "Unpaid invoices" in text
+        assert "Invoices today: 3" in text
+        assert "Unpaid invoices: 2" in text
+        assert "Unpaid total: 12 000" in text
+        assert "Mode: read-only invoice aggregate snapshot" in text
+        assert test_patient.first_name not in text
+        if test_patient.phone:
+            assert test_patient.phone not in text
+        assert "7209" not in text
+        audit_log = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_command_received")
+            .one()
+        )
+        assert audit_log.payload["command_key"] == "staff_menu_item"
+        assert audit_log.payload["menu_item_key"] == "unpaid_invoices"
         assert audit_log.payload["read_only"] is True
         assert audit_log.payload["state_changing_action"] is False
 


### PR DESCRIPTION
## Summary
- enables the staff bot unpaid_invoices read-only domain-data key
- returns only aggregate count and total for pending/processing invoices created today
- advances the next pending staff domain slice to paid_invoices

## Safety
- no patient names, phones, raw patient_id, invoice_id, provider transaction IDs, or payment links are sent to Telegram
- no invoice or payment state is mutated

## Validation
- python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py backend/tests/unit/test_telegram_bot_management_api_service.py
- python -m pytest backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py backend/tests/unit/test_telegram_bot_management_api_service.py backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py -q
- npm.cmd run build

Stacked on #797 / codex/telegram-staff-emr-reminders-main; retarget to main after #797 merges.