### PR TITLE
fix(frontend): label ai settings icon buttons

### DIFF
--- a/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
+++ b/docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md
@@ -46,13 +46,13 @@ Result:
 
 ```text
 Files scanned: 615
-Findings: 26
-Baseline entries: 26
+Findings: 24
+Baseline entries: 24
 New findings: 0
 Stale baseline entries: 0
 ```
 
-The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 26 historical component findings are cleaned up in targeted UI slices.
+The component-aware sweep is now CI-enforced with a separate baseline in `frontend/scripts/a11y/icon-only-component-controls-baseline.json`. This prevents new icon-only `Button`/`MacOSButton` debt while the existing 24 historical component findings are cleaned up in targeted UI slices.
 
 ## Cleanup Progress
 
@@ -112,7 +112,8 @@ The component-aware sweep is now CI-enforced with a separate baseline in `fronte
 - 2026-05-22: payment provider secret visibility labels cleanup removed 2 component findings.
 - 2026-05-22: wizard settings save action labels cleanup removed 2 component findings.
 - 2026-05-22: modern statistics refresh/export labels cleanup removed 2 component findings.
-- Current component-aware baseline: 26 findings.
+- 2026-05-22: AI settings provider action labels cleanup removed 2 component findings.
+- Current component-aware baseline: 24 findings.
 
 ## CI Policy
 

--- a/frontend/scripts/a11y/icon-only-component-controls-baseline.json
+++ b/frontend/scripts/a11y/icon-only-component-controls-baseline.json
@@ -1,24 +1,8 @@
 {
   "version": 1,
   "description": "Temporary baseline for icon-only control accessible-name findings. Remove entries as the UI is cleaned up.",
-  "generatedAt": "2026-05-22T19:04:28.212Z",
+  "generatedAt": "2026-05-22T19:09:38.430Z",
   "entries": [
-    {
-      "signature": "src/components/admin/AISettings.jsx:386:21:Button:missing-accessible-name",
-      "file": "src/components/admin/AISettings.jsx",
-      "line": 386,
-      "column": 21,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
-    {
-      "signature": "src/components/admin/AISettings.jsx:475:17:Button:missing-accessible-name",
-      "file": "src/components/admin/AISettings.jsx",
-      "line": 475,
-      "column": 17,
-      "element": "Button",
-      "reason": "missing-accessible-name"
-    },
     {
       "signature": "src/components/admin/AppointmentModal.jsx:609:15:MacOSButton:missing-accessible-name",
       "file": "src/components/admin/AppointmentModal.jsx",

--- a/frontend/src/components/admin/AISettings.jsx
+++ b/frontend/src/components/admin/AISettings.jsx
@@ -384,11 +384,13 @@ const AISettings = () => {
                       }
                     </span>
                     <Button
+                      type="button"
                       size="sm"
                       variant="ghost"
+                      title={showApiKeys[provider.id] ? `Hide API key for ${provider.display_name}` : `Show API key for ${provider.display_name}`}
+                      aria-label={showApiKeys[provider.id] ? `Hide API key for ${provider.display_name}` : `Show API key for ${provider.display_name}`}
                       onClick={() => toggleApiKeyVisibility(provider.id)}>
-                      
-                      {showApiKeys[provider.id] ? <EyeOff style={{ width: '14px', height: '14px' }} /> : <Eye style={{ width: '14px', height: '14px' }} />}
+                      {showApiKeys[provider.id] ? <EyeOff aria-hidden="true" style={{ width: '14px', height: '14px' }} /> : <Eye aria-hidden="true" style={{ width: '14px', height: '14px' }} />}
                     </Button>
                   </div>
                 </div>
@@ -473,12 +475,14 @@ const AISettings = () => {
                   Настроить
                 </Button>
                 <Button
+                  type="button"
                   size="sm"
                   variant="outline"
+                  title={`Test ${provider.display_name} provider`}
+                  aria-label={`Test ${provider.display_name} provider`}
                   onClick={() => handleTestProvider(provider.id)}
                   disabled={!provider.active || !provider.api_key}>
-                  
-                  <TestTube style={{ width: '14px', height: '14px' }} />
+                  <TestTube aria-hidden="true" style={{ width: '14px', height: '14px' }} />
                 </Button>
               </div>
             </Card>);


### PR DESCRIPTION
## Summary
- Added accessible names to `AISettings` provider API-key visibility and test-provider icon buttons.
- Marked touched provider action icons as decorative with `aria-hidden`.
- Reduced the component-aware icon-only controls baseline from 26 to 24 findings and updated the audit trail.

## Contract Impact
- Canonical surface: frontend admin AI provider action buttons only.
- Request shape: not applicable - no AI provider request payload, test-provider request shape, or settings parameter changed.
- Response shape: not applicable - no AI provider response consumption or API data shape changed.
- Status codes: not applicable - no HTTP status handling or backend endpoint behavior changed.
- Frontend consumer: `frontend/src/components/admin/AISettings.jsx` API-key visibility and provider test controls.
- Compatibility path or alias: not applicable - no route, alias, redirect, or compatibility path changed.
- Contract proof: local lint/build and icon-control audits passed; code diff only adds button metadata and decorative icon hiding.

## RBAC / Permissions
- Roles allowed: unchanged - existing admin AI settings access remains controlled by current app routing and auth logic.
- Roles denied: unchanged - no role guard, permission check, or denied-role path was edited.
- Positive auth proof: not checked in browser because this PR only changes accessible names on already-rendered admin AI provider controls; frontend build/lint passed.
- Negative auth proof: not checked in browser because no auth/RBAC code or route guard was changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, realtime, AI, or provider event channel changed.
- Payload version / ack behavior: not applicable - no event payload, acknowledgement, or retry behavior changed.
- Read/unread or delivery semantics: not applicable - no notification read state or delivery semantics changed.
- Reconnect/resync proof: not checked because no realtime reconnect/resync code changed.

## Frontend Resilience
- Empty data proof: unchanged - AI settings loading/error behavior was not edited.
- Partial data proof: repeated provider action controls include provider display names and reveal/test intent in their accessible names.
- Forbidden secondary path behavior: unchanged - no forbidden route or secondary path behavior changed.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources in the touched action labels.
- Stale route/deep-link behavior: unchanged - no route or deep-link state handling changed.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/AISettings.jsx`, `frontend/scripts/a11y/icon-only-component-controls-baseline.json`, `docs/audits/uiux-hard-audit-2026-05-20/global-icon-only-controls-a11y-sweep.md`.
- Denied paths: backend runtime, route registry, API clients, AI provider endpoint contracts, auth/RBAC, payment, queue, EMR, lab, migrations, packages, workflow files.
- Migration/docs/test impact: no migration; docs audit trail and a11y baseline updated to match the reduced component findings.
- Rollback note: revert this PR to restore the previous AISettings provider action markup, component baseline, and audit-trail count.

## Validation
- Targeted tests or smoke run: `npm run lint:check -- --quiet`; `npm run audit:icon-controls:strict`; `npm run audit:icon-controls:components`; `npm run audit:no-mui-runtime`; `npm run build`; `git diff --check`.
- Result: all local validation commands passed; component-aware audit reports 24 findings / 24 baseline entries / 0 new findings.
- Not checked: authenticated browser smoke, because this PR only adds accessible names to existing admin AI settings controls and does not change runtime behavior.