### PR TITLE
fix(telegram): hide lab notification response metadata

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_notifications.py
+++ b/backend/app/api/v1/endpoints/telegram_notifications.py
@@ -134,7 +134,6 @@ async def send_lab_results(
             return {
                 "success": False,
                 "message": "Пациент не зарегистрирован в Telegram боте",
-                "patient_phone": patient.phone,
             }
 
         # Получаем данные анализов
@@ -195,8 +194,6 @@ async def send_lab_results(
             return {
                 "success": True,
                 "message": "Результаты анализов отправлены",
-                "chat_id": telegram_user.chat_id,
-                "patient": patient.full_name,
                 "lab_results_count": len(lab_results),
             }
         else:

--- a/backend/tests/unit/test_telegram_notifications_privacy.py
+++ b/backend/tests/unit/test_telegram_notifications_privacy.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import BackgroundTasks
+
+from app.api.v1.endpoints import telegram_notifications
+
+
+class FakeTelegramTemplatesService:
+    def __init__(self) -> None:
+        self.template_data = None
+
+    def get_abnormalities_text(self, has_abnormalities, language):
+        return "abnormal" if has_abnormalities else "normal"
+
+    def get_template(self, _template_key, _language, template_data):
+        self.template_data = template_data
+        return {"text": "Lab results are ready", "keyboard": None}
+
+
+@pytest.mark.asyncio
+async def test_send_lab_results_response_hides_patient_contact_metadata(monkeypatch):
+    patient = SimpleNamespace(
+        phone="+998901234567",
+        full_name="Sensitive Patient",
+    )
+    telegram_user = SimpleNamespace(chat_id=998877, language_code="ru")
+    lab_result = SimpleNamespace(
+        test_code="CBC",
+        created_at=datetime(2026, 5, 18, 9, 0, 0),
+        is_abnormal=False,
+        doctor_id=44,
+    )
+    bot_service = SimpleNamespace(
+        active=True,
+        initialize=AsyncMock(),
+        _send_message=AsyncMock(return_value=True),
+    )
+    templates_service = FakeTelegramTemplatesService()
+
+    monkeypatch.setattr(
+        telegram_notifications.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: telegram_user,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_lab,
+        "get_lab_result",
+        lambda _db, _result_id: lab_result,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications,
+        "get_telegram_bot_service",
+        AsyncMock(return_value=bot_service),
+    )
+    monkeypatch.setattr(
+        telegram_notifications,
+        "get_telegram_templates_service",
+        lambda: templates_service,
+    )
+
+    response = await telegram_notifications.send_lab_results(
+        patient_id=123,
+        lab_result_ids=[456],
+        background_tasks=BackgroundTasks(),
+        db=object(),
+        current_user=SimpleNamespace(role="Lab"),
+    )
+
+    assert response == {
+        "success": True,
+        "message": "Результаты анализов отправлены",
+        "lab_results_count": 1,
+    }
+    assert "+998901234567" not in str(response)
+    assert "Sensitive Patient" not in str(response)
+    assert "998877" not in str(response)
+    bot_service._send_message.assert_awaited_once_with(
+        chat_id=998877,
+        text="Lab results are ready",
+        reply_markup=None,
+    )
+    assert templates_service.template_data["patient_name"] == "Sensitive Patient"
+
+
+@pytest.mark.asyncio
+async def test_send_lab_results_unregistered_response_hides_patient_phone(
+    monkeypatch,
+):
+    patient = SimpleNamespace(
+        phone="+998901234567",
+        full_name="Sensitive Patient",
+    )
+
+    monkeypatch.setattr(
+        telegram_notifications.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: None,
+        raising=False,
+    )
+
+    response = await telegram_notifications.send_lab_results(
+        patient_id=123,
+        lab_result_ids=[456],
+        background_tasks=BackgroundTasks(),
+        db=object(),
+        current_user=SimpleNamespace(role="Lab"),
+    )
+
+    assert response["success"] is False
+    assert "patient_phone" not in response
+    assert "+998901234567" not in str(response)
+    assert "Sensitive Patient" not in str(response)


### PR DESCRIPTION
## Summary
- Removes patient phone, Telegram chat id, and patient full name echoes from the legacy `/api/v1/telegram/send-lab-results` HTTP response.
- Keeps the actual Telegram delivery payload unchanged so the bot can still send the lab result message to the linked chat.
- Adds focused unit coverage for both successful send and unregistered Telegram user response privacy.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/telegram_notifications.py` mounted at `/api/v1/telegram` by `backend/app/api/v1/api.py`.
- Request shape: unchanged; `patient_id` and `lab_result_ids` inputs are the same.
- Response shape: changed only for `/send-lab-results`; response no longer includes `patient_phone`, `chat_id`, or `patient`, and still returns `success`, `message`, and `lab_results_count` on success.
- Status codes: unchanged; success, not-registered, 404, and 500 paths keep the same status behavior.
- Frontend consumer: no known frontend consumer; admin UI Telegram manager uses `/admin/telegram/*`, not this legacy notification endpoint.
- Compatibility path or alias: existing `/api/v1/telegram/send-lab-results` path remains mounted.
- Contract proof: unit test calls the endpoint function directly and proves response privacy while verifying Telegram send still uses the linked chat id.

## RBAC / Permissions
- Roles allowed: unchanged; Admin, Lab, and Doctor remain allowed by the existing endpoint dependency.
- Roles denied: unchanged; no permission dependency was changed.
- Positive auth proof: test exercises the endpoint with a Lab-like current user object and a linked Telegram user.
- Negative auth proof: response assertions prove patient phone, patient full name, and Telegram chat id are absent from success and unregistered responses.

## Notification / Realtime
- Event type or websocket channel: Telegram lab-result notification send path only; no websocket, queue, payment, or report event changed.
- Payload version / ack behavior: Telegram message payload is unchanged; only the HTTP acknowledgement metadata is reduced.
- Read/unread or delivery semantics: unchanged; no notification read state or delivery tracking behavior changed.
- Reconnect/resync proof: not applicable because this endpoint does not use realtime reconnect or resync behavior.

## Frontend Resilience
- Empty data proof: unchanged; no frontend empty state changed.
- Partial data proof: unchanged; no frontend partial-data rendering path changed.
- Forbidden secondary path behavior: unchanged; no frontend route or permission fallback changed.
- Missing draft/resource behavior: unchanged; no draft or resource fetch behavior changed.
- Stale route/deep-link behavior: unchanged; no route registry, redirect, or deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/telegram_notifications.py`, `backend/tests/unit/test_telegram_notifications_privacy.py`.
- Denied paths: DB/Alembic, frontend runtime, Bot API command registration, webhook handlers, staff menu runtime, queue fairness, payments, EMR, and lab report generation.
- Migration/docs/test impact: no migration required; no docs required; one focused unit test file added.
- Rollback note: revert commit `4ccf8171` to restore the previous response metadata shape.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\telegram_notifications.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_notifications_privacy.py`; `pytest backend\tests\unit\test_telegram_notifications_privacy.py -q`; `git diff --check -- backend\app\api\v1\endpoints\telegram_notifications.py backend\tests\unit\test_telegram_notifications_privacy.py`; `cd frontend; npm.cmd run build`.
- Result: py_compile passed; targeted pytest passed with 2 tests; diff check passed with existing CRLF warnings only; frontend build passed with existing Vite chunk/dynamic import warnings.
- Not checked: live Telegram delivery against a real bot token, because the unit test verifies the bot send call without external network.