### PR TITLE
fix(frontend): label mobile optimization icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 127
-Baseline entries: 127
+Findings: 122
+Baseline entries: 122
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 127 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 122 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -89,7 +89,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: shared shell/mobile custom button labels cleanup removed 4 component findings.
 - 2026-05-22: navigation/auth/prescription singleton labels cleanup removed 3 component findings.
 - 2026-05-22: display content manager action labels cleanup removed 8 component findings.
-- Current component-aware baseline: 127 findings.
+- 2026-05-22: mobile optimization action labels cleanup removed 5 component findings.
+- Current component-aware baseline: 122 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T13:36:35.255Z",
+  "generatedAt": "2026-05-22T13:42:14.881Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -209,46 +209,6 @@
       "line": 606,
       "column": 15,
       "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/MobileOptimization.jsx:47:11:Button:missing-accessible-name",
-      "file": "src/components/admin/MobileOptimization.jsx",
-      "line": 47,
-      "column": 11,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/MobileOptimization.jsx:60:13:Button:missing-accessible-name",
-      "file": "src/components/admin/MobileOptimization.jsx",
-      "line": 60,
-      "column": 13,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/MobileOptimization.jsx:63:13:Button:missing-accessible-name",
-      "file": "src/components/admin/MobileOptimization.jsx",
-      "line": 63,
-      "column": 13,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/MobileOptimization.jsx:95:17:Button:missing-accessible-name",
-      "file": "src/components/admin/MobileOptimization.jsx",
-      "line": 95,
-      "column": 17,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/MobileOptimization.jsx:255:9:Button:missing-accessible-name",
-      "file": "src/components/admin/MobileOptimization.jsx",
-      "line": 255,
-      "column": 9,
-      "element": "Button",
       "reason": "missing-accessible-name"
     },
     {

--- a/frontend/src/components/admin/MobileOptimization.jsx
+++ b/frontend/src/components/admin/MobileOptimization.jsx
@@ -47,9 +47,12 @@ export const MobileNavigation = ({ sections, currentSection, onNavigate, classNa
           <Button
             variant="ghost"
             onClick={() => setIsOpen(true)}
+            type="button"
+            title="Открыть мобильное меню"
+            aria-label="Открыть мобильное меню"
             className="p-2">
-            
-            <Menu size={20} />
+
+            <Menu aria-hidden="true" size={20} />
           </Button>
           
           <h1 className="text-lg font-semibold text-gray-900 dark:text-white">
@@ -57,11 +60,21 @@ export const MobileNavigation = ({ sections, currentSection, onNavigate, classNa
           </h1>
           
           <div className="flex gap-2">
-            <Button variant="ghost" className="p-2">
-              <Search size={20} />
+            <Button
+              variant="ghost"
+              type="button"
+              title="Открыть поиск"
+              aria-label="Открыть поиск"
+              className="p-2">
+              <Search aria-hidden="true" size={20} />
             </Button>
-            <Button variant="ghost" className="p-2">
-              <Plus size={20} />
+            <Button
+              variant="ghost"
+              type="button"
+              title="Добавить запись"
+              aria-label="Добавить запись"
+              className="p-2">
+              <Plus aria-hidden="true" size={20} />
             </Button>
           </div>
         </div>
@@ -95,9 +108,12 @@ export const MobileNavigation = ({ sections, currentSection, onNavigate, classNa
                 <Button
                 variant="ghost"
                 onClick={() => setIsOpen(false)}
+                type="button"
+                title="Закрыть мобильное меню"
+                aria-label="Закрыть мобильное меню"
                 className="p-2">
-                
-                  <X size={20} />
+
+                  <X aria-hidden="true" size={20} />
                 </Button>
               </div>
             </div>
@@ -255,11 +271,14 @@ export const MobileQuickActions = ({ actions, className = '' }) => {
         <Button
           key={index}
           onClick={action.onClick}
+          type="button"
+          title={action.label || action.title || `Быстрое действие ${index + 1}`}
+          aria-label={action.label || action.title || `Быстрое действие ${index + 1}`}
           className="w-14 h-14 rounded-full shadow-lg"
           variant={action.variant || 'default'}
           disabled={action.disabled}>
-          
-            <action.icon size={20} />
+
+            <action.icon aria-hidden="true" size={20} />
           </Button>
         )}
       </div>
@@ -337,6 +356,8 @@ MobileQuickActions.propTypes = {
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       onClick: PropTypes.func,
+      label: PropTypes.string,
+      title: PropTypes.string,
       variant: PropTypes.string,
       disabled: PropTypes.bool,
       icon: PropTypes.elementType


### PR DESCRIPTION
## Summary
- Added accessible names/titles to mobile admin menu/search/add/close controls and mobile quick-action buttons.
- Marked decorative mobile action icons as `aria-hidden` and added optional action `label`/`title` prop support for accessible quick-action names.
- Refreshed the component-aware icon-only baseline from 127 to 122 and updated the UI/UX audit sweep report.

## Contract Impact
- Canonical surface: frontend admin mobile optimization UI only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: mobile admin navigation and quick-action controls.
- Compatibility path or alias: unchanged.
- Contract proof: no backend, API client, route registry, schema, or network contract files changed.

## RBAC / Permissions
- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: no auth policy, route guard, role map, token, or permission file changed.
- Negative auth proof: navigation callbacks and quick-action handlers are preserved; only button metadata and optional label/title props were added.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no notification, websocket, polling, or realtime files changed.

## Frontend Resilience
- Empty data proof: no empty-state rendering changed.
- Partial data proof: no API result rendering logic changed.
- Forbidden secondary path behavior: no protected route or fallback behavior changed.
- Missing draft/resource behavior: no draft/resource loading behavior changed.
- Stale route/deep-link behavior: no routing behavior changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/MobileOptimization.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, RBAC/auth policy, payment, queue, EMR contracts, lab, migrations, package/dependency files, workflow files.
- Migration/docs/test impact: docs report and a11y baseline only; no migration or test code changed.
- Rollback note: revert this PR to restore the previous mobile admin button metadata and component-aware baseline count.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run audit:icon-controls:components`; `npm.cmd run audit:no-mui-runtime`; `npm.cmd run build`; `git diff --check`.
- Result: all local checks passed; component-aware findings are 122, baseline entries are 122, new findings 0, stale baseline entries 0.
- Not checked: authenticated mobile admin browser flow, because this PR changes accessible names only and preserves callbacks, route behavior, and data flow.