### PR TITLE
fix(frontend): label two factor setup controls

### DIFF
--- a/frontend/src/components/security/TwoFactorSetupWizard.jsx
+++ b/frontend/src/components/security/TwoFactorSetupWizard.jsx
@@ -206,6 +206,7 @@ const TwoFactorSetupWizard = ({ onComplete }) => {
         return (
           <button
             key={method.id}
+            aria-label={`Select ${method.name} 2FA method`}
             onClick={() => handleMethodSelect(method.id)}
             className={`p-6 border-2 rounded-lg text-left transition-all ${selectedMethod === method.id ?
             'border-blue-500 bg-blue-50' :
@@ -264,6 +265,7 @@ const TwoFactorSetupWizard = ({ onComplete }) => {
             </label>
             <input
           type={selectedMethod === 'sms' ? 'tel' : 'email'}
+          aria-label={selectedMethod === 'sms' ? '2FA setup phone number' : '2FA setup email address'}
           value={selectedMethod === 'sms' ? recoveryPhone : recoveryEmail}
           onChange={(e) => {
             if (selectedMethod === 'sms') {
@@ -284,6 +286,7 @@ const TwoFactorSetupWizard = ({ onComplete }) => {
           </label>
           <input
           type="email"
+          aria-label="Recovery email"
           value={recoveryEmail}
           onChange={(e) => setRecoveryEmail(e.target.value)}
           placeholder="recovery@example.com"
@@ -297,6 +300,7 @@ const TwoFactorSetupWizard = ({ onComplete }) => {
           </label>
           <input
           type="tel"
+          aria-label="Recovery phone"
           value={recoveryPhone}
           onChange={(e) => setRecoveryPhone(e.target.value)}
           placeholder="+7 (999) 123-45-67"
@@ -387,6 +391,7 @@ const TwoFactorSetupWizard = ({ onComplete }) => {
         </label>
         <input
         type="text"
+        aria-label="2FA verification code"
         value={verificationCode}
         onChange={(e) => setVerificationCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
         placeholder="000000"


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to the 2FA method card and setup/verification inputs.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `frontend/src/components/security/TwoFactorSetupWizard.jsx` without changing 2FA setup or verification behavior.
- Kept this as a one-file accessibility metadata slice on the security wizard.

## Contract Impact
- Canonical surface: Frontend 2FA setup wizard accessibility metadata only.
- Request shape: Not changed; `/api/v1/2fa/setup` and `/api/v1/2fa/verify-setup` payloads are untouched.
- Response shape: Not changed; response parsing, setup data, backup codes, and error handling are untouched.
- Status codes: Not changed; no network request handling changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for method selection and 2FA inputs; visible UI, state, handlers, and submitted values are unchanged.
- Compatibility path or alias: Not applicable because no route, API path, import alias, or compatibility shim changed in this metadata-only slice.
- Contract proof: `frontend/src/components/security/TwoFactorSetupWizard.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Unchanged; this preserves the existing caller-provided access path to the 2FA wizard.
- Roles denied: Unchanged; no route guard, role gate, permission check, token manager behavior, or 2FA enforcement logic was edited.
- Positive auth proof: Static auth-flow proof only; setup and verify fetch calls still use the same bearer token source and payload shape, and lint/build passed.
- Negative auth proof: Not rerun because no authorization boundary, protected route, denied-role behavior, or token issuance/verification logic was touched.

## Notification / Realtime
- Event type or websocket channel: None changed; no websocket, polling, notification, Telegram, FCM, or realtime files were touched.
- Payload version / ack behavior: Not applicable because this PR does not emit or consume any realtime payloads.
- Read/unread or delivery semantics: Not applicable because no notification state or delivery semantics changed.
- Reconnect/resync proof: Not rerun because no realtime client/server connection behavior changed.

## Frontend Resilience
- Empty data proof: Existing setupData and backupCodes empty-state behavior is unchanged; no conditional rendering logic changed.
- Partial data proof: Existing partial setup data handling is unchanged; only input/button accessible names were added.
- Forbidden secondary path behavior: Existing forbidden-route behavior is unchanged; no route or permission handling changed.
- Missing draft/resource behavior: Existing missing setup resource behavior is unchanged; no lookup or fetch logic changed.
- Stale route/deep-link behavior: Existing deep-link behavior is unchanged; no routing or navigation code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/security/TwoFactorSetupWizard.jsx` only.
- Denied paths: Backend, runtime API, database, migration, route contract, payment, queue, EMR, lab, notification, Telegram, workflow, dependency, and generated artifact paths.
- Migration/docs/test impact: No migrations, docs, tests, snapshots, or generated artifacts changed; validation is via lint, strict icon audit, build, and diff check.
- Rollback note: Reverting this PR removes only the added accessible names and restores the previous metadata state.

## Risk
- Low. This only adds `aria-label` metadata to existing 2FA controls.
- No 2FA API calls, payloads, validation, state transitions, token handling, routes, RBAC, or persistence logic changed.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/security/TwoFactorSetupWizard.jsx --quiet`; `npx.cmd eslint src/components/security/TwoFactorSetupWizard.jsx -f json --output-file %TEMP%/two-factor-setup-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. TwoFactorSetupWizard ESLint JSON reports 0 messages and strict icon-only controls audit reports 0 findings.
- Not checked: Live 2FA setup browser QA was not run because this PR only adds accessibility metadata and does not change layout, auth flow, token handling, route behavior, or API behavior.
