### PR TITLE
[codex] show telegram mini app forms manifest

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -216,6 +216,11 @@ function TelegramMiniAppPatientShell() {
     payload: null,
     error: null,
   });
+  const [formsManifest, setFormsManifest] = useState({
+    status: 'idle',
+    payload: null,
+    error: null,
+  });
 
   useEffect(() => {
     let isMounted = true;
@@ -256,6 +261,62 @@ function TelegramMiniAppPatientShell() {
     };
   }, []);
 
+  useEffect(() => {
+    let isMounted = true;
+
+    if (state.status !== 'ready' || selectedSection !== 'forms') {
+      setFormsManifest({
+        status: 'idle',
+        payload: null,
+        error: null,
+      });
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    const initData = getTelegramMiniAppInitData();
+    if (!initData) {
+      setFormsManifest({
+        status: 'error',
+        payload: null,
+        error: 'РЎРµСЃСЃРёСЏ Mini App РЅРµ РїРѕРґС‚РІРµСЂР¶РґРµРЅР°',
+      });
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    setFormsManifest({
+      status: 'loading',
+      payload: null,
+      error: null,
+    });
+
+    api.post('/telegram/mini-app/forms/manifest', { initData })
+      .then((response) => {
+        if (!isMounted) return;
+        setFormsManifest({
+          status: 'ready',
+          payload: response.data,
+          error: null,
+        });
+      })
+      .catch((error) => {
+        if (!isMounted) return;
+        const reason = error?.response?.data?.detail?.reason || 'forms_manifest_failed';
+        setFormsManifest({
+          status: 'error',
+          payload: null,
+          error: `РђРЅРєРµС‚С‹ РЅРµ РґРѕСЃС‚СѓРїРЅС‹: ${reason}`,
+        });
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedSection, state.status]);
+
   const capabilities = state.manifest?.capabilities || {};
   const capabilityEntries = Object.entries(MINI_APP_CAPABILITY_LABELS);
   const selectedCapability = selectedSection ? capabilities[selectedSection] || {} : null;
@@ -263,6 +324,10 @@ function TelegramMiniAppPatientShell() {
   const canPreviewAppointments = Boolean(
     selectedSection === 'appointments' &&
     selectedCapability?.preview_enabled
+  );
+  const canShowFormsManifest = Boolean(
+    selectedSection === 'forms' &&
+    selectedCapability?.manifest_endpoint
   );
 
   const handleAppointmentPreviewFieldChange = (field) => (event) => {
@@ -318,6 +383,7 @@ function TelegramMiniAppPatientShell() {
   };
 
   const previewAppointment = appointmentPreview.payload?.appointment || null;
+  const formsManifestItems = formsManifest.payload?.forms || [];
 
   return (
     <div style={miniAppPageStyle}>
@@ -374,6 +440,70 @@ function TelegramMiniAppPatientShell() {
                       {selectedCapability?.status || 'manifest_only'}
                     </p>
                   </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {canShowFormsManifest && (
+              <Card padding="small" shadow="none" style={miniAppFormsManifestStyle}>
+                <CardContent style={miniAppFormsManifestContentStyle}>
+                  <div style={miniAppAppointmentPreviewHeaderStyle}>
+                    <div>
+                      <p style={miniAppKickerStyle}>Р—Р°С‰РёС‰РµРЅРЅС‹Рµ Р°РЅРєРµС‚С‹</p>
+                      <h2 style={miniAppSelectedSectionTitleStyle}>РЎС‚Р°С‚СѓСЃ С„РѕСЂРј</h2>
+                    </div>
+                    <Badge variant="secondary" size="small">Р‘РµР· РІРІРѕРґР° РґР°РЅРЅС‹С…</Badge>
+                  </div>
+
+                  {formsManifest.status === 'loading' && (
+                    <Alert severity="info" style={miniAppNoticeStyle}>
+                      Р—Р°РіСЂСѓР·РєР° СЃС‚Р°С‚СѓСЃР° Р°РЅРєРµС‚...
+                    </Alert>
+                  )}
+
+                  {formsManifest.status === 'error' && (
+                    <Alert severity="error" style={miniAppNoticeStyle}>
+                      {formsManifest.error}
+                    </Alert>
+                  )}
+
+                  {formsManifest.status === 'ready' && (
+                    <>
+                      <div style={miniAppFormsSummaryStyle}>
+                        <Badge variant={formsManifest.payload?.forms_enabled ? 'primary' : 'secondary'} size="small">
+                          {formsManifest.payload?.forms_enabled ? 'РђРЅРєРµС‚С‹ РґРѕСЃС‚СѓРїРЅС‹' : 'РђРЅРєРµС‚С‹ РїРѕРєР° РїР»Р°РЅРёСЂСѓСЋС‚СЃСЏ'}
+                        </Badge>
+                        <Badge variant="secondary" size="small">
+                          {formsManifest.payload?.capture_enabled ? 'Р’РІРѕРґ РІРєР»СЋС‡РµРЅ' : 'Р’РІРѕРґ РѕС‚РєР»СЋС‡РµРЅ'}
+                        </Badge>
+                        <Badge variant="secondary" size="small">
+                          {formsManifest.payload?.submission_enabled ? 'РћС‚РїСЂР°РІРєР° РІРєР»СЋС‡РµРЅР°' : 'РћС‚РїСЂР°РІРєР° РѕС‚РєР»СЋС‡РµРЅР°'}
+                        </Badge>
+                      </div>
+
+                      <section style={miniAppFormsGridStyle}>
+                        {formsManifestItems.map((form) => (
+                          <div key={form.key || form.title} style={miniAppFormManifestItemStyle}>
+                            <div>
+                              <h3 style={miniAppFormManifestTitleStyle}>{form.title || form.key}</h3>
+                              <p style={miniAppCapabilityTextStyle}>{form.status || 'planned'}</p>
+                            </div>
+                            <div style={miniAppFormManifestBadgeRowStyle}>
+                              <Badge variant="secondary" size="small">
+                                {form.capture_enabled ? 'capture on' : 'capture off'}
+                              </Badge>
+                              <Badge variant="secondary" size="small">
+                                {form.submission_enabled ? 'submit on' : 'submit off'}
+                              </Badge>
+                              <Badge variant={form.contains_medical_data ? 'warning' : 'success'} size="small">
+                                {form.contains_medical_data ? 'medical data' : 'no medical data'}
+                              </Badge>
+                            </div>
+                          </div>
+                        ))}
+                      </section>
+                    </>
+                  )}
                 </CardContent>
               </Card>
             )}
@@ -839,6 +969,56 @@ const miniAppAppointmentPreviewResultStyle = {
   background: 'rgba(52, 199, 89, 0.08)',
   fontSize: '13px',
   color: 'var(--mac-text-primary, #111827)',
+};
+
+const miniAppFormsManifestStyle = {
+  marginBottom: '12px',
+  borderColor: 'rgba(88, 86, 214, 0.24)',
+};
+
+const miniAppFormsManifestContentStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '14px',
+};
+
+const miniAppFormsSummaryStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  gap: '8px',
+};
+
+const miniAppFormsGridStyle = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(164px, 1fr))',
+  gap: '12px',
+};
+
+const miniAppFormManifestItemStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  gap: '14px',
+  minHeight: '132px',
+  padding: '12px',
+  border: '1px solid rgba(88, 86, 214, 0.22)',
+  borderRadius: '8px',
+  background: 'rgba(88, 86, 214, 0.07)',
+};
+
+const miniAppFormManifestTitleStyle = {
+  margin: '0 0 6px',
+  fontSize: '15px',
+  lineHeight: 1.25,
+  fontWeight: 750,
+  color: 'var(--mac-text-primary, #111827)',
+};
+
+const miniAppFormManifestBadgeRowStyle = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '6px',
 };
 
 const miniAppCapabilityStyle = {


### PR DESCRIPTION
﻿## Summary
- Adds a read-only forms manifest panel to the Telegram Mini App patient shell for `section=forms`.
- Calls the existing `/telegram/mini-app/forms/manifest` endpoint after the protected patient manifest is ready.
- Shows only disabled/capture-off/submission-off form status and intentionally does not render form fields or submission controls.

## Contract Impact
- Canonical surface: Existing `POST /api/v1/telegram/mini-app/forms/manifest` backend contract.
- Request shape: `initData` only, matching the existing patient-scope request.
- Response shape: Existing forms manifest payload with aggregate flags and `forms[]`; frontend reads title/status/safety flags only.
- Status codes: No backend changes; existing forms manifest 200/403/503 behavior remains unchanged.
- Frontend consumer: `frontend/src/App.jsx` route `/telegram/mini-app/patient?section=forms`.
- Compatibility path or alias: Existing `forms` section alias remains unchanged; aggregate patient manifest still drives availability.
- Contract proof: Headless Playwright smoke intercepted one forms manifest request and verified no field details rendered.

## RBAC / Permissions
- Roles allowed: Linked patient Telegram Mini App scope as enforced by existing backend `initData` validation.
- Roles denied: Direct browser/no `initData`, forged sessions, staff scope, and unlinked Telegram users remain denied by the existing backend/session flow.
- Positive auth proof: Mocked Telegram `WebApp.initData` session loaded patient manifest and forms manifest in smoke validation.
- Negative auth proof: Smoke verified the panel did not call appointment preview/create endpoints or expose form inputs/submission controls.

## Notification / Realtime
Not applicable because this read-only forms manifest panel does not emit notifications, websocket events, delivery acknowledgements, or realtime updates.

## Frontend Resilience
- Empty data proof: The panel starts in loading/idle state and renders no form field inputs before manifest data arrives.
- Partial data proof: The UI tolerates planned forms with only `key`, `title`, `status`, and safety flags.
- Forbidden secondary path behavior: Forms manifest API failures render a local error alert and no submission path.
- Missing draft/resource behavior: No form draft is created; the panel is status-only and has no submit controls.
- Stale route/deep-link behavior: The panel renders only for whitelisted `section=forms` when the aggregate manifest advertises a forms endpoint.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`.
- Denied paths: Backend endpoints/services, Alembic migrations, Telegram admin UI, route registry, and plan docs were not changed.
- Migration/docs/test impact: No schema migration; no docs changed because this gate slice was frontend-only.
- Rollback note: Revert commit `4e34e8d3` to remove the forms manifest panel and return the forms section to aggregate status-only display.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- src/App.jsx`; `npm.cmd run build`; `python -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; Telegram plan guard scripts; headless Playwright smoke for patient manifest + forms manifest only.
- Result: Passed. ESLint reported 56 existing warnings and 0 errors; build, py_compile, plan guards, diff checks, and smoke passed.
- Not checked: Real Telegram client rendering and live backend forms manifest with a signed production `initData` were not run locally.
