### PR TITLE
fix(telegram): keep notification toggles in settings

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -857,6 +857,15 @@ def _latest_patient_bot_template_key(db: Session, chat_id: int) -> str | None:
     return str(row[0]) if row and row[0] else None
 
 
+def _is_patient_settings_context_template(template_key: str | None) -> bool:
+    return template_key in {
+        "telegram_patient_settings",
+        "telegram_patient_settings_language_selected",
+        "telegram_patient_settings_notifications_enabled",
+        "telegram_patient_settings_notifications_disabled",
+    }
+
+
 def _upsert_ticket_qr_telegram_user(
     db: Session,
     message: Dict[str, Any],
@@ -2832,6 +2841,7 @@ async def _set_notification_consent(
 ) -> None:
     telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, chat_id)
     language = _normalize_patient_language(getattr(telegram_user, "language_code", None))
+    previous_template_key = _latest_patient_bot_template_key(db, chat_id)
     if telegram_user:
         telegram_user.notifications_enabled = enabled
         telegram_user.appointment_reminders = enabled
@@ -2840,13 +2850,21 @@ async def _set_notification_consent(
         db.commit()
 
     result_key = "notifications_enabled" if enabled else "notifications_disabled"
+    settings_context = _is_patient_settings_context_template(previous_template_key)
+    reply_text = _localized_text(result_key, language)
+    reply_markup = _localized_main_menu(language)
+    template_key = f"telegram_patient_{result_key}"
+    if settings_context:
+        reply_text = f"{reply_text}\n\n{_telegram_settings_message(db, chat_id)}"
+        reply_markup = _localized_settings_menu(language)
+        template_key = f"telegram_patient_settings_{result_key}"
     await _send_patient_bot_reply(
         db,
         bot_service,
         chat_id,
-        _localized_text(result_key, language),
-        _localized_main_menu(language),
-        f"telegram_patient_{result_key}",
+        reply_text,
+        reply_markup,
+        template_key,
     )
 
 
@@ -2942,10 +2960,7 @@ async def _handle_clinic_bot_update(
             "Telegram patient bot language selected",
             extra={"language_code": language},
         )
-        settings_context = previous_template_key in {
-            "telegram_patient_settings",
-            "telegram_patient_settings_language_selected",
-        }
+        settings_context = _is_patient_settings_context_template(previous_template_key)
         reply_text = _localized_text("language_selected", language)
         reply_markup = _localized_main_menu(language)
         template_key = "telegram_patient_language_selected"

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -604,6 +604,76 @@ class TestTelegramWebhookSecurity:
         assert telegram_user.lab_notifications is False
 
     @pytest.mark.asyncio
+    async def test_settings_notification_choice_keeps_localized_settings_menu(
+        self, db_session
+    ):
+        telegram_user = TelegramUser(
+            chat_id=7022,
+            username="patient_chat",
+            first_name="Patient",
+            language_code="ru",
+            notifications_enabled=True,
+            appointment_reminders=True,
+            lab_notifications=True,
+            active=True,
+            blocked=False,
+        )
+        db_session.add(telegram_user)
+        db_session.add(
+            TelegramMessage(
+                chat_id=7022,
+                message_type="patient_bot_reply",
+                template_key="telegram_patient_settings",
+                message_text="settings",
+                status="sent",
+                sent_at=datetime.utcnow(),
+            )
+        )
+        db_session.commit()
+        fake_service = FakeTelegramBotService(active=True)
+        update = {
+            "update_id": 123,
+            "message": {
+                "message_id": 4,
+                "chat": {"id": 7022},
+                "from": {"id": 111},
+                "text": "Без уведомлений",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        db_session.refresh(telegram_user)
+        assert telegram_user.notifications_enabled is False
+        assert telegram_user.appointment_reminders is False
+        assert telegram_user.lab_notifications is False
+        reply_text = fake_service._send_message.await_args.args[1]
+        assert (
+            telegram_webhook._localized_text("notifications_disabled", "ru")
+            in reply_text
+        )
+        assert (
+            telegram_webhook._telegram_settings_message(db_session, 7022)
+            in reply_text
+        )
+        assert fake_service._send_message.await_args.args[2] == (
+            telegram_webhook._localized_settings_menu("ru")
+        )
+        latest_log = (
+            db_session.query(TelegramMessage)
+            .filter(TelegramMessage.chat_id == 7022)
+            .order_by(TelegramMessage.id.desc())
+            .first()
+        )
+        assert (
+            latest_log.template_key
+            == "telegram_patient_settings_notifications_disabled"
+        )
+
+    @pytest.mark.asyncio
     async def test_settings_command_returns_localized_settings_menu(self, db_session):
         telegram_user = TelegramUser(
             chat_id=7009,


### PR DESCRIPTION
## Summary

- Keeps patient notification enable/disable actions inside the Telegram settings menu when the latest bot reply was settings.
- Preserves existing main-menu behavior for the original notification consent flow outside settings.
- Adds a focused regression test for settings-context notification disable behavior.

## Contract Impact

- Canonical surface: patient Telegram bot text handlers in `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Request shape: Unchanged; Telegram message update payload handling is unchanged.
- Response shape: Outside settings, notification toggles still return the localized result with the main menu. Inside settings, the reply now appends the refreshed settings status and returns the localized settings menu.
- Status codes: Unchanged; webhook HTTP handling is not changed.
- Frontend consumer: Not applicable; this is Telegram bot chat UX only.
- Compatibility path or alias: Existing Russian and Uzbek notification button aliases remain unchanged.
- Contract proof: `backend/tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_settings_notification_choice_keeps_localized_settings_menu`.

## RBAC / Permissions

not applicable - this patch only changes patient Telegram bot menu context and does not change staff/admin permissions or authentication checks.

## Notification / Realtime

- Event type or websocket channel: No websocket or internal notification event is emitted or changed; this only changes the Telegram chat reply markup after an existing patient preference toggle.
- Payload version / ack behavior: Telegram webhook HTTP ack behavior is unchanged; the bot still sends one reply through the existing `_send_patient_bot_reply` path.
- Read/unread or delivery semantics: Unchanged; no notification delivery records, inbox state, or read/unread semantics are touched.
- Reconnect/resync proof: Telegram chat context is recomputed on each incoming message from the latest persisted `TelegramMessage.template_key`; the focused regression test seeds that persisted settings reply and verifies the next preference toggle returns the refreshed settings menu.

## Frontend Resilience

not applicable - no frontend files or browser UI behavior changed; `frontend` build still passed as a gate smoke check.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook.py`; `backend/tests/unit/test_telegram_webhook_security.py`.
- Denied paths: DB/Alembic, admin Telegram endpoints, staff-token/linking contracts, frontend Telegram manager, and notification delivery services were left untouched.
- Migration/docs/test impact: No migration or docs impact; unit regression coverage added for patient settings menu behavior.
- Rollback note: Remove settings-context handling from `_set_notification_consent` and remove the new regression test.

## Validation

- Targeted tests or smoke run: `python scripts/agent_gate.py ... --known-root-cause backend/app/api/v1/endpoints/telegram_webhook.py` via bundled Python; `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_webhook_security.py` via bundled Python; `git diff --check -- backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_webhook_security.py`; `cd frontend; npm.cmd run build`.
- Result: Passed locally; frontend build completed with existing chunk-size/static-dynamic import warnings only.
- Not checked: Targeted pytest could not run locally because this session has no system Python, `py -3` reports no installed Python, and the repo venv scripts point to a missing `C:\Users\DrSapaev\AppData\Local\Programs\Python\Python311\python.exe`; full backend suite and browser E2E were not run locally.