### PR TITLE
fix(frontend): label two factor verify controls

### DIFF
--- a/frontend/src/components/TwoFactorVerify.jsx
+++ b/frontend/src/components/TwoFactorVerify.jsx
@@ -86,6 +86,7 @@ const TwoFactorVerify = ({ onSuccess, onCancel, method = 'totp', pendingToken })
         </label>
         <input
         type="text"
+        aria-label="Authenticator code"
         value={totpCode}
         onChange={(e) => setTotpCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
         onKeyPress={handleKeyPress}
@@ -132,6 +133,7 @@ const TwoFactorVerify = ({ onSuccess, onCancel, method = 'totp', pendingToken })
         </label>
         <input
         type="text"
+        aria-label="Backup code"
         value={backupCode}
         onChange={(e) => setBackupCode(e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 8))}
         onKeyPress={handleKeyPress}
@@ -178,6 +180,7 @@ const TwoFactorVerify = ({ onSuccess, onCancel, method = 'totp', pendingToken })
         </label>
         <input
         type="text"
+        aria-label="Recovery token"
         value={recoveryToken}
         onChange={(e) => setRecoveryToken(e.target.value)}
         onKeyPress={handleKeyPress}
@@ -214,6 +217,7 @@ const TwoFactorVerify = ({ onSuccess, onCancel, method = 'totp', pendingToken })
         }}>
             <input
             type="checkbox"
+            aria-label="Remember this device for 30 days"
             checked={rememberDevice}
             onChange={(e) => setRememberDevice(e.target.checked)}
             style={{ margin: 0 }} />


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names to TwoFactorVerify TOTP, backup-code, recovery-token, and remember-device controls.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `TwoFactorVerify.jsx`.
- Kept the slice metadata-only: no pending token handling, `/2fa/verify` request construction, validation lengths, callbacks, or blocking 2FA flow changed.

## Contract Impact

- Canonical surface: frontend 2FA verification control accessibility metadata only.
- Request shape: not changed - `pending_2fa_token`, `totp_code`, `backup_code`, `recovery_token`, and `remember_device` request fields are untouched.
- Response shape: not changed - access-token success handling, error handling, and `onSuccess` callback behavior are untouched.
- Status codes: not changed - no backend endpoint or frontend status-code mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit names for 2FA controls; visible labels, input normalization, length checks, submit disablement, and callback behavior remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect, alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero messages, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - no login route, role model, 2FA role path, or permission check was edited.
- Roles denied: unchanged - no denial path, guard, role helper, or token issuance rule was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels do not alter successful `pending_2fa_token -> verify -> access_token` behavior.
- Negative auth proof: not rerun - metadata-only accessible-name labels do not alter invalid code, missing code, denied role, or token failure behavior.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, SSE, chat, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no realtime payload or acknowledgement contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, retry, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - empty TOTP, backup, and recovery-token validation/disablement remains the existing implementation.
- Partial data proof: unchanged - partial code normalization, max lengths, and disabled submit behavior remain the existing implementation.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - no draft/resource handling was introduced, and missing pending-token behavior was not edited.
- Stale route/deep-link behavior: unchanged - no route, navigation, token expiry, or deep-link behavior was edited.

## Scope Gate

- Allowed paths: `frontend/src/components/TwoFactorVerify.jsx` only.
- Denied paths: backend, auth service, token logic, role models, route contract, database, migration, payment, queue, EMR, lab, notification, Telegram, workflow, dependency, and generated artifact changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/components/TwoFactorVerify.jsx --quiet`; `npx.cmd eslint src/components/TwoFactorVerify.jsx -f json --output-file %TEMP%\two-factor-verify-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero messages and zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully with only the LF-to-CRLF working-copy warning.
- Not checked: browser 2FA login smoke and backend auth tests were not run because this is a metadata-only accessibility label slice.
