### PR TITLE
fix(frontend): label appointment wizard controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -63,7 +63,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: notification template controls cleanup removed 4 baseline findings.
 - 2026-05-21: display board controls cleanup removed 3 baseline findings.
 - 2026-05-21: medical table controls cleanup removed 3 baseline findings.
-- Current baseline after this slice: 17 findings.
+- 2026-05-21: appointment wizard controls cleanup removed 3 baseline findings.
+- Current baseline after this slice: 14 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T08:25:50.381Z",
+  "generatedAt": "2026-05-21T08:29:55.105Z",
   "entries": [
     {
       "signature": "src/components/admin/FinanceModal.jsx:215:13:button:missing-accessible-name",
@@ -104,30 +104,6 @@
       "file": "src/components/ui/native/Modal.jsx",
       "line": 101,
       "column": 15,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/wizard/AppointmentWizardV2.jsx:2628:9:button:title-only",
-      "file": "src/components/wizard/AppointmentWizardV2.jsx",
-      "line": 2628,
-      "column": 9,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/wizard/AppointmentWizardV2.jsx:2663:9:button:title-only",
-      "file": "src/components/wizard/AppointmentWizardV2.jsx",
-      "line": 2663,
-      "column": 9,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/wizard/AppointmentWizardV2.jsx:3764:21:button:missing-accessible-name",
-      "file": "src/components/wizard/AppointmentWizardV2.jsx",
-      "line": 3764,
-      "column": 21,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/wizard/AppointmentWizardV2.jsx
+++ b/frontend/src/components/wizard/AppointmentWizardV2.jsx
@@ -2629,6 +2629,7 @@ const AppointmentWizardV2 = ({
         onClick={handleReloadServices}
         disabled={isReloadingServices}
         title="Обновить список услуг"
+        aria-label={isReloadingServices ? 'Refreshing service list' : 'Refresh service list'}
         style={{
           width: '34px',
           height: '34px',
@@ -2663,6 +2664,7 @@ const AppointmentWizardV2 = ({
         <button
         onClick={onClose}
         title="Закрыть"
+        aria-label="Close appointment wizard"
         style={{
           width: '34px',
           height: '34px',
@@ -3763,6 +3765,7 @@ const CartStepV2 = ({
                     </span>
                     <button
                     onClick={() => onRemoveFromCart(item.id)}
+                    aria-label={`Remove ${displayName} from appointment cart`}
                     style={{
                       border: 'none',
                       background: 'transparent',


### PR DESCRIPTION
﻿## Summary
- Added robust accessible names for appointment wizard refresh, close, and cart removal icon controls.
- Reduced the icon-only controls baseline from 17 to 14 and updated the global sweep report.
- Kept appointment wizard service reload, close, and cart behavior unchanged.

## Contract Impact
- Canonical surface: Frontend-only appointment wizard accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive named wizard controls; wizard handlers and service/cart data flow are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 14 findings, 14 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing wizard service/cart empty states remain unchanged.
- Partial data proof: Cart removal labels reuse the already-rendered display name and do not affect selected service data.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/wizard/AppointmentWizardV2.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous appointment wizard accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/wizard/AppointmentWizardV2.jsx --quiet`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed.
- Not checked: Browser appointment wizard flow was not run because this PR only adds accessible-name metadata and does not change layout, handlers, or service/cart behavior.
