### PR TITLE
feat(telegram): add contact button to settings menu

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -736,6 +736,7 @@ def _localized_settings_menu(language_code: Any) -> Dict[str, Any]:
     )
     main_keyboard = _localized_main_menu(language).get("keyboard", [])
     settings_keyboard = settings_menu.get("keyboard", [])
+    contact_rows = main_keyboard[:1]
     extra_rows = []
     if len(main_keyboard) > 3:
         extra_rows.append(main_keyboard[3])
@@ -743,7 +744,13 @@ def _localized_settings_menu(language_code: Any) -> Dict[str, Any]:
         extra_rows.append([main_keyboard[4][0]])
     return {
         **settings_menu,
-        "keyboard": settings_keyboard[:4] + extra_rows + settings_keyboard[4:],
+        "keyboard": (
+            settings_keyboard[:2]
+            + contact_rows
+            + settings_keyboard[2:4]
+            + extra_rows
+            + settings_keyboard[4:]
+        ),
     }
 
 


### PR DESCRIPTION
## Summary

- Add the localized contact-sharing request row to the patient Telegram `/settings` keyboard.
- Preserve the existing settings order for language, notifications, booking, queue, visits, payments, profile, support, and help.
- Rebased the PR on current `origin/main`, so the diff is only the settings keyboard change.

## Contract Impact

- Canonical surface: patient Telegram reply keyboard built by backend/app/api/v1/endpoints/telegram_webhook.py.
- Request shape: unchanged Telegram update handling.
- Response shape: `/settings` keyboard now includes the same localized `request_contact` phone button used by the main menu.
- Status codes: not applicable - no HTTP API response contract changed.
- Frontend consumer: not applicable - no frontend runtime file changed.
- Compatibility path or alias: existing text aliases and commands remain unchanged.
- Contract proof: focused Telegram webhook tests and py_compile passed.

## RBAC / Permissions

- Roles allowed: unchanged; patient bot chat behavior only.
- Roles denied: unchanged; no staff/admin permissions changed.
- Positive auth proof: existing linked/unlinked Telegram webhook tests passed.
- Negative auth proof: existing contact spoofing and unlinked access tests remain in the focused suite.

## Notification / Realtime

- Event type or websocket channel: Telegram patient bot chat reply keyboard only.
- Payload version / ack behavior: sendMessage payload remains a reply keyboard; the settings keyboard gains a localized `request_contact` row.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable - settings keyboard is rebuilt from saved language state for each request.

## Frontend Resilience

not applicable - no frontend file changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/telegram_webhook.py.
- Denied paths: DB migrations, queue allocation/fairness, Telegram token storage, frontend manager files, generated output.
- Migration/docs/test impact: no migration; no docs update; existing focused Telegram tests cover the menu builder usage.
- Rollback note: revert this PR to remove the contact-sharing row from the settings keyboard.

## Validation

- Targeted tests or smoke run: py_compile for backend/app/api/v1/endpoints/telegram_webhook.py; backend/tests/unit/test_telegram_webhook_security.py -q; git diff --check in the rebase worktree.
- Result: py_compile passed; 35 Telegram webhook tests passed; diff check passed.
- Not checked: live Telegram desktop click-through after merge/restart.