### PR TITLE
fix(frontend): label dental examination controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -52,7 +52,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: dental photo archive controls cleanup removed 13 baseline findings.
 - 2026-05-21: dental diagnosis form controls cleanup removed 7 baseline findings.
 - 2026-05-21: dental visit protocol controls cleanup removed 7 baseline findings.
-- Current baseline after this slice: 65 findings.
+- 2026-05-21: dental examination form controls cleanup removed 5 baseline findings.
+- Current baseline after this slice: 60 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T07:24:12.424Z",
+  "generatedAt": "2026-05-21T07:31:02.720Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -128,46 +128,6 @@
       "file": "src/components/dental/DentalPriceManager.jsx",
       "line": 175,
       "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/ExaminationForm.jsx:565:13:button:missing-accessible-name",
-      "file": "src/components/dental/ExaminationForm.jsx",
-      "line": 565,
-      "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/ExaminationForm.jsx:601:13:button:missing-accessible-name",
-      "file": "src/components/dental/ExaminationForm.jsx",
-      "line": 601,
-      "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/ExaminationForm.jsx:637:13:button:missing-accessible-name",
-      "file": "src/components/dental/ExaminationForm.jsx",
-      "line": 637,
-      "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/ExaminationForm.jsx:673:13:button:missing-accessible-name",
-      "file": "src/components/dental/ExaminationForm.jsx",
-      "line": 673,
-      "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/ExaminationForm.jsx:840:13:button:missing-accessible-name",
-      "file": "src/components/dental/ExaminationForm.jsx",
-      "line": 840,
-      "column": 13,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/dental/ExaminationForm.jsx
+++ b/frontend/src/components/dental/ExaminationForm.jsx
@@ -191,6 +191,7 @@ const ExaminationForm = ({
             Лицо
           </label>
           <textarea
+          aria-label="Осмотр лица"
           value={formData.generalCondition.face || ''}
           onChange={(e) => handleInputChange('generalCondition.face', e.target.value)}
           disabled={!isEditing}
@@ -205,6 +206,7 @@ const ExaminationForm = ({
             Губы
           </label>
           <textarea
+          aria-label="Осмотр губ"
           value={formData.generalCondition.lips || ''}
           onChange={(e) => handleInputChange('generalCondition.lips', e.target.value)}
           disabled={!isEditing}
@@ -219,6 +221,7 @@ const ExaminationForm = ({
             Язык
           </label>
           <textarea
+          aria-label="Осмотр языка"
           value={formData.generalCondition.tongue || ''}
           onChange={(e) => handleInputChange('generalCondition.tongue', e.target.value)}
           disabled={!isEditing}
@@ -233,6 +236,7 @@ const ExaminationForm = ({
             Слизистая оболочка
           </label>
           <textarea
+          aria-label="Осмотр слизистой оболочки"
           value={formData.generalCondition.mucosa || ''}
           onChange={(e) => handleInputChange('generalCondition.mucosa', e.target.value)}
           disabled={!isEditing}
@@ -247,6 +251,7 @@ const ExaminationForm = ({
             Десны
           </label>
           <textarea
+          aria-label="Осмотр десен"
           value={formData.generalCondition.gums || ''}
           onChange={(e) => handleInputChange('generalCondition.gums', e.target.value)}
           disabled={!isEditing}
@@ -277,6 +282,7 @@ const ExaminationForm = ({
           <div className="flex items-center gap-2">
             <input
             type="number"
+            aria-label="Индекс гигиены OHI-S"
             step="0.1"
             min="0"
             max="6"
@@ -301,6 +307,7 @@ const ExaminationForm = ({
           <div className="flex items-center gap-2">
             <input
             type="number"
+            aria-label="Индекс зубного налета PLI"
             step="0.1"
             min="0"
             max="3"
@@ -326,6 +333,7 @@ const ExaminationForm = ({
           <div className="flex items-center gap-2">
             <input
             type="number"
+            aria-label="Пародонтальный индекс CPI"
             step="0.1"
             min="0"
             max="4"
@@ -352,6 +360,7 @@ const ExaminationForm = ({
           <div className="flex items-center gap-2">
             <input
             type="number"
+            aria-label="Индекс кровоточивости"
             step="0.1"
             min="0"
             max="100"
@@ -390,6 +399,7 @@ const ExaminationForm = ({
               <input
                 key={position}
                 type="number"
+                aria-label={`Пародонтальный карман зуб ${toothId}, позиция ${position}`}
                 step="0.5"
                 min="0"
                 max="10"
@@ -418,6 +428,7 @@ const ExaminationForm = ({
               <input
                 key={position}
                 type="number"
+                aria-label={`Пародонтальный карман зуб ${toothId}, позиция ${position}`}
                 step="0.5"
                 min="0"
                 max="10"
@@ -460,6 +471,7 @@ const ExaminationForm = ({
           <div className="flex items-center gap-2">
             <input
             type="number"
+            aria-label="Overjet в миллиметрах"
             step="0.1"
             value={formData.measurements.overjet || ''}
             onChange={(e) => handleInputChange('measurements.overjet', e.target.value)}
@@ -477,6 +489,7 @@ const ExaminationForm = ({
           <div className="flex items-center gap-2">
             <input
             type="number"
+            aria-label="Overbite в миллиметрах"
             step="0.1"
             value={formData.measurements.overbite || ''}
             onChange={(e) => handleInputChange('measurements.overbite', e.target.value)}
@@ -492,6 +505,7 @@ const ExaminationForm = ({
             Срединная линия
           </label>
           <select
+          aria-label="Срединная линия"
           value={formData.measurements.midline || ''}
           onChange={(e) => handleInputChange('measurements.midline', e.target.value)}
           disabled={!isEditing}
@@ -509,6 +523,7 @@ const ExaminationForm = ({
             Перекрестный прикус
           </label>
           <select
+          aria-label="Перекрестный прикус"
           value={formData.measurements.crossbite || ''}
           onChange={(e) => handleInputChange('measurements.crossbite', e.target.value)}
           disabled={!isEditing}
@@ -529,6 +544,7 @@ const ExaminationForm = ({
           <div className="flex items-center gap-2">
             <input
             type="number"
+            aria-label="Открытый прикус в миллиметрах"
             step="0.1"
             value={formData.measurements.openBite || ''}
             onChange={(e) => handleInputChange('measurements.openBite', e.target.value)}
@@ -564,6 +580,7 @@ const ExaminationForm = ({
                 {isEditing &&
             <button
               onClick={() => handleArrayRemove('photos.before', index)}
+              aria-label={`Удалить фото до осмотра ${index + 1}`}
               className="text-red-500 hover:text-red-700">
               
                     <Trash2 className="h-4 w-4" />
@@ -577,6 +594,7 @@ const ExaminationForm = ({
                 <span className="text-sm">Загрузить фото</span>
                 <input
               type="file"
+              aria-label="Загрузить фото до осмотра"
               accept="image/*"
               onChange={(e) => {
                 if (e.target.files[0]) {
@@ -600,6 +618,7 @@ const ExaminationForm = ({
                 {isEditing &&
             <button
               onClick={() => handleArrayRemove('photos.after', index)}
+              aria-label={`Удалить фото после осмотра ${index + 1}`}
               className="text-red-500 hover:text-red-700">
               
                     <Trash2 className="h-4 w-4" />
@@ -613,6 +632,7 @@ const ExaminationForm = ({
                 <span className="text-sm">Загрузить фото</span>
                 <input
               type="file"
+              aria-label="Загрузить фото после осмотра"
               accept="image/*"
               onChange={(e) => {
                 if (e.target.files[0]) {
@@ -636,6 +656,7 @@ const ExaminationForm = ({
                 {isEditing &&
             <button
               onClick={() => handleArrayRemove('photos.intraoral', index)}
+              aria-label={`Удалить внутриротовое фото ${index + 1}`}
               className="text-red-500 hover:text-red-700">
               
                     <Trash2 className="h-4 w-4" />
@@ -649,6 +670,7 @@ const ExaminationForm = ({
                 <span className="text-sm">Загрузить фото</span>
                 <input
               type="file"
+              aria-label="Загрузить внутриротовое фото"
               accept="image/*"
               onChange={(e) => {
                 if (e.target.files[0]) {
@@ -672,6 +694,7 @@ const ExaminationForm = ({
                 {isEditing &&
             <button
               onClick={() => handleArrayRemove('photos.extraoral', index)}
+              aria-label={`Удалить внеротовое фото ${index + 1}`}
               className="text-red-500 hover:text-red-700">
               
                     <Trash2 className="h-4 w-4" />
@@ -685,6 +708,7 @@ const ExaminationForm = ({
                 <span className="text-sm">Загрузить фото</span>
                 <input
               type="file"
+              aria-label="Загрузить внеротовое фото"
               accept="image/*"
               onChange={(e) => {
                 if (e.target.files[0]) {
@@ -709,6 +733,7 @@ const ExaminationForm = ({
             </label>
             <input
             type="text"
+            aria-label="Ортопантомограмма"
             value={formData.radiographs.panoramic || ''}
             onChange={(e) => handleInputChange('radiographs.panoramic', e.target.value)}
             disabled={!isEditing}
@@ -723,6 +748,7 @@ const ExaminationForm = ({
             </label>
             <input
             type="text"
+            aria-label="КЛКТ"
             value={formData.radiographs.cbct || ''}
             onChange={(e) => handleInputChange('radiographs.cbct', e.target.value)}
             disabled={!isEditing}
@@ -750,6 +776,7 @@ const ExaminationForm = ({
           Заключение
         </label>
         <textarea
+        aria-label="Заключение по результатам осмотра"
         value={formData.conclusion || ''}
         onChange={(e) => handleInputChange('conclusion', e.target.value)}
         disabled={!isEditing}
@@ -764,6 +791,7 @@ const ExaminationForm = ({
           Рекомендации
         </label>
         <textarea
+        aria-label="Рекомендации по результатам осмотра"
         value={formData.recommendations || ''}
         onChange={(e) => handleInputChange('recommendations', e.target.value)}
         disabled={!isEditing}
@@ -839,6 +867,7 @@ const ExaminationForm = ({
             }
             <button
               onClick={onClose}
+              aria-label="Закрыть форму осмотра"
               className="p-2 text-gray-500 hover:text-gray-700">
               
               <X className="h-5 w-5" />


### PR DESCRIPTION
﻿## Summary
- Added accessible names to dental examination photo delete/upload controls and modal close.
- Added accessible names to adjacent examination inputs, textareas, selects, periodontal pocket fields, radiograph fields, and summary fields so the touched form is clean under targeted JSX a11y lint.
- Reduced the icon-only controls accessibility baseline from 65 to 60 findings and updated the sweep report.

## Contract Impact
- Canonical surface: Frontend dental examination form controls only; no canonical API surface changed.
- Request shape: Unchanged because examination handlers and data shape were not changed.
- Response shape: Unchanged because no response parsing or backend contract code changed.
- Status codes: Unchanged because no backend endpoint behavior changed.
- Frontend consumer: Dental examination modal UI in `ExaminationForm.jsx`.
- Compatibility path or alias: Not applicable because no route, alias, or compatibility path changed.
- Contract proof: No backend/API files changed; local frontend build completed successfully.

## RBAC / Permissions
- Roles allowed: Unchanged from existing dental route access.
- Roles denied: Unchanged because no auth or role gate logic changed.
- Positive auth proof: Not applicable because this PR only adds accessible-name metadata and touches no auth logic.
- Negative auth proof: Not applicable because this PR only adds accessible-name metadata and touches no auth logic.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no realtime payload or ack behavior changed.
- Read/unread or delivery semantics: Not applicable because no delivery state code changed.
- Reconnect/resync proof: Not applicable because no websocket, polling, or resync code changed.

## Frontend Resilience
- Empty data proof: Existing empty examination sections are untouched; labels only name existing controls.
- Partial data proof: Existing partially filled examination state is untouched; labels use existing field purpose and repeated-row context.
- Forbidden secondary path behavior: Unchanged because no route guard or permission behavior changed.
- Missing draft/resource behavior: Unchanged because no draft/resource loading behavior changed.
- Stale route/deep-link behavior: Unchanged because no route or navigation code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/dental/ExaminationForm.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/dental/ExaminationForm.jsx`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: All commands passed locally. Icon-only controls baseline is now 60 findings with 0 new and 0 stale entries.
- Not checked: Browser-authenticated dental examination flow was not run because this PR only adds accessible-name metadata and does not change visual layout or logic.
