### PR TITLE
feat(telegram): expand localized settings menu

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -729,10 +729,22 @@ def _localized_notification_consent_menu(language_code: Any) -> Dict[str, Any]:
 
 
 def _localized_settings_menu(language_code: Any) -> Dict[str, Any]:
-    return TELEGRAM_SETTINGS_MENUS.get(
-        _normalize_patient_language(language_code),
+    language = _normalize_patient_language(language_code)
+    settings_menu = TELEGRAM_SETTINGS_MENUS.get(
+        language,
         TELEGRAM_SETTINGS_MENUS[TELEGRAM_LANGUAGE_RU],
     )
+    main_keyboard = _localized_main_menu(language).get("keyboard", [])
+    settings_keyboard = settings_menu.get("keyboard", [])
+    extra_rows = []
+    if len(main_keyboard) > 3:
+        extra_rows.append(main_keyboard[3])
+    if len(main_keyboard) > 4 and main_keyboard[4]:
+        extra_rows.append([main_keyboard[4][0]])
+    return {
+        **settings_menu,
+        "keyboard": settings_keyboard[:4] + extra_rows + settings_keyboard[4:],
+    }
 
 
 def _telegram_chat_language(db: Session, chat_id: int) -> str:


### PR DESCRIPTION
## Summary

- Expand the patient bot settings reply keyboard with the same localized patient actions already available from the main menu.
- Keep language and notification controls at the top of settings.
- No DB/schema, webhook secret, token, or transport contract changes.

## Contract Impact

- Canonical surface: Telegram patient bot reply keyboard generated by backend/app/api/v1/endpoints/telegram_webhook.py.
- Request shape: unchanged Telegram update payload handling.
- Response shape: Telegram reply_markup for settings now includes payments/results/profile rows in addition to existing settings controls.
- Status codes: not applicable - no HTTP API response contract changed.
- Frontend consumer: not applicable - no frontend consumer changed.
- Compatibility path or alias: existing command and text aliases remain unchanged.
- Contract proof: focused Telegram webhook tests passed and py_compile passed.

## RBAC / Permissions

- Roles allowed: unchanged; patient bot chat behavior only.
- Roles denied: unchanged; no staff/admin permissions changed.
- Positive auth proof: existing linked patient Telegram webhook tests passed.
- Negative auth proof: existing unlinked/contact rejection Telegram tests remain in the focused suite.

## Notification / Realtime

- Event type or websocket channel: Telegram patient bot chat reply only; no app notification event or websocket channel changed.
- Payload version / ack behavior: Telegram sendMessage payload shape remains the same; only reply_markup rows are expanded.
- Read/unread or delivery semantics: unchanged; no read/unread, delivery status, or TelegramMessage status semantics changed.
- Reconnect/resync proof: not applicable - no websocket reconnect path changed; menu is rebuilt per request from the saved Telegram language.

## Frontend Resilience

not applicable - no frontend runtime file or browser route changed; local frontend build was run as repository validation.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/telegram_webhook.py.
- Denied paths: DB migrations, queue allocation/fairness, Telegram token storage, frontend manager files, generated output.
- Migration/docs/test impact: no migration; no docs update; no test file edit because gate first-touch did not include tests.
- Rollback note: revert commit 0633868d to restore previous settings keyboard shape.

## Validation

- Targeted tests or smoke run: py_compile for admin_telegram.py and telegram_webhook.py; tests/unit/test_telegram_webhook_security.py -q; frontend npm.cmd run build.
- Result: py_compile passed; 35 Telegram webhook tests passed; frontend build passed with existing chunk-size warnings.
- Not checked: live Telegram click-through in the desktop client after merge/restart.