### PR TITLE
refactor(frontend): remove mui from online queue manager

### DIFF
--- a/frontend/src/components/queue/OnlineQueueManager.jsx
+++ b/frontend/src/components/queue/OnlineQueueManager.jsx
@@ -1,46 +1,150 @@
 import { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import {
+  BarChart3,
+  Clock,
+  Download,
+  Phone,
+  Play,
+  Printer,
+  QrCode,
+  RefreshCw,
+  Square,
+  User,
+} from 'lucide-react';
+import { QRCodeSVG } from 'qrcode.react';
 import {
   Alert,
-  Box,
+  Badge,
   Button,
   Card,
   CardContent,
-  Chip,
   CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
-  FormControl,
-  Grid,
-  IconButton,
-  InputLabel,
-  MenuItem,
-  Paper,
+  Input,
   Select,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  TextField,
   Tooltip,
   Typography,
-} from '@mui/material';
-import BarChartIcon from '@mui/icons-material/BarChart';
-import DownloadIcon from '@mui/icons-material/Download';
-import PersonIcon from '@mui/icons-material/Person';
-import PhoneIcon from '@mui/icons-material/Phone';
-import PrintIcon from '@mui/icons-material/Print';
-import QrCode2Icon from '@mui/icons-material/QrCode2';
-import RefreshIcon from '@mui/icons-material/Refresh';
-import StartIcon from '@mui/icons-material/PlayArrow';
-import StopIcon from '@mui/icons-material/Stop';
-import TimeIcon from '@mui/icons-material/Schedule';
-import { QRCodeSVG } from 'qrcode.react';
+} from '../ui/macos';
+import Table, {
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+} from '../ui/macos/Table';
 import { useQueueManager } from '../../hooks/useQueueManager';
 import { openPrintableWindow } from '../../utils/printWindow';
+
+const iconSize = 16;
+
+const iconStyle = {
+  width: iconSize,
+  height: iconSize,
+  flex: '0 0 auto',
+};
+
+const iconButtonStyle = {
+  width: 32,
+  height: 32,
+  padding: 0,
+  borderRadius: 999,
+};
+
+const panelCardStyle = {
+  height: '100%',
+};
+
+const headerRowStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 12,
+  flexWrap: 'wrap',
+  marginBottom: 16,
+};
+
+const compactRowStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  minWidth: 0,
+};
+
+const actionStackStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  marginTop: 16,
+};
+
+const qrFrameStyle = {
+  display: 'inline-block',
+  padding: 16,
+  border: '1px solid var(--mac-border)',
+  borderRadius: 10,
+  background: 'var(--mac-bg-primary)',
+};
+
+const statusVariantMap = {
+  primary: 'primary',
+  warning: 'warning',
+  success: 'success',
+  error: 'danger',
+  default: 'outline',
+};
+
+const StatTile = ({ value, label, variant }) => (
+  <div className={`online-queue-stat online-queue-stat--${variant}`}>
+    <div className="online-queue-stat-value">{value}</div>
+    <div className="online-queue-stat-label">{label}</div>
+  </div>
+);
+
+const DismissibleAlert = ({ severity, children, onClose }) => (
+  <Alert severity={severity} role="status" style={{ marginBottom: 16 }}>
+    <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+      <span>{children}</span>
+      {onClose && (
+        <button
+          type="button"
+          className="online-queue-alert-close"
+          onClick={onClose}
+          aria-label="Закрыть уведомление"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  </Alert>
+);
+
+const IconText = ({ icon: Icon, children }) => (
+  <span style={compactRowStyle}>
+    <Icon style={iconStyle} aria-hidden="true" />
+    <span>{children}</span>
+  </span>
+);
+
+StatTile.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  label: PropTypes.node,
+  variant: PropTypes.string,
+};
+
+DismissibleAlert.propTypes = {
+  severity: PropTypes.string,
+  children: PropTypes.node,
+  onClose: PropTypes.func,
+};
+
+IconText.propTypes = {
+  icon: PropTypes.elementType.isRequired,
+  children: PropTypes.node,
+};
 
 const OnlineQueueManager = () => {
   // Используем кастомный хук вместо прямых API вызовов
@@ -62,13 +166,13 @@ const OnlineQueueManager = () => {
     setQueueData,
     setStatistics
   } = useQueueManager();
-  
+
   // Локальные состояния для UI
   const [qrDialog, setQrDialog] = useState(false);
   const [selectedDate, setSelectedDate] = useState(new Date().toISOString().split('T')[0]);
   const [selectedSpecialist, setSelectedSpecialist] = useState('');
   const [autoRefresh, setAutoRefresh] = useState(false);
-  
+
   // Автообновление очереди
   useEffect(() => {
     let interval;
@@ -102,26 +206,38 @@ const OnlineQueueManager = () => {
     }
   };
 
+  const handleSpecialistChange = (value) => {
+    setSelectedSpecialist(value);
+    setQueueData(null);
+    setStatistics(null);
+    // Загружаем статистику для нового специалиста
+    if (value) {
+      setTimeout(() => loadStatistics(), 100);
+    }
+  };
+
   const downloadQR = () => {
     if (!qrData) return;
-    
+
     const svg = document.querySelector('#qr-code-svg');
+    if (!svg) return;
+
     const svgData = new XMLSerializer().serializeToString(svg);
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
     const img = new Image();
-    
+
     img.onload = () => {
       canvas.width = img.width;
       canvas.height = img.height;
       ctx.drawImage(img, 0, 0);
-      
+
       const link = document.createElement('a');
       link.download = `qr-queue-${selectedDate}-${qrData.specialist_name}.png`;
       link.href = canvas.toDataURL();
       link.click();
     };
-    
+
     img.src = 'data:image/svg+xml;base64,' + btoa(svgData);
   };
 
@@ -187,440 +303,441 @@ const OnlineQueueManager = () => {
     }
   };
 
+  const specialistOptions = specialists.map((specialist) => ({
+    value: specialist.id,
+    label: specialist.full_name || specialist.username,
+  }));
+
   return (
-    <Box sx={{ p: 3 }}>
+    <div className="online-queue-manager">
       <Typography variant="h4" gutterBottom>
         Управление онлайн-очередью
       </Typography>
 
       {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
+        <DismissibleAlert severity="error" onClose={() => setError('')}>
           {error}
-        </Alert>
+        </DismissibleAlert>
       )}
 
       {success && (
-        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess('')}>
+        <DismissibleAlert severity="success" onClose={() => setSuccess('')}>
           {success}
-        </Alert>
+        </DismissibleAlert>
       )}
 
-      <Grid container spacing={3}>
-        {/* Статистика */}
-        {statistics && (
-          <Grid item xs={12}>
-            <Card sx={{ mb: 2 }}>
-              <CardContent>
-                <Typography variant="h6" gutterBottom sx={{ display: 'flex', alignItems: 'center' }}>
-                  <BarChartIcon sx={{ mr: 1 }} />
-                  Статистика очереди
-                </Typography>
-                <Grid container spacing={2}>
-                  <Grid item xs={6} sm={3}>
-                    <Box sx={{ textAlign: 'center', p: 2, bgcolor: 'primary.light', borderRadius: 1 }}>
-                      <Typography variant="h4" color="primary.contrastText">
-                        {statistics.total_entries}
-                      </Typography>
-                      <Typography variant="body2" color="primary.contrastText">
-                        Всего записей
-                      </Typography>
-                    </Box>
-                  </Grid>
-                  <Grid item xs={6} sm={3}>
-                    <Box sx={{ textAlign: 'center', p: 2, bgcolor: 'warning.light', borderRadius: 1 }}>
-                      <Typography variant="h4" color="warning.contrastText">
-                        {statistics.waiting}
-                      </Typography>
-                      <Typography variant="body2" color="warning.contrastText">
-                        Ожидают
-                      </Typography>
-                    </Box>
-                  </Grid>
-                  <Grid item xs={6} sm={3}>
-                    <Box sx={{ textAlign: 'center', p: 2, bgcolor: 'success.light', borderRadius: 1 }}>
-                      <Typography variant="h4" color="success.contrastText">
-                        {statistics.completed}
-                      </Typography>
-                      <Typography variant="body2" color="success.contrastText">
-                        Завершено
-                      </Typography>
-                    </Box>
-                  </Grid>
-                  <Grid item xs={6} sm={3}>
-                    <Box sx={{ textAlign: 'center', p: 2, bgcolor: 'info.light', borderRadius: 1 }}>
-                      <Typography variant="h4" color="info.contrastText">
-                        {statistics.available_slots}
-                      </Typography>
-                      <Typography variant="body2" color="info.contrastText">
-                        Свободных мест
-                      </Typography>
-                    </Box>
-                  </Grid>
-                </Grid>
-              </CardContent>
-            </Card>
-          </Grid>
-        )}
+      {statistics && (
+        <Card style={{ marginBottom: 20 }}>
+          <CardContent>
+            <Typography variant="h6" gutterBottom style={compactRowStyle}>
+              <BarChart3 style={iconStyle} aria-hidden="true" />
+              Статистика очереди
+            </Typography>
+            <div className="online-queue-stats">
+              <StatTile value={statistics.total_entries} label="Всего записей" variant="primary" />
+              <StatTile value={statistics.waiting} label="Ожидают" variant="warning" />
+              <StatTile value={statistics.completed} label="Завершено" variant="success" />
+              <StatTile value={statistics.available_slots} label="Свободных мест" variant="info" />
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
-        {/* Панель управления */}
-        <Grid item xs={12} md={4}>
-          <Card>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                Панель управления
-              </Typography>
+      <div className="online-queue-layout">
+        <Card style={panelCardStyle}>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              Панель управления
+            </Typography>
 
-              <FormControl fullWidth margin="normal">
-                <InputLabel>Специалист</InputLabel>
-                <Select
-                  value={selectedSpecialist}
-                  onChange={(e) => {
-                    setSelectedSpecialist(e.target.value);
-                    setQueueData(null);
-                    setStatistics(null);
-                    // Загружаем статистику для нового специалиста
-                    if (e.target.value) {
-                      setTimeout(() => loadStatistics(), 100);
-                    }
-                  }}
-                  label="Специалист"
-                >
-                  {specialists.map((specialist) => (
-                    <MenuItem key={specialist.id} value={specialist.id}>
-                      {specialist.full_name || specialist.username}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
+            <div className="online-queue-field-stack">
+              <Select
+                label="Специалист"
+                value={selectedSpecialist}
+                onChange={handleSpecialistChange}
+                options={specialistOptions}
+                placeholder="Выберите специалиста"
+              />
 
-              <TextField
-                fullWidth
+              <Input
                 type="date"
                 label="Дата"
                 value={selectedDate}
                 onChange={(e) => setSelectedDate(e.target.value)}
-                margin="normal"
-                InputLabelProps={{ shrink: true }}
               />
+            </div>
 
-              <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
-                <Button
-                  variant="contained"
-                  startIcon={<QrCode2Icon />}
-                  onClick={() => setQrDialog(true)}
-                  disabled={!selectedSpecialist || loading}
-                  fullWidth
-                >
-                  Генерировать QR код
-                </Button>
+            <div style={actionStackStyle}>
+              <Button
+                variant="primary"
+                onClick={() => setQrDialog(true)}
+                disabled={!selectedSpecialist || loading}
+                fullWidth
+              >
+                <IconText icon={QrCode}>Генерировать QR код</IconText>
+              </Button>
 
-                <Button
-                  variant="outlined"
-                  startIcon={<RefreshIcon />}
-                  onClick={loadTodayQueue}
-                  disabled={!selectedSpecialist || loading}
-                  fullWidth
-                >
-                  Обновить очередь
-                </Button>
+              <Button
+                variant="outline"
+                onClick={loadTodayQueue}
+                disabled={!selectedSpecialist || loading}
+                fullWidth
+              >
+                <IconText icon={RefreshCw}>Обновить очередь</IconText>
+              </Button>
 
-                <Button
-                  variant="contained"
-                  color="success"
-                  startIcon={<StartIcon />}
-                  onClick={handleOpenQueue}
-                  disabled={!selectedSpecialist || loading || queueData?.is_open}
-                  fullWidth
-                >
+              <Button
+                variant="success"
+                onClick={handleOpenQueue}
+                disabled={!selectedSpecialist || loading || queueData?.is_open}
+                fullWidth
+              >
+                <IconText icon={Play}>
                   {queueData?.is_open ? 'Прием открыт' : 'Открыть прием'}
-                </Button>
-              </Box>
+                </IconText>
+              </Button>
+            </div>
 
-              <Box sx={{ mt: 2 }}>
-                <FormControl component="fieldset">
-                  <Button
-                    variant={autoRefresh ? 'contained' : 'outlined'}
-                    size="small"
-                    onClick={() => setAutoRefresh(!autoRefresh)}
-                    startIcon={autoRefresh ? <StopIcon /> : <StartIcon />}
-                  >
-                    {autoRefresh ? 'Остановить' : 'Автообновление'}
-                  </Button>
-                </FormControl>
-              </Box>
-            </CardContent>
-          </Card>
-        </Grid>
+            <div style={{ marginTop: 16 }}>
+              <Button
+                variant={autoRefresh ? 'primary' : 'outline'}
+                size="small"
+                onClick={() => setAutoRefresh(!autoRefresh)}
+              >
+                <IconText icon={autoRefresh ? Square : Play}>
+                  {autoRefresh ? 'Остановить' : 'Автообновление'}
+                </IconText>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
 
-        {/* Текущая очередь */}
-        <Grid item xs={12} md={8}>
-          <Card>
-            <CardContent>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Card style={panelCardStyle}>
+          <CardContent>
+            <div style={headerRowStyle}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
                 <Typography variant="h6">
                   Текущая очередь
-                  {queueData && (
-                    <Chip
-                      label={queueData.is_open ? 'Прием открыт' : 'Онлайн-запись'}
-                      color={queueData.is_open ? 'success' : 'primary'}
-                      size="small"
-                      sx={{ ml: 1 }}
-                    />
-                  )}
                 </Typography>
-                
                 {queueData && (
-                  <Box>
-                    <Chip
-                      label={`Всего: ${queueData.total_entries}`}
-                      variant="outlined"
-                      size="small"
-                      sx={{ mr: 1 }}
-                    />
-                    <Chip
-                      label={`Ожидают: ${queueData.waiting_entries}`}
-                      color="primary"
-                      size="small"
-                    />
-                  </Box>
+                  <Badge variant={queueData.is_open ? 'success' : 'primary'} size="small">
+                    {queueData.is_open ? 'Прием открыт' : 'Онлайн-запись'}
+                  </Badge>
                 )}
-              </Box>
+              </div>
 
-              {!selectedSpecialist ? (
-                <Alert severity="info">
-                  Выберите специалиста для просмотра очереди
-                </Alert>
-              ) : !queueData ? (
-                <Alert severity="warning">
-                  Очередь не найдена. Создайте QR код для начала записи.
-                </Alert>
-              ) : queueData.entries.length === 0 ? (
-                <Alert severity="info">
-                  Очередь пуста
-                </Alert>
-              ) : (
-                <TableContainer component={Paper} variant="outlined" sx={{ borderRadius: 2, overflow: 'hidden' }}>
-                  <Table size="small">
-                    <TableHead>
-                      <TableRow sx={{ bgcolor: 'primary.main' }}>
-                        <TableCell sx={{ color: 'white', fontWeight: 'bold' }}>№</TableCell>
-                        <TableCell sx={{ color: 'white', fontWeight: 'bold' }}>Пациент</TableCell>
-                        <TableCell sx={{ color: 'white', fontWeight: 'bold' }}>Телефон</TableCell>
-                        <TableCell sx={{ color: 'white', fontWeight: 'bold' }}>Время записи</TableCell>
-                        <TableCell sx={{ color: 'white', fontWeight: 'bold' }}>Статус</TableCell>
-                        <TableCell sx={{ color: 'white', fontWeight: 'bold' }}>Действия</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {queueData.entries.map((entry, index) => (
-                        <TableRow 
-                          key={entry.id}
-                          sx={{ 
-                            '&:hover': { bgcolor: 'action.hover' },
-                            '&:nth-of-type(odd)': { bgcolor: 'action.selected' },
-                            transition: 'all 0.3s ease',
-                            animation: `slideIn 0.5s ease ${index * 0.1}s both`,
-                            '@keyframes slideIn': {
-                              from: {
-                                opacity: 0,
-                                transform: 'translateX(-20px)'
-                              },
-                              to: {
-                                opacity: 1,
-                                transform: 'translateX(0)'
-                              }
-                            }
-                          }}
-                        >
-                          <TableCell>
-                            <Box sx={{ 
-                              display: 'flex', 
-                              alignItems: 'center',
-                              justifyContent: 'center',
-                              width: 40,
-                              height: 40,
-                              borderRadius: '50%',
-                              bgcolor: entry.status === 'called' ? 'warning.main' : 'primary.main',
-                              color: 'white',
-                              fontWeight: 'bold',
-                              fontSize: '1.1rem',
-                              animation: entry.status === 'called' ? 'pulse 2s infinite' : 'none',
-                              '@keyframes pulse': {
-                                '0%': { transform: 'scale(1)' },
-                                '50%': { transform: 'scale(1.1)' },
-                                '100%': { transform: 'scale(1)' }
-                              }
-                            }}>
-                              {entry.number}
-                            </Box>
-                          </TableCell>
-                          <TableCell>
-                            <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                              <PersonIcon sx={{ mr: 1, color: 'text.secondary' }} />
-                              <Typography variant="body2" fontWeight="medium">
-                                {entry.patient_name || 'Не указано'}
-                              </Typography>
-                            </Box>
-                          </TableCell>
-                          <TableCell>
-                            <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                              <PhoneIcon sx={{ mr: 1, color: 'text.secondary' }} />
-                              <Typography variant="body2" color="text.secondary">
-                                {entry.phone || 'Не указан'}
-                              </Typography>
-                            </Box>
-                          </TableCell>
-                          <TableCell>
-                            <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                              <TimeIcon sx={{ mr: 1, color: 'text.secondary' }} />
-                              <Typography variant="body2" color="text.secondary">
-                                {formatTime(entry.created_at)}
-                              </Typography>
-                            </Box>
-                          </TableCell>
-                          <TableCell>
-                            <Chip
-                              label={getStatusText(entry.status)}
-                              color={getStatusColor(entry.status)}
-                              size="small"
-                              sx={{ 
-                                fontWeight: 'medium',
-                                animation: entry.status === 'called' ? 'glow 2s infinite' : 'none',
-                                '@keyframes glow': {
-                                  '0%, 100%': { boxShadow: '0 0 5px rgba(255, 152, 0, 0.5)' },
-                                  '50%': { boxShadow: '0 0 20px rgba(255, 152, 0, 0.8)' }
-                                }
-                              }}
-                            />
-                          </TableCell>
-                          <TableCell>
-                            {entry.status === 'waiting' && (
-                              <Tooltip title="Вызвать пациента">
-                                <IconButton
-                                  size="small"
-                                  onClick={() => handleCallPatient(entry.id)}
-                                  disabled={loading}
-                                  sx={{ 
-                                    bgcolor: 'success.main',
-                                    color: 'white',
-                                    '&:hover': { bgcolor: 'success.dark' },
-                                    '&:disabled': { bgcolor: 'action.disabled' }
-                                  }}
-                                >
-                                  <StartIcon />
-                                </IconButton>
-                              </Tooltip>
-                            )}
-                            {entry.status === 'called' && (
-                              <Chip 
-                                label="Вызван" 
-                                color="warning" 
-                                size="small"
-                                icon={<StartIcon />}
-                              />
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
+              {queueData && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                  <Badge variant="outline" size="small">
+                    {`Всего: ${queueData.total_entries}`}
+                  </Badge>
+                  <Badge variant="primary" size="small">
+                    {`Ожидают: ${queueData.waiting_entries}`}
+                  </Badge>
+                </div>
               )}
-            </CardContent>
-          </Card>
-        </Grid>
-      </Grid>
+            </div>
 
-      {/* Диалог генерации QR кода */}
+            {!selectedSpecialist ? (
+              <Alert severity="info">
+                Выберите специалиста для просмотра очереди
+              </Alert>
+            ) : !queueData ? (
+              <Alert severity="warning">
+                Очередь не найдена. Создайте QR код для начала записи.
+              </Alert>
+            ) : queueData.entries.length === 0 ? (
+              <Alert severity="info">
+                Очередь пуста
+              </Alert>
+            ) : (
+              <div className="online-queue-table-wrap">
+                <Table aria-label="Текущая очередь">
+                  <TableHead>
+                    <TableRow>
+                      <TableHeaderCell>№</TableHeaderCell>
+                      <TableHeaderCell>Пациент</TableHeaderCell>
+                      <TableHeaderCell>Телефон</TableHeaderCell>
+                      <TableHeaderCell>Время записи</TableHeaderCell>
+                      <TableHeaderCell>Статус</TableHeaderCell>
+                      <TableHeaderCell>Действия</TableHeaderCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {queueData.entries.map((entry, index) => (
+                      <TableRow
+                        key={entry.id}
+                        hover
+                        className={entry.status === 'called' ? 'online-queue-row-called' : ''}
+                        style={{ animationDelay: `${index * 0.1}s` }}
+                      >
+                        <TableCell>
+                          <span className={`online-queue-number ${entry.status === 'called' ? 'online-queue-number--called' : ''}`}>
+                            {entry.number}
+                          </span>
+                        </TableCell>
+                        <TableCell>
+                          <IconText icon={User}>
+                            <span style={{ fontWeight: 500 }}>{entry.patient_name || 'Не указано'}</span>
+                          </IconText>
+                        </TableCell>
+                        <TableCell>
+                          <IconText icon={Phone}>{entry.phone || 'Не указан'}</IconText>
+                        </TableCell>
+                        <TableCell>
+                          <IconText icon={Clock}>{formatTime(entry.created_at)}</IconText>
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={statusVariantMap[getStatusColor(entry.status)] || 'outline'}
+                            size="small"
+                            className={entry.status === 'called' ? 'online-queue-status-called' : ''}
+                          >
+                            {getStatusText(entry.status)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          {entry.status === 'waiting' && (
+                            <Tooltip content="Вызвать пациента">
+                              <Button
+                                variant="success"
+                                size="small"
+                                onClick={() => handleCallPatient(entry.id)}
+                                disabled={loading}
+                                style={iconButtonStyle}
+                                aria-label="Вызвать пациента"
+                              >
+                                <Play style={iconStyle} aria-hidden="true" />
+                              </Button>
+                            </Tooltip>
+                          )}
+                          {entry.status === 'called' && (
+                            <Badge variant="warning" size="small">
+                              <IconText icon={Play}>Вызван</IconText>
+                            </Badge>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
       <Dialog open={qrDialog} onClose={() => setQrDialog(false)} maxWidth="sm" fullWidth>
         <DialogTitle>Генерация QR кода для онлайн-очереди</DialogTitle>
         <DialogContent>
-          <Box sx={{ pt: 1 }}>
-            <TextField
-              fullWidth
+          <div className="online-queue-field-stack">
+            <Input
               type="date"
               label="Дата"
               value={selectedDate}
               onChange={(e) => setSelectedDate(e.target.value)}
-              margin="normal"
-              InputLabelProps={{ shrink: true }}
             />
 
-            <FormControl fullWidth margin="normal">
-              <InputLabel>Специалист</InputLabel>
-              <Select
-                value={selectedSpecialist}
-                onChange={(e) => setSelectedSpecialist(e.target.value)}
-                label="Специалист"
-              >
-                {specialists.map((specialist) => (
-                  <MenuItem key={specialist.id} value={specialist.id}>
-                    {specialist.full_name || specialist.username}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <Select
+              label="Специалист"
+              value={selectedSpecialist}
+              onChange={setSelectedSpecialist}
+              options={specialistOptions}
+              placeholder="Выберите специалиста"
+            />
+          </div>
 
-            {qrData && (
-              <Box sx={{ mt: 3, textAlign: 'center' }}>
-                <Typography variant="h6" gutterBottom>
-                  QR код для записи в очередь
-                </Typography>
-                
-                <Box sx={{ p: 2, border: '1px solid #ddd', borderRadius: 1, display: 'inline-block' }}>
-                  <QRCodeSVG
-                    id="qr-code-svg"
-                    value={`${window.location.origin}/queue/join?token=${qrData.token}`}
-                    size={200}
-                    level="M"
-                    includeMargin={true}
-                  />
-                </Box>
+          {qrData && (
+            <div style={{ marginTop: 24, textAlign: 'center' }}>
+              <Typography variant="h6" gutterBottom>
+                QR код для записи в очередь
+              </Typography>
 
-                <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                  Специалист: {qrData.specialist_name}
-                  <br />
-                  Дата: {new Date(qrData.day).toLocaleDateString('ru-RU')}
-                  <br />
-                  Действует до: {formatTime(qrData.expires_at)}
-                </Typography>
+              <div style={qrFrameStyle}>
+                <QRCodeSVG
+                  id="qr-code-svg"
+                  value={`${window.location.origin}/queue/join?token=${qrData.token}`}
+                  size={200}
+                  level="M"
+                  includeMargin={true}
+                />
+              </div>
 
-                <Box sx={{ mt: 2, display: 'flex', gap: 1, justifyContent: 'center' }}>
-                  <Button
-                    variant="outlined"
-                    startIcon={<DownloadIcon />}
-                    onClick={downloadQR}
-                  >
-                    Скачать
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    startIcon={<PrintIcon />}
-                    onClick={handlePrintQR}
-                  >
-                    Печать
-                  </Button>
-                </Box>
-              </Box>
-            )}
-          </Box>
+              <Typography variant="body2" color="secondary" style={{ marginTop: 8 }}>
+                Специалист: {qrData.specialist_name}
+                <br />
+                Дата: {new Date(qrData.day).toLocaleDateString('ru-RU')}
+                <br />
+                Действует до: {formatTime(qrData.expires_at)}
+              </Typography>
+
+              <div style={{ marginTop: 16, display: 'flex', gap: 8, justifyContent: 'center', flexWrap: 'wrap' }}>
+                <Button variant="outline" onClick={downloadQR}>
+                  <IconText icon={Download}>Скачать</IconText>
+                </Button>
+                <Button variant="outline" onClick={handlePrintQR}>
+                  <IconText icon={Printer}>Печать</IconText>
+                </Button>
+              </div>
+            </div>
+          )}
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setQrDialog(false)}>
+          <Button variant="outline" onClick={() => setQrDialog(false)}>
             Отмена
           </Button>
           <Button
             onClick={handleGenerateQR}
-            variant="contained"
+            variant="primary"
             disabled={!selectedDate || !selectedSpecialist || loading}
           >
-            {loading ? <CircularProgress size={20} /> : 'Генерировать'}
+            {loading ? <CircularProgress size="small" /> : 'Генерировать'}
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+
+      <style>{`
+        .online-queue-manager {
+          padding: 24px;
+          color: var(--mac-text-primary);
+        }
+
+        .online-queue-layout {
+          display: grid;
+          grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+          gap: 24px;
+          align-items: stretch;
+        }
+
+        .online-queue-stats {
+          display: grid;
+          grid-template-columns: repeat(4, minmax(0, 1fr));
+          gap: 12px;
+        }
+
+        .online-queue-stat {
+          border-radius: var(--mac-radius-md);
+          padding: 16px;
+          text-align: center;
+          color: #fff;
+          border: 1px solid transparent;
+        }
+
+        .online-queue-stat--primary { background: var(--mac-accent-blue); }
+        .online-queue-stat--warning { background: var(--mac-warning); }
+        .online-queue-stat--success { background: var(--mac-success); }
+        .online-queue-stat--info { background: #5ac8fa; }
+
+        .online-queue-stat-value {
+          font-size: 28px;
+          line-height: 1.1;
+          font-weight: 700;
+        }
+
+        .online-queue-stat-label {
+          margin-top: 4px;
+          font-size: 13px;
+          opacity: 0.95;
+        }
+
+        .online-queue-field-stack {
+          display: flex;
+          flex-direction: column;
+          gap: 14px;
+        }
+
+        .online-queue-table-wrap {
+          width: 100%;
+          overflow-x: auto;
+          border-radius: 10px;
+        }
+
+        .online-queue-table-wrap svg {
+          color: var(--mac-text-secondary);
+        }
+
+        .online-queue-number {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 40px;
+          height: 40px;
+          border-radius: 999px;
+          background: var(--mac-accent-blue);
+          color: #fff;
+          font-weight: 700;
+          font-size: 17px;
+        }
+
+        .online-queue-number--called {
+          background: var(--mac-warning);
+          animation: online-queue-pulse 2s infinite;
+        }
+
+        .online-queue-row-called {
+          background: color-mix(in srgb, var(--mac-warning), transparent 92%);
+        }
+
+        .online-queue-status-called {
+          animation: online-queue-glow 2s infinite;
+        }
+
+        .online-queue-alert-close {
+          border: 0;
+          background: transparent;
+          color: var(--mac-text-secondary);
+          cursor: pointer;
+          font-size: 18px;
+          line-height: 1;
+          padding: 0 2px;
+        }
+
+        .online-queue-alert-close:focus-visible {
+          outline: 2px solid var(--mac-accent-blue);
+          outline-offset: 2px;
+          border-radius: 4px;
+        }
+
+        @keyframes online-queue-pulse {
+          0% { transform: scale(1); }
+          50% { transform: scale(1.08); }
+          100% { transform: scale(1); }
+        }
+
+        @keyframes online-queue-glow {
+          0%, 100% { box-shadow: 0 0 5px rgba(255, 149, 0, 0.45); }
+          50% { box-shadow: 0 0 18px rgba(255, 149, 0, 0.7); }
+        }
+
+        @media (max-width: 900px) {
+          .online-queue-manager {
+            padding: 16px;
+          }
+
+          .online-queue-layout {
+            grid-template-columns: 1fr;
+          }
+
+          .online-queue-stats {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+          }
+        }
+
+        @media (max-width: 520px) {
+          .online-queue-stats {
+            grid-template-columns: 1fr;
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .online-queue-number--called,
+          .online-queue-status-called {
+            animation: none;
+          }
+        }
+      `}</style>
+    </div>
   );
 };
 
 export default OnlineQueueManager;
-


### PR DESCRIPTION
﻿## Summary
- Remove the final queue-adjacent MUI import island from `OnlineQueueManager.jsx`.
- Replace MUI layout, cards, alerts, table, chips, dialog, buttons, fields, progress, and icons with existing macOS primitives plus lucide icons.
- Preserve queue hook calls, selected specialist/date state, QR generation value, QR download/print behavior, status wording, call/open queue actions, and auto-refresh behavior.

## Contract Impact
- Canonical surface: `frontend/src/components/queue/OnlineQueueManager.jsx` only.
- Request shape: Unchanged; no queue API request payloads or hook method signatures changed.
- Response shape: Unchanged; queue data, statistics, QR token, and entry fields are consumed with the same property names.
- Status codes: Unchanged; no backend or API layer changed.
- Frontend consumer: Unchanged; `rg "OnlineQueueManager" frontend/src -g "*.jsx" -g "*.js"` shows no active importer beyond the component itself.
- Compatibility path or alias: Unchanged; no route registry, alias, or adapter path changed.
- Contract proof: `npm.cmd run test:run -- --run src/routing/__tests__/routeContract.test.js` passed 18/18; `rg -l '@mui|Mui' frontend/src/pages frontend/src/components` now returns only `frontend/src/components/TelegramManager.jsx`.

## RBAC / Permissions
- Roles allowed: Unchanged; no auth, RBAC, route, or permission files touched.
- Roles denied: Unchanged; no auth, RBAC, route, or permission files touched.
- Positive auth proof: Unchanged; build and route contract passed with no route/role edits.
- Negative auth proof: Unchanged; no protected-route or denied-role behavior changed.

## Notification / Realtime
- Event type or websocket channel: Unchanged; queue notification/realtime code not touched.
- Payload version / ack behavior: Unchanged; no websocket or notification payload changes.
- Read/unread or delivery semantics: Unchanged; no notification center state changed.
- Reconnect/resync proof: Unchanged; no websocket reconnect/resync code touched.

## Frontend Resilience
- Empty data proof: Empty queue and missing queue states still render through the same conditional branches with macOS Alert.
- Partial data proof: Patient/phone fallbacks remain `Не указано` / `Не указан`; QR metadata uses the same `qrData` fields.
- Forbidden secondary path behavior: Unchanged; no route guard or secondary path behavior changed.
- Missing draft/resource behavior: Missing specialist, missing queue, and empty queue states remain explicit alerts.
- Stale route/deep-link behavior: Unchanged; no routing or deep-link logic touched.

## Scope Gate
- Allowed paths: `frontend/src/components/queue/OnlineQueueManager.jsx`.
- Denied paths: Backend, migrations, API clients, hooks, routing, docs, tests, workflows, package files, and other frontend runtime files.
- Migration/docs/test impact: No migrations, docs, or tests changed.
- Rollback note: Revert this commit to restore the previous MUI-based queue manager component.

## Validation
- Targeted tests or smoke run: `py -3 ai\\langgraph\\scripts\\agent_gate.py ... --known-root-cause "frontend/src/components/queue/OnlineQueueManager.jsx"`; `npm.cmd run lint:check`; `npm.cmd run test:run -- --run src/routing/__tests__/routeContract.test.js`; `npm.cmd run build`; `rg -l '@mui|Mui' frontend/src/pages frontend/src/components`; `git diff --check`.
- Result: Gate returned narrow override; lint passed with existing 54 warnings and 0 errors; route contract passed 18/18; build passed; MUI search now returns only `frontend/src/components/TelegramManager.jsx`; diff check passed.
- Not checked: Browser QA for this component; source search shows no active importer/route for `OnlineQueueManager.jsx`, so there is no stable local route to open without creating new test harness code.
