### PR TITLE
fix(telegram): hide settings token length

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -1304,7 +1304,6 @@ def get_telegram_settings(
         # Скрываем токен бота в ответе
         if result["bot_token"]:
             result["bot_token_masked"] = "***скрыт***"
-            result["bot_token_length"] = len(result["bot_token"])
             result["bot_token"] = "***скрыт***"
 
         return result

--- a/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
+++ b/backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py
@@ -20,6 +20,29 @@ class TestTelegramStaffBotTokenRuntimeConfig:
             SimpleNamespace(model_config={}),
         )
 
+    def test_admin_settings_masks_patient_bot_token_without_length_leak(
+        self, db_session
+    ):
+        secret_value = "123456789:patient-bot-secret-value"
+        db_session.add(
+            ClinicSettings(
+                key="bot_token",
+                value=secret_value,
+                category="telegram",
+            )
+        )
+        db_session.commit()
+
+        response = admin_telegram.get_telegram_settings(
+            db_session,
+            SimpleNamespace(id=1),
+        )
+
+        assert response["bot_token"] != secret_value
+        assert response["bot_token_masked"]
+        assert "bot_token_length" not in response
+        assert secret_value not in str(response)
+
     def test_reads_env_without_exposing_secret(self, monkeypatch, db_session):
         secret_value = "999999:staff-secret"
         self._clear_staff_bot_token_sources(monkeypatch)


### PR DESCRIPTION
## Summary

- Removes exact Telegram bot token length from the admin settings HTTP response.
- Preserves masked token configured status via the existing masked token fields.
- Adds a focused unit regression test that the token value and length metadata are not exposed.

## Contract Impact

- Canonical surface: `GET /api/v1/admin/telegram/settings` from `backend/app/api/v1/endpoints/admin_telegram.py`.
- Request shape: Unchanged; admin-only settings fetch still takes no request body.
- Response shape: Configured bot token still returns masked token indicators, but no longer includes `bot_token_length`.
- Status codes: Unchanged; success remains HTTP 200 and existing error handling remains unchanged.
- Frontend consumer: Frontend settings callers do not reference `bot_token_length`; no frontend file changed.
- Compatibility path or alias: No route alias or compatibility path changed.
- Contract proof: `backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py::TestTelegramStaffBotTokenRuntimeConfig::test_admin_settings_masks_patient_bot_token_without_length_leak`.

## RBAC / Permissions

not applicable - endpoint guard remains `require_roles(Admin)` and this PR only trims response metadata.

## Notification / Realtime

not applicable - no Telegram send, webhook, websocket, notification, or realtime behavior changed.

## Frontend Resilience

not applicable - no frontend panel, route, or data-loading behavior changed; frontend callers do not use the removed field.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`; `backend/tests/unit/test_telegram_staff_bot_token_runtime_config.py`.
- Denied paths: DB/Alembic, frontend Telegram manager, webhook command UX, staff-token/linking contracts, and runtime configuration were left untouched.
- Migration/docs/test impact: No migration or docs impact; unit regression coverage added for settings token metadata privacy.
- Rollback note: Restore the `bot_token_length` response field and remove the new regression test.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py`; `pytest backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py::TestTelegramStaffBotTokenRuntimeConfig::test_admin_settings_masks_patient_bot_token_without_length_leak -q`; `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py`; `git diff --check -- backend\app\api\v1\endpoints\admin_telegram.py backend\tests\unit\test_telegram_staff_bot_token_runtime_config.py`; `cd frontend; npm.cmd run build`.
- Result: Passed locally; frontend build completed with existing chunk-size/static-dynamic import warnings only.
- Not checked: Full backend suite and browser E2E were not run because the patch only trims one admin API response metadata field and adds focused unit coverage.