### PR TITLE
fix(frontend): label dental protocol template controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -53,7 +53,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: dental diagnosis form controls cleanup removed 7 baseline findings.
 - 2026-05-21: dental visit protocol controls cleanup removed 7 baseline findings.
 - 2026-05-21: dental examination form controls cleanup removed 5 baseline findings.
-- Current baseline after this slice: 60 findings.
+- 2026-05-21: dental protocol template controls cleanup removed 5 baseline findings.
+- Current baseline after this slice: 55 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T07:31:02.720Z",
+  "generatedAt": "2026-05-21T07:38:22.453Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -159,46 +159,6 @@
       "signature": "src/components/dental/PatientCard.jsx:813:13:button:missing-accessible-name",
       "file": "src/components/dental/PatientCard.jsx",
       "line": 813,
-      "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/ProtocolTemplates.jsx:388:9:button:title-only",
-      "file": "src/components/dental/ProtocolTemplates.jsx",
-      "line": 388,
-      "column": 9,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/dental/ProtocolTemplates.jsx:395:9:button:title-only",
-      "file": "src/components/dental/ProtocolTemplates.jsx",
-      "line": 395,
-      "column": 9,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/dental/ProtocolTemplates.jsx:403:7:button:title-only",
-      "file": "src/components/dental/ProtocolTemplates.jsx",
-      "line": 403,
-      "column": 7,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/dental/ProtocolTemplates.jsx:420:9:button:missing-accessible-name",
-      "file": "src/components/dental/ProtocolTemplates.jsx",
-      "line": 420,
-      "column": 9,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/ProtocolTemplates.jsx:555:13:button:missing-accessible-name",
-      "file": "src/components/dental/ProtocolTemplates.jsx",
-      "line": 555,
       "column": 13,
       "element": "button",
       "reason": "missing-accessible-name"

--- a/frontend/src/components/dental/ProtocolTemplates.jsx
+++ b/frontend/src/components/dental/ProtocolTemplates.jsx
@@ -388,6 +388,7 @@ const ProtocolTemplates = ({
         <button
         onClick={() => handleEditTemplate(template)}
         className="px-3 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50"
+        aria-label={`Редактировать шаблон ${template.name}`}
         title="Редактировать">
         
           <Edit className="h-4 w-4" />
@@ -395,6 +396,7 @@ const ProtocolTemplates = ({
         <button
         onClick={() => handleDuplicateTemplate(template)}
         className="px-3 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50"
+        aria-label={`Дублировать шаблон ${template.name}`}
         title="Дублировать">
         
           <Copy className="h-4 w-4" />
@@ -403,6 +405,7 @@ const ProtocolTemplates = ({
       <button
         onClick={() => handleDeleteTemplate(template.id)}
         className="px-3 py-2 border border-gray-300 text-red-700 rounded-md hover:bg-red-50"
+        aria-label={`Удалить шаблон ${template.name}`}
         title="Удалить">
         
             <Trash2 className="h-4 w-4" />
@@ -419,6 +422,7 @@ const ProtocolTemplates = ({
         <h2 className="text-xl font-semibold">{template.name}</h2>
         <button
         onClick={() => setSelectedTemplate(null)}
+        aria-label={`Закрыть просмотр шаблона ${template.name}`}
         className="p-2 text-gray-500 hover:text-gray-700">
         
           <X className="h-5 w-5" />
@@ -554,6 +558,7 @@ const ProtocolTemplates = ({
             </button>
             <button
               onClick={onClose}
+              aria-label="Закрыть шаблоны протоколов"
               className="p-2 text-gray-500 hover:text-gray-700">
               
               <X className="h-5 w-5" />
@@ -571,6 +576,7 @@ const ProtocolTemplates = ({
                 <input
                   type="text"
                   placeholder="Поиск шаблонов..."
+                  aria-label="Поиск шаблонов протоколов"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent" />
@@ -583,6 +589,7 @@ const ProtocolTemplates = ({
               <select
                 value={filterCategory}
                 onChange={(e) => setFilterCategory(e.target.value)}
+                aria-label="Фильтр шаблонов по категории"
                 className="px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent">
                 
                 {categories.map((category) =>
@@ -595,6 +602,7 @@ const ProtocolTemplates = ({
               <select
                 value={filterDifficulty}
                 onChange={(e) => setFilterDifficulty(e.target.value)}
+                aria-label="Фильтр шаблонов по сложности"
                 className="px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent">
                 
                 {difficulties.map((difficulty) =>


### PR DESCRIPTION
﻿## Summary
- Added accessible names for dental protocol template icon-only controls: edit, duplicate, delete, and close actions.
- Added accessible labels to the protocol template search and filter controls surfaced by targeted a11y lint.
- Reduced the icon-only controls baseline from 60 to 55 and updated the global sweep report.

## Contract Impact
- Canonical surface: Frontend-only dental protocol template accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive robust control names; visual UI and handlers are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 55 findings, 55 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing empty/list behavior is unchanged; labels only reference the rendered template name when a template exists.
- Partial data proof: Existing partial template rendering is unchanged; this PR does not alter data branching or fallbacks.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/dental/ProtocolTemplates.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/dental/ProtocolTemplates.jsx`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. Targeted ESLint has one pre-existing `react-hooks/exhaustive-deps` warning in this file and no a11y errors; full quiet lint passed.
- Not checked: Browser-authenticated dental protocol template flow was not run because this PR only adds accessible-name metadata and does not change visual layout or logic.
