### PR TITLE
fix(registrar): preserve aggregation id contract

### DIFF
--- a/frontend/src/utils/__tests__/registrarAggregation.test.js
+++ b/frontend/src/utils/__tests__/registrarAggregation.test.js
@@ -5,6 +5,10 @@ import {
   sortRegistrarRowsForPresentation
 } from '../registrarAggregation';
 
+const pickOverride = (overrides, key, fallback) => (
+  Object.prototype.hasOwnProperty.call(overrides, key) ? overrides[key] : fallback
+);
+
 const makeAppointment = (overrides = {}) => ({
   id: overrides.id ?? 1,
   patient_id: overrides.patient_id ?? 10,
@@ -12,8 +16,8 @@ const makeAppointment = (overrides = {}) => ({
   patient_birth_year: overrides.patient_birth_year ?? 1990,
   patient_phone: overrides.patient_phone ?? '+998900000000',
   address: overrides.address ?? 'Тестовый адрес',
-  visit_id: overrides.visit_id ?? overrides.id ?? 1,
-  appointment_id: overrides.appointment_id ?? overrides.id ?? 1,
+  visit_id: pickOverride(overrides, 'visit_id', overrides.id ?? 1),
+  appointment_id: pickOverride(overrides, 'appointment_id', overrides.id ?? 1),
   queue_entry_id: overrides.queue_entry_id ?? null,
   visit_type: overrides.visit_type ?? null,
   payment_type: overrides.payment_type ?? null,
@@ -170,6 +174,33 @@ describe('aggregatePatientsForAllDepartments', () => {
         can_start_visit: true,
         can_cancel: false,
       },
+    ]);
+  });
+
+  it('does not synthesize visit or appointment ids from online queue row ids', () => {
+    const result = aggregatePatientsForAllDepartments([
+      makeAppointment({
+        id: 900001,
+        record_kind: 'online_queue',
+        record_type: 'online_queue',
+        canonical_record_id: 900001,
+        visit_id: null,
+        appointment_id: null,
+        queue_entry_id: 900001,
+        available_actions: ['cancel'],
+        can_cancel: true,
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].visit_id).toBeNull();
+    expect(result[0].appointment_id).toBeNull();
+    expect(result[0].visit_ids).toEqual([]);
+    expect(result[0].appointment_ids).toEqual([]);
+    expect(result[0].queue_entry_id).toBe(900001);
+    expect(result[0].queue_entry_ids).toEqual([900001]);
+    expect(result[0].grouped_record_refs).toEqual([
+      { record_kind: 'online_queue', record_id: 900001 },
     ]);
   });
 

--- a/frontend/src/utils/registrarAggregation.js
+++ b/frontend/src/utils/registrarAggregation.js
@@ -34,6 +34,10 @@ const normalizeRecordKind = (appointment) => String(
   appointment?.record_kind ?? appointment?.source_kind ?? appointment?.record_type ?? appointment?.type ?? ''
 ).trim().toLowerCase();
 
+const pickCanonicalVisitId = (appointment) => appointment?.visit_id ?? appointment?.visitId ?? null;
+
+const pickCanonicalAppointmentId = (appointment) => appointment?.appointment_id ?? null;
+
 const buildRecordRef = (appointment) => {
   const recordKind = normalizeRecordKind(appointment);
   const recordId = appointment?.canonical_record_id
@@ -78,16 +82,17 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
     const recordRef = buildRecordRef(appointment);
 
     if (!patientGroups[patientKey]) {
-      const initialVisitId = appointment.visit_id || appointment.visitId || appointment.id;
+      const initialVisitId = pickCanonicalVisitId(appointment);
+      const initialAppointmentId = pickCanonicalAppointmentId(appointment);
       const initialQueueEntryId = appointment.queue_entry_id || appointment.queue_numbers?.[0]?.id || null;
 
       patientGroups[patientKey] = {
         id: appointment.id,
         visit_id: initialVisitId,
-        appointment_id: appointment.appointment_id || appointment.id,
+        appointment_id: initialAppointmentId,
         queue_entry_id: initialQueueEntryId,
         visit_ids: initialVisitId !== null && initialVisitId !== undefined ? [initialVisitId] : [],
-        appointment_ids: appointment.id !== null && appointment.id !== undefined ? [appointment.id] : [],
+        appointment_ids: initialAppointmentId !== null && initialAppointmentId !== undefined ? [initialAppointmentId] : [],
         queue_entry_ids: initialQueueEntryId !== null && initialQueueEntryId !== undefined ? [initialQueueEntryId] : [],
         patient_id: appointment.patient_id,
         patient_fio: appointment.patient_fio,
@@ -128,7 +133,8 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
       patientGroups[patientKey].aggregated_ids.push(...newIds);
       patientGroups[patientKey].aggregated_ids = [...new Set(patientGroups[patientKey].aggregated_ids)];
 
-      const nextVisitId = appointment.visit_id || appointment.visitId || appointment.id;
+      const nextVisitId = pickCanonicalVisitId(appointment);
+      const nextAppointmentId = pickCanonicalAppointmentId(appointment);
       const nextQueueEntryId = appointment.queue_entry_id || appointment.queue_numbers?.[0]?.id || null;
 
       if (nextVisitId !== null && nextVisitId !== undefined) {
@@ -139,11 +145,11 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
         }
       }
 
-      if (appointment.id !== null && appointment.id !== undefined) {
-        patientGroups[patientKey].appointment_ids.push(appointment.id);
+      if (nextAppointmentId !== null && nextAppointmentId !== undefined) {
+        patientGroups[patientKey].appointment_ids.push(nextAppointmentId);
         patientGroups[patientKey].appointment_ids = [...new Set(patientGroups[patientKey].appointment_ids)];
         if (!patientGroups[patientKey].appointment_id) {
-          patientGroups[patientKey].appointment_id = appointment.id;
+          patientGroups[patientKey].appointment_id = nextAppointmentId;
         }
       }
 


### PR DESCRIPTION
## Summary

- Stop registrar all-departments aggregation from copying a generic row `id` into `visit_id` / `appointment_id` buckets.
- Preserve `OnlineQueueEntry.id` only as `queue_entry_id` / `queue_entry_ids` for `online_queue` rows without canonical visit or appointment ids.
- Add a regression test so reschedule flows cannot receive a fabricated `Visit.id` through aggregation.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` / `codex/current-main-view` at `e227eda7` after PR #1233 was merged.
- Clean workspace: inspected before edits; only `frontend/src/utils/registrarAggregation.js` and `frontend/src/utils/__tests__/registrarAggregation.test.js` changed.
- Branch: `codex/registrar-aggregation-id-contract`.
- Scope gate: agent gate was run with known root cause `frontend/src/utils/registrarAggregation.js`; result was `narrow_override` for the aggregation utility and targeted regression test only.
- Red-check handling: fix any failed targeted tests or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: frontend `aggregatePatientsForAllDepartments` row aggregation contract feeding registrar context actions.
- Request shape: not changed; no API request payloads changed.
- Response shape: not changed; frontend aggregation now preserves canonical id meaning instead of fabricating ids locally.
- Status codes: not changed; no backend endpoints or HTTP status behavior changed.
- Frontend consumer: registrar all-departments table/context-menu flows, especially reschedule action gating.
- Compatibility path or alias: legacy/queue rows remain supported through `queue_entry_id`, `queue_entry_ids`, and `grouped_record_refs`; generic row `id` is not a compatibility alias for visit or appointment ids.
- Contract proof: targeted aggregation regression plus registrar/doctor panel contract tests.

## RBAC / Permissions

- Roles allowed: not changed; frontend-only aggregation utility does not alter backend role checks.
- Roles denied: not changed; no protected route or permission policy changed.
- Positive auth proof: not applicable because no backend auth path changed.
- Negative auth proof: not applicable because no backend auth path changed.

## Notification / Realtime

- Event type or websocket channel: not applicable because no notification, websocket, polling, or realtime channel changed.
- Payload version / ack behavior: not applicable because no realtime payloads changed.
- Read/unread or delivery semantics: not applicable because no notification delivery state changed.
- Reconnect/resync proof: not applicable because no realtime reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: targeted aggregation test confirms online queue rows without canonical visit/appointment ids produce empty `visit_ids` and `appointment_ids` arrays.
- Partial data proof: online queue row with queue id but missing visit/appointment id remains usable through queue-only fields.
- Forbidden secondary path behavior: rows without real `visit_id` continue to be rejected by the existing registrar reschedule guard instead of calling a wrong visit endpoint.
- Missing draft/resource behavior: not applicable because aggregation does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable because aggregation does not read route or deep-link state.

## Scope Gate

- Allowed paths: `frontend/src/utils/registrarAggregation.js`, `frontend/src/utils/__tests__/registrarAggregation.test.js`.
- Denied paths: backend endpoints, DB/Alembic, `/api/v1/ui/*`, BFF-lite/read-models, unrelated doctor panels, generated artifacts, styling-only changes.
- Migration/docs/test impact: no migration or docs change; one targeted frontend regression test updated.
- Rollback note: revert this PR to restore previous aggregation behavior and remove the regression test.

## Validation

- Targeted tests or smoke run: `npm --prefix frontend run test:run -- src/utils/__tests__/registrarAggregation.test.js src/pages/__tests__/RegistrarPanel.contract.test.jsx src/pages/__tests__/DoctorPanels.contract.test.jsx`; `git diff --check`; `npm --prefix frontend run build`.
- Result: all passed locally.
- Not checked: backend pytest, browser smoke, full frontend E2E.