### PR TITLE
feat(telegram): add patient booking entrypoint

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -1749,6 +1749,7 @@ def get_telegram_integration_status(
                 "default_language": "ru",
                 "onboarding": "language_choice_then_contact_link",
                 "commands": [
+                    {"command": "/book", "label": "Записаться на приём"},
                     {"command": "/queue", "label": "Моя очередь"},
                     {"command": "/payments", "label": "Оплаты и долг"},
                     {"command": "/results", "label": "PDF-результаты"},
@@ -1766,6 +1767,11 @@ def get_telegram_integration_status(
                     {
                         "key": "contact_phone_link",
                         "label": "Привязка через номер телефона",
+                        "enabled": bool(bot_token),
+                    },
+                    {
+                        "key": "patient_booking_entrypoint",
+                        "label": "Безопасная подсказка для записи",
                         "enabled": bool(bot_token),
                     },
                     {

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -131,6 +131,7 @@ TELEGRAM_NEEDS_LINK_MESSAGE = (
 TELEGRAM_MAIN_MENU = {
     "keyboard": [
         [{"text": "📱 Поделиться номером", "request_contact": True}],
+        [{"text": "🏥 Записаться на приём"}],
         [{"text": "🎫 Моя очередь"}, {"text": "📅 Мои визиты"}],
         [{"text": "💳 Оплаты и долг"}, {"text": "📄 Результаты"}],
         [{"text": "👤 Мой статус"}, {"text": "⚙️ Настройки"}],
@@ -163,6 +164,7 @@ TELEGRAM_MAIN_MENUS = {
     TELEGRAM_LANGUAGE_UZ: {
         "keyboard": [
             [{"text": "📱 Telefon raqamni ulashish", "request_contact": True}],
+            [{"text": "🏥 Qabulga yozilish"}],
             [{"text": "🎫 Mening navbatim"}, {"text": "📅 Mening tashriflarim"}],
             [{"text": "💳 To'lovlar va qarz"}, {"text": "📄 Natijalar"}],
             [{"text": "👤 Mening holatim"}, {"text": "⚙️ Sozlamalar"}],
@@ -177,6 +179,7 @@ TELEGRAM_SETTINGS_MENUS = {
         "keyboard": [
             [{"text": "🇷🇺 Русский"}, {"text": "🇺🇿 O'zbekcha"}],
             [{"text": "🔔 Разрешить уведомления"}, {"text": "🔕 Без уведомлений"}],
+            [{"text": "🏥 Записаться на приём"}],
             [{"text": "🎫 Моя очередь"}, {"text": "📅 Мои визиты"}],
             [{"text": "☎️ Связаться с клиникой"}, {"text": "❓ Помощь"}],
         ],
@@ -187,6 +190,7 @@ TELEGRAM_SETTINGS_MENUS = {
         "keyboard": [
             [{"text": "🇷🇺 Русский"}, {"text": "🇺🇿 O'zbekcha"}],
             [{"text": "🔔 Xabarnomalarga roziman"}, {"text": "🔕 Xabarnomasiz"}],
+            [{"text": "🏥 Qabulga yozilish"}],
             [{"text": "🎫 Mening navbatim"}, {"text": "📅 Mening tashriflarim"}],
             [{"text": "☎️ Klinikaga bog'lanish"}, {"text": "❓ Yordam"}],
         ],
@@ -291,6 +295,7 @@ TELEGRAM_LOCALIZED_TEXTS = {
         TELEGRAM_LANGUAGE_RU: (
             "Kosmed Clinic bot\n\n"
             "Для пациента:\n"
+            "🏥 Записаться на приём - безопасная подсказка для связи с регистратурой.\n"
             "🎫 Моя очередь - номер, кабинет, статус и позиция ожидания.\n"
             "📅 Мои визиты - последние и сегодняшние визиты без медицинских деталей.\n"
             "💳 Оплаты и долг - начислено, оплачено, долг и незавершенные платежи.\n"
@@ -298,7 +303,7 @@ TELEGRAM_LOCALIZED_TEXTS = {
             "👤 Мой статус - привязка Telegram к карте пациента.\n"
             "⚙️ Настройки - язык и уведомления.\n\n"
             "☎️ Связаться с клиникой - безопасная подсказка, куда обращаться по записи, кассе и срочным вопросам.\n\n"
-            "Команды: /start, /queue, /visits, /payments, /results, /profile, /settings, /support, /help.\n\n"
+            "Команды: /start, /book, /queue, /visits, /payments, /results, /profile, /settings, /support, /help.\n\n"
             "Для привязки отсканируйте QR с чека или нажмите "
             "\"Поделиться номером\".\n\n"
             "Для сотрудников: доступ отдельно через персональную ссылку администратора "
@@ -308,6 +313,7 @@ TELEGRAM_LOCALIZED_TEXTS = {
         TELEGRAM_LANGUAGE_UZ: (
             "Kosmed Clinic bot\n\n"
             "Bemor uchun:\n"
+            "🏥 Qabulga yozilish - registratura bilan bog'lanish uchun xavfsiz yo'l-yo'riq.\n"
             "🎫 Mening navbatim - raqam, kabinet, holat va kutishdagi o'rin.\n"
             "📅 Mening tashriflarim - so'nggi va bugungi tashriflar, tibbiy tafsilotlarsiz.\n"
             "💳 To'lovlar va qarz - hisoblangan, to'langan, qarz va yakunlanmagan to'lovlar.\n"
@@ -315,7 +321,7 @@ TELEGRAM_LOCALIZED_TEXTS = {
             "👤 Mening holatim - Telegram bemor kartasiga bog'langanini ko'rish.\n"
             "⚙️ Sozlamalar - til va xabarnomalar.\n\n"
             "☎️ Klinikaga bog'lanish - yozilish, kassa va shoshilinch savollar bo'yicha xavfsiz yo'l-yo'riq.\n\n"
-            "Buyruqlar: /start, /queue, /visits, /payments, /results, /profile, /settings, /support, /help.\n\n"
+            "Buyruqlar: /start, /book, /queue, /visits, /payments, /results, /profile, /settings, /support, /help.\n\n"
             "Bog'lash uchun chekdagi QR kodni skaner qiling yoki "
             "\"Telefon raqamni ulashish\" tugmasini bosing.\n\n"
             "Xodimlar uchun: kirish administrator bergan shaxsiy havola orqali "
@@ -333,6 +339,25 @@ TELEGRAM_LOCALIZED_TEXTS = {
             "Telegram sozlamalari\n\n"
             "Xizmat tilini yoki xabarnoma rejimini tanlang. Til o'zgarganda "
             "asosiy menyu darhol yangilanadi."
+        ),
+    },
+    "book": {
+        TELEGRAM_LANGUAGE_RU: (
+            "Записаться на приём\n\n"
+            "Пока онлайн-запись через Telegram не подключена. Для записи обратитесь "
+            "в регистратуру или позвоните по номеру, указанному на чеке и в клинике.\n\n"
+            "Бот не создаёт визит из сообщения в чате и не принимает медицинские "
+            "данные в свободном тексте. После записи вы сможете смотреть очередь, "
+            "визиты, оплаты и готовые результаты в этом меню."
+        ),
+        TELEGRAM_LANGUAGE_UZ: (
+            "Qabulga yozilish\n\n"
+            "Telegram orqali onlayn yozilish hozircha ulanmagan. Qabulga yozilish "
+            "uchun registraturaga murojaat qiling yoki chekda va klinikada "
+            "ko'rsatilgan raqamga qo'ng'iroq qiling.\n\n"
+            "Bot chat xabaridan tashrif yaratmaydi va erkin matnda tibbiy "
+            "ma'lumotlarni qabul qilmaydi. Yozilgandan keyin bu menyuda navbat, "
+            "tashriflar, to'lovlar va tayyor natijalarni ko'rishingiz mumkin."
         ),
     },
     "support": {
@@ -699,6 +724,7 @@ def _telegram_chat_menu(db: Session, chat_id: int) -> Dict[str, Any]:
 
 TELEGRAM_PATIENT_BUTTON_ICON_PREFIXES = (
     "📱",
+    "🏥",
     "🎫",
     "📅",
     "💳",
@@ -2943,6 +2969,17 @@ async def _handle_clinic_bot_update(
             "telegram_patient_share_contact",
         )
 
+    async def book_handler(chat_id: int) -> None:
+        language = _telegram_chat_language(db, chat_id)
+        await _send_patient_bot_reply(
+            db,
+            bot_service,
+            chat_id,
+            _localized_text("book", language),
+            _localized_main_menu(language),
+            "telegram_patient_book",
+        )
+
     async def support_handler(chat_id: int) -> None:
         language = _telegram_chat_language(db, chat_id)
         await _send_patient_bot_reply(
@@ -2968,6 +3005,7 @@ async def _handle_clinic_bot_update(
 
     command_handlers = {
         "/help": help_handler,
+        "/book": book_handler,
         "/queue": queue_handler,
         "/visits": visits_handler,
         "/payments": payments_handler,
@@ -2978,6 +3016,7 @@ async def _handle_clinic_bot_update(
     }
     text_handlers = _patient_text_handler_aliases(
         [
+            ("🏥 Записаться на приём", book_handler),
             ("❓ Помощь", help_handler),
             ("⚙️ Настройки", settings_handler),
             ("🎫 Моя очередь", queue_handler),
@@ -2995,6 +3034,7 @@ async def _handle_clinic_bot_update(
             ("🔕 Без уведомлений", disable_notifications_handler),
             ("🔔 Xabarnomalarga roziman", enable_notifications_handler),
             ("🔕 Xabarnomasiz", disable_notifications_handler),
+            ("🏥 Qabulga yozilish", book_handler),
             ("❓ Yordam", help_handler),
             ("⚙️ Sozlamalar", settings_handler),
             ("🎫 Mening navbatim", queue_handler),

--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 MAX_TELEGRAM_DOCUMENT_BYTES = 20 * 1024 * 1024
 PATIENT_BOT_COMMANDS_RU = [
     {"command": "start", "description": "Начать"},
+    {"command": "book", "description": "Записаться на приём"},
     {"command": "queue", "description": "Моя очередь"},
     {"command": "visits", "description": "Мои визиты"},
     {"command": "payments", "description": "Оплаты и долг"},
@@ -36,6 +37,7 @@ PATIENT_BOT_COMMANDS_RU = [
 ]
 PATIENT_BOT_COMMANDS_UZ = [
     {"command": "start", "description": "Boshlash"},
+    {"command": "book", "description": "Qabulga yozilish"},
     {"command": "queue", "description": "Mening navbatim"},
     {"command": "visits", "description": "Mening tashriflarim"},
     {"command": "payments", "description": "To'lovlar va qarz"},

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -282,7 +282,8 @@ class TestTelegramWebhookSecurity:
         assert "O'zbekchaga" in fake_service._send_message.await_args.args[1]
         reply_markup = fake_service._send_message.await_args.args[2]
         assert reply_markup["keyboard"][0][0]["text"].startswith("📱")
-        assert reply_markup["keyboard"][1][0]["text"].startswith("🎫")
+        assert reply_markup["keyboard"][1][0]["text"].startswith("🏥")
+        assert reply_markup["keyboard"][2][0]["text"].startswith("🎫")
         log = (
             db_session.query(TelegramMessage)
             .filter(TelegramMessage.chat_id == 7006)
@@ -543,6 +544,51 @@ class TestTelegramWebhookSecurity:
             .one()
         )
         assert log.template_key == "telegram_patient_support"
+
+    @pytest.mark.asyncio
+    async def test_book_command_returns_localized_safe_booking_entrypoint(
+        self, db_session
+    ):
+        telegram_user = TelegramUser(
+            chat_id=7022,
+            username="patient_chat",
+            first_name="Patient",
+            language_code="uz-Latn",
+            notifications_enabled=True,
+            appointment_reminders=True,
+            lab_notifications=True,
+            active=True,
+            blocked=False,
+        )
+        db_session.add(telegram_user)
+        db_session.commit()
+        fake_service = FakeTelegramBotService(active=True)
+        update = {
+            "update_id": 126,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7022},
+                "from": {"id": 111},
+                "text": "/book",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once_with(
+            7022,
+            telegram_webhook._localized_text("book", "uz-Latn"),
+            telegram_webhook._localized_main_menu("uz-Latn"),
+        )
+        log = (
+            db_session.query(TelegramMessage)
+            .filter(TelegramMessage.chat_id == 7022)
+            .one()
+        )
+        assert log.template_key == "telegram_patient_book"
 
     @pytest.mark.asyncio
     async def test_staff_start_token_links_user_and_writes_audit(
@@ -1062,6 +1108,7 @@ class TestTelegramWebhookSecurity:
         assert len(uz_command_names) == len(set(uz_command_names))
         assert {command["command"] for command in captured[0]["json"]["commands"]} == {
             "start",
+            "book",
             "queue",
             "visits",
             "payments",
@@ -1073,6 +1120,7 @@ class TestTelegramWebhookSecurity:
         }
         assert {command["command"] for command in captured[1]["json"]["commands"]} == {
             "start",
+            "book",
             "queue",
             "visits",
             "payments",


### PR DESCRIPTION
## Summary

- Add localized patient `/book` command to Telegram Bot API command registration.
- Add RU/UZ booking entry buttons to the patient reply keyboards.
- Return safe booking guidance without creating visits, queue entries, payments, or accepting medical details in free text.
- Expose the booking entrypoint in the admin Telegram integration status payload.

## Contract Impact

- Canonical surface: Telegram patient bot command/menu contract in backend Telegram service and webhook handler
- Request shape: Telegram text command `/book` or localized reply-keyboard button text; no HTTP API request shape changed
- Response shape: localized safe booking guidance plus existing localized patient reply keyboard
- Status codes: not applicable - no HTTP endpoint status behavior changed; Telegram transport handling remains existing webhook/polling dispatch
- Frontend consumer: admin Telegram integration status consumers receive an additive `/book` command and `patient_booking_entrypoint` feature entry
- Compatibility path or alias: existing patient commands and aliases remain; new booking aliases are additive for Russian and Uzbek Latin
- Contract proof: targeted Telegram unit test covers `/book` response and command registration list covers the new Bot API command

## RBAC / Permissions

- Roles allowed: patient Telegram chats can request read-only booking guidance; no role-gated clinic data is returned
- Roles denied: staff mutation paths remain denied in Telegram; booking command does not grant staff, patient-record, queue, payment, or EMR access
- Positive auth proof: `test_book_command_returns_localized_safe_booking_entrypoint` verifies localized patient bot dispatch for `/book`
- Negative auth proof: existing Telegram security tests for contact spoofing, profile privacy, linked-patient boundaries, and staff token handling remain in the same targeted suite

## Notification / Realtime

- Event type or websocket channel: Telegram patient bot reply logged with template key `telegram_patient_book`; no websocket channel added
- Payload version / ack behavior: no payload version or ack behavior changed; polling/webhook dispatch still calls the shared handler
- Read/unread or delivery semantics: no read/unread semantics changed; only the existing TelegramMessage reply log records send status
- Reconnect/resync proof: not applicable - stateless read-only command does not affect notification replay, queue state, visit creation, or realtime resync

## Frontend Resilience

- Empty data proof: not applicable - no frontend data view changed; command returns static localized guidance
- Partial data proof: not applicable - no frontend data shape is required beyond additive admin status metadata
- Forbidden secondary path behavior: not applicable - no secondary frontend route or forbidden fallback path changed
- Missing draft/resource behavior: not applicable - no draft, appointment, visit, document, or Mini App resource is opened by this command
- Stale route/deep-link behavior: not applicable - no frontend route or Telegram deep-link state changed

## Scope Gate

- Allowed paths: Telegram bot service command list, patient webhook handler/menu text, admin Telegram status metadata, targeted Telegram unit tests
- Denied paths: DB schema, Alembic migrations, visit creation, queue fairness, payment mutation, EMR content delivery, Mini App implementation, unrelated frontend screens
- Migration/docs/test impact: no migration; no docs update; targeted Telegram unit tests updated for command registration, `/book` behavior, and menu row order
- Rollback note: revert the booking command/menu additions and the corresponding targeted unit test expectations

## Validation

- Targeted tests or smoke run: backend py_compile for Telegram modules; backend Telegram unit test file; frontend production build; git diff whitespace check
- Result: passed locally: py_compile passed, Telegram unit tests passed with `28 passed, 1 warning`, frontend build passed, diff check passed
- Not checked: live Telegram click-through after merge; full backend suite beyond the targeted Telegram unit file
