### PR TITLE
feat(telegram): add staff confirmation token model contract

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -331,6 +331,54 @@ STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT = {
     ],
 }
 
+STAFF_BOT_CONFIRMATION_TOKEN_STORAGE_CONTRACT = {
+    "contract_version": "staff-confirmation-token-storage-v1",
+    "enabled": True,
+    "migration_created": True,
+    "model_registered": True,
+    "runtime_write_enabled": False,
+    "runtime_consume_enabled": False,
+    "table": "telegram_staff_confirmation_tokens",
+    "raw_token_storage_allowed": False,
+    "migration_revision": "0026_tg_staff_confirm_tokens",
+    "repository": None,
+    "service": None,
+    "columns": [
+        "id",
+        "token_hash",
+        "staff_user_id",
+        "telegram_chat_id",
+        "operation_key",
+        "command_key",
+        "action_payload_hash",
+        "target_type",
+        "target_reference_hash",
+        "idempotency_key_hash",
+        "expires_at",
+        "consumed_at",
+        "created_at",
+        "request_id",
+    ],
+    "required_indexes": [
+        "unique(token_hash)",
+        "index(staff_user_id)",
+        "index(telegram_chat_id)",
+        "index(operation_key)",
+        "partial_index(expires_at) where consumed_at is null",
+    ],
+    "required_constraints": [
+        "expires_at > created_at",
+        "consumed_at is null or consumed_at <= expires_at",
+        "operation_key is not empty",
+        "action_payload_hash is not empty",
+        "staff_user_id references users(id)",
+    ],
+    "retention_policy": {
+        "expired_token_ttl_days": 7,
+        "consumed_token_ttl_days": 30,
+    },
+}
+
 STAFF_BOT_AUTHORIZATION_CONTRACT = {
     "contract_version": "staff-authorization-v1",
     "enabled": True,
@@ -443,6 +491,7 @@ STAFF_BOT_CONFIRMATION_CONTRACT = {
     "state_changing_actions_enabled": False,
     "confirmation_window_seconds": 120,
     "default_state_change_decision": "deny_until_explicit_confirmation_runtime",
+    "token_storage_contract": STAFF_BOT_CONFIRMATION_TOKEN_STORAGE_CONTRACT,
     "operations": [
         {
             "key": "queue_call_or_skip_patient",
@@ -956,6 +1005,9 @@ def _build_staff_bot_status(
         "linking_runtime_contract": STAFF_BOT_LINKING_RUNTIME_CONTRACT,
         "link_token_validation_contract": STAFF_BOT_LINK_TOKEN_VALIDATION_CONTRACT,
         "link_token_storage_contract": STAFF_BOT_LINK_TOKEN_STORAGE_CONTRACT,
+        "confirmation_token_storage_contract": (
+            STAFF_BOT_CONFIRMATION_TOKEN_STORAGE_CONTRACT
+        ),
         "authorization_contract": STAFF_BOT_AUTHORIZATION_CONTRACT,
         "command_registration_contract": command_registration_contract,
         "confirmation_contract": STAFF_BOT_CONFIRMATION_CONTRACT,

--- a/backend/app/models/telegram_config.py
+++ b/backend/app/models/telegram_config.py
@@ -215,6 +215,86 @@ class TelegramStaffLinkToken(Base):
     )
 
 
+class TelegramStaffConfirmationToken(Base):
+    """Hash-only storage shape for one-time staff action confirmation tokens."""
+
+    __tablename__ = "telegram_staff_confirmation_tokens"
+    __table_args__ = (
+        CheckConstraint(
+            "expires_at > created_at",
+            name="ck_telegram_staff_confirmation_tokens_expires_after_created",
+        ),
+        CheckConstraint(
+            "consumed_at IS NULL OR consumed_at <= expires_at",
+            name="ck_telegram_staff_confirmation_tokens_consumed_before_expiry",
+        ),
+        CheckConstraint(
+            "operation_key <> ''",
+            name="ck_telegram_staff_confirmation_tokens_operation_not_empty",
+        ),
+        CheckConstraint(
+            "action_payload_hash <> ''",
+            name="ck_telegram_staff_confirmation_tokens_payload_hash_not_empty",
+        ),
+        Index(
+            "ix_telegram_staff_confirmation_tokens_staff_user_id",
+            "staff_user_id",
+        ),
+        Index(
+            "ix_telegram_staff_confirmation_tokens_telegram_chat_id",
+            "telegram_chat_id",
+        ),
+        Index(
+            "ix_telegram_staff_confirmation_tokens_operation_key",
+            "operation_key",
+        ),
+        Index(
+            "ix_telegram_staff_confirmation_tokens_unconsumed_expires",
+            "expires_at",
+            postgresql_where=text("consumed_at IS NULL"),
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    token_hash: Mapped[str] = mapped_column(
+        String(96), unique=True, nullable=False, index=True
+    )
+    staff_user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    telegram_chat_id: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+    )
+    operation_key: Mapped[str] = mapped_column(String(96), nullable=False)
+    command_key: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    action_payload_hash: Mapped[str] = mapped_column(String(96), nullable=False)
+    target_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    target_reference_hash: Mapped[str | None] = mapped_column(
+        String(96), nullable=True
+    )
+    idempotency_key_hash: Mapped[str | None] = mapped_column(
+        String(96), nullable=True
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    consumed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )
+    request_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    staff_user: Mapped[User] = relationship("User", foreign_keys=[staff_user_id])
+
+
 class TelegramMessage(Base):
     """Лог отправленных сообщений"""
 

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -6,7 +6,10 @@ from types import SimpleNamespace
 import pytest
 
 from app.api.v1.endpoints import admin_telegram
-from app.models.telegram_config import TelegramStaffLinkToken
+from app.models.telegram_config import (
+    TelegramStaffConfirmationToken,
+    TelegramStaffLinkToken,
+)
 from app.services.telegram_staff_link_token_service import (
     TelegramStaffLinkTokenService,
 )
@@ -188,6 +191,113 @@ class TestTelegramBotManagementApiService:
             in constraint_names
         )
 
+    def test_staff_confirmation_token_storage_contract_matches_model_columns(self):
+        contract = admin_telegram.STAFF_BOT_CONFIRMATION_TOKEN_STORAGE_CONTRACT
+        table = TelegramStaffConfirmationToken.__table__
+
+        assert table.name == contract["table"]
+        assert contract["enabled"] is True
+        assert contract["migration_created"] is True
+        assert contract["model_registered"] is True
+        assert contract["runtime_write_enabled"] is False
+        assert contract["runtime_consume_enabled"] is False
+        assert contract["migration_revision"] == "0026_tg_staff_confirm_tokens"
+        assert list(table.columns.keys()) == contract["columns"]
+        assert contract["raw_token_storage_allowed"] is False
+        assert "raw_token" not in table.columns
+        assert "token" not in table.columns
+        assert table.c.token_hash.unique is True
+        assert table.c.token_hash.nullable is False
+        assert table.c.staff_user_id.nullable is False
+        assert table.c.telegram_chat_id.nullable is False
+        assert table.c.operation_key.nullable is False
+        assert table.c.action_payload_hash.nullable is False
+        assert table.c.expires_at.nullable is False
+
+        staff_fk = next(iter(table.c.staff_user_id.foreign_keys))
+        assert staff_fk.target_fullname == "users.id"
+        assert staff_fk.ondelete == "CASCADE"
+
+    def test_staff_confirmation_token_storage_model_has_required_indexes(self):
+        contract = admin_telegram.STAFF_BOT_CONFIRMATION_TOKEN_STORAGE_CONTRACT
+        table = TelegramStaffConfirmationToken.__table__
+
+        assert "unique(token_hash)" in contract["required_indexes"]
+        assert "index(staff_user_id)" in contract["required_indexes"]
+        assert "index(telegram_chat_id)" in contract["required_indexes"]
+        assert "index(operation_key)" in contract["required_indexes"]
+        assert (
+            "partial_index(expires_at) where consumed_at is null"
+            in contract["required_indexes"]
+        )
+
+        indexes_by_name = {index.name: index for index in table.indexes}
+        assert indexes_by_name[
+            "ix_telegram_staff_confirmation_tokens_token_hash"
+        ].unique
+        assert [
+            column.name
+            for column in indexes_by_name[
+                "ix_telegram_staff_confirmation_tokens_staff_user_id"
+            ].columns
+        ] == ["staff_user_id"]
+        assert [
+            column.name
+            for column in indexes_by_name[
+                "ix_telegram_staff_confirmation_tokens_telegram_chat_id"
+            ].columns
+        ] == ["telegram_chat_id"]
+        assert [
+            column.name
+            for column in indexes_by_name[
+                "ix_telegram_staff_confirmation_tokens_operation_key"
+            ].columns
+        ] == ["operation_key"]
+
+        partial_index = indexes_by_name[
+            "ix_telegram_staff_confirmation_tokens_unconsumed_expires"
+        ]
+        assert [column.name for column in partial_index.columns] == ["expires_at"]
+        assert (
+            str(partial_index.dialect_options["postgresql"]["where"]).lower()
+            == "consumed_at is null"
+        )
+
+    def test_staff_confirmation_token_storage_model_has_required_constraints(self):
+        contract = admin_telegram.STAFF_BOT_CONFIRMATION_TOKEN_STORAGE_CONTRACT
+        table = TelegramStaffConfirmationToken.__table__
+
+        assert "expires_at > created_at" in contract["required_constraints"]
+        assert (
+            "consumed_at is null or consumed_at <= expires_at"
+            in contract["required_constraints"]
+        )
+        assert "operation_key is not empty" in contract["required_constraints"]
+        assert "action_payload_hash is not empty" in contract["required_constraints"]
+        assert "staff_user_id references users(id)" in contract[
+            "required_constraints"
+        ]
+
+        constraint_names = {
+            constraint.name for constraint in table.constraints if constraint.name
+        }
+        assert (
+            "ck_telegram_staff_confirmation_tokens_expires_after_created"
+            in constraint_names
+        )
+        assert (
+            "ck_telegram_staff_confirmation_tokens_consumed_before_expiry"
+            in constraint_names
+        )
+        assert (
+            "ck_telegram_staff_confirmation_tokens_operation_not_empty"
+            in constraint_names
+        )
+        assert (
+            "ck_telegram_staff_confirmation_tokens_payload_hash_not_empty"
+            in constraint_names
+        )
+
     def test_staff_bot_status_remains_disabled_until_readiness_gates(self):
         status = admin_telegram._build_staff_bot_status(webhook_set=False)
 
@@ -262,6 +372,7 @@ class TestTelegramBotManagementApiService:
             "linking_runtime_contract",
             "link_token_validation_contract",
             "link_token_storage_contract",
+            "confirmation_token_storage_contract",
             "authorization_contract",
             "command_registration_contract",
             "confirmation_contract",
@@ -273,6 +384,12 @@ class TestTelegramBotManagementApiService:
         )
         assert status["link_token_validation_contract"]["storage_contract"] == (
             status["link_token_storage_contract"]
+        )
+        assert status["confirmation_token_storage_contract"] == (
+            admin_telegram.STAFF_BOT_CONFIRMATION_TOKEN_STORAGE_CONTRACT
+        )
+        assert status["confirmation_contract"]["token_storage_contract"] == (
+            status["confirmation_token_storage_contract"]
         )
         assert status["linking_contract"]["enabled"] is True
         assert (


### PR DESCRIPTION
## Summary

- Add the SQLAlchemy model for `telegram_staff_confirmation_tokens`, matching Alembic revision `0026_tg_staff_confirm_tokens` from #820.
- Publish `confirmation_token_storage_contract` in the staff bot status bundle and link it from `confirmation_contract`.
- Add unit assertions for confirmation-token columns, indexes, constraints, and status contract wiring.
- Keep confirmation token write/consume runtime and all state-changing Telegram actions disabled.

## Contract Impact

- Canonical surface: `GET /api/v1/admin/telegram/integration-status` staff bot status bundle and its backend `_build_staff_bot_status` contract source.
- Request shape: authenticated admin request, no new request body or query fields.
- Response shape: staff bot status gains `confirmation_token_storage_contract`; `confirmation_contract.token_storage_contract` references the same hash-only storage contract; existing runtime booleans remain false.
- Status codes: unchanged for the admin Telegram status endpoint.
- Frontend consumer: existing admin Telegram integration/status consumers may read the additive field; no frontend code changed.
- Compatibility path or alias: no route alias or compatibility path changed.
- Contract proof: targeted unit tests assert the model columns, indexes, constraints, and status contract wiring.

## RBAC / Permissions

- Roles allowed: no roles are newly allowed by this model/contract-only slice; no endpoint or action path is enabled.
- Roles denied: all Telegram state-changing roles remain denied at runtime because confirmation runtime write/consume stays disabled.
- Positive auth proof: not applicable because no runtime auth/action path was added; existing admin status access contract is unchanged.
- Negative auth proof: unit coverage keeps `state_changing_actions_enabled` and `confirmation_token_runtime_enabled` false.
- Data exposure: raw confirmation tokens are not stored or returned; the storage shape is hash-only.

## Notification / Realtime

not applicable - no notification, websocket, chat delivery, Telegram send, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, this additive status contract does not render or fetch list data.
- Partial data proof: backend status still includes existing confirmation booleans and adds a self-contained storage contract.
- Forbidden secondary path behavior: not applicable, no secondary frontend path or route was changed.
- Missing draft/resource behavior: not applicable, this slice does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable, no route or deep-link state changed.

## Scope Gate

- Allowed paths: `backend/app/models/telegram_config.py`, `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/tests/unit/test_telegram_bot_management_api_service.py`.
- Denied paths: Telegram webhook runtime actions, repository/service token issuing, frontend UI, generated output, and extra migrations.
- Migration/docs/test impact: existing migration `0026_tg_staff_confirm_tokens` is reused; targeted backend unit tests updated; no docs or generated artifacts changed.
- Rollback note: revert the model/contract commit to remove the additive status field and SQLAlchemy model mapping.
- Execution gate note: `agent_gate.py` was retried with `--known-root-cause backend/app/models/telegram_config.py`, but still proposed an extra `0027` migration; repo-approved `narrow_override` kept the slice model/contract-only.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\models\telegram_config.py backend\app\api\v1\endpoints\admin_telegram.py backend\tests\unit\test_telegram_bot_management_api_service.py`; `PYTHONPATH=C:\final\backend alembic heads`; `PYTHONPATH=C:\final\backend alembic history --verbose -r 0025:head`; `pytest backend\tests\unit\test_telegram_bot_management_api_service.py -q`; `pytest backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py -q`; `git diff --check -- backend\app\models\telegram_config.py backend\app\api\v1\endpoints\admin_telegram.py backend\tests\unit\test_telegram_bot_management_api_service.py`.
- Result: local checks passed; GitHub backend tests and PR Required Gate passed on the first code run.
- Not checked: full browser admin Telegram panel smoke, because no frontend UI or route behavior changed.