### PR TITLE
fix(frontend): label dental visit protocol controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -51,7 +51,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: dermatology controls cleanup removed 13 baseline findings.
 - 2026-05-21: dental photo archive controls cleanup removed 13 baseline findings.
 - 2026-05-21: dental diagnosis form controls cleanup removed 7 baseline findings.
-- Current baseline after this slice: 72 findings.
+- 2026-05-21: dental visit protocol controls cleanup removed 7 baseline findings.
+- Current baseline after this slice: 65 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T07:17:39.837Z",
+  "generatedAt": "2026-05-21T07:24:12.424Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -272,62 +272,6 @@
       "file": "src/components/dental/TeethChart.jsx",
       "line": 237,
       "column": 15,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/VisitProtocol.jsx:316:11:button:missing-accessible-name",
-      "file": "src/components/dental/VisitProtocol.jsx",
-      "line": 316,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/VisitProtocol.jsx:415:11:button:missing-accessible-name",
-      "file": "src/components/dental/VisitProtocol.jsx",
-      "line": 415,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/VisitProtocol.jsx:546:11:button:missing-accessible-name",
-      "file": "src/components/dental/VisitProtocol.jsx",
-      "line": 546,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/VisitProtocol.jsx:600:13:button:missing-accessible-name",
-      "file": "src/components/dental/VisitProtocol.jsx",
-      "line": 600,
-      "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/VisitProtocol.jsx:690:11:button:missing-accessible-name",
-      "file": "src/components/dental/VisitProtocol.jsx",
-      "line": 690,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/VisitProtocol.jsx:771:11:button:missing-accessible-name",
-      "file": "src/components/dental/VisitProtocol.jsx",
-      "line": 771,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/VisitProtocol.jsx:922:13:button:missing-accessible-name",
-      "file": "src/components/dental/VisitProtocol.jsx",
-      "line": 922,
-      "column": 13,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/dental/VisitProtocol.jsx
+++ b/frontend/src/components/dental/VisitProtocol.jsx
@@ -238,6 +238,7 @@ const VisitProtocol = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Зубы для процедуры ${index + 1}`}
               value={procedure.teeth || ''}
               onChange={(e) => handleArrayUpdate('procedures', index, { teeth: e.target.value })}
               disabled={!isEditing}
@@ -252,6 +253,7 @@ const VisitProtocol = ({
                 </label>
                 <input
               type="time"
+              aria-label={`Время начала процедуры ${index + 1}`}
               value={procedure.startTime || ''}
               onChange={(e) => handleArrayUpdate('procedures', index, { startTime: e.target.value })}
               disabled={!isEditing}
@@ -265,6 +267,7 @@ const VisitProtocol = ({
                 </label>
                 <input
               type="time"
+              aria-label={`Время окончания процедуры ${index + 1}`}
               value={procedure.endTime || ''}
               onChange={(e) => handleArrayUpdate('procedures', index, { endTime: e.target.value })}
               disabled={!isEditing}
@@ -278,6 +281,7 @@ const VisitProtocol = ({
                 Описание процедуры
               </label>
               <textarea
+            aria-label={`Описание процедуры ${index + 1}`}
             value={procedure.description || ''}
             onChange={(e) => handleArrayUpdate('procedures', index, { description: e.target.value })}
             disabled={!isEditing}
@@ -292,6 +296,7 @@ const VisitProtocol = ({
                 <label className="flex items-center gap-2">
                   <input
                 type="checkbox"
+                aria-label={`Процедура ${index + 1} завершена`}
                 checked={procedure.completed || false}
                 onChange={(e) => handleArrayUpdate('procedures', index, { completed: e.target.checked })}
                 disabled={!isEditing}
@@ -303,6 +308,7 @@ const VisitProtocol = ({
                 <label className="flex items-center gap-2">
                   <input
                 type="checkbox"
+                aria-label={`У процедуры ${index + 1} были осложнения`}
                 checked={procedure.complications || false}
                 onChange={(e) => handleArrayUpdate('procedures', index, { complications: e.target.checked })}
                 disabled={!isEditing}
@@ -315,6 +321,7 @@ const VisitProtocol = ({
               {isEditing &&
           <button
             onClick={() => handleArrayRemove('procedures', index)}
+            aria-label={`Удалить процедуру ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <Trash2 className="h-4 w-4" />
@@ -365,6 +372,7 @@ const VisitProtocol = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Название материала ${index + 1}`}
               value={material.name || ''}
               onChange={(e) => handleArrayUpdate('materials', index, { name: e.target.value })}
               disabled={!isEditing}
@@ -379,6 +387,7 @@ const VisitProtocol = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Количество материала ${index + 1}`}
               value={material.quantity || ''}
               onChange={(e) => handleArrayUpdate('materials', index, { quantity: e.target.value })}
               disabled={!isEditing}
@@ -393,6 +402,7 @@ const VisitProtocol = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Партия или срок годности материала ${index + 1}`}
               value={material.batch || ''}
               onChange={(e) => handleArrayUpdate('materials', index, { batch: e.target.value })}
               disabled={!isEditing}
@@ -404,6 +414,7 @@ const VisitProtocol = ({
             
             <div className="flex items-center justify-between">
               <textarea
+            aria-label={`Заметки по материалу ${index + 1}`}
             value={material.notes || ''}
             onChange={(e) => handleArrayUpdate('materials', index, { notes: e.target.value })}
             disabled={!isEditing}
@@ -414,6 +425,7 @@ const VisitProtocol = ({
               {isEditing &&
           <button
             onClick={() => handleArrayRemove('materials', index)}
+            aria-label={`Удалить материал ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <Trash2 className="h-4 w-4" />
@@ -461,6 +473,7 @@ const VisitProtocol = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Препарат анестезии ${index + 1}`}
               value={anesthesia.drug || ''}
               onChange={(e) => handleArrayUpdate('anesthesia', index, { drug: e.target.value })}
               disabled={!isEditing}
@@ -475,6 +488,7 @@ const VisitProtocol = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Доза анестезии ${index + 1}`}
               value={anesthesia.dose || ''}
               onChange={(e) => handleArrayUpdate('anesthesia', index, { dose: e.target.value })}
               disabled={!isEditing}
@@ -508,6 +522,7 @@ const VisitProtocol = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Область анестезии ${index + 1}`}
               value={anesthesia.area || ''}
               onChange={(e) => handleArrayUpdate('anesthesia', index, { area: e.target.value })}
               disabled={!isEditing}
@@ -522,6 +537,7 @@ const VisitProtocol = ({
                 <label className="flex items-center gap-2">
                   <input
                 type="checkbox"
+                aria-label={`Анестезия ${index + 1} эффективна`}
                 checked={anesthesia.effective || false}
                 onChange={(e) => handleArrayUpdate('anesthesia', index, { effective: e.target.checked })}
                 disabled={!isEditing}
@@ -533,6 +549,7 @@ const VisitProtocol = ({
                 <label className="flex items-center gap-2">
                   <input
                 type="checkbox"
+                aria-label={`У анестезии ${index + 1} были осложнения`}
                 checked={anesthesia.complications || false}
                 onChange={(e) => handleArrayUpdate('anesthesia', index, { complications: e.target.checked })}
                 disabled={!isEditing}
@@ -545,6 +562,7 @@ const VisitProtocol = ({
               {isEditing &&
           <button
             onClick={() => handleArrayRemove('anesthesia', index)}
+            aria-label={`Удалить анестезию ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <Trash2 className="h-4 w-4" />
@@ -599,6 +617,7 @@ const VisitProtocol = ({
                   {isEditing &&
             <button
               onClick={() => handleArrayRemove(`photos.${category}`, index)}
+              aria-label={`Удалить фото ${index + 1}`}
               className="text-red-500 hover:text-red-700">
               
                       <Trash2 className="h-4 w-4" />
@@ -612,6 +631,7 @@ const VisitProtocol = ({
                   <span className="text-sm">Загрузить фото</span>
                   <input
               type="file"
+              aria-label={`Загрузить фото: ${category}`}
               accept="image/*"
               onChange={(e) => {
                 if (e.target.files[0]) {
@@ -668,6 +688,7 @@ const VisitProtocol = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Область рентгена ${index + 1}`}
               value={radiograph.area || ''}
               onChange={(e) => handleArrayUpdate('radiographs', index, { area: e.target.value })}
               disabled={!isEditing}
@@ -679,6 +700,7 @@ const VisitProtocol = ({
             
             <div className="flex items-center justify-between">
               <textarea
+            aria-label={`Описание находок рентгена ${index + 1}`}
             value={radiograph.findings || ''}
             onChange={(e) => handleArrayUpdate('radiographs', index, { findings: e.target.value })}
             disabled={!isEditing}
@@ -689,6 +711,7 @@ const VisitProtocol = ({
               {isEditing &&
           <button
             onClick={() => handleArrayRemove('radiographs', index)}
+            aria-label={`Удалить рентген ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <Trash2 className="h-4 w-4" />
@@ -735,6 +758,7 @@ const VisitProtocol = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Препарат назначения ${index + 1}`}
               value={prescription.medication || ''}
               onChange={(e) => handleArrayUpdate('prescriptions', index, { medication: e.target.value })}
               disabled={!isEditing}
@@ -749,6 +773,7 @@ const VisitProtocol = ({
                 </label>
                 <input
               type="text"
+              aria-label={`Дозировка назначения ${index + 1}`}
               value={prescription.dosage || ''}
               onChange={(e) => handleArrayUpdate('prescriptions', index, { dosage: e.target.value })}
               disabled={!isEditing}
@@ -760,6 +785,7 @@ const VisitProtocol = ({
             
             <div className="flex items-center justify-between">
               <textarea
+            aria-label={`Инструкции по назначению ${index + 1}`}
             value={prescription.instructions || ''}
             onChange={(e) => handleArrayUpdate('prescriptions', index, { instructions: e.target.value })}
             disabled={!isEditing}
@@ -770,6 +796,7 @@ const VisitProtocol = ({
               {isEditing &&
           <button
             onClick={() => handleArrayRemove('prescriptions', index)}
+            aria-label={`Удалить назначение ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <Trash2 className="h-4 w-4" />
@@ -800,6 +827,7 @@ const VisitProtocol = ({
           Общие рекомендации
         </label>
         <textarea
+        aria-label="Общие рекомендации протокола визита"
         value={formData.recommendations || ''}
         onChange={(e) => handleInputChange('recommendations', e.target.value)}
         disabled={!isEditing}
@@ -819,6 +847,7 @@ const VisitProtocol = ({
             </label>
             <input
             type="date"
+            aria-label="Дата следующего визита"
             value={formData.nextVisit.date || ''}
             onChange={(e) => handleInputChange('nextVisit.date', e.target.value)}
             disabled={!isEditing}
@@ -832,6 +861,7 @@ const VisitProtocol = ({
             </label>
             <input
             type="time"
+            aria-label="Время следующего визита"
             value={formData.nextVisit.time || ''}
             onChange={(e) => handleInputChange('nextVisit.time', e.target.value)}
             disabled={!isEditing}
@@ -845,6 +875,7 @@ const VisitProtocol = ({
             </label>
             <input
             type="text"
+            aria-label="Цель следующего визита"
             value={formData.nextVisit.purpose || ''}
             onChange={(e) => handleInputChange('nextVisit.purpose', e.target.value)}
             disabled={!isEditing}
@@ -921,6 +952,7 @@ const VisitProtocol = ({
             }
             <button
               onClick={onClose}
+              aria-label="Закрыть протокол визита"
               className="p-2 text-gray-500 hover:text-gray-700">
               
               <X className="h-5 w-5" />


### PR DESCRIPTION
﻿## Summary
- Added accessible names to dental visit protocol delete controls for procedures, materials, anesthesia, photos, radiographs, prescriptions, and modal close.
- Added accessible names to adjacent visit protocol inputs, checkboxes, textareas, and upload controls so the touched form is clean under targeted JSX a11y lint.
- Reduced the icon-only controls accessibility baseline from 72 to 65 findings and updated the sweep report.

## Contract Impact
- Canonical surface: Frontend dental visit protocol controls only; no canonical API surface changed.
- Request shape: Unchanged because visit protocol handlers and data shape were not changed.
- Response shape: Unchanged because no response parsing or backend contract code changed.
- Status codes: Unchanged because no backend endpoint behavior changed.
- Frontend consumer: Dental visit protocol modal UI in `VisitProtocol.jsx`.
- Compatibility path or alias: Not applicable because no route, alias, or compatibility path changed.
- Contract proof: No backend/API files changed; local frontend build completed successfully.

## RBAC / Permissions
- Roles allowed: Unchanged from existing dental route access.
- Roles denied: Unchanged because no auth or role gate logic changed.
- Positive auth proof: Not applicable because this PR only adds accessible-name metadata and touches no auth logic.
- Negative auth proof: Not applicable because this PR only adds accessible-name metadata and touches no auth logic.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no realtime payload or ack behavior changed.
- Read/unread or delivery semantics: Not applicable because no delivery state code changed.
- Reconnect/resync proof: Not applicable because no websocket, polling, or resync code changed.

## Frontend Resilience
- Empty data proof: Existing empty protocol sections are untouched; labels only name existing controls.
- Partial data proof: Existing partially filled protocol state is untouched; labels use existing row index and field purpose.
- Forbidden secondary path behavior: Unchanged because no route guard or permission behavior changed.
- Missing draft/resource behavior: Unchanged because no draft/resource loading behavior changed.
- Stale route/deep-link behavior: Unchanged because no route or navigation code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/dental/VisitProtocol.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/dental/VisitProtocol.jsx`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: All commands passed locally. Icon-only controls baseline is now 65 findings with 0 new and 0 stale entries.
- Not checked: Browser-authenticated dental visit protocol flow was not run because this PR only adds accessible-name metadata and does not change visual layout or logic.
