### PR TITLE
feat(telegram): expose mini app booking preview endpoint

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -317,6 +317,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 - [ ] Implement appointment booking inside the protected Mini App flow.
   - [x] First backend-only booking policy slice: `backend/app/services/telegram_mini_app_init_data.py` builds a non-mutating safe appointment draft only from linked patient Mini App scope, forces scheduled/cash/UZS defaults, rejects staff scope, wrong patient scope, past dates, and invalid times, with focused coverage in `backend/tests/unit/test_telegram_mini_app_init_data.py`.
   - [x] Backend preview response contract: `backend/app/services/telegram_mini_app_init_data.py` now wraps the patient-scoped booking draft in a preview-only Mini App payload with mutation disabled, no appointment id, and no payment provider/transaction/webhook values, with focused coverage in `backend/tests/unit/test_telegram_mini_app_init_data.py`.
+  - [x] Backend preview API slice: `POST /api/v1/telegram/mini-app/appointments/preview` in `backend/app/api/v1/endpoints/telegram_webhook.py` validates Mini App `initData`, resolves linked patient scope, returns the preview-only payload, rejects forged/staff access, and is covered by `backend/tests/unit/test_telegram_webhook_security.py`.
 - [ ] Implement patient forms inside the protected Mini App flow.
 - [ ] Implement patient cabinet inside the protected Mini App flow.
 - [ ] Implement payment details inside the protected Mini App flow.

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from typing import Any, Dict, NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -54,6 +55,13 @@ from app.services.telegram_staff_confirmation_token_service import (
     TelegramStaffConfirmationTokenService,
 )
 from app.services.telegram_bot import get_telegram_bot_service
+from app.services.telegram_mini_app_init_data import (
+    TelegramMiniAppInitDataError,
+    TelegramMiniAppSessionScopeError,
+    build_telegram_mini_app_appointment_booking_preview,
+    resolve_telegram_mini_app_session_scope,
+    validate_telegram_mini_app_init_data,
+)
 from app.services.visit_confirmation_service import (
     TELEGRAM_TICKET_QR_PREFIX,
     consume_telegram_ticket_start_token,
@@ -752,6 +760,18 @@ TELEGRAM_LOCALIZED_TEXTS = {
 TELEGRAM_WEBHOOK_PUBLIC_ERROR = "Ошибка обработки webhook"
 TELEGRAM_SEND_PUBLIC_ERROR = "Ошибка отправки сообщения"
 TELEGRAM_BOT_INFO_PUBLIC_MESSAGE = "Ошибка получения информации о боте"
+MINI_APP_BOOKING_REQUEST_ERROR_REASONS = frozenset(
+    {
+        "appointment_date_invalid",
+        "appointment_date_in_past",
+        "appointment_time_invalid",
+        "appointment_service_invalid",
+        "appointment_service_too_long",
+        "doctor_id_invalid",
+        "department_too_long",
+        "notes_too_long",
+    }
+)
 QUEUE_TERMINAL_STATUSES = {"served", "incomplete", "no_show", "cancelled"}
 QUEUE_WAITING_STATUSES = {"waiting"}
 EMR_CLOSED_VISIT_STATUSES = {
@@ -3742,6 +3762,19 @@ async def _handle_clinic_bot_update(
     return False
 
 
+class TelegramMiniAppAppointmentPreviewRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    init_data: str = Field(..., alias="initData", min_length=1)
+    patient_id: int | None = Field(default=None, alias="patientId")
+    appointment_date: date = Field(..., alias="appointmentDate")
+    appointment_time: str | None = Field(default=None, alias="appointmentTime")
+    doctor_id: int | None = Field(default=None, alias="doctorId")
+    department: str | None = None
+    notes: str | None = None
+    services: list[str] | None = None
+
+
 def _validate_webhook_secret(request: Request, db: Session) -> None:
     config = crud_telegram.get_telegram_config(db)
     expected_secret = getattr(config, "webhook_secret", None)
@@ -3781,6 +3814,63 @@ def _telegram_bot_info_failure(exc: Exception) -> Dict[str, Any]:
         type(exc).__name__,
     )
     return {"active": False, "message": TELEGRAM_BOT_INFO_PUBLIC_MESSAGE}
+
+
+def _mini_app_booking_scope_status_code(reason: str) -> int:
+    if reason in MINI_APP_BOOKING_REQUEST_ERROR_REASONS:
+        return status.HTTP_400_BAD_REQUEST
+    return status.HTTP_403_FORBIDDEN
+
+
+@router.post(
+    "/mini-app/appointments/preview",
+    operation_id="telegram_mini_app_preview_appointment_booking",
+)
+def preview_mini_app_appointment_booking(
+    request_body: TelegramMiniAppAppointmentPreviewRequest,
+    db: Session = Depends(get_db),
+):
+    """Return a trusted Mini App appointment preview without creating it."""
+
+    bot_token = _get_configured_bot_token(db)
+    if not bot_token:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"reason": "bot_token_required"},
+        )
+
+    try:
+        init_data = validate_telegram_mini_app_init_data(
+            request_body.init_data,
+            bot_token=bot_token,
+        )
+        scope = resolve_telegram_mini_app_session_scope(
+            db,
+            init_data,
+            expected_scope="patient",
+        )
+        preview = build_telegram_mini_app_appointment_booking_preview(
+            scope,
+            patient_id=request_body.patient_id,
+            appointment_date=request_body.appointment_date,
+            appointment_time=request_body.appointment_time,
+            doctor_id=request_body.doctor_id,
+            department=request_body.department,
+            notes=request_body.notes,
+            services=request_body.services,
+        )
+    except TelegramMiniAppInitDataError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"reason": exc.reason},
+        ) from exc
+    except TelegramMiniAppSessionScopeError as exc:
+        raise HTTPException(
+            status_code=_mini_app_booking_scope_status_code(exc.reason),
+            detail={"reason": exc.reason},
+        ) from exc
+
+    return preview.to_response_payload()
 
 
 @router.post("/webhook")

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
+import json
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from urllib.parse import urlencode
 
 import pytest
 
 from app.api.v1.endpoints import admin_telegram, telegram_webhook
+from app.models.appointment import Appointment
 from app.models.audit import AuditLog
 from app.services import telegram_bot
 from app.services.telegram_templates import TelegramTemplatesService
@@ -32,6 +37,42 @@ class FakeTelegramBotService:
         self._send_document = AsyncMock(return_value=(True, 77, None))
         self.bot_token = "bot-token"
         self.webhook_url = "https://example.com/webhook"
+
+
+MINI_APP_BOT_TOKEN = "123456:test-mini-app-token"
+
+
+def _signed_mini_app_init_data(
+    telegram_id: int,
+    *,
+    bot_token: str = MINI_APP_BOT_TOKEN,
+    auth_date: datetime | None = None,
+) -> str:
+    checked_at = auth_date or datetime.now(timezone.utc)
+    params = {
+        "auth_date": str(int(checked_at.timestamp())),
+        "query_id": "AAEAAAE",
+        "user": json.dumps({"id": telegram_id}, separators=(",", ":")),
+    }
+    data_check_string = "\n".join(
+        f"{key}={value}" for key, value in sorted(params.items())
+    )
+    secret_key = hmac.new(
+        b"WebAppData",
+        bot_token.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    payload_hash = hmac.new(
+        secret_key,
+        data_check_string.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return urlencode({**params, "hash": payload_hash})
+
+
+def _add_mini_app_telegram_config(db_session) -> None:
+    db_session.add(TelegramConfig(bot_token=MINI_APP_BOT_TOKEN, active=True))
+    db_session.commit()
 
 
 def _link_patient_to_chat(db_session, *, chat_id: int, patient_id: int) -> TelegramUser:
@@ -242,6 +283,109 @@ class TestTelegramWebhookSecurity:
         assert response.status_code == 200
         assert "Telegram webhook update accepted" in caplog.text
         assert "Sensitive Patient Diagnosis" not in caplog.text
+
+    def test_mini_app_booking_preview_endpoint_returns_non_mutating_payload(
+        self,
+        client,
+        db_session,
+        test_patient,
+    ):
+        _add_mini_app_telegram_config(db_session)
+        chat_id = 880201
+        _link_patient_to_chat(db_session, chat_id=chat_id, patient_id=test_patient.id)
+        initial_appointments = db_session.query(Appointment).count()
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/appointments/preview",
+            json={
+                "initData": _signed_mini_app_init_data(chat_id),
+                "patientId": test_patient.id,
+                "doctorId": 12,
+                "appointmentDate": "2026-05-20",
+                "appointmentTime": "09:30",
+                "department": "Cardiology",
+                "notes": "Mini App request",
+                "services": ["Consultation"],
+            },
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        appointment = payload["appointment"]
+        assert payload["preview_only"] is True
+        assert payload["mutation_allowed"] is False
+        assert payload["scope"] == {"type": "patient", "patient_id": test_patient.id}
+        assert "appointment_id" not in appointment
+        assert appointment["patient_id"] == test_patient.id
+        assert appointment["appointment_date"] == "2026-05-20"
+        assert appointment["appointment_time"] == "09:30"
+        assert appointment["status"] == "scheduled"
+        assert appointment["payment_type"] == "cash"
+        assert appointment["payment_currency"] == "UZS"
+        assert appointment["payment_provider"] is None
+        assert appointment["payment_transaction_id"] is None
+        assert appointment["payment_webhook_id"] is None
+        assert db_session.query(Appointment).count() == initial_appointments
+
+    def test_mini_app_booking_preview_endpoint_rejects_forged_init_data(
+        self,
+        client,
+        db_session,
+        test_patient,
+    ):
+        _add_mini_app_telegram_config(db_session)
+        chat_id = 880202
+        _link_patient_to_chat(db_session, chat_id=chat_id, patient_id=test_patient.id)
+        initial_appointments = db_session.query(Appointment).count()
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/appointments/preview",
+            json={
+                "initData": _signed_mini_app_init_data(chat_id).replace(
+                    "hash=",
+                    "hash=forged",
+                    1,
+                ),
+                "patientId": test_patient.id,
+                "appointmentDate": "2026-05-20",
+            },
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == {"reason": "hash_mismatch"}
+        assert db_session.query(Appointment).count() == initial_appointments
+
+    def test_mini_app_booking_preview_endpoint_rejects_staff_scope(
+        self,
+        client,
+        db_session,
+        admin_user,
+    ):
+        _add_mini_app_telegram_config(db_session)
+        chat_id = 880203
+        db_session.add(
+            TelegramUser(
+                chat_id=chat_id,
+                user_id=admin_user.id,
+                language_code="ru",
+                active=True,
+                blocked=False,
+            )
+        )
+        db_session.commit()
+        initial_appointments = db_session.query(Appointment).count()
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/appointments/preview",
+            json={
+                "initData": _signed_mini_app_init_data(chat_id),
+                "appointmentDate": "2026-05-20",
+            },
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == {"reason": "patient_scope_required"}
+        assert db_session.query(Appointment).count() == initial_appointments
 
     def test_send_message_requires_admin_auth(self, client):
         response = client.post(


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/telegram/mini-app/appointments/preview` on the existing Telegram router.
- Validates Telegram Mini App `initData` with the configured patient bot token, resolves linked patient scope, and returns the existing preview-only booking payload.
- Keeps the endpoint non-mutating: no appointment is created, no appointment id is returned, and payment provider/transaction/webhook values stay empty.
- Updates the Telegram strategy plan for the backend preview API slice.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/telegram_webhook.py` mounted under `/api/v1/telegram`.
- Request shape: JSON body with `initData`, optional `patientId`, `doctorId`, `appointmentTime`, `department`, `notes`, `services`, and required `appointmentDate`.
- Response shape: preview-only payload with `preview_only`, `mutation_allowed`, `message_key`, patient scope metadata, and safe appointment draft.
- Status codes: `200` for trusted preview, `400` for invalid booking fields, `403` for untrusted initData or non-patient scope, `503` when the patient bot token is not configured.
- Frontend consumer: none yet; frontend Mini App client remains pending.
- Compatibility path or alias: none; endpoint uses the existing `/telegram` router prefix.
- Contract proof: `backend/tests/unit/test_telegram_webhook_security.py` covers success, forged initData, staff scope denial, and no appointment creation.

## RBAC / Permissions
- Roles allowed: linked patient Mini App scope only.
- Roles denied: staff scope and forged/unlinked Mini App identity.
- Positive auth proof: endpoint test signs Mini App initData with configured bot token and linked patient chat id.
- Negative auth proof: endpoint tests reject forged initData and linked staff scope.

## Notification / Realtime
- Event type or websocket channel: none.
- Payload version / ack behavior: none.
- Read/unread or delivery semantics: none.
- Reconnect/resync proof: not touched.

## Frontend Resilience
- Empty data proof: no frontend consumer in this slice.
- Partial data proof: endpoint returns explicit nullable payment/provider fields through the safe draft payload.
- Forbidden secondary path behavior: forged initData and staff scope return structured reasons.
- Missing draft/resource behavior: invalid draft fields map to `400` through existing booking guards.
- Stale route/deep-link behavior: Mini App direct/forged identity remains rejected by initData validation and scope resolution.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook.py`, `backend/tests/unit/test_telegram_webhook_security.py`, `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`.
- Denied paths: DB/Alembic files, appointment creation service, frontend Mini App UI, webhook secret handling changes.
- Migration/docs/test impact: no migration; strategy plan updated; endpoint tests added.
- Rollback note: revert `c3be38e0` to remove the preview endpoint and tests.
- Gate note: `agent_gate.py` returned `gate ok` with known root cause `backend/app/api/v1/endpoints/telegram_webhook.py`; `gate_misroute=false`, `override_used=false`.

## Validation
- Targeted tests or smoke run: `backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_telegram_webhook_security.py -q`; `backend\.venv\Scripts\python.exe -m pytest backend\tests\unit\test_telegram_mini_app_init_data.py -q`; `backend\.venv\Scripts\python.exe -m py_compile backend\app\api\v1\endpoints\telegram_webhook.py backend\tests\unit\test_telegram_webhook_security.py`; `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py`; `backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file backend/app/api/v1/endpoints/telegram_webhook.py --changed-file backend/tests/unit/test_telegram_webhook_security.py --changed-file .ai-factory/plans/telegram-bot-clinic-full-strategy.md --fail-on-warning`; `git diff --check -- .ai-factory/plans/telegram-bot-clinic-full-strategy.md backend/app/api/v1/endpoints/telegram_webhook.py backend/tests/unit/test_telegram_webhook_security.py`.
- Result: passed; webhook security reports `42 passed, 1 warning`; Mini App service reports `17 passed, 1 warning`.
- Not checked: full backend suite, frontend build, browser smoke, live Telegram Mini App runtime.