### PR TITLE
docs(frontend): document mui island policy

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md
@@ -22,7 +22,7 @@ Rules:
 - [x] PR-UX-7: AdminPanel design-system slice merged.
 - [x] PR-UX-8A: cardiology specialty slice merged.
 - [x] PR-UX-8B: dermatology specialty slice merged.
-- [ ] PR-UX-8C: dentistry specialty slice merged.
+- [x] PR-UX-8C: dentistry specialty slice merged.
 - [ ] PR-UX-9: MUI island policy and inventory merged.
 - [ ] Final: rollout completion summary merged.
 

--- a/frontend/DESIGN_SYSTEM.md
+++ b/frontend/DESIGN_SYSTEM.md
@@ -61,7 +61,7 @@ Prefer the exported macOS primitives from `frontend/src/components/ui/macos/inde
 ### Do not
 
 - Do not create a parallel UI framework.
-- Do not add new MUI usage in app pages or clinic workflow panels.
+- Do not add new MUI usage in app pages or clinic workflow panels. Follow `frontend/MUI_RUNTIME_INVENTORY.md` before touching or adding any MUI island.
 - Do not expand `frontend/src/design-system`, `Modern*`, Tailwind-style utility patterns, or page-specific CSS unless the PR explicitly justifies that legacy boundary.
 - Do not add duplicate primitives such as `MacOSButton2`, `ModernCardNew`, or one-off component systems.
 - Do not add large page-local inline style blocks when an existing primitive, token, or small local style is enough.

--- a/frontend/MUI_RUNTIME_INVENTORY.md
+++ b/frontend/MUI_RUNTIME_INVENTORY.md
@@ -1,6 +1,6 @@
 # MUI Runtime Inventory
 
-Date: 2026-05-15
+Date: 2026-05-20
 
 Scope: `frontend/src/pages` and `frontend/src/components`
 
@@ -13,7 +13,29 @@ rg -n "@mui|Mui" frontend\src\pages frontend\src\components
 
 Initial count: 16 files with runtime or example MUI imports.
 
-Current count after Tasks 36-37: 14 files with runtime or example MUI imports.
+Current count after PR-UX-9 inventory refresh: 14 files with runtime or example MUI imports.
+
+## No-New-MUI Island Policy
+
+MUI is a legacy compatibility layer in this clinic frontend. New clinic runtime UI should not create new MUI islands.
+
+Default rule:
+
+- Do not add new `@mui/material`, `@mui/icons-material`, `@mui/system`, or `@material-ui/*` imports in app pages, route panels, workflow components, forms, tables, dashboards, empty/loading/error states, payment flows, queue flows, EMR/lab/dental/cardiology surfaces, Telegram management, or authenticated role UI.
+- Use `frontend/src/components/ui/macos` and the macOS token/CSS variable layer first.
+- If a touched file already imports MUI, do not expand its MUI surface. Leave the existing island in place unless the PR is explicitly a scoped MUI migration.
+- A new MUI import requires explicit approval in the PR body with:
+  - the exact file and UI surface;
+  - why the canonical macOS primitive cannot safely cover the need;
+  - the intended follow-up or migration/retirement path;
+  - validation that no route, RBAC, payment, queue, EMR, lab, Telegram, notification, or backend contract changed.
+- MUI removal must be staged one file or one component family at a time. Do not mass-remove MUI dependencies until runtime imports reach `0`.
+
+Review command for future PRs:
+
+```powershell
+rg -l '@mui|Mui' frontend/src/pages frontend/src/components
+```
 
 ## Policy
 


### PR DESCRIPTION
﻿## Summary
- Refreshes `frontend/MUI_RUNTIME_INVENTORY.md` and makes it the explicit no-new-MUI island policy for clinic runtime UI.
- Links `frontend/DESIGN_SYSTEM.md` to the MUI inventory before adding or touching MUI islands.
- Marks PR-UX-8C complete in the rollout checklist; PR-UX-9 remains unchecked until this PR is merged.

## Contract Impact
- Canonical surface: Documentation only: frontend UI layer policy and rollout checklist.
- Request shape: Unchanged.
- Response shape: Unchanged.
- Status codes: Unchanged.
- Frontend consumer: No runtime frontend consumer changed.
- Compatibility path or alias: Unchanged.
- Contract proof: Docs-only diff plus `git diff --check`; no runtime files changed.

## RBAC / Permissions
- Roles allowed: Unchanged.
- Roles denied: Unchanged.
- Positive auth proof: Not applicable; docs-only policy PR.
- Negative auth proof: Not applicable; docs-only policy PR.

## Notification / Realtime
- Event type or websocket channel: Unchanged.
- Payload version / ack behavior: Unchanged.
- Read/unread or delivery semantics: Unchanged.
- Reconnect/resync proof: Not applicable; docs-only policy PR.

## Frontend Resilience
- Empty data proof: Not applicable; docs-only policy PR.
- Partial data proof: Not applicable; docs-only policy PR.
- Forbidden secondary path behavior: Unchanged.
- Missing draft/resource behavior: Unchanged.
- Stale route/deep-link behavior: Unchanged.

## Scope Gate
- Allowed paths: `frontend/MUI_RUNTIME_INVENTORY.md`, `frontend/DESIGN_SYSTEM.md`, `docs/audits/uiux-hard-audit-2026-05-20/fix-rollout-checklist.md`.
- Denied paths: Backend, DB migrations, runtime frontend code, tests, workflows, routes, auth/RBAC, queue, payment, EMR, lab, Telegram, notification, and MUI runtime files.
- Migration/docs/test impact: Docs/policy only; no MUI removal or migration performed.
- Rollback note: Revert this PR to restore the previous MUI inventory wording and design-system policy pointer.

## Validation
- Targeted tests or smoke run: `git diff --check`; `rg -l '@mui|Mui' frontend/src/pages frontend/src/components`; PR body template check.
- Result: Passed. MUI inventory command reports 14 files with runtime or example MUI references. Diff is docs-only.
- Not checked: Frontend build/test suites, backend suites, browser QA, production auth, and live DB because this PR changes only documentation/policy.
