### PR TITLE
fix(registrar): stop local cancel state fallback

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -3860,7 +3860,8 @@ const RegistrarPanel = () => {
               recordType,
               source: data?.source,
               fullData: data,
-              idsToCancel
+              idsToCancel,
+              reasonLength: reason?.length || 0
             });
 
             // Функция отмены одной записи
@@ -3925,6 +3926,9 @@ const RegistrarPanel = () => {
             if (failCount > 0) {
               logger.warn(`⚠️ Отменено ${successCount}/${idsToCancel.length} записей, ${failCount} ошибок`);
               notify.warning(`Отменено ${successCount} из ${idsToCancel.length} услуг`);
+              if (successCount === 0) {
+                throw new Error('Cancellation failed for all selected records');
+              }
             } else {
               logger.info(`✅ Все ${successCount} записи успешно отменены на сервере`);
             }
@@ -3937,24 +3941,10 @@ const RegistrarPanel = () => {
             } else {
       notify.error(getErrorMessage(error, 'Не удалось обновить статус на сервере. Проверьте соединение и попробуйте снова.'));
             }
-            // Don't return here, still update locally to remove from view or let the user know
+            throw error;
           }
 
-          // Локальное обновление статуса (для всех ID)
-          const data = appointmentId === cancelDialog.row?.id ? cancelDialog.row : appointments.find((a) => a.id === appointmentId);
-          const idsToCancel = data?.aggregated_ids?.length > 0 ? data.aggregated_ids : [appointmentId];
-
-          setAppointments((prev) => prev.map((apt) =>
-          idsToCancel.includes(apt.id) ? {
-            ...apt,
-            status: 'canceled',
-            _locallyModified: true,
-            _cancelReason: reason
-          } : apt
-          ));
-
-          // Refresh data to ensure consistency
-          setTimeout(() => loadAppointments({ silent: true, source: 'cancel_complete' }), 500);
+          await loadAppointments({ silent: true, source: 'cancel_complete' });
         }} />
 
 


### PR DESCRIPTION
﻿## Summary

- Remove the local post-cancel `setAppointments` fallback from `RegistrarPanel`.
- Keep backend cancel attempts and `/registrar/queues/today` reload as the source of truth.
- Keep this slice frontend-only: no `/api/v1/ui/*` endpoint and no separate BFF service.

## Contract Impact

- Canonical surface: existing cancel endpoints plus `/registrar/queues/today` reload remain the source of truth.
- Request shape: unchanged; existing visit, online queue, and appointment cancel requests remain.
- Response shape: unchanged; no backend DTO/API changes.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/pages/RegistrarPanel.jsx` no longer locally marks rows as canceled after cancel attempts.
- Compatibility path or alias: no backend route changed; appointment cancel still uses the existing PUT path and existing DELETE fallback.
- Contract proof: failed backend cancellation now throws instead of closing as success; successful/partial cancellation reloads canonical queue state.

## RBAC / Permissions

- Roles allowed: unchanged; backend endpoints remain the auth/RBAC owner.
- Roles denied: unchanged.
- Positive auth proof: not applicable - no backend permission behavior changed.
- Negative auth proof: not applicable - no backend permission behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, queue event, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: unchanged; canonical loader handles empty queue data.
- Partial data proof: partial cancel success warns and then reloads backend state.
- Forbidden secondary path behavior: backend failure now leaves state to backend/reload truth and does not force local canceled state.
- Missing draft/resource behavior: not applicable - this change does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - route/deep-link patient preload was not changed.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx` only.
- Denied paths: backend endpoints/schemas/services, `/api/v1/ui/*`, separate BFF service, unrelated Registrar rewrite.
- Migration/docs/test impact: no migration; no docs change; no backend contract test change because API shape is unchanged.
- Rollback note: revert this commit to restore the previous local cancel fallback.

## Validation

- Targeted tests or smoke run: `git diff --check`; `npm.cmd exec eslint src/pages/RegistrarPanel.jsx`; `npm.cmd run build`.
- Result: local ESLint passed with existing warnings only for `accentColor`, `buttonStyle`, `buttonSecondaryStyle`; local build passed; `git diff --check` passed.
- Not checked: browser/manual RegistrarPanel cancel smoke with a live backend; backend pytest not run because no backend code or API contract changed.
