### PR TITLE
feat(telegram): keep notification settings menu localized

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -2832,6 +2832,7 @@ async def _set_notification_consent(
 ) -> None:
     telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, chat_id)
     language = _normalize_patient_language(getattr(telegram_user, "language_code", None))
+    previous_template_key = _latest_patient_bot_template_key(db, chat_id)
     if telegram_user:
         telegram_user.notifications_enabled = enabled
         telegram_user.appointment_reminders = enabled
@@ -2840,13 +2841,26 @@ async def _set_notification_consent(
         db.commit()
 
     result_key = "notifications_enabled" if enabled else "notifications_disabled"
+    settings_context = previous_template_key in {
+        "telegram_patient_settings",
+        "telegram_patient_settings_language_selected",
+        "telegram_patient_settings_notifications_enabled",
+        "telegram_patient_settings_notifications_disabled",
+    }
+    reply_text = _localized_text(result_key, language)
+    reply_markup = _localized_main_menu(language)
+    template_key = f"telegram_patient_{result_key}"
+    if settings_context:
+        reply_text = f"{reply_text}\n\n{_telegram_settings_message(db, chat_id)}"
+        reply_markup = _localized_settings_menu(language)
+        template_key = f"telegram_patient_settings_{result_key}"
     await _send_patient_bot_reply(
         db,
         bot_service,
         chat_id,
-        _localized_text(result_key, language),
-        _localized_main_menu(language),
-        f"telegram_patient_{result_key}",
+        reply_text,
+        reply_markup,
+        template_key,
     )
 
 

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -604,6 +604,73 @@ class TestTelegramWebhookSecurity:
         assert telegram_user.lab_notifications is False
 
     @pytest.mark.asyncio
+    async def test_settings_notification_choice_keeps_localized_settings_menu(
+        self, db_session
+    ):
+        telegram_user = TelegramUser(
+            chat_id=7022,
+            username="patient_chat",
+            first_name="Patient",
+            language_code="ru",
+            notifications_enabled=True,
+            appointment_reminders=True,
+            lab_notifications=True,
+            active=True,
+            blocked=False,
+        )
+        db_session.add(telegram_user)
+        db_session.add(
+            TelegramMessage(
+                chat_id=7022,
+                message_type="patient_bot_reply",
+                template_key="telegram_patient_settings",
+                message_text="settings",
+                status="sent",
+                sent_at=datetime.utcnow(),
+            )
+        )
+        db_session.commit()
+        fake_service = FakeTelegramBotService(active=True)
+        update = {
+            "update_id": 123,
+            "message": {
+                "message_id": 4,
+                "chat": {"id": 7022},
+                "from": {"id": 111},
+                "text": "Без уведомлений",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        db_session.refresh(telegram_user)
+        assert telegram_user.notifications_enabled is False
+        assert telegram_user.appointment_reminders is False
+        assert telegram_user.lab_notifications is False
+        reply_text = fake_service._send_message.await_args.args[1]
+        assert (
+            telegram_webhook._localized_text("notifications_disabled", "ru")
+            in reply_text
+        )
+        assert "Уведомления: отключены" in reply_text
+        assert fake_service._send_message.await_args.args[2] == (
+            telegram_webhook._localized_settings_menu("ru")
+        )
+        latest_log = (
+            db_session.query(TelegramMessage)
+            .filter(TelegramMessage.chat_id == 7022)
+            .order_by(TelegramMessage.id.desc())
+            .first()
+        )
+        assert (
+            latest_log.template_key
+            == "telegram_patient_settings_notifications_disabled"
+        )
+
+    @pytest.mark.asyncio
     async def test_settings_command_returns_localized_settings_menu(self, db_session):
         telegram_user = TelegramUser(
             chat_id=7009,


### PR DESCRIPTION
﻿## Summary

- Keep patient notification enable/disable actions inside the localized settings screen when the user pressed the notification button from `/settings`.
- Preserve the existing notification-consent flow outside settings: it still returns the localized main menu.
- Add a focused Telegram webhook unit test for settings-context notification changes.

## Contract Impact

- Canonical surface: Telegram patient bot notification button handling in `telegram_webhook.py`.
- Request shape: unchanged Telegram text update payload.
- Response shape: same Telegram `sendMessage` response type; settings-context notification choices now return localized settings text and settings keyboard instead of the main menu.
- Status codes: not applicable - this is Telegram update handling, not an HTTP response contract.
- Frontend consumer: not applicable - no frontend consumer changed.
- Compatibility path or alias: existing notification labels in Russian and Uzbek Latin remain unchanged.
- Contract proof: focused unit test added for settings-context notification disable; existing consent tests preserve main-menu behavior outside settings.

## RBAC / Permissions

- Roles allowed: unchanged patient Telegram chat flow after QR/contact/start linking.
- Roles denied: unchanged; no staff/admin access path added.
- Positive auth proof: focused unit test exercises linked patient Telegram settings notification behavior.
- Negative auth proof: not checked - this PR does not change auth, staff linking, role checks, or patient data access.

## Notification / Realtime

- Event type or websocket channel: Telegram patient bot reply for notification button selection; no websocket channel changed.
- Payload version / ack behavior: unchanged Telegram Bot API `sendMessage` text plus reply keyboard; no callback query ack behavior changed.
- Read/unread or delivery semantics: unchanged; the bot still logs a `TelegramMessage` for the outgoing reply, with a distinct template key for settings-context notification selection.
- Reconnect/resync proof: settings context is recomputed from persisted latest patient bot reply log and saved `TelegramUser` notification fields on each update, so polling/webhook restarts do not depend on in-memory state.

## Frontend Resilience

not applicable - no frontend file, route, panel, form, or browser data flow changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/telegram_webhook.py and backend/tests/unit/test_telegram_webhook_security.py.
- Denied paths: DB schema/migrations, Telegram tokens, polling service setup, queue/payment/EMR/result behavior, frontend UI.
- Migration/docs/test impact: no migration; focused Telegram webhook unit test added.
- Rollback note: revert this PR to return settings notification-button replies to the previous main-menu behavior.

## Validation

- Targeted tests or smoke run: py_compile for admin_telegram.py and telegram_webhook.py; git diff --check; frontend npm build; focused Telegram webhook pytest attempted locally.
- Result: py_compile passed, diff-check passed, frontend build passed; local focused pytest was blocked by local environment mismatch: bundled Python 3.12 cannot load cp311 `pydantic_core` from the existing venv.
- Not checked: local focused pytest completion; backend CI is expected to run the test in the repository Python environment.
