### PR TITLE
feat(telegram): register uz latn patient commands

### DIFF
--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -567,6 +567,7 @@ class TelegramBotService:
             [
                 {"commands": PATIENT_BOT_COMMANDS_RU},
                 {"commands": PATIENT_BOT_COMMANDS_UZ, "language_code": "uz"},
+                {"commands": PATIENT_BOT_COMMANDS_UZ, "language_code": "uz-Latn"},
             ],
         )
 

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -896,10 +896,15 @@ class TestTelegramWebhookSecurity:
 
         assert ok is True
         assert error is None
-        assert [item["json"].get("language_code") for item in captured] == [None, "uz"]
+        assert [item["json"].get("language_code") for item in captured] == [
+            None,
+            "uz",
+            "uz-Latn",
+        ]
         assert captured[0]["url"].endswith("/setMyCommands")
         assert captured[0]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_RU
         assert captured[1]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_UZ
+        assert captured[2]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_UZ
         assert {command["command"] for command in captured[0]["json"]["commands"]} == {
             "start",
             "queue",


### PR DESCRIPTION
## Summary

- Register patient Telegram Bot API commands for `uz-Latn` in addition to the existing default and `uz` command menus.
- Reuse the existing Uzbek patient command payload for `uz-Latn` and align the unit test expectation.

## Contract Impact

- Canonical surface: patient Telegram Bot API command registration payload.
- Request shape: existing Telegram `setMyCommands` request shape is unchanged; one additional locale-specific registration call is added.
- Response shape: no backend API response shape changed.
- Status codes: not applicable, no endpoint status behavior changed.
- Frontend consumer: not applicable, no frontend consumer changed.
- Compatibility path or alias: existing RU/default and `uz` command menu registrations remain unchanged.
- Contract proof: targeted unit test asserts the command registration language sequence is `[None, "uz", "uz-Latn"]` and that `uz-Latn` reuses `PATIENT_BOT_COMMANDS_UZ`.

## RBAC / Permissions

not applicable - no route, endpoint guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: Telegram Bot API command menu registration payload only; no websocket channel or app realtime event.
- Payload version / ack behavior: existing Telegram `setMyCommands` acknowledgement handling remains unchanged for each call.
- Read/unread or delivery semantics: not applicable - command menu metadata is not a delivered patient notification/message.
- Reconnect/resync proof: not applicable - no websocket/reconnect path changed; rerunning command registration resends all configured language payloads.

## Frontend Resilience

not applicable - no user-facing frontend panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/app/services/telegram_bot.py`, `backend/tests/unit/test_telegram_webhook_security.py`.
- Denied paths: DB/Alembic, webhook handlers, admin endpoints, frontend runtime, generated output.
- Migration/docs/test impact: no migration; targeted unit test updated.
- Rollback note: remove the `uz-Latn` command registration entry and matching unit-test expectation.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\services\telegram_bot.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; `python -m pytest backend\tests\unit\test_telegram_webhook_security.py -k "registers_patient_commands"`; `cd frontend; npm.cmd run build`.
- Result: passed locally; frontend build passed with existing Vite chunk/dynamic-import warnings.
- Not checked: live Telegram API registration against a production bot token.

## Dev-Brain Gate

- `agent_gate.py` returned `gate_misroute: yes` and `override_used: yes` for the known root-cause command registration file.
- Narrow override stayed limited to Bot API command payload plus its command-registration unit test.
