### PR TITLE
fix(frontend): reduce admin support legacy ui drift

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md
@@ -17,7 +17,7 @@ Rules:
 - [x] PR-UX-2: queue join recovery states merged.
 - [x] PR-UX-3: authenticated UI QA harness merged.
 - [x] PR-UX-4: cashier payment accessibility merged.
-- [ ] PR-UX-5: doctor current patient workflow merged.
+- [x] PR-UX-5: doctor current patient workflow merged.
 - [ ] PR-UX-6: admin support legacy cleanup merged.
 - [ ] PR-UX-7: AdminPanel design-system slice merged.
 - [ ] PR-UX-8A: cardiology specialty slice merged.

--- a/frontend/src/pages/Appointments.jsx
+++ b/frontend/src/pages/Appointments.jsx
@@ -1,9 +1,8 @@
 import { useEffect, useMemo, useState, useCallback } from 'react';
-import Nav from '../components/layout/Nav.jsx';
 import RoleGate from '../components/RoleGate.jsx';
 import AppointmentFlow from '../components/AppointmentFlow.jsx';
 import EnhancedAppointmentsTable from '../components/tables/EnhancedAppointmentsTable.jsx';
-import { AppEmpty, AppError, Button } from '../components/ui/macos';
+import { AppEmpty, AppError, Button, Card, CardContent, CardHeader, Checkbox, Input } from '../components/ui/macos';
 import { api } from '../api/client.js';
 
 import logger from '../utils/logger';
@@ -21,7 +20,6 @@ function todayStr() {
  * Для минимальных перезаписей реализуем только чтение и поиск.
  */
 export default function Appointments() {
-  const [page, setPage] = useState('Appointments');
   const [date, setDate] = useState(todayStr());
   const [rows, setRows] = useState([]);
   const [q, setQ] = useState('');
@@ -61,29 +59,65 @@ export default function Appointments() {
     );
   }, [q, rows]);
   const isFilteredEmpty = q.trim().length > 0 && rows.length > 0 && filtered.length === 0;
+  const toolbarStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+    flexWrap: 'wrap'
+  };
+  const fieldStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    color: 'var(--mac-text-secondary)',
+    fontSize: 13
+  };
+  const tableWrapStyle = {
+    overflowX: 'auto',
+    border: '1px solid var(--mac-card-border)',
+    borderRadius: 8,
+    background: 'var(--mac-card-bg)',
+    marginTop: 16
+  };
+  const tableStyle = {
+    width: '100%',
+    borderCollapse: 'collapse'
+  };
 
   return (
     <div>
-      <Nav active={page} onNavigate={setPage} />
       <RoleGate roles={['Admin', 'Registrar', 'Doctor']}>
-        <div className="legacy-page-shell">
-          <h2 style={{ margin: 0 }}>Записи</h2>
+        <Card>
+          <CardHeader>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+              <h2 style={{ margin: 0, color: 'var(--mac-text-primary)' }}>Записи</h2>
+              <span style={{ color: 'var(--mac-text-secondary)', fontSize: 13 }}>
+                {filtered.length} из {rows.length}
+              </span>
+            </div>
+          </CardHeader>
 
-          <div className="legacy-toolbar">
-            <label>
+          <CardContent>
+          <div style={toolbarStyle}>
+            <label style={fieldStyle}>
               Дата:&nbsp;
-              <input className="legacy-input" type="date" value={date} onChange={(e)=>setDate(e.target.value)} />
+              <Input type="date" value={date} onChange={(e)=>setDate(e.target.value)} />
             </label>
-            <input className="legacy-input" placeholder="Поиск по пациенту/врачу/статусу/ID" value={q} onChange={(e)=>setQ(e.target.value)} style={{ minWidth: 260 }} />
-            <button className="legacy-button" onClick={load} disabled={busy}>{busy ? 'Загрузка' : 'Обновить'}</button>
-            <label>
-              <input 
-                type="checkbox" 
-                checked={useAdvancedTable} 
-                onChange={(e) => setUseAdvancedTable(e.target.checked)} 
-              />
-              &nbsp;Расширенная таблица
-            </label>
+            <Input
+              placeholder="Поиск по пациенту/врачу/статусу/ID"
+              value={q}
+              onChange={(e)=>setQ(e.target.value)}
+              style={{ minWidth: 260 }}
+              aria-label="Поиск по записям"
+            />
+            <Button type="button" variant="outline" size="small" onClick={load} disabled={busy} loading={busy}>
+              Обновить
+            </Button>
+            <Checkbox
+              checked={useAdvancedTable}
+              onChange={(next) => setUseAdvancedTable(next)}
+              label="Расширенная таблица"
+            />
           </div>
 
           {err && (
@@ -107,8 +141,8 @@ export default function Appointments() {
               setShowWizard={(show) => logger.log('Show wizard:', show)}
             />
           ) : (
-            <div className="legacy-table-wrap">
-              <table className="legacy-table">
+            <div style={tableWrapStyle}>
+              <table style={tableStyle}>
               <thead>
                 <tr>
                   <th>ID</th>
@@ -160,7 +194,8 @@ export default function Appointments() {
               </table>
             </div>
           )}
-        </div>
+          </CardContent>
+        </Card>
       </RoleGate>
     </div>
   );

--- a/frontend/src/pages/Audit.jsx
+++ b/frontend/src/pages/Audit.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, useCallback } from 'react';
 import RoleGate from '../components/RoleGate.jsx';
 import { api } from '../api/client.js';
-import { AppEmpty, AppError, AppLoading, Button } from '../components/ui/macos';
+import { AppEmpty, AppError, AppLoading, Button, Card, CardContent, CardHeader, Input } from '../components/ui/macos';
 
 /**
  * Аудит: список последних действий пользователей.
@@ -57,19 +57,50 @@ export default function Audit() {
   const limitInputId = 'audit-limit';
   const searchInputId = 'audit-search';
   const tableCaptionId = 'audit-table-caption';
+  const toolbarStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+    flexWrap: 'wrap'
+  };
+  const fieldStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    color: 'var(--mac-text-secondary)',
+    fontSize: 13
+  };
+  const tableWrapStyle = {
+    overflowX: 'auto',
+    border: '1px solid var(--mac-card-border)',
+    borderRadius: 8,
+    background: 'var(--mac-card-bg)',
+    marginTop: 16
+  };
+  const tableStyle = {
+    width: '100%',
+    borderCollapse: 'collapse'
+  };
 
   return (
     <div>
       <RoleGate roles={['Admin']}>
-        <div className="legacy-page-shell">
-          <h2 style={{ margin: 0 }}>Аудит</h2>
+        <Card>
+          <CardHeader>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+              <h2 style={{ margin: 0, color: 'var(--mac-text-primary)' }}>Аудит</h2>
+              <span style={{ color: 'var(--mac-text-secondary)', fontSize: 13 }}>
+                {filtered.length} из {rows.length}
+              </span>
+            </div>
+          </CardHeader>
 
-          <div className="legacy-toolbar">
-            <label htmlFor={limitInputId}>
+          <CardContent>
+          <div style={toolbarStyle}>
+            <label htmlFor={limitInputId} style={fieldStyle}>
               Порог:&nbsp;
-              <input
+              <Input
                 id={limitInputId}
-                className="legacy-input"
                 type="number"
                 min={10}
                 max={1000}
@@ -81,9 +112,8 @@ export default function Audit() {
             <label htmlFor={searchInputId} style={visuallyHiddenStyle}>
               Поиск по пользователю, действию, сущности или ID
             </label>
-            <input
+            <Input
               id={searchInputId}
-              className="legacy-input"
               placeholder="Поиск по пользователю/действию/сущности"
               value={q}
               onChange={(e) => setQ(e.target.value)}
@@ -122,8 +152,8 @@ export default function Audit() {
             />
           )}
 
-          <div className="legacy-table-wrap" aria-busy={busy} aria-describedby={tableCaptionId}>
-            <table className="legacy-table">
+          <div style={tableWrapStyle} aria-busy={busy} aria-describedby={tableCaptionId}>
+            <table style={tableStyle}>
               <caption id={tableCaptionId} style={visuallyHiddenStyle}>Журнал аудита</caption>
               <thead>
                 <tr>
@@ -174,7 +204,8 @@ export default function Audit() {
               </tbody>
             </table>
           </div>
-        </div>
+          </CardContent>
+        </Card>
       </RoleGate>
     </div>);
 

--- a/frontend/src/pages/UserSelect.jsx
+++ b/frontend/src/pages/UserSelect.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import tokenManager from '../utils/tokenManager';
 import { roleToRoute } from '../constants/routes';
+import { AppEmpty, AppError, AppLoading, Button, Card, CardContent, CardHeader } from '../components/ui/macos';
 
 export default function UserSelect() {
   const [items, setItems] = useState([]);
@@ -28,28 +29,50 @@ export default function UserSelect() {
   }, []);
 
   return (
-    <div className="theme-page-shell" style={{ maxWidth: 860 }}>
-      <h1 style={{ fontSize: 24, fontWeight: 800, marginBottom: 12 }}>Выбор пользователя</h1>
-      <div className="legacy-muted" style={{ marginBottom: 12 }}>Доступно администратору. Нажмите, чтобы перейти к роли.</div>
-      {err && <div className="legacy-error">{err}</div>}
+    <Card style={{ maxWidth: 860 }}>
+      <CardHeader>
+        <h1 style={{ fontSize: 24, fontWeight: 800, margin: 0, color: 'var(--mac-text-primary)' }}>Выбор пользователя</h1>
+        <div style={{ color: 'var(--mac-text-secondary)', fontSize: 13, marginTop: 8 }}>Доступно администратору. Нажмите, чтобы перейти к роли.</div>
+      </CardHeader>
+      <CardContent>
+      {err && <AppError title="Не удалось загрузить пользователей" description={err} style={{ marginBottom: 12 }} />}
       {loading ? (
-        <div>Загрузка…</div>
+        <AppLoading
+          title="Загрузка пользователей"
+          description="Получаем список доступных пользователей."
+          ariaLabel="Загружаем список пользователей"
+          size="sm"
+        />
       ) : (
-        <div className="legacy-list">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
           {items.map(u => (
-            <div key={u.id} className="legacy-list-item">
+            <div
+              key={u.id}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                gap: 12,
+                padding: '12px 14px',
+                border: '1px solid var(--mac-card-border)',
+                borderRadius: '8px',
+                background: 'var(--mac-card-bg)'
+              }}>
               <div>
-                <div style={{ fontWeight: 700 }}>{u.full_name || u.username}</div>
-                <div className="legacy-muted" style={{ fontSize: 12 }}>{u.role || '—'} · {u.email || '—'}</div>
+                <div style={{ fontWeight: 700, color: 'var(--mac-text-primary)' }}>{u.full_name || u.username}</div>
+                <div style={{ fontSize: 12, color: 'var(--mac-text-secondary)' }}>{u.role || '—'} · {u.email || '—'}</div>
               </div>
               <div>
-                <button className="legacy-button" onClick={() => navigate(roleToRoute(u.role))}>Перейти</button>
+                <Button type="button" variant="outline" size="small" onClick={() => navigate(roleToRoute(u.role))}>
+                  Перейти
+                </Button>
               </div>
             </div>
           ))}
-          {items.length === 0 && <div className="legacy-muted">Пользователи не найдены</div>}
+          {items.length === 0 && <AppEmpty title="Пользователи не найдены" description="Нет пользователей, доступных для выбора роли." />}
         </div>
       )}
-    </div>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
﻿## Summary
- Replaced legacy admin support page shells, filters, list states, and table wrappers with existing macOS UI primitives in `Appointments`, `Audit`, and `UserSelect`.
- Removed the duplicate legacy in-page appointments nav so the route relies on the canonical app shell/sidebar.
- Marked PR-UX-5 complete in the rollout checklist; PR-UX-6 remains unchecked until merge.

## Contract Impact
- Canonical surface: `/clinical/appointments`, `/admin/audit`, and `/admin/user-select` presentation only. Note: route registry maps `/admin/appointments` to `AdminPanel`; `Appointments.jsx` is the `/clinical/appointments` surface.
- Request shape: unchanged; existing `GET /appointments`, `GET /audit`, and `GET /api/v1/admin/users` calls were preserved.
- Response shape: unchanged; existing client normalization and empty-state behavior were preserved.
- Status codes: unchanged; no fetch/axios error handling or API status handling was modified.
- Frontend consumer: unchanged page consumers; only page presentation primitives changed, with no route registry or component ownership changes.
- Compatibility path or alias: unchanged; legacy redirects and route aliases were not modified.
- Contract proof: `npm run lint:check`, `npm run build`, and authenticated browser QA passed for the touched route surfaces.

## RBAC / Permissions
- Roles allowed: unchanged; `Appointments` remains `Admin`, `Registrar`, `Doctor`; `Audit` and `UserSelect` remain Admin-only through existing route/RoleGate boundaries.
- Roles denied: unchanged; no route guards, role registry, auth store, or permission files were changed.
- Positive auth proof: local Admin fixture rendered `/clinical/appointments`, `/admin/audit`, and `/admin/user-select` directly.
- Negative auth proof: no auth/RBAC files changed, and browser QA confirmed the touched routes did not redirect to forbidden/unauthorized states for Admin.

## Notification / Realtime
- Event type or websocket channel: unchanged; no notification, websocket, polling, or realtime event producer/consumer was touched.
- Payload version / ack behavior: unchanged; no notification/realtime payload or ack behavior changed.
- Read/unread or delivery semantics: unchanged; no notification state handling changed.
- Reconnect/resync proof: no realtime code changed, so reconnect/resync behavior is outside this presentation-only PR.

## Frontend Resilience
- Empty data proof: existing `AppEmpty` branches were preserved or moved onto macOS primitives for no appointment, no audit rows, and no user rows.
- Partial data proof: browser QA used minimal mocked Admin/user/audit/appointment data and routes still rendered.
- Forbidden secondary path behavior: Admin fixture rendered the pages without forbidden/unauthorized states; denied-role behavior was not modified.
- Missing draft/resource behavior: no draft/resource loading path changed; existing fallbacks remain in place.
- Stale route/deep-link behavior: direct route loads were verified for `/clinical/appointments`, `/admin/audit`, and `/admin/user-select`.

## Scope Gate
- Allowed paths: `frontend/src/pages/Appointments.jsx`, `frontend/src/pages/Audit.jsx`, `frontend/src/pages/UserSelect.jsx`, and `docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md`.
- Denied paths: backend, migrations, route registry, RBAC/auth, payment/queue/EMR/lab business logic, tests, and workflow files.
- Migration/docs/test impact: no migration impact; docs impact is rollout checklist only; no test files changed.
- Rollback note: revert this commit to restore the prior legacy presentation without touching contracts.

## Validation
- Targeted tests or smoke run: `cd frontend; npm run lint:check`; `cd frontend; npm run build`; `git diff --check`; static legacy search in touched files; browser QA with local Admin fixture at 1280x800 for `/clinical/appointments`, `/admin/audit`, and `/admin/user-select`.
- Result: all passed. Lint reports existing warnings only: 0 errors, 67 warnings. Build reports existing Vite chunk/dynamic import warnings. Browser QA screenshots saved under `%TEMP%/uiux-pr-ux-6-admin-support-5173`.
- Not checked: denied-role browser path and live backend DB data, because this PR is presentation-only and uses mocked local QA data.
