### PR TITLE
test(telegram): cover visible uzbek language switch

### DIFF
--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -293,6 +293,59 @@ class TestTelegramWebhookSecurity:
         assert log.status == "sent"
 
     @pytest.mark.asyncio
+    async def test_plain_uzbek_button_switches_next_visible_menu(self, db_session):
+        fake_service = FakeTelegramBotService(active=True)
+        language_update = {
+            "update_id": 120,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7020},
+                "from": {"id": 111, "language_code": "ru"},
+                "text": "O'zbekcha",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            language_update, db_session, fake_service
+        )
+
+        assert handled is True
+        telegram_user = (
+            db_session.query(TelegramUser)
+            .filter(TelegramUser.chat_id == 7020)
+            .one()
+        )
+        assert telegram_user.language_code == "uz-Latn"
+        assert fake_service._send_message.await_args.args[1] == (
+            telegram_webhook._localized_text("language_selected", "uz-Latn")
+        )
+        assert fake_service._send_message.await_args.args[2] == (
+            telegram_webhook._localized_main_menu("uz-Latn")
+        )
+
+        fake_service._send_message.reset_mock()
+        help_update = {
+            "update_id": 121,
+            "message": {
+                "message_id": 2,
+                "chat": {"id": 7020},
+                "from": {"id": 111, "language_code": "ru"},
+                "text": "Yordam",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            help_update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once_with(
+            7020,
+            telegram_webhook._localized_text("help", "uz-Latn"),
+            telegram_webhook._localized_main_menu("uz-Latn"),
+        )
+
+    @pytest.mark.asyncio
     async def test_language_choice_preserves_existing_notification_consent(
         self, db_session
     ):


### PR DESCRIPTION
## Summary

- Add targeted patient Telegram bot coverage for the visible `O'zbekcha` language switch button without relying on the flag prefix.
- Verify the bot stores the patient language as canonical `uz-Latn` after that visible button text.
- Verify the next visible `Yordam` button response uses Uzbek help text and the Uzbek main reply keyboard.

## Contract Impact

- Canonical surface: patient Telegram webhook text dispatcher and localized reply-keyboard behavior.
- Request shape: Telegram message update with plain text `O'zbekcha`, then plain text `Yordam`; no external application HTTP API request shape changed.
- Response shape: first response uses localized `language_selected` text and Uzbek main menu; second response uses localized Uzbek help text and Uzbek main menu.
- Status codes: not applicable - no application endpoint status behavior changed.
- Frontend consumer: not applicable - no frontend file staged or changed by this PR.
- Compatibility path or alias: proves visible plain button text still maps to the same Uzbek language handler as the icon-prefixed button.
- Contract proof: targeted async unit test exercises both update messages against `_handle_clinic_bot_update`.

## RBAC / Permissions

- Roles allowed: patient bot chat can choose language and request help through visible reply-keyboard text.
- Roles denied: not applicable - this is test coverage only and does not grant protected patient data or staff actions.
- Positive auth proof: targeted unit test verifies unlinked patient chat can switch language and receive help/menu copy.
- Negative auth proof: not applicable - no protected data path, role check, or authorization branch changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification event or websocket channel changed.
- Payload version / ack behavior: not applicable - no notification payload, delivery ack, or realtime payload version changed.
- Read/unread or delivery semantics: not applicable - no inbox, message delivery, read/unread, or chat send semantics changed.
- Reconnect/resync proof: not applicable - no websocket reconnect, polling loop, or realtime resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed.
- Partial data proof: not applicable - no frontend data mapping changed.
- Forbidden secondary path behavior: not applicable - no secondary route or panel path changed.
- Missing draft/resource behavior: not applicable - no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link parser changed.

## Scope Gate

- Allowed paths: `backend/tests/unit/test_telegram_webhook_security.py`.
- Denied paths: runtime Telegram handlers, DB migrations, token/config storage, queue fairness logic, frontend runtime, generated output.
- Migration/docs/test impact: no migration or docs change; one targeted unit test added.
- Rollback note: remove the added test if the visible language-switch proof becomes redundant.
- Gate note: narrow override used after `agent_gate.py` reported `gate_misroute: yes` for the known Telegram unit-test root cause.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/tests/unit/test_telegram_webhook_security.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `backend\\.venv\\Scripts\\python.exe -m pytest backend/tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_plain_uzbek_button_switches_next_visible_menu -q`; `backend\\.venv\\Scripts\\python.exe -m pytest backend/tests/unit/test_telegram_webhook_security.py backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py -q`; `cd frontend && npm.cmd run build`.
- Result: passed locally; Telegram unit slice is `39 passed`; frontend build only reported existing Vite dynamic-import/chunk-size warnings.
- Not checked: manual Telegram Desktop/mobile visual refresh.
