### PR TITLE
fix(registrar): consolidate metadata department load

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -1534,41 +1534,16 @@ const RegistrarPanel = () => {
     }
   }, [enrichAppointmentsWithPatientData, showCalendar, historyDate, activeTab, demoAppointments, appointmentsCount]);
 
-  // ✅ ДИНАМИЧЕСКИЕ ОТДЕЛЕНИЯ: загрузка отделений из БД
-  const loadDynamicDepartments = useCallback(async () => {
-    try {
-      const token = tokenManager.getAccessToken();
-      if (!token) return;
-
-      const response = await fetch(`${API_BASE}/api/v1/departments/active`, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        }
-      });
-
-      if (response.ok) {
-        const departments = await response.json();
-        // Backend returns {success: true, data: [...], count: N}
-        const departmentsArray = departments.data || [];
-        setDynamicDepartments(departmentsArray);
-        logger.info('✅ Загружены динамические отделения:', departmentsArray.map((d) => d.key));
-      }
-    } catch (error) {
-      logger.error('Ошибка загрузки отделений:', error);
-    }
-  }, []);
-
   // Слушаем обновления отделений от админ-панели
   useEffect(() => {
     const handleDepartmentsUpdate = (event) => {
       logger.info('RegistrarPanel: Получено обновление отделений, перезагружаю...', event.detail);
-      loadDynamicDepartments();
+      loadIntegratedData();
     };
 
     window.addEventListener('departments:updated', handleDepartmentsUpdate);
     return () => window.removeEventListener('departments:updated', handleDepartmentsUpdate);
-  }, [loadDynamicDepartments]);
+  }, [loadIntegratedData]);
 
   // Первичная загрузка данных (однократно) с защитой от двойного вызова в React 18
   const initialLoadRef = useRef(false);
@@ -1579,10 +1554,9 @@ const RegistrarPanel = () => {
     if (initialLoadRef.current) return;
     initialLoadRef.current = true;
     logger.info('🚀 Starting initial data load (guarded)...');
-    loadDynamicDepartments(); // ✅ Загружаем отделения
     loadAppointments({ source: 'initial_load' });
     loadIntegratedData();
-  }, [loadAppointments, loadIntegratedData, loadDynamicDepartments]);
+  }, [loadAppointments, loadIntegratedData]);
 
   // Слушаем глобальные события обновления очереди для синхронизации статусов
   useEffect(() => {

--- a/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
@@ -32,12 +32,36 @@ describe('RegistrarPanel command contract', () => {
 
   it('passes through registrar queue patient display fields before legacy patient fetch fallback', () => {
     const source = readRegistrarPanelSource();
+    const enrichmentBlock = extractSourceBlock(
+      source,
+      'const enrichAppointmentsWithPatientData = useCallback(async (appointments) => {',
+      'const loadAppointments = useCallback(async (options = {}) => {',
+    );
 
     expect(source).toContain('if (apt.patient_id && !hasBackendPatientDisplayContract(apt))');
     expect(source).toContain('patient_fio: fullEntry.patient_fio ?? fullEntry.patient_name');
     expect(source).toContain('patient_birth_year: fullEntry.patient_birth_year ?? fullEntry.birth_year');
     expect(source).toContain('patient_phone: fullEntry.patient_phone ?? fullEntry.phone');
     expect(source).toContain('address: fullEntry.address ?? entry.address');
+    expect(enrichmentBlock).toContain('if (apt.patient_id && !hasBackendPatientDisplayContract(apt))');
+    expect(enrichmentBlock.indexOf('!hasBackendPatientDisplayContract(apt)')).toBeLessThan(
+      enrichmentBlock.indexOf('fetchPatientData(apt.patient_id)'),
+    );
+  });
+
+  it('loads Registrar metadata departments through one registrar endpoint', () => {
+    const source = readRegistrarPanelSource();
+
+    expect(source).toContain("api.get('/registrar/departments?active_only=true')");
+    expect(source).not.toContain('/api/v1/departments/active');
+    expect(source).not.toContain('const loadDynamicDepartments = useCallback');
+  });
+
+  it('does not add a BFF-lite registrar workbench endpoint', () => {
+    const source = readRegistrarPanelSource();
+
+    expect(source).not.toContain('/api/v1/ui/');
+    expect(source).not.toContain('/ui/registrar/workbench');
   });
 
   it('gates record commands through backend-provided available_actions and can flags', () => {


### PR DESCRIPTION
﻿## Summary
- Consolidate RegistrarPanel department metadata loading onto the existing registrar metadata endpoint.
- Remove the duplicate direct `/api/v1/departments/active` frontend fetch path.
- Extend frontend contract proof that normal registrar queue rows with backend patient display fields do not need `/patients/{id}` enrichment.

## Contract Impact
- Canonical surface: existing frontend consumption of `/registrar/departments?active_only=true` inside RegistrarPanel metadata loading.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `RegistrarPanel` only.
- Compatibility path or alias: no API endpoint removed; only the duplicate RegistrarPanel frontend call path was removed.
- Contract proof: `RegistrarPanel.contract` asserts the registrar departments endpoint is the only RegistrarPanel department metadata path and patient display rows gate legacy `/patients/{id}` fallback.

## RBAC / Permissions
- Roles allowed: unchanged from existing RegistrarPanel access; no backend route or permission surface changed.
- Roles denied: unchanged; no alternate department endpoint or auth bypass was added.
- Positive auth proof: no backend auth surface changed; RegistrarPanel continues to use the existing authenticated registrar metadata request.
- Negative auth proof: no alternate endpoint or bypass added.

## Notification / Realtime
- Event type or websocket channel: unchanged; existing `departments:updated` browser event now reloads the same registrar metadata path.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: unchanged; no websocket code touched.

## Frontend Resilience
- Empty data proof: existing metadata empty-state handling remains inside the existing `loadIntegratedData` path.
- Partial data proof: `Promise.allSettled` metadata loader behavior remains unchanged.
- Forbidden secondary path behavior: RegistrarPanel no longer has the duplicate `/api/v1/departments/active` path.
- Missing draft/resource behavior: not involved; URL patient workflow unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`, `frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, BFF-lite, separate BFF service, QueueJoin, DisplayBoard, command wrappers, runtime command behavior.
- Migration/docs/test impact: no migration or docs; frontend contract test updated.
- Rollback note: revert this commit to restore the previous duplicate department loader.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- RegistrarPanel.contract`; `npm --prefix frontend run build`; `git diff --check`; runtime no-go scan on `RegistrarPanel.jsx` for `/api/v1/ui`, old department path, BFF/read-model markers, and removed loader name.
- Result: all local validation passed; `git diff --check` emitted CRLF normalization warnings only.
- Not checked: backend pytest/OpenAPI were not run because no backend/API DTO changed.
