### PR TITLE
docs(frontend): refresh mui inventory after mcp cleanup

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/mui-risky-islands-handoff.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/mui-risky-islands-handoff.md
@@ -13,7 +13,7 @@ Fresh inventory:
 rg -l "@mui|Mui" frontend\src\pages frontend\src\components
 ```
 
-Current post-continuation result: 9 files.
+Current post-continuation result: 8 files.
 
 ## Global Rule
 
@@ -149,7 +149,10 @@ Validation:
 Files:
 
 - `frontend/src/components/TelegramManager.jsx`
-- `frontend/src/components/ai/MCPMonitor.jsx`
+
+Note: `frontend/src/components/ai/MCPMonitor.jsx` had no active frontend route
+owner/importer and was removed as stale code. MCP API client and active AI
+assistant surfaces remain outside this handoff and unchanged.
 
 Mode:
 
@@ -240,8 +243,8 @@ Stop if:
 ## Result
 
 PR-MUI-4 created the guardrails needed before any remaining runtime MUI
-migration. The current remaining MUI inventory is 9 files across payment
-widget, queue, clinical, Telegram, and AI surfaces.
+migration. The current remaining MUI inventory is 8 files across payment
+widget, queue, clinical, and Telegram surfaces.
 
 ## Next Smallest Step
 

--- a/docs/audits/uiux-hard-audit-2026-05-20/third-cycle-performance-mui-summary.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/third-cycle-performance-mui-summary.md
@@ -49,7 +49,7 @@ Current documented local build evidence after PR-PERF-12:
 | `UnifiedReports-*` | `35.25 KiB` |
 | `WaitTimeAnalytics-*` | `19.27 KiB` |
 
-## MUI Status
+## Historical MUI Status
 
 Fresh inventory command:
 
@@ -57,9 +57,9 @@ Fresh inventory command:
 rg -l "@mui|Mui" frontend\src\pages frontend\src\components
 ```
 
-Current count: 14 files.
+Historical count at third-cycle close: 14 files.
 
-Current classification:
+Historical classification:
 
 - Shared/admin-sensitive:
   - `frontend/src/components/admin/UserManagement.jsx`
@@ -140,7 +140,7 @@ classified, policy-covered, and guarded for future small PRs.
 ## Post-Cycle Continuation Note
 
 Later small PRs reduced the current MUI inventory from the historical third
-cycle count of 14 files to 9 files:
+cycle count of 14 files to 8 files:
 
 - stale `frontend/src/components/dashboard/Dashboard.jsx` removal;
 - gated `frontend/src/components/admin/UserManagement.jsx` actions menu
@@ -149,6 +149,7 @@ cycle count of 14 files to 9 files:
   `frontend/src/components/examples/UnifiedCard.tsx` conversion to
   macOS/native examples;
 - gated `frontend/src/pages/PaymentTest.jsx` internal demo migration.
+- stale caller-free `frontend/src/components/ai/MCPMonitor.jsx` removal.
 
 Current remaining MUI files:
 
@@ -160,4 +161,3 @@ Current remaining MUI files:
 - `frontend/src/components/dental/TreatmentPlanner.jsx`
 - `frontend/src/components/dental/ToothModal.jsx`
 - `frontend/src/components/TelegramManager.jsx`
-- `frontend/src/components/ai/MCPMonitor.jsx`

--- a/frontend/MUI_RUNTIME_INVENTORY.md
+++ b/frontend/MUI_RUNTIME_INVENTORY.md
@@ -46,6 +46,11 @@ after converting `frontend/src/pages/PaymentTest.jsx` to macOS/native controls
 in a gate-limited payment demo slice. `PaymentWidget.jsx` remains the only
 payment MUI runtime island.
 
+MCPMonitor stale component removal: 8 files now contain runtime MUI imports
+after deleting caller-free `frontend/src/components/ai/MCPMonitor.jsx`.
+`TelegramManager.jsx` remains the only Telegram/AI-sensitive MUI runtime
+island in the active inventory.
+
 ## No-New-MUI Island Policy
 
 MUI is a legacy compatibility layer in this clinic frontend. New clinic runtime UI should not create new MUI islands.
@@ -93,7 +98,7 @@ rg -l '@mui|Mui' frontend/src/pages frontend/src/components
 | `frontend/src/components/dental/TreatmentPlanner.jsx` | Clinical-heavy | Dental treatment planning and cost/status semantics. | Clinical safety review before migration. |
 | `frontend/src/components/dental/ToothModal.jsx` | Clinical-heavy | Dental tooth modal and clinical status semantics. | Clinical safety review before migration. |
 | `frontend/src/components/TelegramManager.jsx` | Telegram/AI-sensitive | Telegram integration management. | Gate/handoff only. |
-| `frontend/src/components/ai/MCPMonitor.jsx` | Telegram/AI-sensitive | AI/MCP monitoring surface. | Gate/handoff only; preserve AI safety copy. |
+| `frontend/src/components/ai/MCPMonitor.jsx` | Stale/removed | Caller-free AI/MCP monitoring surface had no active frontend route owner/importer. | Removed after route-owner/source search; MCP API client and active AI assistant surfaces remain unchanged. |
 | `frontend/src/components/examples/UnifiedCard.tsx` | Migrated/example-only | Design-system example file now uses macOS/native card markup with no current `@mui` import. | Keep example-only; do not import into clinic runtime UI. |
 | `frontend/src/components/examples/UnifiedButton.tsx` | Migrated/example-only | Design-system example file now uses macOS/native controls with no current `@mui` import. | Keep example-only; do not import into clinic runtime UI. |
 
@@ -105,7 +110,6 @@ rg -l '@mui|Mui' frontend/src/pages frontend/src/components
 - Queue: `OnlineQueueManager.jsx`
 - Payment: `PaymentWidget.jsx`
 - Telegram: `TelegramManager.jsx`
-- AI: `MCPMonitor.jsx`
 - Patient clinical data: `FamilyRelationsCard.jsx`
 
 ## Completed Low-Risk Runtime Targets
@@ -141,6 +145,8 @@ Result after UnifiedCard example migration: 10 files.
 
 Result after PaymentTest internal demo migration: 9 files.
 
+Result after MCPMonitor stale component removal: 8 files.
+
 Decision: do not force a runtime MUI migration in this PR. The only already
 approved low-risk runtime targets were `ConnectionStatus.jsx` and
 `PWAInstallPrompt.jsx`, and both are already migrated. Every remaining runtime
@@ -157,8 +163,8 @@ handoff:
 The dedicated admin actions menu migration has now removed `UserManagement.jsx`
 from the current MUI search result. The follow-up example migrations removed
 `UnifiedButton.tsx` and `UnifiedCard.tsx` from the current MUI search result.
-Remaining MUI targets are the payment widget, queue, clinical, and
-Telegram/AI surfaces.
+Remaining MUI targets are the payment widget, queue, clinical, and Telegram
+surfaces.
 
 Next safe MUI migration should be a dedicated PR with one first-touch file,
 route/browser smoke, and a PR body that explicitly proves no role, route,
@@ -179,7 +185,8 @@ rg -n "@mui|Mui" frontend\src\pages frontend\src\components
 Historical PR-MUI-1 result: 14 files.
 
 Current post-continuation result after dashboard removal, UserManagement,
-UnifiedButton, UnifiedCard, and PaymentTest migrations: 9 files.
+UnifiedButton, UnifiedCard, PaymentTest migration, and MCPMonitor stale
+component removal: 8 files.
 
 No new MUI imports were introduced by the recent performance PRs. Current
 classification:
@@ -189,7 +196,7 @@ classification:
 | Shared/admin-sensitive | 0 | No current MUI search result after UserManagement migration and stale dashboard removal. |
 | Payment/queue-adjacent | 2 | Gate/handoff only. |
 | Clinical-heavy | 5 | Clinical safety review before migration. |
-| Telegram/AI-sensitive | 2 | Gate/handoff only. |
+| Telegram/AI-sensitive | 1 | Gate/handoff only. |
 | Example-only | 0 | Both `Unified*` examples have been converted away from MUI. |
 
 Current files:
@@ -205,13 +212,12 @@ Current files:
   - `frontend/src/components/dental/ToothModal.jsx`
 - Telegram/AI-sensitive:
   - `frontend/src/components/TelegramManager.jsx`
-  - `frontend/src/components/ai/MCPMonitor.jsx`
 - Example-only:
   - none currently matching `@mui|Mui`
 
 Decision: do not treat the historical PR-MUI-1 inventory as current. The
-current live MUI inventory is 9 files and excludes the migrated/removed
-admin/shared, dashboard, example-only, and PaymentTest surfaces.
+current live MUI inventory is 8 files and excludes the migrated/removed
+admin/shared, dashboard, example-only, PaymentTest, and MCPMonitor surfaces.
 
 ## PR-MUI-2 Low-Risk Admin Decision
 
@@ -270,7 +276,7 @@ Gate-required groups:
 - Queue: `OnlineQueueManager.jsx`
 - Clinical: `LabReportGenerator.jsx`, `ECGViewer.jsx`,
   `TreatmentPlanner.jsx`, `ToothModal.jsx`, `FamilyRelationsCard.jsx`
-- Telegram/AI: `TelegramManager.jsx`, `MCPMonitor.jsx`
+- Telegram/AI: `TelegramManager.jsx`
 
 Default rule: one risky MUI island per PR, with first-touch boundaries,
 read-only references, browser/auth proof, and stop conditions named before


### PR DESCRIPTION
﻿## Summary

- Refresh MUI inventory documentation after merged stale `MCPMonitor.jsx` removal.
- Record the current runtime MUI count as 8 files.
- Update the risky handoff so TelegramManager is the only remaining Telegram/AI-sensitive MUI island.

## Contract Impact

- Canonical surface: Frontend MUI inventory and UI/UX audit documentation only.
- Request shape: Unchanged; no API request payloads or frontend runtime requests were modified.
- Response shape: Unchanged; no backend or frontend data response handling was modified.
- Status codes: Unchanged; no route, endpoint, or HTTP behavior changed.
- Frontend consumer: Unchanged; documentation now reflects that active MUI consumers are 8 files.
- Compatibility path or alias: Unchanged; no compatibility alias or migration path changed.
- Contract proof: Diff is docs-only and static MUI inventory reports 8 current files.

## RBAC / Permissions

- Roles allowed: Unchanged; no role access behavior changed.
- Roles denied: Unchanged; no denied-role behavior changed.
- Positive auth proof: Unchanged by docs-only diff; no authenticated runtime route was edited.
- Negative auth proof: Unchanged by docs-only diff; no protected-route behavior was edited.

## Notification / Realtime

- Event type or websocket channel: Unchanged; no notification, websocket, Telegram, or AI runtime code changed.
- Payload version / ack behavior: Unchanged; no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: Unchanged; no notification delivery semantics changed.
- Reconnect/resync proof: Unchanged by docs-only diff; no reconnect logic was edited.

## Frontend Resilience

- Empty data proof: Unchanged; no runtime empty state changed.
- Partial data proof: Unchanged; no runtime partial-data rendering changed.
- Forbidden secondary path behavior: Unchanged; no forbidden-route behavior changed.
- Missing draft/resource behavior: Unchanged; no draft/resource handling changed.
- Stale route/deep-link behavior: Unchanged; docs now record MCPMonitor as removed stale code.

## Scope Gate

- Allowed paths: `frontend/MUI_RUNTIME_INVENTORY.md`; `docs/audits/uiux-hard-audit-2026-05-20/mui-risky-islands-handoff.md`; `docs/audits/uiux-hard-audit-2026-05-20/third-cycle-performance-mui-summary.md`.
- Denied paths: Frontend runtime source, backend source, tests, workflows, migrations, package files.
- Migration/docs/test impact: Documentation-only refresh; no tests or migrations changed.
- Rollback note: Revert this docs commit to restore the previous inventory wording; no runtime rollback is needed.

## Validation

- Targeted tests or smoke run: `git diff --check`; static `rg -l '@mui|Mui' frontend\\src\\pages frontend\\src\\components` count; PR body template gate.
- Result: `git diff --check` passed with line-ending warnings only; static count is 8 files; template gate passed locally.
- Not checked: Frontend lint/build and browser QA, because this PR changes documentation only.
