### PR TITLE
fix(frontend): label mini app checkbox control

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1605,6 +1605,7 @@ function TelegramMiniAppPatientShell() {
                         <label key={field.key} style={miniAppCheckboxRowStyle}>
                           <input
                             type="checkbox"
+                            aria-label={field.label || field.key}
                             checked={getMiniAppFormFieldValue(formAnswers, form.id, field)}
                             onChange={handlePatientFormFieldChange(form.id, field)}
                             style={miniAppCheckboxStyle}


### PR DESCRIPTION
﻿## Summary
- Added an accessible name to the Telegram mini-app patient form checkbox control.
- Preserved the existing dynamic form field value handling, submit behavior, and layout.

## Contract Impact
- Canonical surface: `frontend/src/App.jsx` Telegram mini-app patient form UI.
- Request shape: not applicable, no API request payload or mini-app submit shape changed.
- Response shape: not applicable, no API response handling changed.
- Status codes: not applicable, no backend or network behavior changed.
- Frontend consumer: screen readers and accessibility tooling can now identify the dynamic checkbox by field label/key.
- Compatibility path or alias: not applicable, no routes, aliases, or mini-app entry paths changed.
- Contract proof: diff only adds `aria-label={field.label || field.key}` to an existing checkbox.

## RBAC / Permissions
- Roles allowed: not applicable, no auth or role gate changed.
- Roles denied: not applicable, no permission denial path changed.
- Positive auth proof: not checked because this PR does not alter authentication or role branches.
- Negative auth proof: not checked because no forbidden/denied behavior changed.

## Notification / Realtime
- Event type or websocket channel: not applicable, no Telegram notification, websocket, or realtime code changed.
- Payload version / ack behavior: not applicable, no payloads or acknowledgements changed.
- Read/unread or delivery semantics: not applicable, no notification state changed.
- Reconnect/resync proof: not checked because no realtime path changed.

## Frontend Resilience
- Empty data proof: not applicable, no empty-state rendering changed.
- Partial data proof: not applicable, no partial-data behavior changed.
- Forbidden secondary path behavior: not applicable, no forbidden state changed.
- Missing draft/resource behavior: not applicable, no draft/resource state changed.
- Stale route/deep-link behavior: not applicable, no routing behavior changed.

## Scope Gate
- Allowed paths: `frontend/src/App.jsx`.
- Denied paths: backend, routing, RBAC, payment, queue, EMR, lab, workflow, migrations, and unrelated frontend files.
- Migration/docs/test impact: no database migrations, docs, or test files changed.
- Rollback note: revert this PR to remove only the checkbox `aria-label` addition.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/App.jsx --quiet`; `npx.cmd eslint src/App.jsx -f json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed; App `jsx-a11y/control-has-associated-label` warnings are 0 and strict icon-control audit findings are 0.
- Not checked: browser smoke, because this is metadata-only on an existing dynamic checkbox and local lint/build covers the changed surface.
