### PR TITLE
fix(frontend): label responsive table controls

### DIFF
--- a/frontend/src/components/ResponsiveTable.jsx
+++ b/frontend/src/components/ResponsiveTable.jsx
@@ -95,6 +95,7 @@ const ResponsiveTable = ({
                 {onRowSelect &&
               <input
                 type="checkbox"
+                aria-label={`Select ${row.name || row.fio || `record ${index + 1}`}`}
                 checked={selectedRows.has(index)}
                 onChange={(e) => onRowSelect(index, e.target.checked)}
                 style={{ transform: 'scale(1.2)' }} />
@@ -242,9 +243,10 @@ const ResponsiveTable = ({
               visibility: 'visible !important',
               opacity: '1 !important',
               color: '#374151 !important'
-            }}>
+            }} aria-label="Row selection">
                 <input
                 type="checkbox"
+                aria-label="Select all rows"
                 checked={selectedRows.size === data.length && data.length > 0}
                 onChange={(e) => {
                   data.forEach((_, index) => onRowSelect(index, e.target.checked));
@@ -329,11 +331,12 @@ const ResponsiveTable = ({
                 e.target.style.background = 'white';
               }
             }}>
-            
+
               {onRowSelect &&
-            <td style={{ padding: '12px', textAlign: 'center' }}>
+            <td style={{ padding: '12px', textAlign: 'center' }} aria-label={`Select ${row.name || row.fio || `record ${index + 1}`}`}>
                   <input
                 type="checkbox"
+                aria-label={`Select ${row.name || row.fio || `record ${index + 1}`}`}
                 checked={selectedRows.has(index)}
                 onChange={(e) => {
                   e.stopPropagation();


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to `ResponsiveTable` row-selection controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `frontend/src/components/ResponsiveTable.jsx` without changing table selection behavior.
- Kept this as a one-file accessibility metadata slice for the shared responsive table component.

## Contract Impact
- Canonical surface: Frontend responsive table selection accessibility metadata only.
- Request shape: Not changed; no table data, selection callback arguments, or API payloads changed.
- Response shape: Not changed; no response handling or row rendering data mapping changed.
- Status codes: Not changed; no network behavior changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for row-selection and select-all controls; visible UI, selectedRows state, callbacks, sorting, and actions are unchanged.
- Compatibility path or alias: Not applicable because no route, API path, import alias, or compatibility shim changed in this metadata-only slice.
- Contract proof: `frontend/src/components/ResponsiveTable.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Unchanged; this shared component preserves all existing caller-provided access and rendering behavior.
- Roles denied: Unchanged; no route guard, role gate, or permission check was edited.
- Positive auth proof: Not rerun because the patch only adds accessible names to existing selection controls and does not change auth or protected route code.
- Negative auth proof: Not rerun because no authorization boundary, protected route, or denied-role behavior was touched.

## Notification / Realtime
- Event type or websocket channel: None changed; no websocket, polling, notification, Telegram, FCM, or realtime files were touched.
- Payload version / ack behavior: Not applicable because this PR does not emit or consume any realtime payloads.
- Read/unread or delivery semantics: Not applicable because no notification state or delivery semantics changed.
- Reconnect/resync proof: Not rerun because no realtime client/server connection behavior changed.

## Frontend Resilience
- Empty data proof: Existing empty-data behavior is unchanged; select-all remains disabled by state expression when data length is zero.
- Partial data proof: Existing partial-row rendering behavior is unchanged; row labels reuse the existing name/fio/fallback display sources.
- Forbidden secondary path behavior: Existing forbidden-route behavior is unchanged; no route or permission handling changed.
- Missing draft/resource behavior: Existing missing-row/resource behavior is unchanged; no lookup or data-fetch logic changed.
- Stale route/deep-link behavior: Existing deep-link behavior is unchanged; no routing or navigation code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/ResponsiveTable.jsx` only.
- Denied paths: Backend, runtime API, database, migration, route contract, payment, queue, EMR, lab, notification, Telegram, workflow, dependency, and generated artifact paths.
- Migration/docs/test impact: No migrations, docs, tests, snapshots, or generated artifacts changed; validation is via lint, strict icon audit, build, and diff check.
- Rollback note: Reverting this PR removes only the added selection accessible names and restores the previous metadata state.

## Risk
- Low. This only adds `aria-label` metadata to existing selection controls and selection cells.
- No table sorting, row click, action rendering, selection callback, or responsive layout behavior changed.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/ResponsiveTable.jsx --quiet`; `npx.cmd eslint src/components/ResponsiveTable.jsx -f json --output-file %TEMP%/responsive-table-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. ResponsiveTable ESLint JSON reports 0 messages and strict icon-only controls audit reports 0 findings.
- Not checked: Browser visual QA was not run because this PR only adds accessibility metadata and does not change layout, business state, route behavior, or API behavior.
