### PR TITLE
test(telegram): guard payment message metadata

### DIFF
--- a/backend/tests/unit/test_notifications_push_logging.py
+++ b/backend/tests/unit/test_notifications_push_logging.py
@@ -184,6 +184,62 @@ class PatientTelegramEventMessagesTest(unittest.TestCase):
         self.assertNotIn("<b>1000</b>", message)
         self.assertNotIn("UZS<script>", message)
 
+    def test_patient_telegram_payment_messages_redact_internal_identifiers(
+        self,
+    ) -> None:
+        sensitive_metadata = {
+            "amount": "150000",
+            "currency": "UZS",
+            "status": "paid",
+            "service_label": "Consultation",
+            "invoice_id": "invoice-internal-778899",
+            "payment_id": "payment-internal-112233",
+            "visit_id": "visit-internal-445566",
+            "patient_id": "patient-internal-987654",
+            "provider_payment_id": "payme-provider-payment-abc",
+            "provider_transaction_id": "click-provider-transaction-def",
+            "receipt_no": "receipt-internal-2026-001",
+        }
+
+        for event_type in (
+            "payment_created",
+            "payment_notification",
+            "payment_paid",
+        ):
+            message = notification_service_module._patient_telegram_event_message(
+                event_type,
+                "ru",
+                sensitive_metadata,
+            )
+
+            self.assertIsNotNone(message)
+            self.assertNotIn("invoice-internal-778899", message)
+            self.assertNotIn("payment-internal-112233", message)
+            self.assertNotIn("visit-internal-445566", message)
+            self.assertNotIn("patient-internal-987654", message)
+            self.assertNotIn("payme-provider-payment-abc", message)
+            self.assertNotIn("click-provider-transaction-def", message)
+            self.assertNotIn("receipt-internal-2026-001", message)
+            self.assertNotIn("invoice_id", message)
+            self.assertNotIn("payment_id", message)
+
+        created_message = notification_service_module._patient_telegram_event_message(
+            "payment_created",
+            "ru",
+            sensitive_metadata,
+        )
+        notification_message = (
+            notification_service_module._patient_telegram_event_message(
+                "payment_notification",
+                "ru",
+                sensitive_metadata,
+            )
+        )
+        self.assertIn("150000", created_message)
+        self.assertIn("UZS", created_message)
+        self.assertIn("150000", notification_message)
+        self.assertIn("UZS", notification_message)
+
 
 @pytest.mark.asyncio
 async def test_patient_telegram_event_helper_sends_safe_localized_message(


### PR DESCRIPTION
﻿## Summary

- Adds a unit guard for patient Telegram payment message rendering.
- Verifies payment-created, payment-notification, and payment-paid messages do not expose raw invoice, payment, visit, patient, provider, or receipt identifiers.
- Keeps amount/currency visible for payment-created and payment-notification patient-facing text.

## Contract Impact

not applicable - test-only change; no API, websocket, event payload, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

- Event type or websocket channel: patient Telegram event message helper for payment_created, payment_notification, and payment_paid.
- Payload version / ack behavior: no payload or delivery contract changed; test-only guard for rendered message content.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable - no websocket or realtime resync path changed.

## Frontend Resilience

not applicable - no user-facing frontend panel or frontend data flow changed.

## Scope Gate

- Allowed paths: backend/tests/unit/test_notifications_push_logging.py.
- Denied paths: runtime notification service, payment provider integrations, frontend screens, migrations, and unrelated dirty .ai-factory/.codex files.
- Migration/docs/test impact: test-only; no migration or docs change.
- Rollback note: revert the single test commit if the guard is no longer desired.

## Validation

- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe -m py_compile backend\tests\unit\test_notifications_push_logging.py`; `$env:PYTHONPATH='C:\final\backend'; backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_notifications_push_logging.py -q`; `git diff --check -- backend/tests/unit/test_notifications_push_logging.py`.
- Result: passed; pytest reported 15 passed, 1 warning.
- Not checked: broader backend test suite, live Telegram delivery, payment provider callbacks.
