### PR TITLE
docs(frontend): refresh mui inventory after ecg cleanup

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/mui-risky-islands-handoff.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/mui-risky-islands-handoff.md
@@ -13,7 +13,7 @@ Fresh inventory:
 rg -l "@mui|Mui" frontend\src\pages frontend\src\components
 ```
 
-Current post-continuation result: 3 files.
+Current post-continuation result: 2 files.
 
 ## Global Rule
 
@@ -113,7 +113,7 @@ Validation:
 
 Files:
 
-- `frontend/src/components/cardiology/ECGViewer.jsx`
+- none currently matching `@mui|Mui`
 
 Note: `frontend/src/components/laboratory/LabReportGenerator.jsx` had no
 active frontend source importer and was removed as stale code. Active lab
@@ -130,6 +130,11 @@ semantics are clinical-sensitive.
 dedicated dental tooth modal slice; future tooth modal changes remain
 dental/clinical-gated because procedure selection, material pricing,
 follow-up state, notes, history, total price, and save semantics are
+clinical-sensitive.
+`frontend/src/components/cardiology/ECGViewer.jsx` was migrated away from MUI
+in a dedicated cardiology viewer slice; future ECG viewer changes remain
+cardiology/clinical-gated because ECG upload metadata, preview/download/delete
+behavior, parsed parameters, and AI interpretation semantics are
 clinical-sensitive.
 
 Mode:
@@ -260,8 +265,8 @@ Stop if:
 ## Result
 
 PR-MUI-4 created the guardrails needed before any remaining runtime MUI
-migration. The current remaining MUI inventory is 3 files across queue,
-cardiology, and Telegram surfaces.
+migration. The current remaining MUI inventory is 2 files across queue and
+Telegram surfaces.
 
 ## Next Smallest Step
 

--- a/docs/audits/uiux-hard-audit-2026-05-20/third-cycle-performance-mui-summary.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/third-cycle-performance-mui-summary.md
@@ -140,7 +140,7 @@ classified, policy-covered, and guarded for future small PRs.
 ## Post-Cycle Continuation Note
 
 Later small PRs reduced the current MUI inventory from the historical third
-cycle count of 14 files to 3 files:
+cycle count of 14 files to 2 files:
 
 - stale `frontend/src/components/dashboard/Dashboard.jsx` removal;
 - gated `frontend/src/components/admin/UserManagement.jsx` actions menu
@@ -160,9 +160,10 @@ cycle count of 14 files to 3 files:
   migration.
 - gated `frontend/src/components/payment/PaymentWidget.jsx` payment widget
   migration.
+- gated `frontend/src/components/cardiology/ECGViewer.jsx` cardiology viewer
+  migration.
 
 Current remaining MUI files:
 
 - `frontend/src/components/queue/OnlineQueueManager.jsx`
-- `frontend/src/components/cardiology/ECGViewer.jsx`
 - `frontend/src/components/TelegramManager.jsx`

--- a/frontend/MUI_RUNTIME_INVENTORY.md
+++ b/frontend/MUI_RUNTIME_INVENTORY.md
@@ -81,6 +81,12 @@ macOS/native controls in a gate-limited payment widget slice. Payment provider
 codes, selected provider state, amount formatting, payment initialization,
 status checks, confirmation, cancellation, and callbacks remain unchanged.
 
+ECGViewer migration: 2 files now contain runtime MUI imports after converting
+`frontend/src/components/cardiology/ECGViewer.jsx` to macOS/native controls in
+a gate-limited cardiology slice. ECG upload metadata, preview/download/delete
+behavior, parsed parameter display, AI analysis payload, analysis warning
+thresholds, and cardiology route/RBAC behavior remain unchanged.
+
 ## No-New-MUI Island Policy
 
 MUI is a legacy compatibility layer in this clinic frontend. New clinic runtime UI should not create new MUI islands.
@@ -124,7 +130,7 @@ rg -l '@mui|Mui' frontend/src/pages frontend/src/components
 | `frontend/src/components/queue/OnlineQueueManager.jsx` | Payment/queue-adjacent | Queue status, print/download, and queue operations. | Gate/handoff only. |
 | `frontend/src/components/patient/FamilyRelationsCard.jsx` | Migrated/clinical | Patient relationship UI now uses macOS/native controls with no current `@mui` import. | Keep future changes clinical-gated because relationship visibility and pickup-role context are patient-sensitive. |
 | `frontend/src/components/laboratory/LabReportGenerator.jsx` | Stale/removed | Caller-free lab report generator had no active frontend source importer. | Removed after source search; active lab panel/report/export behavior remains unchanged. |
-| `frontend/src/components/cardiology/ECGViewer.jsx` | Clinical-heavy | ECG viewer and cardiology data display. | Clinical safety review before migration. |
+| `frontend/src/components/cardiology/ECGViewer.jsx` | Migrated/clinical | ECG viewer UI now uses macOS/native controls with no current `@mui` import. | Keep future changes cardiology/clinical-gated because ECG upload metadata, preview/download/delete behavior, parsed parameters, and AI interpretation semantics are clinical-sensitive. |
 | `frontend/src/components/dental/TreatmentPlanner.jsx` | Migrated/clinical | Dental treatment planner UI now uses macOS/native controls with no current `@mui` import. | Keep future changes dental/clinical-gated because treatment stage, cost, duration, priority, print, and save semantics are clinical-sensitive. |
 | `frontend/src/components/dental/ToothModal.jsx` | Migrated/clinical | Dental tooth modal UI now uses macOS/native controls with no current `@mui` import. | Keep future changes dental/clinical-gated because procedure selection, material pricing, follow-up state, notes, history, total price, and save semantics are clinical-sensitive. |
 | `frontend/src/components/TelegramManager.jsx` | Telegram/AI-sensitive | Telegram integration management. | Gate/handoff only. |
@@ -134,7 +140,6 @@ rg -l '@mui|Mui' frontend/src/pages frontend/src/components
 
 ## Do-Not-Touch Buckets
 
-- Cardiology: `ECGViewer.jsx`
 - Queue: `OnlineQueueManager.jsx`
 - Telegram: `TelegramManager.jsx`
 
@@ -183,6 +188,8 @@ Result after ToothModal dental tooth modal migration: 4 files.
 
 Result after PaymentWidget payment widget migration: 3 files.
 
+Result after ECGViewer cardiology viewer migration: 2 files.
+
 Decision: do not force a runtime MUI migration in this PR. The only already
 approved low-risk runtime targets were `ConnectionStatus.jsx` and
 `PWAInstallPrompt.jsx`, and both are already migrated. Every remaining runtime
@@ -204,7 +211,8 @@ current MUI search result. The dental planning slice removed
 `TreatmentPlanner.jsx` from the current MUI search result. The dental tooth
 modal slice removed `ToothModal.jsx` from the current MUI search result.
 The payment widget slice removed `PaymentWidget.jsx` from the current MUI
-search result. Remaining MUI targets are queue, cardiology, and Telegram
+search result. The cardiology viewer slice removed `ECGViewer.jsx` from the
+current MUI search result. Remaining MUI targets are queue and Telegram
 surfaces.
 
 Next safe MUI migration should be a dedicated PR with one first-touch file,
@@ -230,8 +238,8 @@ UnifiedButton, UnifiedCard, PaymentTest migration, MCPMonitor stale component
 removal, LabReportGenerator stale component removal, and FamilyRelationsCard
 patient relationship migration, TreatmentPlanner dental planning migration, and
 ToothModal dental tooth modal migration, and PaymentWidget payment widget
-migration:
-3 files.
+migration, and ECGViewer cardiology viewer migration:
+2 files.
 
 No new MUI imports were introduced by the recent performance PRs. Current
 classification:
@@ -240,7 +248,7 @@ classification:
 | --- | ---: | --- |
 | Shared/admin-sensitive | 0 | No current MUI search result after UserManagement migration and stale dashboard removal. |
 | Payment/queue-adjacent | 1 | Gate/handoff only. |
-| Clinical-heavy | 1 | Clinical safety review before migration. |
+| Clinical-heavy | 0 | No current MUI search result after cardiology and dental migrations. |
 | Telegram/AI-sensitive | 1 | Gate/handoff only. |
 | Example-only | 0 | Both `Unified*` examples have been converted away from MUI. |
 
@@ -248,18 +256,16 @@ Current files:
 
 - Payment/queue-adjacent:
   - `frontend/src/components/queue/OnlineQueueManager.jsx`
-- Clinical-heavy:
-  - `frontend/src/components/cardiology/ECGViewer.jsx`
 - Telegram/AI-sensitive:
   - `frontend/src/components/TelegramManager.jsx`
 - Example-only:
   - none currently matching `@mui|Mui`
 
 Decision: do not treat the historical PR-MUI-1 inventory as current. The
-current live MUI inventory is 3 files and excludes the migrated/removed
+current live MUI inventory is 2 files and excludes the migrated/removed
 admin/shared, dashboard, example-only, PaymentTest, MCPMonitor,
 LabReportGenerator, FamilyRelationsCard, TreatmentPlanner, and ToothModal
-surfaces, plus the migrated PaymentWidget surface.
+surfaces, plus the migrated PaymentWidget and ECGViewer surfaces.
 
 ## PR-MUI-2 Low-Risk Admin Decision
 
@@ -315,7 +321,6 @@ cleanup PR. They now require the gated handoff in
 Gate-required groups:
 
 - Queue: `OnlineQueueManager.jsx`
-- Clinical: `ECGViewer.jsx`
 - Telegram/AI: `TelegramManager.jsx`
 
 Default rule: one risky MUI island per PR, with first-touch boundaries,


### PR DESCRIPTION
## Summary
- Refresh the live runtime MUI inventory after the ECGViewer migration.
- Record that the current frontend runtime MUI inventory is down to 2 files: OnlineQueueManager and TelegramManager.
- Update the risky-island handoff and third-cycle summary so the next PR can target queue/Telegram from current evidence.

## Contract Impact
- Canonical surface: Unchanged; documentation-only inventory and audit records.
- Request shape: Unchanged; no API or frontend request code changed.
- Response shape: Unchanged; no backend or frontend response handling changed.
- Status codes: Unchanged; no server behavior changed.
- Frontend consumer: Unchanged; no runtime frontend consumers changed.
- Compatibility path or alias: Unchanged; inventory docs now point to the two remaining runtime MUI files.
- Contract proof: `git diff --name-only` shows only audit/inventory markdown files.

## RBAC / Permissions
- Roles allowed: Unchanged; docs-only change.
- Roles denied: Unchanged; docs-only change.
- Positive auth proof: Unchanged; no auth path touched.
- Negative auth proof: Unchanged; no auth path touched.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no notification or realtime code touched.
- Payload version / ack behavior: Unchanged; no payload code touched.
- Read/unread or delivery semantics: Unchanged; no notification state touched.
- Reconnect/resync proof: Unchanged; no realtime reconnect path touched.

## Frontend Resilience
- Empty data proof: Unchanged; docs-only inventory refresh.
- Partial data proof: Unchanged; docs-only inventory refresh.
- Forbidden secondary path behavior: Unchanged; docs-only inventory refresh.
- Missing draft/resource behavior: Unchanged; docs-only inventory refresh.
- Stale route/deep-link behavior: Unchanged; docs-only inventory refresh.

## Scope Gate
- Allowed paths: `frontend/MUI_RUNTIME_INVENTORY.md`, `docs/audits/uiux-hard-audit-2026-05-20/mui-risky-islands-handoff.md`, `docs/audits/uiux-hard-audit-2026-05-20/third-cycle-performance-mui-summary.md`.
- Denied paths: Runtime frontend, backend, workflows, tests, migrations, and package files.
- Migration/docs/test impact: Docs-only inventory update; no migrations or tests changed.
- Rollback note: Revert this docs commit if the inventory summary needs to be restored.

## Validation
- Targeted tests or smoke run: `git diff --check`; `rg -l '@mui|Mui' frontend/src/pages frontend/src/components`; PR body template validation.
- Result: Passed locally; MUI search returns only `frontend/src/components/queue/OnlineQueueManager.jsx` and `frontend/src/components/TelegramManager.jsx`.
- Not checked: Frontend lint/build/browser QA; unchanged because this is docs-only.
