### PR TITLE
fix(registrar): reload payment state from backend

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -1853,34 +1853,6 @@ const RegistrarPanel = () => {
       }
 
       if (successCount > 0 || skippedCount > 0) {
-        // Обновляем статус только для записей, которые были реально оплачены (не пропущены)
-        const paidRecordIds = paymentResults.
-        filter((r) => r.success && !r.skipped).
-        map((r) => String(r.recordId));
-        const paymentResultById = new Map(
-          paymentResults.
-          filter((r) => r.success && !r.skipped).
-          map((r) => [String(r.recordId), r.result || {}])
-        );
-
-        logger.info('✅ Оплата успешна, обновляем локальное состояние для оплаченных записей:', paidRecordIds);
-
-        // Обновляем статус только для реально оплаченных записей
-        recordsToUpdate.
-        filter((record) => paidRecordIds.includes(String(getRegistrarRecordId(record, getRegistrarRecordKind(record))))).
-        forEach((record) => {
-          const result = paymentResultById.get(String(getRegistrarRecordId(record, getRegistrarRecordKind(record)))) || {};
-          const recordWithBackendState = {
-            ...record,
-            status: result.status ?? result.entry?.status ?? record.status,
-            payment_status: result.payment_status ?? record.payment_status,
-            _locallyModified: false
-          };
-
-          delete appointmentOverridesRef.current[String(record.id)];
-          setAppointments((prev) => prev.map((apt) => apt.id === record.id ? recordWithBackendState : apt));
-        });
-
         // Формируем информативное сообщение
         let message = '';
         if (successCount > 0 && skippedCount > 0) {
@@ -3945,8 +3917,8 @@ const RegistrarPanel = () => {
           if (appointment) {
             const updated = await handlePayment(appointment, paymentData);
             if (updated) {
-              // Статус уже установлен в handlePayment из ответа backend
-              logger.info('PaymentDialog: Оплата успешна, статус обновлен:', updated);
+              // Canonical state is refreshed by handlePayment via loadAppointments.
+              logger.info('PaymentDialog: Оплата успешна, данные обновлены:', updated);
             }
           }
         }}


### PR DESCRIPTION
﻿## Summary

- Remove local payment `setAppointments` state rewrites from `RegistrarPanel` after successful payment commands.
- Keep existing payment command calls and `/registrar/queues/today` reload as the source of truth.
- Keep this slice frontend-only: no payment endpoint routing cleanup, no `/api/v1/ui/*` endpoint, and no separate BFF service.

## Contract Impact

- Canonical surface: existing payment command endpoints plus `/registrar/queues/today` reload remain the source of truth.
- Request shape: unchanged.
- Response shape: unchanged; no backend DTO/API changes.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/pages/RegistrarPanel.jsx` no longer writes local `status` or `payment_status` from payment command responses.
- Compatibility path or alias: unchanged; existing payment endpoint selection remains for a later slice.
- Contract proof: successful payment still shows the result message and refreshes rows through the canonical loader.

## RBAC / Permissions

- Roles allowed: unchanged; backend payment endpoints remain the auth/RBAC owner.
- Roles denied: unchanged.
- Positive auth proof: backend permission behavior was not changed; existing endpoint authorization still gates payment command success.
- Negative auth proof: backend permission behavior was not changed; denied roles remain handled by existing payment endpoints.

## Notification / Realtime

- Event type or websocket channel: no event type, websocket channel, chat, notification, or queue realtime channel changed.
- Payload version / ack behavior: no realtime payload, payload version, acknowledgement, or delivery contract changed.
- Read/unread or delivery semantics: no read/unread, delivery, retry, or notification state semantics changed.
- Reconnect/resync proof: existing page resync remains the `/registrar/queues/today` reload after payment success; websocket reconnect behavior was not touched.

## Frontend Resilience

- Empty data proof: unchanged; canonical loader handles empty queue data.
- Partial data proof: unchanged; partial payment success still reports success/failure counts and then reloads backend state.
- Forbidden secondary path behavior: failed payment commands already avoid local mutation; successful payments now avoid local row mutation too.
- Missing draft/resource behavior: this path does not create, reopen, or attach drafts/resources; no draft/resource lifecycle code was touched.
- Stale route/deep-link behavior: route and deep-link handling were not touched; payment success keeps the same page state and refreshes rows through `/registrar/queues/today`.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx` only.
- Denied paths: backend endpoints/schemas/services, payment endpoint routing cleanup, `/api/v1/ui/*`, separate BFF service, unrelated Registrar rewrite.
- Migration/docs/test impact: no migration; no docs change; no backend contract test change because API shape is unchanged.
- Rollback note: revert this commit to restore the previous local payment row state writes.

## Validation

- Targeted tests or smoke run: `npm.cmd ci`; `git diff --check`; `npm.cmd exec eslint src/pages/RegistrarPanel.jsx`; `npm.cmd run build`.
- Result: local ESLint passed with existing warnings only for `accentColor`, `buttonStyle`, `buttonSecondaryStyle`; local build passed; `git diff --check` passed.
- Not checked: browser/manual RegistrarPanel payment smoke with a live backend; backend pytest not run because no backend code or API contract changed.
