### PR TITLE
[codex] add telegram mini app results manifest

### DIFF
--- a/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
+++ b/.ai-factory/plans/telegram-bot-clinic-full-strategy.md
@@ -328,6 +328,7 @@ AI workflow engines such as LangGraph orchestrate steps; they do not train the m
 - [ ] Implement payment details inside the protected Mini App flow.
   - [x] First backend-only payment manifest slice: `POST /api/v1/telegram/mini-app/payments/manifest` in `backend/app/api/v1/endpoints/telegram_webhook.py` validates Mini App `initData`, resolves linked patient scope, returns payment/read/capture-disabled status without amounts, invoices, transactions, provider payloads, or payment records, rejects forged/staff/unlinked access, and is covered by `backend/tests/unit/test_telegram_webhook_security.py`.
 - [ ] Implement protected result/report viewing inside the Mini App flow.
+  - [x] First backend-only result/report manifest slice: `POST /api/v1/telegram/mini-app/results/manifest` in `backend/app/api/v1/endpoints/telegram_webhook.py` validates Mini App `initData`, resolves linked patient scope, returns view/download-disabled status without medical results, lab values, report IDs, file URLs, PDFs, diagnoses, or records, rejects forged/staff/unlinked access, and is covered by `backend/tests/unit/test_telegram_webhook_security.py`.
 - [x] Add tests for forged `initData`, expired auth, wrong patient scope, and direct URL access without Telegram identity: `backend/tests/unit/test_telegram_mini_app_init_data.py` covers `hash_mismatch`, `auth_date_expired`, `patient_scope_mismatch`, and missing Telegram `user` identity rejection.
 
 ### Phase 6: AI assistant approval flows

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -874,6 +874,44 @@ TELEGRAM_MINI_APP_PATIENT_PAYMENTS_MANIFEST = (
         "contains_provider_payloads": False,
     },
 )
+TELEGRAM_MINI_APP_PATIENT_RESULTS_MANIFEST = (
+    {
+        "key": "lab_reports",
+        "title": "Lab reports",
+        "status": "planned",
+        "view_enabled": False,
+        "download_enabled": False,
+        "contains_medical_results": False,
+        "contains_lab_values": False,
+        "contains_report_records": False,
+        "contains_file_urls": False,
+        "contains_diagnoses": False,
+    },
+    {
+        "key": "visit_summaries",
+        "title": "Visit summaries",
+        "status": "planned",
+        "view_enabled": False,
+        "download_enabled": False,
+        "contains_medical_results": False,
+        "contains_lab_values": False,
+        "contains_report_records": False,
+        "contains_file_urls": False,
+        "contains_diagnoses": False,
+    },
+    {
+        "key": "attachments",
+        "title": "Attachments",
+        "status": "planned",
+        "view_enabled": False,
+        "download_enabled": False,
+        "contains_medical_results": False,
+        "contains_lab_values": False,
+        "contains_report_records": False,
+        "contains_file_urls": False,
+        "contains_diagnoses": False,
+    },
+)
 QUEUE_TERMINAL_STATUSES = {"served", "incomplete", "no_show", "cancelled"}
 QUEUE_WAITING_STATUSES = {"waiting"}
 EMR_CLOSED_VISIT_STATUSES = {
@@ -4083,6 +4121,29 @@ def _build_mini_app_patient_payments_manifest_response(scope):
     }
 
 
+def _build_mini_app_patient_results_manifest_response(scope):
+    return {
+        "scope": {
+            "type": scope.scope_type,
+            "patient_id": int(scope.patient_id),
+        },
+        "status": "manifest_only",
+        "results_enabled": False,
+        "view_enabled": False,
+        "download_enabled": False,
+        "contains_medical_results": False,
+        "contains_lab_values": False,
+        "contains_report_records": False,
+        "contains_file_urls": False,
+        "contains_pdfs": False,
+        "contains_diagnoses": False,
+        "message_key": "telegram_mini_app_patient_results_manifest_only",
+        "sections": [
+            dict(section) for section in TELEGRAM_MINI_APP_PATIENT_RESULTS_MANIFEST
+        ],
+    }
+
+
 def _build_mini_app_appointment_booking_preview_from_request(
     request_body: TelegramMiniAppAppointmentPreviewRequest,
     db: Session,
@@ -4160,6 +4221,23 @@ def get_mini_app_patient_payments_manifest(
         db,
     )
     return _build_mini_app_patient_payments_manifest_response(scope)
+
+
+@router.post(
+    "/mini-app/results/manifest",
+    operation_id="telegram_mini_app_patient_results_manifest",
+)
+def get_mini_app_patient_results_manifest(
+    request_body: TelegramMiniAppPatientScopeRequest,
+    db: Session = Depends(get_db),
+):
+    """Return safe patient result/report status for a trusted Mini App session."""
+
+    scope = _resolve_mini_app_patient_scope_from_init_data(
+        request_body.init_data,
+        db,
+    )
+    return _build_mini_app_patient_results_manifest_response(scope)
 
 
 @router.post(

--- a/backend/tests/unit/test_telegram_webhook_security.py
+++ b/backend/tests/unit/test_telegram_webhook_security.py
@@ -767,6 +767,143 @@ class TestTelegramWebhookSecurity:
         assert response.status_code == 503
         assert response.json()["detail"] == {"reason": "bot_token_required"}
 
+    def test_mini_app_results_manifest_endpoint_returns_disabled_status(
+        self,
+        client,
+        db_session,
+        test_patient,
+    ):
+        _add_mini_app_telegram_config(db_session)
+        chat_id = 880223
+        _link_patient_to_chat(db_session, chat_id=chat_id, patient_id=test_patient.id)
+        initial_appointments = db_session.query(Appointment).count()
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/results/manifest",
+            json={"initData": _signed_mini_app_init_data(chat_id)},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["scope"] == {"type": "patient", "patient_id": test_patient.id}
+        assert payload["status"] == "manifest_only"
+        assert payload["results_enabled"] is False
+        assert payload["view_enabled"] is False
+        assert payload["download_enabled"] is False
+        assert payload["contains_medical_results"] is False
+        assert payload["contains_lab_values"] is False
+        assert payload["contains_report_records"] is False
+        assert payload["contains_file_urls"] is False
+        assert payload["contains_pdfs"] is False
+        assert payload["contains_diagnoses"] is False
+        assert payload["sections"]
+        assert all(section["view_enabled"] is False for section in payload["sections"])
+        assert all(
+            section["download_enabled"] is False for section in payload["sections"]
+        )
+        assert all(
+            section["contains_medical_results"] is False
+            for section in payload["sections"]
+        )
+        assert all(
+            section["contains_lab_values"] is False
+            for section in payload["sections"]
+        )
+        assert all(
+            section["contains_report_records"] is False
+            for section in payload["sections"]
+        )
+        assert all(
+            section["contains_file_urls"] is False for section in payload["sections"]
+        )
+        assert all(
+            section["contains_diagnoses"] is False for section in payload["sections"]
+        )
+        assert all("records" not in section for section in payload["sections"])
+        assert all("report_id" not in section for section in payload["sections"])
+        assert all("file_url" not in section for section in payload["sections"])
+        assert all("pdf_url" not in section for section in payload["sections"])
+        assert db_session.query(Appointment).count() == initial_appointments
+
+    def test_mini_app_results_manifest_endpoint_rejects_forged_init_data(
+        self,
+        client,
+        db_session,
+        test_patient,
+    ):
+        _add_mini_app_telegram_config(db_session)
+        chat_id = 880224
+        _link_patient_to_chat(db_session, chat_id=chat_id, patient_id=test_patient.id)
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/results/manifest",
+            json={
+                "initData": _signed_mini_app_init_data(chat_id).replace(
+                    "hash=",
+                    "hash=forged",
+                    1,
+                )
+            },
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == {"reason": "hash_mismatch"}
+
+    def test_mini_app_results_manifest_endpoint_rejects_staff_scope(
+        self,
+        client,
+        db_session,
+        admin_user,
+    ):
+        _add_mini_app_telegram_config(db_session)
+        chat_id = 880225
+        db_session.add(
+            TelegramUser(
+                chat_id=chat_id,
+                user_id=admin_user.id,
+                language_code="ru",
+                active=True,
+                blocked=False,
+            )
+        )
+        db_session.commit()
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/results/manifest",
+            json={"initData": _signed_mini_app_init_data(chat_id)},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == {"reason": "patient_scope_required"}
+
+    def test_mini_app_results_manifest_endpoint_rejects_unlinked_chat(
+        self,
+        client,
+        db_session,
+    ):
+        _add_mini_app_telegram_config(db_session)
+
+        response = client.post(
+            "/api/v1/telegram/mini-app/results/manifest",
+            json={"initData": _signed_mini_app_init_data(880226)},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == {"reason": "telegram_link_required"}
+
+    def test_mini_app_results_manifest_endpoint_requires_configured_bot_token(
+        self,
+        client,
+        db_session,
+    ):
+        response = client.post(
+            "/api/v1/telegram/mini-app/results/manifest",
+            json={"initData": _signed_mini_app_init_data(880227)},
+        )
+
+        assert response.status_code == 503
+        assert response.json()["detail"] == {"reason": "bot_token_required"}
+
     def test_mini_app_booking_preview_endpoint_maps_invalid_booking_field_to_400(
         self,
         client,


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/telegram/mini-app/results/manifest` for trusted patient Mini App sessions.
- Reuse existing Telegram Mini App `initData` validation and linked-patient scope resolution.
- Return a manifest-only, view/download-disabled result/report status with no medical results, lab values, report IDs, file URLs, PDFs, diagnoses, or records.
- Update the Telegram strategy plan with this backend-only result/report slice.

## Contract Impact

- Canonical surface: `POST /api/v1/telegram/mini-app/results/manifest` in `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Request shape: JSON body with `initData` string signed by Telegram Mini App; no patient ID, report ID, file ID, route params, or query params accepted.
- Response shape: JSON object with patient `scope`, `manifest_only` status, disabled results/view/download flags, no medical/lab/report/file/PDF/diagnosis flags, and static safe section descriptors without records.
- Status codes: 200 for linked patient scope, 403 for forged/staff/unlinked Mini App identity, 503 when bot token is not configured, 422 for invalid request body.
- Frontend consumer: future Telegram Mini App protected results/report screen; current web frontend is unchanged.
- Compatibility path or alias: no alias added; existing `/results` bot reply, document entry links, and protected web flows are unchanged.
- Contract proof: focused webhook security tests cover success plus forged, staff, unlinked, and missing bot-token cases.

## RBAC / Permissions

- Roles allowed: active Telegram user link with patient scope only.
- Roles denied: staff/admin Telegram links, unlinked Telegram users, forged `initData`, and direct calls without configured bot token.
- Positive auth proof: `test_mini_app_results_manifest_endpoint_returns_disabled_status` returns 200 for a signed linked-patient Mini App session.
- Negative auth proof: forged hash, staff scope, unlinked chat, and missing-token tests return 403 or 503 with stable `reason` details.

## Notification / Realtime

- Event type or websocket channel: not applicable - endpoint does not publish notifications, websocket events, report-ready events, or queue updates.
- Payload version / ack behavior: not applicable - there is no notification payload or acknowledgement contract in this backend-only read endpoint.
- Read/unread or delivery semantics: not applicable - no message delivery state, unread counters, lab report rows, or notification rows are changed.
- Reconnect/resync proof: not applicable - no realtime client subscription or resync path is introduced.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering was added; backend returns a deterministic manifest section list.
- Partial data proof: not applicable - no frontend consumer parses partial report records in this slice, and the backend intentionally omits report/file payloads.
- Forbidden secondary path behavior: staff, forged, and unlinked paths return explicit 403 reasons before any results section data is exposed.
- Missing draft/resource behavior: not applicable - endpoint does not create drafts, reopen resources, or load mutable result/report records.
- Stale route/deep-link behavior: not applicable - no frontend route, tab, file URL, PDF URL, or deep-link handling changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook.py`, `backend/tests/unit/test_telegram_webhook_security.py`, `.ai-factory/plans/telegram-bot-clinic-full-strategy.md`.
- Denied paths: DB models, Alembic migrations, lab/EMR services, file storage, Telegram admin runtime, frontend UI, generated artifacts, and unrelated clinic workflows.
- Migration/docs/test impact: no migration; strategy plan updated; webhook security tests expanded for the new endpoint contract.
- Rollback note: revert commit `44661f6c` to remove the endpoint, tests, and plan entry without data migration cleanup.

## Validation

- Targeted tests or smoke run: `python -m pytest backend/tests/unit/test_telegram_webhook_security.py -q`; `python -m pytest backend/tests/unit/test_telegram_mini_app_init_data.py -q`; `python -m py_compile backend/app/api/v1/endpoints/telegram_webhook.py backend/tests/unit/test_telegram_webhook_security.py backend/app/api/v1/endpoints/admin_telegram.py`; `python scripts/check_telegram_plan_drift.py --changed-file backend/app/api/v1/endpoints/telegram_webhook.py --changed-file backend/tests/unit/test_telegram_webhook_security.py --changed-file .ai-factory/plans/telegram-bot-clinic-full-strategy.md --fail-on-warning`; `python scripts/check_telegram_plan_content.py`; `git diff --check`; `npm run build`.
- Result: Passed locally. Webhook security suite: 72 passed. Mini App initData suite: 17 passed. Vite build passed with existing chunk/dynamic-import warnings.
- Not checked: Live Telegram Bot API webhook call, live lab report/PDF retrieval, and browser UI flow, because this slice is backend-only and no frontend/report payload consumer was added.