### PR TITLE
fix(registrar): keep queue call-next backend-owned

### DIFF
--- a/frontend/src/components/queue/ModernQueueManager.jsx
+++ b/frontend/src/components/queue/ModernQueueManager.jsx
@@ -487,6 +487,17 @@ const ModernQueueManager = ({
                 {t.refreshQueue}
               </Button>
 
+              <Button
+                variant="primary"
+                size="default"
+                onClick={callPatient}
+                disabled={!effectiveDoctor || loading}
+                className="mqm-button-icon"
+                title="Backend call-next command">
+                <Icon name="bell.fill" size="small" style={{ color: 'white' }} />
+                {t.call}
+              </Button>
+
               <button
                 type="button"
                 style={{
@@ -530,7 +541,6 @@ const ModernQueueManager = ({
             queueData={queueData}
             effectiveDoctor={effectiveDoctor}
             onGenerateQR={generateQR}
-            onCallPatient={callPatient}
             loading={loading}
             t={t} />
 

--- a/frontend/src/components/queue/QueueTable.jsx
+++ b/frontend/src/components/queue/QueueTable.jsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Icon } from '../ui/macos';
+import { Badge, Icon } from '../ui/macos';
 import PropTypes from 'prop-types';
 
 /**
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 const QueueTable = ({
     queueData,
     effectiveDoctor,
-    onCallPatient,
     loading,
     t
 }) => {
@@ -247,17 +246,6 @@ const QueueTable = ({
                                 padding: '12px 16px',
                                 textAlign: 'right'
                             }}>
-                                {entry.status === 'waiting' && (
-                                    <Button
-                                        size="sm"
-                                        variant="primary"
-                                        onClick={() => onCallPatient(entry)}
-                                        disabled={loading}
-                                    >
-                                        <Icon name="bell.fill" size="small" style={{ marginRight: '4px' }} />
-                                        {t?.call || 'Вызвать'}
-                                    </Button>
-                                )}
                                 {entry.status === 'called' && (
                                     <Badge variant="info">
                                         <Icon name="bell.fill" size="small" style={{ marginRight: '4px' }} />
@@ -281,7 +269,6 @@ QueueTable.propTypes = {
     }),
     effectiveDoctor: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     onGenerateQR: PropTypes.func,
-    onCallPatient: PropTypes.func,
     loading: PropTypes.bool,
     t: PropTypes.object
 };
@@ -290,7 +277,6 @@ QueueTable.defaultProps = {
     queueData: null,
     effectiveDoctor: null,
     onGenerateQR: () => { },
-    onCallPatient: () => { },
     loading: false,
     t: {}
 };

--- a/frontend/src/components/queue/__tests__/QueueManager.contract.test.jsx
+++ b/frontend/src/components/queue/__tests__/QueueManager.contract.test.jsx
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(process.cwd(), 'src');
+const read = (filePath) => fs.readFileSync(path.join(ROOT, filePath), 'utf8');
+
+describe('Queue manager command contract', () => {
+  it('keeps registrar queue call-next as a backend-owned command, not a row command', () => {
+    const tableSource = read('components/queue/QueueTable.jsx');
+    const managerSource = read('components/queue/ModernQueueManager.jsx');
+
+    expect(managerSource).toContain('callNextPatientInQueue');
+    expect(managerSource).toContain('onClick={callPatient}');
+    expect(managerSource).toContain('title="Backend call-next command"');
+    expect(managerSource).not.toContain('onCallPatient={callPatient}');
+
+    expect(tableSource).not.toContain('Button');
+    expect(tableSource).not.toContain('{false && (');
+    expect(tableSource).not.toContain('onCallPatient(entry)');
+    expect(tableSource).not.toContain("entry.status === 'waiting' && (");
+  });
+});


### PR DESCRIPTION
## Summary
- Moves the registrar queue call-next affordance out of per-row `QueueTable` actions and keeps it as a single backend-owned `callNextPatientInQueue` command in `ModernQueueManager`.
- Removes the misleading row-level `onCallPatient(entry)` command surface from `QueueTable`.
- Adds a focused frontend contract test proving the table cannot reintroduce a row call button or row command gate.

## Cyclic Execution Evidence
- Fresh main sync: branch `codex/registrar-queue-call-next-affordance` was created from current `main` at `765f4534` after PR #1224 merged.
- Clean workspace: inspected before edits; only registrar queue manager/table files and a targeted contract test changed.
- Branch: `codex/registrar-queue-call-next-affordance`.
- Scope gate: allowed `frontend/src/components/queue/ModernQueueManager.jsx`, `frontend/src/components/queue/QueueTable.jsx`, and `frontend/src/components/queue/__tests__/QueueManager.contract.test.jsx`; denied backend, `/api/v1/ui/*`, BFF-lite, QueueJoin, DisplayBoard, migrations, and generated output.
- Red-check handling: local targeted test, frontend build, and diff check were run before PR; failed PR Review Quality Gate is addressed by this body update without runtime code changes.

## Contract Impact
- Canonical surface: existing registrar queue call-next flow through `callNextPatientInQueue`; backend still selects the next patient.
- Request shape: unchanged existing frontend command invocation with specialist/date facts from `ModernQueueManager`.
- Response shape: unchanged existing call-next response consumed by the existing toast/refresh path.
- Status codes: no backend/API change, so HTTP status behavior is unchanged.
- Frontend consumer: `ModernQueueManager` owns the single call-next affordance; `QueueTable` renders row status only.
- Compatibility path or alias: no new path or alias; removed the row-level prop path that implied frontend-selected row calling.
- Contract proof: `QueueManager.contract` asserts the manager uses `callNextPatientInQueue` and the table has no row call button or `onCallPatient(entry)` command path.

## RBAC / Permissions
- Roles allowed: unchanged from existing backend queue command authorization; this PR does not alter auth or role checks.
- Roles denied: unchanged from existing backend queue command authorization; this PR does not add a bypass path.
- Positive auth proof: covered by unchanged backend command contract; local proof focused on frontend command ownership because no backend code changed.
- Negative auth proof: no new endpoint or permission path was added, so existing backend denial behavior remains the source of truth.

## Notification / Realtime
not applicable - this PR does not change websocket, notification, audio, board broadcast, or realtime refresh behavior; it only moves the visible call-next affordance inside the same frontend queue manager surface.

## Frontend Resilience
- Empty data proof: unchanged `QueueTable` empty state remains in place; removing the row call button cannot make empty rows crash.
- Partial data proof: unchanged status badge fallback still handles unknown/missing status presentation.
- Forbidden secondary path behavior: no secondary command path remains in `QueueTable`; the only visible call-next path is the manager button.
- Missing draft/resource behavior: not applicable - registrar queue call-next does not create or reopen drafts/resources in this frontend surface.
- Stale route/deep-link behavior: not applicable - this component does not read route params or deep-link state for call-next.

## Scope Gate
- Allowed paths: `frontend/src/components/queue/ModernQueueManager.jsx`, `frontend/src/components/queue/QueueTable.jsx`, `frontend/src/components/queue/__tests__/QueueManager.contract.test.jsx`.
- Denied paths: backend endpoints/services/schemas, `/api/v1/ui/*`, separate BFF service, QueueJoin, DisplayBoard, migrations, generated output, unrelated cleanup.
- Migration/docs/test impact: no migration or docs changes; one targeted frontend contract test was added.
- Rollback note: revert this single commit to restore the previous row-level visual placement, but any future row-level call must first expose a backend-owned row action contract.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- QueueManager.contract`; `npm --prefix frontend run build`; `git diff --check`.
- Result: targeted test passed, frontend build passed, diff check passed with only CRLF normalization warnings.
- Not checked: backend pytest was not run because this PR has no backend/API changes; browser visual smoke was not run because the change is a small command-affordance placement and the Vite build passed.