### PR TITLE
fix(frontend): label schedule modal controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -64,7 +64,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: display board controls cleanup removed 3 baseline findings.
 - 2026-05-21: medical table controls cleanup removed 3 baseline findings.
 - 2026-05-21: appointment wizard controls cleanup removed 3 baseline findings.
-- Current baseline after this slice: 14 findings.
+- 2026-05-21: schedule next modal controls cleanup removed 2 baseline findings.
+- Current baseline after this slice: 12 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T08:29:55.105Z",
+  "generatedAt": "2026-05-21T08:34:27.111Z",
   "entries": [
     {
       "signature": "src/components/admin/FinanceModal.jsx:215:13:button:missing-accessible-name",
@@ -25,22 +25,6 @@
       "line": 47,
       "column": 7,
       "element": "div",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/common/ScheduleNextModal.jsx:428:11:button:missing-accessible-name",
-      "file": "src/components/common/ScheduleNextModal.jsx",
-      "line": 428,
-      "column": 11,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/common/ScheduleNextModal.jsx:537:17:button:missing-accessible-name",
-      "file": "src/components/common/ScheduleNextModal.jsx",
-      "line": 537,
-      "column": 17,
-      "element": "button",
       "reason": "missing-accessible-name"
     },
     {

--- a/frontend/src/components/common/ScheduleNextModal.jsx
+++ b/frontend/src/components/common/ScheduleNextModal.jsx
@@ -425,7 +425,11 @@ const ScheduleNextModal = ({
         {/* Заголовок */}
         <div style={headerStyle}>
           <h2 style={titleStyle}>{getModalTitle()}</h2>
-          <button style={closeButtonStyle} onClick={onClose}>
+          <button
+            style={closeButtonStyle}
+            onClick={onClose}
+            aria-label="Close schedule next visit modal"
+          >
             <X size={20} />
           </button>
         </div>
@@ -538,7 +542,8 @@ const ScheduleNextModal = ({
                 type="button"
                 style={dangerButtonStyle}
                 onClick={() => removeService(index)}
-                disabled={formData.services.length === 1}>
+                disabled={formData.services.length === 1}
+                aria-label={`Remove service ${index + 1}`}>
                 
                   <Trash2 size={16} />
                 </button>


### PR DESCRIPTION
﻿## Summary
- Added robust accessible names for ScheduleNextModal close and remove-service icon controls.
- Reduced the icon-only controls baseline from 14 to 12 and updated the global sweep report.
- Kept next-visit scheduling form state and service validation unchanged.

## Contract Impact
- Canonical surface: Frontend-only schedule-next modal accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive named modal controls; scheduling form handlers are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 12 findings, 12 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing single-service disabled remove button behavior remains unchanged.
- Partial data proof: Remove-service labels use the list index and do not depend on optional service metadata.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/common/ScheduleNextModal.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous ScheduleNextModal accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/common/ScheduleNextModal.jsx --quiet`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed.
- Not checked: Browser next-visit modal flow was not run because this PR only adds accessible-name metadata and does not change layout, validation, or submission handlers.
