### PR TITLE
fix(frontend): label appointment wizard controls

### DIFF
--- a/frontend/src/components/wizard/AppointmentWizardV2.jsx
+++ b/frontend/src/components/wizard/AppointmentWizardV2.jsx
@@ -3233,6 +3233,7 @@ const PatientStepV2 = ({
               type="radio"
               name="discount_mode"
               value="none"
+              aria-label="Select paid visit discount mode"
               checked={cart?.discount_mode === 'none'}
               onChange={(e) => onUpdateCart('discount_mode', e.target.value)}
               style={{ margin: 0 }} />
@@ -3263,6 +3264,7 @@ const PatientStepV2 = ({
               type="radio"
               name="discount_mode"
               value="repeat"
+              aria-label="Select repeat visit discount mode"
               checked={cart?.discount_mode === 'repeat'}
               onChange={(e) => onUpdateCart('discount_mode', e.target.value)}
               style={{ margin: 0 }} />
@@ -3293,6 +3295,7 @@ const PatientStepV2 = ({
               type="radio"
               name="discount_mode"
               value="benefit"
+              aria-label="Select benefit discount mode"
               checked={cart?.discount_mode === 'benefit'}
               onChange={(e) => onUpdateCart('discount_mode', e.target.value)}
               style={{ margin: 0 }} />
@@ -3323,6 +3326,7 @@ const PatientStepV2 = ({
 
             <input
               type="checkbox"
+              aria-label="Request all services free approval"
               checked={cart?.all_free}
               onChange={(e) => onUpdateCart('all_free', e.target.checked)}
               style={{ margin: 0 }} />
@@ -3577,6 +3581,7 @@ const CartStepV2 = ({
 
                 <input
                   type="checkbox"
+                  aria-label={`Select service ${service.name || service.service_code || service.id}`}
                   checked={isInCart}
                   onChange={() => handleServiceToggle(service)}
                   style={{ width: '14px', height: '14px', cursor: 'pointer', flexShrink: 0, margin: 0 }} />


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to appointment wizard discount mode, all-free approval, and service selection controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `frontend/src/components/wizard/AppointmentWizardV2.jsx` without changing appointment wizard behavior.
- Kept this as a one-file accessibility metadata slice for the appointment wizard.

## Contract Impact
- Canonical surface: Frontend appointment wizard accessibility metadata only.
- Request shape: Not changed; appointment, queue, service, doctor, discount, and cart payload fields are untouched.
- Response shape: Not changed; no response handling, draft hydration, queue handling, or save behavior changed.
- Status codes: Not changed; no network behavior changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for existing wizard controls; visible UI, selection state, validation, pricing, cart behavior, service/doctor selection, and submitted values are unchanged.
- Compatibility path or alias: Not applicable because no route, API path, import alias, or compatibility shim changed in this metadata-only slice.
- Contract proof: `frontend/src/components/wizard/AppointmentWizardV2.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Unchanged; this preserves the existing appointment wizard access path provided by callers.
- Roles denied: Unchanged; no route guard, role gate, permission check, or auth logic was edited.
- Positive auth proof: Not rerun because the patch only adds accessible names to existing controls and does not change auth or route access code.
- Negative auth proof: Not rerun because no authorization boundary, protected route, or denied-role behavior was touched.

## Notification / Realtime
- Event type or websocket channel: None changed; no websocket, polling, notification, Telegram, FCM, or realtime files were touched.
- Payload version / ack behavior: Not applicable because this PR does not emit or consume any realtime payloads.
- Read/unread or delivery semantics: Not applicable because no notification state or delivery semantics changed.
- Reconnect/resync proof: Not rerun because no realtime client/server connection behavior changed.

## Frontend Resilience
- Empty data proof: Existing empty service list and cart behavior is unchanged; no fallback state logic changed.
- Partial data proof: Existing partial service fallback for accessible names uses already-rendered service metadata and does not alter form values or validation.
- Forbidden secondary path behavior: Existing forbidden-route behavior is unchanged; no route or permission handling changed.
- Missing draft/resource behavior: Existing missing draft/resource behavior is unchanged; no draft/resource lookup logic changed.
- Stale route/deep-link behavior: Existing deep-link behavior is unchanged; no routing or navigation code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/wizard/AppointmentWizardV2.jsx` only.
- Denied paths: Backend, runtime API, database, migration, route contract, payment, queue, EMR, lab, notification, Telegram, workflow, dependency, and generated artifact paths.
- Migration/docs/test impact: No migrations, docs, tests, snapshots, or generated artifacts changed; validation is via lint, strict icon audit, build, and diff check.
- Rollback note: Reverting this PR removes only the added accessible names and restores the previous metadata state.

## Risk
- Low. This only adds `aria-label` metadata to existing appointment wizard controls.
- No appointment flow, service filtering, cart state, discount mode logic, all-free approval behavior, doctor assignment, queue/payment/EMR behavior, routes, RBAC, or persistence logic changed.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/wizard/AppointmentWizardV2.jsx --quiet`; `npx.cmd eslint src/components/wizard/AppointmentWizardV2.jsx -f json --output-file %TEMP%/appointment-wizard-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. AppointmentWizardV2 ESLint JSON reports 0 messages and strict icon-only controls audit reports 0 findings.
- Not checked: Browser visual QA was not run because this PR only adds accessibility metadata and does not change layout, appointment behavior, route behavior, or API behavior.
