### PR TITLE
fix(frontend): label notification template controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -60,7 +60,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: remaining dental close controls cleanup removed 4 baseline findings.
 - 2026-05-21: two-factor security controls cleanup removed 7 baseline findings.
 - 2026-05-21: auth password controls cleanup removed 6 baseline findings.
-- Current baseline after this slice: 27 findings.
+- 2026-05-21: notification template controls cleanup removed 4 baseline findings.
+- Current baseline after this slice: 23 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T08:09:58.128Z",
+  "generatedAt": "2026-05-21T08:16:23.741Z",
   "entries": [
     {
       "signature": "src/components/admin/FinanceModal.jsx:215:13:button:missing-accessible-name",
@@ -96,38 +96,6 @@
       "file": "src/components/mobile/PWAInstallPrompt.jsx",
       "line": 104,
       "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/notifications/EmailSMSManager.jsx:676:21:button:missing-accessible-name",
-      "file": "src/components/notifications/EmailSMSManager.jsx",
-      "line": 676,
-      "column": 21,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/notifications/EmailSMSManager.jsx:679:21:button:missing-accessible-name",
-      "file": "src/components/notifications/EmailSMSManager.jsx",
-      "line": 679,
-      "column": 21,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/notifications/EmailSMSManager.jsx:709:21:button:missing-accessible-name",
-      "file": "src/components/notifications/EmailSMSManager.jsx",
-      "line": 709,
-      "column": 21,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/notifications/EmailSMSManager.jsx:712:21:button:missing-accessible-name",
-      "file": "src/components/notifications/EmailSMSManager.jsx",
-      "line": 712,
-      "column": 21,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/notifications/EmailSMSManager.jsx
+++ b/frontend/src/components/notifications/EmailSMSManager.jsx
@@ -673,10 +673,16 @@ const EmailSMSManager = () => {void
                     <p className="text-sm text-gray-600">{template.description}</p>
                   </div>
                   <div className="flex space-x-2">
-                    <button className="p-2 text-gray-400 hover:text-blue-600">
+                    <button
+                      className="p-2 text-gray-400 hover:text-blue-600"
+                      aria-label={`View email template ${template.title}`}
+                    >
                       <Eye className="w-4 h-4" />
                     </button>
-                    <button className="p-2 text-gray-400 hover:text-blue-600">
+                    <button
+                      className="p-2 text-gray-400 hover:text-blue-600"
+                      aria-label={`Edit email template ${template.title}`}
+                    >
                       <Edit className="w-4 h-4" />
                     </button>
                   </div>
@@ -706,10 +712,16 @@ const EmailSMSManager = () => {void
                     <p className="text-sm text-gray-600">{template.description}</p>
                   </div>
                   <div className="flex space-x-2">
-                    <button className="p-2 text-gray-400 hover:text-green-600">
+                    <button
+                      className="p-2 text-gray-400 hover:text-green-600"
+                      aria-label={`View SMS template ${template.title}`}
+                    >
                       <Eye className="w-4 h-4" />
                     </button>
-                    <button className="p-2 text-gray-400 hover:text-green-600">
+                    <button
+                      className="p-2 text-gray-400 hover:text-green-600"
+                      aria-label={`Edit SMS template ${template.title}`}
+                    >
                       <Edit className="w-4 h-4" />
                     </button>
                   </div>


### PR DESCRIPTION
﻿## Summary
- Added robust accessible names for Email/SMS template preview and edit icon controls.
- Reduced the icon-only controls baseline from 27 to 23 and updated the global sweep report.
- Kept notification template loading, delivery, and UI handlers unchanged.

## Contract Impact
- Canonical surface: Frontend-only notification template accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive named template preview/edit controls; notification APIs and visual behavior are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 23 findings, 23 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not changed.
- Payload version / ack behavior: Not changed.
- Read/unread or delivery semantics: Not changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing empty template array rendering remains unchanged.
- Partial data proof: Labels reuse the already-rendered `template.title` field and do not affect template cards or forms.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/notifications/EmailSMSManager.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous notification template accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/notifications/EmailSMSManager.jsx --quiet`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed.
- Not checked: Browser-authenticated notification manager flow was not run because this PR only adds accessible-name metadata and does not change delivery logic, layout, or handlers.
