### PR TITLE
fix(frontend): label lab report workbench controls

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -737,7 +737,12 @@ export default function LabReportWorkbench({
                 {['lab_technician_label', 'lab_technician_name', 'approver_label', 'approver_name'].map((key) => (
                   <label key={key} style={{ display: 'grid', gap: '6px' }}>
                     <span>{signerFieldLabels[key] || key}</span>
-                    <input className="macos-input" value={signerSnapshot?.[key] || ''} onChange={(event) => setSignerSnapshot((prev) => ({ ...prev, [key]: event.target.value }))} />
+                    <input
+                      className="macos-input"
+                      aria-label={signerFieldLabels[key] || key}
+                      value={signerSnapshot?.[key] || ''}
+                      onChange={(event) => setSignerSnapshot((prev) => ({ ...prev, [key]: event.target.value }))}
+                    />
                   </label>
                 ))}
               </div>
@@ -836,6 +841,7 @@ export default function LabReportWorkbench({
                             ) : field.value_type === 'multiline' ? (
                               <textarea
                                 className="macos-input"
+                                aria-label={`Lab result for ${field.label}`}
                                 rows={3}
                                 value={currentValue}
                                 onChange={(event) => updateField(field.field_key, event.target.value)}
@@ -844,6 +850,7 @@ export default function LabReportWorkbench({
                             ) : (
                               <input
                                 className="macos-input"
+                                aria-label={`Lab result for ${field.label}`}
                                 value={currentValue}
                                 onChange={(event) => updateField(field.field_key, event.target.value)}
                                 disabled={activeInstance.status === 'FINALIZED' || activeInstance.status === 'PRINTED'}


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names to LabReportWorkbench signer inputs and free-text/numeric lab result controls.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `LabReportWorkbench.jsx`.
- Kept the slice metadata-only: no lab report creation, update, finalize, print, history, queue, template, or flagging behavior changed.

## Contract Impact

- Canonical surface: LabReportWorkbench frontend accessibility metadata only.
- Request shape: not changed - lab report create/update/finalize/print payloads keep the same signerSnapshot and draftValues values.
- Response shape: not changed - activeInstance, sections, fields, critical findings, history, and print feedback are consumed the same way as before.
- Status codes: not changed - no labReportingApi endpoint, status-code mapping, or error handling branch was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit names for signer and lab result entry controls; visible layout, disabled states, value updates, save/finalize/print actions, and flag badges remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect, alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero `control-has-associated-label` warnings, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - no lab role permission, route guard, bearer token retrieval, or role check was edited.
- Roles denied: unchanged - no permission helper, forbidden state, or denial behavior was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels do not alter successful lab workbench rendering or report actions.
- Negative auth proof: not rerun - metadata-only accessible-name labels do not alter denied lab access or failed lab action behavior.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, SSE, lab event, queue event, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no realtime payload, acknowledgement, or versioned event contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, polling, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - existing no appointment, no active instance, empty history, and empty template states were not edited.
- Partial data proof: unchanged - existing optional patient snapshot, section, field, signer, critical finding, and template fallback rendering remains the same.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - no missing draft/resource behavior was introduced, and missing activeInstance/template behavior was not edited.
- Stale route/deep-link behavior: unchanged - no route, navigation, or deep-link behavior was edited.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/LabReportWorkbench.jsx` only.
- Denied paths: backend, lab API contracts, queue contracts, report persistence, templates, print service behavior, role/RBAC models, database, Alembic migration, routes, dependencies, generated artifacts, and application behavior changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/components/laboratory/LabReportWorkbench.jsx --quiet`; `npx.cmd eslint src/components/laboratory/LabReportWorkbench.jsx -f json --output-file %TEMP%\lab-report-workbench-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully.
- Not checked: authenticated lab browser QA was not run because this is a metadata-only accessibility label slice.
