### PR TITLE
feat(telegram): expose staff reconciliation alert snapshot

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -150,6 +150,7 @@ STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS = [
     "emr_reminders",
     "unpaid_invoices",
     "paid_invoices",
+    "reconciliation_alerts",
     "payment_status",
     "ready_reports",
     "daily_summary",
@@ -588,7 +589,6 @@ STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
     "domain_data_commands_status": "partial",
     "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
     "pending_domain_data_command_keys": [
-        "reconciliation_alerts",
         "pending_reports",
         "delivery_status",
         "integration_errors",

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -41,6 +41,9 @@ from app.models.user import User
 from app.models.visit import Visit
 from app.services.lab_report_pdf_service import lab_report_pdf_service
 from app.services.lab_reporting_service import LabReportingService
+from app.services.payment_reconciliation_api_service import (
+    PaymentReconciliationApiService,
+)
 from app.services.telegram_bot import get_telegram_bot_service
 from app.services.visit_confirmation_service import (
     TELEGRAM_TICKET_QR_PREFIX,
@@ -520,6 +523,7 @@ PAYMENT_PAID_STATUSES = {"paid", "completed"}
 PAYMENT_PENDING_STATUSES = {"pending", "processing"}
 UNPAID_INVOICE_STATUSES = {"pending", "processing"}
 PAID_INVOICE_STATUSES = {"paid"}
+RECONCILIATION_ALERT_THRESHOLD = Decimal("1000")
 LAB_REPORT_READY_STATUSES = {"FINALIZED", "PRINTED"}
 MAX_TELEGRAM_LAB_REPORTS = 3
 
@@ -1197,6 +1201,43 @@ def _staff_paid_invoices_message(db: Session) -> str:
     )
 
 
+def _staff_reconciliation_alerts_message(db: Session) -> str:
+    result = PaymentReconciliationApiService(db).get_reconciliation_alerts(
+        threshold=float(RECONCILIATION_ALERT_THRESHOLD)
+    )
+    alerts = result.get("alerts") or []
+    severity_counts = {
+        "error": sum(1 for alert in alerts if alert.get("severity") == "error"),
+        "high": int(
+            result.get("high_severity_count")
+            or sum(1 for alert in alerts if alert.get("severity") == "high")
+        ),
+        "medium": sum(1 for alert in alerts if alert.get("severity") == "medium"),
+    }
+    providers = sorted(
+        {
+            str(alert.get("provider") or "unknown")
+            for alert in alerts
+            if alert.get("provider")
+        }
+    )
+    provider_summary = ", ".join(providers[:3]) if providers else "none"
+    if len(providers) > 3:
+        provider_summary = f"{provider_summary} +{len(providers) - 3}"
+    return "\n".join(
+        [
+            "Reconciliation alerts",
+            f"Date: {date.today().isoformat()}",
+            f"Alerts: {int(result.get('alert_count') or len(alerts))}",
+            f"High severity: {severity_counts['high']}",
+            f"Medium severity: {severity_counts['medium']}",
+            f"Error severity: {severity_counts['error']}",
+            f"Providers: {provider_summary}",
+            "Mode: read-only reconciliation aggregate snapshot",
+        ]
+    )
+
+
 def _staff_payment_status_message(db: Session) -> str:
     rows = _payment_status_rows(db)
     total_count = sum(count for _status, count, _amount in rows)
@@ -1328,6 +1369,8 @@ def _staff_read_only_domain_data_message(
         return _staff_unpaid_invoices_message(db)
     if item_key == "paid_invoices":
         return _staff_paid_invoices_message(db)
+    if item_key == "reconciliation_alerts":
+        return _staff_reconciliation_alerts_message(db)
     if item_key == "payment_status":
         return _staff_payment_status_message(db)
     if item_key == "ready_reports":

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -227,6 +227,7 @@ class TestTelegramBotManagementApiService:
             "emr_reminders",
             "unpaid_invoices",
             "paid_invoices",
+            "reconciliation_alerts",
             "payment_status",
             "ready_reports",
             "daily_summary",

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -42,9 +42,9 @@ class TestTelegramStaffBotTokenRuntimeConfig:
             status["role_menu_enablement_contract"][
                 "pending_domain_data_command_keys"
             ][0]
-            == "reconciliation_alerts"
+            == "pending_reports"
         )
-        assert status["next_slice"] == "staff_read_only_reconciliation_alerts_runtime"
+        assert status["next_slice"] == "staff_read_only_pending_reports_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )
@@ -75,7 +75,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_read_only_reconciliation_alerts_runtime"
+        assert status["next_slice"] == "staff_read_only_pending_reports_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -552,6 +552,87 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         assert audit_log.payload["state_changing_action"] is False
 
     @pytest.mark.asyncio
+    async def test_staff_reconciliation_alerts_menu_item_returns_safe_aggregate(
+        self, db_session, admin_user, monkeypatch
+    ):
+        admin_user.role = "cashier"
+        db_session.flush()
+        _link_staff_chat(db_session, chat_id=7211, user_id=admin_user.id)
+
+        class FakeReconciliationApiService:
+            def __init__(self, db):
+                self.db = db
+
+            def get_reconciliation_alerts(self, *, threshold):
+                assert threshold == 1000.0
+                return {
+                    "alerts": [
+                        {
+                            "severity": "high",
+                            "provider": "click",
+                            "message": "transaction 123 mismatch",
+                        },
+                        {
+                            "severity": "medium",
+                            "provider": "payme",
+                            "message": "payment 456 missing",
+                        },
+                        {
+                            "severity": "error",
+                            "provider": "kaspi",
+                            "message": "provider secret failed",
+                        },
+                    ],
+                    "alert_count": 3,
+                    "high_severity_count": 1,
+                }
+
+        monkeypatch.setattr(
+            telegram_webhook,
+            "PaymentReconciliationApiService",
+            FakeReconciliationApiService,
+        )
+
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 211,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7211},
+                "from": {"id": 7211},
+                "text": "reconciliation_alerts",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        text = fake_service._send_message.await_args.args[1]
+        assert "Reconciliation alerts" in text
+        assert "Alerts: 3" in text
+        assert "High severity: 1" in text
+        assert "Medium severity: 1" in text
+        assert "Error severity: 1" in text
+        assert "Providers: click, kaspi, payme" in text
+        assert "Mode: read-only reconciliation aggregate snapshot" in text
+        assert "transaction 123" not in text
+        assert "payment 456" not in text
+        assert "secret" not in text
+        assert "7211" not in text
+        audit_log = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_command_received")
+            .one()
+        )
+        assert audit_log.payload["command_key"] == "staff_menu_item"
+        assert audit_log.payload["menu_item_key"] == "reconciliation_alerts"
+        assert audit_log.payload["read_only"] is True
+        assert audit_log.payload["state_changing_action"] is False
+
+    @pytest.mark.asyncio
     async def test_staff_state_change_command_is_denied_without_domain_mutation(
         self, db_session, admin_user
     ):


### PR DESCRIPTION
## Summary
- Enables the staff bot `reconciliation_alerts` read-only domain-data key.
- Returns aggregate alert counts by severity and provider names without raw reconciliation alert messages.
- Advances the next pending staff domain-data slice to `pending_reports`.

## Contract Impact
- Canonical surface: staff Telegram read-only domain data in `backend/app/api/v1/endpoints/admin_telegram.py` and `backend/app/api/v1/endpoints/telegram_webhook.py`, backed by `PaymentReconciliationApiService.get_reconciliation_alerts`.
- Request shape: linked staff Telegram chat sends the existing `reconciliation_alerts` menu item text/command through the webhook update shape.
- Response shape: plain Telegram text with date, alert count, high/medium/error severity counts, provider summary, and read-only mode marker.
- Status codes: not applicable - Telegram webhook handling returns chat messages and does not add an HTTP response surface.
- Frontend consumer: not applicable - no frontend route, panel, or browser consumer changed.
- Compatibility path or alias: existing cashier staff menu item remains the command surface; domain-data status now marks `reconciliation_alerts` implemented and moves pending status to `pending_reports`.
- Contract proof: targeted Telegram unit tests cover management status keys, next-slice derivation, and safe aggregate Telegram response content.

## RBAC / Permissions
- Roles allowed: existing linked staff users whose role menu includes `reconciliation_alerts`, covered with cashier-style staff access.
- Roles denied: unlinked chats and state-changing commands remain denied by existing staff bot guard paths.
- Positive auth proof: `test_staff_reconciliation_alerts_menu_item_returns_safe_aggregate` links a staff chat and receives the aggregate response.
- Negative auth proof: existing staff read-only menu runtime tests continue to cover denial of state-changing commands without domain mutation.

## Notification / Realtime
- Not applicable - this is a pull-based Telegram command response and does not publish realtime events, websocket messages, SMS, or automatic notifications.

## Frontend Resilience
- Not applicable - no frontend files, client-side state, or browser recovery/deep-link behavior changed in this slice.

## Scope Gate
- Allowed paths: Telegram staff admin/read-only config, Telegram webhook runtime, and targeted Telegram unit tests.
- Denied paths: payment provider adapters, reconciliation mutation logic, migrations, frontend runtime, queue, EMR, lab, generated artifacts.
- Migration/docs/test impact: no migration or docs change; targeted tests updated for the new read-only domain key and aggregate response.
- Rollback note: revert this commit to return `reconciliation_alerts` to the pending domain-data list and remove its Telegram aggregate handler.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py backend/tests/unit/test_telegram_bot_management_api_service.py`; `python -m pytest backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py backend/tests/unit/test_telegram_bot_management_api_service.py -q`; `npm.cmd run build`; `git diff --check`.
- Result: passed locally; pytest reported 36 passed and frontend build completed with existing chunk/dynamic-import warnings.
- Not checked: live Telegram webhook delivery against a real bot token or live payment provider reconciliation statements.