### PR TITLE
feat(telegram): guide onboarding and map patient events

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -3015,6 +3015,10 @@ async def _handle_clinic_bot_update(
         reply_text = _localized_text("language_selected", language)
         reply_markup = _localized_main_menu(language)
         template_key = "telegram_patient_language_selected"
+        linked_telegram_user = crud_telegram.get_telegram_user_by_chat_id(db, chat_id)
+        if not settings_context and not getattr(linked_telegram_user, "patient_id", None):
+            reply_text = f"{reply_text}\n\n{_localized_text('share_contact', language)}"
+            template_key = "telegram_patient_language_selected_needs_contact"
         if settings_context:
             reply_text = f"{reply_text}\n\n{_telegram_settings_message(db, chat_id)}"
             reply_markup = _localized_settings_menu(language)

--- a/backend/app/crud/telegram_config.py
+++ b/backend/app/crud/telegram_config.py
@@ -141,6 +141,41 @@ def get_telegram_user_by_linked_user_id(
     )
 
 
+def find_telegram_user_by_phone(db: Session, phone: str | None) -> TelegramUser | None:
+    """Find an active Telegram account linked to the patient with this phone."""
+    if not phone:
+        return None
+
+    try:
+        from app.crud.patient import find_patient
+
+        patient = find_patient(db, phone=phone)
+        if not patient:
+            return None
+
+        active_query = db.query(TelegramUser).filter(
+            and_(
+                TelegramUser.active == True,
+                TelegramUser.blocked == False,
+            )
+        )
+
+        telegram_user = (
+            active_query.filter(TelegramUser.patient_id == patient.id).first()
+        )
+        if telegram_user or not patient.user_id:
+            return telegram_user
+
+        return active_query.filter(TelegramUser.user_id == patient.user_id).first()
+
+    except Exception as e:
+        logger.warning(
+            "Telegram user lookup by phone failed error_type=%s",
+            type(e).__name__,
+        )
+        return None
+
+
 def get_telegram_users(
     db: Session, active_only: bool = True, skip: int = 0, limit: int = 100
 ) -> list[TelegramUser]:

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -3,6 +3,7 @@ import smtplib
 from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from html import escape
 from typing import Any
 
 import httpx
@@ -34,10 +35,17 @@ NOTIFICATION_EVENT_TYPE_ALIASES = {
     "queue_status": "queue_status_changed",
     "payment_update": "payment_notification",
     "payment_success": "payment_notification",
+    "paymentcreated": "payment_created",
+    "paymentpaid": "payment_paid",
     "result_ready": "lab_results",
     "lab_result_ready": "lab_results",
+    "labresultready": "lab_results",
     "appointment_rescheduled": "schedule_change",
     "appointment_cancelled": "schedule_change",
+    "visitcreated": "visit_created",
+    "queueticketissued": "queue_ticket_issued",
+    "queuestatuschanged": "queue_status_changed",
+    "patientcalled": "patient_called",
     "all_free_pending": "all_free_requested",
     "all_free_declined": "all_free_rejected",
     "allfree_requested": "all_free_requested",
@@ -77,11 +85,60 @@ REGISTRAR_NOTIFICATION_EVENT_TYPES = {
 }
 
 QUEUE_NOTIFICATION_EVENT_TYPES = {
+    "patient_called",
     "queue_call",
+    "queue_status_changed",
     "queue_position",
     "queue_reminder",
+    "queue_ticket_issued",
     "diagnostics_return_needed",
     "queue_update",
+}
+
+PATIENT_TELEGRAM_EVENT_PREFERENCES = {
+    "visit_created": "appointment_reminders",
+    "queue_ticket_issued": "appointment_reminders",
+    "queue_status_changed": "appointment_reminders",
+    "patient_called": "appointment_reminders",
+    "payment_created": "notifications_enabled",
+    "payment_notification": "notifications_enabled",
+    "payment_paid": "notifications_enabled",
+    "lab_results": "lab_notifications",
+}
+
+PATIENT_TELEGRAM_EVENT_MESSAGES = {
+    "visit_created": {
+        "ru": "Запись создана. Дата: {date}. Врач: {doctor}.",
+        "uz-Latn": "Qabul yaratildi. Sana: {date}. Shifokor: {doctor}.",
+    },
+    "queue_ticket_issued": {
+        "ru": "Талон очереди готов. Номер: {queue_number}. Кабинет: {cabinet}.",
+        "uz-Latn": "Navbat taloni tayyor. Raqam: {queue_number}. Xona: {cabinet}.",
+    },
+    "queue_status_changed": {
+        "ru": "Статус очереди обновлен. Номер: {queue_number}. Статус: {status}.",
+        "uz-Latn": "Navbat holati yangilandi. Raqam: {queue_number}. Holat: {status}.",
+    },
+    "patient_called": {
+        "ru": "Вас приглашают. Номер: {queue_number}. Кабинет: {cabinet}.",
+        "uz-Latn": "Sizni chaqirishmoqda. Raqam: {queue_number}. Xona: {cabinet}.",
+    },
+    "payment_created": {
+        "ru": "Сформирована оплата. Сумма: {amount} {currency}.",
+        "uz-Latn": "To'lov yaratildi. Summa: {amount} {currency}.",
+    },
+    "payment_notification": {
+        "ru": "Статус оплаты обновлен. Сумма: {amount} {currency}.",
+        "uz-Latn": "To'lov holati yangilandi. Summa: {amount} {currency}.",
+    },
+    "payment_paid": {
+        "ru": "Оплата получена. Квитанция доступна в защищенном кабинете.",
+        "uz-Latn": "To'lov qabul qilindi. Kvitansiya himoyalangan kabinetda mavjud.",
+    },
+    "lab_results": {
+        "ru": "Результаты готовы. Откройте защищенный кабинет.",
+        "uz-Latn": "Natijalar tayyor. Himoyalangan kabinetni oching.",
+    },
 }
 
 
@@ -94,6 +151,59 @@ def _normalize_notification_event_type(
     if not normalized:
         return fallback
     return NOTIFICATION_EVENT_TYPE_ALIASES.get(normalized, normalized)
+
+
+def _normalize_patient_telegram_language(language_code: Any) -> str:
+    value = str(language_code or "").strip().lower().replace("_", "-")
+    if value in {"uz", "uz-latn", "uzbek", "o'zbekcha"}:
+        return "uz-Latn"
+    return "ru"
+
+
+def _safe_patient_telegram_value(value: Any, fallback: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        text = fallback
+    return escape(text[:80])
+
+
+def _patient_telegram_event_message(
+    event_type: str,
+    language_code: Any,
+    metadata: dict[str, Any] | None = None,
+) -> str | None:
+    templates = PATIENT_TELEGRAM_EVENT_MESSAGES.get(event_type)
+    if not templates:
+        return None
+
+    language = _normalize_patient_telegram_language(language_code)
+    template = templates.get(language) or templates["ru"]
+    data = metadata or {}
+    safe_data = {
+        "date": _safe_patient_telegram_value(
+            data.get("date") or data.get("visit_date") or data.get("appointment_date"),
+            "-" if language == "ru" else "-",
+        ),
+        "doctor": _safe_patient_telegram_value(
+            data.get("doctor") or data.get("doctor_name"),
+            "уточняется" if language == "ru" else "aniqlanmoqda",
+        ),
+        "queue_number": _safe_patient_telegram_value(
+            data.get("queue_number") or data.get("number"),
+            "-" if language == "ru" else "-",
+        ),
+        "cabinet": _safe_patient_telegram_value(
+            data.get("cabinet") or data.get("cabinet_number"),
+            "уточняется" if language == "ru" else "aniqlanmoqda",
+        ),
+        "status": _safe_patient_telegram_value(
+            data.get("status"),
+            "обновлен" if language == "ru" else "yangilandi",
+        ),
+        "amount": _safe_patient_telegram_value(data.get("amount"), "0"),
+        "currency": _safe_patient_telegram_value(data.get("currency"), "UZS"),
+    }
+    return template.format(**safe_data)
 
 
 class NotificationSenderService:
@@ -119,6 +229,63 @@ class NotificationSenderService:
 
     def _platform_service(self, db: Session):
         return get_notification_platform_service(db)
+
+    async def send_patient_telegram_event_notification(
+        self,
+        *,
+        db: Session,
+        patient_id: int,
+        event_type: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """Send a safe patient Telegram message for a canonical business event."""
+        normalized_event_type = _normalize_notification_event_type(
+            event_type,
+            fallback="notification",
+        )
+        preference_field = PATIENT_TELEGRAM_EVENT_PREFERENCES.get(normalized_event_type)
+        if not preference_field:
+            logger.warning(
+                "Patient Telegram event skipped: unsupported event type",
+                extra={"event_type": normalized_event_type},
+            )
+            return False
+
+        from app.models.telegram_config import TelegramUser
+
+        telegram_user = (
+            db.query(TelegramUser)
+            .filter(
+                TelegramUser.patient_id == patient_id,
+                TelegramUser.active.is_(True),
+                TelegramUser.blocked.is_(False),
+            )
+            .order_by(TelegramUser.id.desc())
+            .first()
+        )
+        if not telegram_user:
+            logger.info(
+                "Patient Telegram event skipped: linked chat not found",
+                extra={"event_type": normalized_event_type},
+            )
+            return False
+
+        if not bool(getattr(telegram_user, "notifications_enabled", False)):
+            return False
+        if preference_field != "notifications_enabled" and not bool(
+            getattr(telegram_user, preference_field, False)
+        ):
+            return False
+
+        message = _patient_telegram_event_message(
+            normalized_event_type,
+            getattr(telegram_user, "language_code", None),
+            metadata,
+        )
+        if not message:
+            return False
+
+        return await self.send_telegram(message, chat_id=str(telegram_user.chat_id))
 
     @staticmethod
     def _extract_prefixed_user_id(actor_ref: str | None, prefix: str) -> int | None:

--- a/backend/tests/unit/test_notifications_push_logging.py
+++ b/backend/tests/unit/test_notifications_push_logging.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 import unittest
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.models.telegram_config import TelegramUser
+from app.services.notifications import NotificationSenderService
+
+from app.services import notifications as notification_service_module
 
 
 SOURCE_PATH = (
@@ -146,6 +154,113 @@ class NotificationsPushLoggingTest(unittest.TestCase):
         self.assertNotIn(
             "Пациент не найден:", payment_notification_source
         )
+
+
+class PatientTelegramEventMessagesTest(unittest.TestCase):
+    def test_patient_telegram_event_alias_normalizes_camel_case(self) -> None:
+        self.assertEqual(
+            notification_service_module._normalize_notification_event_type(
+                "PaymentPaid"
+            ),
+            "payment_paid",
+        )
+        self.assertEqual(
+            notification_service_module._normalize_notification_event_type(
+                "QueueTicketIssued"
+            ),
+            "queue_ticket_issued",
+        )
+
+    def test_patient_telegram_event_message_escapes_template_values(self) -> None:
+        message = notification_service_module._patient_telegram_event_message(
+            "payment_created",
+            "uz",
+            {"amount": "<b>1000</b>", "currency": "UZS<script>"},
+        )
+
+        self.assertIsNotNone(message)
+        self.assertIn("&lt;b&gt;1000&lt;/b&gt;", message)
+        self.assertIn("UZS&lt;script&gt;", message)
+        self.assertNotIn("<b>1000</b>", message)
+        self.assertNotIn("UZS<script>", message)
+
+
+@pytest.mark.asyncio
+async def test_patient_telegram_event_helper_sends_safe_localized_message(
+    db_session,
+    test_patient,
+):
+    telegram_user = TelegramUser(
+        chat_id=8101,
+        patient_id=test_patient.id,
+        username="patient_chat",
+        first_name="Patient",
+        language_code="ru",
+        notifications_enabled=True,
+        appointment_reminders=True,
+        lab_notifications=True,
+        active=True,
+        blocked=False,
+    )
+    db_session.add(telegram_user)
+    db_session.commit()
+
+    service = NotificationSenderService()
+    service.send_telegram = AsyncMock(return_value=True)
+
+    sent = await service.send_patient_telegram_event_notification(
+        db=db_session,
+        patient_id=test_patient.id,
+        event_type="VisitCreated",
+        metadata={
+            "appointment_date": "2026-06-01 09:00",
+            "doctor_name": "<Cardio & Team>",
+            "visit_id": "internal-visit-998877",
+            "patient_id": f"internal-patient-{test_patient.id}",
+        },
+    )
+
+    assert sent is True
+    service.send_telegram.assert_awaited_once()
+    message = service.send_telegram.await_args.args[0]
+    assert service.send_telegram.await_args.kwargs["chat_id"] == "8101"
+    assert "&lt;Cardio &amp; Team&gt;" in message
+    assert "internal-visit-998877" not in message
+    assert f"internal-patient-{test_patient.id}" not in message
+
+
+@pytest.mark.asyncio
+async def test_patient_telegram_event_helper_respects_patient_consent(
+    db_session,
+    test_patient,
+):
+    telegram_user = TelegramUser(
+        chat_id=8102,
+        patient_id=test_patient.id,
+        username="patient_chat",
+        first_name="Patient",
+        language_code="uz-Latn",
+        notifications_enabled=False,
+        appointment_reminders=True,
+        lab_notifications=True,
+        active=True,
+        blocked=False,
+    )
+    db_session.add(telegram_user)
+    db_session.commit()
+
+    service = NotificationSenderService()
+    service.send_telegram = AsyncMock(return_value=True)
+
+    sent = await service.send_patient_telegram_event_notification(
+        db=db_session,
+        patient_id=test_patient.id,
+        event_type="LabResultReady",
+        metadata={"result_id": "internal-result-445566"},
+    )
+
+    assert sent is False
+    service.send_telegram.assert_not_awaited()
 
 
 if __name__ == "__main__":

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -367,7 +367,7 @@ class TestTelegramWebhookSecurity:
             .filter(TelegramMessage.chat_id == 7006)
             .one()
         )
-        assert log.template_key == "telegram_patient_language_selected"
+        assert log.template_key == "telegram_patient_language_selected_needs_contact"
         assert log.message_type == "patient_bot_reply"
         assert log.status == "sent"
 
@@ -395,8 +395,14 @@ class TestTelegramWebhookSecurity:
             .one()
         )
         assert telegram_user.language_code == "uz-Latn"
-        assert fake_service._send_message.await_args.args[1] == (
+        reply_text = fake_service._send_message.await_args.args[1]
+        assert (
             telegram_webhook._localized_text("language_selected", "uz-Latn")
+            in reply_text
+        )
+        assert (
+            telegram_webhook._localized_text("share_contact", "uz-Latn")
+            in reply_text
         )
         assert fake_service._send_message.await_args.args[2] == (
             telegram_webhook._localized_main_menu("uz-Latn")
@@ -1157,11 +1163,17 @@ class TestTelegramWebhookSecurity:
         assert telegram_user.language_code == "uz-Latn"
         assert telegram_user.patient_id is None
         assert telegram_user.notifications_enabled is False
-        fake_service._send_message.assert_awaited_once_with(
-            chat_id,
-            telegram_webhook._localized_text("language_selected", "uz-Latn"),
-            telegram_webhook._localized_main_menu("uz-Latn"),
+        chat_arg, text_arg, reply_markup = fake_service._send_message.await_args.args
+        assert chat_arg == chat_id
+        assert (
+            telegram_webhook._localized_text("language_selected", "uz-Latn")
+            in text_arg
         )
+        assert (
+            telegram_webhook._localized_text("share_contact", "uz-Latn")
+            in text_arg
+        )
+        assert reply_markup == telegram_webhook._localized_main_menu("uz-Latn")
         fake_service._send_message.reset_mock()
 
         contact_update = {
@@ -1232,7 +1244,7 @@ class TestTelegramWebhookSecurity:
         ]
         assert template_keys == [
             "telegram_patient_language_prompt",
-            "telegram_patient_language_selected",
+            "telegram_patient_language_selected_needs_contact",
             "telegram_patient_contact_linked",
             "telegram_patient_notifications_enabled",
         ]


### PR DESCRIPTION
## Summary

- Keep localized phone-sharing guidance after patient language selection when the Telegram account is not linked to a patient.
- Add safe patient Telegram event message mapping for visit, queue, payment, and lab event aliases with RU / uz-Latn text.
- Add phone-to-Telegram user lookup through canonical Patient lookup, returning only active, unblocked Telegram accounts.

## Contract Impact

- Canonical surface: Telegram patient bot reply in backend/app/api/v1/endpoints/telegram_webhook.py and backend notification sender helper in backend/app/services/notifications.py.
- Request shape: unchanged Telegram update payload handling and unchanged notification helper inputs.
- Response shape: unlinked patient language selection includes localized share-contact guidance; patient event helper sends safe localized message text only.
- Status codes: not applicable - no HTTP API response contract changed.
- Frontend consumer: not applicable - no frontend consumer changed.
- Compatibility path or alias: existing command/text aliases remain; notification aliases now normalize PaymentPaid, QueueTicketIssued, QueueStatusChanged, PatientCalled, VisitCreated, and LabResultReady.
- Contract proof: focused Telegram webhook and notification tests passed.

## RBAC / Permissions

- Roles allowed: unchanged; patient bot chat behavior only.
- Roles denied: unchanged; no staff/admin permissions changed.
- Positive auth proof: existing linked and unlinked patient Telegram webhook tests passed.
- Negative auth proof: contact rejection, unlinked access, and patient Telegram consent-off notification tests passed.

## Notification / Realtime

- Event type or websocket channel: no websocket channel changed; added safe Telegram patient-event message helper for visit, queue, payment, and lab event families.
- Payload version / ack behavior: Telegram sendMessage payload shape remains unchanged; dynamic metadata values are escaped and bounded before formatting.
- Read/unread or delivery semantics: unchanged; no read/unread, delivery status, or TelegramMessage status semantics changed.
- Reconnect/resync proof: not applicable - no websocket reconnect path changed; onboarding text is rebuilt per request from saved Telegram language/link state.

## Frontend Resilience

not applicable - no frontend runtime file or browser route changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/telegram_webhook.py; backend/app/crud/telegram_config.py; backend/app/services/notifications.py; backend/tests/unit/test_telegram_webhook_security.py; backend/tests/unit/test_notifications_push_logging.py.
- Denied paths: DB migrations, queue allocation/fairness, Telegram token storage, frontend manager files, generated output.
- Migration/docs/test impact: no migration; no docs update; focused Telegram webhook and notification tests updated.
- Rollback note: revert this PR to return language selection to the previous one-line response and remove patient-event Telegram message mapping.

## Validation

- Targeted tests or smoke run: backend .venv py_compile for touched backend files; backend/tests/unit/test_telegram_webhook_security.py and backend/tests/unit/test_notifications_push_logging.py -q; git diff --check for touched files.
- Result: py_compile passed; 46 focused unit tests passed; diff-check passed.
- Not checked: live Telegram click-through in the desktop client after merge/restart; local frontend build did not complete within local timeout and the PR has no frontend runtime changes.