### PR TITLE
test(telegram): cover ticket qr token rollout cases

### DIFF
--- a/backend/tests/unit/test_visit_confirmation_service.py
+++ b/backend/tests/unit/test_visit_confirmation_service.py
@@ -12,6 +12,8 @@ from app.services.visit_confirmation_service import (
     TELEGRAM_TICKET_QR_TTL_MINUTES,
     VisitConfirmationDomainError,
     VisitConfirmationService,
+    build_telegram_ticket_start_token,
+    consume_telegram_ticket_start_token,
     parse_telegram_ticket_start_token,
 )
 
@@ -156,3 +158,65 @@ class TestVisitConfirmationService:
             )
             <= 1
         )
+
+    def test_ticket_telegram_qr_rollout_rejects_expired_and_malformed_tokens(
+        self,
+    ):
+        expired_token = build_telegram_ticket_start_token(
+            expires_at=datetime.utcnow() - timedelta(minutes=1),
+            nonce="expiredcase",
+        )
+        future_token = build_telegram_ticket_start_token(
+            expires_at=datetime.utcnow() + timedelta(minutes=5),
+            nonce="futurecase",
+        )
+        tampered_token = f"{future_token[:-1]}x"
+
+        assert parse_telegram_ticket_start_token(expired_token) is None
+        assert parse_telegram_ticket_start_token("") is None
+        assert parse_telegram_ticket_start_token("not-a-ticket-token") is None
+        assert parse_telegram_ticket_start_token("tq_notbase36_nonce_sig") is None
+        assert parse_telegram_ticket_start_token(tampered_token) is None
+
+    def test_ticket_telegram_qr_rollout_rejects_expired_stored_token(
+        self, db_session, test_visit
+    ):
+        token = build_telegram_ticket_start_token(
+            expires_at=datetime.utcnow() + timedelta(minutes=5),
+            nonce="storeexpired",
+        )
+        parsed = parse_telegram_ticket_start_token(token)
+        assert parsed is not None
+        test_visit.confirmation_token = parsed["token_hash"]
+        test_visit.confirmation_expires_at = datetime.utcnow() - timedelta(minutes=1)
+        db_session.commit()
+
+        consumed = consume_telegram_ticket_start_token(db_session, token)
+
+        assert consumed is None
+        db_session.refresh(test_visit)
+        assert test_visit.confirmation_token == parsed["token_hash"]
+
+    def test_ticket_telegram_qr_rollout_consumes_once_and_blocks_replay(
+        self, db_session, test_visit
+    ):
+        token = build_telegram_ticket_start_token(
+            expires_at=datetime.utcnow() + timedelta(minutes=5),
+            nonce="replaycase",
+        )
+        parsed = parse_telegram_ticket_start_token(token)
+        assert parsed is not None
+        test_visit.confirmation_token = parsed["token_hash"]
+        test_visit.confirmation_expires_at = parsed["expires_at"]
+        db_session.commit()
+
+        first = consume_telegram_ticket_start_token(db_session, token)
+        db_session.flush()
+        second = consume_telegram_ticket_start_token(db_session, token)
+
+        assert first is not None
+        assert first.id == test_visit.id
+        assert second is None
+        db_session.refresh(test_visit)
+        assert test_visit.confirmation_token is None
+        assert test_visit.confirmation_expires_at is None


### PR DESCRIPTION
﻿## Summary

- Adds rollout validation for Telegram ticket QR `/start` tokens.
- Covers expired signed payloads, malformed/tampered tokens, expired stored visit tokens, and replay after one successful consume.
- Keeps runtime code unchanged; local dev-brain returned `narrow override` for the test-only Telegram token slice.

## Contract Impact

- Canonical surface: unchanged; tests exercise `backend/app/services/visit_confirmation_service.py` token helpers only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged.
- Compatibility path or alias: unchanged.
- Contract proof: test-only diff in `backend/tests/unit/test_visit_confirmation_service.py`; no API, websocket, event, or frontend code changed.

## RBAC / Permissions

- Roles allowed: unchanged; Telegram ticket QR linking still depends on an existing valid visit token and linked patient flow.
- Roles denied: unchanged; malformed, expired, tampered, and replayed tokens resolve to no visit.
- Positive auth proof: rollout test stores the parsed token hash on a visit and verifies first consume returns that visit.
- Negative auth proof: rollout tests verify expired payloads, malformed/tampered tokens, expired stored rows, and second/replayed consume all return `None`.

## Notification / Realtime

- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable - no notification, websocket, chat delivery, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: unchanged; no frontend code changed.
- Partial data proof: unchanged; no frontend code changed.
- Forbidden secondary path behavior: unchanged; no frontend code changed.
- Missing draft/resource behavior: unchanged; no frontend code changed.
- Stale route/deep-link behavior: unchanged; no frontend code changed.

## Scope Gate

- Allowed paths: `backend/tests/unit/test_visit_confirmation_service.py`.
- Denied paths: runtime token service, Telegram webhook endpoint, frontend, migrations, and unrelated dirty `.ai-factory/.codex` files.
- Migration/docs/test impact: test-only; no migration or runtime docs changed because the plan file has pre-existing unstaged worktree edits.
- Rollback note: revert commit `f467fb2e` to remove the rollout validation tests; runtime behavior is unaffected.

## Validation

- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe -m py_compile backend\tests\unit\test_visit_confirmation_service.py`; `$env:PYTHONPATH='C:\final\backend'; backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_visit_confirmation_service.py -q`; `git diff --check -- backend/tests/unit/test_visit_confirmation_service.py`.
- Result: py_compile passed; pytest passed `8 passed, 1 warning`; diff-check passed.
- Not checked: full backend suite, frontend build, browser smoke; runtime code did not change.
