### PR TITLE
fix(frontend): label all free rejection control

### DIFF
--- a/frontend/src/components/admin/AllFreeApproval.jsx
+++ b/frontend/src/components/admin/AllFreeApproval.jsx
@@ -527,10 +527,12 @@ const AllFreeApproval = () => {void
                 </div>
                 
                 <div className="mb-4">
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  <label htmlFor="all-free-rejection-reason" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     Причина отклонения
                   </label>
                   <textarea
+                  id="all-free-rejection-reason"
+                  aria-label="Причина отклонения All Free"
                   value={rejectionReason}
                   onChange={(e) => setRejectionReason(e.target.value)}
                   rows={3}


### PR DESCRIPTION
﻿## Summary
- Added an accessible name and label association for the All Free rejection reason textarea.
- Preserved approval/rejection handlers, disabled state, and modal behavior.

## Contract Impact
- Canonical surface: `frontend/src/components/admin/AllFreeApproval.jsx` admin All Free rejection modal UI.
- Request shape: not applicable, no approval or rejection API request payload changed.
- Response shape: not applicable, no response handling changed.
- Status codes: not applicable, no backend/network handling changed.
- Frontend consumer: screen readers and accessibility tooling can now identify the rejection reason field.
- Compatibility path or alias: not applicable, no routes or aliases changed.
- Contract proof: diff only adds `htmlFor`, `id`, and `aria-label` metadata to an existing textarea/label pair.

## RBAC / Permissions
- Roles allowed: not applicable, no admin role gate or permission check changed.
- Roles denied: not applicable, no denied-role behavior changed.
- Positive auth proof: not checked because this PR does not alter authentication or RBAC branches.
- Negative auth proof: not checked because no forbidden/denied behavior changed.

## Notification / Realtime
- Event type or websocket channel: not applicable, no notification or realtime code changed.
- Payload version / ack behavior: not applicable, no realtime payloads or acknowledgements changed.
- Read/unread or delivery semantics: not applicable, no notification state changed.
- Reconnect/resync proof: not checked because no websocket path changed.

## Frontend Resilience
- Empty data proof: not applicable, no empty-state rendering changed.
- Partial data proof: not applicable, no partial-data behavior changed.
- Forbidden secondary path behavior: not applicable, no forbidden state changed.
- Missing draft/resource behavior: not applicable, no draft/resource state changed.
- Stale route/deep-link behavior: not applicable, no routing behavior changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/AllFreeApproval.jsx`.
- Denied paths: backend, routing, RBAC, payment logic, queue, EMR, lab, workflow, migrations, and unrelated frontend files.
- Migration/docs/test impact: no database migrations, docs, or test files changed.
- Rollback note: revert this PR to remove only the rejection textarea label metadata.

## Validation
- Targeted tests or smoke run: `npx.cmd eslint src/components/admin/AllFreeApproval.jsx --quiet`; `npx.cmd eslint src/components/admin/AllFreeApproval.jsx -f json`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: passed; AllFreeApproval `jsx-a11y/control-has-associated-label` warnings are 0 and strict icon-control audit findings are 0.
- Not checked: browser smoke, because this is metadata-only on an existing modal textarea and local lint/build covers the changed surface.
