### PR TITLE
fix(frontend): label dental teeth chart controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -56,7 +56,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: dental protocol template controls cleanup removed 5 baseline findings.
 - 2026-05-21: dental chart controls cleanup removed 4 baseline findings.
 - 2026-05-21: dental patient card controls cleanup removed 4 baseline findings.
-- Current baseline after this slice: 47 findings.
+- 2026-05-21: dental teeth chart controls cleanup removed 3 baseline findings.
+- Current baseline after this slice: 44 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T07:49:19.163Z",
+  "generatedAt": "2026-05-21T07:53:58.864Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -104,30 +104,6 @@
       "file": "src/components/dental/ReportsAndAnalytics.jsx",
       "line": 566,
       "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/TeethChart.jsx:138:9:button:missing-accessible-name",
-      "file": "src/components/dental/TeethChart.jsx",
-      "line": 138,
-      "column": 9,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/TeethChart.jsx:223:15:button:missing-accessible-name",
-      "file": "src/components/dental/TeethChart.jsx",
-      "line": 223,
-      "column": 15,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/TeethChart.jsx:237:15:button:missing-accessible-name",
-      "file": "src/components/dental/TeethChart.jsx",
-      "line": 237,
-      "column": 15,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/dental/TeethChart.jsx
+++ b/frontend/src/components/dental/TeethChart.jsx
@@ -137,6 +137,7 @@ const TeethChart = ({ onToothClick, initialData = {}, readOnly = false }) => {
         
         <button
           onClick={() => handleToothClick(toothNumber)}
+          aria-label={`Зуб ${toothNumber}: ${STATUS_NAMES[status]}`}
           style={{
             color: STATUS_COLORS[status],
             border: isSelected ? '2px solid var(--mac-accent-blue)' : '1px solid var(--mac-border)',
@@ -222,6 +223,7 @@ const TeethChart = ({ onToothClick, initialData = {}, readOnly = false }) => {
             <div style={{ display: 'flex', border: '1px solid var(--mac-border)', borderRadius: 8, overflow: 'hidden' }}>
               <button
                 onClick={() => setZoom(Math.max(0.5, zoom - 0.1))}
+                aria-label="Уменьшить зубную карту"
                 style={{
                   padding: '8px 12px',
                   border: 'none',
@@ -236,6 +238,7 @@ const TeethChart = ({ onToothClick, initialData = {}, readOnly = false }) => {
               </button>
               <button
                 onClick={() => setZoom(Math.min(2, zoom + 0.1))}
+                aria-label="Увеличить зубную карту"
                 style={{
                   padding: '8px 12px',
                   border: 'none',


### PR DESCRIPTION
﻿## Summary
- Added accessible names for dental teeth chart tooth buttons and zoom controls.
- Reduced the icon-only controls baseline from 47 to 44 and updated the global sweep report.
- Kept dental chart behavior, view mode, and tooth selection logic unchanged.

## Contract Impact
- Canonical surface: Frontend-only dental teeth chart accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive robust control names; visual UI and tooth-selection handlers are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 44 findings, 44 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing missing tooth data fallback remains unchanged.
- Partial data proof: Existing tooth status fallback remains unchanged; labels use the existing rendered tooth number and status name.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/dental/TeethChart.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/dental/TeethChart.jsx`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed.
- Not checked: Browser-authenticated dental teeth chart flow was not run because this PR only adds accessible-name metadata and does not change visual layout or logic.
