### PR TITLE
fix(frontend): label dental patient card controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -55,7 +55,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: dental examination form controls cleanup removed 5 baseline findings.
 - 2026-05-21: dental protocol template controls cleanup removed 5 baseline findings.
 - 2026-05-21: dental chart controls cleanup removed 4 baseline findings.
-- Current baseline after this slice: 51 findings.
+- 2026-05-21: dental patient card controls cleanup removed 4 baseline findings.
+- Current baseline after this slice: 47 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T07:44:51.125Z",
+  "generatedAt": "2026-05-21T07:49:19.163Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -96,38 +96,6 @@
       "file": "src/components/dental/DentalPriceManager.jsx",
       "line": 175,
       "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PatientCard.jsx:509:11:button:missing-accessible-name",
-      "file": "src/components/dental/PatientCard.jsx",
-      "line": 509,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PatientCard.jsx:553:11:button:missing-accessible-name",
-      "file": "src/components/dental/PatientCard.jsx",
-      "line": 553,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PatientCard.jsx:597:11:button:missing-accessible-name",
-      "file": "src/components/dental/PatientCard.jsx",
-      "line": 597,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/PatientCard.jsx:813:13:button:missing-accessible-name",
-      "file": "src/components/dental/PatientCard.jsx",
-      "line": 813,
-      "column": 13,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/dental/PatientCard.jsx
+++ b/frontend/src/components/dental/PatientCard.jsx
@@ -503,12 +503,14 @@ const PatientCard = ({
             }}
             disabled={!isEditing}
             className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100"
+            aria-label={`Соматическое заболевание ${index + 1}`}
             placeholder="Название заболевания" />
           
               {isEditing &&
           <button
             type="button"
             onClick={() => handleArrayRemove('medicalHistory.somaticDiseases', index)}
+            aria-label={`Удалить соматическое заболевание ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <X className="h-4 w-4" />
@@ -547,12 +549,14 @@ const PatientCard = ({
             }}
             disabled={!isEditing}
             className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100"
+            aria-label={`Аллергия ${index + 1}`}
             placeholder="Аллерген (например: лидокаин, пенициллин)" />
           
               {isEditing &&
           <button
             type="button"
             onClick={() => handleArrayRemove('medicalHistory.allergies', index)}
+            aria-label={`Удалить аллергию ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <X className="h-4 w-4" />
@@ -591,12 +595,14 @@ const PatientCard = ({
             }}
             disabled={!isEditing}
             className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100"
+            aria-label={`Текущее лекарство ${index + 1}`}
             placeholder="Название лекарства и дозировка" />
           
               {isEditing &&
           <button
             type="button"
             onClick={() => handleArrayRemove('medicalHistory.currentMedications', index)}
+            aria-label={`Удалить текущее лекарство ${index + 1}`}
             className="text-red-500 hover:text-red-700">
             
                   <X className="h-4 w-4" />
@@ -812,6 +818,7 @@ const PatientCard = ({
             }
             <button
               onClick={onClose}
+              aria-label={`Закрыть карточку пациента ${formData.surname || ''} ${formData.name || ''}`.trim()}
               className="p-2 text-gray-500 hover:text-gray-700">
               
               <X className="h-5 w-5" />


### PR DESCRIPTION
﻿## Summary
- Added accessible names for dental patient card icon-only controls that remove medical-history entries and close the card.
- Added accessible labels to the touched dynamic medical-history text fields.
- Reduced the icon-only controls baseline from 51 to 47 and updated the global sweep report.

## Contract Impact
- Canonical surface: Frontend-only dental patient card accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive robust control names; visual UI and patient-card handlers are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 47 findings, 47 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing empty medical-history array behavior is unchanged.
- Partial data proof: Existing patient-card rendering is unchanged; this PR only adds labels to rendered controls and touched dynamic fields.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/dental/PatientCard.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/dental/PatientCard.jsx`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. Targeted ESLint has pre-existing warning-level form-label debt elsewhere in `PatientCard.jsx`; the full CI lint command with `--quiet` passed, and the icon-only baseline gate is clean.
- Not checked: Browser-authenticated dental patient card flow was not run because this PR only adds accessible-name metadata and does not change visual layout or logic.
