### PR TITLE
🎨 Palette: Refactor interaction state and add focus styles to stat cards

### DIFF
--- a/frontend/src/components/ui/macos/MacOSMetricCard.jsx
+++ b/frontend/src/components/ui/macos/MacOSMetricCard.jsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react';
 import { Minus, ArrowUpRight, ArrowDownRight } from 'lucide-react';
 import PropTypes from 'prop-types';
 
@@ -16,6 +17,9 @@ const MacOSMetricCard = ({
   className,
   style
 }) => {
+  const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+
   const sizeStyles = {
     sm: {
       padding: '12px',
@@ -77,11 +81,14 @@ const MacOSMetricCard = ({
     background: currentVariant.background,
     border: currentVariant.border,
     borderRadius: currentVariant.borderRadius,
-    boxShadow: currentVariant.boxShadow,
+    boxShadow: (isHovered || isFocused) && onClick ? '0 4px 12px rgba(0, 0, 0, 0.15)' : (currentVariant.boxShadow || 'none'),
     cursor: onClick ? 'pointer' : 'default',
     transition: 'all var(--mac-duration-normal) var(--mac-ease)',
     position: 'relative',
     overflow: 'hidden',
+    transform: (isHovered || isFocused) && onClick ? 'translateY(-2px)' : 'translateY(0)',
+    outline: isFocused ? '2px solid var(--mac-accent-blue)' : 'none',
+    outlineOffset: '2px',
     ...style
   };
 
@@ -185,18 +192,12 @@ const MacOSMetricCard = ({
     }
   };
 
-  const handleMouseEnter = (e) => {
-    if (onClick) {
-      e.currentTarget.style.transform = 'translateY(-2px)';
-      e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.15)';
-    }
+  const handleMouseEnter = () => {
+    setIsHovered(true);
   };
 
-  const handleMouseLeave = (e) => {
-    if (onClick) {
-      e.currentTarget.style.transform = 'translateY(0)';
-      e.currentTarget.style.boxShadow = currentVariant.boxShadow || 'none';
-    }
+  const handleMouseLeave = () => {
+    setIsHovered(false);
   };
 
   const renderLoading = () =>
@@ -258,7 +259,9 @@ const MacOSMetricCard = ({
         style={cardStyle}
         onClick={handleClick}
         onMouseEnter={handleMouseEnter}
+        onFocus={() => setIsFocused(true)}
         onMouseLeave={handleMouseLeave}
+        onBlur={() => setIsFocused(false)}
         onKeyDown={handleKeyDown}
         role="button"
         tabIndex={0}

--- a/frontend/src/components/ui/macos/MacOSStatCard.jsx
+++ b/frontend/src/components/ui/macos/MacOSStatCard.jsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react';
 import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import PropTypes from 'prop-types';
 
@@ -17,6 +18,9 @@ const MacOSStatCard = ({
   className,
   style
 }) => {
+  const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+
   const sizeStyles = {
     sm: {
       padding: '12px',
@@ -91,11 +95,14 @@ const MacOSStatCard = ({
     background: currentVariant.background,
     border: currentVariant.border,
     borderRadius: currentVariant.borderRadius,
-    boxShadow: currentVariant.boxShadow,
+    boxShadow: (isHovered || isFocused) && onClick ? '0 4px 12px rgba(0, 0, 0, 0.15)' : (currentVariant.boxShadow || 'none'),
     cursor: onClick ? 'pointer' : 'default',
     transition: 'all var(--mac-duration-normal) var(--mac-ease)',
     position: 'relative',
     overflow: 'hidden',
+    transform: (isHovered || isFocused) && onClick ? 'translateY(-2px)' : 'translateY(0)',
+    outline: isFocused ? '2px solid var(--mac-accent-blue)' : 'none',
+    outlineOffset: '2px',
     ...style
   };
 
@@ -155,18 +162,12 @@ const MacOSStatCard = ({
     }
   };
 
-  const handleMouseEnter = (e) => {
-    if (onClick) {
-      e.currentTarget.style.transform = 'translateY(-2px)';
-      e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.15)';
-    }
+  const handleMouseEnter = () => {
+    setIsHovered(true);
   };
 
-  const handleMouseLeave = (e) => {
-    if (onClick) {
-      e.currentTarget.style.transform = 'translateY(0)';
-      e.currentTarget.style.boxShadow = currentVariant.boxShadow || 'none';
-    }
+  const handleMouseLeave = () => {
+    setIsHovered(false);
   };
 
   const renderTrend = () => {
@@ -247,7 +248,9 @@ const MacOSStatCard = ({
         style={cardStyle}
         onClick={handleClick}
         onMouseEnter={handleMouseEnter}
+        onFocus={() => setIsFocused(true)}
         onMouseLeave={handleMouseLeave}
+        onBlur={() => setIsFocused(false)}
         onKeyDown={handleKeyDown}
         role="button"
         tabIndex={0}


### PR DESCRIPTION
## Summary
- Refactor interaction state in `MacOSStatCard` and `MacOSMetricCard` to use React component state for focus/hover styling.
- Ensure keyboard focus (`onFocus`/`onBlur`) now drives visible focus feedback instead of mouse-only style mutations.
- Keep visual behavior aligned with existing hover interactions while improving accessibility cues.

## Contract Impact
- Canonical surface: frontend UI components only.
- Request shape: not applicable, because this PR does not modify any backend request/response contracts.
- Response shape: not applicable, because this PR does not alter API response schemas.
- Status codes: not applicable, because no endpoint status contract is changed.
- Frontend consumer: existing dashboard and metric cards using `MacOSStatCard`/`MacOSMetricCard`.
- Compatibility path or alias: not applicable, because no route, alias, or compatibility path behavior changed.
- Contract proof: same props and callbacks are preserved; only state handling and rendering style logic changed.

## RBAC / Permissions
- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: not applicable, because no auth-sensitive logic changed.
- Negative auth proof: not applicable, because no permission gates were added or removed.

## Notification / Realtime
- Event type or websocket channel: not applicable, because no notification, websocket, chat, or realtime behavior changed.
- Payload version / ack behavior: not applicable, because no messages, payloads, or acknowledgements were added.
- Read/unread or delivery semantics: not applicable, because no notification delivery path exists in this UI-only change.
- Reconnect/resync proof: not applicable, because no reconnect or realtime subscription code changed.

## Frontend Resilience
- Empty data proof: not applicable, because this component does not alter data source fetching logic.
- Partial data proof: not applicable, because no partial data rendering branches are affected.
- Forbidden secondary path behavior: not applicable, because this UI change keeps only existing interaction branches.
- Missing draft/resource behavior: not applicable, because no draft or resource lifecycle logic exists here.
- Stale route/deep-link behavior: not applicable, because no route or deep-link handling is implemented in these components.

## Scope Gate
- Allowed paths: `frontend/src/components/ui/macos/MacOSMetricCard.jsx`, `frontend/src/components/ui/macos/MacOSStatCard.jsx`
- Denied paths: backend runtime, migrations, routing, notifications, queue/realtime, API clients, unrelated UI modules.
- Migration/docs/test impact: no migration; no test/docs files changed.
- Rollback note: revert the single commit to restore previous interaction-state handling.

## Validation
- Targeted tests or smoke run: frontend-only contract scope; no unit tests changed.
- Result: pending until body validation is rerun.
- Not checked: full browser panel smoke and backend regressions.

## Follow-ups
- Consider extracting a shared hover/focus state helper if more macOS cards receive the same state refactor in a future sweep.