### PR TITLE
fix(frontend): label modern select controls

### DIFF
--- a/frontend/src/components/forms/ModernSelect.jsx
+++ b/frontend/src/components/forms/ModernSelect.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useId } from 'react';
 import PropTypes from 'prop-types';
 import {
   ChevronDown,
@@ -34,6 +34,8 @@ const ModernSelect = ({
   className = '',
   ...props
 }) => {
+  const selectListboxId = useId();
+  const accessibleLabel = typeof label === 'string' && label.trim() ? label : placeholder;
   const { getColor } = useTheme();
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -329,6 +331,8 @@ const ModernSelect = ({
         onBlur={() => setFocused(false)}
         tabIndex={disabled ? -1 : 0}
         role="combobox"
+        aria-label={accessibleLabel}
+        aria-controls={selectListboxId}
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         aria-invalid={hasError}>
@@ -392,6 +396,7 @@ const ModernSelect = ({
             ref={searchInputRef}
             type="text"
             className="search-input"
+            aria-label={`Поиск: ${accessibleLabel}`}
             placeholder="Поиск..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
@@ -404,7 +409,7 @@ const ModernSelect = ({
         }
 
           {/* Опции */}
-          <div className="select-options" role="listbox">
+          <div id={selectListboxId} className="select-options" role="listbox">
             {loading ?
           <div className="select-loading">
                 <div className="loading-spinner" />


### PR DESCRIPTION
﻿## Summary
- Adds a stable listbox id and accessible name to `ModernSelect` combobox controls.
- Adds an accessible name to the searchable select input.
- Keeps option selection, multiple selection, clear action, grouping, and rendering APIs unchanged.

## Contract Impact
- Canonical surface: `frontend/src/components/forms/ModernSelect.jsx` shared frontend select UI.
- Request shape: not applicable because no API request shape changed.
- Response shape: not applicable because no API response shape changed.
- Status codes: not applicable because no backend endpoint behavior changed.
- Frontend consumer: `ModernSelect` props and emitted `onChange` values are unchanged.
- Compatibility path or alias: not applicable because no route, import alias, or compatibility path changed.
- Contract proof: diff is limited to `useId`, combobox/listbox ARIA metadata, and search input accessible labeling.

## RBAC / Permissions
- Roles allowed: unchanged; role access remains controlled by the parent routes using this shared component.
- Roles denied: unchanged; no auth, RBAC, or route guard logic touched.
- Positive auth proof: not rerun because this is a shared component ARIA metadata change with no auth code impact.
- Negative auth proof: not rerun because this is a shared component ARIA metadata change with no auth code impact.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket channel changed.
- Payload version / ack behavior: not applicable because no realtime payload changed.
- Read/unread or delivery semantics: not applicable because no notification state changed.
- Reconnect/resync proof: not applicable because no realtime reconnect path changed.

## Frontend Resilience
- Empty data proof: unchanged; empty options and placeholder rendering still use existing branches.
- Partial data proof: unchanged; grouped, selected, and multiple values still use existing render helpers.
- Forbidden secondary path behavior: unchanged; disabled behavior still follows the existing `disabled` prop.
- Missing draft/resource behavior: unchanged; no draft/resource behavior touched.
- Stale route/deep-link behavior: unchanged; no route or navigation behavior touched.

## Scope Gate
- Allowed paths: `frontend/src/components/forms/ModernSelect.jsx` only.
- Denied paths: backend, tests, workflows, auth/RBAC, routing, queue, payment, lab, notification, and migration files.
- Migration/docs/test impact: no migration, docs, or test files changed.
- Rollback note: revert this single commit to remove only the shared select ARIA metadata additions.

## Validation
- Targeted tests or smoke run: `npx eslint src/components/forms/ModernSelect.jsx --quiet`; targeted JSON eslint counts; `npm run audit:icon-controls:strict`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: all passed locally; targeted `control-has-associated-label` warnings are 0, targeted `role-has-required-aria-props` warnings are 0, and strict icon-control audit findings are 0.
- Not checked: browser route smoke was not run because this PR changes shared ARIA metadata only and preserves select state/value behavior.
