### PR TITLE
fix(lab): expose report action contract

### DIFF
--- a/backend/app/api/v1/endpoints/lab_reporting.py
+++ b/backend/app/api/v1/endpoints/lab_reporting.py
@@ -108,6 +108,7 @@ def _template_out(template) -> LabReportTemplateOut:
 def _instance_out(service: LabReportingService, instance) -> LabReportInstanceOut:
     sections = service.materialize_instance(instance)
     critical_findings = service.summarize_critical_findings(sections)
+    available_actions = service.instance_available_actions(instance)
     return LabReportInstanceOut(
         id=instance.id,
         order_id=instance.order_id,
@@ -143,6 +144,8 @@ def _instance_out(service: LabReportingService, instance) -> LabReportInstanceOu
         critical_findings=[
             LabCriticalFindingOut(**finding) for finding in critical_findings
         ],
+        available_actions=available_actions,
+        **service.instance_action_flags(instance),
     )
 
 
@@ -151,6 +154,7 @@ def _instance_summary_out(
 ) -> LabReportInstanceSummaryOut:
     sections = service.materialize_instance(instance)
     severity_metrics = service.summarize_instance_severity(sections)
+    available_actions = service.instance_available_actions(instance)
     return LabReportInstanceSummaryOut(
         id=instance.id,
         patient_id=instance.patient_id,
@@ -166,6 +170,8 @@ def _instance_summary_out(
         flagged_findings_count=severity_metrics["flagged_findings_count"],
         critical_findings_count=severity_metrics["critical_findings_count"],
         max_flag_severity=severity_metrics["max_flag_severity"],
+        available_actions=available_actions,
+        **service.instance_action_flags(instance),
     )
 
 

--- a/backend/app/schemas/lab_reporting.py
+++ b/backend/app/schemas/lab_reporting.py
@@ -241,6 +241,13 @@ class LabReportInstanceOut(BaseModel):
     template_version: LabReportTemplateVersionOut
     sections: list[LabReportRenderedSectionOut]
     critical_findings: list[LabCriticalFindingOut] = Field(default_factory=list)
+    available_actions: list[str] = Field(default_factory=list)
+    can_edit: bool = False
+    can_save_draft: bool = False
+    can_mark_ready: bool = False
+    can_finalize: bool = False
+    can_revise: bool = False
+    can_print: bool = False
 
 
 class LabReportInstanceSummaryOut(BaseModel):
@@ -258,6 +265,13 @@ class LabReportInstanceSummaryOut(BaseModel):
     flagged_findings_count: int = 0
     critical_findings_count: int = 0
     max_flag_severity: int | None = None
+    available_actions: list[str] = Field(default_factory=list)
+    can_edit: bool = False
+    can_save_draft: bool = False
+    can_mark_ready: bool = False
+    can_finalize: bool = False
+    can_revise: bool = False
+    can_print: bool = False
 
 
 class LabReportBulkSaveResponse(BaseModel):

--- a/backend/app/services/lab_reporting_service.py
+++ b/backend/app/services/lab_reporting_service.py
@@ -672,6 +672,25 @@ class LabReportingService:
         self.repository.commit()
         return self.get_instance(instance.id)
 
+    def instance_available_actions(self, instance: LabReportInstance) -> list[str]:
+        actions: list[str] = []
+        if instance.status not in FINAL_INSTANCE_STATUSES:
+            actions.extend(["edit", "save_draft", "mark_ready", "finalize"])
+        if instance.status in FINAL_INSTANCE_STATUSES:
+            actions.extend(["revise", "print"])
+        return actions
+
+    def instance_action_flags(self, instance: LabReportInstance) -> dict[str, bool]:
+        actions = set(self.instance_available_actions(instance))
+        return {
+            "can_edit": "edit" in actions,
+            "can_save_draft": "save_draft" in actions,
+            "can_mark_ready": "mark_ready" in actions,
+            "can_finalize": "finalize" in actions,
+            "can_revise": "revise" in actions,
+            "can_print": "print" in actions,
+        }
+
     def _normalize_version_payload(self, sections_payload: list[dict[str, Any]]) -> list[dict[str, Any]]:
         normalized_sections: list[dict[str, Any]] = []
         for section in sorted(

--- a/backend/tests/test_lab_reporting_api.py
+++ b/backend/tests/test_lab_reporting_api.py
@@ -37,6 +37,18 @@ def test_lab_reporting_api_flow(client, auth_headers, db_session, test_patient, 
     assert instance_response.status_code == 200
     instance = instance_response.json()
     assert instance["status"] == "DRAFT"
+    assert set(instance["available_actions"]) == {
+        "edit",
+        "save_draft",
+        "mark_ready",
+        "finalize",
+    }
+    assert instance["can_edit"] is True
+    assert instance["can_save_draft"] is True
+    assert instance["can_mark_ready"] is True
+    assert instance["can_finalize"] is True
+    assert instance["can_revise"] is False
+    assert instance["can_print"] is False
     assert instance["signer_snapshot"]["lab_technician_name"] == "Test Admin"
     assert instance["signer_snapshot"]["approver_name"] == "Test Admin"
 
@@ -77,6 +89,10 @@ def test_lab_reporting_api_flow(client, auth_headers, db_session, test_patient, 
     assert summary["flagged_findings_count"] == 0
     assert summary["critical_findings_count"] == 0
     assert summary["max_flag_severity"] is None
+    assert summary["can_edit"] is True
+    assert summary["can_finalize"] is True
+    assert summary["can_revise"] is False
+    assert summary["can_print"] is False
 
     visit_history_response = client.get(
         "/api/v1/lab/report-instances",
@@ -142,14 +158,27 @@ def test_lab_reporting_api_flow(client, auth_headers, db_session, test_patient, 
         headers=auth_headers,
     )
     assert finalize_response.status_code == 200
-    assert finalize_response.json()["status"] == "FINALIZED"
+    finalized = finalize_response.json()
+    assert finalized["status"] == "FINALIZED"
+    assert set(finalized["available_actions"]) == {"revise", "print"}
+    assert finalized["can_edit"] is False
+    assert finalized["can_save_draft"] is False
+    assert finalized["can_mark_ready"] is False
+    assert finalized["can_finalize"] is False
+    assert finalized["can_revise"] is True
+    assert finalized["can_print"] is True
 
     print_once_response = client.post(
         f"/api/v1/lab/report-instances/{instance['id']}/mark-printed",
         headers=auth_headers,
     )
     assert print_once_response.status_code == 200
-    assert print_once_response.json()["status"] == "PRINTED"
+    printed = print_once_response.json()
+    assert printed["status"] == "PRINTED"
+    assert set(printed["available_actions"]) == {"revise", "print"}
+    assert printed["can_edit"] is False
+    assert printed["can_revise"] is True
+    assert printed["can_print"] is True
 
     print_twice_response = client.post(
         f"/api/v1/lab/report-instances/{instance['id']}/mark-printed",

--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -100,6 +100,35 @@ function matchesHistoryFilter(item, filter) {
   return true;
 }
 
+const LAB_REPORT_ACTION_CAN_FIELD = {
+  edit: 'can_edit',
+  save_draft: 'can_save_draft',
+  mark_ready: 'can_mark_ready',
+  finalize: 'can_finalize',
+  revise: 'can_revise',
+  print: 'can_print'
+};
+
+function hasLabReportAction(instance, action) {
+  const normalizedAction = String(action || '').trim().toLowerCase();
+  if (!instance || !normalizedAction) {
+    return false;
+  }
+
+  if (Array.isArray(instance.available_actions)) {
+    return instance.available_actions.some(
+      (availableAction) => String(availableAction || '').trim().toLowerCase() === normalizedAction
+    );
+  }
+
+  const canField = LAB_REPORT_ACTION_CAN_FIELD[normalizedAction];
+  if (canField && Object.prototype.hasOwnProperty.call(instance, canField)) {
+    return Boolean(instance[canField]);
+  }
+
+  return false;
+}
+
 function getServiceContextItems(appointment) {
   const serviceDetails = appointment?.service_details || [];
   if (serviceDetails.length > 0) {
@@ -278,6 +307,12 @@ export default function LabReportWorkbench({
     });
   }, [historySeverityFilter, recentReports]);
   const showRecentReportsBrowser = !selectedAppointment && !activeInstance;
+  const canEditActiveInstance = hasLabReportAction(activeInstance, 'edit');
+  const canSaveDraft = hasLabReportAction(activeInstance, 'save_draft');
+  const canMarkReady = hasLabReportAction(activeInstance, 'mark_ready');
+  const canFinalize = hasLabReportAction(activeInstance, 'finalize');
+  const canRevise = hasLabReportAction(activeInstance, 'revise');
+  const canPrint = hasLabReportAction(activeInstance, 'print');
 
   const handleCreateInstance = useCallback(async (templateIdOverride = null, options = {}) => {
     const templateId = templateIdOverride || selectedTemplateId;
@@ -702,29 +737,29 @@ export default function LabReportWorkbench({
                 </div>
 
                 <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                  {activeInstance.status !== 'FINALIZED' && activeInstance.status !== 'PRINTED' && (
+                  {(canSaveDraft || canMarkReady || canFinalize) && (
                     <>
-                      <Button variant="outline" onClick={handleSaveDraft} disabled={saving}>
+                      <Button variant="outline" onClick={handleSaveDraft} disabled={saving || !canSaveDraft}>
                         <Icon name="square.and.arrow.down" size={16} />
                         {busyAction === 'save' ? 'Сохраняю...' : 'Сохранить черновик'}
                       </Button>
-                      <Button variant="outline" onClick={handleMarkReady} disabled={saving}>
+                      <Button variant="outline" onClick={handleMarkReady} disabled={saving || !canMarkReady}>
                         <Icon name="checkmark.circle" size={16} />
                         {busyAction === 'ready' ? 'Перевожу...' : 'Отметить готовым'}
                       </Button>
-                      <Button variant="primary" onClick={handleFinalize} disabled={saving}>
+                      <Button variant="primary" onClick={handleFinalize} disabled={saving || !canFinalize}>
                         <Icon name="lock.circle" size={16} />
                         {busyAction === 'finalize' ? 'Финализирую...' : 'Финализировать'}
                       </Button>
                     </>
                   )}
-                  {(activeInstance.status === 'FINALIZED' || activeInstance.status === 'PRINTED') && (
+                  {(canRevise || canPrint) && (
                     <>
-                      <Button variant="outline" onClick={handleRevise} disabled={saving}>
+                      <Button variant="outline" onClick={handleRevise} disabled={saving || !canRevise}>
                         <Icon name="arrow.triangle.branch" size={16} />
                         {busyAction === 'revise' ? 'Создаю ревизию...' : 'Создать ревизию'}
                       </Button>
-                      <Button variant="primary" onClick={handlePrint} disabled={saving}>
+                      <Button variant="primary" onClick={handlePrint} disabled={saving || !canPrint}>
                         <Icon name="printer" size={16} />
                         {busyAction === 'print' ? 'Отправляю...' : 'Печать результата'}
                       </Button>
@@ -826,7 +861,7 @@ export default function LabReportWorkbench({
                                 className="macos-input"
                                 value={currentValue}
                                 onChange={(event) => updateField(field.field_key, event.target.value)}
-                                disabled={activeInstance.status === 'FINALIZED' || activeInstance.status === 'PRINTED'}
+                                disabled={!canEditActiveInstance}
                               >
                                 <option value="">Выберите значение</option>
                                 {currentValue && !choiceOptions.includes(currentValue) && (
@@ -845,7 +880,7 @@ export default function LabReportWorkbench({
                                 rows={3}
                                 value={currentValue}
                                 onChange={(event) => updateField(field.field_key, event.target.value)}
-                                disabled={activeInstance.status === 'FINALIZED' || activeInstance.status === 'PRINTED'}
+                                disabled={!canEditActiveInstance}
                               />
                             ) : (
                               <input
@@ -853,7 +888,7 @@ export default function LabReportWorkbench({
                                 aria-label={`Lab result for ${field.label}`}
                                 value={currentValue}
                                 onChange={(event) => updateField(field.field_key, event.target.value)}
-                                disabled={activeInstance.status === 'FINALIZED' || activeInstance.status === 'PRINTED'}
+                                disabled={!canEditActiveInstance}
                               />
                             )}
                             <div style={{ color: 'var(--mac-text-secondary)', fontSize: '13px' }}>

--- a/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import '@testing-library/jest-dom';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import LabReportWorkbench from '../LabReportWorkbench';
 import { ThemeProvider } from '../../../contexts/ThemeContext.jsx';
 import { MacOSThemeProvider } from '../../../theme/macosTheme.jsx';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const workbenchPath = path.resolve(__dirname, '../LabReportWorkbench.jsx');
 
 vi.mock('../../../api/labReporting', () => ({
   labReportingApi: {
@@ -84,5 +90,16 @@ describe('LabReportWorkbench', () => {
     fireEvent.click(reportButton);
 
     expect(onOpenInstance).toHaveBeenCalledWith(22);
+  });
+
+  it('uses backend-provided action availability instead of local finalized status rules', () => {
+    const source = fs.readFileSync(workbenchPath, 'utf8');
+
+    expect(source).toContain('function hasLabReportAction(instance, action)');
+    expect(source).toContain("const canEditActiveInstance = hasLabReportAction(activeInstance, 'edit')");
+    expect(source).toContain("const canFinalize = hasLabReportAction(activeInstance, 'finalize')");
+    expect(source).toContain("const canRevise = hasLabReportAction(activeInstance, 'revise')");
+    expect(source).not.toContain("activeInstance.status !== 'FINALIZED' && activeInstance.status !== 'PRINTED'");
+    expect(source).not.toContain("activeInstance.status === 'FINALIZED' || activeInstance.status === 'PRINTED'");
   });
 });


### PR DESCRIPTION
## Summary
- Add backend-owned lab report action availability to report instance DTOs.
- Compute `available_actions` and `can_*` flags in `LabReportingService`, beside the existing finalize/revise/print immutability rules.
- Update `LabReportWorkbench` to render/edit from backend-provided action flags instead of local `FINALIZED` / `PRINTED` status rules.

## Cyclic Execution Evidence
- Fresh main sync: based on `origin/main` after #1222 merge at `58fba0ae`.
- Clean workspace: branch created from clean main; scope limited to lab reporting DTO/service/endpoint, lab report workbench, and focused tests.
- Branch: `codex/lab-report-actions-ssot-contract`.
- Scope gate: `agent_gate.py` narrowed to `LabReportWorkbench.jsx`; narrow override used because real SSOT repair required backend DTO/service fields, not a frontend-only status workaround.
- Red-check handling: no red checks yet; PR opened after frontend test/build, Python compile, and diff hygiene passed. Backend pytest could not start locally without `DATABASE_URL`.

## Contract Impact
- Canonical surface: existing lab report endpoints under `/api/v1/lab/report-instances*`.
- Request shape: unchanged.
- Response shape: additive fields on `LabReportInstanceOut` and `LabReportInstanceSummaryOut`: `available_actions`, `can_edit`, `can_save_draft`, `can_mark_ready`, `can_finalize`, `can_revise`, `can_print`.
- Status codes: unchanged; service still rejects immutable edits and invalid finalize/revise/print commands.
- Frontend consumer: `LabReportWorkbench` now gates buttons and field editability through backend-provided action fields.
- Compatibility path or alias: no endpoint aliases; no `/api/v1/ui/*` endpoint.
- Contract proof: backend API test updated for draft/finalized/printed action flags; frontend source test forbids local finalized/printed status gating.

## RBAC / Permissions
- Roles allowed: unchanged existing lab endpoint dependencies.
- Roles denied: unchanged.
- Positive auth proof: not rerun locally because backend pytest cannot initialize without `DATABASE_URL`; CI backend checks should cover runtime environment.
- Negative auth proof: unchanged; no auth dependency changed.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: unchanged; workbench continues using existing refresh callbacks.

## Frontend Resilience
- Empty data proof: unchanged; no list loading changes.
- Partial data proof: if action fields are absent, `LabReportWorkbench` does not synthesize lab business permissions locally.
- Forbidden secondary path behavior: no new endpoint or BFF fallback path added.
- Missing draft/resource behavior: unchanged; command endpoints still own not-found/conflict failures.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `backend/app/schemas/lab_reporting.py`, `backend/app/services/lab_reporting_service.py`, `backend/app/api/v1/endpoints/lab_reporting.py`, `backend/tests/test_lab_reporting_api.py`, `frontend/src/components/laboratory/LabReportWorkbench.jsx`, `frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx`.
- Denied paths: `/api/v1/ui/*`, separate BFF service, queue/payment/registrar/doctor runtime code, migrations, unrelated cleanup.
- Migration/docs/test impact: no migration; no docs; backend and frontend focused tests updated.
- Rollback note: revert this commit to remove additive lab action fields and restore previous local status gating.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- LabReportWorkbench`; `npm --prefix frontend run build`; `py -3 -m compileall backend/app/schemas/lab_reporting.py backend/app/services/lab_reporting_service.py backend/app/api/v1/endpoints/lab_reporting.py`; `git diff --check`.
- Result: passed, except backend pytest did not start locally because `DATABASE_URL` is not set in this shell.
- Not checked: `py -3 -m pytest backend/tests/test_lab_reporting_api.py::test_lab_reporting_api_flow backend/tests/test_openapi_contract.py` could not initialize locally due missing `DATABASE_URL`; CI should provide the authoritative backend run.