### PR TITLE
feat(admin): surface staff runtime blocker status

### DIFF
--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -265,6 +265,17 @@ const TelegramManager = () => {
     staffConfirmationContract.deny_only_runtime_enabled ||
     staffConfirmationRuntime.deny_only_runtime_enabled
   );
+  const staffNextSlice = staffBot.next_slice || 'none';
+  const staffConfirmationTokenRuntimeEnabled = Boolean(
+    staffConfirmationContract.confirmation_token_runtime_enabled ||
+    staffConfirmationRuntime.confirmation_token_runtime_enabled
+  );
+  const staffConfirmationBlockedBy = Array.isArray(staffConfirmationContract.runtime_blocked_by) ?
+  staffConfirmationContract.runtime_blocked_by :
+  [];
+  const staffConfirmationBlockerSummary = staffConfirmationBlockedBy.length ?
+  staffConfirmationBlockedBy.join(', ') :
+  'none';
   const staffAuditContract = staffBot.audit_contract || {};
   const staffAuditRuntime = staffBot.audit || {};
   const staffAuditEvents = Array.isArray(staffAuditContract.event_types) ?
@@ -648,6 +659,21 @@ const TelegramManager = () => {
                     size="small">
 
                     {staffConfirmationGuardReady ? 'Guard' : 'Required'}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <Settings />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff next runtime slice"
+                    secondary={`${staffNextSlice}; token runtime: ${staffConfirmationTokenRuntimeEnabled ? 'enabled' : 'blocked'}; blockers: ${staffConfirmationBlockerSummary}`} />
+
+                  <Badge
+                    variant={staffConfirmationBlockedBy.length ? 'warning' : 'success'}
+                    size="small">
+
+                    {staffConfirmationBlockedBy.length ? 'Blocked' : 'Ready'}
                   </Badge>
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
## Summary

- Surface `staff_bot.next_slice` in the Admin Telegram manager.
- Show confirmation token runtime state and current `confirmation_contract.runtime_blocked_by` blockers next to staff action confirmations.

## Contract Impact

- Canonical surface: `/admin/telegram/integration-status` staff bot status payload already exposes `next_slice` and `confirmation_contract.runtime_blocked_by`.
- Request shape: no request shape changed.
- Response shape: no backend response shape changed; frontend now renders existing fields.
- Status codes: not applicable, no endpoint status behavior changed.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` admin Telegram integration view.
- Compatibility path or alias: not applicable, no route alias or API path changed.
- Contract proof: frontend production build succeeds while consuming existing optional fields defensively.

## RBAC / Permissions

not applicable - no route, endpoint guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat delivery, Telegram webhook, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: missing `staff_bot.next_slice` renders `none`; missing blockers render `none`.
- Partial data proof: missing `confirmation_contract` or `confirmations` falls back to existing empty objects.
- Forbidden secondary path behavior: not applicable, no secondary route/path changed.
- Missing draft/resource behavior: not applicable, this view does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable, no route/deep-link state changed.

## Scope Gate

- Allowed paths: `frontend/src/components/TelegramManager.jsx`.
- Denied paths: backend runtime, DB/Alembic, webhook handlers, route registry, generated output.
- Migration/docs/test impact: no migration; no tests changed; frontend build used as smoke proof.
- Rollback note: revert the added staff next runtime list item and derived display fields.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; `cd frontend; npm.cmd run build`.
- Result: passed locally; frontend build passed with existing Vite chunk/dynamic-import warnings.
- Not checked: browser visual smoke, because this slice only renders already-existing optional status fields and no dev server/browser session was started.

## Dev-Brain Gate

- `agent_gate.py` ran for the Telegram staff next-slice task and returned execute with first-touch including `frontend/src/components/TelegramManager.jsx`.
- DB/Alembic confirmation-token persistence remained a stop condition; this PR does not implement storage.
