### PR TITLE
feat(telegram): scope mini app sessions

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -313,7 +313,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 
 - [ ] Status: not implemented. Legacy `WebAppInfo` links do not count as completion without protected Mini App identity validation and scoped runtime flows.
 - [x] Validate Telegram Mini App `initData` server-side before trusting identity: `backend/app/services/telegram_mini_app_init_data.py` validates the Telegram Mini App HMAC data-check string, rejects forged hashes and stale/future `auth_date` values, and is covered by `backend/tests/unit/test_telegram_mini_app_init_data.py`.
-- [ ] Scope Mini App sessions to the linked patient or authenticated staff user.
+- [x] Scope Mini App sessions to the linked patient or authenticated staff user: `backend/app/services/telegram_mini_app_init_data.py` resolves validated `initData` only through existing active `telegram_users` links, returns explicit patient/staff scopes, rejects direct URL or unlinked identity, blocks inactive staff links, and `backend/tests/unit/test_telegram_mini_app_init_data.py` covers wrong-patient scope rejection.
 - [ ] Implement appointment booking inside the protected Mini App flow.
 - [ ] Implement patient forms inside the protected Mini App flow.
 - [ ] Implement patient cabinet inside the protected Mini App flow.

--- a/backend/app/services/telegram_mini_app_init_data.py
+++ b/backend/app/services/telegram_mini_app_init_data.py
@@ -7,14 +7,41 @@ import hmac
 import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import parse_qsl
+
+from sqlalchemy.orm import Session
+
+from app.crud import telegram_config as crud_telegram
+from app.models.patient import Patient
+from app.models.telegram_config import TelegramUser
+from app.models.user import User
 
 
 DEFAULT_MAX_AUTH_AGE_SECONDS = 24 * 60 * 60
 DEFAULT_MAX_FUTURE_SKEW_SECONDS = 60
 _HASH_FIELD = "hash"
 _AUTH_DATE_FIELD = "auth_date"
+_VALID_MINI_APP_SCOPES = {"patient", "staff"}
+_STAFF_MINI_APP_SUPPORTED_ROLES = frozenset(
+    {"admin", "owner", "doctor", "cashier", "lab", "registrar"}
+)
+_STAFF_ROLE_ALIASES = {
+    "administrator": "admin",
+    "super_admin": "admin",
+    "superadmin": "admin",
+    "admin": "admin",
+    "owner": "owner",
+    "doctor": "doctor",
+    "cashier": "cashier",
+    "lab": "lab",
+    "lab_tech": "lab",
+    "laboratory": "lab",
+    "registrar": "registrar",
+    "receptionist": "registrar",
+}
+
+TelegramMiniAppScopeType = Literal["patient", "staff"]
 
 
 class TelegramMiniAppInitDataError(ValueError):
@@ -33,6 +60,26 @@ class TelegramMiniAppInitData:
     auth_date: datetime
     age_seconds: int
     user: dict[str, Any] | None = None
+
+
+class TelegramMiniAppSessionScopeError(ValueError):
+    """Raised when validated Mini App initData has no trusted application scope."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class TelegramMiniAppSessionScope:
+    """Application identity scope bound to an existing Telegram account link."""
+
+    scope_type: TelegramMiniAppScopeType
+    telegram_user_id: int
+    telegram_chat_id: int
+    patient_id: int | None = None
+    staff_user_id: int | None = None
+    staff_role: str | None = None
 
 
 def _utc_now() -> datetime:
@@ -89,6 +136,83 @@ def _parse_user(value: str | None) -> dict[str, Any] | None:
     return parsed
 
 
+def _normalize_staff_role(role: Any) -> str:
+    role_key = str(role or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return _STAFF_ROLE_ALIASES.get(role_key, role_key)
+
+
+def _telegram_account_id(init_data: TelegramMiniAppInitData) -> int:
+    user = init_data.user
+    if not isinstance(user, dict):
+        raise TelegramMiniAppSessionScopeError("telegram_user_required")
+    try:
+        account_id = int(user.get("id"))
+    except (TypeError, ValueError) as exc:
+        raise TelegramMiniAppSessionScopeError("telegram_user_id_required") from exc
+    if account_id <= 0:
+        raise TelegramMiniAppSessionScopeError("telegram_user_id_required")
+    return account_id
+
+
+def _base_scope(
+    telegram_user: TelegramUser,
+    scope_type: TelegramMiniAppScopeType,
+    *,
+    patient_id: int | None = None,
+    staff_user_id: int | None = None,
+    staff_role: str | None = None,
+) -> TelegramMiniAppSessionScope:
+    return TelegramMiniAppSessionScope(
+        scope_type=scope_type,
+        telegram_user_id=int(telegram_user.id),
+        telegram_chat_id=int(telegram_user.chat_id),
+        patient_id=patient_id,
+        staff_user_id=staff_user_id,
+        staff_role=staff_role,
+    )
+
+
+def _patient_scope(
+    db: Session, telegram_user: TelegramUser
+) -> TelegramMiniAppSessionScope | None:
+    patient_id = getattr(telegram_user, "patient_id", None)
+    if not patient_id:
+        return None
+
+    patient = db.query(Patient).filter(Patient.id == int(patient_id)).first()
+    if not patient or getattr(patient, "is_deleted", False):
+        raise TelegramMiniAppSessionScopeError("patient_link_invalid")
+
+    return _base_scope(
+        telegram_user,
+        "patient",
+        patient_id=int(patient.id),
+    )
+
+
+def _staff_scope(
+    db: Session, telegram_user: TelegramUser
+) -> TelegramMiniAppSessionScope | None:
+    staff_user_id = getattr(telegram_user, "user_id", None)
+    if not staff_user_id:
+        return None
+
+    staff_user = db.query(User).filter(User.id == int(staff_user_id)).first()
+    if not staff_user or not getattr(staff_user, "is_active", False):
+        raise TelegramMiniAppSessionScopeError("staff_link_inactive")
+
+    staff_role = _normalize_staff_role(getattr(staff_user, "role", None))
+    if staff_role not in _STAFF_MINI_APP_SUPPORTED_ROLES:
+        raise TelegramMiniAppSessionScopeError("staff_role_not_allowed")
+
+    return _base_scope(
+        telegram_user,
+        "staff",
+        staff_user_id=int(staff_user.id),
+        staff_role=staff_role,
+    )
+
+
 def validate_telegram_mini_app_init_data(
     init_data: str,
     *,
@@ -135,3 +259,81 @@ def validate_telegram_mini_app_init_data(
         age_seconds=age_seconds,
         user=_parse_user(trusted_fields.get("user")),
     )
+
+
+def resolve_telegram_mini_app_session_scope(
+    db: Session,
+    init_data: TelegramMiniAppInitData,
+    *,
+    expected_scope: TelegramMiniAppScopeType | None = None,
+) -> TelegramMiniAppSessionScope:
+    """Resolve validated Mini App identity to a linked patient or staff account."""
+
+    if expected_scope is not None and expected_scope not in _VALID_MINI_APP_SCOPES:
+        raise TelegramMiniAppSessionScopeError("invalid_expected_scope")
+
+    telegram_account_id = _telegram_account_id(init_data)
+    telegram_user = crud_telegram.get_telegram_user_by_chat_id(
+        db,
+        telegram_account_id,
+    )
+    if not telegram_user:
+        raise TelegramMiniAppSessionScopeError("telegram_link_required")
+    if not getattr(telegram_user, "active", False):
+        raise TelegramMiniAppSessionScopeError("telegram_link_inactive")
+    if getattr(telegram_user, "blocked", False):
+        raise TelegramMiniAppSessionScopeError("telegram_link_blocked")
+
+    if expected_scope == "patient":
+        scope = _patient_scope(db, telegram_user)
+        if not scope:
+            raise TelegramMiniAppSessionScopeError("patient_scope_required")
+        return scope
+
+    if expected_scope == "staff":
+        scope = _staff_scope(db, telegram_user)
+        if not scope:
+            raise TelegramMiniAppSessionScopeError("staff_scope_required")
+        return scope
+
+    patient_scope = _patient_scope(db, telegram_user)
+    staff_scope = _staff_scope(db, telegram_user)
+    if patient_scope and staff_scope:
+        raise TelegramMiniAppSessionScopeError("ambiguous_scope")
+    if patient_scope:
+        return patient_scope
+    if staff_scope:
+        return staff_scope
+
+    raise TelegramMiniAppSessionScopeError("linked_identity_required")
+
+
+def require_telegram_mini_app_patient_scope(
+    scope: TelegramMiniAppSessionScope,
+    *,
+    patient_id: int,
+) -> TelegramMiniAppSessionScope:
+    """Require that a Mini App scope belongs to one concrete linked patient."""
+
+    if scope.scope_type != "patient" or scope.patient_id is None:
+        raise TelegramMiniAppSessionScopeError("patient_scope_required")
+    if int(scope.patient_id) != int(patient_id):
+        raise TelegramMiniAppSessionScopeError("patient_scope_mismatch")
+    return scope
+
+
+def require_telegram_mini_app_staff_scope(
+    scope: TelegramMiniAppSessionScope,
+    *,
+    allowed_roles: set[str] | frozenset[str] | None = None,
+) -> TelegramMiniAppSessionScope:
+    """Require that a Mini App scope belongs to an authenticated staff user."""
+
+    if scope.scope_type != "staff" or scope.staff_user_id is None:
+        raise TelegramMiniAppSessionScopeError("staff_scope_required")
+
+    if allowed_roles:
+        normalized_roles = {_normalize_staff_role(role) for role in allowed_roles}
+        if scope.staff_role not in normalized_roles:
+            raise TelegramMiniAppSessionScopeError("staff_role_denied")
+    return scope

--- a/backend/tests/unit/test_telegram_mini_app_init_data.py
+++ b/backend/tests/unit/test_telegram_mini_app_init_data.py
@@ -10,8 +10,14 @@ import pytest
 
 from app.services.telegram_mini_app_init_data import (
     TelegramMiniAppInitDataError,
+    TelegramMiniAppSessionScopeError,
+    require_telegram_mini_app_patient_scope,
+    require_telegram_mini_app_staff_scope,
+    resolve_telegram_mini_app_session_scope,
     validate_telegram_mini_app_init_data,
 )
+from app.models.telegram_config import TelegramUser
+from app.models.user import User
 
 
 BOT_TOKEN = "123456:test-mini-app-token"
@@ -32,6 +38,35 @@ def _signed_init_data(params: dict[str, str], bot_token: str = BOT_TOKEN) -> str
         hashlib.sha256,
     ).hexdigest()
     return urlencode({**params, "hash": payload_hash})
+
+
+def _validated_init_data(telegram_id: int, *, now: datetime):
+    init_data = _signed_init_data(
+        {
+            "auth_date": str(int(now.timestamp())),
+            "query_id": "AAEAAAE",
+            "user": json.dumps({"id": telegram_id}, separators=(",", ":")),
+        }
+    )
+    return validate_telegram_mini_app_init_data(
+        init_data,
+        bot_token=BOT_TOKEN,
+        now=now,
+    )
+
+
+def _telegram_user(chat_id: int, **overrides) -> TelegramUser:
+    defaults = {
+        "chat_id": chat_id,
+        "language_code": "ru",
+        "active": True,
+        "blocked": False,
+        "notifications_enabled": False,
+        "appointment_reminders": False,
+        "lab_notifications": False,
+    }
+    defaults.update(overrides)
+    return TelegramUser(**defaults)
 
 
 def test_validate_telegram_mini_app_init_data_accepts_signed_payload():
@@ -139,3 +174,140 @@ def test_validate_telegram_mini_app_init_data_rejects_duplicate_fields():
         )
 
     assert excinfo.value.reason == "duplicate_field"
+
+
+def test_resolve_telegram_mini_app_session_scope_returns_linked_patient(
+    db_session,
+    test_patient,
+):
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    chat_id = 880101
+    db_session.add(_telegram_user(chat_id, patient_id=test_patient.id))
+    db_session.commit()
+    init_data = _validated_init_data(chat_id, now=now)
+
+    scope = resolve_telegram_mini_app_session_scope(
+        db_session,
+        init_data,
+        expected_scope="patient",
+    )
+
+    assert scope.scope_type == "patient"
+    assert scope.telegram_chat_id == chat_id
+    assert scope.patient_id == test_patient.id
+    assert scope.staff_user_id is None
+    assert require_telegram_mini_app_patient_scope(
+        scope,
+        patient_id=test_patient.id,
+    ) is scope
+
+
+def test_resolve_telegram_mini_app_session_scope_returns_active_staff(
+    db_session,
+    admin_user,
+):
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    chat_id = 880102
+    db_session.add(_telegram_user(chat_id, user_id=admin_user.id))
+    db_session.commit()
+    init_data = _validated_init_data(chat_id, now=now)
+
+    scope = resolve_telegram_mini_app_session_scope(
+        db_session,
+        init_data,
+        expected_scope="staff",
+    )
+
+    assert scope.scope_type == "staff"
+    assert scope.telegram_chat_id == chat_id
+    assert scope.staff_user_id == admin_user.id
+    assert scope.staff_role == "admin"
+    assert scope.patient_id is None
+    assert require_telegram_mini_app_staff_scope(
+        scope,
+        allowed_roles={"Admin"},
+    ) is scope
+
+
+def test_resolve_telegram_mini_app_session_scope_rejects_direct_url_without_user():
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    init_data = validate_telegram_mini_app_init_data(
+        _signed_init_data(
+            {
+                "auth_date": str(int(now.timestamp())),
+                "query_id": "AAEAAAE",
+            }
+        ),
+        bot_token=BOT_TOKEN,
+        now=now,
+    )
+
+    with pytest.raises(TelegramMiniAppSessionScopeError) as excinfo:
+        resolve_telegram_mini_app_session_scope(None, init_data)
+
+    assert excinfo.value.reason == "telegram_user_required"
+
+
+def test_resolve_telegram_mini_app_session_scope_rejects_unlinked_account(
+    db_session,
+):
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    init_data = _validated_init_data(880103, now=now)
+
+    with pytest.raises(TelegramMiniAppSessionScopeError) as excinfo:
+        resolve_telegram_mini_app_session_scope(db_session, init_data)
+
+    assert excinfo.value.reason == "telegram_link_required"
+
+
+def test_require_telegram_mini_app_patient_scope_rejects_wrong_patient(
+    db_session,
+    test_patient,
+):
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    chat_id = 880104
+    db_session.add(_telegram_user(chat_id, patient_id=test_patient.id))
+    db_session.commit()
+    init_data = _validated_init_data(chat_id, now=now)
+    scope = resolve_telegram_mini_app_session_scope(
+        db_session,
+        init_data,
+        expected_scope="patient",
+    )
+
+    with pytest.raises(TelegramMiniAppSessionScopeError) as excinfo:
+        require_telegram_mini_app_patient_scope(
+            scope,
+            patient_id=test_patient.id + 1,
+        )
+
+    assert excinfo.value.reason == "patient_scope_mismatch"
+
+
+def test_resolve_telegram_mini_app_session_scope_rejects_inactive_staff(
+    db_session,
+):
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    staff_user = User(
+        username="inactive_mini_app_staff",
+        email="inactive-mini-app-staff@test.com",
+        full_name="Inactive Mini App Staff",
+        hashed_password="test",
+        role="Doctor",
+        is_active=False,
+    )
+    db_session.add(staff_user)
+    db_session.flush()
+    chat_id = 880105
+    db_session.add(_telegram_user(chat_id, user_id=staff_user.id))
+    db_session.commit()
+    init_data = _validated_init_data(chat_id, now=now)
+
+    with pytest.raises(TelegramMiniAppSessionScopeError) as excinfo:
+        resolve_telegram_mini_app_session_scope(
+            db_session,
+            init_data,
+            expected_scope="staff",
+        )
+
+    assert excinfo.value.reason == "staff_link_inactive"


### PR DESCRIPTION
## Summary
- Extend the Telegram Mini App backend service with a session scope resolver that accepts already validated initData only when it maps to an existing active `telegram_users` link.
- Return explicit patient or staff scopes, require patient/staff-specific scope checks, and reject direct URL access, unlinked Telegram accounts, wrong patient scope, inactive staff links, and ambiguous links.
- Mark the Phase 5 roadmap scoping item complete with focused runtime/test evidence; this PR does not add endpoint, frontend, session-token, or Mini App UI wiring.

## Contract Impact
- Canonical surface: `backend/app/services/telegram_mini_app_init_data.py` now owns both Mini App initData verification and the first server-side application-scope resolver.
- Request shape: caller passes validated `TelegramMiniAppInitData`, a database session, and an optional expected scope of `patient` or `staff`.
- Response shape: `TelegramMiniAppSessionScope` exposes scope type, Telegram link row id, Telegram chat/account id, and either `patient_id` or active `staff_user_id` plus normalized staff role.
- Status codes: no HTTP route is introduced, so API status behavior is unchanged.
- Frontend consumer: no frontend consumer is added; future Mini App session endpoint/UI remains a separate guarded slice.
- Compatibility path or alias: no legacy alias, route redirect, webhook behavior, or DB migration changes.
- Contract proof: `backend/tests/unit/test_telegram_mini_app_init_data.py` covers linked patient, active staff, missing Telegram identity, unlinked identity, wrong patient scope, and inactive staff rejection.

## RBAC / Permissions
- Roles allowed: active linked staff users with supported Telegram staff roles (`admin`, `owner`, `doctor`, `cashier`, `lab`, `registrar`) can resolve staff scope when a staff flow explicitly requests it.
- Roles denied: inactive staff users, unsupported staff roles, unlinked Telegram users, blocked/inactive Telegram links, and patient links used for the wrong patient are denied before future route handlers can trust the scope.
- Positive auth proof: focused tests verify a linked patient scope and an active admin staff scope resolve from signed initData.
- Negative auth proof: focused tests verify missing `user` identity, unlinked Telegram account, wrong patient id, and inactive staff user all raise `TelegramMiniAppSessionScopeError` with explicit reasons.

## Notification / Realtime
- Event type or websocket channel: no Telegram notification, websocket, or realtime event is emitted by this service.
- Payload version / ack behavior: no delivery payload, callback ack, or notification contract changes.
- Read/unread or delivery semantics: no message state, queue event, or notification read state changes.
- Reconnect/resync proof: no realtime client, websocket subscription, or reconnect path is touched.

## Frontend Resilience
- Empty data proof: direct URL-style initData without Telegram `user` is rejected before future frontend data loading can occur.
- Partial data proof: validated initData without an existing application link is rejected as `telegram_link_required`.
- Forbidden secondary path behavior: a patient scope cannot be reused for another patient id; staff scope requires an active linked staff user.
- Missing draft/resource behavior: no draft/resource loader is introduced in this backend-only slice.
- Stale route/deep-link behavior: no route, deep-link, or Telegram button registration changes.

## Scope Gate
- Allowed paths: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`, `backend/app/services/telegram_mini_app_init_data.py`, `backend/tests/unit/test_telegram_mini_app_init_data.py`.
- Denied paths: Telegram webhook endpoints, admin endpoints, frontend manager files, DB models, Alembic revisions, and `.codex` skill/config files stay out of scope.
- Migration/docs/test impact: no migration; roadmap proof updated; focused unit tests expanded from 5 to 11 cases.
- Rollback note: revert this commit to remove scope resolution while preserving the already merged initData validator.
- Gate note: first gate routed this no-wiring server contract into webhook/frontend files; known-root-cause retry returned `narrow override`, so the patch used the repo-approved narrow service/test/plan set.

## Validation
- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_telegram_mini_app_init_data.py -q`; `backend\.venv\Scripts\python.exe -m py_compile backend\app\services\telegram_mini_app_init_data.py backend\tests\unit\test_telegram_mini_app_init_data.py`; `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py`; `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file backend/app/services/telegram_mini_app_init_data.py --changed-file backend/tests/unit/test_telegram_mini_app_init_data.py --changed-file .ai-factory/plans/telegram-bot-clinic-full-strategy.md --fail-on-warning`; `git diff --check -- .ai-factory/plans/telegram-bot-clinic-full-strategy.md backend/app/services/telegram_mini_app_init_data.py backend/tests/unit/test_telegram_mini_app_init_data.py`.
- Result: focused pytest passed with 11 tests; py_compile passed; plan content and drift guards passed; diff whitespace check passed.
- Not checked: `ruff` because `backend\.venv\Scripts\python.exe -m ruff ...` reported `No module named ruff`; frontend build and browser smoke were left for later because this PR adds no frontend or runtime endpoint.