### PR TITLE
fix(frontend): label navigation auth icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 138
-Baseline entries: 138
+Findings: 135
+Baseline entries: 135
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 138 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 135 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -87,7 +87,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - Current baseline after this slice: 0 findings.
 - 2026-05-22: component-aware custom `Button`/`MacOSButton` sweep added with 142 historical findings.
 - 2026-05-22: shared shell/mobile custom button labels cleanup removed 4 component findings.
-- Current component-aware baseline: 138 findings.
+- 2026-05-22: navigation/auth/prescription singleton labels cleanup removed 3 component findings.
+- Current component-aware baseline: 135 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,16 +1,8 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T13:23:32.122Z",
+  "generatedAt": "2026-05-22T13:30:52.529Z",
   "entries": [
-    {
-      "signature": "src/components/PrescriptionSystem.jsx:228:19:Button:missing-accessible-name",
-      "file": "src/components/PrescriptionSystem.jsx",
-      "line": 228,
-      "column": 19,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
       "file": "src/components/admin/AISettings.jsx",
@@ -860,14 +852,6 @@
       "reason": "missing-accessible-name"
     },
     {
-      "signature": "src/components/auth/PhoneVerification.jsx:266:11:Button:missing-accessible-name",
-      "file": "src/components/auth/PhoneVerification.jsx",
-      "line": 266,
-      "column": 11,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
       "signature": "src/components/display/DisplayContentManager.jsx:138:19:Button:missing-accessible-name",
       "file": "src/components/display/DisplayContentManager.jsx",
       "line": 138,
@@ -984,14 +968,6 @@
       "file": "src/components/laboratory/LabResultsManager.jsx",
       "line": 605,
       "column": 15,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/layout/ResponsiveNavigation.jsx:34:11:Button:missing-accessible-name",
-      "file": "src/components/layout/ResponsiveNavigation.jsx",
-      "line": 34,
-      "column": 11,
       "element": "Button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/PrescriptionSystem.jsx
+++ b/frontend/src/components/PrescriptionSystem.jsx
@@ -229,9 +229,12 @@ const PrescriptionSystem = ({ appointment, emr, prescription: initialPrescriptio
                 size="sm"
                 variant="danger"
                 onClick={() => handleMedicationRemove(medication.id)}
+                type="button"
+                title={`Удалить препарат ${index + 1}`}
+                aria-label={`Удалить препарат ${index + 1}`}
                 disabled={!canEdit}>
                 
-                    <X className="w-4 h-4" />
+                    <X aria-hidden="true" className="w-4 h-4" />
                   </Button>
                 </div>
                 

--- a/frontend/src/components/auth/PhoneVerification.jsx
+++ b/frontend/src/components/auth/PhoneVerification.jsx
@@ -266,16 +266,19 @@ const PhoneVerification = ({
           <Button
             onClick={sendVerificationCode}
             disabled={loading || !currentPhone || !validatePhone(currentPhone)}
+            type="button"
+            title={loading ? 'Отправляется код подтверждения' : 'Отправить код подтверждения'}
+            aria-label={loading ? 'Отправляется код подтверждения' : 'Отправить код подтверждения'}
             className="w-full"
           >
             {loading ? (
               <>
-                <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+                <RefreshCw aria-hidden="true" className="h-4 w-4 mr-2 animate-spin" />
                 Отправка...
               </>
             ) : (
               <>
-                <Send className="h-4 w-4 mr-2" />
+                <Send aria-hidden="true" className="h-4 w-4 mr-2" />
                 Отправить код
               </>
             )}

--- a/frontend/src/components/layout/ResponsiveNavigation.jsx
+++ b/frontend/src/components/layout/ResponsiveNavigation.jsx
@@ -35,9 +35,13 @@ const ResponsiveNavigation = ({
             variant="ghost"
             size="sm"
             onClick={() => setIsMenuOpen(!isMenuOpen)}
+            type="button"
+            title={isMenuOpen ? 'Закрыть меню' : 'Открыть меню'}
+            aria-label={isMenuOpen ? 'Закрыть меню' : 'Открыть меню'}
+            aria-expanded={isMenuOpen}
             style={{ minWidth: 'auto', padding: '8px' }}>
             
-            {isMenuOpen ? <X size={20} /> : <Menu size={20} />}
+            {isMenuOpen ? <X aria-hidden="true" size={20} /> : <Menu aria-hidden="true" size={20} />}
           </Button>
         </div>
 


### PR DESCRIPTION
## Summary
- Added accessible names/titles to one shared mobile navigation menu toggle, one phone verification send-code action, and one prescription medication remove icon button.
- Marked decorative menu/close/send/spinner/remove icons as `aria-hidden`.
- Refreshed the component-aware icon-only baseline from 138 to 135 and updated the UI/UX audit sweep report.

## Contract Impact
- Canonical surface: frontend shared UI/auth/prescription components only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: responsive navigation, phone verification UI, prescription medication editor.
- Compatibility path or alias: unchanged.
- Contract proof: no backend, API client, route registry, schema, or network contract files changed.

## RBAC / Permissions
- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: no auth policy, route guard, role map, token, or permission file changed.
- Negative auth proof: phone verification behavior and disable conditions are preserved; only button metadata was added.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no notification, websocket, polling, or realtime files changed.

## Frontend Resilience
- Empty data proof: no data state handling changed.
- Partial data proof: no API result rendering logic changed.
- Forbidden secondary path behavior: no protected route or fallback behavior changed.
- Missing draft/resource behavior: no draft/resource loading behavior changed.
- Stale route/deep-link behavior: no routing behavior changed.

## Scope Gate
- Allowed paths: `frontend/src/components/layout/ResponsiveNavigation.jsx`, `frontend/src/components/auth/PhoneVerification.jsx`, `frontend/src/components/PrescriptionSystem.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, RBAC/auth policy, payment, queue, EMR contracts, lab, migrations, package/dependency files, workflow files.
- Migration/docs/test impact: docs report and a11y baseline only; no migration or test code changed.
- Rollback note: revert this PR to restore the previous icon button metadata and component-aware baseline count.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run audit:icon-controls:components`; `npm.cmd run audit:no-mui-runtime`; `npm.cmd run build`; `git diff --check`.
- Result: all local checks passed; component-aware findings are 135, baseline entries are 135, new findings 0, stale baseline entries 0.
- Not checked: authenticated browser role flows, because this PR changes accessible names only and preserves click handlers, disabled states, and request behavior.