### PR TITLE
fix(frontend): converge admin panel ui slice

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md
@@ -18,7 +18,7 @@ Rules:
 - [x] PR-UX-3: authenticated UI QA harness merged.
 - [x] PR-UX-4: cashier payment accessibility merged.
 - [x] PR-UX-5: doctor current patient workflow merged.
-- [ ] PR-UX-6: admin support legacy cleanup merged.
+- [x] PR-UX-6: admin support legacy cleanup merged.
 - [ ] PR-UX-7: AdminPanel design-system slice merged.
 - [ ] PR-UX-8A: cardiology specialty slice merged.
 - [ ] PR-UX-8B: dermatology specialty slice merged.

--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -231,6 +231,16 @@ const adminSectionShellStyle = {
   backdropFilter: 'var(--mac-blur-light)',
   WebkitBackdropFilter: 'var(--mac-blur-light)'
 };
+const adminKpiGridStyle = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+  gap: 'var(--mac-spacing-6)'
+};
+const adminKpiCardStyle = {
+  minHeight: '112px',
+  background: adminSurfaceStrong,
+  border: adminBorder
+};
 
 const AdminPanel = () => {
   const location = useLocation();
@@ -1225,17 +1235,58 @@ const AdminPanel = () => {
     }
   }
 
+  const dashboardKpis = [
+    {
+      key: 'users',
+      title: 'Всего пользователей',
+      value: stats.totalUsers || 0,
+      icon: Users,
+      color: 'blue'
+    },
+    {
+      key: 'doctors',
+      title: 'Врачи',
+      value: stats.totalDoctors || 0,
+      icon: Stethoscope,
+      color: 'green'
+    },
+    {
+      key: 'patients',
+      title: 'Пациенты',
+      value: stats.totalPatients || 0,
+      icon: Users,
+      color: 'purple'
+    },
+    {
+      key: 'revenue',
+      title: 'Доход',
+      value: formatCurrency(stats.totalRevenue || 0),
+      icon: TrendingUp,
+      color: 'green'
+    },
+    {
+      key: 'appointments-today',
+      title: 'Записи сегодня',
+      value: stats.appointmentsToday || 0,
+      icon: Calendar,
+      color: 'orange'
+    },
+    {
+      key: 'pending-approvals',
+      title: 'Ожидают подтверждения',
+      value: stats.pendingApprovals || 0,
+      icon: Clock,
+      color: 'red'
+    }
+  ];
+
   const renderDashboard = () =>
   <ErrorBoundary>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
         <AdminRouteSwitcher current="dashboard" />
         {/* Красивые KPI карточки */}
         {statsLoading ?
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-        gap: '24px'
-      }}>
+      <div style={adminKpiGridStyle} aria-label="Загрузка ключевых показателей администратора" aria-busy="true">
             <MacOSLoadingSkeleton type="card" count={6} />
           </div> :
       statsError ?
@@ -1251,58 +1302,18 @@ const AdminPanel = () => {
         } /> :
 
 
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-        gap: '24px'
-      }}>
-            <MacOSStatCard
-          title="Всего пользователей"
-          value={stats.totalUsers || 0}
-          icon={Users}
-          color="blue"
-          loading={statsLoading} />
-
-
-            <MacOSStatCard
-          title="Врачи"
-          value={stats.totalDoctors || 0}
-          icon={Stethoscope}
-          color="green"
-          loading={statsLoading} />
-
-
-            <MacOSStatCard
-          title="Пациенты"
-          value={stats.totalPatients || 0}
-          icon={Users}
-          color="purple"
-          loading={statsLoading} />
-
-
-            <MacOSStatCard
-          title="Доход"
-          value={formatCurrency(stats.totalRevenue || 0)}
-          icon={TrendingUp}
-          color="green"
-          loading={statsLoading} />
-
-
-            <MacOSStatCard
-          title="Записи сегодня"
-          value={stats.appointmentsToday || 0}
-          icon={Calendar}
-          color="orange"
-          loading={statsLoading} />
-
-
-            <MacOSStatCard
-          title="Ожидают подтверждения"
-          value={stats.pendingApprovals || 0}
-          icon={Clock}
-          color="red"
-          loading={statsLoading} />
-
+      <div style={adminKpiGridStyle} role="list" aria-label="Ключевые показатели администратора">
+            {dashboardKpis.map((kpi) => (
+            <div key={kpi.key} role="listitem">
+                <MacOSStatCard
+              title={kpi.title}
+              value={kpi.value}
+              icon={kpi.icon}
+              color={kpi.color}
+              loading={statsLoading}
+              style={adminKpiCardStyle} />
+              </div>
+            ))}
           </div>
       }
 


### PR DESCRIPTION
﻿## Summary
- Converged the Admin dashboard KPI/stat-card family into one data-driven map instead of six repeated card blocks.
- Added shared token-aligned KPI grid/card styles and list/listitem semantics for the KPI group.
- Marked PR-UX-6 complete in the rollout checklist; PR-UX-7 remains unchecked until merge.

## Contract Impact
- Canonical surface: `/admin` AdminPanel dashboard KPI presentation only.
- Request shape: unchanged; existing AdminPanel hooks and API calls were preserved.
- Response shape: unchanged; KPI values still read from the existing `stats` object and `formatCurrency` helper.
- Status codes: unchanged; no fetch/axios error handling or API status handling was modified.
- Frontend consumer: unchanged AdminPanel route consumer; only dashboard KPI rendering structure changed.
- Compatibility path or alias: unchanged; route registry, aliases, and redirects were not modified.
- Contract proof: `npm run lint:check`, `npm run build`, and authenticated browser QA passed for `/admin`.

## RBAC / Permissions
- Roles allowed: unchanged; `/admin` remains Admin-scoped through existing route/RBAC boundaries.
- Roles denied: unchanged; no route guards, role registry, auth store, or permission files were changed.
- Positive auth proof: local Admin fixture rendered `/admin` and the KPI list directly.
- Negative auth proof: no auth/RBAC files changed, and browser QA confirmed `/admin` did not redirect away for Admin.

## Notification / Realtime
- Event type or websocket channel: unchanged; no notification, websocket, polling, or realtime event producer/consumer was touched.
- Payload version / ack behavior: unchanged; no notification/realtime payload or ack behavior changed.
- Read/unread or delivery semantics: unchanged; no notification state handling changed.
- Reconnect/resync proof: no realtime code changed, so reconnect/resync behavior is outside this KPI presentation PR.

## Frontend Resilience
- Empty data proof: stats fallback behavior was preserved because the same `stats` object and defaults remain in use.
- Partial data proof: browser QA used a minimal mocked `/admin/stats` payload and the KPI family rendered six cards.
- Forbidden secondary path behavior: Admin fixture rendered `/admin`; denied-role behavior was not modified.
- Missing draft/resource behavior: no draft/resource loading path changed.
- Stale route/deep-link behavior: direct `/admin` route load was verified.

## Scope Gate
- Allowed paths: `frontend/src/pages/AdminPanel.jsx` and `docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md`.
- Denied paths: backend, migrations, route registry, RBAC/auth, payment/queue/EMR/lab business logic, tests, and workflow files.
- Migration/docs/test impact: no migration impact; docs impact is rollout checklist only; no test files changed.
- Rollback note: revert this commit to restore the prior repeated KPI card rendering without touching contracts.

## Validation
- Targeted tests or smoke run: `cd frontend; npm run lint:check`; `cd frontend; npm run build`; `git diff --check`; browser QA with local Admin fixture at 1280x800 for `/admin`.
- Result: all passed. Lint reports existing warnings only: 0 errors, 66 warnings. Build reports existing Vite chunk/dynamic import warnings. Browser QA found 6 KPI list items, route id `admin-dashboard`, no horizontal overflow, screenshot saved under `%TEMP%/uiux-pr-ux-7-admin-panel-5173`.
- Not checked: denied-role browser path and live backend DB data, because this PR is presentation-only and uses mocked local QA data.
