### PR TITLE
fix(frontend): label display board settings controls

### DIFF
--- a/frontend/src/components/admin/DisplayBoardSettings.jsx
+++ b/frontend/src/components/admin/DisplayBoardSettings.jsx
@@ -272,6 +272,7 @@ const DisplayBoardSettings = () => {
               </label>
               <input
                 type="text"
+                aria-label="Display board location"
                 value={selectedBoard.location || ''}
                 onChange={(e) => handleBoardSettingChange('location', e.target.value)}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
@@ -325,6 +326,7 @@ const DisplayBoardSettings = () => {
               </label>
               <input
                 type="number"
+                aria-label="Displayed queue number count"
                 min="1"
                 max="20"
                 value={selectedBoard.queue_display_count}
@@ -340,6 +342,7 @@ const DisplayBoardSettings = () => {
               <label className="flex items-center">
                 <input
                   type="checkbox"
+                  aria-label="Show doctor photos"
                   checked={selectedBoard.show_doctor_photos}
                   onChange={(e) => handleBoardSettingChange('show_doctor_photos', e.target.checked)}
                   className="mr-2" />
@@ -350,6 +353,7 @@ const DisplayBoardSettings = () => {
               <label className="flex items-center">
                 <input
                   type="checkbox"
+                  aria-label="Show announcements"
                   checked={selectedBoard.show_announcements}
                   onChange={(e) => handleBoardSettingChange('show_announcements', e.target.checked)}
                   className="mr-2" />
@@ -360,6 +364,7 @@ const DisplayBoardSettings = () => {
               <label className="flex items-center">
                 <input
                   type="checkbox"
+                  aria-label="Show banners"
                   checked={selectedBoard.show_banners}
                   onChange={(e) => handleBoardSettingChange('show_banners', e.target.checked)}
                   className="mr-2" />
@@ -370,6 +375,7 @@ const DisplayBoardSettings = () => {
               <label className="flex items-center">
                 <input
                   type="checkbox"
+                  aria-label="Show videos"
                   checked={selectedBoard.show_videos}
                   onChange={(e) => handleBoardSettingChange('show_videos', e.target.checked)}
                   className="mr-2" />
@@ -394,6 +400,7 @@ const DisplayBoardSettings = () => {
               </label>
               <input
                 type="number"
+                aria-label="Call display duration seconds"
                 min="5"
                 max="300"
                 value={selectedBoard.call_display_duration}
@@ -406,6 +413,7 @@ const DisplayBoardSettings = () => {
               <label className="flex items-center">
                 <input
                   type="checkbox"
+                  aria-label="Enable sound signals"
                   checked={selectedBoard.sound_enabled}
                   onChange={(e) => handleBoardSettingChange('sound_enabled', e.target.checked)}
                   className="mr-2" />
@@ -416,6 +424,7 @@ const DisplayBoardSettings = () => {
               <label className="flex items-center">
                 <input
                   type="checkbox"
+                  aria-label="Enable voice announcements"
                   checked={selectedBoard.voice_announcements}
                   onChange={(e) => handleBoardSettingChange('voice_announcements', e.target.checked)}
                   className="mr-2" />
@@ -449,6 +458,7 @@ const DisplayBoardSettings = () => {
                   </label>
                   <input
                   type="range"
+                  aria-label="Volume level"
                   min="0"
                   max="100"
                   value={selectedBoard.volume_level}


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to Display Board Settings controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `DisplayBoardSettings.jsx` without changing display board save/test behavior.
- Kept this as a one-file accessibility metadata slice.

## Contract Impact
- Canonical surface: Frontend Display Board Settings form accessibility metadata only.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for board location, queue count, display toggles, sound toggles, duration, and volume controls; visible UI and submitted values are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `DisplayBoardSettings.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change route guards, auth state, role checks, or permissions.
- Negative auth proof: Not applicable because protected route access is unchanged.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing selected-board missing state is unchanged.
- Partial data proof: Existing optional board setting defaults and fallback values are unchanged.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/DisplayBoardSettings.jsx`.
- Denied paths: backend display board APIs, queue runtime, auth/RBAC, route registry, workflows, package files, and runtime business logic.
- Migration/docs/test impact: No migrations, docs, package files, or tests changed.
- Rollback note: Revert this PR to remove the explicit Display Board Settings accessible names.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/admin/DisplayBoardSettings.jsx --quiet`; `npx.cmd eslint src/components/admin/DisplayBoardSettings.jsx -f json --output-file %TEMP%/display-board-eslint-after.json`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. `DisplayBoardSettings.jsx` ESLint JSON reports 0 messages.
- Not checked: Browser visual QA was not run because this PR only adds `aria-label` metadata and does not change layout, queue/display runtime, or save/test behavior.
