### PR TITLE
fix(frontend): label discount benefit controls

### DIFF
--- a/frontend/src/components/admin/DiscountBenefitsManager.jsx
+++ b/frontend/src/components/admin/DiscountBenefitsManager.jsx
@@ -347,30 +347,33 @@ const DiscountBenefitsManager = () => {
       
       </div>
       <div className="flex flex-wrap gap-4">
-        <label className="flex items-center">
-          <input
-          type="checkbox"
-          checked={discountForm.applies_to_services}
-          onChange={(e) => setDiscountForm({ ...discountForm, applies_to_services: e.target.checked })}
-          className="mr-2" />
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              aria-label="Discount applies to services"
+              checked={discountForm.applies_to_services}
+              onChange={(e) => setDiscountForm({ ...discountForm, applies_to_services: e.target.checked })}
+              className="mr-2" />
         
           Применяется к услугам
         </label>
-        <label className="flex items-center">
-          <input
-          type="checkbox"
-          checked={discountForm.applies_to_appointments}
-          onChange={(e) => setDiscountForm({ ...discountForm, applies_to_appointments: e.target.checked })}
-          className="mr-2" />
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              aria-label="Discount applies to appointments"
+              checked={discountForm.applies_to_appointments}
+              onChange={(e) => setDiscountForm({ ...discountForm, applies_to_appointments: e.target.checked })}
+              className="mr-2" />
         
           Применяется к записям
         </label>
-        <label className="flex items-center">
-          <input
-          type="checkbox"
-          checked={discountForm.can_combine_with_others}
-          onChange={(e) => setDiscountForm({ ...discountForm, can_combine_with_others: e.target.checked })}
-          className="mr-2" />
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              aria-label="Discount can combine with other discounts"
+              checked={discountForm.can_combine_with_others}
+              onChange={(e) => setDiscountForm({ ...discountForm, can_combine_with_others: e.target.checked })}
+              className="mr-2" />
         
           Можно комбинировать с другими
         </label>
@@ -480,30 +483,33 @@ const DiscountBenefitsManager = () => {
       
       </div>
       <div className="flex flex-wrap gap-4">
-        <label className="flex items-center">
-          <input
-          type="checkbox"
-          checked={benefitForm.requires_document}
-          onChange={(e) => setBenefitForm({ ...benefitForm, requires_document: e.target.checked })}
-          className="mr-2" />
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              aria-label="Benefit requires documents"
+              checked={benefitForm.requires_document}
+              onChange={(e) => setBenefitForm({ ...benefitForm, requires_document: e.target.checked })}
+              className="mr-2" />
         
           Требует документы
         </label>
-        <label className="flex items-center">
-          <input
-          type="checkbox"
-          checked={benefitForm.applies_to_services}
-          onChange={(e) => setBenefitForm({ ...benefitForm, applies_to_services: e.target.checked })}
-          className="mr-2" />
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              aria-label="Benefit applies to services"
+              checked={benefitForm.applies_to_services}
+              onChange={(e) => setBenefitForm({ ...benefitForm, applies_to_services: e.target.checked })}
+              className="mr-2" />
         
           Применяется к услугам
         </label>
-        <label className="flex items-center">
-          <input
-          type="checkbox"
-          checked={benefitForm.applies_to_appointments}
-          onChange={(e) => setBenefitForm({ ...benefitForm, applies_to_appointments: e.target.checked })}
-          className="mr-2" />
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              aria-label="Benefit applies to appointments"
+              checked={benefitForm.applies_to_appointments}
+              onChange={(e) => setBenefitForm({ ...benefitForm, applies_to_appointments: e.target.checked })}
+              className="mr-2" />
         
           Применяется к записям
         </label>


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to discount and benefit checkbox controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `frontend/src/components/admin/DiscountBenefitsManager.jsx` without changing discount or benefit form behavior.
- Kept this as a one-file accessibility metadata slice.

## Contract Impact
- Canonical surface: Frontend admin discount/benefit accessibility metadata only.
- Request shape: Not changed; no API request payloads or form submit values changed.
- Response shape: Not changed; no response handling or data mapping changed.
- Status codes: Not changed; no network behavior changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for discount/benefit checkbox controls; visible UI, submitted values, handlers, and form state are unchanged.
- Compatibility path or alias: Not applicable because no route, API path, import alias, or compatibility shim changed in this metadata-only slice.
- Contract proof: `frontend/src/components/admin/DiscountBenefitsManager.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Unchanged; this preserves the existing admin discount/benefit management access path.
- Roles denied: Unchanged; no route guard, role gate, or permission check was edited.
- Positive auth proof: Not rerun because the patch only adds `aria-label` attributes to existing inputs and does not change auth or route access code.
- Negative auth proof: Not rerun because no authorization boundary, protected route, or denied-role behavior was touched.

## Notification / Realtime
- Event type or websocket channel: None changed; no websocket, polling, notification, Telegram, FCM, or realtime files were touched.
- Payload version / ack behavior: Not applicable because this PR does not emit or consume any realtime payloads.
- Read/unread or delivery semantics: Not applicable because no notification state or delivery semantics changed.
- Reconnect/resync proof: Not rerun because no realtime client/server connection behavior changed.

## Frontend Resilience
- Empty data proof: Existing empty-data behavior is unchanged; only checkbox accessible names were added.
- Partial data proof: Existing partial-data behavior is unchanged; no data mapping or conditional rendering changed.
- Forbidden secondary path behavior: Existing forbidden-route behavior is unchanged; no route or permission handling changed.
- Missing draft/resource behavior: Existing missing-resource behavior is unchanged; no draft/resource lookup logic changed.
- Stale route/deep-link behavior: Existing deep-link behavior is unchanged; no routing or navigation code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/DiscountBenefitsManager.jsx` only.
- Denied paths: Backend, runtime API, database, migration, route contract, payment, queue, EMR, lab, notification, Telegram, workflow, dependency, and generated artifact paths.
- Migration/docs/test impact: No migrations, docs, tests, snapshots, or generated artifacts changed; validation is via lint, strict icon audit, build, and diff check.
- Rollback note: Reverting this PR removes only the added accessible names and restores the previous metadata state.

## Risk
- Low. This only adds `aria-label` metadata to existing checkbox inputs.
- No discount or benefit API calls, payloads, validation, state transitions, routes, RBAC, or persistence logic changed.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/admin/DiscountBenefitsManager.jsx --quiet`; `npx.cmd eslint src/components/admin/DiscountBenefitsManager.jsx -f json --output-file %TEMP%/discount-benefits-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. DiscountBenefitsManager ESLint JSON reports 0 messages and strict icon-only controls audit reports 0 findings.
- Not checked: Browser visual QA was not run because this PR only adds accessibility metadata and does not change layout, business state, route behavior, or API behavior.
