### PR TITLE
chore(telegram): add roadmap test inventory report

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -351,7 +351,7 @@ Future automation backlog:
 - [x] Add a lightweight repository check that warns when Telegram runtime files change without a corresponding update to this plan: `scripts/check_telegram_plan_drift.py` inspects changed Telegram runtime files, warns when this plan is absent, and supports `--fail-on-warning` for a later CI gate.
 - [x] Add a script or CI job that prints all unchecked Telegram roadmap items for release review: `scripts/report_unchecked_telegram_plan_items.py` prints each unchecked checkbox with section path and line number via `python scripts/report_unchecked_telegram_plan_items.py`.
 - [x] Add a plan drift check that flags stale provider names, unsupported language codes, and hardcoded placeholder URLs: `scripts/check_telegram_plan_content.py` warns on stale provider names, unsupported patient language codes, and placeholder/local URLs in this strategy plan, with `--fail-on-warning` available for a later CI gate.
-- [ ] Add a test inventory check that maps each checked roadmap item to at least one targeted test or smoke command.
+- [x] Add a test inventory check that maps each checked roadmap item to at least one targeted test or smoke command: `scripts/report_telegram_plan_test_inventory.py` reports checked items with detected test/smoke evidence and can use `--fail-on-missing` once historical roadmap evidence is fully backfilled.
 - [ ] Add release-note generation from newly checked items so rollout evidence stays aligned with the plan.
 
 ## Acceptance Criteria

--- a/scripts/report_telegram_plan_test_inventory.py
+++ b/scripts/report_telegram_plan_test_inventory.py
@@ -1,0 +1,121 @@
+"""Report test or smoke evidence for checked Telegram roadmap items.
+
+The script is report-only by default. Use ``--fail-on-missing`` when the plan
+is ready for strict evidence coverage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_PLAN_PATH = Path(".ai-factory/plans/telegram-bot-clinic-full-strategy.md")
+HEADING_RE = re.compile(r"^(?P<marks>#{1,6})\s+(?P<title>.+?)\s*$")
+CHECKED_RE = re.compile(r"^(?P<indent>\s*)-\s+\[x\]\s+(?P<text>.+?)\s*$", re.I)
+EXCLUDED_SECTIONS = {"Implementation Status Legend"}
+EVIDENCE_RE = re.compile(
+    r"(`[^`]*(?:test|tests|pytest|smoke|scripts/|backend/tests|frontend/src/.+__tests__)[^`]*`|"
+    r"backend/tests/[^\s),;]+|frontend/src/[^\s),;]+__tests__/[^\s),;]+|"
+    r"scripts/[^\s),;]+|pytest|smoke)",
+    re.I,
+)
+
+
+@dataclass(frozen=True)
+class CheckedRoadmapItem:
+    line_number: int
+    section: str
+    text: str
+    evidence: tuple[str, ...]
+
+
+def _section_path(stack: list[tuple[int, str]]) -> str:
+    if not stack:
+        return "(no section)"
+    return " > ".join(title for _level, title in stack)
+
+
+def iter_checked_items(plan_path: Path) -> list[CheckedRoadmapItem]:
+    section_stack: list[tuple[int, str]] = []
+    checked: list[CheckedRoadmapItem] = []
+
+    for line_number, raw_line in enumerate(
+        plan_path.read_text(encoding="utf-8").splitlines(), 1
+    ):
+        heading = HEADING_RE.match(raw_line)
+        if heading:
+            level = len(heading.group("marks"))
+            title = heading.group("title").strip()
+            section_stack = [
+                (existing_level, existing_title)
+                for existing_level, existing_title in section_stack
+                if existing_level < level
+            ]
+            section_stack.append((level, title))
+            continue
+
+        item = CHECKED_RE.match(raw_line)
+        if not item:
+            continue
+        if any(title in EXCLUDED_SECTIONS for _level, title in section_stack):
+            continue
+
+        text = item.group("text").strip()
+        evidence = tuple(match.strip("`") for match in EVIDENCE_RE.findall(text))
+        checked.append(
+            CheckedRoadmapItem(
+                line_number=line_number,
+                section=_section_path(section_stack),
+                text=text,
+                evidence=evidence,
+            )
+        )
+    return checked
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Report test or smoke evidence for checked Telegram roadmap items."
+    )
+    parser.add_argument(
+        "--plan",
+        type=Path,
+        default=DEFAULT_PLAN_PATH,
+        help=f"Plan path to inspect. Defaults to {DEFAULT_PLAN_PATH}.",
+    )
+    parser.add_argument(
+        "--only-missing",
+        action="store_true",
+        help="Print only checked items without test/smoke evidence.",
+    )
+    parser.add_argument(
+        "--fail-on-missing",
+        action="store_true",
+        help="Exit with status 1 when checked items lack test/smoke evidence.",
+    )
+    args = parser.parse_args()
+
+    plan_path = args.plan
+    if not plan_path.exists():
+        parser.error(f"plan file not found: {plan_path}")
+
+    checked_items = iter_checked_items(plan_path)
+    missing = [item for item in checked_items if not item.evidence]
+    print(f"Checked Telegram roadmap items: {len(checked_items)}")
+    print(f"Checked items missing test/smoke evidence: {len(missing)}")
+    print(f"Plan: {plan_path}")
+
+    for item in checked_items:
+        if args.only_missing and item.evidence:
+            continue
+        evidence = ", ".join(item.evidence) if item.evidence else "MISSING"
+        print(f"{item.line_number}: {item.section} :: {evidence} :: {item.text}")
+
+    return 1 if args.fail_on_missing and missing else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/report_telegram_plan_test_inventory.py` to report checked Telegram roadmap items and detected test/smoke evidence.
- Supports `--only-missing` for release review and `--fail-on-missing` for a later strict gate after historical evidence is backfilled.
- Marks the matching Telegram roadmap automation backlog item complete.

## Contract Impact
- Canonical surface: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md` and `scripts/report_telegram_plan_test_inventory.py`.
- Request shape: CLI accepts `--plan`, `--only-missing`, and optional `--fail-on-missing`.
- Response shape: CLI prints checked-item totals, missing-evidence totals, and line-numbered item/evidence rows.
- Status codes: report mode exits 0; `--fail-on-missing` exits 1 when checked items lack test/smoke evidence.
- Frontend consumer: no frontend consumer change.
- Compatibility path or alias: no existing script, app route, or Telegram command alias changed.
- Contract proof: current plan report runs; synthetic plan proves detected evidence and missing-evidence fail path.

## RBAC / Permissions
- Roles allowed: no runtime roles or app permissions changed.
- Roles denied: no runtime roles or app permissions changed.
- Positive auth proof: no authenticated surface is introduced; this is a local/CI helper script.
- Negative auth proof: script reads only a plan file and does not access secrets, DB state, or protected runtime endpoints.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel is introduced.
- Payload version / ack behavior: no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: no delivery/read state is created; output is terminal-only release-review text.
- Reconnect/resync proof: no realtime subscription path changes.

## Frontend Resilience
- Empty data proof: no frontend data flow changed; current plan can be reported in missing-only mode.
- Partial data proof: synthetic plan proves one covered item and one missing item can be reported independently.
- Forbidden secondary path behavior: no secondary app path is introduced.
- Missing draft/resource behavior: missing roadmap evidence is reported as `MISSING` rather than inferred as covered.
- Stale route/deep-link behavior: no route or deep-link behavior changed.

## Scope Gate
- Allowed paths: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`, `scripts/report_telegram_plan_test_inventory.py`.
- Denied paths: runtime handlers, frontend components, DB models, migrations, and generated/local `.codex` files were left out of the commit.
- Migration/docs/test impact: docs/tooling only; no migration.
- Rollback note: revert this commit to remove the inventory report script and reopen the roadmap checkbox.

## Validation
- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe scripts\report_telegram_plan_test_inventory.py --only-missing`; synthetic temp plan with one checked item citing `backend/tests/unit/test_example.py::test_ok` and one checked item with no proof using `--fail-on-missing`; `backend\.venv\Scripts\python.exe -m py_compile scripts\report_telegram_plan_test_inventory.py scripts\check_telegram_plan_content.py scripts\check_telegram_plan_drift.py scripts\report_unchecked_telegram_plan_items.py`.
- Result: current plan report exit 0; synthetic missing-evidence plan exit 1 as expected; py_compile passed.
- Not checked: frontend build, because this PR changes only a docs/tooling script and roadmap text.