### PR TITLE
fix(frontend): label data exporter controls

### DIFF
--- a/frontend/src/components/analytics/DataExporter.jsx
+++ b/frontend/src/components/analytics/DataExporter.jsx
@@ -232,6 +232,7 @@ const DataExporter = ({
               <label className="flex items-center space-x-3">
                 <input
                 type="checkbox"
+                aria-label="Include charts in export"
                 checked={includeCharts}
                 onChange={(e) => setIncludeCharts(e.target.checked)}
                 className="rounded" />
@@ -245,6 +246,7 @@ const DataExporter = ({
               <label className="flex items-center space-x-3">
                 <input
                 type="checkbox"
+                aria-label="Include raw data in export"
                 checked={includeRawData}
                 onChange={(e) => setIncludeRawData(e.target.checked)}
                 className="rounded" />
@@ -258,6 +260,7 @@ const DataExporter = ({
               <label className="flex items-center space-x-3">
                 <input
                 type="checkbox"
+                aria-label="Send export by email"
                 checked={emailExport}
                 onChange={(e) => setEmailExport(e.target.checked)}
                 className="rounded" />
@@ -272,6 +275,7 @@ const DataExporter = ({
             <div className="ml-6">
                   <input
                 type="email"
+                aria-label="Export email address"
                 value={emailAddress}
                 onChange={(e) => setEmailAddress(e.target.value)}
                 placeholder="Введите email адрес"


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names to DataExporter advanced export checkboxes and the conditional email address field.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `DataExporter.jsx`.
- Kept the slice metadata-only: no export options, `exportConfig`, `onExport`, status handling, or data shape behavior changed.

## Contract Impact

- Canonical surface: analytics export frontend control accessibility metadata only.
- Request shape: not changed - selected format, selected data type, include charts/raw data flags, email flag, and email address values are untouched.
- Response shape: not changed - export success/error status rendering and `onExport` result handling are untouched.
- Status codes: not changed - no backend endpoint or status-code mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit names for advanced export controls; visible labels, option state, export button behavior, and `exportConfig` construction remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect, alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero messages, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - no route guard, role check, or analytics access policy was edited.
- Roles denied: unchanged - no permission helper or denial behavior was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels do not alter successful authenticated analytics access.
- Negative auth proof: not rerun - metadata-only accessible-name labels do not alter denied analytics access.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, SSE, chat, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no realtime payload or acknowledgement contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, retry, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - the existing no-data export error behavior was not edited.
- Partial data proof: unchanged - partial export option selection and conditional email field behavior remain the existing implementation.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - the component does not introduce draft/resource handling, and export data handling was untouched.
- Stale route/deep-link behavior: unchanged - no route, navigation, or deep-link behavior was edited.

## Scope Gate

- Allowed paths: `frontend/src/components/analytics/DataExporter.jsx` only.
- Denied paths: backend, runtime API, database, migration, route contract, payment, queue, EMR, lab, notification, Telegram, workflow, dependency, and generated artifact changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/components/analytics/DataExporter.jsx --quiet`; `npx.cmd eslint src/components/analytics/DataExporter.jsx -f json --output-file %TEMP%\data-exporter-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero messages and zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully.
- Not checked: browser visual QA and live export smoke were not run because this is a metadata-only accessibility label slice.
