### PR TITLE
[codex] make telegram mini app capability cards navigable

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -629,6 +629,7 @@ function getMiniAppReportFileName(report) {
 
 function TelegramMiniAppPatientShell() {
   const location = useLocation();
+  const navigate = useNavigate();
   const selectedSection = getTelegramMiniAppSelectedSection(location.search);
   const [state, setState] = useState({
     status: 'checking',
@@ -830,6 +831,18 @@ function TelegramMiniAppPatientShell() {
     canPreviewAppointments &&
     selectedCapability?.create_enabled
   );
+
+  const handleMiniAppCapabilitySelect = (section) => {
+    if (!section || section === selectedSection) {
+      return;
+    }
+    const params = new URLSearchParams(location.search || '');
+    params.set('section', section);
+    navigate({
+      pathname: location.pathname,
+      search: `?${params.toString()}`,
+    });
+  };
 
   const handleAppointmentPreviewFieldChange = (field) => (event) => {
     setAppointmentPreviewForm((current) => ({
@@ -1705,6 +1718,10 @@ function TelegramMiniAppPatientShell() {
                 return (
                   <Card
                     key={key}
+                    interactive
+                    onClick={() => handleMiniAppCapabilitySelect(key)}
+                    aria-label={`${t('openSection')}: ${label}`}
+                    aria-pressed={isSelected}
                     padding="small"
                     shadow="none"
                     style={{

--- a/frontend/src/__tests__/telegramMiniAppDeepLinkGuardrails.test.js
+++ b/frontend/src/__tests__/telegramMiniAppDeepLinkGuardrails.test.js
@@ -75,7 +75,7 @@ describe('Telegram Mini App deep-link guardrails', () => {
     const panelGates = sourceBetween(
       appSource,
       'const canPreviewAppointments = Boolean(',
-      'const handleAppointmentPreviewFieldChange = (field) => (event) => {'
+      'const handleMiniAppCapabilitySelect = (section) => {'
     );
     const capabilityGrid = sourceBetween(
       appSource,
@@ -96,6 +96,31 @@ describe('Telegram Mini App deep-link guardrails', () => {
     expect(panelGates).not.toContain('location.search');
     expect(capabilityGrid).toContain('const isSelected = key === selectedSection;');
     expect(capabilityGrid).toContain('...(isSelected ? miniAppCapabilitySelectedStyle : {})');
+  });
+
+  it('lets capability cards switch canonical Mini App sections without legacy URLs or raw patient identifiers', () => {
+    const capabilitySelectHandler = sourceBetween(
+      appSource,
+      'const handleMiniAppCapabilitySelect = (section) => {',
+      'const handleAppointmentPreviewFieldChange = (field) => (event) => {'
+    );
+    const capabilityGrid = sourceBetween(
+      appSource,
+      '<section style={miniAppGridStyle}>',
+      '</section>'
+    );
+
+    expect(capabilitySelectHandler).toContain("new URLSearchParams(location.search || '')");
+    expect(capabilitySelectHandler).toContain("params.set('section', section)");
+    expect(capabilitySelectHandler).toContain('navigate({');
+    expect(capabilitySelectHandler).toContain('pathname: location.pathname');
+    expect(capabilitySelectHandler).toContain('search: `?${params.toString()}`');
+    expect(capabilitySelectHandler).not.toContain('/patient?tab=');
+    expect(capabilitySelectHandler).not.toMatch(/patientId|telegramUserId|chatId/);
+    expect(capabilityGrid).toContain('interactive');
+    expect(capabilityGrid).toContain('onClick={() => handleMiniAppCapabilitySelect(key)}');
+    expect(capabilityGrid).toContain('aria-pressed={isSelected}');
+    expect(capabilityGrid).toContain('aria-label={`${t(\'openSection\')}: ${label}`}');
   });
 
   it('keeps the Mini App shell away from legacy patient tab URLs', () => {


### PR DESCRIPTION
## Summary
- Makes Telegram Mini App capability cards keyboard/click navigable instead of static-looking tiles.
- Preserves the existing protected Mini App URL and only updates the canonical `section` query parameter.
- Adds a source guardrail so card navigation cannot drift to legacy patient tab URLs or raw patient identifiers.

## Contract Impact
- Canonical surface: patient Mini App route `/telegram/mini-app/patient` and canonical `section` query values `appointments`, `visits`, `queue`, `forms`, `cabinet`, `payments`, `results`.
- Request shape: no backend request shape change; existing Mini App auth payload keeps validated `initData` or signed `entryToken`.
- Response shape: no response shape change; existing manifest/cabinet/forms/results responses are consumed unchanged.
- Status codes: no status-code behavior change.
- Frontend consumer: `frontend/src/App.jsx` TelegramMiniAppPatientShell capability grid.
- Compatibility path or alias: existing aliases `doctors -> appointments`, `documents -> results`, `navbat -> queue`; card navigation writes canonical sections only and does not use `/patient?tab=`.
- Contract proof: targeted deep-link/read-only Vitest guardrails passed and frontend build passed locally.

## RBAC / Permissions
- Roles allowed: linked patients opening Mini App through validated Telegram init data or signed entry token.
- Roles denied: no change; unlinked identities, wrong-patient scope, malformed/expired tokens, and staff scope remain denied by existing backend checks.
- Positive auth proof: unchanged protected Mini App auth payload is still used by runtime panels.
- Negative auth proof: new guardrail asserts card navigation does not introduce `patientId`, `telegramUserId`, or `chatId` identifiers.

## Notification / Realtime
- Event type or websocket channel: not applicable because this PR only changes frontend section navigation inside the Mini App shell.
- Payload version / ack behavior: not applicable because no Telegram message payload, inline keyboard callback, or ack contract changes.
- Read/unread or delivery semantics: not applicable because this PR does not touch notification delivery or read/unread state.
- Reconnect/resync proof: Mini App keeps URL-driven section selection; changing cards updates `section`, which reuses the existing manifest/summary effects.

## Frontend Resilience
- Empty data proof: queue empty state remains read-only and covered by the existing read-only manifest guardrail.
- Partial data proof: section panels still use existing fallback arrays/labels; this PR changes only section selection.
- Forbidden secondary path behavior: handled Mini App API error path remains unchanged and still avoids legacy patient tabs.
- Missing draft/resource behavior: no change to appointment drafts, forms, or report download error handling.
- Stale route/deep-link behavior: card navigation writes canonical section values and preserves existing search params such as `entryToken`.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`, `frontend/src/__tests__/telegramMiniAppDeepLinkGuardrails.test.js`.
- Denied paths: backend services, token validation, Telegram webhook/Bot API handlers, queue mutation logic, migrations, secrets.
- Migration/docs/test impact: no migration; targeted source guardrail updated for navigable cards.
- Rollback note: revert commit `80cdd872` to restore static capability cards without affecting backend Mini App contracts.

## Validation
- Targeted tests or smoke run: `npm.cmd run test:run -- src/__tests__/telegramMiniAppDeepLinkGuardrails.test.js src/__tests__/telegramMiniAppReadOnlyManifestGuardrails.test.js`; `npm.cmd run build`; `git diff --check`.
- Result: local targeted Vitest passed 9/9; frontend build passed; diff check passed with only Windows CRLF warnings.
- Not checked: manual browser visual QA; full backend suite because this is frontend-only navigation affordance.