### PR TITLE
docs(telegram): record native service command visibility

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -246,6 +246,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 - [x] Map basic patient business event names to safe Telegram messages through the canonical notification sender path.
 - [x] Wire the first real notification call-site to the patient Telegram event helper: appointment reminders with `db` and `patient_id`.
 - [x] Add a patient `/menu` refresh command that redraws the localized main menu without being intercepted by the staff menu guard: `backend/app/api/v1/endpoints/telegram_webhook.py` handles `/menu` and `backend/tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_menu_command_refreshes_patient_main_menu_without_staff_intercept` covers the patient path.
+- [x] Expose the visible patient service aliases in Telegram's native command menu: `backend/app/services/telegram_bot.py` now registers `/services`, `/forms`, `/documents`, `/doctors`, and `/cabinet` in both Russian and Uzbek `setMyCommands` payloads, while `backend/tests/unit/test_telegram_webhook_security.py::TestTelegramWebhookSecurity::test_telegram_bot_service_registers_patient_commands` keeps the exact command registry covered. These aliases still route to safe placeholder/protected-entry guidance until the protected Mini App flows below are complete.
 - [x] Add or confirm targeted tests for the completed onboarding path: start -> language -> contact/token link -> consent -> localized main menu.
 - [x] Keep full appointment booking out of plain chat unless routed to the future protected Mini App or protected web app.
 


### PR DESCRIPTION
## Summary

- Record that patient service aliases are now visible in Telegram native setMyCommands.
- Keep the plan explicit that these aliases still point to safe placeholder/protected-entry guidance until Mini App flows are implemented.

## Contract Impact

not applicable - documentation/status tracking only, no API, websocket, event, Telegram runtime payload, or frontend consumer contract changed in this PR.

## RBAC / Permissions

not applicable - no route, endpoint guard, role helper, auth flow, or permission-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification delivery, websocket, chat push, or realtime behavior changed.

## Frontend Resilience

not applicable - no frontend component, route, form, table, empty state, or data-fetching behavior changed.

## Scope Gate

- Allowed paths: .ai-factory/plans/telegram-bot-clinic-full-strategy.md.
- Denied paths: backend runtime, frontend runtime, migrations, generated output, and unrelated dirty worktree files.
- Migration/docs/test impact: docs/status update only; no migration or runtime test update expected.
- Rollback note: revert the plan line if the native service command registry change is reverted from main.

## Validation

- Targeted tests or smoke run: git diff --check -- .ai-factory/plans/telegram-bot-clinic-full-strategy.md
- Result: passed locally.
- Not checked: runtime app behavior, because this PR only updates the implementation plan after the runtime change was merged separately.