### PR TITLE
fix(frontend): label statistics icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 28
-Baseline entries: 28
+Findings: 26
+Baseline entries: 26
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 28 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 26 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -111,7 +111,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: advanced charts export/refresh action labels cleanup removed 2 component findings.
 - 2026-05-22: payment provider secret visibility labels cleanup removed 2 component findings.
 - 2026-05-22: wizard settings save action labels cleanup removed 2 component findings.
-- Current component-aware baseline: 28 findings.
+- 2026-05-22: modern statistics refresh/export labels cleanup removed 2 component findings.
+- Current component-aware baseline: 26 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T18:58:33.998Z",
+  "generatedAt": "2026-05-22T19:04:28.212Z",
   "entries": [
     {
       "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
@@ -200,22 +200,6 @@
       "file": "src/components/examples/MacOSDemo.jsx",
       "line": 218,
       "column": 17,
-      "element": "Button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/statistics/ModernStatistics.jsx:294:11:Button:title-only",
-      "file": "src/components/statistics/ModernStatistics.jsx",
-      "line": 294,
-      "column": 11,
-      "element": "Button",
-      "reason": "title-only"
-    },
-    {
-      "signature": "src/components/statistics/ModernStatistics.jsx:297:11:Button:title-only",
-      "file": "src/components/statistics/ModernStatistics.jsx",
-      "line": 297,
-      "column": 11,
       "element": "Button",
       "reason": "title-only"
     },

--- a/frontend/src/components/statistics/ModernStatistics.jsx
+++ b/frontend/src/components/statistics/ModernStatistics.jsx
@@ -291,11 +291,11 @@ const ModernStatistics = ({
         </h2>
         
         <div style={{ display: 'flex', gap: 'var(--mac-spacing-2)' }}>
-          <Button variant="ghost" size="small" onClick={onRefresh} title={t.refresh}>
-            <Icon name="gear" size="small" />
+          <Button type="button" variant="ghost" size="small" onClick={onRefresh} title={t.refresh} aria-label={t.refresh}>
+            <Icon aria-hidden="true" name="gear" size="small" />
           </Button>
-          <Button variant="primary" size="small" onClick={onExport} title={t.export}>
-            <Icon name="square.and.arrow.up" size="small" style={{ color: 'white' }} />
+          <Button type="button" variant="primary" size="small" onClick={onExport} title={t.export} aria-label={t.export}>
+            <Icon aria-hidden="true" name="square.and.arrow.up" size="small" style={{ color: 'white' }} />
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Added `aria-label` to `ModernStatistics` refresh and export icon buttons.
- Marked touched statistic action icons as decorative with `aria-hidden`.
- Reduced the component-aware icon-only controls baseline from 28 to 26 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend statistics refresh/export action buttons only.
- Request shape: not applicable - no statistics request payload, filters, appointment data, or export parameter changed.
- Response shape: not applicable - no statistics response consumption or computed data shape changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: `frontend/src/components/statistics/ModernStatistics.jsx` refresh/export controls.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing statistics screen access remains controlled by current app routing and auth logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered statistics controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, statistics, or export event channel changed.
- Payload version / ack behavior: not applicable - no event payload, acknowledgement, or retry behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - statistics empty/loading behavior was not edited.
- Partial data proof: refresh/export controls now expose translated accessible names even when rendered as icon-only actions.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/statistics/ModernStatistics.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, statistics endpoint contracts, auth/RBAC, payment, queue, EMR, lab, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous ModernStatistics action markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 26 findings / 26 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing statistics controls and does not change runtime behavior.