### PR TITLE
fix(frontend): label doctor panel action controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,7 +46,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: admin security and QR controls cleanup removed 7 baseline findings.
 - 2026-05-21: file manager controls cleanup removed 11 baseline findings.
 - 2026-05-21: doctor panel primary controls cleanup removed 12 baseline findings.
-- Current baseline after this slice: 126 findings.
+- 2026-05-21: doctor panel queue and modal controls cleanup removed 9 baseline findings.
+- Current baseline after this slice: 117 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T06:28:05.712Z",
+  "generatedAt": "2026-05-21T06:33:57.955Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -906,78 +906,6 @@
       "column": 13,
       "element": "button",
       "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1353:33:button:title-only",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1353,
-      "column": 33,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1365:33:button:title-only",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1365,
-      "column": 33,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1373:33:button:title-only",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1373,
-      "column": 33,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1381:33:button:title-only",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1381,
-      "column": 33,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1393:33:button:title-only",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1393,
-      "column": 33,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1401:33:button:title-only",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1401,
-      "column": 33,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1409:33:button:title-only",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1409,
-      "column": 33,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1420:23:button:title-only",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1420,
-      "column": 23,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1544:15:button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1544,
-      "column": 15,
-      "element": "button",
-      "reason": "missing-accessible-name"
     },
     {
       "signature": "src/pages/RegistrarPanel.jsx:3842:19:button:missing-accessible-name",

--- a/frontend/src/pages/DoctorPanel.jsx
+++ b/frontend/src/pages/DoctorPanel.jsx
@@ -1352,6 +1352,7 @@ const DoctorPanel = () => {
                       <>
                                 <button
                           {...getQueueActionA11yProps('Mark no-show', entry)}
+                          aria-label={`Mark no-show for ${getQueuePatientContext(entry)}`}
                           style={{ ...actionButtonStyle, background: getColor('danger', 100), color: dangerColor }}
                           onClick={() => markNoShow(entry.id)}
                           title="Отметить неявку">
@@ -1364,6 +1365,7 @@ const DoctorPanel = () => {
                       <>
                                 <button
                           {...getQueueActionA11yProps('Send to diagnostics', entry)}
+                          aria-label={`Send to diagnostics for ${getQueuePatientContext(entry)}`}
                           style={{ ...actionButtonStyle, background: getColor('info', 100), color: accentColor }}
                           onClick={() => sendToDiagnostics(entry.id)}
                           title="На обследование">
@@ -1372,6 +1374,7 @@ const DoctorPanel = () => {
                                 </button>
                                 <button
                           {...getQueueActionA11yProps('Complete visit', entry)}
+                          aria-label={`Complete visit for ${getQueuePatientContext(entry)}`}
                           style={{ ...actionButtonStyle, background: getColor('success', 100), color: successColor }}
                           onClick={() => completeVisit(entry.id)}
                           title="Завершить приём">
@@ -1380,6 +1383,7 @@ const DoctorPanel = () => {
                                 </button>
                                 <button
                           {...getQueueActionA11yProps('Mark no-show', entry)}
+                          aria-label={`Mark no-show for ${getQueuePatientContext(entry)}`}
                           style={{ ...actionButtonStyle, background: getColor('danger', 100), color: dangerColor }}
                           onClick={() => markNoShow(entry.id)}
                           title="Не явился">
@@ -1392,6 +1396,7 @@ const DoctorPanel = () => {
                       <>
                                 <button
                           {...getQueueActionA11yProps('Call back from diagnostics', entry)}
+                          aria-label={`Call back from diagnostics for ${getQueuePatientContext(entry)}`}
                           style={{ ...actionButtonStyle, background: getColor('primary', 100), color: primaryColor }}
                           onClick={() => callFromDiagnostics(entry.id)}
                           title="Вернуть с диагностики (Push)">
@@ -1400,6 +1405,7 @@ const DoctorPanel = () => {
                                 </button>
                                 <button
                           {...getQueueActionA11yProps('Complete visit', entry)}
+                          aria-label={`Complete visit for ${getQueuePatientContext(entry)}`}
                           style={{ ...actionButtonStyle, background: getColor('success', 100), color: successColor }}
                           onClick={() => completeVisit(entry.id)}
                           title="Завершить приём">
@@ -1408,6 +1414,7 @@ const DoctorPanel = () => {
                                 </button>
                                 <button
                           {...getQueueActionA11yProps('Mark visit incomplete', entry)}
+                          aria-label={`Mark visit incomplete for ${getQueuePatientContext(entry)}`}
                           style={{ ...actionButtonStyle, background: getColor('warning', 100), color: warningColor }}
                           onClick={() => markIncomplete(entry.id, 'Не вернулся с обследования')}
                           title="Не вернулся">
@@ -1419,6 +1426,7 @@ const DoctorPanel = () => {
                             {entry.status === 'no_show' &&
                       <button
                         {...getQueueActionA11yProps('Restore as next patient', entry)}
+                        aria-label={`Restore as next patient for ${getQueuePatientContext(entry)}`}
                         style={{ ...actionButtonStyle, background: getColor('warning', 100), color: warningColor }}
                         onClick={() => restoreToNext(entry.id)}
                         title="Восстановить следующим">
@@ -1542,6 +1550,7 @@ const DoctorPanel = () => {
                 Информация о пациенте
               </h3>
               <button
+              aria-label="Close patient information dialog"
               onClick={patientModal.closeModal}
               style={{
                 color: 'var(--mac-text-tertiary)',


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to DoctorPanel queue action icon buttons.
- Added an accessible name to the patient information dialog close icon button.
- Updated the icon-only controls audit baseline from 126 to 117 findings and recorded the cleanup progress.

## Contract Impact
- Canonical surface: `frontend/src/pages/DoctorPanel.jsx` UI accessibility only.
- Request shape: Not applicable - no API requests or payloads changed.
- Response shape: Not applicable - no API responses or parsing changed.
- Status codes: Not applicable - no HTTP behavior changed.
- Frontend consumer: DoctorPanel queue action and modal controls expose robust accessible names.
- Compatibility path or alias: Not applicable - no route, alias, or compatibility path changed.
- Contract proof: Local lint/build passed with no runtime contract edits.

## RBAC / Permissions
- Roles allowed: Not applicable - doctor route permissions were not changed.
- Roles denied: Not applicable - no RBAC or route guard logic changed.
- Positive auth proof: Not run because this PR only adds accessible names and does not alter auth flows.
- Negative auth proof: Not run because this PR does not alter auth or permissions.

## Notification / Realtime
- Event type or websocket channel: Not applicable - no notification, websocket, or realtime channel changed.
- Payload version / ack behavior: Not applicable - no realtime payload changed.
- Read/unread or delivery semantics: Not applicable - no notification state changed.
- Reconnect/resync proof: Not run because no realtime behavior changed.

## Frontend Resilience
- Empty data proof: Existing empty-state code untouched; build and lint passed.
- Partial data proof: Queue labels use existing `getQueuePatientContext` fallbacks for unknown entries.
- Forbidden secondary path behavior: Not applicable - forbidden/auth paths untouched.
- Missing draft/resource behavior: Not applicable - no draft/resource fetch behavior changed.
- Stale route/deep-link behavior: Not applicable - route registry and deep-link logic untouched.

## Scope Gate
- Allowed paths: `frontend/src/pages/DoctorPanel.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, API clients, RBAC, routing, queue hook logic, EMR logic, tests, workflows, and production config.
- Migration/docs/test impact: No migrations or tests changed; audit docs and baseline updated for removed historical findings.
- Rollback note: Revert this PR to restore the previous DoctorPanel queue/modal labels and baseline only; no data or schema rollback needed.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/pages/DoctorPanel.jsx`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: All passed locally. Icon-control baseline now reports 117 findings, 0 new, 0 stale.
- Not checked: Authenticated browser QA was not run because this PR changes accessible names only and no rendering/flow logic.
