### PR TITLE
fix(frontend): remove invalid notification aria role warnings

### DIFF
--- a/frontend/src/__tests__/notificationGuardrails.test.js
+++ b/frontend/src/__tests__/notificationGuardrails.test.js
@@ -61,6 +61,6 @@ describe('notification guardrails', () => {
     expect(context).not.toContain('[unreadSnapshot]');
 
     expect(roleCenter).toContain('useEffect(() => {');
-    expect(roleCenter).toContain('[runLoadNotifications, role]');
+    expect(roleCenter).toContain('[runLoadNotifications, userRole]');
   });
 });

--- a/frontend/src/components/notifications/NotificationInbox.jsx
+++ b/frontend/src/components/notifications/NotificationInbox.jsx
@@ -57,7 +57,7 @@ function extractMetadata(item) {
   return metadata && typeof metadata === 'object' ? metadata : {};
 }
 
-function resolveNotificationTarget(item, role) {
+function resolveNotificationTarget(item, userRole) {
   const explicitDeepLink = String(item?.deepLink || '').trim();
   if (explicitDeepLink) {
     return explicitDeepLink;
@@ -96,7 +96,7 @@ function resolveNotificationTarget(item, role) {
     case 'registrar_system_alert':
       return '/registrar';
     case 'system_alert':
-      return role === 'admin' ? '/admin' : '/registrar';
+      return userRole === 'admin' ? '/admin' : '/registrar';
     default:
       return null;
   }
@@ -119,7 +119,7 @@ function navigateToNotificationTarget(target) {
   }
 }
 
-export default function NotificationInbox({ role, onClose }) {
+export default function NotificationInbox({ userRole, onClose }) {
   const {
     getNotificationsByRole,
     markAsRead,
@@ -132,7 +132,7 @@ export default function NotificationInbox({ role, onClose }) {
   const [searchText, setSearchText] = useState('');
 
   const notifications = useMemo(() => {
-    const scoped = getNotificationsByRole(role);
+    const scoped = getNotificationsByRole(userRole);
     const query = searchText.trim().toLowerCase();
 
     return scoped
@@ -175,7 +175,7 @@ export default function NotificationInbox({ role, onClose }) {
 
         return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
       });
-  }, [getNotificationsByRole, role, searchText, showUnreadOnly, statusFilter]);
+  }, [getNotificationsByRole, userRole, searchText, showUnreadOnly, statusFilter]);
 
   const unreadCount = useMemo(
     () => notifications.filter((item) => !item.isRead && !item.isArchived).length,
@@ -192,7 +192,7 @@ export default function NotificationInbox({ role, onClose }) {
         await markAsRead(item.id);
       }
 
-      const target = resolveNotificationTarget(item, role);
+      const target = resolveNotificationTarget(item, userRole);
       navigateToNotificationTarget(target);
     } catch (error) {
       logger.warn('[NotificationInbox] failed to mark notification open state', error);
@@ -210,7 +210,7 @@ export default function NotificationInbox({ role, onClose }) {
 
   const handleMarkAllRead = async () => {
     try {
-      await markAllAsRead(role);
+      await markAllAsRead(userRole);
     } catch (error) {
       logger.warn('[NotificationInbox] failed to mark all notifications as read', error);
     }
@@ -249,7 +249,7 @@ export default function NotificationInbox({ role, onClose }) {
         <div>
           <strong style={{ display: 'block' }}>Уведомления</strong>
           <span style={{ fontSize: 12, color: 'var(--mac-text-tertiary)' }}>
-            {role || 'all'} · {unreadCount} unread
+            {userRole || 'all'} · {unreadCount} unread
           </span>
         </div>
         <button
@@ -520,7 +520,7 @@ export default function NotificationInbox({ role, onClose }) {
 }
 
 NotificationInbox.propTypes = {
-  role: PropTypes.oneOf([
+  userRole: PropTypes.oneOf([
     'doctor',
     'registrar',
     'lab',

--- a/frontend/src/components/notifications/RoleNotificationCenter.jsx
+++ b/frontend/src/components/notifications/RoleNotificationCenter.jsx
@@ -7,7 +7,7 @@ import { useNotificationCenter } from '../../contexts/NotificationCenterContext'
 import { getProfile } from '../../stores/auth';
 import logger from '../../utils/logger';
 
-export default function RoleNotificationCenter({ role }) {
+export default function RoleNotificationCenter({ userRole }) {
   const [open, setOpen] = useState(false);
   const [recipientScope, setRecipientScope] = useState(null);
   const { loadNotifications, getUnreadCount } = useNotificationCenter();
@@ -19,13 +19,13 @@ export default function RoleNotificationCenter({ role }) {
       return true;
     }
 
-    const loadKey = `${role}:${scope.recipientId}:${scope.recipientType || 'unknown'}`;
+    const loadKey = `${userRole}:${scope.recipientId}:${scope.recipientType || 'unknown'}`;
     const now = Date.now();
     const withinCooldown = lastLoadKeyRef.current === loadKey && (now - lastLoadAtRef.current) < 15_000;
 
     if (withinCooldown) {
       logger.info('[FIX:NOTIFICATIONS] skipping duplicate role notification load', {
-        role,
+        role: userRole,
         source,
         loadKey,
         ageMs: now - lastLoadAtRef.current
@@ -36,7 +36,7 @@ export default function RoleNotificationCenter({ role }) {
     lastLoadKeyRef.current = loadKey;
     lastLoadAtRef.current = now;
     return false;
-  }, [role]);
+  }, [userRole]);
 
   const runLoadNotifications = useCallback((source) => {
     if (shouldSkipLoad(recipientScope, source)) {
@@ -44,13 +44,13 @@ export default function RoleNotificationCenter({ role }) {
     }
 
     return loadNotifications({
-      role,
+      role: userRole,
       recipient_id: recipientScope.recipientId,
       recipient_type: recipientScope.recipientType,
       status: 'all',
       limit: 50
     });
-  }, [loadNotifications, recipientScope, role, shouldSkipLoad]);
+  }, [loadNotifications, recipientScope, userRole, shouldSkipLoad]);
 
   useEffect(() => {
     let isActive = true;
@@ -63,20 +63,20 @@ export default function RoleNotificationCenter({ role }) {
         }
 
         if (!profile?.id) {
-          logger.warn(`[NotificationCenter] missing auth profile for role=${role}`);
+          logger.warn(`[NotificationCenter] missing auth profile for role=${userRole}`);
           return;
         }
 
         setRecipientScope({
           recipientId: profile.id,
-          recipientType: role
+          recipientType: userRole
         });
       } catch (error) {
         if (!isActive) {
           return;
         }
 
-        logger.warn(`[NotificationCenter] failed to resolve recipient scope for role=${role}`, error);
+        logger.warn(`[NotificationCenter] failed to resolve recipient scope for role=${userRole}`, error);
       }
     };
 
@@ -85,7 +85,7 @@ export default function RoleNotificationCenter({ role }) {
     return () => {
       isActive = false;
     };
-  }, [role]);
+  }, [userRole]);
 
   const refreshNotifications = useCallback(() => {
     return runLoadNotifications('manual');
@@ -93,9 +93,9 @@ export default function RoleNotificationCenter({ role }) {
 
   useEffect(() => {
     runLoadNotifications('initial').catch((error) => {
-      logger.warn(`[NotificationCenter] initial load failed for role=${role}`, error);
+      logger.warn(`[NotificationCenter] initial load failed for role=${userRole}`, error);
     });
-  }, [runLoadNotifications, role]);
+  }, [runLoadNotifications, userRole]);
 
   useEffect(() => {
     if (!open) {
@@ -103,20 +103,20 @@ export default function RoleNotificationCenter({ role }) {
     }
 
     runLoadNotifications('open').catch((error) => {
-      logger.warn(`[NotificationCenter] refresh load failed for role=${role}`, error);
+      logger.warn(`[NotificationCenter] refresh load failed for role=${userRole}`, error);
     });
-  }, [open, runLoadNotifications, role]);
+  }, [open, runLoadNotifications, userRole]);
 
   return (
     <div style={{ position: 'fixed', top: 80, right: 24, zIndex: 1200 }}>
-      <NotificationBell unreadCount={getUnreadCount(role)} onClick={() => setOpen((value) => !value)} />
-      {open ? <NotificationInbox role={role} onClose={() => setOpen(false)} /> : null}
+      <NotificationBell unreadCount={getUnreadCount(userRole)} onClick={() => setOpen((value) => !value)} />
+      {open ? <NotificationInbox userRole={userRole} onClose={() => setOpen(false)} /> : null}
     </div>
   );
 }
 
 RoleNotificationCenter.propTypes = {
-  role: PropTypes.oneOf([
+  userRole: PropTypes.oneOf([
     'doctor',
     'registrar',
     'lab',

--- a/frontend/src/components/notifications/__tests__/NotificationInbox.test.jsx
+++ b/frontend/src/components/notifications/__tests__/NotificationInbox.test.jsx
@@ -95,7 +95,7 @@ describe('NotificationInbox routing', () => {
         }),
       ];
 
-      render(<NotificationInbox role={role} onClose={() => {}} />);
+      render(<NotificationInbox userRole={role} onClose={() => {}} />);
       fireEvent.click(screen.getByLabelText(/Открыть уведомление:/i));
 
       await waitFor(() => {
@@ -117,7 +117,7 @@ describe('NotificationInbox routing', () => {
       }),
     ];
 
-    render(<NotificationInbox role="admin" onClose={() => {}} />);
+    render(<NotificationInbox userRole="admin" onClose={() => {}} />);
     fireEvent.click(screen.getByLabelText(/Открыть уведомление:/i));
 
     await waitFor(() => {
@@ -135,7 +135,7 @@ describe('NotificationInbox routing', () => {
       }),
     ];
 
-    render(<NotificationInbox role="admin" onClose={() => {}} />);
+    render(<NotificationInbox userRole="admin" onClose={() => {}} />);
     fireEvent.click(screen.getByLabelText(/Открыть уведомление:/i));
 
     await waitFor(() => {

--- a/frontend/src/components/notifications/__tests__/RoleNotificationCenter.test.jsx
+++ b/frontend/src/components/notifications/__tests__/RoleNotificationCenter.test.jsx
@@ -56,8 +56,7 @@ describe('RoleNotificationCenter', () => {
   it('loads history for the current recipient scope', async () => {
     getProfileMock.mockResolvedValueOnce({ id: 77, role: 'lab' });
 
-    // eslint-disable-next-line jsx-a11y/aria-role
-    const { rerender } = render(<RoleNotificationCenter role="lab" />);
+    const { rerender } = render(<RoleNotificationCenter userRole="lab" />);
 
     await waitFor(() => {
       expect(loadNotifications).toHaveBeenCalledWith(
@@ -71,7 +70,7 @@ describe('RoleNotificationCenter', () => {
       );
     });
 
-    rerender(<RoleNotificationCenter role="lab" />);
+    rerender(<RoleNotificationCenter userRole="lab" />);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(loadNotifications).toHaveBeenCalledTimes(1);
@@ -80,8 +79,7 @@ describe('RoleNotificationCenter', () => {
   it('skips history load when the auth profile is unavailable', async () => {
     getProfileMock.mockResolvedValueOnce(null);
 
-    // eslint-disable-next-line jsx-a11y/aria-role
-    render(<RoleNotificationCenter role="lab" />);
+    render(<RoleNotificationCenter userRole="lab" />);
 
     await waitFor(() => {
       expect(getProfileMock).toHaveBeenCalled();

--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -4776,7 +4776,7 @@ const AdminPanel = () => {
           isOpen={showHotkeysModal}
           onClose={() => setShowHotkeysModal(false)} />
 
-        <RoleNotificationCenter role="admin" />
+        <RoleNotificationCenter userRole="admin" />
       </div>
     </div>);
 

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -2605,7 +2605,7 @@ const MacOSCardiologistPanelUnified = () => {
           useWebSocket={false}
           position="bottom-right" />
 
-        <RoleNotificationCenter role="cardiologist" />
+        <RoleNotificationCenter userRole="cardiologist" />
       </div>
     </div>);
 

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -4251,7 +4251,7 @@ const DentistPanelUnified = () => {
         useWebSocket={false}
         position="bottom-right" />
 
-      <RoleNotificationCenter role="dentist" />
+      <RoleNotificationCenter userRole="dentist" />
     </div>);
 
 };

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -2880,7 +2880,7 @@ const DermatologistPanelUnified = () => {
           useWebSocket={false}
           position="bottom-right" />
 
-        <RoleNotificationCenter role="dermatologist" />
+        <RoleNotificationCenter userRole="dermatologist" />
       </div>
     </div>);
 

--- a/frontend/src/pages/DoctorPanel.jsx
+++ b/frontend/src/pages/DoctorPanel.jsx
@@ -1629,7 +1629,7 @@ const DoctorPanel = () => {
         useWebSocket={false}
         position="bottom-right" />
 
-      <RoleNotificationCenter role="doctor" />
+      <RoleNotificationCenter userRole="doctor" />
     </div>);
 
 };

--- a/frontend/src/pages/LabPanel.jsx
+++ b/frontend/src/pages/LabPanel.jsx
@@ -466,7 +466,7 @@ export default function LabPanel() {
         />
       )}
 
-      <RoleNotificationCenter role="lab" />
+      <RoleNotificationCenter userRole="lab" />
     </div>
   );
 }

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -4182,7 +4182,7 @@ const RegistrarPanel = () => {
           loadAppointments({ source: 'force_majeure' });
         }} />
 
-      <RoleNotificationCenter role="registrar" />
+      <RoleNotificationCenter userRole="registrar" />
 
     </div>);
 


### PR DESCRIPTION
﻿## Summary
- Renames the internal notification role prop from `role` to `userRole` so JSX a11y lint no longer treats clinic role names as invalid ARIA roles.
- Updates role panels and notification tests to use `userRole`.
- Preserves notification loading payloads: the API/request object still sends the `role` field unchanged.

## Contract Impact
- Canonical surface: Frontend notification center component usage in role panels.
- Request shape: Unchanged; `loadNotifications({ role: userRole, ... })` still sends `role`.
- Response shape: Unchanged.
- Status codes: Unchanged.
- Frontend consumer: Role panels now pass `userRole` to `RoleNotificationCenter`; notification UI behavior remains the same.
- Compatibility path or alias: No backend/API alias changed; this is an internal React prop rename.
- Contract proof: Notification tests passed; frontend build passed; no backend/API files changed.

## RBAC / Permissions
- Roles allowed: Unchanged; the same clinic role names are passed through to notification loading.
- Roles denied: Unchanged.
- Positive auth proof: Existing notification tests verify lab/admin role payload behavior.
- Negative auth proof: Missing-profile notification test still verifies no notification load occurs without an auth profile.

## Notification / Realtime
- Event type or websocket channel: Unchanged.
- Payload version / ack behavior: Unchanged; only the React prop name changed.
- Read/unread or delivery semantics: Unchanged; inbox filtering, unread count, mark-read, mark-all-read, and archive calls still use the same role value.
- Reconnect/resync proof: Not applicable; this PR does not change websocket or reconnect behavior.

## Frontend Resilience
- Empty data proof: Existing notification inbox tests still cover empty/filter behavior through the same provider mocks.
- Partial data proof: Unchanged; notification item parsing and routing logic were not changed.
- Forbidden secondary path behavior: Unchanged.
- Missing draft/resource behavior: Unchanged.
- Stale route/deep-link behavior: Unchanged; deep-link routing tests still passed.

## Scope Gate
- Allowed paths: `frontend/src/components/notifications/**`, role panel call sites for `RoleNotificationCenter` only.
- Denied paths: Backend, DB migrations, workflows, auth/RBAC logic, route contracts, queue, payment, EMR, lab business logic, Telegram, and notification backend services.
- Migration/docs/test impact: Frontend tests updated for the internal prop rename; no migrations or docs changed.
- Rollback note: Revert this PR to restore the previous `role` prop name and the old lint warnings.

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run lint:check`; `cd frontend; npm.cmd run test:run -- src/components/notifications/__tests__/NotificationInbox.test.jsx src/components/notifications/__tests__/RoleNotificationCenter.test.jsx`; `cd frontend; npm.cmd run build`; `git diff --check`; static grep for stale `<RoleNotificationCenter role=` and `<NotificationInbox role=`.
- Result: Passed. `jsx-a11y/aria-role` warnings dropped to zero; notification tests passed 13/13; build passed with existing Vite chunk/import warnings.
- Not checked: Browser visual QA and backend suites because this PR changes only an internal React prop name and notification call sites.
