### PR TITLE
fix(frontend): label email sms controls

### DIFF
--- a/frontend/src/components/notifications/EmailSMSManager.jsx
+++ b/frontend/src/components/notifications/EmailSMSManager.jsx
@@ -349,6 +349,7 @@ const EmailSMSManager = () => {void
             </label>
             <input
             type="email"
+            aria-label="Email recipient"
             value={emailForm.to}
             onChange={(e) => setEmailForm({ ...emailForm, to: e.target.value })}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
@@ -362,6 +363,7 @@ const EmailSMSManager = () => {void
             </label>
             <input
             type="text"
+            aria-label="Email subject"
             value={emailForm.subject}
             onChange={(e) => setEmailForm({ ...emailForm, subject: e.target.value })}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
@@ -407,6 +409,7 @@ const EmailSMSManager = () => {void
             Сообщение
           </label>
           <textarea
+          aria-label="Email message"
           value={emailForm.message}
           onChange={(e) => setEmailForm({ ...emailForm, message: e.target.value })}
           rows={4}
@@ -449,6 +452,7 @@ const EmailSMSManager = () => {void
             </label>
             <input
             type="tel"
+            aria-label="SMS phone number"
             value={smsForm.phone}
             onChange={(e) => setSmsForm({ ...smsForm, phone: e.target.value })}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
@@ -462,6 +466,7 @@ const EmailSMSManager = () => {void
             </label>
             <input
             type="text"
+            aria-label="SMS sender"
             value={smsForm.sender}
             onChange={(e) => setSmsForm({ ...smsForm, sender: e.target.value })}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
@@ -507,6 +512,7 @@ const EmailSMSManager = () => {void
             Сообщение
           </label>
           <textarea
+          aria-label="SMS message"
           value={smsForm.message}
           onChange={(e) => setSmsForm({ ...smsForm, message: e.target.value })}
           rows={3}
@@ -563,6 +569,7 @@ const EmailSMSManager = () => {void
             </label>
             <input
             type="number"
+            aria-label="Bulk batch size"
             value={bulkForm.batchSize}
             onChange={(e) => setBulkForm({ ...bulkForm, batchSize: parseInt(e.target.value) })}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
@@ -578,6 +585,7 @@ const EmailSMSManager = () => {void
             <input
             type="number"
             step="0.1"
+            aria-label="Bulk delay between batches"
             value={bulkForm.delay}
             onChange={(e) => setBulkForm({ ...bulkForm, delay: parseFloat(e.target.value) })}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
@@ -612,6 +620,7 @@ const EmailSMSManager = () => {void
             </label>
             <input
           type="text"
+          aria-label="Bulk email subject"
           value={bulkForm.subject}
           onChange={(e) => setBulkForm({ ...bulkForm, subject: e.target.value })}
           className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
@@ -625,6 +634,7 @@ const EmailSMSManager = () => {void
             Сообщение
           </label>
           <textarea
+          aria-label="Bulk message"
           value={bulkForm.message}
           onChange={(e) => setBulkForm({ ...bulkForm, message: e.target.value })}
           rows={4}
@@ -754,6 +764,7 @@ const EmailSMSManager = () => {void
                 </label>
                 <input
                 type="text"
+                aria-label="SMTP server"
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg"
                 placeholder="smtp.gmail.com" />
               
@@ -764,6 +775,7 @@ const EmailSMSManager = () => {void
                 </label>
                 <input
                 type="number"
+                aria-label="SMTP port"
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg"
                 placeholder="587" />
               
@@ -774,6 +786,7 @@ const EmailSMSManager = () => {void
                 </label>
                 <input
                 type="email"
+                aria-label="SMTP email"
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg"
                 placeholder="clinic@example.com" />
               
@@ -790,6 +803,7 @@ const EmailSMSManager = () => {void
                 </label>
                 <input
                 type="url"
+                aria-label="SMS API URL"
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg"
                 placeholder="https://api.sms-provider.com" />
               
@@ -800,6 +814,7 @@ const EmailSMSManager = () => {void
                 </label>
                 <input
                 type="password"
+                aria-label="SMS API key"
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg"
                 placeholder="••••••••••••••••" />
               
@@ -810,6 +825,7 @@ const EmailSMSManager = () => {void
                 </label>
                 <input
                 type="text"
+                aria-label="SMS default sender"
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg"
                 placeholder="Clinic" />
               


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to Email/SMS Manager form controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `EmailSMSManager.jsx` without changing notification delivery, templates, statistics, or settings behavior.
- Kept this as a one-file accessibility metadata slice.

## Contract Impact
- Canonical surface: Frontend Email/SMS Manager form accessibility metadata only.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for email, SMS, bulk notification, SMTP, and SMS provider controls; visible UI and field values are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `EmailSMSManager.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change route guards, auth state, role checks, or permissions.
- Negative auth proof: Not applicable because protected route access is unchanged.

## Notification / Realtime
- Event type or websocket channel: Not changed.
- Payload version / ack behavior: Not changed.
- Read/unread or delivery semantics: Not changed.
- Reconnect/resync proof: Not applicable because no websocket, polling, or delivery behavior changed.

## Frontend Resilience
- Empty data proof: Existing blank email/SMS/bulk/settings defaults are unchanged.
- Partial data proof: Existing optional template and provider fields are unchanged.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/notifications/EmailSMSManager.jsx`.
- Denied paths: backend notification APIs, delivery services, websocket/realtime code, auth/RBAC, route registry, workflows, package files, and runtime business logic.
- Migration/docs/test impact: No migrations, docs, package files, or tests changed.
- Rollback note: Revert this PR to remove the explicit Email/SMS Manager accessible names.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/notifications/EmailSMSManager.jsx --quiet`; `npx.cmd eslint src/components/notifications/EmailSMSManager.jsx -f json --output-file %TEMP%/email-sms-eslint-after.json`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. `EmailSMSManager.jsx` ESLint JSON reports 0 messages.
- Not checked: Browser visual QA was not run because this PR only adds `aria-label` metadata and does not change layout, notification state, or delivery behavior.
