### PR TITLE
ci(frontend): prevent new mui runtime imports

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -568,6 +568,7 @@ jobs:
       run: |
         cd frontend
         npm run audit:a11y
+        npm run audit:no-mui-runtime
         npm run audit:icon-controls:strict
         echo "Strict accessibility control sweeps passed"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "lint:check": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
     "audit:a11y": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --quiet",
     "audit:control-labels": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --quiet --rule \"jsx-a11y/control-has-associated-label: error\"",
+    "audit:no-mui-runtime": "node scripts/audit-no-mui-runtime.mjs",
     "audit:icon-controls": "node scripts/audit-icon-only-controls.mjs --strict --baseline=scripts/a11y/icon-only-controls-baseline.json",
     "audit:icon-controls:strict": "node scripts/audit-icon-only-controls.mjs --strict",
     "audit:icon-controls:update-baseline": "node scripts/audit-icon-only-controls.mjs --write-baseline=scripts/a11y/icon-only-controls-baseline.json",

--- a/frontend/scripts/audit-no-mui-runtime.mjs
+++ b/frontend/scripts/audit-no-mui-runtime.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(__dirname, '..');
+
+const scanRoots = [
+  path.join(frontendRoot, 'src', 'pages'),
+  path.join(frontendRoot, 'src', 'components'),
+];
+
+const runtimeExtensions = new Set(['.js', '.jsx', '.ts', '.tsx']);
+const ignoredFilePatterns = [
+  /\.test\.[jt]sx?$/i,
+  /\.spec\.[jt]sx?$/i,
+  /\.stories\.[jt]sx?$/i,
+];
+
+const disallowedPatterns = [
+  {
+    name: '@mui package import',
+    pattern: /['"]@mui\//,
+  },
+  {
+    name: '@material-ui package import',
+    pattern: /['"]@material-ui\//,
+  },
+  {
+    name: 'Mui-prefixed runtime symbol',
+    pattern: /\bMui[A-Z0-9_][A-Za-z0-9_]*/,
+  },
+];
+
+function shouldScanFile(filePath) {
+  const ext = path.extname(filePath);
+  if (!runtimeExtensions.has(ext)) {
+    return false;
+  }
+  const basename = path.basename(filePath);
+  return !ignoredFilePatterns.some((pattern) => pattern.test(basename));
+}
+
+function walk(directory) {
+  const entries = readdirSync(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(fullPath));
+      continue;
+    }
+    if (entry.isFile() && shouldScanFile(fullPath)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function lineAndColumn(source, index) {
+  const before = source.slice(0, index);
+  const lines = before.split(/\r?\n/);
+  const line = lines.length;
+  const column = lines[lines.length - 1].length + 1;
+  return { line, column };
+}
+
+const findings = [];
+
+for (const root of scanRoots) {
+  for (const filePath of walk(root)) {
+    const source = readFileSync(filePath, 'utf8');
+    for (const { name, pattern } of disallowedPatterns) {
+      const match = pattern.exec(source);
+      if (!match) {
+        continue;
+      }
+      const { line, column } = lineAndColumn(source, match.index);
+      findings.push({
+        file: path.relative(frontendRoot, filePath).replaceAll(path.sep, '/'),
+        line,
+        column,
+        rule: name,
+        value: match[0],
+      });
+    }
+  }
+}
+
+if (findings.length > 0) {
+  console.error('No-new-MUI runtime gate failed.');
+  console.error('MUI imports/usages are not allowed in frontend/src/pages or frontend/src/components.');
+  console.error('Use existing clinic design-system primitives instead, or create a dedicated approved migration plan.');
+  console.error('');
+  for (const finding of findings) {
+    console.error(
+      `- ${finding.file}:${finding.line}:${finding.column} ${finding.rule} (${finding.value})`,
+    );
+  }
+  process.exit(1);
+}
+
+console.log('No-new-MUI runtime gate passed: 0 MUI imports/usages in pages/components.');


### PR DESCRIPTION
## Summary

- Added `npm run audit:no-mui-runtime` to fail on new MUI imports/usages in runtime page/component source.
- Wired the no-new-MUI audit into the existing frontend lint/accessibility CI block.
- Kept historical docs and old audit notes outside the runtime gate.

## Contract Impact

not applicable - CI/static audit only, no API, websocket, event, route, schema, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, permission policy, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, polling, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no rendered UI state changed.
- Partial data proof: not applicable - no rendered UI state changed.
- Forbidden secondary path behavior: not applicable - no auth or route behavior changed.
- Missing draft/resource behavior: not applicable - no data loading behavior changed.
- Stale route/deep-link behavior: not applicable - no router behavior changed.

## Scope Gate

- Allowed paths: frontend/package.json, frontend/scripts/audit-no-mui-runtime.mjs, .github/workflows/ci-cd-unified.yml
- Denied paths: frontend runtime UI components/pages, backend runtime, migrations, dependencies, generated output
- Migration/docs/test impact: static frontend audit script and CI invocation only; no migration expected
- Rollback note: revert the audit script, package script, and CI command line

## Validation

- Targeted tests or smoke run: `cd frontend; npm.cmd run audit:no-mui-runtime`; `cd frontend; npm.cmd run lint:check -- --quiet`; `cd frontend; npm.cmd run build`; YAML parse via `py -3`; `git diff --check`
- Result: no-new-MUI audit passed with 0 findings; lint passed; build passed; YAML parse passed; diff check passed
- Not checked: browser runtime behavior and backend tests, because this PR only adds a static audit gate and changes no runtime UI/backend files