### PR TITLE
fix(frontend): label emr complaints field control

### DIFF
--- a/frontend/src/components/emr-v2/sections/ComplaintsField.jsx
+++ b/frontend/src/components/emr-v2/sections/ComplaintsField.jsx
@@ -15,7 +15,7 @@
  * 6. ОШИБКА - при попытке подписать пустое
  */
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useId } from 'react';
 import PropTypes from 'prop-types';
 import './ComplaintsField.css';
 import logger from '../../../utils/logger';
@@ -56,6 +56,7 @@ const ComplaintsField = ({
     label = 'Жалобы',
     placeholder = 'Введите жалобы пациента...'
 }) => {
+    const complaintsFieldId = useId();
     const textareaRef = useRef(null);
 
     // Local state
@@ -203,10 +204,12 @@ const ComplaintsField = ({
 
     return (
         <div className="complaints-wrapper">
-            <label className="complaints-label">{label}</label>
+            <label className="complaints-label" htmlFor={complaintsFieldId}>{label}</label>
 
             <div className="complaints-container">
                 <textarea
+                    id={complaintsFieldId}
+                    aria-label={label}
                     ref={textareaRef}
                     className={fieldClasses}
                     value={value}


### PR DESCRIPTION
﻿## Summary
- Associates the visible complaints label with the EMR complaints textarea using a React-generated id.
- Adds an explicit accessible name so the existing eslint accessibility sweep recognizes the control.
- Keeps complaints text entry, AI suggestions, autosave hint, and keyboard behavior unchanged.

## Contract Impact
- Canonical surface: `frontend/src/components/emr-v2/sections/ComplaintsField.jsx` complaints textarea UI.
- Request shape: not applicable because no API request shape changed.
- Response shape: not applicable because no API response shape changed.
- Status codes: not applicable because no backend endpoint behavior changed.
- Frontend consumer: component props remain unchanged: `value`, `onChange`, `isEditable`, `aiEnabled`, `onRequestAI`, `error`, `autoFocus`, `onFieldTouch`, `onBlur`, `label`, and `placeholder`.
- Compatibility path or alias: not applicable because no route, import alias, or compatibility path changed.
- Contract proof: diff is limited to `useId`, `htmlFor`, `id`, and `aria-label` for the existing textarea.

## RBAC / Permissions
- Roles allowed: unchanged; parent EMR route access controls who can use the complaints field.
- Roles denied: unchanged; no auth, RBAC, or route guard logic touched.
- Positive auth proof: not rerun because this is a component-only accessible-name change with no auth code impact.
- Negative auth proof: not rerun because this is a component-only accessible-name change with no auth code impact.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket channel changed.
- Payload version / ack behavior: not applicable because no realtime payload changed.
- Read/unread or delivery semantics: not applicable because no notification state changed.
- Reconnect/resync proof: not applicable because no realtime reconnect path changed.

## Frontend Resilience
- Empty data proof: unchanged; empty complaints still use the same `value` and `placeholder` behavior.
- Partial data proof: unchanged; partial complaints text and AI suggestions still flow through existing handlers.
- Forbidden secondary path behavior: unchanged; read-only/disabled behavior still follows `isEditable`.
- Missing draft/resource behavior: unchanged; no EMR draft/resource loading behavior touched.
- Stale route/deep-link behavior: unchanged; no route or navigation behavior touched.

## Scope Gate
- Allowed paths: `frontend/src/components/emr-v2/sections/ComplaintsField.jsx` only.
- Denied paths: backend, tests, workflows, auth/RBAC, routing, queue, payment, lab, notification, and migration files.
- Migration/docs/test impact: no migration, docs, or test files changed.
- Rollback note: revert this single commit to remove only the complaints textarea labeling addition.

## Validation
- Targeted tests or smoke run: `npx eslint src/components/emr-v2/sections/ComplaintsField.jsx --quiet`; targeted JSON eslint count; `npm run audit:icon-controls:strict`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: all passed locally; targeted `jsx-a11y/control-has-associated-label` warnings for `ComplaintsField.jsx` are 0 and strict icon-control audit findings are 0.
- Not checked: browser EMR complaints smoke was not run because this PR changes only labeling metadata and preserves text entry/AI/autosave behavior.
