### PR TITLE
fix(frontend): fallback when heic service worker conversion fails

### DIFF
--- a/frontend/src/utils/__tests__/heicConverter.test.js
+++ b/frontend/src/utils/__tests__/heicConverter.test.js
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { heic2anyMock, loggerErrorMock } = vi.hoisted(() => ({
+  heic2anyMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock('heic2any', () => ({
+  default: heic2anyMock,
+}));
+
+vi.mock('../logger', () => ({
+  default: {
+    error: loggerErrorMock,
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    log: vi.fn(),
+  },
+}));
+
+import { convertHEICToJPEG } from '../heicConverter';
+
+function createLinkedPort() {
+  return {
+    onmessage: null,
+    target: null,
+    postMessage(data) {
+      this.target?.onmessage?.({ data });
+    },
+  };
+}
+
+class TestMessageChannel {
+  constructor() {
+    this.port1 = createLinkedPort();
+    this.port2 = createLinkedPort();
+    this.port1.target = this.port2;
+    this.port2.target = this.port1;
+  }
+}
+
+function stubServiceWorker(postMessage) {
+  vi.stubGlobal('navigator', {
+    serviceWorker: {
+      ready: Promise.resolve({
+        active: {
+          postMessage,
+        },
+      }),
+    },
+  });
+  vi.stubGlobal('MessageChannel', TestMessageChannel);
+}
+
+describe('heicConverter service worker fallback', () => {
+  beforeEach(() => {
+    heic2anyMock.mockReset();
+    loggerErrorMock.mockReset();
+    heic2anyMock.mockResolvedValue(new Blob(['fallback'], { type: 'image/jpeg' }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the service worker conversion result when it succeeds', async () => {
+    const serviceWorkerBlob = new Blob(['worker'], { type: 'image/jpeg' });
+    const postMessage = vi.fn((message, [port]) => {
+      expect(message.type).toBe('CONVERT_HEIC');
+      port.postMessage({
+        success: true,
+        convertedFile: serviceWorkerBlob,
+      });
+    });
+    stubServiceWorker(postMessage);
+
+    const heicFile = new File(['heic'], 'skin.heic', { type: 'image/heic' });
+    const convertedFile = await convertHEICToJPEG(heicFile, 0.9);
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(heic2anyMock).not.toHaveBeenCalled();
+    expect(convertedFile).toBeInstanceOf(File);
+    expect(convertedFile.name).toBe('skin.jpg');
+    expect(convertedFile.type).toBe('image/jpeg');
+  });
+
+  it('falls back to local heic2any when service worker conversion fails', async () => {
+    const postMessage = vi.fn((message, [port]) => {
+      expect(message.type).toBe('CONVERT_HEIC');
+      port.postMessage({
+        success: false,
+        error: 'cdn blocked',
+      });
+    });
+    stubServiceWorker(postMessage);
+
+    const heicFile = new File(['heic'], 'skin.heic', { type: 'image/heic' });
+    const convertedFile = await convertHEICToJPEG(heicFile, 0.9);
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      'HEIC conversion error:',
+      expect.objectContaining({ message: 'cdn blocked' })
+    );
+    expect(heic2anyMock).toHaveBeenCalledWith({
+      blob: heicFile,
+      toType: 'image/jpeg',
+      quality: 0.9,
+    });
+    expect(convertedFile).toBeInstanceOf(File);
+    expect(convertedFile.name).toBe('skin.jpg');
+    expect(convertedFile.type).toBe('image/jpeg');
+  });
+});

--- a/frontend/src/utils/heicConverter.js
+++ b/frontend/src/utils/heicConverter.js
@@ -60,7 +60,7 @@ export async function convertHEICToJPEG(heicFile, quality = 0.8) {
     // Создаем MessageChannel для двусторонней связи
     const messageChannel = new MessageChannel();
 
-    return new Promise((resolve, reject) => {
+    const convertedFileFromWorker = await new Promise((resolve, reject) => {
       // Настраиваем обработчик ответа
       messageChannel.port1.onmessage = (event) => {
         const { success, convertedFile, error } = event.data;
@@ -80,6 +80,8 @@ export async function convertHEICToJPEG(heicFile, quality = 0.8) {
         quality
       }, [messageChannel.port2]);
     });
+
+    return convertedFileFromWorker;
 
   } catch (error) {
     logger.error('HEIC conversion error:', error);


### PR DESCRIPTION
﻿## Summary
- Fix HEIC conversion fallback so service worker conversion failures are caught and fall back to the bundled local `heic2any` path.
- Add targeted unit coverage for service worker success and service worker failure fallback.
- Keep upload contracts, accepted file types, route behavior, and lazy HEIC chunking unchanged.

## Contract Impact
- Canonical surface: `frontend/src/utils/heicConverter.js` internal frontend utility only.
- Request shape: No public API request shape changes; callers still pass a `File` and optional quality.
- Response shape: No response shape changes; successful conversion still returns a JPEG `File` with `.jpg` name and `image/jpeg` type.
- Status codes: Not applicable because this PR does not change backend HTTP endpoints or status handling.
- Frontend consumer: Existing upload consumers such as generic `FileUpload` and dermatology `PhotoUploader` continue using the same converter API.
- Compatibility path or alias: Existing local `heic2any` fallback path is preserved; this PR makes service worker rejection reach that path.
- Contract proof: Targeted converter, generic upload, and dermatology upload tests passed with unchanged FormData/upload behavior.

## RBAC / Permissions
- Roles allowed: Not applicable because no auth, route guard, or role permission logic changes.
- Roles denied: Not applicable because no auth, route guard, or role permission logic changes.
- Positive auth proof: Not applicable because this PR only changes a frontend file conversion fallback.
- Negative auth proof: Not applicable because this PR only changes a frontend file conversion fallback.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification, websocket, or realtime event behavior changes.
- Payload version / ack behavior: Not applicable because no notification, websocket, or realtime event behavior changes.
- Read/unread or delivery semantics: Not applicable because no notification, websocket, or realtime event behavior changes.
- Reconnect/resync proof: Not applicable because no notification, websocket, or realtime event behavior changes.

## Frontend Resilience
- Empty data proof: Not applicable because no data list or empty-state UI changes.
- Partial data proof: Service worker conversion failure is now covered and falls back to local conversion instead of rejecting the upload path.
- Forbidden secondary path behavior: Not applicable because no RBAC or protected-route behavior changes.
- Missing draft/resource behavior: Not applicable because no draft/resource loading behavior changes.
- Stale route/deep-link behavior: Not applicable because no routing behavior changes.

## Scope Gate
- Allowed paths: `frontend/src/utils/heicConverter.js`; `frontend/src/utils/__tests__/heicConverter.test.js`.
- Denied paths: Backend, database, auth/RBAC, payment, queue, EMR, lab, service worker script, package/dependency, and workflow files were not changed.
- Migration/docs/test impact: No database migration or docs impact; adds targeted frontend unit tests only.
- Rollback note: Revert this PR to restore previous service worker promise behavior; no data migration or cleanup required.

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run test:run -- src/utils/__tests__/heicConverter.test.js`; `cd frontend; npm.cmd run test:run -- src/utils/__tests__/heicConverter.test.js src/components/ui/__tests__/FileUpload.test.jsx src/components/dermatology/__tests__/PhotoUploader.test.jsx`; `cd frontend; npm.cmd run lint:check`; `cd frontend; npm.cmd run build`; `git diff --check`; `py -3 scripts/check_pr_review_template.py --body-file $env:TEMP\\pr-1153-body.md`.
- Result: Converter tests passed 2 tests; combined HEIC tests passed 8 tests across 3 files; lint exited 0 with pre-existing warnings only; build passed; diff check passed; PR body template validation passed locally before PR creation.
- Not checked: Browser upload smoke was not run because this is a narrow utility fallback and unit coverage exercises both service worker success and failure paths.

