### PR TITLE
[codex] add telegram mini app forms manifest

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -322,6 +322,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
   - [x] Backend create API slice: `POST /api/v1/telegram/mini-app/appointments` in `backend/app/api/v1/endpoints/telegram_webhook.py` reuses the trusted preview guard, rejects occupied doctor time slots, creates one safe scheduled/cash/UZS appointment through existing appointment CRUD, and is covered by `backend/tests/unit/test_telegram_webhook_security.py`.
 - [x] Add protected patient section entry buttons for `/forms`, `/documents`, `/doctors`, and `/cabinet`: linked patients now receive `FRONTEND_URL` inline buttons to `/patient?tab=<section>`, while unlinked chats or missing frontend URL keep the safe placeholder services menu, with focused coverage in `backend/tests/unit/test_telegram_webhook_security.py`.
 - [ ] Implement patient forms inside the protected Mini App flow.
+  - [x] First backend-only forms manifest slice: `POST /api/v1/telegram/mini-app/forms/manifest` in `backend/app/api/v1/endpoints/telegram_webhook.py` validates Mini App `initData`, resolves linked patient scope, returns capture-disabled manifest/status without medical/passport fields, rejects forged/staff/unlinked access, and is covered by `backend/tests/unit/test_telegram_webhook_security.py`.
 - [ ] Implement patient cabinet inside the protected Mini App flow.
 - [ ] Implement payment details inside the protected Mini App flow.
 - [ ] Implement protected result/report viewing inside the Mini App flow.

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -790,6 +790,26 @@ MINI_APP_BOOKING_REQUEST_ERROR_REASONS = frozenset(
         "notes_too_long",
     }
 )
+TELEGRAM_MINI_APP_PATIENT_FORMS_MANIFEST = (
+    {
+        "key": "patient_intake",
+        "title": "Patient intake",
+        "status": "planned",
+        "capture_enabled": False,
+        "submission_enabled": False,
+        "contains_medical_data": False,
+        "contains_passport_data": False,
+    },
+    {
+        "key": "treatment_consent",
+        "title": "Treatment consent",
+        "status": "planned",
+        "capture_enabled": False,
+        "submission_enabled": False,
+        "contains_medical_data": False,
+        "contains_passport_data": False,
+    },
+)
 QUEUE_TERMINAL_STATUSES = {"served", "incomplete", "no_show", "cancelled"}
 QUEUE_WAITING_STATUSES = {"waiting"}
 EMR_CLOSED_VISIT_STATUSES = {
@@ -3845,6 +3865,12 @@ async def _handle_clinic_bot_update(
     return False
 
 
+class TelegramMiniAppPatientScopeRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    init_data: str = Field(..., alias="initData", min_length=1)
+
+
 class TelegramMiniAppAppointmentPreviewRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -3905,10 +3931,7 @@ def _mini_app_booking_scope_status_code(reason: str) -> int:
     return status.HTTP_403_FORBIDDEN
 
 
-def _build_mini_app_appointment_booking_preview_from_request(
-    request_body: TelegramMiniAppAppointmentPreviewRequest,
-    db: Session,
-):
+def _resolve_mini_app_patient_scope_from_init_data(init_data_value: str, db: Session):
     bot_token = _get_configured_bot_token(db)
     if not bot_token:
         raise HTTPException(
@@ -3918,14 +3941,52 @@ def _build_mini_app_appointment_booking_preview_from_request(
 
     try:
         init_data = validate_telegram_mini_app_init_data(
-            request_body.init_data,
+            init_data_value,
             bot_token=bot_token,
         )
-        scope = resolve_telegram_mini_app_session_scope(
+        return resolve_telegram_mini_app_session_scope(
             db,
             init_data,
             expected_scope="patient",
         )
+    except TelegramMiniAppInitDataError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"reason": exc.reason},
+        ) from exc
+    except TelegramMiniAppSessionScopeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"reason": exc.reason},
+        ) from exc
+
+
+def _build_mini_app_patient_forms_manifest_response(scope):
+    return {
+        "scope": {
+            "type": scope.scope_type,
+            "patient_id": int(scope.patient_id),
+        },
+        "status": "manifest_only",
+        "forms_enabled": False,
+        "capture_enabled": False,
+        "submission_enabled": False,
+        "contains_medical_data": False,
+        "contains_passport_data": False,
+        "message_key": "telegram_mini_app_patient_forms_manifest_only",
+        "forms": [dict(form) for form in TELEGRAM_MINI_APP_PATIENT_FORMS_MANIFEST],
+    }
+
+
+def _build_mini_app_appointment_booking_preview_from_request(
+    request_body: TelegramMiniAppAppointmentPreviewRequest,
+    db: Session,
+):
+    scope = _resolve_mini_app_patient_scope_from_init_data(
+        request_body.init_data,
+        db,
+    )
+    try:
         preview = build_telegram_mini_app_appointment_booking_preview(
             scope,
             patient_id=request_body.patient_id,
@@ -3936,11 +3997,6 @@ def _build_mini_app_appointment_booking_preview_from_request(
             notes=request_body.notes,
             services=request_body.services,
         )
-    except TelegramMiniAppInitDataError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"reason": exc.reason},
-        ) from exc
     except TelegramMiniAppSessionScopeError as exc:
         raise HTTPException(
             status_code=_mini_app_booking_scope_status_code(exc.reason),
@@ -3948,6 +4004,23 @@ def _build_mini_app_appointment_booking_preview_from_request(
         ) from exc
 
     return preview
+
+
+@router.post(
+    "/mini-app/forms/manifest",
+    operation_id="telegram_mini_app_patient_forms_manifest",
+)
+def get_mini_app_patient_forms_manifest(
+    request_body: TelegramMiniAppPatientScopeRequest,
+    db: Session = Depends(get_db),
+):
+    """Return safe patient forms status for a trusted Mini App session."""
+
+    scope = _resolve_mini_app_patient_scope_from_init_data(
+        request_body.init_data,
+        db,
+    )
+    return _build_mini_app_patient_forms_manifest_response(scope)
 
 
 @router.post(

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -406,6 +406,118 @@ class TestTelegramWebhookSecurity:
         assert response.json()["detail"] == {"reason": "bot_token_required"}
         assert db_session.query(Appointment).count() == initial_appointments
 
+    def test_mini_app_forms_manifest_endpoint_returns_capture_disabled_status(
+        self,
+        client,
+        db_session,
+        test_patient,
+    ):
+        _add_mini_app_telegram_config(db_session)
+        chat_id = 880208
+        _link_patient_to_chat(db_session, chat_id=chat_id, patient_id=test_patient.id)
+        initial_appointments = db_session.query(Appointment).count()
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/forms/manifest",
+            json={"initData": _signed_mini_app_init_data(chat_id)},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["scope"] == {"type": "patient", "patient_id": test_patient.id}
+        assert payload["status"] == "manifest_only"
+        assert payload["forms_enabled"] is False
+        assert payload["capture_enabled"] is False
+        assert payload["submission_enabled"] is False
+        assert payload["contains_medical_data"] is False
+        assert payload["contains_passport_data"] is False
+        assert payload["forms"]
+        assert all(form["capture_enabled"] is False for form in payload["forms"])
+        assert all(form["submission_enabled"] is False for form in payload["forms"])
+        assert all(form["contains_medical_data"] is False for form in payload["forms"])
+        assert all(form["contains_passport_data"] is False for form in payload["forms"])
+        assert all("fields" not in form for form in payload["forms"])
+        assert db_session.query(Appointment).count() == initial_appointments
+
+    def test_mini_app_forms_manifest_endpoint_rejects_forged_init_data(
+        self,
+        client,
+        db_session,
+        test_patient,
+    ):
+        _add_mini_app_telegram_config(db_session)
+        chat_id = 880209
+        _link_patient_to_chat(db_session, chat_id=chat_id, patient_id=test_patient.id)
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/forms/manifest",
+            json={
+                "initData": _signed_mini_app_init_data(chat_id).replace(
+                    "hash=",
+                    "hash=forged",
+                    1,
+                )
+            },
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == {"reason": "hash_mismatch"}
+
+    def test_mini_app_forms_manifest_endpoint_rejects_staff_scope(
+        self,
+        client,
+        db_session,
+        admin_user,
+    ):
+        _add_mini_app_telegram_config(db_session)
+        chat_id = 880210
+        db_session.add(
+            TelegramUser(
+                chat_id=chat_id,
+                user_id=admin_user.id,
+                language_code="ru",
+                active=True,
+                blocked=False,
+            )
+        )
+        db_session.commit()
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/forms/manifest",
+            json={"initData": _signed_mini_app_init_data(chat_id)},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == {"reason": "patient_scope_required"}
+
+    def test_mini_app_forms_manifest_endpoint_rejects_unlinked_chat(
+        self,
+        client,
+        db_session,
+    ):
+        _add_mini_app_telegram_config(db_session)
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/forms/manifest",
+            json={"initData": _signed_mini_app_init_data(880211)},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == {"reason": "telegram_link_required"}
+
+    def test_mini_app_forms_manifest_endpoint_requires_configured_bot_token(
+        self,
+        client,
+        db_session,
+    ):
+        response = client.post(
+            "/api/v1/telegram/mini-app/forms/manifest",
+            json={"initData": _signed_mini_app_init_data(880212)},
+        )
+
+        assert response.status_code == 503
+        assert response.json()["detail"] == {"reason": "bot_token_required"}
+
     def test_mini_app_booking_preview_endpoint_maps_invalid_booking_field_to_400(
         self,
         client,


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/telegram/mini-app/forms/manifest` for trusted patient Mini App sessions.
- Reuse existing Telegram Mini App `initData` HMAC validation and linked-patient scope resolution.
- Return a manifest-only, capture-disabled patient forms status with no medical, passport, or form-field payload.
- Update the Telegram strategy plan with this backend-only forms slice.

## Contract Impact

- Canonical surface: `POST /api/v1/telegram/mini-app/forms/manifest` in `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Request shape: JSON body with `initData` string signed by Telegram Mini App; no query params or DB IDs accepted.
- Response shape: JSON object with patient `scope`, `manifest_only` status, disabled capture/submission flags, no medical/passport flags, and static safe form descriptors without `fields`.
- Status codes: 200 for linked patient scope, 403 for forged/staff/unlinked Mini App identity, 503 when bot token is not configured, 422 for invalid request body.
- Frontend consumer: future Telegram Mini App patient forms screen; current web frontend is unchanged.
- Compatibility path or alias: no alias added; existing Mini App appointment preview/create endpoints keep the same route and response contracts.
- Contract proof: focused webhook security tests cover success plus forged, staff, unlinked, and missing bot-token cases.

## RBAC / Permissions

- Roles allowed: active Telegram user link with patient scope only.
- Roles denied: staff/admin Telegram links, unlinked Telegram users, forged `initData`, and direct calls without configured bot token.
- Positive auth proof: `test_mini_app_forms_manifest_endpoint_returns_capture_disabled_status` returns 200 for a signed linked-patient Mini App session.
- Negative auth proof: forged hash, staff scope, unlinked chat, and missing-token tests return 403 or 503 with stable `reason` details.

## Notification / Realtime

- Event type or websocket channel: not applicable - endpoint does not publish notifications, websocket events, or queue updates.
- Payload version / ack behavior: not applicable - there is no notification payload or acknowledgement contract in this backend-only read endpoint.
- Read/unread or delivery semantics: not applicable - no message delivery state, unread counters, or notification rows are changed.
- Reconnect/resync proof: not applicable - no realtime client subscription or resync path is introduced.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering was added; backend returns a deterministic manifest list.
- Partial data proof: not applicable - no frontend consumer parses partial form data in this slice, and the backend intentionally omits form fields.
- Forbidden secondary path behavior: staff, forged, and unlinked paths return explicit 403 reasons before any form data is exposed.
- Missing draft/resource behavior: not applicable - endpoint does not create drafts, reopen resources, or load mutable form records.
- Stale route/deep-link behavior: not applicable - no frontend route, tab, or deep-link handling changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook.py`, `backend/tests/unit/test_telegram_webhook_security.py`, `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`.
- Denied paths: DB models, Alembic migrations, Telegram admin runtime, frontend UI, generated artifacts, and unrelated clinic workflows.
- Migration/docs/test impact: no migration; strategy plan updated; webhook security tests expanded for the new endpoint contract.
- Rollback note: revert commit `06304363` to remove the endpoint, tests, and plan entry without data migration cleanup.

## Validation

- Targeted tests or smoke run: `python -m pytest backend/tests/unit/test_telegram_webhook_security.py -q`; `python -m pytest backend/tests/unit/test_telegram_mini_app_init_data.py -q`; `python -m py_compile backend/app/api/v1/endpoints/telegram_webhook.py backend/tests/unit/test_telegram_webhook_security.py backend/app/api/v1/endpoints/admin_telegram.py`; `python scripts/check_telegram_plan_drift.py --changed-file backend/app/api/v1/endpoints/telegram_webhook.py --changed-file backend/tests/unit/test_telegram_webhook_security.py --changed-file .ai-factory/plans/telegram-bot-clinic-full-strategy.md --fail-on-warning`; `python scripts/check_telegram_plan_content.py`; `git diff --check`; `npm run build`.
- Result: Passed locally. Webhook security suite: 57 passed. Mini App initData suite: 17 passed. Vite build passed with existing chunk/dynamic-import warnings.
- Not checked: Live Telegram Bot API webhook call and browser UI flow, because this slice is backend-only and no frontend consumer was added.