### PR TITLE
feat(telegram): make staff confirmation replay deterministic

### DIFF
--- a/backend/app/services/telegram_staff_confirmation_token_service.py
+++ b/backend/app/services/telegram_staff_confirmation_token_service.py
@@ -43,6 +43,22 @@ class TelegramStaffConfirmationTokenService:
             raise ValueError(f"{field_name} is required")
         return normalized
 
+    def already_used_result(
+        self, record: TelegramStaffConfirmationToken
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "valid": False,
+            "reason": "already_used",
+            "single_use_enforced": True,
+            "operation_key": record.operation_key,
+            "command_key": record.command_key,
+            "target_type": record.target_type,
+            "request_id": record.request_id,
+        }
+        if record.consumed_at is not None:
+            result["consumed_at"] = self.as_utc(record.consumed_at).isoformat()
+        return result
+
     def issue_token(
         self,
         *,
@@ -134,7 +150,7 @@ class TelegramStaffConfirmationTokenService:
             return {"valid": False, "reason": "action_binding_mismatch"}
 
         if record.consumed_at is not None:
-            return {"valid": False, "reason": "already_used"}
+            return self.already_used_result(record)
 
         expires_at = self.as_utc(record.expires_at)
         if expires_at <= now_utc:
@@ -152,7 +168,7 @@ class TelegramStaffConfirmationTokenService:
         if updated != 1:
             refreshed = self.repository.get_by_token_hash(token_hash)
             if refreshed and refreshed.consumed_at is not None:
-                return {"valid": False, "reason": "already_used"}
+                return self.already_used_result(refreshed)
             return {"valid": False, "reason": "token_consume_conflict"}
 
         self.repository.commit()

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -609,14 +609,19 @@ class TestTelegramBotManagementApiService:
         token_hash = "staff_confirmation_token:" + ("e" * 64)
         payload_hash = "payload:" + ("f" * 64)
         idempotency_hash = "idempotency:" + ("1" * 64)
+        issued_at = datetime.now(timezone.utc)
+        consumed_at = issued_at + timedelta(seconds=1)
         service.issue_token(
             token_hash=token_hash,
             staff_user_id=admin_user.id,
             telegram_chat_id=700801,
             operation_key="queue_call_or_skip_patient",
+            command_key="/queue",
             action_payload_hash=payload_hash,
+            target_type="queue",
             idempotency_key_hash=idempotency_hash,
-            expires_at=datetime.now(timezone.utc) + timedelta(minutes=2),
+            expires_at=issued_at + timedelta(minutes=2),
+            request_id="req-confirm-once",
         )
 
         first = service.consume_for_confirmation(
@@ -626,6 +631,7 @@ class TestTelegramBotManagementApiService:
             operation_key="queue_call_or_skip_patient",
             action_payload_hash=payload_hash,
             idempotency_key_hash=idempotency_hash,
+            now=consumed_at,
         )
         second = service.consume_for_confirmation(
             token_hash=token_hash,
@@ -634,13 +640,23 @@ class TestTelegramBotManagementApiService:
             operation_key="queue_call_or_skip_patient",
             action_payload_hash=payload_hash,
             idempotency_key_hash=idempotency_hash,
+            now=consumed_at + timedelta(seconds=5),
         )
 
         assert first["valid"] is True
         assert first["reason"] == "ok"
         assert first["single_use_enforced"] is True
         assert first["operation_key"] == "queue_call_or_skip_patient"
-        assert second == {"valid": False, "reason": "already_used"}
+        assert second == {
+            "valid": False,
+            "reason": "already_used",
+            "single_use_enforced": True,
+            "operation_key": "queue_call_or_skip_patient",
+            "command_key": "/queue",
+            "target_type": "queue",
+            "request_id": "req-confirm-once",
+            "consumed_at": consumed_at.isoformat(),
+        }
 
     def test_staff_confirmation_token_service_rejects_action_mismatch(
         self, db_session, admin_user


### PR DESCRIPTION
﻿## Summary

- Makes repeated Telegram staff confirmation token consume attempts deterministic after the token is already used.
- Keeps replayed confirmations rejected as already_used while returning the same safe operation metadata and consumed_at timestamp.
- Covers the replay contract in the existing Telegram bot management service unit suite.

## Contract Impact

- Canonical surface: TelegramStaffConfirmationTokenService.consume_for_confirmation in backend/app/services/telegram_staff_confirmation_token_service.py
- Request shape: existing service arguments are unchanged; token_hash, staff_user_id, telegram_chat_id, operation_key, action_payload_hash, and optional idempotency_key_hash remain required for the same call paths
- Response shape: successful consume is unchanged; already-used replay responses now include single_use_enforced, operation_key, command_key, target_type, request_id, and consumed_at metadata while remaining valid=false
- Status codes: not applicable - this is an internal backend service return contract, not an HTTP endpoint change
- Frontend consumer: not applicable - no frontend consumer changed in this slice
- Compatibility path or alias: no command alias, route, webhook transport, or DB compatibility path changed
- Contract proof: targeted Telegram bot management unit suite validates single-use consume and deterministic replay metadata

## RBAC / Permissions

- Roles allowed: unchanged; the service still requires the same staff user and Telegram chat binding supplied by existing callers
- Roles denied: unchanged; mismatched staff user, chat, action, payload, or idempotency key remains rejected
- Positive auth proof: targeted unit test covers the same bound staff user/chat/action consuming a valid unexpired token once
- Negative auth proof: targeted unit test keeps second consume rejected as already_used and existing mismatch test keeps action_binding_mismatch unconsumed

## Notification / Realtime

not applicable - no notification event, websocket channel, read/unread marker, delivery ack, reconnect, or resync behavior changed because this PR only changes internal token replay return metadata.

## Frontend Resilience

- Empty data proof: not applicable - no frontend data rendering path changed
- Partial data proof: not applicable - no frontend partial-data state changed
- Forbidden secondary path behavior: not applicable - no frontend secondary path was changed
- Missing draft/resource behavior: not applicable - confirmation token consumption does not create or reopen frontend drafts/resources
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed

## Scope Gate

- Allowed paths: backend/app/services/telegram_staff_confirmation_token_service.py and backend/tests/unit/test_telegram_bot_management_api_service.py
- Denied paths: DB/Alembic, Telegram webhook execution, frontend manager screens, command registration, token issuance schema, queue fairness, payment state mutation
- Migration/docs/test impact: no migration and no docs file changed; targeted unit test expectation was updated for deterministic replay metadata
- Rollback note: revert commit 6960cd4b to restore the previous minimal already_used replay response

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/services/telegram_staff_confirmation_token_service.py; pytest backend/tests/unit/test_telegram_bot_management_api_service.py -q; git diff --check for the two changed files
- Result: passed locally, including 26 Telegram bot management unit tests
- Not checked: live Telegram staff confirmation click flow and full backend suite were not run in this narrow cycle
