### PR TITLE
fix(frontend): label dental diagnosis controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -50,7 +50,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: EMR v2 controls cleanup removed 12 baseline findings.
 - 2026-05-21: dermatology controls cleanup removed 13 baseline findings.
 - 2026-05-21: dental photo archive controls cleanup removed 13 baseline findings.
-- Current baseline after this slice: 79 findings.
+- 2026-05-21: dental diagnosis form controls cleanup removed 7 baseline findings.
+- Current baseline after this slice: 72 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T07:11:26.305Z",
+  "generatedAt": "2026-05-21T07:17:39.837Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -128,62 +128,6 @@
       "file": "src/components/dental/DentalPriceManager.jsx",
       "line": 175,
       "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/DiagnosisForm.jsx:259:9:button:missing-accessible-name",
-      "file": "src/components/dental/DiagnosisForm.jsx",
-      "line": 259,
-      "column": 9,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/DiagnosisForm.jsx:314:11:button:missing-accessible-name",
-      "file": "src/components/dental/DiagnosisForm.jsx",
-      "line": 314,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/DiagnosisForm.jsx:357:11:button:missing-accessible-name",
-      "file": "src/components/dental/DiagnosisForm.jsx",
-      "line": 357,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/DiagnosisForm.jsx:400:11:button:missing-accessible-name",
-      "file": "src/components/dental/DiagnosisForm.jsx",
-      "line": 400,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/DiagnosisForm.jsx:524:11:button:missing-accessible-name",
-      "file": "src/components/dental/DiagnosisForm.jsx",
-      "line": 524,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/DiagnosisForm.jsx:651:11:button:missing-accessible-name",
-      "file": "src/components/dental/DiagnosisForm.jsx",
-      "line": 651,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/DiagnosisForm.jsx:740:13:button:missing-accessible-name",
-      "file": "src/components/dental/DiagnosisForm.jsx",
-      "line": 740,
-      "column": 13,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/dental/DiagnosisForm.jsx
+++ b/frontend/src/components/dental/DiagnosisForm.jsx
@@ -245,6 +245,7 @@ const DiagnosisForm = ({
       <div key={index} className="flex items-center gap-3 p-3 border rounded-lg">
             <input
           type="text"
+          aria-label={`Общий диагноз ${index + 1}`}
           value={diagnosis}
           onChange={(e) => {
             const newDiagnoses = [...formData.generalDiagnoses];
@@ -258,6 +259,7 @@ const DiagnosisForm = ({
             {isEditing &&
         <button
           onClick={() => handleArrayRemove('generalDiagnoses', index)}
+          aria-label={`Удалить общий диагноз ${index + 1}`}
           className="text-red-500 hover:text-red-700">
           
                 <Trash2 className="h-4 w-4" />
@@ -300,6 +302,7 @@ const DiagnosisForm = ({
         <div key={index} className="flex items-center gap-3 p-3 bg-red-50 border border-red-200 rounded-lg">
               <input
             type="text"
+            aria-label={`Срочная мера лечения ${index + 1}`}
             value={item}
             onChange={(e) => {
               const newItems = [...formData.treatmentPlan.immediate];
@@ -313,6 +316,7 @@ const DiagnosisForm = ({
               {isEditing &&
           <button
             onClick={() => handleArrayRemove('treatmentPlan.immediate', index)}
+            aria-label={`Удалить срочную меру лечения ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <Trash2 className="h-4 w-4" />
@@ -343,6 +347,7 @@ const DiagnosisForm = ({
         <div key={index} className="flex items-center gap-3 p-3 bg-orange-50 border border-orange-200 rounded-lg">
               <input
             type="text"
+            aria-label={`Краткосрочная процедура ${index + 1}`}
             value={item}
             onChange={(e) => {
               const newItems = [...formData.treatmentPlan.shortTerm];
@@ -356,6 +361,7 @@ const DiagnosisForm = ({
               {isEditing &&
           <button
             onClick={() => handleArrayRemove('treatmentPlan.shortTerm', index)}
+            aria-label={`Удалить краткосрочную процедуру ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <Trash2 className="h-4 w-4" />
@@ -386,6 +392,7 @@ const DiagnosisForm = ({
         <div key={index} className="flex items-center gap-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
               <input
             type="text"
+            aria-label={`Долгосрочная процедура ${index + 1}`}
             value={item}
             onChange={(e) => {
               const newItems = [...formData.treatmentPlan.longTerm];
@@ -399,6 +406,7 @@ const DiagnosisForm = ({
               {isEditing &&
           <button
             onClick={() => handleArrayRemove('treatmentPlan.longTerm', index)}
+            aria-label={`Удалить долгосрочную процедуру ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <Trash2 className="h-4 w-4" />
@@ -440,6 +448,7 @@ const DiagnosisForm = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Название препарата ${index + 1}`}
               value={prescription.medication || ''}
               onChange={(e) => {
                 const newPrescriptions = [...formData.prescriptions];
@@ -458,6 +467,7 @@ const DiagnosisForm = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Дозировка препарата ${index + 1}`}
               value={prescription.dosage || ''}
               onChange={(e) => {
                 const newPrescriptions = [...formData.prescriptions];
@@ -476,6 +486,7 @@ const DiagnosisForm = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Способ применения препарата ${index + 1}`}
               value={prescription.administration || ''}
               onChange={(e) => {
                 const newPrescriptions = [...formData.prescriptions];
@@ -494,6 +505,7 @@ const DiagnosisForm = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Продолжительность приема препарата ${index + 1}`}
               value={prescription.duration || ''}
               onChange={(e) => {
                 const newPrescriptions = [...formData.prescriptions];
@@ -509,6 +521,7 @@ const DiagnosisForm = ({
             
             <div className="flex items-center justify-between">
               <textarea
+            aria-label={`Дополнительные указания к рецепту ${index + 1}`}
             value={prescription.notes || ''}
             onChange={(e) => {
               const newPrescriptions = [...formData.prescriptions];
@@ -523,6 +536,7 @@ const DiagnosisForm = ({
               {isEditing &&
           <button
             onClick={() => handleArrayRemove('prescriptions', index)}
+            aria-label={`Удалить рецепт ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <Trash2 className="h-4 w-4" />
@@ -621,6 +635,7 @@ const DiagnosisForm = ({
                 Причина направления
               </label>
               <textarea
+            aria-label={`Причина направления ${index + 1}`}
             value={referral.reason || ''}
             onChange={(e) => {
               const newReferrals = [...formData.referrals];
@@ -637,6 +652,7 @@ const DiagnosisForm = ({
             <div className="flex items-center justify-between">
               <input
             type="text"
+            aria-label={`Дополнительные указания к направлению ${index + 1}`}
             value={referral.notes || ''}
             onChange={(e) => {
               const newReferrals = [...formData.referrals];
@@ -650,6 +666,7 @@ const DiagnosisForm = ({
               {isEditing &&
           <button
             onClick={() => handleArrayRemove('referrals', index)}
+            aria-label={`Удалить направление ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <Trash2 className="h-4 w-4" />
@@ -739,6 +756,7 @@ const DiagnosisForm = ({
             }
             <button
               onClick={onClose}
+              aria-label="Закрыть форму диагнозов и назначений"
               className="p-2 text-gray-500 hover:text-gray-700">
               
               <X className="h-5 w-5" />


### PR DESCRIPTION
﻿## Summary
- Added accessible names to dental diagnosis form delete controls for diagnoses, treatment plan items, prescriptions, referrals, and modal close.
- Added accessible names to adjacent diagnosis/treatment/prescription/referral inputs and textareas so the touched form is clean under targeted JSX a11y lint.
- Reduced the icon-only controls accessibility baseline from 79 to 72 findings and updated the sweep report.

## Contract Impact
- Canonical surface: Frontend dental diagnosis form controls only; no canonical API surface changed.
- Request shape: Unchanged because diagnosis, treatment, prescription, and referral handlers were not changed.
- Response shape: Unchanged because no response parsing or backend contract code changed.
- Status codes: Unchanged because no backend endpoint behavior changed.
- Frontend consumer: Dental diagnosis modal UI in `DiagnosisForm.jsx`.
- Compatibility path or alias: Not applicable because no route, alias, or compatibility path changed.
- Contract proof: No backend/API files changed; local frontend build completed successfully.

## RBAC / Permissions
- Roles allowed: Unchanged from existing dental route access.
- Roles denied: Unchanged because no auth or role gate logic changed.
- Positive auth proof: Not applicable because this PR only adds accessible-name metadata and touches no auth logic.
- Negative auth proof: Not applicable because this PR only adds accessible-name metadata and touches no auth logic.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no realtime payload or ack behavior changed.
- Read/unread or delivery semantics: Not applicable because no delivery state code changed.
- Reconnect/resync proof: Not applicable because no websocket, polling, or resync code changed.

## Frontend Resilience
- Empty data proof: Existing empty diagnosis/treatment/prescription/referral arrays are untouched; labels only name existing controls.
- Partial data proof: Existing partially filled form state is untouched; labels use existing row index and field purpose.
- Forbidden secondary path behavior: Unchanged because no route guard or permission behavior changed.
- Missing draft/resource behavior: Unchanged because no draft/resource loading behavior changed.
- Stale route/deep-link behavior: Unchanged because no route or navigation code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/dental/DiagnosisForm.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/dental/DiagnosisForm.jsx`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: All commands passed locally. Icon-only controls baseline is now 72 findings with 0 new and 0 stale entries.
- Not checked: Browser-authenticated dental diagnosis flow was not run because this PR only adds accessible-name metadata and does not change visual layout or logic.
