### PR TITLE
test(telegram): cover stale staff confirmations

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -301,7 +301,8 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 - [ ] Enable state-changing actions one by one behind explicit configuration and tests.
 - [ ] Add negative tests for unauthorized staff, stale confirmations, repeated confirmations, and cross-role action attempts.
   - [x] Unauthorized/cross-role state-changing command denial is covered by `backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py::TestTelegramStaffReadOnlyMenuRuntime::test_staff_state_change_command_denies_unauthorized_role`.
-  - [ ] Stale and repeated confirmation runtime tests remain pending until confirmation execution is enabled.
+  - [x] Storage/service-level stale and repeated confirmation protection is covered by `backend/tests/unit/test_telegram_bot_management_api_service.py::TestTelegramBotManagementApiService::test_staff_confirmation_token_service_rejects_expired_record_without_consuming` and `backend/tests/unit/test_telegram_bot_management_api_service.py::TestTelegramBotManagementApiService::test_staff_confirmation_token_service_consumes_record_once`.
+  - [ ] Webhook/runtime stale and repeated confirmation execution tests remain pending until confirmed action execution is enabled.
 
 ### Phase 5: Telegram Mini App
 

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -698,6 +698,46 @@ class TestTelegramBotManagementApiService:
             "consumed_at": consumed_at.isoformat(),
         }
 
+    def test_staff_confirmation_token_service_rejects_expired_record_without_consuming(
+        self, db_session, admin_user
+    ):
+        service = TelegramStaffConfirmationTokenService(db_session)
+        token_hash = "staff_confirmation_token:" + ("7" * 64)
+        payload_hash = "payload:" + ("8" * 64)
+        idempotency_hash = "idempotency:" + ("9" * 64)
+        issued_at = datetime.now(timezone.utc)
+        expires_at = issued_at + timedelta(seconds=30)
+        service.issue_token(
+            token_hash=token_hash,
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700803,
+            operation_key="payment_status_change",
+            command_key="/payment_status",
+            action_payload_hash=payload_hash,
+            target_type="payment",
+            idempotency_key_hash=idempotency_hash,
+            expires_at=expires_at,
+            request_id="req-confirm-expired",
+        )
+
+        result = service.consume_for_confirmation(
+            token_hash=token_hash,
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700803,
+            operation_key="payment_status_change",
+            action_payload_hash=payload_hash,
+            idempotency_key_hash=idempotency_hash,
+            now=expires_at + timedelta(seconds=1),
+        )
+        stored = (
+            db_session.query(TelegramStaffConfirmationToken)
+            .filter(TelegramStaffConfirmationToken.token_hash == token_hash)
+            .one()
+        )
+
+        assert result == {"valid": False, "reason": "expired"}
+        assert stored.consumed_at is None
+
     def test_staff_confirmation_token_service_rejects_action_mismatch(
         self, db_session, admin_user
     ):


### PR DESCRIPTION
## Summary
- Adds service-level negative coverage for expired Telegram staff confirmation tokens.
- Verifies expired confirmation tokens return `expired` and remain unconsumed, preserving single-use/replay guard state.
- Updates the AI Factory Telegram plan to distinguish completed storage/service stale/replay proof from future webhook/runtime confirmation execution tests.

## Contract Impact
- Canonical surface: `TelegramStaffConfirmationTokenService.consume_for_confirmation(...)` remains the storage/service confirmation-token boundary; `.ai-factory/plans/telegram-bot-clinic-full-strategy.md` tracks the rollout proof.
- Request shape: no external HTTP request body changes.
- Response shape: no API or Telegram reply shape changes; this is test/docs proof only.
- Status codes: unchanged.
- Frontend consumer: unchanged; no frontend source changes.
- Compatibility path or alias: no route, command, alias, or webhook path changes.
- Contract proof: `backend/tests/unit/test_telegram_bot_management_api_service.py::TestTelegramBotManagementApiService::test_staff_confirmation_token_service_rejects_expired_record_without_consuming` covers stale-token rejection without consuming the token record; existing consume-once coverage remains the repeated-token proof.

## RBAC / Permissions
- Roles allowed: unchanged; no role expansion.
- Roles denied: unchanged; expired confirmation tokens stay invalid before any domain action can execute.
- Positive auth proof: existing staff confirmation service tests still cover valid consume-once behavior.
- Negative auth proof: this PR adds stale-token rejection proof and keeps unauthorized/cross-role proof documented in the plan.

## Notification / Realtime
- Event type or websocket channel: none added.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable because no realtime transport changes.

## Frontend Resilience
- Empty data proof: not applicable; no frontend data shape changes.
- Partial data proof: not applicable; no frontend consumer changes.
- Forbidden secondary path behavior: expired confirmation tokens are rejected without consuming or mutating domain state.
- Missing draft/resource behavior: no draft/domain resource is created; only token storage semantics are tested.
- Stale route/deep-link behavior: stale confirmation tokens return `expired` and leave `consumed_at` unset for audit/debug clarity.

## Scope Gate
- Allowed paths: Telegram management API unit tests and the Telegram AI Factory strategy plan.
- Denied paths: Telegram webhook execution, domain adapters, DB migrations, frontend runtime, queue/payment/schedule mutations, and unrelated `.codex/*` workspace files.
- Migration/docs/test impact: no migration; one unit test added; plan updated to keep future webhook/runtime stale/replay tests pending until action execution is enabled.
- Rollback note: revert commit `9b1c3877` from `codex/telegram-staff-confirmation-replay-tests` to remove this stale-token test and plan clarification.

## Validation
- Targeted tests or smoke run: `python -m pytest backend/tests/unit/test_telegram_bot_management_api_service.py -q`; `python -m py_compile backend/tests/unit/test_telegram_bot_management_api_service.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `git diff --check -- backend/tests/unit/test_telegram_bot_management_api_service.py .ai-factory/plans/telegram-bot-clinic-full-strategy.md`; `npm.cmd run build` from `frontend/`.
- Result: all listed local checks passed; frontend build reports only existing Vite dynamic-import/chunk-size warnings.
- Not checked: live Telegram Bot API delivery and confirmed action execution, because this slice intentionally stays at storage/service-level replay protection.