### PR TITLE
feat(telegram): expose staff result delivery snapshot

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -154,6 +154,7 @@ STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS = [
     "payment_status",
     "ready_reports",
     "pending_reports",
+    "delivery_status",
     "daily_summary",
 ]
 
@@ -590,7 +591,6 @@ STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
     "domain_data_commands_status": "partial",
     "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
     "pending_domain_data_command_keys": [
-        "delivery_status",
         "integration_errors",
         "revenue_summary",
     ],

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -1026,6 +1026,7 @@ def _lab_delivery_status_counts(db: Session) -> Dict[str, int]:
         .join(NotificationEvent, NotificationEvent.id == NotificationDelivery.event_id)
         .filter(
             NotificationDelivery.created_at >= _today_start(),
+            NotificationDelivery.channel == "telegram",
             NotificationEvent.event_type.in_(LAB_RESULT_DELIVERY_EVENT_TYPES),
         )
         .group_by(NotificationDelivery.delivery_status)
@@ -1349,7 +1350,7 @@ def _staff_lab_delivery_status_message(db: Session) -> str:
         [
             "Lab result delivery status",
             f"Date: {date.today().isoformat()}",
-            f"Deliveries today: {total}",
+            f"Telegram deliveries today: {total}",
             f"Delivered/seen/read: {successful}",
             f"Pending/dispatched: {pending}",
             f"Failed: {failed}",

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -32,6 +32,7 @@ from app.crud import telegram_config as crud_telegram
 from app.db.session import get_db
 from app.models.clinic import Doctor
 from app.models.lab import LabReportInstance
+from app.models.notification import NotificationDelivery, NotificationEvent
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.patient import Patient
 from app.models.payment import Payment, PaymentVisit
@@ -526,6 +527,13 @@ PAID_INVOICE_STATUSES = {"paid"}
 RECONCILIATION_ALERT_THRESHOLD = Decimal("1000")
 LAB_REPORT_READY_STATUSES = {"FINALIZED", "PRINTED"}
 LAB_REPORT_PENDING_STATUSES = {"DRAFT", "IN_PROGRESS"}
+LAB_RESULT_DELIVERY_EVENT_TYPES = {
+    "lab_results",
+    "lab_result_sent_confirmation",
+    "lab_critical_result",
+}
+SUCCESSFUL_DELIVERY_STATUSES = {"delivered", "seen", "read", "archived"}
+PENDING_DELIVERY_STATUSES = {"pending", "dispatched"}
 MAX_TELEGRAM_LAB_REPORTS = 3
 
 
@@ -1009,6 +1017,23 @@ def _lab_status_counts(db: Session) -> Dict[str, int]:
     return _status_counts(rows)
 
 
+def _lab_delivery_status_counts(db: Session) -> Dict[str, int]:
+    rows = (
+        db.query(
+            NotificationDelivery.delivery_status,
+            func.count(NotificationDelivery.id),
+        )
+        .join(NotificationEvent, NotificationEvent.id == NotificationDelivery.event_id)
+        .filter(
+            NotificationDelivery.created_at >= _today_start(),
+            NotificationEvent.event_type.in_(LAB_RESULT_DELIVERY_EVENT_TYPES),
+        )
+        .group_by(NotificationDelivery.delivery_status)
+        .all()
+    )
+    return _status_counts(rows)
+
+
 def _visit_status_counts(db: Session, user: User | None = None) -> Dict[str, int]:
     query = db.query(Visit.status, func.count(Visit.id)).filter(
         Visit.visit_date == date.today()
@@ -1311,6 +1336,29 @@ def _staff_pending_lab_reports_message(db: Session) -> str:
     )
 
 
+def _staff_lab_delivery_status_message(db: Session) -> str:
+    counts = _lab_delivery_status_counts(db)
+    total = sum(counts.values())
+    successful = sum(
+        counts.get(status, 0) for status in SUCCESSFUL_DELIVERY_STATUSES
+    )
+    pending = sum(counts.get(status, 0) for status in PENDING_DELIVERY_STATUSES)
+    failed = counts.get("failed", 0)
+    other = max(total - successful - pending - failed, 0)
+    return "\n".join(
+        [
+            "Lab result delivery status",
+            f"Date: {date.today().isoformat()}",
+            f"Deliveries today: {total}",
+            f"Delivered/seen/read: {successful}",
+            f"Pending/dispatched: {pending}",
+            f"Failed: {failed}",
+            f"Other: {other}",
+            "Mode: read-only delivery aggregate snapshot",
+        ]
+    )
+
+
 def _staff_daily_summary_message(db: Session) -> str:
     queue_counts = _queue_status_counts(db)
     payment_rows = _payment_status_rows(db)
@@ -1404,6 +1452,8 @@ def _staff_read_only_domain_data_message(
         return _staff_lab_reports_message(db)
     if item_key == "pending_reports":
         return _staff_pending_lab_reports_message(db)
+    if item_key == "delivery_status":
+        return _staff_lab_delivery_status_message(db)
     if item_key == "daily_summary":
         return _staff_daily_summary_message(db)
     return None

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -231,6 +231,7 @@ class TestTelegramBotManagementApiService:
             "payment_status",
             "ready_reports",
             "pending_reports",
+            "delivery_status",
             "daily_summary",
         ]
 

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -42,9 +42,9 @@ class TestTelegramStaffBotTokenRuntimeConfig:
             status["role_menu_enablement_contract"][
                 "pending_domain_data_command_keys"
             ][0]
-            == "delivery_status"
+            == "integration_errors"
         )
-        assert status["next_slice"] == "staff_read_only_delivery_status_runtime"
+        assert status["next_slice"] == "staff_read_only_integration_errors_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )
@@ -75,7 +75,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_read_only_delivery_status_runtime"
+        assert status["next_slice"] == "staff_read_only_integration_errors_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -772,6 +772,18 @@ class TestTelegramStaffReadOnlyMenuRuntime:
                     last_error="patient phone missing",
                     payload_snapshot={"patient_id": test_patient.id},
                 ),
+                NotificationDelivery(
+                    event_id=event.id,
+                    recipient_type="user",
+                    recipient_id=admin_user.id,
+                    role="lab",
+                    channel="sms",
+                    dedup_key="delivery-status-sms",
+                    sequence_id=4,
+                    delivery_status="delivered",
+                    last_error="sms secret detail",
+                    payload_snapshot={"patient_id": test_patient.id},
+                ),
             ]
         )
         db_session.commit()
@@ -795,7 +807,7 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         fake_service._send_message.assert_awaited_once()
         text = fake_service._send_message.await_args.args[1]
         assert "Lab result delivery status" in text
-        assert "Deliveries today: 3" in text
+        assert "Telegram deliveries today: 3" in text
         assert "Delivered/seen/read: 1" in text
         assert "Pending/dispatched: 1" in text
         assert "Failed: 1" in text
@@ -803,6 +815,7 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         assert test_patient.first_name not in text
         assert "result-77" not in text
         assert "patient phone missing" not in text
+        assert "sms secret detail" not in text
         assert "7213" not in text
         audit_log = (
             db_session.query(AuditLog)

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -8,6 +8,7 @@ import pytest
 from app.api.v1.endpoints import telegram_webhook
 from app.models.audit import AuditLog
 from app.models.lab import LabReportInstance
+from app.models.notification import NotificationDelivery, NotificationEvent
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.payment_invoice import PaymentInvoice
 from app.models.telegram_config import TelegramUser
@@ -710,6 +711,106 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         )
         assert audit_log.payload["command_key"] == "staff_menu_item"
         assert audit_log.payload["menu_item_key"] == "pending_reports"
+        assert audit_log.payload["read_only"] is True
+        assert audit_log.payload["state_changing_action"] is False
+
+    @pytest.mark.asyncio
+    async def test_staff_delivery_status_menu_item_returns_safe_aggregate(
+        self, db_session, admin_user, test_patient
+    ):
+        admin_user.role = "lab"
+        db_session.flush()
+        _link_staff_chat(db_session, chat_id=7213, user_id=admin_user.id)
+        event = NotificationEvent(
+            event_type="lab_results",
+            dedup_key="lab-results-delivery-status-test",
+            source_module="lab",
+            entity_type="lab_result",
+            entity_id="result-77",
+            severity="info",
+            priority="high",
+            title="Lab results ready",
+            message=f"Results for {test_patient.first_name}",
+            payload_snapshot={"patient_id": test_patient.id},
+            deep_link="/lab/results",
+        )
+        db_session.add(event)
+        db_session.flush()
+        db_session.add_all(
+            [
+                NotificationDelivery(
+                    event_id=event.id,
+                    recipient_type="user",
+                    recipient_id=admin_user.id,
+                    role="lab",
+                    channel="telegram",
+                    dedup_key="delivery-status-delivered",
+                    sequence_id=1,
+                    delivery_status="delivered",
+                    payload_snapshot={"patient_id": test_patient.id},
+                ),
+                NotificationDelivery(
+                    event_id=event.id,
+                    recipient_type="user",
+                    recipient_id=admin_user.id,
+                    role="lab",
+                    channel="telegram",
+                    dedup_key="delivery-status-pending",
+                    sequence_id=2,
+                    delivery_status="pending",
+                    payload_snapshot={"patient_id": test_patient.id},
+                ),
+                NotificationDelivery(
+                    event_id=event.id,
+                    recipient_type="user",
+                    recipient_id=admin_user.id,
+                    role="lab",
+                    channel="telegram",
+                    dedup_key="delivery-status-failed",
+                    sequence_id=3,
+                    delivery_status="failed",
+                    last_error="patient phone missing",
+                    payload_snapshot={"patient_id": test_patient.id},
+                ),
+            ]
+        )
+        db_session.commit()
+
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 213,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7213},
+                "from": {"id": 7213},
+                "text": "delivery_status",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        text = fake_service._send_message.await_args.args[1]
+        assert "Lab result delivery status" in text
+        assert "Deliveries today: 3" in text
+        assert "Delivered/seen/read: 1" in text
+        assert "Pending/dispatched: 1" in text
+        assert "Failed: 1" in text
+        assert "Mode: read-only delivery aggregate snapshot" in text
+        assert test_patient.first_name not in text
+        assert "result-77" not in text
+        assert "patient phone missing" not in text
+        assert "7213" not in text
+        audit_log = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_command_received")
+            .one()
+        )
+        assert audit_log.payload["command_key"] == "staff_menu_item"
+        assert audit_log.payload["menu_item_key"] == "delivery_status"
         assert audit_log.payload["read_only"] is True
         assert audit_log.payload["state_changing_action"] is False
 


### PR DESCRIPTION
## Summary

- Enable staff bot `delivery_status` as a read-only lab-result delivery snapshot.
- Count canonical notification delivery states for lab result events, scoped to Telegram channel deliveries only.
- Keep the reply aggregate-only and move the next pending staff domain-data slice to `integration_errors`.

## Contract Impact

- Canonical surface: staff Telegram bot menu command `delivery_status` handled by `backend/app/api/v1/endpoints/telegram_webhook.py` and exposed in admin Telegram status contract.
- Request shape: linked staff Telegram chat sends text `delivery_status`; no request body, patient id, invoice id, entity id, or free-text identifier is trusted.
- Response shape: plain Telegram message with aggregate counts only: Telegram deliveries today, delivered/seen/read, pending/dispatched, failed, other, and read-only mode label.
- Status codes: not applicable - bot polling/webhook handler returns chat messages, not HTTP status changes for this command.
- Frontend consumer: admin Telegram manager/status surface reads command metadata from the backend status contract; no frontend runtime code changed.
- Compatibility path or alias: existing staff menu aliases and unsupported-command fallback remain unchanged.
- Contract proof: targeted staff runtime test covers the command response and targeted management/config tests cover command-key and next-slice metadata.

## RBAC / Permissions

- Roles allowed: linked staff accounts with existing staff bot role access, including lab/admin-style staff coverage used by current tests.
- Roles denied: unlinked Telegram chats and non-staff flows remain denied by the existing staff chat linkage and command handling path.
- Positive auth proof: linked lab staff chat receives the delivery aggregate and audit payload with `read_only=true`.
- Negative auth proof: existing targeted runtime suite still covers denied state-changing staff commands without domain mutation.

## Notification / Realtime

- Event type or websocket channel: reads canonical `NotificationEvent` lab result event types and `NotificationDelivery` rows where `channel='telegram'`.
- Payload version / ack behavior: no new notification payload version or ack protocol; this is a read-only aggregate query over persisted delivery rows.
- Read/unread or delivery semantics: groups canonical statuses into delivered/seen/read/archive success, pending/dispatched, failed, and other without changing read/seen/archive state.
- Reconnect/resync proof: no websocket subscription, reconnect, polling cursor, or resync behavior changes.

## Frontend Resilience

- Empty data proof: zero matching delivery rows produce stable zero counts from the aggregate helper.
- Partial data proof: unknown delivery statuses are counted under `Other` instead of breaking message rendering.
- Forbidden secondary path behavior: unlinked or unauthorized staff chats continue through the existing denial path; no secondary frontend path added.
- Missing draft/resource behavior: not applicable - this command does not open drafts, reports, or mutable resources.
- Stale route/deep-link behavior: not applicable - no route or deep-link is emitted by the aggregate message.

## Scope Gate

- Allowed paths: Telegram backend endpoint, admin Telegram status contract, and targeted Telegram unit tests.
- Denied paths: database migrations, queue fairness code, EMR content, payment mutation paths, generated output, and unrelated frontend runtime files.
- Migration/docs/test impact: no migration; targeted tests updated for command metadata and runtime safety.
- Rollback note: revert the delivery-status command registration, handler branch, aggregate helper, and targeted tests.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py backend/tests/unit/test_telegram_bot_management_api_service.py backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py`; `python -m pytest backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py backend/tests/unit/test_telegram_bot_management_api_service.py backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py -q`; `git diff --check`; `cd frontend; npm.cmd run build`.
- Result: py_compile passed; pytest passed with 38 passed and 1 warning; diff-check passed; frontend build passed with existing Vite chunk/import warnings.
- Not checked: full backend suite and browser E2E, because this slice is a narrow staff bot backend/menu contract update.
