### PR TITLE
fix(frontend): label family relation controls

### DIFF
--- a/frontend/src/components/patient/FamilyRelationsCard.jsx
+++ b/frontend/src/components/patient/FamilyRelationsCard.jsx
@@ -481,6 +481,7 @@ function AddRelationDialog({ open, onClose, patientId, patientName, onSuccess })
           <label style={styles.fieldGroup}>
             <span style={styles.label}>Поиск по ФИО или телефону</span>
             <input
+              aria-label="Search patient by name or phone"
               value={searchQuery}
               onChange={(event) => setSearchQuery(event.target.value)}
               onKeyDown={(event) => event.key === 'Enter' && handleSearch()}
@@ -539,6 +540,7 @@ function AddRelationDialog({ open, onClose, patientId, patientName, onSuccess })
         <label style={styles.fieldGroup}>
           <span style={styles.label}>Описание (необязательно)</span>
           <textarea
+            aria-label="Family relation description"
             value={description}
             onChange={(event) => setDescription(event.target.value)}
             style={styles.textarea}
@@ -549,6 +551,7 @@ function AddRelationDialog({ open, onClose, patientId, patientName, onSuccess })
         <label style={styles.checkboxRow}>
           <input
             type="checkbox"
+            aria-label="Mark as primary contact"
             checked={isPrimaryContact}
             onChange={(event) => setIsPrimaryContact(event.target.checked)}
           />


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names to FamilyRelationsCard add-relation search, description, and primary-contact controls.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `FamilyRelationsCard.jsx`.
- Kept the slice metadata-only: no family relation search, create, delete, refresh, or patient data behavior changed.

## Contract Impact

- Canonical surface: FamilyRelationsCard frontend accessibility metadata only.
- Request shape: not changed - `/patients`, `/patients/{patientId}/family`, and delete requests keep the same params and payload behavior.
- Response shape: not changed - family, is_relative_of, selected patient, and error handling consume the same response data as before.
- Status codes: not changed - no API endpoint or frontend status-code mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit names for add-relation dialog controls; visible labels, search query, selected patient, relation type, description, primary contact flag, submit gating, and delete action remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect, alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero `control-has-associated-label` warnings, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - no patient role permission, canEdit behavior, route guard, bearer token retrieval, or role check was edited.
- Roles denied: unchanged - no permission helper, forbidden state, or denial behavior was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels do not alter successful family relation rendering or add/delete behavior.
- Negative auth proof: not rerun - metadata-only accessible-name labels do not alter denied patient access or failed family relation operations.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, SSE, patient event, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no realtime payload, acknowledgement, or versioned event contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, polling, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - existing empty family state and search result rendering were not edited.
- Partial data proof: unchanged - existing optional patient name, phone, relation description, primary contact, and error fallbacks remain the same.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - no draft/resource behavior was introduced or edited.
- Stale route/deep-link behavior: unchanged - no route, navigation, or deep-link behavior was edited.

## Scope Gate

- Allowed paths: `frontend/src/components/patient/FamilyRelationsCard.jsx` only.
- Denied paths: backend, patient/family API contracts, patient data models, role/RBAC models, database, Alembic migration, routes, dependencies, generated artifacts, and application behavior changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/components/patient/FamilyRelationsCard.jsx --quiet`; `npx.cmd eslint src/components/patient/FamilyRelationsCard.jsx -f json --output-file %TEMP%\family-relations-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully.
- Not checked: authenticated patient browser QA was not run because this is a metadata-only accessibility label slice.
