### PR TITLE
fix(frontend): label loading skeleton controls

### DIFF
--- a/frontend/src/components/common/Loading.jsx
+++ b/frontend/src/components/common/Loading.jsx
@@ -198,7 +198,7 @@ export function TableLoadingOld({ columns = 3, rows = 5 }) {
       <thead>
         <tr>
           {Array.from({ length: columns }).map((_, i) =>
-          <th key={i} style={cellStyle}>
+          <th key={i} style={cellStyle} aria-label={`Loading column ${i + 1}`}>
               <div style={skeletonStyle} />
             </th>
           )}
@@ -208,7 +208,11 @@ export function TableLoadingOld({ columns = 3, rows = 5 }) {
         {Array.from({ length: rows }).map((_, rowIndex) =>
         <tr key={rowIndex}>
             {Array.from({ length: columns }).map((_, colIndex) =>
-          <td key={colIndex} style={cellStyle}>
+          <td
+            key={colIndex}
+            style={cellStyle}
+            aria-label={`Loading cell row ${rowIndex + 1} column ${colIndex + 1}`}
+          >
                 <div style={skeletonStyle} />
               </td>
           )}


### PR DESCRIPTION
﻿## Summary
- Added explicit accessible names to the legacy table loading skeleton header and cell placeholders.
- Cleared the file-level `jsx-a11y/control-has-associated-label` findings for `Loading.jsx`.
- Kept loading visuals, skeleton animation, row/column counts, and public component props unchanged.

## Contract Impact
- Canonical surface: Not applicable because this frontend-only accessibility metadata change does not alter any public API or component prop contract.
- Request shape: Not applicable because no network request, payload, or form submission behavior changed.
- Response shape: Not applicable because no response payload, parser, or data rendering contract changed.
- Status codes: Not applicable because no HTTP or async status handling changed.
- Frontend consumer: Existing Loading/TableLoadingOld consumers keep the same props and rendered skeleton structure.
- Compatibility path or alias: Not applicable because no route, alias, compatibility path, or fallback path changed.
- Contract proof: Diff is limited to `aria-label` metadata in `frontend/src/components/common/Loading.jsx`.

## RBAC / Permissions
- Roles allowed: Not applicable because loading skeleton metadata does not modify role access or auth checks.
- Roles denied: Not applicable because denied-role behavior and protected-route logic are untouched.
- Positive auth proof: Not applicable because no authenticated route guard, token handling, or permission branch changed.
- Negative auth proof: Not applicable because no forbidden-path or unauthorized-state behavior changed.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification event, websocket channel, polling path, or webhook path changed.
- Payload version / ack behavior: Not applicable because no realtime payload, versioning, delivery ack, or acknowledgement behavior changed.
- Read/unread or delivery semantics: Not applicable because no inbox, read marker, delivery state, or subscription state changed.
- Reconnect/resync proof: Not applicable because reconnect and resync logic are not touched by this skeleton label patch.

## Frontend Resilience
- Empty data proof: Existing loading/empty data behavior is preserved because only skeleton placeholder accessible names were added.
- Partial data proof: Partial loading rows and columns still render from the same `rows` and `columns` props.
- Forbidden secondary path behavior: Not applicable because this shared component patch does not touch role redirects or secondary forbidden paths.
- Missing draft/resource behavior: Not applicable because no draft, saved resource, or missing-resource branch changed.
- Stale route/deep-link behavior: Not applicable because no routing, route params, or deep-link handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/common/Loading.jsx` only.
- Denied paths: Backend, APIs, route guards, runtime data flow, workflows, package files, and unrelated frontend files were intentionally left untouched.
- Migration/docs/test impact: Not applicable because this is a narrow frontend accessibility metadata patch with no migration, docs, or test fixture changes.
- Rollback note: Revert this PR to remove only the legacy table skeleton accessible-name additions if an unexpected assistive-tech issue appears.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/common/Loading.jsx --quiet`; file-level eslint JSON check; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: All listed local validation commands passed, and the file-level `jsx-a11y/control-has-associated-label` count is 0 for `Loading.jsx`.
- Not checked: Browser screenshot QA was not rerun because this change adds non-visual accessibility metadata only and does not alter loading layout or animation logic.
