### PR TITLE
test(telegram): cover patient profile command privacy

### DIFF
--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -763,6 +763,42 @@ class TestTelegramWebhookSecurity:
         if test_patient.phone:
             assert test_patient.phone not in message
 
+    @pytest.mark.asyncio
+    async def test_profile_command_returns_linked_patient_status_without_medical_details(
+        self, db_session, test_patient, test_visit
+    ):
+        _link_patient_to_chat(db_session, chat_id=7022, patient_id=test_patient.id)
+        test_visit.status = "open"
+        test_visit.notes = "diagnosis: private clinical note"
+        db_session.commit()
+        fake_service = FakeTelegramBotService(active=True)
+        update = {
+            "update_id": 122,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7022},
+                "from": {"id": 111},
+                "text": "/profile",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        chat_id, message, reply_markup = fake_service._send_message.await_args.args
+        assert chat_id == 7022
+        assert test_patient.first_name in message
+        assert f"#{test_visit.id}" in message
+        assert "open" in message
+        assert reply_markup == telegram_webhook._localized_main_menu("ru")
+        assert "diagnosis" not in message
+        assert "private clinical note" not in message
+        if test_patient.phone:
+            assert test_patient.phone not in message
+
     def test_payments_message_calculates_debt_from_queue_total_and_payments(
         self, db_session, test_patient, test_visit, test_queue_entry
     ):


### PR DESCRIPTION
## Summary
- Adds a regression test for the canonical patient Telegram `/profile` command path through `_handle_clinic_bot_update`.
- Proves linked-patient status includes the patient identity and recent visit summary while excluding phone number, diagnosis text, and private visit notes.
- Leaves Telegram webhook/runtime command handlers unchanged.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/telegram_webhook.py` patient command dispatch is covered by `backend/tests/unit/test_telegram_webhook_security.py`.
- Request shape: unchanged; test sends the existing Telegram update shape with message text `/profile`.
- Response shape: unchanged; expected reply is the existing linked-patient profile/status message plus main menu markup.
- Status codes: unchanged; no HTTP route behavior changed.
- Frontend consumer: none; no frontend files changed.
- Compatibility path or alias: existing `/profile` command and visible profile menu labels remain unchanged.
- Contract proof: targeted `/profile` command regression test and full Telegram webhook security unit file passed locally.

## RBAC / Permissions
- Roles allowed: unchanged; linked patient Telegram chat can use the patient `/profile` command.
- Roles denied: unchanged; no staff/admin/operator permission path was changed.
- Positive auth proof: new test links a Telegram chat to a patient and verifies `/profile` returns linked-patient status.
- Negative auth proof: test asserts phone number, diagnosis text, and private visit notes are absent from the patient profile reply.

## Notification / Realtime
- Event type or websocket channel: none; no notification event, websocket channel, queue event, payment event, or report event changed.
- Payload version / ack behavior: unchanged; no Telegram send payload contract changed beyond test assertions of the existing reply.
- Read/unread or delivery semantics: unchanged; no delivery, read-state, polling, or webhook transport behavior changed.
- Reconnect/resync proof: no realtime reconnect or resync path is touched in this test-only PR.

## Frontend Resilience
- Empty data proof: unchanged; no frontend empty state or API rendering path changed.
- Partial data proof: unchanged; no partial-data frontend contract changed.
- Forbidden secondary path behavior: unchanged; no frontend route or permission fallback changed.
- Missing draft/resource behavior: unchanged; no draft or resource fetch behavior changed.
- Stale route/deep-link behavior: unchanged; no route registry, redirect, or deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/tests/unit/test_telegram_webhook_security.py`.
- Denied paths: Telegram runtime handlers, Bot API command registration, DB/Alembic, frontend manager, staff commands, queue fairness, payments, lab PDFs, and EMR.
- Migration/docs/test impact: no migration required; no docs required; test coverage only.
- Rollback note: revert commit `93e367ac` to remove the added regression proof.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\tests\unit\test_telegram_webhook_security.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; `pytest backend\tests\unit\test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_profile_command_returns_linked_patient_status_without_medical_details -q`; `pytest backend\tests\unit\test_telegram_webhook_security.py -q`; `git diff --check -- backend\tests\unit\test_telegram_webhook_security.py`.
- Result: py_compile passed; targeted pytest passed; full Telegram webhook security unit file passed with 26 tests; diff check passed with only the existing CRLF warning for the test file.
- Not checked: live Telegram bot runtime, because this PR is a test-only regression proof.