### PR TITLE
Slice 1: move QueueJoin specialist selection into QR contract

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -102,6 +102,7 @@ class QRTokenInfoResponse(BaseModel):
     expires_at: Optional[str] = None
     is_clinic_wide: Optional[bool] = False  # Флаг общего QR
     target_date: Optional[str] = None  # Дата очереди
+    selectable_specialists: Optional[List[Dict[str, Any]]] = None
 
 
 class JoinSessionStartRequest(BaseModel):

--- a/backend/app/services/qr_queue_service.py
+++ b/backend/app/services/qr_queue_service.py
@@ -53,6 +53,138 @@ class QRQueueService:
         self.db = db
         self.queue_domain_service = queue_domain_service or QueueDomainService(db)
 
+    @staticmethod
+    def _normalize_specialty_key(value: Any) -> str:
+        normalized = str(value or "").strip().lower()
+        aliases = {
+            "cardio": "cardiology",
+            "derma": "dermatology",
+            "dentist": "stomatology",
+            "dentistry": "stomatology",
+            "laboratory": "lab",
+        }
+        return aliases.get(normalized, normalized)
+
+    @staticmethod
+    def _queue_profile_icon(key: str, configured_icon: str | None) -> str:
+        emoji_map = {
+            "cardiology": "❤️",
+            "ecg": "📊",
+            "dermatology": "✨",
+            "stomatology": "🦷",
+            "lab": "🔬",
+            "laboratory": "🔬",
+            "procedures": "💉",
+            "cosmetology": "💄",
+            "general": "👥",
+        }
+        return emoji_map.get(key, configured_icon or "👨‍⚕️")
+
+    def _get_clinic_wide_selectable_specialists(self) -> list[dict[str, Any]]:
+        from sqlalchemy.orm import joinedload
+
+        from app.models.queue_profile import INITIAL_QUEUE_PROFILES, QueueProfile
+
+        hidden_profile_keys = {"ecg", "general"}
+        try:
+            profiles = (
+                self.db.query(QueueProfile)
+                .filter(
+                    QueueProfile.is_active == True,
+                    QueueProfile.show_on_qr_page == True,
+                )
+                .order_by(QueueProfile.display_order)
+                .all()
+            )
+        except Exception:
+            logger.warning(
+                "[QRQueueService] queue_profiles unavailable; using initial profile fallback",
+                exc_info=True,
+            )
+            profiles = []
+
+        if profiles:
+            profile_items = [
+                {
+                    "key": profile.key,
+                    "title": profile.title,
+                    "title_ru": profile.title_ru,
+                    "queue_tags": profile.queue_tags or [],
+                    "color": profile.color,
+                    "icon": profile.icon,
+                    "order": profile.display_order,
+                }
+                for profile in profiles
+            ]
+        else:
+            profile_items = [
+                {
+                    "key": profile["key"],
+                    "title": profile["title"],
+                    "title_ru": profile.get("title_ru"),
+                    "queue_tags": profile.get("queue_tags") or [],
+                    "color": profile.get("color"),
+                    "icon": profile.get("icon"),
+                    "order": profile.get("order", 0),
+                }
+                for profile in INITIAL_QUEUE_PROFILES
+            ]
+
+        profile_by_specialty: dict[str, dict[str, Any]] = {}
+        for profile in profile_items:
+            profile_key = self._normalize_specialty_key(profile.get("key"))
+            if not profile_key or profile_key in hidden_profile_keys:
+                continue
+            keys = {profile_key}
+            keys.update(
+                self._normalize_specialty_key(tag)
+                for tag in (profile.get("queue_tags") or [])
+            )
+            for key in keys:
+                if key and key not in hidden_profile_keys:
+                    profile_by_specialty.setdefault(key, profile)
+
+        if not profile_by_specialty:
+            return []
+
+        doctors = (
+            self.db.query(Doctor)
+            .filter(Doctor.active == True)
+            .options(joinedload(Doctor.user))
+            .order_by(Doctor.id.asc())
+            .all()
+        )
+        selectable: list[dict[str, Any]] = []
+        seen_ids: set[int] = set()
+        for doctor in doctors:
+            specialty = self._normalize_specialty_key(getattr(doctor, "specialty", None))
+            profile = profile_by_specialty.get(specialty)
+            if not profile or doctor.id in seen_ids:
+                continue
+            profile_key = self._normalize_specialty_key(profile.get("key"))
+            selectable.append(
+                {
+                    "id": doctor.id,
+                    "specialty": profile_key,
+                    "specialty_display": (
+                        profile.get("title_ru")
+                        or profile.get("title")
+                        or profile_key
+                    ),
+                    "icon": self._queue_profile_icon(profile_key, profile.get("icon")),
+                    "color": profile.get("color") or "#6b7280",
+                    "doctor_name": (
+                        doctor.user.full_name
+                        if getattr(doctor, "user", None)
+                        else f"Doctor #{doctor.id}"
+                    ),
+                    "cabinet": doctor.cabinet,
+                }
+            )
+            seen_ids.add(doctor.id)
+
+        return selectable
+
     def _find_or_create_patient(
         self,
         patient_name: str,
@@ -594,6 +726,11 @@ class QRQueueService:
                 "is_clinic_wide": qr_token.is_clinic_wide
                 or qr_token.specialist_id is None,
                 "target_date": target_date.isoformat() if target_date else None,
+                "selectable_specialists": (
+                    self._get_clinic_wide_selectable_specialists()
+                    if qr_token.is_clinic_wide or qr_token.specialist_id is None
+                    else []
+                ),
             }
             logger.debug(
                 f"[QRQueueService.get_qr_token_info] Ответ сформирован успешно: {result}"

--- a/backend/tests/integration/test_qr_queue_join.py
+++ b/backend/tests/integration/test_qr_queue_join.py
@@ -9,6 +9,7 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from app.models.online_queue import DailyQueue, OnlineQueueEntry, QueueToken
+from app.models.queue_profile import QueueProfile
 from app.services.queue_service import QueueBusinessService
 
 
@@ -129,3 +130,60 @@ def test_qr_join_duplicate_is_not_recreated(client, db_session, test_doctor, mon
         .all()
     )
     assert len(entries) == 1
+
+
+@pytest.mark.queue
+def test_clinic_wide_qr_exposes_backend_selectable_specialists(
+    client, db_session, test_doctor, monkeypatch
+):
+    monkeypatch.setattr(QueueBusinessService, "ONLINE_QUEUE_START_TIME", time(0, 0))
+
+    test_doctor.specialty = "cardio"
+    profile = QueueProfile(
+        key="cardiology",
+        title="Cardiology",
+        title_ru="Cardiology",
+        queue_tags=["cardio", "cardiology", "cardiology_common"],
+        display_order=1,
+        is_active=True,
+        show_on_qr_page=True,
+        icon="Heart",
+        color="#FF3B30",
+    )
+    db_session.add(profile)
+
+    token_value = "test-clinic-wide-qr-token"
+    local_now = datetime.now(ZoneInfo("Asia/Tashkent")).replace(tzinfo=None)
+    token = QueueToken(
+        token=token_value,
+        day=date.today(),
+        specialist_id=None,
+        department="clinic",
+        is_clinic_wide=True,
+        expires_at=local_now + timedelta(hours=2),
+        active=True,
+    )
+    db_session.add(token)
+    db_session.commit()
+
+    info_resp = client.get(f"/api/v1/queue/qr-tokens/{token_value}/info")
+    assert info_resp.status_code == 200
+    info_payload = info_resp.json()
+    assert info_payload["is_clinic_wide"] is True
+    assert info_payload["selectable_specialists"] == [
+        {
+            "id": test_doctor.id,
+            "specialty": "cardiology",
+            "specialty_display": "Cardiology",
+            "icon": "❤️",
+            "color": "#FF3B30",
+            "doctor_name": "Test Cardiologist",
+            "cabinet": None,
+        }
+    ]
+
+    start_resp = client.post("/api/v1/queue/join/start", json={"token": token_value})
+    assert start_resp.status_code == 200
+    assert start_resp.json()["queue_info"]["selectable_specialists"] == info_payload[
+        "selectable_specialists"
+    ]

--- a/frontend/src/pages/QueueJoin.jsx
+++ b/frontend/src/pages/QueueJoin.jsx
@@ -13,67 +13,10 @@ import {
 } from 'lucide-react';
 import { A11Y_COLORS } from '../constants/a11yTokens';
 import {
-  fetchAvailableSpecialists,
-  fetchPublicQueueProfiles,
   fetchQrTokenInfo,
   startQueueJoinSession,
   completeQueueJoinSession,
 } from '../api/queue';
-
-const normalizeSpecialtyKey = (value) => {
-  const normalized = String(value || '').toLowerCase().trim();
-  if (!normalized) return '';
-  if (normalized === 'cardio') return 'cardiology';
-  if (normalized === 'derma') return 'dermatology';
-  if (normalized === 'dentist' || normalized === 'dentistry') return 'stomatology';
-  if (normalized === 'laboratory') return 'lab';
-  return normalized;
-};
-
-const mergeVisibleSpecialists = (profilesPayload, specialistsPayload) => {
-  const profileItems = Array.isArray(profilesPayload?.specialists) ? profilesPayload.specialists : [];
-  const specialistItems = Array.isArray(specialistsPayload) ? specialistsPayload : [];
-
-  if (specialistItems.length === 0) {
-    return [];
-  }
-
-  const profileBySpecialty = new Map(
-    profileItems
-      .map((profile) => [normalizeSpecialtyKey(profile.specialty), profile])
-      .filter(([specialty]) => specialty)
-  );
-  const visibleSpecialties = new Set(profileBySpecialty.keys());
-  const merged = [];
-  const seenIds = new Set();
-
-  specialistItems.forEach((specialist) => {
-    const normalizedSpecialty = normalizeSpecialtyKey(specialist.specialty);
-    if (!normalizedSpecialty) return;
-    if (visibleSpecialties.size > 0 && !visibleSpecialties.has(normalizedSpecialty)) {
-      return;
-    }
-    if (specialist.id === undefined || specialist.id === null || seenIds.has(specialist.id)) {
-      return;
-    }
-
-    const profile = profileBySpecialty.get(normalizedSpecialty);
-    merged.push({
-      ...specialist,
-      specialty: normalizedSpecialty,
-      specialty_display:
-        profile?.specialty_display ||
-        specialist.specialty_display ||
-        specialist.name ||
-        specialist.specialty,
-      icon: profile?.icon || specialist.icon || '👨‍⚕️',
-      color: profile?.color || specialist.color || A11Y_COLORS.primary,
-    });
-    seenIds.add(specialist.id);
-  });
-
-  return merged;
-};
 
 const formatSpecialistLabel = (specialist) => {
   const doctorName =
@@ -190,62 +133,33 @@ const QueueJoin = () => {
     localStorage.setItem(formStorageKey, JSON.stringify(formData));
   }, [formData, formStorageKey]);
 
-  // ⭐ SSOT: Загрузка списка доступных специалистов из QueueProfiles (Admin Panel controlled)
-  const loadSpecialists = useCallback(async () => {
-    setIsSpecialistsLoading(true);
-    try {
-      const [profilesResult, specialistsResult] = await Promise.allSettled([
-        fetchPublicQueueProfiles(),
-        fetchAvailableSpecialists(),
-      ]);
-
-      const profilesPayload =
-        profilesResult.status === 'fulfilled' ? profilesResult.value : null;
-      const specialistsPayload =
-        specialistsResult.status === 'fulfilled' ? specialistsResult.value : [];
-
-      const filteredSpecialists = mergeVisibleSpecialists(
-        profilesPayload,
-        specialistsPayload
-      ).filter((specialist) => {
-        const specialty = normalizeSpecialtyKey(specialist.specialty);
-        return specialty !== 'ecg' && specialty !== 'general';
-      });
-
-      setAvailableSpecialists(filteredSpecialists);
-    } catch {
-      setAvailableSpecialists([]);
-    } finally {
-      setIsSpecialistsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!token) {
-      setIsSpecialistsLoading(false);
-      return;
-    }
-    loadSpecialists();
-  }, [loadSpecialists, token]);
-
   // ✅ Функции объявлены до использования в useEffect
   const startJoinSession = useCallback(async () => {
+    setIsSpecialistsLoading(true);
     try {
       const sessionData = await startQueueJoinSession(token);
+      const nextQueueInfo = sessionData.queue_info || {};
+      const selectableSpecialists = Array.isArray(nextQueueInfo.selectable_specialists)
+        ? nextQueueInfo.selectable_specialists
+        : [];
 
       setSessionToken(sessionData.session_token);
       localStorage.setItem(`queue_session_${token}`, sessionData.session_token);
-      setQueueInfo(sessionData.queue_info);
+      setQueueInfo(nextQueueInfo);
+      setAvailableSpecialists(selectableSpecialists);
 
-      if (sessionData.queue_info?.is_clinic_wide) {
+      if (nextQueueInfo.is_clinic_wide) {
         setStep('select-specialists');
       } else {
         setStep('info');
       }
 
     } catch (error) {
+      setAvailableSpecialists([]);
       setError(getApiErrorMessage(error, QUEUE_JOIN_MESSAGES.sessionStartFailed));
       setStep('error');
+    } finally {
+      setIsSpecialistsLoading(false);
     }
   }, [getApiErrorMessage, token]);
 
@@ -253,45 +167,60 @@ const QueueJoin = () => {
     if (!token) {
       setError(MISSING_QUEUE_TOKEN_MESSAGE);
       setStep('error');
+      setIsSpecialistsLoading(false);
       return;
     }
 
     try {
       setStep('loading');
+      setIsSpecialistsLoading(true);
       const tokenInfo = await fetchQrTokenInfo(token);
       setQueueInfo(tokenInfo);
+      setAvailableSpecialists(
+        Array.isArray(tokenInfo.selectable_specialists)
+          ? tokenInfo.selectable_specialists
+          : []
+      );
 
       if (!tokenInfo.queue_active) {
         setError(QUEUE_JOIN_MESSAGES.queueInactive);
         setStep('error');
+        setIsSpecialistsLoading(false);
         return;
       }
 
       if (tokenInfo.status === 'before_start_time') {
         setQueueInfo(tokenInfo);
         setStep('waiting');
+        setIsSpecialistsLoading(false);
         return;
       } else if (tokenInfo.status === 'after_end_time') {
         setError(QUEUE_JOIN_MESSAGES.registrationClosedAt(tokenInfo.end_time));
         setStep('error');
+        setIsSpecialistsLoading(false);
         return;
       } else if (tokenInfo.status === 'closed_reception_opened') {
         setError(QUEUE_JOIN_MESSAGES.receptionAlreadyOpened);
         setStep('error');
+        setIsSpecialistsLoading(false);
         return;
       } else if (tokenInfo.status === 'limit_reached') {
         setError(QUEUE_JOIN_MESSAGES.limitReached(tokenInfo.max_entries));
         setStep('error');
+        setIsSpecialistsLoading(false);
         return;
       } else if (tokenInfo.allowed === false) {
         setError(tokenInfo.message || QUEUE_JOIN_MESSAGES.registrationUnavailable);
         setStep('error');
+        setIsSpecialistsLoading(false);
         return;
       }
 
       await startJoinSession();
 
     } catch (error) {
+      setAvailableSpecialists([]);
+      setIsSpecialistsLoading(false);
       setError(getApiErrorMessage(error, QUEUE_JOIN_MESSAGES.qrTokenUnavailable));
       setStep('error');
     }
@@ -302,6 +231,8 @@ const QueueJoin = () => {
     if (!token) {
       setSessionToken(null);
       setQueueInfo(null);
+      setAvailableSpecialists([]);
+      setIsSpecialistsLoading(false);
       setError(MISSING_QUEUE_TOKEN_MESSAGE);
       setStep('error');
       return;
@@ -1221,7 +1152,7 @@ const QueueJoin = () => {
                   <span>Ҳозирча QR орқали танлаш учун мутахассислар мавжуд эмас.</span>
                   <button
                     type="button"
-                    onClick={loadSpecialists}
+                    onClick={loadTokenInfo}
                     style={{
                       alignSelf: 'center',
                       background: A11Y_COLORS.primary,

--- a/frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx
+++ b/frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx
@@ -31,6 +31,7 @@ function setupQueueApiMock({
     department_name: 'Кардиология',
     specialist_name: 'Кардиолог',
     target_date: '2026-02-21',
+    selectable_specialists: availableSpecialists,
   });
   queueApiMocks.startQueueJoinSession.mockResolvedValue({
     session_token: 'session-token',
@@ -40,6 +41,7 @@ function setupQueueApiMock({
       department_name: 'Кардиология',
       specialist_name: 'Кардиолог',
       target_date: '2026-02-21',
+      selectable_specialists: availableSpecialists,
     },
   });
   queueApiMocks.completeQueueJoinSession.mockResolvedValue({
@@ -173,6 +175,8 @@ describe('QueueJoin Accessibility & UX', () => {
         specialist_ids: [6],
       })
     );
+    expect(queueApiMocks.fetchPublicQueueProfiles).not.toHaveBeenCalled();
+    expect(queueApiMocks.fetchAvailableSpecialists).not.toHaveBeenCalled();
   });
 
   it('provides retry action from error state and recovers to info step', async () => {


### PR DESCRIPTION
﻿## Summary

- Extend the existing `/api/v1/queue/qr-tokens/{token}/info` contract with backend-computed `selectable_specialists` for clinic-wide QR tokens.
- Carry the same data through `/api/v1/queue/join/start` in `queue_info`.
- Remove QueueJoin's React-side specialist/profile merge and stop this screen from calling `/queues/profiles/public` plus `/queue/available-specialists`.

## Contract Impact

- Canonical surface: `GET /api/v1/queue/qr-tokens/{token}/info` and `POST /api/v1/queue/join/start` response `queue_info`.
- Request shape: unchanged for both endpoints.
- Response shape: adds optional `selectable_specialists` list for QR token info; `join/start` carries it through existing `queue_info`.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/pages/QueueJoin.jsx` consumes backend-provided specialist options.
- Compatibility path or alias: no `/api/v1/ui/*`; existing `/queue/available-specialists` and `/queues/profiles/public` remain for other callers.
- Contract proof: backend integration test verifies token info and join/start include matching backend-computed `selectable_specialists`; frontend test verifies QueueJoin no longer calls the two merge-source endpoints.

## RBAC / Permissions

not applicable - only public QR queue read/session endpoints keep their existing access behavior; no role guard, permission helper, or authenticated route changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, delivery, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: existing QueueJoin empty-specialist state remains and refresh now reloads token info.
- Partial data proof: QueueJoin treats missing or non-array `selectable_specialists` as an empty list.
- Forbidden secondary path behavior: not applicable - the removed secondary path calls are no longer used by this screen.
- Missing draft/resource behavior: not applicable - QueueJoin does not create or reopen drafts/resources.
- Stale route/deep-link behavior: missing token path still enters the existing error state without queue API calls.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/qr_queue.py`, `backend/app/services/qr_queue_service.py`, `backend/tests/integration/test_qr_queue_join.py`, `frontend/src/pages/QueueJoin.jsx`, `frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx`.
- Denied paths: `/api/v1/ui/*`, separate BFF service, migrations, generated output, broad RegistrarPanel or DisplayBoard changes.
- Migration/docs/test impact: no migration; targeted backend/frontend tests updated.
- Rollback note: revert commit `29a5adbd` to restore previous QueueJoin dual-call merge behavior.

## Validation

- Targeted tests or smoke run: `py -3 -m py_compile backend\\app\\api\\v1\\endpoints\\qr_queue.py backend\\app\\services\\qr_queue_service.py backend\\tests\\integration\\test_qr_queue_join.py`; `TESTING=1 DATABASE_URL=sqlite:///C:/tmp/final-queuejoin-pytest-bootstrap.db py -3 -m pytest backend\\tests\\integration\\test_qr_queue_join.py -q`; `TESTING=1 DATABASE_URL=sqlite:///C:/tmp/final-queuejoin-openapi-bootstrap.db py -3 -m pytest backend\\tests\\test_openapi_contract.py -q`; `npm run test:run -- src/pages/__tests__/QueueJoin.accessibility.test.jsx`; `npx eslint src/pages/QueueJoin.jsx src/pages/__tests__/QueueJoin.accessibility.test.jsx src/api/queue.js`; `npm run build`.
- Result: all passed locally; GitHub CI passed except the initial PR body template gate, which this body update addresses.
- Not checked: manual browser QR join smoke against a live backend.
