### PR TITLE
fix(queue): cap qr token ttl window

### DIFF
--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -58,6 +58,8 @@ class QueueBusinessService:
 
     # Лимиты по умолчанию
     DEFAULT_MAX_SLOTS = 15
+    QUEUE_QR_TOKEN_MIN_TTL_MINUTES = 5
+    QUEUE_QR_TOKEN_MAX_TTL_MINUTES = 15
 
     def __init__(self) -> None:
         self._cached_settings: dict[str, Any] | None = None
@@ -71,6 +73,22 @@ class QueueBusinessService:
         else:
             current = getattr(queue_token, "current_uses", 0) or 0
             queue_token.current_uses = current + 1
+
+    @classmethod
+    def _bounded_queue_token_ttl_minutes(cls, expires_hours: int | None) -> int:
+        try:
+            requested_minutes = (
+                int(expires_hours) * 60
+                if expires_hours is not None
+                else cls.QUEUE_QR_TOKEN_MAX_TTL_MINUTES
+            )
+        except (TypeError, ValueError):
+            requested_minutes = cls.QUEUE_QR_TOKEN_MAX_TTL_MINUTES
+
+        return min(
+            max(requested_minutes, cls.QUEUE_QR_TOKEN_MIN_TTL_MINUTES),
+            cls.QUEUE_QR_TOKEN_MAX_TTL_MINUTES,
+        )
 
     def _load_queue_settings(self, db: Session) -> dict[str, Any]:
         if self._cached_settings is None:
@@ -564,8 +582,8 @@ class QueueBusinessService:
                 },
             )
 
-        expires_delta = max(1, int(expires_hours))
-        expires_at = now_local + timedelta(hours=expires_delta)
+        expires_minutes = self._bounded_queue_token_ttl_minutes(expires_hours)
+        expires_at = now_local + timedelta(minutes=expires_minutes)
 
         token_value = secrets.token_urlsafe(32)
         queue_token = QueueToken(
@@ -623,6 +641,7 @@ class QueueBusinessService:
             "max_slots": max_slots,
             "current_count": current_count,
             "expires_at": queue_token.expires_at,
+            "ttl_minutes": expires_minutes,
             "is_clinic_wide": is_clinic_wide,
         }
 

--- a/backend/tests/unit/test_queue_time_window.py
+++ b/backend/tests/unit/test_queue_time_window.py
@@ -2,10 +2,28 @@
 Unit tests for queue time window rules (07:00).
 """
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import app.services.queue_service as queue_service
 from app.services.queue_service import QueueBusinessService
+
+
+class _QueueTokenFakeDb:
+    def __init__(self) -> None:
+        self.added = None
+
+    def add(self, obj):
+        self.added = obj
+
+    def flush(self):
+        return None
+
+    def commit(self):
+        return None
+
+    def refresh(self, obj):
+        return None
 
 
 def _freeze_datetime(monkeypatch, frozen_dt: datetime) -> None:
@@ -36,3 +54,61 @@ def test_queue_time_window_allows_after_start(monkeypatch):
     allowed, _ = QueueBusinessService.check_queue_time_window(target)
 
     assert allowed is True
+
+
+def _queue_service_with_static_settings(monkeypatch) -> QueueBusinessService:
+    service = QueueBusinessService()
+    monkeypatch.setattr(
+        service,
+        "_load_queue_settings",
+        lambda db: {
+            "timezone": "Asia/Tashkent",
+            "default_max_slots": 15,
+            "queue_start_hour": 7,
+            "queue_end_hour": 9,
+        },
+    )
+    return service
+
+
+def test_assign_queue_token_caps_sensitive_qr_ttl_at_15_minutes(monkeypatch):
+    frozen = datetime(2026, 1, 1, 8, 0)
+    _freeze_datetime(monkeypatch, frozen)
+    service = _queue_service_with_static_settings(monkeypatch)
+    fake_db = _QueueTokenFakeDb()
+
+    _, metadata = service.assign_queue_token(
+        fake_db,
+        specialist_id=None,
+        department="clinic",
+        generated_by_user_id=10,
+        is_clinic_wide=True,
+        expires_hours=24,
+        commit=False,
+    )
+
+    now = frozen.replace(tzinfo=ZoneInfo("Asia/Tashkent"))
+    assert metadata["expires_at"] - now == timedelta(minutes=15)
+    assert metadata["ttl_minutes"] == 15
+    assert fake_db.added.expires_at == metadata["expires_at"]
+
+
+def test_assign_queue_token_enforces_sensitive_qr_ttl_floor(monkeypatch):
+    frozen = datetime(2026, 1, 1, 8, 0)
+    _freeze_datetime(monkeypatch, frozen)
+    service = _queue_service_with_static_settings(monkeypatch)
+    fake_db = _QueueTokenFakeDb()
+
+    _, metadata = service.assign_queue_token(
+        fake_db,
+        specialist_id=None,
+        department="clinic",
+        generated_by_user_id=10,
+        is_clinic_wide=True,
+        expires_hours=0,
+        commit=False,
+    )
+
+    now = frozen.replace(tzinfo=ZoneInfo("Asia/Tashkent"))
+    assert metadata["expires_at"] - now == timedelta(minutes=5)
+    assert metadata["ttl_minutes"] == 5


### PR DESCRIPTION
## Summary

- Cap queue QR token validity to a sensitive short window: minimum 5 minutes, maximum 15 minutes.
- Preserve existing `expires_hours` input compatibility by bounding it into minutes at token creation time.
- Return `ttl_minutes` in queue token metadata for callers/audits.

## Contract Impact

- Canonical surface: backend/app/services/queue_service.py `QueueBusinessService.assign_queue_token`.
- Request shape: unchanged method signature; `expires_hours` is still accepted.
- Response shape: metadata gains `ttl_minutes`; existing metadata keys remain.
- Status codes: not applicable - service-layer change only.
- Frontend consumer: no frontend file changed.
- Compatibility path or alias: existing callers can continue passing `expires_hours`; long values are bounded to 15 minutes and zero/invalid values floor to 5 minutes.
- Contract proof: focused queue time-window unit tests passed.

## RBAC / Permissions

- Roles allowed: unchanged; existing endpoint/service callers still reach `assign_queue_token` through the same authorization path.
- Roles denied: unchanged; this PR does not add a new caller or bypass authorization, it only bounds TTL after token generation is already allowed.
- Positive auth proof: focused service tests exercise the existing `QueueBusinessService.assign_queue_token` call shape without changing caller permissions.
- Negative auth proof: no denied-role path was modified; authorization remains owned by the existing endpoint/service boundary before this TTL calculation.

## Notification / Realtime

not applicable - no notification event, websocket channel, read/unread, or delivery behavior changed.

## Frontend Resilience

not applicable - no frontend runtime file changed.

## Scope Gate

- Allowed paths: backend/app/services/queue_service.py; backend/tests/unit/test_queue_time_window.py.
- Denied paths: queue allocation/fairness ordering, doctor/specialist mapping, DB migrations, frontend routes, generated output.
- Migration/docs/test impact: no migration; no docs update; focused queue TTL tests updated.
- Rollback note: revert this PR to restore hour-based QR token expiration.

## Validation

- Targeted tests or smoke run: backend .venv py_compile for touched files; backend/tests/unit/test_queue_time_window.py -q; git diff --check for touched files.
- Result: py_compile passed; 4 focused queue tests passed; diff-check passed.
- Not checked: live QR issuance from a browser/API client.