### PR TITLE
feat(telegram): ask consent after patient link

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -908,9 +908,9 @@ def _upsert_ticket_qr_telegram_user(
         db.flush()
         return
 
-    create_notifications_enabled = payload.pop("notifications_enabled", True)
-    create_appointment_reminders = payload.pop("appointment_reminders", True)
-    create_lab_notifications = payload.pop("lab_notifications", True)
+    create_notifications_enabled = payload.pop("notifications_enabled", False)
+    create_appointment_reminders = payload.pop("appointment_reminders", False)
+    create_lab_notifications = payload.pop("lab_notifications", False)
     db.add(
         TelegramUser(
             **payload,
@@ -2063,6 +2063,12 @@ async def _handle_ticket_qr_start(update: Dict[str, Any], db: Session, bot_servi
             return True
 
         try:
+            existing_telegram_user = crud_telegram.get_telegram_user_by_chat_id(
+                db, int(chat_id)
+            )
+            notifications_already_enabled = bool(
+                getattr(existing_telegram_user, "notifications_enabled", False)
+            )
             _upsert_ticket_qr_telegram_user(db, message, visit.patient_id)
             db.commit()
         except Exception as exc:
@@ -2081,11 +2087,15 @@ async def _handle_ticket_qr_start(update: Dict[str, Any], db: Session, bot_servi
             )
             return True
 
-        await bot_service._send_message(
-            int(chat_id),
-            _telegram_chat_text(db, int(chat_id), "ticket_qr_linked"),
-            _telegram_chat_menu(db, int(chat_id)),
-        )
+        language = _telegram_chat_language(db, int(chat_id))
+        reply_text = _telegram_chat_text(db, int(chat_id), "ticket_qr_linked")
+        reply_markup = _telegram_chat_menu(db, int(chat_id))
+        if not notifications_already_enabled:
+            reply_text = (
+                f"{reply_text}\n\n{_localized_text('notification_consent', language)}"
+            )
+            reply_markup = _localized_notification_consent_menu(language)
+        await bot_service._send_message(int(chat_id), reply_text, reply_markup)
     elif chat_id is not None:
         language = _telegram_chat_language(db, int(chat_id))
         await bot_service._send_message(
@@ -2836,6 +2846,21 @@ async def _send_notification_consent(
     )
 
 
+def _patient_contact_linked_text(
+    language_code: str,
+    patient_label: str,
+    patient_name: str,
+    include_notification_consent: bool,
+) -> str:
+    text = (
+        f"{_localized_text('contact_linked', language_code)}\n"
+        f"{patient_label}: {patient_name}"
+    )
+    if include_notification_consent:
+        return f"{text}\n\n{_localized_text('notification_consent', language_code)}"
+    return text
+
+
 async def _set_notification_consent(
     db: Session, bot_service, chat_id: int, enabled: bool
 ) -> None:
@@ -2905,6 +2930,12 @@ async def _handle_contact_link(
         return True
 
     try:
+        existing_telegram_user = crud_telegram.get_telegram_user_by_chat_id(
+            db, int(chat_id)
+        )
+        notifications_already_enabled = bool(
+            getattr(existing_telegram_user, "notifications_enabled", False)
+        )
         _upsert_ticket_qr_telegram_user(db, message, patient.id)
         db.commit()
     except Exception as exc:
@@ -2924,13 +2955,21 @@ async def _handle_contact_link(
         return True
 
     language = _telegram_chat_language(db, chat_id)
+    reply_markup = _localized_main_menu(language)
+    if not notifications_already_enabled:
+        reply_markup = _localized_notification_consent_menu(language)
     patient_label = "Bemor" if language == TELEGRAM_LANGUAGE_UZ else "Пациент"
     await _send_patient_bot_reply(
         db,
         bot_service,
         chat_id,
-        f"{_localized_text('contact_linked', language)}\n{patient_label}: {_patient_display_name(patient)}",
-        _localized_main_menu(language),
+        _patient_contact_linked_text(
+            language,
+            patient_label,
+            _patient_display_name(patient),
+            not notifications_already_enabled,
+        ),
+        reply_markup,
         "telegram_patient_contact_linked",
     )
     return True

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -1021,6 +1021,91 @@ class TestTelegramWebhookSecurity:
         assert handled is True
         assert calls == ["staff"]
 
+    @pytest.mark.asyncio
+    async def test_contact_link_new_user_prompts_notification_consent(
+        self, db_session, test_patient
+    ):
+        fake_service = FakeTelegramBotService(active=True)
+        message = {
+            "message_id": 1,
+            "chat": {"id": 7024},
+            "from": {"id": 7024, "language_code": "ru"},
+            "contact": {
+                "user_id": 7024,
+                "phone_number": test_patient.phone,
+            },
+        }
+
+        handled = await telegram_webhook._handle_contact_link(
+            message, db_session, fake_service
+        )
+
+        assert handled is True
+        telegram_user = (
+            db_session.query(TelegramUser)
+            .filter(TelegramUser.chat_id == 7024)
+            .one()
+        )
+        assert telegram_user.patient_id == test_patient.id
+        assert telegram_user.notifications_enabled is False
+        assert telegram_user.appointment_reminders is False
+        assert telegram_user.lab_notifications is False
+        chat_id, text, reply_markup = fake_service._send_message.await_args.args
+        assert chat_id == 7024
+        assert telegram_webhook._localized_text("contact_linked", "ru") in text
+        assert telegram_webhook._localized_text("notification_consent", "ru") in text
+        assert reply_markup == telegram_webhook._localized_notification_consent_menu(
+            "ru"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ticket_qr_link_new_user_prompts_notification_consent(
+        self, db_session, test_patient, monkeypatch
+    ):
+        fake_service = FakeTelegramBotService(active=True)
+        monkeypatch.setattr(
+            telegram_webhook,
+            "consume_telegram_ticket_start_token",
+            lambda _db, _token: SimpleNamespace(patient_id=test_patient.id),
+        )
+        update = {
+            "update_id": 128,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7025},
+                "from": {"id": 7025, "language_code": "uz"},
+                "text": f"/start {telegram_webhook.TELEGRAM_TICKET_QR_PREFIX}_abc",
+            },
+        }
+
+        handled = await telegram_webhook._handle_ticket_qr_start(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        telegram_user = (
+            db_session.query(TelegramUser)
+            .filter(TelegramUser.chat_id == 7025)
+            .one()
+        )
+        assert telegram_user.patient_id == test_patient.id
+        assert telegram_user.notifications_enabled is False
+        assert telegram_user.appointment_reminders is False
+        assert telegram_user.lab_notifications is False
+        chat_id, text, reply_markup = fake_service._send_message.await_args.args
+        assert chat_id == 7025
+        assert (
+            telegram_webhook._localized_text("ticket_qr_linked", "uz-Latn")
+            in text
+        )
+        assert (
+            telegram_webhook._localized_text("notification_consent", "uz-Latn")
+            in text
+        )
+        assert reply_markup == telegram_webhook._localized_notification_consent_menu(
+            "uz-Latn"
+        )
+
     def test_queue_message_reports_linked_patient_position_and_cabinet(
         self, db_session, test_patient, test_daily_queue, test_queue_entry
     ):


### PR DESCRIPTION
## Summary

- Changes newly linked patient Telegram users to start with notifications disabled by default instead of silent opt-in.
- After ticket QR or contact linking, appends the localized notification consent prompt and returns the consent keyboard when notifications were not already enabled.
- Preserves main-menu behavior for users who had notifications already enabled and adds focused QR/contact regression tests.

## Contract Impact

- Canonical surface: patient Telegram bot QR/contact linking in `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Request shape: Unchanged; Telegram `/start <ticket_qr>` and contact-share update payloads are unchanged.
- Response shape: Newly linked users now receive the existing localized consent prompt and consent keyboard after successful QR/contact linking; already-enabled users still receive the normal linked response and main menu.
- Status codes: Unchanged; webhook HTTP handling and ack behavior are unchanged.
- Frontend consumer: Not applicable; this is Telegram bot chat UX only.
- Compatibility path or alias: Existing QR start prefix, contact share flow, and consent button aliases are unchanged.
- Contract proof: `backend/tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_contact_link_new_user_prompts_notification_consent`; `backend/tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_ticket_qr_link_new_user_prompts_notification_consent`.

## RBAC / Permissions

not applicable - patient Telegram linking behavior changes only notification opt-in state and chat reply markup; staff/admin permissions and authentication checks are untouched.

## Notification / Realtime

- Event type or websocket channel: No websocket or internal notification event type is added or changed; this only controls Telegram chat consent prompt behavior after patient linking.
- Payload version / ack behavior: Telegram webhook HTTP ack behavior is unchanged; QR/contact link handlers still return through the existing bot message send path.
- Read/unread or delivery semantics: Notification delivery records, inbox state, and read/unread semantics are untouched. New Telegram users now persist `notifications_enabled=False`, `appointment_reminders=False`, and `lab_notifications=False` until explicit consent.
- Reconnect/resync proof: Patient notification preference state is persisted on `TelegramUser`; regression tests cover both contact-link and ticket-QR creation paths and assert the stored flags remain disabled before consent.

## Frontend Resilience

not applicable - no frontend files or browser UI behavior changed; `frontend` build still passed as a gate smoke check.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook.py`; `backend/tests/unit/test_telegram_webhook_security.py`.
- Denied paths: DB/Alembic, admin Telegram endpoints, staff-token/linking contracts, frontend Telegram manager, and notification delivery services were left untouched.
- Migration/docs/test impact: No migration or docs impact; unit regression coverage added for QR/contact link notification consent behavior.
- Rollback note: Restore new Telegram user notification defaults to enabled and remove the QR/contact consent prompt tests.

## Validation

- Targeted tests or smoke run: `python scripts/agent_gate.py ... --known-root-cause backend/app/api/v1/endpoints/telegram_webhook.py` via bundled Python; `python -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_webhook_security.py` via bundled Python; `git diff --check -- backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_webhook_security.py`; `cd frontend; npm.cmd run build`.
- Result: Passed locally; frontend build completed with existing chunk-size/static-dynamic import warnings only.
- Not checked: Targeted pytest could not run locally because this session has no system Python, `py -3` reports no installed Python, and the repo venv scripts point to a missing `C:\Users\DrSapaev\AppData\Local\Programs\Python\Python311\python.exe`; full backend suite and browser E2E were not run locally.