### PR TITLE
fix(frontend): label dentistry section controls

### DIFF
--- a/frontend/src/components/emr-v2/sections/specialty/DentistrySection.jsx
+++ b/frontend/src/components/emr-v2/sections/specialty/DentistrySection.jsx
@@ -187,6 +187,7 @@ export function DentistrySection({
                                         <span className="tooth-number">{toothNum}</span>
                                         <input
                                             type="number"
+                                            aria-label={`Periodontal pocket depth for tooth ${toothNum}`}
                                             min="0"
                                             max="15"
                                             value={depth}
@@ -216,6 +217,7 @@ export function DentistrySection({
                                         <span className="tooth-number">{toothNum}</span>
                                         <input
                                             type="number"
+                                            aria-label={`Periodontal pocket depth for tooth ${toothNum}`}
                                             min="0"
                                             max="15"
                                             value={depth}
@@ -301,6 +303,7 @@ export function DentistrySection({
                             <label className="dentistry-checkbox">
                                 <input
                                     type="checkbox"
+                                    aria-label="Crossbite measurement"
                                     checked={measurements?.crossbite || false}
                                     onChange={(e) => handleMeasurementChange('crossbite', e.target.checked)}
                                     disabled={disabled}
@@ -310,6 +313,7 @@ export function DentistrySection({
                             <label className="dentistry-checkbox">
                                 <input
                                     type="checkbox"
+                                    aria-label="Open bite measurement"
                                     checked={measurements?.openBite || false}
                                     onChange={(e) => handleMeasurementChange('openBite', e.target.checked)}
                                     disabled={disabled}


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to dentistry periodontal pocket depth and occlusion measurement controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `frontend/src/components/emr-v2/sections/specialty/DentistrySection.jsx` without changing clinical data behavior.
- Kept this as a one-file accessibility metadata slice for the dental EMR specialty section.

## Contract Impact
- Canonical surface: Frontend dental EMR specialty section accessibility metadata only.
- Request shape: Not changed; `tooth_status`, `hygiene_indices`, `periodontal_pockets`, `measurements`, and `radiographs` data shapes are untouched.
- Response shape: Not changed; no response handling, EMR hydration, save behavior, or specialty data mapping changed.
- Status codes: Not changed; no network behavior changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for periodontal and occlusion controls; visible UI, tab state, tooth values, measurement values, disabled state, and submitted specialty data are unchanged.
- Compatibility path or alias: Not applicable because no route, API path, import alias, or compatibility shim changed in this metadata-only slice.
- Contract proof: `frontend/src/components/emr-v2/sections/specialty/DentistrySection.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Unchanged; this preserves the existing EMR specialty section access path provided by callers.
- Roles denied: Unchanged; no route guard, role gate, permission check, or auth logic was edited.
- Positive auth proof: Not rerun because the patch only adds accessible names to existing controls and does not change auth or route access code.
- Negative auth proof: Not rerun because no authorization boundary, protected route, or denied-role behavior was touched.

## Notification / Realtime
- Event type or websocket channel: None changed; no websocket, polling, notification, Telegram, FCM, or realtime files were touched.
- Payload version / ack behavior: Not applicable because this PR does not emit or consume any realtime payloads.
- Read/unread or delivery semantics: Not applicable because no notification state or delivery semantics changed.
- Reconnect/resync proof: Not rerun because no realtime client/server connection behavior changed.

## Frontend Resilience
- Empty data proof: Existing default empty dental data behavior is unchanged; no fallback state logic changed.
- Partial data proof: Existing optional chaining/default value handling for dental measurements is unchanged; aria labels do not alter field values or validation.
- Forbidden secondary path behavior: Existing forbidden-route behavior is unchanged; no route or permission handling changed.
- Missing draft/resource behavior: Existing missing EMR draft/resource behavior is unchanged; no draft/resource lookup logic changed.
- Stale route/deep-link behavior: Existing deep-link behavior is unchanged; no routing or navigation code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/emr-v2/sections/specialty/DentistrySection.jsx` only.
- Denied paths: Backend, runtime API, database, migration, route contract, payment, queue, EMR persistence, lab, notification, Telegram, workflow, dependency, and generated artifact paths.
- Migration/docs/test impact: No migrations, docs, tests, snapshots, or generated artifacts changed; validation is via lint, strict icon audit, build, and diff check.
- Rollback note: Reverting this PR removes only the added accessible names and restores the previous metadata state.

## Risk
- Low. This only adds `aria-label` metadata to existing dental EMR controls.
- No tooth chart behavior, periodontal calculations, occlusion measurement keys, specialty data shape, EMR save flow, routes, RBAC, or persistence logic changed.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/emr-v2/sections/specialty/DentistrySection.jsx --quiet`; `npx.cmd eslint src/components/emr-v2/sections/specialty/DentistrySection.jsx -f json --output-file %TEMP%/dentistry-section-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. DentistrySection ESLint JSON reports 0 messages and strict icon-only controls audit reports 0 findings.
- Not checked: Browser visual QA was not run because this PR only adds accessibility metadata and does not change layout, clinical behavior, route behavior, or API behavior.
