### PR TITLE
fix(frontend): label display board controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -61,7 +61,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: two-factor security controls cleanup removed 7 baseline findings.
 - 2026-05-21: auth password controls cleanup removed 6 baseline findings.
 - 2026-05-21: notification template controls cleanup removed 4 baseline findings.
-- Current baseline after this slice: 23 findings.
+- 2026-05-21: display board controls cleanup removed 3 baseline findings.
+- Current baseline after this slice: 20 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T08:16:23.741Z",
+  "generatedAt": "2026-05-21T08:21:42.126Z",
   "entries": [
     {
       "signature": "src/components/admin/FinanceModal.jsx:215:13:button:missing-accessible-name",
@@ -154,30 +154,6 @@
       "column": 21,
       "element": "button",
       "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DisplayBoardUnified.jsx:686:13:button:title-only",
-      "file": "src/pages/DisplayBoardUnified.jsx",
-      "line": 686,
-      "column": 13,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DisplayBoardUnified.jsx:704:13:button:title-only",
-      "file": "src/pages/DisplayBoardUnified.jsx",
-      "line": 704,
-      "column": 13,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DisplayBoardUnified.jsx:722:13:button:title-only",
-      "file": "src/pages/DisplayBoardUnified.jsx",
-      "line": 722,
-      "column": 13,
-      "element": "button",
-      "reason": "title-only"
     },
     {
       "signature": "src/pages/RegistrarPanel.jsx:3842:19:button:missing-accessible-name",

--- a/frontend/src/pages/DisplayBoardUnified.jsx
+++ b/frontend/src/pages/DisplayBoardUnified.jsx
@@ -696,7 +696,8 @@ export default function DisplayBoardUnified({
                 alignItems: 'center',
                 gap: '5px'
               }}
-              title="Полноэкранный режим">
+              title="Полноэкранный режим"
+              aria-label={document.fullscreenElement ? 'Выйти из полноэкранного режима' : 'Включить полноэкранный режим'}>
               
               {document.fullscreenElement ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
             </button>
@@ -714,7 +715,8 @@ export default function DisplayBoardUnified({
                 alignItems: 'center',
                 gap: '5px'
               }}
-              title={boardSettings.soundEnabled ? 'Выключить звук' : 'Включить звук'}>
+              title={boardSettings.soundEnabled ? 'Выключить звук' : 'Включить звук'}
+              aria-label={boardSettings.soundEnabled ? 'Выключить звук' : 'Включить звук'}>
               
               {boardSettings.soundEnabled ? <Volume2 size={16} /> : <VolumeX size={16} />}
             </button>
@@ -732,7 +734,8 @@ export default function DisplayBoardUnified({
                 alignItems: 'center',
                 gap: '5px'
               }}
-              title="Контрастный режим">
+              title="Контрастный режим"
+              aria-label={boardSettings.contrastMode ? 'Выключить контрастный режим' : 'Включить контрастный режим'}>
               
               {boardSettings.contrastMode ? <EyeOff size={16} /> : <Eye size={16} />}
             </button>


### PR DESCRIPTION
﻿## Summary
- Added robust accessible names for display board fullscreen, sound, and contrast icon controls.
- Reduced the icon-only controls baseline from 23 to 20 and updated the global sweep report.
- Kept display board control handlers and visual layout unchanged.

## Contract Impact
- Canonical surface: Frontend-only display board accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive named display board controls; display board state handlers are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 20 findings, 20 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not changed.
- Payload version / ack behavior: Not changed.
- Read/unread or delivery semantics: Not changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing display board empty/loading behavior is unchanged.
- Partial data proof: Existing fullscreen, sound, and contrast state rendering remains unchanged; labels mirror current state.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/pages/DisplayBoardUnified.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous display board accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/pages/DisplayBoardUnified.jsx --quiet`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed.
- Not checked: Browser display board smoke was not run because this PR only adds accessible-name metadata and does not change layout or handlers.
