### PR TITLE
[codex] show telegram forms passport safety

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -918,6 +918,9 @@ function TelegramMiniAppPatientShell() {
                               <Badge variant={form.contains_medical_data ? 'warning' : 'success'} size="small">
                                 {form.contains_medical_data ? 'medical data' : 'no medical data'}
                               </Badge>
+                              <Badge variant={form.contains_passport_data ? 'warning' : 'success'} size="small">
+                                {form.contains_passport_data ? 'passport data' : 'no passport data'}
+                              </Badge>
                             </div>
                           </div>
                         ))}


### PR DESCRIPTION
## Summary
- Adds the missing passport-data safety badge to the Telegram Mini App forms manifest shell.
- Keeps the forms flow manifest-only: no passport fields, no patient-entered form data, and no mutation controls are rendered.

## Contract Impact
- Canonical surface: existing `POST /api/v1/telegram/mini-app/forms/manifest` response metadata.
- Request shape: unchanged `{ initData }` Mini App signed session payload.
- Response shape: unchanged; frontend now displays the existing `contains_passport_data` flag already present on form manifest rows.
- Status codes: unchanged.
- Frontend consumer: `TelegramMiniAppPatientShell` in `frontend/src/App.jsx`, forms section only.
- Compatibility path or alias: not applicable because this PR does not add or change route aliases or compatibility endpoints.
- Contract proof: Playwright forms smoke mocks `contains_passport_data: false`, verifies the new `no passport data` badge, and verifies mock passport values are not rendered.

## RBAC / Permissions
- Roles allowed: unchanged because backend Mini App session verification remains canonical and this PR only displays an existing safety flag.
- Roles denied: unchanged because invalid or denied sessions still follow existing endpoint and frontend error behavior.
- Positive auth proof: Playwright smoke provides mock Mini App init data and verifies the forms manifest request is made after selecting forms.
- Negative auth proof: no backend auth behavior changed; no new passport field rendering, form capture, or mutation path is introduced.

## Notification / Realtime
not applicable because this PR does not add notifications, websocket events, callbacks, or delivery behavior.

## Frontend Resilience
- Empty data proof: unchanged; forms manifest rows still default from the existing `formsManifestItems` array.
- Partial data proof: missing `contains_passport_data` remains safely falsey and renders `no passport data`.
- Forbidden secondary path behavior: Playwright smoke verifies cabinet, payments, results, appointment preview, and appointment create endpoints are not called by the forms flow.
- Missing draft/resource behavior: not applicable because this manifest-only panel has no draft, form resource editor, or mutation affordance.
- Stale route/deep-link behavior: unchanged; forms manifest loading remains gated by `selectedSection === 'forms'`.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`.
- Denied paths: backend endpoints, migrations, Telegram webhook services, manager UI, docs, and generated artifacts were not changed.
- Migration/docs/test impact: no DB or Alembic impact; validation used existing Telegram guard scripts and targeted frontend checks.
- Rollback note: revert `c44d59d1` to remove the passport safety badge while leaving forms manifest behavior unchanged.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- src/App.jsx`; `npm.cmd run build`; `C:\final\backend\.venv\Scripts\python.exe -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; Playwright Mini App forms smoke on Vite preview; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file frontend/src/App.jsx --fail-on-warning`; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py --fail-on-warning`; `git diff --check`; `git diff --cached --check`.
- Result: passed; lint reported 54 existing warnings and 0 errors; smoke proved forms endpoint was called once, unrelated section endpoints were not called, and sensitive mock passport values did not render.
- Not checked: full frontend test suite, live Telegram Bot API, and live backend/Postgres runtime.