### PR TITLE
fix(queue): render QR join unavailable messages from backend

### DIFF
--- a/frontend/src/pages/QueueJoin.jsx
+++ b/frontend/src/pages/QueueJoin.jsx
@@ -40,10 +40,6 @@ const formatSpecialistLabel = (specialist) => {
 const MISSING_QUEUE_TOKEN_MESSAGE = 'QR-код не найден. Откройте ссылку из клиники или отсканируйте QR-код заново.';
 const QUEUE_JOIN_MESSAGES = {
   sessionStartFailed: 'Не удалось начать сессию очереди.',
-  queueInactive: 'Очередь сейчас не активна.',
-  registrationClosedAt: (endTime) => `Запись закрылась в ${endTime}.`,
-  receptionAlreadyOpened: 'Запись закрыта: прием уже начался.',
-  limitReached: (maxEntries) => `Лимит записи достигнут (${maxEntries}).`,
   registrationUnavailable: 'Запись в очередь недоступна.',
   qrTokenUnavailable: 'QR-токен не найден или срок его действия истек.',
   requiredFields: 'Заполните обязательные поля.',
@@ -182,34 +178,14 @@ const QueueJoin = () => {
           : []
       );
 
-      if (!tokenInfo.queue_active) {
-        setError(tokenInfo.message || QUEUE_JOIN_MESSAGES.queueInactive);
-        setStep('error');
-        setIsSpecialistsLoading(false);
-        return;
-      }
-
       if (tokenInfo.status === 'before_start_time') {
         setQueueInfo(tokenInfo);
         setStep('waiting');
         setIsSpecialistsLoading(false);
         return;
-      } else if (tokenInfo.status === 'after_end_time') {
-        setError(tokenInfo.message || QUEUE_JOIN_MESSAGES.registrationClosedAt(tokenInfo.end_time));
-        setStep('error');
-        setIsSpecialistsLoading(false);
-        return;
-      } else if (tokenInfo.status === 'closed_reception_opened') {
-        setError(tokenInfo.message || QUEUE_JOIN_MESSAGES.receptionAlreadyOpened);
-        setStep('error');
-        setIsSpecialistsLoading(false);
-        return;
-      } else if (tokenInfo.status === 'limit_reached') {
-        setError(tokenInfo.message || QUEUE_JOIN_MESSAGES.limitReached(tokenInfo.max_entries));
-        setStep('error');
-        setIsSpecialistsLoading(false);
-        return;
-      } else if (tokenInfo.allowed === false) {
+      }
+
+      if (!tokenInfo.queue_active || tokenInfo.allowed === false) {
         setError(tokenInfo.message || QUEUE_JOIN_MESSAGES.registrationUnavailable);
         setStep('error');
         setIsSpecialistsLoading(false);

--- a/frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx
+++ b/frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import fs from 'node:fs';
+import path from 'node:path';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -12,6 +14,9 @@ const queueApiMocks = vi.hoisted(() => ({
 vi.mock('../../api/queue', () => queueApiMocks);
 
 import QueueJoin from '../QueueJoin';
+
+const queueJoinSourcePath = path.resolve(process.cwd(), 'src/pages/QueueJoin.jsx');
+const readQueueJoinSource = () => fs.readFileSync(queueJoinSourcePath, 'utf8');
 
 function setupQueueApiMock({
   selectableSpecialists = [
@@ -158,6 +163,16 @@ describe('QueueJoin Accessibility & UX', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Backend says registration is full');
     expect(queueApiMocks.startQueueJoinSession).not.toHaveBeenCalled();
+  });
+
+  it('does not recreate unavailable queue policy messages from status codes', () => {
+    const source = readQueueJoinSource();
+
+    expect(source).not.toContain('QUEUE_JOIN_MESSAGES.registrationClosedAt');
+    expect(source).not.toContain('QUEUE_JOIN_MESSAGES.receptionAlreadyOpened');
+    expect(source).not.toContain('QUEUE_JOIN_MESSAGES.limitReached');
+    expect(source).not.toContain('QUEUE_JOIN_MESSAGES.queueInactive');
+    expect(source).toContain('setError(tokenInfo.message || QUEUE_JOIN_MESSAGES.registrationUnavailable)');
   });
 
   it('submits real doctor ids for clinic-wide QR instead of queue profile ids', async () => {


### PR DESCRIPTION
## Summary
- Removes QueueJoin's local unavailable-policy messages for queue inactive, closed reception, closed time window, and limit reached states.
- Keeps `before_start_time` as a frontend UI waiting state, but renders unavailable error text from backend `tokenInfo.message`.
- Adds a focused QueueJoin test guard so status-specific local policy messages are not reintroduced.

## Cyclic Execution Evidence
- Fresh main sync: branch `codex/queuejoin-backend-message-contract` was created from current `main` at `3af7f31c` after PR #1226 merged.
- Clean workspace: inspected before edits; only `QueueJoin.jsx` and its focused accessibility/contract test changed.
- Branch: `codex/queuejoin-backend-message-contract`.
- Scope gate: allowed active QR join message contract cleanup in `QueueJoin` and targeted QueueJoin test; denied backend changes, `/api/v1/ui/*`, BFF-lite, command wrappers, RegistrarPanel, DisplayBoard, migrations, and generated output.
- Red-check handling: local targeted test, frontend build, and diff check were run before PR; any CI regression will be fixed in this same PR before merge.

## Contract Impact
- Canonical surface: existing `GET /api/v1/queue/qr-tokens/{token}/info` and `POST /api/v1/queue/join/start` read contract.
- Request shape: unchanged token-based QR join requests.
- Response shape: frontend now relies on backend `message` for unavailable queue states, with only a generic technical fallback.
- Status codes: no backend/API change, so HTTP status behavior is unchanged.
- Frontend consumer: `QueueJoin` still chooses UI step from backend state, but no longer reconstructs business-policy copy for unavailable statuses.
- Compatibility path or alias: no new path or alias; existing QR token info/start shapes remain in use.
- Contract proof: `QueueJoin.accessibility` asserts backend-provided unavailable message rendering and absence of local status-specific message fallbacks.

## RBAC / Permissions
- Roles allowed: unchanged from existing public QR join token flow.
- Roles denied: unchanged; this PR adds no endpoint and no alternate authorization path.
- Positive auth proof: local frontend proof confirms the UI consumes backend QR message state; backend auth/token validation code is untouched.
- Negative auth proof: invalid/missing token behavior remains covered by existing QueueJoin missing-token/error tests and backend token validation.

## Notification / Realtime
not applicable - this PR does not change websocket, notifications, board broadcast, queue update events, or realtime behavior; it only changes QR join unavailable message ownership.

## Frontend Resilience
- Empty data proof: existing clinic-wide empty specialist test still passes.
- Partial data proof: when backend message is absent, QueueJoin falls back to one generic unavailable message instead of local policy-specific text.
- Forbidden secondary path behavior: no secondary endpoint or local status-message policy path was added.
- Missing draft/resource behavior: not applicable - QR join unavailable messaging does not create or reopen drafts/resources.
- Stale route/deep-link behavior: missing-token route behavior is unchanged and remains tested.

## Scope Gate
- Allowed paths: `frontend/src/pages/QueueJoin.jsx`, `frontend/src/pages/__tests__/QueueJoin.accessibility.test.jsx`.
- Denied paths: backend endpoints/services/schemas, `/api/v1/ui/*`, separate BFF service, command wrappers, RegistrarPanel, DisplayBoard, migrations, generated output, unrelated cleanup.
- Migration/docs/test impact: no migration or docs changes; one targeted frontend test was extended.
- Rollback note: revert this single commit to restore frontend status-specific fallback copy, but backend `message` should remain the SSOT for QR join unavailable policy.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- QueueJoin.accessibility`; `npm --prefix frontend run build`; `git diff --check`.
- Result: targeted test passed, frontend build passed, diff check passed with only CRLF normalization warnings.
- Not checked: backend pytest was not run because this PR has no backend/API changes; browser visual smoke was not run because the existing component tests and Vite build covered this narrow UI state path.