### PR TITLE
fix(frontend): fallback when heic service worker is unavailable

### DIFF
--- a/frontend/src/utils/__tests__/heicConverter.test.js
+++ b/frontend/src/utils/__tests__/heicConverter.test.js
@@ -141,4 +141,60 @@ describe('heicConverter service worker fallback', () => {
     expect(convertedFile.name).toBe('skin.jpg');
     expect(convertedFile.type).toBe('image/jpeg');
   });
+
+  it('falls back to local heic2any when no active service worker registration exists', async () => {
+    const getRegistration = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', {
+      serviceWorker: {
+        getRegistration,
+        ready: new Promise(() => {}),
+      },
+    });
+
+    const heicFile = new File(['heic'], 'skin.heic', { type: 'image/heic' });
+    const convertedFile = await convertHEICToJPEG(heicFile, 0.9);
+
+    expect(getRegistration).toHaveBeenCalledTimes(1);
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      'HEIC conversion error:',
+      expect.objectContaining({ message: 'Service Worker is not active' })
+    );
+    expect(heic2anyMock).toHaveBeenCalledWith({
+      blob: heicFile,
+      toType: 'image/jpeg',
+      quality: 0.9,
+    });
+    expect(convertedFile).toBeInstanceOf(File);
+    expect(convertedFile.name).toBe('skin.jpg');
+    expect(convertedFile.type).toBe('image/jpeg');
+  });
+
+  it('falls back to local heic2any when service worker readiness never resolves', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('navigator', {
+      serviceWorker: {
+        ready: new Promise(() => {}),
+      },
+    });
+    vi.stubGlobal('MessageChannel', TestMessageChannel);
+
+    const heicFile = new File(['heic'], 'skin.heic', { type: 'image/heic' });
+    const conversionPromise = convertHEICToJPEG(heicFile, 0.9);
+
+    await vi.advanceTimersByTimeAsync(8000);
+    const convertedFile = await conversionPromise;
+
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      'HEIC conversion error:',
+      expect.objectContaining({ message: 'Service Worker readiness timed out' })
+    );
+    expect(heic2anyMock).toHaveBeenCalledWith({
+      blob: heicFile,
+      toType: 'image/jpeg',
+      quality: 0.9,
+    });
+    expect(convertedFile).toBeInstanceOf(File);
+    expect(convertedFile.name).toBe('skin.jpg');
+    expect(convertedFile.type).toBe('image/jpeg');
+  });
 });

--- a/frontend/src/utils/heicConverter.js
+++ b/frontend/src/utils/heicConverter.js
@@ -40,6 +40,35 @@ function createJPEGFile(sourceFile, convertedBlob) {
   );
 }
 
+function timeoutAfter(ms, message) {
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error(message)), ms);
+  });
+}
+
+async function getActiveServiceWorkerRegistration() {
+  const { serviceWorker } = navigator;
+
+  if (typeof serviceWorker.getRegistration === 'function') {
+    const registration = await serviceWorker.getRegistration();
+    if (!registration?.active) {
+      throw new Error('Service Worker is not active');
+    }
+    return registration;
+  }
+
+  const registration = await Promise.race([
+    serviceWorker.ready,
+    timeoutAfter(SERVICE_WORKER_CONVERSION_TIMEOUT_MS, 'Service Worker readiness timed out')
+  ]);
+
+  if (!registration.active) {
+    throw new Error('Service Worker is not active');
+  }
+
+  return registration;
+}
+
 /**
  * Конвертирует HEIC файл в JPEG через Service Worker
  * @param {File} heicFile - HEIC файл
@@ -53,7 +82,7 @@ export async function convertHEICToJPEG(heicFile, quality = 0.8) {
       throw new Error('Service Worker не поддерживается');
     }
 
-    const registration = await navigator.serviceWorker.ready;
+    const registration = await getActiveServiceWorkerRegistration();
 
     if (!registration.active) {
       throw new Error('Service Worker не активен');


### PR DESCRIPTION
﻿## Summary

- Fix HEIC upload resilience in the frontend converter.
- Avoid an indefinite wait on service worker readiness before falling back to local conversion.
- Preserve the existing dermatology upload contract and multipart payload.

## Contract Impact

- Canonical surface: frontend HEIC conversion helper used before dermatology photo upload to `/visits/{visitId}/files`
- Request shape: unchanged multipart upload with file, kind, visit_id, and metadata fields
- Response shape: unchanged file upload response consumed by PhotoUploader
- Status codes: unchanged; this PR does not alter backend status handling
- Frontend consumer: `frontend/src/components/dermatology/PhotoUploader.jsx` via shared `convertHEICToJPEG`
- Compatibility path or alias: existing service-worker conversion path remains; local `heic2any` fallback is used when no active worker is available
- Contract proof: unit tests plus temporary authenticated dermatology browser smoke verified converted JPEG multipart upload

## RBAC / Permissions

- Roles allowed: unchanged; existing Doctor-authenticated dermatology route access remains the tested path
- Roles denied: unchanged; no route guard or permission logic changed
- Positive auth proof: temporary smoke used the existing authenticated Doctor QA harness and rendered the dermatology route
- Negative auth proof: not applicable - this PR does not change auth/RBAC denial behavior

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime event changed
- Payload version / ack behavior: not applicable - no realtime payload or ack behavior changed
- Read/unread or delivery semantics: not applicable - no notification delivery/read state changed
- Reconnect/resync proof: not applicable - no realtime reconnect or resync logic changed

## Frontend Resilience

- Empty data proof: not applicable - this PR does not change empty panel data rendering
- Partial data proof: not applicable - this PR does not change partial API data rendering
- Forbidden secondary path behavior: not applicable - no forbidden or secondary route path changed
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed
- Stale route/deep-link behavior: authenticated smoke used `/doctor/dermatology?patientId=42&visitId=4242&tab=photos` and verified the upload surface remained reachable

## Scope Gate

- Allowed paths: `frontend/src/utils/heicConverter.js`, `frontend/src/utils/__tests__/heicConverter.test.js`
- Denied paths: backend runtime, API contracts, database migrations, RBAC, payment, queue, EMR, lab, generated output, committed e2e fixture files
- Migration/docs/test impact: no migration or docs changes; targeted frontend unit tests updated
- Rollback note: revert this commit to restore the previous service-worker readiness behavior and its test baseline

## Validation

- Targeted tests or smoke run: `cd frontend; npm run test:run -- src/utils/__tests__/heicConverter.test.js`; `cd frontend; npm run lint:check -- --quiet`; `cd frontend; npm run build`; temporary Playwright smoke with a public 41KB HEIC sample verified dermatology photos route posted converted JPEG multipart; `git diff --check`
- Result: all local checks passed; GitHub frontend lint, frontend build, frontend unit tests, CodeQL, security scans, lifecycle checks, and PR Required Gate passed before this body-only correction
- Not checked: full backend suite was not run locally because this change is frontend-only converter behavior; large multi-megabyte HEIC performance was not accepted as a pass condition
