### PR TITLE
fix(frontend): label service catalog icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 53
-Baseline entries: 53
+Findings: 49
+Baseline entries: 49
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 53 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 49 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -101,7 +101,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: quality control action labels cleanup removed 5 component findings.
 - 2026-05-22: treatment recommendations action labels cleanup removed 4 component findings.
 - 2026-05-22: backup treatment recommendations action labels cleanup removed 4 component findings.
-- Current component-aware baseline: 53 findings.
+- 2026-05-22: service catalog action labels cleanup removed 4 component findings.
+- Current component-aware baseline: 49 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T15:15:45.638Z",
+  "generatedAt": "2026-05-22T15:24:58.171Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -192,38 +192,6 @@
       "file": "src/components/admin/SecuritySettings.jsx",
       "line": 625,
       "column": 15,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/ServiceCatalog.jsx:740:19:MacOSButton:title-only",
-      "file": "src/components/admin/ServiceCatalog.jsx",
-      "line": 740,
-      "column": 19,
-      "element": "MacOSButton",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/ServiceCatalog.jsx:757:19:MacOSButton:title-only",
-      "file": "src/components/admin/ServiceCatalog.jsx",
-      "line": 757,
-      "column": 19,
-      "element": "MacOSButton",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/ServiceCatalog.jsx:774:19:MacOSButton:title-only",
-      "file": "src/components/admin/ServiceCatalog.jsx",
-      "line": 774,
-      "column": 19,
-      "element": "MacOSButton",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/admin/ServiceCatalog.jsx:858:13:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/ServiceCatalog.jsx",
-      "line": 858,
-      "column": 13,
       "element": "MacOSButton",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/admin/ServiceCatalog.jsx
+++ b/frontend/src/components/admin/ServiceCatalog.jsx
@@ -738,8 +738,10 @@ const ServiceCatalog = () => {
               actions:
               <div style={{ display: 'flex', gap: '8px' }}>
                   <MacOSButton
+                  type="button"
                   size="sm"
                   variant="outline"
+                  aria-label={`View change history for ${service.name}`}
                   onClick={() => setShowHistory({ serviceId: service.id, serviceName: service.name })}
                   style={{
                     padding: '6px',
@@ -752,11 +754,13 @@ const ServiceCatalog = () => {
                   }}
                   title="История изменений">
 
-                    <History size={14} />
+                    <History aria-hidden="true" size={14} />
                   </MacOSButton>
                   <MacOSButton
+                  type="button"
                   size="sm"
                   variant="outline"
+                  aria-label={`Edit service ${service.name}`}
                   onClick={() => setEditingService(service)}
                   style={{
                     padding: '6px',
@@ -769,11 +773,13 @@ const ServiceCatalog = () => {
                   }}
                   title="Редактировать">
 
-                    <Edit size={14} />
+                    <Edit aria-hidden="true" size={14} />
                   </MacOSButton>
                   <MacOSButton
+                  type="button"
                   size="sm"
                   variant="outline"
+                  aria-label={`Delete service ${service.name}`}
                   onClick={() => handleDeleteService(service.id)}
                   style={{
                     padding: '6px',
@@ -788,7 +794,7 @@ const ServiceCatalog = () => {
                   }}
                   title="Удалить">
 
-                    <Trash2 size={14} />
+                    <Trash2 aria-hidden="true" size={14} />
                   </MacOSButton>
                 </div>
 
@@ -856,7 +862,10 @@ const ServiceCatalog = () => {
             position: 'relative'
           }}>
             <MacOSButton
+              type="button"
               variant="outline"
+              title="Close service history"
+              aria-label="Close service history"
               onClick={() => setShowHistory(null)}
               style={{
                 position: 'absolute',
@@ -866,7 +875,7 @@ const ServiceCatalog = () => {
                 backgroundColor: 'var(--mac-bg-primary)'
               }}
             >
-              <X size={16} />
+              <X aria-hidden="true" size={16} />
             </MacOSButton>
             <ServiceAuditHistory
               serviceId={showHistory.serviceId}


### PR DESCRIPTION
## Summary
- Added robust accessible names to `ServiceCatalog` icon-only row action buttons and the service-history close button.
- Marked touched decorative ServiceCatalog action icons as `aria-hidden`.
- Reduced the component-aware icon-only controls baseline from 53 to 49 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend admin `ServiceCatalog` action buttons only.
- Request shape: not applicable - no service catalog request payload, mutation body, or query parameter changed.
- Response shape: not applicable - no service catalog response shape or table data contract changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: `frontend/src/components/admin/ServiceCatalog.jsx` row action controls and service-history modal close control.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing admin access to service catalog remains controlled by current app routing and auth logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered admin controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, or service event channel changed.
- Payload version / ack behavior: not applicable - no event payload, acknowledgement, or retry behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - empty-state rendering code was not edited.
- Partial data proof: row action accessible names include the current service name so repeated controls remain distinct.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/ServiceCatalog.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, service catalog endpoint contracts, auth/RBAC, payment, queue, EMR, lab, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous ServiceCatalog button markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 49 findings / 49 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing admin controls and does not change runtime behavior.