### PR TITLE
[codex] show telegram mini app payments manifest

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -226,6 +226,11 @@ function TelegramMiniAppPatientShell() {
     payload: null,
     error: null,
   });
+  const [paymentsManifest, setPaymentsManifest] = useState({
+    status: 'idle',
+    payload: null,
+    error: null,
+  });
 
   useEffect(() => {
     let isMounted = true;
@@ -378,6 +383,62 @@ function TelegramMiniAppPatientShell() {
     };
   }, [selectedSection, state.status]);
 
+  useEffect(() => {
+    let isMounted = true;
+
+    if (state.status !== 'ready' || selectedSection !== 'payments') {
+      setPaymentsManifest({
+        status: 'idle',
+        payload: null,
+        error: null,
+      });
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    const initData = getTelegramMiniAppInitData();
+    if (!initData) {
+      setPaymentsManifest({
+        status: 'error',
+        payload: null,
+        error: 'Mini App session is not confirmed.',
+      });
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    setPaymentsManifest({
+      status: 'loading',
+      payload: null,
+      error: null,
+    });
+
+    api.post('/telegram/mini-app/payments/manifest', { initData })
+      .then((response) => {
+        if (!isMounted) return;
+        setPaymentsManifest({
+          status: 'ready',
+          payload: response.data,
+          error: null,
+        });
+      })
+      .catch((error) => {
+        if (!isMounted) return;
+        const reason = error?.response?.data?.detail?.reason || 'payments_manifest_failed';
+        setPaymentsManifest({
+          status: 'error',
+          payload: null,
+          error: `Patient payments are unavailable: ${reason}`,
+        });
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedSection, state.status]);
+
   const capabilities = state.manifest?.capabilities || {};
   const capabilityEntries = Object.entries(MINI_APP_CAPABILITY_LABELS);
   const selectedCapability = selectedSection ? capabilities[selectedSection] || {} : null;
@@ -392,6 +453,10 @@ function TelegramMiniAppPatientShell() {
   );
   const canShowCabinetManifest = Boolean(
     selectedSection === 'cabinet' &&
+    selectedCapability?.manifest_endpoint
+  );
+  const canShowPaymentsManifest = Boolean(
+    selectedSection === 'payments' &&
     selectedCapability?.manifest_endpoint
   );
 
@@ -450,6 +515,7 @@ function TelegramMiniAppPatientShell() {
   const previewAppointment = appointmentPreview.payload?.appointment || null;
   const formsManifestItems = formsManifest.payload?.forms || [];
   const cabinetManifestSections = cabinetManifest.payload?.sections || [];
+  const paymentsManifestSections = paymentsManifest.payload?.sections || [];
 
   return (
     <div style={miniAppPageStyle}>
@@ -569,6 +635,79 @@ function TelegramMiniAppPatientShell() {
                               </Badge>
                               <Badge variant={section.contains_billing_records ? 'warning' : 'success'} size="small">
                                 {section.contains_billing_records ? 'billing records' : 'no billing records'}
+                              </Badge>
+                            </div>
+                          </div>
+                        ))}
+                      </section>
+                    </>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+
+            {canShowPaymentsManifest && (
+              <Card padding="small" shadow="none" style={miniAppPaymentsManifestStyle}>
+                <CardContent style={miniAppFormsManifestContentStyle}>
+                  <div style={miniAppAppointmentPreviewHeaderStyle}>
+                    <div>
+                      <p style={miniAppKickerStyle}>Patient payments</p>
+                      <h2 style={miniAppSelectedSectionTitleStyle}>Manifest only</h2>
+                    </div>
+                    <Badge variant="secondary" size="small">No amounts or charges</Badge>
+                  </div>
+
+                  {paymentsManifest.status === 'loading' && (
+                    <Alert severity="info" style={miniAppNoticeStyle}>
+                      Loading payment status...
+                    </Alert>
+                  )}
+
+                  {paymentsManifest.status === 'error' && (
+                    <Alert severity="error" style={miniAppNoticeStyle}>
+                      {paymentsManifest.error}
+                    </Alert>
+                  )}
+
+                  {paymentsManifest.status === 'ready' && (
+                    <>
+                      <div style={miniAppFormsSummaryStyle}>
+                        <Badge variant={paymentsManifest.payload?.payments_enabled ? 'primary' : 'secondary'} size="small">
+                          {paymentsManifest.payload?.payments_enabled ? 'payments on' : 'payments planned'}
+                        </Badge>
+                        <Badge variant="secondary" size="small">
+                          {paymentsManifest.payload?.read_enabled ? 'read on' : 'read off'}
+                        </Badge>
+                        <Badge variant="secondary" size="small">
+                          {paymentsManifest.payload?.payment_capture_enabled ? 'capture on' : 'capture off'}
+                        </Badge>
+                        <Badge variant="secondary" size="small">
+                          {paymentsManifest.payload?.provider_redirect_enabled ? 'provider redirect on' : 'provider redirect off'}
+                        </Badge>
+                      </div>
+
+                      <section style={miniAppFormsGridStyle}>
+                        {paymentsManifestSections.map((section) => (
+                          <div key={section.key || section.title} style={miniAppPaymentsManifestItemStyle}>
+                            <div>
+                              <h3 style={miniAppFormManifestTitleStyle}>{section.title || section.key}</h3>
+                              <p style={miniAppCapabilityTextStyle}>{section.status || 'planned'}</p>
+                            </div>
+                            <div style={miniAppFormManifestBadgeRowStyle}>
+                              <Badge variant="secondary" size="small">
+                                {section.read_enabled ? 'read on' : 'read off'}
+                              </Badge>
+                              <Badge variant="secondary" size="small">
+                                {section.payment_enabled ? 'payment on' : 'payment off'}
+                              </Badge>
+                              <Badge variant={section.contains_amounts ? 'warning' : 'success'} size="small">
+                                {section.contains_amounts ? 'amounts present' : 'no amounts'}
+                              </Badge>
+                              <Badge variant={section.contains_payment_records ? 'warning' : 'success'} size="small">
+                                {section.contains_payment_records ? 'payment records' : 'no payment records'}
+                              </Badge>
+                              <Badge variant={section.contains_provider_payloads ? 'warning' : 'success'} size="small">
+                                {section.contains_provider_payloads ? 'provider payloads' : 'no provider payloads'}
                               </Badge>
                             </div>
                           </div>
@@ -1117,6 +1256,11 @@ const miniAppCabinetManifestStyle = {
   borderColor: 'rgba(0, 122, 255, 0.24)',
 };
 
+const miniAppPaymentsManifestStyle = {
+  marginBottom: '12px',
+  borderColor: 'rgba(255, 149, 0, 0.26)',
+};
+
 const miniAppFormsManifestContentStyle = {
   display: 'flex',
   flexDirection: 'column',
@@ -1152,6 +1296,12 @@ const miniAppCabinetManifestItemStyle = {
   ...miniAppFormManifestItemStyle,
   border: '1px solid rgba(0, 122, 255, 0.22)',
   background: 'rgba(0, 122, 255, 0.07)',
+};
+
+const miniAppPaymentsManifestItemStyle = {
+  ...miniAppFormManifestItemStyle,
+  border: '1px solid rgba(255, 149, 0, 0.24)',
+  background: 'rgba(255, 149, 0, 0.08)',
 };
 
 const miniAppFormManifestTitleStyle = {


### PR DESCRIPTION
## Summary
- Adds a read-only patient payments manifest panel to the Telegram Mini App patient shell.
- Fetches the existing `/telegram/mini-app/payments/manifest` endpoint only when the payments section is opened.
- Renders capability and safety flags only, without payment records, billing totals, debt amounts, provider payloads, inputs, or mutations.

## Contract Impact
- Canonical surface: existing `POST /api/v1/telegram/mini-app/payments/manifest` backend endpoint and frontend API base path `/telegram/mini-app/payments/manifest`.
- Request shape: unchanged `{ initData }` Mini App signed session payload.
- Response shape: unchanged manifest object with payment flags and section safety metadata; frontend consumes only flags, titles, and status text.
- Status codes: unchanged backend behavior; frontend shows loading and error states for failed requests.
- Frontend consumer: `TelegramMiniAppPatientShell` in `frontend/src/App.jsx`, payments section only.
- Compatibility path or alias: not applicable because this PR does not add or change route aliases or compatibility endpoints.
- Contract proof: `py_compile` for Telegram endpoint files plus a Playwright smoke that mocks the payments manifest endpoint and verifies sensitive mock payment fields are not rendered.

## RBAC / Permissions
- Roles allowed: unchanged because backend Mini App session verification remains canonical and this PR only adds a frontend read-only consumer.
- Roles denied: unchanged because denied or invalid sessions continue to be handled by the existing endpoint and frontend error path.
- Positive auth proof: Playwright smoke provides mock Mini App init data and verifies the payments manifest request is made after selecting payments.
- Negative auth proof: no backend auth behavior changed; no new bypass path, provider redirect, payment capture, or mutation is introduced.

## Notification / Realtime
not applicable because this PR does not add notifications, websocket events, payment callbacks, or realtime delivery behavior.

## Frontend Resilience
- Empty data proof: `paymentsManifestSections` defaults to an empty array and the ready state can render summary badges without payment rows.
- Partial data proof: section title and status use safe fallbacks, while missing booleans render as disabled or safe badges.
- Forbidden secondary path behavior: Playwright smoke verifies forms, cabinet, appointment preview, and appointment create endpoints are not called by the payments flow.
- Missing draft/resource behavior: not applicable because this read-only panel has no draft, provider resource, amount editor, or mutation affordance.
- Stale route/deep-link behavior: the manifest request is gated by `selectedSection === 'payments'` and resets when leaving the payments section.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`.
- Denied paths: backend endpoints, migrations, payment services, provider integrations, Telegram webhook services, manager UI, docs, and generated artifacts were not changed.
- Migration/docs/test impact: no DB or Alembic impact; validation used existing Telegram guard scripts and targeted frontend checks.
- Rollback note: revert `8893a33a` to remove the payments manifest panel while leaving backend behavior unchanged.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- src/App.jsx`; `npm.cmd run build`; `C:\final\backend\.venv\Scripts\python.exe -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; Playwright Mini App payments smoke on Vite preview; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file frontend/src/App.jsx --fail-on-warning`; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py --fail-on-warning`; `git diff --check`; `git diff --cached --check`.
- Result: passed; lint reported 56 existing warnings and 0 errors; smoke proved payments endpoint was called once, unrelated section endpoints were not called, and sensitive mock payment values did not render.
- Not checked: full frontend test suite, live Telegram Bot API, live backend/Postgres runtime, and real payment provider redirects.