### PR TITLE
test(board): document stats-only board state contract

### DIFF
--- a/backend/app/api/v1/endpoints/board.py
+++ b/backend/app/api/v1/endpoints/board.py
@@ -15,6 +15,11 @@ def board_state(
     date: str = Query(..., description="YYYY-MM-DD"),
     db: Session = Depends(get_db),
 ):
+    """Return the legacy board stats snapshot.
+
+    Live display rows, current calls, and announcements are owned by the
+    display board WebSocket initial_state/update stream.
+    """
     s = load_stats(db, department=department, date_str=date)
     return {
         "department": s.department,

--- a/backend/tests/integration/test_board_state_contract.py
+++ b/backend/tests/integration/test_board_state_contract.py
@@ -1,0 +1,42 @@
+from app.models.setting import Setting
+
+
+def test_board_state_is_stats_only_contract(client, db_session):
+    department = "Reg"
+    date_str = "2026-05-23"
+
+    for name, value in {
+        "last_ticket": "17",
+        "waiting": "4",
+        "serving": "2",
+        "done": "1",
+    }.items():
+        db_session.add(
+            Setting(
+                category="queue",
+                key=f"{department}::{date_str}::{name}",
+                value=value,
+            )
+        )
+    db_session.commit()
+
+    response = client.get(
+        "/api/v1/board/state",
+        params={"department": department, "date": date_str},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload == {
+        "department": department,
+        "date_str": date_str,
+        "is_open": True,
+        "start_number": 1,
+        "last_ticket": 17,
+        "waiting": 4,
+        "serving": 2,
+        "done": 1,
+    }
+    assert "queue_entries" not in payload
+    assert "current_call" not in payload
+    assert "announcements" not in payload

--- a/frontend/src/pages/DisplayBoardUnified.jsx
+++ b/frontend/src/pages/DisplayBoardUnified.jsx
@@ -126,7 +126,7 @@ export default function DisplayBoardUnified({
   const currentBoardId = new URLSearchParams(window.location.search).get('board') || boardId;
   const isBoardView = window.location.pathname.startsWith('/queue-board') || window.location.pathname.startsWith('/display-board');
 
-  // Load board state and stats from the board snapshot endpoint.
+  // /board/state is a stats/settings snapshot; live rows/calls/announcements come from WebSocket initial_state.
   async function loadBoardState() {setErr('');try {const st = (await api.get('/board/state', { params: { department: qs.department, date: qs.d } })).data;if (st && typeof st === 'object') {
         setStats(extractBoardStats(st));
         setBoard({

--- a/frontend/src/pages/__tests__/DisplayBoardUnified.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DisplayBoardUnified.contract.test.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const wsMock = vi.hoisted(() => ({
+  openDisplayBoardWS: vi.fn(),
+}));
+
+const apiMock = vi.hoisted(() => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('../../api/client', () => apiMock);
+vi.mock('../../api/ws', () => wsMock);
+vi.mock('../../contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}));
+vi.mock('../../utils/logger', () => ({
+  default: {
+    log: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import DisplayBoardUnified from '../DisplayBoardUnified';
+
+describe('DisplayBoardUnified contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.getItem.mockReturnValue(null);
+    window.HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it('treats /board/state as stats-only and uses websocket initial_state for live rows', async () => {
+    let wsMessageHandler;
+    apiMock.api.get.mockResolvedValueOnce({
+      data: {
+        department: 'Reg',
+        date_str: '2026-05-23',
+        is_open: true,
+        start_number: 1,
+        last_ticket: 17,
+        waiting: 4,
+        serving: 2,
+        done: 1,
+        queue_entries: [
+          { number: 99, patient_name: 'REST Patient', status: 'waiting' },
+        ],
+        current_call: { queue_number: 99, patient_name: 'REST Call' },
+        announcements: [{ text: 'REST Announcement', created_at: 'rest' }],
+      },
+    });
+    wsMock.openDisplayBoardWS.mockImplementation((_boardId, onMessage, onConnect) => {
+      wsMessageHandler = onMessage;
+      onConnect?.();
+      return vi.fn();
+    });
+
+    render(
+      <DisplayBoardUnified
+        department="Reg"
+        dateStr="2026-05-23"
+        boardId="main_board"
+        refreshMs={60000}
+      />
+    );
+
+    await waitFor(() => {
+      expect(apiMock.api.get).toHaveBeenCalledWith('/board/state', {
+        params: { department: 'Reg', date: '2026-05-23' },
+      });
+    });
+    expect(screen.getByText('17')).toBeInTheDocument();
+    expect(screen.queryByText('REST Patient')).not.toBeInTheDocument();
+    expect(screen.queryByText('REST Call')).not.toBeInTheDocument();
+    expect(screen.queryByText(/REST Announcement/)).not.toBeInTheDocument();
+
+    act(() => {
+      wsMessageHandler({
+        type: 'initial_state',
+        data: {
+          queue_entries: [
+            { number: 5, patient_name: 'WS Patient', status: 'waiting', created_at: '2026-05-23T08:00:00' },
+          ],
+          current_call: {
+            queue_number: 5,
+            patient_name: 'WS Call',
+            doctor_name: 'Dr. Socket',
+          },
+          announcements: [
+            { text: 'WS Announcement', created_at: 'ws', announcement_type: 'info' },
+          ],
+        },
+      });
+    });
+
+    expect(await screen.findByText('WS Call')).toBeInTheDocument();
+    expect(screen.getByText(/WS Announcement/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
﻿## Summary

- Document `GET /api/v1/board/state` as the legacy stats/settings snapshot contract.
- Add backend contract coverage proving `/board/state` does not own live `queue_entries`, `current_call`, or `announcements`.
- Add frontend coverage proving WebSocket `initial_state` owns live DisplayBoard rows/calls/announcements while REST remains stats-only.

## Contract Impact

- Canonical surface: `GET /api/v1/board/state`
- Request shape: query parameters remain `department` and `date`
- Response shape: stats-only payload remains `department`, `date_str`, `is_open`, `start_number`, `last_ticket`, `waiting`, `serving`, `done`
- Status codes: existing 200/error behavior unchanged
- Frontend consumer: `frontend/src/pages/DisplayBoardUnified.jsx`
- Compatibility path or alias: no new endpoint; `/board/state` remains the existing stats snapshot
- Contract proof: backend stats-only contract test and frontend WebSocket ownership contract test

## RBAC / Permissions

- Roles allowed: unchanged from existing board state route behavior
- Roles denied: unchanged from existing board state route behavior
- Positive auth proof: existing route smoke is covered by targeted backend contract test
- Negative auth proof: not applicable - this PR does not change auth or permissions behavior

## Notification / Realtime

- Event type or websocket channel: existing DisplayBoard WebSocket `initial_state` remains live display owner
- Payload version / ack behavior: unchanged; no websocket payload version or ack behavior changed
- Read/unread or delivery semantics: not applicable - DisplayBoard announcements are display state, not inbox read/unread state
- Reconnect/resync proof: frontend contract test proves REST live fields are ignored and WebSocket `initial_state` supplies live rows/calls/announcements

## Frontend Resilience

- Empty data proof: REST stats-only payload can load without live rows from REST
- Partial data proof: REST payload containing accidental live fields is ignored for rows/calls/announcements
- Forbidden secondary path behavior: no secondary REST snapshot path added
- Missing draft/resource behavior: not applicable - DisplayBoard does not manage drafts/resources
- Stale route/deep-link behavior: unchanged; board id/department/date handling remains existing behavior

## Scope Gate

- Allowed paths: board endpoint docstring, DisplayBoard comment, targeted backend/frontend board contract tests
- Denied paths: `/api/v1/ui/*`, separate BFF service, full board snapshot expansion, command wrappers
- Migration/docs/test impact: no migration; targeted tests added
- Rollback note: revert the board contract tests and comments/docstring

## Validation

- Targeted tests or smoke run: `py -3 -m py_compile backend/app/api/v1/endpoints/board.py backend/app/services/online_queue.py`; `py -3 -m pytest backend/tests/integration/test_board_state_contract.py backend/tests/test_openapi_contract.py`; `npm --prefix frontend run test:run -- DisplayBoardUnified.contract`; `npm --prefix frontend run build`; `git diff --check`
- Result: passed locally before PR
- Not checked: full browser DisplayBoard WebSocket smoke against a live backend
