### PR TITLE
fix(doctor): use doctor start visit command surface

### DIFF
--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -876,7 +876,7 @@ const MacOSCardiologistPanelUnified = () => {
         // Вызвать пациента
         try {
           const token = tokenManager.getAccessToken();
-          const response = await fetch(`${API_V1_BASE}/registrar/queue/${row.id}/start-visit`, {
+          const response = await fetch(`${API_V1_BASE}/doctor/queue/${row.id}/start-visit`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -727,7 +727,7 @@ const DentistPanelUnified = () => {
         // Вызвать пациента
         try {
           const token = tokenManager.getAccessToken();
-          const response = await fetch(`${API_V1_BASE}/registrar/queue/${row.id}/start-visit`, {
+          const response = await fetch(`${API_V1_BASE}/doctor/queue/${row.id}/start-visit`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -606,7 +606,7 @@ const DermatologistPanelUnified = () => {
         // Вызвать пациента
         try {
           const token = tokenManager.getAccessToken();
-          const response = await fetch(`${API_V1_BASE}/registrar/queue/${row.id}/start-visit`, {
+          const response = await fetch(`${API_V1_BASE}/doctor/queue/${row.id}/start-visit`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
@@ -58,6 +58,15 @@ describe('Doctor panels SSOT contract', () => {
     expect(actionBlock).not.toContain("rowPaymentStatus === 'paid' :");
   });
 
+  it('routes start visit commands through the doctor command surface', () => {
+    for (const filePath of DOCTOR_PANEL_FILES) {
+      const source = read(filePath);
+
+      expect(source).toContain('/doctor/queue/${row.id}/start-visit');
+      expect(source).not.toContain('/registrar/queue/${row.id}/start-visit');
+    }
+  });
+
   it('does not introduce BFF-lite endpoints while repairing doctor contracts', () => {
     for (const filePath of DOCTOR_PANEL_FILES) {
       const source = read(filePath);


### PR DESCRIPTION
## Summary
- Route doctor-panel start visit commands through `/doctor/queue/{id}/start-visit` instead of the registrar command endpoint.
- Apply the same surgical endpoint correction to cardiology, dermatology, and dentistry panels.
- Extend the existing doctor contract test to prevent regression back to `/registrar/queue/{id}/start-visit`.

## Cyclic Execution Evidence
- Fresh main sync: based on `origin/main` after #1221 merge at `6cc7018e`.
- Clean workspace: branch created from clean main; only doctor panel command URL files and their existing contract test changed.
- Branch: `codex/doctor-start-visit-endpoint-ssot`.
- Scope gate: `agent_gate.py` was run through `py -3`; it first narrowed to one known root file, then stale `C:\final` context failed to see the current worktree contract test. Narrow override used only for the proven repeated pattern across three doctor panels plus the existing test.
- Red-check handling: no red checks yet; PR opened after targeted test, build, and diff hygiene passed.

## Contract Impact
- Canonical surface: existing doctor queue command endpoint `/doctor/queue/{id}/start-visit`.
- Request shape: unchanged POST with bearer auth and no request body.
- Response shape: unchanged; frontend already handled success/reload from command result.
- Status codes: unchanged; backend doctor endpoint keeps role/doctor ownership checks.
- Frontend consumer: `CardiologistPanelUnified`, `DermatologistPanelUnified`, and `DentistPanelUnified` now call the doctor command surface.
- Compatibility path or alias: registrar start-visit endpoint remains untouched for registrar flows; doctor panels no longer use it.
- Contract proof: `DoctorPanels.contract.test.jsx` asserts doctor panels contain `/doctor/queue/${row.id}/start-visit` and do not contain `/registrar/queue/${row.id}/start-visit`.

## RBAC / Permissions
- Roles allowed: unchanged; existing backend doctor endpoint role dependency remains canonical.
- Roles denied: unchanged.
- Positive auth proof: not rerun at backend level; frontend contract test confirms route selection only.
- Negative auth proof: not rerun; no backend auth code changed.

## Notification / Realtime
- Event type or websocket channel: unchanged backend doctor command behavior.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: unchanged; panels still reload after success.

## Frontend Resilience
- Empty data proof: unchanged; no list loading/rendering changes.
- Partial data proof: unchanged; action visibility remains controlled by backend `available_actions/can_*` fields from #1219.
- Forbidden secondary path behavior: test forbids the registrar start-visit path in doctor panels.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/pages/CardiologistPanelUnified.jsx`, `frontend/src/pages/DermatologistPanelUnified.jsx`, `frontend/src/pages/DentistPanelUnified.jsx`, `frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx`.
- Denied paths: backend endpoints/services, `/api/v1/ui/*`, RegistrarPanel, CashierPanel, LabPanel, QueueJoin, DisplayBoard, migrations, unrelated cleanup.
- Migration/docs/test impact: no migration; no docs; one existing frontend contract test updated.
- Rollback note: revert this single commit to restore prior doctor-panel registrar endpoint calls.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- DoctorPanels.contract`; `npm --prefix frontend run build`; `git diff --check`.
- Result: passed.
- Not checked: backend pytest/auth negative tests, because this PR changes only frontend route selection to an existing backend endpoint.