### PR TITLE
fix(frontend): patch dev dependency advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4736,9 +4736,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12122,10 +12122,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -12133,7 +12132,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vfile": {
@@ -13270,9 +13269,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,5 +90,12 @@
     "terser": "^5.24.0",
     "vite": "^6.4.2",
     "vitest": "3.2.4"
+  },
+  "overrides": {
+    "uuid": "11.1.1",
+    "ws": "8.20.1",
+    "minimatch@10.2.5": {
+      "brace-expansion": "5.0.6"
+    }
   }
 }


### PR DESCRIPTION
﻿## Summary
- Patch Dependabot alert #17 for transitive frontend dev dependency `uuid` by overriding it to `11.1.1`.
- Also patch locally visible moderate dev-tooling advisories for `ws` and the `minimatch@10.2.5` `brace-expansion` edge.
- Keep this to frontend dependency metadata only; no runtime app code changes.

## Contract Impact
- Canonical surface: Frontend package metadata only, `frontend/package.json` and `frontend/package-lock.json`.
- Request shape: Not applicable because no API request payloads or client request builders changed.
- Response shape: Not applicable because no backend response or frontend response mapping changed.
- Status codes: Not applicable because no HTTP route or backend handler changed.
- Frontend consumer: Development tooling dependency graph only; clinic runtime components are unchanged.
- Compatibility path or alias: Not applicable because no runtime import path, route alias, or compatibility path changed.
- Contract proof: Diff is limited to frontend package metadata and lockfile dependency resolution.

## RBAC / Permissions
- Roles allowed: Not applicable because this PR changes no role or permission logic.
- Roles denied: Not applicable because this PR changes no denied-role behavior.
- Positive auth proof: Not applicable because no authenticated route implementation changed.
- Negative auth proof: Not applicable because no authorization boundary changed.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification, websocket, Telegram, or realtime app code changed.
- Payload version / ack behavior: Not applicable because no event payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: Not applicable because no notification state semantics changed.
- Reconnect/resync proof: Not applicable because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: Not applicable because no frontend empty state changed.
- Partial data proof: Not applicable because no frontend partial-data state changed.
- Forbidden secondary path behavior: Not applicable because no route guard or forbidden path changed.
- Missing draft/resource behavior: Not applicable because no resource loading or draft flow changed.
- Stale route/deep-link behavior: Not applicable because routing and deep-link code are unchanged.

## Scope Gate
- Allowed paths: `frontend/package.json`, `frontend/package-lock.json`.
- Denied paths: frontend runtime source, backend runtime source, tests, workflows, schema, migrations, docs, and production configuration.
- Migration/docs/test impact: No migrations, docs, or tests changed; lockfile only updates transitive dev-tooling dependency versions.
- Rollback note: Revert this commit to restore the prior dependency graph if a dev-tooling regression appears.

## Validation
- Targeted tests or smoke run: `npx -p npm@10.8.2 npm ci --dry-run`; `npx -p npm@10.8.2 npm audit --audit-level=moderate`; `npm audit --audit-level=moderate`; `npm ls uuid ws brace-expansion --all`; `npm run lint:check`; `npm run build`; `npm run build-storybook`; `git diff --check`.
- Result: npm 10 CI dry-run passed; audit reports 0 vulnerabilities; dependency tree shows `uuid@11.1.1`, `ws@8.20.1`, and `brace-expansion@5.0.6` override where needed; lint/build/storybook build passed; diff check passed.
- Not checked: Full backend test suite was not run because this PR changes only frontend dependency metadata.
