### PR TITLE
fix(lab): separate queue and report status

### DIFF
--- a/frontend/src/pages/LabPanel.jsx
+++ b/frontend/src/pages/LabPanel.jsx
@@ -53,6 +53,8 @@ function formatAppointmentEntry(queue, entry) {
     appointment_time: entry.visit_time || '09:00',
     status: entry.status || 'waiting',
     status_source: 'queue',
+    lab_report_status: null,
+    report_status_source: null,
     report_instance_id: null,
     report_template_name: '',
     flagged_findings_count: 0,
@@ -115,8 +117,11 @@ function mergeQueueEntriesWithLabInstances(queueEntries, labInstances) {
     }
     return {
       ...appointment,
-      status: linkedInstance.status || appointment.status,
-      status_source: 'lab-report',
+      status: appointment.status,
+      queue_status: appointment.queue_status || appointment.status,
+      status_source: 'queue',
+      lab_report_status: linkedInstance.status || null,
+      report_status_source: 'lab-report',
       report_instance_id: linkedInstance.id || null,
       report_template_name: linkedInstance.template?.name || '',
       flagged_findings_count: linkedInstance.flagged_findings_count || 0,

--- a/frontend/src/pages/__tests__/LabPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/LabPanel.contract.test.jsx
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const labPanelPath = path.resolve(__dirname, '../LabPanel.jsx');
+
+const readLabPanelSource = () => fs.readFileSync(labPanelPath, 'utf8');
+
+const extractBlock = (source, startMarker, endMarker) => {
+  const start = source.indexOf(startMarker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf(endMarker, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+};
+
+describe('LabPanel queue/report status contract', () => {
+  it('keeps queue status separate from lab report status when merging report instances', () => {
+    const source = readLabPanelSource();
+    const mergeBlock = extractBlock(
+      source,
+      'function mergeQueueEntriesWithLabInstances(queueEntries, labInstances) {',
+      'function buildTemplateResolutionPayload(appointment) {',
+    );
+
+    expect(mergeBlock).toContain('status: appointment.status');
+    expect(mergeBlock).toContain('queue_status: appointment.queue_status || appointment.status');
+    expect(mergeBlock).toContain("status_source: 'queue'");
+    expect(mergeBlock).toContain('lab_report_status: linkedInstance.status || null');
+    expect(mergeBlock).toContain("report_status_source: 'lab-report'");
+    expect(mergeBlock).not.toContain('status: linkedInstance.status || appointment.status');
+  });
+
+  it('does not add BFF-lite endpoints for the lab queue contract repair', () => {
+    const source = readLabPanelSource();
+
+    expect(source).not.toContain('/api/v1/ui/');
+    expect(source).not.toContain('/ui/lab');
+  });
+});


### PR DESCRIPTION
## Summary
- keeps laboratory queue `status` sourced from queue rows when merging linked lab report instances
- adds explicit `lab_report_status` and `report_status_source` display fields for linked report state
- adds a focused source-level contract test proving queue status is not overwritten by lab report status

## Cyclic Execution Evidence
- Fresh main sync: branch started after PR #1219 merged into current `main` at `c683e682`
- Clean workspace: verified with `git status --short --branch` before this branch
- Branch: `codex/lab-status-ssot-contract`
- Scope gate: touched only `LabPanel.jsx` and a focused `LabPanel.contract` test
- Red-check handling: no red CI checks observed before PR creation; local validation is green

## Contract Impact
- Canonical surface: existing `GET /api/v1/registrar/queues/today` queue rows plus existing lab report instance read data consumed by `LabPanel`
- Request shape: unchanged; no query/body/header contract changes
- Response shape: unchanged backend response; frontend now keeps queue `status/queue_status` separate from linked report `lab_report_status`
- Status codes: unchanged; no backend endpoints changed
- Frontend consumer: `frontend/src/pages/LabPanel.jsx`
- Compatibility path or alias: no new alias; existing lab report instance lookup remains the secondary read source for report display metadata only
- Contract proof: `LabPanel.contract.test.jsx` asserts `mergeQueueEntriesWithLabInstances` does not assign `status` from linked report status and does not add `/api/v1/ui/*`

No `/api/v1/ui/*`, no BFF-lite endpoint, no separate BFF service.

## RBAC / Permissions
- Roles allowed: unchanged from existing backend endpoints
- Roles denied: unchanged from existing backend endpoints
- Positive auth proof: not re-tested in this frontend-only PR because backend route auth is unchanged
- Negative auth proof: not re-tested in this frontend-only PR because no backend auth or role policy changed

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification or websocket code changed
- Payload version / ack behavior: not applicable - no realtime payload changed
- Read/unread or delivery semantics: not applicable - no notification delivery/read state changed
- Reconnect/resync proof: not applicable - no websocket reconnect/resync behavior changed

## Frontend Resilience
- Empty data proof: existing no-appointments branch is unchanged
- Partial data proof: if no linked lab report exists, the original queue appointment object is returned unchanged
- Forbidden secondary path behavior: linked report data can set `lab_report_status`, but cannot overwrite queue `status`
- Missing draft/resource behavior: linked report instance absence keeps `report_instance_id` null and current editor flow unchanged
- Stale route/deep-link behavior: not applicable - no routing or deep-link code changed

## Scope Gate
- Allowed paths: `frontend/src/pages/LabPanel.jsx` and `frontend/src/pages/__tests__/LabPanel.contract.test.jsx`
- Denied paths: no backend, no `/api/v1/ui/*`, no BFF service, no command wrappers, no lab finalization/template rules
- Migration/docs/test impact: no migration or docs changes; added one focused frontend contract test
- Rollback note: revert commit `15c8dc86` to restore the previous merged status behavior

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- LabPanel.contract`; `npm --prefix frontend run build`; `git diff --check`
- Result: all local validation passed
- Not checked: backend pytest and OpenAPI were not run because this PR makes no backend/API DTO changes

## BFF-lite Decision Gate
This is still SSOT contract repair, not BFF-lite. Remaining pre-BFF candidate: Cashier payment action availability should be checked next before any final BFF-lite/read-model planning.