### PR TITLE
feat(telegram): register uz latn patient commands

### DIFF
--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -567,6 +567,7 @@ class TelegramBotService:
             [
                 {"commands": PATIENT_BOT_COMMANDS_RU},
                 {"commands": PATIENT_BOT_COMMANDS_UZ, "language_code": "uz"},
+                {"commands": PATIENT_BOT_COMMANDS_UZ, "language_code": "uz-Latn"},
             ],
         )
 

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -896,10 +896,15 @@ class TestTelegramWebhookSecurity:
 
         assert ok is True
         assert error is None
-        assert [item["json"].get("language_code") for item in captured] == [None, "uz"]
+        assert [item["json"].get("language_code") for item in captured] == [
+            None,
+            "uz",
+            "uz-Latn",
+        ]
         assert captured[0]["url"].endswith("/setMyCommands")
         assert captured[0]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_RU
         assert captured[1]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_UZ
+        assert captured[2]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_UZ
         assert {command["command"] for command in captured[0]["json"]["commands"]} == {
             "start",
             "queue",


### PR DESCRIPTION
## Summary

- Register patient Telegram Bot API commands for both `uz` and canonical `uz-Latn` language codes.
- Keep default Russian command registration unchanged.
- Update the targeted command-registration unit test to prove all expected Bot API command scopes are sent.

## Contract Impact

- Canonical surface: Telegram Bot API `setMyCommands` payload produced by `TelegramBotService.set_patient_bot_commands`.
- Request shape: bot-token authenticated calls to Telegram; no external application HTTP API request shape changed.
- Response shape: Uzbek patient command metadata is registered for both `uz` and `uz-Latn`; Russian/default command metadata remains unchanged.
- Status codes: not applicable - no application endpoint status behavior changed.
- Frontend consumer: not applicable - no frontend file staged or changed by this PR.
- Compatibility path or alias: `uz` remains registered for Telegram clients that use short Uzbek language code; `uz-Latn` is added for the project canonical language code.
- Contract proof: targeted unit test asserts the command scopes are `[None, "uz", "uz-Latn"]` and reuse the Uzbek command payload.

## RBAC / Permissions

- Roles allowed: patient bot users can see command metadata according to Telegram client language; existing handlers still control protected data access.
- Roles denied: not applicable - command metadata does not grant staff actions or patient data access.
- Positive auth proof: targeted command-registration unit test verifies generated Bot API payload.
- Negative auth proof: not applicable - no protected data path, role check, or authorization branch changed.

## Notification / Realtime

- Event type or websocket channel: Telegram Bot API command metadata registration only; no notification event or websocket channel changed.
- Payload version / ack behavior: not applicable - no notification payload, delivery ack, or realtime payload version changed.
- Read/unread or delivery semantics: not applicable - no inbox, message delivery, read/unread, or chat send semantics changed.
- Reconnect/resync proof: not applicable - no websocket reconnect, polling loop, or realtime resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed.
- Partial data proof: not applicable - no frontend data mapping changed.
- Forbidden secondary path behavior: not applicable - no secondary route or panel path changed.
- Missing draft/resource behavior: not applicable - no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link parser changed.

## Scope Gate

- Allowed paths: `backend/app/services/telegram_bot.py`, targeted Telegram webhook/security unit test.
- Denied paths: DB migrations, token/config storage, webhook handlers, queue fairness logic, frontend runtime, generated output.
- Migration/docs/test impact: no migration or docs change; targeted test expectation updated for command-registration contract.
- Rollback note: remove the `uz-Latn` command registration payload and matching test expectation.
- Gate note: narrow override used after `agent_gate.py` reported `gate_misroute: yes` for the known Bot API command registration root cause; test file expansion was necessary because the existing targeted contract test failed on the new scope.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/services/telegram_bot.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `backend\\.venv\\Scripts\\python.exe -m pytest backend/tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_telegram_bot_service_registers_patient_commands -q`; `backend\\.venv\\Scripts\\python.exe -m pytest backend/tests/unit/test_telegram_webhook_security.py backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py -q`; `cd frontend && npm.cmd run build`.
- Result: passed locally; frontend build only reported existing Vite dynamic-import/chunk-size warnings.
- Not checked: manual Telegram client command menu refresh after merge; full CI runs on the PR.
