### PR TITLE
feat(admin): surface staff confirmation next slice

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -907,6 +907,12 @@ def _build_staff_bot_next_slice(token_contract: Dict[str, Any]) -> str:
     if pending_domain_keys:
         return f"staff_read_only_{pending_domain_keys[0]}_runtime"
 
+    confirmation_blockers = (
+        STAFF_BOT_CONFIRMATION_CONTRACT.get("runtime_blocked_by") or []
+    )
+    if confirmation_blockers:
+        return f"staff_state_change_{confirmation_blockers[0]}"
+
     return "staff_read_only_domain_data_runtime_complete"
 
 

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -44,7 +44,18 @@ class TestTelegramStaffBotTokenRuntimeConfig:
             ]
             == []
         )
-        assert status["next_slice"] == "staff_read_only_domain_data_runtime_complete"
+        assert (
+            status["next_slice"]
+            == "staff_state_change_confirmation_token_persistence"
+        )
+        assert (
+            status["confirmation_contract"]["runtime_blocked_by"][0]
+            == "confirmation_token_persistence"
+        )
+        assert (
+            status["confirmations"]["confirmation_token_runtime_enabled"] is False
+        )
+        assert status["confirmations"]["state_changing_actions_enabled"] is False
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )
@@ -75,7 +86,10 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["source_key"] == "STAFF_TELEGRAM_BOT_TOKEN"
         assert contract["enabled"] is True
         assert contract["runtime_blocked_by"] == []
-        assert status["next_slice"] == "staff_read_only_domain_data_runtime_complete"
+        assert (
+            status["next_slice"]
+            == "staff_state_change_confirmation_token_persistence"
+        )
         assert (
             status["command_registration_contract"]["registration_enabled"] is True
         )


### PR DESCRIPTION
﻿## Summary

- Point staff bot `next_slice` to the first state-change confirmation runtime blocker after read-only domain data completion.
- Keep Telegram state-changing actions disabled while exposing the next implementation target.
- Add focused token-runtime coverage that confirms confirmation token runtime remains off.

## Contract Impact

- Canonical surface: admin Telegram staff bot status contract built by `backend/app/api/v1/endpoints/admin_telegram.py`.
- Request shape: no request shape changes; existing status callers read the same staff bot status payload.
- Response shape: `next_slice` changes from `staff_read_only_domain_data_runtime_complete` to `staff_state_change_confirmation_token_persistence` when the dedicated staff bot token is ready and no read-only domain keys remain pending.
- Status codes: no HTTP status code changes.
- Frontend consumer: admin Telegram manager can continue reading `next_slice`; no frontend runtime code changed.
- Compatibility path or alias: read-only command keys, staff menu commands, and command registration payload remain unchanged.
- Contract proof: targeted token-runtime tests cover the new `next_slice` and assert confirmation token runtime/state-changing actions remain disabled.

## RBAC / Permissions

- Roles allowed: no role permission changes; this is status metadata only.
- Roles denied: all state-changing Telegram commands remain denied by the existing guard path.
- Positive auth proof: ready staff bot token status now reports the confirmation-token persistence slice as the next backend target.
- Negative auth proof: tests assert `confirmation_token_runtime_enabled=false` and `state_changing_actions_enabled=false` after the metadata change.

## Notification / Realtime

- Event type or websocket channel: no new notification, websocket, audit event, or delivery channel.
- Payload version / ack behavior: no notification payload or ack protocol changes.
- Read/unread or delivery semantics: not applicable - no message delivery/read state changes.
- Reconnect/resync proof: not applicable - this is a static status contract change, not a realtime subscription change.

## Frontend Resilience

- Empty data proof: not applicable - no data list or resource lookup is added.
- Partial data proof: if confirmation blockers are present, the first blocker is surfaced as the next slice; existing token-not-ready path still returns dedicated token runtime config.
- Forbidden secondary path behavior: state-changing Telegram commands remain blocked by current runtime guards.
- Missing draft/resource behavior: not applicable - no draft or mutable resource is opened.
- Stale route/deep-link behavior: not applicable - no route or deep-link is emitted.

## Scope Gate

- Allowed paths: admin Telegram status contract and targeted Telegram token-runtime tests.
- Denied paths: Telegram webhook mutation handlers, domain action adapters, queue/payment/EMR mutations, database migrations, generated output, and unrelated frontend runtime files.
- Migration/docs/test impact: no migration or docs; targeted tests updated for next-slice metadata.
- Rollback note: revert the confirmation blocker branch in `_build_staff_bot_next_slice` and the corresponding token-runtime assertions.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py backend\tests\unit\test_telegram_bot_management_api_service.py`; `python -m pytest backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py backend\tests\unit\test_telegram_bot_management_api_service.py -q`; `git diff --check`; `cd frontend; npm.cmd run build`.
- Result: py_compile passed; pytest passed with 25 passed and 1 warning; diff-check passed; frontend build passed with existing Vite chunk/import warnings.
- Not checked: full backend suite and browser E2E, because this is a narrow status-contract metadata change with no runtime UI or domain mutation.
