### PR TITLE
feat(telegram): register patient settings command

### DIFF
--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -29,6 +29,7 @@ PATIENT_BOT_COMMANDS_RU = [
     {"command": "payments", "description": "Оплаты и долг"},
     {"command": "results", "description": "Результаты"},
     {"command": "profile", "description": "Мой статус"},
+    {"command": "settings", "description": "Язык и уведомления"},
     {"command": "help", "description": "Помощь"},
 ]
 PATIENT_BOT_COMMANDS_UZ = [
@@ -37,6 +38,7 @@ PATIENT_BOT_COMMANDS_UZ = [
     {"command": "payments", "description": "To'lovlar va qarz"},
     {"command": "results", "description": "Natijalar"},
     {"command": "profile", "description": "Mening holatim"},
+    {"command": "settings", "description": "Til va xabarnomalar"},
     {"command": "help", "description": "Yordam"},
 ]
 STAFF_BOT_COMMANDS_DEFAULT = [

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -906,5 +906,6 @@ class TestTelegramWebhookSecurity:
             "payments",
             "results",
             "profile",
+            "settings",
             "help",
         }


### PR DESCRIPTION
## Summary

- Add `/settings` to the patient Telegram Bot API command payload in RU and UZ.
- Align the patient command registration unit test with the existing settings handler/menu runtime.

## Contract Impact

- Canonical surface: patient Telegram Bot API command registration payload.
- Request shape: no API request shape changed; command registration still posts command arrays to Telegram.
- Response shape: no backend API response shape changed.
- Status codes: not applicable, no endpoint status behavior changed.
- Frontend consumer: not applicable, no frontend consumer changed.
- Compatibility path or alias: existing `/settings` runtime handler/menu stays unchanged; this only exposes it in BotFather command lists.
- Contract proof: targeted unit test asserts the registered patient command set now includes `settings`.

## RBAC / Permissions

not applicable - no route, endpoint guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: Telegram Bot API command menu registration payload only; no websocket channel or app realtime event.
- Payload version / ack behavior: existing Telegram `setMyCommands` request shape remains unchanged; Telegram API acknowledgement handling remains unchanged.
- Read/unread or delivery semantics: not applicable - this is command menu metadata, not a delivered patient notification/message.
- Reconnect/resync proof: not applicable - no websocket/reconnect path changed; rerunning command registration resends the full command menu payload.

## Frontend Resilience

not applicable - no user-facing frontend panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/app/services/telegram_bot.py`, `backend/tests/unit/test_telegram_webhook_security.py`.
- Denied paths: DB/Alembic, webhook handlers, admin endpoints, frontend runtime, generated output.
- Migration/docs/test impact: no migration; targeted unit test updated.
- Rollback note: revert the command payload entries and the matching unit-test expectation.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\services\telegram_bot.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; `python -m pytest backend\tests\unit\test_telegram_webhook_security.py -k "registers_patient_commands or settings_command_returns_localized_settings_menu"`; `cd frontend; npm.cmd run build`.
- Result: passed locally; frontend build passed with existing Vite chunk/dynamic-import warnings.
- Not checked: live Telegram BotFather registration against Telegram API, because no production bot token/API call was used.

## Dev-Brain Gate

- `agent_gate.py` returned `gate_misroute: yes` and `override_used: yes` for the known root-cause command registration file.
- Narrow override stayed limited to Bot API command payload plus its existing command-registration unit test.
