### PR TITLE
fix(frontend): label shared custom icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 142
-Baseline entries: 142
+Findings: 138
+Baseline entries: 138
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 142 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 138 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -85,6 +85,9 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-21: shared primitive controls cleanup removed 5 baseline findings.
 - 2026-05-21: remaining singleton controls cleanup removed 7 baseline findings.
 - Current baseline after this slice: 0 findings.
+- 2026-05-22: component-aware custom `Button`/`MacOSButton` sweep added with 142 historical findings.
+- 2026-05-22: shared shell/mobile custom button labels cleanup removed 4 component findings.
+- Current component-aware baseline: 138 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,29 +1,13 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T12:59:39.728Z",
+  "generatedAt": "2026-05-22T13:23:32.122Z",
   "entries": [
-    {
-      "signature": "src/components/PWAInstallPrompt.jsx:91:11:Button:missing-accessible-name",
-      "file": "src/components/PWAInstallPrompt.jsx",
-      "line": 91,
-      "column": 11,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
     {
       "signature": "src/components/PrescriptionSystem.jsx:228:19:Button:missing-accessible-name",
       "file": "src/components/PrescriptionSystem.jsx",
       "line": 228,
       "column": 19,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ResponsiveModal.jsx:144:13:Button:missing-accessible-name",
-      "file": "src/components/ResponsiveModal.jsx",
-      "line": 144,
-      "column": 13,
       "element": "Button",
       "reason": "missing-accessible-name"
     },
@@ -1026,22 +1010,6 @@
       "column": 11,
       "element": "Button",
       "reason": "title-only"
-    },
-    {
-      "signature": "src/components/ui/macos/Header.jsx:132:9:Button:missing-accessible-name",
-      "file": "src/components/ui/macos/Header.jsx",
-      "line": 132,
-      "column": 9,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ui/macos/Header.jsx:336:7:Button:missing-accessible-name",
-      "file": "src/components/ui/macos/Header.jsx",
-      "line": 336,
-      "column": 7,
-      "element": "Button",
-      "reason": "missing-accessible-name"
     },
     {
       "signature": "src/pages/DentistPanelUnified.jsx:2084:15:Button:title-only",

--- a/frontend/src/components/PWAInstallPrompt.jsx
+++ b/frontend/src/components/PWAInstallPrompt.jsx
@@ -92,9 +92,12 @@ const PWAInstallPrompt = () => {
             variant="ghost"
             size="small"
             onClick={handleDismiss}
+            type="button"
+            title="Закрыть предложение установки приложения"
+            aria-label="Закрыть предложение установки приложения"
             style={{ padding: '4px', minWidth: 'auto' }}
           >
-            <X size={16} />
+            <X aria-hidden="true" size={16} />
           </Button>
         </Box>
         

--- a/frontend/src/components/ResponsiveModal.jsx
+++ b/frontend/src/components/ResponsiveModal.jsx
@@ -145,14 +145,17 @@ const ResponsiveModal = ({
             variant="ghost"
             size="sm"
             onClick={onClose}
+            type="button"
+            title="Закрыть модальное окно"
+            aria-label={typeof title === 'string' ? `Закрыть: ${title}` : 'Закрыть модальное окно'}
             style={{
               minWidth: 'auto',
               padding: '8px',
               color: 'white',
               border: '1px solid rgba(255, 255, 255, 0.2)'
             }}>
-            
-              <X size={isMobile ? 18 : 20} />
+
+              <X aria-hidden="true" size={isMobile ? 18 : 20} />
             </Button>
           </div>
         }

--- a/frontend/src/components/ui/macos/Header.jsx
+++ b/frontend/src/components/ui/macos/Header.jsx
@@ -133,6 +133,9 @@ const Header = React.forwardRef(({
           variant="ghost"
           size="small"
           onClick={onSettingsClick}
+          type="button"
+          title="Открыть настройки"
+          aria-label="Открыть настройки"
           style={{
             width: '32px',
             height: '32px',
@@ -141,8 +144,8 @@ const Header = React.forwardRef(({
             alignItems: 'center',
             justifyContent: 'center'
           }}>
-          
-          <Icon name="gear" size="small" color="accent" />
+
+          <Icon aria-hidden="true" name="gear" size="small" color="accent" />
           </Button>
         }
 
@@ -337,6 +340,9 @@ export const HeaderSearch = React.forwardRef(({
         variant="ghost"
         size="small"
         onClick={onClear}
+        type="button"
+        title="Очистить поиск"
+        aria-label="Очистить поиск"
         style={{
           width: '16px',
           height: '16px',
@@ -347,8 +353,8 @@ export const HeaderSearch = React.forwardRef(({
           justifyContent: 'center',
           marginLeft: '4px'
         }}>
-        
-          <Icon name="xmark" size="small" />
+
+          <Icon aria-hidden="true" name="xmark" size="small" />
         </Button>
       }
 


### PR DESCRIPTION
## Summary
- Added accessible names and hover titles to shared custom icon-only controls in the PWA install prompt, responsive modal close button, macOS header settings button, and macOS header search clear button.
- Marked the decorative close/settings/clear icons as `aria-hidden`.
- Refreshed the component-aware icon-only baseline from 142 to 138 and updated the UI/UX audit sweep report.

## Contract Impact
- Canonical surface: frontend shared UI components only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: PWA install prompt, responsive modal title bar, macOS header settings/search controls.
- Compatibility path or alias: unchanged.
- Contract proof: no backend, API client, route registry, schema, or network contract files changed.

## RBAC / Permissions
- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: no auth/RBAC code touched.
- Negative auth proof: no route guards, permission maps, login, token, or role files changed.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no notification, realtime, websocket, polling, or sync files changed.

## Frontend Resilience
- Empty data proof: no data state handling changed.
- Partial data proof: no API result rendering logic changed.
- Forbidden secondary path behavior: no protected route or fallback behavior changed.
- Missing draft/resource behavior: no draft/resource loading behavior changed.
- Stale route/deep-link behavior: no routing behavior changed.

## Scope Gate
- Allowed paths: `frontend/src/components/PWAInstallPrompt.jsx`, `frontend/src/components/ResponsiveModal.jsx`, `frontend/src/components/ui/macos/Header.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, frontend routes/pages, API clients, auth/RBAC, payment, queue, EMR, lab, migrations, package/dependency files, workflow files.
- Migration/docs/test impact: docs report and a11y baseline only; no migration or runtime test code changed.
- Rollback note: revert this PR to restore the previous shared icon button labels and component-aware baseline count.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run audit:icon-controls:components`; `npm.cmd run audit:no-mui-runtime`; `npm.cmd run build`; `git diff --check`.
- Result: all local checks passed; component-aware findings are 138, baseline entries are 138, new findings 0, stale baseline entries 0.
- Not checked: authenticated browser role flows, because this PR only adds accessible names to shared controls and changes no screen workflow state.