### PR TITLE
test(frontend): add authenticated rbac denial smoke

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/remaining-fix-rollout-checklist.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/remaining-fix-rollout-checklist.md
@@ -18,7 +18,7 @@ This checklist starts the second small-PR cycle for issues that remained after t
 
 - [x] PR-UX-10: fix invalid ARIA role lint warnings in touched frontend surfaces.
 - [x] PR-UX-11: promote the repeated specialty appointment summary/action-bar pattern into one reusable primitive, only if the current duplication stays behavior-identical.
-- [ ] PR-UX-12: extend authenticated QA harness into stable Playwright smoke specs for Admin, Doctor, Cashier, Lab, and specialty panels.
+- [x] PR-UX-12: extend authenticated QA harness into stable Playwright smoke specs for Admin, Doctor, Cashier, Lab, and specialty panels.
 - [ ] PR-UX-13: add negative RBAC browser checks for protected role routes without changing production auth behavior.
 - [ ] PR-UX-14: improve Registrar workflow hierarchy as one narrow visible slice.
 - [ ] PR-UX-15: improve Patient panel readability/accessibility as one narrow visible slice.

--- a/frontend/e2e/AUTHENTICATED_UI_QA.md
+++ b/frontend/e2e/AUTHENTICATED_UI_QA.md
@@ -15,6 +15,7 @@ This Playwright harness is for local UI/UX audit evidence only. It does not chan
 ```powershell
 cd frontend
 npx playwright test e2e/authenticated-role-smoke.spec.js --project=chromium --reporter=line
+npx playwright test e2e/authenticated-rbac-deny.spec.js --project=chromium --reporter=line
 ```
 
 ## Role Coverage
@@ -33,6 +34,17 @@ npx playwright test e2e/authenticated-role-smoke.spec.js --project=chromium --re
 
 `/patient` is currently staff-scoped in the route registry, so the patient QA surface uses the authenticated patient payment entry route.
 
+## Negative RBAC Coverage
+
+These checks seed an authenticated session with a real but wrong role and verify that the route guard sends the user to `/forbidden` instead of rendering the protected app shell or falling back to `/login`.
+
+| Seeded Role | Denied Route | Denied Route ID |
+| --- | --- | --- |
+| Cashier | `/admin` | `admin-dashboard` |
+| Doctor | `/cashier` | `cashier-home` |
+| Cashier | `/lab` | `lab-home` |
+| Registrar | `/doctor/cardiology` | `doctor-cardiology` |
+
 ## Boundaries
 
 - Do not use this harness to bypass backend contract tests.
@@ -40,3 +52,4 @@ npx playwright test e2e/authenticated-role-smoke.spec.js --project=chromium --re
 - Do not weaken `RouteAccessBoundary`, `RoleGate`, or backend RBAC because this harness exists.
 - For business-flow verification, use live QA credentials or dedicated backend fixtures in a separate plan.
 - Keep negative RBAC browser checks in their own focused PR so this smoke harness remains a positive render check.
+- Negative RBAC smoke must not be used as backend authorization proof; it only verifies frontend route-denial UX.

--- a/frontend/e2e/authenticated-rbac-deny.spec.js
+++ b/frontend/e2e/authenticated-rbac-deny.spec.js
@@ -1,0 +1,40 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import {
+  AUTHENTICATED_RBAC_DENY_QA_ROUTES,
+  installAuthenticatedQaHarness,
+} from './support/authenticatedQa.js';
+
+async function expectForbiddenForSeededRole(page, route) {
+  await expect(page).not.toHaveURL(/\/login$/);
+  await expect(page).toHaveURL(/\/forbidden$/);
+  await expect(page.locator(`.app-shell[data-route-id="${route.deniedRouteId}"]`)).toHaveCount(0);
+  await expect(page.locator('body')).toContainText('403');
+}
+
+test.describe('Authenticated RBAC denial UI QA harness', () => {
+  for (const route of AUTHENTICATED_RBAC_DENY_QA_ROUTES) {
+    test(`${route.key} redirects seeded ${route.role} session to forbidden`, async ({ page }, testInfo) => {
+      const pageErrors = [];
+      page.on('pageerror', (error) => {
+        pageErrors.push(error.message);
+      });
+
+      await installAuthenticatedQaHarness(page, { role: route.role });
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await page.goto(route.path, { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle').catch(() => undefined);
+
+      await expectForbiddenForSeededRole(page, route);
+
+      const screenshotPath = testInfo.outputPath(`authenticated-rbac-deny-${route.key}.png`);
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+      await testInfo.attach(`authenticated-rbac-deny-${route.key}`, {
+        path: screenshotPath,
+        contentType: 'image/png',
+      });
+
+      expect(pageErrors).toEqual([]);
+    });
+  }
+});

--- a/frontend/e2e/support/authenticatedQa.js
+++ b/frontend/e2e/support/authenticatedQa.js
@@ -68,6 +68,33 @@ export const AUTHENTICATED_UI_QA_ROUTES = [
   ...AUTHENTICATED_SPECIALTY_QA_ROUTES,
 ];
 
+export const AUTHENTICATED_RBAC_DENY_QA_ROUTES = [
+  {
+    key: 'cashier-denied-admin',
+    role: 'Cashier',
+    path: '/admin',
+    deniedRouteId: 'admin-dashboard',
+  },
+  {
+    key: 'doctor-denied-cashier',
+    role: 'Doctor',
+    path: '/cashier',
+    deniedRouteId: 'cashier-home',
+  },
+  {
+    key: 'cashier-denied-lab',
+    role: 'Cashier',
+    path: '/lab',
+    deniedRouteId: 'lab-home',
+  },
+  {
+    key: 'registrar-denied-cardiology',
+    role: 'Registrar',
+    path: '/doctor/cardiology',
+    deniedRouteId: 'doctor-cardiology',
+  },
+];
+
 function base64UrlEncode(value) {
   return Buffer.from(JSON.stringify(value))
     .toString('base64')


### PR DESCRIPTION
﻿## Summary
- Add a dedicated Playwright negative RBAC smoke spec for authenticated users with the wrong role.
- Add a denial-case matrix to the local authenticated QA harness and document the covered forbidden-route scenarios.
- Mark PR-UX-12 complete in the remaining UI/UX rollout checklist.

## Contract Impact
- Canonical surface: Frontend Playwright QA harness and route-denial documentation only.
- Request shape: Unchanged; no production request code or API client code changed.
- Response shape: Unchanged; no production API response handling changed.
- Status codes: Unchanged; the test verifies existing frontend `/forbidden` behavior and does not change status handling.
- Frontend consumer: New `authenticated-rbac-deny.spec.js` consumes denial cases from `authenticatedQa.js`.
- Compatibility path or alias: No production route, alias, redirect, or compatibility path changed.
- Contract proof: Diff is limited to e2e harness/docs/checklist; local positive and negative authenticated smoke passed.

## RBAC / Permissions
- Roles allowed: Unchanged in production; positive smoke coverage remains intact for allowed seeded roles.
- Roles denied: Covered in the browser harness for Cashier -> `/admin`, Doctor -> `/cashier`, Cashier -> `/lab`, and Registrar -> `/doctor/cardiology`.
- Positive auth proof: Existing authenticated role/specialty smoke passed alongside the new negative spec.
- Negative auth proof: New negative spec passed and verified wrong-role sessions land on `/forbidden`, do not render the denied app-shell route id, and do not fall back to `/login`.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no notification, websocket, polling, or realtime code changed.
- Payload version / ack behavior: Unchanged; no realtime payload or acknowledgement behavior touched.
- Read/unread or delivery semantics: Unchanged; no notification read/delivery state touched.
- Reconnect/resync proof: No subscription, reconnect, polling, or resync code changed; this PR only changes Playwright RBAC smoke coverage and docs.

## Frontend Resilience
- Empty data proof: Harness still uses empty collection payloads; positive route smoke passed in the same local run.
- Partial data proof: No runtime partial-data handling changed; denial cases are route-guard checks before protected panel rendering.
- Forbidden secondary path behavior: New smoke verifies `/forbidden` for wrong-role deep links without rendering protected app-shell surfaces.
- Missing draft/resource behavior: Unchanged; no draft/resource runtime logic changed.
- Stale route/deep-link behavior: Negative smoke opens protected routes directly by path and confirms denied users are redirected to `/forbidden`.

## Scope Gate
- Allowed paths: `frontend/e2e/authenticated-rbac-deny.spec.js`, `frontend/e2e/support/authenticatedQa.js`, `frontend/e2e/AUTHENTICATED_UI_QA.md`, and the rollout checklist.
- Denied paths: Production auth, RBAC implementation, route registry, backend, API clients, runtime UI components, payments, queue, EMR/lab logic, notifications, migrations, and workflows.
- Migration/docs/test impact: No migration impact; docs and Playwright e2e harness only.
- Rollback note: Revert this commit to remove negative RBAC browser smoke coverage without changing production behavior.

## Validation
- Targeted tests or smoke run: `cd frontend; npx.cmd playwright test e2e/authenticated-role-smoke.spec.js e2e/authenticated-rbac-deny.spec.js --project=chromium --reporter=line`; `cd frontend; node --check e2e/authenticated-rbac-deny.spec.js`; `cd frontend; node --check e2e/authenticated-role-smoke.spec.js`; `cd frontend; node --check e2e/support/authenticatedQa.js`; `git diff --cached --check`.
- Result: Passed; 13 Chromium Playwright smoke tests passed.
- Not checked: Backend authorization enforcement, live production credentials, non-Chromium browser matrix, and hosted visual regression screenshots.
