### PR TITLE
fix(frontend): label display content icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 135
-Baseline entries: 135
+Findings: 127
+Baseline entries: 127
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 135 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 127 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -88,7 +88,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: component-aware custom `Button`/`MacOSButton` sweep added with 142 historical findings.
 - 2026-05-22: shared shell/mobile custom button labels cleanup removed 4 component findings.
 - 2026-05-22: navigation/auth/prescription singleton labels cleanup removed 3 component findings.
-- Current component-aware baseline: 135 findings.
+- 2026-05-22: display content manager action labels cleanup removed 8 component findings.
+- Current component-aware baseline: 127 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T13:30:52.529Z",
+  "generatedAt": "2026-05-22T13:36:35.255Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -848,70 +848,6 @@
       "file": "src/components/analytics/AdvancedCharts.jsx",
       "line": 150,
       "column": 15,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/display/DisplayContentManager.jsx:138:19:Button:missing-accessible-name",
-      "file": "src/components/display/DisplayContentManager.jsx",
-      "line": 138,
-      "column": 19,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/display/DisplayContentManager.jsx:141:19:Button:missing-accessible-name",
-      "file": "src/components/display/DisplayContentManager.jsx",
-      "line": 141,
-      "column": 19,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/display/DisplayContentManager.jsx:144:19:Button:missing-accessible-name",
-      "file": "src/components/display/DisplayContentManager.jsx",
-      "line": 144,
-      "column": 19,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/display/DisplayContentManager.jsx:194:17:Button:missing-accessible-name",
-      "file": "src/components/display/DisplayContentManager.jsx",
-      "line": 194,
-      "column": 17,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/display/DisplayContentManager.jsx:197:17:Button:missing-accessible-name",
-      "file": "src/components/display/DisplayContentManager.jsx",
-      "line": 197,
-      "column": 17,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/display/DisplayContentManager.jsx:249:19:Button:missing-accessible-name",
-      "file": "src/components/display/DisplayContentManager.jsx",
-      "line": 249,
-      "column": 19,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/display/DisplayContentManager.jsx:252:19:Button:missing-accessible-name",
-      "file": "src/components/display/DisplayContentManager.jsx",
-      "line": 252,
-      "column": 19,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/display/DisplayContentManager.jsx:255:19:Button:missing-accessible-name",
-      "file": "src/components/display/DisplayContentManager.jsx",
-      "line": 255,
-      "column": 19,
       "element": "Button",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/display/DisplayContentManager.jsx
+++ b/frontend/src/components/display/DisplayContentManager.jsx
@@ -135,18 +135,31 @@ const DisplayContentManager = ({
                   {banner.active ? 'Активен' : 'Неактивен'}
                 </Badge>
                 <div className="flex space-x-1">
-                  <Button size="sm" variant="outline">
-                    <Eye size={12} />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    type="button"
+                    title={`Просмотреть баннер: ${banner.title}`}
+                    aria-label={`Просмотреть баннер: ${banner.title}`}>
+                    <Eye aria-hidden="true" size={12} />
                   </Button>
-                  <Button size="sm" variant="outline">
-                    <Edit size={12} />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    type="button"
+                    title={`Редактировать баннер: ${banner.title}`}
+                    aria-label={`Редактировать баннер: ${banner.title}`}>
+                    <Edit aria-hidden="true" size={12} />
                   </Button>
                   <Button
                 size="sm"
                 variant="outline"
+                type="button"
+                title={`Удалить баннер: ${banner.title}`}
+                aria-label={`Удалить баннер: ${banner.title}`}
                 onClick={() => handleDeleteContent(banner.id, 'banner')}>
-                
-                    <Trash2 size={12} />
+
+                    <Trash2 aria-hidden="true" size={12} />
                   </Button>
                 </div>
               </div>
@@ -191,15 +204,23 @@ const DisplayContentManager = ({
                 </div>
               </div>
               <div className="flex space-x-2 ml-4">
-                <Button size="sm" variant="outline">
-                  <Edit size={14} />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  type="button"
+                  title={`Редактировать объявление: ${announcement.title}`}
+                  aria-label={`Редактировать объявление: ${announcement.title}`}>
+                  <Edit aria-hidden="true" size={14} />
                 </Button>
                 <Button
               size="sm"
               variant="outline"
+              type="button"
+              title={`Удалить объявление: ${announcement.title}`}
+              aria-label={`Удалить объявление: ${announcement.title}`}
               onClick={() => handleDeleteContent(announcement.id, 'announcement')}>
-              
-                  <Trash2 size={14} />
+
+                  <Trash2 aria-hidden="true" size={14} />
                 </Button>
               </div>
             </div>
@@ -246,18 +267,31 @@ const DisplayContentManager = ({
                   {video.active ? 'Показывается' : 'Неактивен'}
                 </Badge>
                 <div className="flex space-x-1">
-                  <Button size="sm" variant="outline">
-                    <Play size={12} />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    type="button"
+                    title={`Воспроизвести видео: ${video.title}`}
+                    aria-label={`Воспроизвести видео: ${video.title}`}>
+                    <Play aria-hidden="true" size={12} />
                   </Button>
-                  <Button size="sm" variant="outline">
-                    <Edit size={12} />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    type="button"
+                    title={`Редактировать видео: ${video.title}`}
+                    aria-label={`Редактировать видео: ${video.title}`}>
+                    <Edit aria-hidden="true" size={12} />
                   </Button>
                   <Button
                 size="sm"
                 variant="outline"
+                type="button"
+                title={`Удалить видео: ${video.title}`}
+                aria-label={`Удалить видео: ${video.title}`}
                 onClick={() => handleDeleteContent(video.id, 'video')}>
-                
-                    <Trash2 size={12} />
+
+                    <Trash2 aria-hidden="true" size={12} />
                   </Button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Added accessible names/titles to banner, announcement, and video icon-only actions in `DisplayContentManager`.
- Marked decorative preview/edit/delete/play icons as `aria-hidden`.
- Refreshed the component-aware icon-only baseline from 135 to 127 and updated the UI/UX audit sweep report.

## Contract Impact
- Canonical surface: frontend display content management UI only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: display board content manager action buttons.
- Compatibility path or alias: unchanged.
- Contract proof: no backend, API client, route registry, schema, or network contract files changed.

## RBAC / Permissions
- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: no auth policy, route guard, role map, token, or permission file changed.
- Negative auth proof: delete handlers and existing action buttons are preserved; only button metadata was added.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no notification, websocket, polling, or realtime files changed.

## Frontend Resilience
- Empty data proof: no empty-state rendering changed.
- Partial data proof: no API result rendering logic changed.
- Forbidden secondary path behavior: no protected route or fallback behavior changed.
- Missing draft/resource behavior: no draft/resource loading behavior changed.
- Stale route/deep-link behavior: no routing behavior changed.

## Scope Gate
- Allowed paths: `frontend/src/components/display/DisplayContentManager.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, RBAC/auth policy, payment, queue, EMR contracts, lab, migrations, package/dependency files, workflow files.
- Migration/docs/test impact: docs report and a11y baseline only; no migration or test code changed.
- Rollback note: revert this PR to restore the previous display content button metadata and component-aware baseline count.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run audit:icon-controls:components`; `npm.cmd run audit:no-mui-runtime`; `npm.cmd run build`; `git diff --check`.
- Result: all local checks passed; component-aware findings are 127, baseline entries are 127, new findings 0, stale baseline entries 0.
- Not checked: authenticated display-board browser flow, because this PR changes accessible names only and preserves action handlers, fetch calls, and delete behavior.