### PR TITLE
fix(registrar): prefer service department contract

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -1353,6 +1353,7 @@ const RegistrarPanel = () => {
               address: fullEntry.address ?? entry.address ?? '',
               services: Array.isArray(fullEntry.services) ? fullEntry.services : [],
               service_codes: Array.isArray(fullEntry.service_codes) ? fullEntry.service_codes : [],
+              service_details: Array.isArray(fullEntry.service_details) ? fullEntry.service_details : [],
               cost: fullEntry.cost || 0,
               payment_status: fullEntry.payment_status ?? null,
               source: fullEntry.source || entry.source || 'desk',
@@ -1969,6 +1970,80 @@ const RegistrarPanel = () => {
     };
 
     // ⭐ Для QR-записей с queue_numbers - собираем услуги из всех queue_numbers
+    const normalizeDepartmentKey = (value) => value ? String(value).toLowerCase().trim() : null;
+    const targetDepartmentKey = normalizeDepartmentKey(departmentKey);
+
+    const getServiceIdentity = (serviceItem) => {
+      if (serviceItem && typeof serviceItem === 'object') {
+        return {
+          id: serviceItem.id ?? serviceItem.service_id ?? null,
+          code: serviceItem.service_code ?? serviceItem.code ?? null,
+          name: serviceItem.name ?? serviceItem.service_name ?? null,
+          departmentKey: serviceItem.department_key ?? serviceItem.departmentKey ?? null
+        };
+      }
+
+      return {
+        id: typeof serviceItem === 'number' || typeof serviceItem === 'string' && !isNaN(serviceItem) ? Number(serviceItem) : null,
+        code: typeof serviceItem === 'string' ? serviceItem : null,
+        name: typeof serviceItem === 'string' ? serviceItem : null,
+        departmentKey: null
+      };
+    };
+
+    const serviceMatchesIdentity = (candidate, identity) => {
+      if (!candidate || typeof candidate !== 'object') return false;
+      const candidateId = candidate.id ?? candidate.service_id ?? null;
+      if (identity.id != null && candidateId != null && Number(candidateId) === Number(identity.id)) return true;
+
+      const candidateCode = candidate.service_code ?? candidate.code ?? null;
+      if (identity.code && candidateCode && String(candidateCode).toUpperCase() === String(identity.code).toUpperCase()) return true;
+
+      const candidateName = candidate.name ?? candidate.service_name ?? null;
+      if (identity.name && candidateName && String(candidateName).trim() === String(identity.name).trim()) return true;
+
+      return false;
+    };
+
+    const findBackendServiceMeta = (serviceItem, index) => {
+      const identity = getServiceIdentity(serviceItem);
+      if (identity.departmentKey) return identity;
+
+      const serviceDetails = Array.isArray(appointment.service_details) ? appointment.service_details : [];
+      const indexedDetail = serviceDetails[index];
+      if (indexedDetail?.department_key) return indexedDetail;
+
+      const detailMatch = serviceDetails.find((detail) => serviceMatchesIdentity(detail, identity));
+      if (detailMatch?.department_key) return detailMatch;
+
+      if (services && typeof services === 'object') {
+        for (const groupServices of Object.values(services)) {
+          if (!Array.isArray(groupServices)) continue;
+          const serviceMatch = groupServices.find((service) => serviceMatchesIdentity(service, identity));
+          if (serviceMatch?.department_key) return serviceMatch;
+        }
+      }
+
+      return null;
+    };
+
+    const filterByBackendDepartment = (appointmentServices) => {
+      if (!targetDepartmentKey || !Array.isArray(appointmentServices) || appointmentServices.length === 0) {
+        return null;
+      }
+
+      let sawBackendDepartment = false;
+      const filtered = appointmentServices.filter((serviceItem, index) => {
+        const serviceMeta = findBackendServiceMeta(serviceItem, index);
+        const serviceDepartmentKey = normalizeDepartmentKey(serviceMeta?.department_key ?? serviceMeta?.departmentKey);
+        if (!serviceDepartmentKey) return false;
+        sawBackendDepartment = true;
+        return serviceDepartmentKey === targetDepartmentKey;
+      });
+
+      return sawBackendDepartment ? filtered : null;
+    };
+
     if (appointment.queue_numbers && Array.isArray(appointment.queue_numbers) && appointment.queue_numbers.length > 0) {
 
       // ⭐ Если НЕТ departmentKey (вкладка "Все отделения") - используем уже имеющиеся services
@@ -1997,6 +2072,11 @@ const RegistrarPanel = () => {
 
       // ⭐ Для конкретной вкладки - фильтруем из существующих services по категории
       // ✅ ИСПРАВЛЕНО: Используем appointment.services напрямую, фильтруя по категории отделения
+      const backendFilteredServices = filterByBackendDepartment(appointment.services || []);
+      if (backendFilteredServices) {
+        return backendFilteredServices;
+      }
+
       const departmentCodePrefixes = {
         'cardio': ['K'], // K01, K11 и т.д. - все кардиоуслуги кроме ECG
         'echokg': ['K10', 'ECG'], // Только ЭКГ (K10)
@@ -2054,6 +2134,11 @@ const RegistrarPanel = () => {
     const appointmentServices = appointment.services || [];
 
     // Создаем маппинг service -> service_code
+    const backendFilteredServices = filterByBackendDepartment(appointmentServices);
+    if (backendFilteredServices) {
+      return backendFilteredServices;
+    }
+
     const serviceToCodeMap = new Map();
 
     appointmentServices.forEach((service, index) => {

--- a/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
@@ -73,6 +73,25 @@ describe('RegistrarPanel command contract', () => {
     expect(loadIntegratedDataBlock).not.toContain('queueRes');
   });
 
+  it('filters displayed services by backend department metadata before legacy code prefixes', () => {
+    const source = readRegistrarPanelSource();
+    const filterBlock = extractSourceBlock(
+      source,
+      'const filterServicesByDepartment = useCallback((appointment, departmentKey) => {',
+      'const filteredAppointments = useMemo(() => {',
+    );
+
+    expect(source).toContain('service_details: Array.isArray(fullEntry.service_details) ? fullEntry.service_details : []');
+    expect(filterBlock).toContain('const filterByBackendDepartment = (appointmentServices) => {');
+    expect(filterBlock).toContain('serviceMeta?.department_key ?? serviceMeta?.departmentKey');
+    expect(filterBlock.indexOf('const backendFilteredServices = filterByBackendDepartment(appointment.services || [])')).toBeLessThan(
+      filterBlock.indexOf('const departmentCodePrefixes = {'),
+    );
+    expect(filterBlock.indexOf('const backendFilteredServices = filterByBackendDepartment(appointmentServices)')).toBeLessThan(
+      filterBlock.indexOf('const serviceToCodeMap = new Map()'),
+    );
+  });
+
   it('does not add a BFF-lite registrar workbench endpoint', () => {
     const source = readRegistrarPanelSource();
 


### PR DESCRIPTION
## Summary

- Prefer backend-provided service department metadata when RegistrarPanel filters displayed services by tab.
- Pass through `service_details` from `/registrar/queues/today` rows so service display filtering can use existing backend contract fields.
- Keep legacy code-prefix filtering only as fallback for DTOs without backend service metadata.

## Cyclic Execution Evidence

- Fresh main sync: branch was created from current `main` after #1227 merged at `708d5c15`.
- Clean workspace: worktree was clean before this PR branch; only the listed frontend files are changed.
- Branch: `codex/registrar-service-filter-ssot`.
- Scope gate: frontend-only Registrar service display filtering; no backend/API/runtime command scope expansion.
- Red-check handling: PR Review Quality Gate failed on missing template field bullets; this body update fills the required bullet fields only.

## Contract Impact

- Canonical surface: existing `/api/v1/registrar/queues/today` row `service_details` and existing `/api/v1/registrar/services` service `department_key` metadata.
- Request shape: unchanged; no new request fields and no new endpoint.
- Response shape: unchanged; frontend now consumes existing `service_details.department_key` / service `department_key` before legacy code prefixes.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/pages/RegistrarPanel.jsx` service display filtering for department tabs.
- Compatibility path or alias: legacy prefix filtering remains as fallback when backend service metadata is absent.
- Contract proof: `RegistrarPanel.contract` asserts `service_details` passthrough and backend department filtering before prefix fallback.

## RBAC / Permissions

- Roles allowed: unchanged from existing RegistrarPanel route and backend endpoints.
- Roles denied: unchanged; this PR does not alter route guards or backend permissions.
- Positive auth proof: not applicable - no auth path changed; frontend build and contract tests cover the changed consumer path.
- Negative auth proof: not applicable - no auth path changed and no endpoint was added.

## Notification / Realtime

- Event type or websocket channel: not applicable - no realtime event or websocket channel changed.
- Payload version / ack behavior: not applicable - no realtime payload or ack behavior changed.
- Read/unread or delivery semantics: not applicable - no notification delivery behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect/resync behavior changed.

## Frontend Resilience

- Empty data proof: legacy behavior is preserved when `appointment.services` is empty; existing fallback returns empty/current services as before.
- Partial data proof: when backend metadata is absent, legacy code-prefix fallback still runs.
- Forbidden secondary path behavior: no `/api/v1/ui/*`, no separate BFF service, and no backend command wrapper was added.
- Missing draft/resource behavior: missing `service_details` does not block rendering because fallback path remains.
- Stale route/deep-link behavior: unchanged; no routing or deep-link code changed.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`, `frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx`.
- Denied paths: backend files, `/api/v1/ui/*`, QueueJoin, DisplayBoard, command handlers, auth/role code.
- Migration/docs/test impact: no migration or docs changes; one frontend contract test updated.
- Rollback note: revert this PR to restore previous prefix-first filtering without affecting backend contracts.

## Validation

- Targeted tests or smoke run: `npm --prefix frontend run test:run -- RegistrarPanel.contract`; `npm --prefix frontend run build`; `git diff --check`.
- Result: all local validations passed; CI frontend build/unit/e2e/lint and Required Gate passed before this PR body fix.
- Not checked: backend pytest was not run locally because this PR has no backend/API changes.