### PR TITLE
refactor(frontend): remove mui from unified card example

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/mui-example-only-policy.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/mui-example-only-policy.md
@@ -81,8 +81,14 @@ not block runtime UI decisions or be treated as safe app patterns.
 to a macOS/native example with no current `@mui` import. It remains example-only
 and must not be imported into clinic runtime UI.
 
-`frontend/src/components/examples/UnifiedCard.tsx` remains the only current
-example-only MUI reference.
+## Follow-Up: UnifiedCard Example Migration
+
+`frontend/src/components/examples/UnifiedCard.tsx` has since been converted to
+a macOS/native example with no current `@mui` import. It remains example-only
+and must not be imported into clinic runtime UI.
+
+The current example-only MUI count is now `0`; remaining MUI files are all
+runtime domain islands that require dedicated gate/handoff slices.
 
 ## Next Smallest Step
 

--- a/docs/audits/uiux-hard-audit-2026-05-20/unified-card-example-mui-removal.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/unified-card-example-mui-removal.md
@@ -1,0 +1,92 @@
+# UnifiedCard Example MUI Removal
+
+Date: 2026-05-20
+
+## Scope
+
+Converted the example-only card reference:
+
+- `frontend/src/components/examples/UnifiedCard.tsx`
+
+This PR did not touch runtime clinic routes, role panels, backend code, RBAC,
+payment, queue, clinical workflows, Telegram, AI/MCP, or notification behavior.
+
+## Why This Was Safe
+
+`UnifiedCard.tsx` was classified as example-only debt in
+`frontend/MUI_RUNTIME_INVENTORY.md` and
+`docs/audits/uiux-hard-audit-2026-05-20/mui-example-only-policy.md`.
+
+Static search found documentation references, but no active app route importing
+or rendering `UnifiedCard`:
+
+```powershell
+rg -n "UnifiedCard|UnifiedButton|MacOSDemo|components/examples" frontend\src\routing frontend\src\pages frontend\src\components -g "!*UnifiedCard.tsx"
+```
+
+Observed route evidence:
+
+- `frontend/src/pages/MacOSDemoPage.jsx` lazy-loads `components/examples/MacOSDemo`.
+- `UnifiedCard.tsx` is not imported by active app pages or route registry files.
+
+## Changed
+
+- Removed all `@mui/material` imports from `UnifiedCard.tsx`.
+- Removed MUI `styled` and MUI `useTheme`.
+- Preserved the public example exports:
+  - `UnifiedCard`
+  - `UnifiedCardShowcase`
+- Preserved the example props and variants:
+  - `variant`
+  - `title`
+  - `subtitle`
+  - `children`
+  - `actions`
+  - `onClick`
+  - `interactive`
+  - `size`
+- Added keyboard semantics for interactive cards with `role="button"`,
+  `tabIndex=0`, and Enter/Space handling.
+- Replaced MUI showcase actions with native buttons styled by existing macOS
+  CSS variables.
+
+## MUI Count
+
+After this slice:
+
+```powershell
+rg -l '@mui|Mui' frontend\src\pages frontend\src\components
+```
+
+Result: 10 files.
+
+The remaining files are all runtime domain islands:
+
+- Payment/queue: `PaymentWidget.jsx`, `PaymentTest.jsx`,
+  `OnlineQueueManager.jsx`
+- Clinical: `FamilyRelationsCard.jsx`, `LabReportGenerator.jsx`,
+  `ECGViewer.jsx`, `TreatmentPlanner.jsx`, `ToothModal.jsx`
+- Telegram/AI: `TelegramManager.jsx`, `MCPMonitor.jsx`
+
+## Validation Plan
+
+- Route ownership test for route registry regressions.
+- Frontend lint.
+- Frontend build.
+- Static MUI count.
+- `git diff --check`.
+
+## Stop Conditions
+
+Stop if:
+
+- `UnifiedCard.tsx` is found to be an active runtime route dependency.
+- Preserving its example API requires touching app pages or route registry files.
+- The change requires payment, queue, clinical, Telegram, AI/MCP, RBAC, backend,
+  or notification behavior changes.
+
+## Next Smallest Step
+
+Move to the risky runtime MUI backlog only through dedicated gate/handoff slices.
+Do not combine payment, queue, clinical, Telegram, or AI/MCP MUI migrations in a
+generic cleanup PR.

--- a/frontend/MUI_RUNTIME_INVENTORY.md
+++ b/frontend/MUI_RUNTIME_INVENTORY.md
@@ -37,6 +37,10 @@ UnifiedButton example migration: 11 files now contain runtime or example MUI
 imports after converting `frontend/src/components/examples/UnifiedButton.tsx`
 to a macOS/native example.
 
+UnifiedCard example migration: 10 files now contain runtime MUI imports after
+converting `frontend/src/components/examples/UnifiedCard.tsx` to a
+macOS/native example. No example-only `Unified*` MUI references remain.
+
 ## No-New-MUI Island Policy
 
 MUI is a legacy compatibility layer in this clinic frontend. New clinic runtime UI should not create new MUI islands.
@@ -85,7 +89,7 @@ rg -l '@mui|Mui' frontend/src/pages frontend/src/components
 | `frontend/src/components/dental/ToothModal.jsx` | Clinical-heavy | Dental tooth modal and clinical status semantics. | Clinical safety review before migration. |
 | `frontend/src/components/TelegramManager.jsx` | Telegram/AI-sensitive | Telegram integration management. | Gate/handoff only. |
 | `frontend/src/components/ai/MCPMonitor.jsx` | Telegram/AI-sensitive | AI/MCP monitoring surface. | Gate/handoff only; preserve AI safety copy. |
-| `frontend/src/components/examples/UnifiedCard.tsx` | Example-only | Design-system example file. | Do not count as blocking app runtime until examples policy is decided. |
+| `frontend/src/components/examples/UnifiedCard.tsx` | Migrated/example-only | Design-system example file now uses macOS/native card markup with no current `@mui` import. | Keep example-only; do not import into clinic runtime UI. |
 | `frontend/src/components/examples/UnifiedButton.tsx` | Migrated/example-only | Design-system example file now uses macOS/native controls with no current `@mui` import. | Keep example-only; do not import into clinic runtime UI. |
 
 ## Do-Not-Touch Buckets
@@ -108,7 +112,7 @@ These targets were low-risk because they are UI-status prompts and were migrated
 
 ## Remaining Runtime Targets
 
-The remaining current `@mui` files are all in do-not-touch buckets or shared/admin-sensitive/example-only categories. Do not migrate them without a dedicated gate/handoff.
+The remaining current `@mui` files are all in do-not-touch runtime buckets. Do not migrate them without a dedicated gate/handoff.
 
 ## PR-UX-17 Decision
 
@@ -128,6 +132,8 @@ Result after UserManagement actions menu migration: 12 files.
 
 Result after UnifiedButton example migration: 11 files.
 
+Result after UnifiedCard example migration: 10 files.
+
 Decision: do not force a runtime MUI migration in this PR. The only already
 approved low-risk runtime targets were `ConnectionStatus.jsx` and
 `PWAInstallPrompt.jsx`, and both are already migrated. Every remaining runtime
@@ -139,12 +145,12 @@ handoff:
 - Queue/payment: protect queue status, payment state, receipts, and print/download actions.
 - Lab/cardiology/dental/patient: preserve clinical meaning, report generation, ECG/dental status, and patient relationship visibility.
 - Telegram/AI/MCP: preserve integration status, security copy, and operational diagnostics.
-- Examples: decide whether example-only files stay as MUI design-system references before counting them as runtime cleanup.
+- Examples: both `Unified*` example files now use macOS/native examples and no longer count in the MUI search result.
 
 The dedicated admin actions menu migration has now removed `UserManagement.jsx`
-from the current MUI search result. The follow-up example migration removed
-`UnifiedButton.tsx` from the current MUI search result. Remaining MUI targets
-are payment, queue, clinical, Telegram/AI, and `UnifiedCard.tsx`.
+from the current MUI search result. The follow-up example migrations removed
+`UnifiedButton.tsx` and `UnifiedCard.tsx` from the current MUI search result.
+Remaining MUI targets are payment, queue, clinical, and Telegram/AI.
 
 Next safe MUI migration should be a dedicated PR with one first-touch file,
 route/browser smoke, and a PR body that explicitly proves no role, route,
@@ -173,7 +179,7 @@ classification:
 | Payment/queue-adjacent | 3 | Gate/handoff only. |
 | Clinical-heavy | 5 | Clinical safety review before migration. |
 | Telegram/AI-sensitive | 2 | Gate/handoff only. |
-| Example-only | 2 | Decide example policy before counting as runtime cleanup. |
+| Example-only | 0 | Both `Unified*` examples have been converted away from MUI. |
 
 Current files:
 
@@ -193,8 +199,7 @@ Current files:
   - `frontend/src/components/TelegramManager.jsx`
   - `frontend/src/components/ai/MCPMonitor.jsx`
 - Example-only:
-  - `frontend/src/components/examples/UnifiedButton.tsx`
-  - `frontend/src/components/examples/UnifiedCard.tsx`
+  - none currently matching `@mui|Mui`
 
 Decision: do not migrate MUI in PR-MUI-1. The next safe step is PR-MUI-2 only
 if one low-risk admin island can be scoped with browser proof; otherwise move to
@@ -223,7 +228,7 @@ Next safe step: PR-MUI-3 example-only policy for
 
 ## PR-MUI-3 Example-Only Policy
 
-The two `components/examples/Unified*` files remain MUI references, but static
+The two `components/examples/Unified*` files were MUI references, but static
 search found no active app callers for `UnifiedButton` or `UnifiedCard`.
 `MacOSDemoPage.jsx` lazy-loads `components/examples/MacOSDemo`, not these two
 files.
@@ -232,7 +237,7 @@ Policy:
 
 - Treat `frontend/src/components/examples/UnifiedButton.tsx` and
   `frontend/src/components/examples/UnifiedCard.tsx` as isolated example-only
-  MUI debt, not active clinic runtime UI.
+  reference files, not active clinic runtime UI.
 - Do not import these files into app pages, role panels, workflow components,
   route views, payment/queue/clinical screens, or authenticated dashboards.
 - Do not copy their MUI patterns into new clinic runtime UI; use
@@ -241,9 +246,9 @@ Policy:
   runtime debt and require a scoped migration/removal PR.
 - Leave MUI dependencies in place while any runtime MUI imports remain.
 
-Future cleanup should be a separate docs/examples PR: convert these examples to
-macOS primitives, archive them, or delete them after confirming no developer
-workflow still uses them.
+The cleanup has now converted both examples to macOS/native examples. Future
+cleanup can update older docs that still mention the historical MUI variants or
+delete/archive the examples if no developer workflow uses them.
 
 ## PR-MUI-4 Risky Runtime Handoff
 

--- a/frontend/src/components/examples/UnifiedCard.tsx
+++ b/frontend/src/components/examples/UnifiedCard.tsx
@@ -1,22 +1,15 @@
 /**
  * Unified Card Component
- * Example of proper MUI Card using theme tokens with variants
+ * Example of a macOS-native card pattern using existing clinic tokens.
+ *
+ * This example is intentionally MUI-free. Clinic runtime UI should prefer
+ * frontend/src/components/ui/macos before copying example code.
  */
 
 import React from 'react';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import CardHeader from '@mui/material/CardHeader';
-import CardActions from '@mui/material/CardActions';
-import Typography from '@mui/material/Typography';
-import { styled } from '@mui/material/styles';
-import { spacing, borderRadius, shadows, shadowsDark, transitions, easing } from '@/theme/tokens';
-import { useTheme } from '@mui/material/styles';
 
-// ============================================================================
-// CARD VARIANTS
-// ============================================================================
 type CardVariant = 'elevated' | 'outlined' | 'filled' | 'soft' | 'glass' | 'interactive';
+type UnifiedCardSize = 'sm' | 'md' | 'lg';
 
 interface UnifiedCardProps {
   variant?: CardVariant;
@@ -26,245 +19,273 @@ interface UnifiedCardProps {
   actions?: React.ReactNode;
   onClick?: () => void;
   interactive?: boolean;
-  size?: 'sm' | 'md' | 'lg';
+  size?: UnifiedCardSize;
+  className?: string;
+  style?: React.CSSProperties;
 }
 
-// ============================================================================
-// STYLED VARIANTS
-// ============================================================================
-const ElevatedCard = styled(Card)(({ theme }) => ({
-  border: 'none',
-  boxShadow: theme.palette.mode === 'light' ? shadows.md : shadowsDark.md,
-  transition: `all ${transitions.base} ${easing.easeInOut}`,
-  '&:hover': {
-    boxShadow: theme.palette.mode === 'light' ? shadows.lg : shadowsDark.lg,
-  },
-}));
+const sizePadding: Record<UnifiedCardSize, string> = {
+  sm: '12px',
+  md: '16px',
+  lg: '24px',
+};
 
-const OutlinedCard = styled(Card)(({ theme }) => ({
-  border: `1px solid ${theme.palette.divider}`,
-  boxShadow: 'none',
-  backgroundColor: theme.palette.background.paper,
-  transition: `all ${transitions.base} ${easing.easeInOut}`,
-  '&:hover': {
-    borderColor: theme.palette.primary.main,
-    boxShadow: theme.palette.mode === 'light' ? shadows.sm : shadowsDark.sm,
-  },
-}));
+const baseCardStyle: React.CSSProperties = {
+  position: 'relative',
+  overflow: 'hidden',
+  borderRadius: 'var(--mac-radius-lg)',
+  color: 'var(--mac-text-primary)',
+  fontFamily: 'var(--mac-font-family, -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif)',
+  transition: 'box-shadow var(--mac-duration-normal) var(--mac-ease), border-color var(--mac-duration-normal) var(--mac-ease), background-color var(--mac-duration-normal) var(--mac-ease), transform var(--mac-duration-fast) var(--mac-ease)',
+  outlineOffset: 2,
+};
 
-const FilledCard = styled(Card)(({ theme }) => ({
-  backgroundColor: theme.palette.action.hover,
-  border: 'none',
-  boxShadow: 'none',
-  transition: `all ${transitions.base} ${easing.easeInOut}`,
-  '&:hover': {
-    backgroundColor: theme.palette.action.selected,
+const variantStyles: Record<CardVariant, React.CSSProperties> = {
+  elevated: {
+    background: 'var(--mac-card-bg, var(--mac-bg-primary))',
+    border: '1px solid var(--mac-border-secondary)',
+    boxShadow: 'var(--mac-shadow-md)',
   },
-}));
-
-const SoftCard = styled(Card)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'light'
-    ? 'rgba(59, 130, 246, 0.05)'
-    : 'rgba(147, 51, 234, 0.1)',
-  border: `1px solid ${theme.palette.mode === 'light'
-    ? 'rgba(59, 130, 246, 0.2)'
-    : 'rgba(147, 51, 234, 0.3)'}`,
-  boxShadow: 'none',
-  transition: `all ${transitions.base} ${easing.easeInOut}`,
-  '&:hover': {
-    backgroundColor: theme.palette.mode === 'light'
-      ? 'rgba(59, 130, 246, 0.1)'
-      : 'rgba(147, 51, 234, 0.15)',
+  outlined: {
+    background: 'var(--mac-card-bg, var(--mac-bg-primary))',
+    border: '1px solid var(--mac-card-border, var(--mac-border))',
+    boxShadow: 'none',
   },
-}));
-
-const GlassCard = styled(Card)(({ theme }) => ({
-  backdropFilter: 'blur(10px)',
-  backgroundColor: theme.palette.mode === 'light'
-    ? 'rgba(255, 255, 255, 0.7)'
-    : 'rgba(30, 30, 40, 0.7)',
-  border: `1px solid ${theme.palette.mode === 'light'
-    ? 'rgba(255, 255, 255, 0.5)'
-    : 'rgba(255, 255, 255, 0.1)'}`,
-  boxShadow: 'none',
-  transition: `all ${transitions.base} ${easing.easeInOut}`,
-  '&:hover': {
-    backgroundColor: theme.palette.mode === 'light'
-      ? 'rgba(255, 255, 255, 0.8)'
-      : 'rgba(40, 40, 50, 0.8)',
-    borderColor: theme.palette.mode === 'light'
-      ? 'rgba(255, 255, 255, 0.7)'
-      : 'rgba(255, 255, 255, 0.2)',
+  filled: {
+    background: 'var(--mac-bg-tertiary)',
+    border: '1px solid var(--mac-border-secondary)',
+    boxShadow: 'none',
   },
-}));
+  soft: {
+    background: 'var(--mac-accent-bg, rgba(0, 122, 255, 0.08))',
+    border: '1px solid var(--mac-accent-border, rgba(0, 122, 255, 0.22))',
+    boxShadow: 'none',
+  },
+  glass: {
+    background: 'var(--mac-glass-bg, rgba(255, 255, 255, 0.72))',
+    border: '1px solid var(--mac-glass-border, rgba(255, 255, 255, 0.58))',
+    boxShadow: 'var(--mac-shadow-sm)',
+    backdropFilter: 'var(--mac-blur-light)',
+    WebkitBackdropFilter: 'var(--mac-blur-light)',
+  },
+  interactive: {
+    background: 'var(--mac-card-bg, var(--mac-bg-primary))',
+    border: '1px solid var(--mac-card-border, var(--mac-border))',
+    boxShadow: 'var(--mac-shadow-sm)',
+  },
+};
 
-const InteractiveCard = styled(Card)(({ theme }) => ({
-  border: `1px solid ${theme.palette.divider}`,
-  boxShadow: theme.palette.mode === 'light' ? shadows.sm : shadowsDark.sm,
+const titleStyle: React.CSSProperties = {
+  margin: 0,
+  color: 'var(--mac-text-primary)',
+  fontSize: 'var(--mac-font-size-lg)',
+  fontWeight: 'var(--mac-font-weight-semibold)',
+  lineHeight: 1.25,
+};
+
+const subtitleStyle: React.CSSProperties = {
+  margin: '4px 0 0',
+  color: 'var(--mac-text-secondary)',
+  fontSize: 'var(--mac-font-size-sm)',
+  lineHeight: 1.4,
+};
+
+const bodyTextStyle: React.CSSProperties = {
+  margin: 0,
+  color: 'var(--mac-text-secondary)',
+  fontSize: 'var(--mac-font-size-base)',
+  lineHeight: 1.55,
+};
+
+const actionButtonStyle: React.CSSProperties = {
+  minHeight: 32,
+  borderRadius: 'var(--mac-radius-md)',
+  border: '1px solid var(--mac-border)',
+  background: 'var(--mac-bg-secondary)',
+  color: 'var(--mac-text-primary)',
+  padding: '8px 14px',
+  font: 'inherit',
   cursor: 'pointer',
-  transition: `all ${transitions.base} ${easing.easeInOut}`,
-  '&:hover': {
-    transform: 'translateY(-4px)',
-    boxShadow: theme.palette.mode === 'light' ? shadows.lg : shadowsDark.lg,
-    borderColor: theme.palette.primary.main,
-  },
-  '&:active': {
-    transform: 'translateY(-2px)',
-  },
-}));
+};
 
-// ============================================================================
-// MAIN COMPONENT
-// ============================================================================
 export const UnifiedCard = React.forwardRef<HTMLDivElement, UnifiedCardProps>(
-  ({ 
-    variant = 'outlined', 
-    title, 
-    subtitle, 
-    children, 
-    actions,
-    onClick,
-    size = 'md',
-  }, ref) => {
-    const theme = useTheme();
+  (
+    {
+      variant = 'outlined',
+      title,
+      subtitle,
+      children,
+      actions,
+      onClick,
+      interactive = false,
+      size = 'md',
+      className = '',
+      style,
+    },
+    ref
+  ) => {
+    const isInteractive = Boolean(interactive || onClick || variant === 'interactive');
 
-    // Get padding based on size
-    const getPadding = (size: 'sm' | 'md' | 'lg') => {
-      switch (size) {
-        case 'sm':
-          return spacing[3];
-        case 'md':
-          return spacing[4];
-        case 'lg':
-          return spacing[6];
-        default:
-          return spacing[4];
+    const cardStyle: React.CSSProperties = {
+      ...baseCardStyle,
+      ...variantStyles[variant],
+      padding: sizePadding[size],
+      cursor: isInteractive ? 'pointer' : 'default',
+      ...style,
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!isInteractive || !onClick) return;
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        onClick();
       }
     };
 
-    // Select variant component
-    const CardComponent = {
-      elevated: ElevatedCard,
-      outlined: OutlinedCard,
-      filled: FilledCard,
-      soft: SoftCard,
-      glass: GlassCard,
-      interactive: InteractiveCard,
-    }[variant];
-
-    return (
-      <CardComponent
-        ref={ref}
-        onClick={onClick}
-        sx={{
-          borderRadius: borderRadius.lg,
-        }}
-      >
+    const content = (
+      <>
         {(title || subtitle) && (
-          <CardHeader
-            title={title}
-            subheader={subtitle}
-            titleTypographyProps={{ variant: 'h5' }}
-            subheaderTypographyProps={{ variant: 'body2' }}
-            sx={{
-              paddingBottom: spacing[3],
+          <header
+            style={{
+              paddingBottom: children ? '12px' : 0,
+              borderBottom: children ? '1px solid var(--mac-separator)' : undefined,
+              marginBottom: children ? '14px' : 0,
             }}
-          />
+          >
+            {title && <h3 style={titleStyle}>{title}</h3>}
+            {subtitle && <p style={subtitleStyle}>{subtitle}</p>}
+          </header>
         )}
 
-        <CardContent
-          sx={{
-            padding: getPadding(size),
-            '&:last-child': {
-              paddingBottom: getPadding(size),
-            },
-          }}
-        >
-          {children}
-        </CardContent>
+        <section>{children}</section>
 
         {actions && (
-          <CardActions
-            sx={{
-              padding: spacing[4],
-              paddingTop: 0,
-              borderTop: `1px solid ${theme.palette.divider}`,
+          <footer
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: '8px',
+              flexWrap: 'wrap',
+              marginTop: '16px',
+              paddingTop: '12px',
+              borderTop: '1px solid var(--mac-separator)',
             }}
           >
             {actions}
-          </CardActions>
+          </footer>
         )}
-      </CardComponent>
+      </>
+    );
+
+    if (isInteractive) {
+      return (
+        <div
+          ref={ref}
+          className={className}
+          role="button"
+          tabIndex={0}
+          onClick={onClick}
+          onKeyDown={handleKeyDown}
+          style={cardStyle}
+        >
+          {content}
+        </div>
+      );
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={className}
+        style={cardStyle}
+      >
+        {content}
+      </div>
     );
   }
 );
 
 UnifiedCard.displayName = 'UnifiedCard';
 
-// ============================================================================
-// USAGE EXAMPLES
-// ============================================================================
-import Button from '@mui/material/Button';
-
 export const UnifiedCardShowcase = () => {
   return (
-    <div style={{ display: 'grid', gap: '24px', padding: '24px', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))' }}>
-      {/* Elevated variant */}
+    <div
+      style={{
+        display: 'grid',
+        gap: '24px',
+        padding: '24px',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+      }}
+    >
       <UnifiedCard variant="elevated" title="Elevated Card" subtitle="With shadow">
-        <Typography>This card has a subtle shadow elevation.</Typography>
+        <p style={bodyTextStyle}>This card has a quiet shadow for high-level summaries.</p>
       </UnifiedCard>
 
-      {/* Outlined variant */}
       <UnifiedCard variant="outlined" title="Outlined Card" subtitle="Minimal style">
-        <Typography>This card uses just a border for definition.</Typography>
+        <p style={bodyTextStyle}>This card uses a border for definition without extra visual weight.</p>
       </UnifiedCard>
 
-      {/* Filled variant */}
       <UnifiedCard variant="filled" title="Filled Card" subtitle="Background colored">
-        <Typography>This card has a filled background.</Typography>
+        <p style={bodyTextStyle}>This card uses a filled surface for secondary grouped content.</p>
       </UnifiedCard>
 
-      {/* Soft variant */}
-      <UnifiedCard variant="soft" title="Soft Card" subtitle="Subtle color">
-        <Typography>This card uses a soft background tint.</Typography>
+      <UnifiedCard variant="soft" title="Soft Card" subtitle="Subtle accent">
+        <p style={bodyTextStyle}>This card uses the accent background for low-risk informational emphasis.</p>
       </UnifiedCard>
 
-      {/* Glass variant */}
-      <UnifiedCard variant="glass" title="Glass Card" subtitle="Modern blur effect">
-        <Typography>This card uses a glassmorphism effect.</Typography>
+      <UnifiedCard variant="glass" title="Glass Card" subtitle="Blurred surface">
+        <p style={bodyTextStyle}>This card demonstrates a restrained glass surface for demo contexts.</p>
       </UnifiedCard>
 
-      {/* Interactive variant */}
-      <UnifiedCard 
-        variant="interactive" 
-        title="Interactive Card" 
-        subtitle="Hover & click"
-        onClick={() => alert('Card clicked!')}
+      <UnifiedCard
+        variant="interactive"
+        title="Interactive Card"
+        subtitle="Keyboard reachable"
+        onClick={() => undefined}
       >
-        <Typography>This card responds to interaction with elevation change.</Typography>
+        <p style={bodyTextStyle}>This card exposes button semantics and handles Enter or Space.</p>
       </UnifiedCard>
 
-      {/* With actions */}
-      <UnifiedCard 
+      <UnifiedCard
         variant="outlined"
         title="Card with Actions"
         subtitle="Contains buttons"
         actions={
           <>
-            <Button variant="text">Cancel</Button>
-            <Button variant="contained" color="primary">Save</Button>
+            <button type="button" style={actionButtonStyle}>Cancel</button>
+            <button
+              type="button"
+              style={{
+                ...actionButtonStyle,
+                background: 'var(--mac-accent-blue)',
+                borderColor: 'var(--mac-accent-blue)',
+                color: 'var(--mac-text-on-accent)',
+              }}
+            >
+              Save
+            </button>
           </>
         }
       >
-        <Typography>This card demonstrates the CardActions component.</Typography>
+        <p style={bodyTextStyle}>This card demonstrates an accessible footer action row.</p>
       </UnifiedCard>
 
-      {/* Large card */}
       <UnifiedCard variant="elevated" title="Large Card" size="lg">
-        <Typography variant="h6" gutterBottom>Medical Department Card</Typography>
-        <Typography>
-          This is a larger card variant useful for displaying detailed information like patient records, diagnostic results, or department details.
-        </Typography>
+        <h4
+          style={{
+            margin: '0 0 8px',
+            color: 'var(--mac-text-primary)',
+            fontSize: 'var(--mac-font-size-base)',
+            fontWeight: 'var(--mac-font-weight-semibold)',
+          }}
+        >
+          Medical Department Card
+        </h4>
+        <p style={bodyTextStyle}>
+          This larger card can describe patient records, diagnostic summaries, or department details
+          without relying on MUI.
+        </p>
       </UnifiedCard>
     </div>
   );


### PR DESCRIPTION
﻿## Summary
- Converted `frontend/src/components/examples/UnifiedCard.tsx` from a MUI example to a macOS/native card example.
- Preserved `UnifiedCard` and `UnifiedCardShowcase` exports plus the existing example props and variants.
- Updated MUI inventory and example-only policy evidence; added a focused removal report.

## Contract Impact
- Canonical surface: Example-only design-system reference under `frontend/src/components/examples`.
- Request shape: Unchanged; no API calls or payloads exist in this example file.
- Response shape: Unchanged; no backend responses are consumed.
- Status codes: Unchanged; no backend status handling touched.
- Frontend consumer: No active runtime caller found; docs mention the example as reference material.
- Compatibility path or alias: Export names `UnifiedCard` and `UnifiedCardShowcase` preserved; example props and variants remain available.
- Contract proof: Static source search shows no app route imports this file; route ownership test and build passed.

## RBAC / Permissions
- Roles allowed: Unchanged; this file is not route/RBAC-owned runtime UI.
- Roles denied: Unchanged.
- Positive auth proof: Unchanged; not required for an unmounted example-only file.
- Negative auth proof: Unchanged; no route guard or denied path touched.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no notification or websocket code touched.
- Payload version / ack behavior: Unchanged.
- Read/unread or delivery semantics: Unchanged.
- Reconnect/resync proof: Unchanged; not relevant to this example-only slice.

## Frontend Resilience
- Empty data proof: Unchanged; example has no data loading state.
- Partial data proof: Unchanged; example has no data contract.
- Forbidden secondary path behavior: Unchanged; no route behavior touched.
- Missing draft/resource behavior: Unchanged; no resource flow touched.
- Stale route/deep-link behavior: Unchanged; no routing file touched.

## Scope Gate
- Allowed paths: `frontend/src/components/examples/UnifiedCard.tsx`, `frontend/MUI_RUNTIME_INVENTORY.md`, `docs/audits/uiux-hard-audit-2026-05-20/mui-example-only-policy.md`, `docs/audits/uiux-hard-audit-2026-05-20/unified-card-example-mui-removal.md`.
- Denied paths: Runtime role panels, backend, schemas, migrations, route registry, RBAC, payment, queue, clinical, Telegram, AI, and dependency files.
- Migration/docs/test impact: Documentation/inventory only; no committed tests changed.
- Rollback note: Revert this PR to restore the older MUI card example if a developer reference workflow needs it.

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run test:run -- src/routing/__tests__/routeOwnershipEnforcement.test.js`; `npm.cmd run lint:check`; `npm.cmd run build`; `rg -l '@mui|Mui' frontend\\src\\pages frontend\\src\\components`; `rg -n '@mui|Mui' frontend\\src\\components\\examples\\UnifiedCard.tsx frontend\\src\\components\\examples\\UnifiedButton.tsx`; `git diff --check`.
- Result: Passed. Route test 2/2; lint 0 errors with 54 existing warnings and no new UnifiedCard warning; build passed; MUI count is now 10; both Unified example files no longer match MUI search.
- Not checked: Browser rendering of `UnifiedCardShowcase`; the file is example-only and not mounted by current app routes.
