### PR TITLE
fix(doctor): expose queue action contract

### DIFF
--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -93,6 +93,34 @@ def _serialize_queue_doctor(doctor: Optional[Doctor], current_user: User, specia
 # ===================== МОДЕЛИ ДАННЫХ =====================
 
 
+def _doctor_queue_available_actions(entry: OnlineQueueEntry) -> list[str]:
+    status_value = (entry.status or "").strip().lower()
+    actions_by_status = {
+        "waiting": ["call", "no_show"],
+        "called": ["send_to_diagnostics", "complete", "no_show"],
+        "diagnostics": [
+            "notify_diagnostics_return",
+            "complete",
+            "mark_incomplete",
+        ],
+        "no_show": ["restore_next"],
+    }
+    return actions_by_status.get(status_value, [])
+
+
+def _doctor_queue_action_flags(entry: OnlineQueueEntry) -> dict[str, bool]:
+    actions = set(_doctor_queue_available_actions(entry))
+    return {
+        "can_call": "call" in actions,
+        "can_no_show": "no_show" in actions,
+        "can_send_to_diagnostics": "send_to_diagnostics" in actions,
+        "can_complete": "complete" in actions,
+        "can_notify_diagnostics_return": "notify_diagnostics_return" in actions,
+        "can_mark_incomplete": "mark_incomplete" in actions,
+        "can_restore_next": "restore_next" in actions,
+    }
+
+
 class ScheduleNextVisitService(BaseModel):
     service_id: int
     quantity: int = 1
@@ -257,6 +285,8 @@ def get_doctor_queue_today(
                 "date": today.isoformat(),
                 "entries": [],
                 "stats": {"total": 0, "waiting": 0, "called": 0, "served": 0},
+                "can_call_next": False,
+                "next_call_entry_id": None,
             }
 
         # Получаем записи очереди
@@ -270,7 +300,13 @@ def get_doctor_queue_today(
 
         # Формируем данные для врача
         queue_entries = []
+        next_call_entry_id = None
         for entry in entries:
+            available_actions = _doctor_queue_available_actions(entry)
+            action_flags = _doctor_queue_action_flags(entry)
+            if next_call_entry_id is None and action_flags["can_call"]:
+                next_call_entry_id = entry.id
+
             patient_data = None
             if entry.patient:
                 patient_data = {
@@ -304,6 +340,8 @@ def get_doctor_queue_today(
                         entry.called_at.isoformat() if entry.called_at else None
                     ),
                     "patient": patient_data,
+                    "available_actions": available_actions,
+                    **action_flags,
                 }
             )
 
@@ -330,6 +368,8 @@ def get_doctor_queue_today(
             "date": today.isoformat(),
             "entries": queue_entries,
             "stats": stats,
+            "can_call_next": next_call_entry_id is not None,
+            "next_call_entry_id": next_call_entry_id,
         }
 
     except HTTPException:
@@ -407,6 +447,12 @@ def call_patient(
             )
 
         # Обновляем статус на "вызван"
+        if "call" not in _doctor_queue_available_actions(queue_entry):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Р’С‹Р·РІР°С‚СЊ РјРѕР¶РЅРѕ С‚РѕР»СЊРєРѕ waiting, С‚РµРєСѓС‰РёР№: {queue_entry.status}",
+            )
+
         queue_entry.status = "called"
         queue_entry.called_at = datetime.utcnow()
 

--- a/backend/tests/integration/test_doctor_general_queue.py
+++ b/backend/tests/integration/test_doctor_general_queue.py
@@ -65,6 +65,12 @@ class TestDoctorGeneralQueue:
         assert len(payload["entries"]) == 1
         assert payload["entries"][0]["id"] == entry.id
         assert payload["entries"][0]["patient_name"] == test_patient.short_name()
+        assert payload["can_call_next"] is True
+        assert payload["next_call_entry_id"] == entry.id
+        assert set(payload["entries"][0]["available_actions"]) == {"call", "no_show"}
+        assert payload["entries"][0]["can_call"] is True
+        assert payload["entries"][0]["can_no_show"] is True
+        assert payload["entries"][0]["can_complete"] is False
 
     def test_general_queue_returns_empty_payload_without_configuration(
         self,
@@ -90,11 +96,69 @@ class TestDoctorGeneralQueue:
             "called": 0,
             "served": 0,
         }
+        assert payload["can_call_next"] is False
+        assert payload["next_call_entry_id"] is None
         assert payload["doctor"]["id"] == test_doctor_user.id
         assert payload["doctor"]["name"] == (
             test_doctor_user.full_name or test_doctor_user.username
         )
         assert payload["doctor"]["specialty"] == "general"
+
+    def test_call_patient_rejects_non_callable_queue_status(
+        self,
+        client,
+        db_session,
+        test_doctor_user,
+        test_patient,
+    ):
+        doctor = Doctor(
+            user_id=test_doctor_user.id,
+            specialty="general",
+            active=True,
+            cabinet="101",
+        )
+        db_session.add(doctor)
+        db_session.commit()
+        db_session.refresh(doctor)
+
+        queue = DailyQueue(
+            day=date.today(),
+            specialist_id=doctor.id,
+            queue_tag="general",
+            active=True,
+        )
+        db_session.add(queue)
+        db_session.commit()
+        db_session.refresh(queue)
+
+        entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=1,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            source="registrar",
+            status="served",
+        )
+        db_session.add(entry)
+        db_session.commit()
+        db_session.refresh(entry)
+
+        login_response = client.post(
+            "/api/v1/authentication/login",
+            json={"username": test_doctor_user.username, "password": "doctor123"},
+        )
+        assert login_response.status_code == 200
+        headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+        response = client.post(
+            f"/api/v1/doctor/queue/{entry.id}/call",
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        db_session.refresh(entry)
+        assert entry.status == "served"
 
     def test_complete_queue_entry_prefers_queue_entry_over_id_collision_with_visit(
         self,

--- a/frontend/src/hooks/useDoctorQueue.js
+++ b/frontend/src/hooks/useDoctorQueue.js
@@ -13,6 +13,28 @@ const ZERO_STATS = {
     total: 0
 };
 
+const hasBackendQueueAction = (entry, action, flagName) => {
+    if (!entry) return false;
+    if (Array.isArray(entry.available_actions)) {
+        return entry.available_actions.includes(action);
+    }
+    if (flagName && Object.prototype.hasOwnProperty.call(entry, flagName)) {
+        return Boolean(entry[flagName]);
+    }
+    return false;
+};
+
+const selectNextCallEntryId = (queuePayload) => {
+    const backendEntryId = queuePayload?.next_call_entry_id;
+    if (backendEntryId !== undefined && backendEntryId !== null) {
+        return backendEntryId;
+    }
+
+    const entries = Array.isArray(queuePayload?.entries) ? queuePayload.entries : [];
+    const callableEntry = entries.find((entry) => hasBackendQueueAction(entry, 'call', 'can_call'));
+    return callableEntry?.id ?? null;
+};
+
 /**
  * @param {string} specialty - Каноническая specialty/queue tag для панели врача
  */
@@ -21,6 +43,10 @@ const useDoctorQueue = (specialty = 'general') => {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [stats, setStats] = useState(ZERO_STATS);
+    const [queueControls, setQueueControls] = useState({
+        canCallNext: false,
+        nextCallEntryId: null
+    });
     const normalizedSpecialty = specialty || 'general';
 
     // Загрузка очереди
@@ -32,8 +58,13 @@ const useDoctorQueue = (specialty = 'general') => {
             const response = await api.get(`/doctor/${encodeURIComponent(normalizedSpecialty)}/queue/today`);
             const entries = Array.isArray(response.data?.entries) ? response.data.entries : [];
             const apiStats = response.data?.stats || {};
+            const nextCallEntryId = selectNextCallEntryId(response.data);
 
             setQueue(entries);
+            setQueueControls({
+                canCallNext: Boolean(response.data?.can_call_next ?? nextCallEntryId),
+                nextCallEntryId
+            });
             setStats({
                 waiting: apiStats.waiting ?? entries.filter((entry) => entry.status === 'waiting').length,
                 called: apiStats.called ?? entries.filter((entry) => entry.status === 'called').length,
@@ -50,6 +81,7 @@ const useDoctorQueue = (specialty = 'general') => {
             logger.error('[useDoctorQueue] Error loading queue:', err);
             setQueue([]);
             setStats(ZERO_STATS);
+            setQueueControls({ canCallNext: false, nextCallEntryId: null });
             setError(err.response?.data?.detail || err.message || 'Ошибка загрузки очереди');
         } finally {
             setLoading(false);
@@ -60,12 +92,12 @@ const useDoctorQueue = (specialty = 'general') => {
     const callNext = useCallback(async () => {
         try {
             const currentQueue = await api.get(`/doctor/${encodeURIComponent(normalizedSpecialty)}/queue/today`);
-            const waitingEntry = currentQueue.data?.entries?.find((entry) => entry.status === 'waiting');
-            if (!waitingEntry) {
+            const nextCallEntryId = selectNextCallEntryId(currentQueue.data);
+            if (!nextCallEntryId) {
                 return { success: false, message: 'Нет ожидающих пациентов' };
             }
 
-            const response = await api.post(`/doctor/queue/${waitingEntry.id}/call`);
+            const response = await api.post(`/doctor/queue/${nextCallEntryId}/call`);
             await loadQueue(); // Обновляем очередь
             return response.data;
         } catch (err) {
@@ -146,6 +178,8 @@ const useDoctorQueue = (specialty = 'general') => {
         loading,
         error,
         stats,
+        canCallNext: queueControls.canCallNext,
+        nextCallEntryId: queueControls.nextCallEntryId,
         loadQueue,
         callNext,
         markNoShow,

--- a/frontend/src/pages/DoctorPanel.jsx
+++ b/frontend/src/pages/DoctorPanel.jsx
@@ -51,6 +51,18 @@ import RoleNotificationCenter from '../components/notifications/RoleNotification
 
 import logger from '../utils/logger';
 import tokenManager from '../utils/tokenManager';
+
+const hasBackendQueueAction = (entry, action, flagName) => {
+  if (!entry) return false;
+  if (Array.isArray(entry.available_actions)) {
+    return entry.available_actions.includes(action);
+  }
+  if (flagName && Object.prototype.hasOwnProperty.call(entry, flagName)) {
+    return Boolean(entry[flagName]);
+  }
+  return false;
+};
+
 const DoctorPanel = () => {
   const location = useLocation();
   const { isMobile, isTablet } = useBreakpoint();void
@@ -87,6 +99,7 @@ const DoctorPanel = () => {
     stats: queueStats,
     loading: queueLoading,
     error: queueError,
+    canCallNext,
     loadQueue,
     callNext,
     markNoShow,
@@ -1239,7 +1252,7 @@ const DoctorPanel = () => {
                         logger.error('Ошибка вызова:', err);
                       }
                     }}
-                    disabled={queueStats.waiting === 0}>
+                    disabled={!canCallNext}>
 
                       <Phone size={16} />
                       {!isMobile && <span style={{ marginLeft: '4px' }}>Вызвать следующего</span>}
@@ -1354,8 +1367,9 @@ const DoctorPanel = () => {
                       }
                           </td>
                           <td style={tdStyle}>
-                            {/* Кнопки в зависимости от статуса */}
-                            {entry.status === 'waiting' &&
+                            {/* Backend-owned queue action contract */}
+                            {hasBackendQueueAction(entry, 'no_show', 'can_no_show') &&
+                            !hasBackendQueueAction(entry, 'send_to_diagnostics', 'can_send_to_diagnostics') &&
                       <>
                                 <button
                           {...getQueueActionA11yProps('Mark no-show', entry)}
@@ -1368,7 +1382,7 @@ const DoctorPanel = () => {
                                 </button>
                               </>
                       }
-                            {entry.status === 'called' &&
+                            {hasBackendQueueAction(entry, 'send_to_diagnostics', 'can_send_to_diagnostics') &&
                       <>
                                 <button
                           {...getQueueActionA11yProps('Send to diagnostics', entry)}
@@ -1399,7 +1413,7 @@ const DoctorPanel = () => {
                                 </button>
                               </>
                       }
-                            {entry.status === 'diagnostics' &&
+                            {hasBackendQueueAction(entry, 'notify_diagnostics_return', 'can_notify_diagnostics_return') &&
                       <>
                                 <button
                           {...getQueueActionA11yProps('Call back from diagnostics', entry)}
@@ -1430,7 +1444,7 @@ const DoctorPanel = () => {
                                 </button>
                               </>
                       }
-                            {entry.status === 'no_show' &&
+                            {hasBackendQueueAction(entry, 'restore_next', 'can_restore_next') &&
                       <button
                         {...getQueueActionA11yProps('Restore as next patient', entry)}
                         aria-label={`Restore as next patient for ${getQueuePatientContext(entry)}`}

--- a/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
@@ -76,4 +76,43 @@ describe('Doctor panels SSOT contract', () => {
       expect(source).not.toContain('/ui/registrar');
     }
   });
+
+  it('keeps the active doctor queue page action visibility backend-owned', () => {
+    const source = read('pages/DoctorPanel.jsx');
+    const actionBlock = extractBlock(
+      source,
+      'Backend-owned queue action contract',
+      '</td>',
+    );
+
+    expect(source).toContain('const hasBackendQueueAction =');
+    expect(source).toContain('canCallNext');
+    expect(source).toContain('disabled={!canCallNext}');
+    expect(actionBlock).toContain("hasBackendQueueAction(entry, 'no_show', 'can_no_show')");
+    expect(actionBlock).toContain("hasBackendQueueAction(entry, 'send_to_diagnostics', 'can_send_to_diagnostics')");
+    expect(actionBlock).toContain("hasBackendQueueAction(entry, 'notify_diagnostics_return', 'can_notify_diagnostics_return')");
+    expect(actionBlock).toContain("hasBackendQueueAction(entry, 'restore_next', 'can_restore_next')");
+    expect(actionBlock).not.toContain("entry.status === 'waiting'");
+    expect(actionBlock).not.toContain("entry.status === 'called'");
+    expect(actionBlock).not.toContain("entry.status === 'diagnostics'");
+    expect(actionBlock).not.toContain("entry.status === 'no_show'");
+  });
+
+  it('selects call-next from backend queue contract instead of local waiting-status scan', () => {
+    const source = read('hooks/useDoctorQueue.js');
+    const callNextBlock = extractBlock(
+      source,
+      'const callNext = useCallback',
+      'const markNoShow = useCallback',
+    );
+
+    expect(source).toContain('const selectNextCallEntryId =');
+    expect(source).toContain('queuePayload?.next_call_entry_id');
+    expect(source).toContain("hasBackendQueueAction(entry, 'call', 'can_call')");
+    expect(source).toContain('canCallNext: queueControls.canCallNext');
+    expect(callNextBlock).toContain('selectNextCallEntryId(currentQueue.data)');
+    expect(callNextBlock).toContain('/doctor/queue/${nextCallEntryId}/call');
+    expect(callNextBlock).not.toContain("entry.status === 'waiting'");
+    expect(callNextBlock).not.toContain('waitingEntry');
+  });
 });


### PR DESCRIPTION
## Summary
- Adds backend-owned doctor queue `available_actions` / `can_*` fields to `GET /api/v1/doctor/{specialty}/queue/today`.
- Makes doctor call-next use backend `next_call_entry_id` / `can_call_next` instead of scanning for `status === 'waiting'` in React.
- Keeps the active `DoctorPanel` queue action buttons gated by backend action fields, not local status branches.
- Adds a backend guard so `POST /api/v1/doctor/queue/{entry_id}/call` rejects non-callable queue statuses.
- No BFF-lite endpoint, no `/api/v1/ui/*`, no separate BFF service.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current local main at `c75592d5` after PR #1223 merge.
- Clean workspace: worktree was clean before this branch; diff is limited to doctor queue contract files and tests.
- Branch: `codex/doctor-queue-actions-ssot-contract`.
- Scope gate: used `final-ssot-contract-repair`, `final-bff-lite-read-model`, `final-openapi-contract-review`; gate returned narrow override anchored on `frontend/src/hooks/useDoctorQueue.js`, then repo evidence required the minimal backend DTO/action owner expansion.
- Red-check handling: PR Review Quality Gate initially failed only because two required prose fields used too-generic wording; this body now spells out concrete no-impact behavior. Runtime checks are green.

## Contract Impact
- Canonical surface: existing doctor queue endpoints only: `GET /api/v1/doctor/{specialty}/queue/today` and `POST /api/v1/doctor/queue/{entry_id}/call`.
- Request shape: unchanged.
- Response shape: additive fields on queue response: `can_call_next`, `next_call_entry_id`; additive fields on each queue entry: `available_actions`, `can_call`, `can_no_show`, `can_send_to_diagnostics`, `can_complete`, `can_notify_diagnostics_return`, `can_mark_incomplete`, `can_restore_next`.
- Status codes: `POST /doctor/queue/{entry_id}/call` now returns `400` when the entry is not callable instead of rewriting non-waiting entries to `called`.
- Frontend consumer: `frontend/src/hooks/useDoctorQueue.js` and `frontend/src/pages/DoctorPanel.jsx` consume backend action fields.
- Compatibility path or alias: no route alias added; no `/api/v1/ui/*`; existing endpoint remains the compatibility surface through additive response fields.
- Contract proof: backend test assertions added for action fields/empty payload/call rejection; frontend contract tests assert no local waiting-status call-next scan and backend-owned action gating.

## RBAC / Permissions
- Roles allowed: unchanged existing endpoint roles for doctor queue read/call.
- Roles denied: unchanged existing `require_roles` behavior and ownership check.
- Positive auth proof: existing `test_general_queue_uses_current_user_when_doctor_row_is_missing` still logs in a doctor and reads queue; new assertions verify action contract.
- Negative auth proof: ownership/RBAC not changed in this PR; new negative proof covers invalid queue status rejection for `call`.

## Notification / Realtime
- Event type or websocket channel: unchanged existing display websocket broadcast in `call_patient` after a successful call.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: this PR introduces no read/unread state; queue action fields are recomputed on `GET /doctor/{specialty}/queue/today` and do not change notification delivery semantics.
- Reconnect/resync proof: unchanged queue reload path after commands; `GET /doctor/{specialty}/queue/today` now includes enough action state for resync.

## Frontend Resilience
- Empty data proof: backend empty queue response now explicitly returns `can_call_next: false` and `next_call_entry_id: null`; existing empty UI path remains.
- Partial data proof: hook falls back from top-level `next_call_entry_id` to backend per-entry `available_actions/can_call`, not local status.
- Forbidden secondary path behavior: no `/api/v1/ui/*`; no separate BFF service; call-next no longer scans for `status === 'waiting'`.
- Missing draft/resource behavior: doctor queue has no draft resource; missing queue configuration continues through the existing `queue_exists: false`, empty `entries`, and disabled call-next path.
- Stale route/deep-link behavior: active `/doctor` route keeps using `DoctorPanel`; no route changes.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/doctor_integration.py`, `backend/tests/integration/test_doctor_general_queue.py`, `frontend/src/hooks/useDoctorQueue.js`, `frontend/src/pages/DoctorPanel.jsx`, `frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx`.
- Denied paths: no QueueJoin, DisplayBoard, Registrar, `/api/v1/ui/*`, migrations, generated docs, or unrelated cleanup.
- Migration/docs/test impact: no migration; tests updated only for doctor queue contract.
- Rollback note: revert this PR to restore the previous status-driven frontend gating and call endpoint behavior; additive response fields are safe for old clients.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- DoctorPanels.contract`; `npm --prefix frontend run build`; `py -3 -m compileall backend\app\api\v1\endpoints\doctor_integration.py`; `git diff --check`; attempted `py -3 -m pytest backend\tests\integration\test_doctor_general_queue.py`.
- Result: frontend contract test passed (6 tests); frontend build passed; Python compile passed; diff check passed with line-ending warnings only; backend pytest blocked locally before collection by missing `DATABASE_URL`; CI backend tests passed.
- Not checked: full backend pytest locally due missing `DATABASE_URL`; CI ran backend tests with configured database and passed.