### PR TITLE
fix(frontend): label advanced chart icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 34
-Baseline entries: 34
+Findings: 32
+Baseline entries: 32
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 34 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 32 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -108,7 +108,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: system management backup action labels cleanup removed 2 component findings.
 - 2026-05-22: doctor panel mobile action labels cleanup removed 2 component findings.
 - 2026-05-22: display board banner action labels cleanup removed 2 component findings.
-- Current component-aware baseline: 34 findings.
+- 2026-05-22: advanced charts export/refresh action labels cleanup removed 2 component findings.
+- Current component-aware baseline: 32 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T18:43:10.417Z",
+  "generatedAt": "2026-05-22T18:47:57.615Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -225,22 +225,6 @@
       "line": 1449,
       "column": 15,
       "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/analytics/AdvancedCharts.jsx:143:15:Button:missing-accessible-name",
-      "file": "src/components/analytics/AdvancedCharts.jsx",
-      "line": 143,
-      "column": 15,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/analytics/AdvancedCharts.jsx:150:15:Button:missing-accessible-name",
-      "file": "src/components/analytics/AdvancedCharts.jsx",
-      "line": 150,
-      "column": 15,
-      "element": "Button",
       "reason": "missing-accessible-name"
     },
     {

--- a/frontend/src/components/analytics/AdvancedCharts.jsx
+++ b/frontend/src/components/analytics/AdvancedCharts.jsx
@@ -128,6 +128,7 @@ const AdvancedCharts = ({
 
   const renderChartCard = (chartName, chartConfig) => {
     const canvasId = `advanced-chart-${chartName}`;
+    const chartLabel = chartConfig.options?.plugins?.title?.text || chartName;
 
     return (
       <Card key={chartName} className="w-full">
@@ -136,23 +137,29 @@ const AdvancedCharts = ({
             <div className="flex items-center space-x-2">
               {getChartIcon(chartConfig.type)}
               <h3 className="text-lg font-semibold">
-                {chartConfig.options?.plugins?.title?.text || chartName}
+                {chartLabel}
               </h3>
             </div>
             <div className="flex items-center space-x-2">
               <Button
+                type="button"
                 variant="ghost"
                 size="sm"
+                title={`Export ${chartLabel}`}
+                aria-label={`Export ${chartLabel}`}
                 onClick={() => onExport?.(chartName)}>
-                
-                <Download className="w-4 h-4" />
+
+                <Download aria-hidden="true" className="w-4 h-4" />
               </Button>
               <Button
+                type="button"
                 variant="ghost"
                 size="sm"
+                title={`Refresh ${chartLabel}`}
+                aria-label={`Refresh ${chartLabel}`}
                 onClick={() => onRefresh?.(chartName)}>
-                
-                <RefreshCw className="w-4 h-4" />
+
+                <RefreshCw aria-hidden="true" className="w-4 h-4" />
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Added accessible names to `AdvancedCharts` export and refresh icon buttons.
- Reused the visible chart title as the action label and marked touched icons as decorative.
- Reduced the component-aware icon-only controls baseline from 34 to 32 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend analytics chart card export/refresh action buttons only.
- Request shape: not applicable - no analytics request payload, filters, metrics, or chart data contract changed.
- Response shape: not applicable - no analytics response consumption or chart data shape changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: `frontend/src/components/analytics/AdvancedCharts.jsx` chart action controls.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata, chart label reuse, and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing analytics screen access remains controlled by current app routing and auth logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered analytics controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, analytics, or chart event channel changed.
- Payload version / ack behavior: not applicable - no event payload, acknowledgement, or retry behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - analytics empty/loading behavior was not edited.
- Partial data proof: repeated chart action controls include the chart title so export/refresh buttons remain distinct.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/analytics/AdvancedCharts.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, analytics endpoint contracts, auth/RBAC, payment, queue, EMR, lab, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous AdvancedCharts action markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 32 findings / 32 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing analytics controls and does not change runtime behavior.