### PR TITLE
fix(frontend): label activation action buttons

### DIFF
--- a/frontend/src/components/admin/ActivationSystem.jsx
+++ b/frontend/src/components/admin/ActivationSystem.jsx
@@ -495,23 +495,29 @@ const ActivationSystem = () => {
             {
               key: 'actions',
               title: 'Действия',
-              render: (activation) =>
+              render: (_actionValue, activation) =>
               <div style={{ display: 'flex', gap: '8px' }}>
                     <Button
                   size="sm"
                   variant="outline"
                   onClick={() => extendActivation((activation || {}).key)}
-                  disabled={(activation || {}).status === 'revoked'}>
+                  disabled={(activation || {}).status === 'revoked'}
+                  type="button"
+                  title="Продлить активацию"
+                  aria-label={`Продлить активацию ${(activation || {}).key || ''}`.trim()}>
                   
-                      <Calendar style={{ width: '14px', height: '14px' }} />
+                      <Calendar aria-hidden="true" style={{ width: '14px', height: '14px' }} />
                     </Button>
                     <Button
                   size="sm"
                   variant="outline"
                   onClick={() => revokeActivation((activation || {}).key)}
-                  disabled={(activation || {}).status === 'revoked'}>
+                  disabled={(activation || {}).status === 'revoked'}
+                  type="button"
+                  title="Отозвать активацию"
+                  aria-label={`Отозвать активацию ${(activation || {}).key || ''}`.trim()}>
                   
-                      <Shield style={{ width: '14px', height: '14px' }} />
+                      <Shield aria-hidden="true" style={{ width: '14px', height: '14px' }} />
                     </Button>
                   </div>
 


### PR DESCRIPTION
## Summary
- Added explicit accessible names and titles to the activation table extend/revoke icon-only action buttons.
- Marked the decorative Calendar/Shield icons as `aria-hidden`.
- Adjusted the action column render callback to use the full `MacOSTable` row argument so labels include the activation key without changing activation API behavior.

## Contract Impact
- Canonical surface: Admin activation UI action buttons in `frontend/src/components/admin/ActivationSystem.jsx`.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `/admin/activation` rendered through `AdminPanel` / `ActivationSystem`.
- Compatibility path or alias: unchanged.
- Contract proof: no backend, API client, route registry, or request/response code changed.

## RBAC / Permissions
- Roles allowed: unchanged existing Admin route behavior.
- Roles denied: unchanged.
- Positive auth proof: temporary Playwright smoke used the authenticated Admin QA harness and a mocked activation row for `/admin/activation`.
- Negative auth proof: not checked because RBAC code and route guards were not touched.

## Notification / Realtime
- Event type or websocket channel: unchanged; this change does not add or edit notification events or websocket channels.
- Payload version / ack behavior: unchanged; no realtime payload or acknowledgement code was touched.
- Read/unread or delivery semantics: unchanged; no notification delivery/read state code was touched.
- Reconnect/resync proof: activation refresh remains the existing HTTP `loadData` / refresh-button flow, and no reconnect or websocket resync path was edited.

## Frontend Resilience
- Empty data proof: existing empty state unchanged.
- Partial data proof: mocked activation row rendered action buttons with accessible names including the row key.
- Forbidden secondary path behavior: unchanged.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: `/admin/activation` browser smoke reached the activation view.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/ActivationSystem.jsx`.
- Denied paths: backend, API contracts, RBAC, routes, migrations, dependencies, CI, unrelated frontend surfaces.
- Migration/docs/test impact: no migration/docs/test files committed; temporary local smoke spec was removed before commit.
- Rollback note: revert this commit to restore prior action button attributes/render signature.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run audit:no-mui-runtime`; `npm.cmd run build`; temporary Playwright smoke for `/admin/activation` activation action accessible names; `git diff --check`.
- Result: all passed. The temporary Playwright run emitted a non-fatal Vite websocket proxy `ECONNREFUSED` because the backend websocket target was not running, while the test itself passed.
- Not checked: full frontend/backend suites, multi-browser Playwright, production activation data.