### PR TITLE
[codex] show telegram mini app cabinet manifest

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -221,6 +221,11 @@ function TelegramMiniAppPatientShell() {
     payload: null,
     error: null,
   });
+  const [cabinetManifest, setCabinetManifest] = useState({
+    status: 'idle',
+    payload: null,
+    error: null,
+  });
 
   useEffect(() => {
     let isMounted = true;
@@ -317,6 +322,62 @@ function TelegramMiniAppPatientShell() {
     };
   }, [selectedSection, state.status]);
 
+  useEffect(() => {
+    let isMounted = true;
+
+    if (state.status !== 'ready' || selectedSection !== 'cabinet') {
+      setCabinetManifest({
+        status: 'idle',
+        payload: null,
+        error: null,
+      });
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    const initData = getTelegramMiniAppInitData();
+    if (!initData) {
+      setCabinetManifest({
+        status: 'error',
+        payload: null,
+        error: 'Mini App session is not confirmed.',
+      });
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    setCabinetManifest({
+      status: 'loading',
+      payload: null,
+      error: null,
+    });
+
+    api.post('/telegram/mini-app/cabinet/manifest', { initData })
+      .then((response) => {
+        if (!isMounted) return;
+        setCabinetManifest({
+          status: 'ready',
+          payload: response.data,
+          error: null,
+        });
+      })
+      .catch((error) => {
+        if (!isMounted) return;
+        const reason = error?.response?.data?.detail?.reason || 'cabinet_manifest_failed';
+        setCabinetManifest({
+          status: 'error',
+          payload: null,
+          error: `Patient cabinet is unavailable: ${reason}`,
+        });
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedSection, state.status]);
+
   const capabilities = state.manifest?.capabilities || {};
   const capabilityEntries = Object.entries(MINI_APP_CAPABILITY_LABELS);
   const selectedCapability = selectedSection ? capabilities[selectedSection] || {} : null;
@@ -327,6 +388,10 @@ function TelegramMiniAppPatientShell() {
   );
   const canShowFormsManifest = Boolean(
     selectedSection === 'forms' &&
+    selectedCapability?.manifest_endpoint
+  );
+  const canShowCabinetManifest = Boolean(
+    selectedSection === 'cabinet' &&
     selectedCapability?.manifest_endpoint
   );
 
@@ -384,6 +449,7 @@ function TelegramMiniAppPatientShell() {
 
   const previewAppointment = appointmentPreview.payload?.appointment || null;
   const formsManifestItems = formsManifest.payload?.forms || [];
+  const cabinetManifestSections = cabinetManifest.payload?.sections || [];
 
   return (
     <div style={miniAppPageStyle}>
@@ -440,6 +506,76 @@ function TelegramMiniAppPatientShell() {
                       {selectedCapability?.status || 'manifest_only'}
                     </p>
                   </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {canShowCabinetManifest && (
+              <Card padding="small" shadow="none" style={miniAppCabinetManifestStyle}>
+                <CardContent style={miniAppFormsManifestContentStyle}>
+                  <div style={miniAppAppointmentPreviewHeaderStyle}>
+                    <div>
+                      <p style={miniAppKickerStyle}>Patient cabinet</p>
+                      <h2 style={miniAppSelectedSectionTitleStyle}>Read-only status</h2>
+                    </div>
+                    <Badge variant="secondary" size="small">No records or edits</Badge>
+                  </div>
+
+                  {cabinetManifest.status === 'loading' && (
+                    <Alert severity="info" style={miniAppNoticeStyle}>
+                      Loading cabinet status...
+                    </Alert>
+                  )}
+
+                  {cabinetManifest.status === 'error' && (
+                    <Alert severity="error" style={miniAppNoticeStyle}>
+                      {cabinetManifest.error}
+                    </Alert>
+                  )}
+
+                  {cabinetManifest.status === 'ready' && (
+                    <>
+                      <div style={miniAppFormsSummaryStyle}>
+                        <Badge variant={cabinetManifest.payload?.cabinet_enabled ? 'primary' : 'secondary'} size="small">
+                          {cabinetManifest.payload?.cabinet_enabled ? 'cabinet on' : 'cabinet planned'}
+                        </Badge>
+                        <Badge variant="secondary" size="small">
+                          {cabinetManifest.payload?.read_enabled ? 'read on' : 'read off'}
+                        </Badge>
+                        <Badge variant="secondary" size="small">
+                          {cabinetManifest.payload?.mutation_enabled ? 'mutation on' : 'mutation off'}
+                        </Badge>
+                      </div>
+
+                      <section style={miniAppFormsGridStyle}>
+                        {cabinetManifestSections.map((section) => (
+                          <div key={section.key || section.title} style={miniAppCabinetManifestItemStyle}>
+                            <div>
+                              <h3 style={miniAppFormManifestTitleStyle}>{section.title || section.key}</h3>
+                              <p style={miniAppCapabilityTextStyle}>{section.status || 'planned'}</p>
+                            </div>
+                            <div style={miniAppFormManifestBadgeRowStyle}>
+                              <Badge variant="secondary" size="small">
+                                {section.read_enabled ? 'read on' : 'read off'}
+                              </Badge>
+                              <Badge variant="secondary" size="small">
+                                {section.write_enabled ? 'write on' : 'write off'}
+                              </Badge>
+                              <Badge variant={section.contains_medical_data ? 'warning' : 'success'} size="small">
+                                {section.contains_medical_data ? 'medical data' : 'no medical data'}
+                              </Badge>
+                              <Badge variant={section.contains_passport_data ? 'warning' : 'success'} size="small">
+                                {section.contains_passport_data ? 'passport data' : 'no passport data'}
+                              </Badge>
+                              <Badge variant={section.contains_billing_records ? 'warning' : 'success'} size="small">
+                                {section.contains_billing_records ? 'billing records' : 'no billing records'}
+                              </Badge>
+                            </div>
+                          </div>
+                        ))}
+                      </section>
+                    </>
+                  )}
                 </CardContent>
               </Card>
             )}
@@ -976,6 +1112,11 @@ const miniAppFormsManifestStyle = {
   borderColor: 'rgba(88, 86, 214, 0.24)',
 };
 
+const miniAppCabinetManifestStyle = {
+  marginBottom: '12px',
+  borderColor: 'rgba(0, 122, 255, 0.24)',
+};
+
 const miniAppFormsManifestContentStyle = {
   display: 'flex',
   flexDirection: 'column',
@@ -1005,6 +1146,12 @@ const miniAppFormManifestItemStyle = {
   border: '1px solid rgba(88, 86, 214, 0.22)',
   borderRadius: '8px',
   background: 'rgba(88, 86, 214, 0.07)',
+};
+
+const miniAppCabinetManifestItemStyle = {
+  ...miniAppFormManifestItemStyle,
+  border: '1px solid rgba(0, 122, 255, 0.22)',
+  background: 'rgba(0, 122, 255, 0.07)',
 };
 
 const miniAppFormManifestTitleStyle = {


### PR DESCRIPTION
## Summary
- Adds a read-only patient cabinet status panel to the Telegram Mini App patient shell.
- Fetches the existing `/telegram/mini-app/cabinet/manifest` endpoint only after the cabinet section is opened.
- Renders capability and safety flags only, without cabinet records, passport data, billing records, inputs, or mutations.

## Contract Impact
- Canonical surface: existing `POST /api/v1/telegram/mini-app/cabinet/manifest` backend endpoint and frontend API base path `/telegram/mini-app/cabinet/manifest`.
- Request shape: unchanged `{ initData }` Mini App signed session payload.
- Response shape: unchanged manifest object with cabinet flags and section safety metadata; frontend consumes only flags, titles, and status text.
- Status codes: unchanged backend behavior; frontend shows loading and error states for failed requests.
- Frontend consumer: `TelegramMiniAppPatientShell` in `frontend/src/App.jsx`, cabinet section only.
- Compatibility path or alias: not applicable because this PR does not add or change route aliases or compatibility endpoints.
- Contract proof: `py_compile` for Telegram endpoint files plus a Playwright smoke that mocks the manifest endpoint once and verifies sensitive mock data is not rendered.

## RBAC / Permissions
- Roles allowed: unchanged because backend Mini App session verification remains canonical and this PR only adds a frontend read-only consumer.
- Roles denied: unchanged because denied or invalid sessions continue to be handled by the existing endpoint and frontend error path.
- Positive auth proof: Playwright smoke provides mock Mini App init data and verifies the cabinet manifest request is made after selecting cabinet.
- Negative auth proof: no backend auth behavior changed; no new bypass path or mutation is introduced.

## Notification / Realtime
not applicable because this PR does not add notifications, websocket events, or realtime delivery behavior.

## Frontend Resilience
- Empty data proof: `cabinetManifestSections` defaults to an empty array and the ready state can render summary badges without record rows.
- Partial data proof: section title and status use safe fallbacks, while missing booleans render as disabled or safe badges.
- Forbidden secondary path behavior: Playwright smoke verifies forms, appointment preview, and appointment create endpoints are not called by the cabinet flow.
- Missing draft/resource behavior: not applicable because this read-only panel has no draft, resource editor, or mutation affordance.
- Stale route/deep-link behavior: the manifest request is gated by `selectedSection === 'cabinet'` and resets when leaving the cabinet section.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`.
- Denied paths: backend endpoints, migrations, Telegram webhook services, manager UI, docs, and generated artifacts were not changed.
- Migration/docs/test impact: no DB or Alembic impact; validation used existing Telegram guard scripts and targeted frontend checks.
- Rollback note: revert `ba0b5052` to remove the cabinet manifest panel while leaving backend behavior unchanged.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- src/App.jsx`; `npm.cmd run build`; `C:\final\backend\.venv\Scripts\python.exe -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; headless Playwright Mini App smoke for cabinet manifest safety; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file frontend/src/App.jsx --fail-on-warning`; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py --fail-on-warning`; `git diff --check`; `git diff --cached --check`.
- Result: passed; lint reported 56 existing warnings and 0 errors.
- Not checked: full frontend test suite, live Telegram Bot API, and live backend/Postgres runtime.