### PR TITLE
feat(telegram): guard mini app booking draft

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -315,6 +315,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 - [x] Validate Telegram Mini App `initData` server-side before trusting identity: `backend/app/services/telegram_mini_app_init_data.py` validates the Telegram Mini App HMAC data-check string, rejects forged hashes and stale/future `auth_date` values, and is covered by `backend/tests/unit/test_telegram_mini_app_init_data.py`.
 - [x] Scope Mini App sessions to the linked patient or authenticated staff user: `backend/app/services/telegram_mini_app_init_data.py` resolves validated `initData` only through existing active `telegram_users` links, returns explicit patient/staff scopes, rejects direct URL or unlinked identity, blocks inactive staff links, and `backend/tests/unit/test_telegram_mini_app_init_data.py` covers wrong-patient scope rejection.
 - [ ] Implement appointment booking inside the protected Mini App flow.
+  - [x] First backend-only booking policy slice: `backend/app/services/telegram_mini_app_init_data.py` builds a non-mutating safe appointment draft only from linked patient Mini App scope, forces scheduled/cash/UZS defaults, rejects staff scope, wrong patient scope, past dates, and invalid times, with focused coverage in `backend/tests/unit/test_telegram_mini_app_init_data.py`.
 - [ ] Implement patient forms inside the protected Mini App flow.
 - [ ] Implement patient cabinet inside the protected Mini App flow.
 - [ ] Implement payment details inside the protected Mini App flow.

--- a/backend/app/services/telegram_mini_app_init_data.py
+++ b/backend/app/services/telegram_mini_app_init_data.py
@@ -6,7 +6,7 @@ import hashlib
 import hmac
 import json
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any, Literal
 from urllib.parse import parse_qsl
 
@@ -82,6 +82,43 @@ class TelegramMiniAppSessionScope:
     staff_role: str | None = None
 
 
+@dataclass(frozen=True)
+class TelegramMiniAppAppointmentBookingDraft:
+    """Safe appointment booking payload prepared from a patient Mini App scope."""
+
+    patient_id: int
+    appointment_date: date
+    appointment_time: str | None = None
+    doctor_id: int | None = None
+    department: str | None = None
+    notes: str | None = None
+    services: tuple[str, ...] = ()
+    status: str = "scheduled"
+    visit_type: str = "paid"
+    payment_type: str = "cash"
+    payment_currency: str = "UZS"
+
+    def to_appointment_create_payload(self) -> dict[str, Any]:
+        return {
+            "patient_id": self.patient_id,
+            "doctor_id": self.doctor_id,
+            "department": self.department,
+            "appointment_date": self.appointment_date,
+            "appointment_time": self.appointment_time,
+            "notes": self.notes,
+            "status": self.status,
+            "visit_type": self.visit_type,
+            "payment_type": self.payment_type,
+            "services": list(self.services),
+            "payment_amount": None,
+            "payment_currency": self.payment_currency,
+            "payment_provider": None,
+            "payment_transaction_id": None,
+            "payment_webhook_id": None,
+            "payment_processed_at": None,
+        }
+
+
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -134,6 +171,51 @@ def _parse_user(value: str | None) -> dict[str, Any] | None:
     if not isinstance(parsed, dict):
         raise TelegramMiniAppInitDataError("invalid_user_json")
     return parsed
+
+
+def _trim_optional_text(
+    value: str | None,
+    *,
+    max_length: int,
+    reason: str,
+) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if len(text) > max_length:
+        raise TelegramMiniAppSessionScopeError(reason)
+    return text
+
+
+def _normalize_services(values: list[str] | tuple[str, ...] | None) -> tuple[str, ...]:
+    if not values:
+        return ()
+    services: list[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if not text:
+            raise TelegramMiniAppSessionScopeError("appointment_service_invalid")
+        if len(text) > 128:
+            raise TelegramMiniAppSessionScopeError("appointment_service_too_long")
+        services.append(text)
+    return tuple(services)
+
+
+def _normalize_appointment_time(value: str | None) -> str | None:
+    text = _trim_optional_text(
+        value,
+        max_length=8,
+        reason="appointment_time_invalid",
+    )
+    if text is None:
+        return None
+    try:
+        parsed = datetime.strptime(text, "%H:%M")
+    except ValueError as exc:
+        raise TelegramMiniAppSessionScopeError("appointment_time_invalid") from exc
+    return f"{parsed.hour:02d}:{parsed.minute:02d}"
 
 
 def _normalize_staff_role(role: Any) -> str:
@@ -337,3 +419,58 @@ def require_telegram_mini_app_staff_scope(
         if scope.staff_role not in normalized_roles:
             raise TelegramMiniAppSessionScopeError("staff_role_denied")
     return scope
+
+
+def build_telegram_mini_app_appointment_booking_draft(
+    scope: TelegramMiniAppSessionScope,
+    *,
+    appointment_date: date,
+    appointment_time: str | None = None,
+    doctor_id: int | None = None,
+    department: str | None = None,
+    notes: str | None = None,
+    services: list[str] | tuple[str, ...] | None = None,
+    patient_id: int | None = None,
+    today: date | None = None,
+) -> TelegramMiniAppAppointmentBookingDraft:
+    """Prepare a non-mutating appointment booking draft for a linked patient."""
+
+    if scope.patient_id is None:
+        raise TelegramMiniAppSessionScopeError("patient_scope_required")
+    if patient_id is not None:
+        require_telegram_mini_app_patient_scope(scope, patient_id=patient_id)
+    elif scope.scope_type != "patient":
+        raise TelegramMiniAppSessionScopeError("patient_scope_required")
+
+    if not isinstance(appointment_date, date) or isinstance(appointment_date, datetime):
+        raise TelegramMiniAppSessionScopeError("appointment_date_invalid")
+    current_day = today or date.today()
+    if appointment_date < current_day:
+        raise TelegramMiniAppSessionScopeError("appointment_date_in_past")
+
+    normalized_doctor_id = None
+    if doctor_id is not None:
+        try:
+            normalized_doctor_id = int(doctor_id)
+        except (TypeError, ValueError) as exc:
+            raise TelegramMiniAppSessionScopeError("doctor_id_invalid") from exc
+        if normalized_doctor_id <= 0:
+            raise TelegramMiniAppSessionScopeError("doctor_id_invalid")
+
+    return TelegramMiniAppAppointmentBookingDraft(
+        patient_id=int(scope.patient_id),
+        appointment_date=appointment_date,
+        appointment_time=_normalize_appointment_time(appointment_time),
+        doctor_id=normalized_doctor_id,
+        department=_trim_optional_text(
+            department,
+            max_length=64,
+            reason="department_too_long",
+        ),
+        notes=_trim_optional_text(
+            notes,
+            max_length=1000,
+            reason="notes_too_long",
+        ),
+        services=_normalize_services(services),
+    )

--- a/backend/tests/unit/test_telegram_mini_app_init_data.py
+++ b/backend/tests/unit/test_telegram_mini_app_init_data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from urllib.parse import urlencode
 
 import pytest
@@ -11,6 +11,7 @@ import pytest
 from app.services.telegram_mini_app_init_data import (
     TelegramMiniAppInitDataError,
     TelegramMiniAppSessionScopeError,
+    build_telegram_mini_app_appointment_booking_draft,
     require_telegram_mini_app_patient_scope,
     require_telegram_mini_app_staff_scope,
     resolve_telegram_mini_app_session_scope,
@@ -311,3 +312,128 @@ def test_resolve_telegram_mini_app_session_scope_rejects_inactive_staff(
         )
 
     assert excinfo.value.reason == "staff_link_inactive"
+
+
+def test_build_telegram_mini_app_appointment_booking_draft_uses_patient_scope(
+    db_session,
+    test_patient,
+):
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    chat_id = 880106
+    db_session.add(_telegram_user(chat_id, patient_id=test_patient.id))
+    db_session.commit()
+    init_data = _validated_init_data(chat_id, now=now)
+    scope = resolve_telegram_mini_app_session_scope(
+        db_session,
+        init_data,
+        expected_scope="patient",
+    )
+
+    draft = build_telegram_mini_app_appointment_booking_draft(
+        scope,
+        patient_id=test_patient.id,
+        doctor_id=12,
+        appointment_date=date(2026, 5, 20),
+        appointment_time="09:30",
+        department="Cardiology",
+        notes="Mini App request",
+        services=["Consultation"],
+        today=date(2026, 5, 19),
+    )
+
+    payload = draft.to_appointment_create_payload()
+    assert payload["patient_id"] == test_patient.id
+    assert payload["doctor_id"] == 12
+    assert payload["appointment_date"] == date(2026, 5, 20)
+    assert payload["appointment_time"] == "09:30"
+    assert payload["status"] == "scheduled"
+    assert payload["visit_type"] == "paid"
+    assert payload["payment_type"] == "cash"
+    assert payload["payment_currency"] == "UZS"
+    assert payload["payment_provider"] is None
+    assert payload["payment_transaction_id"] is None
+    assert payload["services"] == ["Consultation"]
+
+
+def test_build_telegram_mini_app_appointment_booking_draft_rejects_staff_scope(
+    db_session,
+    admin_user,
+):
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    chat_id = 880107
+    db_session.add(_telegram_user(chat_id, user_id=admin_user.id))
+    db_session.commit()
+    init_data = _validated_init_data(chat_id, now=now)
+    scope = resolve_telegram_mini_app_session_scope(
+        db_session,
+        init_data,
+        expected_scope="staff",
+    )
+
+    with pytest.raises(TelegramMiniAppSessionScopeError) as excinfo:
+        build_telegram_mini_app_appointment_booking_draft(
+            scope,
+            appointment_date=date(2026, 5, 20),
+            today=date(2026, 5, 19),
+        )
+
+    assert excinfo.value.reason == "patient_scope_required"
+
+
+def test_build_telegram_mini_app_appointment_booking_draft_rejects_wrong_patient(
+    db_session,
+    test_patient,
+):
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    chat_id = 880108
+    db_session.add(_telegram_user(chat_id, patient_id=test_patient.id))
+    db_session.commit()
+    init_data = _validated_init_data(chat_id, now=now)
+    scope = resolve_telegram_mini_app_session_scope(
+        db_session,
+        init_data,
+        expected_scope="patient",
+    )
+
+    with pytest.raises(TelegramMiniAppSessionScopeError) as excinfo:
+        build_telegram_mini_app_appointment_booking_draft(
+            scope,
+            patient_id=test_patient.id + 1,
+            appointment_date=date(2026, 5, 20),
+            today=date(2026, 5, 19),
+        )
+
+    assert excinfo.value.reason == "patient_scope_mismatch"
+
+
+def test_build_telegram_mini_app_appointment_booking_draft_rejects_unsafe_fields(
+    db_session,
+    test_patient,
+):
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    chat_id = 880109
+    db_session.add(_telegram_user(chat_id, patient_id=test_patient.id))
+    db_session.commit()
+    init_data = _validated_init_data(chat_id, now=now)
+    scope = resolve_telegram_mini_app_session_scope(
+        db_session,
+        init_data,
+        expected_scope="patient",
+    )
+
+    with pytest.raises(TelegramMiniAppSessionScopeError) as past_exc:
+        build_telegram_mini_app_appointment_booking_draft(
+            scope,
+            appointment_date=date(2026, 5, 18),
+            today=date(2026, 5, 19),
+        )
+    assert past_exc.value.reason == "appointment_date_in_past"
+
+    with pytest.raises(TelegramMiniAppSessionScopeError) as time_exc:
+        build_telegram_mini_app_appointment_booking_draft(
+            scope,
+            appointment_date=date(2026, 5, 20),
+            appointment_time="25:99",
+            today=date(2026, 5, 19),
+        )
+    assert time_exc.value.reason == "appointment_time_invalid"


### PR DESCRIPTION
## Summary
- Add the first backend-only Telegram Mini App appointment booking policy slice: a non-mutating booking draft built only from linked patient Mini App scope.
- Force safe appointment defaults (`scheduled`, `paid`, `cash`, `UZS`) and keep payment provider/transaction fields empty before any future appointment creation endpoint exists.
- Reject staff scope, wrong patient scope, past appointment dates, invalid times, invalid doctor ids, and unsafe text/service fields; parent appointment-booking roadmap item stays unchecked until endpoint/UI/creation are implemented.

## Contract Impact
- Canonical surface: `backend/app/services/telegram_mini_app_init_data.py` extends the Mini App identity service with `TelegramMiniAppAppointmentBookingDraft` and `build_telegram_mini_app_appointment_booking_draft`.
- Request shape: caller passes a resolved Mini App session scope plus appointment date/time, optional doctor/department/notes/services, optional patient id assertion, and optional testable `today` date.
- Response shape: draft object can produce an `AppointmentCreate`-compatible payload with patient id copied from scope and payment mutation fields empty.
- Status codes: no HTTP route is introduced, so API status behavior is unchanged.
- Frontend consumer: no frontend consumer is added; future Mini App booking endpoint/UI remains a later guarded slice.
- Compatibility path or alias: no legacy alias, route redirect, webhook behavior, or DB migration changes.
- Contract proof: `backend/tests/unit/test_telegram_mini_app_init_data.py` now covers patient-scope draft creation plus staff-scope, wrong-patient, past-date, and invalid-time rejection.

## RBAC / Permissions
- Roles allowed: linked patient Mini App scope can prepare a draft for its own patient id only.
- Roles denied: staff Mini App scope, wrong patient id, unlinked/missing identity covered by prior scope tests, and malformed booking fields are denied before any future mutation path.
- Positive auth proof: focused test verifies linked patient scope yields a scheduled/cash/UZS draft for the linked patient id.
- Negative auth proof: focused tests verify staff scope, wrong patient scope, past date, and invalid time raise `TelegramMiniAppSessionScopeError`.

## Notification / Realtime
- Event type or websocket channel: no Telegram notification, websocket, queue event, or realtime event is emitted.
- Payload version / ack behavior: no delivery payload, callback ack, or notification contract changes.
- Read/unread or delivery semantics: no message state, queue status, or notification read state changes.
- Reconnect/resync proof: no realtime client, websocket subscription, or reconnect path is touched.

## Frontend Resilience
- Empty data proof: no frontend data path is added; backend draft rejects missing or non-patient scope before future UI can create a booking.
- Partial data proof: optional text fields are trimmed and blank values become absent rather than unsafe payload text.
- Forbidden secondary path behavior: patient id assertion must match the linked patient scope.
- Missing draft/resource behavior: no draft persistence or resource loader is introduced.
- Stale route/deep-link behavior: no route, deep-link, or Telegram button registration changes.

## Scope Gate
- Allowed paths: `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`, `backend/app/services/telegram_mini_app_init_data.py`, `backend/tests/unit/test_telegram_mini_app_init_data.py`.
- Denied paths: Telegram webhook endpoints, admin endpoints, frontend manager files, DB models, Alembic revisions, and `.codex` skill/config files stay out of scope.
- Migration/docs/test impact: no migration; roadmap gets a checked child proof while the parent booking feature remains unchecked; focused unit tests expand from 11 to 15 cases.
- Rollback note: revert this commit to remove the booking draft policy while preserving prior initData validation and scope resolution.
- Gate note: first gate routed this backend-only policy toward webhook/frontend files; known-root-cause retry returned `narrow override`, so the patch used the repo-approved service/test/plan set only.

## Validation
- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_telegram_mini_app_init_data.py -q`; `backend\.venv\Scripts\python.exe -m py_compile backend\app\services\telegram_mini_app_init_data.py backend\tests\unit\test_telegram_mini_app_init_data.py`; `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py`; `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file backend/app/services/telegram_mini_app_init_data.py --changed-file backend/tests/unit/test_telegram_mini_app_init_data.py --changed-file .ai-factory/plans/telegram-bot-clinic-full-strategy.md --fail-on-warning`; `git diff --check -- .ai-factory/plans/telegram-bot-clinic-full-strategy.md backend/app/services/telegram_mini_app_init_data.py backend/tests/unit/test_telegram_mini_app_init_data.py`.
- Result: focused pytest passed with 15 tests; py_compile passed; plan content and drift guards passed; diff whitespace check passed.
- Not checked: full backend suite, frontend build, and browser smoke because this PR adds no route, frontend, DB migration, or runtime booking mutation.