### PR TITLE
test(telegram): cover patient onboarding consent flow

### DIFF
--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -1106,6 +1106,137 @@ class TestTelegramWebhookSecurity:
             "uz-Latn"
         )
 
+    @pytest.mark.asyncio
+    async def test_patient_onboarding_contact_consent_reaches_localized_menu(
+        self, db_session, test_patient
+    ):
+        chat_id = 7026
+        fake_service = FakeTelegramBotService(active=True)
+        start_update = {
+            "update_id": 129,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": chat_id},
+                "from": {"id": chat_id, "language_code": "ru"},
+                "text": "/start",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            start_update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once_with(
+            chat_id,
+            telegram_webhook._localized_text("language_prompt", "ru"),
+            telegram_webhook.TELEGRAM_LANGUAGE_MENU,
+        )
+        fake_service._send_message.reset_mock()
+
+        language_update = {
+            "update_id": 130,
+            "message": {
+                "message_id": 2,
+                "chat": {"id": chat_id},
+                "from": {"id": chat_id, "language_code": "ru"},
+                "text": "O'zbekcha",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            language_update, db_session, fake_service
+        )
+
+        assert handled is True
+        telegram_user = (
+            db_session.query(TelegramUser)
+            .filter(TelegramUser.chat_id == chat_id)
+            .one()
+        )
+        assert telegram_user.language_code == "uz-Latn"
+        assert telegram_user.patient_id is None
+        assert telegram_user.notifications_enabled is False
+        fake_service._send_message.assert_awaited_once_with(
+            chat_id,
+            telegram_webhook._localized_text("language_selected", "uz-Latn"),
+            telegram_webhook._localized_main_menu("uz-Latn"),
+        )
+        fake_service._send_message.reset_mock()
+
+        contact_update = {
+            "update_id": 131,
+            "message": {
+                "message_id": 3,
+                "chat": {"id": chat_id},
+                "from": {"id": chat_id, "language_code": "uz"},
+                "contact": {
+                    "user_id": chat_id,
+                    "phone_number": test_patient.phone,
+                },
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            contact_update, db_session, fake_service
+        )
+
+        assert handled is True
+        db_session.refresh(telegram_user)
+        assert telegram_user.patient_id == test_patient.id
+        assert telegram_user.notifications_enabled is False
+        chat_arg, text_arg, reply_markup = fake_service._send_message.await_args.args
+        assert chat_arg == chat_id
+        assert telegram_webhook._localized_text("contact_linked", "uz-Latn") in text_arg
+        assert (
+            telegram_webhook._localized_text("notification_consent", "uz-Latn")
+            in text_arg
+        )
+        assert reply_markup == telegram_webhook._localized_notification_consent_menu(
+            "uz-Latn"
+        )
+        fake_service._send_message.reset_mock()
+
+        consent_update = {
+            "update_id": 132,
+            "message": {
+                "message_id": 4,
+                "chat": {"id": chat_id},
+                "from": {"id": chat_id, "language_code": "uz"},
+                "text": "Xabarnomalarga roziman",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            consent_update, db_session, fake_service
+        )
+
+        assert handled is True
+        db_session.refresh(telegram_user)
+        assert telegram_user.notifications_enabled is True
+        assert telegram_user.appointment_reminders is True
+        assert telegram_user.lab_notifications is True
+        fake_service._send_message.assert_awaited_once_with(
+            chat_id,
+            telegram_webhook._localized_text("notifications_enabled", "uz-Latn"),
+            telegram_webhook._localized_main_menu("uz-Latn"),
+        )
+        template_keys = [
+            row.template_key
+            for row in (
+                db_session.query(TelegramMessage)
+                .filter(TelegramMessage.chat_id == chat_id)
+                .order_by(TelegramMessage.id.asc())
+                .all()
+            )
+        ]
+        assert template_keys == [
+            "telegram_patient_language_prompt",
+            "telegram_patient_language_selected",
+            "telegram_patient_contact_linked",
+            "telegram_patient_notifications_enabled",
+        ]
+
     def test_queue_message_reports_linked_patient_position_and_cabinet(
         self, db_session, test_patient, test_daily_queue, test_queue_entry
     ):


### PR DESCRIPTION
## Summary

- Adds a focused regression for the patient Telegram onboarding path: `/start`, language selection, trusted contact linking, notification consent, and final localized main menu.
- Verifies the linked Telegram user keeps Uzbek Latin language, starts with notifications disabled, and enables all notification flags only after consent.
- Verifies the persisted patient bot reply template sequence for the onboarding flow.

## Contract Impact

- Canonical surface: patient Telegram bot update handling in `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Request shape: Unchanged; this is test-only coverage for existing Telegram update payload handling.
- Response shape: Unchanged; the regression asserts the current localized prompts, consent keyboard, and final main menu behavior.
- Status codes: Unchanged; no endpoint or webhook response behavior changes.
- Frontend consumer: Not changed; frontend files and API contracts are untouched.
- Compatibility path or alias: Existing `/start`, plain `O'zbekcha`, trusted contact share, and `Xabarnomalarga roziman` aliases are preserved.
- Contract proof: `backend/tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_patient_onboarding_contact_consent_reaches_localized_menu`.

## RBAC / Permissions

not applicable - this patch is test-only and does not change staff/admin permissions, patient authorization, or role checks.

## Notification / Realtime

- Event type or websocket channel: No notification event, websocket channel, or realtime payload is added or changed.
- Payload version / ack behavior: Telegram webhook ack behavior is unchanged; the test exercises existing patient bot update handling only.
- Read/unread or delivery semantics: Unchanged; no notification delivery record, inbox state, or read/unread behavior is touched.
- Reconnect/resync proof: The regression verifies persisted `TelegramMessage.template_key` ordering for the onboarding replies so later chat-context logic can resync from saved bot replies.

## Frontend Resilience

not applicable - no frontend files or browser UI behavior changed; `frontend` build still passed as the gate smoke check.

## Scope Gate

- Allowed paths: `backend/tests/unit/test_telegram_webhook_security.py`.
- Denied paths: Telegram runtime handlers, DB/Alembic, admin Telegram endpoints, frontend Telegram manager, and notification delivery services were left untouched.
- Migration/docs/test impact: No migration or docs impact; focused unit regression coverage added for completed patient onboarding.
- Rollback note: Remove the new regression test; runtime behavior is unchanged.
- Gate note: `agent_gate.py` returned `narrow override` with `gate_misroute=yes`, `override_used=yes`, and known root cause `backend/tests/unit/test_telegram_webhook_security.py`; execution stayed test-only.

## Validation

- Targeted tests or smoke run: `python scripts/agent_gate.py ... --known-root-cause backend/tests/unit/test_telegram_webhook_security.py` via bundled Python; `python -m py_compile backend\tests\unit\test_telegram_webhook_security.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py` via bundled Python; `git diff --check -- backend\tests\unit\test_telegram_webhook_security.py`; `cd frontend; npm.cmd run build`; local PR review body gate.
- Result: Passed locally; frontend build completed with existing static/dynamic import and chunk-size warnings only.
- Not checked: Targeted pytest could not run locally because bundled Python has no `pytest`, `py -3` reports no installed Python, and the repo venv points to missing `C:\Users\DrSapaev\AppData\Local\Programs\Python\Python311\python.exe`; full backend suite and browser E2E were not run locally.