### PR TITLE
fix(frontend): label cardiologist panel controls

### DIFF
--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -1938,6 +1938,7 @@ const MacOSCardiologistPanelUnified = () => {
                         </label>
                         <input
                       type="date"
+                      aria-label="Blood test date"
                       value={bloodTestForm.test_date}
                       onChange={(e) => setBloodTestForm({ ...bloodTestForm, test_date: e.target.value })}
                       className="w-full rounded-md focus:outline-none focus:ring-2 dark:text-white"
@@ -1963,6 +1964,7 @@ const MacOSCardiologistPanelUnified = () => {
                         </label>
                         <input
                       type="number"
+                      aria-label="Total cholesterol"
                       value={bloodTestForm.cholesterol_total}
                       onChange={(e) => setBloodTestForm({ ...bloodTestForm, cholesterol_total: e.target.value })}
                       className="w-full rounded-md focus:outline-none focus:ring-2 dark:text-white"
@@ -1991,6 +1993,7 @@ const MacOSCardiologistPanelUnified = () => {
                         </label>
                         <input
                       type="number"
+                      aria-label="HDL cholesterol"
                       value={bloodTestForm.cholesterol_hdl}
                       onChange={(e) => setBloodTestForm({ ...bloodTestForm, cholesterol_hdl: e.target.value })}
                       className="w-full rounded-md focus:outline-none focus:ring-2 dark:text-white"
@@ -2016,6 +2019,7 @@ const MacOSCardiologistPanelUnified = () => {
                         </label>
                         <input
                       type="number"
+                      aria-label="LDL cholesterol"
                       value={bloodTestForm.cholesterol_ldl}
                       onChange={(e) => setBloodTestForm({ ...bloodTestForm, cholesterol_ldl: e.target.value })}
                       className="w-full rounded-md focus:outline-none focus:ring-2 dark:text-white"
@@ -2041,6 +2045,7 @@ const MacOSCardiologistPanelUnified = () => {
                         </label>
                         <input
                       type="number"
+                      aria-label="Triglycerides"
                       value={bloodTestForm.triglycerides}
                       onChange={(e) => setBloodTestForm({ ...bloodTestForm, triglycerides: e.target.value })}
                       className="w-full rounded-md focus:outline-none focus:ring-2 dark:text-white"
@@ -2069,6 +2074,7 @@ const MacOSCardiologistPanelUnified = () => {
                         </label>
                         <input
                       type="number"
+                      aria-label="Glucose"
                       value={bloodTestForm.glucose}
                       onChange={(e) => setBloodTestForm({ ...bloodTestForm, glucose: e.target.value })}
                       className="w-full rounded-md focus:outline-none focus:ring-2 dark:text-white"
@@ -2094,6 +2100,7 @@ const MacOSCardiologistPanelUnified = () => {
                         </label>
                         <input
                       type="number"
+                      aria-label="CRP"
                       value={bloodTestForm.crp}
                       onChange={(e) => setBloodTestForm({ ...bloodTestForm, crp: e.target.value })}
                       className="w-full rounded-md focus:outline-none focus:ring-2 dark:text-white"
@@ -2119,6 +2126,7 @@ const MacOSCardiologistPanelUnified = () => {
                         </label>
                         <input
                       type="number"
+                      aria-label="Troponin"
                       value={bloodTestForm.troponin}
                       onChange={(e) => setBloodTestForm({ ...bloodTestForm, troponin: e.target.value })}
                       className="w-full rounded-md focus:outline-none focus:ring-2 dark:text-white"
@@ -2544,6 +2552,7 @@ const MacOSCardiologistPanelUnified = () => {
               }}>Порог LDL (мг/дл)</div>
                 <input
                 type="number"
+                aria-label="LDL threshold"
                 value={settings.ldlThreshold}
                 onChange={(e) => setSettings({ ...settings, ldlThreshold: Number(e.target.value) })}
                 style={{


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to Cardiologist Panel blood-test and LDL-threshold controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `CardiologistPanelUnified.jsx` without changing cardiology workflows, form state, or API behavior.
- Kept this as a one-file accessibility metadata slice.

## Contract Impact
- Canonical surface: Frontend Cardiologist Panel accessibility metadata only.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for cardiology blood-test numeric/date inputs and the LDL threshold setting; visible UI and submitted values are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `CardiologistPanelUnified.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change route guards, auth state, role checks, or permissions.
- Negative auth proof: Not applicable because protected route access is unchanged.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing selected-patient and empty cardiology states are unchanged.
- Partial data proof: Existing optional blood-test fields and settings values are unchanged.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/pages/CardiologistPanelUnified.jsx`.
- Denied paths: backend cardiology APIs, EMR logic, auth/RBAC, route registry, workflows, package files, and runtime business logic.
- Migration/docs/test impact: No migrations, docs, package files, or tests changed.
- Rollback note: Revert this PR to remove the explicit Cardiologist Panel accessible names.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/pages/CardiologistPanelUnified.jsx --quiet`; `npx.cmd eslint src/pages/CardiologistPanelUnified.jsx -f json --output-file %TEMP%/cardiologist-panel-eslint-after.json`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. `CardiologistPanelUnified.jsx` ESLint JSON reports 0 messages and strict icon-only controls audit reports 0 findings.
- Not checked: Browser visual QA was not run because this PR only adds `aria-label` metadata and does not change layout, clinical state, or API behavior.
