### PR TITLE
feat(telegram): add visit queue link adapters

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -285,7 +285,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 
 ### Phase 4: Staff bot
 
-- [ ] Status: partially closed. Staff bot read-only operations, pre-mutation confirmation requests, hash-only idempotency binding for replay protection, the required confirmed/completed/failed audit event contract, queue adapter readiness metadata, and queue `/call` + `/skip` domain adapter methods are implemented; confirmed state-changing actions remain disabled until remaining domain adapters and explicit action enablement are complete.
+- [ ] Status: partially closed. Staff bot read-only operations, pre-mutation confirmation requests, hash-only idempotency binding for replay protection, the required confirmed/completed/failed audit event contract, queue adapter readiness metadata, queue `/call` + `/skip` domain adapter methods, and `/cancel_visit` + `/move_visit` queue-link adapter methods are implemented; confirmed state-changing actions remain disabled until full visit/payment/schedule domain mutation adapters and explicit action enablement are complete.
 - [x] Role-based read-only menus exist for registrar, doctor, cashier, lab, admin, and owner/admin style users.
 - [x] Staff bot token is configured separately from the patient bot token.
 - [x] Staff linking is protected by server-side token validation.
@@ -297,7 +297,8 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 - [ ] Add domain service adapters for confirmed queue actions: call patient, skip patient, cancel/move visit.
   - [x] `/call` and `/skip` queue-domain adapter methods are available in `backend/app/services/queue_service.py` as `QueueBusinessService.staff_call_next_patient(...)` and `QueueBusinessService.staff_skip_queue_entry(...)`; focused coverage in `backend/tests/unit/test_queue_time_window.py` verifies server-side selection/status updates preserve `queue_time`.
   - [x] Staff bot contract now marks the `/call` + `/skip` queue adapter runtime as available while keeping `explicit_action_enablement` blocked in `backend/app/api/v1/endpoints/admin_telegram.py`.
-  - [ ] `/cancel_visit` and `/move_visit` remain pending because full visit mutation/queue-link ownership needs a separate gate slice beyond the current queue-service adapter boundary.
+  - [x] `/cancel_visit` and `/move_visit` queue-link adapter methods are available in `backend/app/services/queue_service.py` as `QueueBusinessService.staff_cancel_visit_queue_link(...)` and `QueueBusinessService.staff_move_visit_queue_link(...)`; focused coverage verifies queue entry status changes preserve `queue_time`.
+  - [ ] Full protected visit-record mutation remains pending: the current `/cancel_visit` + `/move_visit` adapter scope is queue-link status only, with `visit_record_mutation_adapter` still blocked before Telegram action enablement.
 - [ ] Add domain service adapters for confirmed payment actions: status change, refund where policy allows it.
 - [ ] Add domain service adapters for confirmed schedule actions.
 - [ ] Add remaining audit events for confirmed, failed, and completed state-changing actions; confirmation-requested audit is implemented with `staff_action_confirmation_requested`, and the required future event taxonomy is published as `staff_action_confirmed`, `staff_action_completed`, and `staff_action_failed` in `backend/app/api/v1/endpoints/admin_telegram.py`, but action execution is still disabled.

--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -530,7 +530,14 @@ STAFF_BOT_DOMAIN_ADAPTER_CONTRACT = {
             "domain": "queue",
             "domain_service_required": "visit",
             "telegram_commands": ["/cancel_visit", "/move_visit"],
-            "runtime_enabled": False,
+            "runtime_enabled": True,
+            "runtime_scope": "queue_link_status_only",
+            "runtime_owner": "QueueBusinessService",
+            "runtime_methods": [
+                "staff_cancel_visit_queue_link",
+                "staff_move_visit_queue_link",
+            ],
+            "visit_record_mutation_enabled": False,
             "required_before_enablement": True,
             "required_runtime_checks": [
                 "visit_target_resolved_server_side",
@@ -543,13 +550,13 @@ STAFF_BOT_DOMAIN_ADAPTER_CONTRACT = {
                 "staff_action_completed_or_failed_audit_written",
             ],
             "blocked_by": [
-                "visit_queue_domain_mutation_adapter",
+                "visit_record_mutation_adapter",
                 "explicit_action_enablement",
             ],
         },
     ],
     "blocked_by": [
-        "visit_queue_domain_mutation_adapter",
+        "visit_record_mutation_adapter",
         "payment_domain_mutation_adapter",
         "schedule_domain_mutation_adapter",
         "explicit_action_enablement",
@@ -1140,6 +1147,7 @@ def _build_staff_bot_status(
             "idempotency_key_returned_to_telegram": False,
             "domain_adapter_runtime_enabled": False,
             "queue_action_adapter_runtime_enabled": True,
+            "visit_queue_link_adapter_runtime_enabled": True,
             "domain_adapter_blockers": list(
                 STAFF_BOT_DOMAIN_ADAPTER_CONTRACT["blocked_by"]
             ),

--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -1021,6 +1021,7 @@ class QueueBusinessService:
             "action": action,
             "entry_id": entry.id,
             "queue_id": entry.queue_id,
+            "visit_id": entry.visit_id,
             "number": entry.number,
             "previous_status": previous_status,
             "status": entry.status,
@@ -1120,6 +1121,86 @@ class QueueBusinessService:
         return self._staff_action_result(
             entry,
             action="staff_skip_queue_entry",
+            previous_status=previous_status,
+            original_queue_time=original_queue_time,
+        )
+
+    def _staff_visit_queue_link_entry(
+        self,
+        db: Session,
+        *,
+        visit_id: int,
+    ) -> OnlineQueueEntry:
+        active_statuses = {"waiting", "called", "in_service", "diagnostics"}
+        entries = (
+            db.query(OnlineQueueEntry)
+            .filter(
+                OnlineQueueEntry.visit_id == visit_id,
+                OnlineQueueEntry.status.in_(active_statuses),
+            )
+            .order_by(
+                func.coalesce(
+                    OnlineQueueEntry.queue_time,
+                    OnlineQueueEntry.created_at,
+                ).asc(),
+                OnlineQueueEntry.id.asc(),
+            )
+            .all()
+        )
+        if not entries:
+            raise QueueNotFoundError(f"Active queue link for visit {visit_id} not found")
+        if len(entries) > 1:
+            raise QueueConflictError(
+                f"Visit {visit_id} has multiple active queue links"
+            )
+        return entries[0]
+
+    def staff_cancel_visit_queue_link(
+        self,
+        db: Session,
+        *,
+        visit_id: int,
+        actor_user_id: int | None = None,
+        commit: bool = True,
+    ) -> dict[str, Any]:
+        entry = self._staff_visit_queue_link_entry(db, visit_id=visit_id)
+        original_queue_time = entry.queue_time
+        previous_status = entry.status
+        entry.status = "cancelled"
+        if commit:
+            db.commit()
+            db.refresh(entry)
+        else:
+            db.flush()
+
+        return self._staff_action_result(
+            entry,
+            action="staff_cancel_visit_queue_link",
+            previous_status=previous_status,
+            original_queue_time=original_queue_time,
+        )
+
+    def staff_move_visit_queue_link(
+        self,
+        db: Session,
+        *,
+        visit_id: int,
+        actor_user_id: int | None = None,
+        commit: bool = True,
+    ) -> dict[str, Any]:
+        entry = self._staff_visit_queue_link_entry(db, visit_id=visit_id)
+        original_queue_time = entry.queue_time
+        previous_status = entry.status
+        entry.status = "rescheduled"
+        if commit:
+            db.commit()
+            db.refresh(entry)
+        else:
+            db.flush()
+
+        return self._staff_action_result(
+            entry,
+            action="staff_move_visit_queue_link",
             previous_status=previous_status,
             original_queue_time=original_queue_time,
         )

--- a/backend/tests/unit/test_queue_time_window.py
+++ b/backend/tests/unit/test_queue_time_window.py
@@ -202,3 +202,55 @@ def test_staff_skip_queue_entry_preserves_queue_time(db_session):
     assert result["queue_time_preserved"] is True
     assert first.status == "no_show"
     assert first.queue_time == datetime(2026, 1, 1, 7, 30)
+
+
+def test_staff_cancel_visit_queue_link_preserves_queue_time(db_session):
+    target_day = date(2026, 1, 1)
+    _daily_queue, first, _second = _queue_with_entries(
+        db_session,
+        target_day=target_day,
+    )
+    first.visit_id = 1001
+    db_session.flush()
+
+    result = QueueBusinessService().staff_cancel_visit_queue_link(
+        db_session,
+        visit_id=1001,
+        actor_user_id=42,
+        commit=False,
+    )
+
+    assert result["success"] is True
+    assert result["action"] == "staff_cancel_visit_queue_link"
+    assert result["visit_id"] == 1001
+    assert result["previous_status"] == "waiting"
+    assert result["status"] == "cancelled"
+    assert result["queue_time_preserved"] is True
+    assert first.status == "cancelled"
+    assert first.queue_time == datetime(2026, 1, 1, 7, 30)
+
+
+def test_staff_move_visit_queue_link_preserves_queue_time(db_session):
+    target_day = date(2026, 1, 1)
+    _daily_queue, first, _second = _queue_with_entries(
+        db_session,
+        target_day=target_day,
+    )
+    first.visit_id = 1002
+    db_session.flush()
+
+    result = QueueBusinessService().staff_move_visit_queue_link(
+        db_session,
+        visit_id=1002,
+        actor_user_id=42,
+        commit=False,
+    )
+
+    assert result["success"] is True
+    assert result["action"] == "staff_move_visit_queue_link"
+    assert result["visit_id"] == 1002
+    assert result["previous_status"] == "waiting"
+    assert result["status"] == "rescheduled"
+    assert result["queue_time_preserved"] is True
+    assert first.status == "rescheduled"
+    assert first.queue_time == datetime(2026, 1, 1, 7, 30)

--- a/backend/tests/unit/test_telegram_bot_management_api_service.py
+++ b/backend/tests/unit/test_telegram_bot_management_api_service.py
@@ -445,14 +445,22 @@ class TestTelegramBotManagementApiService:
             "/cancel_visit",
             "/move_visit",
         ]
-        assert visit_adapter["runtime_enabled"] is False
+        assert visit_adapter["runtime_enabled"] is True
+        assert visit_adapter["runtime_scope"] == "queue_link_status_only"
+        assert visit_adapter["runtime_owner"] == "QueueBusinessService"
+        assert visit_adapter["runtime_methods"] == [
+            "staff_cancel_visit_queue_link",
+            "staff_move_visit_queue_link",
+        ]
+        assert visit_adapter["visit_record_mutation_enabled"] is False
         assert "queue_fairness_not_reordered" in visit_adapter[
             "required_runtime_checks"
         ]
         assert "queue_time_not_rewritten" in visit_adapter[
             "required_runtime_checks"
         ]
-        assert "visit_queue_domain_mutation_adapter" in visit_adapter["blocked_by"]
+        assert "visit_record_mutation_adapter" in visit_adapter["blocked_by"]
+        assert "explicit_action_enablement" in visit_adapter["blocked_by"]
         assert status["linking_contract"]["enabled"] is True
         assert (
             status["linking_runtime_contract"]["runtime_handler"]
@@ -532,6 +540,10 @@ class TestTelegramBotManagementApiService:
         )
         assert status["confirmations"]["domain_adapter_runtime_enabled"] is False
         assert status["confirmations"]["queue_action_adapter_runtime_enabled"] is True
+        assert (
+            status["confirmations"]["visit_queue_link_adapter_runtime_enabled"]
+            is True
+        )
         assert status["confirmations"]["domain_adapter_blockers"] == (
             admin_telegram.STAFF_BOT_DOMAIN_ADAPTER_CONTRACT["blocked_by"]
         )

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -1127,6 +1127,95 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         assert "7204" not in str(audit_log.payload)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("command", ["/call", "/skip"])
+    async def test_staff_queue_state_change_command_requests_confirmation_without_queue_mutation(
+        self, db_session, registrar_user, test_doctor, test_patient, command
+    ):
+        _link_staff_chat(db_session, chat_id=7220, user_id=registrar_user.id)
+        queue = DailyQueue(
+            day=date.today(),
+            specialist_id=test_doctor.id,
+            queue_tag="cardiology_common",
+            active=True,
+        )
+        db_session.add(queue)
+        db_session.flush()
+
+        original_queue_time = datetime.utcnow().replace(microsecond=0)
+        entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=14,
+            patient_id=test_patient.id,
+            patient_name="Queue Mutation Guard",
+            phone="+998901234570",
+            source="desk",
+            status="waiting",
+            queue_time=original_queue_time,
+        )
+        db_session.add(entry)
+        db_session.commit()
+        db_session.refresh(entry)
+
+        fake_service = FakeTelegramBotService()
+        update = {
+            "update_id": 220,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7220},
+                "from": {"id": 7220},
+                "text": command,
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        text = fake_service._send_message.await_args.args[1]
+        assert "Staff action confirmation requested" in text
+        assert "Domain: queue" in text
+        assert "Telegram execution: disabled" in text
+        assert "Domain mutation: not performed" in text
+        assert "Queue Mutation Guard" not in text
+        assert "7220" not in text
+
+        db_session.refresh(entry)
+        assert entry.status == "waiting"
+        assert entry.queue_time == original_queue_time
+        assert entry.called_at is None
+
+        confirmation_record = (
+            db_session.query(TelegramStaffConfirmationToken)
+            .filter(
+                TelegramStaffConfirmationToken.staff_user_id == registrar_user.id,
+                TelegramStaffConfirmationToken.telegram_chat_id == 7220,
+            )
+            .one()
+        )
+        assert confirmation_record.operation_key == "queue_call_or_skip_patient"
+        assert confirmation_record.command_key == command
+        assert confirmation_record.consumed_at is None
+        assert confirmation_record.token_hash not in text
+        assert confirmation_record.idempotency_key_hash not in text
+
+        audit_log = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "staff_action_confirmation_requested")
+            .one()
+        )
+        assert audit_log.actor_user_id == registrar_user.id
+        assert audit_log.payload["actor_role"] == "registrar"
+        assert audit_log.payload["operation_key"] == "queue_call_or_skip_patient"
+        assert audit_log.payload["command_key"] == command
+        assert audit_log.payload["telegram_execution_enabled"] is False
+        assert audit_log.payload["domain_mutation"] is False
+        assert audit_log.payload["state_changing_action"] is True
+        assert confirmation_record.idempotency_key_hash not in str(audit_log.payload)
+        assert "7220" not in str(audit_log.payload)
+
+    @pytest.mark.asyncio
     async def test_staff_state_change_command_denies_unauthorized_role(
         self, db_session, admin_user
     ):


### PR DESCRIPTION
## Summary
- Add visit queue-link backend adapters for staff `/cancel_visit` and `/move_visit` readiness.
- Keep Telegram state-changing execution blocked behind confirmation and explicit action enablement.
- Add runtime guard coverage proving staff `/call` and `/skip` still request confirmation without mutating queue entries.
- Update focused queue-time, management contract, and roadmap coverage.

## Contract Impact
- Canonical surface: `backend/app/services/queue_service.py`, `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py`.
- Request shape: no public Telegram execution request shape is enabled; adapter methods receive server-side identifiers only.
- Response shape: backend adapter results include safe action metadata and `queue_time_preserved` proof.
- Status codes: no HTTP status code changes.
- Frontend consumer: no frontend code changes; Telegram manager continues reading readiness metadata.
- Compatibility path or alias: existing confirmation-request flow remains the only Telegram state-change path.
- Contract proof: management API tests assert adapter readiness, and staff runtime tests assert `/call` and `/skip` remain confirmation-only.

## RBAC / Permissions
- Roles allowed: existing staff contracts keep queue actions scoped to registrar/admin-style role rules as defined in the staff operation contract.
- Roles denied: unauthorized staff commands remain denied by existing negative tests.
- Positive auth proof: focused staff runtime tests create confirmation tokens for allowed registrar queue commands.
- Negative auth proof: staff runtime tests assert `telegram_execution_enabled` is false and `domain_mutation` is false.

## Notification / Realtime
- Event type or websocket channel: no Telegram notification or websocket event emission is enabled by this PR.
- Payload version / ack behavior: no callback acknowledgement behavior changes.
- Read/unread or delivery semantics: this PR creates no delivery record or read/unread state because queue mutation remains blocked in Telegram.
- Reconnect/resync proof: no realtime subscription path changes; staff status remains resynced through the existing management status response.

## Frontend Resilience
- Empty data proof: staff readiness metadata remains available through existing status fields and no empty-list frontend branch changes.
- Partial data proof: no frontend component changes; existing staff manager rendering continues to tolerate partial readiness fields.
- Forbidden secondary path behavior: Telegram state-changing execution remains disabled until explicit enablement.
- Missing draft/resource behavior: no draft or resource fetch path is introduced; confirmation tokens are created server-side only.
- Stale route/deep-link behavior: no route or deep-link is added, so stale navigation behavior is unchanged.

## Scope Gate
- Allowed paths: queue service, admin Telegram readiness contract, Telegram strategy roadmap, focused backend unit tests.
- Denied paths: Telegram webhook mutation execution, frontend components, DB migrations, unrelated `.codex` skill files.
- Migration/docs/test impact: no migration; roadmap and backend unit tests updated.
- Rollback note: revert this PR to remove visit queue-link adapter readiness and the additional confirmation-only runtime guard.

## Validation
- Targeted tests or smoke run: `backend/.venv/Scripts/python.exe -m pytest backend/tests/unit/test_queue_time_window.py backend/tests/unit/test_telegram_bot_management_api_service.py backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py -q`; `backend/.venv/Scripts/python.exe -m py_compile backend/app/services/queue_service.py backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py backend/tests/unit/test_queue_time_window.py backend/tests/unit/test_telegram_bot_management_api_service.py backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py`.
- Result: 56 passed, 1 warning locally; py_compile passed.
- Not checked: full backend suite and frontend build locally; CI is running required repository gates.