### PR TITLE
fix(telegram): route appointment reminders through patient events

### DIFF
--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -96,6 +96,7 @@ QUEUE_NOTIFICATION_EVENT_TYPES = {
 }
 
 PATIENT_TELEGRAM_EVENT_PREFERENCES = {
+    "appointment_reminder": "appointment_reminders",
     "visit_created": "appointment_reminders",
     "queue_ticket_issued": "appointment_reminders",
     "queue_status_changed": "appointment_reminders",
@@ -107,6 +108,10 @@ PATIENT_TELEGRAM_EVENT_PREFERENCES = {
 }
 
 PATIENT_TELEGRAM_EVENT_MESSAGES = {
+    "appointment_reminder": {
+        "ru": "Напоминание о записи. Дата: {date}. Врач: {doctor}.",
+        "uz-Latn": "Qabul eslatmasi. Sana: {date}. Shifokor: {doctor}.",
+    },
     "visit_created": {
         "ru": "Запись создана. Дата: {date}. Врач: {doctor}.",
         "uz-Latn": "Qabul yaratildi. Sana: {date}. Shifokor: {doctor}.",
@@ -905,7 +910,19 @@ class NotificationSenderService:
         if patient_phone:
             results["sms"] = await self.send_sms(patient_phone, sms_message)
 
-        results["telegram"] = await self.send_telegram(telegram_message)
+        if db and patient_id:
+            results["telegram"] = await self.send_patient_telegram_event_notification(
+                db=db,
+                patient_id=patient_id,
+                event_type="appointment_reminder",
+                metadata={
+                    "appointment_date": appointment_date.strftime("%d.%m.%Y %H:%M"),
+                    "doctor_name": doctor_name,
+                    "department": department,
+                },
+            )
+        else:
+            results["telegram"] = await self.send_telegram(telegram_message)
 
         return results
 

--- a/backend/tests/unit/test_notifications_push_logging.py
+++ b/backend/tests/unit/test_notifications_push_logging.py
@@ -263,5 +263,49 @@ async def test_patient_telegram_event_helper_respects_patient_consent(
     service.send_telegram.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_appointment_reminder_uses_patient_telegram_event_call_site(
+    db_session,
+    test_patient,
+):
+    telegram_user = TelegramUser(
+        chat_id=8103,
+        patient_id=test_patient.id,
+        username="patient_chat",
+        first_name="Patient",
+        language_code="ru",
+        notifications_enabled=True,
+        appointment_reminders=True,
+        lab_notifications=True,
+        active=True,
+        blocked=False,
+    )
+    db_session.add(telegram_user)
+    db_session.commit()
+
+    service = NotificationSenderService()
+    service.send_email = AsyncMock(return_value=False)
+    service.send_sms = AsyncMock(return_value=False)
+    service.send_telegram = AsyncMock(return_value=True)
+
+    result = await service.send_appointment_reminder(
+        patient_email="private@example.test",
+        patient_phone="+998901112233",
+        appointment_date=notification_service_module.datetime(2026, 6, 1, 9, 30),
+        doctor_name="<Doctor>",
+        department="Cardiology",
+        db=db_session,
+        patient_id=test_patient.id,
+    )
+
+    assert result["telegram"] is True
+    service.send_telegram.assert_awaited_once()
+    message = service.send_telegram.await_args.args[0]
+    assert service.send_telegram.await_args.kwargs["chat_id"] == "8103"
+    assert "&lt;Doctor&gt;" in message
+    assert "private@example.test" not in message
+    assert "+998901112233" not in message
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Route appointment reminder Telegram delivery through the safe patient Telegram event helper when `db` and `patient_id` are available.
- Add `appointment_reminder` to patient Telegram event preferences and localized RU / uz-Latn message templates.
- Keep legacy direct Telegram fallback when no patient database context is available.

## Contract Impact

- Canonical surface: backend/app/services/notifications.py appointment reminder helper.
- Request shape: unchanged Python service method parameters.
- Response shape: unchanged result dictionary keys; `results[telegram]` remains boolean.
- Status codes: not applicable - no HTTP endpoint changed.
- Frontend consumer: not applicable - backend notification helper only.
- Compatibility path or alias: legacy direct Telegram send remains when patient context is unavailable.
- Contract proof: focused notification unit tests passed.

## RBAC / Permissions

- Roles allowed: unchanged; this is service-layer delivery routing.
- Roles denied: unchanged.
- Positive auth proof: patient Telegram account with notifications and appointment reminders enabled receives the safe localized message.
- Negative auth proof: existing consent-off patient Telegram event test remains passing.

## Notification / Realtime

- Event type or websocket channel: adds `appointment_reminder` patient Telegram event mapping; no websocket channel changed.
- Payload version / ack behavior: Telegram sendMessage behavior remains boolean success/failure; dynamic values are escaped before formatting.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable - no websocket reconnect path changed.

## Frontend Resilience

not applicable - no frontend runtime file or browser route changed.

## Scope Gate

- Allowed paths: backend/app/services/notifications.py; backend/tests/unit/test_notifications_push_logging.py.
- Denied paths: DB migrations, queue allocation/fairness, route registry, frontend manager files, generated output.
- Migration/docs/test impact: no migration; no docs update; focused notification tests updated.
- Rollback note: revert this PR to send appointment reminder Telegram messages through the previous direct fallback path.

## Validation

- Targeted tests or smoke run: backend .venv py_compile for touched files; backend/tests/unit/test_notifications_push_logging.py -q; git diff --check for touched files.
- Result: py_compile passed; 14 focused unit tests passed; diff-check passed.
- Not checked: live Telegram delivery against a real bot token.