### PR TITLE
feat(telegram): expose staff queue adapter readiness

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -493,6 +493,63 @@ STAFF_BOT_COMMAND_REGISTRATION_CONTRACT = {
     "state_changing_commands_registered": False,
 }
 
+STAFF_BOT_DOMAIN_ADAPTER_CONTRACT = {
+    "contract_version": "staff-action-domain-adapters-v1",
+    "enabled": True,
+    "runtime_enabled": False,
+    "required_before_state_change_enablement": True,
+    "adapters": [
+        {
+            "operation_key": "queue_call_or_skip_patient",
+            "adapter_key": "staff_queue_call_or_skip_adapter",
+            "domain": "queue",
+            "domain_service_required": "queue",
+            "telegram_commands": ["/call", "/skip"],
+            "runtime_enabled": False,
+            "required_before_enablement": True,
+            "required_runtime_checks": [
+                "queue_target_resolved_server_side",
+                "queue_domain_service_authorizes_target",
+                "queue_time_not_rewritten",
+                "idempotency_key_consumed_once",
+                "staff_action_confirmed_audit_written",
+                "staff_action_completed_or_failed_audit_written",
+            ],
+            "blocked_by": [
+                "queue_domain_mutation_adapter",
+                "explicit_action_enablement",
+            ],
+        },
+        {
+            "operation_key": "visit_cancel_or_move",
+            "adapter_key": "staff_queue_visit_cancel_or_move_adapter",
+            "domain": "queue",
+            "domain_service_required": "visit",
+            "telegram_commands": ["/cancel_visit", "/move_visit"],
+            "runtime_enabled": False,
+            "required_before_enablement": True,
+            "required_runtime_checks": [
+                "visit_target_resolved_server_side",
+                "queue_entry_resolved_server_side",
+                "visit_domain_service_authorizes_target",
+                "queue_fairness_not_reordered",
+                "queue_time_not_rewritten",
+                "idempotency_key_consumed_once",
+                "staff_action_confirmed_audit_written",
+                "staff_action_completed_or_failed_audit_written",
+            ],
+            "blocked_by": [
+                "visit_queue_domain_mutation_adapter",
+                "explicit_action_enablement",
+            ],
+        },
+    ],
+    "blocked_by": [
+        "domain_service_action_adapters",
+        "explicit_action_enablement",
+    ],
+}
+
 STAFF_BOT_CONFIRMATION_CONTRACT = {
     "contract_version": "staff-confirmations-v1",
     "enabled": True,
@@ -509,6 +566,7 @@ STAFF_BOT_CONFIRMATION_CONTRACT = {
     "confirmation_window_seconds": 120,
     "default_state_change_decision": "deny_until_domain_adapters_and_action_enablement",
     "token_storage_contract": STAFF_BOT_CONFIRMATION_TOKEN_STORAGE_CONTRACT,
+    "domain_adapter_contract": STAFF_BOT_DOMAIN_ADAPTER_CONTRACT,
     "operations": [
         {
             "key": "queue_call_or_skip_patient",
@@ -1038,6 +1096,7 @@ def _build_staff_bot_status(
         "authorization_contract": STAFF_BOT_AUTHORIZATION_CONTRACT,
         "command_registration_contract": command_registration_contract,
         "confirmation_contract": STAFF_BOT_CONFIRMATION_CONTRACT,
+        "domain_adapter_contract": STAFF_BOT_DOMAIN_ADAPTER_CONTRACT,
         "audit_contract": STAFF_BOT_AUDIT_CONTRACT,
         "authorization": {
             "source": "application_rbac",
@@ -1073,6 +1132,11 @@ def _build_staff_bot_status(
             "confirmation_token_runtime_enabled": True,
             "idempotency_request_hash_runtime_enabled": True,
             "idempotency_key_returned_to_telegram": False,
+            "domain_adapter_runtime_enabled": False,
+            "queue_action_adapter_runtime_enabled": False,
+            "domain_adapter_blockers": list(
+                STAFF_BOT_DOMAIN_ADAPTER_CONTRACT["blocked_by"]
+            ),
             "state_changing_actions_enabled": False,
             "default_state_change_decision": (
                 "deny_until_domain_adapters_and_action_enablement"

--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -293,6 +293,19 @@ const TelegramManager = () => {
   const staffConfirmationBlockerSummary = staffConfirmationBlockedBy.length ?
   staffConfirmationBlockedBy.join(', ') :
   'none';
+  const staffDomainAdapterContract =
+  staffBot.domain_adapter_contract || staffConfirmationContract.domain_adapter_contract || {};
+  const staffDomainAdapters = Array.isArray(staffDomainAdapterContract.adapters) ?
+  staffDomainAdapterContract.adapters :
+  [];
+  const staffQueueDomainAdapters = staffDomainAdapters.filter((adapter) => adapter?.domain === 'queue');
+  const readyStaffDomainAdapters = staffDomainAdapters.filter((adapter) => adapter?.runtime_enabled);
+  const staffDomainAdapterBlockedBy = Array.isArray(staffDomainAdapterContract.blocked_by) ?
+  staffDomainAdapterContract.blocked_by :
+  [];
+  const staffQueueAdapterCommands = staffQueueDomainAdapters.flatMap((adapter) =>
+  Array.isArray(adapter?.telegram_commands) ? adapter.telegram_commands : []
+  );
   const staffAuditContract = staffBot.audit_contract || {};
   const staffAuditRuntime = staffBot.audit || {};
   const staffAuditEvents = Array.isArray(staffAuditContract.event_types) ?
@@ -900,6 +913,23 @@ const TelegramManager = () => {
                     size="small">
 
                     {staffConfirmationGuardReady ? 'Guard' : 'Required'}
+                  </Badge>
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon>
+                    <Settings />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Staff queue action adapters"
+                    secondary={staffQueueDomainAdapters.length ?
+                    `${readyStaffDomainAdapters.length}/${staffDomainAdapters.length} adapters enabled; queue commands: ${staffQueueAdapterCommands.join(' ') || 'none'}; blockers: ${staffDomainAdapterBlockedBy.join(', ') || 'none'}` :
+                    'Queue action adapter contract not published'} />
+
+                  <Badge
+                    variant={staffDomainAdapterContract.runtime_enabled ? 'success' : 'warning'}
+                    size="small">
+
+                    {staffDomainAdapterContract.runtime_enabled ? 'Enabled' : 'Blocked'}
                   </Badge>
                 </ListItem>
                 <ListItem>


### PR DESCRIPTION
﻿## Summary
- Publishes a staff action domain-adapter readiness contract for the queue `/call` and `/skip` Telegram commands.
- Keeps `runtime_enabled` and `state_changing_actions_enabled` false, so Telegram still never mutates queue state.
- Shows queue adapter readiness/blockers in the Telegram manager staff section.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/admin_telegram.py` staff bot integration status and `frontend/src/components/TelegramManager.jsx` status consumer.
- Request shape: no request shape change.
- Response shape: adds `staff_bot.domain_adapter_contract` and `staff_bot.confirmations.domain_adapter_*` readiness fields for queue staff action adapters.
- Status codes: no status code changes.
- Frontend consumer: Telegram manager displays queue adapter readiness next to staff confirmations.
- Compatibility path or alias: existing confirmation, audit, command, and readiness fields remain available.
- Contract proof: local `py_compile`, `git diff --check`, and frontend build passed; no Telegram execution path changed.

## RBAC / Permissions
- Roles allowed: unchanged; registrar remains the planned role for queue `/call` and `/skip`, but execution is still disabled.
- Roles denied: unchanged; existing server-side deny/default behavior remains in place.
- Positive auth proof: not applicable - this PR only exposes readiness metadata and does not enable executable staff actions.
- Negative auth proof: state-changing actions remain blocked by `domain_service_action_adapters` and `explicit_action_enablement`.

## Notification / Realtime
- Event type or websocket channel: no realtime channel change.
- Payload version / ack behavior: no ack behavior change.
- Read/unread or delivery semantics: no delivery semantics change.
- Reconnect/resync proof: integration status remains reloadable through the existing admin Telegram status endpoint.

## Frontend Resilience
- Empty data proof: Telegram manager shows `Queue action adapter contract not published` if adapter metadata is absent.
- Partial data proof: queue commands and blockers fall back to `none` when arrays are absent.
- Forbidden secondary path behavior: unchanged; no secondary route/path added.
- Missing draft/resource behavior: unchanged; no draft/resource behavior touched.
- Stale route/deep-link behavior: unchanged; no route/deep-link behavior touched.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `frontend/src/components/TelegramManager.jsx`.
- Denied paths: webhook execution, queue mutation services, confirmation consumption, migrations, unrelated `.codex/*` local files.
- Migration/docs/test impact: no migration; no runtime test file changed in this first readiness slice.
- Rollback note: revert this commit to remove queue adapter readiness metadata while preserving existing staff bot confirmation behavior.

## Validation
- Targeted tests or smoke run: `backend/.venv/Scripts/python.exe -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `git diff --check -- backend/app/api/v1/endpoints/admin_telegram.py frontend/src/components/TelegramManager.jsx`; `cd frontend; npm.cmd run build`.
- Result: passed. Frontend build still emits existing Vite warnings about dynamic import chunking and large chunks.
- Not checked: browser visual smoke and broader backend suite.
