### PR TITLE
fix(telegram): shorten ticket QR token ttl

### DIFF
--- a/backend/app/services/visit_confirmation_service.py
+++ b/backend/app/services/visit_confirmation_service.py
@@ -36,7 +36,7 @@ CANONICAL_ACTIVE_CONFIRMATION_STATUSES = (
 TELEGRAM_TICKET_QR_PREFIX = "tq"
 TELEGRAM_TICKET_QR_HASH_PREFIX = "ticket_qr:"
 TELEGRAM_TICKET_QR_SEPARATOR = "_"
-TELEGRAM_TICKET_QR_TTL_HOURS = 24
+TELEGRAM_TICKET_QR_TTL_MINUTES = 15
 TELEGRAM_USERNAME_RE = re.compile(r"^[A-Za-z0-9_]{5,32}$")
 
 
@@ -759,7 +759,9 @@ class VisitConfirmationService:
         if not bot_username:
             return None
 
-        expires_at = datetime.utcnow() + timedelta(hours=TELEGRAM_TICKET_QR_TTL_HOURS)
+        expires_at = datetime.utcnow() + timedelta(
+            minutes=TELEGRAM_TICKET_QR_TTL_MINUTES
+        )
         token = build_telegram_ticket_start_token(expires_at=expires_at)
         visit.confirmation_token = _hash_telegram_ticket_start_token(token)
         visit.confirmation_expires_at = expires_at

--- a/backend/tests/unit/test_visit_confirmation_service.py
+++ b/backend/tests/unit/test_visit_confirmation_service.py
@@ -6,10 +6,13 @@ import pytest
 
 from app.models.online_queue import DailyQueue
 from app.models.service import Service
+from app.models.telegram_config import TelegramConfig
 from app.models.visit import VisitService
 from app.services.visit_confirmation_service import (
+    TELEGRAM_TICKET_QR_TTL_MINUTES,
     VisitConfirmationDomainError,
     VisitConfirmationService,
+    parse_telegram_ticket_start_token,
 )
 
 
@@ -111,3 +114,45 @@ class TestVisitConfirmationService:
         assert daily_queue is not None
         assert daily_queue.specialist_id == test_doctor.id
         assert print_tickets[0]["doctor_cabinet"] == test_doctor.cabinet
+
+    def test_ticket_telegram_qr_payload_uses_short_security_ttl(
+        self, db_session, test_visit
+    ):
+        db_session.add(
+            TelegramConfig(
+                bot_token="bot-token",
+                bot_username="clinic_bot",
+                active=True,
+            )
+        )
+        db_session.commit()
+
+        confirmation_service = VisitConfirmationService(db_session)
+        issued_at = datetime.utcnow()
+
+        payload = confirmation_service._build_ticket_telegram_qr_payload(test_visit)
+
+        assert payload is not None
+        assert payload.startswith("https://t.me/clinic_bot?start=")
+        assert test_visit.confirmation_token is not None
+        assert test_visit.confirmation_expires_at is not None
+        assert 5 <= TELEGRAM_TICKET_QR_TTL_MINUTES <= 15
+        assert (
+            0
+            < (test_visit.confirmation_expires_at - issued_at).total_seconds()
+            <= (TELEGRAM_TICKET_QR_TTL_MINUTES * 60) + 2
+        )
+
+        token = payload.rsplit("start=", 1)[1]
+        parsed = parse_telegram_ticket_start_token(token)
+
+        assert parsed is not None
+        assert parsed["token_hash"] == test_visit.confirmation_token
+        assert (
+            abs(
+                (
+                    parsed["expires_at"] - test_visit.confirmation_expires_at
+                ).total_seconds()
+            )
+            <= 1
+        )


### PR DESCRIPTION
## Summary

- Shortens generated Telegram ticket QR `/start` token validity from 24 hours to 15 minutes.
- Keeps the signed opaque token and hash-only storage contract unchanged.
- Adds a focused unit regression that verifies the configured TTL window, persisted expiry, and parsed token hash alignment.

## Contract Impact

- Canonical surface: Telegram ticket QR payload generation in `backend/app/services/visit_confirmation_service.py`.
- Request shape: Unchanged; Telegram `/start <ticket_qr>` payload format remains the existing signed opaque token.
- Response shape: Printed ticket `qr_payload` URL shape is unchanged; only the generated token expiry is shorter.
- Status codes: Unchanged; QR/start consumption and webhook responses are unchanged.
- Frontend consumer: Not changed; frontend files and API contracts are untouched.
- Compatibility path or alias: Existing `tq_...` token prefix, parser, token hash, and one-time consumption path are preserved.
- Contract proof: `backend/tests/unit/test_visit_confirmation_service.py::TestVisitConfirmationService::test_ticket_telegram_qr_payload_uses_short_security_ttl`.

## RBAC / Permissions

not applicable - this patch changes patient QR token lifetime only; staff/admin roles, permissions, and authentication checks are untouched.

## Notification / Realtime

- Event type or websocket channel: No notification, websocket, or realtime event is added or changed.
- Payload version / ack behavior: Telegram webhook ack behavior is unchanged; expired QR/start tokens continue to be rejected by the existing parser/consumer path.
- Read/unread or delivery semantics: Unchanged; no notification delivery record, inbox state, or read/unread behavior is touched.
- Reconnect/resync proof: The token expiry is encoded in the signed token and mirrored in `Visit.confirmation_expires_at`; the focused regression parses the generated token and checks it matches the stored hash/expiry contract.

## Frontend Resilience

not applicable - no frontend files or browser UI behavior changed; `frontend` build still passed as the gate smoke check.

## Scope Gate

- Allowed paths: `backend/app/services/visit_confirmation_service.py`; `backend/tests/unit/test_visit_confirmation_service.py`.
- Denied paths: DB/Alembic, Telegram webhook handlers, admin Telegram endpoints, frontend Telegram manager, and queue mutation paths were left untouched.
- Migration/docs/test impact: No migration impact; focused unit coverage added for generated ticket QR token TTL.
- Rollback note: Restore the ticket QR TTL constant to the previous 24-hour behavior and remove the focused regression test.
- Gate note: `agent_gate.py` returned `narrow override` with `gate_misroute=yes`, `override_used=yes`, and known root cause `backend/app/services/visit_confirmation_service.py`; execution stayed on the confirmed service owner plus its focused unit test.

## Validation

- Targeted tests or smoke run: `python scripts/agent_gate.py ... --known-root-cause backend/app/services/visit_confirmation_service.py` via bundled Python; `python -m py_compile backend\app\services\visit_confirmation_service.py backend\tests\unit\test_visit_confirmation_service.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py` via bundled Python; `git diff --check -- backend\app\services\visit_confirmation_service.py backend\tests\unit\test_visit_confirmation_service.py`; `cd frontend; npm.cmd run build`.
- Result: Passed locally; frontend build completed with existing static/dynamic import and chunk-size warnings only.
- Not checked: Targeted pytest could not run locally because bundled Python has no `pytest`, `py -3` reports no installed Python, and the repo venv points to missing `C:\Users\DrSapaev\AppData\Local\Programs\Python\Python311\python.exe`; full backend suite and browser E2E were not run locally.