### PR TITLE
[codex] show telegram appointment safety summary

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -951,6 +951,18 @@ function TelegramMiniAppPatientShell() {
                     <Badge variant="secondary" size="small">Р‘РµР· СЃРѕР·РґР°РЅРёСЏ</Badge>
                   </div>
 
+                  <div style={miniAppFormsSummaryStyle}>
+                    <Badge variant="secondary" size="small">
+                      {selectedCapability?.preview_enabled ? 'preview on' : 'preview off'}
+                    </Badge>
+                    <Badge variant={selectedCapability?.contains_medical_data ? 'warning' : 'success'} size="small">
+                      {selectedCapability?.contains_medical_data ? 'medical data' : 'no medical data'}
+                    </Badge>
+                    <Badge variant={selectedCapability?.contains_payment_provider_data ? 'warning' : 'success'} size="small">
+                      {selectedCapability?.contains_payment_provider_data ? 'provider payloads' : 'no provider payloads'}
+                    </Badge>
+                  </div>
+
                   <form style={miniAppAppointmentFormStyle} onSubmit={handleAppointmentPreviewSubmit}>
                     <div style={miniAppAppointmentFormGridStyle}>
                       <Input


### PR DESCRIPTION
## Summary
- Adds top-level safety badges to the Telegram Mini App appointment preview card.
- Displays existing patient manifest flags for preview availability, medical data, and payment-provider payloads.
- Keeps the appointment flow preview-only in the UI: no create control, appointment creation behavior, provider redirect, payment record, or backend contract is changed.

## Contract Impact
- Canonical surface: existing `POST /api/v1/telegram/mini-app/patient/manifest` appointment capability metadata and existing `POST /api/v1/telegram/mini-app/appointments/preview` preview call.
- Request shape: unchanged `{ initData }` patient manifest request and unchanged preview request body.
- Response shape: unchanged; frontend now displays existing `preview_enabled`, `contains_medical_data`, and `contains_payment_provider_data` appointment capability flags.
- Status codes: unchanged.
- Frontend consumer: `TelegramMiniAppPatientShell` in `frontend/src/App.jsx`, appointments section only.
- Compatibility path or alias: not applicable because this PR does not add or change route aliases or compatibility endpoints.
- Contract proof: Playwright appointment smoke mocks the patient manifest and preview response, verifies the new badges, verifies the preview endpoint is called once after submit, and verifies the create endpoint is not called.

## RBAC / Permissions
- Roles allowed: unchanged because backend Mini App session verification remains canonical and this PR only displays existing safety flags.
- Roles denied: unchanged because invalid or denied sessions still follow existing backend and frontend error behavior.
- Positive auth proof: Playwright smoke provides mock Mini App init data, verifies the patient manifest request, and verifies the preview request carries the same init data.
- Negative auth proof: no backend auth behavior changed; no create endpoint control, payment provider payload, medical record rendering, or mutation path is introduced.

## Notification / Realtime
not applicable because this PR does not add notifications, websocket events, callbacks, or delivery behavior.

## Frontend Resilience
- Empty data proof: unchanged; appointment preview form still uses the existing default appointment date/time draft state.
- Partial data proof: missing safety booleans remain safely falsey and render `preview off`, `no medical data`, and `no provider payloads`.
- Forbidden secondary path behavior: Playwright smoke verifies forms, cabinet, payments, results, and appointment create endpoints are not called by the appointments preview flow.
- Missing draft/resource behavior: unchanged because the preview form still posts only after Mini App init data and appointment date are available.
- Stale route/deep-link behavior: unchanged; appointment preview remains gated by `selectedSection === 'appointments'` and `preview_enabled`.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`.
- Denied paths: backend endpoints, migrations, appointment creation services, payment/provider integrations, Telegram webhook services, manager UI, docs, and generated artifacts were not changed.
- Migration/docs/test impact: no DB or Alembic impact; validation used existing Telegram guard scripts and targeted frontend checks.
- Rollback note: revert `5640636b` to remove the appointment safety badges while leaving preview behavior unchanged.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- src/App.jsx`; `npm.cmd run build`; `C:\final\backend\.venv\Scripts\python.exe -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; Playwright Mini App appointments smoke on Vite preview; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file frontend/src/App.jsx --fail-on-warning`; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py --fail-on-warning`; `git diff --check`; `git diff --cached --check`.
- Result: passed; lint reported 54 existing warnings and 0 errors; smoke proved patient manifest was called once, appointment preview was called once, appointment create and unrelated section endpoints were not called, and sensitive mock medical/provider values did not render.
- Not checked: full frontend test suite, live Telegram Bot API, live backend/Postgres runtime, real appointment creation, and real payment provider redirects.