### PR TITLE
test(telegram): cover queue adapter readiness contract

### DIFF
--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -393,6 +393,7 @@ class TestTelegramBotManagementApiService:
             "authorization_contract",
             "command_registration_contract",
             "confirmation_contract",
+            "domain_adapter_contract",
             "audit_contract",
         }
         assert expected_contract_keys <= set(status)
@@ -408,6 +409,44 @@ class TestTelegramBotManagementApiService:
         assert status["confirmation_contract"]["token_storage_contract"] == (
             status["confirmation_token_storage_contract"]
         )
+        assert status["domain_adapter_contract"] == (
+            admin_telegram.STAFF_BOT_DOMAIN_ADAPTER_CONTRACT
+        )
+        assert status["confirmation_contract"]["domain_adapter_contract"] == (
+            status["domain_adapter_contract"]
+        )
+        adapters_by_operation = {
+            adapter["operation_key"]: adapter
+            for adapter in status["domain_adapter_contract"]["adapters"]
+        }
+        assert set(adapters_by_operation) == {
+            "queue_call_or_skip_patient",
+            "visit_cancel_or_move",
+        }
+        queue_adapter = adapters_by_operation["queue_call_or_skip_patient"]
+        assert queue_adapter["adapter_key"] == "staff_queue_call_or_skip_adapter"
+        assert queue_adapter["domain"] == "queue"
+        assert queue_adapter["telegram_commands"] == ["/call", "/skip"]
+        assert queue_adapter["runtime_enabled"] is False
+        assert "queue_time_not_rewritten" in queue_adapter["required_runtime_checks"]
+        assert "queue_domain_mutation_adapter" in queue_adapter["blocked_by"]
+        visit_adapter = adapters_by_operation["visit_cancel_or_move"]
+        assert (
+            visit_adapter["adapter_key"] == "staff_queue_visit_cancel_or_move_adapter"
+        )
+        assert visit_adapter["domain"] == "queue"
+        assert visit_adapter["telegram_commands"] == [
+            "/cancel_visit",
+            "/move_visit",
+        ]
+        assert visit_adapter["runtime_enabled"] is False
+        assert "queue_fairness_not_reordered" in visit_adapter[
+            "required_runtime_checks"
+        ]
+        assert "queue_time_not_rewritten" in visit_adapter[
+            "required_runtime_checks"
+        ]
+        assert "visit_queue_domain_mutation_adapter" in visit_adapter["blocked_by"]
         assert status["linking_contract"]["enabled"] is True
         assert (
             status["linking_runtime_contract"]["runtime_handler"]
@@ -484,6 +523,11 @@ class TestTelegramBotManagementApiService:
         assert (
             status["confirmation_contract"]["runtime_blocked_by"][0]
             == "domain_service_action_adapters"
+        )
+        assert status["confirmations"]["domain_adapter_runtime_enabled"] is False
+        assert status["confirmations"]["queue_action_adapter_runtime_enabled"] is False
+        assert status["confirmations"]["domain_adapter_blockers"] == (
+            admin_telegram.STAFF_BOT_DOMAIN_ADAPTER_CONTRACT["blocked_by"]
         )
 
     def test_staff_link_start_token_validator_reports_expired_reason(self):


### PR DESCRIPTION
## Summary
- Adds focused unit coverage for the staff Telegram queue adapter readiness contract.
- Verifies both queue adapter groups remain advertised but disabled: /call//skip and /cancel_visit//move_visit.
- Confirms the status payload still reports domain adapter runtime and queue action adapter runtime as disabled.

## Contract Impact
- Canonical surface: ackend/app/api/v1/endpoints/admin_telegram.py status contract, validated through ackend/tests/unit/test_telegram_bot_management_api_service.py.
- Request shape: unchanged because this PR adds tests only.
- Response shape: unchanged; tests lock the already-merged domain_adapter_contract and confirmations readiness fields.
- Status codes: unchanged because no endpoint behavior changed.
- Frontend consumer: unchanged; existing Telegram Manager contract continues to consume the same staff readiness/status shape.
- Compatibility path or alias: unchanged because no route or alias changed.
- Contract proof: focused pytest asserts STAFF_BOT_DOMAIN_ADAPTER_CONTRACT is exposed through staff bot status and nested confirmation contract.

## RBAC / Permissions
- Roles allowed: unchanged because no permission code changed.
- Roles denied: unchanged because no permission code changed.
- Positive auth proof: focused pytest exercises the staff status helper contract directly; no executable auth boundary or role decision path changed in this test-only slice.
- Negative auth proof: focused assertions confirm state-changing action/runtime flags remain disabled.

## Notification / Realtime
- Event type or websocket channel: unchanged because no notification or realtime code changed.
- Payload version / ack behavior: unchanged because no runtime payload changed.
- Read/unread or delivery semantics: unchanged because no delivery code changed.
- Reconnect/resync proof: no realtime channel changed; backend py_compile and frontend build confirm this slice does not touch websocket, notification, or resync code paths.

## Frontend Resilience
- Empty data proof: no frontend runtime changed; backend status tests confirm existing payload fields remain present for the frontend consumer.
- Partial data proof: no frontend runtime changed; this test-only slice does not alter frontend fallback or parsing behavior.
- Forbidden secondary path behavior: no secondary route changed; staff queue actions remain runtime-disabled and blocked server-side.
- Missing draft/resource behavior: no resource handling changed; this slice only asserts readiness metadata.
- Stale route/deep-link behavior: no route or deep-link changed; Telegram command metadata remains non-executable readiness data only.

## Scope Gate
- Allowed paths: ackend/tests/unit/test_telegram_bot_management_api_service.py.
- Denied paths: Telegram runtime handlers, queue mutation services, frontend runtime, migrations, .codex/*, and unrelated dirty local files.
- Migration/docs/test impact: test-only update; no migration and no runtime docs changed.
- Rollback note: revert commit $shortSha to remove the added contract assertions.

## Validation
- Targeted tests or smoke run: py -3.11 -m py_compile backend\tests\unit\test_telegram_bot_management_api_service.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py; py -3.11 -m pytest backend\tests\unit\test_telegram_bot_management_api_service.py::TestTelegramBotManagementApiService::test_staff_bot_status_remains_disabled_until_readiness_gates backend\tests\unit\test_telegram_bot_management_api_service.py::TestTelegramBotManagementApiService::test_staff_bot_status_exposes_contract_bundle_and_next_slice -q; git diff --check -- backend/tests/unit/test_telegram_bot_management_api_service.py; cd frontend && npm.cmd run build.
- Result: passed; pytest reported 3 passed with one existing warning, Vite build completed with existing chunk/dynamic-import warnings.
- Not checked: live Telegram bot runtime, because this PR intentionally changes only backend unit assertions.
