### PR TITLE
test(frontend): guard heic upload conversion boundary

### DIFF
--- a/frontend/src/components/ui/__tests__/FileUpload.test.jsx
+++ b/frontend/src/components/ui/__tests__/FileUpload.test.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import heic2any from 'heic2any';
 
 import FileUpload from '../FileUpload';
 
+const { heic2anyMock } = vi.hoisted(() => ({
+  heic2anyMock: vi.fn(),
+}));
+
 vi.mock('heic2any', () => ({
-  default: vi.fn().mockResolvedValue(new Blob(['test'], { type: 'image/jpeg' })),
+  default: heic2anyMock,
 }));
 
 vi.mock('../../../utils/logger', () => ({
@@ -25,7 +28,8 @@ describe('FileUpload accessibility', () => {
       createObjectURL: vi.fn(() => 'blob:test'),
       revokeObjectURL: vi.fn(),
     });
-    heic2any.mockClear();
+    heic2anyMock.mockReset();
+    heic2anyMock.mockResolvedValue(new Blob(['test'], { type: 'image/jpeg' }));
   });
 
   it('links upload errors to the input', async () => {
@@ -54,6 +58,25 @@ describe('FileUpload accessibility', () => {
     expect(await screen.findByRole('button', { name: /remove test\.png/i })).toBeInTheDocument();
   });
 
+  it('does not invoke the HEIC fallback dependency for non-HEIC image uploads', async () => {
+    const onFilesSelected = vi.fn();
+    const { container } = render(<FileUpload onFilesSelected={onFilesSelected} />);
+    const input = container.querySelector('input');
+    const imageFile = new File(['test'], 'scan.png', { type: 'image/png' });
+
+    fireEvent.change(input, { target: { files: [imageFile] } });
+
+    await waitFor(() => {
+      expect(onFilesSelected).toHaveBeenCalledTimes(1);
+    });
+
+    expect(heic2anyMock).not.toHaveBeenCalled();
+
+    const [processedFiles] = onFilesSelected.mock.calls[0];
+    expect(processedFiles).toHaveLength(1);
+    expect(processedFiles[0]).toBe(imageFile);
+  });
+
   it('converts HEIC uploads to JPEG through the shared converter boundary', async () => {
     const onFilesSelected = vi.fn();
     const { container } = render(<FileUpload onFilesSelected={onFilesSelected} />);
@@ -66,7 +89,7 @@ describe('FileUpload accessibility', () => {
       expect(onFilesSelected).toHaveBeenCalledTimes(1);
     });
 
-    expect(heic2any).toHaveBeenCalledWith({
+    expect(heic2anyMock).toHaveBeenCalledWith({
       blob: heicFile,
       toType: 'image/jpeg',
       quality: 0.9,


### PR DESCRIPTION
﻿## Summary
- Strengthens `FileUpload` HEIC boundary coverage without changing runtime upload behavior.
- Removes the test's static `heic2any` import and keeps the dependency behind a Vitest module mock.
- Adds a non-HEIC image upload guard proving PNG uploads call `onFilesSelected` with the original file and do not invoke the HEIC fallback dependency.
- Preserves the existing HEIC conversion test and asserts the fallback still receives the expected blob, output type, and quality.

## Contract Impact
- Canonical surface: `frontend/src/components/ui/FileUpload.jsx` behavior is covered by tests only; no runtime surface changed.
- Request shape: Not applicable because no API request payloads or upload `FormData` fields changed.
- Response shape: Not applicable because no backend response parsing or frontend runtime consumer changed.
- Status codes: Not applicable because no HTTP client, endpoint, or error mapping changed.
- Frontend consumer: Shared `FileUpload` test coverage only; component source and public props remain unchanged.
- Compatibility path or alias: Not applicable because no import alias, route alias, or compatibility path changed.
- Contract proof: Diff is limited to `frontend/src/components/ui/__tests__/FileUpload.test.jsx`; runtime source files are unchanged.

## RBAC / Permissions
- Roles allowed: Not applicable because this PR changes only a frontend unit test.
- Roles denied: Not applicable because no role gates, protected routes, or auth behavior changed.
- Positive auth proof: Not applicable because no authenticated route rendering changed.
- Negative auth proof: Not applicable because no denied-role behavior changed.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no websocket, notification, queue, or realtime event changed.
- Payload version / ack behavior: Not applicable because no realtime payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: Not applicable because notification state was not touched.
- Reconnect/resync proof: Not applicable because no realtime connection code changed.

## Frontend Resilience
- Empty data proof: Not applicable because no visible empty-state rendering changed.
- Partial data proof: Not applicable because no runtime data handling changed.
- Forbidden secondary path behavior: Not applicable because no protected route fallback changed.
- Missing draft/resource behavior: Not applicable because no resource loading behavior changed.
- Stale route/deep-link behavior: Not applicable because no route registry or navigation behavior changed.

## Scope Gate
- Allowed paths: `frontend/src/components/ui/__tests__/FileUpload.test.jsx`.
- Denied paths: Runtime frontend code, backend code, dependencies, Vite config, service worker code, route registry, upload contracts, RBAC, payment, queue, EMR, and lab files.
- Migration/docs/test impact: Test-only impact; no migrations or docs changed.
- Rollback note: Revert this commit to restore the previous `FileUpload` test coverage.

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run test:run -- src/components/ui/__tests__/FileUpload.test.jsx`; `npm.cmd run lint:check`; `npm.cmd run build`; static search for removed `import heic2any`; `git diff --cached --check`; PR body template validator.
- Result: Targeted Vitest passed with 4 tests; lint exited 0 with pre-existing warnings; build passed; static search found no static `import heic2any` in the touched test; staged diff check passed; PR body template gate passed locally.
- Not checked: Browser upload smoke was not run because this PR changes only unit tests and no runtime upload code.
