### PR TITLE
fix(frontend): label settings controls

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -33,7 +33,7 @@ function Row({ k, v, onSave }) {
   return (
     <div style={row}>
       <div style={{ fontWeight: 600 }}>{k}</div>
-      <input value={val} onChange={(e) => setVal(e.target.value)} style={inp} />
+      <input aria-label={`Setting value for ${k}`} value={val} onChange={(e) => setVal(e.target.value)} style={inp} />
       <button onClick={() => onSave(k, val)} style={btn}>Сохранить</button>
     </div>);
 
@@ -269,6 +269,7 @@ export default function Settings() {void
                 <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
                   <input
                   placeholder="Вставьте ключ активации"
+                  aria-label="Activation key"
                   value={key}
                   onChange={(e) => setKey(e.target.value)}
                   style={{ ...inp, minWidth: 320 }} />
@@ -534,6 +535,7 @@ function ProviderModal({ provider, onClose, onSave, title }) {
             <label style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>Название *</label>
             <input
               type="text"
+              aria-label="Provider name"
               value={formData.name}
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
               required
@@ -552,6 +554,7 @@ function ProviderModal({ provider, onClose, onSave, title }) {
             <label style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>Код *</label>
             <input
               type="text"
+              aria-label="Provider code"
               value={formData.code}
               onChange={(e) => setFormData({ ...formData, code: e.target.value })}
               required
@@ -569,6 +572,7 @@ function ProviderModal({ provider, onClose, onSave, title }) {
           <div>
             <label style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>Описание</label>
             <textarea
+              aria-label="Provider description"
               value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
               rows={3}
@@ -588,6 +592,7 @@ function ProviderModal({ provider, onClose, onSave, title }) {
             <label style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>Секретный ключ *</label>
             <input
               type="password"
+              aria-label="Provider secret key"
               value={formData.secret_key}
               onChange={(e) => setFormData({ ...formData, secret_key: e.target.value })}
               required
@@ -606,6 +611,7 @@ function ProviderModal({ provider, onClose, onSave, title }) {
             <label style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>Webhook URL</label>
             <input
               type="url"
+              aria-label="Provider webhook URL"
               value={formData.webhook_url}
               onChange={(e) => setFormData({ ...formData, webhook_url: e.target.value })}
               style={{
@@ -623,6 +629,7 @@ function ProviderModal({ provider, onClose, onSave, title }) {
             <label style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>API URL</label>
             <input
               type="url"
+              aria-label="Provider API URL"
               value={formData.api_url}
               onChange={(e) => setFormData({ ...formData, api_url: e.target.value })}
               style={{
@@ -640,6 +647,7 @@ function ProviderModal({ provider, onClose, onSave, title }) {
             <input
               type="checkbox"
               id="is_active"
+              aria-label="Provider active"
               checked={formData.is_active}
               onChange={(e) => setFormData({ ...formData, is_active: e.target.checked })} />
             
@@ -737,7 +745,7 @@ function KVField({ label, defKey, items, onSave }) {
   return (
     <div style={row}>
       <div style={{ fontWeight: 600 }}>{label}</div>
-      <input value={val} onChange={(e) => setVal(e.target.value)} style={inp} />
+      <input aria-label={`${label} setting value`} value={val} onChange={(e) => setVal(e.target.value)} style={inp} />
       <button onClick={() => onSave(defKey, val)} style={btn}>Сохранить</button>
     </div>);
 
@@ -753,6 +761,7 @@ function RoleMapItem({ role, items, onSave }) {
     <div style={row}>
       <div style={{ fontWeight: 600 }}>{role}</div>
       <input
+        aria-label={`Route target for ${role}`}
         value={val}
         onChange={(e) => setVal(e.target.value)}
         style={inp}


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to Settings page form controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `Settings.jsx` without changing activation, provider, printer, queue, display-board, or role mapping behavior.
- Kept this as a one-file accessibility metadata slice.

## Contract Impact
- Canonical surface: Frontend Settings page form accessibility metadata only.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for settings, activation, provider, and route mapping controls; visible UI and submitted values are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `Settings.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change route guards, auth state, role checks, or permissions.
- Negative auth proof: Not applicable because protected route access is unchanged.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing blank settings/provider form defaults are unchanged.
- Partial data proof: Existing optional provider URL and route mapping fields are unchanged.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/pages/Settings.jsx`.
- Denied paths: backend settings/payment provider APIs, auth/RBAC, route registry, workflows, package files, and runtime business logic.
- Migration/docs/test impact: No migrations, docs, package files, or tests changed.
- Rollback note: Revert this PR to remove the explicit Settings page accessible names.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/pages/Settings.jsx --quiet`; `npx.cmd eslint src/pages/Settings.jsx -f json --output-file %TEMP%/settings-eslint-after.json`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. `Settings.jsx` ESLint JSON reports 0 messages.
- Not checked: Browser visual QA was not run because this PR only adds `aria-label` metadata and does not change layout, settings state, or save behavior.
