### PR TITLE
fix(telegram): route payment confirmations to payment entry

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_notifications.py
+++ b/backend/app/api/v1/endpoints/telegram_notifications.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, s
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user, get_db, require_roles
+from app.api.v1.endpoints.admin_telegram import PATIENT_PAYMENT_ENTRY_ROUTE
 from app.core.config import settings
 from app.crud import (
     appointment as crud_appointment,
@@ -26,7 +27,7 @@ router = APIRouter()
 
 PROTECTED_LAB_RESULTS_URL = "https://clinic.example.com/patient/lab-results"
 PROTECTED_DOCTOR_CONTACT_REFERENCE = "assigned"
-PROTECTED_PAYMENT_HISTORY_PATH = "/patient"
+PROTECTED_PAYMENT_HISTORY_PATH = PATIENT_PAYMENT_ENTRY_ROUTE
 PROTECTED_PAYMENT_REFERENCE = "available-in-protected-account"
 
 

--- a/backend/tests/unit/test_telegram_notifications_privacy.py
+++ b/backend/tests/unit/test_telegram_notifications_privacy.py
@@ -41,7 +41,7 @@ def test_safe_payment_template_data_uses_configured_protected_patient_route(
         }
     )
 
-    assert template_data["receipt_link"] == "https://portal.example.com/patient"
+    assert template_data["receipt_link"] == "https://portal.example.com/patient/payments"
     assert template_data["transaction_id"] == "available-in-protected-account"
     assert "txn-secret" not in str(template_data)
     assert "invoice-secret" not in str(template_data)
@@ -529,7 +529,7 @@ async def test_send_payment_confirmation_response_hides_patient_contact_metadata
         "available-in-protected-account"
     )
     assert templates_service.template_data["receipt_link"] == (
-        "https://clinic.example.com/patient"
+        "https://clinic.example.com/patient/payments"
     )
     assert "txn-secret" not in str(templates_service.template_data)
 
@@ -595,7 +595,7 @@ async def test_send_payment_confirmation_message_omits_raw_payment_identifiers(
     assert "receipt-secret-internal" not in telegram_payload
     assert "/receipt/" not in telegram_payload
     assert "Sensitive Patient" not in telegram_payload
-    assert "https://clinic.example.com/patient" in telegram_payload
+    assert "https://clinic.example.com/patient/payments" in telegram_payload
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Reuse the canonical protected patient payment entry route for Telegram payment confirmation receipt links.
- Keep payment confirmation messages free of transaction, invoice, receipt, and patient identifiers.
- Update Telegram notification privacy tests to expect `/patient/payments` instead of the generic `/patient` cabinet path.

## Contract Impact

- Canonical surface: Telegram payment confirmation notification template data and sent chat payload.
- Request shape: unchanged admin-triggered payment notification request.
- Response shape: unchanged success response; generated Telegram receipt link now points to `/patient/payments` under `FRONTEND_URL`.
- Status codes: unchanged.
- Frontend consumer: existing protected patient payment entry route `/patient/payments`; no new frontend route.
- Compatibility path or alias: `/patient` remains unchanged; payment confirmation deep links now use the payment-specific protected entry.
- Contract proof: `test_telegram_notifications_privacy.py` asserts protected links and absence of raw internal identifiers.

## RBAC / Permissions

- Roles allowed: unchanged admin/staff caller permissions for triggering notifications; patient-facing link goes to the authenticated protected-app payment entry.
- Roles denied: unauthenticated protected-app users remain denied by the frontend route/session layer; no Telegram chat URL contains patient/payment identifiers.
- Positive auth proof: notification code uses `PATIENT_PAYMENT_ENTRY_ROUTE`, which is published by the Telegram admin status contract.
- Negative auth proof: privacy tests assert transaction, invoice, receipt, and patient metadata are not present in template data or Telegram payloads.

## Notification / Realtime

- Event type or websocket channel: Telegram payment confirmation message; no websocket channel is added or changed.
- Payload version / ack behavior: existing Telegram notification send/response behavior is unchanged.
- Read/unread or delivery semantics: no notification-center read/unread semantics are introduced; the bot sends a direct Telegram message.
- Reconnect/resync proof: not applicable because this is not a websocket/realtime flow; receipt link is regenerated from current route config for each notification.

## Frontend Resilience

- Empty data proof: unchanged; no frontend component rendering behavior changes.
- Partial data proof: `FRONTEND_URL` composition continues to use the configured base URL plus protected payment path.
- Forbidden secondary path behavior: no raw receipt/invoice fallback URL is emitted.
- Missing draft/resource behavior: not applicable, no draft/resource creation.
- Stale route/deep-link behavior: route constant is reused from the Telegram admin contract instead of duplicating `/patient` locally.

## Scope Gate

- Allowed paths: Telegram notifications endpoint and targeted Telegram notification privacy tests.
- Denied paths: migrations, payment processing, invoice storage, PatientPanel UI, route registry changes.
- Migration/docs/test impact: no migration; targeted privacy test expectations updated.
- Rollback note: revert commit `c0e4cca4` to restore the generic `/patient` payment confirmation link.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/telegram_notifications.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py backend/tests/unit/test_telegram_notifications_privacy.py`; `pytest backend/tests/unit/test_telegram_notifications_privacy.py -q`; `npm.cmd run build`; `git diff --check` for touched files.
- Result: passed locally. Frontend build produced only existing Vite chunk/dynamic-import warnings.
- Not checked: live Telegram Bot API delivery.