### PR TITLE
feat(telegram): expose staff paid invoice snapshot

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -149,6 +149,7 @@ STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS = [
     "today_schedule",
     "emr_reminders",
     "unpaid_invoices",
+    "paid_invoices",
     "payment_status",
     "ready_reports",
     "daily_summary",
@@ -587,7 +588,6 @@ STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
     "domain_data_commands_status": "partial",
     "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
     "pending_domain_data_command_keys": [
-        "paid_invoices",
         "reconciliation_alerts",
         "pending_reports",
         "delivery_status",

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -519,6 +519,7 @@ QUEUE_STATUS_LABELS_BY_LANGUAGE = {
 PAYMENT_PAID_STATUSES = {"paid", "completed"}
 PAYMENT_PENDING_STATUSES = {"pending", "processing"}
 UNPAID_INVOICE_STATUSES = {"pending", "processing"}
+PAID_INVOICE_STATUSES = {"paid", "completed"}
 LAB_REPORT_READY_STATUSES = {"FINALIZED", "PRINTED"}
 MAX_TELEGRAM_LAB_REPORTS = 3
 
@@ -1174,6 +1175,28 @@ def _staff_unpaid_invoices_message(db: Session) -> str:
     )
 
 
+def _staff_paid_invoices_message(db: Session) -> str:
+    rows = _payment_invoice_status_rows(db)
+    total_count = sum(count for _status, count, _amount in rows)
+    paid_count = sum(
+        count for status, count, _amount in rows if status in PAID_INVOICE_STATUSES
+    )
+    paid_total = sum(
+        (amount for status, _count, amount in rows if status in PAID_INVOICE_STATUSES),
+        Decimal("0"),
+    )
+    return "\n".join(
+        [
+            "Paid invoices",
+            f"Date: {date.today().isoformat()}",
+            f"Invoices today: {total_count}",
+            f"Paid invoices: {paid_count}",
+            f"Paid total: {_format_money(paid_total)}",
+            "Mode: read-only invoice aggregate snapshot",
+        ]
+    )
+
+
 def _staff_payment_status_message(db: Session) -> str:
     rows = _payment_status_rows(db)
     total_count = sum(count for _status, count, _amount in rows)
@@ -1303,6 +1326,8 @@ def _staff_read_only_domain_data_message(
         return _staff_emr_reminders_message(db, user)
     if item_key == "unpaid_invoices":
         return _staff_unpaid_invoices_message(db)
+    if item_key == "paid_invoices":
+        return _staff_paid_invoices_message(db)
     if item_key == "payment_status":
         return _staff_payment_status_message(db)
     if item_key == "ready_reports":

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -226,6 +226,7 @@ class TestTelegramBotManagementApiService:
             "today_schedule",
             "emr_reminders",
             "unpaid_invoices",
+            "paid_invoices",
             "payment_status",
             "ready_reports",
             "daily_summary",

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -42,9 +42,9 @@ class TestTelegramStaffBotTokenRuntimeConfig:
             status["role_menu_enablement_contract"][
                 "pending_domain_data_command_keys"
             ][0]
-            == "paid_invoices"
+            == "reconciliation_alerts"
         )
-        assert status["next_slice"] == "staff_read_only_paid_invoices_runtime"
+        assert status["next_slice"] == "staff_read_only_reconciliation_alerts_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )
@@ -75,7 +75,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_read_only_paid_invoices_runtime"
+        assert status["next_slice"] == "staff_read_only_reconciliation_alerts_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -478,6 +478,80 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         assert audit_log.payload["state_changing_action"] is False
 
     @pytest.mark.asyncio
+    async def test_staff_paid_invoices_menu_item_returns_safe_aggregate(
+        self, db_session, admin_user, test_patient
+    ):
+        admin_user.role = "cashier"
+        db_session.flush()
+        _link_staff_chat(db_session, chat_id=7210, user_id=admin_user.id)
+        db_session.add_all(
+            [
+                PaymentInvoice(
+                    patient_id=test_patient.id,
+                    total_amount=9000,
+                    currency="UZS",
+                    status="paid",
+                    payment_method="cash",
+                    provider=None,
+                ),
+                PaymentInvoice(
+                    patient_id=test_patient.id,
+                    total_amount=4000,
+                    currency="UZS",
+                    status="completed",
+                    payment_method="click",
+                    provider="click",
+                ),
+                PaymentInvoice(
+                    patient_id=test_patient.id,
+                    total_amount=3000,
+                    currency="UZS",
+                    status="pending",
+                    payment_method="payme",
+                    provider="payme",
+                ),
+            ]
+        )
+        db_session.commit()
+
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 210,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7210},
+                "from": {"id": 7210},
+                "text": "paid_invoices",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        text = fake_service._send_message.await_args.args[1]
+        assert "Paid invoices" in text
+        assert "Invoices today: 3" in text
+        assert "Paid invoices: 2" in text
+        assert "Paid total: 13 000" in text
+        assert "Mode: read-only invoice aggregate snapshot" in text
+        assert test_patient.first_name not in text
+        if test_patient.phone:
+            assert test_patient.phone not in text
+        assert "7210" not in text
+        audit_log = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_command_received")
+            .one()
+        )
+        assert audit_log.payload["command_key"] == "staff_menu_item"
+        assert audit_log.payload["menu_item_key"] == "paid_invoices"
+        assert audit_log.payload["read_only"] is True
+        assert audit_log.payload["state_changing_action"] is False
+
+    @pytest.mark.asyncio
     async def test_staff_state_change_command_is_denied_without_domain_mutation(
         self, db_session, admin_user
     ):


### PR DESCRIPTION
## Summary

- Enables the staff bot `paid_invoices` read-only domain-data key.
- Returns only aggregate count and total for paid/completed invoices created today.
- Advances the next pending staff domain slice to `reconciliation_alerts`.

## Contract Impact

- Canonical surface: Telegram staff bot read-only domain-data command routing.
- Request shape: linked staff Telegram command/keyboard action, no free-text patient or invoice identifiers accepted.
- Response shape: aggregate paid invoice count and total only, scoped to today and paid/completed statuses.
- Status codes: not applicable - Telegram bot transport returns chat messages, not HTTP status codes for staff users.
- Frontend consumer: not applicable - no frontend route or panel changed.
- Compatibility path or alias: existing staff bot read-only command keys remain unchanged; this adds one key and moves the next pending slice marker.
- Contract proof: targeted backend unit tests for menu config, runtime command handling, and token/runtime config.

## RBAC / Permissions

- Roles allowed: existing linked staff Telegram users who can access staff read-only domain data; cashier/admin coverage is exercised by targeted tests.
- Roles denied: unlinked Telegram users and patient bot users remain outside the staff command path.
- Positive auth proof: targeted staff read-only runtime test exercises a linked cashier-style user.
- Negative auth proof: existing staff bot tests continue to cover token/runtime guard behavior; no new public endpoint was added.

## Notification / Realtime

- Event type or websocket channel: explicit staff Telegram command response only; no websocket channel, broadcast event, SMS, or automatic patient notification is introduced.
- Payload version / ack behavior: existing Telegram send-message behavior is reused; no new versioned event payload or client ack contract is added.
- Read/unread or delivery semantics: not applicable - this PR does not add inbox/read-state tracking or delivery receipts.
- Reconnect/resync proof: not applicable - no websocket subscription or realtime resync path changes.
- Safety proof: message content is aggregate-only with no patient names, phones, raw patient_id, invoice_id, provider transaction IDs, payment links, diagnoses, or EMR content.
- Mutation proof: no invoice/payment state is mutated.

## Frontend Resilience

not applicable - backend staff Telegram bot runtime only; no user-facing frontend panel, route state, draft/resource reopen flow, or deep-link consumer changed.

## Scope Gate

- Allowed paths: backend Telegram admin/read-only config, backend Telegram webhook/service runtime, targeted Telegram unit tests.
- Denied paths: frontend runtime, migrations, queue fairness, EMR content, payment provider adapters, generated output.
- Migration/docs/test impact: no migration; no docs change; targeted tests updated.
- Rollback note: revert the paid invoice command key, runtime aggregate handler, and targeted tests.

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py backend/tests/unit/test_telegram_bot_management_api_service.py; python -m pytest backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py backend/tests/unit/test_telegram_bot_management_api_service.py backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py -q; npm.cmd run build
- Result: passed locally; pytest collected 35 targeted tests and all passed; frontend build completed with existing warnings only.
- Not checked: live Telegram polling/webhook against a real bot token; full browser smoke, because no frontend behavior changed.