### PR TITLE
fix(frontend): label payment test controls

### DIFF
--- a/frontend/src/pages/PaymentTest.jsx
+++ b/frontend/src/pages/PaymentTest.jsx
@@ -187,6 +187,7 @@ const PaymentTest = () => {
                   <input
                     id="payment-test-visit-id"
                     type="number"
+                    aria-label="Payment test visit id"
                     value={testData.visitId}
                     onChange={(e) => setTestData({ ...testData, visitId: parseInt(e.target.value, 10) })}
                     style={fieldControlStyle}
@@ -198,6 +199,7 @@ const PaymentTest = () => {
                   <input
                     id="payment-test-amount"
                     type="number"
+                    aria-label="Payment test amount"
                     value={testData.amount}
                     onChange={(e) => setTestData({ ...testData, amount: parseFloat(e.target.value) })}
                     style={fieldControlStyle}
@@ -222,6 +224,7 @@ const PaymentTest = () => {
                   Описание
                   <textarea
                     id="payment-test-description"
+                    aria-label="Payment test description"
                     rows={2}
                     value={testData.description}
                     onChange={(e) => setTestData({ ...testData, description: e.target.value })}


### PR DESCRIPTION
﻿## Summary

- Added explicit accessible names to PaymentTest visit id, amount, and description controls.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `PaymentTest.jsx`.
- Kept the slice metadata-only: no payment widget launch, auth redirect, token reset, success/error/cancel handling, or payment test data behavior changed.

## Contract Impact

- Canonical surface: PaymentTest frontend accessibility metadata only.
- Request shape: not changed - PaymentWidget still receives the same visitId, amount, currency, and description props.
- Response shape: not changed - payment success/error/cancel result handling consumes the same data as before.
- Status codes: not changed - no backend endpoint or frontend status-code mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit names for test payment controls; visible labels, field values, login redirect, token reset, and widget start behavior remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero `control-has-associated-label` warnings, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions

- Roles allowed: unchanged - no role permission, payment auth requirement, route guard, bearer token retrieval, or role check was edited.
- Roles denied: unchanged - no permission helper, forbidden state, or denial behavior was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels do not alter authenticated PaymentWidget test behavior.
- Negative auth proof: not rerun - metadata-only accessible-name labels do not alter unauthenticated login redirect or disabled start behavior.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, SSE, payment event, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no realtime payload, acknowledgement, or versioned event contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, polling, or resync behavior changed.

## Frontend Resilience

- Empty data proof: unchanged - existing result placeholder and no-widget state were not edited.
- Partial data proof: unchanged - existing testData field state, result data JSON rendering, and error/info fallback behavior remain the same.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - no draft/resource behavior was introduced or edited.
- Stale route/deep-link behavior: unchanged - no route, navigation, or deep-link behavior was edited.

## Scope Gate

- Allowed paths: `frontend/src/pages/PaymentTest.jsx` only.
- Denied paths: backend, payment API contracts, PaymentWidget behavior, auth/token helpers, payment providers, route contracts, role/RBAC models, database, Alembic migration, dependencies, generated artifacts, and application behavior changes.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation

- Targeted tests or smoke run: `npx.cmd eslint src/pages/PaymentTest.jsx --quiet`; `npx.cmd eslint src/pages/PaymentTest.jsx -f json --output-file %TEMP%\payment-test-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully.
- Not checked: live payment test/browser QA was not run because this is a metadata-only accessibility label slice.
