### PR TITLE
fix(registrar): centralize queue command contract

### DIFF
--- a/backend/app/api/v1/endpoints/appointment_flow.py
+++ b/backend/app/api/v1/endpoints/appointment_flow.py
@@ -538,7 +538,7 @@ def complete_visit(
 def mark_appointment_paid(
     appointment_id: int,
     db: Session = Depends(deps.get_db),
-    # current_user: User = Depends(deps.require_roles("Admin", "Cashier", "Registrar")),
+    current_user: User = Depends(deps.require_roles("Admin", "Cashier", "Registrar")),
 ) -> Any:
     """
     Отметить запись как оплаченную (переход pending -> paid)

--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -55,9 +55,11 @@ REGISTRAR_START_VISIT_ROLES = {
 }
 REGISTRAR_PRINT_TICKET_ROLES = {"admin", "registrar", "cashier", "doctor"}
 REGISTRAR_COMPLETE_ROLES = {"admin", "registrar", "doctor", "cashier", "receptionist"}
+REGISTRAR_CANCEL_ROLES = {"admin", "registrar", "cashier", "receptionist", "doctor"}
 REGISTRAR_START_STATUSES = {"waiting", "queued"}
 REGISTRAR_PRINT_STATUSES = {"waiting", "queued"}
 REGISTRAR_COMPLETE_STATUSES = {"called", "in_cabinet", "in_progress"}
+REGISTRAR_CANCEL_BLOCKED_STATUSES = {"canceled", "cancelled", "completed", "done", "served"}
 
 
 def _registrar_user_role_names(user: User | None) -> set[str]:
@@ -113,6 +115,14 @@ def _registrar_can_complete(user: User | None, queue_status: str | None) -> bool
     )
 
 
+def _registrar_can_cancel(user: User | None, queue_status: str | None) -> bool:
+    normalized_status = str(queue_status or "").strip().lower()
+    return (
+        normalized_status not in REGISTRAR_CANCEL_BLOCKED_STATUSES
+        and bool(_registrar_user_role_names(user) & REGISTRAR_CANCEL_ROLES)
+    )
+
+
 def _registrar_available_actions(
     *,
     user: User | None,
@@ -132,6 +142,8 @@ def _registrar_available_actions(
         actions.append("print_ticket")
     if _registrar_can_complete(user, queue_status):
         actions.append("complete")
+    if _registrar_can_cancel(user, queue_status):
+        actions.append("cancel")
     return actions
 
 
@@ -2913,6 +2925,7 @@ def get_today_queues(
                 can_start_visit = "start_visit" in available_actions
                 can_print_ticket = "print_ticket" in available_actions
                 can_complete = "complete" in available_actions
+                can_cancel = "cancel" in available_actions
 
                 entries.append(
                     {
@@ -2940,6 +2953,7 @@ def get_today_queues(
                         "can_start_visit": can_start_visit,
                         "can_print_ticket": can_print_ticket,
                         "can_complete": can_complete,
+                        "can_cancel": can_cancel,
                         "available_actions": available_actions,
                         "source": source,
                         "status": canonical_status,

--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -23,15 +23,21 @@ from app.models.payment_invoice import PaymentInvoice, PaymentInvoiceVisit
 from app.models.service import Service
 from app.models.user import User
 from app.models.visit import Visit, VisitService
+from app.crud.appointment import appointment as crud_appointment
 from app.services.feature_flags import is_feature_enabled
 from app.services.registrar_wizard_queue_assignment_service import (
     RegistrarWizardQueueAssignmentService,
 )
 from app.services.notifications import notification_sender_service
+from app.services.online_queue_new_service import (
+    OnlineQueueNewDomainError,
+    OnlineQueueNewService,
+)
 from app.services.payment_provider_manager_factory import get_payment_manager
 from app.services.queue_service import queue_service
 from app.services.queue_session import get_or_create_session_id
 from app.services.service_mapping import get_service_code, normalize_service_code
+from app.services.visits_api_service import VisitsApiService
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +88,41 @@ class CartResponse(BaseModel):
 class MarkPaidRequest(BaseModel):
     amount: Optional[Decimal] = None
     method: Optional[str] = Field(default="cash")
+
+
+class RegistrarRecordRef(BaseModel):
+    record_kind: str
+    record_id: int
+
+
+class RegistrarRecordActionRequest(BaseModel):
+    action: str
+    record_kind: Optional[str] = None
+    record_id: Optional[int] = None
+    records: Optional[List[RegistrarRecordRef]] = None
+    reason: Optional[str] = None
+    amount: Optional[Decimal] = None
+    method: Optional[str] = Field(default="cash")
+
+
+class RegistrarRecordActionItemResponse(BaseModel):
+    record_kind: str
+    record_id: int
+    success: bool
+    skipped: bool = False
+    status: Optional[str] = None
+    payment_status: Optional[str] = None
+    error: Optional[str] = None
+    result: Optional[Dict[str, Any]] = None
+
+
+class RegistrarRecordActionResponse(BaseModel):
+    action: str
+    success: bool
+    success_count: int
+    skipped_count: int
+    failed_count: int
+    results: List[RegistrarRecordActionItemResponse]
 
 
 class RepeatEligibilityCandidate(BaseModel):
@@ -2373,14 +2414,281 @@ def _preserve_operational_status_on_payment(raw_status: str | None) -> str:
     return raw_status
 
 
+REGISTRAR_COMMAND_ROLE_BY_ACTION = {
+    "mark_paid": {"admin", "registrar", "cashier"},
+    "start_visit": {
+        "admin",
+        "registrar",
+        "doctor",
+        "cardio",
+        "cardiology",
+        "cardiologist",
+        "derma",
+        "dermatologist",
+        "dentist",
+        "lab",
+    },
+    "complete": {"admin", "registrar", "doctor", "cashier", "receptionist"},
+    "cancel": {"admin", "registrar", "cashier", "receptionist", "doctor"},
+}
+
+REGISTRAR_SUPPORTED_RECORD_KINDS = {"visit", "online_queue", "appointment"}
+
+
+def _registrar_user_role_names(user: User | None) -> set[str]:
+    role_names: set[str] = set()
+    primary_role = getattr(user, "role", None)
+    if primary_role:
+        role_names.add(str(primary_role).strip().lower())
+
+    for role in getattr(user, "roles", None) or []:
+        role_name = getattr(role, "name", None)
+        if role_name:
+            role_names.add(str(role_name).strip().lower())
+
+    return role_names
+
+
+def _normalize_registrar_action(action: str | None) -> str:
+    return str(action or "").strip().lower().replace("-", "_")
+
+
+def _normalize_registrar_record_kind(record_kind: str | None) -> str:
+    return str(record_kind or "").strip().lower()
+
+
+def _ensure_registrar_command_role(user: User | None, action: str) -> None:
+    allowed_roles = REGISTRAR_COMMAND_ROLE_BY_ACTION.get(action)
+    if not allowed_roles:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported registrar action: {action}",
+        )
+    if not (_registrar_user_role_names(user) & allowed_roles):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Action is not available for this user",
+        )
+
+
+def _registrar_command_item(
+    *,
+    record_kind: str,
+    record_id: int,
+    success: bool,
+    skipped: bool = False,
+    status_value: str | None = None,
+    payment_status: str | None = None,
+    error: str | None = None,
+    result: dict[str, Any] | None = None,
+) -> RegistrarRecordActionItemResponse:
+    return RegistrarRecordActionItemResponse(
+        record_kind=record_kind,
+        record_id=record_id,
+        success=success,
+        skipped=skipped,
+        status=status_value,
+        payment_status=payment_status,
+        error=error,
+        result=result,
+    )
+
+
+def _run_single_registrar_record_action(
+    *,
+    db: Session,
+    current_user: User,
+    record: RegistrarRecordRef,
+    action: str,
+    request: RegistrarRecordActionRequest,
+) -> RegistrarRecordActionItemResponse:
+    record_kind = _normalize_registrar_record_kind(record.record_kind)
+    record_id = record.record_id
+
+    if record_kind not in REGISTRAR_SUPPORTED_RECORD_KINDS:
+        return _registrar_command_item(
+            record_kind=record_kind,
+            record_id=record_id,
+            success=False,
+            error="unsupported_record_kind",
+        )
+
+    try:
+        if action == "mark_paid":
+            if record_kind == "visit":
+                result = mark_visit_as_paid(
+                    record_id,
+                    payment_req=MarkPaidRequest(
+                        amount=request.amount,
+                        method=request.method,
+                    ),
+                    db=db,
+                    current_user=current_user,
+                )
+            elif record_kind == "online_queue":
+                result = mark_queue_entry_as_paid(
+                    record_id,
+                    payment_req=MarkPaidRequest(
+                        amount=request.amount,
+                        method=request.method,
+                    ),
+                    db=db,
+                    current_user=current_user,
+                )
+            else:
+                appointment = crud_appointment.get(db, id=record_id)
+                if not appointment:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="Appointment not found",
+                    )
+                if str(appointment.status or "").lower() == "paid":
+                    return _registrar_command_item(
+                        record_kind=record_kind,
+                        record_id=record_id,
+                        success=True,
+                        skipped=True,
+                        status_value=appointment.status,
+                        payment_status="paid",
+                    )
+                appointment = crud_appointment.mark_paid(db, appointment_id=record_id)
+                if not appointment:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="Appointment not found",
+                    )
+                result = {
+                    "id": appointment.id,
+                    "status": appointment.status,
+                    "payment_status": "paid",
+                }
+            return _registrar_command_item(
+                record_kind=record_kind,
+                record_id=record_id,
+                success=True,
+                status_value=str(result.get("status") or ""),
+                payment_status=str(result.get("payment_status") or "") or None,
+                result=result,
+            )
+
+        if action == "cancel":
+            if record_kind == "visit":
+                visit = VisitsApiService(db).set_status(
+                    visit_id=record_id,
+                    status_new="canceled",
+                )
+                if request.reason:
+                    visit.notes = (visit.notes or "") + f"\nCanceled: {request.reason}"
+                    db.commit()
+                    db.refresh(visit)
+                result = {"id": visit.id, "status": visit.status}
+            elif record_kind == "online_queue":
+                entry = OnlineQueueNewService(db).cancel_entry(entry_id=record_id)
+                result = {"id": entry.id, "status": entry.status}
+            else:
+                appointment = crud_appointment.cancel_appointment(
+                    db,
+                    appointment_id=record_id,
+                )
+                if not appointment:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="Appointment not found",
+                    )
+                result = {"id": appointment.id, "status": appointment.status}
+            return _registrar_command_item(
+                record_kind=record_kind,
+                record_id=record_id,
+                success=True,
+                status_value=str(result.get("status") or ""),
+                result=result,
+            )
+
+        if action == "start_visit":
+            if record_kind == "appointment":
+                appointment = crud_appointment.start_visit(db, appointment_id=record_id)
+                if not appointment:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="Appointment not found",
+                    )
+                result = {"id": appointment.id, "status": appointment.status}
+            elif record_kind == "visit":
+                result = start_visit(record_id, db=db, current_user=current_user)
+            else:
+                from app.api.v1.endpoints.registrar_integration import start_queue_visit
+
+                result = start_queue_visit(
+                    record_id,
+                    db=db,
+                    current_user=current_user,
+                )
+            status_value = None
+            if isinstance(result, dict):
+                status_value = result.get("status") or (
+                    result.get("entry") or {}
+                ).get("status")
+            return _registrar_command_item(
+                record_kind=record_kind,
+                record_id=record_id,
+                success=True,
+                status_value=str(status_value or ""),
+                result=result if isinstance(result, dict) else None,
+            )
+
+        if action == "complete":
+            if record_kind == "appointment":
+                appointment = crud_appointment.complete_visit(db, appointment_id=record_id)
+                if not appointment:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="Appointment not found",
+                    )
+                result = {"id": appointment.id, "status": appointment.status}
+            elif record_kind == "visit":
+                result = complete_visit(record_id, db=db, current_user=current_user)
+            else:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Complete is not available for online queue records",
+                )
+            return _registrar_command_item(
+                record_kind=record_kind,
+                record_id=record_id,
+                success=True,
+                status_value=str(result.get("status") or ""),
+                result=result if isinstance(result, dict) else None,
+            )
+
+    except OnlineQueueNewDomainError as exc:
+        return _registrar_command_item(
+            record_kind=record_kind,
+            record_id=record_id,
+            success=False,
+            error=exc.detail,
+        )
+    except HTTPException as exc:
+        return _registrar_command_item(
+            record_kind=record_kind,
+            record_id=record_id,
+            success=False,
+            error=str(exc.detail),
+        )
+
+    return _registrar_command_item(
+        record_kind=record_kind,
+        record_id=record_id,
+        success=False,
+        error="unsupported_action",
+    )
+
+
 @router.post("/registrar/visits/{visit_id}/mark-paid")
 def mark_visit_as_paid(
     visit_id: int,
     payment_req: Optional[MarkPaidRequest] = Body(default=None),
     db: Session = Depends(get_db),
-    current_user: User = Depends(
-        require_roles("Admin", "Registrar", "Cashier", "Receptionist", "Doctor")
-    ),
+    current_user: User = Depends(require_roles("Admin", "Registrar", "Cashier")),
 ):
     """Отметить запись из таблицы visits как оплаченную и создать платеж (SSOT)"""
     try:
@@ -2527,9 +2835,7 @@ def mark_queue_entry_as_paid(
     entry_id: int,
     payment_req: Optional[MarkPaidRequest] = Body(default=None),
     db: Session = Depends(get_db),
-    current_user: User = Depends(
-        require_roles("Admin", "Registrar", "Cashier", "Receptionist", "Doctor")
-    ),
+    current_user: User = Depends(require_roles("Admin", "Registrar", "Cashier")),
 ):
     """
     Отметить запись OnlineQueueEntry как оплаченную.
@@ -2792,6 +3098,89 @@ def start_visit(
 """
 
 # ===================== ПОДТВЕРЖДЕНИЕ ВИЗИТОВ =====================
+
+
+@router.post(
+    "/registrar/records/actions",
+    response_model=RegistrarRecordActionResponse,
+)
+def run_registrar_record_action(
+    request: RegistrarRecordActionRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(
+        require_roles(
+            "Admin",
+            "Registrar",
+            "Cashier",
+            "Receptionist",
+            "Doctor",
+            "cardio",
+            "cardiology",
+            "cardiologist",
+            "derma",
+            "dermatologist",
+            "dentist",
+            "Lab",
+        )
+    ),
+) -> RegistrarRecordActionResponse:
+    """Run registrar-owned record commands through a single backend contract."""
+
+    action = _normalize_registrar_action(request.action)
+    _ensure_registrar_command_role(current_user, action)
+
+    records: list[RegistrarRecordRef] = []
+    if request.records:
+        records.extend(request.records)
+    if request.record_kind and request.record_id is not None:
+        records.append(
+            RegistrarRecordRef(
+                record_kind=request.record_kind,
+                record_id=request.record_id,
+            )
+        )
+
+    unique_records: list[RegistrarRecordRef] = []
+    seen: set[tuple[str, int]] = set()
+    for record in records:
+        record_kind = _normalize_registrar_record_kind(record.record_kind)
+        key = (record_kind, record.record_id)
+        if record.record_id <= 0 or key in seen:
+            continue
+        seen.add(key)
+        unique_records.append(
+            RegistrarRecordRef(record_kind=record_kind, record_id=record.record_id)
+        )
+
+    if not unique_records:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No registrar records provided",
+        )
+
+    results = [
+        _run_single_registrar_record_action(
+            db=db,
+            current_user=current_user,
+            record=record,
+            action=action,
+            request=request,
+        )
+        for record in unique_records
+    ]
+
+    success_count = len([item for item in results if item.success and not item.skipped])
+    skipped_count = len([item for item in results if item.success and item.skipped])
+    failed_count = len([item for item in results if not item.success])
+
+    return RegistrarRecordActionResponse(
+        action=action,
+        success=failed_count == 0,
+        success_count=success_count,
+        skipped_count=skipped_count,
+        failed_count=failed_count,
+        results=results,
+    )
 
 
 class ConfirmVisitRequest(BaseModel):

--- a/backend/tests/integration/test_registrar_all_appointments.py
+++ b/backend/tests/integration/test_registrar_all_appointments.py
@@ -187,12 +187,14 @@ class TestRegistrarAllAppointments:
         assert found_entry["queue_position"] == entry.number
         assert found_entry["can_mark_paid"] is True
         assert found_entry["can_start_visit"] is True
+        assert found_entry["can_cancel"] is True
         assert found_entry["can_print_ticket"] is True
         assert found_entry["can_complete"] is False
         assert set(found_entry["available_actions"]) == {
             "mark_paid",
             "start_visit",
             "print_ticket",
+            "cancel",
         }
         assert found_entry["queue_time"] == _serialize_registrar_datetime(entry.queue_time)
         assert found_entry["created_at"] == _serialize_registrar_datetime(entry.created_at)

--- a/backend/tests/integration/test_registrar_record_actions.py
+++ b/backend/tests/integration/test_registrar_record_actions.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+def test_registrar_record_action_can_cancel_online_queue_entry(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_queue_entry,
+):
+    response = client.post(
+        "/api/v1/registrar/records/actions",
+        headers=registrar_auth_headers,
+        json={
+            "action": "cancel",
+            "records": [
+                {
+                    "record_kind": "online_queue",
+                    "record_id": test_queue_entry.id,
+                }
+            ],
+            "reason": "contract test",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["action"] == "cancel"
+    assert payload["success"] is True
+    assert payload["success_count"] == 1
+    assert payload["failed_count"] == 0
+    assert payload["results"][0]["record_kind"] == "online_queue"
+    assert payload["results"][0]["record_id"] == test_queue_entry.id
+
+    db_session.refresh(test_queue_entry)
+    assert test_queue_entry.status == "canceled"
+
+
+@pytest.mark.integration
+def test_registrar_record_action_rejects_doctor_mark_paid(
+    client,
+    cardio_auth_headers,
+    test_visit,
+):
+    response = client.post(
+        "/api/v1/registrar/records/actions",
+        headers=cardio_auth_headers,
+        json={
+            "action": "mark_paid",
+            "record_kind": "visit",
+            "record_id": test_visit.id,
+        },
+    )
+
+    assert response.status_code == 403
+

--- a/backend/tests/test_openapi_contract.py
+++ b/backend/tests/test_openapi_contract.py
@@ -31,6 +31,7 @@ def test_openapi_schema_not_fallback_and_has_paths(client: TestClient) -> None:
         ("/api/v1/auth/me", "get"),
         ("/api/v1/queue/join/start", "post"),
         ("/api/v1/queue/join/complete", "post"),
+        ("/api/v1/registrar/records/actions", "post"),
         ("/api/v1/payments/init", "post"),
         ("/api/v1/payments/{payment_id}", "get"),
         ("/api/v1/health", "get"),

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -101,6 +101,47 @@ const getRegistrarRecordId = (record, recordKind = getRegistrarRecordKind(record
   return record.id ?? null;
 };
 
+const REGISTRAR_RECORD_KINDS = new Set(['visit', 'online_queue', 'appointment']);
+
+const getRegistrarRecordRefs = (record) => {
+  if (!record) return [];
+
+  const candidates = [];
+  if (Array.isArray(record.grouped_record_refs)) {
+    candidates.push(...record.grouped_record_refs);
+  }
+  if (Array.isArray(record.grouped_records)) {
+    record.grouped_records.forEach((groupedRecord) => {
+      if (groupedRecord?.record_ref) {
+        candidates.push(groupedRecord.record_ref);
+      }
+    });
+  }
+
+  const recordKind = getRegistrarRecordKind(record);
+  const recordId = getRegistrarRecordId(record, recordKind);
+  if (recordKind && recordId !== null && recordId !== undefined) {
+    candidates.push({ record_kind: recordKind, record_id: recordId });
+  }
+
+  const seen = new Set();
+  return candidates.reduce((refs, candidate) => {
+    const kind = getRegistrarRecordKind(candidate);
+    const id = candidate?.record_id ?? candidate?.recordId ?? getRegistrarRecordId(candidate, kind);
+    const numericId = Number(id);
+    if (!REGISTRAR_RECORD_KINDS.has(kind) || !Number.isFinite(numericId) || numericId <= 0) {
+      return refs;
+    }
+    const key = `${kind}:${numericId}`;
+    if (seen.has(key)) {
+      return refs;
+    }
+    seen.add(key);
+    refs.push({ record_kind: kind, record_id: numericId });
+    return refs;
+  }, []);
+};
+
 const hasOwn = (object, key) => Object.prototype.hasOwnProperty.call(object || {}, key);
 
 const hasBackendAction = (record, action) => {
@@ -111,6 +152,11 @@ const hasBackendAction = (record, action) => {
     normalizedAction.replace('_', '-'),
     normalizedAction.replace('-', '_')
   ]);
+  if (Array.isArray(record.grouped_records) && record.grouped_records.length > 0) {
+    return record.grouped_records.every((groupedRecord) =>
+      hasBackendAction(groupedRecord, normalizedAction)
+    );
+  }
   if (Array.isArray(record.available_actions)) {
     return record.available_actions.some((availableAction) =>
       equivalentActions.has(String(availableAction || '').trim())
@@ -121,7 +167,8 @@ const hasBackendAction = (record, action) => {
     mark_paid: 'can_mark_paid',
     start_visit: 'can_start_visit',
     print_ticket: 'can_print_ticket',
-    complete: 'can_complete'
+    complete: 'can_complete',
+    cancel: 'can_cancel'
   };
   const flagName = actionFlagByName[normalizedAction.replace('-', '_')];
   if (flagName && record[flagName] !== undefined) {
@@ -136,6 +183,7 @@ const getRegistrarActionForStatus = (status) => {
   if (normalizedStatus === 'complete' || normalizedStatus === 'done') return 'complete';
   if (normalizedStatus === 'paid' || normalizedStatus === 'mark_paid') return 'mark_paid';
   if (normalizedStatus === 'in_cabinet') return 'start_visit';
+  if (normalizedStatus === 'cancelled' || normalizedStatus === 'canceled' || normalizedStatus === 'no_show') return 'cancel';
   return null;
 };
 
@@ -1333,6 +1381,7 @@ const RegistrarPanel = () => {
               available_actions: Array.isArray(fullEntry.available_actions) ? fullEntry.available_actions : [],
               can_mark_paid: Boolean(fullEntry.can_mark_paid),
               can_start_visit: Boolean(fullEntry.can_start_visit),
+              can_cancel: Boolean(fullEntry.can_cancel),
               can_print_ticket: Boolean(fullEntry.can_print_ticket),
               can_complete: Boolean(fullEntry.can_complete),
 
@@ -1695,292 +1744,101 @@ const RegistrarPanel = () => {
   }, [autoRefresh, showWizard, paymentDialog.open, printDialog.open, cancelDialog.open, loadAppointments]);
 
   // Функции для жесткого потока
+  const runRegistrarRecordAction = useCallback(async (record, action, payload = {}) => {
+    const records = getRegistrarRecordRefs(record);
+    if (records.length === 0) {
+      logger.warn('RegistrarPanel: action requires backend record refs', { action, record });
+      notify.error('Missing backend record data for action');
+      return null;
+    }
+    if (!hasBackendAction(record, action)) {
+      logger.warn('RegistrarPanel: backend did not expose requested action', { action, record });
+      notify.error('Action is not available for this record');
+      return null;
+    }
+
+    const response = await api.post('/registrar/records/actions', {
+      ...payload,
+      action,
+      records
+    });
+    return response.data;
+  }, []);
+
   const handleStartVisit = useCallback(async (appointment) => {
     try {
-      logger.info('🔍 handleStartVisit вызван с данными:', appointment);
-      logger.info('🔍 appointment.id:', appointment.id, 'тип:', typeof appointment.id);
-
-      // ✅ ИСПРАВЛЕНО: Используем правильный эндпоинт для queue entries
-      const recordKind = getRegistrarRecordKind(appointment);
-      const recordId = getRegistrarRecordId(appointment, recordKind);
-      if (!recordId || (recordKind !== 'visit' && recordKind !== 'online_queue' && recordKind !== 'appointment')) {
-        logger.warn('RegistrarPanel: start-visit requires backend record kind/id', { recordKind, recordId, appointment });
-        notify.error('Missing backend record data for start visit');
-        return;
-      }
-      if (!hasBackendAction(appointment, 'start_visit')) {
-        logger.warn('RegistrarPanel: backend did not expose start_visit action', { recordKind, recordId, appointment });
-        notify.error('Action is not available for this record');
-        return;
+      const result = await runRegistrarRecordAction(appointment, 'start_visit');
+      if (!result) return null;
+      if (!result.success) {
+        throw new Error(result.results?.find((item) => !item.success)?.error || 'start_visit_failed');
       }
 
-      const url = recordKind === 'visit' ?
-        `${API_BASE}/api/v1/registrar/visits/${recordId}/start-visit` :
-        `${API_BASE}/api/v1/registrar/queue/${recordId}/start-visit`;
-      logger.info('🔍 Отправляем запрос на:', url);
-
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${tokenManager.getAccessToken()}`
-        }
-      });
-
-      if (response.ok) {
-        const result = await response.json();
-        logger.info('Обновленная запись:', result);
-
-        notify.success('Пациент вызван успешно!');
-
-        // Перезагружаем данные для синхронизации с сервером
-        await loadAppointments({ source: 'start_visit_success' });
-      } else {
-        const errorText = await response.text().catch(() => '');
-        logger.error('Ошибка API start-visit:', response.status, errorText);
-        throw new Error(`API ${response.status}: ${errorText}`);
-      }
+      logger.info('RegistrarPanel: start_visit completed through backend command contract', result);
+      notify.success('Patient called successfully');
+      await loadAppointments({ source: 'start_visit_success' });
+      return result;
     } catch (error) {
       logger.error('RegistrarPanel: Start visit API error:', error);
-          notify.error(getErrorMessage(error, 'Не удалось вызвать пациента. Проверьте соединение и попробуйте снова.'));
+      notify.error(getErrorMessage(error, 'Could not start visit. Check connection and try again.'));
+      return null;
     }
-  }, [loadAppointments]);
+  }, [loadAppointments, runRegistrarRecordAction]);
 
   const handlePayment = async (appointment, paymentData = null) => {
     try {
-      logger.info('🔍 handlePayment вызван с данными:', appointment);
-      logger.info('🔍 appointment.id:', appointment.id, 'тип:', typeof appointment.id);
-      logger.info('🔍 appointment.record_type:', appointment.record_type);
-      logger.info('🔍 Все ключи appointment:', Object.keys(appointment));
-      logger.info('🔍 Полный объект appointment:', JSON.stringify(appointment, null, 2));
+      const result = await runRegistrarRecordAction(appointment, 'mark_paid', {
+        amount: paymentData?.amount ?? null,
+        method: paymentData?.method ?? null
+      });
+      if (!result) return null;
 
-      // Определяем, является ли это агрегированной записью
-      const isAggregated = appointment.departments && appointment.departments instanceof Set;
-      logger.info('🔍 Это агрегированная запись:', isAggregated);
-
-      // Если это агрегированная запись, находим все оригинальные записи пациента
-      let recordsToUpdate = [appointment]; // По умолчанию только текущая запись
-      if (isAggregated) {
-        logger.info('🔍 Ищем все записи пациента:', appointment.patient_fio);
-        // Находим все записи этого пациента в оригинальном массиве
-        const allPatientRecords = appointments.filter((apt) => apt.patient_fio === appointment.patient_fio);
-        logger.info('🔍 Найдено записей пациента:', allPatientRecords.length);
-        recordsToUpdate = allPatientRecords;
-      }
-
-      logger.info('Попытка оплатить записи:', recordsToUpdate.map((r) => r.id));
-
-      // ✅ ИСПРАВЛЕНИЕ: Оплачиваем ВСЕ записи пациента, а не только первую
-      logger.info('🔍 Оплачиваем ВСЕ записи пациента:', recordsToUpdate.length);
-
-      const paymentResults = [];
-      for (const record of recordsToUpdate) {
-        const recordType = getRegistrarRecordKind(record);
-        const recordId = getRegistrarRecordId(record, recordType);
-        if (!recordId || (recordType !== 'visit' && recordType !== 'online_queue' && recordType !== 'appointment')) {
-          logger.warn('RegistrarPanel: payment requires backend record kind/id', { recordType, recordId, record });
-          paymentResults.push({ success: false, recordId: record.id, error: 'missing_backend_record_contract' });
-          continue;
-        }
-        if (!hasBackendAction(record, 'mark_paid')) {
-          logger.warn('RegistrarPanel: backend did not expose mark_paid action', { recordType, recordId, record });
-          paymentResults.push({ success: false, recordId, error: 'action_not_available' });
-          continue;
-        }
-
-        // ✅ ИСПРАВЛЕНИЕ: Проверяем статус КАЖДОЙ записи перед попыткой оплаты
-        const paymentStatus = normalizeRegistrarContractValue(record.payment_status);
-        const status = normalizeRegistrarContractValue(record.status);
-        logger.info(`🔍 Запись ${recordId}: статус оплаты=${paymentStatus}, статус=${status}`);
-
-        // Пропускаем записи, которые уже оплачены
-        if (paymentStatus === 'paid' || (!paymentStatus && status === 'paid')) {
-          logger.info(`⏭️ Запись ${recordId} уже оплачена, пропускаем`);
-          paymentResults.push({ success: true, recordId, skipped: true, reason: 'already_paid' });
-          continue;
-        }
-
-        let url;
-        if (recordType === 'visit') {
-          url = `${API_BASE}/api/v1/registrar/visits/${recordId}/mark-paid`;
-        } else if (recordType === 'online_queue') {
-          // ✅ ИСПРАВЛЕНО: Для online_queue используем специальный endpoint
-          url = `${API_BASE}/api/v1/registrar/queue/entry/${recordId}/mark-paid`;
-        } else {
-          url = `${API_BASE}/api/v1/appointments/${recordId}/mark-paid`;
-        }
-
-        logger.info(`🔍 Оплата записи ${recordId} (${recordType}):`, url);
-
-        try {
-          const response = await fetch(url, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${tokenManager.getAccessToken()}`
-            },
-            body: JSON.stringify({
-              amount: paymentData?.amount ?? null,
-              method: paymentData?.method ?? null
-            })
-          });
-
-          if (response.ok) {
-            const result = await response.json();
-            paymentResults.push({ success: true, recordId, result });
-            logger.info(`✅ Запись ${recordId} успешно оплачена`);
-          } else {
-            const errorText = await response.text();
-            logger.warn(`⚠️ Ошибка оплаты записи ${recordId}:`, errorText);
-            paymentResults.push({ success: false, recordId, error: errorText });
-          }
-        } catch (error) {
-          logger.error(`❌ Ошибка при оплате записи ${recordId}:`, error);
-          paymentResults.push({ success: false, recordId, error: error.message });
-        }
-      }
-
-      const successCount = paymentResults.filter((r) => r.success && !r.skipped).length;
-      const skippedCount = paymentResults.filter((r) => r.success && r.skipped).length;
-      const failedCount = paymentResults.filter((r) => !r.success).length;
-
-      logger.info(`✅ Успешно оплачено ${successCount} из ${recordsToUpdate.length} записей`);
-      if (skippedCount > 0) {
-        logger.info(`⏭️ Пропущено уже оплаченных записей: ${skippedCount}`);
-      }
-      if (failedCount > 0) {
-        logger.info(`❌ Ошибок при оплате: ${failedCount}`);
-      }
+      const successCount = Number(result.success_count || 0);
+      const skippedCount = Number(result.skipped_count || 0);
+      const failedCount = Number(result.failed_count || 0);
 
       if (successCount > 0 || skippedCount > 0) {
-        // Формируем информативное сообщение
-        let message = '';
-        if (successCount > 0 && skippedCount > 0) {
-          message = `Оплачено ${successCount} записей, ${skippedCount} уже были оплачены ранее`;
-        } else if (successCount > 0) {
-          message = `Оплачено ${successCount} записей пациента`;
-        } else if (skippedCount > 0) {
-          message = 'Все записи уже оплачены';
-        }
-
-        if (failedCount > 0) {
-          message += `. Ошибок: ${failedCount}`;
-        }
-
-        notify.success(message);
-        // Мягко подтянем данные из API, чтобы зафиксировать статус с бэкенда
+        const message = skippedCount > 0
+          ? 'Payment completed: ' + successCount + ', already paid: ' + skippedCount
+          : 'Payment completed: ' + successCount;
+        notify.success(failedCount > 0 ? message + '. Failed: ' + failedCount : message);
         setTimeout(() => loadAppointments({ silent: true, source: 'payment_success' }), 800);
-        return paymentResults;
-      } else {
-        notify.error('Не удалось оплатить записи');
-        return paymentResults;
+        return result.results || [];
       }
+
+      notify.error(result.results?.find((item) => !item.success)?.error || 'Payment failed');
+      return result.results || [];
     } catch (error) {
       logger.error('RegistrarPanel: Payment error:', error);
-      notify.error('Ошибка при оплате');
+      notify.error(getErrorMessage(error, 'Payment failed'));
+      return null;
     }
   };
 
-  // Обработчики событий
   const updateAppointmentStatus = useCallback(async (appointmentId, status, reason = '', sourceRecord = null) => {
     try {
-      if (!appointmentId || Number(appointmentId) <= 0) {
-        notify.error('Некорректный идентификатор записи');
-        return;
-      }
-      const token = tokenManager.getAccessToken();
-      if (!token) {
-        notify.error('Требуется вход в систему');
-        return;
-      }
-      let url = '';
-      const method = 'POST';
-      let body;
-
-      // Определяем источник записи и правильный ID
       const record = sourceRecord || appointments.find((apt) => apt.id === appointmentId);
-      const recordType = getRegistrarRecordKind(record);
-      const realId = getRegistrarRecordId(record, recordType);
-      if (!realId || (recordType !== 'visit' && recordType !== 'online_queue' && recordType !== 'appointment')) {
-        logger.warn('RegistrarPanel: status update requires backend record kind/id', { appointmentId, status, recordType, realId, record });
-        notify.error('Missing backend record data for status update');
-        return null;
-      }
-
       const requiredBackendAction = getRegistrarActionForStatus(status);
       if (!requiredBackendAction) {
-        logger.warn('RegistrarPanel: unsupported command without backend action contract', { appointmentId, status, recordType, realId, record });
-        notify.error('Action is not available for this record');
-        return null;
-      }
-      if (!hasBackendAction(record, requiredBackendAction)) {
-        logger.warn('RegistrarPanel: backend did not expose requested action', { appointmentId, status, requiredBackendAction, recordType, realId, record });
+        logger.warn('RegistrarPanel: unsupported status command', { appointmentId, status, record });
         notify.error('Action is not available for this record');
         return null;
       }
 
-      if (status === 'complete' || status === 'done') {
-        if (recordType === 'visit') {
-          url = `${API_BASE}/api/v1/registrar/visits/${realId}/complete`;
-        } else if (recordType === 'appointment') {
-          url = `${API_BASE}/api/v1/appointments/${realId}/complete`;
-        } else {
-          notify.error('Action is not available for this record');
-          return null;
-        }
-        body = JSON.stringify({ reason });
-      } else if (status === 'paid' || status === 'mark-paid') {
-        if (recordType === 'visit') {
-          url = `${API_BASE}/api/v1/registrar/visits/${realId}/mark-paid`;
-        } else if (recordType === 'online_queue') {
-          url = `${API_BASE}/api/v1/registrar/queue/entry/${realId}/mark-paid`;
-        } else {
-          url = `${API_BASE}/api/v1/appointments/${realId}/mark-paid`;
-        }
-      } else if (status === 'in_cabinet') {
-        if (recordType === 'visit') {
-          url = `${API_BASE}/api/v1/registrar/visits/${realId}/start-visit`;
-        } else {
-          // Используем эндпоинт для очереди регистратора
-          url = `${API_BASE}/api/v1/registrar/queue/${realId}/start-visit`;
-        }
-      } else {
-        logger.info('Неподдерживаемый статус:', status);
-        notify.error('Изменение данного статуса не поддерживается');
-        return;
+      const result = await runRegistrarRecordAction(record, requiredBackendAction, { reason });
+      if (!result) return null;
+      if (!result.success) {
+        throw new Error(result.results?.find((item) => !item.success)?.error || 'status_update_failed');
       }
-
-      logger.info('Обновляем статус записи:', appointmentId, 'на', status, 'URL:', url);
-
-      const response = await fetch(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
-        body
-      });
-
-      logger.info('Ответ API обновления статуса:', response.status, response.statusText);
-
-      if (!response.ok) {
-        const errText = await response.text().catch(() => '');
-        logger.error('Ошибка API обновления статуса:', response.status, errText);
-        throw new Error(errText || `API ${response.status}`);
-      }
-
-      const updatedAppointment = await response.json();
-      logger.info('Обновленная запись:', updatedAppointment);
 
       await loadAppointments({ source: 'status_update' });
-      notify.success('Статус обновлен');
-      return updatedAppointment;
+      notify.success('Status updated');
+      return result;
     } catch (error) {
       logger.error('RegistrarPanel: Update status error:', error);
-      notify.error(getErrorMessage(error, 'Не удалось обновить статус. Проверьте соединение и попробуйте снова.'));
+      notify.error(getErrorMessage(error, 'Could not update status. Check connection and try again.'));
       return null;
     }
-  }, [appointments, loadAppointments]);
+  }, [appointments, loadAppointments, runRegistrarRecordAction]);
 
   const handleBulkAction = useCallback(async (action, reason = '') => {
     if (appointmentsSelected.size === 0) return;
@@ -3790,120 +3648,26 @@ const RegistrarPanel = () => {
         onClose={() => setCancelDialog({ open: false, row: null, reason: '' })}
         appointment={cancelDialog.row}
         onCancel={async (appointmentId, reason) => {
-          // ✅ FIX: Call backend to cancel visit OR appointment OR queue entry
-          // Supports cancelling multiple aggregated IDs (for multi-QR entries)
-
-          // ⭐ TODO: BATCH API MIGRATION
-          // После тестирования batch API замените текущую логику на:
-          // const patientId = data?.patient_id;
-          // const date = formatDateForAPI(data?.date);
-          // if (patientId && date) {
-          //   const result = await cancelAllPatientEntries(patientId, date, reason);
-          //   if (result.success) { ... }
-          // }
-          // См. docs/BATCH_UPDATE_ARCHITECTURE.md
-
           try {
-            const data = appointmentId === cancelDialog.row?.id ? cancelDialog.row : appointments.find((a) => a.id === appointmentId);
-            const recordType = getRegistrarRecordKind(data);
-            if (recordType !== 'visit' && recordType !== 'online_queue' && recordType !== 'appointment') {
-              logger.warn('RegistrarPanel: cancel requires backend record kind', { appointmentId, recordType, data });
-              notify.error('Missing backend record data for cancellation');
-              return;
-            }
-
-            // Определяем список ID для отмены (если это агрегированная запись - отменяем все)
-            const idsToCancel = data?.aggregated_ids?.length > 0 ? data.aggregated_ids : [appointmentId];
-
-            logger.info(`🔍 Отмена записи(ей). IDs: [${idsToCancel.join(', ')}]`, {
-              recordType,
-              source: data?.source,
-              fullData: data,
-              idsToCancel,
-              reasonLength: reason?.length || 0
-            });
-
-            // Функция отмены одной записи
-            const cancelSingleRecord = async (targetId) => {
-              const tryCancelVisit = async () => {
-                await api.post(`/visits/${targetId}/status`, null, {
-                  params: { status_new: 'canceled' }
-                });
-              };
-
-              const tryCancelOnlineQueue = async () => {
-                await api.post(`/online-queue/entries/${targetId}/cancel`);
-              };
-
-              const tryCancelAppointment = async () => {
-                try {
-                  await api.put(`/appointments/${targetId}`, { status: 'canceled' });
-                } catch {
-                  logger.warn('PUT failed, trying DELETE for appointment cancellation');
-                  await api.delete(`/appointments/${targetId}`);
-                }
-              };
-
-              if (recordType === 'visit') {
-                await tryCancelVisit();
-                return;
-              }
-              if (recordType === 'appointment') {
-                await tryCancelAppointment();
-                return;
-              }
-              if (recordType === 'online_queue') {
-                await tryCancelOnlineQueue();
-                return;
-              }
-
-            };
-
-            // Выполняем отмену для всех ID
-            // Используем Promise.allSettled или loop для попытки отмены всех
-            // Для надежности используем последовательную отмену
-            const cancelResults = [];
-            for (const id of idsToCancel) {
-              try {
-                await cancelSingleRecord(id);
-                cancelResults.push({ id, success: true });
-              } catch (err) {
-                // ✅ FIX: Не прерываем цикл при 404 (запись уже отменена или не существует)
-                if (err.response?.status === 404) {
-                  logger.warn(`⚠️ ID ${id} не найден (возможно уже отменён), продолжаем...`);
-                  cancelResults.push({ id, success: true, alreadyCancelled: true });
-                } else {
-                  logger.error(`❌ Ошибка отмены ID ${id}:`, err);
-                  cancelResults.push({ id, success: false, error: err });
-                }
-              }
-            }
-
-            const successCount = cancelResults.filter((r) => r.success).length;
-            const failCount = cancelResults.filter((r) => !r.success).length;
-
-            if (failCount > 0) {
-              logger.warn(`⚠️ Отменено ${successCount}/${idsToCancel.length} записей, ${failCount} ошибок`);
-              notify.warning(`Отменено ${successCount} из ${idsToCancel.length} услуг`);
+            const data = appointmentId === cancelDialog.row?.id
+              ? cancelDialog.row
+              : appointments.find((a) => a.id === appointmentId);
+            const result = await runRegistrarRecordAction(data, 'cancel', { reason });
+            if (!result) return;
+            if (!result.success) {
+              const successCount = Number(result.success_count || 0);
+              const failedCount = Number(result.failed_count || 0);
               if (successCount === 0) {
-                throw new Error('Cancellation failed for all selected records');
+                throw new Error(result.results?.find((item) => !item.success)?.error || 'cancel_failed');
               }
-            } else {
-              logger.info(`✅ Все ${successCount} записи успешно отменены на сервере`);
+              notify.warning('Cancelled ' + successCount + '; failed ' + failedCount);
             }
+            await loadAppointments({ silent: true, source: 'cancel_complete' });
           } catch (error) {
-            logger.error('❌ Критическая ошибка отмены визита на сервере:', error);
-
-            // Если это 404 после всех попыток
-            if (error.response?.status === 404) {
-        notify.error(`Не удалось найти запись ${appointmentId} в базе данных`);
-            } else {
-      notify.error(getErrorMessage(error, 'Не удалось обновить статус на сервере. Проверьте соединение и попробуйте снова.'));
-            }
+            logger.error('RegistrarPanel: cancellation failed:', error);
+            notify.error(getErrorMessage(error, 'Could not cancel record. Check connection and try again.'));
             throw error;
           }
-
-          await loadAppointments({ silent: true, source: 'cancel_complete' });
         }} />
 
 

--- a/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const registrarPanelPath = path.resolve(__dirname, '../RegistrarPanel.jsx');
+
+describe('RegistrarPanel command contract', () => {
+  it('uses the backend registrar record action endpoint for queue/payment/status commands', () => {
+    const source = fs.readFileSync(registrarPanelPath, 'utf8');
+
+    expect(source).toContain("api.post('/registrar/records/actions'");
+    expect(source).not.toContain('/registrar/visits/${recordId}/mark-paid');
+    expect(source).not.toContain('/registrar/queue/entry/${recordId}/mark-paid');
+    expect(source).not.toContain('/appointments/${recordId}/mark-paid');
+    expect(source).not.toContain('/registrar/visits/${realId}/complete');
+    expect(source).not.toContain('/registrar/queue/${realId}/start-visit');
+    expect(source).not.toContain('/online-queue/entries/${targetId}/cancel');
+  });
+});
+

--- a/frontend/src/utils/registrarAggregation.js
+++ b/frontend/src/utils/registrarAggregation.js
@@ -10,6 +10,24 @@ export const getRecordAmount = (appointment) => {
   return Number.isFinite(amount) ? amount : 0;
 };
 
+const normalizeRecordKind = (appointment) => String(
+  appointment?.record_kind ?? appointment?.source_kind ?? appointment?.record_type ?? appointment?.type ?? ''
+).trim().toLowerCase();
+
+const buildRecordRef = (appointment) => {
+  const recordKind = normalizeRecordKind(appointment);
+  const recordId = appointment?.canonical_record_id
+    ?? (recordKind === 'visit' ? appointment?.visit_id : null)
+    ?? (recordKind === 'online_queue' ? appointment?.queue_entry_id : null)
+    ?? (recordKind === 'appointment' ? appointment?.appointment_id : null)
+    ?? appointment?.id;
+
+  if (!['visit', 'online_queue', 'appointment'].includes(recordKind)) return null;
+  const numericId = Number(recordId);
+  if (!Number.isFinite(numericId) || numericId <= 0) return null;
+  return { record_kind: recordKind, record_id: numericId };
+};
+
 export const aggregatePatientsForAllDepartments = (appointments = []) => {
   const patientGroups = {};
 
@@ -37,6 +55,7 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
     const normalizedDiscountMode = normalizeRegistrationMode(appointment.discount_mode);
     const normalizedPayment = normalizePaymentStatus(appointment.payment_status);
     const appointmentCost = getRecordAmount(appointment);
+    const recordRef = buildRecordRef(appointment);
 
     if (!patientGroups[patientKey]) {
       const initialVisitId = appointment.visit_id || appointment.visitId || appointment.id;
@@ -81,6 +100,7 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
         grouped_payment_statuses: [],
         grouped_payment_types: [],
         grouped_records: [],
+        grouped_record_refs: [],
         aggregated_ids: appointment.aggregated_ids ? [...appointment.aggregated_ids] : [appointment.id],
       };
     } else {
@@ -150,7 +170,23 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
     if (appointment.payment_type) {
       patientGroups[patientKey].grouped_payment_types.push(appointment.payment_type);
     }
+    if (recordRef) {
+      const refKey = `${recordRef.record_kind}:${recordRef.record_id}`;
+      const existingRefKeys = new Set(
+        patientGroups[patientKey].grouped_record_refs.map((ref) => `${ref.record_kind}:${ref.record_id}`),
+      );
+      if (!existingRefKeys.has(refKey)) {
+        patientGroups[patientKey].grouped_record_refs.push(recordRef);
+      }
+    }
     patientGroups[patientKey].grouped_records.push({
+      record_ref: recordRef,
+      available_actions: Array.isArray(appointment.available_actions) ? [...appointment.available_actions] : [],
+      can_mark_paid: Boolean(appointment.can_mark_paid),
+      can_start_visit: Boolean(appointment.can_start_visit),
+      can_cancel: Boolean(appointment.can_cancel),
+      can_print_ticket: Boolean(appointment.can_print_ticket),
+      can_complete: Boolean(appointment.can_complete),
       discount_mode: normalizedDiscountMode,
       approval_status: appointment.approval_status,
       payment_status: normalizedPayment,


### PR DESCRIPTION
## Summary
- Adds a backend-owned registrar record command contract: `POST /api/v1/registrar/records/actions`.
- Routes `mark_paid`, `cancel`, `start_visit`, and `complete` through existing FastAPI domain endpoints/services instead of React choosing per-record URLs.
- Refactors `RegistrarPanel` to send backend record refs and action names only, including grouped registrar rows.
- Adds `cancel`/`can_cancel` to the existing registrar queue contract.

## Contract Impact
- Canonical surface: Existing FastAPI backend under registrar/appointments routes; no `/api/v1/ui/*` surface and no separate BFF.
- Request shape: `RegistrarRecordActionRequest` with `action`, either `record_kind` + `record_id` or `records[]`, optional `reason`, `amount`, `method`.
- Response shape: `RegistrarRecordActionResponse` with `action`, aggregate success/skipped/failed counts, and per-record result objects.
- Status codes: `200` for accepted command batch, `400` for unsupported/no records, `403` for denied roles, per-record domain failures returned in `results`.
- Frontend consumer: `frontend/src/pages/RegistrarPanel.jsx` uses `api.post('/registrar/records/actions')` for payment/cancel/start/complete workflows.
- Compatibility path or alias: Existing direct domain endpoints remain for compatibility, but RegistrarPanel no longer selects them itself.
- Contract proof: `backend/tests/test_openapi_contract.py`, `backend/tests/integration/test_registrar_record_actions.py`, and `frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx`.

## RBAC / Permissions
- Roles allowed: `mark_paid` is Admin/Registrar/Cashier; `start_visit`, `cancel`, and `complete` follow backend registrar action role maps.
- Roles denied: Doctor/cardio is denied for `mark_paid`; unsupported roles are denied by `require_roles` and `_ensure_registrar_command_role`.
- Positive auth proof: Registrar cancels an online queue record in `test_registrar_record_action_can_cancel_online_queue_entry`.
- Negative auth proof: Cardio/doctor role receives `403` for `mark_paid` in `test_registrar_record_action_rejects_doctor_mark_paid`.

## Notification / Realtime
- Event type or websocket channel: Not applicable because this PR does not add or change websocket/notification events; it preserves existing reload-after-command behavior.
- Payload version / ack behavior: Not applicable because no realtime payload shape or ack contract changes.
- Read/unread or delivery semantics: Not applicable because no notification inbox/read state is touched.
- Reconnect/resync proof: Frontend still reloads registrar data after successful command; no websocket reconnect behavior changed.

## Frontend Resilience
- Empty data proof: `getRegistrarRecordRefs` returns an empty list and command execution denies with a user-visible error instead of guessing an endpoint.
- Partial data proof: Grouped rows use `grouped_record_refs`/`grouped_records[].record_ref`; missing action flags remain deny-by-default.
- Forbidden secondary path behavior: RegistrarPanel no longer falls back to old mark-paid/start/cancel/complete URLs when the command contract is missing.
- Missing draft/resource behavior: Per-record backend failures are returned in `results`; frontend surfaces failure without inventing local state transitions.
- Stale route/deep-link behavior: Not applicable because this PR does not change routes or deep-link parsing.

## Scope Gate
- Allowed paths: Registrar/queue command contract endpoint, existing registrar/appointment RBAC alignment, RegistrarPanel command caller, grouped row record refs, targeted tests.
- Denied paths: No `/api/v1/ui/*`, no separate BFF service, no DB/Alembic migration, no broad RegistrarPanel rewrite, no queue/payment/visit business logic in React.
- Migration/docs/test impact: No migration or runtime docs change; targeted backend/frontend/OpenAPI tests added or updated.
- Rollback note: Revert this PR to restore the previous direct endpoint selection path; existing direct endpoints remain available during rollback.

## Validation
- Targeted tests or smoke run: `py -3 -m py_compile backend\\app\\api\\v1\\endpoints\\registrar_wizard.py backend\\app\\api\\v1\\endpoints\\appointment_flow.py backend\\app\\api\\v1\\endpoints\\registrar_integration.py`; targeted pytest; targeted Vitest; frontend build; `git diff --check`.
- Result: Targeted pytest `14 passed`; targeted Vitest `1 passed`; frontend build passed; py_compile passed; diff check passed.
- Not checked: Full production database migration cycle not applicable; full manual browser smoke not run because this PR is command-contract focused and automated frontend build/tests passed.