### PR TITLE
fix(registrar): stop queue start appointment fallback

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -1281,16 +1281,23 @@ def start_queue_visit(
 ):
     """
     Начать прием для записи в очереди (статус в процессе)
-    Работает с Visit и Appointment записями
+    Legacy queue endpoint accepts only OnlineQueueEntry IDs.
     """
     try:
-        from app.models.appointment import Appointment
         from app.models.online_queue import OnlineQueueEntry
         from app.models.visit import Visit
 
         queue_entry = (
             db.query(OnlineQueueEntry).filter(OnlineQueueEntry.id == entry_id).first()
         )
+        if not queue_entry:
+            # This legacy queue route must not fall back to Visit or Appointment IDs:
+            # numeric IDs can collide across tables and mutate the wrong record.
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Queue entry not found",
+            )
+
         if queue_entry:
             linked_visit = None
             if queue_entry.visit_id:
@@ -1324,61 +1331,6 @@ def start_queue_visit(
                     "visit_id": queue_entry.visit_id,
                 },
             }
-
-        # Сначала ищем в Visit
-        visit = db.query(Visit).filter(Visit.id == entry_id).first()
-        if visit:
-            # Обновляем статус визита
-            visit.status = "in_progress"
-
-            logger.info(
-                "[FIX:PAYMENT_STATUS] start_queue_visit preserves registration type for visit %d; operational status is %s",
-                visit.id,
-                visit.status,
-            )
-
-            db.commit()
-            db.refresh(visit)
-
-            return {
-                "success": True,
-                "message": "Прием начат успешно",
-                "entry": {
-                    "id": visit.id,
-                    "status": visit.status,
-                    "patient_id": visit.patient_id,
-                },
-            }
-
-        # Если не найден в Visit, ищем в Appointment
-        appointment = db.query(Appointment).filter(Appointment.id == entry_id).first()
-        if appointment:
-            # Обновляем статус appointment
-            appointment.status = "in_progress"
-
-            logger.info(
-                "[FIX:PAYMENT_STATUS] start_queue_visit preserves appointment visit_type for appointment %d; operational status is %s",
-                appointment.id,
-                appointment.status,
-            )
-
-            db.commit()
-            db.refresh(appointment)
-
-            return {
-                "success": True,
-                "message": "Прием начат успешно",
-                "entry": {
-                    "id": appointment.id,
-                    "status": appointment.status,
-                    "patient_id": appointment.patient_id,
-                },
-            }
-
-        # Если не найден ни в Visit, ни в Appointment
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Запись не найдена"
-        )
 
     except HTTPException:
         raise

--- a/backend/tests/integration/test_registrar_record_actions.py
+++ b/backend/tests/integration/test_registrar_record_actions.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
+
+from app.models.appointment import Appointment
 
 
 @pytest.mark.integration
@@ -55,4 +59,83 @@ def test_registrar_record_action_rejects_doctor_mark_paid(
     )
 
     assert response.status_code == 403
+
+
+@pytest.mark.integration
+def test_registrar_record_action_starts_appointment_when_ids_collide_with_queue_entry(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_queue_entry,
+    test_patient,
+    test_doctor,
+):
+    appointment = Appointment(
+        id=test_queue_entry.id,
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        appointment_date=date.today(),
+        appointment_time="11:00",
+        status="paid",
+        visit_type="paid",
+        payment_type="cash",
+        services=["consultation"],
+    )
+    db_session.add(appointment)
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/registrar/records/actions",
+        headers=registrar_auth_headers,
+        json={
+            "action": "start_visit",
+            "record_kind": "appointment",
+            "record_id": appointment.id,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["results"][0]["record_kind"] == "appointment"
+    assert payload["results"][0]["record_id"] == appointment.id
+
+    db_session.refresh(appointment)
+    db_session.refresh(test_queue_entry)
+    assert appointment.status == "in_visit"
+    assert test_queue_entry.status == "waiting"
+
+
+@pytest.mark.integration
+def test_legacy_queue_start_endpoint_does_not_fallback_to_appointment_id(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+):
+    appointment = Appointment(
+        id=987654,
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        appointment_date=date.today(),
+        appointment_time="11:30",
+        status="paid",
+        visit_type="paid",
+        payment_type="cash",
+        services=["consultation"],
+    )
+    db_session.add(appointment)
+    db_session.commit()
+
+    response = client.post(
+        f"/api/v1/registrar/queue/{appointment.id}/start-visit",
+        headers=registrar_auth_headers,
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Queue entry not found"
+
+    db_session.refresh(appointment)
+    assert appointment.status == "paid"
 


### PR DESCRIPTION
## Summary

- Make legacy `POST /api/v1/registrar/queue/{entry_id}/start-visit` queue-entry-only.
- Remove Visit/Appointment fallback from that ambiguous route to prevent cross-table id collision mutation.
- Add regression coverage for typed registrar record actions with colliding appointment/queue ids.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/legacy-queue-start-id-collision` created from current `origin/main`.
- Clean workspace: inspected before edits; only scoped registrar endpoint and targeted backend tests changed.
- Branch: `codex/legacy-queue-start-id-collision`.
- Scope gate: agent gate used narrow overrides for `backend/app/api/v1/endpoints/registrar_integration.py` and `backend/tests/integration/test_registrar_record_actions.py`.
- Red-check handling: PR Review Quality Gate failed on missing template sections only; this body update fills the required sections without runtime code changes.

## Contract Impact

- Canonical surface: `POST /api/v1/registrar/queue/{entry_id}/start-visit` legacy queue command and `POST /api/v1/registrar/records/actions` typed registrar command.
- Request shape: legacy queue command still accepts path `entry_id`; typed command still accepts `record_kind` and `record_id`.
- Response shape: unchanged for valid queue entries and typed registrar actions.
- Status codes: legacy queue command now returns 404 `Queue entry not found` when `entry_id` is not an `OnlineQueueEntry.id` instead of falling back to Visit/Appointment lookup.
- Frontend consumer: no frontend runtime consumer changed; RegistrarPanel already uses `/registrar/records/actions`.
- Compatibility path or alias: legacy queue route remains available for queue entry IDs only.
- Contract proof: targeted backend regression tests cover appointment/queue id collision and legacy no-fallback behavior.

## RBAC / Permissions

- Roles allowed: unchanged from existing endpoint role dependencies.
- Roles denied: unchanged from existing endpoint role dependencies.
- Positive auth proof: targeted tests use `registrar_auth_headers` successfully for allowed registrar actions.
- Negative auth proof: existing `test_registrar_record_action_rejects_doctor_mark_paid` remains passing.

## Notification / Realtime

not applicable - no notification, websocket, queue broadcast, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend data rendering changed.
- Partial data proof: not applicable - no frontend DTO rendering changed.
- Forbidden secondary path behavior: legacy queue endpoint no longer falls back to Appointment/Visit IDs.
- Missing draft/resource behavior: not applicable - no drafts or resources are created.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/registrar_integration.py`, `backend/tests/integration/test_registrar_record_actions.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read-model code, frontend runtime files, migrations, unrelated registrar flows.
- Migration/docs/test impact: no migration; no docs required; targeted backend tests updated.
- Rollback note: revert commit `401a6cb2` to restore previous legacy fallback behavior.

## Validation

- Targeted tests or smoke run: `py -3 -m py_compile backend\\app\\api\\v1\\endpoints\\registrar_integration.py backend\\tests\\integration\\test_registrar_record_actions.py`; `py -3 -m pytest backend\\tests\\integration\\test_registrar_record_actions.py`; `py -3 -m pytest backend\\tests\\integration\\test_registrar_all_appointments.py backend\\tests\\integration\\test_registrar_record_actions.py`; `git diff --check`.
- Result: all local validation passed; combined targeted pytest result was 8 passed, 1 warning.
- Not checked: full backend suite and frontend build, because this PR changes only backend endpoint/test contract and no frontend files.