### PR TITLE
fix(frontend): label auth password controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -59,7 +59,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: dental teeth chart controls cleanup removed 3 baseline findings.
 - 2026-05-21: remaining dental close controls cleanup removed 4 baseline findings.
 - 2026-05-21: two-factor security controls cleanup removed 7 baseline findings.
-- Current baseline after this slice: 33 findings.
+- 2026-05-21: auth password controls cleanup removed 6 baseline findings.
+- Current baseline after this slice: 27 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T08:04:39.260Z",
+  "generatedAt": "2026-05-21T08:09:58.128Z",
   "entries": [
     {
       "signature": "src/components/admin/FinanceModal.jsx:215:13:button:missing-accessible-name",
@@ -17,30 +17,6 @@
       "line": 74,
       "column": 11,
       "element": "div",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/auth/ForgotPassword.jsx:337:11:button:missing-accessible-name",
-      "file": "src/components/auth/ForgotPassword.jsx",
-      "line": 337,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/auth/ForgotPassword.jsx:399:11:button:missing-accessible-name",
-      "file": "src/components/auth/ForgotPassword.jsx",
-      "line": 399,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/auth/ForgotPassword.jsx:491:9:button:missing-accessible-name",
-      "file": "src/components/auth/ForgotPassword.jsx",
-      "line": 491,
-      "column": 9,
-      "element": "button",
       "reason": "missing-accessible-name"
     },
     {
@@ -240,30 +216,6 @@
       "file": "src/pages/RegistrarPanel.jsx",
       "line": 3842,
       "column": 19,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/auth/ChangePasswordRequired.jsx:213:25:button:missing-accessible-name",
-      "file": "src/pages/auth/ChangePasswordRequired.jsx",
-      "line": 213,
-      "column": 25,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/auth/ChangePasswordRequired.jsx:232:25:button:missing-accessible-name",
-      "file": "src/pages/auth/ChangePasswordRequired.jsx",
-      "line": 232,
-      "column": 25,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/auth/ChangePasswordRequired.jsx:264:25:button:missing-accessible-name",
-      "file": "src/pages/auth/ChangePasswordRequired.jsx",
-      "line": 264,
-      "column": 25,
       "element": "button",
       "reason": "missing-accessible-name"
     }

--- a/frontend/src/components/auth/ForgotPassword.jsx
+++ b/frontend/src/components/auth/ForgotPassword.jsx
@@ -338,6 +338,7 @@ const ForgotPassword = ({ onBack, onSuccess, language = 'RU' }) => {
           onClick={handleMethodSelect}
           className="btn-premium btn-primary"
           style={{ flex: 1, justifyContent: 'center' }}
+          aria-label={loading ? t.sending : t.continue}
           disabled={loading || !contact.trim()}>
 
             {loading ?
@@ -400,6 +401,7 @@ const ForgotPassword = ({ onBack, onSuccess, language = 'RU' }) => {
           onClick={handleVerifyPhoneCode}
           className="btn-premium btn-primary"
           style={{ flex: 1, justifyContent: 'center' }}
+          aria-label={loading ? 'Проверка кода восстановления' : 'Подтвердить код восстановления'}
           disabled={loading || !verificationCode || verificationCode.length !== 6}>
 
             {loading ?
@@ -492,6 +494,7 @@ const ForgotPassword = ({ onBack, onSuccess, language = 'RU' }) => {
         onClick={handlePasswordReset}
         className="btn-premium btn-primary"
         style={{ width: '100%', justifyContent: 'center' }}
+        aria-label={loading ? t.resetting : t.resetPassword}
         disabled={loading || !newPassword || !confirmPassword}>
 
           {loading ?

--- a/frontend/src/pages/auth/ChangePasswordRequired.jsx
+++ b/frontend/src/pages/auth/ChangePasswordRequired.jsx
@@ -213,6 +213,7 @@ export default function ChangePasswordRequired({ currentPassword }) {
                         <button
                             type="button"
                             style={toggleButtonStyle}
+                            aria-label={showCurrentPassword ? 'Скрыть текущий пароль' : 'Показать текущий пароль'}
                             onClick={() => setShowCurrentPassword(!showCurrentPassword)}
                         >
                             {showCurrentPassword ? <EyeOff size={18} /> : <Eye size={18} />}
@@ -232,6 +233,7 @@ export default function ChangePasswordRequired({ currentPassword }) {
                         <button
                             type="button"
                             style={toggleButtonStyle}
+                            aria-label={showNewPassword ? 'Скрыть новый пароль' : 'Показать новый пароль'}
                             onClick={() => setShowNewPassword(!showNewPassword)}
                         >
                             {showNewPassword ? <EyeOff size={18} /> : <Eye size={18} />}
@@ -264,6 +266,7 @@ export default function ChangePasswordRequired({ currentPassword }) {
                         <button
                             type="button"
                             style={toggleButtonStyle}
+                            aria-label={showConfirmPassword ? 'Скрыть подтверждение пароля' : 'Показать подтверждение пароля'}
                             onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                         >
                             {showConfirmPassword ? <EyeOff size={18} /> : <Eye size={18} />}


### PR DESCRIPTION
﻿## Summary
- Added accessible names for password recovery and forced password-change icon/conditional controls.
- Reduced the icon-only controls baseline from 33 to 27 and updated the global sweep report.
- Kept auth/password reset flows unchanged.

## Contract Impact
- Canonical surface: Frontend-only auth password accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive robust control names; visual UI and auth handlers are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 27 findings, 27 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing reset/change password disabled/loading behavior remains unchanged.
- Partial data proof: Existing password visibility and recovery-step rendering remains unchanged; labels reuse already-rendered state.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/auth/ForgotPassword.jsx`, `frontend/src/pages/auth/ChangePasswordRequired.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/auth/ForgotPassword.jsx src/pages/auth/ChangePasswordRequired.jsx --quiet`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed.
- Not checked: Browser-authenticated auth/password flows were not run because this PR only adds accessible-name metadata and does not change visual layout or auth logic.
