### PR TITLE
chore(telegram): report unchecked roadmap items

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -306,6 +306,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 - [ ] Add negative tests for unauthorized staff, stale confirmations, repeated confirmations, and cross-role action attempts.
   - [x] Unauthorized/cross-role state-changing command denial is covered by `backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py::TestTelegramStaffReadOnlyMenuRuntime::test_staff_state_change_command_denies_unauthorized_role`.
   - [x] Storage/service-level stale and repeated confirmation protection is covered by `backend/tests/unit/test_telegram_bot_management_api_service.py::TestTelegramBotManagementApiService::test_staff_confirmation_token_service_rejects_expired_record_without_consuming` and `backend/tests/unit/test_telegram_bot_management_api_service.py::TestTelegramBotManagementApiService::test_staff_confirmation_token_service_consumes_record_once`.
+  - [x] Runtime confirmation callbacks remain inert while state-changing execution is disabled: `backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py::TestTelegramStaffReadOnlyMenuRuntime::test_staff_queue_confirmation_callback_is_ignored_until_execution_enabled` proves no queue mutation, token consumption, or confirmed/completed/failed audit event is produced.
   - [ ] Webhook/runtime stale and repeated confirmation execution tests remain pending until confirmed action execution is enabled.
 
 ### Phase 5: Telegram Mini App

--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -348,7 +348,7 @@ Use this loop after every Telegram implementation slice:
 Future automation backlog:
 
 - [ ] Add a lightweight repository check that warns when Telegram runtime files change without a corresponding update to this plan.
-- [ ] Add a script or CI job that prints all unchecked Telegram roadmap items for release review.
+- [x] Add a script or CI job that prints all unchecked Telegram roadmap items for release review: `scripts/report_unchecked_telegram_plan_items.py` prints each unchecked checkbox with section path and line number via `python scripts/report_unchecked_telegram_plan_items.py`.
 - [ ] Add a plan drift check that flags stale provider names, unsupported language codes, and hardcoded placeholder URLs.
 - [ ] Add a test inventory check that maps each checked roadmap item to at least one targeted test or smoke command.
 - [ ] Add release-note generation from newly checked items so rollout evidence stays aligned with the plan.

--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -1216,6 +1216,106 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         assert "7220" not in str(audit_log.payload)
 
     @pytest.mark.asyncio
+    async def test_staff_queue_confirmation_callback_is_ignored_until_execution_enabled(
+        self, db_session, registrar_user, test_doctor, test_patient
+    ):
+        assert (
+            telegram_webhook.STAFF_BOT_CONFIRMATION_CONTRACT[
+                "state_changing_actions_enabled"
+            ]
+            is False
+        )
+        _link_staff_chat(db_session, chat_id=7221, user_id=registrar_user.id)
+        queue = DailyQueue(
+            day=date.today(),
+            specialist_id=test_doctor.id,
+            queue_tag="cardiology_common",
+            active=True,
+        )
+        db_session.add(queue)
+        db_session.flush()
+
+        original_queue_time = datetime.utcnow().replace(microsecond=0)
+        entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=15,
+            patient_id=test_patient.id,
+            patient_name="Callback Guard",
+            phone="+998901234571",
+            source="desk",
+            status="waiting",
+            queue_time=original_queue_time,
+        )
+        db_session.add(entry)
+        db_session.commit()
+
+        fake_service = FakeTelegramBotService()
+        command_update = {
+            "update_id": 221,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7221},
+                "from": {"id": 7221},
+                "text": "/call",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            command_update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        reply_markup = fake_service._send_message.await_args.args[2]
+        assert "callback_data" not in str(reply_markup)
+
+        confirmation_record = (
+            db_session.query(TelegramStaffConfirmationToken)
+            .filter(
+                TelegramStaffConfirmationToken.staff_user_id == registrar_user.id,
+                TelegramStaffConfirmationToken.telegram_chat_id == 7221,
+            )
+            .one()
+        )
+        fake_service._send_message.reset_mock()
+        callback_update = {
+            "update_id": 222,
+            "callback_query": {
+                "id": "staff-confirmation-callback",
+                "from": {"id": 7221},
+                "message": {"message_id": 2, "chat": {"id": 7221}},
+                "data": f"staff_action_confirm:{confirmation_record.token_hash}",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            callback_update, db_session, fake_service
+        )
+
+        assert handled is False
+        fake_service._send_message.assert_not_awaited()
+        db_session.refresh(entry)
+        db_session.refresh(confirmation_record)
+        assert entry.status == "waiting"
+        assert entry.queue_time == original_queue_time
+        assert entry.called_at is None
+        assert confirmation_record.consumed_at is None
+        assert (
+            db_session.query(AuditLog)
+            .filter(
+                AuditLog.action.in_(
+                    [
+                        "staff_action_confirmed",
+                        "staff_action_completed",
+                        "staff_action_failed",
+                    ]
+                )
+            )
+            .count()
+            == 0
+        )
+
+    @pytest.mark.asyncio
     async def test_staff_state_change_command_denies_unauthorized_role(
         self, db_session, admin_user
     ):

--- a/scripts/report_unchecked_telegram_plan_items.py
+++ b/scripts/report_unchecked_telegram_plan_items.py
@@ -1,0 +1,81 @@
+"""Print unchecked Telegram roadmap items for release review.
+
+The script intentionally uses only the standard library so it can run in CI,
+from a developer shell, or inside an agent handoff without project setup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+DEFAULT_PLAN_PATH = Path(".ai-factory/plans/telegram-bot-clinic-full-strategy.md")
+HEADING_RE = re.compile(r"^(?P<marks>#{1,6})\s+(?P<title>.+?)\s*$")
+UNCHECKED_RE = re.compile(r"^(?P<indent>\s*)-\s+\[\s\]\s+(?P<text>.+?)\s*$")
+EXCLUDED_SECTIONS = {"Implementation Status Legend"}
+
+
+def _section_path(stack: list[tuple[int, str]]) -> str:
+    if not stack:
+        return "(no section)"
+    return " > ".join(title for _level, title in stack)
+
+
+def iter_unchecked_items(plan_path: Path) -> list[tuple[int, str, str]]:
+    """Return unchecked checkbox items as (line_number, section, text)."""
+    section_stack: list[tuple[int, str]] = []
+    unchecked: list[tuple[int, str, str]] = []
+
+    for line_number, raw_line in enumerate(plan_path.read_text(encoding="utf-8").splitlines(), 1):
+        heading = HEADING_RE.match(raw_line)
+        if heading:
+            level = len(heading.group("marks"))
+            title = heading.group("title").strip()
+            section_stack = [
+                (existing_level, existing_title)
+                for existing_level, existing_title in section_stack
+                if existing_level < level
+            ]
+            section_stack.append((level, title))
+            continue
+
+        item = UNCHECKED_RE.match(raw_line)
+        if item:
+            section = _section_path(section_stack)
+            if any(title in EXCLUDED_SECTIONS for _level, title in section_stack):
+                continue
+            unchecked.append((line_number, section, item.group("text").strip()))
+
+    return unchecked
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Print unchecked Telegram strategy plan items for release review."
+    )
+    parser.add_argument(
+        "--plan",
+        type=Path,
+        default=DEFAULT_PLAN_PATH,
+        help=f"Plan path to inspect. Defaults to {DEFAULT_PLAN_PATH}.",
+    )
+    args = parser.parse_args()
+
+    plan_path = args.plan
+    if not plan_path.exists():
+        parser.error(f"plan file not found: {plan_path}")
+
+    unchecked = iter_unchecked_items(plan_path)
+    print(f"Unchecked Telegram roadmap items: {len(unchecked)}")
+    print(f"Plan: {plan_path}")
+
+    for line_number, section, text in unchecked:
+        print(f"{line_number}: {section} :: {text}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `scripts/report_unchecked_telegram_plan_items.py` to print unchecked Telegram strategy plan checkboxes with section path and line number for release review.
- Mark the matching continuous-plan automation backlog item complete in `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`.
- Add a staff runtime guard test proving confirmation callbacks remain inert while Telegram state-changing execution is disabled.
- Record the new Phase 4 guard coverage in the Telegram strategy plan without marking parent execution items complete.

## Contract Impact
- Canonical surface: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`, `scripts/report_unchecked_telegram_plan_items.py`, and `backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py`.
- Request shape: no API or Telegram request shape changed.
- Response shape: no API or Telegram response shape changed.
- Status codes: no HTTP status code changes.
- Frontend consumer: no frontend code changes.
- Compatibility path or alias: no route, alias, or webhook execution path changed.
- Contract proof: the new test verifies disabled confirmation callbacks do not mutate queue state, consume tokens, or write confirmed/completed/failed audit events.

## RBAC / Permissions
- Roles allowed: no role permissions were expanded.
- Roles denied: existing denial behavior remains unchanged.
- Positive auth proof: the callback guard uses an already linked registrar only to create a confirmation request.
- Negative auth proof: even with a linked registrar and a stored token, callback-style confirmation data is ignored while execution remains disabled.

## Notification / Realtime
- Event type or websocket channel: no notification, websocket, or realtime channel changes.
- Payload version / ack behavior: no payload version or callback acknowledgement behavior was enabled.
- Read/unread or delivery semantics: no read/unread, delivery, retry, or acknowledgement state is created or modified.
- Reconnect/resync proof: not applicable; this PR does not change a realtime data path.

## Frontend Resilience
- Empty data proof: no frontend data path changed.
- Partial data proof: no frontend partial-data behavior changed.
- Forbidden secondary path behavior: the new test covers a forbidden secondary callback path and verifies no mutation/audit completion occurs.
- Missing draft/resource behavior: no draft/resource lookup path was added.
- Stale route/deep-link behavior: no route or deep-link behavior changed.

## Scope Gate
- Allowed paths: Telegram strategy plan, release-review helper script, focused Telegram staff runtime test.
- Denied paths: runtime Telegram execution enablement, domain mutation services, DB migrations, frontend UI, unrelated `.codex` skill files.
- Migration/docs/test impact: no migration; plan docs updated; one focused backend unit test added.
- Rollback note: revert this PR to remove the unchecked-item report script and disabled-callback guard coverage.

## Validation
- Targeted tests or smoke run: `C:\final\.venv\Scripts\python.exe -m py_compile scripts\report_unchecked_telegram_plan_items.py`; `C:\final\.venv\Scripts\python.exe scripts\report_unchecked_telegram_plan_items.py`; `C:\final\backend\.venv\Scripts\pytest.exe backend\tests\unit\test_telegram_staff_read_only_menu_runtime.py::TestTelegramStaffReadOnlyMenuRuntime::test_staff_queue_confirmation_callback_is_ignored_until_execution_enabled -q`.
- Result: py_compile passed; unchecked-item script printed 42 actionable unchecked items; targeted backend test passed (`1 passed`, `1 warning`).
- Not checked: full backend suite and frontend build were not run for this docs/test-only slice.