### PR TITLE
fix(telegram): hide send-message response chat id

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -3217,7 +3217,7 @@ async def send_message_to_user(
         )
 
         if success:
-            return {"status": "sent", "chat_id": chat_id}
+            return {"status": "sent"}
         else:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -201,6 +201,33 @@ class TestTelegramWebhookSecurity:
         assert response.status_code in {401, 403}
 
     @pytest.mark.asyncio
+    async def test_send_message_response_hides_chat_id(self, monkeypatch):
+        fake_service = FakeTelegramBotService(active=True)
+        monkeypatch.setattr(
+            telegram_webhook,
+            "get_telegram_bot_service",
+            AsyncMock(return_value=fake_service),
+        )
+
+        response = await telegram_webhook.send_message_to_user(
+            chat_id=123456,
+            message="Private follow-up",
+            parse_mode="HTML",
+            reply_markup=None,
+            db=object(),
+            current_user=SimpleNamespace(role="Admin"),
+        )
+
+        assert response == {"status": "sent"}
+        assert "chat_id" not in response
+        assert "123456" not in str(response)
+        fake_service._send_message.assert_awaited_once_with(
+            chat_id=123456,
+            text="Private follow-up",
+            reply_markup=None,
+        )
+
+    @pytest.mark.asyncio
     async def test_contact_spoof_is_rejected(self, db_session):
         fake_service = FakeTelegramBotService(active=True)
         update = {


### PR DESCRIPTION
## Summary

- Removes Telegram `chat_id` from the admin send-message HTTP response.
- Preserves admin-only send behavior: `_send_message` still receives the requested `chat_id`, text, and reply markup.
- Adds a focused unit regression test for the response shape.

## Contract Impact

- Canonical surface: `POST /api/v1/telegram/send-message` from `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Request shape: Unchanged: `chat_id`, `message`, optional `parse_mode`, optional `reply_markup`.
- Response shape: Success now returns only `{status: sent}` instead of echoing `chat_id`; error responses are unchanged.
- Status codes: Unchanged; success remains HTTP 200, send failure remains HTTP 400, unexpected failures remain internal errors.
- Frontend consumer: No frontend file changed; this trims an admin Telegram API response identifier echo.
- Compatibility path or alias: No route alias or compatibility path changed.
- Contract proof: `backend/tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_send_message_response_hides_chat_id` verifies send behavior and response privacy.

## RBAC / Permissions

not applicable - endpoint guard remains `require_roles(Admin)` and this PR only trims response metadata.

## Notification / Realtime

- Event type or websocket channel: Telegram Bot API send path for admin direct messages.
- Payload version / ack behavior: Unchanged; `_send_message` is still called with the supplied `chat_id`, message text, and reply markup.
- Read/unread or delivery semantics: Unchanged; no delivery state, ack, or read/unread behavior is added or removed.
- Reconnect/resync proof: Not applicable because this endpoint does not use websocket or realtime reconnect flows.

## Frontend Resilience

not applicable - no frontend panel, route, or data-loading behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook.py`; `backend/tests/unit/test_telegram_webhook_security.py`.
- Denied paths: DB/Alembic, frontend Telegram manager, webhook command UX, staff-token/linking contracts, and runtime configuration were left untouched.
- Migration/docs/test impact: No migration or docs impact; unit regression coverage added for send-message response privacy.
- Rollback note: Restore the `chat_id` response field and remove the new response privacy test.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_webhook_security.py`; `pytest backend\tests\unit\test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_send_message_requires_admin_auth backend\tests\unit\test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_send_message_response_hides_chat_id -q`; `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_webhook_security.py`; `git diff --check -- backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_webhook_security.py`; `cd frontend; npm.cmd run build`.
- Result: All passed locally; frontend build completed with existing Vite dynamic import and chunk-size warnings.
- Not checked: Full backend suite and browser E2E were not run because the patch only trims one admin API response and adds focused unit coverage.