### PR TITLE
[codex] guard telegram mini app deep links

### DIFF
--- a/frontend/src/__tests__/telegramMiniAppDeepLinkGuardrails.test.js
+++ b/frontend/src/__tests__/telegramMiniAppDeepLinkGuardrails.test.js
@@ -1,0 +1,112 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const appSource = fs.readFileSync(path.resolve(process.cwd(), 'src/App.jsx'), 'utf8');
+
+const CANONICAL_SECTIONS = ['appointments', 'forms', 'cabinet', 'payments', 'results'];
+const ALIAS_MAPPINGS = {
+  doctors: 'appointments',
+  documents: 'results',
+};
+
+function sourceBetween(source, start, end) {
+  const startIndex = source.indexOf(start);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  expect(endIndex).toBeGreaterThan(startIndex);
+
+  return source.slice(startIndex, endIndex);
+}
+
+describe('Telegram Mini App deep-link guardrails', () => {
+  it('keeps section deep links limited to canonical sections and approved aliases', () => {
+    const aliases = sourceBetween(
+      appSource,
+      'const MINI_APP_SECTION_ALIASES = {',
+      'const MINI_APP_CAPABILITY_SAFETY_FLAGS = ['
+    );
+    const selectedSectionParser = sourceBetween(
+      appSource,
+      'function getTelegramMiniAppSelectedSection(search) {',
+      'function getDefaultMiniAppAppointmentDate() {'
+    );
+
+    CANONICAL_SECTIONS.forEach((section) => {
+      expect(aliases).toContain(`${section}: '${section}'`);
+    });
+    Object.entries(ALIAS_MAPPINGS).forEach(([alias, canonical]) => {
+      expect(aliases).toContain(`${alias}: '${canonical}'`);
+    });
+
+    expect(aliases).not.toContain('patient:');
+    expect(aliases).not.toContain('admin:');
+    expect(aliases).not.toContain('record:');
+    expect(aliases).not.toContain('billing:');
+    expect(selectedSectionParser).toContain("new URLSearchParams(search || '').get('section') || ''");
+    expect(selectedSectionParser).toContain('section.trim().toLowerCase()');
+    expect(selectedSectionParser).toContain("MINI_APP_SECTION_ALIASES[section.trim().toLowerCase()] || ''");
+  });
+
+  it('keeps unknown sections from opening a selected-section panel', () => {
+    const shellSetup = sourceBetween(
+      appSource,
+      'function TelegramMiniAppPatientShell() {',
+      'useEffect(() => {'
+    );
+    const selectedSectionPanel = sourceBetween(
+      appSource,
+      '{selectedSection && (',
+      '{canShowCabinetManifest && ('
+    );
+
+    expect(shellSetup).toContain('const selectedSection = getTelegramMiniAppSelectedSection(location.search);');
+    expect(appSource).toContain('const selectedCapability = selectedSection ? capabilities[selectedSection] || {} : null;');
+    expect(selectedSectionPanel).toContain('{selectedSection && (');
+    expect(selectedSectionPanel).toContain('{MINI_APP_CAPABILITY_LABELS[selectedSection]}');
+    expect(selectedSectionPanel).toContain("{selectedCapability?.status || 'manifest_only'}");
+    expect(selectedSectionPanel).not.toContain('URLSearchParams');
+    expect(selectedSectionPanel).not.toContain('location.search');
+  });
+
+  it('ties each runtime panel to the canonical selected section, not aliases or raw query text', () => {
+    const panelGates = sourceBetween(
+      appSource,
+      'const canPreviewAppointments = Boolean(',
+      'const statusBadge = getMiniAppStatusBadge(state.status);'
+    );
+    const capabilityGrid = sourceBetween(
+      appSource,
+      '<section style={miniAppGridStyle}>',
+      '</section>'
+    );
+
+    CANONICAL_SECTIONS.forEach((section) => {
+      expect(panelGates).toContain(`selectedSection === '${section}'`);
+    });
+    Object.keys(ALIAS_MAPPINGS).forEach((alias) => {
+      expect(panelGates).not.toContain(`selectedSection === '${alias}'`);
+    });
+
+    expect(panelGates).toContain('selectedCapability?.preview_enabled');
+    expect(panelGates.match(/selectedCapability\?\.manifest_endpoint/g)).toHaveLength(4);
+    expect(panelGates).not.toContain('URLSearchParams');
+    expect(panelGates).not.toContain('location.search');
+    expect(capabilityGrid).toContain('const isSelected = key === selectedSection;');
+    expect(capabilityGrid).toContain('...(isSelected ? miniAppCapabilitySelectedStyle : {})');
+  });
+
+  it('keeps the Mini App shell away from legacy patient tab URLs', () => {
+    const miniAppShell = sourceBetween(
+      appSource,
+      'function TelegramMiniAppPatientShell() {',
+      'function AppShell({ children }) {'
+    );
+
+    expect(miniAppShell).toContain('/telegram/mini-app/patient/manifest');
+    expect(miniAppShell).not.toContain('/patient?tab=');
+    expect(miniAppShell).not.toContain('tab=<section>');
+    expect(miniAppShell).not.toContain('WebAppInfo');
+  });
+});


### PR DESCRIPTION
## Summary

- Add a focused Vitest source guardrail for Telegram Mini App section deep links.
- Assert canonical Mini App sections plus approved `/doctors` and `/documents` aliases stay mapped safely.
- Guard unknown sections, selected-section panels, capability gates, and legacy `/patient?tab=` URL drift.

## Contract Impact

not applicable - test-only frontend guardrail; no API, websocket, event, request/response, status-code, frontend consumer, compatibility path, or alias contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, auth-sensitive runtime behavior, allowed role, or denied role changed.

## Notification / Realtime

not applicable - no notification event, websocket channel, chat delivery, unread state, reconnect behavior, or realtime payload changed.

## Frontend Resilience

- Empty data proof: source guardrail keeps unknown section values mapped to an empty selected section instead of opening a panel.
- Partial data proof: selected capability lookup remains `capabilities[selectedSection] || {}` for manifest-only fallback rendering.
- Forbidden secondary path behavior: source guardrail forbids legacy `/patient?tab=` and `WebAppInfo` drift inside the Mini App shell.
- Missing draft/resource behavior: not applicable - appointment draft/create runtime is not changed in this test-only slice.
- Stale route/deep-link behavior: source guardrail pins aliases `doctors -> appointments` and `documents -> results` while runtime gates use canonical section keys only.

## Scope Gate

- Allowed paths: frontend/src/__tests__/telegramMiniAppDeepLinkGuardrails.test.js
- Denied paths: backend runtime, frontend runtime, migrations, generated output
- Migration/docs/test impact: frontend test-only guardrail; no migration or runtime change expected
- Rollback note: revert the test commit

## Validation

- Targeted tests or smoke run: npm.cmd run test:run -- src/__tests__/telegramMiniAppDeepLinkGuardrails.test.js src/__tests__/telegramMiniAppReadOnlyManifestGuardrails.test.js src/__tests__/telegramMiniAppExpiredLinkGuardrails.test.js src/__tests__/telegramMiniAppAppointmentCreateGuardrails.test.js; git diff --check; git diff --cached --check
- Result: passed locally; 4 Vitest files and 15 tests passed, diff hygiene passed
- Not checked: browser/runtime Mini App behavior, because this slice only adds source guardrail coverage