### PR TITLE
fix(frontend): label tooth follow-up control

### DIFF
--- a/frontend/src/components/dental/ToothModal.jsx
+++ b/frontend/src/components/dental/ToothModal.jsx
@@ -433,6 +433,7 @@ const ToothModal = ({
         <label style={styles.checkboxRow}>
           <input
             type="checkbox"
+            aria-label={COPY.followUpLabel}
             checked={formData.requiresFollowUp}
             onChange={(e) => setFormData({ ...formData, requiresFollowUp: e.target.checked })}
           />


### PR DESCRIPTION
﻿## Summary
- Added an explicit accessible name to the dental tooth follow-up checkbox in `ToothModal`.
- Keeps the existing visible label and form state flow unchanged.

## Contract Impact
- Canonical surface: frontend dental tooth modal accessibility metadata only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged; same `requiresFollowUp` checkbox state and save path.
- Compatibility path or alias: not affected; no route/API alias changes.
- Contract proof: diff only touches `frontend/src/components/dental/ToothModal.jsx` and adds `aria-label` to an existing checkbox.

## RBAC / Permissions
- Roles allowed: unchanged from existing dental panel/modal access.
- Roles denied: unchanged.
- Positive auth proof: not applicable because this PR does not change auth or route access; frontend lint/build passed.
- Negative auth proof: not applicable because no RBAC logic changed.

## Notification / Realtime
- Event type or websocket channel: none changed.
- Payload version / ack behavior: none changed.
- Read/unread or delivery semantics: none changed.
- Reconnect/resync proof: not applicable because no realtime code changed.

## Frontend Resilience
- Empty data proof: modal rendering/data paths unchanged.
- Partial data proof: `toothData` fallback behavior unchanged.
- Forbidden secondary path behavior: unchanged.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/components/dental/ToothModal.jsx`.
- Denied paths: backend, database migrations, workflow, route contracts, payment/queue/EMR/lab behavior.
- Migration/docs/test impact: no migrations, docs, or tests changed.
- Rollback note: revert this commit to remove the checkbox `aria-label` only.

## Validation
- Targeted tests or smoke run: `npx eslint src/components/dental/ToothModal.jsx --quiet`; target JSON eslint check for `jsx-a11y/control-has-associated-label`; `npm run audit:icon-controls:strict`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: passed locally; target `control-has-associated-label` warnings for `ToothModal.jsx` are 0.
- Not checked: browser dental modal QA, because this is a metadata-only label fix with no visual or behavior change.
