### PR TITLE
fix(telegram): sanitize payment confirmation content

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_notifications.py
+++ b/backend/app/api/v1/endpoints/telegram_notifications.py
@@ -23,6 +23,9 @@ from app.services.telegram_templates import get_telegram_templates_service
 
 router = APIRouter()
 
+PROTECTED_PAYMENT_HISTORY_URL = "https://clinic.example.com/patient/payments"
+PROTECTED_PAYMENT_REFERENCE = "available-in-protected-account"
+
 
 def _telegram_notification_allowed(telegram_user: Any, *preference_fields: str) -> bool:
     if not bool(getattr(telegram_user, "notifications_enabled", True)):
@@ -34,6 +37,17 @@ def _telegram_notifications_disabled_response() -> Dict[str, Any]:
     return {
         "success": False,
         "message": "Telegram notifications disabled by patient preference",
+    }
+
+
+def _safe_payment_template_data(payment_data: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "amount": payment_data.get("amount", 0),
+        "currency": payment_data.get("currency", "UZS"),
+        "payment_method": payment_data.get("payment_method", "Карта"),
+        "payment_date": datetime.now().strftime("%d.%m.%Y %H:%M"),
+        "transaction_id": PROTECTED_PAYMENT_REFERENCE,
+        "receipt_link": PROTECTED_PAYMENT_HISTORY_URL,
     }
 
 
@@ -263,15 +277,7 @@ async def send_payment_confirmation(
             await bot_service.initialize(db)
 
         # Формируем данные для шаблона
-        template_data = {
-            "patient_name": patient.full_name,
-            "amount": payment_data.get("amount", 0),
-            "currency": payment_data.get("currency", "UZS"),
-            "payment_method": payment_data.get("payment_method", "Карта"),
-            "payment_date": datetime.now().strftime("%d.%m.%Y %H:%M"),
-            "transaction_id": payment_data.get("transaction_id", "N/A"),
-            "receipt_link": f"https://clinic.example.com/receipt/{payment_data.get('transaction_id')}",
-        }
+        template_data = _safe_payment_template_data(payment_data)
 
         # Получаем шаблон
         templates_service = get_telegram_templates_service()

--- a/backend/tests/unit/test_telegram_notifications_privacy.py
+++ b/backend/tests/unit/test_telegram_notifications_privacy.py
@@ -421,8 +421,74 @@ async def test_send_payment_confirmation_response_hides_patient_contact_metadata
         text="Lab results are ready",
         reply_markup=None,
     )
-    assert templates_service.template_data["patient_name"] == "Sensitive Patient"
     assert templates_service.template_data["amount"] == 125000
+    assert "patient_name" not in templates_service.template_data
+    assert templates_service.template_data["transaction_id"] == (
+        "available-in-protected-account"
+    )
+    assert templates_service.template_data["receipt_link"] == (
+        "https://clinic.example.com/patient/payments"
+    )
+    assert "txn-secret" not in str(templates_service.template_data)
+
+
+@pytest.mark.asyncio
+async def test_send_payment_confirmation_message_omits_raw_payment_identifiers(
+    monkeypatch,
+):
+    patient = SimpleNamespace(
+        phone="+998901234567",
+        full_name="Sensitive Patient",
+    )
+    telegram_user = SimpleNamespace(chat_id=998877, language_code="ru")
+    bot_service = SimpleNamespace(
+        active=True,
+        initialize=AsyncMock(),
+        _send_message=AsyncMock(return_value=True),
+    )
+
+    monkeypatch.setattr(
+        telegram_notifications.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: telegram_user,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications,
+        "get_telegram_bot_service",
+        AsyncMock(return_value=bot_service),
+    )
+
+    response = await telegram_notifications.send_payment_confirmation(
+        patient_id=123,
+        payment_data={
+            "amount": 125000,
+            "transaction_id": "txn-secret-internal",
+            "invoice_id": "invoice-secret-internal",
+            "receipt_id": "receipt-secret-internal",
+            "receipt_link": "https://clinic.example.com/receipt/txn-secret-internal",
+        },
+        background_tasks=BackgroundTasks(),
+        db=object(),
+        current_user=SimpleNamespace(role="Cashier"),
+    )
+
+    assert response["success"] is True
+    sent_message = bot_service._send_message.await_args.kwargs
+    telegram_payload = f"{sent_message['text']} {sent_message['reply_markup']}"
+    assert "125000" in sent_message["text"]
+    assert "txn-secret-internal" not in telegram_payload
+    assert "invoice-secret-internal" not in telegram_payload
+    assert "receipt-secret-internal" not in telegram_payload
+    assert "/receipt/" not in telegram_payload
+    assert "Sensitive Patient" not in telegram_payload
+    assert "https://clinic.example.com/patient/payments" in telegram_payload
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Sanitizes Telegram payment confirmation template data so raw payment transaction IDs, invoice IDs, receipt IDs, and receipt-specific URLs are not exposed in patient chat messages.
- Routes the payment receipt button to a generic protected payment-history URL instead of `/receipt/{transaction_id}`.
- Adds focused privacy coverage using the real Telegram template service to assert the final sent Telegram payload contains only safe payment summary content.

## Contract Impact

- Canonical surface: `backend/app/api/v1/endpoints/telegram_notifications.py` payment confirmation send endpoint.
- Request shape: unchanged; `patient_id` and `payment_data` inputs are still accepted as before.
- Response shape: unchanged for success, unregistered patient, and preference-disabled responses.
- Status codes: unchanged; this patch only sanitizes outgoing Telegram template data.
- Frontend consumer: not changed; frontend build still passes.
- Compatibility path or alias: the existing `payment_confirmation` template still receives the keys it expects (`transaction_id` and `receipt_link`), but those values are now safe placeholders/generic protected URL.
- Contract proof: `backend/tests/unit/test_telegram_notifications_privacy.py::test_send_payment_confirmation_message_omits_raw_payment_identifiers` checks the actual Telegram payload built from the real template service.

## RBAC / Permissions

- Roles allowed: unchanged, payment confirmation remains limited to Admin and Cashier through the existing dependency.
- Roles denied: unchanged through the existing `require_roles("Admin", "Cashier")` dependency for all other roles.
- Positive auth proof: dependency declaration is unchanged and direct endpoint tests continue to exercise successful send behavior.
- Negative auth proof: not checked locally; no auth dependency or role list was changed in this patch.

## Notification / Realtime

- Event type or websocket channel: no websocket/internal notification event changed.
- Payload version / ack behavior: Telegram payment confirmation still sends one message through the existing bot service path when allowed.
- Read/unread or delivery semantics: no delivery record, unread state, or notification history model is changed.
- Reconnect/resync proof: direct staff-triggered sends recompute sanitized template data from the current request on every call, and the focused test proves the final sent payload omits raw identifiers at send time.

## Frontend Resilience

- Empty data proof: not applicable, no frontend data rendering changed.
- Partial data proof: not applicable, no frontend consumer or response parser changed.
- Forbidden secondary path behavior: not applicable, no frontend secondary path changed.
- Missing draft/resource behavior: not applicable, this endpoint does not create or reopen frontend drafts/resources.
- Stale route/deep-link behavior: not applicable, no frontend route or deep-link state changed.

## Scope Gate

- Selected mode: `gate_known_root_cause`, then `narrow_override` after the local gate widened first-touch files beyond this confirmed endpoint/test slice.
- gate_misroute: yes.
- override_used: yes.
- known_root_cause_file: `backend/app/api/v1/endpoints/telegram_notifications.py`.
- Allowed paths: `backend/app/api/v1/endpoints/telegram_notifications.py`; `backend/tests/unit/test_telegram_notifications_privacy.py`.
- Denied paths: DB/Alembic, payment/billing services, Telegram webhook onboarding/settings, admin Telegram config, frontend Telegram manager, and notification event services were left untouched.
- Migration/docs/test impact: no migration or docs impact; focused unit coverage added/updated.
- Rollback note: restore the old payment template-data dict and remove the added raw-identifier payload assertion.

## Validation

- Targeted tests or smoke run: local gate with known root cause; bundled-Python `py_compile` over Telegram notification/webhook/admin endpoint and privacy test; `git diff --check` over touched files; frontend `npm.cmd run build`; attempted targeted pytest.
- Result: gate returned narrow override as documented; `py_compile` passed; `git diff --check` passed; frontend build passed with existing Vite dynamic/static import and chunk-size warnings only; targeted pytest could not start locally because bundled Python has no `pytest` module.
- Not checked: local pytest execution, full backend suite, browser E2E, and live Telegram delivery; GitHub CI remains the backend test authority.
