### PR TITLE
fix(doctor): keep queue action contract backend-owned

### DIFF
--- a/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
+++ b/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
@@ -1608,12 +1608,14 @@ const EnhancedAppointmentsTable = ({
               );
               const canPay = !isDoctorView && (backendCanPay ?? legacyCanPay);
               const canCall = backendCanCall ?? (
-                isDoctorView ?
-                  rowStatus === 'queued' || rowStatus === 'waiting' || rowPaymentStatus === 'paid' :
-                  rowStatus === 'queued' || rowStatus === 'waiting'
+                isDoctorView ? false : rowStatus === 'queued' || rowStatus === 'waiting'
               );
-              const canPrint = backendCanPrint ?? (rowPaymentStatus === 'paid' || rowStatus === 'queued' || rowStatus === 'waiting');
-              const canComplete = backendCanComplete ?? (rowStatus === 'in_cabinet' || rowStatus === 'called');
+              const canPrint = backendCanPrint ?? (
+                isDoctorView ? false : rowPaymentStatus === 'paid' || rowStatus === 'queued' || rowStatus === 'waiting'
+              );
+              const canComplete = backendCanComplete ?? (
+                isDoctorView ? false : rowStatus === 'in_cabinet' || rowStatus === 'called'
+              );
 
               return (
                 <tr

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -572,6 +572,18 @@ const MacOSCardiologistPanelUnified = () => {
                   service_codes: entry.service_codes || [],
                   payment_type: entry.payment_type || null,
                   payment_status: entry.payment_status || 'pending',
+                  available_actions: entry.available_actions || [],
+                  can_mark_paid: Boolean(entry.can_mark_paid),
+                  can_start_visit: Boolean(entry.can_start_visit),
+                  can_print_ticket: Boolean(entry.can_print_ticket),
+                  can_complete: Boolean(entry.can_complete),
+                  can_cancel: Boolean(entry.can_cancel),
+                  canonical_record_id: entry.canonical_record_id || entry.id,
+                  record_kind: entry.record_kind,
+                  source_kind: entry.source_kind,
+                  canonical_status: entry.canonical_status || entry.status,
+                  queue_status: entry.queue_status || entry.status,
+                  queue_position: entry.queue_position,
                   doctor: entry.doctor_name || 'Врач',
                   specialty: queue.specialty,
                   created_at: entry.created_at,
@@ -618,78 +630,6 @@ const MacOSCardiologistPanelUnified = () => {
           // Если есть консультация кардиолога и specialty правильный, включаем
           return isCardiology && (hasCardiologyConsultation || serviceCodes.length === 0);
         });
-
-        // 2. Получаем актуальный payment_status из БД через all-appointments
-        const today = new Date().toISOString().split('T')[0];
-        try {
-          const appointmentsResponse = await fetch(`${API_V1_BASE}/registrar/all-appointments?date_from=${today}&date_to=${today}&limit=500`, {
-            headers: {
-              'Authorization': `Bearer ${token}`,
-              'Content-Type': 'application/json'
-            }
-          });
-
-          if (appointmentsResponse.ok) {
-            const appointmentsDBResponse = await appointmentsResponse.json();
-            const appointmentsDBData = appointmentsDBResponse.data || appointmentsDBResponse || []; // ✅ ИСПРАВЛЕНО: Извлекаем data из ответа
-
-            // Создаем карту id -> payment_status (используем id без смещения, так как бэкенд добавляет +20000 для Visit)
-            const appointmentMetaMap = new Map();
-            appointmentsDBData.forEach((apt) => {
-              const appointmentMeta = {
-                payment_status: apt.payment_status || 'pending',
-                payment_type: apt.payment_type || null,
-                visit_id: apt.visit_id || null,
-                appointment_id: apt.appointment_id || (apt.source === 'appointments' ? apt.id : null)
-              };
-              if (apt.id) {
-                appointmentMetaMap.set(apt.id, appointmentMeta);
-              }
-              if (apt.patient_id && apt.appointment_date) {
-                const key = `${apt.patient_id}_${apt.appointment_date}`;
-                appointmentMetaMap.set(key, appointmentMeta);
-              }
-            });
-
-            // Обновляем payment_status и canonical visit_id в наших записях
-            allAppointments = allAppointments.map((apt) => {
-              let appointmentMeta = appointmentMetaMap.get(apt.appointment_id || apt.id);
-              if (!appointmentMeta && apt.patient_id && apt.appointment_date) {
-                const key = `${apt.patient_id}_${apt.appointment_date}`;
-                appointmentMeta = appointmentMetaMap.get(key);
-              }
-              return {
-                ...apt,
-                appointment_id: appointmentMeta?.appointment_id || apt.appointment_id,
-                visit_id: appointmentMeta?.visit_id || apt.visit_id || null,
-                payment_status: appointmentMeta?.payment_status || apt.payment_status || 'pending',
-                payment_type: appointmentMeta?.payment_type || apt.payment_type || null
-              };
-            });
-            appointmentsData = appointmentsData.map((apt) => {
-              let appointmentMeta = appointmentMetaMap.get(apt.appointment_id || apt.id);
-              if (!appointmentMeta && apt.patient_id && apt.appointment_date) {
-                const key = `${apt.patient_id}_${apt.appointment_date}`;
-                appointmentMeta = appointmentMetaMap.get(key);
-              }
-              return {
-                ...apt,
-                appointment_id: appointmentMeta?.appointment_id || apt.appointment_id,
-                visit_id: appointmentMeta?.visit_id || apt.visit_id || null,
-                payment_status: appointmentMeta?.payment_status || apt.payment_status || 'pending',
-                payment_type: appointmentMeta?.payment_type || apt.payment_type || null
-              };
-            });
-          }
-        } catch (err) {
-      setMessage({
-        type: 'warning',
-        text: getErrorMessage(
-          err,
-          'Не удалось обновить статусы оплат, показаны данные очереди. Проверьте соединение и попробуйте снова.'
-        )
-      });
-        }
 
         // Добавляем информацию о всех услугах пациента в каждую запись
         const enrichedAppointmentsData = appointmentsData.map((apt) => {

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -573,6 +573,18 @@ const DentistPanelUnified = () => {
                     service_codes: entry.service_codes || [],
                     payment_type: entry.payment_type || null,
                     payment_status: entry.payment_status || 'pending',
+                    available_actions: entry.available_actions || [],
+                    can_mark_paid: Boolean(entry.can_mark_paid),
+                    can_start_visit: Boolean(entry.can_start_visit),
+                    can_print_ticket: Boolean(entry.can_print_ticket),
+                    can_complete: Boolean(entry.can_complete),
+                    can_cancel: Boolean(entry.can_cancel),
+                    canonical_record_id: entry.canonical_record_id || entry.id,
+                    record_kind: entry.record_kind,
+                    source_kind: entry.source_kind,
+                    canonical_status: entry.canonical_status || entry.status,
+                    queue_status: entry.queue_status || entry.status,
+                    queue_position: entry.queue_position,
                     doctor: entry.doctor_name || 'Врач',
                     specialty: queue.specialty,
                     created_at: entry.created_at,
@@ -590,75 +602,6 @@ const DentistPanelUnified = () => {
           let appointmentsData = allAppointments.filter((apt) =>
             isDentistrySpecialty(apt.specialty)
           );
-
-          // 2. Получаем актуальный payment_status из БД через all-appointments
-          const today = new Date().toISOString().split('T')[0];
-          try {
-            const appointmentsResponse = await fetch(`${API_V1_BASE}/registrar/all-appointments?date_from=${today}&date_to=${today}&limit=500`, {
-              headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-              }
-            });
-
-            if (appointmentsResponse.ok) {
-              const appointmentsDBResponse = await appointmentsResponse.json();
-              const appointmentsDBData = appointmentsDBResponse.data || appointmentsDBResponse || []; // ✅ ИСПРАВЛЕНО: Извлекаем data из ответа
-              logger.info('[Dentist] Получены appointments из БД:', appointmentsDBData.length);
-
-              // Создаем карту id -> payment_status
-              const appointmentMetaMap = new Map();
-              appointmentsDBData.forEach((apt) => {
-                const appointmentMeta = {
-                  payment_status: apt.payment_status || 'pending',
-                  payment_type: apt.payment_type || null,
-                  visit_id: apt.visit_id || null,
-                  appointment_id: apt.appointment_id || (apt.source === 'appointments' ? apt.id : null)
-                };
-                if (apt.id) {
-                  appointmentMetaMap.set(apt.id, appointmentMeta);
-                }
-                if (apt.patient_id && apt.appointment_date) {
-                  const key = `${apt.patient_id}_${apt.appointment_date}`;
-                  appointmentMetaMap.set(key, appointmentMeta);
-                }
-              });
-
-              // Обновляем payment_status в наших записях
-              allAppointments = allAppointments.map((apt) => {
-                let appointmentMeta = appointmentMetaMap.get(apt.appointment_id || apt.id);
-                if (!appointmentMeta && apt.patient_id && apt.appointment_date) {
-                  const key = `${apt.patient_id}_${apt.appointment_date}`;
-                  appointmentMeta = appointmentMetaMap.get(key);
-                }
-                return {
-                  ...apt,
-                  appointment_id: appointmentMeta?.appointment_id || apt.appointment_id,
-                  visit_id: appointmentMeta?.visit_id || apt.visit_id || null,
-                  payment_status: appointmentMeta?.payment_status || apt.payment_status || 'pending',
-                  payment_type: appointmentMeta?.payment_type || apt.payment_type || null
-                };
-              });
-              appointmentsData = appointmentsData.map((apt) => {
-                let appointmentMeta = appointmentMetaMap.get(apt.appointment_id || apt.id);
-                if (!appointmentMeta && apt.patient_id && apt.appointment_date) {
-                  const key = `${apt.patient_id}_${apt.appointment_date}`;
-                  appointmentMeta = appointmentMetaMap.get(key);
-                }
-                return {
-                  ...apt,
-                  appointment_id: appointmentMeta?.appointment_id || apt.appointment_id,
-                  visit_id: appointmentMeta?.visit_id || apt.visit_id || null,
-                  payment_status: appointmentMeta?.payment_status || apt.payment_status || 'pending',
-                  payment_type: appointmentMeta?.payment_type || apt.payment_type || null
-                };
-              });
-
-              logger.info('[Dentist] Обновлены payment_status для', allAppointments.length, 'записей');
-            }
-          } catch (err) {
-            logger.warn('[Dentist] Не удалось загрузить payment_status из БД:', err);
-          }
 
           // Добавляем информацию о всех услугах пациента в каждую запись
           const enrichedAppointmentsData = appointmentsData.map((apt) => {

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -425,6 +425,18 @@ const DermatologistPanelUnified = () => {
                     service_codes: entry.service_codes || [],
                     payment_type: entry.payment_type || null,
                     payment_status: entry.payment_status || 'pending',
+                    available_actions: entry.available_actions || [],
+                    can_mark_paid: Boolean(entry.can_mark_paid),
+                    can_start_visit: Boolean(entry.can_start_visit),
+                    can_print_ticket: Boolean(entry.can_print_ticket),
+                    can_complete: Boolean(entry.can_complete),
+                    can_cancel: Boolean(entry.can_cancel),
+                    canonical_record_id: entry.canonical_record_id || entry.id,
+                    record_kind: entry.record_kind,
+                    source_kind: entry.source_kind,
+                    canonical_status: entry.canonical_status || entry.status,
+                    queue_status: entry.queue_status || entry.status,
+                    queue_position: entry.queue_position,
                     doctor: entry.doctor_name || 'Врач',
                     specialty: queue.specialty,
                     created_at: entry.created_at,
@@ -438,60 +450,6 @@ const DermatologistPanelUnified = () => {
               }
             });
           }
-        }
-
-        // 2. Получаем актуальный payment_status из БД через all-appointments
-        try {
-          const appointmentsResponse = await fetch(`${API_V1_BASE}/registrar/all-appointments?date_from=${today}&date_to=${today}&limit=500`, {
-            headers: {
-              'Authorization': `Bearer ${token}`,
-              'Content-Type': 'application/json'
-            }
-          });
-
-          if (appointmentsResponse.ok) {
-            const appointmentsDBResponse = await appointmentsResponse.json();
-            const appointmentsDBData = appointmentsDBResponse.data || appointmentsDBResponse || []; // ✅ ИСПРАВЛЕНО: Извлекаем data из ответа
-            logger.info('[Dermatology] Получены appointments из БД:', appointmentsDBData.length);
-
-            // Создаем карту id -> payment_status
-            const appointmentMetaMap = new Map();
-            appointmentsDBData.forEach((apt) => {
-              const appointmentMeta = {
-                payment_status: apt.payment_status || 'pending',
-                payment_type: apt.payment_type || null,
-                visit_id: apt.visit_id || null,
-                appointment_id: apt.appointment_id || (apt.source === 'appointments' ? apt.id : null)
-              };
-              if (apt.id) {
-                appointmentMetaMap.set(apt.id, appointmentMeta);
-              }
-              if (apt.patient_id && apt.appointment_date) {
-                const key = `${apt.patient_id}_${apt.appointment_date}`;
-                appointmentMetaMap.set(key, appointmentMeta);
-              }
-            });
-
-            // Обновляем payment_status в наших записях
-            allAppointments = allAppointments.map((apt) => {
-              let appointmentMeta = appointmentMetaMap.get(apt.appointment_id || apt.id);
-              if (!appointmentMeta && apt.patient_id && apt.appointment_date) {
-                const key = `${apt.patient_id}_${apt.appointment_date}`;
-                appointmentMeta = appointmentMetaMap.get(key);
-              }
-              return {
-                ...apt,
-                appointment_id: appointmentMeta?.appointment_id || apt.appointment_id,
-                visit_id: appointmentMeta?.visit_id || apt.visit_id || null,
-                payment_status: appointmentMeta?.payment_status || apt.payment_status || 'pending',
-                payment_type: appointmentMeta?.payment_type || apt.payment_type || null
-              };
-            });
-
-            logger.info('[Dermatology] Обновлены payment_status для', allAppointments.length, 'записей');
-          }
-        } catch (err) {
-          logger.warn('[Dermatology] Не удалось загрузить payment_status из БД:', err);
         }
 
         // Фильтруем только дерматологические записи

--- a/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(process.cwd(), 'src');
+
+const DOCTOR_PANEL_FILES = [
+  'pages/CardiologistPanelUnified.jsx',
+  'pages/DentistPanelUnified.jsx',
+  'pages/DermatologistPanelUnified.jsx',
+];
+
+const read = (filePath) => fs.readFileSync(path.join(ROOT, filePath), 'utf8');
+
+const extractBlock = (source, startMarker, endMarker) => {
+  const start = source.indexOf(startMarker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf(endMarker, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+};
+
+describe('Doctor panels SSOT contract', () => {
+  it('uses registrar queue DTO payment/action fields without all-appointments overlay', () => {
+    for (const filePath of DOCTOR_PANEL_FILES) {
+      const source = read(filePath);
+
+      expect(source).toContain('/registrar/queues/today');
+      expect(source).not.toContain('/registrar/all-appointments');
+      expect(source).not.toContain('appointmentMetaMap');
+      expect(source).not.toContain('appointmentsDBData');
+
+      expect(source).toContain('payment_status: entry.payment_status');
+      expect(source).toContain('payment_type: entry.payment_type');
+      expect(source).toContain('available_actions: entry.available_actions || []');
+      expect(source).toContain('can_mark_paid: Boolean(entry.can_mark_paid)');
+      expect(source).toContain('can_start_visit: Boolean(entry.can_start_visit)');
+      expect(source).toContain('can_print_ticket: Boolean(entry.can_print_ticket)');
+      expect(source).toContain('can_complete: Boolean(entry.can_complete)');
+      expect(source).toContain('can_cancel: Boolean(entry.can_cancel)');
+    }
+  });
+
+  it('keeps doctor table command visibility backend-owned when rows are missing action fields', () => {
+    const table = read('components/tables/EnhancedAppointmentsTable.jsx');
+    const actionBlock = extractBlock(
+      table,
+      'const backendCanPay = getBackendActionAvailability',
+      'return (',
+    );
+
+    expect(actionBlock).toContain("getBackendActionAvailability(row, 'call', 'can_start_visit')");
+    expect(actionBlock).toContain("getBackendActionAvailability(row, 'print', 'can_print_ticket')");
+    expect(actionBlock).toContain("getBackendActionAvailability(row, 'complete', 'can_complete')");
+    expect(actionBlock).toContain('isDoctorView ? false : rowStatus');
+    expect(actionBlock).not.toContain('isDoctorView ?\n                  rowStatus');
+    expect(actionBlock).not.toContain("rowPaymentStatus === 'paid' :");
+  });
+
+  it('does not introduce BFF-lite endpoints while repairing doctor contracts', () => {
+    for (const filePath of DOCTOR_PANEL_FILES) {
+      const source = read(filePath);
+
+      expect(source).not.toContain('/api/v1/ui/');
+      expect(source).not.toContain('/ui/doctor');
+      expect(source).not.toContain('/ui/registrar');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- preserves backend-provided `available_actions` and `can_*` flags when doctor panels adapt `/registrar/queues/today` rows
- removes the doctor-panel `/registrar/all-appointments` payment-status overlay so payment/action truth comes from the queue DTO contract
- hardens `EnhancedAppointmentsTable` so doctor-view command buttons do not fall back to local `status/payment_status` decisions when backend action fields are missing
- adds source-level contract tests for the doctor panel SSOT boundary

## Cyclic Execution Evidence
- Fresh main sync: `git fetch origin --prune`; branch started from current `main` at `31d7544c`
- Clean workspace: verified before branch work with `git status --short --branch`
- Branch: `codex/doctor-panels-ssot-contract-repair`
- Scope gate: touched only doctor panels, shared appointments table, and a focused contract test
- Red-check handling: PR Review Quality Gate initially failed only on missing field-level PR-body answers; this edit fills those required fields without runtime code changes

## Contract Impact
- Canonical surface: existing `GET /api/v1/registrar/queues/today` frontend consumer contract for doctor panels
- Request shape: unchanged; no query/body/header contract changes
- Response shape: unchanged backend response; frontend now preserves existing `available_actions`, `can_mark_paid`, `can_start_visit`, `can_print_ticket`, `can_complete`, `can_cancel`, `canonical_record_id`, `record_kind`, `source_kind`, `canonical_status`, `queue_status`, and `queue_position` from queue entries
- Status codes: unchanged; no backend endpoints changed
- Frontend consumer: `CardiologistPanelUnified.jsx`, `DentistPanelUnified.jsx`, `DermatologistPanelUnified.jsx`, and `EnhancedAppointmentsTable.jsx`
- Compatibility path or alias: no new alias; `/registrar/all-appointments` overlay is removed from these doctor-panel load paths because `/registrar/queues/today` is the contract source for these rows
- Contract proof: `DoctorPanels.contract.test.jsx` asserts doctor panels use queue DTO payment/action fields, do not call `/registrar/all-appointments`, and do not add `/api/v1/ui/*`

No `/api/v1/ui/*`, no BFF-lite endpoint, no separate BFF service.

## RBAC / Permissions
- Roles allowed: unchanged from existing backend endpoints
- Roles denied: unchanged from existing backend endpoints
- Positive auth proof: not re-tested in this frontend-only PR because existing backend route auth remains authoritative
- Negative auth proof: not re-tested in this frontend-only PR because no backend auth or role policy changed

Command authorization remains backend-owned. This PR only changes frontend command visibility to depend on backend-provided `available_actions/can_*` in doctor views.

## Notification / Realtime
- Event type or websocket channel: not applicable - this PR does not touch notifications, websocket, or realtime code
- Payload version / ack behavior: not applicable - no realtime payload changed
- Read/unread or delivery semantics: not applicable - no notification read/unread or delivery behavior changed
- Reconnect/resync proof: not applicable - no websocket reconnect or resync behavior changed

## Frontend Resilience
- Empty data proof: existing doctor panel empty-state behavior is unchanged; source-level tests cover only contract routing
- Partial data proof: if doctor rows lack backend action fields, doctor-view action buttons now remain hidden instead of enabling commands from local status/payment heuristics
- Forbidden secondary path behavior: `DoctorPanels.contract.test.jsx` asserts these doctor panels do not use `/registrar/all-appointments` for payment metadata overlay
- Missing draft/resource behavior: not applicable - no draft/resource workflow changed
- Stale route/deep-link behavior: unchanged because no route or deep-link code changed

## Scope Gate
- Allowed paths: doctor panel adapters, shared appointment table command visibility, and focused frontend contract tests
- Denied paths: no backend, no `/api/v1/ui/*`, no separate BFF service, no RegistrarPanel, no QueueJoin, no DisplayBoard, no command wrapper, no command endpoint semantics change
- Migration/docs/test impact: no migration or docs changes; added `frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx`
- Rollback note: revert commit `b0da3973` to restore the previous doctor-panel overlay/fallback behavior

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- DoctorPanels.contract notificationGuardrails`; `npm --prefix frontend run build`; `git diff --check`
- Result: all local validation passed; CI currently has frontend build/lint/unit/e2e, CodeQL, PR Required Gate, Analyze jobs, security, lifecycle, and CI Scope passing
- Not checked: backend pytest and OpenAPI were not run because this PR makes no backend/API DTO changes

## BFF-lite Decision Gate
This moves the project closer to the BFF-lite decision gate, but does not implement BFF-lite. Remaining pre-BFF candidates are LabPanel queue/report status separation and Cashier payment action availability.