### PR TITLE
fix(frontend): label service catalog controls

### DIFF
--- a/frontend/src/components/admin/ServiceCatalog.jsx
+++ b/frontend/src/components/admin/ServiceCatalog.jsx
@@ -622,6 +622,7 @@ const ServiceCatalog = () => {
             title: (
               <input
                 type="checkbox"
+                aria-label="Select all filtered services"
                 checked={selectedServiceIds.size === filteredServices.length && filteredServices.length > 0}
                 onChange={toggleSelectAll}
                 style={{ cursor: 'pointer' }}
@@ -652,6 +653,7 @@ const ServiceCatalog = () => {
               select:
               <input
                 type="checkbox"
+                aria-label={`Select service ${service.name || service.id}`}
                 checked={selectedServiceIds.has(service.id)}
                 onChange={() => toggleServiceSelection(service.id)}
                 style={{ cursor: 'pointer' }}


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to ServiceCatalog table selection controls.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `ServiceCatalog.jsx`.
- Kept the slice metadata-only: no service loading, filtering, selection state, batch edit, create/update/delete, pricing, queue-tag, or admin service behavior changed.

## Contract Impact
- Canonical surface: ServiceCatalog frontend accessibility metadata only.
- Request shape: not changed - service API requests, filter params, and selection callbacks remain the same.
- Response shape: not changed - service/category/doctor/department/queue-profile response handling was not edited.
- Status codes: not changed - no backend endpoint or frontend status-code mapping was edited.
- Frontend consumer: screen readers and a11y tooling now receive explicit names for select-all and per-service row selection controls; visible UI and table selection behavior remain unchanged.
- Compatibility path or alias: not applicable - no route, endpoint, redirect alias, or compatibility fallback changed.
- Contract proof: targeted file ESLint reports zero `control-has-associated-label` warnings, strict icon-control audit passes, and the frontend build succeeds.

## RBAC / Permissions
- Roles allowed: unchanged - no admin permission, route guard, auth helper, or role check was edited.
- Roles denied: unchanged - no permission helper, forbidden state, or denial behavior was edited.
- Positive auth proof: not rerun - metadata-only accessible-name labels do not alter authenticated admin service catalog behavior.
- Negative auth proof: not rerun - metadata-only accessible-name labels do not alter access-control behavior.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, SSE, or realtime event surface changed.
- Payload version / ack behavior: not applicable - no realtime payload, acknowledgement, or versioned event contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect, polling, or resync behavior changed.

## Frontend Resilience
- Empty data proof: unchanged - existing empty and no-services presentation was not edited.
- Partial data proof: unchanged - existing partial API-load handling for services/categories/doctors/departments/queue profiles remains the same.
- Forbidden secondary path behavior: unchanged - no route guard or forbidden secondary path behavior was edited.
- Missing draft/resource behavior: unchanged - no draft/resource behavior was introduced or edited.
- Stale route/deep-link behavior: unchanged - no route, navigation, or deep-link behavior was edited.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/ServiceCatalog.jsx` only.
- Denied paths: backend, APIs, routing, auth/RBAC, queue/payment/EMR/lab behavior, service create/update/delete logic, batch-edit behavior, dependencies, generated artifacts, and broad design-system migration.
- Migration/docs/test impact: none - no migration, docs, or test files changed; validation is via lint, strict accessibility audit, build, and diff check.
- Rollback note: reverting this PR removes only the added accessible-name metadata.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/admin/ServiceCatalog.jsx --quiet`; `npx.cmd eslint src/components/admin/ServiceCatalog.jsx -f json --output-file %TEMP%\service-catalog-eslint-after.json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed - targeted file ESLint returned zero `control-has-associated-label` warnings, strict icon-control audit returned zero findings and zero parse errors, full frontend lint/build passed, and diff check exited successfully.
- Not checked: browser/admin QA was not run because this is a metadata-only accessibility label slice with no visual or behavioral change.
