### PR TITLE
fix(frontend): label reports manager icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 49
-Baseline entries: 49
+Findings: 46
+Baseline entries: 46
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 49 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 46 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -102,7 +102,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: treatment recommendations action labels cleanup removed 4 component findings.
 - 2026-05-22: backup treatment recommendations action labels cleanup removed 4 component findings.
 - 2026-05-22: service catalog action labels cleanup removed 4 component findings.
-- Current component-aware baseline: 49 findings.
+- 2026-05-22: reports manager action labels cleanup removed 3 component findings.
+- Current component-aware baseline: 46 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T15:24:58.171Z",
+  "generatedAt": "2026-05-22T15:32:23.433Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -161,30 +161,6 @@
       "line": 731,
       "column": 11,
       "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/ReportsManager.jsx:314:11:Button:missing-accessible-name",
-      "file": "src/components/admin/ReportsManager.jsx",
-      "line": 314,
-      "column": 11,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/ReportsManager.jsx:439:11:Button:missing-accessible-name",
-      "file": "src/components/admin/ReportsManager.jsx",
-      "line": 439,
-      "column": 11,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/ReportsManager.jsx:543:11:Button:missing-accessible-name",
-      "file": "src/components/admin/ReportsManager.jsx",
-      "line": 543,
-      "column": 11,
-      "element": "Button",
       "reason": "missing-accessible-name"
     },
     {

--- a/frontend/src/components/admin/ReportsManager.jsx
+++ b/frontend/src/components/admin/ReportsManager.jsx
@@ -312,6 +312,9 @@ const ReportsManager = () => {
 
         <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
           <Button
+          type="button"
+          title={loading ? 'Generating report' : 'Generate report'}
+          aria-label={loading ? 'Generating report' : 'Generate report'}
           onClick={generateReport}
           disabled={loading}
           style={{
@@ -328,12 +331,12 @@ const ReportsManager = () => {
 
             {loading ?
           <>
-                <Loader2 style={{ width: '18px', height: '18px', animation: 'spin 1s linear infinite' }} className="animate-spin" />
+                <Loader2 aria-hidden="true" style={{ width: '18px', height: '18px', animation: 'spin 1s linear infinite' }} className="animate-spin" />
                 <span>Генерация...</span>
               </> :
 
           <>
-                <FileText style={{ width: '18px', height: '18px' }} />
+                <FileText aria-hidden="true" style={{ width: '18px', height: '18px' }} />
                 <span>Сгенерировать отчет</span>
               </>
           }
@@ -436,8 +439,14 @@ const ReportsManager = () => {
           header: 'Действия',
           align: 'right',
           render: (row) =>
-          <Button size="sm" variant="outline" onClick={() => downloadFile(row.filename)}>
-                    <Download style={{ width: '16px', height: '16px' }} />
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            title={`Download report ${row.filename}`}
+            aria-label={`Download report ${row.filename}`}
+            onClick={() => downloadFile(row.filename)}>
+                    <Download aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                   </Button>
 
         }]
@@ -541,11 +550,14 @@ const ReportsManager = () => {
           align: 'right',
           render: (row) =>
           <Button
+            type="button"
             size="sm"
             variant="ghost"
+            title={`Download report file ${row.filename}`}
+            aria-label={`Download report file ${row.filename}`}
             onClick={() => downloadFile(row.filename)}>
 
-                    <Download style={{ width: '18px', height: '18px', color: 'var(--mac-text-secondary)' }} />
+                    <Download aria-hidden="true" style={{ width: '18px', height: '18px', color: 'var(--mac-text-secondary)' }} />
                   </Button>
 
         }]


### PR DESCRIPTION
## Summary
- Added robust accessible names to `ReportsManager` generate and download action buttons.
- Marked touched decorative ReportsManager action icons as `aria-hidden`.
- Reduced the component-aware icon-only controls baseline from 49 to 46 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend admin `ReportsManager` action buttons only.
- Request shape: not applicable - no report generation request payload, filter, or download parameter changed.
- Response shape: not applicable - no report response shape or table data contract changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: `frontend/src/components/admin/ReportsManager.jsx` generate and download controls.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing admin/report access remains controlled by current app routing and auth logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered admin report controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, or report event channel changed.
- Payload version / ack behavior: not applicable - no event payload, acknowledgement, or retry behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - empty-state rendering code was not edited.
- Partial data proof: download controls include the report filename so repeated controls remain distinct.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/ReportsManager.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, report endpoint contracts, auth/RBAC, payment, queue, EMR, lab, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous ReportsManager button markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 46 findings / 46 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing admin report controls and does not change runtime behavior.