### PR TITLE
feat(telegram): expose staff action audit contract

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -582,6 +582,11 @@ STAFF_BOT_AUDIT_CONTRACT = {
     "state_change_denial_events_enabled": True,
     "confirmation_request_events_enabled": True,
     "state_change_events_enabled": False,
+    "required_state_change_event_types": [
+        "staff_action_confirmed",
+        "staff_action_completed",
+        "staff_action_failed",
+    ],
     "recorded_event_types": [
         "staff_link_created",
         "staff_link_token_rejected",
@@ -591,6 +596,7 @@ STAFF_BOT_AUDIT_CONTRACT = {
     ],
     "pending_event_types": [
         "staff_action_confirmed",
+        "staff_action_completed",
         "staff_action_failed",
     ],
     "required_before_enablement": True,
@@ -613,6 +619,11 @@ STAFF_BOT_AUDIT_CONTRACT = {
         {
             "key": "staff_action_confirmed",
             "label": "Действие подтверждено сотрудником",
+            "required": True,
+        },
+        {
+            "key": "staff_action_completed",
+            "label": "Completed staff action after confirmed domain execution",
             "required": True,
         },
         {
@@ -1044,6 +1055,12 @@ def _build_staff_bot_status(
             "state_change_denial_events_ready": True,
             "confirmation_request_events_ready": True,
             "state_change_events_ready": False,
+            "required_state_change_event_types": list(
+                STAFF_BOT_AUDIT_CONTRACT["required_state_change_event_types"]
+            ),
+            "pending_state_change_event_types": list(
+                STAFF_BOT_AUDIT_CONTRACT["required_state_change_event_types"]
+            ),
         },
         "confirmations": {
             "required": True,

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -304,6 +304,12 @@ const TelegramManager = () => {
   const staffAuditPendingEvents = Array.isArray(staffAuditContract.pending_event_types) ?
   staffAuditContract.pending_event_types :
   [];
+  const staffAuditRequiredStateEvents = Array.isArray(staffAuditContract.required_state_change_event_types) ?
+  staffAuditContract.required_state_change_event_types :
+  [];
+  const staffAuditPendingStateEvents = Array.isArray(staffAuditRuntime.pending_state_change_event_types) ?
+  staffAuditRuntime.pending_state_change_event_types :
+  staffAuditRequiredStateEvents;
   const staffAuditReady = Boolean(
     staffAuditContract.enabled ||
     staffAuditRuntime.ready
@@ -918,7 +924,7 @@ const TelegramManager = () => {
                   <ListItemText
                     primary="Staff audit logging"
                     secondary={staffAuditEvents.length ?
-                    `${staffAuditRecordedEvents.length} recorded, ${staffAuditPendingEvents.length} pending; writer: ${staffAuditContract.record_writer_enabled ? 'enabled' : 'disabled'}; read-only commands: ${staffAuditReadOnlyReady ? 'audited' : 'pending'}` :
+                    `${staffAuditRecordedEvents.length} recorded, ${staffAuditPendingEvents.length} pending; state-change pending: ${staffAuditPendingStateEvents.join(', ') || 'none'}; writer: ${staffAuditContract.record_writer_enabled ? 'enabled' : 'disabled'}; read-only commands: ${staffAuditReadOnlyReady ? 'audited' : 'pending'}` :
                     'Audit contract не опубликован'} />
 
                   <Badge


### PR DESCRIPTION
## Summary
- Exposes the required staff state-change audit event taxonomy for future confirmed, completed, and failed Telegram staff actions.
- Keeps state-changing Telegram staff actions disabled until domain adapters and explicit action enablement are implemented.
- Shows pending state-change audit events in the Telegram manager staff audit status.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/admin_telegram.py` staff bot integration status contract and `frontend/src/components/TelegramManager.jsx` consumer display.
- Request shape: no request shape change.
- Response shape: `staff_bot.audit_contract.required_state_change_event_types` and `staff_bot.audit.pending_state_change_event_types` now list `staff_action_confirmed`, `staff_action_completed`, and `staff_action_failed`.
- Status codes: no status code changes.
- Frontend consumer: Telegram manager reads the new audit event lists when present and falls back to the contract list.
- Compatibility path or alias: existing `audit_contract.event_types`, `recorded_event_types`, and `pending_event_types` remain available.
- Contract proof: CI backend tests, frontend build, frontend unit tests, CodeQL, role-system check, and frontend-backend parity passed; no mutation/action enablement changed.

## RBAC / Permissions
- Roles allowed: unchanged; staff state-changing actions remain disabled.
- Roles denied: unchanged; server-side deny/default guards remain in place.
- Positive auth proof: status visibility remains through the existing admin Telegram manager/status path.
- Negative auth proof: no authorization path changed; action execution still reports blockers and no staff action can execute from this status contract.

## Notification / Realtime
- Event type or websocket channel: no realtime channel change.
- Payload version / ack behavior: no ack behavior change.
- Read/unread or delivery semantics: no delivery semantics change.
- Reconnect/resync proof: integration status remains reloadable from the existing admin endpoint.

## Frontend Resilience
- Empty data proof: Telegram manager keeps existing fallbacks for missing audit events.
- Partial data proof: pending state-change audit display falls back from runtime list to contract list.
- Forbidden secondary path behavior: unchanged; this only displays status metadata and does not enable forbidden actions.
- Missing draft/resource behavior: unchanged; no resource creation or draft state added.
- Stale route/deep-link behavior: unchanged; no route or deep-link change.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `frontend/src/components/TelegramManager.jsx`.
- Denied paths: webhook execution, domain adapters, migrations, token storage, unrelated `.codex/*` and local dirty files.
- Migration/docs/test impact: no migration; no test file touched because `agent_gate.py` restricted first-touch to runtime/admin/frontend files.
- Rollback note: revert commit `4c45de15` to remove the audit taxonomy/status display while preserving previous read-only staff bot behavior.

## Validation
- Targeted tests or smoke run: `backend/.venv/Scripts/python.exe -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `git diff --check -- backend/app/api/v1/endpoints/admin_telegram.py frontend/src/components/TelegramManager.jsx`; `cd frontend; npm.cmd run build`; CI backend tests; CI frontend build; CI frontend unit tests; CI frontend-backend parity; CI role-system check; CI CodeQL.
- Result: local checks and listed CI checks passed. Frontend build still emits existing Vite warnings about dynamic import chunking and large chunks.
- Not checked: browser visual smoke beyond build/unit coverage.