### PR TITLE
fix(frontend): label dental photo archive controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -49,7 +49,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: doctor panel queue and modal controls cleanup removed 9 baseline findings.
 - 2026-05-21: EMR v2 controls cleanup removed 12 baseline findings.
 - 2026-05-21: dermatology controls cleanup removed 13 baseline findings.
-- Current baseline after this slice: 92 findings.
+- 2026-05-21: dental photo archive controls cleanup removed 13 baseline findings.
+- Current baseline after this slice: 79 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T07:03:12.222Z",
+  "generatedAt": "2026-05-21T07:11:26.305Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -256,110 +256,6 @@
       "file": "src/components/dental/PatientCard.jsx",
       "line": 813,
       "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:301:17:button:missing-accessible-name",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 301,
-      "column": 17,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:307:17:button:missing-accessible-name",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 307,
-      "column": 17,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:328:13:div:missing-accessible-name",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 328,
-      "column": 13,
-      "element": "div",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:394:15:button:title-only",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 394,
-      "column": 15,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:405:15:button:title-only",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 405,
-      "column": 15,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:419:11:button:title-only",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 419,
-      "column": 11,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:464:19:div:missing-accessible-name",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 464,
-      "column": 19,
-      "element": "div",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:523:11:button:missing-accessible-name",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 523,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:562:17:button:missing-accessible-name",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 562,
-      "column": 17,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:623:13:button:missing-accessible-name",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 623,
-      "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:705:17:button:missing-accessible-name",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 705,
-      "column": 17,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:711:17:button:missing-accessible-name",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 711,
-      "column": 17,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PhotoArchive.jsx:717:17:button:missing-accessible-name",
-      "file": "src/components/dental/PhotoArchive.jsx",
-      "line": 717,
-      "column": 17,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/dental/PhotoArchive.jsx
+++ b/frontend/src/components/dental/PhotoArchive.jsx
@@ -300,12 +300,14 @@ const PhotoArchive = ({
         <div className="mt-2 flex gap-1">
                 <button
             onClick={() => handleFileUpdate(file.id, {})}
+            aria-label={`Редактировать файл ${file.name}`}
             className="flex-1 px-2 py-1 text-xs bg-blue-100 text-blue-700 rounded hover:bg-blue-200">
             
                   <Edit className="h-3 w-3 mx-auto" />
                 </button>
                 <button
             onClick={() => handleFileDelete(file.id)}
+            aria-label={`Удалить файл ${file.name}`}
             className="flex-1 px-2 py-1 text-xs bg-red-100 text-red-700 rounded hover:bg-red-200">
             
                   <Trash2 className="h-3 w-3 mx-auto" />
@@ -328,6 +330,7 @@ const PhotoArchive = ({
             <div
           className="w-16 h-16 bg-gray-100 rounded flex items-center justify-center cursor-pointer"
           role="button"
+          aria-label={`Открыть файл ${file.name}`}
           tabIndex={0}
           onClick={() => openFileViewer(file)}
           onKeyDown={(event) => handleActivationKeyDown(event, () => openFileViewer(file))}>
@@ -397,6 +400,7 @@ const PhotoArchive = ({
               setShowImageViewer(true);
             }}
             className="p-2 text-gray-500 hover:text-blue-600"
+            aria-label={`Просмотреть файл ${file.name}`}
             title="Просмотр">
             
                 <Eye className="h-4 w-4" />
@@ -410,6 +414,7 @@ const PhotoArchive = ({
               link.click();
             }}
             className="p-2 text-gray-500 hover:text-green-600"
+            aria-label={`Скачать файл ${file.name}`}
             title="Скачать">
             
                 <Download className="h-4 w-4" />
@@ -419,6 +424,7 @@ const PhotoArchive = ({
           <button
             onClick={() => handleFileDelete(file.id)}
             className="p-2 text-gray-500 hover:text-red-600"
+            aria-label={`Удалить файл ${file.name}`}
             title="Удалить">
             
                   <Trash2 className="h-4 w-4" />
@@ -464,6 +470,7 @@ const PhotoArchive = ({
                   <div
                 className="aspect-video bg-gray-100 flex items-center justify-center cursor-pointer"
                 role="button"
+                aria-label={`Открыть файл ${file.name}`}
                 tabIndex={0}
                 onClick={() => openFileViewer(file)}
                 onKeyDown={(event) => handleActivationKeyDown(event, () => openFileViewer(file))}>
@@ -522,6 +529,7 @@ const PhotoArchive = ({
           {/* Кнопка закрытия */}
           <button
             onClick={() => setShowImageViewer(false)}
+            aria-label="Закрыть просмотр файла"
             className="absolute top-4 right-4 z-10 p-2 bg-black bg-opacity-50 text-white rounded-full hover:bg-opacity-75">
             
             <X className="h-6 w-6" />
@@ -566,6 +574,7 @@ const PhotoArchive = ({
                     link.download = selectedFile.name;
                     link.click();
                   }}
+                  aria-label={`Скачать файл ${selectedFile.name}`}
                   className="p-2 bg-blue-600 text-white rounded hover:bg-blue-700">
                   
                   <Download className="h-4 w-4" />
@@ -622,6 +631,7 @@ const PhotoArchive = ({
             }
             <button
               onClick={onClose}
+              aria-label="Закрыть фотоархив"
               className="p-2 text-gray-500 hover:text-gray-700">
               
               <X className="h-5 w-5" />
@@ -638,6 +648,7 @@ const PhotoArchive = ({
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
                 <input
                   type="text"
+                  aria-label="Поиск файлов фотоархива"
                   placeholder="Поиск файлов..."
                   value={formData.searchQuery}
                   onChange={(e) => handleInputChange('searchQuery', e.target.value)}
@@ -673,6 +684,7 @@ const PhotoArchive = ({
               
               <input
                 type="date"
+                aria-label="Фильтр фотоархива: дата с"
                 value={formData.filters.dateFrom}
                 onChange={(e) => handleInputChange('filters.dateFrom', e.target.value)}
                 placeholder="От"
@@ -681,6 +693,7 @@ const PhotoArchive = ({
               
               <input
                 type="date"
+                aria-label="Фильтр фотоархива: дата до"
                 value={formData.filters.dateTo}
                 onChange={(e) => handleInputChange('filters.dateTo', e.target.value)}
                 placeholder="До"
@@ -704,18 +717,21 @@ const PhotoArchive = ({
               <div className="flex border border-gray-300 rounded-md">
                 <button
                   onClick={() => setViewMode('grid')}
+                  aria-label="Показать архив плиткой"
                   className={`px-3 py-2 ${viewMode === 'grid' ? 'bg-blue-500 text-white' : 'text-gray-700'}`}>
                   
                   <ImageIcon className="h-4 w-4" />
                 </button>
                 <button
                   onClick={() => setViewMode('list')}
+                  aria-label="Показать архив списком"
                   className={`px-3 py-2 ${viewMode === 'list' ? 'bg-blue-500 text-white' : 'text-gray-700'}`}>
                   
                   <FileText className="h-4 w-4" />
                 </button>
                 <button
                   onClick={() => setViewMode('timeline')}
+                  aria-label="Показать архив по временной шкале"
                   className={`px-3 py-2 ${viewMode === 'timeline' ? 'bg-blue-500 text-white' : 'text-gray-700'}`}>
                   
                   <Calendar className="h-4 w-4" />
@@ -733,6 +749,7 @@ const PhotoArchive = ({
               <span className="text-blue-700">Загрузить файлы</span>
               <input
               type="file"
+              aria-label="Загрузить файлы в фотоархив"
               multiple
               accept="image/*,video/*,.pdf,.doc,.docx"
               onChange={(e) => handleFileUpload(e.target.files)}
@@ -757,6 +774,7 @@ const PhotoArchive = ({
                   Загрузить файлы
                   <input
                 type="file"
+                aria-label="Загрузить файлы в пустой фотоархив"
                 multiple
                 accept="image/*,video/*,.pdf,.doc,.docx"
                 onChange={(e) => handleFileUpload(e.target.files)}


### PR DESCRIPTION
﻿## Summary
- Added accessible names to dental photo archive icon-only file actions, preview/open controls, modal controls, upload inputs, filters, and view-mode buttons.
- Reduced the icon-only controls accessibility baseline from 92 to 79 findings.
- Updated the global icon-only controls sweep report with this cleanup slice.

## Contract Impact
- Canonical surface: Frontend dental photo archive controls only; no canonical API surface changed.
- Request shape: Unchanged because file upload/download/delete handlers and request construction were not changed.
- Response shape: Unchanged because no response parsing or backend contract code changed.
- Status codes: Unchanged because no backend endpoint behavior changed.
- Frontend consumer: Dental photo archive UI controls in `PhotoArchive.jsx`.
- Compatibility path or alias: Not applicable because no route, alias, or compatibility path changed.
- Contract proof: No backend/API files changed; local frontend build completed successfully.

## RBAC / Permissions
- Roles allowed: Unchanged from existing dental route access.
- Roles denied: Unchanged because no auth or role gate logic changed.
- Positive auth proof: Not applicable because this PR only adds accessible-name metadata and touches no auth logic.
- Negative auth proof: Not applicable because this PR only adds accessible-name metadata and touches no auth logic.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no realtime payload or ack behavior changed.
- Read/unread or delivery semantics: Not applicable because no delivery state code changed.
- Reconnect/resync proof: Not applicable because no websocket, polling, or resync code changed.

## Frontend Resilience
- Empty data proof: Existing empty archive rendering is untouched; hidden upload inputs now have accessible names.
- Partial data proof: Existing file-card/list/timeline rendering is untouched; labels use the existing file name.
- Forbidden secondary path behavior: Unchanged because no route guard or permission behavior changed.
- Missing draft/resource behavior: Unchanged because no resource loading behavior changed.
- Stale route/deep-link behavior: Unchanged because no route or navigation code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/dental/PhotoArchive.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/dental/PhotoArchive.jsx`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: All commands passed locally. Icon-only controls baseline is now 79 findings with 0 new and 0 stale entries.
- Not checked: Browser-authenticated dental flow was not run because this PR only adds accessible-name metadata and does not change visual layout or logic.
