### PR TITLE
fix(frontend): label payment dialog control

### DIFF
--- a/frontend/src/components/dialogs/PaymentDialog.jsx
+++ b/frontend/src/components/dialogs/PaymentDialog.jsx
@@ -260,6 +260,7 @@ const PaymentDialog = ({
             {/* Сумма */}
             <div>
               <label
+                htmlFor="payment-amount"
                 style={{
                   display: 'block',
                   fontSize: '14px',
@@ -271,7 +272,11 @@ const PaymentDialog = ({
                 Сумма к оплате *
               </label>
               <input
+                id="payment-amount"
                 type="number"
+                aria-label="Сумма к оплате"
+                aria-invalid={!!errors.amount}
+                aria-describedby={errors.amount ? 'payment-amount-error' : undefined}
                 value={paymentAmount}
                 onChange={(e) => {
                   setPaymentAmount(e.target.value);
@@ -314,6 +319,7 @@ const PaymentDialog = ({
               />
               {errors.amount && (
                 <p
+                  id="payment-amount-error"
                   style={{
                     color: '#ef4444',
                     fontSize: '12px',


### PR DESCRIPTION
﻿## Summary
- Added an explicit accessible name and label association for the payment amount input.
- Linked the existing amount validation error to the input with `aria-describedby` while preserving payment behavior.

## Contract Impact
- Canonical surface: frontend payment dialog accessibility metadata only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged; same payment amount state and submit path.
- Compatibility path or alias: not affected; no route/API alias changes.
- Contract proof: diff only touches `frontend/src/components/dialogs/PaymentDialog.jsx` and adds label/ARIA metadata to an existing input.

## RBAC / Permissions
- Roles allowed: unchanged from existing payment dialog access.
- Roles denied: unchanged.
- Positive auth proof: not applicable because this PR does not change auth or route access; frontend lint/build passed.
- Negative auth proof: not applicable because no RBAC logic changed.

## Notification / Realtime
- Event type or websocket channel: none changed.
- Payload version / ack behavior: none changed.
- Read/unread or delivery semantics: none changed.
- Reconnect/resync proof: not applicable because no realtime code changed.

## Frontend Resilience
- Empty data proof: existing dialog data flow unchanged.
- Partial data proof: appointment/service display behavior unchanged.
- Forbidden secondary path behavior: unchanged.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/components/dialogs/PaymentDialog.jsx`.
- Denied paths: backend, database migrations, workflow, route contracts, payment API behavior, queue/EMR/lab behavior.
- Migration/docs/test impact: no migrations, docs, or tests changed.
- Rollback note: revert this commit to remove the payment amount field accessibility metadata only.

## Validation
- Targeted tests or smoke run: `npx eslint src/components/dialogs/PaymentDialog.jsx --quiet`; target JSON eslint check for `jsx-a11y/control-has-associated-label`; `npm run audit:icon-controls:strict`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: passed locally; target `control-has-associated-label` warnings for `PaymentDialog.jsx` are 0.
- Not checked: browser payment dialog QA, because this is a metadata-only label fix with no visual or business behavior change.
