### PR TITLE
fix(frontend): label doctor queue row control

### DIFF
--- a/frontend/src/components/doctor/DoctorQueuePanel.jsx
+++ b/frontend/src/components/doctor/DoctorQueuePanel.jsx
@@ -514,6 +514,7 @@ const DoctorQueuePanel = ({
                 key={entry.id}
                 role="button"
                 tabIndex={0}
+                aria-label={`Выбрать пациента ${entry.patient_name || entry.number} из очереди`}
                 style={{
                   padding: '16px',
                   cursor: 'pointer',


### PR DESCRIPTION
﻿## Summary
- Added an accessible name to the doctor queue patient row control.
- Preserved the existing click and keyboard selection behavior for queued patients.

## Contract Impact
- Canonical surface: frontend doctor queue panel accessibility metadata only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged; same `setSelectedPatient` and `onPatientSelect` behavior.
- Compatibility path or alias: not affected; no route/API alias changes.
- Contract proof: diff only touches `frontend/src/components/doctor/DoctorQueuePanel.jsx` and adds `aria-label` to an existing `role="button"` row.

## RBAC / Permissions
- Roles allowed: unchanged from existing doctor queue panel access.
- Roles denied: unchanged.
- Positive auth proof: not applicable because this PR does not change auth or route access; frontend lint/build passed.
- Negative auth proof: not applicable because no RBAC logic changed.

## Notification / Realtime
- Event type or websocket channel: none changed.
- Payload version / ack behavior: none changed.
- Read/unread or delivery semantics: none changed.
- Reconnect/resync proof: not applicable because no realtime code changed.

## Frontend Resilience
- Empty data proof: existing empty queue state unchanged.
- Partial data proof: row label falls back to queue number if patient name is missing.
- Forbidden secondary path behavior: unchanged.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/components/doctor/DoctorQueuePanel.jsx`.
- Denied paths: backend, database migrations, workflow, route contracts, queue API behavior, payment/EMR/lab behavior.
- Migration/docs/test impact: no migrations, docs, or tests changed.
- Rollback note: revert this commit to remove the queue row `aria-label` only.

## Validation
- Targeted tests or smoke run: `npx eslint src/components/doctor/DoctorQueuePanel.jsx --quiet`; target JSON eslint check for `jsx-a11y/control-has-associated-label`; `npm run audit:icon-controls:strict`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: passed locally; target `control-has-associated-label` warnings for `DoctorQueuePanel.jsx` are 0.
- Not checked: authenticated doctor browser QA, because this is a metadata-only label fix with no visual or queue behavior change.
