### PR TITLE
fix(frontend): label doctor panel icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 38
-Baseline entries: 38
+Findings: 36
+Baseline entries: 36
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 38 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 36 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -106,7 +106,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: lab results manager action labels cleanup removed 3 component findings.
 - 2026-05-22: doctor service selector action labels cleanup removed 3 component findings.
 - 2026-05-22: system management backup action labels cleanup removed 2 component findings.
-- Current component-aware baseline: 38 findings.
+- 2026-05-22: doctor panel mobile action labels cleanup removed 2 component findings.
+- Current component-aware baseline: 36 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T18:32:15.899Z",
+  "generatedAt": "2026-05-22T18:37:44.247Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -290,22 +290,6 @@
       "column": 25,
       "element": "MacOSButton",
       "reason": "title-only"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:910:21:Button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 910,
-      "column": 21,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/pages/DoctorPanel.jsx:1090:21:Button:missing-accessible-name",
-      "file": "src/pages/DoctorPanel.jsx",
-      "line": 1090,
-      "column": 21,
-      "element": "Button",
-      "reason": "missing-accessible-name"
     }
   ]
 }

--- a/frontend/src/pages/DoctorPanel.jsx
+++ b/frontend/src/pages/DoctorPanel.jsx
@@ -907,8 +907,12 @@ const DoctorPanel = () => {
                       <option value="recovery">Выздоравливающие</option>
                       <option value="critical">Критические</option>
                     </select>
-                    <Button variant="primary">
-                      <Plus size={16} />
+                    <Button
+                      type="button"
+                      variant="primary"
+                      title="Add patient"
+                      aria-label="Add patient">
+                      <Plus aria-hidden="true" size={16} />
                       {!isMobile && <span>Добавить</span>}
                     </Button>
                   </div>
@@ -1088,10 +1092,13 @@ const DoctorPanel = () => {
                       <option value="cancelled">Отменены</option>
                     </select>
                     <Button
+                    type="button"
                     variant="primary"
+                    title="Schedule next visit"
+                    aria-label="Schedule next visit"
                     onClick={() => setScheduleNextModal({ open: true, patient: null })}>
 
-                      <Plus size={16} />
+                      <Plus aria-hidden="true" size={16} />
                       {!isMobile && <span>Назначить следующий визит</span>}
                     </Button>
                   </div>


### PR DESCRIPTION
## Summary
- Added robust accessible names to mobile-sensitive `DoctorPanel` primary action icon buttons.
- Marked touched plus icons as decorative with `aria-hidden`.
- Reduced the component-aware icon-only controls baseline from 38 to 36 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend doctor panel primary patient and appointment action buttons only.
- Request shape: not applicable - no patient, appointment, queue, EMR, or visit request payload changed.
- Response shape: not applicable - no doctor panel response consumption or API data shape changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: `frontend/src/pages/DoctorPanel.jsx` patient add and schedule-next-visit action controls.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing doctor panel access remains controlled by current app routing and auth logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered doctor panel controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, queue, or visit event channel changed.
- Payload version / ack behavior: not applicable - no event payload, acknowledgement, or retry behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - empty/loading/error rendering code was not edited.
- Partial data proof: mobile action controls now keep explicit accessible names when visible text is hidden.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/pages/DoctorPanel.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, doctor/appointment endpoint contracts, auth/RBAC, payment, queue, EMR, lab, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous DoctorPanel action markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 36 findings / 36 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing doctor panel controls and does not change runtime behavior.