### PR TITLE
feat(telegram): validate mini app init data

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -312,7 +312,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 ### Phase 5: Telegram Mini App
 
 - [ ] Status: not implemented. Legacy `WebAppInfo` links do not count as completion without protected Mini App identity validation and scoped runtime flows.
-- [ ] Validate Telegram Mini App `initData` server-side before trusting identity.
+- [x] Validate Telegram Mini App `initData` server-side before trusting identity: `backend/app/services/telegram_mini_app_init_data.py` validates the Telegram Mini App HMAC data-check string, rejects forged hashes and stale/future `auth_date` values, and is covered by `backend/tests/unit/test_telegram_mini_app_init_data.py`.
 - [ ] Scope Mini App sessions to the linked patient or authenticated staff user.
 - [ ] Implement appointment booking inside the protected Mini App flow.
 - [ ] Implement patient forms inside the protected Mini App flow.

--- a/backend/app/services/telegram_mini_app_init_data.py
+++ b/backend/app/services/telegram_mini_app_init_data.py
@@ -1,0 +1,137 @@
+"""Telegram Mini App initData validation helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import parse_qsl
+
+
+DEFAULT_MAX_AUTH_AGE_SECONDS = 24 * 60 * 60
+DEFAULT_MAX_FUTURE_SKEW_SECONDS = 60
+_HASH_FIELD = "hash"
+_AUTH_DATE_FIELD = "auth_date"
+
+
+class TelegramMiniAppInitDataError(ValueError):
+    """Raised when Telegram Mini App initData cannot be trusted."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class TelegramMiniAppInitData:
+    """Validated Telegram Mini App initData without the untrusted hash field."""
+
+    fields: dict[str, str]
+    auth_date: datetime
+    age_seconds: int
+    user: dict[str, Any] | None = None
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_init_data(init_data: str) -> dict[str, str]:
+    pairs = parse_qsl(str(init_data or ""), keep_blank_values=True, strict_parsing=False)
+    fields: dict[str, str] = {}
+    for key, value in pairs:
+        key_text = str(key)
+        if key_text in fields:
+            raise TelegramMiniAppInitDataError("duplicate_field")
+        fields[key_text] = str(value)
+    return fields
+
+
+def _data_check_string(fields: dict[str, str]) -> str:
+    return "\n".join(
+        f"{key}={value}" for key, value in sorted(fields.items()) if key != _HASH_FIELD
+    )
+
+
+def _expected_hash(data_check_string: str, bot_token: str) -> str:
+    secret_key = hmac.new(
+        b"WebAppData",
+        bot_token.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return hmac.new(
+        secret_key,
+        data_check_string.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _parse_auth_date(value: str) -> datetime:
+    try:
+        timestamp = int(value)
+    except (TypeError, ValueError) as exc:
+        raise TelegramMiniAppInitDataError("invalid_auth_date") from exc
+    return datetime.fromtimestamp(timestamp, timezone.utc)
+
+
+def _parse_user(value: str | None) -> dict[str, Any] | None:
+    if not value:
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise TelegramMiniAppInitDataError("invalid_user_json") from exc
+    if not isinstance(parsed, dict):
+        raise TelegramMiniAppInitDataError("invalid_user_json")
+    return parsed
+
+
+def validate_telegram_mini_app_init_data(
+    init_data: str,
+    *,
+    bot_token: str,
+    max_age_seconds: int = DEFAULT_MAX_AUTH_AGE_SECONDS,
+    max_future_skew_seconds: int = DEFAULT_MAX_FUTURE_SKEW_SECONDS,
+    now: datetime | None = None,
+) -> TelegramMiniAppInitData:
+    """Validate Telegram Mini App initData before trusting Mini App identity."""
+
+    token = str(bot_token or "").strip()
+    if not token:
+        raise TelegramMiniAppInitDataError("bot_token_required")
+
+    fields = _parse_init_data(init_data)
+    received_hash = fields.get(_HASH_FIELD)
+    if not received_hash:
+        raise TelegramMiniAppInitDataError("hash_required")
+    if _AUTH_DATE_FIELD not in fields:
+        raise TelegramMiniAppInitDataError("auth_date_required")
+
+    data_check_string = _data_check_string(fields)
+    expected_hash = _expected_hash(data_check_string, token)
+    if not hmac.compare_digest(received_hash, expected_hash):
+        raise TelegramMiniAppInitDataError("hash_mismatch")
+
+    checked_at = now or _utc_now()
+    if checked_at.tzinfo is None:
+        checked_at = checked_at.replace(tzinfo=timezone.utc)
+    else:
+        checked_at = checked_at.astimezone(timezone.utc)
+
+    auth_date = _parse_auth_date(fields[_AUTH_DATE_FIELD])
+    age_seconds = int((checked_at - auth_date).total_seconds())
+    if age_seconds > int(max_age_seconds):
+        raise TelegramMiniAppInitDataError("auth_date_expired")
+    if age_seconds < -int(max_future_skew_seconds):
+        raise TelegramMiniAppInitDataError("auth_date_in_future")
+
+    trusted_fields = {key: value for key, value in fields.items() if key != _HASH_FIELD}
+    return TelegramMiniAppInitData(
+        fields=trusted_fields,
+        auth_date=auth_date,
+        age_seconds=age_seconds,
+        user=_parse_user(trusted_fields.get("user")),
+    )

--- a/backend/tests/unit/test_telegram_mini_app_init_data.py
+++ b/backend/tests/unit/test_telegram_mini_app_init_data.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import pytest
+
+from app.services.telegram_mini_app_init_data import (
+    TelegramMiniAppInitDataError,
+    validate_telegram_mini_app_init_data,
+)
+
+
+BOT_TOKEN = "123456:test-mini-app-token"
+
+
+def _signed_init_data(params: dict[str, str], bot_token: str = BOT_TOKEN) -> str:
+    data_check_string = "\n".join(
+        f"{key}={value}" for key, value in sorted(params.items())
+    )
+    secret_key = hmac.new(
+        b"WebAppData",
+        bot_token.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    payload_hash = hmac.new(
+        secret_key,
+        data_check_string.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return urlencode({**params, "hash": payload_hash})
+
+
+def test_validate_telegram_mini_app_init_data_accepts_signed_payload():
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    init_data = _signed_init_data(
+        {
+            "auth_date": str(int((now - timedelta(minutes=3)).timestamp())),
+            "query_id": "AAEAAAE",
+            "user": json.dumps(
+                {"id": 42, "first_name": "Ali", "language_code": "ru"},
+                separators=(",", ":"),
+            ),
+        }
+    )
+
+    result = validate_telegram_mini_app_init_data(
+        init_data,
+        bot_token=BOT_TOKEN,
+        now=now,
+    )
+
+    assert result.user == {"id": 42, "first_name": "Ali", "language_code": "ru"}
+    assert result.fields["query_id"] == "AAEAAAE"
+    assert "hash" not in result.fields
+    assert result.age_seconds == 180
+
+
+def test_validate_telegram_mini_app_init_data_rejects_forged_hash():
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    init_data = _signed_init_data(
+        {
+            "auth_date": str(int(now.timestamp())),
+            "query_id": "AAEAAAE",
+            "user": json.dumps({"id": 42}, separators=(",", ":")),
+        }
+    ).replace("hash=", "hash=forged", 1)
+
+    with pytest.raises(TelegramMiniAppInitDataError) as excinfo:
+        validate_telegram_mini_app_init_data(
+            init_data,
+            bot_token=BOT_TOKEN,
+            now=now,
+        )
+
+    assert excinfo.value.reason == "hash_mismatch"
+
+
+def test_validate_telegram_mini_app_init_data_rejects_expired_auth_date():
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    init_data = _signed_init_data(
+        {
+            "auth_date": str(int((now - timedelta(days=2)).timestamp())),
+            "query_id": "AAEAAAE",
+            "user": json.dumps({"id": 42}, separators=(",", ":")),
+        }
+    )
+
+    with pytest.raises(TelegramMiniAppInitDataError) as excinfo:
+        validate_telegram_mini_app_init_data(
+            init_data,
+            bot_token=BOT_TOKEN,
+            max_age_seconds=24 * 60 * 60,
+            now=now,
+        )
+
+    assert excinfo.value.reason == "auth_date_expired"
+
+
+def test_validate_telegram_mini_app_init_data_rejects_future_auth_date():
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    init_data = _signed_init_data(
+        {
+            "auth_date": str(int((now + timedelta(minutes=5)).timestamp())),
+            "query_id": "AAEAAAE",
+            "user": json.dumps({"id": 42}, separators=(",", ":")),
+        }
+    )
+
+    with pytest.raises(TelegramMiniAppInitDataError) as excinfo:
+        validate_telegram_mini_app_init_data(
+            init_data,
+            bot_token=BOT_TOKEN,
+            max_future_skew_seconds=60,
+            now=now,
+        )
+
+    assert excinfo.value.reason == "auth_date_in_future"
+
+
+def test_validate_telegram_mini_app_init_data_rejects_duplicate_fields():
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    init_data = _signed_init_data(
+        {
+            "auth_date": str(int(now.timestamp())),
+            "query_id": "AAEAAAE",
+            "user": json.dumps({"id": 42}, separators=(",", ":")),
+        }
+    )
+
+    with pytest.raises(TelegramMiniAppInitDataError) as excinfo:
+        validate_telegram_mini_app_init_data(
+            f"{init_data}&query_id=duplicate",
+            bot_token=BOT_TOKEN,
+            now=now,
+        )
+
+    assert excinfo.value.reason == "duplicate_field"


### PR DESCRIPTION
## Summary
- Add a server-side Telegram Mini App initData validator that rebuilds the Telegram data-check string, verifies the HMAC hash with the bot token secret, and returns sanitized fields without the hash.
- Reject forged hashes, duplicate fields, stale auth_date values, and auth_date values too far in the future before any identity is trusted.
- Mark the roadmap item complete with the exact service/test proof; this PR does not wire Mini App sessions into endpoints or frontend runtime yet.

## Contract Impact
- Canonical surface: new backend service module `backend/app/services/telegram_mini_app_init_data.py` for future Mini App identity validation.
- Request shape: raw Telegram Mini App initData query string plus server-owned bot token and explicit age/skew limits.
- Response shape: `TelegramMiniAppInitData` dataclass with sanitized fields, parsed `auth_date`, age seconds, and optional parsed user dictionary; the Telegram `hash` field is not returned to consumers.
- Status codes: no HTTP route is introduced in this slice, so API status behavior is unchanged.
- Frontend consumer: no frontend consumer is added; the future Mini App session bridge remains a separate guarded slice.
- Compatibility path or alias: no legacy alias, route, webhook, or migration compatibility path changes.
- Contract proof: `backend/tests/unit/test_telegram_mini_app_init_data.py` covers valid signed input plus forged, expired, future-dated, and duplicate-field rejection.

## RBAC / Permissions
- Roles allowed: no application role gains access because this service is not wired to a route or session yet.
- Roles denied: forged or stale Telegram payloads are denied before role resolution can occur.
- Positive auth proof: a correctly signed payload with current `auth_date` is accepted by the focused unit test.
- Negative auth proof: forged hash, expired timestamp, future timestamp, and duplicate-field payloads all raise `TelegramMiniAppInitDataError` with explicit reasons.

## Notification / Realtime
- Event type or websocket channel: no Telegram notification, websocket, or realtime event is emitted by this validator.
- Payload version / ack behavior: no delivery payload or ack contract changes.
- Read/unread or delivery semantics: no message state, queue event, or notification read state changes.
- Reconnect/resync proof: no realtime client or reconnect path is touched.

## Frontend Resilience
- Empty data proof: frontend data paths are unchanged in this server-only slice.
- Partial data proof: malformed or partial Mini App initData is rejected server-side before future frontend identity trust.
- Forbidden secondary path behavior: no secondary UI path is created or enabled.
- Missing draft/resource behavior: no draft, resource loader, or frontend persistence behavior changes.
- Stale route/deep-link behavior: no route or deep-link registration changes.

## Scope Gate
- Allowed paths: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`, `backend/app/services/telegram_mini_app_init_data.py`, `backend/tests/unit/test_telegram_mini_app_init_data.py`.
- Denied paths: Telegram endpoints, webhook runtime, frontend manager files, DB models, Alembic revisions, and `.codex` skill/config files stay out of scope.
- Migration/docs/test impact: no migration; roadmap proof updated; focused unit tests added.
- Rollback note: remove the new service/test and revert the roadmap checkbox to return to the previous unwired state.
- Gate note: `agent_gate.py` first routed this mixed Telegram task toward webhook/frontend files; retry with the new service as known root cause stopped because the file did not exist yet, so this used the repo-approved `narrow_override` for a new-file root cause.

## Validation
- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_telegram_mini_app_init_data.py -q`; `backend\.venv\Scripts\python.exe -m py_compile backend\app\services\telegram_mini_app_init_data.py backend\tests\unit\test_telegram_mini_app_init_data.py`; `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py`.
- Result: focused pytest passed with 5 tests; py_compile passed; Telegram plan content guard passed.
- Not checked: full backend suite, frontend build, and browser smoke because this PR adds no runtime endpoint or frontend consumer.