### PR TITLE
fix(telegram): sanitize webhook info response

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -1077,6 +1077,19 @@ def webhook_info_error_response(
     return {"webhook_set": False, "error": public_error}
 
 
+def _sanitize_telegram_webhook_info(webhook_info: Dict[str, Any]) -> Dict[str, Any]:
+    pending_update_count = webhook_info.get("pending_update_count")
+    if isinstance(pending_update_count, bool) or not isinstance(
+        pending_update_count, int
+    ):
+        pending_update_count = 0
+
+    return {
+        "url": str(webhook_info.get("url") or ""),
+        "pending_update_count": pending_update_count,
+    }
+
+
 class TelegramWebhookRequest(BaseModel):
     webhook_url: Optional[str] = None
 
@@ -1626,7 +1639,7 @@ def get_telegram_webhook_info(
                 webhook_info = result["result"]
                 return {
                     "webhook_set": bool(webhook_info.get("url")),
-                    "webhook_info": webhook_info,
+                    "webhook_info": _sanitize_telegram_webhook_info(webhook_info),
                 }
             else:
                 raise Exception(f"Ошибка API: {result.get('description')}")

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -81,6 +81,57 @@ def _create_lab_report_instance(
 
 @pytest.mark.unit
 class TestTelegramWebhookSecurity:
+    def test_admin_webhook_info_response_hides_raw_telegram_payload(
+        self, db_session, monkeypatch
+    ):
+        db_session.add(
+            TelegramConfig(
+                bot_token="bot-token",
+                webhook_secret="topsecret",
+                active=True,
+            )
+        )
+        db_session.commit()
+
+        class FakeResponse:
+            status_code = 200
+
+            def json(self):
+                return {
+                    "ok": True,
+                    "result": {
+                        "url": "https://clinic.example/api/v1/telegram/webhook",
+                        "pending_update_count": 3,
+                        "last_error_message": "provider-secret-detail",
+                        "ip_address": "203.0.113.10",
+                        "allowed_updates": ["message"],
+                        "unexpected_secret": "raw-provider-secret",
+                    },
+                }
+
+        monkeypatch.setattr(
+            admin_telegram.requests,
+            "get",
+            lambda *_args, **_kwargs: FakeResponse(),
+        )
+
+        response = admin_telegram.get_telegram_webhook_info(
+            db_session,
+            SimpleNamespace(id=1),
+        )
+
+        assert response == {
+            "webhook_set": True,
+            "webhook_info": {
+                "url": "https://clinic.example/api/v1/telegram/webhook",
+                "pending_update_count": 3,
+            },
+        }
+        assert "last_error_message" not in str(response)
+        assert "ip_address" not in str(response)
+        assert "allowed_updates" not in str(response)
+        assert "raw-provider-secret" not in str(response)
+
     def test_webhook_rejects_missing_secret_configuration(
         self, client, monkeypatch
     ):


### PR DESCRIPTION
## Summary

- Sanitizes the admin Telegram webhook-info response instead of returning the raw Telegram `getWebhookInfo` payload.
- Keeps the UI-facing `webhook_info.url` and `webhook_info.pending_update_count` fields unchanged.
- Adds a focused unit regression test proving raw Telegram fields and unexpected secret-like payload data are not exposed.

## Contract Impact

- Canonical surface: `GET /api/v1/admin/telegram/webhook-info` from `backend/app/api/v1/endpoints/admin_telegram.py`.
- Request shape: Unchanged; admin-only webhook info fetch still takes no request body.
- Response shape: `webhook_set` remains unchanged; `webhook_info` now contains only `url` and `pending_update_count` instead of raw Telegram API payload fields.
- Status codes: Unchanged; success and existing error response handling remain unchanged.
- Frontend consumer: `frontend/src/components/admin/TelegramSettings.jsx` reads only `webhook_info.url` and `webhook_info.pending_update_count`, so no frontend change is required.
- Compatibility path or alias: No route alias or compatibility path changed.
- Contract proof: `backend/tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_admin_webhook_info_response_hides_raw_telegram_payload`.

## RBAC / Permissions

not applicable - endpoint guard remains `require_roles(Admin)` and this PR only sanitizes the response body for that admin-only endpoint.

## Notification / Realtime

not applicable - no Telegram send, webhook processing, websocket, notification, or realtime delivery behavior changed.

## Frontend Resilience

not applicable - the existing frontend consumer already uses only the two preserved fields, and `npm.cmd run build` passed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`; `backend/tests/unit/test_telegram_webhook_security.py`.
- Denied paths: DB/Alembic, webhook processing runtime, Telegram manager UI behavior, staff-token/linking contracts, and notification delivery were left untouched.
- Migration/docs/test impact: No migration or docs impact; unit regression coverage added for webhook-info response privacy.
- Rollback note: Replace the sanitized `webhook_info` response with the raw Telegram payload and remove the new regression test.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\tests\unit\test_telegram_webhook_security.py`; `pytest backend\tests\unit\test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_admin_webhook_info_response_hides_raw_telegram_payload -q`; `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_webhook_security.py`; `git diff --check -- backend\app\api\v1\endpoints\admin_telegram.py backend\tests\unit\test_telegram_webhook_security.py`; `cd frontend; npm.cmd run build`.
- Result: Passed locally; frontend build completed with existing chunk-size/static-dynamic import warnings only.
- Not checked: Full backend suite and browser E2E were not run because the patch only sanitizes one admin API response and adds focused unit coverage.