### PR TITLE
feat(telegram): add mini app booking preview contract

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -316,6 +316,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 - [x] Scope Mini App sessions to the linked patient or authenticated staff user: `backend/app/services/telegram_mini_app_init_data.py` resolves validated `initData` only through existing active `telegram_users` links, returns explicit patient/staff scopes, rejects direct URL or unlinked identity, blocks inactive staff links, and `backend/tests/unit/test_telegram_mini_app_init_data.py` covers wrong-patient scope rejection.
 - [ ] Implement appointment booking inside the protected Mini App flow.
   - [x] First backend-only booking policy slice: `backend/app/services/telegram_mini_app_init_data.py` builds a non-mutating safe appointment draft only from linked patient Mini App scope, forces scheduled/cash/UZS defaults, rejects staff scope, wrong patient scope, past dates, and invalid times, with focused coverage in `backend/tests/unit/test_telegram_mini_app_init_data.py`.
+  - [x] Backend preview response contract: `backend/app/services/telegram_mini_app_init_data.py` now wraps the patient-scoped booking draft in a preview-only Mini App payload with mutation disabled, no appointment id, and no payment provider/transaction/webhook values, with focused coverage in `backend/tests/unit/test_telegram_mini_app_init_data.py`.
 - [ ] Implement patient forms inside the protected Mini App flow.
 - [ ] Implement patient cabinet inside the protected Mini App flow.
 - [ ] Implement payment details inside the protected Mini App flow.

--- a/backend/app/services/telegram_mini_app_init_data.py
+++ b/backend/app/services/telegram_mini_app_init_data.py
@@ -119,6 +119,29 @@ class TelegramMiniAppAppointmentBookingDraft:
         }
 
 
+@dataclass(frozen=True)
+class TelegramMiniAppAppointmentBookingPreview:
+    """Preview-only booking response prepared before any appointment mutation."""
+
+    scope: TelegramMiniAppSessionScope
+    draft: TelegramMiniAppAppointmentBookingDraft
+    preview_only: bool = True
+    mutation_allowed: bool = False
+    message_key: str = "telegram_mini_app_booking_preview_ready"
+
+    def to_response_payload(self) -> dict[str, Any]:
+        return {
+            "preview_only": self.preview_only,
+            "mutation_allowed": self.mutation_allowed,
+            "message_key": self.message_key,
+            "scope": {
+                "type": self.scope.scope_type,
+                "patient_id": self.draft.patient_id,
+            },
+            "appointment": self.draft.to_appointment_create_payload(),
+        }
+
+
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -473,4 +496,35 @@ def build_telegram_mini_app_appointment_booking_draft(
             reason="notes_too_long",
         ),
         services=_normalize_services(services),
+    )
+
+
+def build_telegram_mini_app_appointment_booking_preview(
+    scope: TelegramMiniAppSessionScope,
+    *,
+    appointment_date: date,
+    appointment_time: str | None = None,
+    doctor_id: int | None = None,
+    department: str | None = None,
+    notes: str | None = None,
+    services: list[str] | tuple[str, ...] | None = None,
+    patient_id: int | None = None,
+    today: date | None = None,
+) -> TelegramMiniAppAppointmentBookingPreview:
+    """Prepare a Mini App booking preview without creating an appointment."""
+
+    draft = build_telegram_mini_app_appointment_booking_draft(
+        scope,
+        appointment_date=appointment_date,
+        appointment_time=appointment_time,
+        doctor_id=doctor_id,
+        department=department,
+        notes=notes,
+        services=services,
+        patient_id=patient_id,
+        today=today,
+    )
+    return TelegramMiniAppAppointmentBookingPreview(
+        scope=scope,
+        draft=draft,
     )

--- a/backend/tests/unit/test_telegram_mini_app_init_data.py
+++ b/backend/tests/unit/test_telegram_mini_app_init_data.py
@@ -12,6 +12,7 @@ from app.services.telegram_mini_app_init_data import (
     TelegramMiniAppInitDataError,
     TelegramMiniAppSessionScopeError,
     build_telegram_mini_app_appointment_booking_draft,
+    build_telegram_mini_app_appointment_booking_preview,
     require_telegram_mini_app_patient_scope,
     require_telegram_mini_app_staff_scope,
     resolve_telegram_mini_app_session_scope,
@@ -355,6 +356,49 @@ def test_build_telegram_mini_app_appointment_booking_draft_uses_patient_scope(
     assert payload["services"] == ["Consultation"]
 
 
+def test_build_telegram_mini_app_appointment_booking_preview_is_non_mutating(
+    db_session,
+    test_patient,
+):
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    chat_id = 880110
+    db_session.add(_telegram_user(chat_id, patient_id=test_patient.id))
+    db_session.commit()
+    init_data = _validated_init_data(chat_id, now=now)
+    scope = resolve_telegram_mini_app_session_scope(
+        db_session,
+        init_data,
+        expected_scope="patient",
+    )
+
+    preview = build_telegram_mini_app_appointment_booking_preview(
+        scope,
+        patient_id=test_patient.id,
+        doctor_id=12,
+        appointment_date=date(2026, 5, 20),
+        appointment_time="09:30",
+        department="Cardiology",
+        notes="Mini App request",
+        services=["Consultation"],
+        today=date(2026, 5, 19),
+    )
+
+    payload = preview.to_response_payload()
+    appointment = payload["appointment"]
+    assert payload["preview_only"] is True
+    assert payload["mutation_allowed"] is False
+    assert payload["message_key"] == "telegram_mini_app_booking_preview_ready"
+    assert payload["scope"] == {"type": "patient", "patient_id": test_patient.id}
+    assert "appointment_id" not in appointment
+    assert appointment["patient_id"] == test_patient.id
+    assert appointment["status"] == "scheduled"
+    assert appointment["payment_type"] == "cash"
+    assert appointment["payment_currency"] == "UZS"
+    assert appointment["payment_provider"] is None
+    assert appointment["payment_transaction_id"] is None
+    assert appointment["payment_webhook_id"] is None
+
+
 def test_build_telegram_mini_app_appointment_booking_draft_rejects_staff_scope(
     db_session,
     admin_user,
@@ -372,6 +416,31 @@ def test_build_telegram_mini_app_appointment_booking_draft_rejects_staff_scope(
 
     with pytest.raises(TelegramMiniAppSessionScopeError) as excinfo:
         build_telegram_mini_app_appointment_booking_draft(
+            scope,
+            appointment_date=date(2026, 5, 20),
+            today=date(2026, 5, 19),
+        )
+
+    assert excinfo.value.reason == "patient_scope_required"
+
+
+def test_build_telegram_mini_app_appointment_booking_preview_rejects_staff_scope(
+    db_session,
+    admin_user,
+):
+    now = datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc)
+    chat_id = 880111
+    db_session.add(_telegram_user(chat_id, user_id=admin_user.id))
+    db_session.commit()
+    init_data = _validated_init_data(chat_id, now=now)
+    scope = resolve_telegram_mini_app_session_scope(
+        db_session,
+        init_data,
+        expected_scope="staff",
+    )
+
+    with pytest.raises(TelegramMiniAppSessionScopeError) as excinfo:
+        build_telegram_mini_app_appointment_booking_preview(
             scope,
             appointment_date=date(2026, 5, 20),
             today=date(2026, 5, 19),


### PR DESCRIPTION
## Summary
- Adds a service-level Telegram Mini App booking preview contract that wraps the existing patient-scoped booking draft in a preview-only payload.
- Keeps appointment mutation disabled: no appointment id is returned and payment provider/transaction/webhook values remain empty.
- Updates the Telegram strategy plan to mark this backend preview contract slice complete.

## Contract Impact
- Canonical surface: `backend/app/services/telegram_mini_app_init_data.py`.
- Request shape: service helper receives a resolved linked patient Mini App scope plus draft booking inputs.
- Response shape: preview payload includes `preview_only`, `mutation_allowed`, `message_key`, patient scope metadata, and a safe appointment draft.
- Status codes: none; this slice does not add an HTTP endpoint.
- Frontend consumer: none yet; endpoint/router/frontend work remains pending.
- Compatibility path or alias: none.
- Contract proof: `backend/tests/unit/test_telegram_mini_app_init_data.py` asserts non-mutating preview shape and staff-scope rejection.

## RBAC / Permissions
- Roles allowed: linked patient Mini App scope only.
- Roles denied: staff scope is rejected by the same patient-scope guard as booking drafts.
- Positive auth proof: unit test resolves a linked patient through validated Mini App initData and builds the preview payload.
- Negative auth proof: unit test rejects a linked staff scope with `patient_scope_required`.

## Notification / Realtime
- Event type or websocket channel: none.
- Payload version / ack behavior: none.
- Read/unread or delivery semantics: none.
- Reconnect/resync proof: not touched.

## Frontend Resilience
- Empty data proof: not touched; no frontend consumer in this slice.
- Partial data proof: safe nullable payment/provider fields remain explicit in the preview appointment draft.
- Forbidden secondary path behavior: staff scope rejection is covered.
- Missing draft/resource behavior: invalid draft inputs continue through existing booking draft guards.
- Stale route/deep-link behavior: not touched.

## Scope Gate
- Allowed paths: `backend/app/services/telegram_mini_app_init_data.py`, `backend/tests/unit/test_telegram_mini_app_init_data.py`, `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`.
- Denied paths: endpoint/router/frontend/webhook files and DB/Alembic files.
- Migration/docs/test impact: no migration; strategy plan updated; focused unit tests added.
- Rollback note: revert `37ed160c` to remove the preview wrapper and tests.
- Gate note: `agent_gate.py` returned `narrow override` with `gate_misroute=true`, `override_used=true`, known root cause `backend/app/services/telegram_mini_app_init_data.py`; endpoint/router/frontend edits were intentionally excluded.

## Validation
- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_telegram_mini_app_init_data.py -q`; `backend\.venv\Scripts\python.exe -m py_compile backend\app\services\telegram_mini_app_init_data.py backend\tests\unit\test_telegram_mini_app_init_data.py`; `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py`; `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file backend/app/services/telegram_mini_app_init_data.py --changed-file backend/tests/unit/test_telegram_mini_app_init_data.py --changed-file .ai-factory/plans/telegram-bot-clinic-full-strategy.md --fail-on-warning`; `git diff --check -- .ai-factory/plans/telegram-bot-clinic-full-strategy.md backend/app/services/telegram_mini_app_init_data.py backend/tests/unit/test_telegram_mini_app_init_data.py`.
- Result: passed; Mini App unit file reports `17 passed, 1 warning`.
- Not checked: full backend suite, frontend build, browser smoke, live Telegram Mini App runtime.