### PR TITLE
fix(frontend): label dynamic pricing icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 116
-Baseline entries: 116
+Findings: 109
+Baseline entries: 109
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 116 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 109 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -91,7 +91,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: display content manager action labels cleanup removed 8 component findings.
 - 2026-05-22: mobile optimization action labels cleanup removed 5 component findings.
 - 2026-05-22: billing manager invoice/payment action labels cleanup removed 6 component findings.
-- Current component-aware baseline: 116 findings.
+- 2026-05-22: dynamic pricing action labels cleanup removed 7 component findings.
+- Current component-aware baseline: 109 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T14:03:31.250Z",
+  "generatedAt": "2026-05-22T14:09:30.225Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -73,62 +73,6 @@
       "line": 581,
       "column": 21,
       "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/DynamicPricingManager.jsx:414:19:MacOSButton:title-only",
-      "file": "src/components/admin/DynamicPricingManager.jsx",
-      "line": 414,
-      "column": 19,
-      "element": "MacOSButton",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/DynamicPricingManager.jsx:430:19:MacOSButton:title-only",
-      "file": "src/components/admin/DynamicPricingManager.jsx",
-      "line": 430,
-      "column": 19,
-      "element": "MacOSButton",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/DynamicPricingManager.jsx:446:19:MacOSButton:title-only",
-      "file": "src/components/admin/DynamicPricingManager.jsx",
-      "line": 446,
-      "column": 19,
-      "element": "MacOSButton",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/DynamicPricingManager.jsx:486:13:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/DynamicPricingManager.jsx",
-      "line": 486,
-      "column": 13,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/DynamicPricingManager.jsx:848:19:MacOSButton:title-only",
-      "file": "src/components/admin/DynamicPricingManager.jsx",
-      "line": 848,
-      "column": 19,
-      "element": "MacOSButton",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/DynamicPricingManager.jsx:864:19:MacOSButton:title-only",
-      "file": "src/components/admin/DynamicPricingManager.jsx",
-      "line": 864,
-      "column": 19,
-      "element": "MacOSButton",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/DynamicPricingManager.jsx:904:13:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/DynamicPricingManager.jsx",
-      "line": 904,
-      "column": 13,
-      "element": "MacOSButton",
       "reason": "missing-accessible-name"
     },
     {

--- a/frontend/src/components/admin/DynamicPricingManager.jsx
+++ b/frontend/src/components/admin/DynamicPricingManager.jsx
@@ -423,9 +423,11 @@ const DynamicPricingManager = () => {
                 alignItems: 'center',
                 justifyContent: 'center'
               }}
-              title={rule.is_active ? 'Приостановить' : 'Активировать'}>
-              
-                    {rule.is_active ? <Pause size={16} /> : <Play size={16} />}
+              title={rule.is_active ? 'Приостановить правило' : 'Активировать правило'}
+              type="button"
+              aria-label={`${rule.is_active ? 'Приостановить' : 'Активировать'} правило ${rule.name || rule.id}`}>
+
+                    {rule.is_active ? <Pause aria-hidden="true" size={16} /> : <Play aria-hidden="true" size={16} />}
                   </MacOSButton>
                   <MacOSButton
               variant="outline"
@@ -439,9 +441,11 @@ const DynamicPricingManager = () => {
                 alignItems: 'center',
                 justifyContent: 'center'
               }}
-              title="Редактировать">
-              
-                    <Edit size={16} />
+              title="Редактировать правило"
+              type="button"
+              aria-label={`Редактировать правило ${rule.name || rule.id}`}>
+
+                    <Edit aria-hidden="true" size={16} />
                   </MacOSButton>
                   <MacOSButton
               variant="outline"
@@ -455,9 +459,11 @@ const DynamicPricingManager = () => {
                 alignItems: 'center',
                 justifyContent: 'center'
               }}
-              title="Удалить">
-              
-                    <Trash2 size={16} />
+              title="Удалить правило"
+              type="button"
+              aria-label={`Удалить правило ${rule.name || rule.id}`}>
+
+                    <Trash2 aria-hidden="true" size={16} />
                   </MacOSButton>
                 </div>
               </div>
@@ -483,8 +489,13 @@ const DynamicPricingManager = () => {
         }}>
               Создать правило ценообразования
             </h4>
-            <MacOSButton variant="outline" onClick={() => setShowCreateRule(false)}>
-              <X size={16} />
+            <MacOSButton
+              variant="outline"
+              onClick={() => setShowCreateRule(false)}
+              type="button"
+              title="Закрыть форму создания правила"
+              aria-label="Закрыть форму создания правила">
+              <X aria-hidden="true" size={16} />
             </MacOSButton>
           </div>
 
@@ -857,9 +868,11 @@ const DynamicPricingManager = () => {
                 alignItems: 'center',
                 justifyContent: 'center'
               }}
-              title="Редактировать">
-              
-                    <Edit size={16} />
+              title="Редактировать пакет"
+              type="button"
+              aria-label={`Редактировать пакет ${pkg.name || pkg.id}`}>
+
+                    <Edit aria-hidden="true" size={16} />
                   </MacOSButton>
                   <MacOSButton
               variant="outline"
@@ -873,9 +886,11 @@ const DynamicPricingManager = () => {
                 alignItems: 'center',
                 justifyContent: 'center'
               }}
-              title="Удалить">
-              
-                    <Trash2 size={16} />
+              title="Удалить пакет"
+              type="button"
+              aria-label={`Удалить пакет ${pkg.name || pkg.id}`}>
+
+                    <Trash2 aria-hidden="true" size={16} />
                   </MacOSButton>
                 </div>
               </div>
@@ -901,8 +916,13 @@ const DynamicPricingManager = () => {
         }}>
               Создать пакет услуг
             </h4>
-            <MacOSButton variant="outline" onClick={() => setShowCreatePackage(false)}>
-              <X size={16} />
+            <MacOSButton
+              variant="outline"
+              onClick={() => setShowCreatePackage(false)}
+              type="button"
+              title="Закрыть форму создания пакета"
+              aria-label="Закрыть форму создания пакета">
+              <X aria-hidden="true" size={16} />
             </MacOSButton>
           </div>
 


### PR DESCRIPTION
## Summary
- Added accessible names/titles to DynamicPricingManager rule/package activate, edit, delete, and close form icon buttons.
- Marked decorative pricing action icons as `aria-hidden`.
- Refreshed the component-aware icon-only baseline from 116 to 109 and updated the UI/UX audit sweep report.

## Contract Impact
- Canonical surface: frontend dynamic pricing management UI only.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: dynamic pricing rule and service package action controls.
- Compatibility path or alias: unchanged.
- Contract proof: no backend, API client, route registry, schema, pricing API contract, or network contract files changed.

## RBAC / Permissions
- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: no auth policy, route guard, role map, token, or permission file changed.
- Negative auth proof: pricing rule/package handlers and disabled states are preserved; only button metadata was added.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no notification, websocket, polling, or realtime files changed.

## Frontend Resilience
- Empty data proof: no empty-state rendering changed.
- Partial data proof: no API result rendering logic changed.
- Forbidden secondary path behavior: no protected route or fallback behavior changed.
- Missing draft/resource behavior: no draft/resource loading behavior changed.
- Stale route/deep-link behavior: no routing behavior changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/DynamicPricingManager.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, RBAC/auth policy, pricing/backend contracts, payment provider code, queue, EMR contracts, lab, migrations, package/dependency files, workflow files.
- Migration/docs/test impact: docs report and a11y baseline only; no migration or test code changed.
- Rollback note: revert this PR to restore the previous dynamic pricing button metadata and component-aware baseline count.

## Validation
- Targeted tests or smoke run: `npm.cmd run lint:check -- --quiet`; `npm.cmd run audit:icon-controls:strict`; `npm.cmd run audit:icon-controls:components`; `npm.cmd run audit:no-mui-runtime`; `npm.cmd run build`; `git diff --check`.
- Result: all local checks passed; component-aware findings are 109, baseline entries are 109, new findings 0, stale baseline entries 0.
- Not checked: authenticated dynamic pricing browser flow, because this PR changes accessible names only and preserves handlers, forms, API calls, and pricing behavior.