### PR TITLE
feat(telegram): add staff confirmation token service

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -336,13 +336,13 @@ STAFF_BOT_CONFIRMATION_TOKEN_STORAGE_CONTRACT = {
     "enabled": True,
     "migration_created": True,
     "model_registered": True,
-    "runtime_write_enabled": False,
-    "runtime_consume_enabled": False,
+    "runtime_write_enabled": True,
+    "runtime_consume_enabled": True,
     "table": "telegram_staff_confirmation_tokens",
     "raw_token_storage_allowed": False,
     "migration_revision": "0026_tg_staff_confirm_tokens",
-    "repository": None,
-    "service": None,
+    "repository": "TelegramStaffConfirmationTokenRepository",
+    "service": "TelegramStaffConfirmationTokenService",
     "columns": [
         "id",
         "token_hash",
@@ -487,10 +487,10 @@ STAFF_BOT_CONFIRMATION_CONTRACT = {
     "runtime_guard_enabled": True,
     "deny_only_runtime_enabled": True,
     "state_change_command_guard_enabled": True,
-    "confirmation_token_runtime_enabled": False,
+    "confirmation_token_runtime_enabled": True,
     "state_changing_actions_enabled": False,
     "confirmation_window_seconds": 120,
-    "default_state_change_decision": "deny_until_explicit_confirmation_runtime",
+    "default_state_change_decision": "deny_until_idempotency_and_action_enablement",
     "token_storage_contract": STAFF_BOT_CONFIRMATION_TOKEN_STORAGE_CONTRACT,
     "operations": [
         {
@@ -546,7 +546,6 @@ STAFF_BOT_CONFIRMATION_CONTRACT = {
         "audit_log_write_succeeds",
     ],
     "runtime_blocked_by": [
-        "confirmation_token_persistence",
         "idempotency_runtime",
         "domain_service_action_adapters",
         "explicit_action_enablement",
@@ -1034,10 +1033,10 @@ def _build_staff_bot_status(
             "runtime_guard_enabled": True,
             "deny_only_runtime_enabled": True,
             "state_change_command_guard_enabled": True,
-            "confirmation_token_runtime_enabled": False,
+            "confirmation_token_runtime_enabled": True,
             "state_changing_actions_enabled": False,
             "default_state_change_decision": (
-                "deny_until_explicit_confirmation_runtime"
+                "deny_until_idempotency_and_action_enablement"
             ),
         },
         "state_changing_actions_enabled": False,

--- a/backend/app/repositories/telegram_staff_confirmation_token_repository.py
+++ b/backend/app/repositories/telegram_staff_confirmation_token_repository.py
@@ -1,0 +1,100 @@
+"""Repository for one-time Telegram staff action confirmation tokens."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.models.telegram_config import TelegramStaffConfirmationToken
+
+
+class TelegramStaffConfirmationTokenRepository:
+    """Encapsulates storage access for hash-only staff confirmation tokens."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(
+        self,
+        *,
+        token_hash: str,
+        staff_user_id: int,
+        telegram_chat_id: int,
+        operation_key: str,
+        action_payload_hash: str,
+        expires_at: datetime,
+        command_key: str | None = None,
+        target_type: str | None = None,
+        target_reference_hash: str | None = None,
+        idempotency_key_hash: str | None = None,
+        request_id: str | None = None,
+    ) -> TelegramStaffConfirmationToken:
+        record = TelegramStaffConfirmationToken(
+            token_hash=token_hash,
+            staff_user_id=staff_user_id,
+            telegram_chat_id=telegram_chat_id,
+            operation_key=operation_key,
+            command_key=command_key,
+            action_payload_hash=action_payload_hash,
+            target_type=target_type,
+            target_reference_hash=target_reference_hash,
+            idempotency_key_hash=idempotency_key_hash,
+            expires_at=expires_at,
+            request_id=request_id,
+        )
+        self.db.add(record)
+        self.db.flush()
+        self.db.refresh(record)
+        return record
+
+    def get_by_token_hash(
+        self, token_hash: str
+    ) -> TelegramStaffConfirmationToken | None:
+        return (
+            self.db.query(TelegramStaffConfirmationToken)
+            .filter(TelegramStaffConfirmationToken.token_hash == token_hash)
+            .first()
+        )
+
+    def consume_active(
+        self,
+        *,
+        token_hash: str,
+        staff_user_id: int,
+        telegram_chat_id: int,
+        operation_key: str,
+        action_payload_hash: str,
+        idempotency_key_hash: str | None,
+        consumed_at: datetime,
+    ) -> int:
+        query = self.db.query(TelegramStaffConfirmationToken).filter(
+            TelegramStaffConfirmationToken.token_hash == token_hash,
+            TelegramStaffConfirmationToken.staff_user_id == staff_user_id,
+            TelegramStaffConfirmationToken.telegram_chat_id == telegram_chat_id,
+            TelegramStaffConfirmationToken.operation_key == operation_key,
+            TelegramStaffConfirmationToken.action_payload_hash
+            == action_payload_hash,
+            TelegramStaffConfirmationToken.consumed_at.is_(None),
+            TelegramStaffConfirmationToken.expires_at > consumed_at,
+        )
+        if idempotency_key_hash is None:
+            query = query.filter(
+                TelegramStaffConfirmationToken.idempotency_key_hash.is_(None)
+            )
+        else:
+            query = query.filter(
+                TelegramStaffConfirmationToken.idempotency_key_hash
+                == idempotency_key_hash
+            )
+
+        return query.update(
+            {TelegramStaffConfirmationToken.consumed_at: consumed_at},
+            synchronize_session=False,
+        )
+
+    def commit(self) -> None:
+        self.db.commit()
+
+    def rollback(self) -> None:
+        self.db.rollback()

--- a/backend/app/services/telegram_staff_confirmation_token_service.py
+++ b/backend/app/services/telegram_staff_confirmation_token_service.py
@@ -1,0 +1,175 @@
+"""Service for one-time Telegram staff action confirmation token storage."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.telegram_config import TelegramStaffConfirmationToken
+from app.repositories.telegram_staff_confirmation_token_repository import (
+    TelegramStaffConfirmationTokenRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TelegramStaffConfirmationTokenService:
+    """Issues and consumes hash-only staff action confirmation tokens."""
+
+    def __init__(
+        self,
+        db: Session,
+        repository: TelegramStaffConfirmationTokenRepository | None = None,
+    ):
+        self.repository = repository or TelegramStaffConfirmationTokenRepository(db)
+
+    @staticmethod
+    def utc_now() -> datetime:
+        return datetime.now(timezone.utc)
+
+    @staticmethod
+    def as_utc(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    @staticmethod
+    def require_non_empty(value: str, field_name: str) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            raise ValueError(f"{field_name} is required")
+        return normalized
+
+    def issue_token(
+        self,
+        *,
+        token_hash: str,
+        staff_user_id: int,
+        telegram_chat_id: int,
+        operation_key: str,
+        action_payload_hash: str,
+        expires_at: datetime,
+        command_key: str | None = None,
+        target_type: str | None = None,
+        target_reference_hash: str | None = None,
+        idempotency_key_hash: str | None = None,
+        request_id: str | None = None,
+        now: datetime | None = None,
+    ) -> TelegramStaffConfirmationToken:
+        token_hash = self.require_non_empty(token_hash, "token_hash")
+        operation_key = self.require_non_empty(operation_key, "operation_key")
+        action_payload_hash = self.require_non_empty(
+            action_payload_hash,
+            "action_payload_hash",
+        )
+        expires_at_utc = self.as_utc(expires_at)
+        now_utc = self.as_utc(now or self.utc_now())
+        if expires_at_utc <= now_utc:
+            raise ValueError("staff confirmation token expiry must be in the future")
+
+        try:
+            logger.info(
+                "Issuing Telegram staff confirmation token user_id=%s "
+                "chat_id=%s operation_key=%s",
+                staff_user_id,
+                telegram_chat_id,
+                operation_key,
+            )
+            record = self.repository.create(
+                token_hash=token_hash,
+                staff_user_id=staff_user_id,
+                telegram_chat_id=telegram_chat_id,
+                operation_key=operation_key,
+                command_key=command_key,
+                action_payload_hash=action_payload_hash,
+                target_type=target_type,
+                target_reference_hash=target_reference_hash,
+                idempotency_key_hash=idempotency_key_hash,
+                expires_at=expires_at_utc,
+                request_id=request_id,
+            )
+            self.repository.commit()
+            return record
+        except Exception:
+            self.repository.rollback()
+            logger.exception(
+                "Failed to issue Telegram staff confirmation token user_id=%s "
+                "chat_id=%s operation_key=%s",
+                staff_user_id,
+                telegram_chat_id,
+                operation_key,
+            )
+            raise
+
+    def consume_for_confirmation(
+        self,
+        *,
+        token_hash: str,
+        staff_user_id: int,
+        telegram_chat_id: int,
+        operation_key: str,
+        action_payload_hash: str,
+        idempotency_key_hash: str | None = None,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        now_utc = self.as_utc(now or self.utc_now())
+        record = self.repository.get_by_token_hash(token_hash)
+        if record is None:
+            return {"valid": False, "reason": "token_not_issued"}
+
+        if (
+            int(record.staff_user_id) != int(staff_user_id)
+            or int(record.telegram_chat_id) != int(telegram_chat_id)
+        ):
+            return {"valid": False, "reason": "token_binding_mismatch"}
+
+        if (
+            record.operation_key != operation_key
+            or record.action_payload_hash != action_payload_hash
+            or record.idempotency_key_hash != idempotency_key_hash
+        ):
+            return {"valid": False, "reason": "action_binding_mismatch"}
+
+        if record.consumed_at is not None:
+            return {"valid": False, "reason": "already_used"}
+
+        expires_at = self.as_utc(record.expires_at)
+        if expires_at <= now_utc:
+            return {"valid": False, "reason": "expired"}
+
+        updated = self.repository.consume_active(
+            token_hash=token_hash,
+            staff_user_id=staff_user_id,
+            telegram_chat_id=telegram_chat_id,
+            operation_key=operation_key,
+            action_payload_hash=action_payload_hash,
+            idempotency_key_hash=idempotency_key_hash,
+            consumed_at=now_utc,
+        )
+        if updated != 1:
+            refreshed = self.repository.get_by_token_hash(token_hash)
+            if refreshed and refreshed.consumed_at is not None:
+                return {"valid": False, "reason": "already_used"}
+            return {"valid": False, "reason": "token_consume_conflict"}
+
+        self.repository.commit()
+        logger.info(
+            "Consumed Telegram staff confirmation token user_id=%s "
+            "chat_id=%s operation_key=%s",
+            staff_user_id,
+            telegram_chat_id,
+            operation_key,
+        )
+        return {
+            "valid": True,
+            "reason": "ok",
+            "single_use_enforced": True,
+            "consumed_at": now_utc.isoformat(),
+            "operation_key": record.operation_key,
+            "command_key": record.command_key,
+            "target_type": record.target_type,
+            "request_id": record.request_id,
+        }

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -13,6 +13,9 @@ from app.models.telegram_config import (
 from app.services.telegram_staff_link_token_service import (
     TelegramStaffLinkTokenService,
 )
+from app.services.telegram_staff_confirmation_token_service import (
+    TelegramStaffConfirmationTokenService,
+)
 from app.services.telegram_bot_management_api_service import (
     TelegramBotManagementApiService,
 )
@@ -199,9 +202,11 @@ class TestTelegramBotManagementApiService:
         assert contract["enabled"] is True
         assert contract["migration_created"] is True
         assert contract["model_registered"] is True
-        assert contract["runtime_write_enabled"] is False
-        assert contract["runtime_consume_enabled"] is False
+        assert contract["runtime_write_enabled"] is True
+        assert contract["runtime_consume_enabled"] is True
         assert contract["migration_revision"] == "0026_tg_staff_confirm_tokens"
+        assert contract["repository"] == "TelegramStaffConfirmationTokenRepository"
+        assert contract["service"] == "TelegramStaffConfirmationTokenService"
         assert list(table.columns.keys()) == contract["columns"]
         assert contract["raw_token_storage_allowed"] is False
         assert "raw_token" not in table.columns
@@ -319,7 +324,7 @@ class TestTelegramBotManagementApiService:
         assert status["confirmations"]["runtime_guard_enabled"] is True
         assert status["confirmations"]["deny_only_runtime_enabled"] is True
         assert (
-            status["confirmations"]["confirmation_token_runtime_enabled"] is False
+            status["confirmations"]["confirmation_token_runtime_enabled"] is True
         )
         assert status["confirmations"]["state_changing_actions_enabled"] is False
 
@@ -429,9 +434,17 @@ class TestTelegramBotManagementApiService:
         assert status["confirmation_contract"]["deny_only_runtime_enabled"] is True
         assert (
             status["confirmation_contract"]["confirmation_token_runtime_enabled"]
-            is False
+            is True
         )
         assert status["confirmation_contract"]["state_changing_actions_enabled"] is False
+        assert (
+            "confirmation_token_persistence"
+            not in status["confirmation_contract"]["runtime_blocked_by"]
+        )
+        assert (
+            status["confirmation_contract"]["runtime_blocked_by"][0]
+            == "idempotency_runtime"
+        )
 
     def test_staff_link_start_token_validator_reports_expired_reason(self):
         token = admin_telegram.build_staff_link_start_token(
@@ -553,6 +566,111 @@ class TestTelegramBotManagementApiService:
         assert first["valid"] is True
         assert first["single_use_enforced"] is True
         assert second == {"valid": False, "reason": "already_used"}
+
+    def test_staff_confirmation_token_service_issues_hash_only_record(
+        self, db_session, admin_user
+    ):
+        raw_token = "plain-confirm-token"
+        service = TelegramStaffConfirmationTokenService(db_session)
+
+        record = service.issue_token(
+            token_hash="staff_confirmation_token:" + ("a" * 64),
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700800,
+            operation_key="payment_status_change",
+            command_key="/payment_status",
+            action_payload_hash="payload:" + ("b" * 64),
+            target_type="payment",
+            target_reference_hash="target:" + ("c" * 64),
+            idempotency_key_hash="idempotency:" + ("d" * 64),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=2),
+            request_id="req-confirm-1",
+        )
+
+        stored = (
+            db_session.query(TelegramStaffConfirmationToken)
+            .filter(TelegramStaffConfirmationToken.id == record.id)
+            .one()
+        )
+        assert stored.token_hash.startswith("staff_confirmation_token:")
+        assert stored.token_hash != raw_token
+        assert stored.operation_key == "payment_status_change"
+        assert stored.command_key == "/payment_status"
+        assert stored.action_payload_hash.startswith("payload:")
+        assert stored.target_reference_hash.startswith("target:")
+        assert stored.idempotency_key_hash.startswith("idempotency:")
+        assert stored.consumed_at is None
+        assert stored.request_id == "req-confirm-1"
+
+    def test_staff_confirmation_token_service_consumes_record_once(
+        self, db_session, admin_user
+    ):
+        service = TelegramStaffConfirmationTokenService(db_session)
+        token_hash = "staff_confirmation_token:" + ("e" * 64)
+        payload_hash = "payload:" + ("f" * 64)
+        idempotency_hash = "idempotency:" + ("1" * 64)
+        service.issue_token(
+            token_hash=token_hash,
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700801,
+            operation_key="queue_call_or_skip_patient",
+            action_payload_hash=payload_hash,
+            idempotency_key_hash=idempotency_hash,
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=2),
+        )
+
+        first = service.consume_for_confirmation(
+            token_hash=token_hash,
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700801,
+            operation_key="queue_call_or_skip_patient",
+            action_payload_hash=payload_hash,
+            idempotency_key_hash=idempotency_hash,
+        )
+        second = service.consume_for_confirmation(
+            token_hash=token_hash,
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700801,
+            operation_key="queue_call_or_skip_patient",
+            action_payload_hash=payload_hash,
+            idempotency_key_hash=idempotency_hash,
+        )
+
+        assert first["valid"] is True
+        assert first["reason"] == "ok"
+        assert first["single_use_enforced"] is True
+        assert first["operation_key"] == "queue_call_or_skip_patient"
+        assert second == {"valid": False, "reason": "already_used"}
+
+    def test_staff_confirmation_token_service_rejects_action_mismatch(
+        self, db_session, admin_user
+    ):
+        service = TelegramStaffConfirmationTokenService(db_session)
+        token_hash = "staff_confirmation_token:" + ("9" * 64)
+        service.issue_token(
+            token_hash=token_hash,
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700802,
+            operation_key="visit_cancel_or_move",
+            action_payload_hash="payload:" + ("2" * 64),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=2),
+        )
+
+        result = service.consume_for_confirmation(
+            token_hash=token_hash,
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700802,
+            operation_key="visit_cancel_or_move",
+            action_payload_hash="payload:" + ("3" * 64),
+        )
+        stored = (
+            db_session.query(TelegramStaffConfirmationToken)
+            .filter(TelegramStaffConfirmationToken.token_hash == token_hash)
+            .one()
+        )
+
+        assert result == {"valid": False, "reason": "action_binding_mismatch"}
+        assert stored.consumed_at is None
 
     def test_staff_link_start_token_validator_consumes_storage_record(
         self, db_session, admin_user

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -46,14 +46,14 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         )
         assert (
             status["next_slice"]
-            == "staff_state_change_confirmation_token_persistence"
+            == "staff_state_change_idempotency_runtime"
         )
         assert (
             status["confirmation_contract"]["runtime_blocked_by"][0]
-            == "confirmation_token_persistence"
+            == "idempotency_runtime"
         )
         assert (
-            status["confirmations"]["confirmation_token_runtime_enabled"] is False
+            status["confirmations"]["confirmation_token_runtime_enabled"] is True
         )
         assert status["confirmations"]["state_changing_actions_enabled"] is False
         assert (
@@ -88,7 +88,7 @@ class TestTelegramStaffBotTokenRuntimeConfig:
         assert contract["runtime_blocked_by"] == []
         assert (
             status["next_slice"]
-            == "staff_state_change_confirmation_token_persistence"
+            == "staff_state_change_idempotency_runtime"
         )
         assert (
             status["command_registration_contract"]["registration_enabled"] is True


### PR DESCRIPTION
## Summary

- Add hash-only repository and service helpers for `TelegramStaffConfirmationToken` issue/consume flows.
- Mark confirmation-token persistence runtime as available in the staff bot contract while keeping all state-changing Telegram actions disabled.
- Move the published next slice from `confirmation_token_persistence` to `idempotency_runtime`.
- Add targeted unit coverage for hash-only storage, single-use consume, action binding mismatch, and status contract changes.

## Contract Impact

- Canonical surface: `GET /api/v1/admin/telegram/integration-status` staff bot status bundle and backend `_build_staff_bot_status` contract source.
- Request shape: authenticated admin request, no new request body or query fields.
- Response shape: `confirmation_token_storage_contract.runtime_write_enabled` and `runtime_consume_enabled` become true; repository/service names are published; `confirmation_token_runtime_enabled` becomes true; `runtime_blocked_by` now starts with `idempotency_runtime`; state-changing actions remain false.
- Status codes: unchanged for the admin Telegram status endpoint.
- Frontend consumer: existing admin Telegram integration/status consumers may see updated readiness fields; no frontend code changed.
- Compatibility path or alias: no route alias or compatibility path changed.
- Contract proof: targeted unit tests assert status contract wiring and helper behavior.

## RBAC / Permissions

- Roles allowed: no roles are newly allowed; no Telegram state-changing endpoint, webhook path, or command execution path is enabled.
- Roles denied: all Telegram state-changing roles remain denied because `state_changing_actions_enabled` stays false and blockers remain for idempotency, domain adapters, and explicit enablement.
- Positive auth proof: not applicable because no runtime action authorization path was added; this slice only persists confirmation tokens.
- Negative auth proof: unit coverage keeps `state_changing_actions_enabled` false and verifies the next blocker is `idempotency_runtime`.
- Data exposure: raw confirmation tokens, raw target references, and raw action payloads are not stored; helper inputs use hashes only and logs omit token/payload contents.

## Notification / Realtime

not applicable - no notification, websocket, chat delivery, Telegram send, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, this slice does not render or fetch list data.
- Partial data proof: backend status keeps existing confirmation/readiness fields while updating token runtime readiness.
- Forbidden secondary path behavior: not applicable, no secondary frontend path or route was changed.
- Missing draft/resource behavior: not applicable, this slice does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable, no route or deep-link state changed.

## Scope Gate

- Allowed paths: confirmation token repository/service, admin Telegram status contract, targeted Telegram unit tests.
- Denied paths: Telegram webhook state-changing execution, domain action adapters, frontend UI, generated output, and extra Alembic migrations.
- Migration/docs/test impact: no new migration; existing Alembic chain remains at `0027_repair_tg_user_lang_len`; targeted backend unit tests updated.
- Rollback note: revert this commit to return confirmation-token runtime to persistence-blocked status and remove the helper layer.
- Execution gate note: `agent_gate.py` and the known-root-cause retry still proposed an extra `0028` migration; repo-approved `narrow_override` kept the slice runtime-helper-only.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\repositories\telegram_staff_confirmation_token_repository.py backend\app\services\telegram_staff_confirmation_token_service.py backend\app\api\v1\endpoints\admin_telegram.py backend\tests\unit\test_telegram_bot_management_api_service.py backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py`; `PYTHONPATH=C:\final\backend alembic heads`; `PYTHONPATH=C:\final\backend alembic history --verbose -r 0026:head`; `pytest backend\tests\unit\test_telegram_bot_management_api_service.py -q`; `pytest backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py -q`; `git diff --check -- backend\app\repositories\telegram_staff_confirmation_token_repository.py backend\app\services\telegram_staff_confirmation_token_service.py backend\app\api\v1\endpoints\admin_telegram.py backend\tests\unit\test_telegram_bot_management_api_service.py backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py`.
- Result: local checks passed (`26 passed` and `5 passed` for targeted pytest suites).
- Not checked: full browser admin Telegram panel smoke, because no frontend UI or route behavior changed.