### PR TITLE
fix(frontend): label finance modal controls

### DIFF
--- a/frontend/src/components/admin/FinanceModal.jsx
+++ b/frontend/src/components/admin/FinanceModal.jsx
@@ -308,6 +308,7 @@ const FinanceModal = ({
                                 style={{ color: 'var(--text-tertiary)' }} />
                     <input
                       type="number"
+                      aria-label="Finance transaction amount"
                       value={formData.amount}
                       onChange={(e) => handleChange('amount', e.target.value)}
                       className={`w-full pl-10 pr-3 py-2 rounded-lg border focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
@@ -346,6 +347,7 @@ const FinanceModal = ({
                               style={{ color: 'var(--text-tertiary)' }} />
                     <input
                       type="date"
+                      aria-label="Finance transaction date"
                       value={formData.transactionDate}
                       onChange={(e) => handleChange('transactionDate', e.target.value)}
                       className={`w-full pl-10 pr-3 py-2 rounded-lg border focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
@@ -373,6 +375,7 @@ const FinanceModal = ({
                   Описание *
                 </label>
                 <textarea
+                  aria-label="Finance transaction description"
                   value={formData.description}
                   onChange={(e) => handleChange('description', e.target.value)}
                   className={`w-full px-3 py-2 rounded-lg border focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
@@ -525,6 +528,7 @@ const FinanceModal = ({
                               style={{ color: 'var(--text-tertiary)' }} />
                     <input
                       type="text"
+                      aria-label="Finance card or transaction reference"
                       value={formData.reference}
                       onChange={(e) => handleChange('reference', e.target.value)}
                       className={`w-full pl-10 pr-3 py-2 rounded-lg border focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
@@ -558,6 +562,7 @@ const FinanceModal = ({
                   Заметки
                 </label>
                 <textarea
+                  aria-label="Finance transaction notes"
                   value={formData.notes}
                   onChange={(e) => handleChange('notes', e.target.value)}
                   className="w-full px-3 py-2 rounded-lg border focus:ring-2 focus:ring-blue-500 focus:border-transparent"


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to finance transaction amount, date, description, reference, and notes controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `frontend/src/components/admin/FinanceModal.jsx` without changing finance form behavior.
- Kept this as a one-file accessibility metadata slice for the admin finance modal.

## Contract Impact
- Canonical surface: Frontend admin finance modal accessibility metadata only.
- Request shape: Not changed; finance transaction payload fields and parsing are untouched.
- Response shape: Not changed; no response handling or save callback behavior changed.
- Status codes: Not changed; no network behavior changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for finance form fields; visible UI, validation, amount parsing, payment method logic, and submitted values are unchanged.
- Compatibility path or alias: Not applicable because no route, API path, import alias, or compatibility shim changed in this metadata-only slice.
- Contract proof: `frontend/src/components/admin/FinanceModal.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Unchanged; this preserves the existing admin finance modal access path provided by callers.
- Roles denied: Unchanged; no route guard, role gate, permission check, or auth logic was edited.
- Positive auth proof: Not rerun because the patch only adds accessible names to existing form controls and does not change auth or route access code.
- Negative auth proof: Not rerun because no authorization boundary, protected route, or denied-role behavior was touched.

## Notification / Realtime
- Event type or websocket channel: None changed; no websocket, polling, notification, Telegram, FCM, or realtime files were touched.
- Payload version / ack behavior: Not applicable because this PR does not emit or consume any realtime payloads.
- Read/unread or delivery semantics: Not applicable because no notification state or delivery semantics changed.
- Reconnect/resync proof: Not rerun because no realtime client/server connection behavior changed.

## Frontend Resilience
- Empty data proof: Existing transaction/default form initialization behavior is unchanged; no fallback state logic changed.
- Partial data proof: Existing partial transaction handling is unchanged; aria labels do not alter field values or validation.
- Forbidden secondary path behavior: Existing forbidden-route behavior is unchanged; no route or permission handling changed.
- Missing draft/resource behavior: Existing missing transaction behavior is unchanged; no draft/resource lookup logic changed.
- Stale route/deep-link behavior: Existing deep-link behavior is unchanged; no routing or navigation code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/FinanceModal.jsx` only.
- Denied paths: Backend, runtime API, database, migration, route contract, payment, queue, EMR, lab, notification, Telegram, workflow, dependency, and generated artifact paths.
- Migration/docs/test impact: No migrations, docs, tests, snapshots, or generated artifacts changed; validation is via lint, strict icon audit, build, and diff check.
- Rollback note: Reverting this PR removes only the added accessible names and restores the previous metadata state.

## Risk
- Low. This only adds `aria-label` metadata to existing finance form controls.
- No finance calculations, validation rules, payment method behavior, save callback, payload shape, routes, RBAC, or persistence logic changed.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/admin/FinanceModal.jsx --quiet`; `npx.cmd eslint src/components/admin/FinanceModal.jsx -f json --output-file %TEMP%/finance-modal-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. FinanceModal ESLint JSON reports 0 messages and strict icon-only controls audit reports 0 findings.
- Not checked: Browser visual QA was not run because this PR only adds accessibility metadata and does not change layout, finance behavior, route behavior, or API behavior.
