### PR TITLE
fix(frontend): remove heic service worker cdn conversion

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -381,36 +381,18 @@ async function syncClinicData() {
 // Обработка HEIC конвертации
 self.addEventListener('message', (event) => {
   if (event.data && event.data.type === 'CONVERT_HEIC') {
-    event.waitUntil(convertHEICToJPEG(event.data.file, event.ports[0], event.data.quality));
+    event.waitUntil(convertHEICToJPEG(event.ports[0]));
   }
 });
 
 // HEIC → JPEG конвертация
-async function convertHEICToJPEG(heicFile, port, quality = 0.8) {
-  try {
-    // Импортируем heic2any динамически
-    const heic2any = (await import('https://cdn.skypack.dev/heic2any')).default;
-    
-    const jpegBlob = await heic2any({
-      blob: heicFile,
-      toType: 'image/jpeg',
-      quality
-    });
-    
-    port.postMessage({
-      success: true,
-      convertedFile: jpegBlob
-    });
-    
-    console.log('Service Worker: HEIC converted to JPEG');
-    
-  } catch (error) {
-    console.error('Service Worker: HEIC conversion failed', error);
-    port.postMessage({
-      success: false,
-      error: error.message
-    });
-  }
+async function convertHEICToJPEG(port) {
+  if (!port) return;
+
+  port.postMessage({
+    success: false,
+    error: 'HEIC conversion is handled by the app fallback'
+  });
 }
 
 // Обработка офлайн очереди

--- a/frontend/src/__tests__/serviceWorkerHeicPolicy.test.js
+++ b/frontend/src/__tests__/serviceWorkerHeicPolicy.test.js
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const serviceWorkerSource = fs
+  .readFileSync(path.resolve(process.cwd(), 'public/sw.js'), 'utf8')
+  .replace(/\r\n/g, '\n');
+
+describe('service worker HEIC policy', () => {
+  it('does not execute a remote HEIC converter from a CDN', () => {
+    expect(serviceWorkerSource).not.toContain('https://cdn.skypack.dev/heic2any');
+    expect(serviceWorkerSource).not.toMatch(/import\(['"`]https?:\/\/[^'"`]+heic2any/);
+  });
+
+  it('routes HEIC conversion messages to the app fallback path', () => {
+    expect(serviceWorkerSource).toContain('type === \'CONVERT_HEIC\'');
+    expect(serviceWorkerSource).toContain('HEIC conversion is handled by the app fallback');
+    expect(serviceWorkerSource).toMatch(/success:\s*false/);
+  });
+});


### PR DESCRIPTION
﻿## Summary
- Remove the service worker HEIC conversion path that imported `heic2any` from `https://cdn.skypack.dev`.
- Keep `CONVERT_HEIC` message handling explicit by returning a fallback signal to the app converter.
- Add a static guard test so remote service worker HEIC CDN execution cannot be reintroduced silently.

## Contract Impact
- Canonical surface: `frontend/public/sw.js` HEIC message handler and frontend static guard test.
- Request shape: No public API request shape changes; upload callers still pass the same `File` and FormData fields.
- Response shape: No backend response shape changes; converted frontend output remains a JPEG `File` via the app fallback path.
- Status codes: Not applicable because this PR does not change backend HTTP endpoints or status handling.
- Frontend consumer: Existing upload consumers continue calling `convertHEICToJPEG`; the already-tested app fallback now handles conversion instead of remote service worker code.
- Compatibility path or alias: `CONVERT_HEIC` remains handled in the service worker and explicitly returns a fallback signal, preserving message-channel compatibility.
- Contract proof: Converter tests cover explicit service worker failure and no-response fallback; service worker policy test proves no remote `heic2any` import remains.

## RBAC / Permissions
- Roles allowed: Not applicable because no auth, route guard, or role permission logic changes.
- Roles denied: Not applicable because no auth, route guard, or role permission logic changes.
- Positive auth proof: Not applicable because this PR only changes frontend HEIC conversion routing.
- Negative auth proof: Not applicable because this PR only changes frontend HEIC conversion routing.

## Notification / Realtime
- Event type or websocket channel: Not applicable because no notification, websocket, or realtime event behavior changes.
- Payload version / ack behavior: Not applicable because no notification, websocket, or realtime event behavior changes.
- Read/unread or delivery semantics: Not applicable because no notification, websocket, or realtime event behavior changes.
- Reconnect/resync proof: Not applicable because no notification, websocket, or realtime event behavior changes.

## Frontend Resilience
- Empty data proof: Not applicable because no data list or empty-state UI changes.
- Partial data proof: Service worker HEIC conversion now explicitly falls back to the app path without depending on a third-party CDN.
- Forbidden secondary path behavior: Not applicable because no RBAC or protected-route behavior changes.
- Missing draft/resource behavior: Not applicable because no draft/resource loading behavior changes.
- Stale route/deep-link behavior: Not applicable because no routing behavior changes.

## Scope Gate
- Allowed paths: `frontend/public/sw.js`; `frontend/src/__tests__/serviceWorkerHeicPolicy.test.js`.
- Denied paths: Backend, database, auth/RBAC, payment, queue, EMR, lab, packages/dependencies, docs, workflows, and upload components were not changed.
- Migration/docs/test impact: No database migration or docs impact; adds one frontend static guard test.
- Rollback note: Revert this PR to restore service worker CDN conversion; no data migration or cleanup required.

## Validation
- Targeted tests or smoke run: `cd frontend; npm.cmd run test:run -- src/__tests__/serviceWorkerHeicPolicy.test.js src/utils/__tests__/heicConverter.test.js src/components/ui/__tests__/FileUpload.test.jsx src/components/dermatology/__tests__/PhotoUploader.test.jsx`; `cd frontend; npm.cmd run lint:check`; `cd frontend; npm.cmd run build`; static no-remote-import check for `frontend/public/sw.js`; `git diff --check`; `py -3 scripts/check_pr_review_template.py --body-file $env:TEMP\\pr-1155-body.md`.
- Result: Targeted service worker/converter/upload tests passed 11 tests across 4 files; lint exited 0 with pre-existing warnings only; build passed; static no-remote-import check passed; diff check passed; PR body template validation passed locally before PR creation.
- Not checked: Browser HEIC upload smoke was not run because this PR relies on the already-tested app fallback and adds a static guard for the service worker policy.
