### PR TITLE
fix(registrar): remove unused queue settings metadata fetch

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -1020,17 +1020,15 @@ const RegistrarPanel = () => {
 
         // ✅ ОПТИМИЗАЦИЯ: Загружаем все данные параллельно с Promise.allSettled
         logger.info('🚀 Загружаем данные параллельно...');
-        const [doctorsResult, servicesResult, queueResult, departmentsResult] = await Promise.allSettled([
+        const [doctorsResult, servicesResult, departmentsResult] = await Promise.allSettled([
         api.get('/registrar/doctors'),
         api.get('/registrar/services'),
-        api.get('/registrar/queue-settings'),
         api.get('/registrar/departments?active_only=true')]
         );
 
         // Обрабатываем результаты
         const doctorsRes = doctorsResult.status === 'fulfilled' ? doctorsResult.value : { ok: false };
         const servicesRes = servicesResult.status === 'fulfilled' ? servicesResult.value : { ok: false };
-        const queueRes = queueResult.status === 'fulfilled' ? queueResult.value : { ok: false };
         const departmentsRes = departmentsResult.status === 'fulfilled' ? departmentsResult.value : { success: false };
 
         // Логируем результаты
@@ -1044,11 +1042,6 @@ const RegistrarPanel = () => {
         } else {
           logger.error('❌ Ошибка загрузки услуг:', servicesResult.reason?.message);
         }
-        if (queueResult.status === 'fulfilled') {
-          logger.info('📊 Ответ настроек очереди: OK');
-        } else {
-          logger.error('❌ Ошибка загрузки настроек очереди:', queueResult.reason?.message);
-        }
         if (departmentsResult.status === 'fulfilled') {
           logger.info('📊 Ответ отделений: OK', departmentsRes.data);
         } else {
@@ -1058,11 +1051,10 @@ const RegistrarPanel = () => {
         logger.info('🔄 Обрабатываем ответы API...');
 
         // Проверяем, что все ответы успешны
-        const allSuccess = doctorsRes && doctorsRes.data && servicesRes && servicesRes.data && queueRes && queueRes.data;
+        const allSuccess = doctorsRes && doctorsRes.data && servicesRes && servicesRes.data;
         logger.info('📊 Статус ответов:', {
           doctors: doctorsRes && doctorsRes.data ? 'OK' : 'ERROR',
           services: servicesRes && servicesRes.data ? 'OK' : 'ERROR',
-          queueSettings: queueRes && queueRes.data ? 'OK' : 'ERROR',
           allSuccess
         });
 
@@ -1113,15 +1105,6 @@ const RegistrarPanel = () => {
           logger.warn('❌ API услуг недоступен, оставляем пустое состояние');
         }
 
-        if (queueRes && queueRes.data) {
-          try {
-            logger.info('✅ Настройки очереди обновлены из API');
-          } catch (error) {
-            logger.warn('Ошибка обработки данных настроек очереди:', error.message);
-          }
-        } else {
-          logger.warn('❌ API настроек очереди недоступен, оставляем пустое состояние');
-        }
 
         logger.info('🎯 Загрузка интегрированных данных завершена');
       } catch (fetchError) {

--- a/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
@@ -57,6 +57,22 @@ describe('RegistrarPanel command contract', () => {
     expect(source).not.toContain('const loadDynamicDepartments = useCallback');
   });
 
+  it('does not fetch unused queue settings in the Registrar metadata bundle', () => {
+    const source = readRegistrarPanelSource();
+    const loadIntegratedDataBlock = extractSourceBlock(
+      source,
+      'const loadIntegratedData = useCallback(async () => {',
+      'const fetchPatientData = useCallback(async (patientId) => {',
+    );
+
+    expect(loadIntegratedDataBlock).toContain("api.get('/registrar/doctors')");
+    expect(loadIntegratedDataBlock).toContain("api.get('/registrar/services')");
+    expect(loadIntegratedDataBlock).toContain("api.get('/registrar/departments?active_only=true')");
+    expect(loadIntegratedDataBlock).not.toContain("api.get('/registrar/queue-settings')");
+    expect(loadIntegratedDataBlock).not.toContain('queueResult');
+    expect(loadIntegratedDataBlock).not.toContain('queueRes');
+  });
+
   it('does not add a BFF-lite registrar workbench endpoint', () => {
     const source = readRegistrarPanelSource();
 


### PR DESCRIPTION
## Summary
- Remove the unused `/registrar/queue-settings` fetch from RegistrarPanel metadata loading.
- Keep RegistrarPanel command behavior untouched.
- Add contract proof that the Registrar metadata bundle uses only active doctors, services, and departments for this path.

## Cyclic Execution Evidence
- Fresh main sync: branch was created from current `origin/main` after PR #1215; `git fetch origin main` confirmed current base moved to `558e4907` while this PR remains a narrow frontend-only delta.
- Clean workspace: working tree was clean before the patch; only the two allowed frontend files are changed in the PR.
- Branch: `codex/registrar-metadata-queue-settings-cleanup`.
- Scope gate: no backend, no `/api/v1/ui/*`, no BFF-lite, no QueueJoin/DisplayBoard, no command behavior changes.
- Red-check handling: initial PR Review Quality Gate failed only because this newly required section was missing; fixed by updating PR body, not runtime code.

## Contract Impact
- Canonical surface: existing RegistrarPanel frontend metadata loading.
- Request shape: changed only by removing an unused frontend GET from `loadIntegratedData`; no backend request or response contract changed.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `RegistrarPanel` only.
- Compatibility path or alias: no API removed; other consumers of `/registrar/queue-settings` are untouched.
- Contract proof: `RegistrarPanel.contract` asserts `loadIntegratedData` no longer references `/registrar/queue-settings`, `queueResult`, or `queueRes`.

## RBAC / Permissions
- Roles allowed: unchanged from existing RegistrarPanel access; no backend route or permission surface changed.
- Roles denied: unchanged; no alternate endpoint or auth bypass was added.
- Positive auth proof: no backend auth surface changed; RegistrarPanel still uses existing authenticated registrar metadata endpoints.
- Negative auth proof: no new request path or bypass added.

## Notification / Realtime
- Event type or websocket channel: unchanged; existing browser events still reload Registrar metadata through `loadIntegratedData`.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: unchanged; no websocket code touched.

## Frontend Resilience
- Empty data proof: existing doctors/services/departments empty-state handling remains in `loadIntegratedData`.
- Partial data proof: `Promise.allSettled` metadata loader remains for the metadata endpoints still used by RegistrarPanel.
- Forbidden secondary path behavior: RegistrarPanel no longer makes an unused queue-settings metadata request in this load path.
- Missing draft/resource behavior: not involved; URL patient workflow unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`, `frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, BFF-lite, separate BFF service, QueueJoin, DisplayBoard, command wrappers, runtime command behavior.
- Migration/docs/test impact: no migration or docs; frontend contract test updated.
- Rollback note: revert this commit to restore the previous unused queue-settings metadata fetch.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- RegistrarPanel.contract`; runtime no-go scan on `RegistrarPanel.jsx`; `npm --prefix frontend run build`; `git diff --check`.
- Result: all local validation passed; `git diff --check` emitted CRLF normalization warning only for the touched test file.
- Not checked: backend pytest/OpenAPI were not run because no backend/API DTO changed.