### PR TITLE
test(frontend): add manual heic upload smoke

### DIFF
--- a/frontend/e2e/AUTHENTICATED_UI_QA.md
+++ b/frontend/e2e/AUTHENTICATED_UI_QA.md
@@ -18,6 +18,27 @@ npx playwright test e2e/authenticated-role-smoke.spec.js --project=chromium --re
 npx playwright test e2e/authenticated-rbac-deny.spec.js --project=chromium --reporter=line
 ```
 
+## Manual HEIC Upload Smoke
+
+The dermatology HEIC upload smoke is opt-in because it needs a real local
+`.heic` or `.heif` fixture. It skips automatically when `HEIC_SMOKE_FILE` is not
+set, so CI does not need a private image fixture.
+
+```powershell
+cd frontend
+$env:HEIC_SMOKE_FILE = "C:\path\to\safe-fixture.heic"
+npx playwright test e2e/dermatology-heic-upload-smoke.spec.js --project=chromium --reporter=line
+Remove-Item Env:\HEIC_SMOKE_FILE
+```
+
+Expected proof:
+
+- authenticated Doctor harness renders `/doctor/dermatology?patientId=42&visitId=4242&tab=photos`;
+- the selected HEIC/HEIF file is converted before upload;
+- mocked upload receives multipart POST to `/api/v1/visits/4242/files`;
+- multipart metadata includes `photo_before`, `visit_id=4242`, converted `.jpg`
+  filename, and `Content-Type: image/jpeg`.
+
 ## Role Coverage
 
 | Role | Route | Route ID |

--- a/frontend/e2e/dermatology-heic-upload-smoke.spec.js
+++ b/frontend/e2e/dermatology-heic-upload-smoke.spec.js
@@ -1,0 +1,83 @@
+// @ts-check
+import fs from 'fs';
+import { test, expect } from '@playwright/test';
+import { installAuthenticatedQaHarness } from './support/authenticatedQa.js';
+
+const heicSmokeFile = process.env.HEIC_SMOKE_FILE;
+
+test.describe('Dermatology HEIC upload manual smoke', () => {
+  test.skip(!heicSmokeFile, 'Set HEIC_SMOKE_FILE to a local .heic/.heif file to run this manual smoke.');
+
+  test('converts a local HEIC fixture to JPEG multipart upload', async ({ page }) => {
+    test.setTimeout(180_000);
+
+    expect(fs.existsSync(heicSmokeFile), `HEIC fixture should exist at ${heicSmokeFile}`).toBe(true);
+    const expectedJpegName = heicSmokeFile.replace(/^.*[\\/]/, '').replace(/\.(heic|heif)$/i, '.jpg');
+
+    const pageErrors = [];
+    const uploadRequests = [];
+
+    page.on('pageerror', (error) => {
+      pageErrors.push(error.message);
+    });
+
+    await installAuthenticatedQaHarness(page, { role: 'Doctor' });
+    await page.route('**/api/v1/visits/*/files', async (route) => {
+      const request = route.request();
+      const bodyText = (request.postDataBuffer() || Buffer.from('')).toString('latin1');
+
+      uploadRequests.push({
+        url: request.url(),
+        method: request.method(),
+        contentType: request.headers()['content-type'] || '',
+        hasPhotoBeforeKind: bodyText.includes('photo_before'),
+        hasVisitId: bodyText.includes('4242'),
+        hasExpectedJpegName: bodyText.includes(expectedJpegName),
+        hasJpegContentType: bodyText.includes('Content-Type: image/jpeg'),
+        bodyLength: bodyText.length,
+      });
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'qa-heic-photo',
+          url: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2w==',
+        }),
+      });
+    });
+
+    await page.goto('/doctor/dermatology?patientId=42&visitId=4242&tab=photos', {
+      waitUntil: 'domcontentloaded',
+    });
+    await expect(page.locator('.app-shell[data-route-id="doctor-dermatology"]')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const startedAt = Date.now();
+    await page.locator('input[type="file"]').first().setInputFiles(heicSmokeFile);
+
+    await expect.poll(() => uploadRequests.length, {
+      timeout: 120_000,
+      message: 'HEIC upload should post converted JPEG FormData',
+    }).toBe(1);
+
+    const upload = uploadRequests[0];
+    expect(upload).toMatchObject({
+      method: 'POST',
+      hasPhotoBeforeKind: true,
+      hasVisitId: true,
+      hasExpectedJpegName: true,
+      hasJpegContentType: true,
+    });
+    expect(upload.url).toContain('/api/v1/visits/4242/files');
+    expect(upload.contentType).toContain('multipart/form-data');
+    expect(upload.bodyLength).toBeGreaterThan(0);
+    expect(pageErrors).toEqual([]);
+
+    test.info().annotations.push({
+      type: 'duration-ms',
+      description: String(Date.now() - startedAt),
+    });
+  });
+});


### PR DESCRIPTION
﻿## Summary

- Add an opt-in Playwright smoke for dermatology HEIC uploads using a local fixture path from `HEIC_SMOKE_FILE`.
- Document the manual command in the authenticated UI QA runbook.
- Keep CI/private data safe by skipping the smoke automatically when no local HEIC fixture is provided.

## Contract Impact

- Canonical surface: manual Playwright QA for dermatology photo upload to `/visits/{visitId}/files`
- Request shape: unchanged multipart upload proof checks file, kind, visit_id, and metadata behavior without changing production code
- Response shape: unchanged mocked upload response in the Playwright route handler
- Status codes: unchanged; mocked upload returns 200 only inside the test
- Frontend consumer: `frontend/e2e/dermatology-heic-upload-smoke.spec.js` manual QA harness around the existing PhotoUploader flow
- Compatibility path or alias: not applicable - no production compatibility path or alias changed
- Contract proof: local manual smoke passed with a real HEIC file and verified converted JPEG multipart fields

## RBAC / Permissions

- Roles allowed: unchanged; smoke seeds the existing Doctor QA harness for the dermatology route
- Roles denied: unchanged; no route guard, auth, or RBAC logic changed
- Positive auth proof: local smoke rendered `.app-shell[data-route-id="doctor-dermatology"]` with the Doctor QA session
- Negative auth proof: not applicable - this PR adds a positive manual upload smoke only and does not change denial behavior

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime event changed
- Payload version / ack behavior: not applicable - no realtime payload or ack behavior changed
- Read/unread or delivery semantics: not applicable - no notification delivery/read state changed
- Reconnect/resync proof: not applicable - no realtime reconnect or resync logic changed

## Frontend Resilience

- Empty data proof: not applicable - this PR does not change empty panel rendering
- Partial data proof: not applicable - this PR does not change partial API data rendering
- Forbidden secondary path behavior: not applicable - no forbidden or secondary path changed
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed
- Stale route/deep-link behavior: manual smoke deep-links to `/doctor/dermatology?patientId=42&visitId=4242&tab=photos` and verifies the upload surface is reachable

## Scope Gate

- Allowed paths: `frontend/e2e/dermatology-heic-upload-smoke.spec.js`, `frontend/e2e/AUTHENTICATED_UI_QA.md`
- Denied paths: backend runtime, frontend runtime code, API clients, RBAC, database migrations, payment, queue, EMR, lab, generated output, committed private HEIC fixtures
- Migration/docs/test impact: no migration; adds one opt-in Playwright smoke and runbook docs
- Rollback note: revert this commit to remove the manual smoke and its runbook instructions

## Validation

- Targeted tests or smoke run: `cd frontend; npx playwright test e2e/dermatology-heic-upload-smoke.spec.js --project=chromium --reporter=line` without `HEIC_SMOKE_FILE`; same command with `HEIC_SMOKE_FILE` pointing to `C:\Users\DrSapaev\Downloads\Phone Link\20260509_183009.heic`; `git diff --check`
- Result: no-env run skipped as expected; real HEIC run passed and posted converted JPEG multipart; `git diff --check` passed
- Not checked: full frontend/backend suites were not run locally because this PR adds an opt-in manual QA smoke and docs only
