### PR TITLE
feat(telegram): notify patients about unpaid invoices

### DIFF
--- a/backend/app/services/payment_invoice_service.py
+++ b/backend/app/services/payment_invoice_service.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from dataclasses import dataclass
 from typing import Any
 
 from app.models.enums import PaymentStatus
 from app.models.payment_invoice import PaymentInvoice
 from app.repositories.payment_invoice_repository import PaymentInvoiceRepository
+from app.services.notifications import notification_sender_service
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -53,6 +59,8 @@ class PaymentInvoiceService:
             self.repository.commit()
             self.repository.refresh(invoice)
 
+            self._notify_unpaid_invoice_created(invoice)
+
             return self._serialize_invoice(invoice)
         except PaymentInvoiceDomainError:
             raise
@@ -87,6 +95,81 @@ class PaymentInvoiceService:
                     status_code=400, detail=f"Некорректный patient_id: {value}"
                 )
         return 0
+
+    def _notify_unpaid_invoice_created(self, invoice: PaymentInvoice) -> None:
+        patient_id = getattr(invoice, "patient_id", None)
+        if not patient_id:
+            return
+
+        try:
+            patient_id_int = int(patient_id)
+        except (TypeError, ValueError):
+            return
+
+        if patient_id_int <= 0:
+            return
+
+        metadata = {
+            "amount": invoice.total_amount,
+            "currency": invoice.currency,
+            "status": invoice.status,
+            "provider": invoice.provider,
+        }
+        sender = notification_sender_service
+
+        async def _send() -> None:
+            await sender.send_patient_telegram_event_notification(
+                db=self.repository.db,
+                patient_id=patient_id_int,
+                event_type="payment_created",
+                metadata=metadata,
+            )
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            async def _send_detached() -> None:
+                from app.db.session import SessionLocal
+
+                db = SessionLocal()
+                try:
+                    await sender.send_patient_telegram_event_notification(
+                        db=db,
+                        patient_id=patient_id_int,
+                        event_type="payment_created",
+                        metadata=metadata,
+                    )
+                finally:
+                    db.close()
+
+            task = loop.create_task(_send_detached())
+            task.add_done_callback(
+                self._log_unpaid_invoice_created_notification_result
+            )
+            return
+
+        try:
+            asyncio.run(_send())
+        except Exception as exc:
+            logger.warning(
+                "Payment invoice Telegram unpaid bill notification failed",
+                extra={"error_type": type(exc).__name__},
+            )
+
+    @staticmethod
+    def _log_unpaid_invoice_created_notification_result(
+        task: asyncio.Task[None],
+    ) -> None:
+        try:
+            task.result()
+        except Exception as exc:
+            logger.warning(
+                "Payment invoice Telegram unpaid bill notification failed",
+                extra={"error_type": type(exc).__name__},
+            )
 
     @staticmethod
     def _serialize_invoice(invoice: PaymentInvoice) -> dict[str, Any]:

--- a/backend/tests/unit/test_payment_invoice_service.py
+++ b/backend/tests/unit/test_payment_invoice_service.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from app.models.payment_invoice import PaymentInvoice
+from app.services import payment_invoice_service as payment_invoice_service_module
 from app.services.payment_invoice_service import (
     PaymentInvoiceDomainError,
     PaymentInvoiceService,
@@ -32,6 +35,64 @@ class TestPaymentInvoiceService:
         assert result["amount"] == 12_500.0
         assert result["description"] == "unit invoice"
         assert invoice.provider_data["created_by_id"] == admin_user.id
+
+    def test_create_invoice_emits_safe_patient_telegram_unpaid_bill_event(
+        self, db_session, admin_user, test_patient, monkeypatch
+    ):
+        telegram_mock = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            payment_invoice_service_module.notification_sender_service,
+            "send_patient_telegram_event_notification",
+            telegram_mock,
+        )
+
+        service = PaymentInvoiceService(db_session)
+        result = service.create_invoice(
+            amount=18_000.0,
+            currency="UZS",
+            provider="click",
+            description="cardiology invoice",
+            patient_info={"patient_id": test_patient.id},
+            created_by_id=admin_user.id,
+        )
+
+        telegram_mock.assert_awaited_once()
+        kwargs = telegram_mock.await_args.kwargs
+        assert kwargs["db"] is db_session
+        assert kwargs["patient_id"] == test_patient.id
+        assert kwargs["event_type"] == "payment_created"
+        assert kwargs["metadata"] == {
+            "amount": 18_000.0,
+            "currency": "UZS",
+            "status": "pending",
+            "provider": "click",
+        }
+        assert "invoice_id" not in kwargs["metadata"]
+        assert "payment_id" not in kwargs["metadata"]
+        assert "provider_payment_id" not in kwargs["metadata"]
+        assert result["invoice_id"]
+
+    def test_create_invoice_without_patient_skips_patient_telegram_event(
+        self, db_session, admin_user, monkeypatch
+    ):
+        telegram_mock = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            payment_invoice_service_module.notification_sender_service,
+            "send_patient_telegram_event_notification",
+            telegram_mock,
+        )
+
+        service = PaymentInvoiceService(db_session)
+        service.create_invoice(
+            amount=12_500.0,
+            currency="UZS",
+            provider="click",
+            description="unit invoice",
+            patient_info=None,
+            created_by_id=admin_user.id,
+        )
+
+        telegram_mock.assert_not_awaited()
 
     def test_create_invoice_invalid_patient_id(self, db_session):
         service = PaymentInvoiceService(db_session)


### PR DESCRIPTION
﻿## Summary

- Emits a safe patient Telegram `payment_created` event when a payment invoice is created for a linked patient.
- Keeps Telegram metadata limited to amount, currency, status, and provider, with no raw invoice/payment/provider identifiers.
- Adds unit coverage for patient-linked invoice notifications and the no-patient skip path.

## Contract Impact

- Canonical surface: payment invoice creation service used by `POST /payments/invoice/create`.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged.
- Compatibility path or alias: unchanged.
- Contract proof: `test_payment_invoice_service.py` verifies invoice response still returns and Telegram event metadata excludes raw invoice/payment identifiers.

## RBAC / Permissions

not applicable - no route guard or permission behavior changed; invoice creation keeps the existing endpoint authorization path.

## Notification / Realtime

- Event type or websocket channel: patient Telegram `payment_created` event via `notification_sender_service.send_patient_telegram_event_notification`.
- Payload version / ack behavior: no public payload version changed; metadata is restricted to safe amount/currency/status/provider labels.
- Read/unread or delivery semantics: unchanged; notification failure is logged and does not roll back invoice creation.
- Reconnect/resync proof: not applicable - no websocket or resync path changed.

## Frontend Resilience

not applicable - no frontend component, route, or data flow changed.

## Scope Gate

- Allowed paths: `backend/app/services/payment_invoice_service.py`, `backend/tests/unit/test_payment_invoice_service.py`.
- Denied paths: payment provider integrations, DB migrations, frontend routes/components, Telegram webhook/staff endpoints, and unrelated dirty `.ai-factory/.codex` files.
- Migration/docs/test impact: no migration; unit coverage added for the notification side effect.
- Rollback note: revert this commit to stop emitting Telegram unpaid invoice events from invoice creation.

## Validation

- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe -m py_compile backend\app\services\payment_invoice_service.py backend\tests\unit\test_payment_invoice_service.py`; `$env:PYTHONPATH='C:\final\backend'; backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_payment_invoice_service.py -q`; `git diff --check -- backend/app/services/payment_invoice_service.py backend/tests/unit/test_payment_invoice_service.py`.
- Result: passed; pytest reported 5 passed, 1 warning.
- Not checked: broader backend suite, live Telegram delivery, provider reconciliation callbacks.
