### PR TITLE
fix(frontend): label two factor controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -58,7 +58,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: dental patient card controls cleanup removed 4 baseline findings.
 - 2026-05-21: dental teeth chart controls cleanup removed 3 baseline findings.
 - 2026-05-21: remaining dental close controls cleanup removed 4 baseline findings.
-- Current baseline after this slice: 40 findings.
+- 2026-05-21: two-factor security controls cleanup removed 7 baseline findings.
+- Current baseline after this slice: 33 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,32 +1,8 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T07:59:03.935Z",
+  "generatedAt": "2026-05-21T08:04:39.260Z",
   "entries": [
-    {
-      "signature": "src/components/TwoFactorSettings.jsx:369:21:button:missing-accessible-name",
-      "file": "src/components/TwoFactorSettings.jsx",
-      "line": 369,
-      "column": 21,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/TwoFactorSetup.jsx:253:13:button:missing-accessible-name",
-      "file": "src/components/TwoFactorSetup.jsx",
-      "line": 253,
-      "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/TwoFactorSetup.jsx:421:15:button:missing-accessible-name",
-      "file": "src/components/TwoFactorSetup.jsx",
-      "line": 421,
-      "column": 15,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
     {
       "signature": "src/components/admin/FinanceModal.jsx:215:13:button:missing-accessible-name",
       "file": "src/components/admin/FinanceModal.jsx",
@@ -176,38 +152,6 @@
       "file": "src/components/notifications/EmailSMSManager.jsx",
       "line": 712,
       "column": 21,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/security/SMSEmail2FA.jsx:214:15:button:missing-accessible-name",
-      "file": "src/components/security/SMSEmail2FA.jsx",
-      "line": 214,
-      "column": 15,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/security/TwoFactorSetupWizard.jsx:365:15:button:missing-accessible-name",
-      "file": "src/components/security/TwoFactorSetupWizard.jsx",
-      "line": 365,
-      "column": 15,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/security/TwoFactorSetupWizard.jsx:371:15:button:missing-accessible-name",
-      "file": "src/components/security/TwoFactorSetupWizard.jsx",
-      "line": 371,
-      "column": 15,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/security/TwoFactorSetupWizard.jsx:441:15:button:missing-accessible-name",
-      "file": "src/components/security/TwoFactorSetupWizard.jsx",
-      "line": 441,
-      "column": 15,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/TwoFactorSettings.jsx
+++ b/frontend/src/components/TwoFactorSettings.jsx
@@ -368,6 +368,7 @@ const TwoFactorSettings = () => {
                     </code>
                     <button
                 onClick={() => copyToClipboard(code, `code-${index}`)}
+                aria-label={`Скопировать резервный код ${index + 1}`}
                 style={{
                   padding: '4px',
                   background: 'transparent',

--- a/frontend/src/components/TwoFactorSetup.jsx
+++ b/frontend/src/components/TwoFactorSetup.jsx
@@ -252,6 +252,7 @@ const TwoFactorSetup = ({ onComplete, onCancel }) => {
             </code>
             <button
             onClick={() => copyToClipboard(setupData?.secret_key, 'secret')}
+            aria-label="Скопировать секретный ключ двухфакторной аутентификации"
             style={{
               padding: '4px 8px',
               background: 'var(--accent-color)',
@@ -420,6 +421,7 @@ const TwoFactorSetup = ({ onComplete, onCancel }) => {
               </code>
               <button
             onClick={() => copyToClipboard(code, `code-${index}`)}
+            aria-label={`Скопировать резервный код ${index + 1}`}
             style={{
               padding: '4px',
               background: 'transparent',

--- a/frontend/src/components/security/SMSEmail2FA.jsx
+++ b/frontend/src/components/security/SMSEmail2FA.jsx
@@ -214,6 +214,7 @@ const SMSEmail2FA = ({
               <button
                 type="button"
                 onClick={() => setShowCode(!showCode)}
+                aria-label={showCode ? 'Скрыть код подтверждения' : 'Показать код подтверждения'}
                 className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600">
                 
                 {showCode ?

--- a/frontend/src/components/security/TwoFactorSetupWizard.jsx
+++ b/frontend/src/components/security/TwoFactorSetupWizard.jsx
@@ -364,12 +364,14 @@ const TwoFactorSetupWizard = ({ onComplete }) => {
               </code>
               <button
             onClick={() => setShowSecret(!showSecret)}
+            aria-label={showSecret ? 'Скрыть секретный ключ' : 'Показать секретный ключ'}
             className="text-gray-400 hover:text-gray-600">
             
                 {showSecret ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
               </button>
               <button
             onClick={() => copyToClipboard(setupData.secret)}
+            aria-label="Скопировать секретный ключ"
             className="text-gray-400 hover:text-gray-600">
             
                 <Copy className="w-4 h-4" />
@@ -440,6 +442,7 @@ const TwoFactorSetupWizard = ({ onComplete }) => {
               <code className="font-mono text-sm">{code}</code>
               <button
             onClick={() => copyToClipboard(code)}
+            aria-label={`Скопировать резервный код ${index + 1}`}
             className="text-gray-400 hover:text-gray-600">
             
                 <Copy className="w-4 h-4" />


### PR DESCRIPTION
﻿## Summary
- Added accessible names for icon-only two-factor/security controls: copy secret, copy backup code, show/hide confirmation code, and show/hide setup secret.
- Reduced the icon-only controls baseline from 40 to 33 and updated the global sweep report.
- Kept 2FA setup, copy, verification, and security flows unchanged.

## Contract Impact
- Canonical surface: Frontend-only 2FA/security accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive robust control names; visual UI and security handlers are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 33 findings, 33 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing 2FA setup and backup-code rendering remains unchanged.
- Partial data proof: Existing secret and backup-code display/copy behavior remains unchanged; labels reuse already-rendered state and indexes.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/TwoFactorSettings.jsx`, `frontend/src/components/TwoFactorSetup.jsx`, `frontend/src/components/security/SMSEmail2FA.jsx`, `frontend/src/components/security/TwoFactorSetupWizard.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/TwoFactorSettings.jsx src/components/TwoFactorSetup.jsx src/components/security/SMSEmail2FA.jsx src/components/security/TwoFactorSetupWizard.jsx --quiet`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed.
- Not checked: Browser-authenticated 2FA setup flow was not run because this PR only adds accessible-name metadata and does not change visual layout or security logic.
