### PR TITLE
fix(frontend): label common table controls

### DIFF
--- a/frontend/src/components/common/Table.jsx
+++ b/frontend/src/components/common/Table.jsx
@@ -218,6 +218,7 @@ export function Table({
                   {column.filterable !== false && (
                     <input
                       type="text"
+                      aria-label={`Filter ${column.title}`}
                       placeholder={`Фильтр по ${column.title.toLowerCase()}`}
                       value={filters[column.key] || ''}
                       onChange={(e) => handleFilter(column.key, e.target.value)}
@@ -269,6 +270,7 @@ export function Table({
           <div>
             <button
               style={pageButtonStyle}
+              aria-label="Previous table page"
               onClick={() => handlePageChange(currentPage - 1)}
               disabled={currentPage === 1}
             >
@@ -290,6 +292,7 @@ export function Table({
             
             <button
               style={pageButtonStyle}
+              aria-label="Next table page"
               onClick={() => handlePageChange(currentPage + 1)}
               disabled={currentPage === totalPages}
             >
@@ -334,7 +337,7 @@ function TableLoading({ columns = 3, rows = 5 }) {
       <thead>
         <tr>
           {Array.from({ length: columns }).map((_, i) => (
-            <th key={i} style={cellStyle}>
+            <th key={i} style={cellStyle} aria-label={`Loading table column ${i + 1}`}>
               <div style={skeletonStyle} />
             </th>
           ))}
@@ -344,7 +347,11 @@ function TableLoading({ columns = 3, rows = 5 }) {
         {Array.from({ length: rows }).map((_, rowIndex) => (
           <tr key={rowIndex}>
             {Array.from({ length: columns }).map((_, colIndex) => (
-              <td key={colIndex} style={cellStyle}>
+              <td
+                key={colIndex}
+                style={cellStyle}
+                aria-label={`Loading table row ${rowIndex + 1} column ${colIndex + 1}`}
+              >
                 <div style={skeletonStyle} />
               </td>
             ))}


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names to the shared Table filter input, pagination arrow buttons, and loading skeleton cells.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `Table.jsx`.
- Kept the slice metadata-only: no sorting, filtering, pagination, row rendering, export, or loading behavior changed.

## Contract Impact

- Canonical surface: shared frontend table accessibility metadata only.
- Request shape: not applicable - this shared component does not issue API requests; no request payloads were added or changed.
- Response shape: not applicable - this shared component does not parse API responses; table data and column props are consumed exactly as before.
- Status codes: not applicable - no backend endpoint or frontend status-code mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit names for table filtering, pagination, and loading skeleton cells; visible text, table props, sorting state, filter state, page state, and render callbacks remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect, alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero `control-has-associated-label` warnings, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - no route guard, permission helper, bearer token retrieval, or role check was edited.
- Roles denied: unchanged - no denial behavior or fallback access path was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels in a shared table component do not alter authorized route access.
- Negative auth proof: not rerun - metadata-only accessible-name labels in a shared table component do not alter denied route access.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, SSE, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no realtime payload, acknowledgement, or versioned event contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, polling, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - existing empty table rendering was not edited.
- Partial data proof: unchanged - column/data rendering and optional column render callbacks remain the existing implementation.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - no draft/resource behavior exists in this shared table component, and none was introduced.
- Stale route/deep-link behavior: unchanged - no route, navigation, or deep-link behavior was edited.

## Scope Gate

- Allowed paths: `frontend/src/components/common/Table.jsx` only.
- Denied paths: backend, route contracts, RBAC, queue, payment, Telegram, EMR, lab, notification workflow, dependency, generated artifact, and application behavior changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/components/common/Table.jsx --quiet`; `npx.cmd eslint src/components/common/Table.jsx -f json --output-file %TEMP%\common-table-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully.
- Not checked: browser visual QA was not run because this is a metadata-only accessibility label slice in a shared table component.
