### PR TITLE
feat(telegram): clarify staff help menu

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -1047,14 +1047,24 @@ def _staff_menu_message(user: User, role_menu: Dict[str, Any]) -> str:
         f"Роль: {role_label} ({role_key})",
         f"Role: {role_key}",
         "",
-        "Доступно:",
+        "Что можно смотреть в Telegram:",
     ]
     lines.extend(f"- {item}" for item in items)
     lines.extend(
         [
             "",
+            "Команды:",
+            "/staff или /help - открыть это меню",
+            "/queue - очередь по роли",
+            "/schedule - расписание",
+            "/payments - статусы оплат",
+            "/reports - готовность результатов",
+            "/summary - операционная сводка",
+            "",
             "Действия, которые меняют данные, в Telegram отключены.",
             "State-changing actions are disabled in Telegram.",
+            "Для вызова пациента, изменения очереди, оплаты или EMR откройте приложение клиники.",
+            "No patient names, phone numbers, diagnoses, or full EMR content are shown here.",
         ]
     )
     return "\n".join(lines)


### PR DESCRIPTION
﻿## Summary

- Clarifies the staff/admin Telegram read-only menu so roles can see what is available from Telegram.
- Adds visible command guidance for /staff, /help, /queue, /schedule, /payments, /reports, and /summary.
- Makes the safety boundary explicit: state-changing actions and EMR/payment/queue mutations stay in the clinic app.

## Contract Impact

- Canonical surface: Telegram staff read-only menu text generated by backend/app/api/v1/endpoints/telegram_webhook.py for linked staff help/menu commands
- Request shape: existing Telegram webhook update payload and staff linked-user context; no new request fields or command aliases
- Response shape: existing Telegram sendMessage text changes only; reply keyboard and webhook HTTP response contract are unchanged
- Status codes: webhook HTTP dispatch behavior is unchanged; chat handler still returns the existing Telegram response path after authorized staff menu handling
- Frontend consumer: not applicable - no frontend consumer changed because this is Telegram chat text only
- Compatibility path or alias: /staff, /help, /queue, /schedule, /payments, /reports, and /summary remain existing commands; no alias migration
- Contract proof: python py_compile for telegram_webhook.py and targeted staff read-only menu runtime unit suite

## RBAC / Permissions

- Roles allowed: unchanged linked staff/admin roles that already reach the staff menu
- Roles denied: unchanged non-linked or non-staff Telegram users; no role expansion in this text-only slice
- Positive auth proof: backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py passed and covers linked staff command menu handling
- Negative auth proof: existing staff read-only menu runtime suite still covers disabled state-changing Telegram actions; no mutation action was enabled

## Notification / Realtime

not applicable - no notification event, websocket channel, delivery ack, read/unread marker, reconnect, or resync behavior changed because this PR only edits static Telegram menu text.

## Frontend Resilience

- Empty data proof: not applicable - no frontend data rendering path changed
- Partial data proof: not applicable - no frontend partial-data state changed
- Forbidden secondary path behavior: not applicable - Telegram command authorization paths are unchanged
- Missing draft/resource behavior: not applicable - this menu does not create, reopen, or depend on drafts/resources
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link behavior changed

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/telegram_webhook.py
- Denied paths: DB/Alembic, token storage, frontend manager screens, Telegram command registration, webhook transport, queue fairness, payment state behavior, staff write actions
- Migration/docs/test impact: no migration and no docs file changed; targeted runtime tests were run without code changes to test files
- Rollback note: revert commit 06a1ff56 to restore the previous staff help menu text

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/api/v1/endpoints/telegram_webhook.py; pytest backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py -q
- Result: passed locally, including 15 staff read-only Telegram runtime tests
- Not checked: live Telegram staff click flow, because a live polling/webhook worker was not restarted in this local cycle
