### PR TITLE
refactor(frontend): remove user management mui actions menu

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/user-management-actions-menu-mui-removal.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/user-management-actions-menu-mui-removal.md
@@ -1,0 +1,69 @@
+# UserManagement Actions Menu MUI Removal
+
+Date: 2026-05-20
+
+## Scope
+
+Mode: `safe-patch` with `gate_known_root_cause` / narrow override.
+
+First-touch runtime file:
+
+- `frontend/src/components/admin/UserManagement.jsx`
+
+Documentation evidence:
+
+- `frontend/MUI_RUNTIME_INVENTORY.md`
+
+## Shape Brief
+
+- Role/workflow: Admin user lifecycle management on `/admin/advanced-users`.
+- Primary action: open the per-user actions menu, then edit, activate/deactivate, or open delete confirmation.
+- Risk level: admin-sensitive because the surface exposes user update/delete/deactivate actions and self-delete guardrails.
+- Current drift source: the actions menu was the only remaining MUI island in `UserManagement.jsx`.
+- Intended tone: quiet, clinical, keyboard-reachable, consistent with existing macOS UI primitives.
+- Out of scope: no API, RBAC, route, user lifecycle, self-delete guardrail, role list, filter, modal, or table behavior changes.
+
+## Changed
+
+- Removed the `@mui/material` actions-menu import from `UserManagement.jsx`.
+- Replaced the MUI `Menu`, `MenuItem`, `ListItemIcon`, `ListItemText`, `Divider`, and `IconButton` usage with:
+  - existing `MacOSButton` for the trigger;
+  - native `button` menu items;
+  - `role="menu"` and `role="menuitem"` semantics;
+  - Escape, outside-click, scroll, and resize close behavior.
+- Preserved the existing action callbacks:
+  - edit opens `UserModal`;
+  - activate/deactivate calls `handleToggleUserStatus`;
+  - delete opens the existing delete confirmation dialog.
+
+## Validation
+
+Commands and results:
+
+- `cd C:\final\ai\langgraph; py -3 scripts\agent_gate.py ... --known-root-cause "frontend/src/components/admin/UserManagement.jsx"`: passed with narrow override; first-touch file approved.
+- `cd frontend; npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js`: passed, 2 tests.
+- `cd frontend; npm.cmd run lint:check`: passed with 54 existing warnings, 0 errors; `UserManagement.jsx` a11y warnings removed.
+- `cd frontend; npm.cmd run build`: passed.
+- Static MUI search: `UserManagement.jsx` no longer matches `@mui|Mui`.
+- Current MUI search count: 12 files.
+- One-off authenticated browser smoke for `/admin/advanced-users`: passed with seeded Admin session, mocked user list, actions menu open, three menu items visible, Escape close, no horizontal overflow, no page errors.
+
+Browser artifact:
+
+- `output/playwright/user-management-actions-menu.png` (ignored generated artifact, not committed).
+
+## Contract And Safety
+
+- API request paths and payloads unchanged.
+- User create/update/delete/deactivate code paths unchanged.
+- Self-delete and deactivate fallback guardrails unchanged.
+- Route owner remains `admin-advanced-users` / `admin.users`.
+- No backend, schema, RBAC, notification, payment, queue, EMR, lab, Telegram, or AI behavior changed.
+
+## Remaining Risk
+
+The browser smoke uses a local QA harness and mocked API responses, so it proves route rendering and menu interaction, not backend authorization. Backend authorization remains covered by the existing backend/API guardrails outside this UI-only slice.
+
+## Next Smallest Step
+
+Continue one risky MUI island per PR. The remaining runtime MUI targets are payment, queue, clinical, Telegram/AI, and example-only files; each still needs its own gate/handoff and route-specific proof.

--- a/frontend/MUI_RUNTIME_INVENTORY.md
+++ b/frontend/MUI_RUNTIME_INVENTORY.md
@@ -29,6 +29,10 @@ Dashboard stale component removal: 13 files now contain runtime or example MUI
 imports after deleting the caller-free `frontend/src/components/dashboard`
 barrel and component.
 
+UserManagement actions menu migration: 12 files now contain runtime or example
+MUI imports after replacing the admin user actions menu with macOS/native
+controls in `frontend/src/components/admin/UserManagement.jsx`.
+
 ## No-New-MUI Island Policy
 
 MUI is a legacy compatibility layer in this clinic frontend. New clinic runtime UI should not create new MUI islands.
@@ -65,7 +69,7 @@ rg -l '@mui|Mui' frontend/src/pages frontend/src/components
 | --- | --- | --- | --- |
 | `frontend/src/components/pwa/ConnectionStatus.jsx` | Low-risk | PWA online/offline/sync status UI; no backend contract ownership. | Migrated in Task 36; no current `@mui` import. |
 | `frontend/src/components/pwa/PWAInstallPrompt.jsx` | Low-risk | PWA install/update/notification prompt UI. | Migrated in Task 37; no current `@mui` import. |
-| `frontend/src/components/admin/UserManagement.jsx` | Shared/admin-sensitive | Legacy actions menu imports MUI. Admin user workflow is role-sensitive. | Do not touch until dedicated admin slice. |
+| `frontend/src/components/admin/UserManagement.jsx` | Migrated/admin-sensitive | Admin user actions menu now uses macOS/native controls with no current `@mui` import. Admin user workflow remains role-sensitive. | Migrated in dedicated gated admin slice; keep future changes scoped to user lifecycle behavior. |
 | `frontend/src/components/dashboard/Dashboard.jsx` | Stale/removed | No active route owner or caller found. | Removed after route-owner discovery. |
 | `frontend/src/components/payment/PaymentWidget.jsx` | Payment/queue-adjacent | Payment flow behavior and error handling are payment-sensitive. | Gate/handoff only. |
 | `frontend/src/pages/PaymentTest.jsx` | Payment/queue-adjacent | Internal payment demo/test surface. | Gate/handoff only; do not alter payment semantics. |
@@ -116,6 +120,8 @@ $files.Count
 
 Result after stale dashboard removal: 13 files.
 
+Result after UserManagement actions menu migration: 12 files.
+
 Decision: do not force a runtime MUI migration in this PR. The only already
 approved low-risk runtime targets were `ConnectionStatus.jsx` and
 `PWAInstallPrompt.jsx`, and both are already migrated. Every remaining runtime
@@ -128,6 +134,10 @@ handoff:
 - Lab/cardiology/dental/patient: preserve clinical meaning, report generation, ECG/dental status, and patient relationship visibility.
 - Telegram/AI/MCP: preserve integration status, security copy, and operational diagnostics.
 - Examples: decide whether example-only files stay as MUI design-system references before counting them as runtime cleanup.
+
+The dedicated admin actions menu migration has now removed `UserManagement.jsx`
+from the current MUI search result. Remaining runtime MUI targets are payment,
+queue, clinical, Telegram/AI, and example-only files.
 
 Next safe MUI migration should be a dedicated PR with one first-touch file,
 route/browser smoke, and a PR body that explicitly proves no role, route,

--- a/frontend/src/components/admin/UserManagement.jsx
+++ b/frontend/src/components/admin/UserManagement.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { api } from '../../api/client';
 import logger from '../../utils/logger';
 import {
@@ -27,7 +27,6 @@ import {
 
 
 'lucide-react';
-import { Menu, MenuItem, ListItemIcon, ListItemText, Divider, IconButton } from '@mui/material'; // Legacy for Actions menu
 import UserModal from './UserModal';
 import { useRoles } from '../../hooks/useRoles';
 import { getProfile } from '../../stores/auth';
@@ -46,7 +45,9 @@ const UserManagement = () => {
   const [currentProfile, setCurrentProfile] = useState(null);
   const [deleteDialogMode, setDeleteDialogMode] = useState('confirm');
   const [deleteDialogMessage, setDeleteDialogMessage] = useState('');
-  const [anchorEl, setAnchorEl] = useState(null);
+  const [actionsMenuUser, setActionsMenuUser] = useState(null);
+  const [actionsMenuPosition, setActionsMenuPosition] = useState(null);
+  const actionsMenuRef = useRef(null);
 
   // Load roles from API (Phase 4: DB-driven roles)
   const { roleOptions: apiRoleOptions } = useRoles({ includeAll: true });
@@ -97,6 +98,47 @@ const UserManagement = () => {
       isMounted = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (!actionsMenuUser) {
+      return undefined;
+    }
+
+    const closeMenu = () => {
+      setActionsMenuUser(null);
+      setActionsMenuPosition(null);
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        closeMenu();
+      }
+    };
+
+    const handlePointerDown = (event) => {
+      if (actionsMenuRef.current?.contains(event.target)) {
+        return;
+      }
+
+      if (event.target.closest?.('[data-user-actions-trigger="true"]')) {
+        return;
+      }
+
+      closeMenu();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('mousedown', handlePointerDown);
+    window.addEventListener('resize', closeMenu);
+    window.addEventListener('scroll', closeMenu, true);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('mousedown', handlePointerDown);
+      window.removeEventListener('resize', closeMenu);
+      window.removeEventListener('scroll', closeMenu, true);
+    };
+  }, [actionsMenuUser]);
 
   const loadUsers = async () => {
     try {
@@ -231,6 +273,53 @@ const UserManagement = () => {
     setShowUserModal(true);
   };
 
+  const closeActionsMenu = () => {
+    setActionsMenuUser(null);
+    setActionsMenuPosition(null);
+  };
+
+  const openActionsMenu = (event, user) => {
+    event.stopPropagation();
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    const menuWidth = 208;
+    const left = Math.max(8, Math.min(rect.right - menuWidth, window.innerWidth - menuWidth - 8));
+
+    setSelectedUser(user);
+    setActionsMenuUser(user);
+    setActionsMenuPosition({
+      top: rect.bottom + 6,
+      left
+    });
+  };
+
+  const handleEditFromActionsMenu = () => {
+    if (!actionsMenuUser) {
+      return;
+    }
+
+    openUserDialog(actionsMenuUser);
+    closeActionsMenu();
+  };
+
+  const handleToggleStatusFromActionsMenu = () => {
+    if (!actionsMenuUser) {
+      return;
+    }
+
+    handleToggleUserStatus(actionsMenuUser.id, actionsMenuUser.is_active);
+    closeActionsMenu();
+  };
+
+  const handleDeleteFromActionsMenu = () => {
+    if (!actionsMenuUser) {
+      return;
+    }
+
+    openDeleteDialog(actionsMenuUser);
+    closeActionsMenu();
+  };
+
   const getRoleBadgeVariant = (role) => {
     const variants = {
       'Admin': 'error',
@@ -260,6 +349,31 @@ const UserManagement = () => {
 
     return matchesSearch && matchesRole && matchesStatus;
   });
+
+  const actionMenuItemStyle = {
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
+    padding: '9px 10px',
+    border: 'none',
+    borderRadius: 'var(--mac-radius-sm)',
+    background: 'transparent',
+    color: 'var(--mac-text-primary)',
+    font: 'inherit',
+    fontSize: '13px',
+    textAlign: 'left',
+    cursor: 'pointer'
+  };
+
+  const actionMenuIconStyle = {
+    width: '18px',
+    minWidth: '18px',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: 'var(--mac-text-secondary)'
+  };
 
   // Table Columns Configuration
   const columns = [
@@ -327,19 +441,22 @@ const UserManagement = () => {
     key: 'actions',
     title: '',
     render: (_, user) =>
-    <div onClick={(e) => e.stopPropagation()}>
-          <IconButton
-        aria-label="Действия"
+    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <MacOSButton
+        data-user-actions-trigger="true"
+        aria-label={`Действия: ${user.full_name || user.username}`}
+        aria-haspopup="menu"
+        aria-expanded={actionsMenuUser?.id === user.id}
         title="Действия"
         onClick={(e) => {
-          e.stopPropagation();
-          setAnchorEl(e.currentTarget);
-          setSelectedUser(user);
+          openActionsMenu(e, user);
         }}
-        size="small">
+        variant="ghost"
+        size="sm"
+        style={{ width: '32px', height: '32px', padding: 0 }}>
         
             <MoreVertical size={16} />
-          </IconButton>
+          </MacOSButton>
         </div>
 
   }];
@@ -439,44 +556,48 @@ const UserManagement = () => {
         
       </MacOSCard>
 
-      {/* Actions Menu (MUI Legacy for now) */}
-      <Menu
-        anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
-        onClose={() => setAnchorEl(null)}
-        PaperProps={{
-          style: {
-            borderRadius: '10px',
-            boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
-            border: '1px solid #e5e7eb'
-          }
+      {/* Actions Menu */}
+      {actionsMenuUser && actionsMenuPosition &&
+      <div
+        ref={actionsMenuRef}
+        role="menu"
+        aria-label="Действия пользователя"
+        style={{
+          position: 'fixed',
+          top: actionsMenuPosition.top,
+          left: actionsMenuPosition.left,
+          zIndex: 2000,
+          width: '208px',
+          padding: '6px',
+          borderRadius: 'var(--mac-radius-md)',
+          border: '1px solid var(--mac-border)',
+          background: 'var(--mac-bg-primary)',
+          boxShadow: 'var(--mac-shadow-lg)',
+          display: 'grid',
+          gap: '2px'
         }}>
-        
-        <MenuItem onClick={() => {openUserDialog(selectedUser);setAnchorEl(null);}}>
-          <ListItemIcon><Edit size={16} /></ListItemIcon>
-          <ListItemText primary="Редактировать" primaryTypographyProps={{ fontSize: '13px' }} />
-        </MenuItem>
-        <MenuItem onClick={() => {
-          handleToggleUserStatus(selectedUser.id, selectedUser.is_active);
-          setAnchorEl(null);
-        }}>
-          <ListItemIcon>
-            {selectedUser?.is_active ? <Ban size={16} /> : <CheckCircle size={16} />}
-          </ListItemIcon>
-          <ListItemText
-            primary={selectedUser?.is_active ? 'Деактивировать' : 'Активировать'}
-            primaryTypographyProps={{ fontSize: '13px' }} />
-          
-        </MenuItem>
-        <Divider />
-        <MenuItem onClick={() => {
-          openDeleteDialog(selectedUser);
-          setAnchorEl(null);
-        }}>
-          <ListItemIcon><Trash2 size={16} color="#ef4444" /></ListItemIcon>
-          <ListItemText primary="Удалить" primaryTypographyProps={{ fontSize: '13px', color: '#ef4444' }} />
-        </MenuItem>
-      </Menu>
+
+        <button type="button" role="menuitem" style={actionMenuItemStyle} onClick={handleEditFromActionsMenu}>
+          <span style={actionMenuIconStyle}><Edit size={16} /></span>
+          <span>Редактировать</span>
+        </button>
+        <button type="button" role="menuitem" style={actionMenuItemStyle} onClick={handleToggleStatusFromActionsMenu}>
+          <span style={actionMenuIconStyle}>
+            {actionsMenuUser.is_active ? <Ban size={16} /> : <CheckCircle size={16} />}
+          </span>
+          <span>{actionsMenuUser.is_active ? 'Деактивировать' : 'Активировать'}</span>
+        </button>
+        <div role="separator" style={{ height: '1px', background: 'var(--mac-border)', margin: '4px 0' }} />
+        <button
+          type="button"
+          role="menuitem"
+          style={{ ...actionMenuItemStyle, color: 'var(--mac-error)' }}
+          onClick={handleDeleteFromActionsMenu}>
+          <span style={{ ...actionMenuIconStyle, color: 'var(--mac-error)' }}><Trash2 size={16} /></span>
+          <span>Удалить</span>
+        </button>
+      </div>
+      }
 
       {/* User Modal (New MacOS Styled) */}
       <UserModal


### PR DESCRIPTION
﻿## Summary
- Replaced the remaining MUI actions menu in `frontend/src/components/admin/UserManagement.jsx` with native/macOS controls.
- Preserved edit, activate/deactivate, delete-dialog, and self-delete guardrail behavior.
- Updated MUI inventory and added audit evidence for this gated admin slice.

## Contract Impact
- Canonical surface: `frontend/src/components/admin/UserManagement.jsx` on `/admin/advanced-users`.
- Request shape: Unchanged; no API calls or payloads changed.
- Response shape: Unchanged; existing users list/user update responses are consumed the same way.
- Status codes: Unchanged; this PR does not alter backend status handling.
- Frontend consumer: Admin user management route only.
- Compatibility path or alias: Unchanged; `/advanced-users` legacy redirect remains route-registry owned.
- Contract proof: Static diff shows only actions menu UI implementation changed; build and authenticated browser smoke passed.

## RBAC / Permissions
- Roles allowed: Unchanged; existing admin route guard remains the authority.
- Roles denied: Unchanged; this PR does not alter route/RBAC logic.
- Positive auth proof: One-off Playwright smoke seeded an Admin session and rendered `/admin/advanced-users`.
- Negative auth proof: Unchanged; no RBAC denial path changed in this UI-only slice.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no notification or websocket code touched.
- Payload version / ack behavior: Unchanged.
- Read/unread or delivery semantics: Unchanged.
- Reconnect/resync proof: Unchanged; not relevant to this admin menu slice.

## Frontend Resilience
- Empty data proof: Existing empty table behavior unchanged; mocked browser smoke provided two users to exercise the menu.
- Partial data proof: Menu labels use `full_name || username`, preserving fallback behavior.
- Forbidden secondary path behavior: Unchanged; no route guard or forbidden state code touched.
- Missing draft/resource behavior: Unchanged; user modal/delete dialog behavior is reused.
- Stale route/deep-link behavior: `/admin/advanced-users` rendered under route id `admin-advanced-users` in the smoke.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/UserManagement.jsx`, `frontend/MUI_RUNTIME_INVENTORY.md`, `docs/audits/uiux-hard-audit-2026-05-20/user-management-actions-menu-mui-removal.md`.
- Denied paths: Backend, schemas, migrations, route registry, RBAC, payment, queue, clinical, Telegram, AI, and unrelated frontend files.
- Migration/docs/test impact: Documentation/inventory only; no committed tests changed.
- Rollback note: Revert this PR to restore previous menu implementation if a UI regression appears.

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js`; `npm.cmd run lint:check`; `npm.cmd run build`; one-off authenticated Playwright smoke for `/admin/advanced-users`; `rg -l '@mui|Mui' frontend\\src\\pages frontend\\src\\components`; `git diff --check`.
- Result: Passed. Route test 2/2; lint 0 errors with 54 existing warnings; build passed; browser smoke passed; MUI count is now 12; `UserManagement.jsx` no longer matches MUI search.
- Not checked: Backend authorization and production data paths; unchanged by this UI-only PR.
