### PR TITLE
fix(frontend): label notification inbox search control

### DIFF
--- a/frontend/src/components/notifications/NotificationInbox.jsx
+++ b/frontend/src/components/notifications/NotificationInbox.jsx
@@ -284,6 +284,7 @@ export default function NotificationInbox({ userRole, onClose }) {
           <Search size={16} />
           <input
             type="search"
+            aria-label="Поиск по уведомлениям"
             value={searchText}
             onChange={(event) => setSearchText(event.target.value)}
             placeholder="Поиск по уведомлениям"


### PR DESCRIPTION
﻿## Summary
- Adds an explicit accessible name to the notification inbox search input.
- Keeps notification filtering, read/archive actions, and navigation behavior unchanged.

## Contract Impact
- Canonical surface: `frontend/src/components/notifications/NotificationInbox.jsx` notification inbox filter UI.
- Request shape: not applicable because no API request shape changed.
- Response shape: not applicable because no API response shape changed.
- Status codes: not applicable because no backend endpoint behavior changed.
- Frontend consumer: notification inbox search still filters the same local notification list by the existing `searchText` state.
- Compatibility path or alias: not applicable because no route, import alias, or compatibility path changed.
- Contract proof: diff is limited to an accessible label on the existing search input.

## RBAC / Permissions
- Roles allowed: unchanged; notification visibility still comes from existing role-scoped notification context.
- Roles denied: unchanged; no auth, RBAC, or role filter logic touched.
- Positive auth proof: not rerun because this is a component-only accessible-name change with no auth code impact.
- Negative auth proof: not rerun because this is a component-only accessible-name change with no auth code impact.

## Notification / Realtime
- Event type or websocket channel: unchanged; notification event types and channels are not modified.
- Payload version / ack behavior: unchanged; no notification payload or ack behavior changed.
- Read/unread or delivery semantics: unchanged; mark read, seen, archive, and mark-all-read handlers are untouched.
- Reconnect/resync proof: not rerun because this PR only labels the local search input and does not touch realtime resync code.

## Frontend Resilience
- Empty data proof: unchanged; empty filtered notification state still uses the existing branch.
- Partial data proof: unchanged; filtering still handles existing optional notification fields the same way.
- Forbidden secondary path behavior: unchanged; no route or permission secondary path touched.
- Missing draft/resource behavior: not applicable because notification inbox does not use drafts or resource editing in this slice.
- Stale route/deep-link behavior: unchanged; notification target navigation helper is untouched.

## Scope Gate
- Allowed paths: `frontend/src/components/notifications/NotificationInbox.jsx` only.
- Denied paths: backend, tests, workflows, auth/RBAC, routing, queue, payment, migration, and notification transport files.
- Migration/docs/test impact: no migration, docs, or test files changed.
- Rollback note: revert this single commit to remove only the search input accessible-name addition.

## Validation
- Targeted tests or smoke run: `npx eslint src/components/notifications/NotificationInbox.jsx --quiet`; targeted JSON eslint count; `npm run audit:icon-controls:strict`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: all passed locally; targeted `jsx-a11y/control-has-associated-label` warnings for `NotificationInbox.jsx` are 0 and strict icon-control audit findings are 0.
- Not checked: browser notification inbox smoke was not run because this PR changes only an accessible name and preserves notification behavior.
