### PR TITLE
feat(telegram): register patient visits command

### DIFF
--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -26,6 +26,8 @@ MAX_TELEGRAM_DOCUMENT_BYTES = 20 * 1024 * 1024
 PATIENT_BOT_COMMANDS_RU = [
     {"command": "start", "description": "Начать"},
     {"command": "queue", "description": "Моя очередь"},
+    {"command": "visits", "description": "Мои визиты"},
+    {"command": "visits", "description": "Мои визиты"},
     {"command": "payments", "description": "Оплаты и долг"},
     {"command": "results", "description": "Результаты"},
     {"command": "profile", "description": "Мой статус"},
@@ -35,6 +37,8 @@ PATIENT_BOT_COMMANDS_RU = [
 PATIENT_BOT_COMMANDS_UZ = [
     {"command": "start", "description": "Boshlash"},
     {"command": "queue", "description": "Mening navbatim"},
+    {"command": "visits", "description": "Mening tashriflarim"},
+    {"command": "visits", "description": "Mening tashriflarim"},
     {"command": "payments", "description": "To'lovlar va qarz"},
     {"command": "results", "description": "Natijalar"},
     {"command": "profile", "description": "Mening holatim"},

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -974,6 +974,17 @@ class TestTelegramWebhookSecurity:
         assert {command["command"] for command in captured[0]["json"]["commands"]} == {
             "start",
             "queue",
+            "visits",
+            "payments",
+            "results",
+            "profile",
+            "settings",
+            "help",
+        }
+        assert {command["command"] for command in captured[1]["json"]["commands"]} == {
+            "start",
+            "queue",
+            "visits",
             "payments",
             "results",
             "profile",


### PR DESCRIPTION
﻿## Summary

- Registers the patient `/visits` command in Telegram Bot API command lists.
- Adds the command for both Russian/default and Uzbek patient command scopes.
- Extends the existing command registration unit proof to assert `/visits` is published in both command lists.

## Contract Impact

- Canonical surface: backend/app/services/telegram_bot.py patient Bot API setMyCommands payloads
- Request shape: not applicable - no webhook update payload, HTTP API request body, or command handler input changed
- Response shape: Telegram Bot API command menu now includes `/visits`; webhook `/visits` response behavior is unchanged
- Status codes: not applicable - no HTTP endpoint status behavior changed
- Frontend consumer: not applicable - no frontend consumer changed
- Compatibility path or alias: existing patient commands remain registered; `/visits` is added to match the already-merged handler and reply keyboard
- Contract proof: targeted command registration unit test asserts both RU/default and UZ command payloads include visits

## RBAC / Permissions

- Roles allowed: unchanged linked patient chat behavior; command registration only exposes the command in Telegram UI
- Roles denied: unchanged unlinked chat and staff behavior; no authorization path changed
- Positive auth proof: existing Telegram webhook security suite command registration test passed with `/visits` in both command lists
- Negative auth proof: no runtime access path changed; `/visits` handler continues to rely on the existing linked-patient checks from prior slice

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification event or websocket channel changed
- Payload version / ack behavior: not applicable - no notification payload, ack, polling transport, or webhook HTTP contract changed
- Read/unread or delivery semantics: not applicable - no delivery state changed
- Reconnect/resync proof: not applicable - no realtime reconnect/resync path changed

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed
- Partial data proof: not applicable - no frontend partial-data path changed
- Forbidden secondary path behavior: not applicable - no frontend secondary path changed
- Missing draft/resource behavior: not applicable - no draft/resource behavior changed
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed

## Scope Gate

- Allowed paths: backend/app/services/telegram_bot.py and backend/tests/unit/test_telegram_webhook_security.py
- Denied paths: DB/Alembic, webhook handler behavior, frontend manager screens, token/security handling, queue/payment/lab behavior
- Migration/docs/test impact: no migration and no docs update; targeted command registration unit test updated
- Rollback note: revert commit a223d739 to remove `/visits` from Bot API command registration

## Validation

- Targeted tests or smoke run: python -m py_compile backend/app/services/telegram_bot.py; pytest backend/tests/unit/test_telegram_webhook_security.py -q; git diff --check for the changed files
- Result: passed locally, including 25 Telegram webhook security tests
- Not checked: live Telegram setMyCommands call against production bot token because this PR only updates code and unit proof
