### PR TITLE
[codex] add branch lifecycle cleanup guard

### DIFF
--- a/docs/runbooks/BRANCH_LIFECYCLE_CLEANUP.md
+++ b/docs/runbooks/BRANCH_LIFECYCLE_CLEANUP.md
@@ -1,0 +1,51 @@
+# Branch Lifecycle Cleanup
+
+Use short-lived branches for the normal implementation loop:
+
+1. Create a task branch from fresh `origin/main`.
+2. Implement the slice.
+3. Commit, push, wait for GitHub Actions.
+4. Merge the PR.
+5. Delete the local branch and stale worktree metadata.
+
+## Guarded Local Cleanup
+
+Always start with a dry run:
+
+```powershell
+py -3 scripts\cleanup_merged_branches.py --repo drsapaev/final --prune-worktrees
+```
+
+If local `main` is behind `origin/main`, fast-forward it explicitly:
+
+```powershell
+py -3 scripts\cleanup_merged_branches.py --repo drsapaev/final --prune-worktrees --sync-local-base
+```
+
+If the output only lists branches that should be removed, rerun with explicit
+deletion:
+
+```powershell
+py -3 scripts\cleanup_merged_branches.py --repo drsapaev/final --prune-worktrees --delete
+```
+
+The script uses `origin/main` by default, not the local `main`, because local
+`main` can be stale or checked out in another worktree. It also checks GitHub PR
+state so squash-merged or rebase-merged branches can still be recognized as
+complete.
+
+The local base freshness check is intentionally separate from branch deletion:
+`--sync-local-base` only fast-forwards local `main` when it has no local-only
+commits and its worktree is clean. If local `main` has ahead commits or dirty
+files, the script reports the problem and refuses to guess.
+
+## Safety Rules
+
+- Active worktree branches are never deleted.
+- Local `main` freshness is checked against `origin/main` every run.
+- Protected names such as `main`, `master`, `develop`, `staging`, and
+  `production` are never deleted.
+- Branches with no merged evidence are reported as kept.
+- Graph-merged branches are removed with `git branch -d`.
+- GitHub-confirmed merged branches use `git branch -D`, because squash/rebase
+  merges may not be visible in the local commit graph.

--- a/scripts/cleanup_merged_branches.py
+++ b/scripts/cleanup_merged_branches.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Clean up local task branches after the PR lifecycle is complete.
+
+Default mode is dry-run. The script only deletes branches with explicit
+evidence that they are already merged into the base branch, or that GitHub says
+their PR is MERGED. Branches checked out by any worktree are always kept.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Sequence
+
+
+DEFAULT_BASE = "origin/main"
+DEFAULT_PROTECTED_BRANCHES = ("main", "master", "develop", "staging", "production")
+PR_BRANCH_RE = re.compile(r"^pr[-_/](?P<number>\d+)$", re.IGNORECASE)
+
+
+class Evidence(str, Enum):
+    GRAPH_MERGED = "graph-merged"
+    GITHUB_MERGED = "github-merged"
+
+
+@dataclass(frozen=True)
+class DeleteCandidate:
+    branch: str
+    evidence: Evidence
+    detail: str
+
+
+@dataclass(frozen=True)
+class KeptBranch:
+    branch: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class CleanupPlan:
+    candidates: tuple[DeleteCandidate, ...]
+    kept: tuple[KeptBranch, ...]
+
+
+@dataclass(frozen=True)
+class LocalBaseStatus:
+    branch: str
+    base: str
+    ahead: int
+    behind: int
+    worktree_path: str | None
+    clean: bool | None
+    detail: str
+
+
+def run_command(args: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+def git_lines(args: Sequence[str]) -> tuple[str, ...]:
+    result = run_command(("git", *args))
+    return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def parse_worktree_branches(porcelain: str) -> frozenset[str]:
+    return frozenset(parse_worktree_branch_paths(porcelain))
+
+
+def parse_worktree_branch_paths(porcelain: str) -> dict[str, str]:
+    paths: dict[str, str] = {}
+    current_path: str | None = None
+    prefix = "branch refs/heads/"
+    for raw_line in porcelain.splitlines():
+        line = raw_line.strip()
+        if line.startswith("worktree "):
+            current_path = line.removeprefix("worktree ")
+            continue
+        if line.startswith(prefix) and current_path:
+            paths[line.removeprefix(prefix)] = current_path
+    return paths
+
+
+def is_protected_branch(branch: str, protected: Iterable[str]) -> bool:
+    protected_set = set(protected)
+    return (
+        branch in protected_set
+        or branch.startswith("release/")
+        or branch.startswith("hotfix/")
+        or branch.startswith("protected/")
+    )
+
+
+def parse_pr_number_from_branch(branch: str) -> int | None:
+    match = PR_BRANCH_RE.match(branch)
+    if not match:
+        return None
+    return int(match.group("number"))
+
+
+def local_branch_for_base(base: str) -> str | None:
+    if base.startswith("origin/") and base.count("/") == 1:
+        return base.split("/", 1)[1]
+    return None
+
+
+def parse_ahead_behind(stdout: str) -> tuple[int, int]:
+    parts = stdout.strip().split()
+    if len(parts) != 2:
+        raise ValueError(f"unexpected rev-list output: {stdout!r}")
+    ahead, behind = parts
+    return int(ahead), int(behind)
+
+
+def worktree_is_clean(path: str) -> bool:
+    result = run_command(("git", "-C", path, "status", "--porcelain"))
+    return not result.stdout.strip()
+
+
+def inspect_local_base_status(
+    *,
+    base: str,
+    branches: Iterable[str],
+    worktree_branch_paths: dict[str, str],
+) -> LocalBaseStatus | None:
+    local_branch = local_branch_for_base(base)
+    if not local_branch or local_branch not in set(branches):
+        return None
+
+    result = run_command(
+        ("git", "rev-list", "--left-right", "--count", f"{local_branch}...{base}")
+    )
+    ahead, behind = parse_ahead_behind(result.stdout)
+    path = worktree_branch_paths.get(local_branch)
+    clean = worktree_is_clean(path) if path else None
+
+    if ahead:
+        detail = f"local {local_branch} has {ahead} commit(s) not in {base}; manual review required"
+    elif behind:
+        detail = f"local {local_branch} is behind {base} by {behind} commit(s)"
+    else:
+        detail = f"local {local_branch} is aligned with {base}"
+
+    if path and clean is False:
+        detail += "; worktree has uncommitted changes"
+
+    return LocalBaseStatus(
+        branch=local_branch,
+        base=base,
+        ahead=ahead,
+        behind=behind,
+        worktree_path=path,
+        clean=clean,
+        detail=detail,
+    )
+
+
+def sync_local_base(status: LocalBaseStatus) -> None:
+    if status.ahead:
+        raise RuntimeError(status.detail)
+    if not status.behind:
+        print(f"local {status.branch} already aligned with {status.base}")
+        return
+
+    if status.worktree_path:
+        if status.clean is False:
+            raise RuntimeError(status.detail)
+        run_command(("git", "-C", status.worktree_path, "merge", "--ff-only", status.base))
+    else:
+        run_command(("git", "branch", "-f", status.branch, status.base))
+    print(f"fast-forwarded local {status.branch} to {status.base}")
+
+
+def parse_gh_pr_list(stdout: str) -> tuple[dict, ...]:
+    if not stdout.strip():
+        return ()
+    payload = json.loads(stdout)
+    if not isinstance(payload, list):
+        return ()
+    return tuple(item for item in payload if isinstance(item, dict))
+
+
+def branch_has_merged_pr(branch: str, *, repo: str | None) -> str | None:
+    base_args = ["gh", "pr", "list", "--state", "all", "--head", branch]
+    if repo:
+        base_args.extend(["--repo", repo])
+    base_args.extend(["--json", "number,state,mergedAt,title", "--limit", "5"])
+
+    result = run_command(base_args, check=False)
+    if result.returncode == 0:
+        for pr in parse_gh_pr_list(result.stdout):
+            if pr.get("state") == "MERGED" and pr.get("mergedAt"):
+                title = pr.get("title") or ""
+                return f"PR #{pr.get('number')} merged at {pr.get('mergedAt')}: {title}"
+
+    pr_number = parse_pr_number_from_branch(branch)
+    if pr_number is None:
+        return None
+
+    view_args = ["gh", "pr", "view", str(pr_number)]
+    if repo:
+        view_args.extend(["--repo", repo])
+    view_args.extend(["--json", "number,state,mergedAt,title"])
+    view = run_command(view_args, check=False)
+    if view.returncode != 0 or not view.stdout.strip():
+        return None
+
+    pr = json.loads(view.stdout)
+    if pr.get("state") == "MERGED" and pr.get("mergedAt"):
+        title = pr.get("title") or ""
+        return f"PR #{pr.get('number')} merged at {pr.get('mergedAt')}: {title}"
+    return None
+
+
+def build_cleanup_plan(
+    *,
+    branches: Iterable[str],
+    graph_merged: Iterable[str],
+    active_worktree_branches: Iterable[str],
+    protected_branches: Iterable[str],
+    repo: str | None,
+    include_github: bool,
+) -> CleanupPlan:
+    active = set(active_worktree_branches)
+    merged = set(graph_merged)
+
+    candidates: list[DeleteCandidate] = []
+    kept: list[KeptBranch] = []
+    seen_candidates: set[str] = set()
+
+    for branch in sorted(set(branches)):
+        if branch in active:
+            kept.append(KeptBranch(branch, "checked out by an active worktree"))
+            continue
+        if is_protected_branch(branch, protected_branches):
+            kept.append(KeptBranch(branch, "protected branch name"))
+            continue
+        if branch in merged:
+            candidates.append(
+                DeleteCandidate(
+                    branch=branch,
+                    evidence=Evidence.GRAPH_MERGED,
+                    detail="reachable from base branch commit graph",
+                )
+            )
+            seen_candidates.add(branch)
+            continue
+
+        if include_github:
+            detail = branch_has_merged_pr(branch, repo=repo)
+            if detail:
+                candidates.append(
+                    DeleteCandidate(
+                        branch=branch,
+                        evidence=Evidence.GITHUB_MERGED,
+                        detail=detail,
+                    )
+                )
+                seen_candidates.add(branch)
+                continue
+
+        if branch not in seen_candidates:
+            kept.append(KeptBranch(branch, "no merged evidence found"))
+
+    return CleanupPlan(candidates=tuple(candidates), kept=tuple(kept))
+
+
+def print_plan(
+    plan: CleanupPlan,
+    *,
+    base: str,
+    delete: bool,
+    local_base_status: LocalBaseStatus | None,
+) -> None:
+    mode = "delete" if delete else "dry-run"
+    print(f"Branch lifecycle cleanup ({mode})")
+    print(f"base: {base}")
+    print()
+
+    print("Local base freshness:")
+    if not local_base_status:
+        print("- skipped: base is not an origin/<branch> ref or local branch is absent")
+    else:
+        print(f"- {local_base_status.detail}")
+        if local_base_status.behind and not local_base_status.ahead:
+            print("- run with --sync-local-base to fast-forward it")
+    print()
+
+    print("Delete candidates:")
+    if not plan.candidates:
+        print("- none")
+    for candidate in plan.candidates:
+        print(f"- {candidate.branch} [{candidate.evidence.value}] {candidate.detail}")
+
+    print()
+    print("Kept branches:")
+    if not plan.kept:
+        print("- none")
+    for kept in plan.kept:
+        print(f"- {kept.branch}: {kept.reason}")
+
+
+def delete_candidates(candidates: Iterable[DeleteCandidate]) -> None:
+    for candidate in candidates:
+        flag = "-d" if candidate.evidence is Evidence.GRAPH_MERGED else "-D"
+        run_command(("git", "branch", flag, candidate.branch))
+        print(f"deleted {candidate.branch} ({candidate.evidence.value})")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default=DEFAULT_BASE, help=f"Base ref, default: {DEFAULT_BASE}")
+    parser.add_argument("--repo", help="GitHub repo in owner/name form for PR status checks.")
+    parser.add_argument(
+        "--protected",
+        action="append",
+        default=[],
+        help="Additional protected local branch name. Can be passed multiple times.",
+    )
+    parser.add_argument("--delete", action="store_true", help="Delete candidates instead of dry-run.")
+    parser.add_argument("--no-fetch", action="store_true", help="Skip `git fetch --prune origin`.")
+    parser.add_argument(
+        "--no-github",
+        action="store_true",
+        help="Do not query GitHub for squash/rebase-merged PR evidence.",
+    )
+    parser.add_argument(
+        "--prune-worktrees",
+        action="store_true",
+        help="Run `git worktree prune` before branch analysis.",
+    )
+    parser.add_argument(
+        "--sync-local-base",
+        action="store_true",
+        help="Fast-forward the local base branch, for example main -> origin/main, when safe.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+
+    if not args.no_fetch:
+        run_command(("git", "fetch", "--prune", "origin"))
+    if args.prune_worktrees:
+        run_command(("git", "worktree", "prune"))
+
+    branches = git_lines(("branch", "--format=%(refname:short)"))
+    graph_merged = git_lines(("branch", "--format=%(refname:short)", "--merged", args.base))
+    worktree = run_command(("git", "worktree", "list", "--porcelain"))
+    worktree_branch_paths = parse_worktree_branch_paths(worktree.stdout)
+    active = frozenset(worktree_branch_paths)
+    protected = (*DEFAULT_PROTECTED_BRANCHES, *args.protected)
+    local_base_status = inspect_local_base_status(
+        base=args.base,
+        branches=branches,
+        worktree_branch_paths=worktree_branch_paths,
+    )
+
+    if args.sync_local_base and local_base_status:
+        sync_local_base(local_base_status)
+        branches = git_lines(("branch", "--format=%(refname:short)"))
+        graph_merged = git_lines(("branch", "--format=%(refname:short)", "--merged", args.base))
+        local_base_status = inspect_local_base_status(
+            base=args.base,
+            branches=branches,
+            worktree_branch_paths=worktree_branch_paths,
+        )
+
+    plan = build_cleanup_plan(
+        branches=branches,
+        graph_merged=graph_merged,
+        active_worktree_branches=active,
+        protected_branches=protected,
+        repo=args.repo,
+        include_github=not args.no_github,
+    )
+    print_plan(plan, base=args.base, delete=args.delete, local_base_status=local_base_status)
+
+    if args.delete:
+        print()
+        delete_candidates(plan.candidates)
+    elif plan.candidates:
+        print()
+        print("Dry-run only. Re-run with --delete to remove delete candidates.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test_cleanup_merged_branches.py
+++ b/test_cleanup_merged_branches.py
@@ -1,0 +1,138 @@
+import unittest
+from unittest.mock import patch
+
+from scripts.cleanup_merged_branches import (
+    Evidence,
+    build_cleanup_plan,
+    inspect_local_base_status,
+    local_branch_for_base,
+    parse_ahead_behind,
+    parse_pr_number_from_branch,
+    parse_worktree_branches,
+    parse_worktree_branch_paths,
+)
+
+
+class CleanupMergedBranchesTests(unittest.TestCase):
+    def test_parse_worktree_branches_collects_checked_out_refs(self):
+        porcelain = """
+worktree C:/final
+HEAD abc123
+branch refs/heads/codex/example
+
+worktree C:/tmp/repo
+HEAD def456
+detached
+
+worktree C:/tmp/main
+HEAD 123abc
+branch refs/heads/main
+"""
+
+        self.assertEqual(
+            parse_worktree_branches(porcelain),
+            frozenset({"codex/example", "main"}),
+        )
+        self.assertEqual(
+            parse_worktree_branch_paths(porcelain),
+            {"codex/example": "C:/final", "main": "C:/tmp/main"},
+        )
+
+    def test_plan_keeps_active_and_protected_branches(self):
+        plan = build_cleanup_plan(
+            branches=["main", "codex/done", "codex/active"],
+            graph_merged=["main", "codex/done", "codex/active"],
+            active_worktree_branches=["codex/active"],
+            protected_branches=["main"],
+            repo=None,
+            include_github=False,
+        )
+
+        self.assertEqual([candidate.branch for candidate in plan.candidates], ["codex/done"])
+        self.assertEqual(
+            {kept.branch: kept.reason for kept in plan.kept},
+            {
+                "codex/active": "checked out by an active worktree",
+                "main": "protected branch name",
+            },
+        )
+
+    def test_plan_uses_github_merged_evidence_for_squash_branch(self):
+        with patch(
+            "scripts.cleanup_merged_branches.branch_has_merged_pr",
+            return_value="PR #123 merged at 2026-05-22T00:00:00Z: title",
+        ):
+            plan = build_cleanup_plan(
+                branches=["codex/squashed"],
+                graph_merged=[],
+                active_worktree_branches=[],
+                protected_branches=[],
+                repo="drsapaev/final",
+                include_github=True,
+            )
+
+        self.assertEqual(len(plan.candidates), 1)
+        self.assertEqual(plan.candidates[0].branch, "codex/squashed")
+        self.assertEqual(plan.candidates[0].evidence, Evidence.GITHUB_MERGED)
+
+    def test_plan_keeps_unknown_unmerged_branch(self):
+        with patch("scripts.cleanup_merged_branches.branch_has_merged_pr", return_value=None):
+            plan = build_cleanup_plan(
+                branches=["codex/not-found"],
+                graph_merged=[],
+                active_worktree_branches=[],
+                protected_branches=[],
+                repo="drsapaev/final",
+                include_github=True,
+            )
+
+        self.assertEqual(plan.candidates, ())
+        self.assertEqual(plan.kept[0].reason, "no merged evidence found")
+
+    def test_parse_pr_number_from_local_pr_branch(self):
+        self.assertEqual(parse_pr_number_from_branch("pr-854"), 854)
+        self.assertEqual(parse_pr_number_from_branch("pr/854"), 854)
+        self.assertIsNone(parse_pr_number_from_branch("codex/pr-854"))
+
+    def test_local_branch_for_origin_base(self):
+        self.assertEqual(local_branch_for_base("origin/main"), "main")
+        self.assertEqual(local_branch_for_base("origin/develop"), "develop")
+        self.assertIsNone(local_branch_for_base("upstream/main"))
+        self.assertIsNone(local_branch_for_base("origin/release/one"))
+
+    def test_parse_ahead_behind(self):
+        self.assertEqual(parse_ahead_behind("0\t4\n"), (0, 4))
+
+    def test_inspect_local_base_status_reports_behind(self):
+        with patch("scripts.cleanup_merged_branches.run_command") as run_command:
+            run_command.return_value.stdout = "0\t3\n"
+            with patch("scripts.cleanup_merged_branches.worktree_is_clean", return_value=True):
+                status = inspect_local_base_status(
+                    base="origin/main",
+                    branches=["main", "codex/task"],
+                    worktree_branch_paths={"main": "C:/repo-main"},
+                )
+
+        self.assertIsNotNone(status)
+        self.assertEqual(status.branch, "main")
+        self.assertEqual(status.behind, 3)
+        self.assertEqual(status.ahead, 0)
+        self.assertTrue(status.clean)
+        self.assertIn("behind origin/main by 3", status.detail)
+
+    def test_inspect_local_base_status_reports_ahead_as_manual_review(self):
+        with patch("scripts.cleanup_merged_branches.run_command") as run_command:
+            run_command.return_value.stdout = "2\t0\n"
+            status = inspect_local_base_status(
+                base="origin/main",
+                branches=["main"],
+                worktree_branch_paths={},
+            )
+
+        self.assertIsNotNone(status)
+        self.assertEqual(status.ahead, 2)
+        self.assertIn("manual review required", status.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add guarded local branch lifecycle cleanup tooling for the implementation -> PR -> actions -> merge loop.
- Check local `main` freshness against `origin/main` on every cleanup run.
- Keep active worktree branches protected while allowing explicit cleanup of graph-merged and GitHub-confirmed merged task branches.

## Contract Impact

- Canonical surface: local developer script `scripts/cleanup_merged_branches.py` and runbook `docs/runbooks/BRANCH_LIFECYCLE_CLEANUP.md`.
- Request shape: command-line flags only; no HTTP/API contract changed.
- Response shape: terminal report with local base freshness, delete candidates, and kept branches.
- Status codes: not applicable - no backend endpoint changed.
- Frontend consumer: not applicable - no frontend runtime consumer changed.
- Compatibility path or alias: not applicable - new local tooling only.
- Contract proof: targeted unittest covers worktree parsing, merged evidence, protected branches, and stale local base reporting.

## RBAC / Permissions

not applicable - no application auth, user roles, permissions, or protected runtime routes changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, queue realtime, or background delivery behavior changed.

## Frontend Resilience

- Empty data proof: dry-run reports `Delete candidates: none` cleanly when no cleanup is needed.
- Partial data proof: branches without merged evidence are kept and reported instead of deleted.
- Forbidden secondary path behavior: not applicable - no frontend route or secondary API path changed.
- Missing draft/resource behavior: not applicable - no user draft/resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `scripts/cleanup_merged_branches.py`, `test_cleanup_merged_branches.py`, `docs/runbooks/BRANCH_LIFECYCLE_CLEANUP.md`.
- Denied paths: backend runtime, frontend runtime, migrations, generated output, and unrelated worktree state.
- Migration/docs/test impact: no migration; docs runbook added; targeted unittest added.
- Rollback note: revert commit `ec8a1dc1` to remove the guard script, tests, and runbook.

## Validation

- Targeted tests or smoke run: `py -3 -m unittest test_cleanup_merged_branches.py`; `py -3 -m py_compile scripts\cleanup_merged_branches.py test_cleanup_merged_branches.py`; `py -3 scripts\cleanup_merged_branches.py --repo drsapaev/final --prune-worktrees --no-fetch --sync-local-base`.
- Result: passed locally; guard reported local `main` aligned with `origin/main` and no delete candidates.
- Not checked: full backend/frontend runtime suites, because this PR only changes local Git lifecycle tooling and docs.