### PR TITLE
[codex] guard telegram mini app expired link state

### DIFF
--- a/frontend/src/__tests__/telegramMiniAppExpiredLinkGuardrails.test.js
+++ b/frontend/src/__tests__/telegramMiniAppExpiredLinkGuardrails.test.js
@@ -1,0 +1,101 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const appSource = fs.readFileSync(path.resolve(process.cwd(), 'src/App.jsx'), 'utf8');
+
+function sourceBetween(source, start, end) {
+  const startIndex = source.indexOf(start);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  expect(endIndex).toBeGreaterThan(startIndex);
+
+  return source.slice(startIndex, endIndex);
+}
+
+describe('Telegram Mini App expired link guardrails', () => {
+  it('maps expired entry-token reasons to patient-safe copy', () => {
+    const reasonMapping = sourceBetween(
+      appSource,
+      "const MINI_APP_EXPIRED_ENTRY_TOKEN_REASONS = new Set",
+      'function createMiniAppAppointmentPreviewForm()'
+    );
+
+    expect(reasonMapping).toContain("'entry_token_invalid'");
+    expect(reasonMapping).toContain("'entry_token_expired'");
+    expect(reasonMapping).toContain('Ссылка устарела. Откройте Mini App заново из Telegram');
+    expect(reasonMapping).toContain('MINI_APP_EXPIRED_ENTRY_TOKEN_REASONS.has(reason)');
+    expect(reasonMapping).toContain('return MINI_APP_EXPIRED_ENTRY_TOKEN_MESSAGE;');
+    expect(reasonMapping).toContain('return MINI_APP_SESSION_UNCONFIRMED_MESSAGE;');
+    expect(reasonMapping).not.toContain('Request failed with status code');
+  });
+
+  it('keeps handled Mini App API errors out of the global raw-toast path', () => {
+    const handledConfig = sourceBetween(
+      appSource,
+      'const MINI_APP_HANDLED_ERROR_REQUEST_CONFIG = {',
+      'const MINI_APP_ERROR_ALERT_PROPS = {'
+    );
+    const miniAppShell = sourceBetween(
+      appSource,
+      'function TelegramMiniAppPatientShell() {',
+      'const previewAppointment = appointmentPreview.payload?.appointment || null;'
+    );
+
+    expect(handledConfig).toContain('silent: true');
+    expect(handledConfig).toContain('expectedErrorStatuses: [400, 403, 503]');
+
+    [
+      '/telegram/mini-app/patient/manifest',
+      '/telegram/mini-app/forms/manifest',
+      '/telegram/mini-app/cabinet/manifest',
+      '/telegram/mini-app/payments/manifest',
+      '/telegram/mini-app/results/manifest',
+      '/telegram/mini-app/appointments/preview',
+    ].forEach((endpoint) => {
+      expect(miniAppShell).toContain(
+        `api.post('${endpoint}', ${endpoint.endsWith('/preview') ? 'requestBody' : '{ initData }'}, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)`
+      );
+    });
+  });
+
+  it('keeps the session error state visually and accessibly distinct', () => {
+    const statusBadge = sourceBetween(
+      appSource,
+      'function getMiniAppStatusBadge(status) {',
+      'function createMiniAppAppointmentPreviewForm()'
+    );
+    const heroMarkup = sourceBetween(
+      appSource,
+      '<Badge\n            variant={statusBadge.variant}',
+      '{state.status === \'ready\' && ('
+    );
+
+    expect(statusBadge).toContain("case 'error':");
+    expect(statusBadge).toContain("variant: 'danger'");
+    expect(statusBadge).toContain('Сессия недоступна');
+    expect(heroMarkup).toContain("aria-live={state.status === 'error' ? 'assertive' : 'polite'}");
+    expect(heroMarkup).toContain('<Alert severity="error" style={miniAppNoticeStyle} {...MINI_APP_ERROR_ALERT_PROPS}>');
+    expect(appSource).toContain("role: 'alert'");
+    expect(appSource).toContain("'aria-live': 'assertive'");
+  });
+
+  it('allows the status badge to wrap instead of crowding the mobile title', () => {
+    const heroStyle = sourceBetween(
+      appSource,
+      'const miniAppHeroStyle = {',
+      'const miniAppKickerStyle = {'
+    );
+    const badgeStyle = sourceBetween(
+      appSource,
+      'const miniAppStatusBadgeStyle = {',
+      'const miniAppNoticeStyle = {'
+    );
+
+    expect(heroStyle).toContain("flexWrap: 'wrap'");
+    expect(badgeStyle).toContain("maxWidth: '100%'");
+    expect(badgeStyle).toContain("whiteSpace: 'normal'");
+    expect(badgeStyle).toContain("textAlign: 'center'");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a focused frontend guardrail test for the Telegram Mini App expired entry-token state.
- Verifies patient-safe expired-link copy, handled Mini App API error suppression, error badge/live alert behavior, and mobile-friendly status badge wrapping remain in `frontend/src/App.jsx`.

## Contract Impact

- Canonical surface: Telegram Mini App patient shell in `frontend/src/App.jsx`
- Request shape: unchanged; this PR adds source-level guardrail tests only
- Response shape: unchanged; test verifies existing `{ detail: { reason } }` mapping remains present
- Status codes: unchanged; test preserves existing handled `400/403/503` UI path assumptions
- Frontend consumer: `TelegramMiniAppPatientShell` guardrails only, no runtime code changed
- Compatibility path or alias: unchanged; no route or alias behavior changed
- Contract proof: `npm.cmd run test:run -- src/__tests__/telegramMiniAppExpiredLinkGuardrails.test.js src/__tests__/telegramMiniAppAppointmentCreateGuardrails.test.js`

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive runtime behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, Telegram send, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, test-only PR does not render or change empty states
- Partial data proof: not applicable, test-only PR does not change partial-data rendering
- Forbidden secondary path behavior: test asserts expired/invalid Mini App entry token reasons stay mapped to patient-safe copy and handled silent request config
- Missing draft/resource behavior: existing appointment create guardrail test still passes in the same targeted run
- Stale route/deep-link behavior: test asserts error badge and wrapping guardrails remain in the Mini App shell source

## Scope Gate

- Allowed paths: `frontend/src/__tests__/telegramMiniAppExpiredLinkGuardrails.test.js`
- Denied paths: `frontend/src/App.jsx`, backend endpoints/services, API client/interceptor ownership, migrations, provider/payment behavior, medical result behavior, and unrelated tests
- Migration/docs/test impact: frontend test coverage only; no migration or docs update expected
- Rollback note: revert the new guardrail test file if this test-only coverage needs to be removed

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/__tests__/telegramMiniAppExpiredLinkGuardrails.test.js src/__tests__/telegramMiniAppAppointmentCreateGuardrails.test.js`; `git diff --check`; `git diff --cached --check`
- Result: targeted Vitest files passed with 7 tests; diff checks passed
- Not checked: runtime Telegram Mini App/browser/API behavior, because this PR adds a focused source guardrail test only
