### PR TITLE
fix(frontend): clarify doctor current patient workflow

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md
@@ -16,7 +16,7 @@ Rules:
 - [x] PR-UX-1: payment cancel semantic status merged.
 - [x] PR-UX-2: queue join recovery states merged.
 - [x] PR-UX-3: authenticated UI QA harness merged.
-- [ ] PR-UX-4: cashier payment accessibility merged.
+- [x] PR-UX-4: cashier payment accessibility merged.
 - [ ] PR-UX-5: doctor current patient workflow merged.
 - [ ] PR-UX-6: admin support legacy cleanup merged.
 - [ ] PR-UX-7: AdminPanel design-system slice merged.

--- a/frontend/src/pages/DoctorPanel.jsx
+++ b/frontend/src/pages/DoctorPanel.jsx
@@ -437,6 +437,8 @@ const DoctorPanel = () => {
     padding: getSpacing('xs'),
     borderRadius: '8px',
     border: 'none',
+    outline: '2px solid transparent',
+    outlineOffset: '2px',
     cursor: 'pointer',
     transition: 'all 0.2s ease',
     display: 'inline-flex',
@@ -487,6 +489,35 @@ const DoctorPanel = () => {
     };
     return statusMap[status] || status;
   };
+
+  const getQueuePatientContext = (entry) => {
+    const queueNumber = entry?.number || entry?.id || 'unknown';
+    const patientName = entry?.patient_name || 'unknown patient';
+    return `queue entry ${queueNumber} for ${patientName}`;
+  };
+
+  const getCurrentVisitMeta = (entry) => {
+    const statusMap = {
+      called: { label: 'Текущий прием', variant: 'primary' },
+      in_service: { label: 'На приеме', variant: 'info' },
+      diagnostics: { label: 'На диагностике', variant: 'info' }
+    };
+
+    return statusMap[entry?.status] || null;
+  };
+
+  const getQueueActionA11yProps = (action, entry) => ({
+    type: 'button',
+    'aria-label': `${action} for ${getQueuePatientContext(entry)}`,
+    onFocus: (event) => {
+      event.currentTarget.style.outline = `2px solid ${primaryColor}`;
+      event.currentTarget.style.boxShadow = '0 0 0 4px color-mix(in srgb, var(--mac-accent), transparent 72%)';
+    },
+    onBlur: (event) => {
+      event.currentTarget.style.outline = '2px solid transparent';
+      event.currentTarget.style.boxShadow = 'none';
+    }
+  });
 
   const renderEmptyState = ({ icon: Icon, title, description, tone = 'default', action = null }) => {
     const color = tone === 'error' ? dangerColor : getColor('secondary', 500);
@@ -1164,6 +1195,7 @@ const DoctorPanel = () => {
                   <div style={{ display: 'flex', gap: getSpacing('sm') }}>
                     <Button
                     variant="primary"
+                    aria-label="Call next queue patient"
                     onClick={async () => {
                       try {
                         await callNext();
@@ -1179,7 +1211,8 @@ const DoctorPanel = () => {
                     </Button>
                     <Button
                     variant="ghost"
-                    onClick={loadQueue}>
+                    onClick={loadQueue}
+                    aria-label="Refresh doctor queue">
 
                       <RotateCcw size={16} />
                     </Button>
@@ -1215,13 +1248,17 @@ const DoctorPanel = () => {
                       </tr>
                     </thead>
                     <tbody>
-                      {queueEntries.map((entry, index) =>
+                      {queueEntries.map((entry, index) => {
+                    const currentVisitMeta = getCurrentVisitMeta(entry);
+
+                    return (
                   <tr
                     key={entry.id}
                     style={{
-                      background: entry.priority > 0 ? `${warningColor}10` : 'transparent',
-                      borderLeft: entry.priority > 0 ? `3px solid ${warningColor}` : 'none'
-                    }}>
+                      background: currentVisitMeta ? 'color-mix(in srgb, var(--mac-accent), transparent 92%)' : entry.priority > 0 ? `${warningColor}10` : 'transparent',
+                      borderLeft: currentVisitMeta ? `3px solid ${primaryColor}` : entry.priority > 0 ? `3px solid ${warningColor}` : 'none'
+                    }}
+                    aria-label={currentVisitMeta ? `Current patient ${getQueuePatientContext(entry)}` : undefined}>
 
                           <td style={tdStyle}>
                             <Badge variant={entry.priority > 0 ? 'warning' : 'default'}>
@@ -1229,8 +1266,24 @@ const DoctorPanel = () => {
                             </Badge>
                           </td>
                           <td style={tdStyle}>
-                            <strong>{entry.patient_name}</strong>
-                            {entry.priority > 0 && <span style={{ marginLeft: '4px', fontSize: '10px', color: warningColor }}>⚡ Следующий</span>}
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: getSpacing('xs') }}>
+                              <strong>{entry.patient_name}</strong>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: getSpacing('xs'), flexWrap: 'wrap' }}>
+                                {currentVisitMeta &&
+                                <Badge
+                                  variant={currentVisitMeta.variant}
+                                  role="status"
+                                  aria-label={`Current patient context: ${currentVisitMeta.label} for ${getQueuePatientContext(entry)}`}>
+                                  {currentVisitMeta.label}
+                                </Badge>
+                                }
+                                {entry.priority > 0 &&
+                                <span style={{ fontSize: '10px', color: warningColor }}>
+                                  ⚡ Следующий
+                                </span>
+                                }
+                              </div>
+                            </div>
                           </td>
                           <td style={tdStyle}>{entry.phone || '—'}</td>
                           <td style={tdStyle}>
@@ -1270,6 +1323,7 @@ const DoctorPanel = () => {
                             {entry.status === 'waiting' &&
                       <>
                                 <button
+                          {...getQueueActionA11yProps('Mark no-show', entry)}
                           style={{ ...actionButtonStyle, background: getColor('danger', 100), color: dangerColor }}
                           onClick={() => markNoShow(entry.id)}
                           title="Отметить неявку">
@@ -1281,6 +1335,7 @@ const DoctorPanel = () => {
                             {entry.status === 'called' &&
                       <>
                                 <button
+                          {...getQueueActionA11yProps('Send to diagnostics', entry)}
                           style={{ ...actionButtonStyle, background: getColor('info', 100), color: accentColor }}
                           onClick={() => sendToDiagnostics(entry.id)}
                           title="На обследование">
@@ -1288,6 +1343,7 @@ const DoctorPanel = () => {
                                   <Stethoscope size={16} />
                                 </button>
                                 <button
+                          {...getQueueActionA11yProps('Complete visit', entry)}
                           style={{ ...actionButtonStyle, background: getColor('success', 100), color: successColor }}
                           onClick={() => completeVisit(entry.id)}
                           title="Завершить приём">
@@ -1295,6 +1351,7 @@ const DoctorPanel = () => {
                                   <CheckCircle size={16} />
                                 </button>
                                 <button
+                          {...getQueueActionA11yProps('Mark no-show', entry)}
                           style={{ ...actionButtonStyle, background: getColor('danger', 100), color: dangerColor }}
                           onClick={() => markNoShow(entry.id)}
                           title="Не явился">
@@ -1306,6 +1363,7 @@ const DoctorPanel = () => {
                             {entry.status === 'diagnostics' &&
                       <>
                                 <button
+                          {...getQueueActionA11yProps('Call back from diagnostics', entry)}
                           style={{ ...actionButtonStyle, background: getColor('primary', 100), color: primaryColor }}
                           onClick={() => callFromDiagnostics(entry.id)}
                           title="Вернуть с диагностики (Push)">
@@ -1313,6 +1371,7 @@ const DoctorPanel = () => {
                                   <Bell size={16} />
                                 </button>
                                 <button
+                          {...getQueueActionA11yProps('Complete visit', entry)}
                           style={{ ...actionButtonStyle, background: getColor('success', 100), color: successColor }}
                           onClick={() => completeVisit(entry.id)}
                           title="Завершить приём">
@@ -1320,6 +1379,7 @@ const DoctorPanel = () => {
                                   <CheckCircle size={16} />
                                 </button>
                                 <button
+                          {...getQueueActionA11yProps('Mark visit incomplete', entry)}
                           style={{ ...actionButtonStyle, background: getColor('warning', 100), color: warningColor }}
                           onClick={() => markIncomplete(entry.id, 'Не вернулся с обследования')}
                           title="Не вернулся">
@@ -1330,6 +1390,7 @@ const DoctorPanel = () => {
                       }
                             {entry.status === 'no_show' &&
                       <button
+                        {...getQueueActionA11yProps('Restore as next patient', entry)}
                         style={{ ...actionButtonStyle, background: getColor('warning', 100), color: warningColor }}
                         onClick={() => restoreToNext(entry.id)}
                         title="Восстановить следующим">
@@ -1339,7 +1400,8 @@ const DoctorPanel = () => {
                       }
                           </td>
                         </tr>
-                  )}
+                    );
+                  })}
                     </tbody>
                   </table>
               }


### PR DESCRIPTION
﻿## Summary
- Clarified the doctor queue current-patient context for called, in-service, and diagnostics rows.
- Added semantic current-patient status badges and contextual `aria-label` values for primary queue/visit actions.
- Added visible focus styling for queue action buttons and labels for the queue refresh/call-next controls.
- Marked PR-UX-4 complete in the UI/UX rollout checklist.

## Contract Impact
- Canonical surface: `/doctor` doctor queue/current patient presentation only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/pages/DoctorPanel.jsx` queue/current patient table and primary visit actions.
- Compatibility path or alias: unchanged canonical `/doctor`; existing `/doctor-panel` alias untouched.
- Contract proof: frontend lint/build passed, authenticated doctor smoke passed, and browser QA verified mocked queue rows without backend contract changes.

## RBAC / Permissions
- Roles allowed: unchanged existing Doctor/Admin access through current route guards.
- Roles denied: unchanged; no RBAC, auth, route guard, or permission code changed.
- Positive auth proof: authenticated doctor QA rendered `.app-shell[data-route-id="doctor-home"]` and verified doctor queue action semantics.
- Negative auth proof: no auth/RBAC files changed and no route permission behavior was altered.

## Notification / Realtime
- Event type or websocket channel: unchanged; no notification or realtime surface touched.
- Payload version / ack behavior: unchanged; queue action handlers still call the same existing functions.
- Read/unread or delivery semantics: unchanged; no notification delivery files changed.
- Reconnect/resync proof: no websocket/realtime consumer files changed, and doctor browser QA loaded queue state via mocked REST responses only.

## Frontend Resilience
- Empty data proof: existing authenticated role smoke covers `/doctor` rendering with empty mocked API payloads.
- Partial data proof: browser QA used mocked called/diagnostics/waiting queue rows with limited service fields and verified fallback action labels.
- Forbidden secondary path behavior: not changed; seeded Doctor auth rendered the protected panel through the existing route shell.
- Missing draft/resource behavior: no draft/resource flow touched; screen-reader action context falls back to `unknown` only when queue identity fields are absent.
- Stale route/deep-link behavior: direct `/doctor` load tested through authenticated browser QA.

## Scope Gate
- Allowed paths: `frontend/src/pages/DoctorPanel.jsx`, `docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md`.
- Denied paths: backend, queue APIs/hooks, RBAC/auth, routes, migrations, Telegram, payment, EMR/reporting logic, lab, deployment, workflow files.
- Migration/docs/test impact: checklist-only docs update; no tests or migrations changed.
- Rollback note: revert this commit to remove only doctor queue presentation semantics and the checklist mark.

## Validation
- Targeted tests or smoke run: `cd frontend; npm run lint:check` -> passed with existing 67 warnings, 0 errors.
- Targeted tests or smoke run: `cd frontend; npm run build` -> passed with existing Vite chunk/dynamic import warnings.
- Targeted tests or smoke run: `cd frontend; npx playwright test e2e/authenticated-role-smoke.spec.js --project=chromium --grep "doctor" --reporter=line` -> passed 1/1.
- Browser QA: `/doctor` at `1280x800` with mocked called/diagnostics/waiting queue rows -> current context badges 2, current rows 2, all primary visit action labels present, call-next/refresh labels present, focus visible, no unlabeled icon buttons, no horizontal overflow, no page errors, screenshot saved locally.
- Static check: `git diff --check` -> passed.
- PR body check: `py -3 scripts/check_pr_review_template.py --body-file <body>` -> passed.
- Result: all local required validation passed.
- Not checked: live queue backend, real patient records, EMR/report generation, or production notification effects because this PR intentionally avoids live DB/API side effects.
