### PR TITLE
fix(frontend): label display board icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 36
-Baseline entries: 36
+Findings: 34
+Baseline entries: 34
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 36 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 34 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -107,7 +107,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: doctor service selector action labels cleanup removed 3 component findings.
 - 2026-05-22: system management backup action labels cleanup removed 2 component findings.
 - 2026-05-22: doctor panel mobile action labels cleanup removed 2 component findings.
-- Current component-aware baseline: 36 findings.
+- 2026-05-22: display board banner action labels cleanup removed 2 component findings.
+- Current component-aware baseline: 34 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T18:37:44.247Z",
+  "generatedAt": "2026-05-22T18:43:10.417Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -57,22 +57,6 @@
       "line": 170,
       "column": 11,
       "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/DisplayBoardSettings.jsx:578:21:Button:missing-accessible-name",
-      "file": "src/components/admin/DisplayBoardSettings.jsx",
-      "line": 578,
-      "column": 21,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/DisplayBoardSettings.jsx:581:21:Button:missing-accessible-name",
-      "file": "src/components/admin/DisplayBoardSettings.jsx",
-      "line": 581,
-      "column": 21,
-      "element": "Button",
       "reason": "missing-accessible-name"
     },
     {

--- a/frontend/src/components/admin/DisplayBoardSettings.jsx
+++ b/frontend/src/components/admin/DisplayBoardSettings.jsx
@@ -575,11 +575,21 @@ const DisplayBoardSettings = () => {
                     </div>
                   </div>
                   <div className="flex gap-2">
-                    <Button size="sm" variant="outline">
-                      <Edit size={14} />
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      title={`Edit banner ${banner.title}`}
+                      aria-label={`Edit banner ${banner.title}`}>
+                      <Edit aria-hidden="true" size={14} />
                     </Button>
-                    <Button size="sm" variant="outline">
-                      <Trash2 size={14} />
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      title={`Delete banner ${banner.title}`}
+                      aria-label={`Delete banner ${banner.title}`}>
+                      <Trash2 aria-hidden="true" size={14} />
                     </Button>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Added accessible names to `DisplayBoardSettings` banner edit/delete icon buttons.
- Marked touched banner action icons as decorative with `aria-hidden`.
- Reduced the component-aware icon-only controls baseline from 36 to 34 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend admin display board banner action buttons only.
- Request shape: not applicable - no display board, theme, banner, or announcement request payload changed.
- Response shape: not applicable - no display board response consumption or API data shape changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: `frontend/src/components/admin/DisplayBoardSettings.jsx` banner edit/delete action controls.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing admin display board settings access remains controlled by current app routing and auth logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered admin banner controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, display-board, or announcement event channel changed.
- Payload version / ack behavior: not applicable - no event payload, acknowledgement, or retry behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - banner empty-state rendering code was not edited.
- Partial data proof: repeated banner action controls include the banner title in their accessible names.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/DisplayBoardSettings.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, display-board endpoint contracts, auth/RBAC, payment, queue, EMR, lab, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous DisplayBoardSettings banner action markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 34 findings / 34 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing admin banner controls and does not change runtime behavior.