### PR TITLE
test(telegram): cover patient visits menu privacy

### DIFF
--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -745,6 +745,24 @@ class TestTelegramWebhookSecurity:
         assert "Кабинет 205" in message
         assert "Кардиология" in message
 
+    def test_visits_message_lists_linked_patient_visits_without_medical_details(
+        self, db_session, test_patient, test_visit
+    ):
+        _link_patient_to_chat(db_session, chat_id=7005, patient_id=test_patient.id)
+        test_visit.status = "open"
+        test_visit.notes = "diagnosis: private clinical note"
+        db_session.commit()
+
+        message = telegram_webhook._clinic_visits_message(db_session, 7005)
+
+        assert f"#{test_visit.id}" in message
+        assert test_visit.visit_date.isoformat() in message
+        assert "open" in message
+        assert "diagnosis" not in message
+        assert "private clinical note" not in message
+        if test_patient.phone:
+            assert test_patient.phone not in message
+
     def test_payments_message_calculates_debt_from_queue_total_and_payments(
         self, db_session, test_patient, test_visit, test_queue_entry
     ):


### PR DESCRIPTION
﻿## Summary

- Adds a targeted unit proof for the patient Telegram /visits menu added in the previous slice.
- Verifies linked-patient visit output includes visit id, date, and status.
- Verifies visit notes/medical detail strings and patient phone are not exposed in the Telegram visits message.

## Contract Impact

- Canonical surface: backend/app/api/v1/endpoints/telegram_webhook.py patient /visits message behavior, covered through backend/tests/unit/test_telegram_webhook_security.py
- Request shape: not applicable - test-only change, no Telegram update payload or service arguments changed
- Response shape: not applicable - test-only change, existing /visits response behavior is only covered by a new assertion
- Status codes: not applicable - no HTTP endpoint or webhook status behavior changed
- Frontend consumer: not applicable - no frontend consumer changed
- Compatibility path or alias: not applicable - no command alias, route, or menu label changed
- Contract proof: new targeted unit test plus full Telegram webhook security unit file passing locally

## RBAC / Permissions

- Roles allowed: unchanged linked patient chats only, asserted by linking test_patient to the test chat
- Roles denied: unchanged unlinked/staff behavior; this test does not expand access paths
- Positive auth proof: new test calls the linked-patient visits message path and verifies the linked visit is shown
- Negative auth proof: new test verifies phone and medical note strings are not present in the message

## Notification / Realtime

- Event type or websocket channel: not applicable - test-only change, no notification or websocket channel changed
- Payload version / ack behavior: not applicable - no delivery payload, ack, polling, or webhook transport behavior changed
- Read/unread or delivery semantics: not applicable - no read/unread state changed
- Reconnect/resync proof: not applicable - no realtime reconnect/resync path changed

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed
- Partial data proof: not applicable - no frontend partial-data path changed
- Forbidden secondary path behavior: not applicable - no frontend secondary path changed
- Missing draft/resource behavior: not applicable - no draft/resource behavior changed
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed

## Scope Gate

- Allowed paths: backend/tests/unit/test_telegram_webhook_security.py
- Denied paths: runtime code, DB/Alembic, Telegram command registration, frontend, staff actions, payment/queue/lab behavior
- Migration/docs/test impact: test-only change; no migration or docs update
- Rollback note: revert commit d4d122a3 to remove the new test proof

## Validation

- Targeted tests or smoke run: pytest backend/tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_visits_message_lists_linked_patient_visits_without_medical_details -q; pytest backend/tests/unit/test_telegram_webhook_security.py -q; git diff --check for the changed test file
- Result: passed locally, including 25 Telegram webhook security tests
- Not checked: live Telegram /visits click flow because this is test-only coverage
