### PR TITLE
fix(frontend): label telegram manager controls

### DIFF
--- a/frontend/src/components/telegram/TelegramManager.jsx
+++ b/frontend/src/components/telegram/TelegramManager.jsx
@@ -390,6 +390,7 @@ const TelegramManager = () => {
             <div className="flex space-x-2">
               <input
               type="password"
+              aria-label="Telegram bot token"
               value={settings.bot_token || ''}
               onChange={(e) => setSettings({ ...settings, bot_token: e.target.value })}
               placeholder="123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
@@ -398,6 +399,7 @@ const TelegramManager = () => {
               <Button
               onClick={() => setSettings({ ...settings, bot_token: '' })}
               variant="outline"
+              aria-label="Clear Telegram bot token"
               size="sm">
               
                 <Trash2 className="w-4 h-4" />
@@ -414,6 +416,7 @@ const TelegramManager = () => {
             </label>
             <input
             type="url"
+            aria-label="Telegram webhook URL"
             value={settings.webhook_url || ''}
             onChange={(e) => setSettings({ ...settings, webhook_url: e.target.value })}
             placeholder="https://yourdomain.com/api/v1/telegram/webhook"
@@ -505,7 +508,10 @@ const TelegramManager = () => {
       <Card key={key} className="p-4">
             <div className="flex items-center justify-between mb-2">
               <h4 className="font-medium capitalize">{key.replace('_', ' ')}</h4>
-              <Button variant="ghost" size="sm">
+              <Button
+              variant="ghost"
+              size="sm"
+              aria-label={`Edit Telegram template ${key}`}>
                 <Edit className="w-4 h-4" />
               </Button>
             </div>
@@ -574,7 +580,10 @@ const TelegramManager = () => {
             }>
                     {user.active ? 'Активен' : 'Неактивен'}
                   </span>
-                  <Button variant="ghost" size="sm">
+                  <Button
+                  variant="ghost"
+                  size="sm"
+                  aria-label={`Message Telegram user ${user.username || user.chat_id}`}>
                     <MessageSquare className="w-4 h-4" />
                   </Button>
                 </div>
@@ -669,6 +678,7 @@ const TelegramManager = () => {
                 </label>
                 <input
                 type="number"
+                aria-label="Telegram test chat ID"
                 value={testChatId}
                 onChange={(e) => setTestChatId(e.target.value)}
                 placeholder="123456789"
@@ -681,6 +691,7 @@ const TelegramManager = () => {
                   Сообщение
                 </label>
                 <textarea
+                aria-label="Telegram test message"
                 value={testMessage}
                 onChange={(e) => setTestMessage(e.target.value)}
                 placeholder="Введите тестовое сообщение..."


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names to TelegramManager bot-token, webhook URL, test-message modal, and icon-only manager controls.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `TelegramManager.jsx`.
- Kept the slice metadata-only: no Bot API/webhook calls, token storage, settings payloads, request bodies, or Telegram backend behavior changed.

## Contract Impact

- Canonical surface: Telegram manager frontend accessibility metadata only.
- Request shape: not changed - bot token, webhook URL, test chat ID, test message, settings update, webhook setup, and send-test-message request payloads are untouched.
- Response shape: not changed - bot status/settings/templates/users/stats loading and success/error rendering are untouched.
- Status codes: not changed - no backend endpoint or frontend status-code mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit names for Telegram manager controls; visible labels, button icons, settings state, modal state, and submit behavior remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect, alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero messages, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - no Telegram route guard, admin permission, bearer token retrieval, or role check was edited.
- Roles denied: unchanged - no permission helper or denial behavior was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels do not alter successful authorized Telegram manager usage.
- Negative auth proof: not rerun - metadata-only accessible-name labels do not alter denied Telegram manager access.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, SSE, chat, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no Telegram Bot API payload, webhook acknowledgement, or realtime payload changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, webhook retry, polling, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - existing empty users/templates/status/stats rendering was not edited.
- Partial data proof: unchanged - partial settings, bot status, user, and template fallbacks remain the existing implementation.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - no draft/resource handling was introduced, and missing Telegram settings/status behavior was not edited.
- Stale route/deep-link behavior: unchanged - no route, navigation, or deep-link behavior was edited.

## Scope Gate

- Allowed paths: `frontend/src/components/telegram/TelegramManager.jsx` only.
- Denied paths: backend, Telegram Bot API/service code, webhook handler, token storage, database, Alembic migration, route contract, payment, queue, EMR, lab, notification workflow, dependency, and generated artifact changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/components/telegram/TelegramManager.jsx --quiet`; `npx.cmd eslint src/components/telegram/TelegramManager.jsx -f json --output-file %TEMP%\telegram-manager-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero messages and zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully.
- Not checked: live Telegram Bot API/webhook smoke and browser visual QA were not run because this is a metadata-only accessibility label slice.
