### PR TITLE
fix(frontend): label emr help dialog close control

### DIFF
--- a/frontend/src/components/emr-v2/EMRHelpDialog.jsx
+++ b/frontend/src/components/emr-v2/EMRHelpDialog.jsx
@@ -17,6 +17,7 @@ const EMRHelpDialog = ({ isOpen, onClose }) => {
             className="emr-v2-modal-overlay"
             role="button"
             tabIndex={0}
+            aria-label="Закрыть справку EMR"
             onClick={onClose}
             onKeyDown={(event) => handleActivationKeyDown(event, onClose)}>
             <div className="emr-v2-modal-content theme-soft-surface" onClickCapture={e => e.stopPropagation()} style={{ maxWidth: '600px', borderRadius: '12px' }}>


### PR DESCRIPTION
﻿## Summary
- Adds an explicit accessible name to the EMR help dialog overlay close control.
- Keeps click, Enter, and Space close behavior unchanged.

## Contract Impact
- Canonical surface: `frontend/src/components/emr-v2/EMRHelpDialog.jsx` modal overlay close UI.
- Request shape: not applicable because no API request shape changed.
- Response shape: not applicable because no API response shape changed.
- Status codes: not applicable because no backend endpoint behavior changed.
- Frontend consumer: EMR help dialog still receives the same `isOpen` and `onClose` props.
- Compatibility path or alias: not applicable because no route, import alias, or compatibility path changed.
- Contract proof: diff is limited to an `aria-label` on the existing overlay control.

## RBAC / Permissions
- Roles allowed: unchanged; parent EMR route access controls dialog availability.
- Roles denied: unchanged; no auth, RBAC, or route guard logic touched.
- Positive auth proof: not rerun because this is a component-only accessible-name change with no auth code impact.
- Negative auth proof: not rerun because this is a component-only accessible-name change with no auth code impact.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket channel changed.
- Payload version / ack behavior: not applicable because no realtime payload changed.
- Read/unread or delivery semantics: not applicable because no notification state changed.
- Reconnect/resync proof: not applicable because no realtime reconnect path changed.

## Frontend Resilience
- Empty data proof: unchanged; dialog still returns `null` when `isOpen` is false.
- Partial data proof: unchanged; static help content and close controls render the same content.
- Forbidden secondary path behavior: unchanged; no route or permission secondary path touched.
- Missing draft/resource behavior: unchanged; no draft/resource loading behavior touched.
- Stale route/deep-link behavior: unchanged; no navigation or route behavior touched.

## Scope Gate
- Allowed paths: `frontend/src/components/emr-v2/EMRHelpDialog.jsx` only.
- Denied paths: backend, tests, workflows, auth/RBAC, routing, queue, payment, lab, notification, and migration files.
- Migration/docs/test impact: no migration, docs, or test files changed.
- Rollback note: revert this single commit to remove only the overlay accessible-name addition.

## Validation
- Targeted tests or smoke run: `npx eslint src/components/emr-v2/EMRHelpDialog.jsx --quiet`; targeted JSON eslint count; `npm run audit:icon-controls:strict`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: all passed locally; targeted `jsx-a11y/control-has-associated-label` warnings for `EMRHelpDialog.jsx` are 0 and strict icon-control audit findings are 0.
- Not checked: browser EMR dialog smoke was not run because this PR changes only an accessible name and preserves visible UI/close behavior.
