### PR TITLE
fix(doctor): preserve appointment id contract

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -2691,7 +2691,7 @@ def get_today_queues(
 
                 # [OK] УПРОЩЕНО: Добавляем appointment_id для Visit (если был создан соответствующий Appointment)
                 # Используем проверки вместо try/except (Single Source of Truth)
-                appointment_id_value = record_id
+                appointment_id_value = record_id if entry_type == "appointment" else None
                 if entry_type == "visit" and patient_id:
                     # Проверяем, есть ли Appointment для этого Visit
                     visit_date = getattr(entry_data, 'visit_date', None) or today

--- a/backend/tests/integration/test_registrar_all_appointments.py
+++ b/backend/tests/integration/test_registrar_all_appointments.py
@@ -183,6 +183,7 @@ class TestRegistrarAllAppointments:
         assert found_entry["id"] == entry.id
         assert found_entry["canonical_record_id"] == entry.id
         assert found_entry["record_kind"] == "online_queue"
+        assert found_entry["appointment_id"] is None
         assert found_entry["source_kind"] == "desk"
         assert found_entry["canonical_status"] == "waiting"
         assert found_entry["queue_status"] == "waiting"

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -423,8 +423,8 @@ const MacOSCardiologistPanelUnified = () => {
   };
 
   const ensureCanonicalVisitId = useCallback(async (row) => {
-    const appointmentId = row?.appointment_id || row?.id;
-    const visitId = row?.visit_id || await resolveCanonicalVisitId(appointmentId);
+    const appointmentId = row?.appointment_id || null;
+    const visitId = row?.visit_id || (appointmentId ? await resolveCanonicalVisitId(appointmentId) : null);
 
     if (visitId) {
       setAppointments((prev) => prev.map((appointment) =>
@@ -462,7 +462,7 @@ const MacOSCardiologistPanelUnified = () => {
         return prev;
       }
 
-      const nextAppointmentId = matchingAppointment.appointment_id || matchingAppointment.id || prev?.appointment_id || null;
+      const nextAppointmentId = matchingAppointment.appointment_id || prev?.appointment_id || null;
       const nextVisitId = matchingAppointment.visit_id || visitIdFromUrl || prev?.visit_id || null;
       const nextPatientName = matchingAppointment.patient_fio || prev?.patient_name || prev?.patient_fio || '';
       const nextPatient = {
@@ -544,8 +544,8 @@ const MacOSCardiologistPanelUnified = () => {
           data.queues.forEach((queue) => {
             if (queue.entries) {
               queue.entries.forEach((entry) => {
-                const appointmentId = entry.appointment_id || entry.id;
-                const recordKey = `${entry.patient_id}_${appointmentId}_${queue.specialty}`;
+                const appointmentId = entry.appointment_id || null;
+                const recordKey = `${entry.patient_id}_${entry.canonical_record_id || entry.id}_${queue.specialty}`;
 
                 // Пропускаем дубликаты (один и тот же пациент с одним и тем же appointment_id в одной специальности)
                 if (seenIds.has(recordKey)) {
@@ -554,8 +554,8 @@ const MacOSCardiologistPanelUnified = () => {
                 seenIds.add(recordKey);
 
                 allAppointments.push({
-                  id: appointmentId, // Приоритет appointment_id
-                  appointment_id: appointmentId, // Явно указываем appointment_id
+                  id: entry.id,
+                  appointment_id: appointmentId,
                   visit_id: entry.visit_id || null,
                   patient_id: entry.patient_id,
                   patient_fio: entry.patient_name || `${entry.patient?.first_name || ''} ${entry.patient?.last_name || ''}`.trim(),
@@ -795,7 +795,7 @@ const MacOSCardiologistPanelUnified = () => {
   const handleAppointmentRowClick = async (row) => {
     // Можно открыть детали записи или переключиться на прием
     if (row.patient_fio) {
-      const appointmentId = row.appointment_id || row.id;
+      const appointmentId = row.appointment_id || null;
       const visitId = await ensureCanonicalVisitId(row);
       if (!visitId) {
         setMessage({ type: 'error', text: 'Не удалось определить канонический visit_id для пациента' });
@@ -803,8 +803,8 @@ const MacOSCardiologistPanelUnified = () => {
       }
 
       const patientData = {
-        id: row.id, // Это appointment ID
-        appointment_id: appointmentId, // Явно указываем appointment_id
+        id: row.id,
+        appointment_id: appointmentId,
         visit_id: visitId,
         patient_id: row.patient_id,
         patient_name: row.patient_fio,
@@ -840,7 +840,7 @@ const MacOSCardiologistPanelUnified = () => {
         break;
       case 'view_emr':{
           // Просмотр EMR для завершённой записи
-          const appointmentId = row.appointment_id || row.id;
+          const appointmentId = row.appointment_id || null;
           const visitId = await ensureCanonicalVisitId(row);
           if (!visitId) {
             setMessage({ type: 'error', text: 'Не удалось открыть EMR без канонического visit_id' });
@@ -926,7 +926,7 @@ const MacOSCardiologistPanelUnified = () => {
             // Переходим на вкладку визита для завершения
             const patient = {
               id: row.id,
-              appointment_id: row.appointment_id || row.id,
+              appointment_id: row.appointment_id || null,
               visit_id: visitId,
               patient_id: row.patient_id,
               patient_name: row.patient_fio,

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -122,7 +122,7 @@ function buildPatientsFromAppointments(appointments) {
     patientsById.set(patientId, {
       id: patientId,
       patient_id: patientId,
-      appointment_id: appointment.appointment_id || appointment.id || null,
+      appointment_id: appointment.appointment_id || null,
       visit_id: normalizeNumericId(appointment.visit_id),
       name: patientName,
       patient_name: patientName,
@@ -669,8 +669,8 @@ const DentistPanelUnified = () => {
   }, [activeTab, loadDentistryAppointments]);
 
   const ensureCanonicalVisitId = useCallback(async (row) => {
-    const appointmentId = row?.appointment_id || row?.id;
-    const visitId = row?.visit_id || await resolveCanonicalVisitId(appointmentId);
+    const appointmentId = row?.appointment_id || null;
+    const visitId = row?.visit_id || (appointmentId ? await resolveCanonicalVisitId(appointmentId) : null);
 
     if (visitId) {
       setAppointmentsTableData((prev) => prev.map((appointment) =>
@@ -703,7 +703,7 @@ const DentistPanelUnified = () => {
       // Создаем объект пациента для переключения на прием
       const patientData = {
         id: row.id,
-        appointment_id: row.appointment_id || row.id,
+        appointment_id: row.appointment_id || null,
         visit_id: visitId,
         patient_name: row.patient_fio,
         phone: row.patient_phone,
@@ -770,7 +770,7 @@ const DentistPanelUnified = () => {
 
           const patient = {
             id: row.id,
-            appointment_id: row.appointment_id || row.id,
+            appointment_id: row.appointment_id || null,
             visit_id: visitId,
             patient_name: row.patient_fio,
             phone: row.patient_phone,
@@ -962,7 +962,7 @@ const DentistPanelUnified = () => {
           const patientObj = {
             id: matchingAppointment.appointment_id || matchingAppointment.id || patientIdFromUrl || visitIdFromUrl,
             patient_id: matchingAppointment.patient_id || patientIdFromUrl || matchingAppointment.id,
-            appointment_id: matchingAppointment.appointment_id || matchingAppointment.id || null,
+            appointment_id: matchingAppointment.appointment_id || null,
             visit_id: visitIdFromUrl || normalizeNumericId(matchingAppointment.visit_id) || null,
             patient_name: patientName,
             patient_fio: patientName,

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -116,7 +116,7 @@ function buildDermatologyPatientFromAppointment(appointment) {
   return {
     id: patientId,
     patient_id: patientId,
-    appointment_id: appointment.appointment_id || appointment.id || null,
+    appointment_id: appointment.appointment_id || null,
     visit_id: normalizeNumericId(appointment.visit_id),
     patient_name: patientName,
     patient_fio: patientName,
@@ -409,7 +409,7 @@ const DermatologistPanelUnified = () => {
                 queue.entries.forEach((entry) => {
                   allAppointments.push({
                     id: entry.id,
-                    appointment_id: entry.appointment_id || entry.id,
+                    appointment_id: entry.appointment_id || null,
                     patient_id: entry.patient_id,
                     patient_fio: entry.patient_name || `${entry.patient?.first_name || ''} ${entry.patient?.last_name || ''}`.trim(),
                     patient_phone: entry.phone || '',
@@ -516,8 +516,8 @@ const DermatologistPanelUnified = () => {
   }, [activeTab, loadDermatologyAppointments]);
 
   const ensureCanonicalVisitId = useCallback(async (row) => {
-    const appointmentId = row?.appointment_id || row?.id;
-    const visitId = row?.visit_id || await resolveCanonicalVisitId(appointmentId);
+    const appointmentId = row?.appointment_id || null;
+    const visitId = row?.visit_id || (appointmentId ? await resolveCanonicalVisitId(appointmentId) : null);
 
     if (visitId) {
       setAppointments((prev) => prev.map((appointment) =>
@@ -577,8 +577,8 @@ const DermatologistPanelUnified = () => {
 
       // Создаем объект пациента для переключения на прием
       const patientData = {
-        id: row.appointment_id || row.id,
-        appointment_id: row.appointment_id || row.id,
+        id: row.id,
+        appointment_id: row.appointment_id || null,
         visit_id: normalizeNumericId(visitId),
         patient_id: row.patient_id,
         patient_name: row.patient_fio,
@@ -651,8 +651,8 @@ const DermatologistPanelUnified = () => {
           }
 
           const patient = {
-            id: row.appointment_id || row.id,
-            appointment_id: row.appointment_id || row.id,
+            id: row.id,
+            appointment_id: row.appointment_id || null,
             visit_id: normalizeNumericId(visitId),
             patient_id: row.patient_id,
             patient_name: row.patient_fio,
@@ -1004,9 +1004,7 @@ const DermatologistPanelUnified = () => {
   }, [location.search, getPatientIdFromUrl, getVisitIdFromUrl, selectedPatient?.patient_id, selectedPatient?.visit_id, currentAppointment?.visit_id, appointments, loadDermatologyAppointments]);
 
   useEffect(() => {
-    const appointmentId =
-      currentAppointment?.appointment_id ||
-      (currentAppointment?.source !== 'url' ? currentAppointment?.id : null);
+    const appointmentId = currentAppointment?.appointment_id || null;
     if (!appointmentId) {
       setEmr(null);
       setPrescription(null);
@@ -1084,7 +1082,11 @@ const DermatologistPanelUnified = () => {
 
   const savePrescription = async (prescriptionData) => {
     try {
-      const appointmentId = currentAppointment?.appointment_id || currentAppointment?.id;
+      const appointmentId = currentAppointment?.appointment_id || null;
+      if (!appointmentId) {
+        notify.error('Не удалось определить запись для сохранения рецепта');
+        return;
+      }
       const response = await fetch(`${API_V1_BASE}/appointments/${appointmentId}/prescription`, {
         method: 'POST',
         headers: {

--- a/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
@@ -67,6 +67,17 @@ describe('Doctor panels SSOT contract', () => {
     }
   });
 
+  it('does not treat queue row ids as appointment ids for legacy appointment flow', () => {
+    for (const filePath of DOCTOR_PANEL_FILES) {
+      const source = read(filePath);
+
+      expect(source).not.toContain('entry.appointment_id || entry.id');
+      expect(source).not.toContain('row?.appointment_id || row?.id');
+      expect(source).not.toContain('row.appointment_id || row.id');
+      expect(source).not.toContain('appointment.appointment_id || appointment.id');
+    }
+  });
+
   it('does not introduce BFF-lite endpoints while repairing doctor contracts', () => {
     for (const filePath of DOCTOR_PANEL_FILES) {
       const source = read(filePath);


### PR DESCRIPTION
## Summary

- Stop `/registrar/queues/today` from exposing online queue ids as `appointment_id`.
- Stop cardiology, dermatology, and dentistry panels from falling back to `row.id` or `entry.id` for legacy `/appointments/*` flows.
- Add backend and frontend contract coverage for the appointment id boundary.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/doctor-panels-appointment-id-contract` was created from current `origin/main` after PR #1231 merge.
- Clean workspace: inspected `git status` before edits; only registrar queue DTO, doctor panel consumers, and targeted tests changed.
- Branch: `codex/doctor-panels-appointment-id-contract`.
- Scope gate: used `agent_gate.py` narrow overrides for backend DTO, registrar regression test, each doctor panel, and frontend contract test.
- Red-check handling: local targeted tests/build passed; PR Review Quality Gate failure was PR body template only and this update fixes it without runtime code changes.

## Contract Impact

- Canonical surface: `GET /api/v1/registrar/queues/today`.
- Request shape: unchanged authenticated read request.
- Response shape: `appointment_id` now means real `Appointment.id` only; `online_queue` rows keep `canonical_record_id`, `record_kind`, and queue ids for queue flows.
- Status codes: unchanged.
- Frontend consumer: cardiology, dermatology, and dentistry doctor panels.
- Compatibility path or alias: legacy `/appointments/*` calls remain, but they are used only when backend provides a real `appointment_id`.
- Contract proof: backend regression asserts online queue DTO does not synthesize `appointment_id`; frontend contract test rejects `row.id` / `entry.id` appointment-id fallbacks.

## RBAC / Permissions

not applicable - no roles, permissions, auth dependency, or access policy changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, display board, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: unchanged; panels already handle missing `visit_id` by showing existing error/stop paths.
- Partial data proof: missing `appointment_id` no longer causes legacy appointment-flow calls with queue ids.
- Forbidden secondary path behavior: legacy appointment fallback through `row.id` is removed.
- Missing draft/resource behavior: dermatology prescription save now stops when no real appointment id exists instead of writing through a guessed id.
- Stale route/deep-link behavior: URL/deep-link visit flows rely on `visit_id` and do not synthesize appointment ids.

## Scope Gate

- Allowed paths: `registrar_integration.py`, registrar integration test, cardiology/dermatology/dentistry panels, doctor panel contract test.
- Denied paths: `/api/v1/ui/*`, BFF-lite, separate BFF service, command wrappers, migrations, unrelated panels.
- Migration/docs/test impact: no migration; targeted backend/frontend tests updated.
- Rollback note: revert this PR to restore previous synthetic `appointment_id` behavior and frontend fallbacks.

## Validation

- Targeted tests or smoke run: `py -3 -m py_compile backend\\app\\api\\v1\\endpoints\\registrar_integration.py backend\\tests\\integration\\test_registrar_all_appointments.py`; `py -3 -m pytest backend\\tests\\integration\\test_registrar_all_appointments.py`; `npm --prefix frontend run test:run -- src/pages/__tests__/DoctorPanels.contract.test.jsx`; `npm --prefix frontend run build`; `git diff --check`.
- Result: passed locally.
- Not checked: manual browser doctor-panel smoke; full backend suite beyond targeted registrar integration test.