### PR TITLE
fix(frontend): label admin queue controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -42,7 +42,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: chat and AI controls cleanup removed 18 baseline findings.
 - 2026-05-21: payment and cashier controls cleanup removed 6 baseline findings.
 - 2026-05-21: runtime queue controls cleanup removed 9 baseline findings.
-- Current baseline after this slice: 167 findings.
+- 2026-05-21: admin queue configuration controls cleanup removed 11 baseline findings.
+- Current baseline after this slice: 156 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T05:35:05.269Z",
+  "generatedAt": "2026-05-21T05:46:37.476Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -74,94 +74,6 @@
       "column": 19,
       "element": "button",
       "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/QueueProfilesManager.jsx:643:25:button:missing-accessible-name",
-      "file": "src/components/admin/QueueProfilesManager.jsx",
-      "line": 643,
-      "column": 25,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/QueueProfilesManager.jsx:664:25:button:missing-accessible-name",
-      "file": "src/components/admin/QueueProfilesManager.jsx",
-      "line": 664,
-      "column": 25,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/QueueProfilesManager.jsx:721:33:button:missing-accessible-name",
-      "file": "src/components/admin/QueueProfilesManager.jsx",
-      "line": 721,
-      "column": 33,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/QueueProfilesManager.jsx:742:37:button:missing-accessible-name",
-      "file": "src/components/admin/QueueProfilesManager.jsx",
-      "line": 742,
-      "column": 37,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/QueueProfilesManager.jsx:824:41:button:title-only",
-      "file": "src/components/admin/QueueProfilesManager.jsx",
-      "line": 824,
-      "column": 41,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/QueueProfilesManager.jsx:832:41:button:title-only",
-      "file": "src/components/admin/QueueProfilesManager.jsx",
-      "line": 832,
-      "column": 41,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/QueueProfilesManager.jsx:840:41:button:title-only",
-      "file": "src/components/admin/QueueProfilesManager.jsx",
-      "line": 840,
-      "column": 41,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/QueueProfilesManager.jsx:1055:21:button:missing-accessible-name",
-      "file": "src/components/admin/QueueProfilesManager.jsx",
-      "line": 1055,
-      "column": 21,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/QueueProfilesManager.jsx:1157:33:button:missing-accessible-name",
-      "file": "src/components/admin/QueueProfilesManager.jsx",
-      "line": 1157,
-      "column": 33,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/QueueProfilesManager.jsx:1210:25:button:missing-accessible-name",
-      "file": "src/components/admin/QueueProfilesManager.jsx",
-      "line": 1210,
-      "column": 25,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/QueueSettings.jsx:406:13:button:missing-accessible-name",
-      "file": "src/components/admin/QueueSettings.jsx",
-      "line": 406,
-      "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
     },
     {
       "signature": "src/components/admin/SecuritySettings.jsx:318:19:button:missing-accessible-name",

--- a/frontend/src/components/admin/QueueProfilesManager.jsx
+++ b/frontend/src/components/admin/QueueProfilesManager.jsx
@@ -603,6 +603,7 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                             <Search size={16} style={styles.searchIcon} />
                             <input
                                 style={styles.searchInput}
+                                aria-label="Поиск профилей очереди"
                                 placeholder="Поиск..."
                                 value={searchTerm}
                                 onChange={e => setSearchTerm(e.target.value)}
@@ -632,6 +633,7 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                             Импорт
                             <input
                                 type="file"
+                                aria-label="Импортировать профили очереди из CSV"
                                 accept=".csv"
                                 onChange={handleImport}
                                 style={{ display: 'none' }}
@@ -640,7 +642,12 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                         </label>
 
                         {/* Refresh */}
-                        <button style={styles.button} onClick={loadProfiles} disabled={saving}>
+                        <button
+                            style={styles.button}
+                            onClick={loadProfiles}
+                            disabled={saving}
+                            aria-label="Обновить профили очереди"
+                        >
                             <RefreshCw size={16} />
                         </button>
 
@@ -664,6 +671,7 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                         <button
                             style={{ marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer' }}
                             onClick={() => setError(null)}
+                            aria-label="Скрыть сообщение об ошибке"
                         >
                             <X size={16} />
                         </button>
@@ -721,6 +729,7 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                                 <button
                                     style={styles.iconButton}
                                     onClick={() => handleSelectAll(!isAllSelected)}
+                                    aria-label={isAllSelected ? 'Снять выбор со всех вкладок очереди' : 'Выбрать все вкладки очереди'}
                                 >
                                     {isAllSelected ? <CheckSquare size={18} /> : <Square size={18} />}
                                 </button>
@@ -745,6 +754,7 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                                             profile.key,
                                             !selectedProfiles.includes(profile.key)
                                         )}
+                                        aria-label={selectedProfiles.includes(profile.key) ? `Снять выбор вкладки ${profile.name}` : `Выбрать вкладку ${profile.name}`}
                                     >
                                         {selectedProfiles.includes(profile.key)
                                             ? <CheckSquare size={18} style={{ color: 'var(--mac-accent-blue)' }} />
@@ -799,6 +809,8 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                                 </td>
                                 <td style={styles.td}>
                                     <div
+                                        role="img"
+                                        aria-label={`Цвет вкладки ${profile.name}: ${profile.color || 'не задан'}`}
                                         style={{
                                             ...styles.colorDot,
                                             backgroundColor: profile.color || '#718096'
@@ -824,6 +836,7 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                                         <button
                                             style={styles.iconButton}
                                             onClick={() => handleToggleActive(profile)}
+                                            aria-label={profile.is_active !== false ? `Скрыть вкладку ${profile.name}` : `Показать вкладку ${profile.name}`}
                                             title={profile.is_active !== false ? 'Скрыть' : 'Показать'}
                                             disabled={saving}
                                         >
@@ -832,6 +845,7 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                                         <button
                                             style={styles.iconButton}
                                             onClick={() => setEditingProfile(profile)}
+                                            aria-label={`Редактировать вкладку ${profile.name}`}
                                             title="Редактировать"
                                             disabled={saving}
                                         >
@@ -840,6 +854,7 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                                         <button
                                             style={{ ...styles.iconButton, color: '#EF4444' }}
                                             onClick={() => handleDelete(profile.key)}
+                                            aria-label={`Удалить вкладку ${profile.name}`}
                                             title="Удалить"
                                             disabled={saving}
                                         >
@@ -1045,6 +1060,7 @@ const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = fal
             style={styles.overlay}
             role="button"
             tabIndex={0}
+            aria-label="Закрыть форму вкладки очереди"
             onClick={onCancel}
             onKeyDown={(event) => handleActivationKeyDown(event, onCancel)}>
             <div style={styles.modal} onClickCapture={e => e.stopPropagation()}>
@@ -1052,7 +1068,11 @@ const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = fal
                     <h3 style={styles.title}>
                         {isEdit ? 'Редактирование вкладки' : 'Новая вкладка'}
                     </h3>
-                    <button style={styles.closeButton} onClick={onCancel}>
+                    <button
+                        style={styles.closeButton}
+                        onClick={onCancel}
+                        aria-label="Закрыть форму вкладки очереди"
+                    >
                         <X size={20} />
                     </button>
                 </div>
@@ -1064,6 +1084,7 @@ const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = fal
                             <label style={styles.label}>Уникальный ключ *</label>
                             <input
                                 style={styles.input}
+                                aria-label="Уникальный ключ вкладки очереди"
                                 value={formData.key}
                                 onChange={e => setFormData({ ...formData, key: e.target.value })}
                                 placeholder="например: cardiology"
@@ -1080,6 +1101,7 @@ const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = fal
                             <label style={styles.label}>Название (EN) *</label>
                             <input
                                 style={styles.input}
+                                aria-label="Название вкладки очереди на английском"
                                 value={formData.title}
                                 onChange={e => setFormData({ ...formData, title: e.target.value })}
                                 placeholder="Cardiology"
@@ -1090,6 +1112,7 @@ const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = fal
                             <label style={styles.label}>Название (RU)</label>
                             <input
                                 style={styles.input}
+                                aria-label="Название вкладки очереди на русском"
                                 value={formData.title_ru}
                                 onChange={e => setFormData({ ...formData, title_ru: e.target.value })}
                                 placeholder="Кардиология"
@@ -1102,6 +1125,7 @@ const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = fal
                         <label style={styles.label}>Queue Tags</label>
                         <input
                             style={styles.input}
+                            aria-label="Queue Tags"
                             value={formData.queue_tags}
                             onChange={e => setFormData({ ...formData, queue_tags: e.target.value })}
                             placeholder="cardio, cardiology, cardiology_common"
@@ -1115,6 +1139,7 @@ const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = fal
                         <input
                             style={{ ...styles.input, width: '100px' }}
                             type="number"
+                            aria-label="Порядок отображения вкладки очереди"
                             min="0"
                             value={formData.display_order}
                             onChange={e => setFormData({ ...formData, display_order: e.target.value })}
@@ -1164,10 +1189,13 @@ const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = fal
                                         boxShadow: formData.color === color ? `0 0 0 2px ${color}` : 'none',
                                     }}
                                     onClick={() => setFormData({ ...formData, color })}
+                                    aria-label={`Выбрать цвет ${color}`}
+                                    title={color}
                                 />
                             ))}
                             <input
                                 type="color"
+                                aria-label="Пользовательский цвет вкладки очереди"
                                 value={formData.color}
                                 onChange={e => setFormData({ ...formData, color: e.target.value })}
                                 style={{ width: '32px', height: '32px', border: 'none', cursor: 'pointer' }}
@@ -1180,6 +1208,7 @@ const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = fal
                         <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
                             <input
                                 type="checkbox"
+                                aria-label="Активная вкладка очереди"
                                 checked={formData.is_active}
                                 onChange={e => setFormData({ ...formData, is_active: e.target.checked })}
                             />
@@ -1192,6 +1221,7 @@ const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = fal
                         <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
                             <input
                                 type="checkbox"
+                                aria-label="Показывать вкладку на QR-странице"
                                 checked={formData.show_on_qr_page}
                                 onChange={e => setFormData({ ...formData, show_on_qr_page: e.target.checked })}
                             />
@@ -1207,7 +1237,12 @@ const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = fal
                         <button type="button" style={styles.cancelButton} onClick={onCancel}>
                             Отмена
                         </button>
-                        <button type="submit" style={styles.submitButton} disabled={saving}>
+                        <button
+                            type="submit"
+                            style={styles.submitButton}
+                            disabled={saving}
+                            aria-label={isEdit ? 'Сохранить вкладку очереди' : 'Создать вкладку очереди'}
+                        >
                             {saving ? (
                                 <>Сохранение...</>
                             ) : (

--- a/frontend/src/components/admin/QueueSettings.jsx
+++ b/frontend/src/components/admin/QueueSettings.jsx
@@ -405,6 +405,7 @@ const QueueSettings = () => {
             </div>
             <button
               onClick={() => handleSettingChange('dev_mode_enabled', !settings.dev_mode_enabled)}
+              aria-label={settings.dev_mode_enabled ? 'Отключить режим разработки очереди' : 'Включить режим разработки очереди'}
               style={{
                 display: 'flex',
                 alignItems: 'center',


### PR DESCRIPTION
## Summary

- Added accessible names to admin queue configuration icon-only controls in `QueueProfilesManager` and `QueueSettings`.
- Cleaned neighboring queue profile form controls that targeted accessibility lint flagged in the same surface.
- Reduced the tracked icon-only controls baseline from 167 to 156 findings and updated audit progress.

## Contract Impact

- Canonical surface: Frontend admin queue configuration controls only.
- Request shape: Unchanged - queue settings/profile API request payloads were not modified.
- Response shape: Unchanged - response parsing and queue profile state handling were not modified.
- Status codes: Unchanged - no HTTP behavior was touched.
- Frontend consumer: Existing admin queue components keep the same props, callbacks, form fields, and state transitions.
- Compatibility path or alias: Not applicable - no route, alias, or compatibility path changed.
- Contract proof: Diff touches aria labels, local control names, audit baseline JSON, and audit progress docs; no API client or queue service logic changed.

## RBAC / Permissions

- Roles allowed: Unchanged; existing admin access to queue configuration remains governed by current routing and auth.
- Roles denied: Unchanged; no auth guard or protected route behavior changed.
- Positive auth proof: Not applicable - accessibility metadata only; no allowed-role path changed.
- Negative auth proof: Not applicable - accessibility metadata only; no denied-role path changed.

## Notification / Realtime

- Event type or websocket channel: Not applicable - no notification event or realtime channel changed.
- Payload version / ack behavior: Not applicable - no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: Not applicable - no notification delivery state changed.
- Reconnect/resync proof: Not applicable - no reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: Existing empty/no-profile behavior is unchanged; only control names and label associations changed.
- Partial data proof: Existing partial profile rendering is unchanged; labels use already-rendered profile fields or static field names.
- Forbidden secondary path behavior: Unchanged; no protected route fallback or secondary action path changed.
- Missing draft/resource behavior: Unchanged; no resource lookup or recovery behavior changed.
- Stale route/deep-link behavior: Unchanged; no route registry or navigation behavior changed.

## Scope Gate

- Allowed paths: `frontend/src/components/admin/QueueProfilesManager.jsx`, `frontend/src/components/admin/QueueSettings.jsx`, icon-control baseline JSON, and the audit progress doc.
- Denied paths: Backend, database, migrations, queue API/service logic, routing, RBAC, payment, Telegram, and unrelated frontend pages.
- Migration/docs/test impact: No migrations or runtime tests changed; docs updated only to record audit cleanup progress and baseline JSON updated to 156 findings.
- Rollback note: Revert this commit to restore the previous admin queue labels/baseline; queue configuration behavior remains otherwise unchanged.

## Validation

- Targeted tests or smoke run: `npx eslint src/components/admin/QueueProfilesManager.jsx src/components/admin/QueueSettings.jsx`; `npm run audit:icon-controls`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: Passed locally; icon-only controls audit reports 156 findings, 156 baseline entries, 0 new findings, 0 stale entries.
- Not checked: Browser visual QA was not rerun for this narrow metadata-only cleanup; no live admin queue backend flow was exercised.
