### PR TITLE
fix(registrar): remove local status fallback commands

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -1973,44 +1973,6 @@ const RegistrarPanel = () => {
         } else {
           url = `${API_BASE}/api/v1/appointments/${realId}/mark-paid`;
         }
-      } else if (status === 'cancelled' || status === 'canceled') {
-        // Пока нет API для отмены, обновляем локально
-        logger.info('Отмена записи (локально):', appointmentId);
-        setAppointments((prev) => prev.map((apt) =>
-        apt.id === appointmentId ? {
-          ...apt,
-          status: 'cancelled',
-          _locallyModified: true,
-          _cancelReason: reason
-        } : apt
-        ));
-        notify.success('Запись отменена (локально)');
-        return { id: appointmentId, status: 'cancelled' };
-      } else if (status === 'confirmed') {
-        // Пока нет API для подтверждения, обновляем локально
-        logger.info('Подтверждение записи (локально):', appointmentId);
-        setAppointments((prev) => prev.map((apt) =>
-        apt.id === appointmentId ? {
-          ...apt,
-          status: 'confirmed',
-          _locallyModified: true
-        } : apt
-        ));
-        notify.success('Запись подтверждена (локально)');
-        return { id: appointmentId, status: 'confirmed' };
-      } else if (status === 'no_show') {
-        // Пока нет API для неявки, обновляем локально
-        logger.info('Неявка записи (локально):', appointmentId, 'Причина:', reason);
-        setAppointments((prev) => prev.map((apt) =>
-        apt.id === appointmentId ? {
-          ...apt,
-          status: 'no_show',
-          _locallyModified: true,
-          _noShowReason: reason
-        } : apt
-        ));
-        notify.success('Отмечено как неявка (локально)');
-        return { id: appointmentId, status: 'no_show' };
       } else if (status === 'in_cabinet') {
         if (recordType === 'visit') {
           url = `${API_BASE}/api/v1/registrar/visits/${realId}/start-visit`;


### PR DESCRIPTION
﻿## Summary

- Remove unreachable local status mutation branches from `RegistrarPanel` command routing.
- Keep unsupported commands blocked by the existing backend `available_actions` gate.
- Keep this slice frontend-only: no `/api/v1/ui/*` endpoint and no separate BFF service.

## Contract Impact

- Canonical surface: existing `/registrar/queues/today` `available_actions` / `can_*` command availability contract remains the source of truth.
- Request shape: unchanged; no backend requests changed.
- Response shape: unchanged; frontend still consumes existing canonical action fields.
- Status codes: unchanged; no backend route or DTO changes.
- Frontend consumer: `frontend/src/pages/RegistrarPanel.jsx` no longer contains fallback local transitions for `cancelled`, `confirmed`, or `no_show` inside `updateAppointmentStatus`.
- Compatibility path or alias: no compatibility route changed; local-only fallback commands were removed from an already unreachable branch.
- Contract proof: `updateAppointmentStatus` still rejects commands with no backend action contract before endpoint routing; local validation and CI cover build/lint.

## RBAC / Permissions

- Roles allowed: unchanged; backend auth/RBAC remains owned by existing endpoints and `available_actions`.
- Roles denied: unchanged.
- Positive auth proof: not applicable - no backend permission behavior changed.
- Negative auth proof: not applicable - no backend permission behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, queue event, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: unchanged; queue loading path was not changed.
- Partial data proof: unchanged; canonical adapter was not changed.
- Forbidden secondary path behavior: unsupported commands still return the existing Action is not available path instead of mutating local state.
- Missing draft/resource behavior: not applicable - this change does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - route/deep-link patient preload was not changed.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx` only.
- Denied paths: backend endpoints/schemas/services, `/api/v1/ui/*`, separate BFF service, unrelated Registrar rewrite.
- Migration/docs/test impact: no migration; no docs change; no backend contract test change because API shape is unchanged.
- Rollback note: revert commit `89d33b83` to restore the previous local fallback branches.

## Validation

- Targeted tests or smoke run: `npm.cmd ci`; `npm.cmd exec eslint src/pages/RegistrarPanel.jsx`; `npm.cmd run build`; `git diff --check`.
- Result: local ESLint passed with existing warnings only for `accentColor`, `buttonStyle`, `buttonSecondaryStyle`; local build passed; `git diff --check` passed.
- Not checked: browser/manual RegistrarPanel command smoke with a live backend; backend pytest not run because no backend code or API contract changed.
