### PR TITLE
fix(frontend): label display content controls

### DIFF
--- a/frontend/src/components/display/DisplayContentManager.jsx
+++ b/frontend/src/components/display/DisplayContentManager.jsx
@@ -345,22 +345,26 @@ const DisplayContentManager = ({
 
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                  <label htmlFor="display-content-title" className="block text-sm font-medium text-gray-700 mb-2">
                     Название:
                   </label>
                   <input
+                  id="display-content-title"
                   type="text"
+                  aria-label="Display content title"
                   className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                   placeholder="Введите название..." />
                 
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                  <label htmlFor="display-content-file" className="block text-sm font-medium text-gray-700 mb-2">
                     Файл:
                   </label>
                   <input
+                  id="display-content-file"
                   type="file"
+                  aria-label="Display content file"
                   accept={
                   uploadDialog.type === 'banner' ? 'image/*' :
                   uploadDialog.type === 'video' ? 'video/*' : '*/*'


### PR DESCRIPTION
﻿## Summary
- Associated DisplayContentManager upload-dialog labels with the title and file controls.
- Added explicit accessible names to those title and file inputs to clear the file-level control-label findings.
- Kept content loading, upload dialog state, accepted file types, and display-board API behavior unchanged.

## Contract Impact
- Canonical surface: Not applicable because this frontend-only accessibility metadata change does not alter any display-board API or content-management contract surface.
- Request shape: Not applicable because no upload payload, fetch request, delete request, or form submission behavior changed.
- Response shape: Not applicable because no display content response parsing, schema, or data mapping changed.
- Status codes: Not applicable because no network request or status handling changed.
- Frontend consumer: DisplayContentManager remains the only touched consumer; upload dialog controls keep the same type, placeholder, accept expression, and styling.
- Compatibility path or alias: Not applicable because no route, alias, compatibility path, or fallback path changed.
- Contract proof: Diff is limited to `htmlFor`, `id`, and `aria-label` metadata in `frontend/src/components/display/DisplayContentManager.jsx`.

## RBAC / Permissions
- Roles allowed: Not applicable because display-board admin access and token usage were not modified.
- Roles denied: Not applicable because denied-role behavior and protected-route logic are untouched.
- Positive auth proof: Not applicable because no authenticated route guard, token handling, or permission branch changed.
- Negative auth proof: Not applicable because no forbidden-path or unauthorized-state behavior changed.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification event, websocket channel, polling path, or webhook path changed.
- Payload version / ack behavior: Not applicable because no realtime payload, versioning, delivery ack, or acknowledgement behavior changed.
- Read/unread or delivery semantics: Not applicable because no inbox, read marker, delivery state, or subscription state changed.
- Reconnect/resync proof: Not applicable because reconnect and resync logic are not touched by this upload-dialog label patch.

## Frontend Resilience
- Empty data proof: Existing no-content behavior is preserved because only upload-dialog input metadata changed.
- Partial data proof: Partial banner/video/content data still uses the same content arrays and tab rendering logic.
- Forbidden secondary path behavior: Not applicable because this component patch does not touch role redirects or secondary forbidden paths.
- Missing draft/resource behavior: Not applicable because no draft, saved resource, or missing-resource branch changed.
- Stale route/deep-link behavior: Not applicable because no routing, route params, or deep-link handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/display/DisplayContentManager.jsx` only.
- Denied paths: Backend, display-board APIs, upload handlers, auth/RBAC, workflows, package files, and unrelated frontend files were intentionally left untouched.
- Migration/docs/test impact: Not applicable because this is a narrow frontend accessibility metadata patch with no migration, docs, or test fixture changes.
- Rollback note: Revert this PR to remove only the upload-dialog label association and accessible-name additions if an unexpected assistive-tech issue appears.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/display/DisplayContentManager.jsx --quiet`; file-level eslint JSON check; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: All listed local validation commands passed, and the file-level `jsx-a11y/control-has-associated-label` count is 0 for `DisplayContentManager.jsx`.
- Not checked: Browser upload-dialog QA was not rerun because this change adds non-visual accessibility metadata only and does not alter upload, content, or display-board API behavior.
