### PR TITLE
fix(telegram): honor notification preferences

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_notifications.py
+++ b/backend/app/api/v1/endpoints/telegram_notifications.py
@@ -24,6 +24,19 @@ from app.services.telegram_templates import get_telegram_templates_service
 router = APIRouter()
 
 
+def _telegram_notification_allowed(telegram_user: Any, *preference_fields: str) -> bool:
+    if not bool(getattr(telegram_user, "notifications_enabled", True)):
+        return False
+    return all(bool(getattr(telegram_user, field, True)) for field in preference_fields)
+
+
+def _telegram_notifications_disabled_response() -> Dict[str, Any]:
+    return {
+        "success": False,
+        "message": "Telegram notifications disabled by patient preference",
+    }
+
+
 @router.post("/send-appointment-reminder")
 async def send_appointment_reminder(
     appointment_id: int,
@@ -55,6 +68,11 @@ async def send_appointment_reminder(
                 "success": False,
                 "message": "Пациент не зарегистрирован в Telegram боте",
             }
+
+        if not _telegram_notification_allowed(
+            telegram_user, "appointment_reminders"
+        ):
+            return _telegram_notifications_disabled_response()
 
         # Получаем сервис бота
         bot_service = await get_telegram_bot_service()
@@ -132,6 +150,9 @@ async def send_lab_results(
                 "success": False,
                 "message": "Пациент не зарегистрирован в Telegram боте",
             }
+
+        if not _telegram_notification_allowed(telegram_user, "lab_notifications"):
+            return _telegram_notifications_disabled_response()
 
         # Получаем данные анализов
         lab_results = []
@@ -232,6 +253,9 @@ async def send_payment_confirmation(
                 "success": False,
                 "message": "Пациент не зарегистрирован в Telegram боте",
             }
+
+        if not _telegram_notification_allowed(telegram_user):
+            return _telegram_notifications_disabled_response()
 
         # Получаем сервис бота
         bot_service = await get_telegram_bot_service()

--- a/backend/tests/unit/test_telegram_notifications_privacy.py
+++ b/backend/tests/unit/test_telegram_notifications_privacy.py
@@ -144,6 +144,65 @@ async def test_send_appointment_reminder_unregistered_response_hides_patient_pho
 
 
 @pytest.mark.asyncio
+async def test_send_appointment_reminder_respects_notification_preferences(
+    monkeypatch,
+):
+    patient = SimpleNamespace(
+        phone="+998901234567",
+        full_name="Sensitive Patient",
+    )
+    appointment = SimpleNamespace(id=456, patient_id=123)
+    telegram_user = SimpleNamespace(
+        chat_id=998877,
+        language_code="ru",
+        notifications_enabled=True,
+        appointment_reminders=False,
+    )
+    get_bot_service = AsyncMock()
+
+    monkeypatch.setattr(
+        telegram_notifications.crud_appointment,
+        "get_appointment",
+        lambda _db, _appointment_id: appointment,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: telegram_user,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications,
+        "get_telegram_bot_service",
+        get_bot_service,
+    )
+
+    response = await telegram_notifications.send_appointment_reminder(
+        appointment_id=456,
+        reminder_type="24h",
+        background_tasks=BackgroundTasks(),
+        db=object(),
+        current_user=SimpleNamespace(role="Registrar"),
+    )
+
+    assert response == {
+        "success": False,
+        "message": "Telegram notifications disabled by patient preference",
+    }
+    assert "+998901234567" not in str(response)
+    assert "Sensitive Patient" not in str(response)
+    assert "998877" not in str(response)
+    get_bot_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_send_lab_results_response_hides_patient_contact_metadata(monkeypatch):
     patient = SimpleNamespace(
         phone="+998901234567",
@@ -253,6 +312,56 @@ async def test_send_lab_results_unregistered_response_hides_patient_phone(
 
 
 @pytest.mark.asyncio
+async def test_send_lab_results_respects_notification_preferences(monkeypatch):
+    patient = SimpleNamespace(
+        phone="+998901234567",
+        full_name="Sensitive Patient",
+    )
+    telegram_user = SimpleNamespace(
+        chat_id=998877,
+        language_code="ru",
+        notifications_enabled=True,
+        lab_notifications=False,
+    )
+    get_bot_service = AsyncMock()
+
+    monkeypatch.setattr(
+        telegram_notifications.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: telegram_user,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications,
+        "get_telegram_bot_service",
+        get_bot_service,
+    )
+
+    response = await telegram_notifications.send_lab_results(
+        patient_id=123,
+        lab_result_ids=[456],
+        background_tasks=BackgroundTasks(),
+        db=object(),
+        current_user=SimpleNamespace(role="Lab"),
+    )
+
+    assert response == {
+        "success": False,
+        "message": "Telegram notifications disabled by patient preference",
+    }
+    assert "+998901234567" not in str(response)
+    assert "Sensitive Patient" not in str(response)
+    assert "998877" not in str(response)
+    get_bot_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_send_payment_confirmation_response_hides_patient_contact_metadata(
     monkeypatch,
 ):
@@ -350,3 +459,54 @@ async def test_send_payment_confirmation_unregistered_response_hides_patient_pho
     assert "patient_phone" not in response
     assert "+998901234567" not in str(response)
     assert "Sensitive Patient" not in str(response)
+
+
+@pytest.mark.asyncio
+async def test_send_payment_confirmation_respects_global_notification_preference(
+    monkeypatch,
+):
+    patient = SimpleNamespace(
+        phone="+998901234567",
+        full_name="Sensitive Patient",
+    )
+    telegram_user = SimpleNamespace(
+        chat_id=998877,
+        language_code="ru",
+        notifications_enabled=False,
+    )
+    get_bot_service = AsyncMock()
+
+    monkeypatch.setattr(
+        telegram_notifications.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: telegram_user,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications,
+        "get_telegram_bot_service",
+        get_bot_service,
+    )
+
+    response = await telegram_notifications.send_payment_confirmation(
+        patient_id=123,
+        payment_data={"amount": 125000, "transaction_id": "txn-secret"},
+        background_tasks=BackgroundTasks(),
+        db=object(),
+        current_user=SimpleNamespace(role="Cashier"),
+    )
+
+    assert response == {
+        "success": False,
+        "message": "Telegram notifications disabled by patient preference",
+    }
+    assert "+998901234567" not in str(response)
+    assert "Sensitive Patient" not in str(response)
+    assert "998877" not in str(response)
+    get_bot_service.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Adds a shared Telegram notification preference guard for direct appointment, lab, and payment send endpoints.
- Blocks appointment reminders when `appointment_reminders` is disabled, lab result sends when `lab_notifications` is disabled, and payment confirmations when global patient Telegram notifications are disabled.
- Adds focused privacy regressions proving disabled preferences do not call the Telegram bot service and do not leak patient phone/name/chat id in responses.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/telegram_notifications.py` direct staff-triggered Telegram notification endpoints.
- Request shape: unchanged for appointment reminder, lab results, and payment confirmation endpoints.
- Response shape: existing successful and unregistered responses are unchanged. A registered patient with disabled Telegram notification preferences now receives `{ "success": false, "message": "Telegram notifications disabled by patient preference" }` instead of a bot send attempt.
- Status codes: unchanged; preference opt-out returns the existing JSON response style instead of raising HTTP errors.
- Frontend consumer: not changed; frontend build still passes.
- Compatibility path or alias: existing Telegram user rows without mocked preference attributes keep permissive default behavior in tests; real DB columns are non-null booleans.
- Contract proof: `backend/tests/unit/test_telegram_notifications_privacy.py` adds disabled-preference coverage for appointment, lab, and payment sends.

## RBAC / Permissions

- Roles allowed: unchanged: appointment reminders allow Admin, Registrar, Doctor; lab results allow Admin, Lab, Doctor; payment confirmations allow Admin, Cashier.
- Roles denied: unchanged through existing `require_roles(...)` dependencies for all other roles.
- Positive auth proof: dependency declarations remain unchanged and existing endpoint tests continue to exercise direct function behavior.
- Negative auth proof: not checked locally; no auth dependency or role list was changed in this patch.

## Notification / Realtime

- Event type or websocket channel: no websocket/internal notification event changed.
- Payload version / ack behavior: HTTP response style remains JSON with `success: false` for non-delivery cases.
- Read/unread or delivery semantics: direct Telegram delivery now short-circuits before `get_telegram_bot_service()` when patient preferences disallow the message type; no read/unread or delivery record model is touched.
- Reconnect/resync proof: preferences are read from the persisted Telegram user record found by patient phone at send time.

## Frontend Resilience

- Empty data proof: not applicable, no frontend data rendering changed.
- Partial data proof: not applicable, no frontend consumer or response parser changed.
- Forbidden secondary path behavior: not applicable, no frontend secondary path changed.
- Missing draft/resource behavior: not applicable, these Telegram send endpoints do not create or reopen frontend drafts/resources.
- Stale route/deep-link behavior: not applicable, no frontend route or deep-link state changed.

## Scope Gate

- Selected mode: `gate_known_root_cause`, then `narrow_override` after the local gate widened first-touch files beyond this confirmed endpoint/test slice.
- gate_misroute: yes.
- override_used: yes.
- known_root_cause_file: `backend/app/api/v1/endpoints/telegram_notifications.py`.
- Allowed paths: `backend/app/api/v1/endpoints/telegram_notifications.py`; `backend/tests/unit/test_telegram_notifications_privacy.py`.
- Denied paths: DB/Alembic, Telegram webhook onboarding/settings, admin Telegram config, frontend Telegram manager, and notification event services were left untouched.
- Migration/docs/test impact: no migration or docs impact; focused unit coverage added.
- Rollback note: remove `_telegram_notification_allowed`, the three endpoint short-circuits, and the three new privacy tests.

## Validation

- Targeted tests or smoke run: local gate with known root cause; bundled-Python `py_compile` over Telegram notification/webhook/admin endpoint and privacy test; `git diff --check` over touched files; frontend `npm.cmd run build`; attempted targeted pytest.
- Result: gate returned narrow override as documented; `py_compile` passed; `git diff --check` passed; frontend build passed with existing Vite dynamic/static import and chunk-size warnings only; targeted pytest could not start locally because bundled Python has no `pytest` module.
- Not checked: local pytest execution, full backend suite, browser E2E, and live Telegram delivery; GitHub CI remains the backend test authority.
