### PR TITLE
test(telegram): guard queue refresh as readonly

### DIFF
--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -1277,6 +1277,70 @@ class TestTelegramWebhookSecurity:
         assert "Кабинет 205" in message
         assert "Кардиология" in message
 
+    def test_queue_status_refresh_preserves_ordering_and_queue_time(
+        self, db_session, test_patient, test_daily_queue, test_queue_entry
+    ):
+        _link_patient_to_chat(db_session, chat_id=7003, patient_id=test_patient.id)
+        test_daily_queue.day = date.today()
+        first_time = datetime.utcnow().replace(microsecond=0) - timedelta(minutes=20)
+        linked_time = first_time + timedelta(minutes=10)
+        later_time = linked_time + timedelta(minutes=10)
+        test_queue_entry.number = 2
+        test_queue_entry.status = "waiting"
+        test_queue_entry.queue_time = linked_time
+        test_queue_entry.patient_id = test_patient.id
+        first_entry = OnlineQueueEntry(
+            queue_id=test_daily_queue.id,
+            number=1,
+            patient_id=None,
+            patient_name="First Patient",
+            source="desk",
+            status="waiting",
+            queue_time=first_time,
+        )
+        later_entry = OnlineQueueEntry(
+            queue_id=test_daily_queue.id,
+            number=3,
+            patient_id=None,
+            patient_name="Later Patient",
+            source="desk",
+            status="waiting",
+            queue_time=later_time,
+        )
+        db_session.add_all([later_entry, first_entry])
+        db_session.commit()
+        db_session.refresh(test_queue_entry)
+        db_session.refresh(first_entry)
+        db_session.refresh(later_entry)
+        original_snapshot = [
+            (entry.id, entry.number, entry.status, entry.queue_time)
+            for entry in [first_entry, test_queue_entry, later_entry]
+        ]
+
+        first_message = telegram_webhook._clinic_queue_message(db_session, 7003)
+        second_message = telegram_webhook._clinic_queue_message(db_session, 7003)
+
+        assert first_message == second_message
+        assert str(test_queue_entry.number) in second_message
+        assert telegram_webhook._queue_entry_position(db_session, test_queue_entry) == 2
+        db_session.refresh(first_entry)
+        db_session.refresh(test_queue_entry)
+        db_session.refresh(later_entry)
+        assert [
+            (entry.id, entry.number, entry.status, entry.queue_time)
+            for entry in [first_entry, test_queue_entry, later_entry]
+        ] == original_snapshot
+        assert (
+            db_session.query(OnlineQueueEntry)
+            .filter(OnlineQueueEntry.queue_id == test_daily_queue.id)
+            .order_by(
+                OnlineQueueEntry.priority.desc(),
+                OnlineQueueEntry.queue_time.asc(),
+                OnlineQueueEntry.id.asc(),
+            )
+            .all()
+        ) == [first_entry, test_queue_entry, later_entry]
+
     def test_visits_message_lists_linked_patient_visits_without_medical_details(
         self, db_session, test_patient, test_visit
     ):


### PR DESCRIPTION
﻿## Summary

- Adds a targeted unit regression test for patient Telegram queue status refresh.
- Proves repeated `_clinic_queue_message` calls preserve queue ordering, status, and `queue_time`.
- Keeps runtime code unchanged; local dev-brain returned `narrow override` for a test-only queue/Telegram guardrail.

## Contract Impact

- Canonical surface: unchanged; test exercises existing `backend/app/api/v1/endpoints/telegram_webhook.py` helper path only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged.
- Compatibility path or alias: unchanged.
- Contract proof: test-only diff in `backend/tests/unit/test_telegram_webhook_security.py`; no API, websocket, event, or frontend code changed.

## RBAC / Permissions

- Roles allowed: unchanged; linked patient Telegram chats remain the only patient queue-status consumer covered here.
- Roles denied: unchanged; unlinked chats still use existing `needs_link` behavior and no auth guard was modified.
- Positive auth proof: test uses `_link_patient_to_chat(...)` before reading queue status, matching the existing linked-patient path.
- Negative auth proof: no auth-sensitive behavior changed; existing webhook security tests in the same file still cover rejected/missing webhook secrets and linked-patient boundaries.

## Notification / Realtime

- Event type or websocket channel: unchanged; no new notification event or websocket channel.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable - no realtime path changed.

## Frontend Resilience

- Empty data proof: unchanged; no frontend code changed.
- Partial data proof: unchanged; no frontend code changed.
- Forbidden secondary path behavior: unchanged; no frontend code changed.
- Missing draft/resource behavior: unchanged; no frontend code changed.
- Stale route/deep-link behavior: unchanged; no frontend code changed.

## Scope Gate

- Allowed paths: `backend/tests/unit/test_telegram_webhook_security.py`.
- Denied paths: runtime queue services, Telegram webhook implementation, frontend, migrations, and unrelated dirty `.ai-factory/.codex` files.
- Migration/docs/test impact: test-only; no migration or runtime docs changed because the plan file has pre-existing unstaged user/worktree edits.
- Rollback note: revert commit `bb5a3f2c` to remove the regression test; runtime behavior is unaffected.

## Validation

- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe -m py_compile backend\tests\unit\test_telegram_webhook_security.py`; `$env:PYTHONPATH='C:\final\backend'; backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_telegram_webhook_security.py -q`; `git diff --check -- backend/tests/unit/test_telegram_webhook_security.py`.
- Result: py_compile passed; pytest passed `36 passed, 1 warning`; diff-check passed.
- Not checked: full backend suite, frontend build, browser smoke; runtime code did not change.
