### PR TITLE
fix(cashier): keep payment action gating backend-owned

### DIFF
--- a/frontend/src/pages/CashierPanel.jsx
+++ b/frontend/src/pages/CashierPanel.jsx
@@ -227,6 +227,33 @@ const getAppointmentPaymentActionContext = (appointment) => {
   return `appointment ${appointmentId} for ${patientName}`;
 };
 
+const PAYMENT_ACTION_CAN_FIELD = {
+  cancel: 'can_cancel',
+  refund: 'can_refund',
+  print_receipt: 'can_print_receipt',
+  confirm: 'can_confirm'
+};
+
+const hasBackendPaymentAction = (paymentRow, action) => {
+  const normalizedAction = String(action || '').trim().toLowerCase();
+  if (!normalizedAction) {
+    return false;
+  }
+
+  if (Array.isArray(paymentRow?.available_actions)) {
+    return paymentRow.available_actions.some(
+      (availableAction) => String(availableAction || '').trim().toLowerCase() === normalizedAction
+    );
+  }
+
+  const canField = PAYMENT_ACTION_CAN_FIELD[normalizedAction];
+  if (canField && Object.prototype.hasOwnProperty.call(paymentRow || {}, canField)) {
+    return Boolean(paymentRow[canField]);
+  }
+
+  return true;
+};
+
 const CashierPanel = () => {void
   useBreakpoint();
   const location = useLocation();
@@ -1399,7 +1426,7 @@ const CashierPanel = () => {void
                           size="sm"
                           variant="outline"
                           onClick={() => openCancelDialog(row.id)}
-                          disabled={row.status === 'cancelled'}
+                          disabled={!hasBackendPaymentAction(row, 'cancel')}
                           aria-label={`Cancel ${getPaymentActionContext(row)}`}>
 
                                   ❌ Отмена
@@ -1409,7 +1436,7 @@ const CashierPanel = () => {void
                           size="sm"
                           variant="outline"
                           onClick={() => openRefundDialog(row)}
-                          disabled={row.status === 'cancelled' || row.status === 'refunded'}
+                          disabled={!hasBackendPaymentAction(row, 'refund')}
                           aria-label={`Refund ${getPaymentActionContext(row)}`}
                           title="Возврат средств">
 


### PR DESCRIPTION
## Summary
- Remove CashierPanel local payment-status gating for cancel/refund buttons.
- Prefer backend-provided payment action contract fields (`available_actions`, `can_cancel`, `can_refund`) when present.
- Keep this as SSOT/readiness hardening only: no BFF-lite endpoint, no backend change, no command wrapper.

## Cyclic Execution Evidence
- Fresh main sync: based on `origin/main` after #1220 merge at `7f607afb`.
- Clean workspace: branch created from clean main; only `frontend/src/pages/CashierPanel.jsx` changed.
- Branch: `codex/cashier-payment-action-ssot`.
- Scope gate: `agent_gate.py` ran through `py -3` with known root cause `frontend/src/pages/CashierPanel.jsx`; result was narrow override / first-touch CashierPanel only.
- Red-check handling: no red checks yet; PR opened after local build and diff hygiene passed.

## Contract Impact
- Canonical surface: existing cashier payment command endpoints remain canonical (`/cashier/payments/{id}/cancel`, `/cashier/payments/{id}/refund`).
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged; backend continues to reject invalid payment transitions.
- Frontend consumer: `CashierPanel` no longer disables cancel/refund from local `row.status` comparisons; it consumes `available_actions` or `can_*` fields if backend provides them.
- Compatibility path or alias: if backend does not provide action fields, the UI leaves the command available and backend remains the enforcement point.
- Contract proof: source grep shows old `disabled={row.status ...}` action gating was removed; frontend build passed.

## RBAC / Permissions
- Roles allowed: unchanged; existing backend cashier endpoints still enforce `Admin` / `Cashier` role dependencies.
- Roles denied: unchanged.
- Positive auth proof: not rerun; no backend/auth code changed.
- Negative auth proof: not rerun; no backend/auth code changed.

## Notification / Realtime
- Event type or websocket channel: unchanged cashier payment notification/realtime paths.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable; no realtime code changed.

## Frontend Resilience
- Empty data proof: unchanged; no list loading/rendering changes.
- Partial data proof: backend action fields are optional; missing fields fall through to backend enforcement instead of local status inference.
- Forbidden secondary path behavior: no new endpoint or fallback path added.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/pages/CashierPanel.jsx`.
- Denied paths: backend endpoints/services, `/api/v1/ui/*`, QueueJoin, DisplayBoard, RegistrarPanel, migrations, unrelated cleanup.
- Migration/docs/test impact: no migration; no docs; no test file added because gate first-touch was CashierPanel only.
- Rollback note: revert this single commit to restore previous local status-based button disabling.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run build`; `git diff --check`; source grep for removed `disabled={row.status ...}` gating.
- Result: passed.
- Not checked: backend pytest and auth negative tests, because this PR does not change backend/API behavior.