### PR TITLE
fix(frontend): label doctor service selector icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 43
-Baseline entries: 43
+Findings: 40
+Baseline entries: 40
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 43 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 40 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -104,7 +104,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: service catalog action labels cleanup removed 4 component findings.
 - 2026-05-22: reports manager action labels cleanup removed 3 component findings.
 - 2026-05-22: lab results manager action labels cleanup removed 3 component findings.
-- Current component-aware baseline: 43 findings.
+- 2026-05-22: doctor service selector action labels cleanup removed 3 component findings.
+- Current component-aware baseline: 40 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T15:40:24.012Z",
+  "generatedAt": "2026-05-22T18:24:27.100Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -273,30 +273,6 @@
       "line": 150,
       "column": 15,
       "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/doctor/DoctorServiceSelector.jsx:301:21:MacOSButton:missing-accessible-name",
-      "file": "src/components/doctor/DoctorServiceSelector.jsx",
-      "line": 301,
-      "column": 21,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/doctor/DoctorServiceSelector.jsx:315:21:MacOSButton:missing-accessible-name",
-      "file": "src/components/doctor/DoctorServiceSelector.jsx",
-      "line": 315,
-      "column": 21,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/doctor/DoctorServiceSelector.jsx:367:19:MacOSButton:missing-accessible-name",
-      "file": "src/components/doctor/DoctorServiceSelector.jsx",
-      "line": 367,
-      "column": 19,
-      "element": "MacOSButton",
       "reason": "missing-accessible-name"
     },
     {

--- a/frontend/src/components/doctor/DoctorServiceSelector.jsx
+++ b/frontend/src/components/doctor/DoctorServiceSelector.jsx
@@ -299,12 +299,15 @@ const DoctorServiceSelector = ({
                 gap: '8px'
               }}>
                     <MacOSButton
+                  type="button"
                   size="sm"
                   variant="ghost"
+                  title={`Decrease quantity for ${service.name}`}
+                  aria-label={`Decrease quantity for ${service.name}`}
                   onClick={() => handleQuantityChange(service.id, service.quantity - 1)}
                   disabled={service.quantity <= 1}>
-                  
-                      <Minus size={14} />
+
+                      <Minus aria-hidden="true" size={14} />
                     </MacOSButton>
                     <span style={{
                   width: '32px',
@@ -313,11 +316,14 @@ const DoctorServiceSelector = ({
                   color: 'var(--mac-text-primary)'
                 }}>{service.quantity}</span>
                     <MacOSButton
+                  type="button"
                   size="sm"
                   variant="ghost"
+                  title={`Increase quantity for ${service.name}`}
+                  aria-label={`Increase quantity for ${service.name}`}
                   onClick={() => handleQuantityChange(service.id, service.quantity + 1)}>
-                  
-                      <Plus size={14} />
+
+                      <Plus aria-hidden="true" size={14} />
                     </MacOSButton>
                   </div>
 
@@ -365,11 +371,14 @@ const DoctorServiceSelector = ({
 
                   {/* Убрать услугу */}
                   <MacOSButton
+                type="button"
                 size="sm"
                 variant="ghost"
+                title={`Remove service ${service.name}`}
+                aria-label={`Remove service ${service.name}`}
                 onClick={() => handleServiceToggle(service)}>
-                
-                    <Minus size={14} />
+
+                    <Minus aria-hidden="true" size={14} />
                   </MacOSButton>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Added accessible names to `DoctorServiceSelector` quantity and remove-service icon buttons.
- Marked touched decorative doctor service selector action icons as `aria-hidden`.
- Reduced the component-aware icon-only controls baseline from 43 to 40 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend doctor `DoctorServiceSelector` action buttons only.
- Request shape: not applicable - no service selection request payload, price field, or appointment/service parameter changed.
- Response shape: not applicable - no service catalog response shape or selected service data contract changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: `frontend/src/components/doctor/DoctorServiceSelector.jsx` selected-service quantity and remove controls.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing doctor service selector access remains controlled by current app routing and auth logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered doctor service controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, or service event channel changed.
- Payload version / ack behavior: not applicable - no event payload, acknowledgement, or retry behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - empty/loading/error rendering code was not edited.
- Partial data proof: quantity and remove controls include the selected service name so repeated controls remain distinct.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/doctor/DoctorServiceSelector.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, service catalog endpoint contracts, auth/RBAC, payment, queue, EMR, lab, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous DoctorServiceSelector button markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 40 findings / 40 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing doctor service controls and does not change runtime behavior.