### PR TITLE
feat(telegram): set patient bot menu button

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -24,6 +24,7 @@ from app.services.telegram_staff_link_token_service import TelegramStaffLinkToke
 from app.services.telegram_bot import (
     PATIENT_BOT_COMMANDS_RU,
     PATIENT_BOT_COMMANDS_UZ,
+    PATIENT_BOT_MENU_BUTTON,
     get_telegram_bot_service,
 )
 
@@ -1461,8 +1462,9 @@ async def register_patient_bot_commands(
 
         return {
             "success": True,
-            "message": "Telegram patient bot commands registered",
+            "message": "Telegram patient bot commands and menu button registered",
             "registered_languages": ["ru", "uz"],
+            "menu_button": PATIENT_BOT_MENU_BUTTON,
             "commands": {
                 "ru": PATIENT_BOT_COMMANDS_RU,
                 "uz": PATIENT_BOT_COMMANDS_UZ,

--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -47,6 +47,7 @@ PATIENT_BOT_COMMANDS_UZ = [
     {"command": "support", "description": "Klinika bilan aloqa"},
     {"command": "help", "description": "Yordam"},
 ]
+PATIENT_BOT_MENU_BUTTON = {"type": "commands"}
 STAFF_BOT_COMMANDS_DEFAULT = [
     {"command": "staff", "description": "Staff status"},
     {"command": "queue", "description": "Role queue"},
@@ -566,9 +567,45 @@ class TelegramBotService:
 
         return True, None
 
+    async def _set_chat_menu_button(
+        self, bot_token: str | None, menu_button: dict[str, Any]
+    ) -> tuple[bool, str | None]:
+        if not bot_token:
+            logger.error("Bot token is not configured for Telegram menu button setup")
+            return False, "bot_token_not_configured"
+
+        url = f"https://api.telegram.org/bot{bot_token}/setChatMenuButton"
+        try:
+            response = requests.post(url, json={"menu_button": menu_button}, timeout=10)
+        except requests.RequestException as exc:
+            logger.warning(
+                "Telegram menu button setup request failed error_type=%s",
+                type(exc).__name__,
+            )
+            return False, type(exc).__name__
+
+        if response.status_code != 200:
+            logger.warning(
+                "Telegram menu button setup failed status_code=%s",
+                response.status_code,
+            )
+            return False, f"telegram_http_{response.status_code}"
+
+        try:
+            result = response.json()
+        except ValueError:
+            logger.warning("Telegram menu button setup returned invalid json")
+            return False, "telegram_invalid_json"
+
+        if not result.get("ok"):
+            logger.warning("Telegram menu button setup returned not ok")
+            return False, "telegram_api_error"
+
+        return True, None
+
     async def set_patient_bot_commands(self) -> tuple[bool, str | None]:
         """Register patient bot command menu in Telegram."""
-        return await self._set_bot_commands(
+        ok, error = await self._set_bot_commands(
             self.bot_token,
             [
                 {"commands": PATIENT_BOT_COMMANDS_RU},
@@ -577,6 +614,9 @@ class TelegramBotService:
                 {"commands": PATIENT_BOT_COMMANDS_UZ, "language_code": "uz"},
             ],
         )
+        if not ok:
+            return ok, error
+        return await self._set_chat_menu_button(self.bot_token, PATIENT_BOT_MENU_BUTTON)
 
     async def set_staff_bot_commands(
         self,

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -1599,10 +1599,19 @@ class TestTelegramWebhookSecurity:
 
         assert ok is True
         assert error is None
-        assert [item["json"].get("language_code") for item in captured] == [None, "uz"]
+        assert len(captured) == 3
+        assert [item["json"].get("language_code") for item in captured[:2]] == [
+            None,
+            "uz",
+        ]
         assert captured[0]["url"].endswith("/setMyCommands")
+        assert captured[1]["url"].endswith("/setMyCommands")
+        assert captured[2]["url"].endswith("/setChatMenuButton")
         assert captured[0]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_RU
         assert captured[1]["json"]["commands"] == telegram_bot.PATIENT_BOT_COMMANDS_UZ
+        assert captured[2]["json"] == {
+            "menu_button": telegram_bot.PATIENT_BOT_MENU_BUTTON
+        }
         ru_command_names = [
             command["command"] for command in captured[0]["json"]["commands"]
         ]


### PR DESCRIPTION
﻿## Summary

- Register the patient bot default Telegram chat menu button as `commands` after `setMyCommands` succeeds.
- Return the registered `menu_button` from the admin patient command registration endpoint.
- Keep patient commands, language scopes, webhook handling, tokens, queue, payments, and DB schema unchanged.

## Contract Impact

- Canonical surface: Telegram Bot API registration in backend/app/services/telegram_bot.py and admin response from backend/app/api/v1/endpoints/admin_telegram.py.
- Request shape: unchanged admin `POST /api/v1/admin/telegram/register-patient-commands` request.
- Response shape: adds `menu_button: { type: "commands" }` and updates the success message to mention the menu button.
- Status codes: unchanged.
- Frontend consumer: compatible additive response field; existing frontend success handling does not depend on the exact message text.
- Compatibility path or alias: existing patient bot command names and Telegram language scopes remain unchanged.
- Contract proof: focused Telegram tests passed and py_compile passed.

## RBAC / Permissions

- Roles allowed: unchanged; admin-only command registration endpoint remains protected by `require_roles("Admin")`.
- Roles denied: unchanged.
- Positive auth proof: existing endpoint dependency contract unchanged; service-level Bot API registration test passed.
- Negative auth proof: no new patient/staff permission path added; no staff action registration changed.

## Notification / Realtime

- Event type or websocket channel: none.
- Payload version / ack behavior: Telegram Bot API receives two existing `setMyCommands` payloads and one new `setChatMenuButton` payload.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable because this config is applied through Telegram Bot API registration, independent of polling/webhook transport.

## Frontend Resilience

- Empty data proof: not applicable because no frontend table, list, or empty state consumes `menu_button`; the admin UI already handles the existing success path.
- Partial data proof: additive backend response field only; if `menu_button` is absent from an older backend response, the existing frontend success handler still works because it reads command registration status rather than this field.
- Forbidden secondary path behavior: unchanged; the admin endpoint remains protected by `require_roles("Admin")`, and no secondary frontend path was added.
- Missing draft/resource behavior: not applicable because this does not create, edit, or display draft resources; it registers static Bot API settings.
- Stale route/deep-link behavior: not applicable because no frontend route, router alias, or deep link changed; existing Telegram commands and `/start` links remain unchanged.
- Local frontend build passed as the gate validation requested.

## Scope Gate

- Allowed paths: backend/app/services/telegram_bot.py; backend/app/api/v1/endpoints/admin_telegram.py; backend/tests/unit/test_telegram_webhook_security.py.
- Denied paths: DB migrations, queue fairness, Telegram token storage, webhook dispatcher, frontend manager files, generated output.
- Migration/docs/test impact: no migration; no docs update; focused Telegram unit test updated.
- Rollback note: revert this PR to keep command registration limited to `setMyCommands` only.

## Validation

- Targeted tests or smoke run: py_compile for telegram_bot.py, admin_telegram.py, telegram_webhook.py, and test_telegram_webhook_security.py; tests/unit/test_telegram_webhook_security.py -q; git diff --check; frontend npm.cmd run build.
- Result: py_compile passed; 36 Telegram webhook/service tests passed; diff check passed; frontend build passed with existing chunk-size and dynamic/static import warnings.
- Not checked: live Telegram client menu rendering after merge and Bot API re-registration.
