### PR TITLE
docs(frontend): refresh mui inventory after lab cleanup

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/mui-risky-islands-handoff.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/mui-risky-islands-handoff.md
@@ -13,7 +13,7 @@ Fresh inventory:
 rg -l "@mui|Mui" frontend\src\pages frontend\src\components
 ```
 
-Current post-continuation result: 8 files.
+Current post-continuation result: 7 files.
 
 ## Global Rule
 
@@ -109,11 +109,14 @@ Validation:
 
 Files:
 
-- `frontend/src/components/laboratory/LabReportGenerator.jsx`
 - `frontend/src/components/cardiology/ECGViewer.jsx`
 - `frontend/src/components/dental/TreatmentPlanner.jsx`
 - `frontend/src/components/dental/ToothModal.jsx`
 - `frontend/src/components/patient/FamilyRelationsCard.jsx`
+
+Note: `frontend/src/components/laboratory/LabReportGenerator.jsx` had no
+active frontend source importer and was removed as stale code. Active lab
+panel/report/export behavior remains outside this handoff and unchanged.
 
 Mode:
 
@@ -243,7 +246,7 @@ Stop if:
 ## Result
 
 PR-MUI-4 created the guardrails needed before any remaining runtime MUI
-migration. The current remaining MUI inventory is 8 files across payment
+migration. The current remaining MUI inventory is 7 files across payment
 widget, queue, clinical, and Telegram surfaces.
 
 ## Next Smallest Step

--- a/docs/audits/uiux-hard-audit-2026-05-20/third-cycle-performance-mui-summary.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/third-cycle-performance-mui-summary.md
@@ -140,7 +140,7 @@ classified, policy-covered, and guarded for future small PRs.
 ## Post-Cycle Continuation Note
 
 Later small PRs reduced the current MUI inventory from the historical third
-cycle count of 14 files to 8 files:
+cycle count of 14 files to 7 files:
 
 - stale `frontend/src/components/dashboard/Dashboard.jsx` removal;
 - gated `frontend/src/components/admin/UserManagement.jsx` actions menu
@@ -150,13 +150,14 @@ cycle count of 14 files to 8 files:
   macOS/native examples;
 - gated `frontend/src/pages/PaymentTest.jsx` internal demo migration.
 - stale caller-free `frontend/src/components/ai/MCPMonitor.jsx` removal.
+- stale caller-free `frontend/src/components/laboratory/LabReportGenerator.jsx`
+  removal.
 
 Current remaining MUI files:
 
 - `frontend/src/components/payment/PaymentWidget.jsx`
 - `frontend/src/components/queue/OnlineQueueManager.jsx`
 - `frontend/src/components/patient/FamilyRelationsCard.jsx`
-- `frontend/src/components/laboratory/LabReportGenerator.jsx`
 - `frontend/src/components/cardiology/ECGViewer.jsx`
 - `frontend/src/components/dental/TreatmentPlanner.jsx`
 - `frontend/src/components/dental/ToothModal.jsx`

--- a/frontend/MUI_RUNTIME_INVENTORY.md
+++ b/frontend/MUI_RUNTIME_INVENTORY.md
@@ -51,6 +51,11 @@ after deleting caller-free `frontend/src/components/ai/MCPMonitor.jsx`.
 `TelegramManager.jsx` remains the only Telegram/AI-sensitive MUI runtime
 island in the active inventory.
 
+LabReportGenerator stale component removal: 7 files now contain runtime MUI
+imports after deleting caller-free
+`frontend/src/components/laboratory/LabReportGenerator.jsx`. Active lab panel,
+report, and export behavior remains owned by the mounted lab routes/components.
+
 ## No-New-MUI Island Policy
 
 MUI is a legacy compatibility layer in this clinic frontend. New clinic runtime UI should not create new MUI islands.
@@ -93,7 +98,7 @@ rg -l '@mui|Mui' frontend/src/pages frontend/src/components
 | `frontend/src/pages/PaymentTest.jsx` | Migrated/payment-demo | Internal payment demo/test surface now uses macOS/native controls with no current `@mui` import. | Keep route, admin/internal-demo visibility, and payment demo semantics unchanged; future behavior changes still require payment gate review. |
 | `frontend/src/components/queue/OnlineQueueManager.jsx` | Payment/queue-adjacent | Queue status, print/download, and queue operations. | Gate/handoff only. |
 | `frontend/src/components/patient/FamilyRelationsCard.jsx` | Clinical-heavy | Patient relationship data and visibility semantics. | Clinical safety review before migration. |
-| `frontend/src/components/laboratory/LabReportGenerator.jsx` | Clinical-heavy | Lab report generation UI. | Clinical safety review before migration. |
+| `frontend/src/components/laboratory/LabReportGenerator.jsx` | Stale/removed | Caller-free lab report generator had no active frontend source importer. | Removed after source search; active lab panel/report/export behavior remains unchanged. |
 | `frontend/src/components/cardiology/ECGViewer.jsx` | Clinical-heavy | ECG viewer and cardiology data display. | Clinical safety review before migration. |
 | `frontend/src/components/dental/TreatmentPlanner.jsx` | Clinical-heavy | Dental treatment planning and cost/status semantics. | Clinical safety review before migration. |
 | `frontend/src/components/dental/ToothModal.jsx` | Clinical-heavy | Dental tooth modal and clinical status semantics. | Clinical safety review before migration. |
@@ -106,7 +111,6 @@ rg -l '@mui|Mui' frontend/src/pages frontend/src/components
 
 - Dental: `TreatmentPlanner.jsx`, `ToothModal.jsx`
 - Cardiology: `ECGViewer.jsx`
-- Lab: `LabReportGenerator.jsx`
 - Queue: `OnlineQueueManager.jsx`
 - Payment: `PaymentWidget.jsx`
 - Telegram: `TelegramManager.jsx`
@@ -147,6 +151,8 @@ Result after PaymentTest internal demo migration: 9 files.
 
 Result after MCPMonitor stale component removal: 8 files.
 
+Result after LabReportGenerator stale component removal: 7 files.
+
 Decision: do not force a runtime MUI migration in this PR. The only already
 approved low-risk runtime targets were `ConnectionStatus.jsx` and
 `PWAInstallPrompt.jsx`, and both are already migrated. Every remaining runtime
@@ -185,8 +191,8 @@ rg -n "@mui|Mui" frontend\src\pages frontend\src\components
 Historical PR-MUI-1 result: 14 files.
 
 Current post-continuation result after dashboard removal, UserManagement,
-UnifiedButton, UnifiedCard, PaymentTest migration, and MCPMonitor stale
-component removal: 8 files.
+UnifiedButton, UnifiedCard, PaymentTest migration, MCPMonitor stale component
+removal, and LabReportGenerator stale component removal: 7 files.
 
 No new MUI imports were introduced by the recent performance PRs. Current
 classification:
@@ -195,7 +201,7 @@ classification:
 | --- | ---: | --- |
 | Shared/admin-sensitive | 0 | No current MUI search result after UserManagement migration and stale dashboard removal. |
 | Payment/queue-adjacent | 2 | Gate/handoff only. |
-| Clinical-heavy | 5 | Clinical safety review before migration. |
+| Clinical-heavy | 4 | Clinical safety review before migration. |
 | Telegram/AI-sensitive | 1 | Gate/handoff only. |
 | Example-only | 0 | Both `Unified*` examples have been converted away from MUI. |
 
@@ -206,7 +212,6 @@ Current files:
   - `frontend/src/components/queue/OnlineQueueManager.jsx`
 - Clinical-heavy:
   - `frontend/src/components/patient/FamilyRelationsCard.jsx`
-  - `frontend/src/components/laboratory/LabReportGenerator.jsx`
   - `frontend/src/components/cardiology/ECGViewer.jsx`
   - `frontend/src/components/dental/TreatmentPlanner.jsx`
   - `frontend/src/components/dental/ToothModal.jsx`
@@ -216,8 +221,9 @@ Current files:
   - none currently matching `@mui|Mui`
 
 Decision: do not treat the historical PR-MUI-1 inventory as current. The
-current live MUI inventory is 8 files and excludes the migrated/removed
-admin/shared, dashboard, example-only, PaymentTest, and MCPMonitor surfaces.
+current live MUI inventory is 7 files and excludes the migrated/removed
+admin/shared, dashboard, example-only, PaymentTest, MCPMonitor, and
+LabReportGenerator surfaces.
 
 ## PR-MUI-2 Low-Risk Admin Decision
 
@@ -274,8 +280,8 @@ Gate-required groups:
 
 - Payment: `PaymentWidget.jsx`
 - Queue: `OnlineQueueManager.jsx`
-- Clinical: `LabReportGenerator.jsx`, `ECGViewer.jsx`,
-  `TreatmentPlanner.jsx`, `ToothModal.jsx`, `FamilyRelationsCard.jsx`
+- Clinical: `ECGViewer.jsx`, `TreatmentPlanner.jsx`, `ToothModal.jsx`,
+  `FamilyRelationsCard.jsx`
 - Telegram/AI: `TelegramManager.jsx`
 
 Default rule: one risky MUI island per PR, with first-touch boundaries,


### PR DESCRIPTION
﻿## Summary

- Refresh MUI inventory documentation after merged stale `LabReportGenerator.jsx` removal.
- Record the current runtime MUI count as 7 files.
- Update clinical handoff documentation so active lab/report/export behavior is no longer listed as a current MUI island.

## Contract Impact

- Canonical surface: Frontend MUI inventory and UI/UX audit documentation only.
- Request shape: Unchanged; no API request payloads or frontend runtime requests were modified.
- Response shape: Unchanged; no backend or frontend data response handling was modified.
- Status codes: Unchanged; no route, endpoint, or HTTP behavior changed.
- Frontend consumer: Unchanged; documentation now reflects that active MUI consumers are 7 files.
- Compatibility path or alias: Unchanged; no compatibility alias or migration path changed.
- Contract proof: Diff is docs-only and static MUI inventory reports 7 current files.

## RBAC / Permissions

- Roles allowed: Unchanged; no role access behavior changed.
- Roles denied: Unchanged; no denied-role behavior changed.
- Positive auth proof: Unchanged by docs-only diff; no authenticated runtime route was edited.
- Negative auth proof: Unchanged by docs-only diff; no protected-route behavior was edited.

## Notification / Realtime

- Event type or websocket channel: Unchanged; no notification, websocket, lab, or report-delivery code changed.
- Payload version / ack behavior: Unchanged; no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: Unchanged; no notification delivery semantics changed.
- Reconnect/resync proof: Unchanged by docs-only diff; no reconnect logic was edited.

## Frontend Resilience

- Empty data proof: Unchanged; no runtime empty state changed.
- Partial data proof: Unchanged; no runtime partial-data rendering changed.
- Forbidden secondary path behavior: Unchanged; no forbidden-route behavior changed.
- Missing draft/resource behavior: Unchanged; no draft/resource handling changed.
- Stale route/deep-link behavior: Unchanged; docs now record LabReportGenerator as removed stale code.

## Scope Gate

- Allowed paths: `frontend/MUI_RUNTIME_INVENTORY.md`; `docs/audits/uiux-hard-audit-2026-05-20/mui-risky-islands-handoff.md`; `docs/audits/uiux-hard-audit-2026-05-20/third-cycle-performance-mui-summary.md`.
- Denied paths: Frontend runtime source, backend source, tests, workflows, migrations, package files.
- Migration/docs/test impact: Documentation-only refresh; no tests or migrations changed.
- Rollback note: Revert this docs commit to restore the previous inventory wording; no runtime rollback is needed.

## Validation

- Targeted tests or smoke run: `git diff --check`; static `rg -l '@mui|Mui' frontend\\src\\pages frontend\\src\\components` count; PR body template gate.
- Result: `git diff --check` passed with line-ending warnings only; static count is 7 files; template gate passed locally.
- Not checked: Frontend lint/build and browser QA, because this PR changes documentation only.
