### PR TITLE
test(telegram): cover confirmation binding mismatches

### DIFF
--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -738,6 +738,47 @@ class TestTelegramBotManagementApiService:
         assert result == {"valid": False, "reason": "expired"}
         assert stored.consumed_at is None
 
+    @pytest.mark.parametrize(
+        ("staff_user_delta", "telegram_chat_id"),
+        [
+            (1, 700804),
+            (0, 700805),
+        ],
+    )
+    def test_staff_confirmation_token_service_rejects_binding_mismatch_without_consuming(
+        self, db_session, admin_user, staff_user_delta, telegram_chat_id
+    ):
+        service = TelegramStaffConfirmationTokenService(db_session)
+        token_hash = "staff_confirmation_token:" + ("6" * 64)
+        payload_hash = "payload:" + ("5" * 64)
+        service.issue_token(
+            token_hash=token_hash,
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700804,
+            operation_key="visit_cancel_or_move",
+            command_key="/move",
+            action_payload_hash=payload_hash,
+            target_type="visit",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=2),
+            request_id="req-confirm-binding",
+        )
+
+        result = service.consume_for_confirmation(
+            token_hash=token_hash,
+            staff_user_id=admin_user.id + staff_user_delta,
+            telegram_chat_id=telegram_chat_id,
+            operation_key="visit_cancel_or_move",
+            action_payload_hash=payload_hash,
+        )
+        stored = (
+            db_session.query(TelegramStaffConfirmationToken)
+            .filter(TelegramStaffConfirmationToken.token_hash == token_hash)
+            .one()
+        )
+
+        assert result == {"valid": False, "reason": "token_binding_mismatch"}
+        assert stored.consumed_at is None
+
     def test_staff_confirmation_token_service_rejects_action_mismatch(
         self, db_session, admin_user
     ):


### PR DESCRIPTION
## Summary
- Adds service-level negative coverage for Telegram staff confirmation token binding mismatches.
- Verifies a token issued for one staff/chat binding cannot be consumed by a different staff user or Telegram chat.
- Keeps the token unconsumed after binding mismatch so future valid handling/debug remains clear.

## Contract Impact
- Canonical surface: `TelegramStaffConfirmationTokenService.consume_for_confirmation(...)` token binding checks are covered through `backend/tests/unit/test_telegram_bot_management_api_service.py`.
- Request shape: no external HTTP request body changes.
- Response shape: no API or Telegram reply shape changes; this is unit-test proof only.
- Status codes: unchanged.
- Frontend consumer: unchanged; no frontend source changes.
- Compatibility path or alias: no route, command, alias, or webhook path changes.
- Contract proof: `TestTelegramBotManagementApiService::test_staff_confirmation_token_service_rejects_binding_mismatch_without_consuming` covers wrong staff id and wrong Telegram chat id returning `token_binding_mismatch` with `consumed_at` still unset.

## RBAC / Permissions
- Roles allowed: unchanged; no role or permission expansion.
- Roles denied: unchanged; mismatched staff/chat bindings cannot consume another confirmation token.
- Positive auth proof: existing consume-once service test still covers valid binding consumption.
- Negative auth proof: this PR adds two binding mismatch cases for staff id and Telegram chat id.

## Notification / Realtime
- Event type or websocket channel: none added.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable because no realtime transport changes.

## Frontend Resilience
- Empty data proof: not applicable; no frontend data shape changes.
- Partial data proof: not applicable; no frontend consumer changes.
- Forbidden secondary path behavior: mismatched confirmation bindings are rejected before any domain action can execute.
- Missing draft/resource behavior: no draft/domain resource is created or mutated.
- Stale route/deep-link behavior: not applicable; no route/deep-link behavior changes.

## Scope Gate
- Allowed paths: Telegram management API unit tests only.
- Denied paths: Telegram webhook execution, domain adapters, DB migrations, frontend runtime, queue/payment/schedule mutations, and unrelated dirty workspace files.
- Migration/docs/test impact: no migration or docs change; one unit test added with two param cases.
- Rollback note: revert commit `6004f6e5` from `codex/telegram-staff-confirmation-binding-tests` to remove this binding mismatch proof.

## Validation
- Targeted tests or smoke run: `python -m pytest backend/tests/unit/test_telegram_bot_management_api_service.py -q`; `python -m py_compile backend/tests/unit/test_telegram_bot_management_api_service.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `git diff --check -- backend/tests/unit/test_telegram_bot_management_api_service.py`; `npm.cmd run build` from `frontend/`.
- Result: all listed local checks passed; frontend build reports only existing Vite dynamic-import/chunk-size warnings.
- Not checked: live Telegram Bot API delivery and confirmed action execution, because this slice intentionally stays at storage/service-level token binding protection.