### PR TITLE
fix(frontend): lazy load utility route components

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,16 +18,9 @@ import { Alert, Badge, Card, CardContent, Sidebar } from './components/ui/macos'
 import HeaderNew from './components/layout/HeaderNew.jsx';
 import Health from './pages/Health.jsx';
 import Landing from './pages/Landing.jsx';
-import ButtonShowcase from './components/buttons/ButtonShowcase.jsx';
 import LoginFormStyled from './components/auth/LoginFormStyled.jsx';
 import Setup from './pages/Setup.jsx';
 import { useSetupStatus } from './hooks/useSetupStatus.js';
-import TelegramManager from './components/TelegramManager.jsx';
-import EmailSMSManager from './components/notifications/EmailSMSManager.jsx';
-import TwoFactorManager from './components/security/TwoFactorManager.jsx';
-import FileManager from './components/files/FileManager.jsx';
-import UserManagement from './components/admin/UserManagement.jsx';
-import IntegrationDemo from './components/integration/IntegrationDemo.jsx';
 import { api } from './api/client.js';
 import auth from './stores/auth.js';
 import { ROUTE_REGISTRY } from './routing/routeRegistry.js';
@@ -68,6 +61,13 @@ const SecurityPage = lazy(() => import('./pages/SecurityPage.jsx'));
 const ChangePasswordRequired = lazy(() => import('./pages/auth/ChangePasswordRequired.jsx'));
 const PatientPickupView = lazy(() => import('./pages/PatientPickupView.jsx'));
 const UserProfile = lazy(() => import('./pages/UserProfile.jsx'));
+const ButtonShowcase = lazy(() => import('./components/buttons/ButtonShowcase.jsx'));
+const TelegramManager = lazy(() => import('./components/TelegramManager.jsx'));
+const EmailSMSManager = lazy(() => import('./components/notifications/EmailSMSManager.jsx'));
+const TwoFactorManager = lazy(() => import('./components/security/TwoFactorManager.jsx'));
+const FileManager = lazy(() => import('./components/files/FileManager.jsx'));
+const UserManagement = lazy(() => import('./components/admin/UserManagement.jsx'));
+const IntegrationDemo = lazy(() => import('./components/integration/IntegrationDemo.jsx'));
 
 const ROUTE_COMPONENTS = {
   Landing,


### PR DESCRIPTION
﻿## Summary
- Lazy-load rare utility route components from `frontend/src/App.jsx` instead of statically importing them into the initial app graph.
- Moved `TelegramManager`, `EmailSMSManager`, `TwoFactorManager`, `FileManager`, `UserManagement`, `IntegrationDemo`, and `ButtonShowcase` behind the existing `React.lazy` + route `Suspense` boundary.
- Preserved route registry entries, RBAC boundaries, component internals, and public route behavior.

## Contract Impact
- Canonical surface: `frontend/src/App.jsx` route component registry.
- Request shape: Unchanged; no API request payloads changed.
- Response shape: Unchanged; no API response handling changed.
- Status codes: Unchanged; no backend or HTTP contract changed.
- Frontend consumer: Route renderer still resolves the same component names from `ROUTE_REGISTRY`.
- Compatibility path or alias: Unchanged; legacy redirects and route aliases remain registry-owned.
- Contract proof: `npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js` passed.

## RBAC / Permissions
- Roles allowed: Unchanged; route access remains enforced by `RouteAccessBoundary` and `ROUTE_REGISTRY`.
- Roles denied: Unchanged; no auth guard, role list, or denial surface changed.
- Positive auth proof: Existing authenticated route components remain rendered through the same registry keys after lazy resolution.
- Negative auth proof: No protected route or denial behavior changed in this frontend-only import boundary slice.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no notification, websocket, Telegram, or realtime event channel changed.
- Payload version / ack behavior: Unchanged; no payload or ack behavior changed.
- Read/unread or delivery semantics: Unchanged; notification manager internals were not edited.
- Reconnect/resync proof: Unchanged; this PR changes only route component import timing.

## Frontend Resilience
- Empty data proof: Unchanged; utility route empty states remain inside their original components.
- Partial data proof: Unchanged; lazy loading does not alter component data handling.
- Forbidden secondary path behavior: Unchanged; route guard still wraps the resolved component before rendering.
- Missing draft/resource behavior: Unchanged; no draft/resource route logic changed.
- Stale route/deep-link behavior: Unchanged; deep links still resolve through `ROUTE_REGISTRY` and `RouteRenderer`.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`.
- Denied paths: Backend, database migrations, route registry, RBAC rules, payment/queue/EMR/lab/Telegram logic, package files, Vite config.
- Migration/docs/test impact: No migration or docs changes; targeted route ownership test validates registry coupling.
- Rollback note: Revert the single commit to restore previous static imports if an unexpected route lazy-loading regression appears.

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js`; `cd frontend; npm.cmd run lint:check`; `cd frontend; npm.cmd run build`; `git diff --check`.
- Result: Passed. Lint still reports the existing 56 warnings and 0 errors. Build passed; top initial `index` chunk dropped from about `1731.55 KiB` before this slice to about `1385.64 KiB`, below the current Vite warning threshold.
- Not checked: Browser navigation smoke for every lazy utility route was left to CI/frontend e2e because component internals, route paths, and guards were not changed.
