### PR TITLE
fix(frontend): remove legacy ui class names

### DIFF
--- a/frontend/src/components/laboratory/LabResultsManager.jsx
+++ b/frontend/src/components/laboratory/LabResultsManager.jsx
@@ -354,8 +354,8 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
           {loading ?
           <Progress /> :
           filteredResults.length > 0 ?
-          <div className="legacy-table-wrap">
-              <table className="legacy-table">
+          <div className="clinic-ops-table-wrap">
+              <table className="clinic-ops-table">
                 <thead>
                   <tr>
                     <th style={{ textAlign: 'left' }}>Исследование</th>

--- a/frontend/src/components/layout/Nav.jsx
+++ b/frontend/src/components/layout/Nav.jsx
@@ -16,7 +16,7 @@ export default function Nav() {
   }).filter((route) => route.nav?.menu);
 
   return (
-    <div className="legacy-nav-bar">
+    <div className="clinic-ops-nav-bar">
       <div style={{ fontWeight: 700, marginRight: 12, opacity: 0.85 }} aria-hidden="true"> </div>
 
       <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 6 }}>
@@ -53,13 +53,13 @@ export default function Nav() {
                 setProfile(null);
                 navigate('/login');
               }}
-              className="legacy-button"
+              className="clinic-ops-button"
             >
               Выйти
             </button>
           </>
         ) : (
-          <button onClick={() => navigate('/login')} className="legacy-button">
+          <button onClick={() => navigate('/login')} className="clinic-ops-button">
             Войти
           </button>
         )}

--- a/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
+++ b/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
@@ -123,7 +123,7 @@ const EnhancedAppointmentsTable = ({
 
   // ✅ FIX 17: Helper для безопасного парсинга даты
   // Контракт: backend должен отдавать ISO 8601 с корректным timezone.
-  // Для legacy-naive строк считаем, что это время клиники Asia/Tashkent.
+  // Для исторических naive строк считаем, что это время клиники Asia/Tashkent.
   const safeParseDate = useCallback((dateStr) => {
     return parseRegistrarTimestamp(dateStr);
   }, []);

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -3882,7 +3882,7 @@ const RegistrarPanel = () => {
                 </div>
             }
 
-              {/* Старая таблица и legacy-конфигурация удалены - используется EnhancedAppointmentsTable */}
+              {/* Старая таблица и прежняя конфигурация удалены - используется EnhancedAppointmentsTable */}
             </div>
           </div>
         }

--- a/frontend/src/pages/Scheduler.jsx
+++ b/frontend/src/pages/Scheduler.jsx
@@ -54,22 +54,22 @@ export default function Scheduler() {
   return (
     <div>
       <RoleGate roles={['Admin', 'Registrar', 'Doctor']}>
-        <div className="legacy-page-shell">
+        <div className="clinic-ops-page-shell">
           <h2 style={{ margin: 0 }}>Расписание</h2>
 
-          <div className="legacy-toolbar">
-            <label>
+          <div className="clinic-ops-toolbar">
+            <label htmlFor="scheduler-date">
               Дата:&nbsp;
-              <input className="legacy-input" type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+              <input id="scheduler-date" className="clinic-ops-input" type="date" value={date} onChange={(e) => setDate(e.target.value)} />
             </label>
-            <input className="legacy-input" placeholder="Поиск по врачу/кабинету/статусу" value={q} onChange={(e) => setQ(e.target.value)} style={{ minWidth: 260 }} />
-            <button className="legacy-button" onClick={load} disabled={busy}>{busy ? 'Загрузка' : 'Обновить'}</button>
+            <input className="clinic-ops-input" aria-label="Поиск по врачу, кабинету или статусу" placeholder="Поиск по врачу/кабинету/статусу" value={q} onChange={(e) => setQ(e.target.value)} style={{ minWidth: 260 }} />
+            <button className="clinic-ops-button" onClick={load} disabled={busy}>{busy ? 'Загрузка' : 'Обновить'}</button>
           </div>
 
-          {err && <div className="legacy-error">{String(err)}</div>}
+          {err && <div className="clinic-ops-error">{String(err)}</div>}
 
-          <div className="legacy-table-wrap">
-            <table className="legacy-table">
+          <div className="clinic-ops-table-wrap">
+            <table className="clinic-ops-table">
               <thead>
                 <tr>
                   <th>Врач</th>

--- a/frontend/src/styles/macos.css
+++ b/frontend/src/styles/macos.css
@@ -593,14 +593,14 @@ body {
   border-radius: 0 0 8px 8px;
 }
 
-/* Legacy pages: normalize old JSX inline surfaces to token-based theme */
-.legacy-page-shell {
+/* Clinic operations surfaces: token-based shells for older route slices */
+.clinic-ops-page-shell {
   padding: 16px;
   display: grid;
   gap: 12px;
 }
 
-.legacy-toolbar {
+.clinic-ops-toolbar {
   display: flex;
   gap: 12px;
   align-items: center;
@@ -615,7 +615,7 @@ body {
   );
 }
 
-.legacy-input {
+.clinic-ops-input {
   padding: 6px 10px;
   border: 1px solid var(--mac-border);
   border-radius: 8px;
@@ -623,12 +623,12 @@ body {
   color: var(--mac-text-primary);
 }
 
-.legacy-input:focus-visible {
+.clinic-ops-input:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--mac-accent), white 24%);
   outline-offset: 1px;
 }
 
-.legacy-button {
+.clinic-ops-button {
   padding: 6px 10px;
   border-radius: 8px;
   border: 1px solid var(--mac-border);
@@ -638,17 +638,17 @@ body {
   transition: all 0.2s ease;
 }
 
-.legacy-button:hover:not(:disabled) {
+.clinic-ops-button:hover:not(:disabled) {
   background: color-mix(in srgb, var(--mac-bg-secondary), white 4%);
   border-color: color-mix(in srgb, var(--mac-border), white 12%);
 }
 
-.legacy-button:disabled {
+.clinic-ops-button:disabled {
   cursor: not-allowed;
   opacity: 0.6;
 }
 
-.legacy-table-wrap {
+.clinic-ops-table-wrap {
   overflow: auto;
   border: 1px solid var(--mac-card-border);
   border-radius: 12px;
@@ -656,13 +656,13 @@ body {
   box-shadow: var(--mac-shadow-sm);
 }
 
-.legacy-table {
+.clinic-ops-table {
   width: 100%;
   border-collapse: collapse;
   color: var(--mac-text-primary);
 }
 
-.legacy-table th {
+.clinic-ops-table th {
   text-align: left;
   padding: 10px;
   border-bottom: 1px solid var(--mac-separator);
@@ -671,13 +671,13 @@ body {
   background: color-mix(in srgb, var(--mac-bg-secondary), transparent 8%);
 }
 
-.legacy-table td {
+.clinic-ops-table td {
   padding: 10px;
   border-bottom: 1px solid color-mix(in srgb, var(--mac-separator), transparent 25%);
   vertical-align: top;
 }
 
-.legacy-error {
+.clinic-ops-error {
   color: var(--mac-error);
   background: var(--mac-error-bg);
   border: 1px solid var(--mac-error-border);
@@ -685,27 +685,7 @@ body {
   padding: 8px;
 }
 
-.legacy-muted {
-  color: var(--mac-text-secondary);
-}
-
-.legacy-list {
-  display: grid;
-  gap: 10px;
-}
-
-.legacy-list-item {
-  border: 1px solid var(--mac-card-border);
-  border-radius: 10px;
-  padding: 12px;
-  background: var(--mac-card-bg);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-}
-
-.legacy-nav-bar {
+.clinic-ops-nav-bar {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -719,32 +699,7 @@ body {
   -webkit-backdrop-filter: var(--mac-blur-light);
 }
 
-.legacy-nav-link {
-  display: inline-flex;
-  align-items: center;
-  padding: 8px 12px;
-  border-radius: 10px;
-  border: 1px solid var(--mac-border);
-  margin-right: 6px;
-  text-decoration: none;
-  background: var(--mac-bg-primary);
-  color: var(--mac-text-primary);
-  transition: all 0.2s ease;
-}
-
-.legacy-nav-link:hover {
-  background: var(--mac-nav-item-hover);
-  border-color: color-mix(in srgb, var(--mac-border), white 10%);
-}
-
-.legacy-nav-link--active {
-  background: var(--mac-nav-item-active);
-  color: var(--mac-nav-item-active-text);
-  border-color: var(--mac-nav-item-active-border);
-  box-shadow: var(--mac-shadow-sm);
-}
-
-/* Legacy hardcoded inline rescue layer: normalize old white/gray surfaces */
+/* Historical hardcoded inline rescue layer: normalize old white/gray surfaces */
 [data-theme] main :is(div, section, article, aside, table, thead, tbody, tr, th, td)[style*="background: #fff"],
 [data-theme] main :is(div, section, article, aside, table, thead, tbody, tr, th, td)[style*="background:#fff"],
 [data-theme] main :is(div, section, article, aside, table, thead, tbody, tr, th, td)[style*="background: #ffffff"],


### PR DESCRIPTION
﻿## Summary
- Replaced the remaining runtime `legacy-*` UI class names with token-based `clinic-ops-*` class names.
- Removed unused legacy list/nav-link CSS selectors while preserving the active scheduler, lab table, and nav visual rules.
- Added explicit accessible names for the touched scheduler date/search inputs.

## Contract Impact
- Canonical surface: Frontend UI class names and CSS selectors for Scheduler, LabResultsManager table wrapper, and app Nav shell.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Visual styling remains token-based and equivalent for the touched surfaces; Scheduler date/search inputs now have clearer accessible names.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: Static search shows no remaining `legacy-` matches under `frontend/src`, and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change route guards, RoleGate roles, auth state, or permissions.
- Negative auth proof: Not applicable because protected route access is unchanged.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Scheduler empty table row and LabResultsManager empty-state branch are preserved.
- Partial data proof: Scheduler row fallback values and Lab result rendering are unchanged.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/styles/macos.css`, `frontend/src/pages/Scheduler.jsx`, `frontend/src/components/laboratory/LabResultsManager.jsx`, `frontend/src/components/layout/Nav.jsx`, `frontend/src/components/tables/EnhancedAppointmentsTable.jsx`, `frontend/src/pages/RegistrarPanel.jsx`.
- Denied paths: backend, database migrations, API clients, route registry, RBAC, payment logic, queue logic, EMR/lab business logic, workflows, package files.
- Migration/docs/test impact: No migrations or tests changed; two comments were updated only to remove stale legacy wording.
- Rollback note: Revert this PR to restore the prior `legacy-*` class names and unused CSS selectors.

## Validation
- Targeted tests or smoke run: `rg -n "legacy-" frontend\\src`; `npx.cmd eslint src/pages/Scheduler.jsx src/components/laboratory/LabResultsManager.jsx src/components/layout/Nav.jsx src/components/tables/EnhancedAppointmentsTable.jsx src/pages/RegistrarPanel.jsx --quiet`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. `rg -n "legacy-" frontend\\src` returned no matches.
- Not checked: Browser visual QA was not run because this PR preserves the same CSS declarations under renamed class names and does not change route, data, or interaction behavior.
