### PR TITLE
fix(frontend): label remaining dental controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -57,7 +57,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: dental chart controls cleanup removed 4 baseline findings.
 - 2026-05-21: dental patient card controls cleanup removed 4 baseline findings.
 - 2026-05-21: dental teeth chart controls cleanup removed 3 baseline findings.
-- Current baseline after this slice: 44 findings.
+- 2026-05-21: remaining dental close controls cleanup removed 4 baseline findings.
+- Current baseline after this slice: 40 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T07:53:58.864Z",
+  "generatedAt": "2026-05-21T07:59:03.935Z",
   "entries": [
     {
       "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
@@ -88,22 +88,6 @@
       "file": "src/components/common/ScheduleNextModal.jsx",
       "line": 537,
       "column": 17,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/DentalPriceManager.jsx:175:11:button:missing-accessible-name",
-      "file": "src/components/dental/DentalPriceManager.jsx",
-      "line": 175,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/dental/ReportsAndAnalytics.jsx:566:13:button:missing-accessible-name",
-      "file": "src/components/dental/ReportsAndAnalytics.jsx",
-      "line": 566,
-      "column": 13,
       "element": "button",
       "reason": "missing-accessible-name"
     },
@@ -280,22 +264,6 @@
       "file": "src/components/wizard/AppointmentWizardV2.jsx",
       "line": 3764,
       "column": 21,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DentistPanelUnified.jsx:3588:15:button:missing-accessible-name",
-      "file": "src/pages/DentistPanelUnified.jsx",
-      "line": 3588,
-      "column": 15,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DentistPanelUnified.jsx:3661:15:button:missing-accessible-name",
-      "file": "src/pages/DentistPanelUnified.jsx",
-      "line": 3661,
-      "column": 15,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/dental/DentalPriceManager.jsx
+++ b/frontend/src/components/dental/DentalPriceManager.jsx
@@ -174,6 +174,7 @@ const DentalPriceManager = ({
           </div>
           <button
             onClick={onClose}
+            aria-label={`Закрыть указание цены для услуги ${serviceName}`}
             className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
             
             <X size={24} />

--- a/frontend/src/components/dental/ReportsAndAnalytics.jsx
+++ b/frontend/src/components/dental/ReportsAndAnalytics.jsx
@@ -565,6 +565,7 @@ const ReportsAndAnalytics = ({
             
             <button
               onClick={onClose}
+              aria-label="Закрыть отчеты и аналитику стоматологии"
               className="p-2 text-gray-500 hover:text-gray-700">
               
               <X className="h-5 w-5" />

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -3587,6 +3587,7 @@ const DentistPanelUnified = () => {
               </h2>
               <button
               onClick={() => setShowDentalChart(false)}
+              aria-label={`Закрыть схему зубов пациента ${selectedPatientDisplayName}`}
               style={{
                 background: 'none',
                 border: 'none',
@@ -3660,6 +3661,7 @@ const DentistPanelUnified = () => {
               </h2>
               <button
               onClick={() => setShowTreatmentPlanner(false)}
+              aria-label={`Закрыть план лечения пациента ${selectedPatientDisplayName}`}
               style={{
                 background: 'none',
                 border: 'none',


### PR DESCRIPTION
﻿## Summary
- Added accessible names to the remaining dental close icon controls in price manager, analytics, dental chart overlay, and treatment planner overlay.
- Reduced the icon-only controls baseline from 44 to 40 and updated the global sweep report.
- Closed the remaining dental-specific icon-only baseline entries.

## Contract Impact
- Canonical surface: Frontend-only dental close-control accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive robust control names; visual UI and close handlers are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 40 findings, 40 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing dental overlay/modal rendering is unchanged.
- Partial data proof: Existing selected patient/service display remains unchanged; labels reuse already-rendered context.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/dental/DentalPriceManager.jsx`, `frontend/src/components/dental/ReportsAndAnalytics.jsx`, `frontend/src/pages/DentistPanelUnified.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/dental/DentalPriceManager.jsx src/components/dental/ReportsAndAnalytics.jsx src/pages/DentistPanelUnified.jsx --quiet`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed.
- Not checked: Browser-authenticated dental overlays were not run because this PR only adds accessible-name metadata and does not change visual layout or logic.
