### PR TITLE
test(telegram): guard disabled staff confirmations

### DIFF
--- a/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
+++ b/backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py
@@ -1216,6 +1216,106 @@ class TestTelegramStaffReadOnlyMenuRuntime:
         assert "7220" not in str(audit_log.payload)
 
     @pytest.mark.asyncio
+    async def test_staff_queue_confirmation_callback_is_ignored_until_execution_enabled(
+        self, db_session, registrar_user, test_doctor, test_patient
+    ):
+        assert (
+            telegram_webhook.STAFF_BOT_CONFIRMATION_CONTRACT[
+                "state_changing_actions_enabled"
+            ]
+            is False
+        )
+        _link_staff_chat(db_session, chat_id=7221, user_id=registrar_user.id)
+        queue = DailyQueue(
+            day=date.today(),
+            specialist_id=test_doctor.id,
+            queue_tag="cardiology_common",
+            active=True,
+        )
+        db_session.add(queue)
+        db_session.flush()
+
+        original_queue_time = datetime.utcnow().replace(microsecond=0)
+        entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=15,
+            patient_id=test_patient.id,
+            patient_name="Callback Guard",
+            phone="+998901234571",
+            source="desk",
+            status="waiting",
+            queue_time=original_queue_time,
+        )
+        db_session.add(entry)
+        db_session.commit()
+
+        fake_service = FakeTelegramBotService()
+        command_update = {
+            "update_id": 221,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 7221},
+                "from": {"id": 7221},
+                "text": "/call",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            command_update, db_session, fake_service
+        )
+
+        assert handled is True
+        fake_service._send_message.assert_awaited_once()
+        reply_markup = fake_service._send_message.await_args.args[2]
+        assert "callback_data" not in str(reply_markup)
+
+        confirmation_record = (
+            db_session.query(TelegramStaffConfirmationToken)
+            .filter(
+                TelegramStaffConfirmationToken.staff_user_id == registrar_user.id,
+                TelegramStaffConfirmationToken.telegram_chat_id == 7221,
+            )
+            .one()
+        )
+        fake_service._send_message.reset_mock()
+        callback_update = {
+            "update_id": 222,
+            "callback_query": {
+                "id": "staff-confirmation-callback",
+                "from": {"id": 7221},
+                "message": {"message_id": 2, "chat": {"id": 7221}},
+                "data": f"staff_action_confirm:{confirmation_record.token_hash}",
+            },
+        }
+
+        handled = await telegram_webhook._handle_clinic_bot_update(
+            callback_update, db_session, fake_service
+        )
+
+        assert handled is False
+        fake_service._send_message.assert_not_awaited()
+        db_session.refresh(entry)
+        db_session.refresh(confirmation_record)
+        assert entry.status == "waiting"
+        assert entry.queue_time == original_queue_time
+        assert entry.called_at is None
+        assert confirmation_record.consumed_at is None
+        assert (
+            db_session.query(AuditLog)
+            .filter(
+                AuditLog.action.in_(
+                    [
+                        "staff_action_confirmed",
+                        "staff_action_completed",
+                        "staff_action_failed",
+                    ]
+                )
+            )
+            .count()
+            == 0
+        )
+
+    @pytest.mark.asyncio
     async def test_staff_state_change_command_denies_unauthorized_role(
         self, db_session, admin_user
     ):


### PR DESCRIPTION
## Summary
- Adds a focused Telegram staff queue confirmation guard test.
- Verifies `/call` still creates only a hash-only confirmation request while Telegram state-changing execution is disabled.
- Verifies callback-like staff confirmation data is ignored by the clinic runtime, does not consume the token, and does not mutate queue state.

## Contract Impact
- Canonical surface: `backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py` covers the canonical clinic bot webhook runtime guard around `telegram_webhook._handle_clinic_bot_update`.
- Request shape: staff `/call` message plus a callback-query-shaped staff confirmation payload used as a disabled-runtime guard.
- Response shape: `/call` returns the existing confirmation-request text and reply markup without `callback_data`; callback-like confirmation data is not handled by the clinic runtime.
- Status codes: no HTTP endpoint or status-code behavior changed.
- Frontend consumer: no frontend consumer changes; protected clinic app remains the intended future confirmation surface.
- Compatibility path or alias: no command alias, route alias, or legacy compatibility path changed.
- Contract proof: targeted Telegram staff runtime, management contract, and queue-time tests pass locally.

## RBAC / Permissions
- Roles allowed: existing registrar `/call` confirmation-request path remains allowed.
- Roles denied: existing denied-role coverage remains in the same test file and is not relaxed.
- Positive auth proof: the new test links a registrar Telegram chat before requesting `/call`.
- Negative auth proof: callback-like confirmation data does not bypass role/runtime enablement because execution remains disabled and unhandled.

## Notification / Realtime
- Event type or websocket channel: no websocket channel or notification event is introduced.
- Payload version / ack behavior: callback-like staff confirmation payload is ignored by the clinic runtime while explicit action enablement is false.
- Read/unread or delivery semantics: no delivery/read state is created because this guard only covers the disabled Telegram execution path.
- Reconnect/resync proof: staff status remains exposed through the existing management contract covered by `test_telegram_bot_management_api_service.py`.

## Frontend Resilience
- Empty data proof: no frontend data path is changed; the queue fixture proves the waiting queue entry remains unchanged after the disabled callback path.
- Partial data proof: no partial-data rendering path is introduced; the runtime does not emit inline confirmation callback data.
- Forbidden secondary path behavior: callback-like staff confirmation data is not accepted as a secondary execution path while Telegram mutations are disabled.
- Missing draft/resource behavior: no draft/resource fetch path is introduced; the confirmation token remains server-side, hash-only, and unconsumed.
- Stale route/deep-link behavior: no route or deep link is added; the reply markup is asserted to contain no `callback_data`.

## Scope Gate
- Allowed paths: `backend/tests/unit/test_telegram_staff_read_only_menu_runtime.py`.
- Denied paths: runtime handlers, frontend manager, DB models, migrations, and generated/local `.codex` skill files were left out of the commit.
- Migration/docs/test impact: test-only backend guard; no migration or docs contract change.
- Rollback note: revert this commit to remove only the added guard test.

## Validation
- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_telegram_staff_read_only_menu_runtime.py backend\tests\unit\test_telegram_bot_management_api_service.py backend\tests\unit\test_queue_time_window.py -q`; `backend\.venv\Scripts\python.exe -m py_compile backend\tests\unit\test_telegram_staff_read_only_menu_runtime.py backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`.
- Result: 57 passed, 1 warning; py_compile passed.
- Not checked: frontend build, because this PR changes only a backend unit test and no frontend/runtime implementation file.