### PR TITLE
fix(frontend): align admin route switcher tokens

### DIFF
--- a/frontend/src/components/admin/AdminRouteSwitcher.jsx
+++ b/frontend/src/components/admin/AdminRouteSwitcher.jsx
@@ -18,6 +18,75 @@ const ROUTES = [
   },
 ];
 
+const switcherStyle = {
+  display: 'grid',
+  gap: 'var(--mac-spacing-3)',
+  padding: 'var(--mac-spacing-4)',
+  borderRadius: 'var(--mac-radius-xl)',
+  border: '1px solid var(--mac-card-border)',
+  background: 'linear-gradient(135deg, color-mix(in srgb, var(--mac-card-bg), white 10%) 0%, var(--mac-card-bg) 100%)',
+  boxShadow: 'var(--mac-shadow-sm)',
+};
+
+const switcherLabelStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--mac-spacing-2)',
+  color: 'var(--mac-text-secondary)',
+  fontSize: 'var(--mac-font-size-sm)',
+  fontWeight: 'var(--mac-font-weight-semibold)',
+};
+
+const routeGridStyle = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+  gap: 'var(--mac-spacing-2)',
+};
+
+const routeTextStyle = {
+  display: 'grid',
+  gap: '3px',
+  minWidth: 0,
+};
+
+const routeTitleStyle = {
+  fontSize: 'var(--mac-font-size-base)',
+  fontWeight: 'var(--mac-font-weight-bold)',
+};
+
+const routeDescriptionStyle = {
+  fontSize: 'var(--mac-font-size-xs)',
+  lineHeight: 1.4,
+  color: 'var(--mac-text-secondary)',
+};
+
+const getRouteButtonStyle = (isActive) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--mac-spacing-3)',
+  padding: 'var(--mac-spacing-3) var(--mac-spacing-4)',
+  borderRadius: 'var(--mac-radius-lg)',
+  border: '1px solid',
+  borderColor: isActive ? 'var(--mac-accent-blue)' : 'var(--mac-card-border)',
+  background: isActive ? 'color-mix(in srgb, var(--mac-accent-blue), transparent 88%)' : 'var(--mac-card-bg)',
+  color: 'var(--mac-text-primary)',
+  cursor: 'pointer',
+  textAlign: 'left',
+  boxShadow: isActive ? 'var(--mac-shadow-md)' : 'var(--mac-shadow-sm)',
+});
+
+const getRouteIconStyle = (isActive) => ({
+  width: '38px',
+  height: '38px',
+  borderRadius: 'var(--mac-radius-md)',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: isActive ? 'var(--mac-accent-blue)' : 'color-mix(in srgb, var(--mac-card-border), white 44%)',
+  color: isActive ? 'var(--mac-text-on-accent, white)' : 'var(--mac-text-secondary)',
+  flex: '0 0 auto',
+});
+
 export default function AdminRouteSwitcher({ current }) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -26,28 +95,14 @@ export default function AdminRouteSwitcher({ current }) {
 
   return (
     <section
-      style={{
-        display: 'grid',
-        gap: '12px',
-        padding: '16px',
-        borderRadius: '18px',
-        border: '1px solid var(--mac-card-border)',
-        background: 'linear-gradient(135deg, color-mix(in srgb, var(--mac-card-bg), white 10%) 0%, var(--mac-card-bg) 100%)',
-        boxShadow: 'var(--mac-shadow-sm)',
-      }}
+      style={switcherStyle}
       aria-label="Навигация между разделами админки"
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: '10px', color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600 }}>
-        <ArrowLeftRight size={14} />
+      <div style={switcherLabelStyle}>
+        <ArrowLeftRight size={14} aria-hidden="true" />
         Быстрый переход между экранами
       </div>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
-          gap: '10px',
-        }}
-      >
+      <div style={routeGridStyle}>
         {ROUTES.map((route) => {
           const Icon = route.icon;
           const isActive = activeId === route.id;
@@ -55,40 +110,17 @@ export default function AdminRouteSwitcher({ current }) {
           return (
             <button
               key={route.id}
+              type="button"
               onClick={() => navigate(route.path)}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '12px',
-                padding: '14px 16px',
-                borderRadius: '14px',
-                border: '1px solid',
-                borderColor: isActive ? '#2563eb' : 'var(--border-color)',
-                background: isActive ? 'color-mix(in srgb, var(--mac-accent-blue), transparent 88%)' : 'var(--mac-card-bg)',
-                color: 'var(--mac-text-primary)',
-                cursor: 'pointer',
-                textAlign: 'left',
-                boxShadow: isActive ? '0 10px 20px rgba(37, 99, 235, 0.12)' : 'none',
-              }}
+              style={getRouteButtonStyle(isActive)}
+              aria-current={isActive ? 'page' : undefined}
             >
-              <span
-                style={{
-                  width: '38px',
-                  height: '38px',
-                  borderRadius: '12px',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  background: isActive ? '#2563eb' : 'color-mix(in srgb, var(--mac-card-border), white 44%)',
-                  color: isActive ? '#fff' : 'var(--text-secondary)',
-                  flex: '0 0 auto',
-                }}
-              >
-                <Icon size={18} />
+              <span style={getRouteIconStyle(isActive)}>
+                <Icon size={18} aria-hidden="true" />
               </span>
-              <span style={{ display: 'grid', gap: '3px', minWidth: 0 }}>
-                <span style={{ fontSize: '15px', fontWeight: 700 }}>{route.label}</span>
-                <span style={{ fontSize: '12px', lineHeight: 1.4, color: 'var(--text-secondary)' }}>
+              <span style={routeTextStyle}>
+                <span style={routeTitleStyle}>{route.label}</span>
+                <span style={routeDescriptionStyle}>
                   {route.description}
                 </span>
               </span>


### PR DESCRIPTION
## Summary
- Aligns `AdminRouteSwitcher` active navigation styling with the macOS token layer.
- Removes hardcoded active blue/shadow values and old `--text-secondary` / `--border-color` references from this switcher.
- Adds `type=button`, decorative icon hiding, and `aria-current=page` for the active admin destination.

## Contract Impact
- Canonical surface: admin navigation switcher rendered by `AdminPanel` and `AnalyticsPage`.
- Request shape: not applicable - no API requests changed.
- Response shape: not applicable - no API responses changed.
- Status codes: not applicable - no network handling changed.
- Frontend consumer: `frontend/src/pages/AdminPanel.jsx` and `frontend/src/pages/AnalyticsPage.jsx` continue importing the same component.
- Compatibility path or alias: unchanged; `/admin` and `/admin/analytics` navigation paths are preserved.
- Contract proof: local build passed and authenticated admin route smoke rendered with the QA harness.

## RBAC / Permissions
- Roles allowed: unchanged; admin route guard and registry were not touched.
- Roles denied: unchanged; no permission logic changed.
- Positive auth proof: `npx.cmd playwright test e2e/authenticated-role-smoke.spec.js --project=chromium --grep admin --reporter=line` passed.
- Negative auth proof: not checked in this PR because RBAC logic was not touched.

## Notification / Realtime
- Event type or websocket channel: not applicable - static admin navigation presentation only.
- Payload version / ack behavior: not applicable - no realtime payloads changed.
- Read/unread or delivery semantics: not applicable - no notification behavior changed.
- Reconnect/resync proof: not applicable - no websocket/realtime behavior changed.

## Frontend Resilience
- Empty data proof: not applicable - component does not render fetched collections.
- Partial data proof: not applicable - component uses static route metadata only.
- Forbidden secondary path behavior: unchanged; route guard remains outside this component.
- Missing draft/resource behavior: not applicable - no drafts/resources involved.
- Stale route/deep-link behavior: unchanged; existing `navigate(route.path)` behavior is preserved.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/AdminRouteSwitcher.jsx`.
- Denied paths: backend, API contracts, RBAC, route registry, payment/queue/EMR/lab logic, dependencies, workflows.
- Migration/docs/test impact: no migrations; no docs or tests changed.
- Rollback note: revert this commit to restore the previous visual switcher while keeping admin routing untouched.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run audit:no-mui-runtime`; `npm.cmd run build`; `npx.cmd playwright test e2e/authenticated-role-smoke.spec.js --project=chromium --grep admin --reporter=line`; `git diff --check`.
- Result: all passed. Playwright emitted a non-fatal Vite websocket proxy `ECONNREFUSED` after the test because the local backend websocket target was not running.
- Not checked: full frontend test suite, full multi-browser e2e, and production data flows.