### PR TITLE
fix(telegram): use supported uz command scope

### DIFF
--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -566,8 +566,9 @@ class TelegramBotService:
             self.bot_token,
             [
                 {"commands": PATIENT_BOT_COMMANDS_RU},
+                # Telegram Bot API rejects "uz-Latn" here; keep app storage canonical
+                # as "uz-Latn", but register the command menu with Telegram's "uz".
                 {"commands": PATIENT_BOT_COMMANDS_UZ, "language_code": "uz"},
-                {"commands": PATIENT_BOT_COMMANDS_UZ, "language_code": "uz-Latn"},
             ],
         )
 

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -896,15 +896,10 @@ class TestTelegramWebhookSecurity:
 
         assert ok is True
         assert error is None
-        assert [item["json"].get("language_code") for item in captured] == [
-            None,
-            "uz",
-            "uz-Latn",
-        ]
+        assert [item["json"].get("language_code") for item in captured] == [None, "uz"]
         assert captured[0]["url"].endswith("/setMyCommands")
         assert captured[0]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_RU
         assert captured[1]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_UZ
-        assert captured[2]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_UZ
         assert {command["command"] for command in captured[0]["json"]["commands"]} == {
             "start",
             "queue",


### PR DESCRIPTION
## Summary

- Fix patient Telegram command registration after the live Telegram Bot API rejected `language_code=uz-Latn` with HTTP 400.
- Keep application/user language storage canonical as `uz-Latn`, but register Uzbek command metadata with Telegram-supported `uz` scope.
- Update the targeted command-registration unit test to match the runtime-safe Bot API payload.

## Contract Impact

- Canonical surface: Telegram Bot API `setMyCommands` payload produced by `TelegramBotService.set_patient_bot_commands`.
- Request shape: bot-token authenticated calls to Telegram; no external application HTTP API request shape changed.
- Response shape: command registration sends default Russian commands plus Uzbek commands under Telegram `uz`; it no longer sends rejected `uz-Latn` Bot API scope.
- Status codes: live registration returns success instead of Telegram HTTP 400 from the unsupported scope.
- Frontend consumer: not applicable - no frontend file staged or changed by this PR.
- Compatibility path or alias: patient language still normalizes/stores Uzbek Latin as `uz-Latn` inside the app; only Telegram Bot API command scope maps to `uz`.
- Contract proof: targeted unit test asserts command scopes `[None, "uz"]`; live `setMyCommands` smoke passed after this change.

## RBAC / Permissions

- Roles allowed: patient bot users can see command metadata according to Telegram client language; existing handlers still control protected data access.
- Roles denied: not applicable - command metadata does not grant staff actions or patient data access.
- Positive auth proof: targeted command-registration unit test verifies generated Bot API payload.
- Negative auth proof: not applicable - no protected data path, role check, or authorization branch changed.

## Notification / Realtime

- Event type or websocket channel: Telegram Bot API command metadata registration only; no notification event or websocket channel changed.
- Payload version / ack behavior: not applicable - no notification payload, delivery ack, or realtime payload version changed.
- Read/unread or delivery semantics: not applicable - no inbox, message delivery, read/unread, or chat send semantics changed.
- Reconnect/resync proof: not applicable - no websocket reconnect, polling loop, or realtime resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed.
- Partial data proof: not applicable - no frontend data mapping changed.
- Forbidden secondary path behavior: not applicable - no secondary route or panel path changed.
- Missing draft/resource behavior: not applicable - no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link parser changed.

## Scope Gate

- Allowed paths: `backend/app/services/telegram_bot.py`, targeted Telegram webhook/security unit test.
- Denied paths: DB migrations, token/config storage, webhook handlers, queue fairness logic, frontend runtime, generated output.
- Migration/docs/test impact: no migration or docs change; targeted test expectation updated for command-registration contract.
- Rollback note: re-adding `uz-Latn` to Bot API command registration would reproduce the live Telegram HTTP 400, so rollback should instead be avoided unless Telegram changes accepted language scopes.
- Gate note: narrow override used after `agent_gate.py` reported `gate_misroute: yes` for the known Bot API command registration root cause.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/services/telegram_bot.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `backend\\.venv\\Scripts\\python.exe -m pytest backend/tests/unit/test_telegram_webhook_security.py backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py -q`; `cd frontend && npm.cmd run build`; live `TelegramBotService.set_patient_bot_commands()`; live `getMyCommands` for default and `uz`.
- Result: passed locally and live; `getMyCommands` returned `start,queue,payments,results,profile,settings,help` for default and `uz`; frontend build only reported existing Vite dynamic-import/chunk-size warnings.
- Not checked: manual Telegram Desktop refresh timing/caching.
