### PR TITLE
chore(telegram): add plan release note report

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -352,7 +352,7 @@ Future automation backlog:
 - [x] Add a script or CI job that prints all unchecked Telegram roadmap items for release review: `scripts/report_unchecked_telegram_plan_items.py` prints each unchecked checkbox with section path and line number via `python scripts/report_unchecked_telegram_plan_items.py`.
 - [x] Add a plan drift check that flags stale provider names, unsupported language codes, and hardcoded placeholder URLs: `scripts/check_telegram_plan_content.py` warns on stale provider names, unsupported patient language codes, and placeholder/local URLs in this strategy plan, with `--fail-on-warning` available for a later CI gate.
 - [x] Add a test inventory check that maps each checked roadmap item to at least one targeted test or smoke command: `scripts/report_telegram_plan_test_inventory.py` reports checked items with detected test/smoke evidence and can use `--fail-on-missing` once historical roadmap evidence is fully backfilled.
-- [ ] Add release-note generation from newly checked items so rollout evidence stays aligned with the plan.
+- [x] Add release-note generation from newly checked items so rollout evidence stays aligned with the plan: `scripts/report_telegram_plan_release_notes.py` compares checked roadmap items across refs or supplied plan files and prints release-note bullets for newly checked items.
 
 ## Acceptance Criteria
 

--- a/scripts/report_telegram_plan_release_notes.py
+++ b/scripts/report_telegram_plan_release_notes.py
@@ -1,0 +1,126 @@
+"""Generate release-note bullets from newly checked Telegram roadmap items."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_PLAN_PATH = ".ai-factory/plans/telegram-bot-clinic-full-strategy.md"
+HEADING_RE = re.compile(r"^(?P<marks>#{1,6})\s+(?P<title>.+?)\s*$")
+CHECKED_RE = re.compile(r"^\s*-\s+\[x\]\s+(?P<text>.+?)\s*$", re.I)
+EXCLUDED_SECTIONS = {"Implementation Status Legend"}
+
+
+@dataclass(frozen=True)
+class CheckedItem:
+    section: str
+    text: str
+
+
+def _section_path(stack: list[tuple[int, str]]) -> str:
+    if not stack:
+        return "(no section)"
+    return " > ".join(title for _level, title in stack)
+
+
+def checked_items_from_text(plan_text: str) -> list[CheckedItem]:
+    section_stack: list[tuple[int, str]] = []
+    checked: list[CheckedItem] = []
+
+    for raw_line in plan_text.splitlines():
+        heading = HEADING_RE.match(raw_line)
+        if heading:
+            level = len(heading.group("marks"))
+            title = heading.group("title").strip()
+            section_stack = [
+                (existing_level, existing_title)
+                for existing_level, existing_title in section_stack
+                if existing_level < level
+            ]
+            section_stack.append((level, title))
+            continue
+
+        item = CHECKED_RE.match(raw_line)
+        if not item:
+            continue
+        if any(title in EXCLUDED_SECTIONS for _level, title in section_stack):
+            continue
+        checked.append(
+            CheckedItem(section=_section_path(section_stack), text=item.group("text").strip())
+        )
+    return checked
+
+
+def _git_show_text(ref: str, path: str) -> str:
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def newly_checked_items(base_text: str, head_text: str) -> list[CheckedItem]:
+    base_checked = {item.text for item in checked_items_from_text(base_text)}
+    return [
+        item
+        for item in checked_items_from_text(head_text)
+        if item.text not in base_checked
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate Telegram release-note bullets from newly checked plan items."
+    )
+    parser.add_argument("--base", default="origin/main", help="Base git ref.")
+    parser.add_argument("--head", default="HEAD", help="Head git ref.")
+    parser.add_argument(
+        "--plan-path",
+        default=DEFAULT_PLAN_PATH,
+        help=f"Plan path inside git refs. Defaults to {DEFAULT_PLAN_PATH}.",
+    )
+    parser.add_argument(
+        "--base-plan",
+        type=Path,
+        help="Read base plan from a file instead of git.",
+    )
+    parser.add_argument(
+        "--head-plan",
+        type=Path,
+        help="Read head plan from a file instead of git.",
+    )
+    args = parser.parse_args()
+
+    if bool(args.base_plan) != bool(args.head_plan):
+        parser.error("--base-plan and --head-plan must be provided together")
+
+    if args.base_plan and args.head_plan:
+        base_text = _read_text(args.base_plan)
+        head_text = _read_text(args.head_plan)
+        source = f"{args.base_plan}..{args.head_plan}"
+    else:
+        base_text = _git_show_text(args.base, args.plan_path)
+        head_text = _git_show_text(args.head, args.plan_path)
+        source = f"{args.base}:{args.plan_path}..{args.head}:{args.plan_path}"
+
+    items = newly_checked_items(base_text, head_text)
+    print("# Telegram Plan Release Notes")
+    print(f"Source: {source}")
+    print(f"Newly checked items: {len(items)}")
+    for item in items:
+        print(f"- {item.section}: {item.text}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/report_telegram_plan_release_notes.py` to generate release-note bullets from newly checked Telegram roadmap items.
- Supports git-ref comparison and synthetic `--base-plan` / `--head-plan` files for smoke testing.
- Marks the matching Telegram roadmap automation backlog item complete.

## Contract Impact
- Canonical surface: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md` and `scripts/report_telegram_plan_release_notes.py`.
- Request shape: CLI accepts `--base`, `--head`, `--plan-path`, or paired `--base-plan` and `--head-plan` file inputs.
- Response shape: CLI prints a markdown-style release-note report with source, newly checked count, and bullets by section.
- Status codes: report generation exits 0 when inputs are valid; missing paired plan-file input is rejected by argparse.
- Frontend consumer: no frontend consumer change.
- Compatibility path or alias: no existing script, app route, or Telegram command alias changed.
- Contract proof: synthetic base/head plans produce exactly one newly checked release-note bullet.

## RBAC / Permissions
- Roles allowed: no runtime roles or app permissions changed.
- Roles denied: no runtime roles or app permissions changed.
- Positive auth proof: no authenticated surface is introduced; this is a local/CI helper script.
- Negative auth proof: script reads only plan text from git refs or supplied files and does not access secrets, DB state, or protected runtime endpoints.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel is introduced.
- Payload version / ack behavior: no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: no delivery/read state is created; output is terminal-only release-review text.
- Reconnect/resync proof: no realtime subscription path changes.

## Frontend Resilience
- Empty data proof: no frontend data flow changed; zero newly checked items still produces a valid report.
- Partial data proof: synthetic base/head files prove a single newly checked item can be isolated from already checked items.
- Forbidden secondary path behavior: no secondary app path is introduced.
- Missing draft/resource behavior: script requires paired synthetic plan files, so partial file input is rejected before report generation.
- Stale route/deep-link behavior: no route or deep-link behavior changed.

## Scope Gate
- Allowed paths: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`, `scripts/report_telegram_plan_release_notes.py`.
- Denied paths: runtime handlers, frontend components, DB models, migrations, and generated/local `.codex` files were left out of the commit.
- Migration/docs/test impact: docs/tooling only; no migration.
- Rollback note: revert this commit to remove the release-note report script and reopen the roadmap checkbox.

## Validation
- Targeted tests or smoke run: synthetic base/head plan files where one checkbox changes from unchecked to checked; `backend\.venv\Scripts\python.exe -m py_compile scripts\report_telegram_plan_release_notes.py scripts\report_telegram_plan_test_inventory.py scripts\check_telegram_plan_content.py scripts\check_telegram_plan_drift.py scripts\report_unchecked_telegram_plan_items.py`.
- Result: synthetic report printed exactly one newly checked item; py_compile passed.
- Not checked: frontend build, because this PR changes only a docs/tooling script and roadmap text.