### PR TITLE
ci(frontend): enforce jsx a11y rules

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -567,7 +567,7 @@ jobs:
     - name: Icon-only controls accessibility sweep
       run: |
         cd frontend
-        npm run audit:control-labels
+        npm run audit:a11y
         npm run audit:icon-controls:strict
         echo "Strict accessibility control sweeps passed"
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -62,15 +62,15 @@ export default [
       'react/jsx-no-undef': 'error',
       
       // Accessibility (основные правила)
-      'jsx-a11y/alt-text': 'warn',
-      'jsx-a11y/aria-props': 'warn',
-      'jsx-a11y/aria-role': 'warn',
-      'jsx-a11y/aria-unsupported-elements': 'warn',
-      'jsx-a11y/click-events-have-key-events': 'warn',
+      'jsx-a11y/alt-text': 'error',
+      'jsx-a11y/aria-props': 'error',
+      'jsx-a11y/aria-role': 'error',
+      'jsx-a11y/aria-unsupported-elements': 'error',
+      'jsx-a11y/click-events-have-key-events': 'error',
       'jsx-a11y/control-has-associated-label': 'error',
-      'jsx-a11y/interactive-supports-focus': 'warn',
-      'jsx-a11y/no-static-element-interactions': 'warn',
-      'jsx-a11y/role-has-required-aria-props': 'warn',
+      'jsx-a11y/interactive-supports-focus': 'error',
+      'jsx-a11y/no-static-element-interactions': 'error',
+      'jsx-a11y/role-has-required-aria-props': 'error',
     },
   },
   {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview --host 0.0.0.0 --port 5173",
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --fix",
     "lint:check": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
+    "audit:a11y": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --quiet",
     "audit:control-labels": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --quiet --rule \"jsx-a11y/control-has-associated-label: error\"",
     "audit:icon-controls": "node scripts/audit-icon-only-controls.mjs --strict --baseline=scripts/a11y/icon-only-controls-baseline.json",
     "audit:icon-controls:strict": "node scripts/audit-icon-only-controls.mjs --strict",


### PR DESCRIPTION
﻿## Summary
- Promoted the remaining configured `jsx-a11y` rules from warning to error after confirming their current baseline is zero.
- Added `npm run audit:a11y` as the general frontend accessibility lint sweep.
- Updated unified CI to run the general a11y sweep before the strict icon-only controls audit.

## Contract Impact
- Canonical surface: frontend lint/a11y enforcement and GitHub Actions frontend lint job only.
- Request shape: unchanged; no API request body, query string, endpoint, or client call changed.
- Response shape: unchanged; no API response parsing or frontend data contract changed.
- Status codes: unchanged; no backend status handling or frontend status-code branching changed.
- Frontend consumer: unchanged at runtime; this PR changes only build-time lint enforcement.
- Compatibility path or alias: unchanged; no route, redirect, alias, or compatibility path changed.
- Contract proof: `npm run build` passed after the lint/script/workflow-only changes.

## RBAC / Permissions
- Roles allowed: unchanged; no role gate, permission check, or allowed-role list changed.
- Roles denied: unchanged; denied-role behavior is untouched.
- Positive auth proof: unchanged by scope; this PR does not touch auth code or protected route rendering.
- Negative auth proof: unchanged by scope; no token, RBAC, permission, or RoleGate logic changed.

## Notification / Realtime
- Event type or websocket channel: unchanged; no notification, websocket, polling, or realtime code touched.
- Payload version / ack behavior: unchanged; no realtime payload creation, ack, or version handling touched.
- Read/unread or delivery semantics: unchanged; no notification read/unread or delivery semantics touched.
- Reconnect/resync proof: unchanged; no reconnect/resync path changed, and validation focused on lint/build/workflow syntax.

## Frontend Resilience
- Empty data proof: unchanged; no UI runtime state or empty-data rendering changed.
- Partial data proof: unchanged; no partial-data rendering or fallback logic changed.
- Forbidden secondary path behavior: unchanged; no protected route or forbidden-state behavior changed.
- Missing draft/resource behavior: unchanged; no draft/resource loading path changed.
- Stale route/deep-link behavior: unchanged; no route or navigation behavior changed.

## Scope Gate
- Allowed paths: `frontend/eslint.config.js`, `frontend/package.json`, `.github/workflows/ci-cd-unified.yml`.
- Denied paths: backend code, frontend runtime components/pages, auth/RBAC, migrations, API clients, queue/payment/EMR/lab logic.
- Migration/docs/test impact: no database migration, docs, or test source changes; only lint script/config and workflow enforcement changed.
- Rollback note: revert this PR to return these `jsx-a11y` rules to warning-level enforcement and restore the CI accessibility step to the previous targeted sweep.

## Validation
- Targeted tests or smoke run: baseline JSON sweep for configured `jsx-a11y` rules showed zero findings; `npm run audit:a11y`; `npm run audit:control-labels`; `npm run audit:icon-controls:strict`; `npm run lint:check -- --quiet`; `npm run build`; `py -3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-cd-unified.yml', encoding='utf-8')); print('workflow yaml ok')"`; `git diff --check`.
- Result: passed locally; all configured `jsx-a11y` rules are clean and now enforced as errors.
- Not checked: browser screenshots, backend suites, and frontend unit tests were not run locally because this is lint/workflow enforcement only.
