### PR TITLE
fix(frontend): label voice to text controls

### DIFF
--- a/frontend/src/components/ai/VoiceToText.jsx
+++ b/frontend/src/components/ai/VoiceToText.jsx
@@ -407,6 +407,7 @@ const VoiceToText = () => {
         <div style={{ display: 'flex', justifyContent: 'center', gap: '16px' }}>
           <input
           type="file"
+          aria-label="Upload audio file"
           accept="audio/*"
           onChange={handleFileUpload}
           ref={fileInputRef}
@@ -437,6 +438,7 @@ const VoiceToText = () => {
       <div style={{ display: 'flex', justifyContent: 'center' }}>
             <audio
           controls
+          aria-label="Recorded audio preview"
           src={audioUrl}
           style={{
             width: '100%',


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to the VoiceToText audio upload input and recorded-audio preview control.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for this AI voice UI slice.
- Kept recording, upload, reset, transcription, and result-editing behavior unchanged.

## Contract Impact
- Canonical surface: Not applicable because this frontend-only accessibility metadata change does not alter any AI, audio, or transcription contract surface.
- Request shape: Not applicable because audio upload/transcription request payloads and form state are unchanged.
- Response shape: Not applicable because transcription response parsing, result rendering, and editable result state are unchanged.
- Status codes: Not applicable because no network request or HTTP status handling changed.
- Frontend consumer: VoiceToText remains the only touched consumer; its upload and audio preview controls keep the same refs, handlers, and source values.
- Compatibility path or alias: Not applicable because no route, alias, compatibility path, or fallback path changed.
- Contract proof: Diff is limited to `aria-label` attributes on existing controls in `frontend/src/components/ai/VoiceToText.jsx`.

## RBAC / Permissions
- Roles allowed: Not applicable because this component-level accessibility metadata change does not modify role access or auth checks.
- Roles denied: Not applicable because denied-role behavior and protected-route logic are untouched.
- Positive auth proof: Not applicable because no authenticated route guard, token handling, or permission branch changed.
- Negative auth proof: Not applicable because no forbidden-path or unauthorized-state behavior changed.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification event, websocket channel, polling path, or webhook path changed.
- Payload version / ack behavior: Not applicable because no realtime payload, versioning, delivery ack, or acknowledgement behavior changed.
- Read/unread or delivery semantics: Not applicable because no inbox, read marker, delivery state, or subscription state changed.
- Reconnect/resync proof: Not applicable because reconnect and resync logic are not touched by this audio-control label patch.

## Frontend Resilience
- Empty data proof: Existing no-audio/no-result behavior is preserved because only accessible names were added to existing controls.
- Partial data proof: Partial recording/upload state still uses the same `audioBlob`, `audioUrl`, and file input ref behavior.
- Forbidden secondary path behavior: Not applicable because this component patch does not touch role redirects or secondary forbidden paths.
- Missing draft/resource behavior: Not applicable because no draft, saved resource, or missing-resource branch changed.
- Stale route/deep-link behavior: Not applicable because no routing, route params, or deep-link handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/ai/VoiceToText.jsx` only.
- Denied paths: Backend, AI API clients, audio recording logic, auth/RBAC, workflows, package files, and unrelated frontend files were intentionally left untouched.
- Migration/docs/test impact: Not applicable because this is a narrow frontend accessibility metadata patch with no migration, docs, or test fixture changes.
- Rollback note: Revert this PR to remove only the accessible-name additions and EOF newline normalization if an unexpected assistive-tech issue appears.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/ai/VoiceToText.jsx --quiet`; file-level eslint JSON check; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: All listed local validation commands passed, and the file-level `jsx-a11y/control-has-associated-label` count is 0 for `VoiceToText.jsx`.
- Not checked: Browser screenshot/audio-device QA was not rerun because this change adds non-visual accessibility metadata only and does not alter microphone, file upload, or playback logic.
