### PR TITLE
Fix Registrar queue SSOT action contract leaks

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -42,6 +42,99 @@ def _normalize_queue_status_for_registrar(raw_status: str | None) -> str:
     return raw_status
 
 
+REGISTRAR_PAYMENT_ROLES = {"admin", "registrar", "cashier"}
+REGISTRAR_START_VISIT_ROLES = {
+    "admin",
+    "registrar",
+    "doctor",
+    "cardio",
+    "cardiology",
+    "derma",
+    "dentist",
+    "lab",
+}
+REGISTRAR_PRINT_TICKET_ROLES = {"admin", "registrar", "cashier", "doctor"}
+REGISTRAR_COMPLETE_ROLES = {"admin", "registrar", "doctor", "cashier", "receptionist"}
+REGISTRAR_START_STATUSES = {"waiting", "queued"}
+REGISTRAR_PRINT_STATUSES = {"waiting", "queued"}
+REGISTRAR_COMPLETE_STATUSES = {"called", "in_cabinet", "in_progress"}
+
+
+def _registrar_user_role_names(user: User | None) -> set[str]:
+    role_names: set[str] = set()
+    primary_role = getattr(user, "role", None)
+    if primary_role:
+        role_names.add(str(primary_role).strip().lower())
+
+    for role in getattr(user, "roles", None) or []:
+        role_name = getattr(role, "name", None)
+        if role_name:
+            role_names.add(str(role_name).strip().lower())
+
+    return role_names
+
+
+def _registrar_can_mark_paid(user: User | None, payment_status: str | None) -> bool:
+    if str(payment_status or "").strip().lower() == "paid":
+        return False
+    return bool(_registrar_user_role_names(user) & REGISTRAR_PAYMENT_ROLES)
+
+
+def _registrar_can_start_visit(user: User | None, queue_status: str | None) -> bool:
+    normalized_status = str(queue_status or "").strip().lower()
+    return (
+        normalized_status in REGISTRAR_START_STATUSES
+        and bool(_registrar_user_role_names(user) & REGISTRAR_START_VISIT_ROLES)
+    )
+
+
+def _registrar_can_print_ticket(
+    user: User | None,
+    *,
+    payment_status: str | None,
+    queue_status: str | None,
+) -> bool:
+    normalized_payment_status = str(payment_status or "").strip().lower()
+    normalized_queue_status = str(queue_status or "").strip().lower()
+    return (
+        (
+            normalized_payment_status == "paid"
+            or normalized_queue_status in REGISTRAR_PRINT_STATUSES
+        )
+        and bool(_registrar_user_role_names(user) & REGISTRAR_PRINT_TICKET_ROLES)
+    )
+
+
+def _registrar_can_complete(user: User | None, queue_status: str | None) -> bool:
+    normalized_status = str(queue_status or "").strip().lower()
+    return (
+        normalized_status in REGISTRAR_COMPLETE_STATUSES
+        and bool(_registrar_user_role_names(user) & REGISTRAR_COMPLETE_ROLES)
+    )
+
+
+def _registrar_available_actions(
+    *,
+    user: User | None,
+    payment_status: str | None,
+    queue_status: str | None,
+) -> list[str]:
+    actions: list[str] = []
+    if _registrar_can_mark_paid(user, payment_status):
+        actions.append("mark_paid")
+    if _registrar_can_start_visit(user, queue_status):
+        actions.append("start_visit")
+    if _registrar_can_print_ticket(
+        user,
+        payment_status=payment_status,
+        queue_status=queue_status,
+    ):
+        actions.append("print_ticket")
+    if _registrar_can_complete(user, queue_status):
+        actions.append("complete")
+    return actions
+
+
 REGISTRATION_DISCOUNT_MODES = {"none", "repeat", "benefit", "all_free"}
 
 
@@ -2772,10 +2865,23 @@ def get_today_queues(
                     visit_id=entry_visit_id,
                     legacy_paid_at=getattr(entry_data, "payment_processed_at", None),
                 )
+                canonical_status = _normalize_queue_status_for_registrar(entry_status)
+                available_actions = _registrar_available_actions(
+                    user=current_user,
+                    payment_status=payment_status,
+                    queue_status=canonical_status,
+                )
+                can_mark_paid = "mark_paid" in available_actions
+                can_start_visit = "start_visit" in available_actions
+                can_print_ticket = "print_ticket" in available_actions
+                can_complete = "complete" in available_actions
 
                 entries.append(
                     {
                         "id": record_id,
+                        "canonical_record_id": record_id,
+                        "record_kind": entry_type,
+                        "source_kind": source,
                         "appointment_id": appointment_id_value,  # Явно добавляем appointment_id
                         "visit_id": entry_visit_id,
                         "number": queue_entry_number,  # [OK] ИСПРАВЛЕНО: реальный номер из queue_entries
@@ -2792,10 +2898,16 @@ def get_today_queues(
                         "cost": total_cost,
                         "payment_status": payment_status,
                         "payment_type": payment_type,
+                        "can_mark_paid": can_mark_paid,
+                        "can_start_visit": can_start_visit,
+                        "can_print_ticket": can_print_ticket,
+                        "can_complete": can_complete,
+                        "available_actions": available_actions,
                         "source": source,
-                        "status": _normalize_queue_status_for_registrar(
-                            entry_status
-                        ),
+                        "status": canonical_status,
+                        "canonical_status": canonical_status,
+                        "queue_status": canonical_status,
+                        "queue_position": queue_entry_number,
                         "created_at": _serialize_registrar_datetime(
                             entry_wrapper.get("created_at")
                         ),

--- a/backend/tests/integration/test_registrar_all_appointments.py
+++ b/backend/tests/integration/test_registrar_all_appointments.py
@@ -178,5 +178,20 @@ class TestRegistrarAllAppointments:
 
         assert found_entry is not None
         assert found_entry["id"] == entry.id
+        assert found_entry["canonical_record_id"] == entry.id
+        assert found_entry["record_kind"] == "online_queue"
+        assert found_entry["source_kind"] == "desk"
+        assert found_entry["canonical_status"] == "waiting"
+        assert found_entry["queue_status"] == "waiting"
+        assert found_entry["queue_position"] == entry.number
+        assert found_entry["can_mark_paid"] is True
+        assert found_entry["can_start_visit"] is True
+        assert found_entry["can_print_ticket"] is True
+        assert found_entry["can_complete"] is False
+        assert set(found_entry["available_actions"]) == {
+            "mark_paid",
+            "start_visit",
+            "print_ticket",
+        }
         assert found_entry["queue_time"] == _serialize_registrar_datetime(entry.queue_time)
         assert found_entry["created_at"] == _serialize_registrar_datetime(entry.created_at)

--- a/frontend/src/__tests__/notificationGuardrails.test.js
+++ b/frontend/src/__tests__/notificationGuardrails.test.js
@@ -63,4 +63,21 @@ describe('notification guardrails', () => {
     expect(roleCenter).toContain('useEffect(() => {');
     expect(roleCenter).toContain('[runLoadNotifications, userRole]');
   });
+
+  it('keeps registrar table action visibility on backend-provided actions', () => {
+    const table = read('components/tables/EnhancedAppointmentsTable.jsx');
+
+    expect(table).toContain('getBackendActionAvailability');
+    expect(table).toContain('can_mark_paid');
+    expect(table).toContain('can_start_visit');
+    expect(table).toContain('can_print_ticket');
+    expect(table).toContain('can_complete');
+    expect(table).toContain('available_actions');
+    expect(table).toContain('{canPay &&');
+    expect(table).not.toContain('{!isDoctorView && (() => {');
+    const quote = String.fromCharCode(39);
+    expect(table).not.toContain(
+      'status === ' + quote + 'queued' + quote + ' && paymentStatus !== ' + quote + 'paid' + quote
+    );
+  });
 });

--- a/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
+++ b/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
@@ -54,6 +54,27 @@ const SESSION_COLORS = [
   '#84CC16' // lime
 ];
 
+const ACTION_ALIASES = {
+  payment: ['payment', 'mark_paid', 'mark-paid'],
+  call: ['call', 'start_visit', 'start-visit'],
+  print: ['print', 'print_ticket', 'print-ticket'],
+  complete: ['complete', 'complete_visit', 'complete-visit']
+};
+
+const getBackendActionAvailability = (row, action, flagName) => {
+  if (row && flagName && Object.prototype.hasOwnProperty.call(row, flagName)) {
+    return Boolean(row[flagName]);
+  }
+
+  if (!Array.isArray(row?.available_actions)) {
+    return null;
+  }
+
+  const actions = new Set(row.available_actions.map((item) => String(item).trim().toLowerCase()));
+  const aliases = ACTION_ALIASES[action] || [action];
+  return aliases.some((alias) => actions.has(alias));
+};
+
 const EnhancedAppointmentsTable = ({
   data = [],
   loading = false,
@@ -1570,6 +1591,29 @@ const EnhancedAppointmentsTable = ({
             paginatedData.map((row, index) => {
               // ⭐ SSOT: Get session color for visual grouping (presentation only)
               const sessionColor = getSessionColor(row.session_id);
+              const rowStatus = String(row.status || '').toLowerCase();
+              const rowPaymentStatus = String(row.payment_status || '').toLowerCase();
+              const backendCanPay = getBackendActionAvailability(row, 'payment', 'can_mark_paid');
+              const backendCanCall = getBackendActionAvailability(row, 'call', 'can_start_visit');
+              const backendCanPrint = getBackendActionAvailability(row, 'print', 'can_print_ticket');
+              const backendCanComplete = getBackendActionAvailability(row, 'complete', 'can_complete');
+              const legacyCanPay = (
+                rowStatus === 'paid_pending' ||
+                rowPaymentStatus === 'pending' ||
+                rowStatus === 'scheduled' && rowPaymentStatus !== 'paid' ||
+                rowStatus === 'confirmed' && rowPaymentStatus !== 'paid' ||
+                rowStatus === 'waiting' && rowPaymentStatus !== 'paid' ||
+                rowStatus === 'queued' && rowPaymentStatus !== 'paid' ||
+                !rowPaymentStatus && rowStatus !== 'paid' && rowStatus !== 'done' && rowStatus !== 'served' && rowStatus !== 'completed' && rowStatus !== 'cancelled'
+              );
+              const canPay = !isDoctorView && (backendCanPay ?? legacyCanPay);
+              const canCall = backendCanCall ?? (
+                isDoctorView ?
+                  rowStatus === 'queued' || rowStatus === 'waiting' || rowPaymentStatus === 'paid' :
+                  rowStatus === 'queued' || rowStatus === 'waiting'
+              );
+              const canPrint = backendCanPrint ?? (rowPaymentStatus === 'paid' || rowStatus === 'queued' || rowStatus === 'waiting');
+              const canComplete = backendCanComplete ?? (rowStatus === 'in_cabinet' || rowStatus === 'called');
 
               return (
                 <tr
@@ -2008,19 +2052,7 @@ const EnhancedAppointmentsTable = ({
                       }}>
 
                         {/* В режиме панели врача кнопки оплаты не показываем */}
-                        {!isDoctorView && (() => {
-                        const status = (row.status || '').toLowerCase();
-                        const paymentStatus = (row.payment_status || '').toLowerCase();
-                        return (
-                          status === 'paid_pending' ||
-                          paymentStatus === 'pending' ||
-                          status === 'scheduled' && paymentStatus !== 'paid' ||
-                          status === 'confirmed' && paymentStatus !== 'paid' ||
-                          status === 'waiting' && paymentStatus !== 'paid' ||
-                          status === 'queued' && paymentStatus !== 'paid' ||
-                          !paymentStatus && status !== 'paid' && status !== 'done' && status !== 'served' && status !== 'completed' && status !== 'cancelled');
-
-                      })() &&
+                        {canPay &&
                       <button
                         className="action-button"
                         onMouseDown={(e) => {
@@ -2049,7 +2081,7 @@ const EnhancedAppointmentsTable = ({
                       }
 
                         {/* Вызвать */}
-                        {(isDoctorView ? row.status === 'queued' || row.status === 'waiting' || row.payment_status === 'paid' : row.status === 'queued' || row.status === 'waiting') &&
+                        {canCall &&
                       <button
                         className="action-button"
                         onMouseDown={(e) => {
@@ -2078,7 +2110,7 @@ const EnhancedAppointmentsTable = ({
                       }
 
                         {/* Печать */}
-                        {(row.payment_status === 'paid' || row.status === 'queued' || row.status === 'waiting') &&
+                        {canPrint &&
                       <button
                         className="action-button"
                         onMouseDown={(e) => {
@@ -2107,7 +2139,7 @@ const EnhancedAppointmentsTable = ({
                       }
 
                         {/* Завершить */}
-                        {(row.status === 'in_cabinet' || row.status === 'called') &&
+                        {canComplete &&
                       <button
                         className="action-button"
                         onMouseDown={(e) => {

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -19,7 +19,6 @@ import notify from '../services/notify';
 import RoleNotificationCenter from '../components/notifications/RoleNotificationCenter';
 
 const API_BASE = getApiOrigin();
-const APPOINTMENT_OVERRIDE_TTL_MS = 10 * 60 * 1000;
 const REGISTRAR_TAB_LABEL_KEYS = {
   appointments: 'tabs_appointments',
   cardio: 'tabs_cardio',
@@ -74,6 +73,40 @@ const registrarWorkflowActionsStyle = {
   gap: 'var(--mac-spacing-2)',
   flexWrap: 'wrap',
   minWidth: 0
+};
+
+const normalizeRegistrarContractValue = (value) => {
+  if (value === null || value === undefined) return '';
+  return String(value).trim().toLowerCase();
+};
+
+const getRegistrarRecordKind = (record) => normalizeRegistrarContractValue(
+  record?.record_kind ?? record?.source_kind ?? record?.record_type ?? record?.type
+);
+
+const getRegistrarRecordId = (record, recordKind = getRegistrarRecordKind(record)) => {
+  if (!record) return null;
+  if (record.canonical_record_id !== undefined && record.canonical_record_id !== null) {
+    return record.canonical_record_id;
+  }
+  if (recordKind === 'visit' && record.visit_id !== undefined && record.visit_id !== null) {
+    return record.visit_id;
+  }
+  if (recordKind === 'online_queue' && record.queue_entry_id !== undefined && record.queue_entry_id !== null) {
+    return record.queue_entry_id;
+  }
+  if (recordKind === 'appointment' && record.appointment_id !== undefined && record.appointment_id !== null) {
+    return record.appointment_id;
+  }
+  return record.id ?? null;
+};
+
+const hasBackendAction = (record, action) => {
+  if (action === 'mark_paid' && record?.can_mark_paid !== undefined) {
+    return Boolean(record.can_mark_paid);
+  }
+  if (!Array.isArray(record?.available_actions)) return true;
+  return record.available_actions.includes(action) || record.available_actions.includes(action.replace('_', '-'));
 };
 
 // Современные диалоги
@@ -1601,7 +1634,7 @@ const RegistrarPanel = () => {
                   source: entry.source,
                   created_at: entry.created_at, // ✅ ИСПРАВЛЕНО: Добавляем created_at
                   visit_time: entry.visit_time || null, // ✅ ДОБАВЛЕНО: Время визита
-                  record_type: entry.record_type || 'visit', // ✅ ДОБАВЛЕНО: Тип записи
+                  record_type: entry.record_type || entry.type || 'unknown', // ✅ ДОБАВЛЕНО: Тип записи
                   service_details: entry.service_details || [], // ✅ НОВОЕ: Полные данные услуг
                   queue_numbers: [{
                     id: entry.id, // ✅ ВАЖНО для AppointmentWizardV2: originalQueueIds использует это поле
@@ -1645,7 +1678,7 @@ const RegistrarPanel = () => {
                     source: entry.source,
                     created_at: entry.created_at, // ✅ ИСПРАВЛЕНО: Добавляем created_at
                     visit_time: entry.visit_time || null, // ✅ ДОБАВЛЕНО: Время визита
-                    record_type: entry.record_type || 'visit', // ✅ ДОБАВЛЕНО: Тип записи
+                    record_type: entry.record_type || entry.type || 'unknown', // ✅ ДОБАВЛЕНО: Тип записи
                     service_details: entry.service_details || [], // ✅ НОВОЕ: Полные данные услуг
                     queue_numbers: [{
                       id: entry.id, // ✅ ВАЖНО для AppointmentWizardV2: originalQueueIds использует это поле
@@ -1774,7 +1807,17 @@ const RegistrarPanel = () => {
       logger.info('🔍 appointment.id:', appointment.id, 'тип:', typeof appointment.id);
 
       // ✅ ИСПРАВЛЕНО: Используем правильный эндпоинт для queue entries
-      const url = `${API_BASE}/api/v1/registrar/queue/${appointment.id}/start-visit`;
+      const recordKind = getRegistrarRecordKind(appointment);
+      const recordId = getRegistrarRecordId(appointment, recordKind);
+      if (!recordId || (recordKind !== 'visit' && recordKind !== 'online_queue' && recordKind !== 'appointment')) {
+        logger.warn('RegistrarPanel: start-visit requires backend record kind/id', { recordKind, recordId, appointment });
+        notify.error('Missing backend record data for start visit');
+        return;
+      }
+
+      const url = recordKind === 'visit' ?
+        `${API_BASE}/api/v1/registrar/visits/${recordId}/start-visit` :
+        `${API_BASE}/api/v1/registrar/queue/${recordId}/start-visit`;
       logger.info('🔍 Отправляем запрос на:', url);
 
       const response = await fetch(url, {
@@ -1841,18 +1884,26 @@ const RegistrarPanel = () => {
 
       const paymentResults = [];
       for (const record of recordsToUpdate) {
-        const recordType = record.record_type || (record.id >= 20000 ? 'visit' : 'appointment');
-        const recordId = record.id;
+        const recordType = getRegistrarRecordKind(record);
+        const recordId = getRegistrarRecordId(record, recordType);
+        if (!recordId || (recordType !== 'visit' && recordType !== 'online_queue' && recordType !== 'appointment')) {
+          logger.warn('RegistrarPanel: payment requires backend record kind/id', { recordType, recordId, record });
+          paymentResults.push({ success: false, recordId: record.id, error: 'missing_backend_record_contract' });
+          continue;
+        }
+        if (!hasBackendAction(record, 'mark_paid')) {
+          logger.warn('RegistrarPanel: backend did not expose mark_paid action', { recordType, recordId, record });
+          paymentResults.push({ success: false, recordId, error: 'action_not_available' });
+          continue;
+        }
 
         // ✅ ИСПРАВЛЕНИЕ: Проверяем статус КАЖДОЙ записи перед попыткой оплаты
-        const paymentStatus = (record.payment_status || '').toLowerCase();
-        const status = (record.status || '').toLowerCase();
+        const paymentStatus = normalizeRegistrarContractValue(record.payment_status);
+        const status = normalizeRegistrarContractValue(record.status);
         logger.info(`🔍 Запись ${recordId}: статус оплаты=${paymentStatus}, статус=${status}`);
 
         // Пропускаем записи, которые уже оплачены
-        if (paymentStatus === 'paid' ||
-        status === 'paid' ||
-        status === 'queued') {
+        if (paymentStatus === 'paid' || (!paymentStatus && status === 'paid')) {
           logger.info(`⏭️ Запись ${recordId} уже оплачена, пропускаем`);
           paymentResults.push({ success: true, recordId, skipped: true, reason: 'already_paid' });
           continue;
@@ -1914,29 +1965,29 @@ const RegistrarPanel = () => {
         // Обновляем статус только для записей, которые были реально оплачены (не пропущены)
         const paidRecordIds = paymentResults.
         filter((r) => r.success && !r.skipped).
-        map((r) => r.recordId);
+        map((r) => String(r.recordId));
+        const paymentResultById = new Map(
+          paymentResults.
+          filter((r) => r.success && !r.skipped).
+          map((r) => [String(r.recordId), r.result || {}])
+        );
 
         logger.info('✅ Оплата успешна, обновляем локальное состояние для оплаченных записей:', paidRecordIds);
 
         // Обновляем статус только для реально оплаченных записей
         recordsToUpdate.
-        filter((record) => paidRecordIds.includes(record.id)).
+        filter((record) => paidRecordIds.includes(String(getRegistrarRecordId(record, getRegistrarRecordKind(record))))).
         forEach((record) => {
-          const recordWithQueuedStatus = {
+          const result = paymentResultById.get(String(getRegistrarRecordId(record, getRegistrarRecordKind(record)))) || {};
+          const recordWithBackendState = {
             ...record,
-            status: 'queued', // Принудительно устанавливаем статус "В очереди" после оплаты
-            payment_status: 'paid',
-            _locallyModified: true // Помечаем как локально измененную, чтобы избежать перезаписи при обновлении
+            status: result.status ?? result.entry?.status ?? record.status,
+            payment_status: result.payment_status ?? record.payment_status,
+            _locallyModified: false
           };
 
-          // Сохраняем локальный оверрайд для каждой записи только в памяти текущей страницы
-          appointmentOverridesRef.current[String(record.id)] = {
-            status: recordWithQueuedStatus.status,
-            payment_status: recordWithQueuedStatus.payment_status,
-            // TTL 10 минут
-            expiresAt: Date.now() + APPOINTMENT_OVERRIDE_TTL_MS
-          }; // Обновляем состояние для каждой записи
-          setAppointments((prev) => prev.map((apt) => apt.id === record.id ? recordWithQueuedStatus : apt));
+          delete appointmentOverridesRef.current[String(record.id)];
+          setAppointments((prev) => prev.map((apt) => apt.id === record.id ? recordWithBackendState : apt));
         });
 
         // Формируем информативное сообщение
@@ -1944,7 +1995,7 @@ const RegistrarPanel = () => {
         if (successCount > 0 && skippedCount > 0) {
           message = `Оплачено ${successCount} записей, ${skippedCount} уже были оплачены ранее`;
         } else if (successCount > 0) {
-          message = `Оплачено ${successCount} записей пациента и добавлены в очередь!`;
+          message = `Оплачено ${successCount} записей пациента`;
         } else if (skippedCount > 0) {
           message = 'Все записи уже оплачены';
         }
@@ -1968,7 +2019,7 @@ const RegistrarPanel = () => {
   };
 
   // Обработчики событий
-  const updateAppointmentStatus = useCallback(async (appointmentId, status, reason = '') => {
+  const updateAppointmentStatus = useCallback(async (appointmentId, status, reason = '', sourceRecord = null) => {
     try {
       if (!appointmentId || Number(appointmentId) <= 0) {
         notify.error('Некорректный идентификатор записи');
@@ -1984,19 +2035,30 @@ const RegistrarPanel = () => {
       let body;
 
       // Определяем источник записи и правильный ID
-      const isFromVisits = appointmentId >= 20000;
-      const realId = isFromVisits ? appointmentId - 20000 : appointmentId;
+      const record = sourceRecord || appointments.find((apt) => apt.id === appointmentId);
+      const recordType = getRegistrarRecordKind(record);
+      const realId = getRegistrarRecordId(record, recordType);
+      if (!realId || (recordType !== 'visit' && recordType !== 'online_queue' && recordType !== 'appointment')) {
+        logger.warn('RegistrarPanel: status update requires backend record kind/id', { appointmentId, status, recordType, realId, record });
+        notify.error('Missing backend record data for status update');
+        return null;
+      }
 
       if (status === 'complete' || status === 'done') {
-        if (isFromVisits) {
+        if (recordType === 'visit') {
           url = `${API_BASE}/api/v1/registrar/visits/${realId}/complete`;
-        } else {
+        } else if (recordType === 'appointment') {
           url = `${API_BASE}/api/v1/appointments/${realId}/complete`;
+        } else {
+          notify.error('Action is not available for this record');
+          return null;
         }
         body = JSON.stringify({ reason });
       } else if (status === 'paid' || status === 'mark-paid') {
-        if (isFromVisits) {
+        if (recordType === 'visit') {
           url = `${API_BASE}/api/v1/registrar/visits/${realId}/mark-paid`;
+        } else if (recordType === 'online_queue') {
+          url = `${API_BASE}/api/v1/registrar/queue/entry/${realId}/mark-paid`;
         } else {
           url = `${API_BASE}/api/v1/appointments/${realId}/mark-paid`;
         }
@@ -2039,7 +2101,7 @@ const RegistrarPanel = () => {
         notify.success('Отмечено как неявка (локально)');
         return { id: appointmentId, status: 'no_show' };
       } else if (status === 'in_cabinet') {
-        if (isFromVisits) {
+        if (recordType === 'visit') {
           url = `${API_BASE}/api/v1/registrar/visits/${realId}/start-visit`;
         } else {
           // Используем эндпоинт для очереди регистратора
@@ -2086,7 +2148,7 @@ const RegistrarPanel = () => {
       notify.error(getErrorMessage(error, 'Не удалось обновить статус. Проверьте соединение и попробуйте снова.'));
       return null;
     }
-  }, [loadAppointments]);
+  }, [appointments, loadAppointments]);
 
   const handleBulkAction = useCallback(async (action, reason = '') => {
     if (appointmentsSelected.size === 0) return;
@@ -2740,14 +2802,14 @@ const RegistrarPanel = () => {
         logger.info('Редактирование записи:', row);
         break;
       case 'in_cabinet':
-        await updateAppointmentStatus(row.id, 'in_cabinet');
+        await updateAppointmentStatus(row.id, 'in_cabinet', '', row);
         notify.success('Пациент отправлен в кабинет');
         break;
       case 'call':
         await handleStartVisit(row);
         break;
       case 'complete':
-        await updateAppointmentStatus(row.id, 'done');
+        await updateAppointmentStatus(row.id, 'done', '', row);
         notify.success('Приём завершён');
         break;
       case 'payment':
@@ -3455,7 +3517,7 @@ const RegistrarPanel = () => {
                           break;
                         case 'in_cabinet':
                           logger.info('Отправка пациента в кабинет (welcome):', row);
-                          updateAppointmentStatus(row.id, 'in_cabinet');
+                          updateAppointmentStatus(row.id, 'in_cabinet', '', row);
                           break;
                         case 'call':
                           logger.info('Вызов пациента (welcome):', row);
@@ -3463,7 +3525,7 @@ const RegistrarPanel = () => {
                           break;
                         case 'complete':
                           logger.info('Завершение приёма (welcome):', row);
-                          updateAppointmentStatus(row.id, 'done');
+                          updateAppointmentStatus(row.id, 'done', '', row);
                           break;
                         case 'print':
                           logger.info('Печать талона (welcome):', row);
@@ -3797,7 +3859,7 @@ const RegistrarPanel = () => {
                     break;
                   case 'in_cabinet':
                     logger.info('Отправка пациента в кабинет:', row);
-                    updateAppointmentStatus(row.id, 'in_cabinet');
+                    updateAppointmentStatus(row.id, 'in_cabinet', '', row);
                     break;
                   case 'call':
                     logger.info('Вызов пациента:', row);
@@ -3805,7 +3867,7 @@ const RegistrarPanel = () => {
                     break;
                   case 'complete':
                     logger.info('Завершение приёма:', row);
-                    updateAppointmentStatus(row.id, 'done');
+                    updateAppointmentStatus(row.id, 'done', '', row);
                     break;
                   case 'print':
                     logger.info('Печать талона:', row);
@@ -3911,7 +3973,12 @@ const RegistrarPanel = () => {
 
           try {
             const data = appointmentId === cancelDialog.row?.id ? cancelDialog.row : appointments.find((a) => a.id === appointmentId);
-            const recordType = data?.record_type || 'visit';
+            const recordType = getRegistrarRecordKind(data);
+            if (recordType !== 'visit' && recordType !== 'online_queue' && recordType !== 'appointment') {
+              logger.warn('RegistrarPanel: cancel requires backend record kind', { appointmentId, recordType, data });
+              notify.error('Missing backend record data for cancellation');
+              return;
+            }
 
             // Определяем список ID для отмены (если это агрегированная запись - отменяем все)
             const idsToCancel = data?.aggregated_ids?.length > 0 ? data.aggregated_ids : [appointmentId];
@@ -3945,33 +4012,18 @@ const RegistrarPanel = () => {
               };
 
               if (recordType === 'visit') {
-                try {
-                  await tryCancelVisit();
-                } catch (visitError) {
-                  if (visitError.response?.status === 404) {
-                    logger.warn(`⚠️ Попытка отмены как 'visit' вернула 404. Пробуем как 'online_queue' (ID=${targetId})`);
-                    await tryCancelOnlineQueue();
-                  } else {
-                    throw visitError;
-                  }
-                }
-              } else if (recordType === 'appointment') {
-                await tryCancelAppointment();
-              } else if (recordType === 'online_queue') {
-                await tryCancelOnlineQueue();
-              } else {
-                // Fallback default strategy
-                try {
-                  await tryCancelVisit();
-                } catch (err) {
-                  if (err.response?.status === 404) {
-                    logger.warn('Fallback visit cancel failed 404, trying online_queue...');
-                    await tryCancelOnlineQueue();
-                  } else {
-                    throw err;
-                  }
-                }
+                await tryCancelVisit();
+                return;
               }
+              if (recordType === 'appointment') {
+                await tryCancelAppointment();
+                return;
+              }
+              if (recordType === 'online_queue') {
+                await tryCancelOnlineQueue();
+                return;
+              }
+
             };
 
             // Выполняем отмену для всех ID
@@ -4043,7 +4095,7 @@ const RegistrarPanel = () => {
           if (appointment) {
             const updated = await handlePayment(appointment, paymentData);
             if (updated) {
-              // Статус уже правильно установлен в handlePayment (status: 'queued')
+              // Статус уже установлен в handlePayment из ответа backend
               logger.info('PaymentDialog: Оплата успешна, статус обновлен:', updated);
             }
           }


### PR DESCRIPTION
## Summary

- Repair Registrar/Queue SSOT contract leaks without adding BFF-lite or `/api/v1/ui/*`.
- Extend existing `/registrar/queues/today` rows with canonical identity/status fields and backend-owned action availability.
- Update `RegistrarPanel` and `EnhancedAppointmentsTable` to consume backend-provided action/status contract instead of guessing from id/status/record_type.

## Contract Impact

- Canonical surface: `GET /api/v1/registrar/queues/today` existing endpoint.
- Request shape: unchanged authenticated request with optional `target_date` and `department` query params.
- Response shape: existing queue row payload now includes `canonical_record_id`, `record_kind`, `source_kind`, `canonical_status`, `queue_status`, `queue_position`, `available_actions`, `can_mark_paid`, `can_start_visit`, `can_print_ticket`, `can_complete`.
- Status codes: unchanged for this endpoint.
- Frontend consumer: `RegistrarPanel.jsx` and `EnhancedAppointmentsTable.jsx`.
- Compatibility path or alias: no new `/api/v1/ui/*`; legacy `type` and `record_type` remain in payload for compatibility.
- Contract proof: backend integration assertion in `test_registrar_all_appointments.py` and frontend guardrail assertion in `notificationGuardrails.test.js`.

## RBAC / Permissions

- Roles allowed: unchanged endpoint roles from existing registrar queue endpoint.
- Roles denied: unchanged endpoint auth/role enforcement.
- Positive auth proof: existing authenticated registrar queue integration test returns 200 and asserts action fields.
- Negative auth proof: not changed in this PR; no auth policy expansion was introduced.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: existing table empty state remains unchanged.
- Partial data proof: table supports `available_actions`/`can_*` when present and keeps fallback for rows not yet carrying the new action contract.
- Forbidden secondary path behavior: unknown/missing backend record contract blocks commands instead of guessing alternate command endpoints.
- Missing draft/resource behavior: not applicable, no draft/resource lifecycle changed.
- Stale route/deep-link behavior: not applicable, no route/deep-link behavior changed.

## Scope Gate

- Allowed paths: registrar queue endpoint, registrar queue integration test, RegistrarPanel consumer, EnhancedAppointmentsTable consumer, focused frontend guardrail test.
- Denied paths: no `/api/v1/ui/*`, no separate BFF service, no migrations, no broad RegistrarPanel rewrite, no unrelated Telegram/runtime behavior changes.
- Migration/docs/test impact: no migration; targeted backend and frontend tests updated.
- Rollback note: revert the five changed Slice 0 files to restore previous contract and frontend action behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/registrar_integration.py backend/tests/integration/test_registrar_all_appointments.py`; `python -m pytest backend/tests/integration/test_registrar_all_appointments.py -q`; `npm.cmd run test:run -- src/__tests__/notificationGuardrails.test.js`; `npm.cmd run lint:check -- src/pages/RegistrarPanel.jsx src/components/tables/EnhancedAppointmentsTable.jsx src/__tests__/notificationGuardrails.test.js`; `npm.cmd run build`; `git diff --check`.
- Result: all local validation passed; lint has existing warnings only.
- Not checked: full manual browser registrar workflow smoke; full backend suite locally.