### PR TITLE
docs(agents): route Telegram bot work to builder skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,11 @@ Primary repo-level operating rules for Codex, Cursor agents, Claude Code style a
 
 ## Skill Routing Policy
 
-Installed repo skills live in `.agents/skills`. Load skills only when the task matches their trigger, and prefer the most project-specific skill first.
+Installed repo skills live in `.agents/skills`. User-level skills may live under `$HOME/.agents/skills`. Load skills only when the task matches their trigger, and prefer the most project-specific skill first.
 
 - Codex/Superpowers local SSOT: use `docs/runbooks/CODEX_SUPERPOWERS_GUARD.md` together with this file. The external Superpowers plugin is a manual workflow guard, not repo runtime code, and must not be vendored into this repository.
 - Skill discovery/setup: use `find-skills` only when searching for or installing new skills.
+- Telegram bot work: use `telegram-bot-builder` for Telegram Bot API, command/menu UX, inline keyboards, webhook architecture, and bot interaction design, but only after this file and `agent_gate.py` have established the execution mode, canonical anchors, and first-touch boundaries. Treat the skill as advisory; it must not override DB/Alembic routing, Postgres SSOT, token/security handling, or canonical backend/frontend ownership.
 - Clinic frontend UI/UX: `clinic-frontend-design` is mandatory first for Admin, Doctor, Registrar, Cashier, Lab, dashboard, route view, form, table, empty/loading/error, accessibility, responsive, or visual consistency work.
 - React implementation: use `vercel-react-best-practices` for performance, bundle, data-fetching, and rerender concerns; add `vercel-composition-patterns` when component APIs, contexts, providers, or boolean-prop-heavy components are involved.
 - UI audit: use `web-design-guidelines` only as a secondary accessibility/interface audit after `clinic-frontend-design`; do not let it override clinic workflow readability or the existing design system.
@@ -248,6 +249,10 @@ Telegram:
 
 - Consider both frontend manager files and backend Telegram endpoint/service contracts.
 - Do not infer integration behavior from frontend text alone.
+- Use `telegram-bot-builder` only as a Bot API, bot UX, command/menu, inline keyboard, and webhook design helper after confirming the task is not primarily DB/storage/migration ownership.
+- If a Telegram task mentions Alembic, SQLAlchemy model, table missing, Postgres SSOT, storage migration, create table, link token storage, or revision, apply the DB/Alembic/SQLAlchemy migration guardrail first. The first-touch owner is the new Alembic revision when a table is missing for an existing model.
+- Do not let Telegram bot skill guidance route migration/root-cause work into Telegram status, webhook, endpoint, or UI files.
+- Treat bot tokens, staff link tokens, webhook secrets, and one-time token storage as security-sensitive; do not hardcode secrets, expose tokens in logs, or weaken expiry/single-use guarantees.
 - Keep the first patch slice narrow even for mixed frontend/backend changes.
 
 EMR, Lab, Rollout-sensitive areas:


### PR DESCRIPTION
﻿## Summary

- Document that Telegram bot work should use the installed telegram-bot-builder skill.
- Clarify that user-level skills under $HOME/.agents/skills are valid sources.
- Preserve repo gate, DB/Alembic, security, and canonical ownership guardrails above skill guidance.

## Contract Impact

not applicable - documentation/process only, no API, websocket, event, bot runtime, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint guard, role helper, authorization policy, or runtime permission behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, Telegram runtime, polling, webhook, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: AGENTS.md.
- Denied paths: backend runtime, frontend runtime, migrations, generated output, bot secrets.
- Migration/docs/test impact: docs/process only; no migration expected.
- Rollback note: revert the AGENTS.md rule commit.

## Validation

- Targeted tests or smoke run: git diff --check; python scripts/check_pr_review_template.py --body-file for this PR body.
- Result: passed locally.
- Not checked: runtime app behavior, because no runtime files changed.
