### PR TITLE
docs(telegram): record queue adapter readiness

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -285,7 +285,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 
 ### Phase 4: Staff bot
 
-- [ ] Status: partially closed. Staff bot read-only operations, pre-mutation confirmation requests, hash-only idempotency binding for replay protection, and the required confirmed/completed/failed audit event contract are implemented; confirmed state-changing actions remain disabled until domain adapters and explicit action enablement are complete.
+- [ ] Status: partially closed. Staff bot read-only operations, pre-mutation confirmation requests, hash-only idempotency binding for replay protection, the required confirmed/completed/failed audit event contract, and queue adapter readiness metadata for `/call`, `/skip`, `/cancel_visit`, and `/move_visit` are implemented; confirmed state-changing actions remain disabled until domain adapters and explicit action enablement are complete.
 - [x] Role-based read-only menus exist for registrar, doctor, cashier, lab, admin, and owner/admin style users.
 - [x] Staff bot token is configured separately from the patient bot token.
 - [x] Staff linking is protected by server-side token validation.
@@ -294,7 +294,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 - [x] Runtime guard blocks Telegram execution of state-changing staff commands until domain adapters and explicit action enablement are implemented.
 - [x] Add confirmation request flow for each state-changing action before mutation: `backend/app/api/v1/endpoints/telegram_webhook.py` now creates a hash-only `TelegramStaffConfirmationToken`, hash-only idempotency binding, and `staff_action_confirmation_requested` audit event for allowed state-changing staff commands, while keeping Telegram execution and domain mutation disabled; focused coverage is in `backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py::TestTelegramStaffReadOnlyMenuRuntime::test_staff_state_change_command_requests_confirmation_without_mutation`.
 - [x] Add idempotency keys or equivalent replay protection for confirmed staff actions: confirmation requests now persist `staff_action_idempotency:*` hash-only bindings, expose `idempotency_request_hash_runtime_enabled` in the staff bot contract, keep raw idempotency material out of Telegram/audit output, and rely on `TelegramStaffConfirmationTokenService.consume_for_confirmation(...)` single-use checks for future confirmed-action replay protection.
-- [ ] Add domain service adapters for confirmed queue actions: call patient, skip patient, cancel/move visit.
+- [ ] Add domain service adapters for confirmed queue actions: call patient, skip patient, cancel/move visit. Readiness metadata for `/call`, `/skip`, `/cancel_visit`, and `/move_visit` queue-flow adapters is published in `backend/app/api/v1/endpoints/admin_telegram.py`, but adapter runtime remains disabled and queue/visit mutation is still blocked.
 - [ ] Add domain service adapters for confirmed payment actions: status change, refund where policy allows it.
 - [ ] Add domain service adapters for confirmed schedule actions.
 - [ ] Add remaining audit events for confirmed, failed, and completed state-changing actions; confirmation-requested audit is implemented with `staff_action_confirmation_requested`, and the required future event taxonomy is published as `staff_action_confirmed`, `staff_action_completed`, and `staff_action_failed` in `backend/app/api/v1/endpoints/admin_telegram.py`, but action execution is still disabled.


### PR DESCRIPTION
## Summary
- Updates the AI Factory Telegram strategy plan after the staff queue adapter readiness merge.
- Records that `/call`, `/skip`, `/cancel_visit`, and `/move_visit` queue-flow adapter metadata is published.
- Keeps Phase 4 explicitly blocked until real domain adapters and action enablement are implemented.

## Contract Impact
- Canonical surface: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md` planning documentation only.
- Request shape: not applicable because this docs-only PR changes no API request contract.
- Response shape: not applicable because this docs-only PR changes no API response contract.
- Status codes: not applicable because no endpoint behavior changed.
- Frontend consumer: not applicable because no frontend runtime changed.
- Compatibility path or alias: not applicable because no runtime path or alias changed.
- Contract proof: plan text now matches the already-merged `STAFF_BOT_DOMAIN_ADAPTER_CONTRACT` in `backend/app/api/v1/endpoints/admin_telegram.py`.

## RBAC / Permissions
- Roles allowed: not applicable because no permission code changed.
- Roles denied: not applicable because no permission code changed.
- Positive auth proof: not applicable because this only updates plan text.
- Negative auth proof: not applicable because this only updates plan text and keeps staff actions disabled.

## Notification / Realtime
- Event type or websocket channel: no notification or websocket implementation changed.
- Payload version / ack behavior: not applicable because no runtime payload changed.
- Read/unread or delivery semantics: not applicable because no delivery path changed.
- Reconnect/resync proof: not applicable because this is a planning document update.

## Frontend Resilience
- Empty data proof: not applicable because no frontend data handling changed.
- Partial data proof: not applicable because no frontend data handling changed.
- Forbidden secondary path behavior: not applicable because no route or action path changed.
- Missing draft/resource behavior: not applicable because no resource handling changed.
- Stale route/deep-link behavior: not applicable because no route or deep-link changed.

## Scope Gate
- Allowed paths: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`.
- Denied paths: backend runtime, frontend runtime, migrations, tests, `.codex/*`, and unrelated local dirty files.
- Migration/docs/test impact: docs-only plan update; no migration and no tests changed.
- Rollback note: revert commit `ae63a05f` to restore the previous Phase 4 queue adapter wording.

## Validation
- Targeted tests or smoke run: `git diff --check -- .ai-factory/plans/telegram-bot-clinic-full-strategy.md`; `rg -n "queue adapter readiness metadata|/cancel_visit|/move_visit" .ai-factory/plans/telegram-bot-clinic-full-strategy.md`.
- Result: passed; Git reported only the existing LF-to-CRLF working-copy warning for this markdown file.
- Not checked: runtime tests because this PR changes planning documentation only.
