### PR TITLE
fix(doctor): avoid complete id collision

### DIFF
--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -647,10 +647,7 @@ def complete_patient_visit(
             # If the numeric ID collides with an unrelated queue entry, do not
             # mutate the queue entry; allow the typed legacy fallback below.
             logger.warning(
-                "complete_patient_visit: queue entry id %s belongs to patient %s, request payload targets patient %s; trying legacy record fallback",
-                entry_id,
-                queue_entry.patient_id,
-                requested_patient_id,
+                "complete_patient_visit: route id matched a queue entry for a different patient than the request payload; trying legacy record fallback"
             )
             queue_entry = None
 

--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -627,6 +627,32 @@ def complete_patient_visit(
         queue_entry = (
             db.query(OnlineQueueEntry).filter(OnlineQueueEntry.id == entry_id).first()
         )
+        requested_patient_id = None
+        if isinstance(visit_data, dict):
+            raw_patient_id = visit_data.get("patient_id")
+            try:
+                requested_patient_id = (
+                    int(raw_patient_id) if raw_patient_id is not None else None
+                )
+            except (TypeError, ValueError):
+                requested_patient_id = None
+
+        if (
+            queue_entry
+            and requested_patient_id is not None
+            and queue_entry.patient_id is not None
+            and queue_entry.patient_id != requested_patient_id
+        ):
+            # Some legacy doctor flows pass appointment/visit IDs to this route.
+            # If the numeric ID collides with an unrelated queue entry, do not
+            # mutate the queue entry; allow the typed legacy fallback below.
+            logger.warning(
+                "complete_patient_visit: queue entry id %s belongs to patient %s, request payload targets patient %s; trying legacy record fallback",
+                entry_id,
+                queue_entry.patient_id,
+                requested_patient_id,
+            )
+            queue_entry = None
 
         visit = None
         if not queue_entry:

--- a/backend/tests/integration/test_doctor_general_queue.py
+++ b/backend/tests/integration/test_doctor_general_queue.py
@@ -5,6 +5,7 @@ from datetime import date
 import pytest
 
 from app.models.clinic import Doctor
+from app.models.appointment import Appointment
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.patient import Patient
 from app.models.visit import Visit
@@ -247,6 +248,93 @@ class TestDoctorGeneralQueue:
         db_session.refresh(unrelated_visit)
         assert entry.status == "served"
         assert unrelated_visit.status == "open"
+
+    def test_complete_does_not_mutate_unrelated_queue_entry_on_appointment_collision(
+        self,
+        client,
+        db_session,
+        test_doctor_user,
+        test_patient,
+    ):
+        doctor = Doctor(
+            user_id=test_doctor_user.id,
+            specialty="general",
+            active=True,
+            cabinet="101",
+        )
+        db_session.add(doctor)
+        db_session.commit()
+        db_session.refresh(doctor)
+
+        queue = DailyQueue(
+            day=date.today(),
+            specialist_id=doctor.id,
+            queue_tag="general",
+            active=True,
+        )
+        db_session.add(queue)
+        db_session.commit()
+        db_session.refresh(queue)
+
+        other_patient = Patient(
+            first_name="Collision",
+            last_name="Queue",
+            middle_name="Patient",
+            phone="+998901111111",
+            birth_date=date(1985, 4, 4),
+            address="Queue patient address",
+        )
+        db_session.add(other_patient)
+        db_session.commit()
+        db_session.refresh(other_patient)
+
+        collision_id = 9002
+        appointment = Appointment(
+            id=collision_id,
+            patient_id=test_patient.id,
+            doctor_id=doctor.id,
+            appointment_date=date.today(),
+            appointment_time="12:00",
+            status="paid",
+            visit_type="paid",
+            payment_type="cash",
+            services=["consultation"],
+        )
+        entry = OnlineQueueEntry(
+            id=collision_id,
+            queue_id=queue.id,
+            number=2,
+            patient_id=other_patient.id,
+            patient_name=other_patient.short_name(),
+            phone=other_patient.phone,
+            source="registrar",
+            status="diagnostics",
+        )
+        db_session.add_all([appointment, entry])
+        db_session.commit()
+
+        login_response = client.post(
+            "/api/v1/authentication/login",
+            json={"username": test_doctor_user.username, "password": "doctor123"},
+        )
+        assert login_response.status_code == 200
+        headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+        response = client.post(
+            f"/api/v1/doctor/queue/{collision_id}/complete",
+            json={"patient_id": test_patient.id, "notes": "appointment complete"},
+            headers=headers,
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["status"] == "completed"
+
+        db_session.refresh(appointment)
+        db_session.refresh(entry)
+        assert appointment.status == "completed"
+        assert entry.status == "diagnostics"
 
     def test_cardiologist_role_can_complete_queue_entry(
         self,


### PR DESCRIPTION
## Summary

- Guard `POST /api/v1/doctor/queue/{entry_id}/complete` against cross-table id collisions when legacy doctor flows pass an appointment/visit id with a patient payload.
- If the route id resolves to a queue entry for a different patient than the request payload, skip mutating that queue entry and allow the legacy Visit/Appointment fallback to handle the intended record.
- Add regression coverage proving appointment completion does not mutate an unrelated queue entry with the same numeric id.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/doctor-complete-id-collision` created from current `origin/main` after PR #1230.
- Clean workspace: inspected before edits; only scoped doctor endpoint and targeted backend test changed.
- Branch: `codex/doctor-complete-id-collision`.
- Scope gate: agent gate used narrow overrides for `backend/app/api/v1/endpoints/doctor_integration.py` and `backend/tests/integration/test_doctor_general_queue.py`.
- Red-check handling: local targeted tests are green before PR; CI checks will be fixed in this PR before merge if they fail.

## Contract Impact

- Canonical surface: `POST /api/v1/doctor/queue/{entry_id}/complete`.
- Request shape: unchanged; optional JSON body may include `patient_id` as existing doctor EMR save flows already do.
- Response shape: unchanged for successful queue, visit, and appointment completion paths.
- Status codes: unchanged for valid requests; wrong-record queue mutation is avoided when body patient_id proves the route id collision targets another patient.
- Frontend consumer: no frontend runtime code changed; existing doctor panels already send patient_id in complete payloads.
- Compatibility path or alias: legacy Visit/Appointment fallback remains, but no longer mutates an unrelated queue entry when patient_id proves the mismatch.
- Contract proof: targeted backend regression tests cover both queue-entry-preferred collision and appointment-payload collision.

## RBAC / Permissions

- Roles allowed: unchanged from existing doctor complete endpoint role dependency.
- Roles denied: unchanged from existing endpoint role dependency.
- Positive auth proof: targeted tests use doctor/cardiologist auth successfully for allowed queue completion.
- Negative auth proof: not changed in this PR; role dependency behavior is untouched.

## Notification / Realtime

not applicable - no notification, websocket, queue broadcast, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering changed.
- Partial data proof: not applicable - no frontend DTO rendering changed.
- Forbidden secondary path behavior: mismatched patient payload no longer completes an unrelated queue entry on numeric id collision.
- Missing draft/resource behavior: not applicable - no drafts or resources are created.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/doctor_integration.py`, `backend/tests/integration/test_doctor_general_queue.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read-model code, frontend runtime files, migrations, unrelated doctor/registrar flows.
- Migration/docs/test impact: no migration; no docs required; targeted backend tests updated.
- Rollback note: revert commit `9420eec9` to restore previous doctor complete collision behavior.

## Validation

- Targeted tests or smoke run: `py -3 -m py_compile backend\\app\\api\\v1\\endpoints\\doctor_integration.py backend\\tests\\integration\\test_doctor_general_queue.py`; `py -3 -m pytest backend\\tests\\integration\\test_doctor_general_queue.py`; `py -3 -m pytest backend\\tests\\integration\\test_doctor_general_queue.py backend\\tests\\integration\\test_registrar_record_actions.py`; `git diff --check`.
- Result: all local validation passed; combined targeted pytest result was 11 passed, 1 warning.
- Not checked: full backend suite and frontend build, because this PR changes only backend endpoint/test contract and no frontend files.