### PR TITLE
fix(frontend): label webhook manager icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 109
-Baseline entries: 109
+Findings: 103
+Baseline entries: 103
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 109 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 103 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -92,7 +92,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: mobile optimization action labels cleanup removed 5 component findings.
 - 2026-05-22: billing manager invoice/payment action labels cleanup removed 6 component findings.
 - 2026-05-22: dynamic pricing action labels cleanup removed 7 component findings.
-- Current component-aware baseline: 109 findings.
+- 2026-05-22: webhook manager action labels cleanup removed 6 component findings.
+- Current component-aware baseline: 103 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T14:09:30.225Z",
+  "generatedAt": "2026-05-22T14:15:34.287Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -272,54 +272,6 @@
       "file": "src/components/admin/UserModal.jsx",
       "line": 341,
       "column": 11,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/WebhookManager.jsx:434:21:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/WebhookManager.jsx",
-      "line": 434,
-      "column": 21,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/WebhookManager.jsx:445:21:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/WebhookManager.jsx",
-      "line": 445,
-      "column": 21,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/WebhookManager.jsx:456:21:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/WebhookManager.jsx",
-      "line": 456,
-      "column": 21,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/WebhookManager.jsx:476:17:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/WebhookManager.jsx",
-      "line": 476,
-      "column": 17,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/WebhookManager.jsx:468:17:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/WebhookManager.jsx",
-      "line": 468,
-      "column": 17,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/WebhookManager.jsx:485:21:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/WebhookManager.jsx",
-      "line": 485,
-      "column": 21,
       "element": "MacOSButton",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/admin/WebhookManager.jsx
+++ b/frontend/src/components/admin/WebhookManager.jsx
@@ -434,61 +434,79 @@ const WebhookManager = () => {
                     <MacOSButton
                   size="sm"
                   variant="outline"
+                  type="button"
+                  title="Просмотреть вызовы webhook"
+                  aria-label={`Просмотреть вызовы webhook ${webhook.name || webhook.id}`}
                   onClick={() => {
                     setSelectedWebhook(webhook);
                     loadWebhookCalls(webhook.id);
                   }}>
 
-                      <Eye style={{ width: '16px', height: '16px' }} />
+                      <Eye aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                     </MacOSButton>
                     
                     <MacOSButton
                   size="sm"
                   variant="outline"
+                  type="button"
+                  title="Протестировать webhook"
+                  aria-label={`Протестировать webhook ${webhook.name || webhook.id}`}
                   onClick={() => {
                     setSelectedWebhook(webhook);
                     setShowTestModal(true);
                   }}>
 
-                      <TestTube style={{ width: '16px', height: '16px' }} />
+                      <TestTube aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                     </MacOSButton>
                     
                     <MacOSButton
                   size="sm"
                   variant="outline"
+                  type="button"
+                  title="Редактировать webhook"
+                  aria-label={`Редактировать webhook ${webhook.name || webhook.id}`}
                   onClick={() => {
                     setSelectedWebhook(webhook);
                     setShowEditModal(true);
                   }}>
 
-                      <Edit style={{ width: '16px', height: '16px' }} />
+                      <Edit aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                     </MacOSButton>
                     
                     {webhook.is_active ?
                 <MacOSButton
                   size="sm"
                   variant="outline"
+                  type="button"
+                  title="Приостановить webhook"
+                  aria-label={`Приостановить webhook ${webhook.name || webhook.id}`}
                   onClick={() => handleDeactivateWebhook(webhook.id)}>
 
-                        <Pause style={{ width: '16px', height: '16px' }} />
+                        <Pause aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                       </MacOSButton> :
 
                 <MacOSButton
                   size="sm"
                   variant="outline"
+                  type="button"
+                  title="Активировать webhook"
+                  aria-label={`Активировать webhook ${webhook.name || webhook.id}`}
                   onClick={() => handleActivateWebhook(webhook.id)}>
 
-                        <Play style={{ width: '16px', height: '16px' }} />
+                        <Play aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                       </MacOSButton>
                 }
                     
                     <MacOSButton
                   size="sm"
                   variant="outline"
+                  type="button"
+                  title="Удалить webhook"
+                  aria-label={`Удалить webhook ${webhook.name || webhook.id}`}
                   onClick={() => handleDeleteWebhook(webhook.id)}
                   style={{ color: 'var(--mac-error)' }}>
 
-                      <Trash2 style={{ width: '16px', height: '16px' }} />
+                      <Trash2 aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                     </MacOSButton>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Added accessible names/titles to `WebhookManager` icon-only action buttons for view calls, test, edit, activate, deactivate, and delete actions.
- Marked decorative webhook action icons as `aria-hidden`.
- Reduced the component-aware icon-only controls baseline from 109 to 103 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend admin `WebhookManager` action buttons only.
- Request shape: not applicable - no request body, query parameter, or form payload contract changed.
- Response shape: not applicable - no API response contract or webhook payload shape changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: Admin webhook manager UI action row in `frontend/src/components/admin/WebhookManager.jsx`.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing admin access and rendered action availability remain controlled by current app logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered admin controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, or webhook event channel changed.
- Payload version / ack behavior: not applicable - no webhook payload, delivery acknowledgement, retry, or backend delivery behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - empty webhook list/data rendering code was not edited.
- Partial data proof: button labels fall back from `webhook.name` to `webhook.id`, matching partial display resilience for unnamed webhooks.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/WebhookManager.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, RBAC/auth, webhook backend contracts/delivery, payment, queue, EMR, lab, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous button markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 103 findings / 103 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing admin webhook icon buttons and does not change runtime behavior.