### PR TITLE
fix(telegram): route payment receipts to protected app

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_notifications.py
+++ b/backend/app/api/v1/endpoints/telegram_notifications.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, s
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user, get_db, require_roles
+from app.core.config import settings
 from app.crud import (
     appointment as crud_appointment,
     lab_result as crud_lab,
@@ -25,7 +26,7 @@ router = APIRouter()
 
 PROTECTED_LAB_RESULTS_URL = "https://clinic.example.com/patient/lab-results"
 PROTECTED_DOCTOR_CONTACT_REFERENCE = "assigned"
-PROTECTED_PAYMENT_HISTORY_URL = "https://clinic.example.com/patient/payments"
+PROTECTED_PAYMENT_HISTORY_PATH = "/patient"
 PROTECTED_PAYMENT_REFERENCE = "available-in-protected-account"
 
 
@@ -40,6 +41,19 @@ def _telegram_notifications_disabled_response() -> Dict[str, Any]:
         "success": False,
         "message": "Telegram notifications disabled by patient preference",
     }
+
+
+def _protected_frontend_url(path: str) -> str:
+    base_url = str(
+        getattr(settings, "FRONTEND_URL", None) or "http://localhost:5173"
+    ).strip()
+    normalized_base = base_url.rstrip("/") or "http://localhost:5173"
+    normalized_path = f"/{str(path or '').strip().lstrip('/')}"
+    return f"{normalized_base}{normalized_path}"
+
+
+def _protected_payment_history_url() -> str:
+    return _protected_frontend_url(PROTECTED_PAYMENT_HISTORY_PATH)
 
 
 def _safe_lab_template_data(
@@ -74,7 +88,7 @@ def _safe_payment_template_data(payment_data: Dict[str, Any]) -> Dict[str, Any]:
         "payment_method": payment_data.get("payment_method", "Карта"),
         "payment_date": datetime.now().strftime("%d.%m.%Y %H:%M"),
         "transaction_id": PROTECTED_PAYMENT_REFERENCE,
-        "receipt_link": PROTECTED_PAYMENT_HISTORY_URL,
+        "receipt_link": _protected_payment_history_url(),
     }
 
 

--- a/backend/tests/unit/test_telegram_notifications_privacy.py
+++ b/backend/tests/unit/test_telegram_notifications_privacy.py
@@ -22,6 +22,33 @@ class FakeTelegramTemplatesService:
         return {"text": "Lab results are ready", "keyboard": None}
 
 
+def test_safe_payment_template_data_uses_configured_protected_patient_route(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        telegram_notifications.settings,
+        "FRONTEND_URL",
+        "https://portal.example.com/",
+    )
+
+    template_data = telegram_notifications._safe_payment_template_data(
+        {
+            "amount": 125000,
+            "transaction_id": "txn-secret",
+            "invoice_id": "invoice-secret",
+            "provider_payment_id": "provider-secret",
+            "receipt_link": "https://provider.example.com/receipt/txn-secret",
+        }
+    )
+
+    assert template_data["receipt_link"] == "https://portal.example.com/patient"
+    assert template_data["transaction_id"] == "available-in-protected-account"
+    assert "txn-secret" not in str(template_data)
+    assert "invoice-secret" not in str(template_data)
+    assert "provider-secret" not in str(template_data)
+    assert "provider.example.com" not in str(template_data)
+
+
 @pytest.mark.asyncio
 async def test_send_appointment_reminder_response_hides_patient_contact_metadata(
     monkeypatch,
@@ -448,6 +475,11 @@ async def test_send_payment_confirmation_response_hides_patient_contact_metadata
     templates_service = FakeTelegramTemplatesService()
 
     monkeypatch.setattr(
+        telegram_notifications.settings,
+        "FRONTEND_URL",
+        "https://clinic.example.com",
+    )
+    monkeypatch.setattr(
         telegram_notifications.crud_patient,
         "get_patient",
         lambda _db, _patient_id: patient,
@@ -497,7 +529,7 @@ async def test_send_payment_confirmation_response_hides_patient_contact_metadata
         "available-in-protected-account"
     )
     assert templates_service.template_data["receipt_link"] == (
-        "https://clinic.example.com/patient/payments"
+        "https://clinic.example.com/patient"
     )
     assert "txn-secret" not in str(templates_service.template_data)
 
@@ -517,6 +549,11 @@ async def test_send_payment_confirmation_message_omits_raw_payment_identifiers(
         _send_message=AsyncMock(return_value=True),
     )
 
+    monkeypatch.setattr(
+        telegram_notifications.settings,
+        "FRONTEND_URL",
+        "https://clinic.example.com",
+    )
     monkeypatch.setattr(
         telegram_notifications.crud_patient,
         "get_patient",
@@ -558,7 +595,7 @@ async def test_send_payment_confirmation_message_omits_raw_payment_identifiers(
     assert "receipt-secret-internal" not in telegram_payload
     assert "/receipt/" not in telegram_payload
     assert "Sensitive Patient" not in telegram_payload
-    assert "https://clinic.example.com/patient/payments" in telegram_payload
+    assert "https://clinic.example.com/patient" in telegram_payload
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
﻿## Summary

- Replaces the hardcoded Telegram payment receipt placeholder URL with a protected frontend route built from `settings.FRONTEND_URL`.
- Keeps Telegram payment confirmation templates free of raw transaction, invoice, provider payment, and provider receipt URLs.
- Adds privacy coverage for the protected route and sanitized payment template data.

## Contract Impact

- Canonical surface: `POST /telegram-notifications/send-payment-confirmation` rendered Telegram template data.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: protected app route at `${FRONTEND_URL}/patient`; no new frontend route introduced.
- Compatibility path or alias: no API alias changed; only the Telegram inline receipt URL target changes from placeholder host/path to configured frontend app.
- Contract proof: targeted privacy tests assert the receipt link uses the configured protected patient route and omits raw payment/invoice/provider identifiers.

## RBAC / Permissions

not applicable - no route authorization, role helper, or permission behavior changed; existing Admin/Cashier endpoint guard remains in place.

## Notification / Realtime

- Event type or websocket channel: Telegram payment confirmation message.
- Payload version / ack behavior: no delivery acknowledgement behavior changed; template data now contains a settings-based protected app URL.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable - no websocket/realtime path changed.

## Frontend Resilience

not applicable - no frontend component, route registry, or user-facing panel changed in this narrow backend notification slice.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_notifications.py`, `backend/tests/unit/test_telegram_notifications_privacy.py`.
- Denied paths: frontend routing/components, payment provider integrations, migrations, Telegram webhook/staff endpoints, and unrelated dirty `.ai-factory/.codex` files.
- Migration/docs/test impact: no migration; test coverage updated in privacy unit tests.
- Rollback note: revert this commit to restore the previous placeholder receipt URL behavior.

## Validation

- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe -m py_compile backend\app\api\v1\endpoints\telegram_notifications.py backend\tests\unit\test_telegram_notifications_privacy.py`; `$env:PYTHONPATH='C:\final\backend'; backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_telegram_notifications_privacy.py -q`; `git diff --check -- backend/app/api/v1/endpoints/telegram_notifications.py backend/tests/unit/test_telegram_notifications_privacy.py`.
- Result: passed; pytest reported 12 passed, 1 warning.
- Not checked: broader backend suite, live Telegram delivery, real frontend route smoke, provider payment callbacks.
