### PR TITLE
fix(registrar): require backend actions for commands

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -131,6 +131,14 @@ const hasBackendAction = (record, action) => {
   return false;
 };
 
+const getRegistrarActionForStatus = (status) => {
+  const normalizedStatus = normalizeRegistrarContractValue(status).replace('-', '_');
+  if (normalizedStatus === 'complete' || normalizedStatus === 'done') return 'complete';
+  if (normalizedStatus === 'paid' || normalizedStatus === 'mark_paid') return 'mark_paid';
+  if (normalizedStatus === 'in_cabinet') return 'start_visit';
+  return null;
+};
+
 const hasBackendPatientDisplayContract = (record) => {
   if (!record) return false;
   const hasName = Boolean(record.patient_fio || record.patient_name);
@@ -1858,6 +1866,11 @@ const RegistrarPanel = () => {
         notify.error('Missing backend record data for start visit');
         return;
       }
+      if (!hasBackendAction(appointment, 'start_visit')) {
+        logger.warn('RegistrarPanel: backend did not expose start_visit action', { recordKind, recordId, appointment });
+        notify.error('Action is not available for this record');
+        return;
+      }
 
       const url = recordKind === 'visit' ?
         `${API_BASE}/api/v1/registrar/visits/${recordId}/start-visit` :
@@ -2088,6 +2101,18 @@ const RegistrarPanel = () => {
         return null;
       }
 
+      const requiredBackendAction = getRegistrarActionForStatus(status);
+      if (!requiredBackendAction) {
+        logger.warn('RegistrarPanel: unsupported command without backend action contract', { appointmentId, status, recordType, realId, record });
+        notify.error('Action is not available for this record');
+        return null;
+      }
+      if (!hasBackendAction(record, requiredBackendAction)) {
+        logger.warn('RegistrarPanel: backend did not expose requested action', { appointmentId, status, requiredBackendAction, recordType, realId, record });
+        notify.error('Action is not available for this record');
+        return null;
+      }
+
       if (status === 'complete' || status === 'done') {
         if (recordType === 'visit') {
           url = `${API_BASE}/api/v1/registrar/visits/${realId}/complete`;
@@ -2206,7 +2231,7 @@ const RegistrarPanel = () => {
       Array.from(appointmentsSelected).map((id) => updateAppointmentStatus(id, action, reason))
     );
 
-    const successCount = results.filter((r) => r.status === 'fulfilled').length;
+    const successCount = results.filter((r) => r.status === 'fulfilled' && r.value).length;
     const failCount = results.length - successCount;
 
     if (successCount > 0) notify.success(`Обновлено: ${successCount}`);


### PR DESCRIPTION
## Summary

- Require backend-provided available_actions/can_* before RegistrarPanel executes start_visit, mark_paid, or complete commands.
- Stop counting unsupported local-only bulk status updates as successful.
- Prevent local-only confirm/cancel/no_show bulk actions from pretending to persist without a backend action contract.
- No /api/v1/ui/* endpoint and no separate BFF service.

## Contract Impact

- Canonical surface: GET /api/v1/registrar/queues/today action contract plus existing registrar/appointment command endpoints
- Request shape: unchanged frontend command requests for supported actions
- Response shape: unchanged; RegistrarPanel consumes existing available_actions/can_* fields
- Status codes: unchanged
- Frontend consumer: frontend/src/pages/RegistrarPanel.jsx
- Compatibility path or alias: no new endpoint, no /api/v1/ui/*, no separate BFF service
- Contract proof: frontend command smoke via targeted build/lint; backend command endpoints not changed

## RBAC / Permissions

- Roles allowed: unchanged; backend still owns route authorization and action availability
- Roles denied: unchanged
- Positive auth proof: not checked in this frontend-only slice; supported commands still call existing backend endpoints
- Negative auth proof: not checked in this frontend-only slice; React no longer treats unsupported actions as allowed

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: unchanged empty queue handling
- Partial data proof: missing available_actions/can_* disables backend-owned commands instead of allowing local mutation
- Forbidden secondary path behavior: unsupported bulk confirm/cancel/no_show returns action-not-available instead of local-only status mutation
- Missing draft/resource behavior: not applicable, no draft/resource lifecycle changed
- Stale route/deep-link behavior: not applicable, no route or deep-link behavior changed

## Scope Gate

- Allowed paths: frontend/src/pages/RegistrarPanel.jsx only
- Denied paths: backend endpoints, /api/v1/ui/*, separate BFF service, migrations, unrelated panels
- Migration/docs/test impact: no migration; no docs; targeted frontend validation only
- Rollback note: revert this PR to restore previous RegistrarPanel command fallback behavior

## Validation

- Targeted tests or smoke run: npm.cmd ci; npm.cmd exec eslint src/pages/RegistrarPanel.jsx; npm.cmd run build; git diff --check
- Result: passed; eslint reported only existing unused-var warnings in RegistrarPanel.jsx
- Not checked: backend pytest, browser smoke, manual registrar workflow
