### PR TITLE
fix(frontend): label activation key control

### DIFF
--- a/frontend/src/components/activation/AppActivation.jsx
+++ b/frontend/src/components/activation/AppActivation.jsx
@@ -163,7 +163,7 @@ const AppActivation = () => {
       )}
 
       <div style={{ marginBottom: '24px' }}>
-        <label style={{
+        <label htmlFor="activation-key" style={{
           display: 'block',
           marginBottom: '8px',
           fontSize: '13px',
@@ -176,7 +176,9 @@ const AppActivation = () => {
         <div style={{ position: 'relative' }}>
           <Key size={18} style={{ position: 'absolute', left: '16px', top: '50%', transform: 'translateY(-50%)', color: 'var(--mac-text-secondary)' }} />
           <input
+            id="activation-key"
             type="text"
+            aria-label="Ключ активации"
             className="glass-input"
             style={{ paddingLeft: '44px' }}
             value={activationKey}


### PR DESCRIPTION
﻿## Summary
- Associated the activation key label with its input and added an explicit accessible name.
- Preserved activation key state, loading, keyboard handling, and activation behavior.

## Contract Impact
- Canonical surface: `frontend/src/components/activation/AppActivation.jsx` activation form UI.
- Request shape: not applicable, no activation request payload changed.
- Response shape: not applicable, no activation response handling changed.
- Status codes: not applicable, no backend/network handling changed.
- Frontend consumer: screen readers and accessibility tooling can now identify the activation key field.
- Compatibility path or alias: not applicable, no routes or aliases changed.
- Contract proof: diff only adds `htmlFor`, `id`, and `aria-label` metadata to an existing input/label pair.

## RBAC / Permissions
- Roles allowed: not applicable, no auth or role gate changed.
- Roles denied: not applicable, no permission denial path changed.
- Positive auth proof: not checked because this PR does not alter authentication or role branches.
- Negative auth proof: not checked because no forbidden/denied behavior changed.

## Notification / Realtime
- Event type or websocket channel: not applicable, no notification or realtime code changed.
- Payload version / ack behavior: not applicable, no realtime payloads or acknowledgements changed.
- Read/unread or delivery semantics: not applicable, no notification state changed.
- Reconnect/resync proof: not checked because no websocket path changed.

## Frontend Resilience
- Empty data proof: not applicable, no empty-state rendering changed.
- Partial data proof: not applicable, no partial-data behavior changed.
- Forbidden secondary path behavior: not applicable, no forbidden state changed.
- Missing draft/resource behavior: not applicable, no draft/resource state changed.
- Stale route/deep-link behavior: not applicable, no routing behavior changed.

## Scope Gate
- Allowed paths: `frontend/src/components/activation/AppActivation.jsx`.
- Denied paths: backend, routing, RBAC, payment, queue, EMR, lab, workflow, migrations, and unrelated frontend files.
- Migration/docs/test impact: no database migrations, docs, or test files changed.
- Rollback note: revert this PR to remove only the activation input label metadata.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/activation/AppActivation.jsx --quiet`; `npx.cmd eslint src/components/activation/AppActivation.jsx -f json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed; AppActivation `jsx-a11y/control-has-associated-label` warnings are 0 and strict icon-control audit findings are 0.
- Not checked: browser smoke, because this is metadata-only on an existing activation input and local lint/build covers the changed surface.
