### PR TITLE
feat(telegram): notify patients after successful payments

### DIFF
--- a/backend/app/services/visit_payment_integration.py
+++ b/backend/app/services/visit_payment_integration.py
@@ -1,4 +1,5 @@
 # app/services/visit_payment_integration.py
+import asyncio
 import logging
 from datetime import datetime
 from typing import Any
@@ -20,6 +21,171 @@ class VisitPaymentIntegrationService:
     @staticmethod
     def _repo(db: Session) -> VisitPaymentIntegrationRepository:
         return VisitPaymentIntegrationRepository(db)
+
+    @staticmethod
+    def _safe_int(value: Any) -> int | None:
+        try:
+            if value is None:
+                return None
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _row_value(row: Any, field_name: str) -> Any:
+        if row is None:
+            return None
+        if hasattr(row, field_name):
+            return getattr(row, field_name)
+
+        mapping = getattr(row, "_mapping", None)
+        if mapping is not None:
+            try:
+                if field_name in mapping:
+                    return mapping[field_name]
+            except TypeError:
+                pass
+
+        return None
+
+    @staticmethod
+    def _format_webhook_amount(amount: Any) -> str | None:
+        try:
+            value = float(amount) / 100
+        except (TypeError, ValueError):
+            return None
+
+        if value.is_integer():
+            return str(int(value))
+        return f"{value:.2f}"
+
+    @staticmethod
+    def _payment_status_event_type(payment_status: str) -> str:
+        normalized = str(payment_status or "").strip().lower()
+        if normalized in {"paid", "processed", "success", "completed"}:
+            return "payment_paid"
+        return "payment_notification"
+
+    @staticmethod
+    def _payment_status_metadata(
+        payment_status: str, webhook: PaymentWebhookOut | None
+    ) -> dict[str, str]:
+        metadata = {"status": str(payment_status or "updated")}
+        if webhook is None:
+            return metadata
+
+        amount = VisitPaymentIntegrationService._format_webhook_amount(
+            getattr(webhook, "amount", None)
+        )
+        if amount is not None:
+            metadata["amount"] = amount
+
+        currency = str(getattr(webhook, "currency", "") or "").strip()
+        if currency:
+            metadata["currency"] = currency
+
+        provider = str(getattr(webhook, "provider", "") or "").strip()
+        if provider:
+            metadata["provider"] = provider
+
+        return metadata
+
+    @staticmethod
+    def _dispatch_patient_payment_status_notification(
+        *,
+        db: Session,
+        patient_id: int | None,
+        payment_status: str,
+        webhook: PaymentWebhookOut | None,
+    ) -> None:
+        patient_id = VisitPaymentIntegrationService._safe_int(patient_id)
+        if patient_id is None:
+            return
+
+        event_type = VisitPaymentIntegrationService._payment_status_event_type(
+            payment_status
+        )
+        metadata = VisitPaymentIntegrationService._payment_status_metadata(
+            payment_status, webhook
+        )
+
+        async def _send() -> None:
+            from app.services.notifications import notification_sender_service
+
+            await notification_sender_service.send_patient_telegram_event_notification(
+                db=db,
+                patient_id=patient_id,
+                event_type=event_type,
+                metadata=metadata,
+            )
+
+        def _log_failure(exc: BaseException) -> None:
+            logger.warning(
+                "Patient payment Telegram status notification failed",
+                extra={
+                    "event_type": event_type,
+                    "payment_status": payment_status,
+                    "error_type": type(exc).__name__,
+                },
+            )
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                asyncio.run(_send())
+            except Exception as exc:
+                _log_failure(exc)
+            return
+
+        async def _send_detached() -> None:
+            from app.db.session import SessionLocal
+            from app.services.notifications import notification_sender_service
+
+            detached_db = SessionLocal()
+            try:
+                await notification_sender_service.send_patient_telegram_event_notification(
+                    db=detached_db,
+                    patient_id=patient_id,
+                    event_type=event_type,
+                    metadata=metadata,
+                )
+            finally:
+                detached_db.close()
+
+        task = running_loop.create_task(_send_detached())
+
+        def _handle_task_result(done_task: asyncio.Task) -> None:
+            try:
+                done_task.result()
+            except Exception as exc:
+                _log_failure(exc)
+
+        task.add_done_callback(_handle_task_result)
+
+    @staticmethod
+    def _resolve_appointment_patient_id(
+        db: Session,
+        appointment_id: int,
+        webhook: PaymentWebhookOut | None,
+    ) -> int | None:
+        try:
+            from app.models.appointment import Appointment
+
+            patient_id = (
+                db.query(Appointment.patient_id)
+                .filter(Appointment.id == appointment_id)
+                .scalar()
+            )
+            return VisitPaymentIntegrationService._safe_int(patient_id)
+        except Exception as exc:
+            logger.warning(
+                "Appointment patient lookup for payment Telegram notification failed",
+                extra={"error_type": type(exc).__name__},
+            )
+            return VisitPaymentIntegrationService._safe_int(
+                getattr(webhook, "patient_id", None)
+            )
 
     @staticmethod
     def create_visit_from_payment(
@@ -88,6 +254,8 @@ class VisitPaymentIntegrationService:
         payment_status: str,
         webhook: PaymentWebhookOut | None = None,
         additional_data: dict[str, Any] | None = None,
+        *,
+        notify_patient: bool = False,
     ) -> tuple[bool, str]:
         """
         Обновление статуса платежа для существующего визита
@@ -136,6 +304,17 @@ class VisitPaymentIntegrationService:
             # Обновляем визит
             repo.update_visit(visit_id, update_data)
             db.commit()
+
+            if notify_patient:
+                patient_id = VisitPaymentIntegrationService._safe_int(
+                    VisitPaymentIntegrationService._row_value(visit, "patient_id")
+                )
+                VisitPaymentIntegrationService._dispatch_patient_payment_status_notification(
+                    db=db,
+                    patient_id=patient_id,
+                    payment_status=payment_status,
+                    webhook=webhook,
+                )
 
             return (
                 True,
@@ -214,7 +393,7 @@ class VisitPaymentIntegrationService:
             # Обновляем статус платежа
             success, message = (
                 VisitPaymentIntegrationService.update_visit_payment_status(
-                    db, visit_id, "paid", webhook
+                    db, visit_id, "paid", webhook, notify_patient=True
                 )
             )
 
@@ -441,6 +620,16 @@ class VisitPaymentIntegrationService:
 
             # Обновляем статус вебхука
             repo.update_webhook_status(webhook_id=webhook.id, status="appointment_updated")
+
+            patient_id = VisitPaymentIntegrationService._resolve_appointment_patient_id(
+                db, appointment_id, webhook
+            )
+            VisitPaymentIntegrationService._dispatch_patient_payment_status_notification(
+                db=db,
+                patient_id=patient_id,
+                payment_status="paid",
+                webhook=webhook,
+            )
 
             return True, f"Платёж для записи {appointment_id} обработан успешно"
 

--- a/backend/app/services/visit_payment_integration.py
+++ b/backend/app/services/visit_payment_integration.py
@@ -620,6 +620,7 @@ class VisitPaymentIntegrationService:
 
             # Обновляем статус вебхука
             repo.update_webhook_status(webhook_id=webhook.id, status="appointment_updated")
+            db.commit()
 
             patient_id = VisitPaymentIntegrationService._resolve_appointment_patient_id(
                 db, appointment_id, webhook

--- a/backend/tests/unit/test_visit_payment_integration_service.py
+++ b/backend/tests/unit/test_visit_payment_integration_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -176,6 +176,70 @@ class TestVisitPaymentIntegrationService:
         )
 
         assert patient_id == 88
+
+    def test_process_payment_for_appointment_sends_safe_patient_telegram_status(self):
+        webhook = SimpleNamespace(
+            id=55,
+            amount=1234500,
+            currency="UZS",
+            provider="click",
+            transaction_id="trx-55",
+        )
+        repo = SimpleNamespace(
+            update_appointment_status=lambda **_: True,
+            update_appointment_fields=lambda **_: True,
+            update_webhook_status=lambda **_: None,
+        )
+        db = SimpleNamespace(commit=Mock())
+        send_event = AsyncMock(return_value=True)
+
+        with (
+            patch(
+                "app.services.visit_payment_integration.VisitPaymentIntegrationRepository",
+                return_value=repo,
+            ),
+            patch.object(
+                VisitPaymentIntegrationService,
+                "_resolve_appointment_patient_id",
+                return_value=88,
+            ),
+            patch(
+                "app.services.notifications.notification_sender_service.send_patient_telegram_event_notification",
+                send_event,
+            ),
+        ):
+            success, message = VisitPaymentIntegrationService.process_payment_for_appointment(
+                db,
+                appointment_id=42,
+                webhook=webhook,
+            )
+
+        assert success is True
+        assert "42" in message
+        db.commit.assert_called_once()
+        send_event.assert_awaited_once()
+        _, kwargs = send_event.await_args
+        assert kwargs["db"] is db
+        assert kwargs["patient_id"] == 88
+        assert kwargs["event_type"] == "payment_paid"
+        assert kwargs["metadata"] == {
+            "status": "paid",
+            "amount": "12345",
+            "currency": "UZS",
+            "provider": "click",
+        }
+        assert "trx-55" not in kwargs["metadata"].values()
+        for internal_key in (
+            "appointment_id",
+            "invoice_id",
+            "payment_id",
+            "visit_id",
+            "patient_id",
+            "webhook_id",
+            "transaction_id",
+            "provider_transaction_id",
+        ):
+            assert internal_key not in kwargs["metadata"]
 
     def test_process_payment_for_appointment_updates_repository(self, db_session):
         webhook = SimpleNamespace(

--- a/backend/tests/unit/test_visit_payment_integration_service.py
+++ b/backend/tests/unit/test_visit_payment_integration_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -96,6 +96,86 @@ class TestVisitPaymentIntegrationService:
             )
 
         assert result is True
+
+    def test_process_payment_for_existing_visit_sends_safe_patient_telegram_status(
+        self, db_session
+    ):
+        webhook = SimpleNamespace(
+            id=55,
+            amount=1234500,
+            currency="UZS",
+            provider="click",
+            transaction_id="trx-55",
+        )
+        repo = SimpleNamespace(
+            get_visit=lambda _visit_id: SimpleNamespace(patient_id=77),
+            update_visit=lambda _visit_id, _values: None,
+            find_appointment_by_visit_id=lambda _visit_id: None,
+            update_webhook_status=lambda **_: None,
+        )
+        send_event = AsyncMock(return_value=True)
+
+        with (
+            patch(
+                "app.services.visit_payment_integration.VisitPaymentIntegrationRepository",
+                return_value=repo,
+            ),
+            patch(
+                "app.services.notifications.notification_sender_service.send_patient_telegram_event_notification",
+                send_event,
+            ),
+        ):
+            success, message = (
+                VisitPaymentIntegrationService.process_payment_for_existing_visit(
+                    db_session,
+                    visit_id=42,
+                    webhook=webhook,
+                )
+            )
+
+        assert success is True
+        assert "42" in message
+        send_event.assert_awaited_once()
+        _, kwargs = send_event.await_args
+        assert kwargs["db"] is db_session
+        assert kwargs["patient_id"] == 77
+        assert kwargs["event_type"] == "payment_paid"
+        assert kwargs["metadata"] == {
+            "status": "paid",
+            "amount": "12345",
+            "currency": "UZS",
+            "provider": "click",
+        }
+        assert "trx-55" not in kwargs["metadata"].values()
+        for internal_key in (
+            "invoice_id",
+            "payment_id",
+            "visit_id",
+            "patient_id",
+            "webhook_id",
+            "transaction_id",
+            "provider_transaction_id",
+        ):
+            assert internal_key not in kwargs["metadata"]
+
+    def test_resolve_appointment_patient_id_prefers_appointment_record(self):
+        class _Query:
+            def filter(self, *_args):
+                return self
+
+            def scalar(self):
+                return 88
+
+        db = SimpleNamespace(query=lambda *_args: _Query())
+        webhook = SimpleNamespace(patient_id=77)
+
+        patient_id = VisitPaymentIntegrationService._resolve_appointment_patient_id(
+            db,
+            appointment_id=42,
+            webhook=webhook,
+        )
+
+        assert patient_id == 88
 
     def test_process_payment_for_appointment_updates_repository(self, db_session):
         webhook = SimpleNamespace(


### PR DESCRIPTION
## Summary

- Send privacy-safe patient Telegram payment status events after successful visit or appointment payment processing.
- Include only safe metadata in Telegram event rendering: status, amount, currency, and provider.
- Keep internal identifiers out of patient-facing metadata: transaction_id, provider_transaction_id, visit_id, appointment_id, patient_id, invoice_id, payment_id, and webhook_id.
- Use a detached DB session when dispatching from an already-running event loop, and commit appointment payment updates before dispatch.

## Contract Impact

- Canonical surface: visit/payment integration service emits patient Telegram event notifications for successful payment status updates.
- Request shape: no external API request shape changes; webhook processing and visit payment APIs keep their existing inputs.
- Response shape: no external API response shape changes; notification dispatch is best-effort and does not alter success payloads.
- Status codes: unchanged.
- Frontend consumer: none directly; patient Telegram event messages use the existing notification sender service and protected patient payment UX.
- Compatibility path or alias: existing visit and appointment payment flows remain in place; notification metadata is additive and safe.
- Contract proof: targeted unit tests assert `payment_paid` event type, safe metadata, and absence of raw internal identifiers.

## RBAC / Permissions

- Roles allowed: unchanged backend webhook/payment processing permissions; Telegram delivery only targets linked active Telegram users for the resolved patient.
- Roles denied: no staff/admin recipient is added; no unlinked, blocked, disabled, or preference-disabled Telegram user receives a message under existing notification sender checks.
- Positive auth proof: unit tests assert resolved patient id is passed to `send_patient_telegram_event_notification` with `payment_paid` and safe metadata.
- Negative auth proof: unit tests assert internal id keys and raw transaction values are absent from metadata; notification sender keeps existing linked-chat and preference checks.

## Notification / Realtime

- Event type or websocket channel: Telegram patient event notification with `event_type=payment_paid`; no websocket channel is added or changed.
- Payload version / ack behavior: no versioned payload; dispatch remains best-effort and failures are logged without failing payment processing.
- Read/unread or delivery semantics: no notification-center read/unread semantics are introduced; this sends a Telegram patient event through the existing sender.
- Reconnect/resync proof: not applicable because this is not a websocket flow; payment status metadata is regenerated from the webhook/service state for each successful payment processing call.

## Frontend Resilience

- Empty data proof: no frontend rendering changes.
- Partial data proof: metadata builder omits amount/currency/provider when missing or invalid instead of emitting internal fallback ids.
- Forbidden secondary path behavior: no raw invoice, receipt, transaction, visit, appointment, patient, or webhook id is emitted in Telegram metadata.
- Missing draft/resource behavior: not applicable, no draft/resource creation.
- Stale route/deep-link behavior: this backend service does not create or change route/deep-link URLs; payment details continue to use the protected `/patient/payments` entry from the prior merged route contract, so stale Telegram messages cannot expose raw payment or receipt identifiers.

## Scope Gate

- Allowed paths: visit payment integration service and targeted unit tests.
- Denied paths: migrations, payment provider storage, Telegram webhook command UX, frontend route registry, PatientPanel UI.
- Migration/docs/test impact: no migration; targeted unit tests added/updated for notification dispatch and privacy.
- Rollback note: revert commits `e2e03525` and `638dfd57` from this branch to remove payment status Telegram dispatch.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/services/visit_payment_integration.py backend/tests/unit/test_visit_payment_integration_service.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `pytest backend/tests/unit/test_visit_payment_integration_service.py -q`; `pytest backend/tests/unit/test_visit_payment_integration_service.py backend/tests/unit/test_notifications_push_logging.py::PatientTelegramEventMessagesTest::test_patient_telegram_event_alias_normalizes_camel_case -q`; `npm.cmd run build`; `git diff --check` for touched files.
- Result: passed locally. Frontend build produced only existing Vite chunk/dynamic-import warnings.
- Not checked: live Telegram Bot API delivery and real payment provider webhook callbacks.
