### PR TITLE
fix(frontend): label queue join controls

### DIFF
--- a/frontend/src/pages/QueueJoin.jsx
+++ b/frontend/src/pages/QueueJoin.jsx
@@ -1265,6 +1265,7 @@ const QueueJoin = () => {
                     >
                       <input
                         type="checkbox"
+                        aria-label={`Select specialist: ${formatSpecialistLabel(specialist)}`}
                         checked={isSelected}
                         onChange={() => {
                           if (error) {
@@ -1492,6 +1493,7 @@ const QueueJoin = () => {
                     id="queue-patient-name"
                     name="patient_name"
                     type="text"
+                    aria-label="Patient full name"
                     value={formData.patientName}
                     onChange={(e) => handleInputChange('patientName', e.target.value)}
                     style={{
@@ -1548,6 +1550,7 @@ const QueueJoin = () => {
                     id="queue-phone"
                     name="phone"
                     type="tel"
+                    aria-label="Patient phone number"
                     value={formData.phone}
                     onChange={handlePhoneChange}
                     onKeyDown={(e) => {
@@ -1633,6 +1636,7 @@ const QueueJoin = () => {
                   id="queue-telegram-id"
                   name="telegram_id"
                   type="number"
+                  aria-label="Telegram ID"
                   value={formData.telegramId}
                   onChange={(e) => handleInputChange('telegramId', e.target.value)}
                   style={{


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names to the public queue join specialist checkbox and patient form controls.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `QueueJoin.jsx`.
- Kept the slice metadata-only: no QR token parsing, specialist selection logic, queue API payload, storage, validation, or submission behavior changed.

## Contract Impact

- Canonical surface: `/queue/join` frontend accessibility metadata for existing controls only.
- Request shape: not changed - queue join request fields, selected specialist IDs, normalized phone, and optional Telegram ID payload are untouched.
- Response shape: not changed - queue session, queue join success/error handling, and result rendering are untouched.
- Status codes: not changed - no backend endpoint or frontend status-code mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit control names; visible labels, QR/session flow, specialist checkbox state, form validation, local storage, and submit behavior remain unchanged.
- Compatibility path or alias: not applicable - no route, redirect, alias, or legacy queue path changed.
- Contract proof: targeted file ESLint reports zero messages, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - the public queue join route availability was not edited.
- Roles denied: unchanged - no guard, permission helper, or role-specific queue access rule was edited.
- Positive auth proof: not applicable - this public queue join metadata slice does not alter authenticated role access or successful auth behavior.
- Negative auth proof: not applicable - this public queue join metadata slice does not alter denied auth behavior or route protection.

## Notification / Realtime

- Event type or websocket channel: not applicable - no queue notification, websocket, SSE, chat, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no realtime payload or acknowledgement contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, retry, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - missing QR/session and empty specialist/form states were not edited.
- Partial data proof: unchanged - partial name, phone, Telegram ID, and selected-specialist handling remain the existing implementation.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - queue token/session missing-resource handling was not edited.
- Stale route/deep-link behavior: unchanged - queue token, deep-link, countdown, and session-expiry behavior were not edited.

## Scope Gate

- Allowed paths: `frontend/src/pages/QueueJoin.jsx` only.
- Denied paths: backend, runtime API, database, migration, route contract, payment, EMR, lab, notification, Telegram service, workflow, dependency, and generated artifact changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/pages/QueueJoin.jsx --quiet`; `npx.cmd eslint src/pages/QueueJoin.jsx -f json --output-file %TEMP%\queue-join-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero messages and zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully with only the LF-to-CRLF working-copy warning.
- Not checked: browser visual QA and live queue API smoke were not run because this is a metadata-only accessibility label slice.
