### PR TITLE
[codex] show telegram mini app results manifest

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -231,6 +231,11 @@ function TelegramMiniAppPatientShell() {
     payload: null,
     error: null,
   });
+  const [resultsManifest, setResultsManifest] = useState({
+    status: 'idle',
+    payload: null,
+    error: null,
+  });
 
   useEffect(() => {
     let isMounted = true;
@@ -439,6 +444,62 @@ function TelegramMiniAppPatientShell() {
     };
   }, [selectedSection, state.status]);
 
+  useEffect(() => {
+    let isMounted = true;
+
+    if (state.status !== 'ready' || selectedSection !== 'results') {
+      setResultsManifest({
+        status: 'idle',
+        payload: null,
+        error: null,
+      });
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    const initData = getTelegramMiniAppInitData();
+    if (!initData) {
+      setResultsManifest({
+        status: 'error',
+        payload: null,
+        error: 'Mini App session is not confirmed.',
+      });
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    setResultsManifest({
+      status: 'loading',
+      payload: null,
+      error: null,
+    });
+
+    api.post('/telegram/mini-app/results/manifest', { initData })
+      .then((response) => {
+        if (!isMounted) return;
+        setResultsManifest({
+          status: 'ready',
+          payload: response.data,
+          error: null,
+        });
+      })
+      .catch((error) => {
+        if (!isMounted) return;
+        const reason = error?.response?.data?.detail?.reason || 'results_manifest_failed';
+        setResultsManifest({
+          status: 'error',
+          payload: null,
+          error: `Patient results are unavailable: ${reason}`,
+        });
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedSection, state.status]);
+
   const capabilities = state.manifest?.capabilities || {};
   const capabilityEntries = Object.entries(MINI_APP_CAPABILITY_LABELS);
   const selectedCapability = selectedSection ? capabilities[selectedSection] || {} : null;
@@ -457,6 +518,10 @@ function TelegramMiniAppPatientShell() {
   );
   const canShowPaymentsManifest = Boolean(
     selectedSection === 'payments' &&
+    selectedCapability?.manifest_endpoint
+  );
+  const canShowResultsManifest = Boolean(
+    selectedSection === 'results' &&
     selectedCapability?.manifest_endpoint
   );
 
@@ -516,6 +581,7 @@ function TelegramMiniAppPatientShell() {
   const formsManifestItems = formsManifest.payload?.forms || [];
   const cabinetManifestSections = cabinetManifest.payload?.sections || [];
   const paymentsManifestSections = paymentsManifest.payload?.sections || [];
+  const resultsManifestSections = resultsManifest.payload?.sections || [];
 
   return (
     <div style={miniAppPageStyle}>
@@ -708,6 +774,85 @@ function TelegramMiniAppPatientShell() {
                               </Badge>
                               <Badge variant={section.contains_provider_payloads ? 'warning' : 'success'} size="small">
                                 {section.contains_provider_payloads ? 'provider payloads' : 'no provider payloads'}
+                              </Badge>
+                            </div>
+                          </div>
+                        ))}
+                      </section>
+                    </>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+
+            {canShowResultsManifest && (
+              <Card padding="small" shadow="none" style={miniAppResultsManifestStyle}>
+                <CardContent style={miniAppFormsManifestContentStyle}>
+                  <div style={miniAppAppointmentPreviewHeaderStyle}>
+                    <div>
+                      <p style={miniAppKickerStyle}>Patient results</p>
+                      <h2 style={miniAppSelectedSectionTitleStyle}>Manifest only</h2>
+                    </div>
+                    <Badge variant="secondary" size="small">No reports or files</Badge>
+                  </div>
+
+                  {resultsManifest.status === 'loading' && (
+                    <Alert severity="info" style={miniAppNoticeStyle}>
+                      Loading result status...
+                    </Alert>
+                  )}
+
+                  {resultsManifest.status === 'error' && (
+                    <Alert severity="error" style={miniAppNoticeStyle}>
+                      {resultsManifest.error}
+                    </Alert>
+                  )}
+
+                  {resultsManifest.status === 'ready' && (
+                    <>
+                      <div style={miniAppFormsSummaryStyle}>
+                        <Badge variant={resultsManifest.payload?.results_enabled ? 'primary' : 'secondary'} size="small">
+                          {resultsManifest.payload?.results_enabled ? 'results on' : 'results planned'}
+                        </Badge>
+                        <Badge variant="secondary" size="small">
+                          {resultsManifest.payload?.view_enabled ? 'view on' : 'view off'}
+                        </Badge>
+                        <Badge variant="secondary" size="small">
+                          {resultsManifest.payload?.download_enabled ? 'download on' : 'download off'}
+                        </Badge>
+                        <Badge variant={resultsManifest.payload?.contains_pdfs ? 'warning' : 'success'} size="small">
+                          {resultsManifest.payload?.contains_pdfs ? 'PDFs present' : 'no PDFs'}
+                        </Badge>
+                      </div>
+
+                      <section style={miniAppFormsGridStyle}>
+                        {resultsManifestSections.map((section) => (
+                          <div key={section.key || section.title} style={miniAppResultsManifestItemStyle}>
+                            <div>
+                              <h3 style={miniAppFormManifestTitleStyle}>{section.title || section.key}</h3>
+                              <p style={miniAppCapabilityTextStyle}>{section.status || 'planned'}</p>
+                            </div>
+                            <div style={miniAppFormManifestBadgeRowStyle}>
+                              <Badge variant="secondary" size="small">
+                                {section.view_enabled ? 'view on' : 'view off'}
+                              </Badge>
+                              <Badge variant="secondary" size="small">
+                                {section.download_enabled ? 'download on' : 'download off'}
+                              </Badge>
+                              <Badge variant={section.contains_medical_results ? 'warning' : 'success'} size="small">
+                                {section.contains_medical_results ? 'medical results' : 'no medical results'}
+                              </Badge>
+                              <Badge variant={section.contains_lab_values ? 'warning' : 'success'} size="small">
+                                {section.contains_lab_values ? 'lab values' : 'no lab values'}
+                              </Badge>
+                              <Badge variant={section.contains_report_records ? 'warning' : 'success'} size="small">
+                                {section.contains_report_records ? 'report records' : 'no report records'}
+                              </Badge>
+                              <Badge variant={section.contains_file_urls ? 'warning' : 'success'} size="small">
+                                {section.contains_file_urls ? 'file URLs' : 'no file URLs'}
+                              </Badge>
+                              <Badge variant={section.contains_diagnoses ? 'warning' : 'success'} size="small">
+                                {section.contains_diagnoses ? 'diagnoses' : 'no diagnoses'}
                               </Badge>
                             </div>
                           </div>
@@ -1261,6 +1406,11 @@ const miniAppPaymentsManifestStyle = {
   borderColor: 'rgba(255, 149, 0, 0.26)',
 };
 
+const miniAppResultsManifestStyle = {
+  marginBottom: '12px',
+  borderColor: 'rgba(52, 199, 89, 0.26)',
+};
+
 const miniAppFormsManifestContentStyle = {
   display: 'flex',
   flexDirection: 'column',
@@ -1302,6 +1452,12 @@ const miniAppPaymentsManifestItemStyle = {
   ...miniAppFormManifestItemStyle,
   border: '1px solid rgba(255, 149, 0, 0.24)',
   background: 'rgba(255, 149, 0, 0.08)',
+};
+
+const miniAppResultsManifestItemStyle = {
+  ...miniAppFormManifestItemStyle,
+  border: '1px solid rgba(52, 199, 89, 0.24)',
+  background: 'rgba(52, 199, 89, 0.08)',
 };
 
 const miniAppFormManifestTitleStyle = {


### PR DESCRIPTION
## Summary
- Adds a read-only patient results manifest panel to the Telegram Mini App patient shell.
- Fetches the existing `/telegram/mini-app/results/manifest` endpoint only when the results section is opened.
- Renders capability and safety flags only, without medical results, lab values, report records, file URLs, PDFs, diagnoses, inputs, or mutations.

## Contract Impact
- Canonical surface: existing `POST /api/v1/telegram/mini-app/results/manifest` backend endpoint and frontend API base path `/telegram/mini-app/results/manifest`.
- Request shape: unchanged `{ initData }` Mini App signed session payload.
- Response shape: unchanged manifest object with results flags and section safety metadata; frontend consumes only flags, titles, and status text.
- Status codes: unchanged backend behavior; frontend shows loading and error states for failed requests.
- Frontend consumer: `TelegramMiniAppPatientShell` in `frontend/src/App.jsx`, results section only.
- Compatibility path or alias: not applicable because this PR does not add or change route aliases or compatibility endpoints.
- Contract proof: `py_compile` for Telegram endpoint files plus a Playwright smoke that mocks the results manifest endpoint and verifies sensitive mock medical/report/file fields are not rendered.

## RBAC / Permissions
- Roles allowed: unchanged because backend Mini App session verification remains canonical and this PR only adds a frontend read-only consumer.
- Roles denied: unchanged because denied or invalid sessions continue to be handled by the existing endpoint and frontend error path.
- Positive auth proof: Playwright smoke provides mock Mini App init data and verifies the results manifest request is made after selecting results.
- Negative auth proof: no backend auth behavior changed; no new bypass path, download path, file URL rendering, or mutation is introduced.

## Notification / Realtime
not applicable because this PR does not add notifications, websocket events, result delivery, or realtime report behavior.

## Frontend Resilience
- Empty data proof: `resultsManifestSections` defaults to an empty array and the ready state can render summary badges without result rows.
- Partial data proof: section title and status use safe fallbacks, while missing booleans render as disabled or safe badges.
- Forbidden secondary path behavior: Playwright smoke verifies forms, cabinet, payments, appointment preview, and appointment create endpoints are not called by the results flow.
- Missing draft/resource behavior: not applicable because this read-only panel has no draft, report resource viewer, file download link, or mutation affordance.
- Stale route/deep-link behavior: the manifest request is gated by `selectedSection === 'results'` and resets when leaving the results section.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`.
- Denied paths: backend endpoints, migrations, medical results services, lab/report storage, file download code, Telegram webhook services, manager UI, docs, and generated artifacts were not changed.
- Migration/docs/test impact: no DB or Alembic impact; validation used existing Telegram guard scripts and targeted frontend checks.
- Rollback note: revert `3780859b` to remove the results manifest panel while leaving backend behavior unchanged.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- src/App.jsx`; `npm.cmd run build`; `C:\final\backend\.venv\Scripts\python.exe -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; Playwright Mini App results smoke on Vite preview; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file frontend/src/App.jsx --fail-on-warning`; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py --fail-on-warning`; `git diff --check`; `git diff --cached --check`.
- Result: passed; lint reported 56 existing warnings and 0 errors; smoke proved results endpoint was called once, unrelated section endpoints were not called, and sensitive mock result/report/file values did not render.
- Not checked: full frontend test suite, live Telegram Bot API, live backend/Postgres runtime, and real lab/report file storage.