### PR TITLE
fix(telegram): harden polling pid guard on Windows

### DIFF
--- a/backend/app/scripts/telegram_polling_worker.py
+++ b/backend/app/scripts/telegram_polling_worker.py
@@ -248,11 +248,35 @@ class PidFile:
 
     @staticmethod
     def _process_exists(pid: int) -> bool:
+        if os.name == "nt":
+            return PidFile._windows_process_exists(pid)
+
         try:
             os.kill(pid, 0)
         except OSError:
             return False
         return True
+
+    @staticmethod
+    def _windows_process_exists(pid: int) -> bool:
+        if pid <= 0:
+            return False
+
+        import ctypes
+
+        process_query_limited_information = 0x1000
+        error_access_denied = 5
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        handle = kernel32.OpenProcess(
+            process_query_limited_information,
+            False,
+            int(pid),
+        )
+        if handle:
+            kernel32.CloseHandle(handle)
+            return True
+
+        return ctypes.get_last_error() == error_access_denied
 
 
 def configure_logging(log_file: Path | None) -> None:


### PR DESCRIPTION
## Summary

- Make Telegram polling worker pid-file checks Windows-safe.
- Prevent stale pid files from crashing scheduled-task startup after reboot.
- Keep polling token loading, Telegram update handling, webhook deletion, and bot business logic unchanged.

## Contract Impact

- Canonical surface: `python -m app.scripts.telegram_polling_worker`
- Request shape: not applicable - no HTTP/API request contract changed.
- Response shape: not applicable - no HTTP/API response contract changed.
- Status codes: not applicable - no endpoint status behavior changed.
- Frontend consumer: not applicable - no frontend consumer changed.
- Compatibility path or alias: existing pid-file path and CLI arguments remain unchanged.
- Contract proof: targeted `py_compile`, direct `PidFile` smoke, and live scheduled-task startup proof.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, staff action, or auth-sensitive permission behavior changed.

## Notification / Realtime

- Event type or websocket channel: Telegram polling transport only; no new notification event type or websocket channel added.
- Payload version / ack behavior: unchanged; worker still calls the same Telegram update handler and advances Telegram `offset` after handling each `update_id`.
- Read/unread or delivery semantics: unchanged; no message template, TelegramMessage delivery state, read/unread state, or notification fanout changed.
- Reconnect/resync proof: local Task Scheduler start proof plus worker log showing `Telegram polling worker started`; stale pid smoke prevents Windows reboot resync from crashing on old pid files.

## Frontend Resilience

not applicable - no user-facing panel, route, deep link UI, frontend data flow, or browser state handling changed.

## Scope Gate

- Allowed paths: `backend/app/scripts/telegram_polling_worker.py`
- Denied paths: Telegram webhook handlers, admin Telegram contracts, frontend runtime, migrations, generated output, token/config storage
- Migration/docs/test impact: no migration; no docs change; no test file change because the slice only hardens Windows pid detection in the worker guard
- Rollback note: revert the worker pid-guard change; scheduled task can continue using the previous command but stale pid risk returns on Windows

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/scripts/telegram_polling_worker.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; direct `PidFile._process_exists` smoke for current PID and bogus PID; `git diff --check`; `npm.cmd run build`; local Task Scheduler start of `KosmedTelegramPollingWorker`
- Result: passed locally; GitHub checks mostly passed, PR body gate was updated after initial template failure
- Not checked: full reboot proof, because that requires restarting the user machine/server