### PR TITLE
fix(frontend): label shared primitive controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -65,7 +65,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: medical table controls cleanup removed 3 baseline findings.
 - 2026-05-21: appointment wizard controls cleanup removed 3 baseline findings.
 - 2026-05-21: schedule next modal controls cleanup removed 2 baseline findings.
-- Current baseline after this slice: 12 findings.
+- 2026-05-21: shared primitive controls cleanup removed 5 baseline findings.
+- Current baseline after this slice: 7 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T08:34:27.111Z",
+  "generatedAt": "2026-05-21T08:39:16.062Z",
   "entries": [
     {
       "signature": "src/components/admin/FinanceModal.jsx:215:13:button:missing-accessible-name",
@@ -28,28 +28,12 @@
       "reason": "missing-accessible-name"
     },
     {
-      "signature": "src/components/forms/ModernTextarea.jsx:124:9:button:title-only",
-      "file": "src/components/forms/ModernTextarea.jsx",
-      "line": 124,
-      "column": 9,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
       "signature": "src/components/layout/UnifiedLayout.jsx:91:7:div:missing-accessible-name",
       "file": "src/components/layout/UnifiedLayout.jsx",
       "line": 91,
       "column": 7,
       "element": "div",
       "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/layout/UnifiedSidebar.jsx:248:9:button:title-only",
-      "file": "src/components/layout/UnifiedSidebar.jsx",
-      "line": 248,
-      "column": 9,
-      "element": "button",
-      "reason": "title-only"
     },
     {
       "signature": "src/components/mobile/PWAInstallPrompt.jsx:104:13:button:missing-accessible-name",
@@ -64,30 +48,6 @@
       "file": "src/components/tickets/MultipleTicketsPrinter.jsx",
       "line": 78,
       "column": 9,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ui/macos/AccentPicker.jsx:29:11:button:title-only",
-      "file": "src/components/ui/macos/AccentPicker.jsx",
-      "line": 29,
-      "column": 11,
-      "element": "button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/ui/macos/Switch.jsx:73:7:input:missing-accessible-name",
-      "file": "src/components/ui/macos/Switch.jsx",
-      "line": 73,
-      "column": 7,
-      "element": "input",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ui/native/Modal.jsx:101:15:button:missing-accessible-name",
-      "file": "src/components/ui/native/Modal.jsx",
-      "line": 101,
-      "column": 15,
       "element": "button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/forms/ModernTextarea.jsx
+++ b/frontend/src/components/forms/ModernTextarea.jsx
@@ -126,6 +126,7 @@ const ModernTextarea = ({
           className="expand-btn"
           onClick={toggleExpanded}
           title={isExpanded ? 'Свернуть' : 'Развернуть'}
+          aria-label={isExpanded ? 'Collapse textarea' : 'Expand textarea'}
           style={{ color: getColor('textSecondary') }}>
           
               {isExpanded ? <Minimize2 size={16} /> : <Maximize2 size={16} />}

--- a/frontend/src/components/layout/UnifiedSidebar.jsx
+++ b/frontend/src/components/layout/UnifiedSidebar.jsx
@@ -265,7 +265,8 @@ const UnifiedSidebar = ({ isCollapsed = false, onToggle }) => {
             e.target.style.color = isDark ? '#9ca3af' : '#6b7280';
             e.target.style.filter = 'brightness(1)';
           }}
-          title={isCollapsed ? 'Развернуть сайдбар' : 'Свернуть сайдбар'}>
+          title={isCollapsed ? 'Развернуть сайдбар' : 'Свернуть сайдбар'}
+          aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}>
 
           <Icon name={isCollapsed ? 'ChevronRight' : 'ChevronLeft'} size={16} />
         </button>

--- a/frontend/src/components/ui/macos/AccentPicker.jsx
+++ b/frontend/src/components/ui/macos/AccentPicker.jsx
@@ -30,6 +30,7 @@ export default function AccentPicker({ size = 22, className = '', style = {} }) 
             key={key}
             role="radio"
             aria-checked={isActive}
+            aria-label={LABELS[key] || key}
             onClick={() => setAccent(key)}
             title={LABELS[key] || key}
             style={{

--- a/frontend/src/components/ui/macos/Switch.jsx
+++ b/frontend/src/components/ui/macos/Switch.jsx
@@ -67,6 +67,7 @@ const Switch = React.forwardRef(({
   };
 
   const labelStyles = { fontSize: '13px', color: 'var(--mac-text-primary)' };
+  const accessibleLabel = props['aria-label'] || (typeof label === 'string' ? label : 'Toggle setting');
 
   return (
     <label className={`mac-switch ${className}`} style={wrapper} htmlFor={controlId} aria-disabled={disabled}>
@@ -80,6 +81,7 @@ const Switch = React.forwardRef(({
         disabled={disabled}
         className="mac-switch-input"
         style={{ position: 'absolute', opacity: 0, pointerEvents: 'none' }}
+        aria-label={accessibleLabel}
         {...props}
       />
       <span className="mac-switch-track" aria-hidden style={track}>

--- a/frontend/src/components/ui/native/Modal.jsx
+++ b/frontend/src/components/ui/native/Modal.jsx
@@ -101,6 +101,7 @@ const Modal = React.forwardRef(({
               <button
                 onClick={onClose}
                 className="p-1 text-gray-400 hover:text-gray-600 transition-colors rounded-md hover:bg-gray-100"
+                aria-label="Close modal"
               >
                 <X className="w-5 h-5" />
               </button>


### PR DESCRIPTION
﻿## Summary
- Added robust accessible names for shared primitive icon controls: textarea expand, sidebar collapse, accent colors, macOS switch, and native modal close.
- Reduced the icon-only controls baseline from 12 to 7 and updated the global sweep report.
- Kept primitive APIs, visual styling, and callbacks unchanged.

## Contract Impact
- Canonical surface: Frontend-only shared primitive accessibility metadata.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive named shared controls; component props and handlers are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` reported 7 findings, 7 baseline entries, 0 new findings, 0 stale baseline entries.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Shared primitive rendering behavior remains unchanged when optional labels/titles are absent.
- Partial data proof: Switch falls back to an explicit default accessible name when no string label is available; existing `aria-label` props can still override through spread props.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/forms/ModernTextarea.jsx`, `frontend/src/components/layout/UnifiedSidebar.jsx`, `frontend/src/components/ui/macos/AccentPicker.jsx`, `frontend/src/components/ui/macos/Switch.jsx`, `frontend/src/components/ui/native/Modal.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous shared primitive accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/forms/ModernTextarea.jsx src/components/layout/UnifiedSidebar.jsx src/components/ui/macos/AccentPicker.jsx src/components/ui/macos/Switch.jsx src/components/ui/native/Modal.jsx --quiet`; `npm.cmd run audit:icon-controls`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed.
- Not checked: Browser visual QA was not run because this PR only adds accessible-name metadata and does not change layout, styling, or component callbacks.
