### PR TITLE
fix(frontend): label payment provider icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 32
-Baseline entries: 32
+Findings: 30
+Baseline entries: 30
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 32 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 30 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -109,7 +109,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: doctor panel mobile action labels cleanup removed 2 component findings.
 - 2026-05-22: display board banner action labels cleanup removed 2 component findings.
 - 2026-05-22: advanced charts export/refresh action labels cleanup removed 2 component findings.
-- Current component-aware baseline: 32 findings.
+- 2026-05-22: payment provider secret visibility labels cleanup removed 2 component findings.
+- Current component-aware baseline: 30 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T18:47:57.615Z",
+  "generatedAt": "2026-05-22T18:52:52.148Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -96,22 +96,6 @@
       "file": "src/components/admin/PatientModal.jsx",
       "line": 698,
       "column": 11,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/PaymentProviderSettings.jsx:320:21:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/PaymentProviderSettings.jsx",
-      "line": 320,
-      "column": 21,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/PaymentProviderSettings.jsx:404:21:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/PaymentProviderSettings.jsx",
-      "line": 404,
-      "column": 21,
       "element": "MacOSButton",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/admin/PaymentProviderSettings.jsx
+++ b/frontend/src/components/admin/PaymentProviderSettings.jsx
@@ -320,6 +320,8 @@ const PaymentProviderSettings = () => {
                     <MacOSButton
                       type="button"
                       variant="outline"
+                      title={showSecrets.click ? 'Hide Click secret key' : 'Show Click secret key'}
+                      aria-label={showSecrets.click ? 'Hide Click secret key' : 'Show Click secret key'}
                       onClick={() => toggleShowSecret('click')}
                       style={{
                         position: 'absolute',
@@ -333,9 +335,9 @@ const PaymentProviderSettings = () => {
                       }}
                     >
                       {showSecrets.click ? (
-                        <EyeOff style={{ width: '16px', height: '16px' }} />
+                        <EyeOff aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                       ) : (
-                        <Eye style={{ width: '16px', height: '16px' }} />
+                        <Eye aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                       )}
                     </MacOSButton>
                   </div>
@@ -404,6 +406,8 @@ const PaymentProviderSettings = () => {
                     <MacOSButton
                       type="button"
                       variant="outline"
+                      title={showSecrets.payme ? 'Hide Payme secret key' : 'Show Payme secret key'}
+                      aria-label={showSecrets.payme ? 'Hide Payme secret key' : 'Show Payme secret key'}
                       onClick={() => toggleShowSecret('payme')}
                       style={{
                         position: 'absolute',
@@ -417,9 +421,9 @@ const PaymentProviderSettings = () => {
                       }}
                     >
                       {showSecrets.payme ? (
-                        <EyeOff style={{ width: '16px', height: '16px' }} />
+                        <EyeOff aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                       ) : (
-                        <Eye style={{ width: '16px', height: '16px' }} />
+                        <Eye aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                       )}
                     </MacOSButton>
                   </div>


### PR DESCRIPTION
## Summary
- Added accessible names to Click and Payme secret visibility icon buttons in `PaymentProviderSettings`.
- Marked touched eye icons as decorative with `aria-hidden`.
- Reduced the component-aware icon-only controls baseline from 32 to 30 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend admin payment provider secret visibility controls only.
- Request shape: not applicable - no payment provider request payload, settings save shape, or test-payment parameter changed.
- Response shape: not applicable - no payment provider settings response consumption or API data shape changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: `frontend/src/components/admin/PaymentProviderSettings.jsx` Click/Payme secret key visibility buttons.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing admin payment provider settings access remains controlled by current app routing and auth logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered admin payment settings controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, payment, or settings event channel changed.
- Payload version / ack behavior: not applicable - no event payload, acknowledgement, or retry behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - loading/error behavior for provider settings was not edited.
- Partial data proof: secret visibility buttons identify both the provider and current reveal/hide action.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/PaymentProviderSettings.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, payment provider endpoint contracts, auth/RBAC, queue, EMR, lab, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous PaymentProviderSettings secret visibility markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 30 findings / 30 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing admin payment settings controls and does not change runtime behavior.