### PR TITLE
feat(telegram): expose staff integration error snapshot

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -155,6 +155,7 @@ STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS = [
     "ready_reports",
     "pending_reports",
     "delivery_status",
+    "integration_errors",
     "daily_summary",
 ]
 
@@ -591,7 +592,6 @@ STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
     "domain_data_commands_status": "partial",
     "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
     "pending_domain_data_command_keys": [
-        "integration_errors",
         "revenue_summary",
     ],
     "state_changing_actions_enabled": False,

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -37,9 +37,11 @@ from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.patient import Patient
 from app.models.payment import Payment, PaymentVisit
 from app.models.payment_invoice import PaymentInvoice
+from app.models.payment_webhook import PaymentWebhook
 from app.models.telegram_config import TelegramMessage, TelegramUser
 from app.models.user import User
 from app.models.visit import Visit
+from app.models.webhook import WebhookCall, WebhookCallStatus, WebhookEvent
 from app.services.lab_report_pdf_service import lab_report_pdf_service
 from app.services.lab_reporting_service import LabReportingService
 from app.services.payment_reconciliation_api_service import (
@@ -1035,6 +1037,45 @@ def _lab_delivery_status_counts(db: Session) -> Dict[str, int]:
     return _status_counts(rows)
 
 
+def _integration_error_counts(db: Session) -> Dict[str, int]:
+    failed_webhook_calls_today = (
+        db.query(func.count(WebhookCall.id))
+        .filter(
+            WebhookCall.created_at >= _today_start(),
+            WebhookCall.status == WebhookCallStatus.FAILED,
+        )
+        .scalar()
+        or 0
+    )
+    retrying_webhook_calls = (
+        db.query(func.count(WebhookCall.id))
+        .filter(WebhookCall.status == WebhookCallStatus.RETRYING)
+        .scalar()
+        or 0
+    )
+    unprocessed_webhook_events = (
+        db.query(func.count(WebhookEvent.id))
+        .filter(WebhookEvent.processed.is_(False))
+        .scalar()
+        or 0
+    )
+    failed_payment_webhooks_today = (
+        db.query(func.count(PaymentWebhook.id))
+        .filter(
+            PaymentWebhook.created_at >= _today_start(),
+            PaymentWebhook.status == "failed",
+        )
+        .scalar()
+        or 0
+    )
+    return {
+        "failed_webhook_calls_today": int(failed_webhook_calls_today),
+        "retrying_webhook_calls": int(retrying_webhook_calls),
+        "unprocessed_webhook_events": int(unprocessed_webhook_events),
+        "failed_payment_webhooks_today": int(failed_payment_webhooks_today),
+    }
+
+
 def _visit_status_counts(db: Session, user: User | None = None) -> Dict[str, int]:
     query = db.query(Visit.status, func.count(Visit.id)).filter(
         Visit.visit_date == date.today()
@@ -1360,6 +1401,23 @@ def _staff_lab_delivery_status_message(db: Session) -> str:
     )
 
 
+def _staff_integration_errors_message(db: Session) -> str:
+    counts = _integration_error_counts(db)
+    total = sum(counts.values())
+    return "\n".join(
+        [
+            "Integration errors",
+            f"Date: {date.today().isoformat()}",
+            f"Total attention items: {total}",
+            f"Failed webhook calls today: {counts['failed_webhook_calls_today']}",
+            f"Retrying webhook calls: {counts['retrying_webhook_calls']}",
+            f"Unprocessed webhook events: {counts['unprocessed_webhook_events']}",
+            f"Failed payment webhooks today: {counts['failed_payment_webhooks_today']}",
+            "Mode: read-only integration aggregate snapshot",
+        ]
+    )
+
+
 def _staff_daily_summary_message(db: Session) -> str:
     queue_counts = _queue_status_counts(db)
     payment_rows = _payment_status_rows(db)
@@ -1455,6 +1513,8 @@ def _staff_read_only_domain_data_message(
         return _staff_pending_lab_reports_message(db)
     if item_key == "delivery_status":
         return _staff_lab_delivery_status_message(db)
+    if item_key == "integration_errors":
+        return _staff_integration_errors_message(db)
     if item_key == "daily_summary":
         return _staff_daily_summary_message(db)
     return None

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -232,6 +232,7 @@ class TestTelegramBotManagementApiService:
             "ready_reports",
             "pending_reports",
             "delivery_status",
+            "integration_errors",
             "daily_summary",
         ]
 

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -42,9 +42,9 @@ class TestTelegramStaffBotTokenRuntimeConfig:
             status["role_menu_enablement_contract"][
                 "pending_domain_data_command_keys"
             ][0]
-            == "integration_errors"
+            == "revenue_summary"
         )
-        assert status["next_slice"] == "staff_read_only_integration_errors_runtime"
+        assert status["next_slice"] == "staff_read_only_revenue_summary_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )
@@ -75,7 +75,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_read_only_integration_errors_runtime"
+        assert status["next_slice"] == "staff_read_only_revenue_summary_runtime"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -11,8 +11,17 @@ from app.models.lab import LabReportInstance
 from app.models.notification import NotificationDelivery, NotificationEvent
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.payment_invoice import PaymentInvoice
+from app.models.payment_webhook import PaymentWebhook
 from app.models.telegram_config import TelegramUser
 from app.models.visit import Visit
+from app.models.webhook import (
+    Webhook,
+    WebhookCall,
+    WebhookCallStatus,
+    WebhookEvent,
+    WebhookEventType,
+    WebhookStatus,
+)
 from app.services.lab_reporting_service import LabReportingService
 
 
@@ -824,6 +833,127 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         )
         assert audit_log.payload["command_key"] == "staff_menu_item"
         assert audit_log.payload["menu_item_key"] == "delivery_status"
+        assert audit_log.payload["read_only"] is True
+        assert audit_log.payload["state_changing_action"] is False
+
+    @pytest.mark.asyncio
+    async def test_staff_integration_errors_menu_item_returns_safe_aggregate(
+        self, db_session, admin_user, test_patient
+    ):
+        admin_user.role = "admin"
+        db_session.flush()
+        _link_staff_chat(db_session, chat_id=7214, user_id=admin_user.id)
+        webhook = Webhook(
+            name="Provider sync",
+            url="https://integrations.example/secret-hook",
+            events=[WebhookEventType.PAYMENT_COMPLETED.value],
+            headers={"Authorization": "secret-token"},
+            status=WebhookStatus.ACTIVE,
+            is_active=True,
+            created_by=admin_user.id,
+        )
+        db_session.add(webhook)
+        db_session.flush()
+        now = datetime.utcnow()
+        db_session.add_all(
+            [
+                WebhookCall(
+                    webhook_id=webhook.id,
+                    event_type=WebhookEventType.PAYMENT_COMPLETED,
+                    event_data={"patient": test_patient.first_name},
+                    url="https://integrations.example/secret-call",
+                    method="POST",
+                    headers={"Authorization": "secret-token"},
+                    payload={"patient_id": test_patient.id},
+                    status=WebhookCallStatus.FAILED,
+                    response_status_code=500,
+                    response_body="private provider response",
+                    error_message="provider rejected patient payload",
+                    attempt_number=1,
+                    max_attempts=3,
+                    created_at=now,
+                ),
+                WebhookCall(
+                    webhook_id=webhook.id,
+                    event_type=WebhookEventType.PAYMENT_FAILED,
+                    event_data={"transaction": "secret-transaction"},
+                    url="https://integrations.example/retry-call",
+                    method="POST",
+                    headers={},
+                    payload={"secret": "retry-payload"},
+                    status=WebhookCallStatus.RETRYING,
+                    response_status_code=503,
+                    error_message="retry later secret",
+                    attempt_number=2,
+                    max_attempts=3,
+                    created_at=now,
+                ),
+                WebhookEvent(
+                    event_type=WebhookEventType.PAYMENT_COMPLETED,
+                    event_data={"patient_id": test_patient.id},
+                    source="provider-secret",
+                    source_id="source-77",
+                    processed=False,
+                    failed_webhooks=[webhook.id],
+                    created_at=now,
+                ),
+                PaymentWebhook(
+                    provider="payme",
+                    webhook_id="payment-webhook-secret",
+                    transaction_id="transaction-secret",
+                    status="failed",
+                    amount=120000,
+                    raw_data={"patient": test_patient.first_name},
+                    signature="signature-secret",
+                    visit_id=1001,
+                    patient_id=test_patient.id,
+                    created_at=now,
+                    error_message="signature mismatch secret",
+                ),
+            ]
+        )
+        db_session.commit()
+
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 214,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7214},
+                "from": {"id": 7214},
+                "text": "integration_errors",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        text = fake_service._send_message.await_args.args[1]
+        assert "Integration errors" in text
+        assert "Total attention items: 4" in text
+        assert "Failed webhook calls today: 1" in text
+        assert "Retrying webhook calls: 1" in text
+        assert "Unprocessed webhook events: 1" in text
+        assert "Failed payment webhooks today: 1" in text
+        assert "Mode: read-only integration aggregate snapshot" in text
+        assert test_patient.first_name not in text
+        assert "secret-token" not in text
+        assert "secret-hook" not in text
+        assert "private provider response" not in text
+        assert "provider rejected patient payload" not in text
+        assert "transaction-secret" not in text
+        assert "signature mismatch secret" not in text
+        assert "7214" not in text
+        audit_log = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_command_received")
+            .one()
+        )
+        assert audit_log.payload["command_key"] == "staff_menu_item"
+        assert audit_log.payload["menu_item_key"] == "integration_errors"
         assert audit_log.payload["read_only"] is True
         assert audit_log.payload["state_changing_action"] is False
 


### PR DESCRIPTION
## Summary

- Enable staff bot `integration_errors` as a read-only admin/owner integration health snapshot.
- Aggregate outbound webhook failures, retrying webhook calls, unprocessed webhook events, and failed payment webhook rows.
- Keep the Telegram reply aggregate-only and move the next pending staff domain-data slice to `revenue_summary`.

## Contract Impact

- Canonical surface: staff Telegram bot menu command `integration_errors` handled by `backend/app/api/v1/endpoints/telegram_webhook.py` and exposed in admin Telegram status contract.
- Request shape: linked staff Telegram chat sends text `integration_errors`; no request body, patient id, webhook id, transaction id, URL, provider payload, or free-text identifier is trusted.
- Response shape: plain Telegram message with aggregate counts only: total attention items, failed webhook calls today, retrying webhook calls, unprocessed webhook events, failed payment webhooks today, and read-only mode label.
- Status codes: not applicable - bot polling/webhook handler returns chat messages, not HTTP status changes for this command.
- Frontend consumer: admin Telegram manager/status surface reads command metadata from the backend status contract; no frontend runtime code changed.
- Compatibility path or alias: existing staff command aliases and unsupported-command fallback remain unchanged.
- Contract proof: targeted staff runtime test covers the command response and targeted management/config tests cover command-key and next-slice metadata.

## RBAC / Permissions

- Roles allowed: linked staff accounts with existing staff bot role access for admin/owner menu usage; the runtime proof uses an admin-linked staff chat.
- Roles denied: unlinked Telegram chats and non-staff flows remain denied by the existing staff chat linkage and command handling path.
- Positive auth proof: linked admin staff chat receives the integration aggregate and audit payload with `read_only=true`.
- Negative auth proof: existing targeted runtime suite still covers denied state-changing staff commands without domain mutation.

## Notification / Realtime

- Event type or websocket channel: no new websocket event; reads persisted `WebhookCall`, `WebhookEvent`, and `PaymentWebhook` integration records.
- Payload version / ack behavior: no notification payload version or ack protocol changes; this is a read-only aggregate query over stored integration records.
- Read/unread or delivery semantics: not applicable - no delivery/read state is changed by this command.
- Reconnect/resync proof: no websocket subscription, reconnect, polling cursor, or resync behavior changes.

## Frontend Resilience

- Empty data proof: zero matching integration rows produce stable zero counts from the aggregate helper.
- Partial data proof: missing URLs, payloads, response bodies, signatures, and error text are never rendered because the response uses counts only.
- Forbidden secondary path behavior: unlinked or unauthorized chats continue through the existing denial path; no secondary frontend path added.
- Missing draft/resource behavior: not applicable - this command does not open drafts, reports, or mutable resources.
- Stale route/deep-link behavior: not applicable - no route or deep-link is emitted by the aggregate message.

## Scope Gate

- Allowed paths: Telegram backend endpoint, admin Telegram status contract, and targeted Telegram unit tests.
- Denied paths: database migrations, queue fairness code, EMR content, payment mutation paths, generated output, and unrelated frontend runtime files.
- Migration/docs/test impact: no migration; targeted tests updated for command metadata and runtime safety.
- Rollback note: revert the integration-errors command registration, handler branch, aggregate helper, and targeted tests.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py backend/tests/unit/test_telegram_bot_management_api_service.py backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py`; `python -m pytest backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py backend/tests/unit/test_telegram_bot_management_api_service.py backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py -q`; `git diff --check`; `cd frontend; npm.cmd run build`.
- Result: py_compile passed; pytest passed with 39 passed and 1 warning; diff-check passed; frontend build passed with existing Vite chunk/import warnings.
- Not checked: full backend suite and browser E2E, because this slice is a narrow staff bot backend/menu contract update.
