### PR TITLE
feat(telegram): expose staff revenue summary snapshot

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -156,6 +156,7 @@ STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS = [
     "pending_reports",
     "delivery_status",
     "integration_errors",
+    "revenue_summary",
     "daily_summary",
 ]
 
@@ -589,11 +590,9 @@ STAFF_BOT_ROLE_MENU_ENABLEMENT_CONTRACT = {
     "state_changing_menu_items_enabled": False,
     "runtime_handler": "_handle_staff_read_only_menu",
     "domain_data_commands_enabled": True,
-    "domain_data_commands_status": "partial",
+    "domain_data_commands_status": "complete",
     "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
-    "pending_domain_data_command_keys": [
-        "revenue_summary",
-    ],
+    "pending_domain_data_command_keys": [],
     "state_changing_actions_enabled": False,
     "allowed_until_enabled": [
         "read_status_contract",
@@ -880,12 +879,10 @@ def _build_staff_role_menus_summary() -> Dict[str, Any]:
         "item_count": menu_item_count,
         "handler": "_handle_staff_read_only_menu",
         "domain_data_commands_enabled": True,
-        "domain_data_commands_status": "partial",
+        "domain_data_commands_status": "complete",
         "domain_data_command_keys": list(STAFF_BOT_READ_ONLY_DOMAIN_DATA_COMMAND_KEYS),
         "state_changing_actions_enabled": False,
-        "blocked_until": [
-            "role_specific_domain_read_models",
-        ],
+        "blocked_until": [],
     }
 
 

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -1333,6 +1333,33 @@ def _staff_payment_status_message(db: Session) -> str:
     )
 
 
+def _staff_revenue_summary_message(db: Session) -> str:
+    rows = _payment_invoice_status_rows(db)
+    invoice_count = sum(count for _status, count, _amount in rows)
+    gross_total = sum((amount for _status, _count, amount in rows), Decimal("0"))
+    collected_total = sum(
+        (amount for status, _count, amount in rows if status in PAID_INVOICE_STATUSES),
+        Decimal("0"),
+    )
+    pending_total = sum(
+        (amount for status, _count, amount in rows if status in UNPAID_INVOICE_STATUSES),
+        Decimal("0"),
+    )
+    other_total = max(gross_total - collected_total - pending_total, Decimal("0"))
+    return "\n".join(
+        [
+            "Revenue summary",
+            f"Date: {date.today().isoformat()}",
+            f"Invoices today: {invoice_count}",
+            f"Gross invoiced: {_format_money(gross_total)}",
+            f"Collected revenue: {_format_money(collected_total)}",
+            f"Pending revenue: {_format_money(pending_total)}",
+            f"Other invoice total: {_format_money(other_total)}",
+            "Mode: read-only revenue aggregate snapshot",
+        ]
+    )
+
+
 def _staff_lab_reports_message(db: Session) -> str:
     counts = _lab_status_counts(db)
     ready = sum(
@@ -1515,6 +1542,8 @@ def _staff_read_only_domain_data_message(
         return _staff_lab_delivery_status_message(db)
     if item_key == "integration_errors":
         return _staff_integration_errors_message(db)
+    if item_key == "revenue_summary":
+        return _staff_revenue_summary_message(db)
     if item_key == "daily_summary":
         return _staff_daily_summary_message(db)
     return None

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -218,7 +218,7 @@ class TestTelegramBotManagementApiService:
         assert role_menu_enablement["runtime_menu_enabled"] is True
         assert role_menu_enablement["state_changing_menu_items_enabled"] is False
         assert role_menu_enablement["domain_data_commands_enabled"] is True
-        assert role_menu_enablement["domain_data_commands_status"] == "partial"
+        assert role_menu_enablement["domain_data_commands_status"] == "complete"
         assert role_menu_enablement["domain_data_command_keys"] == [
             "staff_readiness",
             "queue_overview",
@@ -233,6 +233,7 @@ class TestTelegramBotManagementApiService:
             "pending_reports",
             "delivery_status",
             "integration_errors",
+            "revenue_summary",
             "daily_summary",
         ]
 

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -41,10 +41,10 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert (
             status["role_menu_enablement_contract"][
                 "pending_domain_data_command_keys"
-            ][0]
-            == "revenue_summary"
+            ]
+            == []
         )
-        assert status["next_slice"] == "staff_read_only_revenue_summary_runtime"
+        assert status["next_slice"] == "staff_read_only_domain_data_runtime_complete"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )
@@ -75,7 +75,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_read_only_revenue_summary_runtime"
+        assert status["next_slice"] == "staff_read_only_domain_data_runtime_complete"
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -564,6 +564,103 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         assert audit_log.payload["state_changing_action"] is False
 
     @pytest.mark.asyncio
+    async def test_staff_revenue_summary_menu_item_returns_safe_aggregate(
+        self, db_session, admin_user, test_patient
+    ):
+        admin_user.role = "owner"
+        db_session.flush()
+        _link_staff_chat(db_session, chat_id=7215, user_id=admin_user.id)
+        db_session.add_all(
+            [
+                PaymentInvoice(
+                    patient_id=test_patient.id,
+                    total_amount=9000,
+                    currency="UZS",
+                    status="paid",
+                    payment_method="cash",
+                    provider="cashier",
+                    provider_payment_id="paid-provider-secret",
+                    provider_transaction_id="paid-transaction-secret",
+                    payment_url="https://pay.example/paid-secret",
+                ),
+                PaymentInvoice(
+                    patient_id=test_patient.id,
+                    total_amount=5000,
+                    currency="UZS",
+                    status="pending",
+                    payment_method="click",
+                    provider="click",
+                    provider_payment_id="pending-provider-secret",
+                ),
+                PaymentInvoice(
+                    patient_id=test_patient.id,
+                    total_amount=2000,
+                    currency="UZS",
+                    status="processing",
+                    payment_method="payme",
+                    provider="payme",
+                    provider_transaction_id="processing-transaction-secret",
+                ),
+                PaymentInvoice(
+                    patient_id=test_patient.id,
+                    total_amount=4000,
+                    currency="UZS",
+                    status="refunded",
+                    payment_method="card",
+                    provider="card",
+                    provider_data={"secret": "refund-provider-secret"},
+                    notes="patient-visible secret note",
+                ),
+            ]
+        )
+        db_session.commit()
+
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 215,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7215},
+                "from": {"id": 7215},
+                "text": "revenue_summary",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        text = fake_service._send_message.await_args.args[1]
+        assert "Revenue summary" in text
+        assert "Invoices today: 4" in text
+        assert "Gross invoiced: 20 000" in text
+        assert "Collected revenue: 9 000" in text
+        assert "Pending revenue: 7 000" in text
+        assert "Other invoice total: 4 000" in text
+        assert "Mode: read-only revenue aggregate snapshot" in text
+        assert test_patient.first_name not in text
+        if test_patient.phone:
+            assert test_patient.phone not in text
+        assert "paid-provider-secret" not in text
+        assert "paid-transaction-secret" not in text
+        assert "pending-provider-secret" not in text
+        assert "processing-transaction-secret" not in text
+        assert "refund-provider-secret" not in text
+        assert "patient-visible secret note" not in text
+        assert "7215" not in text
+        audit_log = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_command_received")
+            .one()
+        )
+        assert audit_log.payload["command_key"] == "staff_menu_item"
+        assert audit_log.payload["menu_item_key"] == "revenue_summary"
+        assert audit_log.payload["read_only"] is True
+        assert audit_log.payload["state_changing_action"] is False
+
+    @pytest.mark.asyncio
     async def test_staff_reconciliation_alerts_menu_item_returns_safe_aggregate(
         self, db_session, admin_user, monkeypatch
     ):


### PR DESCRIPTION
﻿## Summary

- Enable staff bot `revenue_summary` as the final read-only owner revenue snapshot.
- Aggregate today's invoice totals by status using the existing invoice read model helper.
- Mark staff read-only domain data command coverage complete after the revenue slice.

## Contract Impact

- Canonical surface: staff Telegram bot menu command `revenue_summary` handled by `backend/app/api/v1/endpoints/telegram_webhook.py` and exposed in the admin Telegram status contract.
- Request shape: linked staff Telegram chat sends text `revenue_summary`; no request body, patient id, invoice id, provider id, transaction id, payment URL, or note is trusted.
- Response shape: plain Telegram message with aggregate counts and totals only: invoices today, gross invoiced, collected revenue, pending revenue, other invoice total, and read-only mode label.
- Status codes: not applicable - bot polling/webhook handler returns chat messages, not HTTP status changes for this command.
- Frontend consumer: admin Telegram manager/status surface reads command metadata from the backend status contract; no frontend runtime code changed.
- Compatibility path or alias: existing staff command aliases and unsupported-command fallback remain unchanged; `/payments` and `/summary` can resolve owner menu items through the existing role-menu selection path.
- Contract proof: targeted staff runtime test covers the command response and targeted management/config tests cover command-key and completion metadata.

## RBAC / Permissions

- Roles allowed: linked staff accounts with existing staff bot role access for the owner menu; the runtime proof uses an owner-linked staff chat.
- Roles denied: unlinked Telegram chats and non-staff flows remain denied by the existing staff chat linkage and command handling path.
- Positive auth proof: linked owner staff chat receives the revenue aggregate and audit payload with `read_only=true`.
- Negative auth proof: existing targeted runtime suite still covers denied state-changing staff commands without domain mutation.

## Notification / Realtime

- Event type or websocket channel: no new websocket event; reads persisted `PaymentInvoice` rows through the existing invoice aggregate helper.
- Payload version / ack behavior: no notification payload version or ack protocol changes; this is a read-only aggregate query over stored invoices.
- Read/unread or delivery semantics: not applicable - no delivery/read state is changed by this command.
- Reconnect/resync proof: no websocket subscription, reconnect, polling cursor, or resync behavior changes.

## Frontend Resilience

- Empty data proof: zero matching invoice rows produce stable zero totals from the aggregate helper.
- Partial data proof: provider ids, transaction ids, payment URLs, provider payloads, and notes are never rendered because the response uses counts and money totals only.
- Forbidden secondary path behavior: unlinked or unauthorized chats continue through the existing denial path; no secondary frontend path added.
- Missing draft/resource behavior: not applicable - this command does not open drafts, reports, or mutable resources.
- Stale route/deep-link behavior: not applicable - no route or deep-link is emitted by the aggregate message.

## Scope Gate

- Allowed paths: Telegram backend endpoint, admin Telegram status contract, and targeted Telegram unit tests.
- Denied paths: database migrations, payment mutation paths, queue fairness code, EMR content, generated output, and unrelated frontend runtime files.
- Migration/docs/test impact: no migration; targeted tests updated for command metadata, completion status, next-slice metadata, and runtime safety.
- Rollback note: revert the revenue-summary command registration, handler branch, aggregate helper, completion metadata, and targeted tests.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_staff_read_only_menu_runtime.py backend\tests\unit\test_telegram_bot_management_api_service.py backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py`; `python -m pytest backend\tests\unit\test_telegram_staff_read_only_menu_runtime.py backend\tests\unit\test_telegram_bot_management_api_service.py backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py -q`; `git diff --check`; `cd frontend; npm.cmd run build`.
- Result: py_compile passed; pytest passed with 40 passed and 1 warning; diff-check passed; frontend build passed with existing Vite chunk/import warnings.
- Not checked: full backend suite and browser E2E, because this slice is a narrow staff bot backend/menu contract update.
