### PR TITLE
test(telegram): cover confirmation idempotency mismatch

### DIFF
--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -809,6 +809,40 @@ class TestTelegramBotManagementApiService:
         assert result == {"valid": False, "reason": "action_binding_mismatch"}
         assert stored.consumed_at is None
 
+    def test_staff_confirmation_token_service_rejects_idempotency_mismatch_without_consuming(
+        self, db_session, admin_user
+    ):
+        service = TelegramStaffConfirmationTokenService(db_session)
+        token_hash = "staff_confirmation_token:" + ("4" * 64)
+        payload_hash = "payload:" + ("3" * 64)
+        service.issue_token(
+            token_hash=token_hash,
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700806,
+            operation_key="payment_status_change",
+            action_payload_hash=payload_hash,
+            idempotency_key_hash="idempotency:" + ("2" * 64),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=2),
+            request_id="req-confirm-idempotency",
+        )
+
+        result = service.consume_for_confirmation(
+            token_hash=token_hash,
+            staff_user_id=admin_user.id,
+            telegram_chat_id=700806,
+            operation_key="payment_status_change",
+            action_payload_hash=payload_hash,
+            idempotency_key_hash="idempotency:" + ("1" * 64),
+        )
+        stored = (
+            db_session.query(TelegramStaffConfirmationToken)
+            .filter(TelegramStaffConfirmationToken.token_hash == token_hash)
+            .one()
+        )
+
+        assert result == {"valid": False, "reason": "action_binding_mismatch"}
+        assert stored.consumed_at is None
+
     def test_staff_link_start_token_validator_consumes_storage_record(
         self, db_session, admin_user
     ):


### PR DESCRIPTION
## Summary
- Adds service-level negative coverage for Telegram staff confirmation idempotency hash mismatches.
- Verifies a token with the right staff/chat/action still rejects a different idempotency hash.
- Keeps the token unconsumed after idempotency mismatch, preserving replay-safety semantics.

## Contract Impact
- Canonical surface: `TelegramStaffConfirmationTokenService.consume_for_confirmation(...)` idempotency binding checks are covered through `backend/tests/unit/test_telegram_bot_management_api_service.py`.
- Request shape: no external HTTP request body changes.
- Response shape: no API or Telegram reply shape changes; this is unit-test proof only.
- Status codes: unchanged.
- Frontend consumer: unchanged; no frontend source changes.
- Compatibility path or alias: no route, command, alias, or webhook path changes.
- Contract proof: `TestTelegramBotManagementApiService::test_staff_confirmation_token_service_rejects_idempotency_mismatch_without_consuming` covers idempotency hash mismatch returning `action_binding_mismatch` with `consumed_at` still unset.

## RBAC / Permissions
- Roles allowed: unchanged; no role or permission expansion.
- Roles denied: unchanged; idempotency mismatch cannot consume a confirmation token.
- Positive auth proof: existing consume-once service test still covers valid idempotency binding consumption.
- Negative auth proof: this PR adds a mismatched idempotency hash case.

## Notification / Realtime
- Event type or websocket channel: none added.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable because no realtime transport changes.

## Frontend Resilience
- Empty data proof: not applicable; no frontend data shape changes.
- Partial data proof: not applicable; no frontend consumer changes.
- Forbidden secondary path behavior: mismatched idempotency binding is rejected before any domain action can execute.
- Missing draft/resource behavior: no draft/domain resource is created or mutated.
- Stale route/deep-link behavior: not applicable; no route/deep-link behavior changes.

## Scope Gate
- Allowed paths: Telegram management API unit tests only.
- Denied paths: Telegram webhook execution, domain adapters, DB migrations, frontend runtime, queue/payment/schedule mutations, and unrelated dirty workspace files.
- Migration/docs/test impact: no migration or docs change; one unit test added.
- Rollback note: revert commit `04581a8a` from `codex/telegram-staff-confirmation-idempotency-tests` to remove this idempotency mismatch proof.

## Validation
- Targeted tests or smoke run: `python -m pytest backend/tests/unit/test_telegram_bot_management_api_service.py -q`; `python -m py_compile backend/tests/unit/test_telegram_bot_management_api_service.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `git diff --check -- backend/tests/unit/test_telegram_bot_management_api_service.py`; `npm.cmd run build` from `frontend/`.
- Result: all listed local checks passed; frontend build reports only existing Vite dynamic-import/chunk-size warnings.
- Not checked: live Telegram Bot API delivery and confirmed action execution, because this slice intentionally stays at storage/service-level idempotency binding protection.