### PR TITLE
feat(telegram): clarify patient help menu

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -285,34 +285,46 @@ TELEGRAM_LOCALIZED_TEXTS = {
     },
     "help": {
         TELEGRAM_LANGUAGE_RU: (
-            "Команды бота:\n"
-            "/start - главное меню\n"
-            "/queue - моя очередь\n"
-            "/payments - оплаты и долг\n"
-            "/profile - статус привязки\n"
-            "/settings - язык и уведомления\n"
-            "/results - получить готовые PDF-результаты\n\n"
-            "Для привязки можно отсканировать QR с чека или нажать "
-            "\"Поделиться номером\"."
+            "Kosmed Clinic bot\n\n"
+            "Для пациента:\n"
+            "🎫 Моя очередь - номер, кабинет, статус и позиция ожидания.\n"
+            "💳 Оплаты и долг - начислено, оплачено, долг и незавершенные платежи.\n"
+            "📄 Результаты - до 3 готовых PDF-отчетов, только после привязки.\n"
+            "👤 Мой статус - привязка Telegram к карте пациента.\n"
+            "⚙️ Настройки - язык и уведомления.\n\n"
+            "Команды: /start, /queue, /payments, /results, /profile, /settings.\n\n"
+            "Для привязки отсканируйте QR с чека или нажмите "
+            "\"Поделиться номером\".\n\n"
+            "Для сотрудников: доступ отдельно через персональную ссылку администратора "
+            "или /staff после привязки. В Telegram режим сотрудника только для просмотра; "
+            "действия выполняются в приложении клиники."
         ),
         TELEGRAM_LANGUAGE_UZ: (
-            "Bot buyruqlari:\n"
-            "/start - asosiy menyu\n"
-            "/queue - mening navbatim\n"
-            "/payments - to'lovlar va qarz\n"
-            "/profile - bog'lanish holati\n"
-            "/settings - til va xabarnomalar\n"
-            "/results - tayyor PDF natijalarni olish\n\n"
+            "Kosmed Clinic bot\n\n"
+            "Bemor uchun:\n"
+            "🎫 Mening navbatim - raqam, kabinet, holat va kutishdagi o'rin.\n"
+            "💳 To'lovlar va qarz - hisoblangan, to'langan, qarz va yakunlanmagan to'lovlar.\n"
+            "📄 Natijalar - faqat bog'langan bemor uchun 3 tagacha tayyor PDF hisobot.\n"
+            "👤 Mening holatim - Telegram bemor kartasiga bog'langanini ko'rish.\n"
+            "⚙️ Sozlamalar - til va xabarnomalar.\n\n"
+            "Buyruqlar: /start, /queue, /payments, /results, /profile, /settings.\n\n"
             "Bog'lash uchun chekdagi QR kodni skaner qiling yoki "
-            "\"Telefon raqamni ulashish\" tugmasini bosing."
+            "\"Telefon raqamni ulashish\" tugmasini bosing.\n\n"
+            "Xodimlar uchun: kirish administrator bergan shaxsiy havola orqali "
+            "yoki bog'langandan keyin /staff orqali. Telegramdagi xodim rejimi faqat "
+            "ko'rish uchun; amallar klinika ilovasida bajariladi."
         ),
     },
     "settings": {
         TELEGRAM_LANGUAGE_RU: (
-            "Настройки Telegram: выберите язык обслуживания или режим уведомлений."
+            "Настройки Telegram\n\n"
+            "Выберите язык обслуживания или режим уведомлений. После смены языка "
+            "главное меню сразу обновится."
         ),
         TELEGRAM_LANGUAGE_UZ: (
-            "Telegram sozlamalari: xizmat tilini yoki xabarnoma rejimini tanlang."
+            "Telegram sozlamalari\n\n"
+            "Xizmat tilini yoki xabarnoma rejimini tanlang. Til o'zgarganda "
+            "asosiy menyu darhol yangilanadi."
         ),
     },
     "lab_results_empty": {


### PR DESCRIPTION
## Summary

- Clarify patient-facing `/help` text in Russian and Uzbek Latin.
- Explain visible patient bot features: queue, payments/debt, results, profile, settings.
- Make staff/admin access expectations explicit: separate staff link or `/staff`, read-only in Telegram, data-changing actions stay in the clinic app.
- Clarify settings copy so language changes feel immediate and intentional.

## Contract Impact

- Canonical surface: Telegram patient bot text replies for `/help`, `Помощь`, and `Yordam`; settings copy for `/settings` and localized settings buttons.
- Request shape: unchanged - no Bot API command, webhook payload, HTTP request, or keyboard schema changed.
- Response shape: text content changed only; reply markup remains the existing localized patient menu/settings menu.
- Status codes: not applicable - no HTTP endpoint behavior changed.
- Frontend consumer: not applicable - no frontend source changed.
- Compatibility path or alias: existing `/help`, plain Help/Yordam button aliases, and localized menus are preserved.
- Contract proof: targeted Telegram webhook tests plus backend py_compile.

## RBAC / Permissions

- Roles allowed: unchanged; patient bot help remains available to Telegram chats, staff mode still requires existing staff link/user mapping.
- Roles denied: unchanged; no role permissions were widened.
- Positive auth proof: not applicable - no authenticated HTTP endpoint changed.
- Negative auth proof: not applicable - no authorization behavior changed.

## Notification / Realtime

not applicable - no notification template delivery, websocket channel, polling transport, or Telegram send policy changed. This PR only changes existing localized text content.

## Frontend Resilience

- Empty data proof: not applicable - no frontend data rendering changed.
- Partial data proof: not applicable - no frontend data rendering changed.
- Forbidden secondary path behavior: not applicable - no frontend route or secondary path changed.
- Missing draft/resource behavior: not applicable - no draft/resource frontend flow changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link frontend behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Denied paths: DB/Alembic, frontend code, Telegram Bot API command registration, generated output, unrelated `.codex` and `.ai-factory` changes.
- Migration/docs/test impact: no migration; no docs; existing targeted tests exercised.
- Rollback note: revert the one text-only commit to restore previous bot copy.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `cd backend; pytest tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_plain_uzbek_button_switches_next_visible_menu tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_settings_command_returns_localized_settings_menu -q`; `cd frontend; npm.cmd run build`.
- Result: passed locally; frontend build emitted existing Vite chunk/dynamic-import warnings only.
- Not checked: live Telegram manual click, because this branch is not merged/restarted yet.