### PR TITLE
[codex] show telegram mini app manifest safety summary

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -142,6 +142,22 @@ const MINI_APP_SECTION_ALIASES = {
   documents: 'results',
 };
 
+const MINI_APP_CAPABILITY_SAFETY_FLAGS = [
+  ['contains_medical_data', 'medical data', 'no medical data'],
+  ['contains_payment_provider_data', 'provider payloads', 'no provider payloads'],
+  ['contains_passport_data', 'passport data', 'no passport data'],
+  ['contains_billing_records', 'billing records', 'no billing records'],
+  ['contains_amounts', 'amounts present', 'no amounts'],
+  ['contains_payment_records', 'payment records', 'no payment records'],
+  ['contains_provider_payloads', 'provider payloads', 'no provider payloads'],
+  ['contains_medical_results', 'medical results', 'no medical results'],
+  ['contains_lab_values', 'lab values', 'no lab values'],
+  ['contains_report_records', 'report records', 'no report records'],
+  ['contains_file_urls', 'file URLs', 'no file URLs'],
+  ['contains_pdfs', 'PDFs present', 'no PDFs'],
+  ['contains_diagnoses', 'diagnoses', 'no diagnoses'],
+];
+
 function getTelegramMiniAppInitData() {
   if (typeof window === 'undefined') {
     return '';
@@ -182,6 +198,23 @@ function isMiniAppCapabilityEnabled(capability) {
     capability?.capture_enabled ||
     capability?.payment_capture_enabled
   );
+}
+
+function getMiniAppCapabilitySafetyBadges(capability) {
+  if (!capability) {
+    return [];
+  }
+
+  return MINI_APP_CAPABILITY_SAFETY_FLAGS
+    .filter(([key]) => Object.prototype.hasOwnProperty.call(capability, key))
+    .map(([key, unsafeLabel, safeLabel]) => {
+      const unsafe = Boolean(capability[key]);
+      return {
+        key,
+        label: unsafe ? unsafeLabel : safeLabel,
+        variant: unsafe ? 'warning' : 'success',
+      };
+    });
 }
 
 function notifyTelegramMiniAppReady() {
@@ -504,6 +537,7 @@ function TelegramMiniAppPatientShell() {
   const capabilityEntries = Object.entries(MINI_APP_CAPABILITY_LABELS);
   const selectedCapability = selectedSection ? capabilities[selectedSection] || {} : null;
   const selectedCapabilityEnabled = isMiniAppCapabilityEnabled(selectedCapability);
+  const selectedCapabilitySafetyBadges = getMiniAppCapabilitySafetyBadges(selectedCapability);
   const canPreviewAppointments = Boolean(
     selectedSection === 'appointments' &&
     selectedCapability?.preview_enabled
@@ -637,6 +671,15 @@ function TelegramMiniAppPatientShell() {
                     <p style={miniAppCapabilityTextStyle}>
                       {selectedCapability?.status || 'manifest_only'}
                     </p>
+                    {selectedCapabilitySafetyBadges.length > 0 && (
+                      <div style={miniAppSelectedSectionSafetyStyle}>
+                        {selectedCapabilitySafetyBadges.map((badge) => (
+                          <Badge key={badge.key} variant={badge.variant} size="small">
+                            {badge.label}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 </CardContent>
               </Card>
@@ -1364,6 +1407,14 @@ const miniAppSelectedSectionStatusStyle = {
   alignItems: 'flex-end',
   gap: '8px',
   minWidth: '128px',
+};
+
+const miniAppSelectedSectionSafetyStyle = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  justifyContent: 'flex-end',
+  gap: '6px',
+  maxWidth: '360px',
 };
 
 const miniAppAppointmentPreviewStyle = {


### PR DESCRIPTION
## Summary
- Adds reusable selected-section safety badges for Telegram Mini App aggregate patient manifest capabilities.
- Displays existing `contains_*` safety flags in the top selected-section card before any deeper section UI is used.
- Keeps the change frontend-only: no backend contracts, endpoint calls, appointment creation, payment capture, provider redirects, records, or downloads are changed.

## Contract Impact
- Canonical surface: existing `POST /api/v1/telegram/mini-app/patient/manifest` capability metadata.
- Request shape: unchanged `{ initData }` aggregate patient manifest request.
- Response shape: unchanged; frontend now displays existing capability booleans when they are present.
- Status codes: unchanged.
- Frontend consumer: `TelegramMiniAppPatientShell` in `frontend/src/App.jsx`, selected-section summary only.
- Compatibility path or alias: not applicable because this PR does not add or change route aliases or compatibility endpoints.
- Contract proof: Playwright smoke mocks the aggregate patient manifest, verifies aggregate safety badges render, verifies hidden mock values are not rendered, and verifies no preview/create/forms/cabinet/payments/results endpoints are called by the selected-section summary.

## RBAC / Permissions
- Roles allowed: unchanged because backend Mini App session verification remains canonical and this PR only displays existing aggregate manifest flags.
- Roles denied: unchanged because invalid or denied sessions still follow existing endpoint and frontend error behavior.
- Positive auth proof: Playwright smoke provides mock Mini App init data and verifies the aggregate patient manifest request is made once.
- Negative auth proof: no backend auth behavior changed; no record rendering, mutation control, payment provider payload, download, or secondary endpoint path is introduced.

## Notification / Realtime
not applicable because this PR does not add notifications, websocket events, callbacks, or delivery behavior.

## Frontend Resilience
- Empty data proof: missing capability flags produce no extra badges and leave the selected-section status behavior unchanged.
- Partial data proof: only capability booleans present in the aggregate manifest are rendered; falsey safety values render safe labels such as `no medical data` or `no provider payloads`.
- Forbidden secondary path behavior: Playwright smoke verifies appointment preview/create and forms/cabinet/payments/results endpoints are not called by the selected-section summary.
- Missing draft/resource behavior: unchanged because this summary has no draft/resource dependency and no mutation affordance.
- Stale route/deep-link behavior: unchanged; unknown section aliases still resolve to the existing non-selected behavior.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`.
- Denied paths: backend endpoints, migrations, Telegram webhook services, payment/provider integrations, records/download flows, manager UI, docs, and generated artifacts were not changed.
- Migration/docs/test impact: no DB or Alembic impact; validation used existing Telegram guard scripts and targeted frontend checks.
- Rollback note: revert `efe73751` to remove the aggregate selected-section safety badges while leaving all Mini App endpoint behavior unchanged.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- src/App.jsx`; `npm.cmd run build`; `C:\final\backend\.venv\Scripts\python.exe -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; Playwright Mini App aggregate selected-section smoke on Vite preview; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file frontend/src/App.jsx --fail-on-warning`; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py --fail-on-warning`; `git diff --check`; `git diff --cached --check`.
- Result: passed; lint reported 54 existing warnings and 0 errors; smoke proved aggregate selected-section badges render, the patient manifest is called once, secondary Mini App endpoints are not called, and hidden mock values do not render.
- Not checked: full frontend test suite, live Telegram Bot API, live backend/Postgres runtime, real appointment creation, real payment provider redirects, and real result downloads.