### PR TITLE
chore(telegram): add plan content guard

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -350,7 +350,7 @@ Future automation backlog:
 
 - [x] Add a lightweight repository check that warns when Telegram runtime files change without a corresponding update to this plan: `scripts/check_telegram_plan_drift.py` inspects changed Telegram runtime files, warns when this plan is absent, and supports `--fail-on-warning` for a later CI gate.
 - [x] Add a script or CI job that prints all unchecked Telegram roadmap items for release review: `scripts/report_unchecked_telegram_plan_items.py` prints each unchecked checkbox with section path and line number via `python scripts/report_unchecked_telegram_plan_items.py`.
-- [ ] Add a plan drift check that flags stale provider names, unsupported language codes, and hardcoded placeholder URLs.
+- [x] Add a plan drift check that flags stale provider names, unsupported language codes, and hardcoded placeholder URLs: `scripts/check_telegram_plan_content.py` warns on stale provider names, unsupported patient language codes, and placeholder/local URLs in this strategy plan, with `--fail-on-warning` available for a later CI gate.
 - [ ] Add a test inventory check that maps each checked roadmap item to at least one targeted test or smoke command.
 - [ ] Add release-note generation from newly checked items so rollout evidence stays aligned with the plan.
 

--- a/scripts/check_telegram_plan_content.py
+++ b/scripts/check_telegram_plan_content.py
@@ -1,0 +1,124 @@
+"""Check Telegram strategy plan content for stale rollout values.
+
+Default behavior is warning-only. Use ``--fail-on-warning`` when wiring this
+into CI or a release gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_PLAN_PATH = Path(".ai-factory/plans/telegram-bot-clinic-full-strategy.md")
+SUPPORTED_LANGUAGE_CODES = {"ru", "uz-Latn"}
+UNSUPPORTED_LANGUAGE_CODES = {"en", "en-US", "ru-RU", "uz", "uz-Cyrl"}
+STALE_PROVIDER_NAMES = {"apelsin"}
+STALE_PROVIDER_ALLOWED_CONTEXT = (
+    "explicitly remove apelsin",
+    "non-apelsin",
+    "not apelsin",
+    "not supported",
+)
+PLACEHOLDER_URL_RE = re.compile(
+    r"https?://[^\s`)]*(?:clinic\.example\.com|example\.com|localhost|127\.0\.0\.1)",
+    re.IGNORECASE,
+)
+CODE_SPAN_RE = re.compile(r"`([^`]+)`")
+
+
+@dataclass(frozen=True)
+class PlanContentWarning:
+    line_number: int
+    category: str
+    detail: str
+    text: str
+
+
+def _stale_provider_allowed(line: str) -> bool:
+    normalized = line.lower()
+    return any(context in normalized for context in STALE_PROVIDER_ALLOWED_CONTEXT)
+
+
+def iter_plan_content_warnings(plan_text: str) -> list[PlanContentWarning]:
+    warnings: list[PlanContentWarning] = []
+    for line_number, line in enumerate(plan_text.splitlines(), 1):
+        normalized = line.lower()
+        for provider in STALE_PROVIDER_NAMES:
+            if provider in normalized and not _stale_provider_allowed(line):
+                warnings.append(
+                    PlanContentWarning(
+                        line_number=line_number,
+                        category="stale_provider",
+                        detail=f"stale provider name: {provider}",
+                        text=line.strip(),
+                    )
+                )
+
+        for code in CODE_SPAN_RE.findall(line):
+            if code in UNSUPPORTED_LANGUAGE_CODES:
+                warnings.append(
+                    PlanContentWarning(
+                        line_number=line_number,
+                        category="unsupported_language",
+                        detail=(
+                            f"unsupported language code: {code}; "
+                            f"supported={sorted(SUPPORTED_LANGUAGE_CODES)}"
+                        ),
+                        text=line.strip(),
+                    )
+                )
+
+        if PLACEHOLDER_URL_RE.search(line):
+            warnings.append(
+                PlanContentWarning(
+                    line_number=line_number,
+                    category="placeholder_url",
+                    detail="hardcoded placeholder/local URL",
+                    text=line.strip(),
+                )
+            )
+    return warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check Telegram strategy plan for stale provider, language, and URL values."
+    )
+    parser.add_argument(
+        "--plan",
+        type=Path,
+        default=DEFAULT_PLAN_PATH,
+        help=f"Plan path to inspect. Defaults to {DEFAULT_PLAN_PATH}.",
+    )
+    parser.add_argument(
+        "--fail-on-warning",
+        action="store_true",
+        help="Exit with status 1 when content warnings are detected.",
+    )
+    args = parser.parse_args()
+
+    plan_path = args.plan
+    if not plan_path.exists():
+        parser.error(f"plan file not found: {plan_path}")
+
+    warnings = iter_plan_content_warnings(plan_path.read_text(encoding="utf-8"))
+    if not warnings:
+        print("OK: Telegram plan content matches provider/language/url guardrails.")
+        print(f"Plan: {plan_path}")
+        return 0
+
+    print("WARNING: Telegram plan content drift detected.")
+    print(f"Plan: {plan_path}")
+    for warning in warnings:
+        print(
+            f"{warning.line_number}: {warning.category}: "
+            f"{warning.detail} :: {warning.text}"
+        )
+    return 1 if args.fail_on_warning else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/check_telegram_plan_content.py` to warn on stale Telegram strategy values.
- Flags stale provider names, unsupported patient language codes, and hardcoded placeholder/local URLs in the plan.
- Marks the matching Telegram roadmap automation backlog item complete while leaving CI enforcement for a later explicit gate.

## Contract Impact
- Canonical surface: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md` and `scripts/check_telegram_plan_content.py`.
- Request shape: CLI accepts `--plan` and optional `--fail-on-warning`.
- Response shape: CLI prints OK for clean plans or line-numbered warnings grouped by category for content drift.
- Status codes: default warning mode exits 0; `--fail-on-warning` exits 1 when warnings are detected.
- Frontend consumer: no frontend consumer change.
- Compatibility path or alias: no existing script, app route, or Telegram command alias changed.
- Contract proof: current plan smoke passes; synthetic bad plan detects stale provider, unsupported language, and placeholder URL warnings.

## RBAC / Permissions
- Roles allowed: no runtime roles or app permissions changed.
- Roles denied: no runtime roles or app permissions changed.
- Positive auth proof: no authenticated surface is introduced; this is a local/CI helper script.
- Negative auth proof: script reads only a plan file and does not access secrets, DB state, or protected runtime endpoints.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel is introduced.
- Payload version / ack behavior: no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: no delivery/read state is created; output is terminal-only release-review text.
- Reconnect/resync proof: no realtime subscription path changes.

## Frontend Resilience
- Empty data proof: no frontend data flow changed; current plan reports OK.
- Partial data proof: synthetic bad plan proves independent category detection without requiring repository-wide scans.
- Forbidden secondary path behavior: no secondary app path is introduced.
- Missing draft/resource behavior: missing or stale rollout values are reported as warnings rather than inferred as complete work.
- Stale route/deep-link behavior: placeholder/local URLs are flagged as plan content drift.

## Scope Gate
- Allowed paths: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`, `scripts/check_telegram_plan_content.py`.
- Denied paths: runtime handlers, frontend components, DB models, migrations, and generated/local `.codex` files were left out of the commit.
- Migration/docs/test impact: docs/tooling only; no migration.
- Rollback note: revert this commit to remove the content guard script and reopen the roadmap checkbox.

## Validation
- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py`; synthetic temp plan with `Apelsin`, `uz`, and `https://clinic.example.com/pay` using `--fail-on-warning`; `backend\.venv\Scripts\python.exe -m py_compile scripts\check_telegram_plan_content.py scripts\check_telegram_plan_drift.py scripts\report_unchecked_telegram_plan_items.py`.
- Result: current plan exit 0; synthetic bad plan emitted 3 warnings and exit 1 as expected; py_compile passed.
- Not checked: frontend build, because this PR changes only a docs/tooling script and roadmap text.