### PR TITLE
fix(registrar): reload status commands from backend state

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -1731,14 +1731,6 @@ const RegistrarPanel = () => {
         const result = await response.json();
         logger.info('Обновленная запись:', result);
 
-        // Обновляем список записей с новым статусом
-        setAppointments((prev) => prev.map((apt) =>
-        apt.id === appointment.id ? {
-          ...apt,
-          status: result.entry?.status || 'in_progress',
-          _locallyModified: false
-        } : apt
-        ));
         notify.success('Пациент вызван успешно!');
 
         // Перезагружаем данные для синхронизации с сервером
@@ -2007,11 +1999,6 @@ const RegistrarPanel = () => {
 
       const updatedAppointment = await response.json();
       logger.info('Обновленная запись:', updatedAppointment);
-
-      // Обновляем локальное состояние
-      setAppointments((prev) => prev.map((apt) =>
-      apt.id === appointmentId ? { ...apt, status: updatedAppointment.status || status } : apt
-      ));
 
       await loadAppointments({ source: 'status_update' });
       notify.success('Статус обновлен');


### PR DESCRIPTION
﻿## Summary

- Remove optimistic local `setAppointments` status mutations after Registrar start/status commands.
- Keep existing command calls and `/registrar/queues/today` reload as the source of truth.
- Keep this slice frontend-only: no payment cleanup, no `/api/v1/ui/*` endpoint, and no separate BFF service.

## Contract Impact

- Canonical surface: existing start/status command endpoints plus `/registrar/queues/today` reload remain the source of truth.
- Request shape: unchanged.
- Response shape: unchanged; no backend DTO/API changes.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/pages/RegistrarPanel.jsx` no longer writes local status after start/status command success.
- Compatibility path or alias: unchanged; existing command endpoint selection remains for a later slice.
- Contract proof: successful commands now rely on canonical reload before refreshed row state is shown.

## RBAC / Permissions

- Roles allowed: unchanged; backend endpoints remain the auth/RBAC owner.
- Roles denied: unchanged.
- Positive auth proof: backend permission behavior was not changed; existing endpoint authorization still gates command success.
- Negative auth proof: backend permission behavior was not changed; denied roles remain handled by existing command endpoints.

## Notification / Realtime

- Event type or websocket channel: no event type, websocket channel, chat, notification, or queue realtime channel changed.
- Payload version / ack behavior: no realtime payload, payload version, acknowledgement, or delivery contract changed.
- Read/unread or delivery semantics: no read/unread, delivery, retry, or notification state semantics changed.
- Reconnect/resync proof: existing page resync remains the `/registrar/queues/today` reload after command success; websocket reconnect behavior was not touched.

## Frontend Resilience

- Empty data proof: unchanged; canonical loader handles empty queue data.
- Partial data proof: unchanged; this slice only removes local optimistic status writes.
- Forbidden secondary path behavior: failed commands already avoid local mutation; successful commands now reload backend state.
- Missing draft/resource behavior: this path does not create, reopen, or attach drafts/resources; no draft/resource lifecycle code was touched.
- Stale route/deep-link behavior: route and deep-link handling were not touched; command success still returns to the same page state and refreshes rows through `/registrar/queues/today`.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx` only.
- Denied paths: backend endpoints/schemas/services, payment cleanup, `/api/v1/ui/*`, separate BFF service, unrelated Registrar rewrite.
- Migration/docs/test impact: no migration; no docs change; no backend contract test change because API shape is unchanged.
- Rollback note: revert this commit to restore the previous optimistic start/status local status writes.

## Validation

- Targeted tests or smoke run: `npm.cmd ci`; `git diff --check`; `npm.cmd exec eslint src/pages/RegistrarPanel.jsx`; `npm.cmd run build`.
- Result: local ESLint passed with existing warnings only for `accentColor`, `buttonStyle`, `buttonSecondaryStyle`; local build passed; `git diff --check` passed.
- Not checked: browser/manual RegistrarPanel start/status smoke with a live backend; backend pytest not run because no backend code or API contract changed.
