### PR TITLE
fix(frontend): label doctor panel primary controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -45,7 +45,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: admin queue configuration controls cleanup removed 11 baseline findings.
 - 2026-05-21: admin security and QR controls cleanup removed 7 baseline findings.
 - 2026-05-21: file manager controls cleanup removed 11 baseline findings.
-- Current baseline after this slice: 138 findings.
+- 2026-05-21: doctor panel primary controls cleanup removed 12 baseline findings.
+- Current baseline after this slice: 126 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T06:14:13.431Z",
+  "generatedAt": "2026-05-21T06:28:05.712Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -908,126 +908,6 @@
       "reason": "title-only"
     },
     {
-      "signature": "src/pages/DoctorPanel.jsx:582:11:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 582,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:592:11:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 592,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:602:11:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 602,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:613:11:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 613,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:628:11:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 628,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:638:11:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 638,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:979:29:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 979,
-      "column": 29,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:988:29:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 988,
-      "column": 29,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:997:29:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 997,
-      "column": 29,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1136:29:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1136,
-      "column": 29,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1145:29:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1145,
-      "column": 29,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1154:29:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1154,
-      "column": 29,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1325:33:button:title-only",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1325,
-      "column": 33,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1337:33:button:title-only",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1337,
-      "column": 33,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1345:33:button:title-only",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1345,
-      "column": 33,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
       "signature": "src/pages/DoctorPanel.jsx:1353:33:button:title-only",
       "file": "src/pages/DoctorPanel.jsx",
       "line": 1353,
@@ -1060,17 +940,41 @@
       "reason": "title-only"
     },
     {
-      "signature": "src/pages/DoctorPanel.jsx:1392:23:button:title-only",
+      "signature": "src/pages/DoctorPanel.jsx:1393:33:button:title-only",
       "file": "src/pages/DoctorPanel.jsx",
-      "line": 1392,
+      "line": 1393,
+      "column": 33,
+      "element": "button",
+      "reason": "title-only"
+    },
+    {
+      "signature": "src/pages/DoctorPanel.jsx:1401:33:button:title-only",
+      "file": "src/pages/DoctorPanel.jsx",
+      "line": 1401,
+      "column": 33,
+      "element": "button",
+      "reason": "title-only"
+    },
+    {
+      "signature": "src/pages/DoctorPanel.jsx:1409:33:button:title-only",
+      "file": "src/pages/DoctorPanel.jsx",
+      "line": 1409,
+      "column": 33,
+      "element": "button",
+      "reason": "title-only"
+    },
+    {
+      "signature": "src/pages/DoctorPanel.jsx:1420:23:button:title-only",
+      "file": "src/pages/DoctorPanel.jsx",
+      "line": 1420,
       "column": 23,
       "element": "button",
       "reason": "title-only"
     },
     {
-      "signature": "src/pages/DoctorPanel.jsx:1516:15:button:missing-accessible-name",
+      "signature": "src/pages/DoctorPanel.jsx:1544:15:button:missing-accessible-name",
       "file": "src/pages/DoctorPanel.jsx",
-      "line": 1516,
+      "line": 1544,
       "column": 15,
       "element": "button",
       "reason": "missing-accessible-name"

--- a/frontend/src/pages/DoctorPanel.jsx
+++ b/frontend/src/pages/DoctorPanel.jsx
@@ -496,6 +496,19 @@ const DoctorPanel = () => {
     return `queue entry ${queueNumber} for ${patientName}`;
   };
 
+  const getPatientA11yContext = (patient) => {
+    const patientId = patient?.id || 'unknown';
+    const patientName = patient?.name || 'patient';
+    return `patient ${patientName} (${patientId})`;
+  };
+
+  const getAppointmentA11yContext = (appointment) => {
+    const appointmentId = appointment?.id || 'unknown';
+    const patientName = appointment?.patientName || 'patient';
+    const appointmentTime = appointment?.time ? ` at ${appointment.time}` : '';
+    return `appointment ${appointmentId} for ${patientName}${appointmentTime}`;
+  };
+
   const getCurrentVisitMeta = (entry) => {
     const statusMap = {
       called: { label: 'Текущий прием', variant: 'primary' },
@@ -580,6 +593,7 @@ const DoctorPanel = () => {
         {/* Вкладки */}
         <div style={tabsStyle}>
           <button
+            aria-label="Open doctor dashboard tab"
             style={activeTab === 'dashboard' ? activeTabStyle : tabStyle}
             onClick={() => setActiveTab('dashboard')}
             onMouseEnter={(e) => handleInactiveTabHover(e, activeTab === 'dashboard', true)}
@@ -590,6 +604,7 @@ const DoctorPanel = () => {
           </button>
 
           <button
+            aria-label="Open patients tab"
             style={activeTab === 'patients' ? activeTabStyle : tabStyle}
             onClick={() => setActiveTab('patients')}
             onMouseEnter={(e) => handleInactiveTabHover(e, activeTab === 'patients', true)}
@@ -600,6 +615,7 @@ const DoctorPanel = () => {
           </button>
 
           <button
+            aria-label="Open appointments tab"
             style={activeTab === 'appointments' ? activeTabStyle : tabStyle}
             onClick={() => setActiveTab('appointments')}
             onMouseEnter={(e) => handleInactiveTabHover(e, activeTab === 'appointments', true)}
@@ -611,6 +627,7 @@ const DoctorPanel = () => {
 
           {/* ✅ НОВОЕ: Таб очереди */}
           <button
+            aria-label="Open queue tab"
             style={activeTab === 'queue' ? activeTabStyle : tabStyle}
             onClick={() => setActiveTab('queue')}
             onMouseEnter={(e) => handleInactiveTabHover(e, activeTab === 'queue', true)}
@@ -626,6 +643,7 @@ const DoctorPanel = () => {
           </button>
 
           <button
+            aria-label="Open AI assistant tab"
             style={activeTab === 'ai' ? activeTabStyle : tabStyle}
             onClick={() => setActiveTab('ai')}
             onMouseEnter={(e) => handleInactiveTabHover(e, activeTab === 'ai', true)}
@@ -636,6 +654,7 @@ const DoctorPanel = () => {
           </button>
 
           <button
+            aria-label="Open reports tab"
             style={activeTab === 'reports' ? activeTabStyle : tabStyle}
             onClick={() => setActiveTab('reports')}
             onMouseEnter={(e) => handleInactiveTabHover(e, activeTab === 'reports', true)}
@@ -857,6 +876,7 @@ const DoctorPanel = () => {
                     <div style={{ position: 'relative' }}>
                       <Search size={20} style={{ position: 'absolute', left: getSpacing('sm'), top: '50%', transform: 'translateY(-50%)', color: getColor('secondary', 400) }} />
                       <input
+                      aria-label="Search patients"
                       type="text"
                       placeholder="Поиск пациентов..."
                       value={searchQuery}
@@ -939,9 +959,10 @@ const DoctorPanel = () => {
                     onMouseLeave={(e) => {
                       e.currentTarget.style.backgroundColor = 'transparent';
                     }}
+                    aria-label={`Open ${getPatientA11yContext(patient)}`}
                     onClick={() => handlePatientClick(patient)}>
 
-                          <td style={tdStyle}>
+                          <td style={tdStyle} aria-label={getPatientA11yContext(patient)}>
                             <div style={{ display: 'flex', alignItems: 'center', gap: getSpacing('sm') }}>
                               <div style={{
                           width: '32px',
@@ -970,13 +991,14 @@ const DoctorPanel = () => {
                           <td style={tdStyle}>{patient.age ? `${patient.age} лет` : '—'}</td>
                           <td style={tdStyle}>{patient.phone || '—'}</td>
                           <td style={tdStyle}>{patient.diagnosis || '—'}</td>
-                          <td style={tdStyle}>
+                          <td style={tdStyle} aria-label={`${getPatientA11yContext(patient)} status`}>
                             <Badge variant={getStatusVariant(patient.status)} size="md">
                               {getStatusText(patient.status)}
                             </Badge>
                           </td>
-                          <td style={tdStyle}>
+                          <td style={tdStyle} aria-label={`${getPatientA11yContext(patient)} actions`}>
                             <button
+                        aria-label={`Edit ${getPatientA11yContext(patient)}`}
                         style={{ ...actionButtonStyle, background: getColor('primary', 100), color: primaryColor }}
                         onClick={(e) => {
                           e.stopPropagation();
@@ -986,6 +1008,7 @@ const DoctorPanel = () => {
                               <Edit size={16} />
                             </button>
                             <button
+                        aria-label={`View ${getPatientA11yContext(patient)}`}
                         style={{ ...actionButtonStyle, background: getColor('success', 100), color: successColor }}
                         onClick={(e) => {
                           e.stopPropagation();
@@ -995,6 +1018,7 @@ const DoctorPanel = () => {
                               <Eye size={16} />
                             </button>
                             <button
+                        aria-label={`Delete ${getPatientA11yContext(patient)}`}
                         style={{ ...actionButtonStyle, background: getColor('danger', 100), color: dangerColor }}
                         onClick={(e) => {
                           e.stopPropagation();
@@ -1031,6 +1055,7 @@ const DoctorPanel = () => {
                     <div style={{ position: 'relative' }}>
                       <Search size={20} style={{ position: 'absolute', left: getSpacing('sm'), top: '50%', transform: 'translateY(-50%)', color: getColor('secondary', 400) }} />
                       <input
+                      aria-label="Search appointments"
                       type="text"
                       placeholder="Поиск записей..."
                       value={searchQuery}
@@ -1134,6 +1159,7 @@ const DoctorPanel = () => {
                           <td style={tdStyle}>{appointment.notes || '—'}</td>
                           <td style={tdStyle}>
                             <button
+                        aria-label={`Edit ${getAppointmentA11yContext(appointment)}`}
                         style={{ ...actionButtonStyle, background: getColor('primary', 100), color: primaryColor }}
                         onClick={(e) => {
                           e.stopPropagation();
@@ -1143,6 +1169,7 @@ const DoctorPanel = () => {
                               <Edit size={16} />
                             </button>
                             <button
+                        aria-label={`Complete ${getAppointmentA11yContext(appointment)}`}
                         style={{ ...actionButtonStyle, background: getColor('success', 100), color: successColor }}
                         onClick={(e) => {
                           e.stopPropagation();
@@ -1152,6 +1179,7 @@ const DoctorPanel = () => {
                               <CheckCircle size={16} />
                             </button>
                             <button
+                        aria-label={`Cancel ${getAppointmentA11yContext(appointment)}`}
                         style={{ ...actionButtonStyle, background: getColor('danger', 100), color: dangerColor }}
                         onClick={(e) => {
                           e.stopPropagation();
@@ -1265,7 +1293,7 @@ const DoctorPanel = () => {
                               {entry.number || index + 1}
                             </Badge>
                           </td>
-                          <td style={tdStyle}>
+                          <td style={tdStyle} aria-label={getQueuePatientContext(entry)}>
                             <div style={{ display: 'flex', flexDirection: 'column', gap: getSpacing('xs') }}>
                               <strong>{entry.patient_name}</strong>
                               <div style={{ display: 'flex', alignItems: 'center', gap: getSpacing('xs'), flexWrap: 'wrap' }}>


### PR DESCRIPTION
﻿## Summary
- Added accessible names to DoctorPanel tab icon buttons for mobile/icon-only states.
- Added contextual accessible names for patient and appointment table action buttons.
- Updated the icon-only controls audit baseline from 138 to 126 findings and recorded the cleanup progress.

## Contract Impact
- Canonical surface: `frontend/src/pages/DoctorPanel.jsx` UI accessibility only.
- Request shape: Not applicable - no API requests or payloads changed.
- Response shape: Not applicable - no API responses or parsing changed.
- Status codes: Not applicable - no HTTP behavior changed.
- Frontend consumer: DoctorPanel screen-reader and keyboard users receive clearer control names.
- Compatibility path or alias: Not applicable - no route, alias, or compatibility path changed.
- Contract proof: Local lint/build passed with no runtime contract edits.

## RBAC / Permissions
- Roles allowed: Not applicable - doctor route permissions were not changed.
- Roles denied: Not applicable - no RBAC or route guard logic changed.
- Positive auth proof: Not run because this PR only adds labels and does not alter auth flows.
- Negative auth proof: Not run because this PR does not alter auth or permissions.

## Notification / Realtime
- Event type or websocket channel: Not applicable - no notification, websocket, or realtime channel changed.
- Payload version / ack behavior: Not applicable - no realtime payload changed.
- Read/unread or delivery semantics: Not applicable - no notification state changed.
- Reconnect/resync proof: Not run because no realtime behavior changed.

## Frontend Resilience
- Empty data proof: Existing empty-state code untouched; build and lint passed.
- Partial data proof: Label helpers fall back to `patient`, `unknown`, or omitted appointment time.
- Forbidden secondary path behavior: Not applicable - forbidden/auth paths untouched.
- Missing draft/resource behavior: Not applicable - no draft/resource fetch behavior changed.
- Stale route/deep-link behavior: Not applicable - route registry and deep-link logic untouched.

## Scope Gate
- Allowed paths: `frontend/src/pages/DoctorPanel.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, API clients, RBAC, routing, queue hook logic, EMR logic, tests, workflows, and production config.
- Migration/docs/test impact: No migrations or tests changed; audit docs and baseline updated for removed historical findings.
- Rollback note: Revert this PR to restore the previous DoctorPanel labels/baseline only; no data or schema rollback needed.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/pages/DoctorPanel.jsx`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: All passed locally. Icon-control baseline now reports 126 findings, 0 new, 0 stale.
- Not checked: Authenticated browser QA was not run because this PR changes accessible names only and no rendering/flow logic.
