### PR TITLE
fix(frontend): label schedule next controls

### DIFF
--- a/frontend/src/components/common/ScheduleNextModal.jsx
+++ b/frontend/src/components/common/ScheduleNextModal.jsx
@@ -453,11 +453,13 @@ const ScheduleNextModal = ({
         <form onSubmit={handleSubmit}>
           {/* Пациент */}
           <div style={formGroupStyle}>
-            <label style={labelStyle}>
+            <label htmlFor="schedule-next-patient" style={labelStyle}>
               <User size={16} style={{ display: 'inline', marginRight: getSpacing('xs') }} />
               Пациент
             </label>
             <select
+              id="schedule-next-patient"
+              aria-label="Schedule next visit patient"
               style={selectStyle}
               value={formData.patient_id}
               onChange={(e) => handleInputChange('patient_id', e.target.value)}
@@ -475,12 +477,14 @@ const ScheduleNextModal = ({
           {/* Дата и время */}
           <div style={{ display: 'flex', gap: getSpacing('md') }}>
             <div style={{ ...formGroupStyle, flex: 1 }}>
-              <label style={labelStyle}>
+              <label htmlFor="schedule-next-visit-date" style={labelStyle}>
                 <Calendar size={16} style={{ display: 'inline', marginRight: getSpacing('xs') }} />
                 Дата визита
               </label>
               <input
+                id="schedule-next-visit-date"
                 type="date"
+                aria-label="Schedule next visit date"
                 style={inputStyle}
                 value={formData.visit_date}
                 onChange={(e) => handleInputChange('visit_date', e.target.value)}
@@ -490,12 +494,14 @@ const ScheduleNextModal = ({
             </div>
 
             <div style={{ ...formGroupStyle, flex: 1 }}>
-              <label style={labelStyle}>
+              <label htmlFor="schedule-next-visit-time" style={labelStyle}>
                 <Clock size={16} style={{ display: 'inline', marginRight: getSpacing('xs') }} />
                 Время
               </label>
               <input
+                id="schedule-next-visit-time"
                 type="time"
+                aria-label="Schedule next visit time"
                 style={inputStyle}
                 value={formData.visit_time}
                 onChange={(e) => handleInputChange('visit_time', e.target.value)}
@@ -515,6 +521,8 @@ const ScheduleNextModal = ({
             <div key={index} style={serviceRowStyle}>
                 <div style={{ flex: 2 }}>
                   <select
+                  id={`schedule-next-service-${index}`}
+                  aria-label={`Schedule next visit service ${index + 1}`}
                   style={selectStyle}
                   value={service.service_id}
                   onChange={(e) => handleServiceChange(index, 'service_id', e.target.value)}
@@ -530,7 +538,9 @@ const ScheduleNextModal = ({
                 </div>
                 <div style={{ flex: 1 }}>
                   <input
+                  id={`schedule-next-service-quantity-${index}`}
                   type="number"
+                  aria-label={`Schedule next visit service ${index + 1} quantity`}
                   style={inputStyle}
                   value={service.quantity}
                   onChange={(e) => handleServiceChange(index, 'quantity', parseInt(e.target.value))}
@@ -561,8 +571,10 @@ const ScheduleNextModal = ({
 
           {/* Тип визита */}
           <div style={formGroupStyle}>
-            <label style={labelStyle}>Тип визита</label>
+            <label htmlFor="schedule-next-discount-mode" style={labelStyle}>Тип визита</label>
             <select
+              id="schedule-next-discount-mode"
+              aria-label="Schedule next visit type"
               style={selectStyle}
               value={formData.discount_mode}
               onChange={(e) => handleInputChange('discount_mode', e.target.value)}>
@@ -575,8 +587,10 @@ const ScheduleNextModal = ({
 
           {/* Канал подтверждения */}
           <div style={formGroupStyle}>
-            <label style={labelStyle}>Канал подтверждения</label>
+            <label htmlFor="schedule-next-confirmation-channel" style={labelStyle}>Канал подтверждения</label>
             <select
+              id="schedule-next-confirmation-channel"
+              aria-label="Schedule next visit confirmation channel"
               style={selectStyle}
               value={formData.confirmation_channel}
               onChange={(e) => handleInputChange('confirmation_channel', e.target.value)}>


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names and label associations to ScheduleNextModal patient, date, time, service, quantity, visit type, and confirmation channel controls.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `ScheduleNextModal.jsx`.
- Kept the slice metadata-only: no scheduling payload, specialty filtering, service list, validation, timeout close, or submit behavior changed.

## Contract Impact

- Canonical surface: schedule-next modal frontend accessibility metadata only.
- Request shape: not changed - schedule-next still submits the same formData fields to `/api/v1/doctor/visits/schedule-next`.
- Response shape: not changed - success handling, normalized callback data, confirmation token display, and error handling are untouched.
- Status codes: not changed - no backend endpoint or frontend status-code mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit names for schedule-next form controls; visible labels, state updates, required fields, specialty service filtering, and submit/reset behavior remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect, alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero `control-has-associated-label` warnings, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - no doctor/specialty permission, route guard, bearer token retrieval, or role check was edited.
- Roles denied: unchanged - no permission helper or denial behavior was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels do not alter successful authorized schedule-next usage.
- Negative auth proof: not rerun - metadata-only accessible-name labels do not alter denied schedule-next access.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, SSE, Telegram/PWA/phone confirmation event, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no confirmation payload, acknowledgement, or versioned realtime contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, polling, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - existing empty patient/service option rendering was not edited.
- Partial data proof: unchanged - patient/service data, specialty filter, and optional patient prop handling remain the existing implementation.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - no draft/resource behavior was introduced, and missing patient/service behavior was not edited.
- Stale route/deep-link behavior: unchanged - no route, navigation, or deep-link behavior was edited.

## Scope Gate

- Allowed paths: `frontend/src/components/common/ScheduleNextModal.jsx` only.
- Denied paths: backend, schedule-next API/service code, route contracts, RBAC, queue, payment, Telegram, EMR, lab, notification workflow, dependency, generated artifact, and application behavior changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/components/common/ScheduleNextModal.jsx --quiet`; `npx.cmd eslint src/components/common/ScheduleNextModal.jsx -f json --output-file %TEMP%\schedule-next-modal-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully.
- Not checked: live schedule-next API smoke and browser visual QA were not run because this is a metadata-only accessibility label slice.
