### PR TITLE
fix(frontend): label vitals widget controls

### DIFF
--- a/frontend/src/components/emr-v2/sections/VitalsWidget.jsx
+++ b/frontend/src/components/emr-v2/sections/VitalsWidget.jsx
@@ -32,6 +32,7 @@ const VitalsWidget = ({ vitals = {}, onChange, onFieldTouch, disabled }) => {
                     <label>АД сист.</label>
                     <input
                         type="number"
+                        aria-label="Systolic blood pressure"
                         value={vitals?.systolic || ''}
                         onChange={(e) => handleChange('systolic', e.target.value)}
                         placeholder="120"
@@ -43,6 +44,7 @@ const VitalsWidget = ({ vitals = {}, onChange, onFieldTouch, disabled }) => {
                     <label>АД диаст.</label>
                     <input
                         type="number"
+                        aria-label="Diastolic blood pressure"
                         value={vitals?.diastolic || ''}
                         onChange={(e) => handleChange('diastolic', e.target.value)}
                         placeholder="80"
@@ -53,6 +55,7 @@ const VitalsWidget = ({ vitals = {}, onChange, onFieldTouch, disabled }) => {
                     <label>Пульс</label>
                     <input
                         type="number"
+                        aria-label="Pulse"
                         value={vitals?.pulse || ''}
                         onChange={(e) => handleChange('pulse', e.target.value)}
                         placeholder="72"
@@ -63,6 +66,7 @@ const VitalsWidget = ({ vitals = {}, onChange, onFieldTouch, disabled }) => {
                     <label>SpO₂</label>
                     <input
                         type="number"
+                        aria-label="Blood oxygen saturation"
                         value={vitals?.spo2 || ''}
                         onChange={(e) => handleChange('spo2', e.target.value)}
                         placeholder="98"
@@ -83,6 +87,7 @@ const VitalsWidget = ({ vitals = {}, onChange, onFieldTouch, disabled }) => {
                     <label>Рост {vitals?.heightSource && <small>({vitals.heightSource})</small>}</label>
                     <input
                         type="number"
+                        aria-label="Height in centimeters"
                         value={vitals?.height || ''}
                         onChange={(e) => handleChange('height', e.target.value)}
                         placeholder="170"
@@ -94,6 +99,7 @@ const VitalsWidget = ({ vitals = {}, onChange, onFieldTouch, disabled }) => {
                     <label>Вес {vitals?.weightSource && <small>({vitals.weightSource})</small>}</label>
                     <input
                         type="number"
+                        aria-label="Weight in kilograms"
                         value={vitals?.weight || ''}
                         onChange={(e) => handleChange('weight', e.target.value)}
                         placeholder="70"


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to EMR Vitals Widget controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `VitalsWidget.jsx` without changing vitals values, BMI calculation, BP thresholds, or touched-field behavior.
- Kept this as a one-file accessibility metadata slice.

## Contract Impact
- Canonical surface: Frontend EMR Vitals Widget accessibility metadata only.
- Request shape: Not changed.
- Response shape: Not changed.
- Status codes: Not changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for blood pressure, pulse, SpO2, height, and weight fields; visible UI and submitted values are unchanged.
- Compatibility path or alias: Not applicable because no route, API, or compatibility alias changed.
- Contract proof: `VitalsWidget.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Not changed.
- Roles denied: Not changed.
- Positive auth proof: Not applicable because this PR does not change route guards, auth state, role checks, or permissions.
- Negative auth proof: Not applicable because protected route access is unchanged.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification or realtime code changed.
- Payload version / ack behavior: Not applicable because no payloads changed.
- Read/unread or delivery semantics: Not applicable because no notification state changed.
- Reconnect/resync proof: Not applicable because no websocket or polling behavior changed.

## Frontend Resilience
- Empty data proof: Existing empty vitals values are unchanged.
- Partial data proof: Existing optional vitals fields, BMI rendering, and source labels are unchanged.
- Forbidden secondary path behavior: Not changed.
- Missing draft/resource behavior: Not changed.
- Stale route/deep-link behavior: Not changed.

## Scope Gate
- Allowed paths: `frontend/src/components/emr-v2/sections/VitalsWidget.jsx`.
- Denied paths: backend EMR APIs, vitals calculations, BP thresholds, auth/RBAC, route registry, workflows, package files, and runtime business logic.
- Migration/docs/test impact: No migrations, docs, package files, or tests changed.
- Rollback note: Revert this PR to remove the explicit Vitals Widget accessible names.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/emr-v2/sections/VitalsWidget.jsx --quiet`; `npx.cmd eslint src/components/emr-v2/sections/VitalsWidget.jsx -f json --output-file %TEMP%/vitals-widget-eslint-after.json`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. `VitalsWidget.jsx` ESLint JSON reports 0 messages and strict icon-only controls audit reports 0 findings.
- Not checked: Browser visual QA was not run because this PR only adds `aria-label` metadata and does not change layout, clinical state, or API behavior.
