### PR TITLE
fix(queue): stabilize QR join read contract

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -103,6 +103,9 @@ class QRTokenInfoResponse(BaseModel):
     is_clinic_wide: Optional[bool] = False  # Флаг общего QR
     target_date: Optional[str] = None  # Дата очереди
     selectable_specialists: Optional[List[Dict[str, Any]]] = None
+    allowed: Optional[bool] = None
+    status: Optional[str] = None
+    message: Optional[str] = None
 
 
 class JoinSessionStartRequest(BaseModel):

--- a/backend/app/services/qr_queue_service.py
+++ b/backend/app/services/qr_queue_service.py
@@ -714,6 +714,13 @@ class QRQueueService:
                     expires_aware = qr_token.expires_at
                 expires_at_str = expires_aware.isoformat()
 
+            time_check = self._check_online_time_restrictions(token)
+            time_check.setdefault(
+                "status",
+                "available" if time_check.get("allowed") else "unavailable",
+            )
+            time_check.setdefault("message", "")
+
             result = {
                 "token": token,
                 "specialist_id": qr_token.specialist_id,
@@ -732,6 +739,7 @@ class QRQueueService:
                     else []
                 ),
             }
+            result.update(time_check)
             logger.debug(
                 f"[QRQueueService.get_qr_token_info] Ответ сформирован успешно: {result}"
             )

--- a/backend/tests/integration/test_qr_queue_join.py
+++ b/backend/tests/integration/test_qr_queue_join.py
@@ -170,6 +170,10 @@ def test_clinic_wide_qr_exposes_backend_selectable_specialists(
     assert info_resp.status_code == 200
     info_payload = info_resp.json()
     assert info_payload["is_clinic_wide"] is True
+    assert info_payload["queue_active"] is True
+    assert info_payload["allowed"] is True
+    assert info_payload["status"] in {"available", "dev_mode"}
+    assert isinstance(info_payload["message"], str)
     assert info_payload["selectable_specialists"] == [
         {
             "id": test_doctor.id,
@@ -184,6 +188,12 @@ def test_clinic_wide_qr_exposes_backend_selectable_specialists(
 
     start_resp = client.post("/api/v1/queue/join/start", json={"token": token_value})
     assert start_resp.status_code == 200
-    assert start_resp.json()["queue_info"]["selectable_specialists"] == info_payload[
-        "selectable_specialists"
-    ]
+    start_queue_info = start_resp.json()["queue_info"]
+    for key in (
+        "selectable_specialists",
+        "queue_active",
+        "allowed",
+        "status",
+        "message",
+    ):
+        assert start_queue_info[key] == info_payload[key]

--- a/backend/tests/test_openapi_contract.py
+++ b/backend/tests/test_openapi_contract.py
@@ -29,6 +29,7 @@ def test_openapi_schema_not_fallback_and_has_paths(client: TestClient) -> None:
     [
         ("/api/v1/auth/login", "post"),
         ("/api/v1/auth/me", "get"),
+        ("/api/v1/queue/qr-tokens/{token}/info", "get"),
         ("/api/v1/queue/join/start", "post"),
         ("/api/v1/queue/join/complete", "post"),
         ("/api/v1/registrar/records/actions", "post"),
@@ -55,6 +56,23 @@ def test_openapi_queue_join_contract_has_request_and_responses(client: TestClien
     assert operation["requestBody"].get("required") is True
     assert "responses" in operation
     assert any(code in operation["responses"] for code in ("200", "201", "400", "422"))
+
+
+def test_openapi_qr_token_info_exposes_join_read_contract(client: TestClient) -> None:
+    schema = _get_openapi_schema(client)
+    operation = schema["paths"]["/api/v1/queue/qr-tokens/{token}/info"]["get"]
+    response_schema = operation["responses"]["200"]["content"]["application/json"]["schema"]
+    schema_name = response_schema["$ref"].rsplit("/", 1)[-1]
+    properties = schema["components"]["schemas"][schema_name]["properties"]
+
+    for field_name in (
+        "selectable_specialists",
+        "queue_active",
+        "allowed",
+        "status",
+        "message",
+    ):
+        assert field_name in properties
 
 
 def test_openapi_has_no_duplicate_operation_id_warnings() -> None:

--- a/frontend/src/pages/QueueJoin.jsx
+++ b/frontend/src/pages/QueueJoin.jsx
@@ -183,7 +183,7 @@ const QueueJoin = () => {
       );
 
       if (!tokenInfo.queue_active) {
-        setError(QUEUE_JOIN_MESSAGES.queueInactive);
+        setError(tokenInfo.message || QUEUE_JOIN_MESSAGES.queueInactive);
         setStep('error');
         setIsSpecialistsLoading(false);
         return;
@@ -195,17 +195,17 @@ const QueueJoin = () => {
         setIsSpecialistsLoading(false);
         return;
       } else if (tokenInfo.status === 'after_end_time') {
-        setError(QUEUE_JOIN_MESSAGES.registrationClosedAt(tokenInfo.end_time));
+        setError(tokenInfo.message || QUEUE_JOIN_MESSAGES.registrationClosedAt(tokenInfo.end_time));
         setStep('error');
         setIsSpecialistsLoading(false);
         return;
       } else if (tokenInfo.status === 'closed_reception_opened') {
-        setError(QUEUE_JOIN_MESSAGES.receptionAlreadyOpened);
+        setError(tokenInfo.message || QUEUE_JOIN_MESSAGES.receptionAlreadyOpened);
         setStep('error');
         setIsSpecialistsLoading(false);
         return;
       } else if (tokenInfo.status === 'limit_reached') {
-        setError(QUEUE_JOIN_MESSAGES.limitReached(tokenInfo.max_entries));
+        setError(tokenInfo.message || QUEUE_JOIN_MESSAGES.limitReached(tokenInfo.max_entries));
         setStep('error');
         setIsSpecialistsLoading(false);
         return;

--- a/frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx
+++ b/frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx
@@ -4,8 +4,6 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const queueApiMocks = vi.hoisted(() => ({
-  fetchAvailableSpecialists: vi.fn(),
-  fetchPublicQueueProfiles: vi.fn(),
   fetchQrTokenInfo: vi.fn(),
   startQueueJoinSession: vi.fn(),
   completeQueueJoinSession: vi.fn(),
@@ -16,32 +14,38 @@ vi.mock('../../api/queue', () => queueApiMocks);
 import QueueJoin from '../QueueJoin';
 
 function setupQueueApiMock({
-  specialists = [
+  selectableSpecialists = [
     { id: 1, specialty: 'cardiology', specialty_display: 'Кардиолог', icon: '❤️', color: '#FF3B30' },
   ],
-  availableSpecialists = specialists,
   clinicWide = false,
+  allowed = true,
+  status = 'available',
+  message = 'Р—Р°РїРёСЃСЊ РґРѕСЃС‚СѓРїРЅР°',
 } = {}) {
-  queueApiMocks.fetchPublicQueueProfiles.mockResolvedValue({ specialists });
-  queueApiMocks.fetchAvailableSpecialists.mockResolvedValue(availableSpecialists);
   queueApiMocks.fetchQrTokenInfo.mockResolvedValue({
     queue_active: true,
-    allowed: true,
+    allowed,
+    status,
+    message,
     queue_length: 2,
     department_name: 'Кардиология',
     specialist_name: 'Кардиолог',
     target_date: '2026-02-21',
-    selectable_specialists: availableSpecialists,
+    selectable_specialists: selectableSpecialists,
   });
   queueApiMocks.startQueueJoinSession.mockResolvedValue({
     session_token: 'session-token',
     queue_info: {
       is_clinic_wide: clinicWide,
+      queue_active: true,
+      allowed,
+      status,
+      message,
       queue_length: 2,
       department_name: 'Кардиология',
       specialist_name: 'Кардиолог',
       target_date: '2026-02-21',
-      selectable_specialists: availableSpecialists,
+      selectable_specialists: selectableSpecialists,
     },
   });
   queueApiMocks.completeQueueJoinSession.mockResolvedValue({
@@ -95,8 +99,6 @@ describe('QueueJoin Accessibility & UX', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent(/QR-код не найден/i);
     expect(queueApiMocks.fetchQrTokenInfo).not.toHaveBeenCalled();
     expect(queueApiMocks.startQueueJoinSession).not.toHaveBeenCalled();
-    expect(queueApiMocks.fetchPublicQueueProfiles).not.toHaveBeenCalled();
-    expect(queueApiMocks.fetchAvailableSpecialists).not.toHaveBeenCalled();
   });
 
   it('exposes labeled required fields and announces validation errors', async () => {
@@ -139,19 +141,28 @@ describe('QueueJoin Accessibility & UX', () => {
   });
 
   it('shows meaningful empty state when no specialists are available for clinic-wide QR', async () => {
-    setupQueueApiMock({ specialists: [], availableSpecialists: [], clinicWide: true });
+    setupQueueApiMock({ selectableSpecialists: [], clinicWide: true });
     renderQueueJoin('clinic-wide-token');
 
     expect(await screen.findByText(/ҳозирча qr орқали танлаш учун мутахассислар мавжуд эмас/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /янгилаш/i })).toBeInTheDocument();
   });
 
+  it('renders backend-provided unavailable message without local queue rule assembly', async () => {
+    setupQueueApiMock({
+      allowed: false,
+      status: 'limit_reached',
+      message: 'Backend says registration is full',
+    });
+    renderQueueJoin('backend-status-token');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Backend says registration is full');
+    expect(queueApiMocks.startQueueJoinSession).not.toHaveBeenCalled();
+  });
+
   it('submits real doctor ids for clinic-wide QR instead of queue profile ids', async () => {
     setupQueueApiMock({
-      specialists: [
-        { id: 101, specialty: 'cardiology', specialty_display: 'Кардиолог', icon: '❤️', color: '#FF3B30' },
-      ],
-      availableSpecialists: [
+      selectableSpecialists: [
         { id: 6, specialty: 'cardio', specialty_display: 'Кардиолог', icon: '❤️', color: '#FF3B30' },
       ],
       clinicWide: true,
@@ -175,8 +186,6 @@ describe('QueueJoin Accessibility & UX', () => {
         specialist_ids: [6],
       })
     );
-    expect(queueApiMocks.fetchPublicQueueProfiles).not.toHaveBeenCalled();
-    expect(queueApiMocks.fetchAvailableSpecialists).not.toHaveBeenCalled();
   });
 
   it('provides retry action from error state and recovers to info step', async () => {


### PR DESCRIPTION
﻿## Summary

- Stabilize `GET /api/v1/queue/qr-tokens/{token}/info` so it exposes the display-safe `allowed/status/message` contract used by `POST /api/v1/queue/join/start.queue_info`.
- Make QueueJoin render backend-provided unavailable messages instead of locally reconstructing queue status text.
- Update QR/OpenAPI/frontend tests around backend-provided selectable specialists and status/message fields.

## Contract Impact

- Canonical surface: `GET /api/v1/queue/qr-tokens/{token}/info`, `POST /api/v1/queue/join/start`
- Request shape: token info remains path-token read; join start request shape unchanged
- Response shape: token info and join start queue_info expose `selectable_specialists`, `queue_active`, `allowed`, `status`, and `message`
- Status codes: existing QR queue status behavior preserved; unavailable queues are represented through response `allowed/status/message`
- Frontend consumer: `frontend/src/pages/QueueJoin.jsx`
- Compatibility path or alias: no new endpoint; existing QR queue endpoints are extended additively
- Contract proof: targeted QR queue integration tests, OpenAPI contract test, and QueueJoin frontend tests

## RBAC / Permissions

- Roles allowed: public QR token flow remains public by token contract
- Roles denied: not applicable - token authorization is handled by existing QR token validity, not role login
- Positive auth proof: valid public QR token returns token info/start queue_info
- Negative auth proof: inactive/invalid/unavailable token flow returns backend-owned allowed/status/message without exposing hidden doctors

## Notification / Realtime

not applicable - QueueJoin does not change notification, websocket, chat, or realtime behavior.

## Frontend Resilience

- Empty data proof: QueueJoin renders backend unavailable message when selectable specialists are absent or queue is not allowed
- Partial data proof: backend status/message drive unavailable UI without client-side queue rule reconstruction
- Forbidden secondary path behavior: QueueJoin no longer needs `/queues/profiles/public` or `/queue/available-specialists` for specialist choices
- Missing draft/resource behavior: not applicable - QueueJoin does not manage drafts/resources
- Stale route/deep-link behavior: invalid or stale QR token remains handled by existing token info error/status path

## Scope Gate

- Allowed paths: QR queue endpoint/service, QueueJoin API/page, targeted QR queue/OpenAPI/frontend tests
- Denied paths: `/api/v1/ui/*`, separate BFF service, command wrappers, unrelated queue/payment/role logic
- Migration/docs/test impact: no migration; targeted tests updated
- Rollback note: revert the QR queue contract additions and QueueJoin consumer/test updates

## Validation

- Targeted tests or smoke run: `py -3 -m py_compile backend/app/api/v1/endpoints/qr_queue.py backend/app/services/qr_queue_service.py`; `py -3 -m pytest backend/tests/integration/test_qr_queue_join.py backend/tests/test_openapi_contract.py`; `npm --prefix frontend run test:run -- QueueJoin.accessibility queue`; `npm --prefix frontend run build`; `git diff --check`
- Result: passed locally before PR
- Not checked: full manual browser QR join flow against a deployed environment
