### PR TITLE
fix(frontend): label voice to text icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 103
-Baseline entries: 103
+Findings: 93
+Baseline entries: 93
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 103 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 93 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -93,7 +93,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: billing manager invoice/payment action labels cleanup removed 6 component findings.
 - 2026-05-22: dynamic pricing action labels cleanup removed 7 component findings.
 - 2026-05-22: webhook manager action labels cleanup removed 6 component findings.
-- Current component-aware baseline: 103 findings.
+- 2026-05-22: voice-to-text action labels cleanup removed 10 component findings.
+- Current component-aware baseline: 93 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T14:15:34.287Z",
+  "generatedAt": "2026-05-22T14:27:32.366Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -560,86 +560,6 @@
       "file": "src/components/ai/TreatmentRecommendations_backup.jsx",
       "line": 750,
       "column": 11,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ai/VoiceToText.jsx:340:15:MacOSButton:missing-accessible-name",
-      "file": "src/components/ai/VoiceToText.jsx",
-      "line": 340,
-      "column": 15,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ai/VoiceToText.jsx:359:15:MacOSButton:missing-accessible-name",
-      "file": "src/components/ai/VoiceToText.jsx",
-      "line": 359,
-      "column": 15,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ai/VoiceToText.jsx:323:9:MacOSButton:missing-accessible-name",
-      "file": "src/components/ai/VoiceToText.jsx",
-      "line": 323,
-      "column": 9,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ai/VoiceToText.jsx:593:11:MacOSButton:missing-accessible-name",
-      "file": "src/components/ai/VoiceToText.jsx",
-      "line": 593,
-      "column": 11,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ai/VoiceToText.jsx:670:11:MacOSButton:missing-accessible-name",
-      "file": "src/components/ai/VoiceToText.jsx",
-      "line": 670,
-      "column": 11,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ai/VoiceToText.jsx:747:11:MacOSButton:missing-accessible-name",
-      "file": "src/components/ai/VoiceToText.jsx",
-      "line": 747,
-      "column": 11,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ai/VoiceToText.jsx:825:11:MacOSButton:missing-accessible-name",
-      "file": "src/components/ai/VoiceToText.jsx",
-      "line": 825,
-      "column": 11,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ai/VoiceToText.jsx:938:19:MacOSButton:missing-accessible-name",
-      "file": "src/components/ai/VoiceToText.jsx",
-      "line": 938,
-      "column": 19,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ai/VoiceToText.jsx:946:17:MacOSButton:missing-accessible-name",
-      "file": "src/components/ai/VoiceToText.jsx",
-      "line": 946,
-      "column": 17,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/ai/VoiceToText.jsx:1229:17:MacOSButton:missing-accessible-name",
-      "file": "src/components/ai/VoiceToText.jsx",
-      "line": 1229,
-      "column": 17,
       "element": "MacOSButton",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/ai/VoiceToText.jsx
+++ b/frontend/src/components/ai/VoiceToText.jsx
@@ -321,6 +321,9 @@ const VoiceToText = () => {
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '16px' }}>
           {!isRecording ?
         <MacOSButton
+          type="button"
+          title="Start voice recording"
+          aria-label="Start voice recording"
           onClick={startRecording}
           style={{
             width: '64px',
@@ -332,12 +335,15 @@ const VoiceToText = () => {
             alignItems: 'center',
             justifyContent: 'center'
           }}>
-          
-              <Mic style={{ width: '32px', height: '32px', color: 'white' }} />
+
+              <Mic aria-hidden="true" style={{ width: '32px', height: '32px', color: 'white' }} />
             </MacOSButton> :
 
         <>
               <MacOSButton
+            type="button"
+            title={isPaused ? 'Resume voice recording' : 'Pause voice recording'}
+            aria-label={isPaused ? 'Resume voice recording' : 'Pause voice recording'}
             onClick={pauseRecording}
             style={{
               width: '48px',
@@ -349,14 +355,17 @@ const VoiceToText = () => {
               alignItems: 'center',
               justifyContent: 'center'
             }}>
-            
-                {isPaused ?
-            <Play style={{ width: '24px', height: '24px', color: 'white' }} /> :
 
-            <Pause style={{ width: '24px', height: '24px', color: 'white' }} />
+                {isPaused ?
+            <Play aria-hidden="true" style={{ width: '24px', height: '24px', color: 'white' }} /> :
+
+            <Pause aria-hidden="true" style={{ width: '24px', height: '24px', color: 'white' }} />
             }
               </MacOSButton>
               <MacOSButton
+            type="button"
+            title="Stop voice recording"
+            aria-label="Stop voice recording"
             onClick={stopRecording}
             style={{
               width: '64px',
@@ -368,8 +377,8 @@ const VoiceToText = () => {
               alignItems: 'center',
               justifyContent: 'center'
             }}>
-            
-                <Square style={{ width: '32px', height: '32px', color: 'white' }} />
+
+                <Square aria-hidden="true" style={{ width: '32px', height: '32px', color: 'white' }} />
               </MacOSButton>
             </>
         }
@@ -591,13 +600,16 @@ const VoiceToText = () => {
         
         <div style={{ display: 'flex', justifyContent: 'center' }}>
           <MacOSButton
+          type="button"
+          title={loading ? 'Structuring medical text' : 'Structure medical text'}
+          aria-label={loading ? 'Structuring medical text' : 'Structure medical text'}
           onClick={handleStructuring}
           disabled={loading || !textInput.trim()}
           style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
           
             {loading ?
           <>
-                <Loader style={{
+                <Loader aria-hidden="true" style={{
               width: '20px',
               height: '20px',
               animation: 'spin 1s linear infinite'
@@ -606,7 +618,7 @@ const VoiceToText = () => {
               </> :
 
           <>
-                <FileText style={{ width: '20px', height: '20px' }} />
+                <FileText aria-hidden="true" style={{ width: '20px', height: '20px' }} />
                 Структурировать
               </>
           }
@@ -668,13 +680,16 @@ const VoiceToText = () => {
         
         <div style={{ display: 'flex', justifyContent: 'center' }}>
           <MacOSButton
+          type="button"
+          title={loading ? 'Extracting medical entities' : 'Extract medical entities'}
+          aria-label={loading ? 'Extracting medical entities' : 'Extract medical entities'}
           onClick={handleEntityExtraction}
           disabled={loading || !textInput.trim()}
           style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
           
             {loading ?
           <>
-                <Loader style={{
+                <Loader aria-hidden="true" style={{
               width: '20px',
               height: '20px',
               animation: 'spin 1s linear infinite'
@@ -683,7 +698,7 @@ const VoiceToText = () => {
               </> :
 
           <>
-                <Brain style={{ width: '20px', height: '20px' }} />
+                <Brain aria-hidden="true" style={{ width: '20px', height: '20px' }} />
                 Извлечь сущности
               </>
           }
@@ -745,13 +760,16 @@ const VoiceToText = () => {
         
         <div style={{ display: 'flex', justifyContent: 'center' }}>
           <MacOSButton
+          type="button"
+          title={loading ? 'Creating medical summary' : 'Create medical summary'}
+          aria-label={loading ? 'Creating medical summary' : 'Create medical summary'}
           onClick={handleSummaryGeneration}
           disabled={loading || !textInput.trim()}
           style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
           
             {loading ?
           <>
-                <Loader style={{
+                <Loader aria-hidden="true" style={{
               width: '20px',
               height: '20px',
               animation: 'spin 1s linear infinite'
@@ -760,7 +778,7 @@ const VoiceToText = () => {
               </> :
 
           <>
-                <Edit3 style={{ width: '20px', height: '20px' }} />
+                <Edit3 aria-hidden="true" style={{ width: '20px', height: '20px' }} />
                 Создать резюме
               </>
           }
@@ -823,13 +841,16 @@ const VoiceToText = () => {
         
         <div style={{ display: 'flex', justifyContent: 'center' }}>
           <MacOSButton
+          type="button"
+          title={loading ? 'Validating medical record' : 'Validate medical record'}
+          aria-label={loading ? 'Validating medical record' : 'Validate medical record'}
           onClick={handleValidation}
           disabled={loading || !textInput.trim()}
           style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
           
             {loading ?
           <>
-                <Loader style={{
+                <Loader aria-hidden="true" style={{
               width: '20px',
               height: '20px',
               animation: 'spin 1s linear infinite'
@@ -838,7 +859,7 @@ const VoiceToText = () => {
               </> :
 
           <>
-                <CheckCircle style={{ width: '20px', height: '20px' }} />
+                <CheckCircle aria-hidden="true" style={{ width: '20px', height: '20px' }} />
                 Валидировать
               </>
           }
@@ -936,19 +957,25 @@ const VoiceToText = () => {
                 </h4>
                 <div style={{ display: 'flex', gap: '8px' }}>
                   <MacOSButton
+                  type="button"
+                  title={isEditing ? 'Close transcription editor' : 'Edit transcribed text'}
+                  aria-label={isEditing ? 'Close transcription editor' : 'Edit transcribed text'}
                   onClick={() => setIsEditing(!isEditing)}
                   variant="outline"
                   style={{ padding: '4px', minWidth: 'auto' }}>
-                  
-                    <Edit3 style={{ width: '16px', height: '16px' }} />
+
+                    <Edit3 aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                   </MacOSButton>
                   {isEditing &&
                 <MacOSButton
+                  type="button"
+                  title="Save edited transcription"
+                  aria-label="Save edited transcription"
                   onClick={saveEditedText}
                   variant="outline"
                   style={{ padding: '4px', minWidth: 'auto' }}>
-                  
-                      <Save style={{ width: '16px', height: '16px' }} />
+
+                      <Save aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                     </MacOSButton>
                 }
                 </div>
@@ -1227,13 +1254,16 @@ const VoiceToText = () => {
             {activeTab === 'transcription' && audioBlob &&
             <div style={{ marginTop: '24px', display: 'flex', justifyContent: 'center' }}>
                 <MacOSButton
+                type="button"
+                title={loading ? 'Transcribing audio' : 'Transcribe audio'}
+                aria-label={loading ? 'Transcribing audio' : 'Transcribe audio'}
                 onClick={handleTranscription}
                 disabled={loading}
                 style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                 
                   {loading ?
                 <>
-                      <Loader style={{
+                      <Loader aria-hidden="true" style={{
                     width: '20px',
                     height: '20px',
                     animation: 'spin 1s linear infinite'
@@ -1242,7 +1272,7 @@ const VoiceToText = () => {
                     </> :
 
                 <>
-                      <Brain style={{ width: '20px', height: '20px' }} />
+                      <Brain aria-hidden="true" style={{ width: '20px', height: '20px' }} />
                       Транскрибировать
                     </>
                 }


### PR DESCRIPTION
## Summary
- Added accessible names/titles to `VoiceToText` recording, processing, transcription edit/save, and transcribe action buttons.
- Marked decorative action icons as `aria-hidden` for the touched controls.
- Reduced the component-aware icon-only controls baseline from 103 to 93 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend AI `VoiceToText` action buttons only.
- Request shape: not applicable - no audio upload form payload, AI request body, or validation contract changed.
- Response shape: not applicable - no AI transcription/processing response contract changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: `frontend/src/components/ai/VoiceToText.jsx` voice recording and text-processing UI controls.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing access to the AI voice/text UI remains controlled by current app routing and auth logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, or bot event channel changed.
- Payload version / ack behavior: not applicable - no event payload, delivery acknowledgement, or retry behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - empty result rendering code was not edited.
- Partial data proof: unchanged - existing result/text fallback behavior was not edited.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/ai/VoiceToText.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, AI endpoint contracts, auth/RBAC, payment, queue, EMR, lab, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous button markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 93 findings / 93 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing AI voice/text controls and does not change runtime behavior.