### PR TITLE
fix(frontend): bound heic service worker fallback wait

### DIFF
--- a/frontend/src/utils/__tests__/heicConverter.test.js
+++ b/frontend/src/utils/__tests__/heicConverter.test.js
@@ -61,6 +61,7 @@ describe('heicConverter service worker fallback', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -102,6 +103,34 @@ describe('heicConverter service worker fallback', () => {
     expect(loggerErrorMock).toHaveBeenCalledWith(
       'HEIC conversion error:',
       expect.objectContaining({ message: 'cdn blocked' })
+    );
+    expect(heic2anyMock).toHaveBeenCalledWith({
+      blob: heicFile,
+      toType: 'image/jpeg',
+      quality: 0.9,
+    });
+    expect(convertedFile).toBeInstanceOf(File);
+    expect(convertedFile.name).toBe('skin.jpg');
+    expect(convertedFile.type).toBe('image/jpeg');
+  });
+
+  it('falls back to local heic2any when the service worker does not respond', async () => {
+    vi.useFakeTimers();
+    const postMessage = vi.fn((message) => {
+      expect(message.type).toBe('CONVERT_HEIC');
+    });
+    stubServiceWorker(postMessage);
+
+    const heicFile = new File(['heic'], 'skin.heic', { type: 'image/heic' });
+    const conversionPromise = convertHEICToJPEG(heicFile, 0.9);
+
+    await vi.advanceTimersByTimeAsync(8000);
+    const convertedFile = await conversionPromise;
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      'HEIC conversion error:',
+      expect.objectContaining({ message: 'Service Worker HEIC conversion timed out' })
     );
     expect(heic2anyMock).toHaveBeenCalledWith({
       blob: heicFile,

--- a/frontend/src/utils/heicConverter.js
+++ b/frontend/src/utils/heicConverter.js
@@ -1,5 +1,7 @@
 import logger from '../utils/logger';
 
+const SERVICE_WORKER_CONVERSION_TIMEOUT_MS = 8000;
+
 /**
  * HEIC → JPEG конвертация на клиенте
  * Использует Service Worker для фоновой конвертации
@@ -60,14 +62,28 @@ export async function convertHEICToJPEG(heicFile, quality = 0.8) {
     // Создаем MessageChannel для двусторонней связи
     const messageChannel = new MessageChannel();
 
-    const convertedFileFromWorker = await new Promise((resolve, reject) => {
+    const convertedFileFromWorker = await new Promise((resolve, rejectWorker) => {
+      let isSettled = false;
+      const settle = (handler, value) => {
+        if (isSettled) return;
+        isSettled = true;
+        clearTimeout(timeoutId);
+        messageChannel.port1.close?.();
+        messageChannel.port2.close?.();
+        handler(value);
+      };
+      const reject = (value) => settle(rejectWorker, value);
+      const timeoutId = setTimeout(() => {
+        reject(new Error('Service Worker HEIC conversion timed out'));
+      }, SERVICE_WORKER_CONVERSION_TIMEOUT_MS);
+
       // Настраиваем обработчик ответа
       messageChannel.port1.onmessage = (event) => {
         const { success, convertedFile, error } = event.data;
 
         if (success) {
           // Создаем новый File объект из Blob
-          resolve(createJPEGFile(heicFile, convertedFile));
+          settle(resolve, createJPEGFile(heicFile, convertedFile));
         } else {
           reject(new Error(error || 'Ошибка конвертации'));
         }


### PR DESCRIPTION
﻿## Summary
- Add an 8 second timeout around the HEIC service worker message-channel conversion path.
- If the service worker never responds, the converter now falls back to the bundled lazy `heic2any` path instead of leaving upload waiting indefinitely.
- Extend converter tests to cover service worker success, explicit failure, and no-response timeout fallback.

## Contract Impact
- Canonical surface: `frontend/src/utils/heicConverter.js` internal frontend utility only.
- Request shape: No public API request shape changes; callers still pass a `File` and optional quality.
- Response shape: No response shape changes; successful conversion still returns a JPEG `File` with `.jpg` name and `image/jpeg` type.
- Status codes: Not applicable because this PR does not change backend HTTP endpoints or status handling.
- Frontend consumer: Existing upload consumers such as generic `FileUpload` and dermatology `PhotoUploader` continue using the same converter API.
- Compatibility path or alias: Existing local `heic2any` fallback path is preserved; this PR adds a timeout path into that fallback when the worker is silent.
- Contract proof: Converter and upload boundary tests passed with unchanged accepted file/output/upload behavior.

## RBAC / Permissions
- Roles allowed: Not applicable because no auth, route guard, or role permission logic changes.
- Roles denied: Not applicable because no auth, route guard, or role permission logic changes.
- Positive auth proof: Not applicable because this PR only changes a frontend file conversion fallback timeout.
- Negative auth proof: Not applicable because this PR only changes a frontend file conversion fallback timeout.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification, websocket, or realtime event behavior changes.
- Payload version / ack behavior: Not applicable because no notification, websocket, or realtime event behavior changes.
- Read/unread or delivery semantics: Not applicable because no notification, websocket, or realtime event behavior changes.
- Reconnect/resync proof: Not applicable because no notification, websocket, or realtime event behavior changes.

## Frontend Resilience
- Empty data proof: Not applicable because no data list or empty-state UI changes.
- Partial data proof: Service worker no-response behavior is now covered and falls back to local conversion after a bounded timeout.
- Forbidden secondary path behavior: Not applicable because no RBAC or protected-route behavior changes.
- Missing draft/resource behavior: Not applicable because no draft/resource loading behavior changes.
- Stale route/deep-link behavior: Not applicable because no routing behavior changes.

## Scope Gate
- Allowed paths: `frontend/src/utils/heicConverter.js`; `frontend/src/utils/__tests__/heicConverter.test.js`.
- Denied paths: Backend, database, auth/RBAC, payment, queue, EMR, lab, service worker script, package/dependency, docs, and workflow files were not changed.
- Migration/docs/test impact: No database migration or docs impact; extends targeted frontend unit tests only.
- Rollback note: Revert this PR to restore previous unbounded service worker wait behavior; no data migration or cleanup required.

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run test:run -- src/utils/__tests__/heicConverter.test.js`; `cd frontend; npm.cmd run test:run -- src/utils/__tests__/heicConverter.test.js src/components/ui/__tests__/FileUpload.test.jsx src/components/dermatology/__tests__/PhotoUploader.test.jsx`; `cd frontend; npm.cmd run lint:check`; `cd frontend; npm.cmd run build`; `git diff --check`; `py -3 scripts/check_pr_review_template.py --body-file $env:TEMP\\pr-1154-body.md`.
- Result: Converter tests passed 3 tests; combined HEIC/upload tests passed 9 tests across 3 files; lint exited 0 with pre-existing warnings only; build passed; diff check passed; PR body template validation passed locally before PR creation.
- Not checked: Browser upload smoke was not run because this is a narrow utility fallback timeout and unit coverage exercises the no-response path deterministically.
