### PR TITLE
fix(registrar): use queue specialist contract for manager options

### DIFF
--- a/frontend/src/components/queue/ModernQueueManager.jsx
+++ b/frontend/src/components/queue/ModernQueueManager.jsx
@@ -24,6 +24,7 @@ const ModernQueueManager = ({
     queueData,
     statistics,
     qrData,
+    specialists,
     loadQueueSnapshot,
     generateDoctorQRCode,
     generateClinicQRCode,
@@ -240,95 +241,23 @@ const ModernQueueManager = ({
     }
   };
 
-  // Мемоизация списка врачей для выпадающего списка
-  // ⭐ SSOT: queueProfiles загружаются из API и используются для фильтрации
-  const [queueProfiles, setQueueProfiles] = useState([]);
-
-  // ⭐ SSOT: Load queue profiles for filtering (show_on_qr_page=true)
-  useEffect(() => {
-    const loadQueueProfiles = async () => {
-      try {
-        // Используем публичный endpoint который возвращает только профили с show_on_qr_page=true
-        const response = await fetch('/api/v1/queues/profiles/public');
-        if (response.ok) {
-          const data = await response.json();
-          setQueueProfiles(data.specialists || []);
-          logger.log('[ModernQueueManager] SSOT: Loaded queue profiles for filtering:', data.specialists?.length || 0);
-        }
-      } catch (error) {
-        logger.error('[ModernQueueManager] Error loading queue profiles:', error);
-      }
-    };
-    loadQueueProfiles();
-  }, []);
-
   const doctorOptions = useMemo(() => {
-    if (!doctors || doctors.length === 0) return [];
+    if (!Array.isArray(specialists) || specialists.length === 0) return [];
 
-    // ⭐ SSOT: Получаем список специальностей из queueProfiles (с show_on_qr_page=true)
-    const allowedSpecialties = new Set(
-      queueProfiles.map((p) => p.specialty?.toLowerCase())
-    );
-
-    // Маппинг специальностей на русские названия (можно расширить)
-    const specialtyNames = {
-      'cardiology': 'Кардиолог',
-      'cardio': 'Кардиолог',
-      'dermatology': 'Дерматолог',
-      'derma': 'Дерматолог',
-      'stomatology': 'Стоматолог',
-      'dentist': 'Стоматолог',
-      'dentistry': 'Стоматолог',
-      'laboratory': 'Лаборатория',
-      'lab': 'Лаборатория',
-      'neurology': 'Невролог',
-      'pediatrics': 'Педиатр',
-      'therapy': 'Терапевт',
-      'surgery': 'Хирург',
-      'ophthalmology': 'Окулист',
-      'ent': 'ЛОР',
-      'gynecology': 'Гинеколог',
-      'urology': 'Уролог',
-      'endocrinology': 'Эндокринолог',
-      'traumatology': 'Травматолог',
-      'ultrasound': 'УЗИ',
-      'ecg': 'ЭКГ',
-      'procedures': 'Процедуры',
-      'cosmetology': 'Косметология',
-      'general': 'Общая очередь'
-    };
-
-    const normalizeSpecialty = (spec) => {
-      const s = spec?.toLowerCase();
-      if (s === 'cardio') return 'cardiology';
-      if (s === 'derma') return 'dermatology';
-      if (s === 'dentist' || s === 'dentistry') return 'stomatology';
-      if (s === 'lab') return 'laboratory';
-      return s;
-    };
-
-    return doctors.
-    filter((d) => d.id !== undefined && d.id !== null) // Только врачи с canonical id
-    .filter((d) => {
-      // ⭐ SSOT Filter: Показываем только тех врачей, чья специальность есть в queueProfiles
-      if (allowedSpecialties.size === 0) return true; // Если профили не загружены - показываем всех
-      const normalizedSpec = normalizeSpecialty(d.specialty);
-      return allowedSpecialties.has(normalizedSpec);
-    }).
+    return specialists.
+    filter((d) => d.id !== undefined && d.id !== null).
     map((d) => {
-      const normalizedSpec = normalizeSpecialty(d.specialty);
-
-      const specialtyLabel = specialtyNames[normalizedSpec] || d.specialty;
+      const doctorName = d.doctor_name || d.full_name || d.user?.full_name || d.name || `Врач #${d.id}`;
+      const specialtyLabel = d.specialty_display || d.specialty || '';
       const cabinetInfo = d.cabinet ? ` (Каб. ${d.cabinet})` : '';
-
       return {
         id: d.id,
-        label: `${d.full_name || d.user?.full_name || d.name || `Врач #${d.id}`}${specialtyLabel ? ` • ${specialtyLabel}` : ''}${cabinetInfo}`,
-        specialty: normalizedSpec
+        label: `${doctorName}${specialtyLabel ? ` • ${specialtyLabel}` : ''}${cabinetInfo}`,
+        specialty: d.specialty
       };
     }).
     sort((a, b) => a.label.localeCompare(b.label));
-  }, [doctors, queueProfiles]);
+  }, [specialists]);
 
   return (
     <div className="modern-queue-manager">

--- a/frontend/src/components/queue/__tests__/QueueManager.contract.test.jsx
+++ b/frontend/src/components/queue/__tests__/QueueManager.contract.test.jsx
@@ -21,4 +21,15 @@ describe('Queue manager command contract', () => {
     expect(tableSource).not.toContain('onCallPatient(entry)');
     expect(tableSource).not.toContain("entry.status === 'waiting' && (");
   });
+
+  it('uses backend-provided available specialists for queue doctor options', () => {
+    const managerSource = read('components/queue/ModernQueueManager.jsx');
+
+    expect(managerSource).toContain('specialists,');
+    expect(managerSource).toContain('if (!Array.isArray(specialists) || specialists.length === 0) return []');
+    expect(managerSource).toContain('d.specialty_display || d.specialty');
+    expect(managerSource).not.toContain("fetch('/api/v1/queues/profiles/public')");
+    expect(managerSource).not.toContain('allowedSpecialties');
+    expect(managerSource).not.toContain('normalizeSpecialty');
+  });
 });


### PR DESCRIPTION
## Summary
- Removes the extra `ModernQueueManager` fetch to `/queues/profiles/public` for registrar queue doctor options.
- Uses the existing backend-provided `/queue/available-specialists` contract already loaded by `useQueueManager`.
- Removes frontend specialty alias filtering and the unsafe fallback that showed all doctors when queue profiles were unavailable.

## Cyclic Execution Evidence
- Fresh main sync: branch `codex/registrar-queue-metadata-ssot` was created from current `main` at `b1445594` after PR #1225 merged.
- Clean workspace: inspected before edits; only `ModernQueueManager` and its focused contract test changed.
- Branch: `codex/registrar-queue-metadata-ssot`.
- Scope gate: allowed registrar queue metadata SSOT cleanup in `ModernQueueManager` and targeted queue manager contract test; denied backend changes, `/api/v1/ui/*`, BFF-lite, command wrappers, QueueJoin, DisplayBoard, migrations, and generated output.
- Red-check handling: local targeted test, frontend build, and diff check were run before PR; any CI regression will be fixed in this same PR before merge.

## Contract Impact
- Canonical surface: existing `GET /api/v1/queue/available-specialists` via `useQueueManager`.
- Request shape: unchanged authenticated frontend request from the existing queue API client.
- Response shape: frontend now consumes backend-provided specialist display fields such as `doctor_name`, `specialty_display`, `specialty`, and `cabinet` for options.
- Status codes: no backend/API change, so HTTP status behavior is unchanged.
- Frontend consumer: `ModernQueueManager` doctor options use `specialists` from `useQueueManager` instead of locally joining registrar doctors with public queue profiles.
- Compatibility path or alias: local specialty alias normalization was removed; backend specialist display fields are now the compatibility surface.
- Contract proof: `QueueManager.contract` asserts no `/queues/profiles/public` fetch, no `allowedSpecialties`, and no `normalizeSpecialty` remain in `ModernQueueManager`.

## RBAC / Permissions
- Roles allowed: unchanged from existing backend `/queue/available-specialists` and queue command permissions.
- Roles denied: unchanged; this PR removes a frontend fallback path that could show all passed doctors when profile metadata failed.
- Positive auth proof: local frontend proof confirms the UI consumes the existing backend specialist contract; no backend role code changed.
- Negative auth proof: no new endpoint or permission path was added, so existing backend denial behavior remains the source of truth.

## Notification / Realtime
not applicable - this PR does not change websocket, notification, audio, board broadcast, queue refresh events, or realtime behavior; it only changes the metadata source for the doctor dropdown.

## Frontend Resilience
- Empty data proof: if `specialists` is missing or empty, doctor options render as an empty list instead of falling back to all doctors.
- Partial data proof: option labels tolerate missing optional `specialty_display`, `specialty`, and `cabinet` fields.
- Forbidden secondary path behavior: the old secondary `/queues/profiles/public` path was removed from `ModernQueueManager`.
- Missing draft/resource behavior: not applicable - queue specialist option loading does not create or reopen drafts/resources.
- Stale route/deep-link behavior: selected doctor/date URL handling is unchanged; this PR only changes dropdown option metadata.

## Scope Gate
- Allowed paths: `frontend/src/components/queue/ModernQueueManager.jsx`, `frontend/src/components/queue/__tests__/QueueManager.contract.test.jsx`.
- Denied paths: backend endpoints/services/schemas, `/api/v1/ui/*`, separate BFF service, command wrappers, QueueJoin, DisplayBoard, migrations, generated output, unrelated cleanup.
- Migration/docs/test impact: no migration or docs changes; one targeted frontend contract test was extended.
- Rollback note: revert this single commit to restore the old queue profile filtering path, but any restoration should first prove why `/queue/available-specialists` is insufficient.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- QueueManager.contract`; `npm --prefix frontend run build`; `git diff --check`.
- Result: targeted test passed, frontend build passed, diff check passed with only CRLF normalization warnings.
- Not checked: backend pytest was not run because this PR has no backend/API changes; browser visual smoke was not run because the Vite build covered the component bundle.