### PR TITLE
fix(frontend): label emr v2 icon controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -47,7 +47,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: file manager controls cleanup removed 11 baseline findings.
 - 2026-05-21: doctor panel primary controls cleanup removed 12 baseline findings.
 - 2026-05-21: doctor panel queue and modal controls cleanup removed 9 baseline findings.
-- Current baseline after this slice: 117 findings.
+- 2026-05-21: EMR v2 controls cleanup removed 12 baseline findings.
+- Current baseline after this slice: 105 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T06:33:57.955Z",
+  "generatedAt": "2026-05-21T06:53:30.895Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -593,102 +593,6 @@
       "line": 353,
       "column": 21,
       "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/emr-v2/DoctorTemplatesPanel.jsx:126:21:button:title-only",
-      "file": "src/components/emr-v2/DoctorTemplatesPanel.jsx",
-      "line": 126,
-      "column": 21,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/emr-v2/DoctorTemplatesPanel.jsx:163:41:button:title-only",
-      "file": "src/components/emr-v2/DoctorTemplatesPanel.jsx",
-      "line": 163,
-      "column": 41,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/emr-v2/DoctorTemplatesPanel.jsx:171:41:button:title-only",
-      "file": "src/components/emr-v2/DoctorTemplatesPanel.jsx",
-      "line": 171,
-      "column": 41,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/emr-v2/DoctorTemplatesPanel.jsx:179:41:button:title-only",
-      "file": "src/components/emr-v2/DoctorTemplatesPanel.jsx",
-      "line": 179,
-      "column": 41,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/emr-v2/sections/ExaminationMatrix.jsx:189:33:button:title-only",
-      "file": "src/components/emr-v2/sections/ExaminationMatrix.jsx",
-      "line": 189,
-      "column": 33,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/emr-v2/sections/ExaminationMatrix.jsx:197:33:button:title-only",
-      "file": "src/components/emr-v2/sections/ExaminationMatrix.jsx",
-      "line": 197,
-      "column": 33,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/emr-v2/sections/TreatmentSection.jsx:268:41:button:title-only",
-      "file": "src/components/emr-v2/sections/TreatmentSection.jsx",
-      "line": 268,
-      "column": 41,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/emr-v2/sections/TreatmentSection.jsx:290:41:button:title-only",
-      "file": "src/components/emr-v2/sections/TreatmentSection.jsx",
-      "line": 290,
-      "column": 41,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/emr-v2/sections/specialty/DermatologySection.jsx:207:33:img:missing-accessible-name",
-      "file": "src/components/emr-v2/sections/specialty/DermatologySection.jsx",
-      "line": 207,
-      "column": 33,
-      "element": "img",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/emr-v2/sections/specialty/DermatologySection.jsx:222:13:button:missing-accessible-name",
-      "file": "src/components/emr-v2/sections/specialty/DermatologySection.jsx",
-      "line": 222,
-      "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/emr-v2/sections/specialty/DermatologySection.jsx:269:25:button:missing-accessible-name",
-      "file": "src/components/emr-v2/sections/specialty/DermatologySection.jsx",
-      "line": 269,
-      "column": 25,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/emr-v2/templates/TreatmentTemplatesPanel.jsx:128:13:div:missing-accessible-name",
-      "file": "src/components/emr-v2/templates/TreatmentTemplatesPanel.jsx",
-      "line": 128,
-      "column": 13,
-      "element": "div",
       "reason": "missing-accessible-name"
     },
     {

--- a/frontend/src/components/emr-v2/DoctorTemplatesPanel.jsx
+++ b/frontend/src/components/emr-v2/DoctorTemplatesPanel.jsx
@@ -126,6 +126,7 @@ export function DoctorTemplatesPanel({
                     <button
                         className="doctor-templates-close"
                         onClick={handleClose}
+                        aria-label={`Закрыть панель шаблонов ${sectionLabel}`}
                         title="Закрыть"
                     >
                         <X size={18} />
@@ -164,6 +165,7 @@ export function DoctorTemplatesPanel({
                                             type="button"
                                             onClick={(e) => handlePinToggle(template, e)}
                                             className={`doctor-templates-action-btn ${template.is_pinned ? 'active' : ''}`}
+                                            aria-label={`${template.is_pinned ? 'Открепить' : 'Закрепить'} шаблон врача`}
                                             title={template.is_pinned ? 'Открепить' : 'Закрепить'}
                                         >
                                             <Pin size={14} />
@@ -172,6 +174,7 @@ export function DoctorTemplatesPanel({
                                             type="button"
                                             onClick={(e) => handleEditStart(template, e)}
                                             className="doctor-templates-action-btn"
+                                            aria-label="Редактировать шаблон врача"
                                             title="Редактировать"
                                         >
                                             <Edit2 size={14} />
@@ -180,6 +183,7 @@ export function DoctorTemplatesPanel({
                                             type="button"
                                             onClick={(e) => handleDelete(template, e)}
                                             className="doctor-templates-action-btn doctor-templates-action-btn--danger"
+                                            aria-label="Удалить шаблон врача"
                                             title="Удалить"
                                         >
                                             <Trash2 size={14} />
@@ -232,6 +236,7 @@ export function DoctorTemplatesPanel({
                             </div>
                             <textarea
                                 className="doctor-templates-edit-textarea"
+                                aria-label="Текст шаблона врача"
                                 value={editText}
                                 onChange={(e) => setEditText(e.target.value)}
                                 rows={6}

--- a/frontend/src/components/emr-v2/sections/ExaminationMatrix.jsx
+++ b/frontend/src/components/emr-v2/sections/ExaminationMatrix.jsx
@@ -189,6 +189,7 @@ const ExaminationMatrix = ({
                                 <button
                   className={'ex-matrix__action-btn ex-matrix__action-btn--norm'}
                   onClick={() => handleToggle(item, 'norm')}
+                  aria-label={`Отметить "${item}" как норму`}
                   title="Норма">
                   
                                     <Check size={14} />
@@ -197,6 +198,7 @@ const ExaminationMatrix = ({
                                 <button
                   className={'ex-matrix__action-btn ex-matrix__action-btn--path'}
                   onClick={() => handleToggle(item, 'path')}
+                  aria-label={`Отметить "${item}" как патологию`}
                   title="Патология">
                   
                                     <AlertCircle size={14} />

--- a/frontend/src/components/emr-v2/sections/TreatmentSection.jsx
+++ b/frontend/src/components/emr-v2/sections/TreatmentSection.jsx
@@ -273,6 +273,7 @@ export function TreatmentSection({
                   unpinTemplate(t.id) :
                   pinTemplate(t.id);
                 }}
+                aria-label={`${t.is_pinned ? 'Открепить' : 'Закрепить'} шаблон лечения`}
                 title={t.is_pinned ? 'Открепить' : 'Закрепить (макс 3)'}
                 style={{
                   padding: '4px 8px',
@@ -294,6 +295,7 @@ export function TreatmentSection({
                   setEditingTemplate(t);
                   setEditText(t.treatment_text);
                 }}
+                aria-label="Редактировать шаблон лечения"
                 title="Редактировать"
                 style={{
                   padding: '4px 8px',
@@ -408,6 +410,7 @@ export function TreatmentSection({
         }}
         role="button"
         tabIndex={0}
+        aria-label="Закрыть окно редактирования шаблона лечения"
         onClick={() => setEditingTemplate(null)}
         onKeyDown={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
@@ -430,6 +433,7 @@ export function TreatmentSection({
                             ✏️ Редактировать шаблон
                         </h3>
                         <textarea
+            aria-label="Текст шаблона лечения"
             value={editText}
             onChange={(e) => setEditText(e.target.value)}
             style={{

--- a/frontend/src/components/emr-v2/sections/specialty/DermatologySection.jsx
+++ b/frontend/src/components/emr-v2/sections/specialty/DermatologySection.jsx
@@ -155,6 +155,7 @@ export function DermatologySection({
           <label key={condition} className="dermatology-checkbox">
                             <input
               type="checkbox"
+              aria-label={`Состояние кожи: ${condition}`}
               checked={conditions.includes(condition)}
               onChange={(e) => {
                 if (e.target.checked) {
@@ -190,6 +191,7 @@ export function DermatologySection({
                 <input
           ref={fileInputRef}
           type="file"
+          aria-label="Загрузить фото для дерматологического осмотра"
           accept="image/*"
           onChange={handleFileSelect}
           style={{ display: 'none' }} />
@@ -207,6 +209,7 @@ export function DermatologySection({
                                 <img
               src={photo.url}
               alt={`Фото ${photo.category}`}
+              aria-label={`Открыть фото ${photo.category}`}
               role="button"
               tabIndex={0}
               onClick={() => setSelectedPhoto(photo)}
@@ -222,6 +225,7 @@ export function DermatologySection({
             <button
               type="button"
               onClick={() => handlePhotoDelete(photo.id)}
+              aria-label={`Удалить фото ${photo.category}`}
               className="dermatology-photo-delete">
               
                                         <X size={14} />
@@ -269,6 +273,7 @@ export function DermatologySection({
                         <button
             type="button"
             onClick={() => setSelectedPhoto(null)}
+            aria-label="Закрыть просмотр фото"
             className="dermatology-photo-modal-close">
             
                             <X size={20} />

--- a/frontend/src/components/emr-v2/templates/TreatmentTemplatesPanel.jsx
+++ b/frontend/src/components/emr-v2/templates/TreatmentTemplatesPanel.jsx
@@ -129,6 +129,7 @@ export function TreatmentTemplatesPanel({
                 className="treatment-templates-backdrop"
                 role="button"
                 tabIndex={0}
+                aria-label="Закрыть панель шаблонов лечения"
                 onClick={handleClose}
                 onKeyDown={(event) => handleActivationKeyDown(event, handleClose)} />
 
@@ -146,6 +147,7 @@ export function TreatmentTemplatesPanel({
                 <div className="treatment-templates-search">
                     <input
                         type="text"
+                        aria-label="Поиск шаблона лечения"
                         placeholder="Поиск шаблона..."
                         value={searchQuery}
                         onChange={(e) => setSearchQuery(e.target.value)}


### PR DESCRIPTION
﻿## Summary
- Added accessible names to EMR v2 template, examination, treatment, and dermatology icon-only controls.
- Added labels to adjacent EMR inputs/backdrops that targeted ESLint flagged in the same surfaces.
- Updated the icon-only controls audit baseline from 117 to 105 findings and recorded the cleanup progress.

## Contract Impact
- Canonical surface: `frontend/src/components/emr-v2/**` UI accessibility only.
- Request shape: Not applicable - no API requests, save/sign calls, or payloads changed.
- Response shape: Not applicable - no API responses or parsing changed.
- Status codes: Not applicable - no HTTP behavior changed.
- Frontend consumer: EMR v2 screen-reader and keyboard users receive clearer control names.
- Compatibility path or alias: Not applicable - no route, alias, or compatibility path changed.
- Contract proof: Local lint/build passed with no runtime contract edits.

## RBAC / Permissions
- Roles allowed: Not applicable - doctor/EMR permissions were not changed.
- Roles denied: Not applicable - no RBAC or route guard logic changed.
- Positive auth proof: Not run because this PR only adds accessible names and does not alter auth flows.
- Negative auth proof: Not run because this PR does not alter auth or permissions.

## Notification / Realtime
- Event type or websocket channel: Not applicable - no notification, websocket, or realtime channel changed.
- Payload version / ack behavior: Not applicable - no realtime payload changed.
- Read/unread or delivery semantics: Not applicable - no notification state changed.
- Reconnect/resync proof: Not run because no realtime behavior changed.

## Frontend Resilience
- Empty data proof: Existing empty/loading states untouched; build and lint passed.
- Partial data proof: Labels use existing visible item/template/photo context or generic fallbacks and do not depend on API data.
- Forbidden secondary path behavior: Not applicable - forbidden/auth paths untouched.
- Missing draft/resource behavior: Not applicable - no draft/resource fetch behavior changed.
- Stale route/deep-link behavior: Not applicable - route registry and deep-link logic untouched.

## Scope Gate
- Allowed paths: EMR v2 component files with icon-only baseline entries, `frontend/scripts/a11y/icon-only-controls-baseline.json`, and `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, API clients, RBAC, routes, EMR save/sign logic, queue/payment logic, tests, workflows, and production config.
- Migration/docs/test impact: No migrations or tests changed; audit docs and baseline updated for removed historical findings.
- Rollback note: Revert this PR to restore the previous EMR labels and baseline only; no data or schema rollback needed.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/emr-v2/DoctorTemplatesPanel.jsx src/components/emr-v2/sections/ExaminationMatrix.jsx src/components/emr-v2/sections/TreatmentSection.jsx src/components/emr-v2/sections/specialty/DermatologySection.jsx src/components/emr-v2/templates/TreatmentTemplatesPanel.jsx`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: All passed locally. Icon-control baseline now reports 105 findings, 0 new, 0 stale.
- Not checked: Authenticated browser QA was not run because this PR changes accessible names only and no EMR rendering/data-flow logic.
