### PR TITLE
fix(frontend): label medical table controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -62,7 +62,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: auth password controls cleanup removed 6 baseline findings.
 - 2026-05-21: notification template controls cleanup removed 4 baseline findings.
 - 2026-05-21: display board controls cleanup removed 3 baseline findings.
-- Current baseline after this slice: 20 findings.
+- 2026-05-21: medical table controls cleanup removed 3 baseline findings.
+- Current baseline after this slice: 17 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T08:21:42.126Z",
+  "generatedAt": "2026-05-21T08:25:50.381Z",
   "entries": [
     {
       "signature": "src/components/admin/FinanceModal.jsx:215:13:button:missing-accessible-name",
@@ -63,30 +63,6 @@
       "signature": "src/components/layout/UnifiedSidebar.jsx:248:9:button:title-only",
       "file": "src/components/layout/UnifiedSidebar.jsx",
       "line": 248,
-      "column": 9,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/medical/MedicalTable.jsx:75:9:button:title-only",
-      "file": "src/components/medical/MedicalTable.jsx",
-      "line": 75,
-      "column": 9,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/medical/MedicalTable.jsx:88:9:button:title-only",
-      "file": "src/components/medical/MedicalTable.jsx",
-      "line": 88,
-      "column": 9,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/medical/MedicalTable.jsx:101:9:button:title-only",
-      "file": "src/components/medical/MedicalTable.jsx",
-      "line": 101,
       "column": 9,
       "element": "button",
       "reason": "title-only"

--- a/frontend/src/components/medical/MedicalTable.jsx
+++ b/frontend/src/components/medical/MedicalTable.jsx
@@ -77,6 +77,7 @@ const MedicalTable = ({
           onClick={() => onView(row, index)}
           className="p-2 text-green-600 hover:bg-green-50 rounded-md transition-colors interactive-element hover-scale ripple-effect magnetic-hover focus-ring"
           title="View details"
+          aria-label="View row details"
         >
           <Icon name="Eye" size={16} />
         </button>
@@ -90,6 +91,7 @@ const MedicalTable = ({
           onClick={() => onEdit(row, index)}
           className="p-2 text-blue-600 hover:bg-blue-50 rounded-md transition-colors interactive-element hover-scale ripple-effect magnetic-hover focus-ring"
           title="Edit"
+          aria-label="Edit row"
         >
           <Icon name="Edit" size={16} />
         </button>
@@ -103,6 +105,7 @@ const MedicalTable = ({
           onClick={() => onDelete(row, index)}
           className="p-2 text-red-600 hover:bg-red-50 rounded-md transition-colors interactive-element hover-scale ripple-effect magnetic-hover focus-ring"
           title="Delete"
+          aria-label="Delete row"
         >
           <Icon name="Trash2" size={16} />
         </button>


### PR DESCRIPTION
﻿## Summary
- Added robust accessible names for generic MedicalTable row view, edit, and delete icon controls.
- Reduced the icon-only controls baseline from 20 to 17 and updated the global sweep report.
- Kept MedicalTable props, row actions, and rendering behavior unchanged.

## Contract Impact
- Canonical surface: Frontend-only shared medical table accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive named row action controls; table props and callbacks are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 17 findings, 17 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing MedicalTable empty data rendering remains unchanged.
- Partial data proof: Generic row action labels do not depend on optional row fields.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/medical/MedicalTable.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous MedicalTable accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/medical/MedicalTable.jsx --quiet`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed.
- Not checked: Browser table flow was not run because this PR only adds accessible-name metadata and does not change layout, callbacks, or data flow.
