### PR TITLE
fix(frontend): label forgot password controls

### DIFF
--- a/frontend/src/components/auth/ForgotPassword.jsx
+++ b/frontend/src/components/auth/ForgotPassword.jsx
@@ -309,6 +309,7 @@ const ForgotPassword = ({ onBack, onSuccess, language = 'RU' }) => {
           </label>
           <input
           type={method === 'phone' ? 'tel' : 'email'}
+          aria-label={method === 'phone' ? t.phoneLabel : t.emailLabel}
           value={contact}
           onChange={(e) => {
             const value = method === 'phone' ? formatPhone(e.target.value) : e.target.value;
@@ -376,6 +377,7 @@ const ForgotPassword = ({ onBack, onSuccess, language = 'RU' }) => {
           <label style={{ display: 'block', marginBottom: '8px', fontSize: '13px', fontWeight: '600', color: 'var(--mac-text-secondary)', marginLeft: '4px' }}>Код подтверждения</label>
           <input
           type="text"
+          aria-label="Verification code"
           value={verificationCode}
           onChange={(e) => setVerificationCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
           placeholder="000000"
@@ -470,6 +472,7 @@ const ForgotPassword = ({ onBack, onSuccess, language = 'RU' }) => {
           <label style={{ display: 'block', marginBottom: '8px', fontSize: '13px', fontWeight: '600', color: 'var(--mac-text-secondary)', marginLeft: '4px' }}>{t.newPassword}</label>
           <input
           type="password"
+          aria-label={t.newPassword}
           value={newPassword}
           onChange={(e) => setNewPassword(e.target.value)}
           placeholder="••••••••"
@@ -482,6 +485,7 @@ const ForgotPassword = ({ onBack, onSuccess, language = 'RU' }) => {
           <label style={{ display: 'block', marginBottom: '8px', fontSize: '13px', fontWeight: '600', color: 'var(--mac-text-secondary)', marginLeft: '4px' }}>{t.confirmPassword}</label>
           <input
           type="password"
+          aria-label={t.confirmPassword}
           value={confirmPassword}
           onChange={(e) => setConfirmPassword(e.target.value)}
           placeholder="••••••••"


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names to the forgot-password contact, verification-code, new-password, and confirm-password controls.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `ForgotPassword.jsx`.
- Kept the slice metadata-only: no visible UI, auth flow, token, validation, API, or routing behavior changes.

## Contract Impact

- Canonical surface: frontend forgot-password form control accessibility metadata only.
- Request shape: not changed - password reset initiation, verification, and confirmation payloads are untouched.
- Response shape: not changed - success/error handling, reset token flow, and step transitions are untouched.
- Status codes: not changed - no backend request handling or error mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit control names; visible labels, validators, contact formatting, password values, confirmation behavior, and submit behavior remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect, alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero messages, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - the forgot-password surface remains available through the existing unauthenticated recovery flow.
- Roles denied: unchanged - no route guard, role check, or permission helper was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels do not alter successful password reset or authenticated-session behavior.
- Negative auth proof: not rerun - metadata-only accessible-name labels do not alter credential, token, 2FA, role, or denial behavior.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, SSE, chat, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no realtime payload or acknowledgement contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, retry, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - the existing forgot-password empty contact/code/password states and validation messages were not edited.
- Partial data proof: unchanged - partial contact/code/password entry handling and button enablement remain the existing implementation.
- Forbidden secondary path behavior: unchanged - no route guard, forbidden screen, or secondary auth path was edited.
- Missing draft/resource behavior: unchanged - the flow does not introduce or consume draft resources, and reset-token handling was untouched.
- Stale route/deep-link behavior: unchanged - no route, navigation, timeout, token, or deep-link behavior was edited.

## Scope Gate

- Allowed paths: `frontend/src/components/auth/ForgotPassword.jsx` only.
- Denied paths: backend, runtime API, database, migration, route contract, payment, queue, EMR, lab, notification, Telegram, workflow, dependency, and generated artifact changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/components/auth/ForgotPassword.jsx --quiet`; `npx.cmd eslint src/components/auth/ForgotPassword.jsx -f json --output-file %TEMP%\forgot-password-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero messages, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully with only the LF-to-CRLF working-copy warning.
- Not checked: browser visual QA and full auth-flow browser smoke were not run because this is a metadata-only accessibility label slice.
