### PR TITLE
fix(frontend): label wizard settings icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 30
-Baseline entries: 30
+Findings: 28
+Baseline entries: 28
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 30 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 28 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -110,7 +110,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: display board banner action labels cleanup removed 2 component findings.
 - 2026-05-22: advanced charts export/refresh action labels cleanup removed 2 component findings.
 - 2026-05-22: payment provider secret visibility labels cleanup removed 2 component findings.
-- Current component-aware baseline: 30 findings.
+- 2026-05-22: wizard settings save action labels cleanup removed 2 component findings.
+- Current component-aware baseline: 28 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T18:52:52.148Z",
+  "generatedAt": "2026-05-22T18:58:33.998Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -168,22 +168,6 @@
       "file": "src/components/admin/UserModal.jsx",
       "line": 341,
       "column": 11,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/WizardSettings.jsx:449:13:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/WizardSettings.jsx",
-      "line": 449,
-      "column": 13,
-      "element": "MacOSButton",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/WizardSettings.jsx:512:13:MacOSButton:missing-accessible-name",
-      "file": "src/components/admin/WizardSettings.jsx",
-      "line": 512,
-      "column": 13,
       "element": "MacOSButton",
       "reason": "missing-accessible-name"
     },

--- a/frontend/src/components/admin/WizardSettings.jsx
+++ b/frontend/src/components/admin/WizardSettings.jsx
@@ -447,6 +447,9 @@ const WizardSettings = () => {
             </MacOSButton>
             
             <MacOSButton
+              type="button"
+              title={saving ? 'Saving wizard settings' : 'Save wizard settings'}
+              aria-label={saving ? 'Saving wizard settings' : 'Save wizard settings'}
               onClick={handleSave}
               disabled={!hasChanges || saving}
               style={{
@@ -461,7 +464,7 @@ const WizardSettings = () => {
 
               {saving ?
               <>
-                  <RefreshCw style={{
+                  <RefreshCw aria-hidden="true" style={{
                   width: '16px',
                   height: '16px',
                   animation: 'spin 1s linear infinite'
@@ -470,7 +473,7 @@ const WizardSettings = () => {
                 </> :
 
               <>
-                  <Save style={{ width: '16px', height: '16px' }} />
+                  <Save aria-hidden="true" style={{ width: '16px', height: '16px' }} />
                   Сохранить
                 </>
               }
@@ -510,6 +513,9 @@ const WizardSettings = () => {
               Отмена
             </MacOSButton>
             <MacOSButton
+              type="button"
+              title={saving ? 'Saving wizard settings' : 'Confirm wizard settings save'}
+              aria-label={saving ? 'Saving wizard settings' : 'Confirm wizard settings save'}
               onClick={confirmSave}
               disabled={saving}
               style={{
@@ -519,7 +525,7 @@ const WizardSettings = () => {
 
               {saving ?
               <>
-                  <RefreshCw style={{
+                  <RefreshCw aria-hidden="true" style={{
                   width: '16px',
                   height: '16px',
                   animation: 'spin 1s linear infinite',
@@ -529,7 +535,7 @@ const WizardSettings = () => {
                 </> :
 
               <>
-                  <Save style={{
+                  <Save aria-hidden="true" style={{
                   width: '16px',
                   height: '16px',
                   marginRight: '4px'


### PR DESCRIPTION
## Summary
- Added accessible names to `WizardSettings` save and confirm-save action buttons.
- Marked touched save/loading icons as decorative with `aria-hidden`.
- Reduced the component-aware icon-only controls baseline from 30 to 28 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend admin wizard settings save controls only.
- Request shape: not applicable - no wizard settings request payload or admin settings parameter changed.
- Response shape: not applicable - no wizard settings response consumption or API data shape changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: `frontend/src/components/admin/WizardSettings.jsx` save and confirm-save action controls.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing admin wizard settings access remains controlled by current app routing and auth logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered admin wizard settings controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, wizard, or settings event channel changed.
- Payload version / ack behavior: not applicable - no event payload, acknowledgement, or retry behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - loading/error behavior for wizard settings was not edited.
- Partial data proof: save controls now keep explicit accessible names across normal and saving states.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/WizardSettings.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, wizard endpoint contracts, auth/RBAC, payment, queue, EMR, lab, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous WizardSettings save action markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 28 findings / 28 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing admin wizard settings controls and does not change runtime behavior.