### PR TITLE
[codex] add telegram mini app appointment create action

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -189,6 +189,16 @@ function createMiniAppAppointmentPreviewForm() {
   };
 }
 
+function buildMiniAppAppointmentRequestBody(initData, form) {
+  return {
+    initData,
+    appointmentDate: form.appointmentDate,
+    appointmentTime: form.appointmentTime || undefined,
+    department: form.department.trim() || undefined,
+    notes: form.notes.trim() || undefined,
+  };
+}
+
 function isMiniAppCapabilityEnabled(capability) {
   return Boolean(
     capability?.create_enabled ||
@@ -245,6 +255,11 @@ function TelegramMiniAppPatientShell() {
   });
   const [appointmentPreviewForm, setAppointmentPreviewForm] = useState(createMiniAppAppointmentPreviewForm);
   const [appointmentPreview, setAppointmentPreview] = useState({
+    status: 'idle',
+    payload: null,
+    error: null,
+  });
+  const [appointmentCreate, setAppointmentCreate] = useState({
     status: 'idle',
     payload: null,
     error: null,
@@ -564,6 +579,16 @@ function TelegramMiniAppPatientShell() {
       ...current,
       [field]: event.target.value,
     }));
+    setAppointmentPreview({
+      status: 'idle',
+      payload: null,
+      error: null,
+    });
+    setAppointmentCreate({
+      status: 'idle',
+      payload: null,
+      error: null,
+    });
   };
 
   const handleAppointmentPreviewSubmit = (event) => {
@@ -579,16 +604,15 @@ function TelegramMiniAppPatientShell() {
       return;
     }
 
-    const requestBody = {
-      initData,
-      appointmentDate: appointmentPreviewForm.appointmentDate,
-      appointmentTime: appointmentPreviewForm.appointmentTime || undefined,
-      department: appointmentPreviewForm.department.trim() || undefined,
-      notes: appointmentPreviewForm.notes.trim() || undefined,
-    };
+    const requestBody = buildMiniAppAppointmentRequestBody(initData, appointmentPreviewForm);
 
     setAppointmentPreview({
       status: 'loading',
+      payload: null,
+      error: null,
+    });
+    setAppointmentCreate({
+      status: 'idle',
       payload: null,
       error: null,
     });
@@ -607,6 +631,43 @@ function TelegramMiniAppPatientShell() {
           status: 'error',
           payload: null,
           error: `Р§РµСЂРЅРѕРІРёРє Р·Р°РїРёСЃРё РЅРµ РїРѕРґС‚РІРµСЂР¶РґРµРЅ: ${reason}`,
+        });
+      });
+  };
+
+  const handleAppointmentCreate = () => {
+    const initData = getTelegramMiniAppInitData();
+    if (!initData || !appointmentPreviewForm.appointmentDate) {
+      setAppointmentCreate({
+        status: 'error',
+        payload: null,
+        error: 'Open Mini App from Telegram and preview the appointment date first.',
+      });
+      return;
+    }
+
+    const requestBody = buildMiniAppAppointmentRequestBody(initData, appointmentPreviewForm);
+
+    setAppointmentCreate({
+      status: 'loading',
+      payload: null,
+      error: null,
+    });
+
+    api.post('/telegram/mini-app/appointments', requestBody)
+      .then((response) => {
+        setAppointmentCreate({
+          status: 'ready',
+          payload: response.data,
+          error: null,
+        });
+      })
+      .catch((error) => {
+        const reason = error?.response?.data?.detail?.reason || 'create_failed';
+        setAppointmentCreate({
+          status: 'error',
+          payload: null,
+          error: `Appointment was not created: ${reason}`,
         });
       });
   };
@@ -1045,7 +1106,7 @@ function TelegramMiniAppPatientShell() {
                       variant="primary"
                       size="small"
                       loading={appointmentPreview.status === 'loading'}
-                      disabled={appointmentPreview.status === 'loading'}
+                      disabled={appointmentPreview.status === 'loading' || appointmentCreate.status === 'loading'}
                     >
                       РџСЂРѕРІРµСЂРёС‚СЊ С‡РµСЂРЅРѕРІРёРє
                     </Button>
@@ -1075,6 +1136,36 @@ function TelegramMiniAppPatientShell() {
                         {appointmentPreview.payload?.preview_only ? 'РўРѕР»СЊРєРѕ РїСЂРµРґРїСЂРѕСЃРјРѕС‚СЂ' : 'РўСЂРµР±СѓРµС‚ РїСЂРѕРІРµСЂРєРё'}
                       </Badge>
                     </div>
+                  )}
+
+                  {appointmentPreview.status === 'ready' && previewAppointment && selectedCapability?.create_enabled && (
+                    <div style={miniAppAppointmentCreateActionStyle}>
+                      <Button
+                        type="button"
+                        variant="primary"
+                        size="small"
+                        loading={appointmentCreate.status === 'loading'}
+                        disabled={appointmentCreate.status === 'loading' || appointmentCreate.status === 'ready'}
+                        onClick={handleAppointmentCreate}
+                      >
+                        Create appointment
+                      </Button>
+                      <Badge variant={appointmentCreate.status === 'ready' ? 'success' : 'secondary'} size="small">
+                        {appointmentCreate.status === 'ready' ? 'created' : 'creates one scheduled visit'}
+                      </Badge>
+                    </div>
+                  )}
+
+                  {appointmentCreate.status === 'error' && (
+                    <Alert severity="error" style={miniAppNoticeStyle}>
+                      {appointmentCreate.error}
+                    </Alert>
+                  )}
+
+                  {appointmentCreate.status === 'ready' && (
+                    <Alert severity="success" style={miniAppNoticeStyle}>
+                      Appointment request accepted. The clinic will continue the visit workflow in the protected system.
+                    </Alert>
                   )}
                 </CardContent>
               </Card>
@@ -1464,6 +1555,13 @@ const miniAppAppointmentPreviewResultStyle = {
   background: 'rgba(52, 199, 89, 0.08)',
   fontSize: '13px',
   color: 'var(--mac-text-primary, #111827)',
+};
+
+const miniAppAppointmentCreateActionStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  gap: '8px',
 };
 
 const miniAppFormsManifestStyle = {


### PR DESCRIPTION
## Summary
- Adds a protected appointment create action to the Telegram Mini App patient shell after a successful preview.
- Reuses the existing `POST /api/v1/telegram/mini-app/appointments` contract and sends the same safe preview form payload.
- Resets stale preview/create state when the patient edits the draft, and disables duplicate create submissions after success.

## Contract Impact
- Canonical surface: existing `POST /api/v1/telegram/mini-app/patient/manifest`, `POST /api/v1/telegram/mini-app/appointments/preview`, and `POST /api/v1/telegram/mini-app/appointments` endpoints.
- Request shape: unchanged; the frontend posts the existing Mini App signed session payload plus appointment draft fields already accepted by preview/create.
- Response shape: unchanged; the UI uses create success only as a status signal and does not render `appointment_id` or provider payload values.
- Status codes: unchanged.
- Frontend consumer: `TelegramMiniAppPatientShell` in `frontend/src/App.jsx`, appointments section only.
- Compatibility path or alias: not applicable because this PR does not add or change route aliases or compatibility endpoints.
- Contract proof: Playwright smoke mocks patient manifest, preview, and create endpoints; verifies the create button appears only after preview; verifies create is called once; verifies unrelated Mini App section endpoints are not called; verifies internal appointment id and provider secrets are not rendered.

## RBAC / Permissions
- Roles allowed: unchanged because backend Mini App session verification remains canonical and this PR only invokes the existing protected create endpoint after preview.
- Roles denied: unchanged because invalid, unlinked, forged, staff, or denied sessions still follow existing backend endpoint behavior.
- Positive auth proof: Playwright smoke provides mock Mini App init data and verifies both preview and create requests carry that init data.
- Negative auth proof: no backend auth behavior changed; no patient id, payment provider payload, payment record, or internal appointment id is rendered by the frontend.

## Notification / Realtime
not applicable because this PR does not add notifications, websocket events, callbacks, or delivery behavior.

## Frontend Resilience
- Empty data proof: create action is absent until preview returns a ready appointment payload.
- Partial data proof: editing any draft field clears stale preview/create state before another create can be attempted.
- Forbidden secondary path behavior: Playwright smoke verifies forms, cabinet, payments, and results endpoints are not called by the appointment create flow.
- Missing draft/resource behavior: missing Mini App init data or appointment date keeps create in an error state and does not invent a backend request.
- Stale route/deep-link behavior: unchanged; appointment UI remains gated by `selectedSection === 'appointments'` and `preview_enabled`, with create gated by existing `create_enabled` capability metadata.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`.
- Denied paths: backend endpoints, migrations, appointment services, payment/provider integrations, Telegram webhook services, manager UI, docs, and generated artifacts were not changed.
- Migration/docs/test impact: no DB or Alembic impact; validation used existing Telegram guard scripts, targeted frontend checks, build, and browser smoke.
- Rollback note: revert `8f42bb36` to remove the frontend create action while leaving backend preview/create contracts unchanged.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- src/App.jsx`; `npm.cmd run build`; `C:\final\backend\.venv\Scripts\python.exe -m py_compile backend\app\api\v1\endpoints\admin_telegram.py backend\app\api\v1\endpoints\telegram_webhook.py`; Playwright Mini App appointment create smoke on Vite preview; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_drift.py --changed-file frontend/src/App.jsx --fail-on-warning`; `C:\final\backend\.venv\Scripts\python.exe scripts\check_telegram_plan_content.py --fail-on-warning`; `git diff --check`; `git diff --cached --check`.
- Result: passed; lint reported 54 existing warnings and 0 errors; smoke proved create is gated by preview, create endpoint is called once, unrelated section endpoints are not called, and mocked internal/provider values do not render.
- Not checked: full frontend test suite, live Telegram Bot API, live backend/Postgres runtime, real appointment creation against a database, and targeted backend pytest because this shell has no `DATABASE_URL` and pytest stopped during conftest before collecting the selected tests.