### PR TITLE
[codex] add telegram mini app cabinet manifest

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -324,6 +324,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 - [ ] Implement patient forms inside the protected Mini App flow.
   - [x] First backend-only forms manifest slice: `POST /api/v1/telegram/mini-app/forms/manifest` in `backend/app/api/v1/endpoints/telegram_webhook.py` validates Mini App `initData`, resolves linked patient scope, returns capture-disabled manifest/status without medical/passport fields, rejects forged/staff/unlinked access, and is covered by `backend/tests/unit/test_telegram_webhook_security.py`.
 - [ ] Implement patient cabinet inside the protected Mini App flow.
+  - [x] First backend-only cabinet manifest slice: `POST /api/v1/telegram/mini-app/cabinet/manifest` in `backend/app/api/v1/endpoints/telegram_webhook.py` validates Mini App `initData`, resolves linked patient scope, returns read/mutation-disabled cabinet status without medical/passport/billing records, rejects forged/staff/unlinked access, and is covered by `backend/tests/unit/test_telegram_webhook_security.py`.
 - [ ] Implement payment details inside the protected Mini App flow.
 - [ ] Implement protected result/report viewing inside the Mini App flow.
 - [x] Add tests for forged `initData`, expired auth, wrong patient scope, and direct URL access without Telegram identity: `backend/tests/unit/test_telegram_mini_app_init_data.py` covers `hash_mismatch`, `auth_date_expired`, `patient_scope_mismatch`, and missing Telegram `user` identity rejection.

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -810,6 +810,38 @@ TELEGRAM_MINI_APP_PATIENT_FORMS_MANIFEST = (
         "contains_passport_data": False,
     },
 )
+TELEGRAM_MINI_APP_PATIENT_CABINET_MANIFEST = (
+    {
+        "key": "appointments",
+        "title": "Appointments",
+        "status": "planned",
+        "read_enabled": False,
+        "write_enabled": False,
+        "contains_medical_data": False,
+        "contains_passport_data": False,
+        "contains_billing_records": False,
+    },
+    {
+        "key": "documents",
+        "title": "Documents",
+        "status": "planned",
+        "read_enabled": False,
+        "write_enabled": False,
+        "contains_medical_data": False,
+        "contains_passport_data": False,
+        "contains_billing_records": False,
+    },
+    {
+        "key": "payments",
+        "title": "Payments",
+        "status": "planned",
+        "read_enabled": False,
+        "write_enabled": False,
+        "contains_medical_data": False,
+        "contains_passport_data": False,
+        "contains_billing_records": False,
+    },
+)
 QUEUE_TERMINAL_STATUSES = {"served", "incomplete", "no_show", "cancelled"}
 QUEUE_WAITING_STATUSES = {"waiting"}
 EMR_CLOSED_VISIT_STATUSES = {
@@ -3978,6 +4010,26 @@ def _build_mini_app_patient_forms_manifest_response(scope):
     }
 
 
+def _build_mini_app_patient_cabinet_manifest_response(scope):
+    return {
+        "scope": {
+            "type": scope.scope_type,
+            "patient_id": int(scope.patient_id),
+        },
+        "status": "manifest_only",
+        "cabinet_enabled": False,
+        "read_enabled": False,
+        "mutation_enabled": False,
+        "contains_medical_data": False,
+        "contains_passport_data": False,
+        "contains_billing_records": False,
+        "message_key": "telegram_mini_app_patient_cabinet_manifest_only",
+        "sections": [
+            dict(section) for section in TELEGRAM_MINI_APP_PATIENT_CABINET_MANIFEST
+        ],
+    }
+
+
 def _build_mini_app_appointment_booking_preview_from_request(
     request_body: TelegramMiniAppAppointmentPreviewRequest,
     db: Session,
@@ -4021,6 +4073,23 @@ def get_mini_app_patient_forms_manifest(
         db,
     )
     return _build_mini_app_patient_forms_manifest_response(scope)
+
+
+@router.post(
+    "/mini-app/cabinet/manifest",
+    operation_id="telegram_mini_app_patient_cabinet_manifest",
+)
+def get_mini_app_patient_cabinet_manifest(
+    request_body: TelegramMiniAppPatientScopeRequest,
+    db: Session = Depends(get_db),
+):
+    """Return safe patient cabinet status for a trusted Mini App session."""
+
+    scope = _resolve_mini_app_patient_scope_from_init_data(
+        request_body.init_data,
+        db,
+    )
+    return _build_mini_app_patient_cabinet_manifest_response(scope)
 
 
 @router.post(

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -518,6 +518,128 @@ class TestTelegramWebhookSecurity:
         assert response.status_code == 503
         assert response.json()["detail"] == {"reason": "bot_token_required"}
 
+    def test_mini_app_cabinet_manifest_endpoint_returns_disabled_status(
+        self,
+        client,
+        db_session,
+        test_patient,
+    ):
+        _add_mini_app_telegram_config(db_session)
+        chat_id = 880213
+        _link_patient_to_chat(db_session, chat_id=chat_id, patient_id=test_patient.id)
+        initial_appointments = db_session.query(Appointment).count()
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/cabinet/manifest",
+            json={"initData": _signed_mini_app_init_data(chat_id)},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["scope"] == {"type": "patient", "patient_id": test_patient.id}
+        assert payload["status"] == "manifest_only"
+        assert payload["cabinet_enabled"] is False
+        assert payload["read_enabled"] is False
+        assert payload["mutation_enabled"] is False
+        assert payload["contains_medical_data"] is False
+        assert payload["contains_passport_data"] is False
+        assert payload["contains_billing_records"] is False
+        assert payload["sections"]
+        assert all(section["read_enabled"] is False for section in payload["sections"])
+        assert all(section["write_enabled"] is False for section in payload["sections"])
+        assert all(
+            section["contains_medical_data"] is False for section in payload["sections"]
+        )
+        assert all(
+            section["contains_passport_data"] is False
+            for section in payload["sections"]
+        )
+        assert all(
+            section["contains_billing_records"] is False
+            for section in payload["sections"]
+        )
+        assert all("records" not in section for section in payload["sections"])
+        assert db_session.query(Appointment).count() == initial_appointments
+
+    def test_mini_app_cabinet_manifest_endpoint_rejects_forged_init_data(
+        self,
+        client,
+        db_session,
+        test_patient,
+    ):
+        _add_mini_app_telegram_config(db_session)
+        chat_id = 880214
+        _link_patient_to_chat(db_session, chat_id=chat_id, patient_id=test_patient.id)
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/cabinet/manifest",
+            json={
+                "initData": _signed_mini_app_init_data(chat_id).replace(
+                    "hash=",
+                    "hash=forged",
+                    1,
+                )
+            },
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == {"reason": "hash_mismatch"}
+
+    def test_mini_app_cabinet_manifest_endpoint_rejects_staff_scope(
+        self,
+        client,
+        db_session,
+        admin_user,
+    ):
+        _add_mini_app_telegram_config(db_session)
+        chat_id = 880215
+        db_session.add(
+            TelegramUser(
+                chat_id=chat_id,
+                user_id=admin_user.id,
+                language_code="ru",
+                active=True,
+                blocked=False,
+            )
+        )
+        db_session.commit()
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/cabinet/manifest",
+            json={"initData": _signed_mini_app_init_data(chat_id)},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == {"reason": "patient_scope_required"}
+
+    def test_mini_app_cabinet_manifest_endpoint_rejects_unlinked_chat(
+        self,
+        client,
+        db_session,
+    ):
+        _add_mini_app_telegram_config(db_session)
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/cabinet/manifest",
+            json={"initData": _signed_mini_app_init_data(880216)},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == {"reason": "telegram_link_required"}
+
+    def test_mini_app_cabinet_manifest_endpoint_requires_configured_bot_token(
+        self,
+        client,
+        db_session,
+    ):
+        response = client.post(
+            "/api/v1/telegram/mini-app/cabinet/manifest",
+            json={"initData": _signed_mini_app_init_data(880217)},
+        )
+
+        assert response.status_code == 503
+        assert response.json()["detail"] == {"reason": "bot_token_required"}
+
     def test_mini_app_booking_preview_endpoint_maps_invalid_booking_field_to_400(
         self,
         client,


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/telegram/mini-app/cabinet/manifest` for trusted patient Mini App sessions.
- Reuse existing Telegram Mini App `initData` validation and linked-patient scope resolution.
- Return a manifest-only, read/mutation-disabled cabinet status with no medical, passport, billing, or record payloads.
- Update the Telegram strategy plan with this backend-only patient cabinet slice.

## Contract Impact

- Canonical surface: `POST /api/v1/telegram/mini-app/cabinet/manifest` in `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Request shape: JSON body with `initData` string signed by Telegram Mini App; no patient ID, route params, or query params accepted.
- Response shape: JSON object with patient `scope`, `manifest_only` status, disabled cabinet/read/mutation flags, no medical/passport/billing flags, and static safe section descriptors without `records`.
- Status codes: 200 for linked patient scope, 403 for forged/staff/unlinked Mini App identity, 503 when bot token is not configured, 422 for invalid request body.
- Frontend consumer: future Telegram Mini App patient cabinet screen; current web frontend is unchanged.
- Compatibility path or alias: no alias added; existing Mini App forms and appointment endpoints keep their route and response contracts.
- Contract proof: focused webhook security tests cover success plus forged, staff, unlinked, and missing bot-token cases.

## RBAC / Permissions

- Roles allowed: active Telegram user link with patient scope only.
- Roles denied: staff/admin Telegram links, unlinked Telegram users, forged `initData`, and direct calls without configured bot token.
- Positive auth proof: `test_mini_app_cabinet_manifest_endpoint_returns_disabled_status` returns 200 for a signed linked-patient Mini App session.
- Negative auth proof: forged hash, staff scope, unlinked chat, and missing-token tests return 403 or 503 with stable `reason` details.

## Notification / Realtime

- Event type or websocket channel: not applicable - endpoint does not publish notifications, websocket events, or queue updates.
- Payload version / ack behavior: not applicable - there is no notification payload or acknowledgement contract in this backend-only read endpoint.
- Read/unread or delivery semantics: not applicable - no message delivery state, unread counters, or notification rows are changed.
- Reconnect/resync proof: not applicable - no realtime client subscription or resync path is introduced.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering was added; backend returns a deterministic manifest section list.
- Partial data proof: not applicable - no frontend consumer parses partial cabinet records in this slice, and the backend intentionally omits record payloads.
- Forbidden secondary path behavior: staff, forged, and unlinked paths return explicit 403 reasons before any cabinet section data is exposed.
- Missing draft/resource behavior: not applicable - endpoint does not create drafts, reopen resources, or load mutable cabinet records.
- Stale route/deep-link behavior: not applicable - no frontend route, tab, or deep-link handling changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook.py`, `backend/tests/unit/test_telegram_webhook_security.py`, `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`.
- Denied paths: DB models, Alembic migrations, Telegram admin runtime, frontend UI, generated artifacts, and unrelated clinic workflows.
- Migration/docs/test impact: no migration; strategy plan updated; webhook security tests expanded for the new endpoint contract.
- Rollback note: revert commit `8e16b93c` to remove the endpoint, tests, and plan entry without data migration cleanup.

## Validation

- Targeted tests or smoke run: `python -m pytest backend/tests/unit/test_telegram_webhook_security.py -q`; `python -m pytest backend/tests/unit/test_telegram_mini_app_init_data.py -q`; `python -m py_compile backend/app/api/v1/endpoints/telegram_webhook.py backend/tests/unit/test_telegram_webhook_security.py backend/app/api/v1/endpoints/admin_telegram.py`; `python scripts/check_telegram_plan_drift.py --changed-file backend/app/api/v1/endpoints/telegram_webhook.py --changed-file backend/tests/unit/test_telegram_webhook_security.py --changed-file .ai-factory/plans/telegram-bot-clinic-full-strategy.md --fail-on-warning`; `python scripts/check_telegram_plan_content.py`; `git diff --check`; `npm run build`.
- Result: Passed locally. Webhook security suite: 62 passed. Mini App initData suite: 17 passed. Vite build passed with existing chunk/dynamic-import warnings.
- Not checked: Live Telegram Bot API webhook call and browser UI flow, because this slice is backend-only and no frontend consumer was added.