### PR TITLE
docs(frontend): refresh mui inventory after queue cleanup

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/mui-risky-islands-handoff.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/mui-risky-islands-handoff.md
@@ -13,7 +13,7 @@ Fresh inventory:
 rg -l "@mui|Mui" frontend\src\pages frontend\src\components
 ```
 
-Current post-continuation result: 2 files.
+Current post-continuation result: 1 file.
 
 ## Global Rule
 
@@ -77,9 +77,16 @@ Validation:
 
 ## Queue Handoff
 
-File:
+Files:
 
-- `frontend/src/components/queue/OnlineQueueManager.jsx`
+- none currently matching `@mui|Mui`
+
+Note: `frontend/src/components/queue/OnlineQueueManager.jsx` was migrated to
+macOS/native controls in a gate-limited queue manager slice and no longer
+appears in the MUI runtime inventory. Future behavior changes to the component
+still require queue gate review because status wording, QR generation,
+print/download behavior, call/open queue actions, and auto-refresh semantics
+are queue-sensitive.
 
 Mode:
 
@@ -265,8 +272,8 @@ Stop if:
 ## Result
 
 PR-MUI-4 created the guardrails needed before any remaining runtime MUI
-migration. The current remaining MUI inventory is 2 files across queue and
-Telegram surfaces.
+migration. The current remaining MUI inventory is 1 file in the Telegram
+surface.
 
 ## Next Smallest Step
 

--- a/docs/audits/uiux-hard-audit-2026-05-20/third-cycle-performance-mui-summary.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/third-cycle-performance-mui-summary.md
@@ -140,7 +140,7 @@ classified, policy-covered, and guarded for future small PRs.
 ## Post-Cycle Continuation Note
 
 Later small PRs reduced the current MUI inventory from the historical third
-cycle count of 14 files to 2 files:
+cycle count of 14 files to 1 file:
 
 - stale `frontend/src/components/dashboard/Dashboard.jsx` removal;
 - gated `frontend/src/components/admin/UserManagement.jsx` actions menu
@@ -162,8 +162,9 @@ cycle count of 14 files to 2 files:
   migration.
 - gated `frontend/src/components/cardiology/ECGViewer.jsx` cardiology viewer
   migration.
+- gated `frontend/src/components/queue/OnlineQueueManager.jsx` queue manager
+  migration.
 
 Current remaining MUI files:
 
-- `frontend/src/components/queue/OnlineQueueManager.jsx`
 - `frontend/src/components/TelegramManager.jsx`

--- a/frontend/MUI_RUNTIME_INVENTORY.md
+++ b/frontend/MUI_RUNTIME_INVENTORY.md
@@ -87,6 +87,12 @@ a gate-limited cardiology slice. ECG upload metadata, preview/download/delete
 behavior, parsed parameter display, AI analysis payload, analysis warning
 thresholds, and cardiology route/RBAC behavior remain unchanged.
 
+OnlineQueueManager migration: 1 file now contains runtime MUI imports after
+converting `frontend/src/components/queue/OnlineQueueManager.jsx` to
+macOS/native controls in a gate-limited queue slice. Queue hook calls, selected
+specialist/date state, QR generation value, QR download/print behavior, status
+wording, call/open queue actions, and auto-refresh behavior remain unchanged.
+
 ## No-New-MUI Island Policy
 
 MUI is a legacy compatibility layer in this clinic frontend. New clinic runtime UI should not create new MUI islands.
@@ -127,7 +133,7 @@ rg -l '@mui|Mui' frontend/src/pages frontend/src/components
 | `frontend/src/components/dashboard/Dashboard.jsx` | Stale/removed | No active route owner or caller found. | Removed after route-owner discovery. |
 | `frontend/src/components/payment/PaymentWidget.jsx` | Migrated/payment-sensitive | Payment widget UI now uses macOS/native controls with no current `@mui` import. | Keep future changes payment-gated because provider flow, status, confirmation, retry/error handling, and callback semantics are payment-sensitive. |
 | `frontend/src/pages/PaymentTest.jsx` | Migrated/payment-demo | Internal payment demo/test surface now uses macOS/native controls with no current `@mui` import. | Keep route, admin/internal-demo visibility, and payment demo semantics unchanged; future behavior changes still require payment gate review. |
-| `frontend/src/components/queue/OnlineQueueManager.jsx` | Payment/queue-adjacent | Queue status, print/download, and queue operations. | Gate/handoff only. |
+| `frontend/src/components/queue/OnlineQueueManager.jsx` | Migrated/queue-sensitive | Queue manager UI now uses macOS/native controls with no current `@mui` import. | Keep future changes queue-gated because status wording, QR generation, print/download behavior, call/open queue actions, and auto-refresh semantics are queue-sensitive. |
 | `frontend/src/components/patient/FamilyRelationsCard.jsx` | Migrated/clinical | Patient relationship UI now uses macOS/native controls with no current `@mui` import. | Keep future changes clinical-gated because relationship visibility and pickup-role context are patient-sensitive. |
 | `frontend/src/components/laboratory/LabReportGenerator.jsx` | Stale/removed | Caller-free lab report generator had no active frontend source importer. | Removed after source search; active lab panel/report/export behavior remains unchanged. |
 | `frontend/src/components/cardiology/ECGViewer.jsx` | Migrated/clinical | ECG viewer UI now uses macOS/native controls with no current `@mui` import. | Keep future changes cardiology/clinical-gated because ECG upload metadata, preview/download/delete behavior, parsed parameters, and AI interpretation semantics are clinical-sensitive. |
@@ -140,7 +146,6 @@ rg -l '@mui|Mui' frontend/src/pages frontend/src/components
 
 ## Do-Not-Touch Buckets
 
-- Queue: `OnlineQueueManager.jsx`
 - Telegram: `TelegramManager.jsx`
 
 ## Completed Low-Risk Runtime Targets
@@ -152,7 +157,8 @@ These targets were low-risk because they are UI-status prompts and were migrated
 
 ## Remaining Runtime Targets
 
-The remaining current `@mui` files are all in do-not-touch runtime buckets. Do not migrate them without a dedicated gate/handoff.
+The remaining current `@mui` file is in the Telegram/AI do-not-touch runtime
+bucket. Do not migrate it without a dedicated gate/handoff.
 
 ## PR-UX-17 Decision
 
@@ -190,6 +196,8 @@ Result after PaymentWidget payment widget migration: 3 files.
 
 Result after ECGViewer cardiology viewer migration: 2 files.
 
+Result after OnlineQueueManager queue manager migration: 1 file.
+
 Decision: do not force a runtime MUI migration in this PR. The only already
 approved low-risk runtime targets were `ConnectionStatus.jsx` and
 `PWAInstallPrompt.jsx`, and both are already migrated. Every remaining runtime
@@ -212,8 +220,9 @@ current MUI search result. The dental planning slice removed
 modal slice removed `ToothModal.jsx` from the current MUI search result.
 The payment widget slice removed `PaymentWidget.jsx` from the current MUI
 search result. The cardiology viewer slice removed `ECGViewer.jsx` from the
-current MUI search result. Remaining MUI targets are queue and Telegram
-surfaces.
+current MUI search result. The queue manager slice removed
+`OnlineQueueManager.jsx` from the current MUI search result. The remaining MUI
+target is the Telegram surface.
 
 Next safe MUI migration should be a dedicated PR with one first-touch file,
 route/browser smoke, and a PR body that explicitly proves no role, route,
@@ -239,7 +248,7 @@ removal, LabReportGenerator stale component removal, and FamilyRelationsCard
 patient relationship migration, TreatmentPlanner dental planning migration, and
 ToothModal dental tooth modal migration, and PaymentWidget payment widget
 migration, and ECGViewer cardiology viewer migration:
-2 files.
+1 file.
 
 No new MUI imports were introduced by the recent performance PRs. Current
 classification:
@@ -247,25 +256,24 @@ classification:
 | Category | Files | Decision |
 | --- | ---: | --- |
 | Shared/admin-sensitive | 0 | No current MUI search result after UserManagement migration and stale dashboard removal. |
-| Payment/queue-adjacent | 1 | Gate/handoff only. |
+| Payment/queue-adjacent | 0 | No current MUI search result after payment and queue migrations. |
 | Clinical-heavy | 0 | No current MUI search result after cardiology and dental migrations. |
 | Telegram/AI-sensitive | 1 | Gate/handoff only. |
 | Example-only | 0 | Both `Unified*` examples have been converted away from MUI. |
 
 Current files:
 
-- Payment/queue-adjacent:
-  - `frontend/src/components/queue/OnlineQueueManager.jsx`
 - Telegram/AI-sensitive:
   - `frontend/src/components/TelegramManager.jsx`
 - Example-only:
   - none currently matching `@mui|Mui`
 
 Decision: do not treat the historical PR-MUI-1 inventory as current. The
-current live MUI inventory is 2 files and excludes the migrated/removed
+current live MUI inventory is 1 file and excludes the migrated/removed
 admin/shared, dashboard, example-only, PaymentTest, MCPMonitor,
 LabReportGenerator, FamilyRelationsCard, TreatmentPlanner, and ToothModal
-surfaces, plus the migrated PaymentWidget and ECGViewer surfaces.
+surfaces, plus the migrated PaymentWidget, ECGViewer, and OnlineQueueManager
+surfaces.
 
 ## PR-MUI-2 Low-Risk Admin Decision
 
@@ -320,7 +328,6 @@ cleanup PR. They now require the gated handoff in
 
 Gate-required groups:
 
-- Queue: `OnlineQueueManager.jsx`
 - Telegram/AI: `TelegramManager.jsx`
 
 Default rule: one risky MUI island per PR, with first-touch boundaries,


### PR DESCRIPTION
﻿## Summary
- Refresh MUI inventory docs after the OnlineQueueManager queue slice migrated away from MUI.
- Record that the current runtime MUI inventory is down to 1 file: `TelegramManager.jsx`.
- Update the risky-island handoff and third-cycle summary so the remaining work is correctly scoped to Telegram/AI only.

## Contract Impact
- Canonical surface: Unchanged; documentation-only inventory and audit records.
- Request shape: Unchanged; no API or frontend request code changed.
- Response shape: Unchanged; no backend or frontend response handling changed.
- Status codes: Unchanged; no server behavior changed.
- Frontend consumer: Unchanged; no runtime frontend consumers changed.
- Compatibility path or alias: Unchanged; inventory docs now point to the one remaining runtime MUI file.
- Contract proof: `git diff --name-only` shows only audit/inventory markdown files.

## RBAC / Permissions
- Roles allowed: Unchanged; docs-only change.
- Roles denied: Unchanged; docs-only change.
- Positive auth proof: Unchanged; no auth path touched.
- Negative auth proof: Unchanged; no auth path touched.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no notification or realtime code touched.
- Payload version / ack behavior: Unchanged; no payload code touched.
- Read/unread or delivery semantics: Unchanged; no notification state touched.
- Reconnect/resync proof: Unchanged; no realtime reconnect path touched.

## Frontend Resilience
- Empty data proof: Unchanged; docs-only inventory refresh.
- Partial data proof: Unchanged; docs-only inventory refresh.
- Forbidden secondary path behavior: Unchanged; docs-only inventory refresh.
- Missing draft/resource behavior: Unchanged; docs-only inventory refresh.
- Stale route/deep-link behavior: Unchanged; docs-only inventory refresh.

## Scope Gate
- Allowed paths: `frontend/MUI_RUNTIME_INVENTORY.md`, `docs/audits/uiux-hard-audit-2026-05-20/mui-risky-islands-handoff.md`, `docs/audits/uiux-hard-audit-2026-05-20/third-cycle-performance-mui-summary.md`.
- Denied paths: Runtime frontend, backend, workflows, tests, migrations, and package files.
- Migration/docs/test impact: Docs-only inventory update; no migrations or tests changed.
- Rollback note: Revert this docs commit if the inventory summary needs to be restored.

## Validation
- Targeted tests or smoke run: `git diff --check`; `rg -l '@mui|Mui' frontend/src/pages frontend/src/components`; PR body template validation.
- Result: Passed locally; MUI search returns only `frontend/src/components/TelegramManager.jsx`.
- Not checked: Frontend lint/build/browser QA; unchanged because this is docs-only.
