### PR TITLE
fix(frontend): label cancel dialog control

### DIFF
--- a/frontend/src/components/dialogs/CancelDialog.jsx
+++ b/frontend/src/components/dialogs/CancelDialog.jsx
@@ -239,6 +239,7 @@ const CancelDialog = ({ isOpen, onClose, appointment, onCancel }) => {
         {/* Причина отмены */}
         <div>
           <label
+            htmlFor="cancel-reason"
             style={{
               display: 'block',
               fontSize: '14px',
@@ -251,10 +252,14 @@ const CancelDialog = ({ isOpen, onClose, appointment, onCancel }) => {
           </label>
 
           <textarea
+            id="cancel-reason"
+            aria-label="Причина отмены записи"
             value={reason}
             onChange={handleReasonChange}
             placeholder="Укажите причину отмены записи..."
             rows={4}
+            aria-invalid={!!error}
+            aria-describedby={error ? 'cancel-reason-error' : undefined}
             style={{
               width: '100%',
               padding: '12px 14px',
@@ -305,6 +310,7 @@ const CancelDialog = ({ isOpen, onClose, appointment, onCancel }) => {
             <div>
               {error && (
                 <p
+                  id="cancel-reason-error"
                   style={{
                     color: '#ef4444',
                     fontSize: '12px',


### PR DESCRIPTION
﻿## Summary
- Added an explicit accessible name and label association for the cancellation reason textarea.
- Linked the existing validation error text to the field with `aria-describedby` while preserving the current validation and cancel flow.

## Contract Impact
- Canonical surface: frontend appointment cancellation dialog accessibility metadata only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged; same `reason` state and `onCancel(appointment.id, reason.trim())` path.
- Compatibility path or alias: not affected; no route/API alias changes.
- Contract proof: diff only touches `frontend/src/components/dialogs/CancelDialog.jsx` and adds label/ARIA metadata to an existing textarea.

## RBAC / Permissions
- Roles allowed: unchanged from existing appointment cancellation access.
- Roles denied: unchanged.
- Positive auth proof: not applicable because this PR does not change auth or route access; frontend lint/build passed.
- Negative auth proof: not applicable because no RBAC logic changed.

## Notification / Realtime
- Event type or websocket channel: none changed.
- Payload version / ack behavior: none changed.
- Read/unread or delivery semantics: none changed.
- Reconnect/resync proof: not applicable because no realtime code changed.

## Frontend Resilience
- Empty data proof: dialog null guard for missing appointment unchanged.
- Partial data proof: appointment detail rendering unchanged.
- Forbidden secondary path behavior: unchanged.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/components/dialogs/CancelDialog.jsx`.
- Denied paths: backend, database migrations, workflow, route contracts, payment/queue/EMR/lab behavior.
- Migration/docs/test impact: no migrations, docs, or tests changed.
- Rollback note: revert this commit to remove the cancellation reason field accessibility metadata only.

## Validation
- Targeted tests or smoke run: `npx eslint src/components/dialogs/CancelDialog.jsx --quiet`; target JSON eslint check for `jsx-a11y/control-has-associated-label`; `npm run audit:icon-controls:strict`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: passed locally; target `control-has-associated-label` warnings for `CancelDialog.jsx` are 0.
- Not checked: browser cancellation dialog QA, because this is a metadata-only label fix with no visual or behavior change.
