### PR TITLE
[codex] guard telegram mini app appointment create action

### DIFF
--- a/frontend/src/__tests__/telegramMiniAppAppointmentCreateGuardrails.test.js
+++ b/frontend/src/__tests__/telegramMiniAppAppointmentCreateGuardrails.test.js
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const appSource = fs.readFileSync(path.resolve(process.cwd(), 'src/App.jsx'), 'utf8');
+
+function sourceBetween(source, start, end) {
+  const startIndex = source.indexOf(start);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  expect(endIndex).toBeGreaterThan(startIndex);
+
+  return source.slice(startIndex, endIndex);
+}
+
+describe('Telegram Mini App appointment create guardrails', () => {
+  it('keeps the create action behind a successful preview and create capability gate', () => {
+    const createActionMarkup = sourceBetween(
+      appSource,
+      "{appointmentPreview.status === 'ready' && previewAppointment && selectedCapability?.create_enabled && (",
+      "{appointmentCreate.status === 'error' && ("
+    );
+
+    expect(createActionMarkup).toContain('onClick={handleAppointmentCreate}');
+    expect(createActionMarkup).toContain(
+      "disabled={appointmentCreate.status === 'loading' || appointmentCreate.status === 'ready'}"
+    );
+    expect(createActionMarkup).not.toContain('payment provider');
+    expect(createActionMarkup).not.toContain('provider payload');
+  });
+
+  it('posts creates through the existing appointment endpoint with the preview request body shape', () => {
+    const createHandler = sourceBetween(
+      appSource,
+      'const handleAppointmentCreate = () => {',
+      'const previewAppointment = appointmentPreview.payload?.appointment || null;'
+    );
+
+    expect(createHandler).toContain(
+      'const requestBody = buildMiniAppAppointmentRequestBody(initData, appointmentPreviewForm);'
+    );
+    expect(createHandler).toContain("api.post('/telegram/mini-app/appointments', requestBody)");
+    expect(createHandler).not.toContain('/telegram/mini-app/appointments/preview');
+    expect(createHandler).not.toMatch(/payment_provider|provider_payload|providerPayload|transaction|webhook|invoice|amount/i);
+  });
+
+  it('clears stale create state when the appointment draft or preview submission changes', () => {
+    const fieldChangeHandler = sourceBetween(
+      appSource,
+      'const handleAppointmentPreviewFieldChange = (field) => (event) => {',
+      'const handleAppointmentPreviewSubmit = (event) => {'
+    );
+    const previewSubmitHandler = sourceBetween(
+      appSource,
+      'const handleAppointmentPreviewSubmit = (event) => {',
+      'const handleAppointmentCreate = () => {'
+    );
+
+    expect(fieldChangeHandler).toContain('setAppointmentCreate({');
+    expect(fieldChangeHandler).toContain("status: 'idle'");
+    expect(previewSubmitHandler).toContain('setAppointmentCreate({');
+    expect(previewSubmitHandler).toContain("status: 'idle'");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a focused frontend guardrail test for the Telegram Mini App appointment create action.
- Verifies the create button remains behind successful preview plus `create_enabled`, uses the existing create endpoint/request body, and clears stale create state when the draft or preview changes.

## Contract Impact

- Canonical surface: Telegram Mini App patient shell appointment create flow in `frontend/src/App.jsx`
- Request shape: unchanged; create continues to use `buildMiniAppAppointmentRequestBody(initData, appointmentPreviewForm)`
- Response shape: unchanged; this PR adds tests only
- Status codes: unchanged; no backend runtime touched
- Frontend consumer: `TelegramMiniAppPatientShell` guardrails only, no runtime code changed
- Compatibility path or alias: unchanged; no route or alias behavior changed
- Contract proof: `npm.cmd run test:run -- src/__tests__/telegramMiniAppAppointmentCreateGuardrails.test.js`

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, Telegram send, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, test-only PR does not render or change empty states
- Partial data proof: not applicable, test-only PR does not change partial-data rendering
- Forbidden secondary path behavior: create action is asserted to stay gated behind preview plus `create_enabled`
- Missing draft/resource behavior: test asserts stale create state is cleared when the appointment draft or preview changes
- Stale route/deep-link behavior: not applicable, no route/deep-link behavior changed

## Scope Gate

- Allowed paths: `frontend/src/__tests__/telegramMiniAppAppointmentCreateGuardrails.test.js`
- Denied paths: `frontend/src/App.jsx`, backend endpoints/services, migrations, provider/payment behavior, medical result behavior, and unrelated tests
- Migration/docs/test impact: frontend test coverage only; no migration or docs update expected
- Rollback note: revert the new guardrail test file if this test-only coverage needs to be removed

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/__tests__/telegramMiniAppAppointmentCreateGuardrails.test.js`; `git diff --check`; `git diff --cached --check`
- Result: targeted Vitest file passed with 3 tests; diff checks passed
- Not checked: runtime Telegram Mini App/browser/API behavior, because this PR adds a focused source guardrail test only
