### PR TITLE
fix(frontend): improve queue join recovery states

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md
@@ -13,7 +13,7 @@ Rules:
 ## Rollout Status
 
 - [x] PR-0: audit baseline and rollout checklist merged.
-- [ ] PR-UX-1: payment cancel semantic status merged.
+- [x] PR-UX-1: payment cancel semantic status merged.
 - [ ] PR-UX-2: queue join recovery states merged.
 - [ ] PR-UX-3: authenticated UI QA harness merged.
 - [ ] PR-UX-4: cashier payment accessibility merged.

--- a/frontend/src/pages/QueueJoin.jsx
+++ b/frontend/src/pages/QueueJoin.jsx
@@ -636,6 +636,44 @@ const QueueJoin = () => {
     fontWeight: '500'
   };
 
+  const statusActionStackStyle = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px'
+  };
+
+  const recoveryButtonBaseStyle = {
+    width: '100%',
+    padding: '16px 24px',
+    borderRadius: '12px',
+    border: 'none',
+    fontSize: '17px',
+    fontWeight: '600',
+    cursor: 'pointer',
+    transition: 'background 0.2s ease, box-shadow 0.2s ease'
+  };
+
+  const primaryRecoveryButtonStyle = {
+    ...recoveryButtonBaseStyle,
+    background: A11Y_COLORS.primary,
+    color: 'var(--mac-text-on-accent)',
+    boxShadow: '0 4px 12px color-mix(in srgb, var(--mac-accent), transparent 70%)'
+  };
+
+  const dangerRecoveryButtonStyle = {
+    ...recoveryButtonBaseStyle,
+    background: A11Y_COLORS.danger,
+    color: 'var(--mac-text-on-accent)',
+    boxShadow: '0 4px 12px color-mix(in srgb, var(--mac-error), transparent 70%)'
+  };
+
+  const successRecoveryButtonStyle = {
+    ...recoveryButtonBaseStyle,
+    background: A11Y_COLORS.success,
+    color: 'var(--mac-text-on-accent)',
+    boxShadow: '0 4px 12px color-mix(in srgb, var(--mac-success), transparent 70%)'
+  };
+
   // Компонент загрузки - macOS стиль
   if (step === 'loading') {
     return (
@@ -654,69 +692,43 @@ const QueueJoin = () => {
   // Компонент ошибки - macOS стиль
   if (step === 'error') {
     return (
-      <div className="min-h-screen flex items-center justify-center p-4" style={pageBaseStyle}>
-        <div className="max-w-md w-full text-center" style={glassCardStyle}>
+      <main className="min-h-screen flex items-center justify-center p-4" style={pageBaseStyle} aria-labelledby="queue-join-error-title">
+        <div className="max-w-md w-full text-center" style={glassCardStyle} aria-describedby="queue-join-error-message">
           <AlertCircle style={{
             width: '64px',
             height: '64px',
             color: 'var(--mac-error)',
             margin: '0 auto 16px'
-          }} />
-          <h2 style={{
+          }} aria-hidden="true" />
+          <h2 id="queue-join-error-title" style={{
             ...titleStyle,
             marginBottom: '12px',
           }}>Хатолик</h2>
           <p style={{
             ...bodyTextStyle,
             marginBottom: '24px',
-          }} role="alert" aria-live="assertive">{error}</p>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          }} id="queue-join-error-message" role="alert" aria-live="assertive">{error}</p>
+          <div style={statusActionStackStyle}>
             <button
+              type="button"
               onClick={() => {
                 setError(null);
                 loadTokenInfo();
               }}
-              style={{
-                width: '100%',
-                background: A11Y_COLORS.primary,
-                color: 'var(--mac-text-on-accent)',
-                padding: '16px 24px',
-                borderRadius: '12px',
-                border: 'none',
-                fontSize: '17px',
-                fontWeight: '600',
-                cursor: 'pointer',
-                transition: 'all 0.2s ease',
-                boxShadow: '0 4px 12px color-mix(in srgb, var(--mac-accent), transparent 70%)'
-              }}
-              onMouseEnter={(e) => e.target.style.background = A11Y_COLORS.primaryHover}
-              onMouseLeave={(e) => e.target.style.background = A11Y_COLORS.primary}
+              style={primaryRecoveryButtonStyle}
             >
               Қайта уриниш
             </button>
             <button
+              type="button"
               onClick={() => navigate('/')}
-              style={{
-                width: '100%',
-                background: A11Y_COLORS.danger,
-                color: 'var(--mac-text-on-accent)',
-                padding: '16px 24px',
-                borderRadius: '12px',
-                border: 'none',
-                fontSize: '17px',
-                fontWeight: '600',
-                cursor: 'pointer',
-                transition: 'all 0.2s ease',
-                boxShadow: '0 4px 12px color-mix(in srgb, var(--mac-error), transparent 70%)'
-              }}
-              onMouseEnter={(e) => e.target.style.background = 'color-mix(in srgb, var(--mac-error), black 20%)'}
-              onMouseLeave={(e) => e.target.style.background = A11Y_COLORS.danger}
+              style={dangerRecoveryButtonStyle}
             >
               Асосий саҳифа
             </button>
           </div>
         </div>
-      </div>
+      </main>
     );
   }
 
@@ -897,15 +909,15 @@ const QueueJoin = () => {
     const departmentName = getDepartmentName(result.entries?.[0]?.department || result.entries?.[0]?.specialty);
 
     return (
-      <div className="min-h-screen flex items-center justify-center p-4" style={pageBaseStyle}>
-        <div className="max-w-md w-full text-center" style={glassCardStyle}>
+      <main className="min-h-screen flex items-center justify-center p-4" style={pageBaseStyle} aria-labelledby="queue-join-success-title">
+        <div className="max-w-md w-full text-center" style={glassCardStyle} role="status" aria-live="polite">
           <CheckCircle style={{
             width: '64px',
             height: '64px',
             color: A11Y_COLORS.success,
             margin: '0 auto 20px'
-          }} />
-          <h2 style={{
+          }} aria-hidden="true" />
+          <h2 id="queue-join-success-title" style={{
             fontSize: '24px',
             fontWeight: '600',
             color: 'var(--mac-text-primary)',
@@ -1071,26 +1083,13 @@ const QueueJoin = () => {
 
           <button
             onClick={() => navigate('/')}
-            style={{
-              width: '100%',
-              background: A11Y_COLORS.success,
-              color: 'var(--mac-text-on-accent)',
-              padding: '16px 24px',
-              borderRadius: '12px',
-              border: 'none',
-              fontSize: '17px',
-              fontWeight: '600',
-              cursor: 'pointer',
-              transition: 'all 0.2s ease',
-              boxShadow: '0 4px 12px color-mix(in srgb, var(--mac-success), transparent 70%)'
-            }}
-            onMouseEnter={(e) => e.target.style.background = A11Y_COLORS.successHover}
-            onMouseLeave={(e) => e.target.style.background = A11Y_COLORS.success}
+            type="button"
+            style={successRecoveryButtonStyle}
           >
             Тушунарли
           </button>
         </div>
-      </div>
+      </main>
     );
   }
 


### PR DESCRIPTION
﻿## Summary
- Improve `/queue/join` recovery shells for missing-QR/error and success states.
- Add semantic error/success landmarks and shared recovery action styles.
- Mark PR-UX-1 as merged in the UI/UX rollout checklist.
- No queue API/session/form behavior changed.

## Contract Impact
- Canonical surface: frontend route `/queue/join` recovery presentation only.
- Request shape: unchanged browser navigation and unchanged existing QR/query parsing inputs.
- Response shape: unchanged rendered route data model; only semantic wrappers/styles for recovery states changed.
- Status codes: unchanged because no backend request or API status handling was modified.
- Frontend consumer: public queue join page recovery UI for missing QR/error/success states.
- Compatibility path or alias: existing `/queue/join` direct link and QR-token entry paths remain unchanged.
- Contract proof: local browser QA confirmed direct `/queue/join` missing-token deep link still renders a recoverable state.

## RBAC / Permissions
- Roles allowed: unchanged public queue join access for patients/visitors using clinic QR links.
- Roles denied: unchanged because this PR adds no protected route, auth guard, role check, or redirect branch.
- Positive auth proof: public direct route `/queue/join` rendered without login redirect during browser QA.
- Negative auth proof: no auth/RBAC files or protected role routes were changed in this PR.

## Notification / Realtime
- Event type or websocket channel: none; queue recovery presentation does not publish or subscribe to realtime events.
- Payload version / ack behavior: unchanged because no notification, websocket, polling, or ack payload code changed.
- Read/unread or delivery semantics: unchanged because no notification delivery/read state code changed.
- Reconnect/resync proof: unchanged because this PR does not touch realtime reconnect or resync behavior.

## Frontend Resilience
- Empty data proof: `/queue/join` without a QR/token renders a stable missing-QR recovery state.
- Partial data proof: existing optional URL/query token behavior remains unchanged.
- Forbidden secondary path behavior: this public recovery page has no access-denied branch, and this PR adds no new forbidden/redirect path.
- Missing draft/resource behavior: the missing QR/token case is the resource-absent state and remains recoverable with an assertive alert plus retry/home actions.
- Stale route/deep-link behavior: direct `/queue/join` deep link remains supported and recoverable.

## Scope Gate
- Allowed paths: `frontend/src/pages/QueueJoin.jsx`, `docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md`
- Denied paths: backend runtime, queue API/session logic, RBAC, payment logic, unrelated frontend panels
- Migration/docs/test impact: no migration; rollout checklist marks PR-UX-1 complete
- Rollback note: revert this PR to restore previous queue recovery presentation

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run lint:check`; `cd frontend; npm.cmd run build`; Playwright browser QA for `/queue/join` missing-QR state at `375x812`, `768x1024`, `1280x800`, `1920x1080`; `git diff --check`
- Result: lint passed with existing warnings only; build passed; browser QA passed with `alerts=1`, `liveRegions=2`, `unnamedButtons=0`, `overflowX=false`, `consoleErrors=0`, and `badResponses=0` at every viewport; diff check passed
- Not checked: valid QR happy path, because no safe QR fixture was available in this PR
