### PR TITLE
docs(telegram): close mini app test checklist

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -319,7 +319,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 - [ ] Implement patient cabinet inside the protected Mini App flow.
 - [ ] Implement payment details inside the protected Mini App flow.
 - [ ] Implement protected result/report viewing inside the Mini App flow.
-- [ ] Add tests for forged `initData`, expired auth, wrong patient scope, and direct URL access without Telegram identity.
+- [x] Add tests for forged `initData`, expired auth, wrong patient scope, and direct URL access without Telegram identity: `backend/tests/unit/test_telegram_mini_app_init_data.py` covers `hash_mismatch`, `auth_date_expired`, `patient_scope_mismatch`, and missing Telegram `user` identity rejection.
 
 ### Phase 6: AI assistant approval flows
 


### PR DESCRIPTION
## Summary
- Mark the Phase 5 Mini App security-test checklist item complete now that the focused Mini App unit test file covers every listed case.
- Tie the checkbox to concrete proof in `backend/tests/unit/test_telegram_mini_app_init_data.py`: forged hash, expired auth, wrong patient scope, and missing Telegram user identity.
- No runtime code, endpoint, frontend, DB, or migration behavior changes in this slice.

## Contract Impact
- Canonical surface: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md` roadmap status only.
- Request shape: no request contract changes.
- Response shape: no response contract changes.
- Status codes: no HTTP route behavior changes.
- Frontend consumer: no frontend consumer changes.
- Compatibility path or alias: no route alias, legacy path, webhook, or adapter changes.
- Contract proof: `backend/tests/unit/test_telegram_mini_app_init_data.py` already includes assertions for `hash_mismatch`, `auth_date_expired`, `patient_scope_mismatch`, and missing Telegram `user` identity rejection.

## RBAC / Permissions
- Roles allowed: no role permissions are changed by this docs-only status update.
- Roles denied: no denial matrix changes; the referenced tests prove forged/stale/wrong-scope Mini App identity remains denied.
- Positive auth proof: previous Mini App tests continue to prove linked patient and active staff scope resolution.
- Negative auth proof: focused tests prove forged initData, expired auth, wrong patient scope, and direct URL-style missing Telegram identity rejection.

## Notification / Realtime
- Event type or websocket channel: no notification, Telegram send, websocket, or realtime event changes.
- Payload version / ack behavior: no delivery payload or ack contract changes.
- Read/unread or delivery semantics: no message state or notification read state changes.
- Reconnect/resync proof: no realtime client or reconnect path is touched.

## Frontend Resilience
- Empty data proof: no frontend data path changes; the roadmap now points to backend proof for missing Telegram identity rejection.
- Partial data proof: no partial frontend payload path changes.
- Forbidden secondary path behavior: wrong patient scope remains covered by backend unit proof.
- Missing draft/resource behavior: no draft or resource loader behavior changes.
- Stale route/deep-link behavior: no route, deep-link, or Telegram button registration changes.

## Scope Gate
- Allowed paths: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`.
- Denied paths: runtime backend services, Telegram endpoints, frontend files, DB models, Alembic revisions, and `.codex` skill/config files stay out of scope.
- Migration/docs/test impact: docs roadmap status only; no new migration or test file modification.
- Rollback note: revert the single roadmap line if the referenced tests are removed or renamed.

## Validation
- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py`; `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file .ai-factory/plans/telegram-bot-clinic-full-strategy.md --fail-on-warning`; `backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_telegram_mini_app_init_data.py -q`.
- Result: plan content guard passed; plan drift guard reported no runtime changes; focused Mini App pytest passed with 11 tests.
- Not checked: full backend suite, frontend build, and browser smoke because this PR changes only the roadmap status line.