### PR TITLE
fix(frontend): label appointments table controls

### DIFF
--- a/frontend/src/components/AppointmentsTable.jsx
+++ b/frontend/src/components/AppointmentsTable.jsx
@@ -406,6 +406,7 @@ const AppointmentsTable = ({
                  <Button
                       variant="primary"
                       size="sm"
+                      aria-label="Print appointment ticket"
                       title="Печать талона"
                       style={{ width: '36px', height: '36px', padding: '0' }}>
                       
@@ -414,6 +415,7 @@ const AppointmentsTable = ({
                  <Button
                       variant="danger"
                       size="sm"
+                      aria-label="Cancel appointment"
                       title="Отмена"
                       style={{ width: '36px', height: '36px', padding: '0' }}>
                       
@@ -422,6 +424,7 @@ const AppointmentsTable = ({
                  <Button
                       variant="warning"
                       size="sm"
+                      aria-label="Reschedule appointment"
                       title="Перенос"
                       style={{ width: '36px', height: '36px', padding: '0' }}>
                       
@@ -430,6 +433,7 @@ const AppointmentsTable = ({
                  <Button
                       variant="info"
                       size="sm"
+                      aria-label="Open appointment payment"
                       title="Оплата"
                       style={{ width: '36px', height: '36px', padding: '0' }}>
                       
@@ -503,6 +507,7 @@ const AppointmentsTable = ({
                   <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                  <input
                       type="checkbox"
+                      aria-label={`Select appointment ${appointment.patient_fio || appointment.id || index + 1}`}
                       checked={appointmentsSelected.has(appointment.id)}
                       onChange={(e) => {
                         const next = new Set(appointmentsSelected);
@@ -637,6 +642,7 @@ const AppointmentsTable = ({
                  <Button
                       variant="primary"
                       size="sm"
+                      aria-label="Print appointment ticket"
                       title="Печать талона"
                       style={{ width: '36px', height: '36px', padding: '0' }}>
                       
@@ -645,6 +651,7 @@ const AppointmentsTable = ({
                  <Button
                       variant="danger"
                       size="sm"
+                      aria-label="Cancel appointment"
                       title="Отмена"
                       style={{ width: '36px', height: '36px', padding: '0' }}>
                       
@@ -653,6 +660,7 @@ const AppointmentsTable = ({
                  <Button
                       variant="warning"
                       size="sm"
+                      aria-label="Reschedule appointment"
                       title="Перенос"
                       style={{ width: '36px', height: '36px', padding: '0' }}>
                       
@@ -661,6 +669,7 @@ const AppointmentsTable = ({
                  <Button
                       variant="info"
                       size="sm"
+                      aria-label="Open appointment payment"
                       title="Оплата"
                       style={{ width: '36px', height: '36px', padding: '0' }}>
                       


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names to AppointmentsTable icon-only action buttons and row-selection checkbox.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `AppointmentsTable.jsx`.
- Kept the slice metadata-only: no appointment data flow, selection state semantics, action handlers, table layout, or API behavior changed.

## Contract Impact

- Canonical surface: appointment table frontend accessibility metadata only.
- Request shape: not changed - no appointment request, selection payload, payment, print, cancel, or reschedule payload was edited.
- Response shape: not changed - appointment row rendering, badge/status rendering, and table data mapping are untouched.
- Status codes: not changed - no backend endpoint or frontend status-code mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit names for icon-only actions and the row-selection checkbox; visible titles/icons, selected-set updates, and appointment row behavior remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect, alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero messages, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - no appointment route guard, role check, or action permission was edited.
- Roles denied: unchanged - no permission helper or denial behavior was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels do not alter successful appointment table access.
- Negative auth proof: not rerun - metadata-only accessible-name labels do not alter denied appointment access.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, SSE, chat, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no realtime payload or acknowledgement contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, retry, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - existing empty appointment rows and placeholders were not edited beyond action metadata.
- Partial data proof: unchanged - partial appointment fields, fallback patient labels, and status/payment/service fallbacks remain the existing implementation.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - the table does not introduce draft/resource handling, and missing appointment values keep existing fallbacks.
- Stale route/deep-link behavior: unchanged - no route, navigation, or deep-link behavior was edited.

## Scope Gate

- Allowed paths: `frontend/src/components/AppointmentsTable.jsx` only.
- Denied paths: backend, runtime API, database, migration, route contract, payment logic, queue, EMR, lab, notification, Telegram, workflow, dependency, and generated artifact changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/components/AppointmentsTable.jsx --quiet`; `npx.cmd eslint src/components/AppointmentsTable.jsx -f json --output-file %TEMP%\appointments-table-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero messages and zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully.
- Not checked: browser visual QA and live appointment action smoke were not run because this is a metadata-only accessibility label slice.
