### PR TITLE
fix(frontend): lazy load admin queue profiles view

### DIFF
--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -165,7 +165,6 @@ import { getApiOrigin } from '../api/runtime';
 
 
 
-import QueueProfilesManager from '../components/admin/QueueProfilesManager'; // ⭐ SSOT: Dynamic queue tabs management
 import { useAdminHotkeys } from '../hooks/useHotkeys';
 import { HotkeysModal } from '../components/admin/HelpTooltip';
 import { MobileNavigation } from '../components/admin/MobileOptimization';
@@ -174,6 +173,7 @@ import tokenManager from '../utils/tokenManager';
 import '../styles/admin-styles.css';
 
 const LazyGraphQLExplorer = React.lazy(() => import('../components/admin/GraphQLExplorer'));
+const LazyQueueProfilesManager = React.lazy(() => import('../components/admin/QueueProfilesManager'));
 
 const getAppointmentPatientDisplayName = (appointment) => {
   const rawName =
@@ -2662,13 +2662,21 @@ const AdminPanel = () => {
 
             {/* Содержимое вкладок */}
             {servicesTab === 'catalog' && <ServiceCatalog />}
-            {servicesTab === 'queue-profiles' && <QueueProfilesManager theme={isDark ? 'dark' : 'light'} />}
+            {servicesTab === 'queue-profiles' && (
+              <React.Suspense fallback={<MacOSLoadingSkeleton style={{ height: '384px' }} />}>
+                <LazyQueueProfilesManager theme={isDark ? 'dark' : 'light'} />
+              </React.Suspense>
+            )}
           </div>);
 
         }
       case 'departments':
         // ⭐ DEPRECATED: Redirect to SSOT queue-profiles
-        return <QueueProfilesManager theme={isDark ? 'dark' : 'light'} />;
+        return (
+          <React.Suspense fallback={<MacOSLoadingSkeleton style={{ height: '384px' }} />}>
+            <LazyQueueProfilesManager theme={isDark ? 'dark' : 'light'} />
+          </React.Suspense>
+        );
       case 'ai-settings':
         return <UnifiedSettings />;
       case 'display-settings':


### PR DESCRIPTION
﻿## Summary
- Lazy-load the admin `QueueProfilesManager` view from `AdminPanel.jsx` instead of keeping it in the base admin route chunk.
- Preserved the services tab behavior, departments compatibility path, query/localStorage state, and admin route ownership.
- Added the same lightweight `MacOSLoadingSkeleton` lazy boundary already used for the GraphQL explorer child view.

## Contract Impact
- Canonical surface: `frontend/src/pages/AdminPanel.jsx` admin route child rendering.
- Request shape: Unchanged; no API request payloads changed.
- Response shape: Unchanged; no API response handling changed.
- Status codes: Unchanged; no backend or HTTP status handling changed.
- Frontend consumer: Admin services/departments views still render `QueueProfilesManager` with the same `theme` prop.
- Compatibility path or alias: Unchanged; the deprecated `departments` case still renders the queue profiles SSOT view.
- Contract proof: `npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js` passed.

## RBAC / Permissions
- Roles allowed: Unchanged; admin route access remains governed by `ROUTE_REGISTRY` and `RouteAccessBoundary`.
- Roles denied: Unchanged; no denial routes, role lists, or auth guards changed.
- Positive auth proof: Existing admin route rendering remains wired through `AdminPanel` and the same `current` switch cases.
- Negative auth proof: No protected route denial behavior changed in this import-boundary-only slice.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no notification, websocket, Telegram, queue, or realtime channel changed.
- Payload version / ack behavior: Unchanged; no payload or ack semantics changed.
- Read/unread or delivery semantics: Unchanged; notification delivery code was not touched.
- Reconnect/resync proof: Unchanged; this PR changes only admin child component loading timing.

## Frontend Resilience
- Empty data proof: Unchanged; `QueueProfilesManager` empty states remain inside the original component.
- Partial data proof: Unchanged; lazy loading does not alter queue profile data handling.
- Forbidden secondary path behavior: Unchanged; admin route guards continue to wrap `AdminPanel` before child rendering.
- Missing draft/resource behavior: Unchanged; no draft/resource flow changed.
- Stale route/deep-link behavior: Unchanged; `servicesTab=queue-profiles` and `departments` still resolve to the same view after the lazy boundary loads.

## Scope Gate
- Allowed paths: `frontend/src/pages/AdminPanel.jsx`.
- Denied paths: Backend, migrations, route registry, RBAC, queue profile logic, services catalog logic, Telegram, payment, lab/EMR, package files, Vite config.
- Migration/docs/test impact: No migration or docs changes; targeted route ownership test validates registry coupling.
- Rollback note: Revert the single commit to restore the previous static `QueueProfilesManager` import.

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js`; `cd frontend; npm.cmd run lint:check`; `cd frontend; npm.cmd run build`; `git diff --check`.
- Result: Passed. Lint still reports the existing 56 warnings and 0 errors. Build passed; `QueueProfilesManager` now emits its own chunk and `AdminPanel` dropped from about `1089.72 KiB` to about `1067.29 KiB` in the local asset inventory.
- Not checked: Browser click-through for the admin services tab was left to CI/frontend e2e because tab state, URL params, localStorage, and queue profile component internals were not changed.
