### PR TITLE
fix(registrar): require visit id for reschedule

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -865,7 +865,7 @@ const RegistrarPanel = () => {
   const [showSlotsModal, setShowSlotsModal] = useState(false);
   const autoRefresh = true; // Новые состояния для интеграции с админ панелью
   const resolveRescheduleVisitId = useCallback((appointmentRow) => {
-    return appointmentRow?.visit_ids?.[0] || appointmentRow?.visit_id || appointmentRow?.visitId || appointmentRow?.appointment_id || appointmentRow?.appointment_ids?.[0] || appointmentRow?.id || null;
+    return appointmentRow?.visit_ids?.[0] || appointmentRow?.visit_id || appointmentRow?.visitId || null;
   }, []);
   const removeRescheduledAppointmentFromView = useCallback((appointmentRow, visitId) => {
     if (!appointmentRow) return;
@@ -1344,7 +1344,7 @@ const RegistrarPanel = () => {
               record_kind: fullEntry.record_kind ?? entry.record_kind ?? null,
               source_kind: fullEntry.source_kind ?? entry.source_kind ?? null,
               visit_id: fullEntry.visit_id || entry.visit_id || null,
-              appointment_id: fullEntry.appointment_id || entry.appointment_id || entryId,
+              appointment_id: fullEntry.appointment_id || entry.appointment_id || null,
               queue_entry_id: fullEntry.queue_entry_id || entry.queue_entry_id || null,
               patient_id: fullEntry.patient_id || entry.patient_id,
               patient_fio: fullEntry.patient_fio ?? fullEntry.patient_name ?? entry.patient_fio ?? entry.patient_name ?? 'Неизвестный пациент',
@@ -3815,6 +3815,10 @@ const RegistrarPanel = () => {
               try {
                 setShowSlotsModal(false);
                 const targetVisitId = resolveRescheduleVisitId(rescheduleData);
+                if (!targetVisitId) {
+                  notify.error('Cannot reschedule without a canonical visit id');
+                  return;
+                }
                 logger.info(`Перенос визита ${targetVisitId} на завтра`);
                 await rescheduleTomorrow(targetVisitId);
                 notify.success('Визит успешно перенесен на завтра');
@@ -3848,6 +3852,10 @@ const RegistrarPanel = () => {
               try {
                 setShowSlotsModal(false);
                 const targetVisitId = resolveRescheduleVisitId(rescheduleData);
+                if (!targetVisitId) {
+                  notify.error('Cannot reschedule without a canonical visit id');
+                  return;
+                }
                 logger.info(`Перенос визита ${targetVisitId} на ${dateStr}`);
                 await rescheduleVisit(targetVisitId, dateStr);
                 notify.success(`Визит перенесен на ${dateStr}`);

--- a/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
@@ -160,5 +160,24 @@ describe('RegistrarPanel command contract', () => {
     expect(source).toContain('const sortedAggregated = sortRegistrarRowsForPresentation(aggregatedPatients)');
     expect(source).toContain('return sortRegistrarRowsForPresentation(appointments)');
   });
+
+  it('does not use appointment or queue ids as visit ids for reschedule commands', () => {
+    const source = readRegistrarPanelSource();
+    const resolverBlock = extractSourceBlock(
+      source,
+      'const resolveRescheduleVisitId = useCallback((appointmentRow) => {',
+      'const removeRescheduledAppointmentFromView = useCallback',
+    );
+
+    expect(source).toContain('appointment_id: fullEntry.appointment_id || entry.appointment_id || null');
+    expect(source).not.toContain('appointment_id: fullEntry.appointment_id || entry.appointment_id || entryId');
+    expect(resolverBlock).toContain('appointmentRow?.visit_ids?.[0]');
+    expect(resolverBlock).toContain('appointmentRow?.visit_id');
+    expect(resolverBlock).toContain('appointmentRow?.visitId');
+    expect(resolverBlock).not.toContain('appointment_id');
+    expect(resolverBlock).not.toContain('appointment_ids');
+    expect(resolverBlock).not.toContain('appointmentRow?.id');
+    expect(source).toContain('Cannot reschedule without a canonical visit id');
+  });
 });
 


### PR DESCRIPTION
## Summary

- Fix Registrar context-menu reschedule so it only targets canonical visit ids.
- Stop adapting online queue row ids into `appointment_id` when the backend did not provide a real appointment id.
- Add a frontend contract test covering the id-boundary invariant.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` at `b8065421`.
- Clean workspace: inspected before edits; only `RegistrarPanel.jsx` and its focused contract test changed.
- Branch: `codex/registrar-reschedule-visit-id-contract`.
- Scope gate: allowed Registrar frontend id-boundary repair and targeted contract test; denied backend queue/service rewrites, migrations, generated output, and BFF-lite endpoints.
- Red-check handling: PR Review Quality Gate failed on missing PR template sections; this body update fills the required sections before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/visits/visits/{visit_id}/reschedule` and `/reschedule/tomorrow` require a real `Visit.id`.
- Request shape: authenticated registrar/admin POST with `visit_id` path parameter and optional `new_date` query for date reschedule.
- Response shape: unchanged `VisitOut` response from the visits endpoint.
- Status codes: unchanged backend behavior; frontend no longer sends a request when no canonical visit id exists.
- Frontend consumer: Registrar context-menu reschedule modal.
- Compatibility path or alias: legacy `appointment_id`/row `id` fallback removed for reschedule targeting; `appointment_id` is preserved only when backend provides it.
- Contract proof: `RegistrarPanel.contract.test.jsx` asserts no appointment/queue id fallback is used as a visit id.

## RBAC / Permissions

not applicable - no backend permission, role, dependency, or route guard changed; existing visits endpoint RBAC remains the enforcement point.

## Notification / Realtime

not applicable - no notification, websocket, display-board, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: rows without `visit_id` now show a local error and skip the reschedule API call.
- Partial data proof: queue rows with `queue_entry_id` but no canonical `visit_id` no longer fabricate `appointment_id` from row id.
- Forbidden secondary path behavior: no secondary/fallback id path remains for reschedule.
- Missing draft/resource behavior: not applicable, no draft/resource creation path changed.
- Stale route/deep-link behavior: not applicable, reschedule target is taken from the selected row only.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`, `frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx`.
- Denied paths: backend endpoints/services, migrations, generated `dist`, BFF-lite/UI endpoints, unrelated doctor/cashier/lab panels.
- Migration/docs/test impact: no migration; targeted frontend contract test updated.
- Rollback note: revert commit `82bc2554` to restore previous frontend reschedule fallback behavior.

## Validation

- Targeted tests or smoke run: `npm --prefix frontend run test:run -- src/pages/__tests__/RegistrarPanel.contract.test.jsx src/pages/__tests__/DoctorPanels.contract.test.jsx`; `git diff --check`; `npm --prefix frontend run build`.
- Result: passed locally.
- Not checked: full browser smoke and backend pytest, because the patch is frontend-only and does not change backend routes or persistence.