### PR TITLE
feat(telegram): expose staff pending report snapshot

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -153,6 +153,7 @@ STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS = [
     "reconciliation_alerts",
     "payment_status",
     "ready_reports",
+    "pending_reports",
     "daily_summary",
 ]
 
@@ -589,7 +590,6 @@ STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
     "domain_data_commands_status": "partial",
     "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
     "pending_domain_data_command_keys": [
-        "pending_reports",
         "delivery_status",
         "integration_errors",
         "revenue_summary",

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -525,6 +525,7 @@ UNPAID_INVOICE_STATUSES = {"pending", "processing"}
 PAID_INVOICE_STATUSES = {"paid"}
 RECONCILIATION_ALERT_THRESHOLD = Decimal("1000")
 LAB_REPORT_READY_STATUSES = {"FINALIZED", "PRINTED"}
+LAB_REPORT_PENDING_STATUSES = {"DRAFT", "IN_PROGRESS"}
 MAX_TELEGRAM_LAB_REPORTS = 3
 
 
@@ -1284,6 +1285,32 @@ def _staff_lab_reports_message(db: Session) -> str:
     )
 
 
+def _staff_pending_lab_reports_message(db: Session) -> str:
+    counts = _lab_status_counts(db)
+    pending = sum(
+        counts.get(status, 0) for status in LAB_REPORT_PENDING_STATUSES
+    )
+    draft = counts.get("DRAFT", 0)
+    in_progress = counts.get("IN_PROGRESS", 0)
+    ready_or_done = sum(
+        counts.get(status, 0)
+        for status in {"READY", "FINALIZED", "PRINTED"} | LAB_REPORT_READY_STATUSES
+    )
+    total = sum(counts.values())
+    return "\n".join(
+        [
+            "Pending lab reports",
+            f"Date: {date.today().isoformat()}",
+            f"Reports today: {total}",
+            f"Pending reports: {pending}",
+            f"Draft reports: {draft}",
+            f"In progress: {in_progress}",
+            f"Ready/final: {ready_or_done}",
+            "Mode: read-only lab aggregate snapshot",
+        ]
+    )
+
+
 def _staff_daily_summary_message(db: Session) -> str:
     queue_counts = _queue_status_counts(db)
     payment_rows = _payment_status_rows(db)
@@ -1375,6 +1402,8 @@ def _staff_read_only_domain_data_message(
         return _staff_payment_status_message(db)
     if item_key == "ready_reports":
         return _staff_lab_reports_message(db)
+    if item_key == "pending_reports":
+        return _staff_pending_lab_reports_message(db)
     if item_key == "daily_summary":
         return _staff_daily_summary_message(db)
     return None

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -230,6 +230,7 @@ class TestTelegramBotManagementApiService:
             "reconciliation_alerts",
             "payment_status",
             "ready_reports",
+            "pending_reports",
             "daily_summary",
         ]
 

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -42,9 +42,9 @@ class TestTelegramStaffBotTokenRuntimeConfig:
             status["role_menu_enablement_contract"][
                 "pending_domain_data_command_keys"
             ][0]
-            == "pending_reports"
+            == "delivery_status"
         )
-        assert status["next_slice"] == "staff_read_only_pending_reports_runtime"
+        assert status["next_slice"] == "staff_read_only_delivery_status_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )
@@ -75,7 +75,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_read_only_pending_reports_runtime"
+        assert status["next_slice"] == "staff_read_only_delivery_status_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -7,10 +7,12 @@ import pytest
 
 from app.api.v1.endpoints import telegram_webhook
 from app.models.audit import AuditLog
+from app.models.lab import LabReportInstance
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.payment_invoice import PaymentInvoice
 from app.models.telegram_config import TelegramUser
 from app.models.visit import Visit
+from app.services.lab_reporting_service import LabReportingService
 
 
 class FakeTelegramBotService:
@@ -629,6 +631,85 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         )
         assert audit_log.payload["command_key"] == "staff_menu_item"
         assert audit_log.payload["menu_item_key"] == "reconciliation_alerts"
+        assert audit_log.payload["read_only"] is True
+        assert audit_log.payload["state_changing_action"] is False
+
+    @pytest.mark.asyncio
+    async def test_staff_pending_reports_menu_item_returns_safe_aggregate(
+        self, db_session, admin_user, test_patient
+    ):
+        admin_user.role = "lab"
+        db_session.flush()
+        _link_staff_chat(db_session, chat_id=7212, user_id=admin_user.id)
+        template = LabReportingService(db_session).list_templates()[0]
+        version = template.versions[-1]
+        db_session.add_all(
+            [
+                LabReportInstance(
+                    patient_id=test_patient.id,
+                    template_id=template.id,
+                    template_version_id=version.id,
+                    status="DRAFT",
+                    patient_snapshot={"name": test_patient.first_name},
+                    branding_snapshot={},
+                    signer_snapshot={},
+                ),
+                LabReportInstance(
+                    patient_id=test_patient.id,
+                    template_id=template.id,
+                    template_version_id=version.id,
+                    status="IN_PROGRESS",
+                    patient_snapshot={"name": test_patient.first_name},
+                    branding_snapshot={},
+                    signer_snapshot={},
+                ),
+                LabReportInstance(
+                    patient_id=test_patient.id,
+                    template_id=template.id,
+                    template_version_id=version.id,
+                    status="READY",
+                    patient_snapshot={"name": test_patient.first_name},
+                    branding_snapshot={},
+                    signer_snapshot={},
+                ),
+            ]
+        )
+        db_session.commit()
+
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 212,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7212},
+                "from": {"id": 7212},
+                "text": "pending_reports",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        text = fake_service._send_message.await_args.args[1]
+        assert "Pending lab reports" in text
+        assert "Reports today: 3" in text
+        assert "Pending reports: 2" in text
+        assert "Draft reports: 1" in text
+        assert "In progress: 1" in text
+        assert "Ready/final: 1" in text
+        assert "Mode: read-only lab aggregate snapshot" in text
+        assert test_patient.first_name not in text
+        assert "7212" not in text
+        audit_log = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_command_received")
+            .one()
+        )
+        assert audit_log.payload["command_key"] == "staff_menu_item"
+        assert audit_log.payload["menu_item_key"] == "pending_reports"
         assert audit_log.payload["read_only"] is True
         assert audit_log.payload["state_changing_action"] is False
 


### PR DESCRIPTION
## Summary

- Enables staff read-only `pending_reports` as a lab aggregate Telegram snapshot.
- Counts `DRAFT` and `IN_PROGRESS` lab report instances separately from ready/final reports.
- Shifts the next pending domain-data slice to `delivery_status`.

## Contract Impact

- Canonical surface: Telegram staff bot read-only domain-data command routing.
- Request shape: linked staff Telegram command/keyboard action, no free-text patient, visit, order, or report identifiers accepted.
- Response shape: aggregate lab report counts for today only: total, pending, draft, in-progress, ready/final.
- Status codes: not applicable - Telegram bot transport returns chat messages, not HTTP status codes for staff users.
- Frontend consumer: not applicable - no frontend route or panel changed.
- Compatibility path or alias: existing staff bot read-only command keys remain unchanged; this adds one key and moves the next pending slice marker.
- Contract proof: targeted backend unit tests for runtime command handling, management status, and token/runtime next-slice config.

## RBAC / Permissions

- Roles allowed: existing linked staff Telegram users who can access staff read-only domain data; lab-role coverage is exercised by the targeted runtime test.
- Roles denied: unlinked Telegram users and patient bot users remain outside the staff command path.
- Positive auth proof: targeted staff read-only runtime test exercises a linked lab-style user.
- Negative auth proof: existing staff bot tests continue to cover token/runtime guard behavior; no new public endpoint was added.

## Notification / Realtime

- Event type or websocket channel: explicit staff Telegram command response only; no websocket channel, broadcast event, SMS, or automatic patient notification is introduced.
- Payload version / ack behavior: existing Telegram send-message behavior is reused; no new versioned event payload or client ack contract is added.
- Read/unread or delivery semantics: not applicable - this PR does not add inbox/read-state tracking or delivery receipts.
- Reconnect/resync proof: not applicable - no websocket subscription or realtime resync path changes.
- Safety proof: message content is aggregate-only with no patient names, phones, raw patient_id, visit_id, order_id, report_id, lab values, diagnoses, or PDF content.
- Mutation proof: no lab report, patient, visit, or notification state is mutated.

## Frontend Resilience

not applicable - backend staff Telegram bot runtime only; no user-facing frontend panel, route state, draft/resource reopen flow, or deep-link consumer changed.

## Scope Gate

- Allowed paths: backend Telegram admin/read-only config, backend Telegram webhook/service runtime, targeted Telegram unit tests.
- Denied paths: frontend runtime, migrations, lab PDF generation, EMR content, payment provider adapters, generated output.
- Migration/docs/test impact: no migration; no docs change; targeted tests updated.
- Rollback note: revert the pending_reports command key, runtime aggregate handler, and targeted tests.

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py backend/tests/unit/test_telegram_bot_management_api_service.py backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py; python -m pytest backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py backend/tests/unit/test_telegram_bot_management_api_service.py backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py -q; git diff --check; npm.cmd run build
- Result: passed locally; pytest collected 37 targeted tests and all passed; frontend build completed with existing warnings only.
- Not checked: live Telegram polling/webhook against a real bot token; full browser smoke, because no frontend behavior changed.