### PR TITLE
feat(telegram): send queue events to patient bot

### DIFF
--- a/backend/app/services/queue_position_notifications.py
+++ b/backend/app/services/queue_position_notifications.py
@@ -44,6 +44,29 @@ class QueuePositionNotificationService:
         self.db = db
         self.fcm_service = get_fcm_service()
 
+    @staticmethod
+    def _patient_telegram_event_type(data: dict[str, Any]) -> str | None:
+        event_type = str((data or {}).get("type") or "").strip().lower()
+        if event_type == "queue_call":
+            return "PatientCalled"
+        if event_type == "queue_position":
+            return "QueueStatusChanged"
+        return None
+
+    @staticmethod
+    def _patient_telegram_metadata(
+        entry: OnlineQueueEntry,
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "queue_number": data.get("queue_number") or getattr(entry, "number", ""),
+            "cabinet": data.get("cabinet") or data.get("cabinet_number") or "",
+        }
+        status_value = data.get("status")
+        if status_value:
+            metadata["status"] = status_value
+        return metadata
+
     async def notify_patient_called(
         self,
         entry: OnlineQueueEntry,
@@ -74,6 +97,7 @@ class QueuePositionNotificationService:
             "entry_id": str(entry.id),
             "queue_number": str(entry.number),
             "cabinet": cabinet_number or "",
+            "status": "called",
             "timestamp": datetime.utcnow().isoformat()
         }
 
@@ -129,6 +153,7 @@ class QueuePositionNotificationService:
             "entry_id": str(entry.id),
             "queue_number": str(entry.number),
             "people_ahead": str(people_ahead),
+            "status": entry.status or "waiting",
             "timestamp": datetime.utcnow().isoformat()
         }
 
@@ -322,6 +347,24 @@ class QueuePositionNotificationService:
         from app.services.notifications import notification_sender_service
 
         user_id = None
+        telegram_sent = False
+
+        telegram_event_type = self._patient_telegram_event_type(data)
+        if entry.patient_id and telegram_event_type:
+            try:
+                telegram_sent = (
+                    await notification_sender_service.send_patient_telegram_event_notification(
+                        db=self.db,
+                        patient_id=entry.patient_id,
+                        event_type=telegram_event_type,
+                        metadata=self._patient_telegram_metadata(entry, data),
+                    )
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Queue patient Telegram notification failed",
+                    extra={"error_type": type(exc).__name__},
+                )
 
         # Определяем user_id
         # Способ 1: Через patient_id
@@ -355,8 +398,16 @@ class QueuePositionNotificationService:
 
             return {
                 "success": True, # Считаем успешным если сервис принял (он сам ошибки логирует)
-                "sent": success,
+                "sent": bool(success or telegram_sent),
+                "telegram_sent": telegram_sent,
                 "user_id": user_id
+            }
+
+        if telegram_sent:
+            return {
+                "success": True,
+                "sent": True,
+                "telegram_sent": True,
             }
 
         return {

--- a/backend/tests/unit/test_queue_position_notifications_telegram.py
+++ b/backend/tests/unit/test_queue_position_notifications_telegram.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services import notifications as notifications_module
+from app.services.queue_position_notifications import QueuePositionNotificationService
+
+
+def _queue_entry(*, patient_id: int, status: str = "waiting") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=9901,
+        patient_id=patient_id,
+        patient_name="Queue Patient",
+        number=8,
+        telegram_id=None,
+        status=status,
+    )
+
+
+@pytest.mark.asyncio
+async def test_patient_called_notification_routes_safe_telegram_event(
+    db_session,
+    test_patient,
+    monkeypatch,
+):
+    test_patient.user_id = None
+    db_session.commit()
+    telegram_mock = AsyncMock(return_value=True)
+    push_mock = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        notifications_module.notification_sender_service,
+        "send_patient_telegram_event_notification",
+        telegram_mock,
+    )
+    monkeypatch.setattr(
+        notifications_module.notification_sender_service,
+        "send_push",
+        push_mock,
+    )
+
+    result = await QueuePositionNotificationService(db_session).notify_patient_called(
+        entry=_queue_entry(patient_id=test_patient.id),
+        cabinet_number="205",
+    )
+
+    assert result["success"] is True
+    assert result["sent"] is True
+    assert result["telegram_sent"] is True
+    push_mock.assert_not_awaited()
+    telegram_mock.assert_awaited_once()
+    kwargs = telegram_mock.await_args.kwargs
+    assert kwargs["db"] is db_session
+    assert kwargs["patient_id"] == test_patient.id
+    assert kwargs["event_type"] == "PatientCalled"
+    assert kwargs["metadata"] == {
+        "queue_number": "8",
+        "cabinet": "205",
+        "status": "called",
+    }
+    assert "entry_id" not in kwargs["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_position_update_notification_routes_queue_status_to_telegram(
+    db_session,
+    test_patient,
+    monkeypatch,
+):
+    test_patient.user_id = None
+    db_session.commit()
+    telegram_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        notifications_module.notification_sender_service,
+        "send_patient_telegram_event_notification",
+        telegram_mock,
+    )
+
+    result = await QueuePositionNotificationService(db_session).notify_position_update(
+        entry=_queue_entry(patient_id=test_patient.id),
+        people_ahead=1,
+    )
+
+    assert result["success"] is True
+    assert result["sent"] is True
+    assert result["telegram_sent"] is True
+    telegram_mock.assert_awaited_once()
+    kwargs = telegram_mock.await_args.kwargs
+    assert kwargs["event_type"] == "QueueStatusChanged"
+    assert kwargs["metadata"] == {
+        "queue_number": "8",
+        "cabinet": "",
+        "status": "waiting",
+    }
+    assert "entry_id" not in kwargs["metadata"]
+    assert "patient_id" not in kwargs["metadata"]


### PR DESCRIPTION
﻿## Summary

- Wires queue-position notification events into the safe patient Telegram helper.
- Maps `queue_call` to `PatientCalled` and `queue_position` to `QueueStatusChanged` without changing queue ordering, status mutation, or endpoint routes.
- Adds focused unit tests proving Telegram metadata contains only safe queue number/cabinet/status fields and no raw entry or patient identifiers.
- Local dev-brain returned `narrow override` after broadening into unrelated Telegram UI/admin files; patch stayed in the queue notification service plus direct tests.

## Contract Impact

- Canonical surface: `backend/app/services/queue_position_notifications.py` notification service path.
- Request shape: unchanged for queue-position notification endpoints.
- Response shape: endpoint schemas remain unchanged; service result may include internal `telegram_sent`, while FastAPI response models continue exposing the existing `success/sent/message_id/reason/error` shape.
- Status codes: unchanged.
- Frontend consumer: unchanged route consumers for queue-position notification endpoints.
- Compatibility path or alias: existing push payload types stay `queue_call` and `queue_position`; Telegram side-channel maps them to canonical patient event names.
- Contract proof: `backend/tests/unit/test_queue_position_notifications_telegram.py` verifies `PatientCalled` and `QueueStatusChanged` helper calls and safe metadata.

## RBAC / Permissions

- Roles allowed: unchanged; existing queue-position notification endpoints still enforce their current Admin/Registrar/Doctor role requirements.
- Roles denied: unchanged; no endpoint guard, role helper, or auth dependency was modified.
- Positive auth proof: no auth path changed; new tests exercise the service after the existing authorized call path would have selected an entry.
- Negative auth proof: no auth path changed; existing endpoint-level role checks remain the permission boundary.

## Notification / Realtime

- Event type or websocket channel: adds patient Telegram side-channel for queue `queue_call` -> `PatientCalled` and `queue_position` -> `QueueStatusChanged`; no websocket channel changed.
- Payload version / ack behavior: existing push payload fields are preserved; Telegram metadata is reduced to `queue_number`, `cabinet`, and `status`.
- Read/unread or delivery semantics: patient Telegram helper honors linked chat, active/blocked state, `notifications_enabled`, and appointment reminder preference gates.
- Reconnect/resync proof: unchanged; no websocket reconnect/resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged; no frontend code changed.
- Partial data proof: unchanged; Telegram metadata falls back through the existing safe helper when values are missing.
- Forbidden secondary path behavior: unchanged; no frontend or auth behavior changed.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate

- Allowed paths: `backend/app/services/queue_position_notifications.py`, `backend/tests/unit/test_queue_position_notifications_telegram.py`.
- Denied paths: queue status mutation endpoints, frontend, migrations, admin Telegram settings, and unrelated dirty `.ai-factory/.codex` files.
- Migration/docs/test impact: no migration; runtime queue notification service plus direct unit tests. Plan file was not staged because it has pre-existing unstaged worktree edits.
- Rollback note: revert commit `3d0370b9` to remove the Telegram side-channel and tests.

## Validation

- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe -m py_compile backend\app\services\queue_position_notifications.py backend\tests\unit\test_queue_position_notifications_telegram.py`; `$env:PYTHONPATH='C:\final\backend'; backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_queue_position_notifications_telegram.py backend\tests\unit\test_notifications_push_logging.py -q`; `git diff --check -- backend/app/services/queue_position_notifications.py backend/tests/unit/test_queue_position_notifications_telegram.py`.
- Result: py_compile passed; pytest passed `16 passed, 1 warning`; diff-check passed.
- Not checked: full backend suite, frontend build, browser smoke.
