### PR TITLE
fix(frontend): label setup form controls

### DIFF
--- a/frontend/src/pages/Setup.jsx
+++ b/frontend/src/pages/Setup.jsx
@@ -193,6 +193,7 @@ export default function Setup() {
                   style={missingRequiredKeys.has('clinicName') ? requiredInputStyle : inputStyle}
                   name="clinicName"
                   required
+                  aria-label="Название клиники"
                   aria-invalid={missingRequiredKeys.has('clinicName')}
                   value={form.clinicName}
                   onChange={updateField('clinicName')}
@@ -200,23 +201,23 @@ export default function Setup() {
               </label>
               <label style={labelStyle}>
                 Телефон
-                <input style={inputStyle} value={form.clinicPhone} onChange={updateField('clinicPhone')} />
+                <input style={inputStyle} aria-label="Телефон клиники" value={form.clinicPhone} onChange={updateField('clinicPhone')} />
               </label>
               <label style={labelStyle}>
                 Email
-                <input style={inputStyle} type="email" value={form.clinicEmail} onChange={updateField('clinicEmail')} />
+                <input style={inputStyle} type="email" aria-label="Email клиники" value={form.clinicEmail} onChange={updateField('clinicEmail')} />
               </label>
               <label style={labelStyle}>
                 Timezone
-                <input style={inputStyle} value={form.clinicTimezone} onChange={updateField('clinicTimezone')} />
+                <input style={inputStyle} aria-label="Timezone клиники" value={form.clinicTimezone} onChange={updateField('clinicTimezone')} />
               </label>
               <label style={{ ...labelStyle, gridColumn: '1 / -1' }}>
                 Адрес
-                <textarea style={textareaStyle} value={form.clinicAddress} onChange={updateField('clinicAddress')} />
+                <textarea style={textareaStyle} aria-label="Адрес клиники" value={form.clinicAddress} onChange={updateField('clinicAddress')} />
               </label>
               <label style={{ ...labelStyle, gridColumn: '1 / -1' }}>
                 URL логотипа
-                <input style={inputStyle} value={form.clinicLogoUrl} onChange={updateField('clinicLogoUrl')} />
+                <input style={inputStyle} aria-label="URL логотипа клиники" value={form.clinicLogoUrl} onChange={updateField('clinicLogoUrl')} />
               </label>
             </div>
           </section>
@@ -231,6 +232,7 @@ export default function Setup() {
                   style={missingRequiredKeys.has('branchName') ? requiredInputStyle : inputStyle}
                   name="branchName"
                   required
+                  aria-label="Название филиала"
                   aria-invalid={missingRequiredKeys.has('branchName')}
                   value={form.branchName}
                   onChange={updateField('branchName')}
@@ -238,23 +240,23 @@ export default function Setup() {
               </label>
               <label style={labelStyle}>
                 Код филиала
-                <input style={inputStyle} value={form.branchCode} onChange={updateField('branchCode')} placeholder="optional" />
+                <input style={inputStyle} aria-label="Код филиала" value={form.branchCode} onChange={updateField('branchCode')} placeholder="optional" />
               </label>
               <label style={labelStyle}>
                 Телефон филиала
-                <input style={inputStyle} value={form.branchPhone} onChange={updateField('branchPhone')} />
+                <input style={inputStyle} aria-label="Телефон филиала" value={form.branchPhone} onChange={updateField('branchPhone')} />
               </label>
               <label style={labelStyle}>
                 Email филиала
-                <input style={inputStyle} type="email" value={form.branchEmail} onChange={updateField('branchEmail')} />
+                <input style={inputStyle} type="email" aria-label="Email филиала" value={form.branchEmail} onChange={updateField('branchEmail')} />
               </label>
               <label style={labelStyle}>
                 Timezone филиала
-                <input style={inputStyle} value={form.branchTimezone} onChange={updateField('branchTimezone')} />
+                <input style={inputStyle} aria-label="Timezone филиала" value={form.branchTimezone} onChange={updateField('branchTimezone')} />
               </label>
               <label style={{ ...labelStyle, gridColumn: '1 / -1' }}>
                 Адрес филиала
-                <textarea style={textareaStyle} value={form.branchAddress} onChange={updateField('branchAddress')} />
+                <textarea style={textareaStyle} aria-label="Адрес филиала" value={form.branchAddress} onChange={updateField('branchAddress')} />
               </label>
             </div>
           </section>
@@ -270,6 +272,7 @@ export default function Setup() {
                   name="adminUsername"
                   required
                   minLength={3}
+                  aria-label="Username администратора"
                   aria-invalid={missingRequiredKeys.has('adminUsername')}
                   value={form.adminUsername}
                   onChange={updateField('adminUsername')}
@@ -282,6 +285,7 @@ export default function Setup() {
                   style={missingRequiredKeys.has('adminFullName') ? requiredInputStyle : inputStyle}
                   name="adminFullName"
                   required
+                  aria-label="Полное имя администратора"
                   aria-invalid={missingRequiredKeys.has('adminFullName')}
                   value={form.adminFullName}
                   onChange={updateField('adminFullName')}
@@ -295,6 +299,7 @@ export default function Setup() {
                   type="email"
                   name="adminEmail"
                   required
+                  aria-label="Email администратора"
                   aria-invalid={missingRequiredKeys.has('adminEmail')}
                   value={form.adminEmail}
                   onChange={updateField('adminEmail')}
@@ -309,6 +314,7 @@ export default function Setup() {
                   name="adminPassword"
                   required
                   minLength={8}
+                  aria-label="Пароль администратора"
                   aria-invalid={missingRequiredKeys.has('adminPassword')}
                   autoComplete="new-password"
                   value={form.adminPassword}
@@ -317,7 +323,7 @@ export default function Setup() {
               </label>
               <label style={{ ...labelStyle, gridColumn: '1 / -1' }}>
                 Ключ активации
-                <input style={inputStyle} value={form.activationKey} onChange={updateField('activationKey')} placeholder="optional" />
+                <input style={inputStyle} aria-label="Ключ активации" value={form.activationKey} onChange={updateField('activationKey')} placeholder="optional" />
               </label>
             </div>
           </section>


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to all first-run setup form controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `Setup.jsx` without changing setup payloads or submit behavior.
- Kept this as a one-file accessibility slice.

## Contract Impact
- Canonical surface: Frontend first-run setup form accessibility metadata only.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for setup inputs and textareas; visible UI, field values, and submit flow are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `Setup.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change route guards, auth state, setup permissions, or role assignment logic.
- Negative auth proof: Not applicable because protected route access is unchanged.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Initial empty setup form values are unchanged.
- Partial data proof: Existing required-field detection, focus-first-missing behavior, and optional field handling are unchanged.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/pages/Setup.jsx`.
- Denied paths: backend, setup API client, database migrations, auth/RBAC, route registry, payment, queue, EMR/lab logic, workflows, package files.
- Migration/docs/test impact: No migrations, docs, package files, or tests changed.
- Rollback note: Revert this PR to remove the explicit setup form accessible names.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/pages/Setup.jsx --quiet`; `npx.cmd eslint src/pages/Setup.jsx -f json --output-file %TEMP%/setup-eslint.json`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. `Setup.jsx` ESLint JSON reports 0 messages.
- Not checked: Browser visual QA was not run because this PR only adds `aria-label` metadata and does not change layout, field state, or submit behavior.
