### PR TITLE
[codex] ignore detached head in branch cleanup

### DIFF
--- a/scripts/cleanup_merged_branches.py
+++ b/scripts/cleanup_merged_branches.py
@@ -74,6 +74,16 @@ def git_lines(args: Sequence[str]) -> tuple[str, ...]:
     return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
 
 
+def list_local_branches() -> tuple[str, ...]:
+    return git_lines(("for-each-ref", "--format=%(refname:short)", "refs/heads"))
+
+
+def list_graph_merged_branches(base: str) -> tuple[str, ...]:
+    return git_lines(
+        ("for-each-ref", f"--merged={base}", "--format=%(refname:short)", "refs/heads")
+    )
+
+
 def parse_worktree_branches(porcelain: str) -> frozenset[str]:
     return frozenset(parse_worktree_branch_paths(porcelain))
 
@@ -356,8 +366,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.prune_worktrees:
         run_command(("git", "worktree", "prune"))
 
-    branches = git_lines(("branch", "--format=%(refname:short)"))
-    graph_merged = git_lines(("branch", "--format=%(refname:short)", "--merged", args.base))
+    branches = list_local_branches()
+    graph_merged = list_graph_merged_branches(args.base)
     worktree = run_command(("git", "worktree", "list", "--porcelain"))
     worktree_branch_paths = parse_worktree_branch_paths(worktree.stdout)
     active = frozenset(worktree_branch_paths)
@@ -370,8 +380,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.sync_local_base and local_base_status:
         sync_local_base(local_base_status)
-        branches = git_lines(("branch", "--format=%(refname:short)"))
-        graph_merged = git_lines(("branch", "--format=%(refname:short)", "--merged", args.base))
+        branches = list_local_branches()
+        graph_merged = list_graph_merged_branches(args.base)
         local_base_status = inspect_local_base_status(
             base=args.base,
             branches=branches,

--- a/test_cleanup_merged_branches.py
+++ b/test_cleanup_merged_branches.py
@@ -5,6 +5,8 @@ from scripts.cleanup_merged_branches import (
     Evidence,
     build_cleanup_plan,
     inspect_local_base_status,
+    list_graph_merged_branches,
+    list_local_branches,
     local_branch_for_base,
     parse_ahead_behind,
     parse_pr_number_from_branch,
@@ -102,6 +104,22 @@ branch refs/heads/main
 
     def test_parse_ahead_behind(self):
         self.assertEqual(parse_ahead_behind("0\t4\n"), (0, 4))
+
+    def test_list_local_branches_uses_refs_heads_only(self):
+        with patch("scripts.cleanup_merged_branches.git_lines", return_value=("main", "codex/task")) as git_lines:
+            branches = list_local_branches()
+
+        self.assertEqual(branches, ("main", "codex/task"))
+        git_lines.assert_called_once_with(("for-each-ref", "--format=%(refname:short)", "refs/heads"))
+
+    def test_list_graph_merged_branches_uses_refs_heads_only(self):
+        with patch("scripts.cleanup_merged_branches.git_lines", return_value=("main",)) as git_lines:
+            branches = list_graph_merged_branches("origin/main")
+
+        self.assertEqual(branches, ("main",))
+        git_lines.assert_called_once_with(
+            ("for-each-ref", "--merged=origin/main", "--format=%(refname:short)", "refs/heads")
+        )
 
     def test_inspect_local_base_status_reports_behind(self):
         with patch("scripts.cleanup_merged_branches.run_command") as run_command:


### PR DESCRIPTION
## Summary

- Fix branch lifecycle cleanup to inventory only real local refs under `refs/heads`.
- Prevent detached HEAD labels such as `(HEAD detached at origin/main)` from appearing as cleanup candidates.
- Add focused tests for the refs-only branch inventory helpers.

## Contract Impact

- Canonical surface: local developer script `scripts/cleanup_merged_branches.py`.
- Request shape: unchanged command-line flags.
- Response shape: cleanup report no longer includes detached HEAD pseudo-labels as branches.
- Status codes: not applicable - no backend endpoint changed.
- Frontend consumer: not applicable - no frontend runtime consumer changed.
- Compatibility path or alias: not applicable - local tooling only.
- Contract proof: targeted unittest covers refs-only branch inventory and dry-run was run after a detached-head cleanup scenario.

## RBAC / Permissions

not applicable - no application auth, user roles, permissions, or protected runtime routes changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, queue realtime, or background delivery behavior changed.

## Frontend Resilience

- Empty data proof: dry-run reports `Delete candidates: none` when no real branch is cleanable.
- Partial data proof: active worktree branches remain kept and reported.
- Forbidden secondary path behavior: not applicable - no frontend route or secondary API path changed.
- Missing draft/resource behavior: not applicable - no user draft/resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `scripts/cleanup_merged_branches.py`, `test_cleanup_merged_branches.py`.
- Denied paths: backend runtime, frontend runtime, migrations, generated output, and unrelated worktree state.
- Migration/docs/test impact: no migration; targeted unittest updated; no docs change needed because operator command remains unchanged.
- Rollback note: revert commit `acbd5de9` to restore the previous branch inventory implementation.

## Validation

- Targeted tests or smoke run: `py -3 -m unittest test_cleanup_merged_branches.py`; `py -3 -m py_compile scripts\cleanup_merged_branches.py test_cleanup_merged_branches.py`; `py -3 scripts\cleanup_merged_branches.py --repo drsapaev/final --prune-worktrees --no-fetch --sync-local-base`; `py -3 scripts\cleanup_merged_branches.py --repo drsapaev/final --prune-worktrees --no-fetch`.
- Result: passed locally; dry-run no longer reports detached HEAD as a delete candidate.
- Not checked: full backend/frontend runtime suites, because this PR only changes local Git lifecycle tooling tests.