### PR TITLE
chore(telegram): add plan drift warning check

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -348,7 +348,7 @@ Use this loop after every Telegram implementation slice:
 
 Future automation backlog:
 
-- [ ] Add a lightweight repository check that warns when Telegram runtime files change without a corresponding update to this plan.
+- [x] Add a lightweight repository check that warns when Telegram runtime files change without a corresponding update to this plan: `scripts/check_telegram_plan_drift.py` inspects changed Telegram runtime files, warns when this plan is absent, and supports `--fail-on-warning` for a later CI gate.
 - [x] Add a script or CI job that prints all unchecked Telegram roadmap items for release review: `scripts/report_unchecked_telegram_plan_items.py` prints each unchecked checkbox with section path and line number via `python scripts/report_unchecked_telegram_plan_items.py`.
 - [ ] Add a plan drift check that flags stale provider names, unsupported language codes, and hardcoded placeholder URLs.
 - [ ] Add a test inventory check that maps each checked roadmap item to at least one targeted test or smoke command.

--- a/scripts/check_telegram_plan_drift.py
+++ b/scripts/check_telegram_plan_drift.py
@@ -1,0 +1,99 @@
+"""Warn when Telegram runtime changes are missing the Telegram strategy plan.
+
+Default behavior is warning-only. Use ``--fail-on-warning`` when wiring this
+into CI or a release gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+PLAN_PATH = ".ai-factory/plans/telegram-bot-clinic-full-strategy.md"
+TELEGRAM_RUNTIME_PREFIXES = (
+    "backend/app/api/v1/endpoints/admin_telegram.py",
+    "backend/app/api/v1/endpoints/telegram_",
+    "backend/app/services/telegram_",
+    "backend/app/models/telegram_",
+    "backend/app/schemas/telegram_",
+    "backend/tests/unit/test_telegram_",
+    "frontend/src/components/Telegram",
+)
+
+
+def _normalize(path: str) -> str:
+    normalized = Path(path).as_posix()
+    if normalized.startswith("./"):
+        return normalized[2:]
+    return normalized
+
+
+def _git_changed_files(base: str, head: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base}...{head}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [_normalize(line) for line in result.stdout.splitlines() if line.strip()]
+
+
+def _is_telegram_runtime_file(path: str) -> bool:
+    normalized = _normalize(path)
+    return any(normalized.startswith(prefix) for prefix in TELEGRAM_RUNTIME_PREFIXES)
+
+
+def check_plan_drift(changed_files: list[str]) -> tuple[bool, list[str]]:
+    normalized = [_normalize(path) for path in changed_files]
+    plan_changed = PLAN_PATH in normalized
+    telegram_runtime_files = [
+        path for path in normalized if _is_telegram_runtime_file(path)
+    ]
+    return bool(telegram_runtime_files and not plan_changed), telegram_runtime_files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Warn when Telegram runtime files changed without the strategy plan."
+    )
+    parser.add_argument("--base", default="origin/main", help="Git diff base.")
+    parser.add_argument("--head", default="HEAD", help="Git diff head.")
+    parser.add_argument(
+        "--changed-file",
+        action="append",
+        default=[],
+        help="Synthetic changed file. Repeat to bypass git diff for tests/smoke.",
+    )
+    parser.add_argument(
+        "--fail-on-warning",
+        action="store_true",
+        help="Exit with status 1 when drift is detected.",
+    )
+    args = parser.parse_args()
+
+    changed_files = (
+        [_normalize(path) for path in args.changed_file]
+        if args.changed_file
+        else _git_changed_files(args.base, args.head)
+    )
+
+    drift_detected, telegram_runtime_files = check_plan_drift(changed_files)
+    if drift_detected:
+        print("WARNING: Telegram runtime files changed without strategy plan update.")
+        print(f"Plan path: {PLAN_PATH}")
+        print("Runtime files:")
+        for path in telegram_runtime_files:
+            print(f"- {path}")
+        return 1 if args.fail_on_warning else 0
+
+    if telegram_runtime_files:
+        print("OK: Telegram runtime changes include the strategy plan.")
+    else:
+        print("OK: no Telegram runtime file changes detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/check_telegram_plan_drift.py`, a warning-only repository check for Telegram runtime changes without the strategy plan.
- Marks the matching Telegram roadmap automation backlog item complete with the script path and behavior.
- Keeps CI wiring out of scope; `--fail-on-warning` is available for a later explicit gate.

## Contract Impact
- Canonical surface: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md` and `scripts/check_telegram_plan_drift.py`.
- Request shape: CLI accepts `--base`, `--head`, repeatable `--changed-file`, and optional `--fail-on-warning`.
- Response shape: CLI prints either a warning with runtime file list or an OK status.
- Status codes: warning-only mode exits 0; `--fail-on-warning` exits 1 when drift is detected and 0 when the plan is included.
- Frontend consumer: no frontend consumer change.
- Compatibility path or alias: no existing script or route alias changed.
- Contract proof: synthetic changed-file smoke covers warning-only, fail-on-warning, and plan-included OK paths.

## RBAC / Permissions
- Roles allowed: no runtime roles or app permissions changed.
- Roles denied: no runtime roles or app permissions changed.
- Positive auth proof: no authenticated surface is introduced; this is a local/CI helper script.
- Negative auth proof: script only reads git diff metadata and does not access secrets or protected runtime state.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel is introduced.
- Payload version / ack behavior: no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: no delivery/read state is created; output is terminal-only release-review text.
- Reconnect/resync proof: no realtime subscription path changes.

## Frontend Resilience
- Empty data proof: no frontend data flow changed; script reports OK for no Telegram runtime changes.
- Partial data proof: synthetic file input supports checking a subset of changed paths without requiring git diff.
- Forbidden secondary path behavior: no secondary app path is introduced.
- Missing draft/resource behavior: missing plan updates are reported as drift warnings rather than inferred as complete work.
- Stale route/deep-link behavior: no route or deep-link behavior changed.

## Scope Gate
- Allowed paths: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`, `scripts/check_telegram_plan_drift.py`.
- Denied paths: runtime handlers, frontend components, DB models, migrations, and generated/local `.codex` files were left out of the commit.
- Migration/docs/test impact: docs/tooling only; no migration.
- Rollback note: revert this commit to remove the warning script and reopen the roadmap checkbox.

## Validation
- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file backend/app/api/v1/endpoints/telegram_webhook.py`; same command with `--fail-on-warning`; same command with the plan path included; `backend\.venv\Scripts\python.exe -m py_compile scripts\check_telegram_plan_drift.py scripts\report_unchecked_telegram_plan_items.py`.
- Result: warning-only exit 0; fail-on-warning exit 1 as expected; plan-included exit 0; py_compile passed.
- Not checked: frontend build, because this PR changes only a docs/tooling script and roadmap text.