### PR TITLE
fix(frontend): label shared table controls

### DIFF
--- a/frontend/src/hooks/useTable.jsx
+++ b/frontend/src/hooks/useTable.jsx
@@ -311,6 +311,7 @@ export const TableRow = ({
       <td style={{ padding: '12px 16px', width: '40px' }}>
           <input
           type="checkbox"
+          aria-label={selected ? 'Deselect table row' : 'Select table row'}
           checked={selected}
           onChange={handleSelect}
           style={{
@@ -324,8 +325,9 @@ export const TableRow = ({
 
       {/* Стрелка для разворачивания */}
       {expandable &&
-      <td style={{ padding: '12px 16px', width: '40px' }}>
+        <td style={{ padding: '12px 16px', width: '40px' }}>
           <button
+          aria-label={expanded ? 'Collapse table row' : 'Expand table row'}
           onClick={handleExpand}
           style={{
             background: 'none',
@@ -569,6 +571,7 @@ export const TableSearch = ({
       <div style={{ fontSize: '16px', color: '#6b7280' }}>🔍</div>
       <input
         type="text"
+        aria-label={placeholder || 'Table search'}
         value={searchTerm}
         onChange={(e) => onSearch(e.target.value)}
         placeholder={placeholder}


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names to shared table row selection, row expansion, and table search controls.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `useTable.jsx`.
- Kept the slice metadata-only: no sorting, filtering, pagination, selection, expansion, row click, or search behavior changed.

## Contract Impact

- Canonical surface: shared frontend table hook/components accessibility metadata only.
- Request shape: not applicable - no API request, payload, or backend contract is involved in this shared table rendering slice.
- Response shape: not applicable - no API response consumption or data model parsing was edited.
- Status codes: not applicable - no backend endpoint or frontend status-code mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit names for reusable table checkbox, expand, and search controls; existing props, callbacks, visible text, pagination, selection state, expansion state, and search value handling remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect, alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero `control-has-associated-label` warnings, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - no role permission, route guard, bearer token retrieval, or role check was edited.
- Roles denied: unchanged - no permission helper, forbidden state, or denial behavior was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels do not alter authenticated table rendering or row actions.
- Negative auth proof: not rerun - metadata-only accessible-name labels do not alter denied routes or protected data access.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, SSE, table refresh event, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no realtime payload, acknowledgement, or versioned event contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, polling, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - existing empty table rendering and emptyMessage behavior were not edited.
- Partial data proof: unchanged - existing column rendering, row rendering, selectedRows, expandedRows, and optional callback handling remain the same.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - no draft/resource behavior was introduced or edited.
- Stale route/deep-link behavior: unchanged - no route, navigation, or deep-link behavior was edited.

## Scope Gate

- Allowed paths: `frontend/src/hooks/useTable.jsx` only.
- Denied paths: backend, table data contracts, API clients, role/RBAC models, database, Alembic migration, routes, dependencies, generated artifacts, and application behavior changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/hooks/useTable.jsx --quiet`; `npx.cmd eslint src/hooks/useTable.jsx -f json --output-file %TEMP%\use-table-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully.
- Not checked: browser visual QA was not run because this is a metadata-only accessibility label slice in a shared table component.
