### PR TITLE
fix(frontend): label dental patient card controls

### DIFF
--- a/frontend/src/components/dental/PatientCard.jsx
+++ b/frontend/src/components/dental/PatientCard.jsx
@@ -194,6 +194,7 @@ const PatientCard = ({
           </label>
           <input
           type="text"
+          aria-label="Patient surname"
           value={formData.surname || ''}
           onChange={(e) => handleInputChange('surname', e.target.value)}
           disabled={!isEditing}
@@ -208,6 +209,7 @@ const PatientCard = ({
           </label>
           <input
           type="text"
+          aria-label="Patient first name"
           value={formData.name || ''}
           onChange={(e) => handleInputChange('name', e.target.value)}
           disabled={!isEditing}
@@ -222,6 +224,7 @@ const PatientCard = ({
           </label>
           <input
           type="text"
+          aria-label="Patient patronymic"
           value={formData.patronymic || ''}
           onChange={(e) => handleInputChange('patronymic', e.target.value)}
           disabled={!isEditing}
@@ -235,6 +238,7 @@ const PatientCard = ({
           </label>
           <input
           type="date"
+          aria-label="Patient birth date"
           value={formData.birthDate || ''}
           onChange={(e) => handleInputChange('birthDate', e.target.value)}
           disabled={!isEditing}
@@ -266,6 +270,7 @@ const PatientCard = ({
           </label>
           <input
           type="text"
+          aria-label="Patient age"
           value={formData.birthDate ?
           Math.floor((new Date() - new Date(formData.birthDate)) / (365.25 * 24 * 60 * 60 * 1000)) : ''
           }
@@ -287,6 +292,7 @@ const PatientCard = ({
               <Phone className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
               <input
               type="tel"
+              aria-label="Patient phone"
               value={formData.phone || ''}
               onChange={(e) => handleInputChange('phone', e.target.value)}
               disabled={!isEditing}
@@ -304,6 +310,7 @@ const PatientCard = ({
               <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
               <input
               type="email"
+              aria-label="Patient email"
               value={formData.email || ''}
               onChange={(e) => handleInputChange('email', e.target.value)}
               disabled={!isEditing}
@@ -319,6 +326,7 @@ const PatientCard = ({
             <div className="relative">
               <MapPin className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
               <textarea
+              aria-label="Patient address"
               value={formData.address || ''}
               onChange={(e) => handleInputChange('address', e.target.value)}
               disabled={!isEditing}
@@ -349,6 +357,7 @@ const PatientCard = ({
             </label>
             <input
             type="text"
+            aria-label="Passport series"
             value={formData.passport.series || ''}
             onChange={(e) => handleInputChange('passport.series', e.target.value)}
             disabled={!isEditing}
@@ -363,6 +372,7 @@ const PatientCard = ({
             </label>
             <input
             type="text"
+            aria-label="Passport number"
             value={formData.passport.number || ''}
             onChange={(e) => handleInputChange('passport.number', e.target.value)}
             disabled={!isEditing}
@@ -377,6 +387,7 @@ const PatientCard = ({
             </label>
             <input
             type="text"
+            aria-label="Passport issued by"
             value={formData.passport.issuedBy || ''}
             onChange={(e) => handleInputChange('passport.issuedBy', e.target.value)}
             disabled={!isEditing}
@@ -391,6 +402,7 @@ const PatientCard = ({
             </label>
             <input
             type="date"
+            aria-label="Passport issue date"
             value={formData.passport.issueDate || ''}
             onChange={(e) => handleInputChange('passport.issueDate', e.target.value)}
             disabled={!isEditing}
@@ -413,6 +425,7 @@ const PatientCard = ({
             </label>
             <input
             type="text"
+            aria-label="Insurance policy number"
             value={formData.insurance.policyNumber || ''}
             onChange={(e) => handleInputChange('insurance.policyNumber', e.target.value)}
             disabled={!isEditing}
@@ -427,6 +440,7 @@ const PatientCard = ({
             </label>
             <input
             type="text"
+            aria-label="Insurance company"
             value={formData.insurance.company || ''}
             onChange={(e) => handleInputChange('insurance.company', e.target.value)}
             disabled={!isEditing}
@@ -441,6 +455,7 @@ const PatientCard = ({
             </label>
             <input
             type="date"
+            aria-label="Insurance valid until"
             value={formData.insurance.validUntil || ''}
             onChange={(e) => handleInputChange('insurance.validUntil', e.target.value)}
             disabled={!isEditing}
@@ -476,6 +491,7 @@ const PatientCard = ({
           Жалобы на момент обращения
         </label>
         <textarea
+        aria-label="Current complaints"
         value={formData.medicalHistory.complaints || ''}
         onChange={(e) => handleInputChange('medicalHistory.complaints', e.target.value)}
         disabled={!isEditing}
@@ -670,6 +686,7 @@ const PatientCard = ({
           Стоматологический анамнез
         </label>
         <textarea
+        aria-label="Dental history"
         value={formData.medicalHistory.dentalHistory || ''}
         onChange={(e) => handleInputChange('medicalHistory.dentalHistory', e.target.value)}
         disabled={!isEditing}
@@ -696,6 +713,7 @@ const PatientCard = ({
             </label>
             <input
             type="text"
+            aria-label="Emergency contact name"
             value={formData.emergencyContact.name || ''}
             onChange={(e) => handleInputChange('emergencyContact.name', e.target.value)}
             disabled={!isEditing}
@@ -731,6 +749,7 @@ const PatientCard = ({
               <Phone className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
               <input
               type="tel"
+              aria-label="Emergency contact phone"
               value={formData.emergencyContact.phone || ''}
               onChange={(e) => handleInputChange('emergencyContact.phone', e.target.value)}
               disabled={!isEditing}
@@ -746,6 +765,7 @@ const PatientCard = ({
             </label>
             <input
             type="text"
+            aria-label="Emergency contact address"
             value={formData.emergencyContact.address || ''}
             onChange={(e) => handleInputChange('emergencyContact.address', e.target.value)}
             disabled={!isEditing}


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to Dental Patient Card form controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `PatientCard.jsx` without changing dental patient data handling or save/cancel behavior.
- Kept this as a one-file accessibility metadata slice.

## Contract Impact
- Canonical surface: Frontend Dental Patient Card form accessibility metadata only.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for personal, contact, passport, insurance, medical history, and emergency contact controls; visible UI and submitted values are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `PatientCard.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change route guards, auth state, role checks, or permissions.
- Negative auth proof: Not applicable because protected route access is unchanged.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing patient/form default values are unchanged.
- Partial data proof: Existing optional contact, passport, insurance, medical history, and emergency contact fields are unchanged.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/dental/PatientCard.jsx`.
- Denied paths: backend dental APIs, EMR logic, auth/RBAC, route registry, workflows, package files, and runtime business logic.
- Migration/docs/test impact: No migrations, docs, package files, or tests changed.
- Rollback note: Revert this PR to remove the explicit Dental Patient Card accessible names.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/dental/PatientCard.jsx --quiet`; `npx.cmd eslint src/components/dental/PatientCard.jsx -f json --output-file %TEMP%/dental-patient-card-eslint-after.json`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. `PatientCard.jsx` ESLint JSON reports 0 messages.
- Not checked: Browser visual QA was not run because this PR only adds `aria-label` metadata and does not change layout, dental state, or save/cancel behavior.
