### PR TITLE
fix(frontend): clarify registrar workflow hierarchy

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/remaining-fix-rollout-checklist.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/remaining-fix-rollout-checklist.md
@@ -19,7 +19,7 @@ This checklist starts the second small-PR cycle for issues that remained after t
 - [x] PR-UX-10: fix invalid ARIA role lint warnings in touched frontend surfaces.
 - [x] PR-UX-11: promote the repeated specialty appointment summary/action-bar pattern into one reusable primitive, only if the current duplication stays behavior-identical.
 - [x] PR-UX-12: extend authenticated QA harness into stable Playwright smoke specs for Admin, Doctor, Cashier, Lab, and specialty panels.
-- [ ] PR-UX-13: add negative RBAC browser checks for protected role routes without changing production auth behavior.
+- [x] PR-UX-13: add negative RBAC browser checks for protected role routes without changing production auth behavior.
 - [ ] PR-UX-14: improve Registrar workflow hierarchy as one narrow visible slice.
 - [ ] PR-UX-15: improve Patient panel readability/accessibility as one narrow visible slice.
 - [ ] PR-UX-16: improve Lab panel visual/accessibility QA as one narrow visible slice.

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -20,6 +20,61 @@ import RoleNotificationCenter from '../components/notifications/RoleNotification
 
 const API_BASE = getApiOrigin();
 const APPOINTMENT_OVERRIDE_TTL_MS = 10 * 60 * 1000;
+const REGISTRAR_TAB_LABEL_KEYS = {
+  appointments: 'tabs_appointments',
+  cardio: 'tabs_cardio',
+  echokg: 'tabs_echokg',
+  derma: 'tabs_derma',
+  dental: 'tabs_dental',
+  lab: 'tabs_lab',
+  procedures: 'tabs_procedures'
+};
+const REGISTRAR_STATUS_LABEL_KEYS = {
+  scheduled: 'status_scheduled',
+  confirmed: 'status_confirmed',
+  queued: 'status_queued',
+  in_cabinet: 'status_in_cabinet',
+  done: 'status_done',
+  cancelled: 'status_cancelled',
+  no_show: 'status_no_show',
+  paid_pending: 'status_paid_pending',
+  paid: 'status_paid'
+};
+const registrarWorkflowHeaderStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 'var(--mac-spacing-4)',
+  flexWrap: 'wrap',
+  padding: 'var(--mac-spacing-4)',
+  marginBottom: 'var(--mac-spacing-4)',
+  background: 'var(--mac-bg-primary)',
+  border: '1px solid var(--mac-separator)',
+  borderRadius: 'var(--mac-radius-lg)',
+  boxShadow: 'var(--mac-shadow-xs)',
+  minWidth: 0
+};
+const registrarWorkflowTitleStyle = {
+  margin: 0,
+  color: 'var(--mac-text-primary)',
+  fontSize: 'var(--mac-font-size-xl)',
+  fontWeight: 'var(--mac-font-weight-semibold)',
+  lineHeight: 1.25
+};
+const registrarWorkflowMetaStyle = {
+  margin: 'var(--mac-spacing-1) 0 0',
+  color: 'var(--mac-text-secondary)',
+  fontSize: 'var(--mac-font-size-sm)',
+  lineHeight: 1.5
+};
+const registrarWorkflowActionsStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+  gap: 'var(--mac-spacing-2)',
+  flexWrap: 'wrap',
+  minWidth: 0
+};
 
 // Современные диалоги
 import PaymentDialog from '../components/dialogs/PaymentDialog';
@@ -739,6 +794,8 @@ const RegistrarPanel = () => {
       status_scheduled: 'Rejalashtirilgan', status_confirmed: 'Tasdiqlangan', status_queued: 'Navbatda', status_in_cabinet: 'Kabinetda', status_done: 'Tugallangan', status_cancelled: 'Bekor qilingan', status_no_show: 'Kelmagan', status_paid_pending: 'To\'lovni kutmoqda', status_paid: 'To\'langan', // Статистика
       total_patients: 'Jami bemorlar', today_appointments: 'Bugungi yozuvlar', pending_payments: 'To\'lovni kutmoqda', active_queues: 'Faol navbatlar', empty_table: 'Ma\'lumot yo\'q', // Сообщения
       appointment_created: 'Yozuv muvaffaqiyatli yaratildi', appointment_cancelled: 'Yozuv bekor qilindi', payment_successful: 'To\'lov muvaffaqiyatli o\'tdi', print_ticket: 'Talon chop etish', auto_refresh: 'Avtomatik yangilash', data_source_demo: 'Demo ma\'lumotlar ko\'rsatilgan', data_source_api: 'Ma\'lumotlar serverdan yuklandi' } };const t = (key) => translations[language] && translations[language][key] || translations.ru[key] || key; // Используем централизованную тему
+  const currentWorklistLabel = t(REGISTRAR_TAB_LABEL_KEYS[activeTab] || 'tabs_appointments');
+  const statusFilterLabel = statusFilter ? t(REGISTRAR_STATUS_LABEL_KEYS[statusFilter] || statusFilter) : null;
   const { theme, isDark, getSpacing, getFontSize, getColor } = useTheme();
   // Адаптивные цвета из централизованной системы темизации
   const cardBg = isDark ? 'var(--color-background-primary)' : 'var(--color-background-secondary)';
@@ -3514,6 +3571,65 @@ const RegistrarPanel = () => {
             ...tableContentStyle,
             padding: isMobile ? '0.5rem' : '1rem'
           }}>
+
+              <div
+                style={registrarWorkflowHeaderStyle}
+                aria-label="Сводка рабочего списка регистратуры">
+                <div style={{ minWidth: 0, flex: '1 1 280px' }}>
+                  <div style={{
+                    color: 'var(--mac-text-secondary)',
+                    fontSize: 'var(--mac-font-size-xs)',
+                    fontWeight: 'var(--mac-font-weight-semibold)',
+                    letterSpacing: '0.04em',
+                    textTransform: 'uppercase',
+                    marginBottom: 'var(--mac-spacing-1)'
+                  }}>
+                    Регистратура
+                  </div>
+                  <h2 style={registrarWorkflowTitleStyle}>
+                    Рабочий список: {currentWorklistLabel}
+                  </h2>
+                  <p style={registrarWorkflowMetaStyle}>
+                    {showCalendar ?
+                    new Date(historyDate).toLocaleDateString(language === 'ru' ? 'ru-RU' : 'uz-UZ', { day: 'numeric', month: 'long', year: 'numeric' }) :
+                    t('today')} · {filteredAppointments.length} {t('tabs_appointments')}
+                  </p>
+                </div>
+
+                <div style={registrarWorkflowActionsStyle}>
+                  {statusFilterLabel &&
+                  <Badge variant="warning" style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 'var(--mac-spacing-1)'
+                  }}>
+                      <Icon name="magnifyingglass" size="small" />
+                      Фильтр: {statusFilterLabel}
+                    </Badge>
+                  }
+                  <Badge variant={appointmentsLoading ? 'info' : 'secondary'}>
+                    {appointmentsLoading ? t('loading') : `${filteredAppointments.length} ${t('tabs_appointments')}`}
+                  </Badge>
+                  <Button
+                  variant="primary"
+                  size="default"
+                  onClick={() => {
+                    setWizardEditMode(false);
+                    setWizardInitialData(null);
+                    setShowWizard(true);
+                  }}
+                  aria-label="Создать новую запись из рабочего списка регистратора"
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 'var(--mac-spacing-2)',
+                    flexShrink: 0
+                  }}>
+                    <Icon name="plus" size="small" style={{ color: 'white' }} />
+                    {t('new_appointment')}
+                  </Button>
+                </div>
+              </div>
 
               {/* Массовые действия */}
               {appointmentsSelected.size > 0 &&


### PR DESCRIPTION
﻿## Summary
- Add a compact Registrar worklist header above the main appointment table.
- Surface the active worklist, selected status filter, visible row count, and primary create action before staff reaches the table.
- Mark PR-UX-13 complete in the remaining UI/UX rollout checklist.

## Contract Impact
- Canonical surface: `RegistrarPanel` visible workflow hierarchy only.
- Request shape: Unchanged; no API client, request builder, or backend call changed.
- Response shape: Unchanged; existing appointment arrays and filters are only displayed more clearly.
- Status codes: Unchanged; no backend or frontend status handling changed.
- Frontend consumer: Registrar route `/registrar` renders an additional worklist header using existing state and macOS UI primitives.
- Compatibility path or alias: No route, alias, redirect, or compatibility path changed.
- Contract proof: No backend/API/RBAC files changed; lint, build, browser smoke, and staged diff check passed.

## RBAC / Permissions
- Roles allowed: Unchanged; `/registrar` remains controlled by the existing route guard.
- Roles denied: Unchanged; no auth, role, token, or route registry code changed.
- Positive auth proof: Authenticated Registrar browser smoke rendered `/registrar` and `/registrar?status=queued` with the new worklist header.
- Negative auth proof: Not changed in this PR; negative RBAC smoke was added in PR-UX-13 and production RBAC logic is untouched here.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no notification, websocket, polling, or realtime code changed.
- Payload version / ack behavior: Unchanged; no realtime payload or acknowledgement behavior touched.
- Read/unread or delivery semantics: Unchanged; no notification read/delivery state touched.
- Reconnect/resync proof: No subscription, reconnect, polling, or resync code changed; this PR only renders existing Registrar state more clearly.

## Frontend Resilience
- Empty data proof: Authenticated browser smoke used the QA harness with empty collection payloads and verified the worklist header renders.
- Partial data proof: The header uses existing `filteredAppointments`, `statusFilter`, and tab state without changing parsing or fallback behavior.
- Forbidden secondary path behavior: Unchanged; route guard behavior was not modified.
- Missing draft/resource behavior: Unchanged; no draft/resource runtime logic changed.
- Stale route/deep-link behavior: Browser smoke opened `/registrar?status=queued` directly and verified the filter badge appears.

## Scope Gate
- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx` and the UI/UX rollout checklist.
- Denied paths: Backend, API clients, route registry, auth/RBAC, payments, queue mutation logic, EMR/lab logic, notifications, migrations, workflows, and shared table behavior.
- Migration/docs/test impact: No migration impact; checklist updated only for rollout tracking.
- Rollback note: Revert this commit to remove the visual worklist header and return to the previous Registrar table layout.

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run lint:check`; `cd frontend; npm.cmd run build`; authenticated browser smoke for `/registrar` at `375x812` and `1280x800`; authenticated browser smoke for `/registrar?status=queued`; `git diff --cached --check`.
- Result: Passed. Lint still reports the existing 56 warnings and build still reports the existing Vite dynamic/static import and large chunk warnings.
- Not checked: Live backend data, production credentials, full e2e matrix, and non-Registrar role workflows.
