### PR TITLE
fix(frontend): split dentistry reports chunk

### DIFF
--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { lazy, Suspense, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTheme } from '../contexts/ThemeContext';
 import { Button, Badge, Card } from '../components/ui/macos';
@@ -16,7 +16,6 @@ import DiagnosisForm from '../components/dental/DiagnosisForm';
 import VisitProtocol from '../components/dental/VisitProtocol';
 import PhotoArchive from '../components/dental/PhotoArchive';
 import ProtocolTemplates from '../components/dental/ProtocolTemplates';
-import ReportsAndAnalytics from '../components/dental/ReportsAndAnalytics';
 import ScheduleNextModal from '../components/common/ScheduleNextModal';
 import EnhancedAppointmentsTable from '../components/tables/EnhancedAppointmentsTable';
 import QueueIntegration from '../components/QueueIntegration';
@@ -62,10 +61,18 @@ import { isDentistrySpecialty } from '../utils/dentistrySpecialty';
 import logger from '../utils/logger';
 import tokenManager from '../utils/tokenManager';
 
+const LazyReportsAndAnalytics = lazy(() => import('../components/dental/ReportsAndAnalytics'));
+
 const API_V1_BASE = getApiBaseUrl();
 const DENTISTRY_WAITING_STATUSES = ['waiting', 'confirmed', 'pending'];
 const DENTISTRY_CALLED_STATUSES = ['called', 'in_progress'];
 const DENTISTRY_COMPLETED_STATUSES = ['completed', 'done'];
+const DENTISTRY_LAZY_FALLBACK_STYLE = {
+  margin: 'var(--mac-spacing-4)',
+  padding: 'var(--mac-spacing-4)',
+  color: 'var(--mac-text-secondary)',
+  textAlign: 'center'
+};
 const dentistryAppointmentsHeaderStyle = {
   display: 'flex',
   justifyContent: 'space-between',
@@ -3522,7 +3529,13 @@ const DentistPanelUnified = () => {
       }
 
       {showReports &&
-      <ReportsAndAnalytics
+      <Suspense
+        fallback={
+          <Card role="status" aria-live="polite" style={DENTISTRY_LAZY_FALLBACK_STYLE}>
+            Загрузка отчетов...
+          </Card>
+        }>
+        <LazyReportsAndAnalytics
         patientId={selectedPatient?.id}
         doctorId={user?.id}
         clinicId={user?.clinic_id}
@@ -3531,7 +3544,8 @@ const DentistPanelUnified = () => {
           logger.info('Сохранение отчета:', reportData);
           setShowReports(false);
         }}
-        onClose={() => setShowReports(false)} />
+          onClose={() => setShowReports(false)} />
+      </Suspense>
 
       }
 


### PR DESCRIPTION
﻿## Summary
- Split the dentistry `ReportsAndAnalytics` optional reports surface into a lazy-loaded chunk from `DentistPanelUnified.jsx`.
- Preserved dentistry route ownership, active tab handling, patient selection, visit identity, print flow, EMR bridge, and clinical status wording.
- Production build now emits a separate `ReportsAndAnalytics-*` chunk around 17 KB and lowers `DentistPanelUnified-*` from the previous ~262 KB baseline to ~248 KB.

## Contract Impact
- Canonical surface: `frontend/src/pages/DentistPanelUnified.jsx` optional reports modal boundary.
- Request shape: Unchanged; reports requests remain owned by `ReportsAndAnalytics.jsx`.
- Response shape: Unchanged; reports data rendering and save callback shape are untouched.
- Status codes: Unchanged; no API status handling changed.
- Frontend consumer: Dentistry users still open reports from the same panel action; the reports component now loads on demand with a small status fallback.
- Compatibility path or alias: Unchanged; no route, tab id, query parameter, or redirect changed.
- Contract proof: `npm.cmd run build` passed and emitted `ReportsAndAnalytics-*`; `npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js` passed.

## RBAC / Permissions
- Roles allowed: Unchanged; `/doctor/dentistry` route roles are untouched.
- Roles denied: Unchanged; no route guard or denial behavior changed.
- Positive auth proof: Route ownership test still passes, and this PR does not edit route registry or auth stores.
- Negative auth proof: No forbidden-route logic, fixture bypass, or permission fallback was added.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no realtime or notification channel changed.
- Payload version / ack behavior: Unchanged; no payload/ack behavior changed.
- Read/unread or delivery semantics: Unchanged; notification state is untouched.
- Reconnect/resync proof: Unchanged; websocket reconnect/resync code was not modified.

## Frontend Resilience
- Empty data proof: Unchanged; reports empty/loading/error behavior stays inside `ReportsAndAnalytics.jsx`.
- Partial data proof: Unchanged; no report parsing or data normalization changed.
- Forbidden secondary path behavior: Unchanged; forbidden behavior remains route/RBAC owned.
- Missing draft/resource behavior: Unchanged; no draft, visit, patient, or EMR resource flow changed.
- Stale route/deep-link behavior: Unchanged; dentistry tab/query handling is untouched.

## Scope Gate
- Allowed paths: `frontend/src/pages/DentistPanelUnified.jsx`.
- Denied paths: Backend, database, route registry, RBAC, EMR bridge internals, visit protocol, print payloads, package files, Vite config, and other specialty panels.
- Migration/docs/test impact: No migrations, docs, or test files changed.
- Rollback note: Revert this commit to restore the static `ReportsAndAnalytics` import in `DentistPanelUnified.jsx`.

## Validation
- Targeted tests or smoke run: `npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js`; `npm.cmd run lint:check`; `npm.cmd run build`; `git diff --check`.
- Result: All commands passed. Lint still reports the existing 56 warnings. Build still reports the existing large chunk warning, but `ReportsAndAnalytics-*` is split out and `DentistPanelUnified-*` is smaller.
- Not checked: Authenticated browser smoke for the dentistry reports modal was not run because this PR only changes a build-proven lazy boundary and local authenticated data is not required for the static/runtime proof.
