### PR TITLE
feat(telegram): keep language settings menu localized

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -844,6 +844,19 @@ async def _send_patient_bot_reply(
     return sent
 
 
+def _latest_patient_bot_template_key(db: Session, chat_id: int) -> str | None:
+    row = (
+        db.query(TelegramMessage.template_key)
+        .filter(
+            TelegramMessage.chat_id == chat_id,
+            TelegramMessage.message_type == "patient_bot_reply",
+        )
+        .order_by(TelegramMessage.id.desc())
+        .first()
+    )
+    return str(row[0]) if row and row[0] else None
+
+
 def _upsert_ticket_qr_telegram_user(
     db: Session,
     message: Dict[str, Any],
@@ -2916,6 +2929,7 @@ async def _handle_clinic_bot_update(
     async def language_handler(chat_id: int, language_code: str) -> None:
         message = _message_from_update(update)
         telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, chat_id)
+        previous_template_key = _latest_patient_bot_template_key(db, chat_id)
         _upsert_ticket_qr_telegram_user(
             db,
             message,
@@ -2928,13 +2942,24 @@ async def _handle_clinic_bot_update(
             "Telegram patient bot language selected",
             extra={"language_code": language},
         )
+        settings_context = previous_template_key in {
+            "telegram_patient_settings",
+            "telegram_patient_settings_language_selected",
+        }
+        reply_text = _localized_text("language_selected", language)
+        reply_markup = _localized_main_menu(language)
+        template_key = "telegram_patient_language_selected"
+        if settings_context:
+            reply_text = f"{reply_text}\n\n{_telegram_settings_message(db, chat_id)}"
+            reply_markup = _localized_settings_menu(language)
+            template_key = "telegram_patient_settings_language_selected"
         await _send_patient_bot_reply(
             db,
             bot_service,
             chat_id,
-            _localized_text("language_selected", language),
-            _localized_main_menu(language),
-            "telegram_patient_language_selected",
+            reply_text,
+            reply_markup,
+            template_key,
         )
 
     async def help_handler(chat_id: int) -> None:

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -374,6 +374,68 @@ class TestTelegramWebhookSecurity:
         )
 
     @pytest.mark.asyncio
+    async def test_settings_language_choice_keeps_localized_settings_menu(
+        self, db_session
+    ):
+        telegram_user = TelegramUser(
+            chat_id=7021,
+            username="patient_chat",
+            first_name="Patient",
+            language_code="ru",
+            notifications_enabled=True,
+            appointment_reminders=True,
+            lab_notifications=True,
+            active=True,
+            blocked=False,
+        )
+        db_session.add(telegram_user)
+        db_session.add(
+            TelegramMessage(
+                chat_id=7021,
+                message_type="patient_bot_reply",
+                template_key="telegram_patient_settings",
+                message_text="settings",
+                status="sent",
+                sent_at=datetime.utcnow(),
+            )
+        )
+        db_session.commit()
+        fake_service = FakeTelegramBotService(active=True)
+        language_update = {
+            "update_id": 122,
+            "message": {
+                "message_id": 3,
+                "chat": {"id": 7021},
+                "from": {"id": 111, "language_code": "ru"},
+                "text": "O'zbekcha",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            language_update, db_session, fake_service
+        )
+
+        assert handled is True
+        db_session.refresh(telegram_user)
+        assert telegram_user.language_code == "uz-Latn"
+        reply_text = fake_service._send_message.await_args.args[1]
+        assert (
+            telegram_webhook._localized_text("language_selected", "uz-Latn")
+            in reply_text
+        )
+        assert "Joriy til: O'zbekcha" in reply_text
+        assert fake_service._send_message.await_args.args[2] == (
+            telegram_webhook._localized_settings_menu("uz-Latn")
+        )
+        latest_log = (
+            db_session.query(TelegramMessage)
+            .filter(TelegramMessage.chat_id == 7021)
+            .order_by(TelegramMessage.id.desc())
+            .first()
+        )
+        assert latest_log.template_key == "telegram_patient_settings_language_selected"
+
+    @pytest.mark.asyncio
     async def test_language_choice_preserves_existing_notification_consent(
         self, db_session
     ):


### PR DESCRIPTION
﻿## Summary

- Keep patient language changes inside the localized settings screen when the user pressed a language button from `/settings`.
- Preserve `/start` and plain language choice behavior outside settings: language still saves and the main menu remains the next visible menu.
- Add a focused Telegram webhook unit test for the settings-language loop.

## Contract Impact

- Canonical surface: Telegram patient bot language button handling in `telegram_webhook.py`.
- Request shape: unchanged Telegram text update payload.
- Response shape: same Telegram `sendMessage` response type; settings-context language choices now return localized settings text and settings keyboard instead of the main menu.
- Status codes: not applicable - this is Telegram update handling, not an HTTP response contract.
- Frontend consumer: not applicable - no frontend consumer changed.
- Compatibility path or alias: existing `Русский`, `O'zbekcha`, flag-prefixed labels, `/start`, and `/settings` routing remain unchanged.
- Contract proof: focused Telegram webhook unit test covers settings-context language selection; existing plain language selection test still proves main-menu behavior outside settings.

## RBAC / Permissions

- Roles allowed: unchanged patient Telegram chat flow after QR/contact/start linking.
- Roles denied: unchanged; no staff/admin access path added.
- Positive auth proof: focused unit tests exercise patient language selection and settings menu behavior.
- Negative auth proof: not checked - this PR does not change auth, staff linking, role checks, or patient data access.

## Notification / Realtime

- Event type or websocket channel: Telegram patient bot reply for language button selection; no websocket channel changed.
- Payload version / ack behavior: unchanged Telegram Bot API `sendMessage` text plus reply keyboard; no callback query ack behavior changed.
- Read/unread or delivery semantics: unchanged; the bot still logs a `TelegramMessage` for the outgoing reply, with a distinct template key for settings-context language selection.
- Reconnect/resync proof: settings context is recomputed from the persisted latest patient bot reply log and the saved `TelegramUser` language on each update, so polling/webhook restarts do not need in-memory state.

## Frontend Resilience

not applicable - no frontend file, route, panel, form, or browser data flow changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/telegram_webhook.py and backend/tests/unit/test_telegram_webhook_security.py.
- Denied paths: DB schema/migrations, Telegram tokens, polling service setup, queue/payment/EMR/result behavior, frontend UI.
- Migration/docs/test impact: no migration; focused Telegram webhook unit test added.
- Rollback note: revert this PR to return language-button replies to the previous main-menu behavior.

## Validation

- Targeted tests or smoke run: py_compile for admin_telegram.py and telegram_webhook.py; test_telegram_webhook_security.py with TESTING=1, ALLOW_SQLITE_DATABASE_URL=1, and a temporary sqlite bootstrap DATABASE_URL; git diff --check; frontend npm build from the existing main frontend checkout because no frontend file changed.
- Result: passed locally: 30 Telegram webhook tests passed, py_compile passed, diff-check passed, frontend build passed.
- Not checked: live Telegram chat smoke after merge/restart, because the branch is not yet on the running backend.
