### PR TITLE
fix(telegram): dedupe patient command menu

### DIFF
--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -27,7 +27,6 @@ PATIENT_BOT_COMMANDS_RU = [
     {"command": "start", "description": "Начать"},
     {"command": "queue", "description": "Моя очередь"},
     {"command": "visits", "description": "Мои визиты"},
-    {"command": "visits", "description": "Мои визиты"},
     {"command": "payments", "description": "Оплаты и долг"},
     {"command": "results", "description": "Результаты"},
     {"command": "profile", "description": "Мой статус"},
@@ -37,7 +36,6 @@ PATIENT_BOT_COMMANDS_RU = [
 PATIENT_BOT_COMMANDS_UZ = [
     {"command": "start", "description": "Boshlash"},
     {"command": "queue", "description": "Mening navbatim"},
-    {"command": "visits", "description": "Mening tashriflarim"},
     {"command": "visits", "description": "Mening tashriflarim"},
     {"command": "payments", "description": "To'lovlar va qarz"},
     {"command": "results", "description": "Natijalar"},

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -971,6 +971,14 @@ class TestTelegramWebhookSecurity:
         assert captured[0]["url"].endswith("/setMyCommands")
         assert captured[0]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_RU
         assert captured[1]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_UZ
+        ru_command_names = [
+            command["command"] for command in captured[0]["json"]["commands"]
+        ]
+        uz_command_names = [
+            command["command"] for command in captured[1]["json"]["commands"]
+        ]
+        assert len(ru_command_names) == len(set(ru_command_names))
+        assert len(uz_command_names) == len(set(uz_command_names))
         assert {command["command"] for command in captured[0]["json"]["commands"]} == {
             "start",
             "queue",


### PR DESCRIPTION
## Summary
- Removes the duplicated `/visits` entry from the patient Bot API command registration payload for Russian and Uzbek menus.
- Adds a targeted assertion that patient command registration payloads contain no duplicate command names.
- Keeps the already-merged patient `/visits` reply button and webhook handler unchanged.

## Contract Impact
- Canonical surface: `PATIENT_BOT_COMMANDS_RU` and `PATIENT_BOT_COMMANDS_UZ` in `backend/app/services/telegram_bot.py`.
- Request shape: unchanged; command registration still calls Telegram `setMyCommands` with two payloads.
- Response shape: unchanged for app APIs; Telegram command menu payload now has exactly one `/visits` command per language.
- Status codes: unchanged.
- Frontend consumer: none; no frontend files changed.
- Compatibility path or alias: existing `/start`, `/queue`, `/visits`, `/payments`, `/results`, `/profile`, `/settings`, and `/help` commands remain available.
- Contract proof: `test_telegram_bot_service_registers_patient_commands` asserts no duplicate command names and passed locally.

## RBAC / Permissions
- Roles allowed: unchanged; patient bot command registration remains available to the bot registration runtime only.
- Roles denied: unchanged; no staff, admin, registrar, doctor, cashier, lab, or anonymous application permission path changed.
- Positive auth proof: targeted unit test verifies patient command payload registration without changing linked-patient authorization logic.
- Negative auth proof: no authorization checks were changed; webhook security regression file passed locally.

## Notification / Realtime
- Event type or websocket channel: none; no notification event, websocket channel, queue event, payment event, or report event changed.
- Payload version / ack behavior: unchanged; only the Telegram `setMyCommands` menu payload removes duplicate command names.
- Read/unread or delivery semantics: unchanged; no message delivery, unread, polling, or webhook transport behavior changed.
- Reconnect/resync proof: not applicable because this PR does not touch realtime transport, reconnect, or resync behavior.

## Frontend Resilience
- Empty data proof: not applicable because no frontend view or API data rendering path changed.
- Partial data proof: not applicable because no frontend view or partial-data contract changed.
- Forbidden secondary path behavior: unchanged; no frontend route or permission fallback changed.
- Missing draft/resource behavior: unchanged; no draft, resource fetch, or missing-resource frontend behavior changed.
- Stale route/deep-link behavior: unchanged; no route registry, redirect, or deep-link behavior changed.

## Security / Privacy
- No bot token, secret, patient data, phone number, diagnosis, invoice ID, or EMR content was added.
- `/visits` remains a linked-patient command from previous slices; this PR only deduplicates its command-menu registration.

## Scope Gate
- Allowed paths: `backend/app/services/telegram_bot.py`, `backend/tests/unit/test_telegram_webhook_security.py`.
- Denied paths: DB/Alembic, frontend manager, webhook handler behavior, staff commands, queue fairness, payments, lab PDFs, and EMR.
- Migration/docs/test impact: no migration required; no docs required; targeted unit test updated for duplicate command names.
- Rollback note: revert commit `2b1d7472` to restore the previous duplicated payload behavior.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\services\telegram_bot.py`; `pytest backend\tests\unit\test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_telegram_bot_service_registers_patient_commands -q`; `pytest backend\tests\unit\test_telegram_webhook_security.py -q`; `git diff --check -- backend\app\services\telegram_bot.py backend\tests\unit\test_telegram_webhook_security.py`.
- Result: py_compile passed; targeted pytest passed; full Telegram webhook security unit file passed with 25 tests; diff check passed with only the existing CRLF warning for the test file.
- Not checked: live Telegram command registration call after merge, because runtime command registration should run from merged main.