### PR TITLE
fix(frontend): lazy load admin service catalog view

### DIFF
--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -113,7 +113,6 @@ import AnalyticsDashboard from '../components/admin/AnalyticsDashboard';
 import AdminRouteSwitcher from '../components/admin/AdminRouteSwitcher';
 
 
-import ServiceCatalog from '../components/admin/ServiceCatalog';
 // ⭐ DEPRECATED: DepartmentManagement replaced by QueueProfilesManager (SSOT)
 // import DepartmentManagement from '../components/admin/DepartmentManagement';
 
@@ -174,6 +173,7 @@ import '../styles/admin-styles.css';
 
 const LazyGraphQLExplorer = React.lazy(() => import('../components/admin/GraphQLExplorer'));
 const LazyQueueProfilesManager = React.lazy(() => import('../components/admin/QueueProfilesManager'));
+const LazyServiceCatalog = React.lazy(() => import('../components/admin/ServiceCatalog'));
 
 const getAppointmentPatientDisplayName = (appointment) => {
   const rawName =
@@ -2661,7 +2661,11 @@ const AdminPanel = () => {
             </div>
 
             {/* Содержимое вкладок */}
-            {servicesTab === 'catalog' && <ServiceCatalog />}
+            {servicesTab === 'catalog' && (
+              <React.Suspense fallback={<MacOSLoadingSkeleton style={{ height: '384px' }} />}>
+                <LazyServiceCatalog />
+              </React.Suspense>
+            )}
             {servicesTab === 'queue-profiles' && (
               <React.Suspense fallback={<MacOSLoadingSkeleton style={{ height: '384px' }} />}>
                 <LazyQueueProfilesManager theme={isDark ? 'dark' : 'light'} />


### PR DESCRIPTION
﻿## Summary
- Lazy-load the admin `ServiceCatalog` view from `AdminPanel.jsx` instead of keeping it in the base admin route chunk.
- Preserved services tab behavior, query/localStorage state, route registry ownership, and the service catalog component internals.
- Reused the existing `React.Suspense` + `MacOSLoadingSkeleton` lazy child pattern already used by admin optional views.

## Contract Impact
- Canonical surface: `frontend/src/pages/AdminPanel.jsx` admin services child rendering.
- Request shape: Unchanged; no API request payloads changed.
- Response shape: Unchanged; no API response handling changed.
- Status codes: Unchanged; no backend or HTTP status handling changed.
- Frontend consumer: Admin services tab still renders `ServiceCatalog`; only the import boundary changed.
- Compatibility path or alias: Unchanged; route registry, legacy redirects, and services tab query behavior remain registry/state-owned.
- Contract proof: `npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js` passed.

## RBAC / Permissions
- Roles allowed: Unchanged; admin route access remains governed by `ROUTE_REGISTRY` and `RouteAccessBoundary`.
- Roles denied: Unchanged; no denial routes, role lists, permissions, or auth guards changed.
- Positive auth proof: Existing admin route rendering remains wired through `AdminPanel` and the same `services` switch case.
- Negative auth proof: No protected route denial behavior changed in this import-boundary-only slice.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no notification, websocket, Telegram, queue, or realtime channel changed.
- Payload version / ack behavior: Unchanged; no payload or ack semantics changed.
- Read/unread or delivery semantics: Unchanged; notification delivery code was not touched.
- Reconnect/resync proof: Unchanged; this PR changes only admin child component loading timing.

## Frontend Resilience
- Empty data proof: Unchanged; `ServiceCatalog` empty states remain inside the original component.
- Partial data proof: Unchanged; lazy loading does not alter service catalog data handling.
- Forbidden secondary path behavior: Unchanged; admin route guards continue to wrap `AdminPanel` before child rendering.
- Missing draft/resource behavior: Unchanged; no draft/resource flow changed.
- Stale route/deep-link behavior: Unchanged; `servicesTab=catalog` still resolves to the same view after the lazy boundary loads.

## Scope Gate
- Allowed paths: `frontend/src/pages/AdminPanel.jsx`.
- Denied paths: Backend, migrations, route registry, RBAC, service catalog logic, queue profile logic, Telegram, payment, lab/EMR, package files, Vite config.
- Migration/docs/test impact: No migration or docs changes; targeted route ownership test validates registry coupling.
- Rollback note: Revert the single commit to restore the previous static `ServiceCatalog` import.

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js`; `cd frontend; npm.cmd run lint:check`; `cd frontend; npm.cmd run build`; `git diff --check`.
- Result: Passed. Lint still reports the existing 56 warnings and 0 errors. Build passed; `ServiceCatalog` now emits its own chunk around `47.62 KiB` and `AdminPanel` dropped from about `1067.29 KiB` to about `1046.32 KiB` in the local build output.
- Not checked: Browser click-through for the admin services catalog was left to CI/frontend e2e because tab state, URL params, localStorage, and service catalog component internals were not changed.
