### PR TITLE
fix(frontend): label lab results icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 46
-Baseline entries: 46
+Findings: 43
+Baseline entries: 43
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 46 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 43 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -103,7 +103,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: backup treatment recommendations action labels cleanup removed 4 component findings.
 - 2026-05-22: service catalog action labels cleanup removed 4 component findings.
 - 2026-05-22: reports manager action labels cleanup removed 3 component findings.
-- Current component-aware baseline: 46 findings.
+- 2026-05-22: lab results manager action labels cleanup removed 3 component findings.
+- Current component-aware baseline: 43 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T15:32:23.433Z",
+  "generatedAt": "2026-05-22T15:40:24.012Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -306,30 +306,6 @@
       "column": 17,
       "element": "Button",
       "reason": "title-only"
-    },
-    {
-      "signature": "src/components/laboratory/LabResultsManager.jsx:404:25:Button:missing-accessible-name",
-      "file": "src/components/laboratory/LabResultsManager.jsx",
-      "line": 404,
-      "column": 25,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/laboratory/LabResultsManager.jsx:414:25:Button:missing-accessible-name",
-      "file": "src/components/laboratory/LabResultsManager.jsx",
-      "line": 414,
-      "column": 25,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/laboratory/LabResultsManager.jsx:605:15:Button:missing-accessible-name",
-      "file": "src/components/laboratory/LabResultsManager.jsx",
-      "line": 605,
-      "column": 15,
-      "element": "Button",
-      "reason": "missing-accessible-name"
     },
     {
       "signature": "src/components/statistics/ModernStatistics.jsx:294:11:Button:title-only",

--- a/frontend/src/components/laboratory/LabResultsManager.jsx
+++ b/frontend/src/components/laboratory/LabResultsManager.jsx
@@ -402,21 +402,27 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
                       
                       <td style={{ textAlign: 'right' }}>
                         <Button
+                      type="button"
                       size="small"
+                      title={`Edit lab result ${result.test_name || result.id}`}
+                      aria-label={`Edit lab result ${result.test_name || result.id}`}
                       onClick={() => {
                         setSelectedResult(result);
                         setResultForm(result);
                         setDialogOpen(true);
                       }}>
                       
-                          <Edit style={{ width: 16, height: 16 }} />
+                          <Edit aria-hidden="true" style={{ width: 16, height: 16 }} />
                         </Button>
                         <Button
+                      type="button"
                       size="small"
                       variant="danger"
+                      title={`Delete lab result ${result.test_name || result.id}`}
+                      aria-label={`Delete lab result ${result.test_name || result.id}`}
                       onClick={() => handleDeleteResult(result.id)}>
 
-                          <Trash2 style={{ width: 16, height: 16 }} />
+                          <Trash2 aria-hidden="true" style={{ width: 16, height: 16 }} />
                         </Button>
                       </td>
                     </tr>
@@ -602,8 +608,13 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
                 <Brain style={{ marginRight: 8, verticalAlign: 'middle' }} />
                 AI Интерпретация результатов
               </Typography>
-              <Button size="small" onClick={() => setShowAIAnalysis(false)}>
-                <X style={{ width: 16, height: 16 }} />
+              <Button
+                type="button"
+                size="small"
+                title="Close lab AI analysis"
+                aria-label="Close lab AI analysis"
+                onClick={() => setShowAIAnalysis(false)}>
+                <X aria-hidden="true" style={{ width: 16, height: 16 }} />
               </Button>
             </Box>
           </DialogTitle>


### PR DESCRIPTION
## Summary
- Added robust accessible names to `LabResultsManager` result edit/delete buttons and the lab AI-analysis close button.
- Marked touched decorative lab result action icons as `aria-hidden`.
- Reduced the component-aware icon-only controls baseline from 46 to 43 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend laboratory `LabResultsManager` action buttons only.
- Request shape: not applicable - no lab result create/update/delete request payload changed.
- Response shape: not applicable - no lab result response shape or table data contract changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: `frontend/src/components/laboratory/LabResultsManager.jsx` edit/delete and AI-analysis close controls.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing lab access remains controlled by current app routing and auth logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered lab controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, or lab result event channel changed.
- Payload version / ack behavior: not applicable - no event payload, acknowledgement, or retry behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - empty-state rendering code was not edited.
- Partial data proof: row action accessible names include the current lab result test name or id so repeated controls remain distinct.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/laboratory/LabResultsManager.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, lab endpoint contracts, auth/RBAC, payment, queue, EMR, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous LabResultsManager button markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 43 findings / 43 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing lab controls and does not change runtime behavior.