### PR TITLE
[codex] relax telegram mini app mobile header

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1084,7 +1084,7 @@ function TelegramMiniAppPatientShell() {
     <div style={miniAppPageStyle}>
       <main style={miniAppMainStyle}>
         <section style={miniAppHeroStyle}>
-          <div>
+          <div style={miniAppHeroTitleGroupStyle}>
             <p style={miniAppKickerStyle}>Kosmed Clinic</p>
             <h1 style={miniAppTitleStyle}>{t('title')}</h1>
           </div>
@@ -1979,9 +1979,15 @@ const miniAppHeroStyle = {
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'flex-start',
-  gap: '16px',
+  columnGap: '16px',
+  rowGap: '10px',
   flexWrap: 'wrap',
   padding: '8px 0 18px',
+};
+
+const miniAppHeroTitleGroupStyle = {
+  flex: '1 1 220px',
+  minWidth: 0,
 };
 
 const miniAppKickerStyle = {
@@ -2002,7 +2008,7 @@ const miniAppTitleStyle = {
 const miniAppStatusBadgeStyle = {
   flexShrink: 0,
   fontWeight: 700,
-  maxWidth: '100%',
+  maxWidth: 'min(100%, 220px)',
   whiteSpace: 'normal',
   textAlign: 'center',
 };

--- a/frontend/src/__tests__/telegramMiniAppExpiredLinkGuardrails.test.js
+++ b/frontend/src/__tests__/telegramMiniAppExpiredLinkGuardrails.test.js
@@ -85,14 +85,28 @@ describe('Telegram Mini App expired link guardrails', () => {
       'const miniAppHeroStyle = {',
       'const miniAppKickerStyle = {'
     );
+    const heroTitleGroupStyle = sourceBetween(
+      appSource,
+      'const miniAppHeroTitleGroupStyle = {',
+      'const miniAppKickerStyle = {'
+    );
     const badgeStyle = sourceBetween(
       appSource,
       'const miniAppStatusBadgeStyle = {',
       'const miniAppNoticeStyle = {'
     );
+    const heroMarkup = sourceBetween(
+      appSource,
+      '<section style={miniAppHeroStyle}>',
+      '</section>'
+    );
 
     expect(heroStyle).toContain("flexWrap: 'wrap'");
-    expect(badgeStyle).toContain("maxWidth: '100%'");
+    expect(heroStyle).toContain("rowGap: '10px'");
+    expect(heroTitleGroupStyle).toContain("flex: '1 1 220px'");
+    expect(heroTitleGroupStyle).toContain('minWidth: 0');
+    expect(heroMarkup).toContain('<div style={miniAppHeroTitleGroupStyle}>');
+    expect(badgeStyle).toContain("maxWidth: 'min(100%, 220px)'");
     expect(badgeStyle).toContain("whiteSpace: 'normal'");
     expect(badgeStyle).toContain("textAlign: 'center'");
   });


### PR DESCRIPTION
## Summary
- Relaxes the Telegram Mini App mobile header so the title and session badge no longer compete on narrow screens.
- Gives the title group its own wrapping flex basis and caps the badge width for cleaner mobile line breaks.
- Extends the existing expired-link/header guardrail to keep the responsive header contract in place.

## Contract Impact
- Canonical surface: patient Mini App route `/telegram/mini-app/patient` header in `TelegramMiniAppPatientShell`.
- Request shape: no backend request shape change.
- Response shape: no response shape change.
- Status codes: no status-code behavior change.
- Frontend consumer: `frontend/src/App.jsx` Mini App hero/header styles and markup.
- Compatibility path or alias: no route or alias change; existing Mini App sections remain unchanged.
- Contract proof: targeted expired-link/header Vitest guardrail passed and frontend build passed locally.

## RBAC / Permissions
- Roles allowed: unchanged linked-patient Mini App access through existing init data or signed entry token.
- Roles denied: unchanged denied paths for missing, expired, malformed, wrong-patient, or unlinked Telegram access.
- Positive auth proof: unchanged session status badge still uses `getMiniAppStatusBadge` from existing session state.
- Negative auth proof: existing expired-link guardrail still asserts patient-safe error copy and handled raw-toast suppression.

## Notification / Realtime
- Event type or websocket channel: not applicable because this is header layout only.
- Payload version / ack behavior: not applicable because no Telegram payload or ack behavior changed.
- Read/unread or delivery semantics: not applicable because notification delivery state is untouched.
- Reconnect/resync proof: not applicable because Mini App data fetch and reopen behavior are unchanged.

## Frontend Resilience
- Empty data proof: not directly changed; queue/forms/results empty states remain under existing guarded panels.
- Partial data proof: header layout no longer depends on badge/title fitting the same row at mobile width.
- Forbidden secondary path behavior: existing error alert and badge behavior remains accessible and patient-safe.
- Missing draft/resource behavior: not changed; appointment/forms/report flows are untouched.
- Stale route/deep-link behavior: not changed; section parsing and card navigation stay canonical.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`, `frontend/src/__tests__/telegramMiniAppExpiredLinkGuardrails.test.js`.
- Denied paths: backend services, Telegram Bot API/webhook handlers, auth/token handling, route registry, queue mutation, migrations, secrets.
- Migration/docs/test impact: no migration; targeted header source guardrail updated.
- Rollback note: revert commit `7e256bef` to restore the previous header flex and badge sizing.

## Validation
- Targeted tests or smoke run: `npm.cmd run test:run -- src/__tests__/telegramMiniAppExpiredLinkGuardrails.test.js`; `npm.cmd run build`; `git diff --check`.
- Result: local targeted Vitest passed 4/4; frontend build passed; diff check passed with only Windows CRLF warnings.
- Not checked: manual browser visual QA; backend suite because this is frontend-only responsive layout polish.