### PR TITLE
feat(telegram): add patient support menu

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -1754,6 +1754,7 @@ def get_telegram_integration_status(
                     {"command": "/results", "label": "PDF-результаты"},
                     {"command": "/profile", "label": "Мой статус"},
                     {"command": "/settings", "label": "Язык и уведомления"},
+                    {"command": "/support", "label": "Связаться с клиникой"},
                     {"command": "/help", "label": "Помощь"},
                 ],
                 "features": [
@@ -1785,6 +1786,11 @@ def get_telegram_integration_status(
                     {
                         "key": "patient_language_notification_settings",
                         "label": "Настройки языка и уведомлений",
+                        "enabled": bool(bot_token),
+                    },
+                    {
+                        "key": "patient_support_contact",
+                        "label": "Безопасная связь с клиникой",
                         "enabled": bool(bot_token),
                     },
                 ],

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -134,7 +134,7 @@ TELEGRAM_MAIN_MENU = {
         [{"text": "🎫 Моя очередь"}, {"text": "📅 Мои визиты"}],
         [{"text": "💳 Оплаты и долг"}, {"text": "📄 Результаты"}],
         [{"text": "👤 Мой статус"}, {"text": "⚙️ Настройки"}],
-        [{"text": "❓ Помощь"}],
+        [{"text": "☎️ Связаться с клиникой"}, {"text": "❓ Помощь"}],
     ],
     "resize_keyboard": True,
     "one_time_keyboard": False,
@@ -166,7 +166,7 @@ TELEGRAM_MAIN_MENUS = {
             [{"text": "🎫 Mening navbatim"}, {"text": "📅 Mening tashriflarim"}],
             [{"text": "💳 To'lovlar va qarz"}, {"text": "📄 Natijalar"}],
             [{"text": "👤 Mening holatim"}, {"text": "⚙️ Sozlamalar"}],
-            [{"text": "❓ Yordam"}],
+            [{"text": "☎️ Klinikaga bog'lanish"}, {"text": "❓ Yordam"}],
         ],
         "resize_keyboard": True,
         "one_time_keyboard": False,
@@ -178,7 +178,7 @@ TELEGRAM_SETTINGS_MENUS = {
             [{"text": "🇷🇺 Русский"}, {"text": "🇺🇿 O'zbekcha"}],
             [{"text": "🔔 Разрешить уведомления"}, {"text": "🔕 Без уведомлений"}],
             [{"text": "🎫 Моя очередь"}, {"text": "📅 Мои визиты"}],
-            [{"text": "❓ Помощь"}],
+            [{"text": "☎️ Связаться с клиникой"}, {"text": "❓ Помощь"}],
         ],
         "resize_keyboard": True,
         "one_time_keyboard": False,
@@ -188,7 +188,7 @@ TELEGRAM_SETTINGS_MENUS = {
             [{"text": "🇷🇺 Русский"}, {"text": "🇺🇿 O'zbekcha"}],
             [{"text": "🔔 Xabarnomalarga roziman"}, {"text": "🔕 Xabarnomasiz"}],
             [{"text": "🎫 Mening navbatim"}, {"text": "📅 Mening tashriflarim"}],
-            [{"text": "❓ Yordam"}],
+            [{"text": "☎️ Klinikaga bog'lanish"}, {"text": "❓ Yordam"}],
         ],
         "resize_keyboard": True,
         "one_time_keyboard": False,
@@ -297,7 +297,8 @@ TELEGRAM_LOCALIZED_TEXTS = {
             "📄 Результаты - до 3 готовых PDF-отчетов, только после привязки.\n"
             "👤 Мой статус - привязка Telegram к карте пациента.\n"
             "⚙️ Настройки - язык и уведомления.\n\n"
-            "Команды: /start, /queue, /visits, /payments, /results, /profile, /settings, /help.\n\n"
+            "☎️ Связаться с клиникой - безопасная подсказка, куда обращаться по записи, кассе и срочным вопросам.\n\n"
+            "Команды: /start, /queue, /visits, /payments, /results, /profile, /settings, /support, /help.\n\n"
             "Для привязки отсканируйте QR с чека или нажмите "
             "\"Поделиться номером\".\n\n"
             "Для сотрудников: доступ отдельно через персональную ссылку администратора "
@@ -313,7 +314,8 @@ TELEGRAM_LOCALIZED_TEXTS = {
             "📄 Natijalar - faqat bog'langan bemor uchun 3 tagacha tayyor PDF hisobot.\n"
             "👤 Mening holatim - Telegram bemor kartasiga bog'langanini ko'rish.\n"
             "⚙️ Sozlamalar - til va xabarnomalar.\n\n"
-            "Buyruqlar: /start, /queue, /visits, /payments, /results, /profile, /settings, /help.\n\n"
+            "☎️ Klinikaga bog'lanish - yozilish, kassa va shoshilinch savollar bo'yicha xavfsiz yo'l-yo'riq.\n\n"
+            "Buyruqlar: /start, /queue, /visits, /payments, /results, /profile, /settings, /support, /help.\n\n"
             "Bog'lash uchun chekdagi QR kodni skaner qiling yoki "
             "\"Telefon raqamni ulashish\" tugmasini bosing.\n\n"
             "Xodimlar uchun: kirish administrator bergan shaxsiy havola orqali "
@@ -331,6 +333,24 @@ TELEGRAM_LOCALIZED_TEXTS = {
             "Telegram sozlamalari\n\n"
             "Xizmat tilini yoki xabarnoma rejimini tanlang. Til o'zgarganda "
             "asosiy menyu darhol yangilanadi."
+        ),
+    },
+    "support": {
+        TELEGRAM_LANGUAGE_RU: (
+            "Связаться с клиникой\n\n"
+            "Для записи, кассы и срочных вопросов обратитесь в регистратуру "
+            "или позвоните по номеру, указанному на чеке и в клинике.\n\n"
+            "Не отправляйте в Telegram диагнозы, результаты анализов, паспортные "
+            "данные или фото документов. Медицинские детали смотрите только в "
+            "защищенном кабинете или у сотрудника клиники."
+        ),
+        TELEGRAM_LANGUAGE_UZ: (
+            "Klinikaga bog'lanish\n\n"
+            "Yozilish, kassa va shoshilinch savollar uchun registraturaga murojaat "
+            "qiling yoki chekda va klinikada ko'rsatilgan raqamga qo'ng'iroq qiling.\n\n"
+            "Telegram chatiga diagnoz, tahlil natijalari, pasport ma'lumotlari yoki "
+            "hujjat rasmlarini yubormang. Tibbiy tafsilotlarni faqat himoyalangan "
+            "kabinetda yoki klinika xodimi orqali ko'ring."
         ),
     },
     "lab_results_empty": {
@@ -686,6 +706,7 @@ TELEGRAM_PATIENT_BUTTON_ICON_PREFIXES = (
     "📄",
     "⚙",
     "❓",
+    "☎",
     "🔔",
     "🔕",
     "🇷🇺",
@@ -2922,6 +2943,17 @@ async def _handle_clinic_bot_update(
             "telegram_patient_share_contact",
         )
 
+    async def support_handler(chat_id: int) -> None:
+        language = _telegram_chat_language(db, chat_id)
+        await _send_patient_bot_reply(
+            db,
+            bot_service,
+            chat_id,
+            _localized_text("support", language),
+            _localized_main_menu(language),
+            "telegram_patient_support",
+        )
+
     async def enable_notifications_handler(chat_id: int) -> None:
         await _set_notification_consent(db, bot_service, chat_id, True)
 
@@ -2942,6 +2974,7 @@ async def _handle_clinic_bot_update(
         "/profile": profile_handler,
         "/results": results_handler,
         "/settings": settings_handler,
+        "/support": support_handler,
     }
     text_handlers = _patient_text_handler_aliases(
         [
@@ -2953,6 +2986,7 @@ async def _handle_clinic_bot_update(
             ("👤 Мой статус", profile_handler),
             ("📄 Результаты", results_handler),
             ("📱 Поделиться номером", share_contact_handler),
+            ("☎️ Связаться с клиникой", support_handler),
             ("🇷🇺 Русский", russian_language_handler),
             ("🇺🇿 O'zbekcha", uzbek_language_handler),
             ("ozbekcha", uzbek_language_handler),
@@ -2969,6 +3003,7 @@ async def _handle_clinic_bot_update(
             ("👤 Mening holatim", profile_handler),
             ("📄 Natijalar", results_handler),
             ("📱 Telefon raqamni ulashish", share_contact_handler),
+            ("☎️ Klinikaga bog'lanish", support_handler),
         ]
     )
 

--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -31,6 +31,7 @@ PATIENT_BOT_COMMANDS_RU = [
     {"command": "results", "description": "Результаты"},
     {"command": "profile", "description": "Мой статус"},
     {"command": "settings", "description": "Язык и уведомления"},
+    {"command": "support", "description": "Связаться с клиникой"},
     {"command": "help", "description": "Помощь"},
 ]
 PATIENT_BOT_COMMANDS_UZ = [
@@ -41,6 +42,7 @@ PATIENT_BOT_COMMANDS_UZ = [
     {"command": "results", "description": "Natijalar"},
     {"command": "profile", "description": "Mening holatim"},
     {"command": "settings", "description": "Til va xabarnomalar"},
+    {"command": "support", "description": "Klinika bilan aloqa"},
     {"command": "help", "description": "Yordam"},
 ]
 STAFF_BOT_COMMANDS_DEFAULT = [

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -500,6 +500,51 @@ class TestTelegramWebhookSecurity:
         )
 
     @pytest.mark.asyncio
+    async def test_support_command_returns_localized_safe_contact_guidance(
+        self, db_session
+    ):
+        telegram_user = TelegramUser(
+            chat_id=7019,
+            username="patient_chat",
+            first_name="Patient",
+            language_code="uz-Latn",
+            notifications_enabled=True,
+            appointment_reminders=True,
+            lab_notifications=True,
+            active=True,
+            blocked=False,
+        )
+        db_session.add(telegram_user)
+        db_session.commit()
+        fake_service = FakeTelegramBotService(active=True)
+        update = {
+            "update_id": 125,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7019},
+                "from": {"id": 111},
+                "text": "/support",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once_with(
+            7019,
+            telegram_webhook._localized_text("support", "uz-Latn"),
+            telegram_webhook._localized_main_menu("uz-Latn"),
+        )
+        log = (
+            db_session.query(TelegramMessage)
+            .filter(TelegramMessage.chat_id == 7019)
+            .one()
+        )
+        assert log.template_key == "telegram_patient_support"
+
+    @pytest.mark.asyncio
     async def test_staff_start_token_links_user_and_writes_audit(
         self, db_session, admin_user
     ):
@@ -1023,6 +1068,7 @@ class TestTelegramWebhookSecurity:
             "results",
             "profile",
             "settings",
+            "support",
             "help",
         }
         assert {command["command"] for command in captured[1]["json"]["commands"]} == {
@@ -1033,5 +1079,6 @@ class TestTelegramWebhookSecurity:
             "results",
             "profile",
             "settings",
+            "support",
             "help",
         }


### PR DESCRIPTION
## Summary

- Add localized patient `/support` command to Telegram Bot API command registration.
- Add RU/UZ support/contact buttons to the patient reply keyboards.
- Return safe clinic-contact guidance without exposing medical details, raw IDs, invoices, phone numbers, or EMR content.
- Expose the support command in the admin Telegram integration status payload.

## Contract Impact

- Canonical surface: Telegram patient bot command/menu contract in backend Telegram service and webhook handler
- Request shape: Telegram text command `/support` or localized reply-keyboard button text; no HTTP API request shape changed
- Response shape: localized safe guidance text plus existing localized patient reply keyboard
- Status codes: not applicable - no HTTP endpoint status behavior changed; Telegram transport handling remains existing webhook/polling dispatch
- Frontend consumer: admin Telegram integration status consumers receive an additive `/support` command and `patient_support_contact` feature entry
- Compatibility path or alias: existing patient commands and aliases remain; new support aliases are additive for Russian and Uzbek Latin
- Contract proof: targeted Telegram unit test covers `/support` response and command registration list covers the new Bot API command

## RBAC / Permissions

- Roles allowed: patient Telegram chats can request read-only support guidance; no role-gated clinic data is returned
- Roles denied: staff mutation paths remain denied in Telegram; support command does not grant staff or patient-record access
- Positive auth proof: `test_support_command_returns_localized_safe_contact_guidance` verifies the command returns localized guidance through patient bot dispatch
- Negative auth proof: existing Telegram security tests for contact spoofing, profile privacy, and linked-patient boundaries remain in the same targeted suite

## Notification / Realtime

- Event type or websocket channel: Telegram patient bot reply logged with template key `telegram_patient_support`; no websocket channel added
- Payload version / ack behavior: no payload version or ack behavior changed; polling/webhook dispatch still calls the shared handler
- Read/unread or delivery semantics: no read/unread semantics changed; only the existing TelegramMessage reply log records send status
- Reconnect/resync proof: not applicable - stateless read-only command does not affect notification replay, queue state, or realtime resync

## Frontend Resilience

- Empty data proof: not applicable - no frontend data view changed; command returns static localized guidance
- Partial data proof: not applicable - no frontend data shape is required beyond additive admin status metadata
- Forbidden secondary path behavior: not applicable - no secondary frontend route or forbidden fallback path changed
- Missing draft/resource behavior: not applicable - no draft, document, report, or Mini App resource is opened by this command
- Stale route/deep-link behavior: not applicable - no frontend route or Telegram deep-link state changed

## Scope Gate

- Allowed paths: Telegram bot service command list, patient webhook handler/menu text, admin Telegram status metadata, targeted Telegram unit tests
- Denied paths: DB schema, Alembic migrations, queue fairness, payment mutation, EMR content delivery, Mini App implementation, unrelated frontend screens
- Migration/docs/test impact: no migration; no docs update; targeted Telegram unit tests updated for command registration and `/support` behavior
- Rollback note: revert the support command/menu additions and the corresponding targeted unit test expectations

## Validation

- Targeted tests or smoke run: backend py_compile for Telegram modules; backend Telegram unit test file; frontend production build; git diff whitespace check
- Result: passed locally: py_compile passed, Telegram unit tests passed with `27 passed, 1 warning`, frontend build passed, diff check passed
- Not checked: live Telegram click-through after merge; full backend suite beyond the targeted Telegram unit file
