### PR TITLE
fix(frontend): label payment cashier controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -40,7 +40,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 ## Cleanup Progress
 
 - 2026-05-21: chat and AI controls cleanup removed 18 baseline findings.
-- Current baseline after this slice: 182 findings.
+- 2026-05-21: payment and cashier controls cleanup removed 6 baseline findings.
+- Current baseline after this slice: 176 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T04:45:35.250Z",
+  "generatedAt": "2026-05-21T05:20:07.324Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -218,30 +218,6 @@
       "column": 7,
       "element": "div",
       "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/cashier/RefundRequestsTable.jsx:242:21:button:missing-accessible-name",
-      "file": "src/components/cashier/RefundRequestsTable.jsx",
-      "line": 242,
-      "column": 21,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/cashier/RefundRequestsTable.jsx:358:57:button:title-only",
-      "file": "src/components/cashier/RefundRequestsTable.jsx",
-      "line": 358,
-      "column": 57,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/cashier/RefundRequestsTable.jsx:372:57:button:title-only",
-      "file": "src/components/cashier/RefundRequestsTable.jsx",
-      "line": 372,
-      "column": 57,
-      "element": "button",
-      "reason": "title-only"
     },
     {
       "signature": "src/components/common/ScheduleNextModal.jsx:428:11:button:missing-accessible-name",
@@ -1032,30 +1008,6 @@
       "file": "src/components/notifications/EmailSMSManager.jsx",
       "line": 712,
       "column": 21,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/payment/CashPaymentModal.jsx:69:21:button:missing-accessible-name",
-      "file": "src/components/payment/CashPaymentModal.jsx",
-      "line": 69,
-      "column": 21,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/payment/PaymentClick.jsx:510:23:button:missing-accessible-name",
-      "file": "src/components/payment/PaymentClick.jsx",
-      "line": 510,
-      "column": 23,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/payment/PaymentPayMe.jsx:510:23:button:missing-accessible-name",
-      "file": "src/components/payment/PaymentPayMe.jsx",
-      "line": 510,
-      "column": 23,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/cashier/RefundRequestsTable.jsx
+++ b/frontend/src/components/cashier/RefundRequestsTable.jsx
@@ -242,6 +242,7 @@ const RefundRequestsTable = ({ onRefresh }) => {
                     <button
             onClick={loadRequests}
             disabled={loading}
+            aria-label="Обновить список заявок на возврат"
             style={{
               padding: '6px 12px',
               borderRadius: '6px',
@@ -358,6 +359,7 @@ const RefundRequestsTable = ({ onRefresh }) => {
                                                         <button
                       onClick={() => handleApprove(request.id)}
                       title="Одобрить"
+                      aria-label={`Одобрить заявку на возврат ${request.id}`}
                       style={{
                         padding: '6px',
                         borderRadius: '4px',
@@ -372,6 +374,7 @@ const RefundRequestsTable = ({ onRefresh }) => {
                                                         <button
                       onClick={() => handleReject(request.id)}
                       title="Отклонить"
+                      aria-label={`Отклонить заявку на возврат ${request.id}`}
                       style={{
                         padding: '6px',
                         borderRadius: '4px',

--- a/frontend/src/components/payment/CashPaymentModal.jsx
+++ b/frontend/src/components/payment/CashPaymentModal.jsx
@@ -66,7 +66,7 @@ const CashPaymentModal = ({ appointment, onProcessPayment, onClose }) => {
             }}>
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '16px' }}>
                     <h3 style={{ fontSize: '18px', fontWeight: '600', color: 'var(--mac-text-primary)' }}>Обработка оплаты</h3>
-                    <button onClick={onClose} style={{ color: 'var(--mac-text-secondary)', cursor: 'pointer', border: 'none', background: 'none' }}>
+                    <button onClick={onClose} aria-label="Закрыть окно обработки оплаты" style={{ color: 'var(--mac-text-secondary)', cursor: 'pointer', border: 'none', background: 'none' }}>
                         <XCircle style={{ width: '24px', height: '24px' }} />
                     </button>
                 </div>
@@ -99,11 +99,13 @@ const CashPaymentModal = ({ appointment, onProcessPayment, onClose }) => {
 
                 <form onSubmit={handleSubmit}>
                     <div style={{ marginBottom: '16px' }}>
-                        <label style={{ display: 'block', fontSize: '14px', fontWeight: '500', color: 'var(--mac-text-primary)', marginBottom: '4px' }}>
+                        <label htmlFor="cash-payment-amount" style={{ display: 'block', fontSize: '14px', fontWeight: '500', color: 'var(--mac-text-primary)', marginBottom: '4px' }}>
                             Сумма (сум)
                         </label>
                         <input
+                            id="cash-payment-amount"
                             type="number"
+                            aria-label="Сумма оплаты"
                             value={paymentData.amount}
                             onChange={(e) => setPaymentData(prev => ({ ...prev, amount: e.target.value }))}
                             style={{
@@ -121,10 +123,11 @@ const CashPaymentModal = ({ appointment, onProcessPayment, onClose }) => {
                     </div>
 
                     <div style={{ marginBottom: '16px' }}>
-                        <label style={{ display: 'block', fontSize: '14px', fontWeight: '500', color: 'var(--mac-text-primary)', marginBottom: '4px' }}>
+                        <label htmlFor="cash-payment-method" style={{ display: 'block', fontSize: '14px', fontWeight: '500', color: 'var(--mac-text-primary)', marginBottom: '4px' }}>
                             Способ оплаты
                         </label>
                         <select
+                            id="cash-payment-method"
                             value={paymentData.method}
                             onChange={(e) => setPaymentData(prev => ({ ...prev, method: e.target.value }))}
                             style={{
@@ -143,10 +146,12 @@ const CashPaymentModal = ({ appointment, onProcessPayment, onClose }) => {
                     </div>
 
                     <div style={{ marginBottom: '24px' }}>
-                        <label style={{ display: 'block', fontSize: '14px', fontWeight: '500', color: 'var(--mac-text-primary)', marginBottom: '4px' }}>
+                        <label htmlFor="cash-payment-note" style={{ display: 'block', fontSize: '14px', fontWeight: '500', color: 'var(--mac-text-primary)', marginBottom: '4px' }}>
                             Примечание (необязательно)
                         </label>
                         <textarea
+                            id="cash-payment-note"
+                            aria-label="Примечание к оплате"
                             value={paymentData.note}
                             onChange={(e) => setPaymentData(prev => ({ ...prev, note: e.target.value }))}
                             style={{

--- a/frontend/src/components/payment/PaymentClick.jsx
+++ b/frontend/src/components/payment/PaymentClick.jsx
@@ -509,6 +509,7 @@ const PaymentClick = ({
                       </div>
                       <button
                     className="print-ticket-btn"
+                    aria-label={`Печать талона для ${ticket.patient_name}`}
                     onClick={() => printTicket(ticket)}>
                     
                         <Printer size={16} />

--- a/frontend/src/components/payment/PaymentPayMe.jsx
+++ b/frontend/src/components/payment/PaymentPayMe.jsx
@@ -509,6 +509,7 @@ const PaymentPayMe = ({
                       </div>
                       <button
                     className="print-ticket-btn"
+                    aria-label={`Печать талона для ${ticket.patient_name}`}
                     onClick={() => printTicket(ticket)}>
                     
                         <Printer size={16} />


### PR DESCRIPTION
## Summary

- Added accessible names to payment and cashier icon-only controls found by the icon-only controls audit baseline.
- Reduced the tracked icon-only controls baseline from 182 to 176 findings.
- Updated the UI/UX audit sweep progress note for this cleanup slice.

## Contract Impact

- Canonical surface: Frontend-only controls in cashier refund table, cash payment modal, Click ticket printing, and PayMe ticket printing.
- Request shape: Unchanged - no request payloads or API calls were modified.
- Response shape: Unchanged - no backend responses or frontend parsing behavior were modified.
- Status codes: Unchanged - no HTTP behavior was touched.
- Frontend consumer: Existing cashier/payment components consume the same props and state as before.
- Compatibility path or alias: Not applicable - no public route, alias, or compatibility path changed.
- Contract proof: Diff touches only aria labels, input ids/htmlFor, audit baseline JSON, and audit docs; no service/API/client calls changed.

## RBAC / Permissions

- Roles allowed: Unchanged; existing cashier/payment UI availability remains governed by current routing and auth.
- Roles denied: Unchanged; this PR does not alter auth checks or protected route behavior.
- Positive auth proof: Not applicable - accessibility metadata only; no auth path or permission check changed.
- Negative auth proof: Not applicable - accessibility metadata only; no denied-role path or guard changed.

## Notification / Realtime

- Event type or websocket channel: Not applicable - no notification event or realtime channel changed.
- Payload version / ack behavior: Not applicable - no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: Not applicable - no notification delivery state changed.
- Reconnect/resync proof: Not applicable - no reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: Existing empty/refund/payment states are unchanged; only control names and label associations changed.
- Partial data proof: Existing partial ticket/payment rendering is unchanged; print labels use the currently rendered patient name.
- Forbidden secondary path behavior: Unchanged; no protected route fallback or secondary action path changed.
- Missing draft/resource behavior: Unchanged; no draft/resource lookup or recovery behavior changed.
- Stale route/deep-link behavior: Unchanged; no route registry or navigation behavior changed.

## Scope Gate

- Allowed paths: `frontend/src/components/cashier/RefundRequestsTable.jsx`, `frontend/src/components/payment/CashPaymentModal.jsx`, `frontend/src/components/payment/PaymentClick.jsx`, `frontend/src/components/payment/PaymentPayMe.jsx`, icon-control baseline JSON, and the audit progress doc.
- Denied paths: Backend, database, migrations, API clients, routing, RBAC, payment provider logic, queue logic, and unrelated frontend pages.
- Migration/docs/test impact: No migrations or runtime tests changed; docs updated only to record audit cleanup progress and baseline JSON updated to 176 findings.
- Rollback note: Revert this commit to restore the previous labels/baseline; payment and cashier behavior remains otherwise unchanged.

## Validation

- Targeted tests or smoke run: `npx eslint src/components/cashier/RefundRequestsTable.jsx src/components/payment/CashPaymentModal.jsx src/components/payment/PaymentClick.jsx src/components/payment/PaymentPayMe.jsx`; `npm run audit:icon-controls`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: Passed locally; icon-only controls audit reports 176 findings, 176 baseline entries, 0 new findings, 0 stale entries.
- Not checked: Browser visual QA was not rerun for this narrow metadata-only cleanup; no payment provider or live backend flow was exercised.
