### PR TITLE
fix(frontend): label remaining icon controls

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -66,7 +66,8 @@ The project now has a required no-new-regression gate for icon-only controls. Th
 - 2026-05-21: appointment wizard controls cleanup removed 3 baseline findings.
 - 2026-05-21: schedule next modal controls cleanup removed 2 baseline findings.
 - 2026-05-21: shared primitive controls cleanup removed 5 baseline findings.
-- Current baseline after this slice: 7 findings.
+- 2026-05-21: remaining singleton controls cleanup removed 7 baseline findings.
+- Current baseline after this slice: 0 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-controls-baseline.json
@@ -1,63 +1,6 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-21T08:39:16.062Z",
-  "entries": [
-    {
-      "signature": "src/components/admin/FinanceModal.jsx:215:13:button:missing-accessible-name",
-      "file": "src/components/admin/FinanceModal.jsx",
-      "line": 215,
-      "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/MobileOptimization.jsx:74:11:div:missing-accessible-name",
-      "file": "src/components/admin/MobileOptimization.jsx",
-      "line": 74,
-      "column": 11,
-      "element": "div",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/buttons/FloatingActionButton.jsx:47:7:div:missing-accessible-name",
-      "file": "src/components/buttons/FloatingActionButton.jsx",
-      "line": 47,
-      "column": 7,
-      "element": "div",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/layout/UnifiedLayout.jsx:91:7:div:missing-accessible-name",
-      "file": "src/components/layout/UnifiedLayout.jsx",
-      "line": 91,
-      "column": 7,
-      "element": "div",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/mobile/PWAInstallPrompt.jsx:104:13:button:missing-accessible-name",
-      "file": "src/components/mobile/PWAInstallPrompt.jsx",
-      "line": 104,
-      "column": 13,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/tickets/MultipleTicketsPrinter.jsx:78:9:button:missing-accessible-name",
-      "file": "src/components/tickets/MultipleTicketsPrinter.jsx",
-      "line": 78,
-      "column": 9,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/RegistrarPanel.jsx:3842:19:button:missing-accessible-name",
-      "file": "src/pages/RegistrarPanel.jsx",
-      "line": 3842,
-      "column": 19,
-      "element": "button",
-      "reason": "missing-accessible-name"
-    }
-  ]
+  "generatedAt": "2026-05-21T08:43:49.311Z",
+  "entries": []
 }

--- a/frontend/src/components/admin/FinanceModal.jsx
+++ b/frontend/src/components/admin/FinanceModal.jsx
@@ -216,6 +216,7 @@ const FinanceModal = ({
               onClick={onClose}
               className="p-1 hover:bg-gray-100 rounded-lg transition-colors"
               style={{ color: 'var(--text-secondary)' }}
+              aria-label="Close finance transaction modal"
             >
               <X className="w-5 h-5" />
             </button>

--- a/frontend/src/components/admin/MobileOptimization.jsx
+++ b/frontend/src/components/admin/MobileOptimization.jsx
@@ -75,6 +75,7 @@ export const MobileNavigation = ({ sections, currentSection, onNavigate, classNa
           className="fixed inset-0 bg-black bg-opacity-50"
           role="button"
           tabIndex={0}
+          aria-label="Close mobile navigation menu"
           onClick={() => setIsOpen(false)}
           onKeyDown={(event) => {
             if (event.key === 'Enter' || event.key === ' ') {

--- a/frontend/src/components/buttons/FloatingActionButton.jsx
+++ b/frontend/src/components/buttons/FloatingActionButton.jsx
@@ -48,6 +48,7 @@ const FloatingActionButton = ({
         className="fab-backdrop"
         role="button"
         tabIndex={0}
+        aria-label="Close floating action menu"
         onClick={() => setIsExpanded(false)}
         onKeyDown={(event) => handleActivationKeyDown(event, () => setIsExpanded(false))} />
 

--- a/frontend/src/components/layout/UnifiedLayout.jsx
+++ b/frontend/src/components/layout/UnifiedLayout.jsx
@@ -91,6 +91,7 @@ const UnifiedLayout = ({ children, showSidebar = true }) => {
       <div
         role="button"
         tabIndex={0}
+        aria-label="Close sidebar overlay"
         style={{
           position: 'fixed',
           top: 0,

--- a/frontend/src/components/mobile/PWAInstallPrompt.jsx
+++ b/frontend/src/components/mobile/PWAInstallPrompt.jsx
@@ -104,6 +104,7 @@ const PWAInstallPrompt = () => {
             <button
               onClick={handleDismiss}
               className="text-white/70 hover:text-white transition-colors"
+              aria-label="Dismiss app install prompt"
             >
               <X className="w-4 h-4" />
             </button>

--- a/frontend/src/components/tickets/MultipleTicketsPrinter.jsx
+++ b/frontend/src/components/tickets/MultipleTicketsPrinter.jsx
@@ -75,7 +75,7 @@ const MultipleTicketsPrinter = ({ tickets, onClose, onAllPrinted }) => {
     <div className="multiple-tickets-printer">
       <div className="printer-header">
         <h3>Печать талонов ({tickets.length})</h3>
-        <button className="close-btn" onClick={onClose}>
+        <button className="close-btn" onClick={onClose} aria-label="Close tickets printer">
           <X size={20} />
         </button>
       </div>

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -3842,6 +3842,7 @@ const RegistrarPanel = () => {
                   <button
                 onClick={loadMoreAppointments}
                 disabled={paginationInfo.loadingMore}
+                aria-label={paginationInfo.loadingMore ? 'Loading more appointments' : 'Load more appointments'}
                 style={{
                   padding: '12px 24px',
                   borderRadius: '8px',


### PR DESCRIPTION
﻿## Summary
- Added robust accessible names for the final remaining singleton icon/backdrop controls.
- Reduced the icon-only controls baseline from 7 to 0 and updated the global sweep report.
- Verified both baseline-gated and strict no-baseline icon-only accessibility audits pass.

## Contract Impact
- Canonical surface: Frontend-only accessibility metadata for modal close, mobile overlays, FAB backdrop, install prompt, ticket printer, and registrar load-more controls.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and accessibility tooling receive named controls; existing click, keyboard, close, dismiss, and load-more handlers are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `npm run audit:icon-controls` and `npm run audit:icon-controls:strict` both reported 0 findings.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change authorization logic.
- Negative auth proof: Not applicable because this PR does not change protected route access.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing dismiss/close/backdrop and load-more empty/no-more behavior remains unchanged.
- Partial data proof: Registrar load-more label mirrors loading state and does not depend on optional appointment fields.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/FinanceModal.jsx`, `frontend/src/components/admin/MobileOptimization.jsx`, `frontend/src/components/buttons/FloatingActionButton.jsx`, `frontend/src/components/layout/UnifiedLayout.jsx`, `frontend/src/components/mobile/PWAInstallPrompt.jsx`, `frontend/src/components/tickets/MultipleTicketsPrinter.jsx`, `frontend/src/pages/RegistrarPanel.jsx`, `frontend/scripts/a11y/icon-only-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend, database migrations, API clients, routing contracts, RBAC, workflows, tests.
- Migration/docs/test impact: No migration or test changes; docs report and a11y baseline updated intentionally.
- Rollback note: Revert this PR to restore previous accessible-name labels and baseline state.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/admin/FinanceModal.jsx src/components/admin/MobileOptimization.jsx src/components/buttons/FloatingActionButton.jsx src/components/layout/UnifiedLayout.jsx src/components/mobile/PWAInstallPrompt.jsx src/components/tickets/MultipleTicketsPrinter.jsx src/pages/RegistrarPanel.jsx --quiet`; `npm.cmd run audit:icon-controls`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed.
- Not checked: Browser visual QA was not run because this PR only adds accessible-name metadata and does not change layout, handlers, or data flow.
