### PR TITLE
fix(frontend): label dental reports controls

### DIFF
--- a/frontend/src/components/dental/ReportsAndAnalytics.jsx
+++ b/frontend/src/components/dental/ReportsAndAnalytics.jsx
@@ -405,8 +405,8 @@ const ReportsAndAnalytics = ({
           <tbody className="bg-white divide-y divide-gray-200">
               {analyticsData.doctors.map((doctor) =>
             <tr key={doctor.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="flex items-center">
+                  <td className="px-6 py-4 whitespace-nowrap" aria-label={`Doctor ${doctor.name}`}>
+                    <div className="flex items-center" aria-label={`Doctor ${doctor.name}`}>
                       <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
                         <User className="h-4 w-4 text-blue-600" />
       </div>
@@ -428,13 +428,13 @@ const ReportsAndAnalytics = ({
                     <div className="text-sm text-gray-900">{doctor.revenue.toLocaleString()} ₽</div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="flex items-center">
+                    <div className="flex items-center" aria-label={`Rating ${doctor.rating}`}>
                       <Star className="h-4 w-4 text-yellow-400 mr-1" />
                       <span className="text-sm text-gray-900">{doctor.rating}</span>
         </div>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="flex items-center">
+                  <td className="px-6 py-4 whitespace-nowrap" aria-label={`Efficiency ${doctor.efficiency}%`}>
+                    <div className="flex items-center" aria-label={`Efficiency ${doctor.efficiency}%`}>
                       <div className="w-16 bg-gray-200 rounded-full h-2 mr-2">
                         <div
                       className="bg-green-500 h-2 rounded-full"
@@ -481,8 +481,8 @@ const ReportsAndAnalytics = ({
           <tbody className="bg-white divide-y divide-gray-200">
               {analyticsData.procedures.map((procedure, index) =>
             <tr key={index} className="hover:bg-gray-50">
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="flex items-center">
+                  <td className="px-6 py-4 whitespace-nowrap" aria-label={`Procedure ${procedure.name}`}>
+                    <div className="flex items-center" aria-label={`Procedure ${procedure.name}`}>
                       <div className={`w-8 h-8 rounded-full flex items-center justify-center ${
                   index === 0 ? 'bg-blue-100' :
                   index === 1 ? 'bg-green-100' :


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to dental reports doctor/procedure table cells and visual metric wrappers.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `frontend/src/components/dental/ReportsAndAnalytics.jsx` without changing analytics data or tab behavior.
- Kept this as a one-file accessibility metadata slice for the dental reports modal.

## Contract Impact
- Canonical surface: Frontend dental reports accessibility metadata only.
- Request shape: Not changed; no API request payloads or export parameters changed.
- Response shape: Not changed; mock analytics data, table rendering values, and report state are untouched.
- Status codes: Not changed; no network behavior changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for doctor, rating, efficiency, and procedure visual rows; visible UI, tabs, export handler, and analytics values are unchanged.
- Compatibility path or alias: Not applicable because no route, API path, import alias, or compatibility shim changed in this metadata-only slice.
- Contract proof: `frontend/src/components/dental/ReportsAndAnalytics.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Unchanged; this preserves the existing caller-provided dental reports access path.
- Roles denied: Unchanged; no route guard, role gate, permission check, or auth logic was edited.
- Positive auth proof: Not rerun because the patch only adds accessible names to existing rendered report cells and does not change auth or route access code.
- Negative auth proof: Not rerun because no authorization boundary, protected route, or denied-role behavior was touched.

## Notification / Realtime
- Event type or websocket channel: None changed; no websocket, polling, notification, Telegram, FCM, or realtime files were touched.
- Payload version / ack behavior: Not applicable because this PR does not emit or consume any realtime payloads.
- Read/unread or delivery semantics: Not applicable because no notification state or delivery semantics changed.
- Reconnect/resync proof: Not rerun because no realtime client/server connection behavior changed.

## Frontend Resilience
- Empty data proof: Existing analytics data rendering is unchanged; this PR does not change empty-state or data availability logic.
- Partial data proof: Existing partial-data behavior is unchanged; labels derive from already-rendered doctor/procedure values.
- Forbidden secondary path behavior: Existing forbidden-route behavior is unchanged; no route or permission handling changed.
- Missing draft/resource behavior: Existing missing-resource behavior is unchanged; no data lookup or fetch logic changed.
- Stale route/deep-link behavior: Existing deep-link behavior is unchanged; no routing or navigation code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/dental/ReportsAndAnalytics.jsx` only.
- Denied paths: Backend, runtime API, database, migration, route contract, payment, queue, EMR, lab, notification, Telegram, workflow, dependency, and generated artifact paths.
- Migration/docs/test impact: No migrations, docs, tests, snapshots, or generated artifacts changed; validation is via lint, strict icon audit, build, and diff check.
- Rollback note: Reverting this PR removes only the added accessible names and restores the previous metadata state.

## Risk
- Low. This only adds `aria-label` metadata to existing report table/visual wrappers.
- No analytics data, export behavior, tab state, modal close behavior, or dental clinical logic changed.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/dental/ReportsAndAnalytics.jsx --quiet`; `npx.cmd eslint src/components/dental/ReportsAndAnalytics.jsx -f json --output-file %TEMP%/dental-reports-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. ReportsAndAnalytics ESLint JSON reports 0 messages and strict icon-only controls audit reports 0 findings.
- Not checked: Browser visual QA was not run because this PR only adds accessibility metadata and does not change layout, business state, route behavior, or API behavior.
