### PR TITLE
refactor(frontend): remove mui from telegram manager

### DIFF
--- a/frontend/src/components/TelegramManager.jsx
+++ b/frontend/src/components/TelegramManager.jsx
@@ -13,9 +13,11 @@ import {
   DialogActions,
   Alert,
   CircularProgress,
+  Input,
   Select,
 
   Switch,
+  Textarea,
 
   Grid,
   List,
@@ -25,7 +27,8 @@ import {
   TableHead,
   TableBody,
   TableRow,
-  TableCell } from
+  TableCell,
+  TableHeaderCell } from
 './ui/macos/Table';
 import {
   ListItem,
@@ -58,15 +61,6 @@ import {
 
 
 'lucide-react';
-import {
-  TableContainer,
-  IconButton,
-  TextField,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  FormControlLabel } from
-'@mui/material';
 import { api } from '../api/client.js';
 
 const TelegramManager = () => {
@@ -510,6 +504,16 @@ const TelegramManager = () => {
       'RBAC, audit и подтверждения обязательны перед действиями.'
     }
   ];
+  const templateTypeOptions = [
+    { value: 'text', label: 'Текст' },
+    { value: 'photo', label: 'Фото' },
+    { value: 'document', label: 'Документ' }
+  ];
+  const iconActionStyle = {
+    width: 32,
+    minHeight: 32,
+    padding: 0
+  };
 
   return (
     <Box sx={{ p: 3 }}>
@@ -1118,14 +1122,14 @@ const TelegramManager = () => {
               <Typography variant="h6" gutterBottom>
                 Шаблоны сообщений
               </Typography>
-              <TableContainer>
-                <Table>
+              <div style={{ width: '100%', overflowX: 'auto' }}>
+                <Table style={{ minWidth: 640 }}>
                   <TableHead>
                     <TableRow>
-                      <TableCell>Название</TableCell>
-                      <TableCell>Тип</TableCell>
-                      <TableCell>Статус</TableCell>
-                      <TableCell align="right">Действия</TableCell>
+                      <TableHeaderCell>Название</TableHeaderCell>
+                      <TableHeaderCell>Тип</TableHeaderCell>
+                      <TableHeaderCell>Статус</TableHeaderCell>
+                      <TableHeaderCell align="right">Действия</TableHeaderCell>
                     </TableRow>
                   </TableHead>
                   <TableBody>
@@ -1149,18 +1153,32 @@ const TelegramManager = () => {
                           </Badge>
                         </TableCell>
                         <TableCell align="right">
-                          <IconButton aria-label="Редактировать" title="Редактировать">
-                            <Edit />
-                          </IconButton>
-                          <IconButton aria-label="Удалить" title="Удалить">
-                            <Trash2 />
-                          </IconButton>
+                          <Box display="inline-flex" gap={0.5} justifyContent="flex-end">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="small"
+                              aria-label="Редактировать"
+                              title="Редактировать"
+                              style={iconActionStyle}>
+                              <Edit size={16} />
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="small"
+                              aria-label="Удалить"
+                              title="Удалить"
+                              style={iconActionStyle}>
+                              <Trash2 size={16} />
+                            </Button>
+                          </Box>
                         </TableCell>
                       </TableRow>
                     )}
                   </TableBody>
                 </Table>
-              </TableContainer>
+              </div>
             </CardContent>
           </Card>
         </Grid>
@@ -1171,50 +1189,40 @@ const TelegramManager = () => {
         <DialogContent>
           <Grid container spacing={2} sx={{ mt: 1 }}>
             <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
+              <Input
                 label="Название шаблона"
                 value={templateForm.name}
                 onChange={(e) => setTemplateForm({ ...templateForm, name: e.target.value })}
+                style={{ width: '100%' }}
                 required />
-              
+
             </Grid>
             <Grid item xs={12} sm={6}>
-              <FormControl fullWidth>
-                <InputLabel>Тип сообщения</InputLabel>
-                <Select
-                  value={templateForm.message_type}
-                  onChange={(e) => setTemplateForm({ ...templateForm, message_type: e.target.value })}
-                  label="Тип сообщения">
-                  
-                  <MenuItem value="text">Текст</MenuItem>
-                  <MenuItem value="photo">Фото</MenuItem>
-                  <MenuItem value="document">Документ</MenuItem>
-                </Select>
-              </FormControl>
+              <Select
+                label="Тип сообщения"
+                value={templateForm.message_type}
+                options={templateTypeOptions}
+                onChange={(messageType) => setTemplateForm({ ...templateForm, message_type: messageType })}
+                style={{ width: '100%' }} />
             </Grid>
             <Grid item xs={12}>
-              <TextField
-                fullWidth
+              <Textarea
                 label="Содержание сообщения"
-                multiline
-                rows={6}
+                minRows={6}
+                maxRows={8}
                 value={templateForm.content}
                 onChange={(e) => setTemplateForm({ ...templateForm, content: e.target.value })}
                 required
+                style={{ width: '100%' }}
                 placeholder="Используйте переменные: {patient_name}, {appointment_date}, {doctor_name}" />
-              
+
             </Grid>
             <Grid item xs={12}>
-              <FormControlLabel
-                control={
-                <Switch
-                  checked={templateForm.is_active}
-                  onChange={(e) => setTemplateForm({ ...templateForm, is_active: e.target.checked })} />
+              <Switch
+                label="Активный шаблон"
+                checked={templateForm.is_active}
+                onChange={(isActive) => setTemplateForm({ ...templateForm, is_active: isActive })} />
 
-                }
-                label="Активный шаблон" />
-              
             </Grid>
           </Grid>
         </DialogContent>


### PR DESCRIPTION
﻿## Summary
- Removed the final MUI runtime import from `TelegramManager.jsx` and replaced the remaining MUI table/form/action controls with existing macOS UI primitives.
- Kept Telegram bot status, webhook/polling display, staff link safety text, payment safety summary display, API calls, request payloads, token visibility rules, route behavior, and RBAC behavior unchanged.
- Confirmed runtime MUI search across `frontend/src/pages` and `frontend/src/components` now returns no files.

## Contract Impact
- Canonical surface: Admin Telegram integration UI at `/admin/integrations/telegram` using `frontend/src/components/TelegramManager.jsx`.
- Request shape: Unchanged; no API calls or request payloads changed.
- Response shape: Unchanged; the component reads the same Telegram status/templates/integration payloads.
- Status codes: Unchanged; no backend endpoint behavior changed.
- Frontend consumer: `TelegramManager` still consumes the same route/component registry wiring.
- Compatibility path or alias: Unchanged; `/telegram-integration` legacy redirect remains untouched.
- Contract proof: `npm.cmd run test:run -- --run src/routing/__tests__/routeContract.test.js` passed and backend Telegram endpoint `py_compile` passed.

## RBAC / Permissions
- Roles allowed: Unchanged; existing admin route access remains controlled by the route registry and auth layer.
- Roles denied: Unchanged; no route guard or permission logic changed.
- Positive auth proof: Route contract test passed for registered route wiring.
- Negative auth proof: Not run in this UI-only MUI cleanup; no auth code touched.

## Notification / Realtime
- Event type or websocket channel: Unchanged; no notification or websocket code touched.
- Payload version / ack behavior: Unchanged.
- Read/unread or delivery semantics: Unchanged.
- Reconnect/resync proof: Unchanged; no realtime flow touched.

## Frontend Resilience
- Empty data proof: Existing template/status fallback rendering preserved; build passed.
- Partial data proof: Existing optional chaining and fallback strings preserved.
- Forbidden secondary path behavior: Unchanged; route/auth behavior not touched.
- Missing draft/resource behavior: Unchanged; template creation still uses the existing backend-contract warning path.
- Stale route/deep-link behavior: Unchanged; route registry and legacy redirect untouched.

## Scope Gate
- Allowed paths: `frontend/src/components/TelegramManager.jsx`.
- Denied paths: Backend, routing, migrations, package dependencies, tests, and runtime business logic.
- Migration/docs/test impact: No migrations or tests changed; docs refresh will be a separate follow-up PR after this lands.
- Rollback note: Revert this commit to restore the previous MUI-backed controls in TelegramManager.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check`; `npm.cmd run test:run -- --run src/routing/__tests__/routeContract.test.js`; `npm.cmd run build`; `py -3 -m py_compile backend\\app\\api\\v1\\endpoints\\admin_telegram.py backend\\app\\api\\v1\\endpoints\\telegram_webhook.py`; `rg -l '@mui|Mui' frontend\\src\\pages frontend\\src\\components`; `git diff --check`.
- Result: Passed. Lint still reports the existing 54 warnings and 0 errors; MUI runtime search returned no files.
- Not checked: Authenticated browser QA for the admin Telegram route; no local authenticated session was used in this PR.
