### PR TITLE
test(registrar): prove readiness before bff

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -223,7 +223,10 @@ import { getLocalDateString, getYesterdayDateString } from '../utils/dateUtils';
 import { rescheduleTomorrow, rescheduleVisit } from '../api/visits';
 import { formatNetworkErrorMessage, isNetworkFetchError } from '../utils/networkErrorMessages';
 import { getErrorMessage } from '../utils/errorHandler';
-import { aggregatePatientsForAllDepartments as aggregateRegistrarPatients } from '../utils/registrarAggregation';
+import {
+  aggregatePatientsForAllDepartments as aggregateRegistrarPatients,
+  sortRegistrarRowsForPresentation
+} from '../utils/registrarAggregation';
 
 // ⭐ SSOT: Centralized service code resolver
 import { toServiceCode as ssotToServiceCode } from '../utils/serviceCodeResolver';
@@ -2225,11 +2228,7 @@ const RegistrarPanel = () => {
       });
 
       // Сортируем по queue_time ASC
-      const sorted = entriesForTab.sort((a, b) => {
-        const aTime = (a.queue_time ? new Date(a.queue_time) : new Date(a.created_at || 0)).getTime();
-        const bTime = (b.queue_time ? new Date(b.queue_time) : new Date(b.created_at || 0)).getTime();
-        return aTime - bTime;
-      });
+      const sorted = sortRegistrarRowsForPresentation(entriesForTab);
 
       logger.info('⭐ FIX 16: Вкладка', activeTab, '- найдено', sorted.length, 'записей из',
       rawEntries?.length || 0, 'rawEntries');
@@ -2257,22 +2256,11 @@ const RegistrarPanel = () => {
     // Для вкладки "Все отделения" (activeTab === null или undefined) - агрегируем пациентов
     if (!activeTab) {
       // Сначала фильтруем по статусу, если задан
-      const filtered = appointments.filter((appointment) => {
+      const filtered = sortRegistrarRowsForPresentation(appointments.filter((appointment) => {
         // Фильтр по статусу (если задан)
         if (statusFilter && appointment.status !== statusFilter) return false;
         return true;
-      });
-
-      // ⭐ ВАЖНО: Сортируем по queue_time ASC (согласно cursor.yaml), иначе по created_at
-      filtered.sort((a, b) => {
-        // Приоритет: queue_time > created_at
-        const aTime = (a.queue_time ? new Date(a.queue_time) : a.created_at ? new Date(a.created_at) : null)?.getTime() || 0;
-        const bTime = (b.queue_time ? new Date(b.queue_time) : b.created_at ? new Date(b.created_at) : null)?.getTime() || 0;
-        if (aTime === bTime) {
-          return (a.id || 0) - (b.id || 0);
-        }
-        return aTime - bTime; // От раннего к позднему (ASC)
-      });
+      }));
 
       // Затем агрегируем пациентов
       logger.info(`📊 Для вкладки "Все отделения": ${filtered.length} записей до агрегации`);
@@ -2307,27 +2295,12 @@ const RegistrarPanel = () => {
 
           return inFio || inPhone || inServices || inId;
         });
-        // ✅ ИСПРАВЛЕНИЕ: Сортируем результат поиска по времени регистрации
-        return searched.sort((a, b) => {
-          const aTime = a.created_at ? new Date(a.created_at).getTime() : 0;
-          const bTime = b.created_at ? new Date(b.created_at).getTime() : 0;
-          if (aTime === bTime) {
-            return (a.id || 0) - (b.id || 0);
-          }
-          return aTime - bTime;
-        });
+        // Presentation-only order: backend queue_time first, then created_at.
+        return sortRegistrarRowsForPresentation(searched);
       }
 
       // ⭐ ВАЖНО: Сортируем агрегированных пациентов по queue_time ASC (согласно cursor.yaml)
-      const sortedAggregated = aggregatedPatients.sort((a, b) => {
-        // Приоритет: queue_time > created_at
-        const aTime = (a.queue_time ? new Date(a.queue_time) : a.created_at ? new Date(a.created_at) : null)?.getTime() || 0;
-        const bTime = (b.queue_time ? new Date(b.queue_time) : b.created_at ? new Date(b.created_at) : null)?.getTime() || 0;
-        if (aTime === bTime) {
-          return (a.id || 0) - (b.id || 0);
-        }
-        return aTime - bTime; // От раннего к позднему (ASC)
-      });
+      const sortedAggregated = sortRegistrarRowsForPresentation(aggregatedPatients);
 
       // ✅ ИСПРАВЛЕНО: Применяем правильное форматирование услуг для вкладки "Все отделения"
       // Это гарантирует, что для QR-записей будут показаны все коды услуг (K01, S01 и т.д.)
@@ -2337,16 +2310,8 @@ const RegistrarPanel = () => {
       }));
     }
 
-    // ⭐ ВАЖНО: Сортируем все записи по queue_time ASC (согласно cursor.yaml), иначе по created_at
-    return appointments.sort((a, b) => {
-      // Приоритет: queue_time > created_at
-      const aTime = (a.queue_time ? new Date(a.queue_time) : a.created_at ? new Date(a.created_at) : null)?.getTime() || 0;
-      const bTime = (b.queue_time ? new Date(b.queue_time) : b.created_at ? new Date(b.created_at) : null)?.getTime() || 0;
-      if (aTime === bTime) {
-        return (a.id || 0) - (b.id || 0);
-      }
-      return aTime - bTime; // От раннего к позднему (ASC)
-    });
+    // Presentation-only order on a copy; backend remains owner of queue facts.
+    return sortRegistrarRowsForPresentation(appointments);
   }, [appointments, rawEntries, activeTab, statusFilter, searchQuery, aggregatePatientsForAllDepartments, filterServicesByDepartment, queueProfiles]);
 
   // ✅ Сохраняем filteredAppointments в ref для использования в handleKeyDown

--- a/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
@@ -7,9 +7,19 @@ import { describe, expect, it } from 'vitest';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const registrarPanelPath = path.resolve(__dirname, '../RegistrarPanel.jsx');
 
+const readRegistrarPanelSource = () => fs.readFileSync(registrarPanelPath, 'utf8');
+
+const extractSourceBlock = (source, startMarker, endMarker) => {
+  const start = source.indexOf(startMarker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf(endMarker, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+};
+
 describe('RegistrarPanel command contract', () => {
   it('uses the backend registrar record action endpoint for queue/payment/status commands', () => {
-    const source = fs.readFileSync(registrarPanelPath, 'utf8');
+    const source = readRegistrarPanelSource();
 
     expect(source).toContain("api.post('/registrar/records/actions'");
     expect(source).not.toContain('/registrar/visits/${recordId}/mark-paid');
@@ -21,13 +31,75 @@ describe('RegistrarPanel command contract', () => {
   });
 
   it('passes through registrar queue patient display fields before legacy patient fetch fallback', () => {
-    const source = fs.readFileSync(registrarPanelPath, 'utf8');
+    const source = readRegistrarPanelSource();
 
     expect(source).toContain('if (apt.patient_id && !hasBackendPatientDisplayContract(apt))');
     expect(source).toContain('patient_fio: fullEntry.patient_fio ?? fullEntry.patient_name');
     expect(source).toContain('patient_birth_year: fullEntry.patient_birth_year ?? fullEntry.birth_year');
     expect(source).toContain('patient_phone: fullEntry.patient_phone ?? fullEntry.phone');
     expect(source).toContain('address: fullEntry.address ?? entry.address');
+  });
+
+  it('gates record commands through backend-provided available_actions and can flags', () => {
+    const source = readRegistrarPanelSource();
+    const hasBackendActionBlock = extractSourceBlock(
+      source,
+      'const hasBackendAction = (record, action) => {',
+      'const getRegistrarActionForStatus = (status) => {',
+    );
+    const runActionBlock = extractSourceBlock(
+      source,
+      'const runRegistrarRecordAction = useCallback(async (record, action, payload = {}) => {',
+      'const handleStartVisit = useCallback(async (appointment) => {',
+    );
+
+    expect(hasBackendActionBlock).toContain('record.available_actions');
+    expect(hasBackendActionBlock).toContain("mark_paid: 'can_mark_paid'");
+    expect(hasBackendActionBlock).toContain("start_visit: 'can_start_visit'");
+    expect(hasBackendActionBlock).toContain("print_ticket: 'can_print_ticket'");
+    expect(hasBackendActionBlock).toContain("complete: 'can_complete'");
+    expect(hasBackendActionBlock).toContain("cancel: 'can_cancel'");
+    expect(runActionBlock.indexOf('if (!hasBackendAction(record, action))')).toBeLessThan(
+      runActionBlock.indexOf("api.post('/registrar/records/actions'"),
+    );
+  });
+
+  it('does not gate command execution from record type or payment display grouping', () => {
+    const source = readRegistrarPanelSource();
+    const hasBackendActionBlock = extractSourceBlock(
+      source,
+      'const hasBackendAction = (record, action) => {',
+      'const getRegistrarActionForStatus = (status) => {',
+    );
+    const runActionBlock = extractSourceBlock(
+      source,
+      'const runRegistrarRecordAction = useCallback(async (record, action, payload = {}) => {',
+      'const handleStartVisit = useCallback(async (appointment) => {',
+    );
+    const forbiddenDecisionInputs = [
+      'record_type',
+      'payment_status',
+      'payment_type',
+      'mixed_payment',
+      'pending_payment',
+      'approval_pending',
+    ];
+
+    forbiddenDecisionInputs.forEach((input) => {
+      expect(hasBackendActionBlock).not.toContain(input);
+      expect(runActionBlock).not.toContain(input);
+    });
+  });
+
+  it('uses presentation-only sorting from backend queue_time facts', () => {
+    const source = readRegistrarPanelSource();
+
+    expect(source).toContain('sortRegistrarRowsForPresentation');
+    expect(source).toContain('const sorted = sortRegistrarRowsForPresentation(entriesForTab)');
+    expect(source).toContain('const filtered = sortRegistrarRowsForPresentation(appointments.filter');
+    expect(source).toContain('return sortRegistrarRowsForPresentation(searched)');
+    expect(source).toContain('const sortedAggregated = sortRegistrarRowsForPresentation(aggregatedPatients)');
+    expect(source).toContain('return sortRegistrarRowsForPresentation(appointments)');
   });
 });
 

--- a/frontend/src/utils/__tests__/registrarAggregation.test.js
+++ b/frontend/src/utils/__tests__/registrarAggregation.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { aggregatePatientsForAllDepartments } from '../registrarAggregation';
+import {
+  aggregatePatientsForAllDepartments,
+  sortRegistrarRowsForPresentation
+} from '../registrarAggregation';
 
 const makeAppointment = (overrides = {}) => ({
   id: overrides.id ?? 1,
@@ -33,6 +36,12 @@ const makeAppointment = (overrides = {}) => ({
   source: overrides.source ?? 'desk',
   discount_mode: overrides.discount_mode ?? 'none',
   approval_status: overrides.approval_status ?? null,
+  available_actions: overrides.available_actions ?? [],
+  can_mark_paid: overrides.can_mark_paid ?? false,
+  can_start_visit: overrides.can_start_visit ?? false,
+  can_cancel: overrides.can_cancel ?? false,
+  can_print_ticket: overrides.can_print_ticket ?? false,
+  can_complete: overrides.can_complete ?? false,
   aggregated_ids: overrides.aggregated_ids,
 });
 
@@ -81,6 +90,10 @@ describe('aggregatePatientsForAllDepartments', () => {
     expect(result[0].discount_mode).toBe('all_free');
     expect(result[0].payment_type).toBe('approval_pending');
     expect(result[0].cost_display).toBe('free');
+    expect(result[0]).not.toHaveProperty('can_mark_paid');
+    expect(result[0]).not.toHaveProperty('can_start_visit');
+    expect(result[0]).not.toHaveProperty('can_cancel');
+    expect(result[0]).not.toHaveProperty('can_print_ticket');
   });
 
   it('shows mixed payment for groups with mixed statuses or methods', () => {
@@ -92,6 +105,10 @@ describe('aggregatePatientsForAllDepartments', () => {
     expect(result[0].payment_status).toBe('mixed');
     expect(result[0].payment_type).toBe('mixed_payment');
     expect(result[0].cost).toBe(150000);
+    expect(result[0]).not.toHaveProperty('can_mark_paid');
+    expect(result[0]).not.toHaveProperty('can_start_visit');
+    expect(result[0]).not.toHaveProperty('can_cancel');
+    expect(result[0]).not.toHaveProperty('can_print_ticket');
   });
 
   it('does not invent cash payment type when backend value is absent', () => {
@@ -101,6 +118,59 @@ describe('aggregatePatientsForAllDepartments', () => {
 
     expect(result[0].payment_type).toBe('pending_payment');
     expect(result[0].grouped_payment_types).toEqual([]);
+    expect(result[0]).not.toHaveProperty('can_mark_paid');
+    expect(result[0]).not.toHaveProperty('can_start_visit');
+    expect(result[0]).not.toHaveProperty('can_cancel');
+    expect(result[0]).not.toHaveProperty('can_print_ticket');
+  });
+
+  it('preserves backend command availability only inside grouped records', () => {
+    const result = aggregatePatientsForAllDepartments([
+      makeAppointment({
+        id: 1,
+        cost: 100000,
+        canonical_record_id: 101,
+        record_kind: 'visit',
+        available_actions: ['mark_paid'],
+        can_mark_paid: true,
+        can_start_visit: false,
+        can_cancel: true,
+      }),
+      makeAppointment({
+        id: 2,
+        cost: 50000,
+        canonical_record_id: 202,
+        record_kind: 'online_queue',
+        queue_entry_id: 202,
+        available_actions: ['start_visit'],
+        can_mark_paid: false,
+        can_start_visit: true,
+        can_cancel: false,
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].payment_type).toBe('pending_payment');
+    expect(result[0]).not.toHaveProperty('available_actions');
+    expect(result[0]).not.toHaveProperty('can_mark_paid');
+    expect(result[0]).not.toHaveProperty('can_start_visit');
+    expect(result[0]).not.toHaveProperty('can_cancel');
+    expect(result[0]).not.toHaveProperty('can_print_ticket');
+    expect(result[0]).not.toHaveProperty('can_complete');
+    expect(result[0].grouped_records).toMatchObject([
+      {
+        available_actions: ['mark_paid'],
+        can_mark_paid: true,
+        can_start_visit: false,
+        can_cancel: true,
+      },
+      {
+        available_actions: ['start_visit'],
+        can_mark_paid: false,
+        can_start_visit: true,
+        can_cancel: false,
+      },
+    ]);
   });
 
   it('preserves the earliest queue_time when grouping all departments', () => {
@@ -120,5 +190,66 @@ describe('aggregatePatientsForAllDepartments', () => {
     expect(result).toHaveLength(1);
     expect(result[0].queue_time).toBe('2026-04-15T09:30:00+05:00');
     expect(result[0].created_at).toBe('2026-04-15T09:31:00+05:00');
+  });
+});
+
+describe('sortRegistrarRowsForPresentation', () => {
+  it('orders by backend-provided queue_time without mutating row facts', () => {
+    const rows = [
+      makeAppointment({
+        id: 2,
+        queue_time: '2026-04-15T09:40:00+05:00',
+        status: 'waiting',
+        queue_numbers: [{ id: 20, number: 2, status: 'waiting' }],
+        available_actions: ['cancel'],
+        can_cancel: true,
+      }),
+      makeAppointment({
+        id: 1,
+        queue_time: '2026-04-15T09:30:00+05:00',
+        status: 'queued',
+        queue_numbers: [{ id: 10, number: 1, status: 'queued' }],
+        available_actions: ['start_visit'],
+        can_start_visit: true,
+      }),
+    ];
+    const originalRows = JSON.parse(JSON.stringify(rows));
+
+    const sorted = sortRegistrarRowsForPresentation(rows);
+
+    expect(sorted.map((row) => row.id)).toEqual([1, 2]);
+    expect(rows).toEqual(originalRows);
+    expect(sorted[0]).toMatchObject({
+      id: 1,
+      status: 'queued',
+      queue_numbers: [{ id: 10, number: 1, status: 'queued' }],
+      available_actions: ['start_visit'],
+      can_start_visit: true,
+    });
+    expect(sorted[1]).toMatchObject({
+      id: 2,
+      status: 'waiting',
+      queue_numbers: [{ id: 20, number: 2, status: 'waiting' }],
+      available_actions: ['cancel'],
+      can_cancel: true,
+    });
+  });
+
+  it('falls back to backend created_at when queue_time is missing', () => {
+    const sorted = sortRegistrarRowsForPresentation([
+      makeAppointment({ id: 3, queue_time: '', created_at: '2026-04-15T09:45:00+05:00' }),
+      makeAppointment({ id: 4, queue_time: '', created_at: '2026-04-15T09:15:00+05:00' }),
+    ]);
+
+    expect(sorted.map((row) => row.id)).toEqual([4, 3]);
+  });
+
+  it('uses id only as a presentation tie-breaker', () => {
+    const sorted = sortRegistrarRowsForPresentation([
+      makeAppointment({ id: 9, queue_time: '2026-04-15T09:30:00+05:00' }),
+      makeAppointment({ id: 7, queue_time: '2026-04-15T09:30:00+05:00' }),
+    ]);
+
+    expect(sorted.map((row) => row.id)).toEqual([7, 9]);
   });
 });

--- a/frontend/src/utils/registrarAggregation.js
+++ b/frontend/src/utils/registrarAggregation.js
@@ -10,6 +10,26 @@ export const getRecordAmount = (appointment) => {
   return Number.isFinite(amount) ? amount : 0;
 };
 
+export const getRegistrarPresentationSortTime = (record) => {
+  const value = record?.queue_time || record?.created_at || null;
+  if (!value) return 0;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 0 : date.getTime();
+};
+
+export const compareRegistrarPresentationOrder = (a, b) => {
+  const aTime = getRegistrarPresentationSortTime(a);
+  const bTime = getRegistrarPresentationSortTime(b);
+  if (aTime === bTime) {
+    return Number(a?.id || 0) - Number(b?.id || 0);
+  }
+  return aTime - bTime;
+};
+
+export const sortRegistrarRowsForPresentation = (records = []) => (
+  [...records].sort(compareRegistrarPresentationOrder)
+);
+
 const normalizeRecordKind = (appointment) => String(
   appointment?.record_kind ?? appointment?.source_kind ?? appointment?.record_type ?? appointment?.type ?? ''
 ).trim().toLowerCase();


### PR DESCRIPTION
## Summary
- Proves `registrarAggregation` payment grouping (`mixed_payment`, `pending_payment`, `approval_pending`) is display-only and does not synthesize top-level command availability.
- Centralizes RegistrarPanel presentation sorting on backend-provided `queue_time` / `created_at` facts without mutating row arrays.
- Extends RegistrarPanel source contract tests for backend-owned command availability and the existing `/registrar/records/actions` endpoint.

## Contract Impact
- Canonical surface: frontend-only proof for existing `GET /api/v1/registrar/queues/today` data consumption and `POST /api/v1/registrar/records/actions` command submission.
- Request shape: unchanged.
- Response shape: unchanged; frontend continues consuming existing `queue_time`, `created_at`, `available_actions`, and backend `can_*` flags.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/pages/RegistrarPanel.jsx`.
- Compatibility path or alias: none added.
- Contract proof: `registrarAggregation` and `RegistrarPanel.contract` tests prove display-only grouping, backend-owned command gating, and presentation-only sort behavior.

## RBAC / Permissions
- Roles allowed: unchanged; this PR does not add or change backend routes, role checks, or permission policy.
- Roles denied: unchanged; denied users remain enforced by the existing backend auth/RBAC path for `/registrar/records/actions`.
- Positive auth proof: frontend command execution still posts only to `/registrar/records/actions`, so existing backend positive authorization tests remain the proof owner.
- Negative auth proof: no frontend bypass or alternate endpoint was added; existing backend negative authorization behavior remains authoritative.

## Notification / Realtime
- Event type or websocket channel: none; no notification event, websocket channel, or realtime subscription changed.
- Payload version / ack behavior: unchanged because this PR does not publish or consume realtime payloads.
- Read/unread or delivery semantics: unchanged because no notification delivery/read state is touched.
- Reconnect/resync proof: unchanged because RegistrarPanel polling/reload behavior is not changed by this proof patch.

## Frontend Resilience
- Empty data proof: `sortRegistrarRowsForPresentation` safely handles missing input with an empty array default.
- Partial data proof: sorting uses backend `queue_time` and falls back to backend `created_at` when `queue_time` is missing.
- Forbidden secondary path behavior: no secondary command path added; command tests assert `/registrar/records/actions` is used.
- Missing draft/resource behavior: unchanged; this PR does not touch draft/resource loading, and URL patient workflow remains on its existing path.
- Stale route/deep-link behavior: unchanged; URL patient workflow is not touched.

## Scope Gate
- Allowed paths: `frontend/src/utils/registrarAggregation.js`, `frontend/src/utils/__tests__/registrarAggregation.test.js`, `frontend/src/pages/RegistrarPanel.jsx`, `frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx`.
- Denied paths: backend, QueueJoin, DisplayBoard, `/api/v1/ui/*`, separate BFF service, command wrappers, broad RegistrarPanel rewrite.
- Migration/docs/test impact: no migration; frontend proof tests updated.
- Rollback note: revert this commit to restore the prior local sort implementation and tests.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- registrarAggregation RegistrarPanel.contract`; `npm --prefix frontend run build`; `git diff --check`; forbidden scan for `/api/v1/ui`, UI endpoint folders, separate BFF, command wrapper/generic command strings.
- Result: all passed; forbidden scan found no matches.
- Not checked: backend pytest/OpenAPI contract tests, because no backend/API DTO code changed.