### PR TITLE
fix(frontend): label service checklist controls

### DIFF
--- a/frontend/src/components/ServiceChecklist.jsx
+++ b/frontend/src/components/ServiceChecklist.jsx
@@ -51,6 +51,7 @@ const ServiceChecklist = ({ value = [], onChange, department }) => {
             <label key={service.id} style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
               <input
                 type="checkbox"
+                aria-label={`Выбрать услугу: ${service.name}`}
                 checked={value.includes(service.id)}
                 onChange={(e) => {
                   const newValue = e.target.checked 


### PR DESCRIPTION
﻿## Summary
- Adds an explicit accessible name to each service checklist checkbox.
- Keeps service selection, grouping, pricing display, and `onChange` behavior unchanged.

## Contract Impact
- Canonical surface: `frontend/src/components/ServiceChecklist.jsx` service selection checklist UI.
- Request shape: not applicable because no API request shape changed.
- Response shape: not applicable because no API response shape changed.
- Status codes: not applicable because no backend endpoint behavior changed.
- Frontend consumer: selected services still flow through the existing `value` array and `onChange(newValue)` callback.
- Compatibility path or alias: not applicable because no route, import alias, or compatibility path changed.
- Contract proof: diff is limited to a dynamic accessible label on the existing checkbox input.

## RBAC / Permissions
- Roles allowed: unchanged; parent role/page controls checklist availability.
- Roles denied: unchanged; no auth, RBAC, or route guard logic touched.
- Positive auth proof: not rerun because this is a component-only accessible-name change with no auth code impact.
- Negative auth proof: not rerun because this is a component-only accessible-name change with no auth code impact.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket channel changed.
- Payload version / ack behavior: not applicable because no realtime payload changed.
- Read/unread or delivery semantics: not applicable because no notification state changed.
- Reconnect/resync proof: not applicable because no realtime reconnect path changed.

## Frontend Resilience
- Empty data proof: unchanged; unknown/empty department still renders the existing empty service set.
- Partial data proof: unchanged; service grouping and price rendering use the same data fields.
- Forbidden secondary path behavior: unchanged; no route or permission secondary path touched.
- Missing draft/resource behavior: not applicable because this checklist does not use drafts/resources in this slice.
- Stale route/deep-link behavior: unchanged; no route or navigation behavior touched.

## Scope Gate
- Allowed paths: `frontend/src/components/ServiceChecklist.jsx` only.
- Denied paths: backend, tests, workflows, auth/RBAC, routing, queue, payment, notification, service catalog API, and migration files.
- Migration/docs/test impact: no migration, docs, or test files changed.
- Rollback note: revert this single commit to remove only the checkbox accessible-name addition.

## Validation
- Targeted tests or smoke run: `npx eslint src/components/ServiceChecklist.jsx --quiet`; targeted JSON eslint count with fail-on-nonzero guard; `npm run audit:icon-controls:strict`; `npm run lint:check -- --quiet`; `npm run build`; `git diff --check`.
- Result: all passed locally; targeted `jsx-a11y/control-has-associated-label` warnings for `ServiceChecklist.jsx` are 0 and strict icon-control audit findings are 0.
- Not checked: browser service checklist smoke was not run because this PR changes only accessible names and preserves service selection behavior.
