### PR TITLE
fix(frontend): label dental chart controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -54,7 +54,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: dental visit protocol controls cleanup removed 7 baseline findings.
 - 2026-05-21: dental examination form controls cleanup removed 5 baseline findings.
 - 2026-05-21: dental protocol template controls cleanup removed 5 baseline findings.
-- Current baseline after this slice: 55 findings.
+- 2026-05-21: dental chart controls cleanup removed 4 baseline findings.
+- Current baseline after this slice: 51 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T07:38:22.453Z",
+  "generatedAt": "2026-05-21T07:44:51.125Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -88,38 +88,6 @@
       "file": "src/components/common/ScheduleNextModal.jsx",
       "line": 537,
       "column": 17,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/DentalChart.jsx:286:11:button:title-only",
-      "file": "src/components/dental/DentalChart.jsx",
-      "line": 286,
-      "column": 11,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/dental/DentalChart.jsx:293:11:button:title-only",
-      "file": "src/components/dental/DentalChart.jsx",
-      "line": 293,
-      "column": 11,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/dental/DentalChart.jsx:300:11:button:title-only",
-      "file": "src/components/dental/DentalChart.jsx",
-      "line": 300,
-      "column": 11,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/dental/DentalChart.jsx:737:21:button:missing-accessible-name",
-      "file": "src/components/dental/DentalChart.jsx",
-      "line": 737,
-      "column": 21,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/dental/DentalChart.jsx
+++ b/frontend/src/components/dental/DentalChart.jsx
@@ -286,6 +286,7 @@ const DentalChart = ({
           <button
             onClick={() => handleZoom('in')}
             className="btn btn-sm"
+            aria-label="Увеличить зубную карту"
             title="Увеличить">
             
             <ZoomIn size={16} />
@@ -293,6 +294,7 @@ const DentalChart = ({
           <button
             onClick={() => handleZoom('out')}
             className="btn btn-sm"
+            aria-label="Уменьшить зубную карту"
             title="Уменьшить">
             
             <ZoomOut size={16} />
@@ -300,6 +302,7 @@ const DentalChart = ({
           <button
             onClick={() => setZoom(1)}
             className="btn btn-sm"
+            aria-label="Сбросить масштаб зубной карты"
             title="Сбросить масштаб">
             
             <RotateCcw size={16} />
@@ -498,6 +501,7 @@ const ToothModal = ({ tooth, toothId, onUpdate, onClose }) => {
               value={formData.condition}
               onChange={(e) => setFormData({ ...formData, condition: e.target.value })}
               placeholder="Введите диагноз"
+              aria-label={`Диагноз зуба ${toothId}`}
               style={{
                 width: '100%',
                 padding: '8px',
@@ -518,6 +522,7 @@ const ToothModal = ({ tooth, toothId, onUpdate, onClose }) => {
               value={formData.treatment}
               onChange={(e) => setFormData({ ...formData, treatment: e.target.value })}
               placeholder="Введите план лечения"
+              aria-label={`План лечения зуба ${toothId}`}
               style={{
                 width: '100%',
                 padding: '8px',
@@ -537,6 +542,7 @@ const ToothModal = ({ tooth, toothId, onUpdate, onClose }) => {
               value={formData.notes}
               onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
               placeholder="Дополнительные заметки"
+              aria-label={`Примечания к зубу ${toothId}`}
               rows={3}
               style={{
                 width: '100%',
@@ -663,6 +669,7 @@ const TreatmentPlanModal = ({ treatmentPlan, onUpdate, onClose, teeth }) => {
               value={newItem.treatment}
               onChange={(e) => setNewItem({ ...newItem, treatment: e.target.value })}
               placeholder="Описание лечения"
+              aria-label="Описание нового пункта лечения"
               style={{ padding: '8px', border: '1px solid var(--mac-border)', borderRadius: '4px', backgroundColor: 'var(--mac-bg-primary)', color: 'var(--mac-text-primary)' }} />
             
           </div>
@@ -681,6 +688,7 @@ const TreatmentPlanModal = ({ treatmentPlan, onUpdate, onClose, teeth }) => {
               value={newItem.estimatedCost}
               onChange={(e) => setNewItem({ ...newItem, estimatedCost: e.target.value })}
               placeholder="Стоимость"
+              aria-label="Стоимость нового пункта лечения"
               style={{ padding: '8px', border: '1px solid var(--mac-border)', borderRadius: '4px', backgroundColor: 'var(--mac-bg-primary)', color: 'var(--mac-text-primary)' }} />
             
             <input
@@ -688,6 +696,7 @@ const TreatmentPlanModal = ({ treatmentPlan, onUpdate, onClose, teeth }) => {
               value={newItem.estimatedTime}
               onChange={(e) => setNewItem({ ...newItem, estimatedTime: e.target.value })}
               placeholder="Время (мин)"
+              aria-label="Время нового пункта лечения в минутах"
               style={{ padding: '8px', border: '1px solid var(--mac-border)', borderRadius: '4px', backgroundColor: 'var(--mac-bg-primary)', color: 'var(--mac-text-primary)' }} />
             
           </div>
@@ -736,6 +745,7 @@ const TreatmentPlanModal = ({ treatmentPlan, onUpdate, onClose, teeth }) => {
                     </div>
                     <button
                   onClick={() => removeItem(item.id)}
+                  aria-label={`Удалить пункт плана лечения для зуба ${item.toothId}`}
                   style={{
                     padding: '4px 8px',
                     border: 'none',


### PR DESCRIPTION
﻿## Summary
- Added accessible names for dental chart zoom controls and treatment-plan delete controls.
- Added accessible labels to adjacent dental chart form fields surfaced by targeted a11y lint.
- Reduced the icon-only controls baseline from 55 to 51 and updated the global sweep report.

## Contract Impact
- Canonical surface: Frontend-only dental chart accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive robust control names; visual UI and chart/treatment handlers are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 51 findings, 51 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing empty treatment-plan behavior is unchanged.
- Partial data proof: Existing tooth/treatment rendering is unchanged; this PR only adds labels to rendered controls and inputs.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/dental/DentalChart.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/dental/DentalChart.jsx`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed.
- Not checked: Browser-authenticated dental chart flow was not run because this PR only adds accessible-name metadata and does not change visual layout or logic.
