### PR TITLE
fix(frontend): label billing manager icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 122
-Baseline entries: 122
+Findings: 116
+Baseline entries: 116
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 122 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 116 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -90,7 +90,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: navigation/auth/prescription singleton labels cleanup removed 3 component findings.
 - 2026-05-22: display content manager action labels cleanup removed 8 component findings.
 - 2026-05-22: mobile optimization action labels cleanup removed 5 component findings.
-- Current component-aware baseline: 122 findings.
+- 2026-05-22: billing manager invoice/payment action labels cleanup removed 6 component findings.
+- Current component-aware baseline: 116 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T13:42:14.881Z",
+  "generatedAt": "2026-05-22T14:03:31.250Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -39,54 +39,6 @@
       "signature": "src/components/admin/BenefitSettings.jsx:831:13:MacOSButton:missing-accessible-name",
       "file": "src/components/admin/BenefitSettings.jsx",
       "line": 831,
-      "column": 13,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/BillingManager.jsx:374:19:MacOSButton:title-only",
-      "file": "src/components/admin/BillingManager.jsx",
-      "line": 374,
-      "column": 19,
-      "element": "MacOSButton",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/BillingManager.jsx:390:19:MacOSButton:title-only",
-      "file": "src/components/admin/BillingManager.jsx",
-      "line": 390,
-      "column": 19,
-      "element": "MacOSButton",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/BillingManager.jsx:406:19:MacOSButton:title-only",
-      "file": "src/components/admin/BillingManager.jsx",
-      "line": 406,
-      "column": 19,
-      "element": "MacOSButton",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/BillingManager.jsx:449:13:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/BillingManager.jsx",
-      "line": 449,
-      "column": 13,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/BillingManager.jsx:602:17:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/BillingManager.jsx",
-      "line": 602,
-      "column": 17,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/BillingManager.jsx:681:13:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/BillingManager.jsx",
-      "line": 681,
       "column": 13,
       "element": "MacOSButton",
       "reason": "missing-accessible-name"

--- a/frontend/src/components/admin/BillingManager.jsx
+++ b/frontend/src/components/admin/BillingManager.jsx
@@ -383,9 +383,11 @@ const BillingManager = () => {
                 alignItems: 'center',
                 justifyContent: 'center'
               }}
-              title="Просмотр">
-              
-                    <Eye size={16} />
+              title="Просмотреть счет"
+              type="button"
+              aria-label={`Просмотреть счет ${invoice.invoice_number || invoice.id}`}>
+
+                    <Eye aria-hidden="true" size={16} />
                   </MacOSButton>
                   <MacOSButton
               variant="outline"
@@ -399,9 +401,11 @@ const BillingManager = () => {
                 alignItems: 'center',
                 justifyContent: 'center'
               }}
-              title="Отправить">
-              
-                    <Send size={16} />
+              title="Отправить счет"
+              type="button"
+              aria-label={`Отправить счет ${invoice.invoice_number || invoice.id}`}>
+
+                    <Send aria-hidden="true" size={16} />
                   </MacOSButton>
                   <MacOSButton
               variant="outline"
@@ -418,9 +422,11 @@ const BillingManager = () => {
                 alignItems: 'center',
                 justifyContent: 'center'
               }}
-              title="Записать платеж">
-              
-                    <CreditCard size={16} />
+              title="Записать платеж"
+              type="button"
+              aria-label={`Записать платеж по счету ${invoice.invoice_number || invoice.id}`}>
+
+                    <CreditCard aria-hidden="true" size={16} />
                   </MacOSButton>
                 </div>
               </div>
@@ -449,6 +455,9 @@ const BillingManager = () => {
             <MacOSButton
           variant="outline"
           onClick={() => setShowCreateInvoice(false)}
+          type="button"
+          title="Закрыть форму создания счета"
+          aria-label="Закрыть форму создания счета"
           style={{
             padding: '6px',
             minWidth: 'auto',
@@ -459,7 +468,7 @@ const BillingManager = () => {
             justifyContent: 'center'
           }}>
           
-              <X size={16} />
+              <X aria-hidden="true" size={16} />
             </MacOSButton>
           </div>
 
@@ -602,6 +611,9 @@ const BillingManager = () => {
                 <MacOSButton
             variant="outline"
             onClick={() => removeInvoiceItem(index)}
+            type="button"
+            title={`Удалить позицию счета ${index + 1}`}
+            aria-label={`Удалить позицию счета ${index + 1}`}
             disabled={invoiceForm.items.length === 1}
             style={{
               padding: '6px',
@@ -613,7 +625,7 @@ const BillingManager = () => {
               justifyContent: 'center'
             }}>
             
-                  <Trash2 size={16} />
+                  <Trash2 aria-hidden="true" size={16} />
                 </MacOSButton>
               </div>
         )}
@@ -681,6 +693,9 @@ const BillingManager = () => {
             <MacOSButton
           variant="outline"
           onClick={() => setShowRecordPayment(false)}
+          type="button"
+          title="Закрыть форму записи платежа"
+          aria-label="Закрыть форму записи платежа"
           style={{
             padding: '6px',
             minWidth: 'auto',
@@ -691,7 +706,7 @@ const BillingManager = () => {
             justifyContent: 'center'
           }}>
           
-              <X size={16} />
+              <X aria-hidden="true" size={16} />
             </MacOSButton>
           </div>
 


### PR DESCRIPTION
## Summary
- Added accessible names/titles to BillingManager invoice view/send/payment icon actions, invoice-item remove, and billing form close buttons.
- Marked decorative billing action icons as `aria-hidden`.
- Refreshed the component-aware icon-only baseline from 122 to 116 and updated the UI/UX audit sweep report.

## Contract Impact
- Canonical surface: frontend billing management UI only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: billing invoice/payment action controls.
- Compatibility path or alias: unchanged.
- Contract proof: no backend, API client, route registry, schema, payment provider, or network contract files changed.

## RBAC / Permissions
- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: no auth policy, route guard, role map, token, or permission file changed.
- Negative auth proof: invoice/payment handlers and disabled states are preserved; only button metadata was added.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no notification, websocket, polling, or realtime files changed.

## Frontend Resilience
- Empty data proof: no empty-state rendering changed.
- Partial data proof: no API result rendering logic changed.
- Forbidden secondary path behavior: no protected route or fallback behavior changed.
- Missing draft/resource behavior: no draft/resource loading behavior changed.
- Stale route/deep-link behavior: no routing behavior changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/BillingManager.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, RBAC/auth policy, payment provider code, queue, EMR contracts, lab, migrations, package/dependency files, workflow files.
- Migration/docs/test impact: docs report and a11y baseline only; no migration or test code changed.
- Rollback note: revert this PR to restore the previous billing button metadata and component-aware baseline count.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run audit:icon-controls:components`; `npm.cmd run audit:no-mui-runtime`; `npm.cmd run build`; `git diff --check`.
- Result: all local checks passed; component-aware findings are 116, baseline entries are 116, new findings 0, stale baseline entries 0.
- Not checked: authenticated billing browser flow, because this PR changes accessible names only and preserves handlers, disabled states, API calls, and payment recording behavior.