### PR TITLE
fix(frontend): label reschedule date control

### DIFF
--- a/frontend/src/components/RescheduleDialog.jsx
+++ b/frontend/src/components/RescheduleDialog.jsx
@@ -102,6 +102,7 @@ export default function RescheduleDialog({ open, onClose, visit, onRescheduled }
             <span>Новая дата</span>
             <input
               type="date"
+              aria-label="Новая дата визита"
               value={d}
               onChange={(e) => setD(e.target.value)}
               style={input}


### PR DESCRIPTION
﻿## Summary
- Adds an explicit accessible name to the reschedule date input.
- Keeps visit date state, reschedule actions, and API calls unchanged.

## Contract Impact
- Canonical surface: `frontend/src/components/RescheduleDialog.jsx` visit reschedule dialog UI.
- Request shape: unchanged; `rescheduleVisit(visit.id, d)` and `rescheduleTomorrow(visit.id)` calls are untouched.
- Response shape: unchanged; `onRescheduled` and close handling remain the same.
- Status codes: unchanged because no backend endpoint behavior changed.
- Frontend consumer: appointment/visit reschedule dialog still uses the same `d` state and existing submit handlers.
- Compatibility path or alias: not applicable because no route, import alias, or compatibility path changed.
- Contract proof: diff is limited to an accessible label on the existing date input.

## RBAC / Permissions
- Roles allowed: unchanged; parent appointment/visit UI controls dialog availability.
- Roles denied: unchanged; no auth, RBAC, or route guard logic touched.
- Positive auth proof: not rerun because this is a component-only accessible-name change with no auth code impact.
- Negative auth proof: not rerun because this is a component-only accessible-name change with no auth code impact.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket channel changed.
- Payload version / ack behavior: not applicable because no realtime payload changed.
- Read/unread or delivery semantics: not applicable because no notification state changed.
- Reconnect/resync proof: not applicable because no realtime reconnect path changed.

## Frontend Resilience
- Empty data proof: unchanged; missing visit id guard remains untouched.
- Partial data proof: unchanged; planned date prefill fallback remains untouched.
- Forbidden secondary path behavior: unchanged; no route or permission secondary path touched.
- Missing draft/resource behavior: not applicable because this dialog does not use drafts/resources in this slice.
- Stale route/deep-link behavior: unchanged; no route or navigation behavior touched.

## Scope Gate
- Allowed paths: `frontend/src/components/RescheduleDialog.jsx` only.
- Denied paths: backend, tests, workflows, auth/RBAC, routing, queue, payment, notification, scheduling API, and migration files.
- Migration/docs/test impact: no migration, docs, or test files changed.
- Rollback note: revert this single commit to remove only the date input accessible-name addition.

## Validation
- Targeted tests or smoke run: `npx eslint src/components/RescheduleDialog.jsx --quiet`; targeted JSON eslint count with fail-on-nonzero guard; `npm run audit:icon-controls:strict`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: all passed locally; targeted `jsx-a11y/control-has-associated-label` warnings for `RescheduleDialog.jsx` are 0 and strict icon-control audit findings are 0.
- Not checked: browser reschedule modal smoke was not run because this PR changes only an accessible name and preserves reschedule behavior.
