### PR TITLE
fix(frontend): label two factor setup inputs

### DIFF
--- a/frontend/src/components/TwoFactorSetup.jsx
+++ b/frontend/src/components/TwoFactorSetup.jsx
@@ -96,7 +96,7 @@ const TwoFactorSetup = ({ onComplete, onCancel }) => {
       </div>
 
       <div style={{ marginBottom: '24px' }}>
-        <label style={{
+        <label htmlFor="two-factor-recovery-email" style={{
         display: 'block',
         marginBottom: '8px',
         fontWeight: '500',
@@ -105,7 +105,9 @@ const TwoFactorSetup = ({ onComplete, onCancel }) => {
           Email для восстановления (необязательно)
         </label>
         <input
+        id="two-factor-recovery-email"
         type="email"
+        aria-label="Two factor recovery email"
         value={recoveryEmail}
         onChange={(e) => setRecoveryEmail(e.target.value)}
         placeholder="your@email.com"
@@ -122,7 +124,7 @@ const TwoFactorSetup = ({ onComplete, onCancel }) => {
       </div>
 
       <div style={{ marginBottom: '32px' }}>
-        <label style={{
+        <label htmlFor="two-factor-recovery-phone" style={{
         display: 'block',
         marginBottom: '8px',
         fontWeight: '500',
@@ -131,7 +133,9 @@ const TwoFactorSetup = ({ onComplete, onCancel }) => {
           Телефон для восстановления (необязательно)
         </label>
         <input
+        id="two-factor-recovery-phone"
         type="tel"
+        aria-label="Two factor recovery phone"
         value={recoveryPhone}
         onChange={(e) => setRecoveryPhone(e.target.value)}
         placeholder="+7 (999) 123-45-67"
@@ -273,7 +277,7 @@ const TwoFactorSetup = ({ onComplete, onCancel }) => {
       </div>
 
       <div style={{ marginBottom: '24px' }}>
-        <label style={{
+        <label htmlFor="two-factor-totp-code" style={{
         display: 'block',
         marginBottom: '8px',
         fontWeight: '500',
@@ -282,7 +286,9 @@ const TwoFactorSetup = ({ onComplete, onCancel }) => {
           Введите 6-значный код из приложения:
         </label>
         <input
+        id="two-factor-totp-code"
         type="text"
+        aria-label="Two factor authentication code"
         value={totpCode}
         onChange={(e) => setTotpCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
         placeholder="123456"


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names and label associations to TwoFactorSetup recovery email, recovery phone, and TOTP verification inputs.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `TwoFactorSetup.jsx`.
- Kept the slice metadata-only: no 2FA setup request, verification request, pending-token flow, backup-code handling, or auth state behavior changed.

## Contract Impact

- Canonical surface: TwoFactorSetup frontend accessibility metadata only.
- Request shape: not changed - `/2fa/setup` still receives the same recovery_email and recovery_phone payload, and `/2fa/verify-setup` still receives the same totp_code params.
- Response shape: not changed - setupData, backup_codes, success, and error handling consume the same response data as before.
- Status codes: not changed - no backend endpoint or frontend status-code mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit names for the setup and verification inputs; visible labels, input state, code filtering, verify gating, backup-code copying, and completion behavior remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect, alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero `control-has-associated-label` warnings, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - no role permission, route guard, bearer token retrieval, pending token handling, or role check was edited.
- Roles denied: unchanged - no permission helper or denial behavior was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels do not alter successful 2FA setup or verification behavior.
- Negative auth proof: not rerun - metadata-only accessible-name labels do not alter failed 2FA setup, failed verification, or denied auth behavior.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, SSE, auth event, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no realtime payload, acknowledgement, or versioned event contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, polling, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - existing empty setupData/backup code rendering behavior was not edited.
- Partial data proof: unchanged - setupData optional chaining, backup code rendering, copied state, success, and error paths remain the existing implementation.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - no draft/resource behavior was introduced, and missing setup data behavior was not edited.
- Stale route/deep-link behavior: unchanged - no route, navigation, or deep-link behavior was edited.

## Scope Gate

- Allowed paths: `frontend/src/components/TwoFactorSetup.jsx` only.
- Denied paths: backend, authentication services, token issuance, pending-token flow, 2FA verify/setup contracts, role/RBAC models, database, Alembic migration, routes, dependencies, generated artifacts, and application behavior changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/components/TwoFactorSetup.jsx --quiet`; `npx.cmd eslint src/components/TwoFactorSetup.jsx -f json --output-file %TEMP%\two-factor-setup-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully.
- Not checked: live 2FA setup/verification smoke and browser visual QA were not run because this is a metadata-only accessibility label slice.
