### PR TITLE
chore(frontend): remove stale root toast dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-hot-toast": "^2.6.0",
         "vite": "^8.0.13"
       },
       "devDependencies": {
@@ -1102,7 +1101,9 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -1501,15 +1502,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/goober": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
-      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -2653,23 +2645,6 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-hot-toast": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
-      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.1.3",
-        "goober": "^2.1.16"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-hot-toast": "^2.6.0",
     "vite": "^8.0.13"
   },
   "name": "final",


### PR DESCRIPTION
﻿## Summary
- Removed unused root-level `react-hot-toast` from `package.json`.
- Updated the root lockfile to drop the root-only toast dependency subtree.
- Left `frontend/package.json` and frontend runtime toast usage unchanged.

## Contract Impact
- Canonical surface: Not applicable - root npm manifest cleanup only; no API or route contract changed.
- Request shape: Not applicable - no request payloads changed.
- Response shape: Not applicable - no response payloads changed.
- Status codes: Not applicable - no backend or HTTP behavior changed.
- Frontend consumer: Not applicable - frontend keeps its own `react-hot-toast` dependency and no runtime consumer changed.
- Compatibility path or alias: Not applicable - no compatibility route, alias, or adapter changed.
- Contract proof: Static grep found no root `react-hot-toast` manifest/lock entry after removal while frontend manifest entries remain; frontend build still passes.

## RBAC / Permissions
- Roles allowed: Not applicable - dependency manifest cleanup does not touch auth or role permissions.
- Roles denied: Not applicable - no RBAC policy or route guard changed.
- Positive auth proof: Not applicable - no protected route behavior changed.
- Negative auth proof: Not applicable - no auth rejection path changed.

## Notification / Realtime
- Event type or websocket channel: Not applicable - no notification, websocket, Telegram, or realtime channel changed.
- Payload version / ack behavior: Not applicable - no payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: Not applicable - no delivery state changed.
- Reconnect/resync proof: Not applicable - no reconnect or resync logic changed.

## Frontend Resilience
- Empty data proof: Not applicable - no UI state rendering changed.
- Partial data proof: Not applicable - no partial-data UI or data flow changed.
- Forbidden secondary path behavior: Not applicable - no protected UI or forbidden path changed.
- Missing draft/resource behavior: Not applicable - no resource lookup or fallback changed.
- Stale route/deep-link behavior: Not applicable - no routing or route registry changed.

## Scope Gate
- Allowed paths: `package.json`, `package-lock.json`.
- Denied paths: backend code, frontend runtime code, frontend package manifests, tests, workflows, migrations, RBAC, routes, notifications, Telegram, payment, queue, EMR, and lab behavior.
- Migration/docs/test impact: Root npm dependency lock only; no DB migration, docs, or tests changed.
- Rollback note: Re-add root `react-hot-toast` and regenerate the root lockfile only if a future approved root-level UI entrypoint requires it.

## Validation
- Targeted tests or smoke run: `npx.cmd -p npm@10 npm ci --dry-run --ignore-scripts`; root JSON parse for `package.json` and `package-lock.json`; static grep for root `react-hot-toast`; static grep confirming frontend `react-hot-toast` remains; `npm.cmd run build`; `npm.cmd audit --audit-level=high`; `git diff --check`.
- Result: Passed. Root `react-hot-toast` grep returned no matches as expected, frontend manifest grep still found the frontend-owned dependency, and build passed. `npm audit --audit-level=high` passed while reporting one existing moderate `ws` advisory.
- Not checked: Full frontend unit suite and browser QA, because this PR changes only root dependency metadata and does not touch runtime UI code.
