### PR TITLE
fix(frontend): split admin graphql explorer chunk

### DIFF
--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -155,7 +155,6 @@ import ClinicManagement from '../components/admin/ClinicManagement';
 
 import WaitTimeAnalytics from '../components/analytics/WaitTimeAnalytics';
 import AIAnalytics from '../components/analytics/AIAnalytics';
-import GraphQLExplorer from '../components/admin/GraphQLExplorer';
 import WebhookManager from '../components/admin/WebhookManager';
 import UnifiedReports from '../components/admin/UnifiedReports';
 import SystemManagement from '../components/admin/SystemManagement';
@@ -173,6 +172,8 @@ import { MobileNavigation } from '../components/admin/MobileOptimization';
 import logger from '../utils/logger';
 import tokenManager from '../utils/tokenManager';
 import '../styles/admin-styles.css';
+
+const LazyGraphQLExplorer = React.lazy(() => import('../components/admin/GraphQLExplorer'));
 
 const getAppointmentPatientDisplayName = (appointment) => {
   const rawName =
@@ -2590,7 +2591,11 @@ const AdminPanel = () => {
       case 'queue-cabinet-management':
         return <QueueCabinetManagement />;
       case 'graphql-explorer':
-        return <GraphQLExplorer />;
+        return (
+          <React.Suspense fallback={<MacOSLoadingSkeleton style={{ height: '384px' }} />}>
+            <LazyGraphQLExplorer />
+          </React.Suspense>
+        );
       case 'services':{
           // Вкладки для секции Services
           // ⭐ SSOT: DepartmentManagement удалён - QueueProfilesManager теперь единственный источник для вкладок регистратуры


### PR DESCRIPTION
﻿## Summary
- Split the admin GraphQL Explorer into its own lazy-loaded chunk inside `AdminPanel.jsx`.
- Left the route registry, Admin-only RBAC, and `/admin/graphql-explorer` ownership unchanged.
- Production build now emits a separate `GraphQLExplorer-*` chunk around 15.5 KB and lowers the `AdminPanel-*` chunk from the previous ~1127 KB baseline to ~1114 KB.

## Contract Impact
- Canonical surface: `frontend/src/pages/AdminPanel.jsx` render branch for the existing `graphql-explorer` admin section.
- Request shape: Unchanged; GraphQL Explorer requests and headers are still owned by `GraphQLExplorer.jsx`.
- Response shape: Unchanged; GraphQL Explorer result rendering is untouched.
- Status codes: Unchanged; no API status handling changed.
- Frontend consumer: Admin users still reach the same GraphQL Explorer surface through `/admin/graphql-explorer` / `section=graphql-explorer`; the component now loads on demand.
- Compatibility path or alias: Unchanged; no route, redirect, alias, or query parameter changed.
- Contract proof: `npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js` passed and `npm.cmd run build` emitted a dedicated `GraphQLExplorer-*` chunk.

## RBAC / Permissions
- Roles allowed: Unchanged; route registry still scopes `/admin/graphql-explorer` to `Admin`.
- Roles denied: Unchanged; no role guards or route protection changed.
- Positive auth proof: Route registry inspection keeps `auth: 'role-scoped'` and `roles: ['Admin']` for `admin-graphql-explorer`.
- Negative auth proof: No forbidden-route logic changed; route guard semantics remain owned by existing routing/RBAC code.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no realtime or notification channel changed.
- Payload version / ack behavior: Unchanged; no payload/ack behavior changed.
- Read/unread or delivery semantics: Unchanged; notification state is untouched.
- Reconnect/resync proof: Unchanged; websocket reconnect/resync code was not modified.

## Frontend Resilience
- Empty data proof: Unchanged; GraphQL Explorer empty/loading/error behavior stays inside the lazily loaded component.
- Partial data proof: Unchanged; no result parsing or data normalization changed.
- Forbidden secondary path behavior: Unchanged; route/RBAC denial behavior is untouched.
- Missing draft/resource behavior: Unchanged; no draft/resource flow changed.
- Stale route/deep-link behavior: Existing direct route/query entry continues to render through the same AdminPanel section, now with a MacOS skeleton fallback while the chunk loads.

## Scope Gate
- Allowed paths: `frontend/src/pages/AdminPanel.jsx`.
- Denied paths: Route registry, backend, RBAC, API clients, GraphQL Explorer internals, package files, Vite config, and unrelated admin sections.
- Migration/docs/test impact: No migrations or docs; no test files changed.
- Rollback note: Revert this commit to restore the static `GraphQLExplorer` import in `AdminPanel.jsx`.

## Validation
- Targeted tests or smoke run: `npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js`; `npm.cmd run lint:check`; `npm.cmd run build`; `git diff --check`.
- Result: All commands passed. Lint still reports the existing 56 warnings. Build still reports the existing large chunk warning, but the GraphQL Explorer is now split into its own chunk and AdminPanel chunk size is reduced.
- Not checked: Authenticated browser smoke for `/admin/graphql-explorer` was not run because the live admin Playwright spec requires prebuilt authenticated storage/backend data; this PR is limited to a build-proven lazy boundary.
