### PR TITLE
fix(frontend): lazy load heic conversion boundary

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -381,12 +381,12 @@ async function syncClinicData() {
 // Обработка HEIC конвертации
 self.addEventListener('message', (event) => {
   if (event.data && event.data.type === 'CONVERT_HEIC') {
-    event.waitUntil(convertHEICToJPEG(event.data.file, event.ports[0]));
+    event.waitUntil(convertHEICToJPEG(event.data.file, event.ports[0], event.data.quality));
   }
 });
 
 // HEIC → JPEG конвертация
-async function convertHEICToJPEG(heicFile, port) {
+async function convertHEICToJPEG(heicFile, port, quality = 0.8) {
   try {
     // Импортируем heic2any динамически
     const heic2any = (await import('https://cdn.skypack.dev/heic2any')).default;
@@ -394,7 +394,7 @@ async function convertHEICToJPEG(heicFile, port) {
     const jpegBlob = await heic2any({
       blob: heicFile,
       toType: 'image/jpeg',
-      quality: 0.8
+      quality
     });
     
     port.postMessage({

--- a/frontend/src/components/dermatology/PhotoUploader.jsx
+++ b/frontend/src/components/dermatology/PhotoUploader.jsx
@@ -34,10 +34,10 @@ import {
 
 'lucide-react';
 import { useDropzone } from 'react-dropzone';
-import heic2any from 'heic2any';
 import { api } from '../../api/client';
 
 import logger from '../../utils/logger';
+import { convertHEICToJPEG, isHEICFile } from '../../utils/heicConverter';
 import PropTypes from 'prop-types';
 const PhotoUploader = ({ visitId, onDataUpdate }) => {
   const [photos, setPhotos] = useState({
@@ -73,25 +73,13 @@ const PhotoUploader = ({ visitId, onDataUpdate }) => {
   const convertHEICtoJPEG = async (file) => {
     setConverting(true);
     try {
-      const blob = await heic2any({
-        blob: file,
-        toType: 'image/jpeg',
-        quality: 0.9
-      });
+      return await convertHEICToJPEG(file, 0.9);
 
-      // Создаем новый File объект
-      const convertedFile = new File(
-        [blob],
-        file.name.replace(/\.heic$/i, '.jpg'),
-        { type: 'image/jpeg' }
-      );
-
-      setConverting(false);
-      return convertedFile;
     } catch (error) {
       logger.error('Ошибка конвертации HEIC:', error);
-      setConverting(false);
       throw error;
+    } finally {
+      setConverting(false);
     }
   };
 
@@ -103,7 +91,7 @@ const PhotoUploader = ({ visitId, onDataUpdate }) => {
       try {
         // Проверяем и конвертируем HEIC
         let processedFile = file;
-        if (file.type === 'image/heic' || file.name.toLowerCase().endsWith('.heic')) {
+        if (isHEICFile(file)) {
           processedFile = await convertHEICtoJPEG(file);
         }
 

--- a/frontend/src/components/ui/FileUpload.jsx
+++ b/frontend/src/components/ui/FileUpload.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
-import heic2any from 'heic2any';
 import { Upload, X, File as FileIcon, AlertCircle, Loader } from 'lucide-react';
 import logger from '../../utils/logger';
+import { convertHEICToJPEG, isHEICFile } from '../../utils/heicConverter';
 import '../../styles/animations.css';
 import PropTypes from 'prop-types';
 
@@ -24,31 +24,6 @@ const FileUpload = ({
   const [converting, setConverting] = useState(false);
   const [error, setError] = useState(null);
   const [previews, setPreviews] = useState([]);
-
-  // Convert HEIC to JPEG
-  const convertHEICtoJPEG = async (file) => {
-    try {
-      const blob = await heic2any({
-        blob: file,
-        toType: 'image/jpeg',
-        quality: 0.9
-      });
-
-      // Handle generic blob or array of blobs
-      const resultBlob = Array.isArray(blob) ? blob[0] : blob;
-
-      const convertedFile = new File(
-        [resultBlob],
-        file.name.replace(/\.heic$/i, '.jpg').replace(/\.heif$/i, '.jpg'),
-        { type: 'image/jpeg' }
-      );
-
-      return convertedFile;
-    } catch (err) {
-      logger.error('HEIC conversion error:', err);
-      throw new Error('Failed to convert HEIC image');
-    }
-  };
 
   const handleDrop = useCallback(async (acceptedFiles, rejectedFiles) => {
     setError(null);
@@ -73,14 +48,9 @@ const FileUpload = ({
         let fileToProcess = file;
 
         // Check if HEIC/HEIF
-        if (
-        file.type === 'image/heic' ||
-        file.type === 'image/heif' ||
-        file.name.toLowerCase().endsWith('.heic') ||
-        file.name.toLowerCase().endsWith('.heif'))
-        {
+        if (isHEICFile(file)) {
           try {
-            fileToProcess = await convertHEICtoJPEG(file);
+            fileToProcess = await convertHEICToJPEG(file, 0.9);
           } catch {
             logger.warn(`Could not convert ${file.name}, using original`);
           }

--- a/frontend/src/components/ui/__tests__/FileUpload.test.jsx
+++ b/frontend/src/components/ui/__tests__/FileUpload.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import heic2any from 'heic2any';
 
 import FileUpload from '../FileUpload';
 
@@ -24,6 +25,7 @@ describe('FileUpload accessibility', () => {
       createObjectURL: vi.fn(() => 'blob:test'),
       revokeObjectURL: vi.fn(),
     });
+    heic2any.mockClear();
   });
 
   it('links upload errors to the input', async () => {
@@ -50,5 +52,29 @@ describe('FileUpload accessibility', () => {
     fireEvent.change(input, { target: { files: [imageFile] } });
 
     expect(await screen.findByRole('button', { name: /remove test\.png/i })).toBeInTheDocument();
+  });
+
+  it('converts HEIC uploads to JPEG through the shared converter boundary', async () => {
+    const onFilesSelected = vi.fn();
+    const { container } = render(<FileUpload onFilesSelected={onFilesSelected} />);
+    const input = container.querySelector('input');
+    const heicFile = new File(['test'], 'skin.heic', { type: 'image/heic' });
+
+    fireEvent.change(input, { target: { files: [heicFile] } });
+
+    await waitFor(() => {
+      expect(onFilesSelected).toHaveBeenCalledTimes(1);
+    });
+
+    expect(heic2any).toHaveBeenCalledWith({
+      blob: heicFile,
+      toType: 'image/jpeg',
+      quality: 0.9,
+    });
+
+    const [processedFiles] = onFilesSelected.mock.calls[0];
+    expect(processedFiles[0]).toBeInstanceOf(File);
+    expect(processedFiles[0].name).toBe('skin.jpg');
+    expect(processedFiles[0].type).toBe('image/jpeg');
   });
 });

--- a/frontend/src/utils/heicConverter.js
+++ b/frontend/src/utils/heicConverter.js
@@ -23,6 +23,21 @@ export function isHEICFile(file) {
   return fileName.endsWith('.heic') || fileName.endsWith('.heif');
 }
 
+function getConvertedBlob(convertedBlob) {
+  return Array.isArray(convertedBlob) ? convertedBlob[0] : convertedBlob;
+}
+
+function createJPEGFile(sourceFile, convertedBlob) {
+  return new File(
+    [getConvertedBlob(convertedBlob)],
+    sourceFile.name.replace(/\.(heic|heif)$/i, '.jpg'),
+    {
+      type: 'image/jpeg',
+      lastModified: Date.now()
+    }
+  );
+}
+
 /**
  * Конвертирует HEIC файл в JPEG через Service Worker
  * @param {File} heicFile - HEIC файл
@@ -52,16 +67,7 @@ export async function convertHEICToJPEG(heicFile, quality = 0.8) {
 
         if (success) {
           // Создаем новый File объект из Blob
-          const jpegFile = new File(
-            [convertedFile],
-            heicFile.name.replace(/\.(heic|heif)$/i, '.jpg'),
-            {
-              type: 'image/jpeg',
-              lastModified: Date.now()
-            }
-          );
-
-          resolve(jpegFile);
+          resolve(createJPEGFile(heicFile, convertedFile));
         } else {
           reject(new Error(error || 'Ошибка конвертации'));
         }
@@ -101,16 +107,7 @@ async function convertHEICFallback(heicFile, quality = 0.8) {
     });
 
     // Создаем File из Blob
-    const jpegFile = new File(
-      [jpegBlob],
-      heicFile.name.replace(/\.(heic|heif)$/i, '.jpg'),
-      {
-        type: 'image/jpeg',
-        lastModified: Date.now()
-      }
-    );
-
-    return jpegFile;
+    return createJPEGFile(heicFile, jpegBlob);
 
   } catch (error) {
     logger.error('HEIC fallback conversion failed:', error);


### PR DESCRIPTION
﻿## Summary
- Removed static runtime `heic2any` imports from `FileUpload.jsx` and dermatology `PhotoUploader.jsx`.
- Routed HEIC/HEIF detection and conversion through the shared `heicConverter.js` boundary, where `heic2any` remains dynamically imported only when conversion is needed.
- Preserved upload conversion quality by passing the requested `quality` through the service worker HEIC conversion path.
- Added a targeted FileUpload test proving HEIC uploads still convert to a JPEG file before `onFilesSelected` receives them.

## Contract Impact
- Canonical surface: Frontend file upload HEIC conversion boundary: `frontend/src/utils/heicConverter.js`, `frontend/src/components/ui/FileUpload.jsx`, dermatology `PhotoUploader.jsx`, and `frontend/public/sw.js` HEIC message handler.
- Request shape: Unchanged; upload forms and multipart payload fields stay the same.
- Response shape: Unchanged; upload API responses and local callback shapes stay the same.
- Status codes: Unchanged; no API status handling changed.
- Frontend consumer: File upload consumers still receive `File[]`; HEIC/HEIF inputs are converted to JPEG when conversion succeeds, otherwise existing fallback behavior keeps the original file.
- Compatibility path or alias: Unchanged; no routes, aliases, or public component names changed.
- Contract proof: `npm.cmd run test:run -- src/components/ui/__tests__/FileUpload.test.jsx` passed and asserts HEIC input becomes `skin.jpg` with `image/jpeg` type.

## RBAC / Permissions
- Roles allowed: Unchanged; no role permissions or route guards changed.
- Roles denied: Unchanged; protected route denial behavior is untouched.
- Positive auth proof: Unchanged; upload API auth behavior was not modified.
- Negative auth proof: Unchanged; no bypass, fixture, or auth fallback was added.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no websocket or notification channel changed.
- Payload version / ack behavior: Unchanged; no realtime payloads changed.
- Read/unread or delivery semantics: Unchanged; notification state is untouched.
- Reconnect/resync proof: Unchanged; no reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: Unchanged; this PR only changes upload conversion boundaries.
- Partial data proof: HEIC conversion failure still falls back to the original file in `FileUpload`; dermatology upload still logs and stops the failed photo upload path as before.
- Forbidden secondary path behavior: Unchanged; no forbidden-route behavior changed.
- Missing draft/resource behavior: Unchanged; no draft/resource logic changed.
- Stale route/deep-link behavior: Unchanged; no routing or deep-link logic changed.

## Scope Gate
- Allowed paths: `frontend/src/utils/heicConverter.js`, `frontend/src/components/ui/FileUpload.jsx`, `frontend/src/components/dermatology/PhotoUploader.jsx`, `frontend/public/sw.js`, `frontend/src/components/ui/__tests__/FileUpload.test.jsx`.
- Denied paths: Backend, database, route registry, RBAC, upload API contracts, package files, Vite config, and unrelated UI surfaces.
- Migration/docs/test impact: No migrations or docs; one targeted frontend test was extended for HEIC conversion proof.
- Rollback note: Revert this commit to restore direct static `heic2any` imports inside the two upload components.

## Validation
- Targeted tests or smoke run: `npm.cmd run test:run -- src/components/ui/__tests__/FileUpload.test.jsx`; `npm.cmd run lint:check`; `npm.cmd run build`; `git diff --check`; `rg 'heic2any' frontend\\src -n`.
- Result: All commands passed. Lint still reports the existing 56 warnings. Build still reports the existing large chunk warning, but runtime static `heic2any` imports are gone from upload components and `heic2any` remains behind the shared dynamic converter boundary.
- Not checked: Browser file-upload smoke with a real HEIC image was not run because no safe local HEIC fixture is present; the mocked conversion test covers the boundary and output file shape.
