### PR TITLE
fix(frontend): label prescription editor controls

### DIFF
--- a/frontend/src/components/emr-v2/sections/PrescriptionEditor.jsx
+++ b/frontend/src/components/emr-v2/sections/PrescriptionEditor.jsx
@@ -136,6 +136,7 @@ const PrescriptionEditor = ({
                                     <label className="prescription-label">Препарат</label>
                                     <input
                 className="prescription-input"
+                aria-label="Prescription medicine name"
                 value={newItem.name}
                 onChange={(e) => handleInputChange('name', e.target.value)}
                 placeholder="Название..."
@@ -170,6 +171,7 @@ const PrescriptionEditor = ({
                                     <label className="prescription-label">Доза</label>
                                     <input
                 className="prescription-input"
+                aria-label="Prescription dose"
                 value={newItem.dose}
                 onChange={(e) => handleInputChange('dose', e.target.value)}
                 placeholder="500 мг" />
@@ -179,6 +181,7 @@ const PrescriptionEditor = ({
                                     <label className="prescription-label">Кратность</label>
                                     <input
                 className="prescription-input"
+                aria-label="Prescription frequency"
                 value={newItem.frequency}
                 onChange={(e) => handleInputChange('frequency', e.target.value)}
                 placeholder="3 р/д" />
@@ -188,6 +191,7 @@ const PrescriptionEditor = ({
                                     <label className="prescription-label">Длит.</label>
                                     <input
                 className="prescription-input"
+                aria-label="Prescription duration"
                 value={newItem.duration}
                 onChange={(e) => handleInputChange('duration', e.target.value)}
                 placeholder="7 дней" />


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to prescription medicine, dose, frequency, and duration controls.
- Removed the `jsx-a11y/control-has-associated-label` warnings from `frontend/src/components/emr-v2/sections/PrescriptionEditor.jsx` without changing prescription behavior.
- Kept this as a one-file accessibility metadata slice for the EMR prescription editor.

## Contract Impact
- Canonical surface: Frontend EMR prescription editor accessibility metadata only.
- Request shape: Not changed; prescription item fields, ids, dose, frequency, duration, notes, and `prescriptions` array shape are untouched.
- Response shape: Not changed; no response handling, EMR hydration, save behavior, or prescription mapping changed.
- Status codes: Not changed; no network behavior changed.
- Frontend consumer: Screen readers and a11y tooling receive explicit names for prescription form controls; visible UI, suggestions, validation guard, add/delete behavior, touched field tracking, and submitted values are unchanged.
- Compatibility path or alias: Not applicable because no route, API path, import alias, or compatibility shim changed in this metadata-only slice.
- Contract proof: `frontend/src/components/emr-v2/sections/PrescriptionEditor.jsx` ESLint JSON reports 0 messages and frontend build succeeds.

## RBAC / Permissions
- Roles allowed: Unchanged; this preserves the existing EMR prescription editor access path provided by callers.
- Roles denied: Unchanged; no route guard, role gate, permission check, or auth logic was edited.
- Positive auth proof: Not rerun because the patch only adds accessible names to existing controls and does not change auth or route access code.
- Negative auth proof: Not rerun because no authorization boundary, protected route, or denied-role behavior was touched.

## Notification / Realtime
- Event type or websocket channel: None changed; no websocket, polling, notification, Telegram, FCM, or realtime files were touched.
- Payload version / ack behavior: Not applicable because this PR does not emit or consume any realtime payloads.
- Read/unread or delivery semantics: Not applicable because no notification state or delivery semantics changed.
- Reconnect/resync proof: Not rerun because no realtime client/server connection behavior changed.

## Frontend Resilience
- Empty data proof: Existing empty prescription list and new-item reset behavior is unchanged; no fallback state logic changed.
- Partial data proof: Existing partial prescription item rendering and optional field behavior is unchanged; aria labels do not alter field values or validation.
- Forbidden secondary path behavior: Existing forbidden-route behavior is unchanged; no route or permission handling changed.
- Missing draft/resource behavior: Existing missing EMR draft/resource behavior is unchanged; no draft/resource lookup logic changed.
- Stale route/deep-link behavior: Existing deep-link behavior is unchanged; no routing or navigation code changed.

## Scope Gate
- Allowed paths: `frontend/src/components/emr-v2/sections/PrescriptionEditor.jsx` only.
- Denied paths: Backend, runtime API, database, migration, route contract, payment, queue, EMR persistence, lab, notification, Telegram, workflow, dependency, and generated artifact paths.
- Migration/docs/test impact: No migrations, docs, tests, snapshots, or generated artifacts changed; validation is via lint, strict icon audit, build, and diff check.
- Rollback note: Reverting this PR removes only the added accessible names and restores the previous metadata state.

## Risk
- Low. This only adds `aria-label` metadata to existing prescription form controls.
- No medication suggestion logic, prescription add/delete behavior, item shape, touched field tracking, EMR save flow, routes, RBAC, or persistence logic changed.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/emr-v2/sections/PrescriptionEditor.jsx --quiet`; `npx.cmd eslint src/components/emr-v2/sections/PrescriptionEditor.jsx -f json --output-file %TEMP%/prescription-editor-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Passed. PrescriptionEditor ESLint JSON reports 0 messages and strict icon-only controls audit reports 0 findings.
- Not checked: Browser visual QA was not run because this PR only adds accessibility metadata and does not change layout, clinical behavior, route behavior, or API behavior.
