### PR TITLE
refactor(frontend): remove mui from payment widget

### DIFF
--- a/frontend/src/components/payment/PaymentWidget.jsx
+++ b/frontend/src/components/payment/PaymentWidget.jsx
@@ -6,6 +6,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
   Box,
+  Badge,
   Card,
   CardContent,
   Typography,
@@ -15,19 +16,10 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
-  DialogActions } from
+  DialogActions,
+  Select } from
 
 '../ui/macos';
-
-// MUI imports - using MUI Select for compatibility with FormControl/MenuItem
-import {
-  Divider,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  Chip } from
-'@mui/material';
 
 import {
   CreditCard,
@@ -44,6 +36,25 @@ import { useTheme } from '../../contexts/ThemeContext';
 import { getErrorMessage } from '../../utils/errorHandler';
 import logger from '../../utils/logger';
 import PropTypes from 'prop-types';
+
+const dividerStyle = {
+  height: 1,
+  marginBottom: 24,
+  background: 'var(--mac-border)'
+};
+
+const providerOptionStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  width: '100%',
+  gap: 8
+};
+
+const providerNameStyle = {
+  textTransform: 'capitalize',
+  flex: '1 1 auto',
+  minWidth: 0
+};
 
 const PaymentWidget = ({
   visitId,
@@ -416,39 +427,39 @@ const PaymentWidget = ({
           </div>
         </Box>
 
-        <Divider style={{ marginBottom: 24 }} />
+        <div style={dividerStyle} />
 
         {/* Выбор провайдера */}
-        <FormControl fullWidth style={{ marginBottom: 24 }}>
-          <InputLabel id="payment-provider-label">Способ оплаты</InputLabel>
-          <Select
-            labelId="payment-provider-label"
-            value={selectedProvider}
-            onChange={(e) => setSelectedProvider(e.target.value)}
-            label="Способ оплаты"
-            disabled={loading}>
-            
-            {providers.map((provider) =>
-            <MenuItem key={provider.code} value={provider.code}>
-                <Box display="flex" alignItems="center">
-                  {providerIcons[provider.code]}
-                  <Typography style={{ marginLeft: 8, textTransform: 'capitalize' }}>
-                    {provider.name}
-                  </Typography>
-                  <Chip
-                  label={provider.supported_currencies.join(', ')}
+        <Select
+          id="payment-provider"
+          label="Способ оплаты"
+          value={selectedProvider}
+          onChange={(value) => setSelectedProvider(value)}
+          disabled={loading}
+          style={{ marginBottom: 24 }}
+          options={providers.map((provider) => ({
+            value: provider.code,
+            label: (
+              <span style={providerOptionStyle}>
+                {providerIcons[provider.code]}
+                <span style={providerNameStyle}>
+                  {provider.name}
+                </span>
+                <Badge
                   size="small"
+                  variant="outline"
                   style={{
                     marginLeft: 'auto',
                     backgroundColor: providerColors[provider.code] + '20',
                     color: providerColors[provider.code]
-                  }} />
-                
-                </Box>
-              </MenuItem>
-            )}
-          </Select>
-        </FormControl>
+                  }}
+                >
+                  {provider.supported_currencies.join(', ')}
+                </Badge>
+              </span>
+            )
+          }))}
+        />
 
         {/* Статус платежа */}
         {renderPaymentStatus()}


### PR DESCRIPTION
﻿## Summary
- Removed the remaining MUI imports from `PaymentWidget.jsx`.
- Replaced the MUI provider select/menu/chip/divider with existing clinic/macOS primitives and native layout.
- Kept payment provider codes, selected provider state, amount formatting, payment initialization, status checks, confirmation, cancellation, and callbacks unchanged.

## Contract Impact
- Canonical surface: `frontend/src/components/payment/PaymentWidget.jsx`.
- Request shape: Unchanged; `paymentRequest` still includes `visit_id`, `provider`, `amount`, `currency`, `description`, `return_url`, and `cancel_url`.
- Response shape: Unchanged; payment init/status/confirm response handling is untouched.
- Status codes: Unchanged; no API status handling changed.
- Frontend consumer: Unchanged; `onSuccess`, `onError`, and `onCancel` behavior is preserved.
- Compatibility path or alias: Unchanged; no routes, aliases, or RBAC paths changed.
- Contract proof: `apiClient.post(endpoint, paymentRequest)`, local smoke confirm flow, `checkPaymentStatus`, `cancelPayment`, and `confirmPayment` logic were not changed.

## RBAC / Permissions
- Roles allowed: Unchanged; no protected route, role guard, or permission code changed.
- Roles denied: Unchanged; no denial path changed.
- Positive auth proof: Unchanged by this component-only UI migration.
- Negative auth proof: Unchanged by this component-only UI migration.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no realtime or notification channel touched.
- Payload version / ack behavior: Unchanged; no payload or ack code touched.
- Read/unread or delivery semantics: Unchanged; no notification state touched.
- Reconnect/resync proof: Unchanged; no reconnect or resync code touched.

## Frontend Resilience
- Empty data proof: Existing no-provider warning path is preserved.
- Partial data proof: Existing missing selected provider, visit id, or amount guard is preserved.
- Forbidden secondary path behavior: Unchanged; auth token missing behavior still calls `onError` and sets the same error path.
- Missing draft/resource behavior: Unchanged; no draft/resource behavior exists in this widget.
- Stale route/deep-link behavior: Unchanged; no routing code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/payment/PaymentWidget.jsx`.
- Denied paths: Backend, payment API contracts, routes, RBAC, migrations, docs, tests, queue, and unrelated frontend files.
- Migration/docs/test impact: No migrations, docs, or tests changed.
- Rollback note: Revert this commit to restore the previous MUI provider select implementation.

## Validation
- Targeted tests or smoke run: `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js src/routing/__tests__/routeOwnershipEnforcement.test.js`; `npm.cmd run lint:check`; `npm.cmd run build`; `git diff --check`; MUI import inventory grep.
- Result: Route tests 20/20 passed; lint exited 0 with existing 54 warnings; build passed; diff check passed; `PaymentWidget.jsx` has no MUI import tokens; active MUI runtime files are now 3.
- Not checked: Authenticated payment browser QA was not run because no safe local protected payment fixture/session is available in this slice.
