### PR TITLE
feat(telegram): show patient settings status

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -198,6 +198,32 @@ TELEGRAM_SETTINGS_MENUS = {
         "one_time_keyboard": False,
     },
 }
+TELEGRAM_SETTINGS_STATUS_LABELS = {
+    TELEGRAM_LANGUAGE_RU: {
+        "language": {
+            TELEGRAM_LANGUAGE_RU: "Русский",
+            TELEGRAM_LANGUAGE_UZ: "O'zbekcha",
+        },
+        "notifications_on": "включены",
+        "notifications_off": "отключены",
+        "template": (
+            "\n\nТекущий язык: {language_label}\n"
+            "Уведомления: {notification_label}"
+        ),
+    },
+    TELEGRAM_LANGUAGE_UZ: {
+        "language": {
+            TELEGRAM_LANGUAGE_RU: "Rus tili",
+            TELEGRAM_LANGUAGE_UZ: "O'zbekcha",
+        },
+        "notifications_on": "yoqilgan",
+        "notifications_off": "o'chirilgan",
+        "template": (
+            "\n\nJoriy til: {language_label}\n"
+            "Xabarnomalar: {notification_label}"
+        ),
+    },
+}
 TELEGRAM_LOCALIZED_TEXTS = {
     "language_prompt": {
         TELEGRAM_LANGUAGE_RU: "Выберите язык обслуживания.\n\nTilni tanlang.",
@@ -720,6 +746,23 @@ def _telegram_chat_text(db: Session, chat_id: int, key: str) -> str:
 
 def _telegram_chat_menu(db: Session, chat_id: int) -> Dict[str, Any]:
     return _localized_main_menu(_telegram_chat_language(db, chat_id))
+
+
+def _telegram_settings_message(db: Session, chat_id: int) -> str:
+    telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, chat_id)
+    language = _normalize_patient_language(getattr(telegram_user, "language_code", None))
+    labels = TELEGRAM_SETTINGS_STATUS_LABELS.get(
+        language, TELEGRAM_SETTINGS_STATUS_LABELS[TELEGRAM_LANGUAGE_RU]
+    )
+    language_label = labels["language"].get(language, labels["language"][TELEGRAM_LANGUAGE_RU])
+    notifications_enabled = bool(getattr(telegram_user, "notifications_enabled", False))
+    notification_label = (
+        labels["notifications_on"] if notifications_enabled else labels["notifications_off"]
+    )
+    return _localized_text("settings", language) + labels["template"].format(
+        language_label=language_label,
+        notification_label=notification_label,
+    )
 
 
 TELEGRAM_PATIENT_BUTTON_ICON_PREFIXES = (
@@ -2911,7 +2954,7 @@ async def _handle_clinic_bot_update(
             db,
             bot_service,
             chat_id,
-            _localized_text("settings", language),
+            _telegram_settings_message(db, chat_id),
             _localized_settings_menu(language),
             "telegram_patient_settings",
         )

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -496,9 +496,12 @@ class TestTelegramWebhookSecurity:
         assert handled is True
         fake_service._send_message.assert_awaited_once_with(
             7009,
-            telegram_webhook._localized_text("settings", "uz-Latn"),
+            telegram_webhook._telegram_settings_message(db_session, 7009),
             telegram_webhook._localized_settings_menu("uz-Latn"),
         )
+        settings_message = fake_service._send_message.await_args.args[1]
+        assert "Joriy til: O'zbekcha" in settings_message
+        assert "Xabarnomalar: yoqilgan" in settings_message
 
     @pytest.mark.asyncio
     async def test_support_command_returns_localized_safe_contact_guidance(


### PR DESCRIPTION
﻿## Summary

- Add a localized current status line to patient `/settings` replies.
- Show the saved patient language and current Telegram notification state in Russian or Uzbek Latin.
- Keep the existing settings keyboard and command routing unchanged.

## Contract Impact

- Canonical surface: Telegram patient bot `/settings` and localized settings button handlers.
- Request shape: unchanged Telegram update payload.
- Response shape: same Telegram text message plus reply keyboard; message body now includes current language and notification status lines.
- Status codes: not applicable - this is bot update handling, not an HTTP response contract.
- Frontend consumer: not applicable - no frontend consumer changed.
- Compatibility path or alias: existing `/settings`, `⚙️ Настройки`, and `⚙️ Sozlamalar` aliases remain unchanged.
- Contract proof: focused Telegram webhook unit test and backend py_compile passed.

## RBAC / Permissions

- Roles allowed: unchanged patient Telegram chat flow after QR/contact/start linking.
- Roles denied: unchanged; no staff/admin access path added.
- Positive auth proof: existing linked Telegram user test exercises `/settings` response.
- Negative auth proof: not checked - this PR does not change auth, staff linking, or role guards.

## Notification / Realtime

- Event type or websocket channel: Telegram patient bot reply for `/settings`; no websocket channel changed.
- Payload version / ack behavior: unchanged Telegram Bot API `sendMessage` text plus reply keyboard; no callback ack behavior changed.
- Read/unread or delivery semantics: unchanged; the bot still logs a `TelegramMessage` with template key `telegram_patient_settings` after send.
- Reconnect/resync proof: not applicable - no polling/webhook transport, websocket reconnect, or resync behavior changed; the settings text is recomputed from the persisted `TelegramUser` language and notification fields on each update.

## Frontend Resilience

not applicable - no frontend file, route, panel, form, or browser data flow changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/telegram_webhook.py and backend/tests/unit/test_telegram_webhook_security.py.
- Denied paths: DB schema/migrations, Telegram tokens, polling service setup, queue/payment/EMR/result behavior, frontend UI.
- Migration/docs/test impact: no migration; focused unit test updated for the new settings text.
- Rollback note: revert this PR branch commit to return `/settings` to the previous plain settings prompt.

## Validation

- Targeted tests or smoke run: py_compile for admin_telegram.py and telegram_webhook.py; test_telegram_webhook_security.py with TESTING=1, ALLOW_SQLITE_DATABASE_URL=1, and a temporary sqlite bootstrap DATABASE_URL; git diff --check; frontend npm build from the existing main frontend checkout because this is backend-only.
- Result: passed locally: 28 Telegram webhook tests passed, py_compile passed, diff-check passed, frontend build passed.
- Not checked: live Telegram chat smoke after merge/restart, because the branch is not yet on the running backend.
