### PR TITLE
fix(telegram): register patient menu command

### DIFF
--- a/backend/app/services/telegram_bot.py
+++ b/backend/app/services/telegram_bot.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 MAX_TELEGRAM_DOCUMENT_BYTES = 20 * 1024 * 1024
 PATIENT_BOT_COMMANDS_RU = [
     {"command": "start", "description": "Начать"},
+    {"command": "menu", "description": "Главное меню"},
     {"command": "book", "description": "Записаться на приём"},
     {"command": "queue", "description": "Моя очередь"},
     {"command": "visits", "description": "Мои визиты"},
@@ -37,6 +38,7 @@ PATIENT_BOT_COMMANDS_RU = [
 ]
 PATIENT_BOT_COMMANDS_UZ = [
     {"command": "start", "description": "Boshlash"},
+    {"command": "menu", "description": "Asosiy menyu"},
     {"command": "book", "description": "Qabulga yozilish"},
     {"command": "queue", "description": "Mening navbatim"},
     {"command": "visits", "description": "Mening tashriflarim"},

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -1771,6 +1771,7 @@ class TestTelegramWebhookSecurity:
         assert len(uz_command_names) == len(set(uz_command_names))
         assert {command["command"] for command in captured[0]["json"]["commands"]} == {
             "start",
+            "menu",
             "book",
             "queue",
             "visits",
@@ -1783,6 +1784,7 @@ class TestTelegramWebhookSecurity:
         }
         assert {command["command"] for command in captured[1]["json"]["commands"]} == {
             "start",
+            "menu",
             "book",
             "queue",
             "visits",


### PR DESCRIPTION
## Summary
- Adds `/menu` to the registered patient Bot API command list for Russian and Uzbek.
- Keeps the already implemented `/menu` runtime handler and localized reply keyboard refresh visible in Telegram's native command menu.
- Updates the focused Telegram command-registration unit test.

## Contract Impact
- Canonical surface: `backend/app/services/telegram_bot.py` patient command registration constants and `TelegramBotService.set_patient_bot_commands()`.
- Request shape: outgoing Telegram `setMyCommands` payload now includes additive `menu` command for RU/default and Uzbek.
- Response shape: no inbound API or webhook response shape changes.
- Status codes: unchanged.
- Frontend consumer: unchanged; no frontend source changes in this PR.
- Compatibility path or alias: existing `/start`, `/book`, `/queue`, `/visits`, `/payments`, `/results`, `/profile`, `/settings`, `/support`, and `/help` remain registered; `/menu` is additive and already handled by webhook runtime.
- Contract proof: `test_telegram_bot_service_registers_patient_commands` asserts `menu` is present in both RU and UZ command payloads and command names remain unique.

## RBAC / Permissions
- Roles allowed: unchanged; patient command registration is public bot metadata only.
- Roles denied: unchanged; staff-only behavior and patient data access rules are not changed.
- Positive auth proof: existing patient `/menu` runtime behavior refreshes the localized patient reply keyboard; this PR covers Bot API registration payload.
- Negative auth proof: no permission expansion; command registration does not grant data access.

## Notification / Realtime
- Event type or websocket channel: none added.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable; Telegram clients receive updated commands after command registration is applied.

## Frontend Resilience
- Empty data proof: unchanged; no frontend data shape changes.
- Partial data proof: unchanged; no frontend consumer changes.
- Forbidden secondary path behavior: `/menu` only refreshes the reply keyboard and does not expose patient/staff data.
- Missing draft/resource behavior: no resource creation.
- Stale route/deep-link behavior: no route/deep-link changes; `/menu` uses stored language at runtime.

## Scope Gate
- Allowed paths: patient Telegram command constants and focused Telegram registration test.
- Denied paths: DB migrations, webhook behavior, staff actions, queue fairness, payment providers, EMR/lab data, frontend runtime, and unrelated `.codex/*` workspace files.
- Migration/docs/test impact: no migration; one focused unit test updated.
- Rollback note: revert commit `b629c8d3` from this branch to remove `/menu` from native command registration while leaving runtime aliases untouched.

## Validation
- Targeted tests or smoke run: `py -3.11 -m py_compile backend/app/services/telegram_bot.py backend/tests/unit/test_telegram_webhook_security.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `py -3.11 -m pytest backend/tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_telegram_bot_service_registers_patient_commands -q`; `git diff --check -- backend/app/services/telegram_bot.py backend/tests/unit/test_telegram_webhook_security.py`; `npm.cmd run build` from `frontend`.
- Result: all listed local checks passed; frontend build reports only existing Vite dynamic-import/chunk-size warnings.
- Not checked: live Telegram Bot API registration after merge; should be applied by `set_patient_bot_commands` after code lands and token/env is configured.