### PR TITLE
fix(frontend): label lab results upload control

### DIFF
--- a/frontend/src/components/laboratory/LabResultsManager.jsx
+++ b/frontend/src/components/laboratory/LabResultsManager.jsx
@@ -563,6 +563,7 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
           <input
             type="file"
             accept=".pdf,.xlsx,.xls,.csv"
+            aria-label="Загрузить файл с результатами лабораторных исследований"
             onChange={handleFileUpload}
             style={{ display: 'none' }}
             id="lab-file-upload" />


### PR DESCRIPTION
﻿## Summary
- Adds an explicit accessible name to the lab results upload file input.
- Keeps upload dialog, accepted file types, and `handleFileUpload` behavior unchanged.

## Contract Impact
- Canonical surface: `frontend/src/components/laboratory/LabResultsManager.jsx` lab results upload dialog UI.
- Request shape: not applicable because no API request shape changed.
- Response shape: not applicable because no API response shape changed.
- Status codes: not applicable because no backend endpoint behavior changed.
- Frontend consumer: lab results upload still submits the same selected file through existing `handleFileUpload`.
- Compatibility path or alias: not applicable because no route, import alias, or compatibility path changed.
- Contract proof: diff is limited to an accessible label on the existing file input.

## RBAC / Permissions
- Roles allowed: unchanged; parent lab/visit UI access controls availability.
- Roles denied: unchanged; no auth, RBAC, or route guard logic touched.
- Positive auth proof: not rerun because this is a component-only accessible-name change with no auth code impact.
- Negative auth proof: not rerun because this is a component-only accessible-name change with no auth code impact.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket channel changed.
- Payload version / ack behavior: not applicable because no realtime payload changed.
- Read/unread or delivery semantics: not applicable because no notification state changed.
- Reconnect/resync proof: not applicable because no realtime reconnect path changed.

## Frontend Resilience
- Empty data proof: unchanged; empty results and upload dialog content use existing branches.
- Partial data proof: unchanged; file upload uses the same file selection and accepted formats.
- Forbidden secondary path behavior: unchanged; no route or permission secondary path touched.
- Missing draft/resource behavior: unchanged; no draft/resource loading behavior touched.
- Stale route/deep-link behavior: unchanged; no route or navigation behavior touched.

## Scope Gate
- Allowed paths: `frontend/src/components/laboratory/LabResultsManager.jsx` only.
- Denied paths: backend, tests, workflows, auth/RBAC, routing, queue, payment, notification, and migration files.
- Migration/docs/test impact: no migration, docs, or test files changed.
- Rollback note: revert this single commit to remove only the file input accessible-name addition.

## Validation
- Targeted tests or smoke run: `npx eslint src/components/laboratory/LabResultsManager.jsx --quiet`; targeted JSON eslint count; `npm run audit:icon-controls:strict`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: all passed locally; targeted `jsx-a11y/control-has-associated-label` warnings for `LabResultsManager.jsx` are 0 and strict icon-control audit findings are 0.
- Not checked: browser lab upload smoke was not run because this PR changes only an accessible name and preserves upload behavior.
