### PR TITLE
fix(telegram): hide appointment response metadata

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_notifications.py
+++ b/backend/app/api/v1/endpoints/telegram_notifications.py
@@ -54,7 +54,6 @@ async def send_appointment_reminder(
             return {
                 "success": False,
                 "message": "Пациент не зарегистрирован в Telegram боте",
-                "patient_phone": patient.phone,
             }
 
         # Получаем сервис бота
@@ -92,8 +91,6 @@ async def send_appointment_reminder(
             return {
                 "success": True,
                 "message": "Напоминание отправлено",
-                "chat_id": telegram_user.chat_id,
-                "patient": patient.full_name,
                 "appointment_id": appointment.id,
             }
         else:

--- a/backend/tests/unit/test_telegram_notifications_privacy.py
+++ b/backend/tests/unit/test_telegram_notifications_privacy.py
@@ -23,6 +23,127 @@ class FakeTelegramTemplatesService:
 
 
 @pytest.mark.asyncio
+async def test_send_appointment_reminder_response_hides_patient_contact_metadata(
+    monkeypatch,
+):
+    patient = SimpleNamespace(
+        phone="+998901234567",
+        full_name="Sensitive Patient",
+    )
+    appointment = SimpleNamespace(
+        id=456,
+        patient_id=123,
+        doctor_name="Dr Privacy",
+        specialty="Cardiology",
+        date=datetime(2026, 5, 18, 9, 0, 0),
+        time="09:00",
+        cabinet="12",
+    )
+    telegram_user = SimpleNamespace(chat_id=998877, language_code="ru")
+    bot_service = SimpleNamespace(
+        active=True,
+        initialize=AsyncMock(),
+        _send_message=AsyncMock(return_value=True),
+    )
+    templates_service = FakeTelegramTemplatesService()
+
+    monkeypatch.setattr(
+        telegram_notifications.crud_appointment,
+        "get_appointment",
+        lambda _db, _appointment_id: appointment,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: telegram_user,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications,
+        "get_telegram_bot_service",
+        AsyncMock(return_value=bot_service),
+    )
+    monkeypatch.setattr(
+        telegram_notifications,
+        "get_telegram_templates_service",
+        lambda: templates_service,
+    )
+
+    response = await telegram_notifications.send_appointment_reminder(
+        appointment_id=456,
+        reminder_type="24h",
+        background_tasks=BackgroundTasks(),
+        db=object(),
+        current_user=SimpleNamespace(role="Registrar"),
+    )
+
+    assert response["success"] is True
+    assert response["appointment_id"] == 456
+    assert "chat_id" not in response
+    assert "patient" not in response
+    assert "+998901234567" not in str(response)
+    assert "Sensitive Patient" not in str(response)
+    assert "998877" not in str(response)
+    bot_service._send_message.assert_awaited_once_with(
+        chat_id=998877,
+        text="Lab results are ready",
+        reply_markup=None,
+    )
+    assert templates_service.template_data["patient_name"] == "Sensitive Patient"
+    assert templates_service.template_data["appointment_id"] == 456
+
+
+@pytest.mark.asyncio
+async def test_send_appointment_reminder_unregistered_response_hides_patient_phone(
+    monkeypatch,
+):
+    patient = SimpleNamespace(
+        phone="+998901234567",
+        full_name="Sensitive Patient",
+    )
+    appointment = SimpleNamespace(id=456, patient_id=123)
+
+    monkeypatch.setattr(
+        telegram_notifications.crud_appointment,
+        "get_appointment",
+        lambda _db, _appointment_id: appointment,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: None,
+        raising=False,
+    )
+
+    response = await telegram_notifications.send_appointment_reminder(
+        appointment_id=456,
+        reminder_type="24h",
+        background_tasks=BackgroundTasks(),
+        db=object(),
+        current_user=SimpleNamespace(role="Registrar"),
+    )
+
+    assert response["success"] is False
+    assert "patient_phone" not in response
+    assert "+998901234567" not in str(response)
+    assert "Sensitive Patient" not in str(response)
+
+
+@pytest.mark.asyncio
 async def test_send_lab_results_response_hides_patient_contact_metadata(monkeypatch):
     patient = SimpleNamespace(
         phone="+998901234567",


### PR DESCRIPTION
## Summary

- Removes patient phone, Telegram chat id, and patient full name from the legacy appointment reminder HTTP response.
- Preserves Telegram delivery behavior and the appointment id response field.
- Adds unit regression coverage for success and unregistered-patient branches.

## Contract Impact

- Canonical surface: `POST /api/v1/telegram/send-appointment-reminder` from `backend/app/api/v1/endpoints/telegram_notifications.py`.
- Request shape: Unchanged: `appointment_id` plus optional `reminder_type` query value.
- Response shape: Success no longer returns `chat_id` or `patient`; unregistered response no longer returns `patient_phone`; existing `success`, `message`, and success `appointment_id` remain.
- Status codes: Unchanged; success/unregistered still return HTTP 200 payloads, existing missing resource and send failure paths still raise HTTP errors.
- Frontend consumer: No frontend file changed; this is a legacy API response privacy trim.
- Compatibility path or alias: No route alias or compatibility path changed.
- Contract proof: `backend/tests/unit/test_telegram_notifications_privacy.py` asserts the trimmed response shape and preserved `_send_message` call.

## RBAC / Permissions

not applicable - endpoint guard remains `require_roles(Admin, Registrar, Doctor)` and this PR only trims response metadata.

## Notification / Realtime

- Event type or websocket channel: Telegram Bot API send path for appointment reminders.
- Payload version / ack behavior: Unchanged; `_send_message` is still called with the resolved `chat_id`, template text, and keyboard.
- Read/unread or delivery semantics: Unchanged; no delivery state, ack, or read/unread behavior is added or removed.
- Reconnect/resync proof: Not applicable because this endpoint does not use websocket or realtime reconnect flows.

## Frontend Resilience

not applicable - no frontend panel, route, or data-loading behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_notifications.py`; `backend/tests/unit/test_telegram_notifications_privacy.py`.
- Denied paths: DB/Alembic, frontend Telegram manager, webhook command UX, and runtime configuration were left untouched.
- Migration/docs/test impact: No migration or docs impact; unit regression coverage added for appointment response privacy.
- Rollback note: Restore the three removed response fields and remove the two appointment privacy tests.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\telegram_notifications.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_notifications_privacy.py`; `pytest backend\tests\unit\test_telegram_notifications_privacy.py -q`; `git diff --check -- backend\app\api\v1\endpoints\telegram_notifications.py backend\tests\unit\test_telegram_notifications_privacy.py`; `cd frontend; npm.cmd run build`.
- Result: All passed locally; frontend build completed with existing Vite dynamic import and chunk-size warnings.
- Not checked: Full backend suite and browser E2E were not run because the patch only trims one legacy API response and adds focused unit coverage.