### PR TITLE
fix: improve demo seed ui smoke coverage

### DIFF
--- a/backend/app/api/v1/endpoints/cashier.py
+++ b/backend/app/api/v1/endpoints/cashier.py
@@ -27,6 +27,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+CASHIER_PENDING_EXCLUDED_VISIT_STATUSES = (
+    "canceled",
+    "cancelled",
+    "paid",
+    "completed",
+    "done",
+    "closed",
+)
+
+
 def _preserve_cashier_visit_status(raw_status: str | None) -> str:
     """Payment belongs to Payment/discount_mode; legacy visit.status='paid' becomes operational waiting."""
     if not raw_status or raw_status == "paid":
@@ -287,7 +297,7 @@ async def get_pending_payments(
         
         # Базовый запрос - получаем все визиты (не отменённые и не оплаченные)
         # Исключаем визиты со статусами: canceled, paid, completed, done, closed
-        excluded_statuses = ["canceled", "cancelled", "paid", "completed", "done", "closed"]
+        excluded_statuses = CASHIER_PENDING_EXCLUDED_VISIT_STATUSES
         
         # ✅ ОПТИМИЗАЦИЯ: Используем joinedload для eager loading services
         # Примечание: Visit.patient relationship не существует, поэтому используем batch loading
@@ -544,7 +554,9 @@ async def get_cashier_stats(
 
         
         # Считаем pending из Visit
-        pending_query = db.query(Visit).filter(Visit.status != "canceled")
+        pending_query = db.query(Visit).options(joinedload(Visit.services)).filter(
+            ~Visit.status.in_(CASHIER_PENDING_EXCLUDED_VISIT_STATUSES)
+        )
         if date_from:
             pending_query = pending_query.filter(Visit.created_at >= datetime.combine(date_from, datetime.min.time()))
         if date_to:

--- a/backend/app/scripts/dev_seed.py
+++ b/backend/app/scripts/dev_seed.py
@@ -22,6 +22,11 @@ DEMO_MARKER = "DEV-DEMO"
 DEMO_TIMEZONE = "Asia/Tashkent"
 DEFAULT_DEMO_PASSCODE_PREFIX = "demo"
 DEFAULT_DEMO_PASSCODE_SUFFIX = str(10_000 + 2_345)
+QUEUE_TAG_ALIASES = {
+    "cardiology": ("cardiology", "cardio"),
+    "dermatology": ("dermatology", "derma"),
+    "dental": ("dental", "dentistry"),
+}
 
 
 @dataclass(frozen=True)
@@ -500,6 +505,7 @@ def _upsert_visit(
     from app.models.visit import Visit, VisitService
 
     notes = f"{DEMO_MARKER}:{marker}"
+    created_at = datetime.combine(date.today(), time.fromisoformat(visit_time))
     visit = db.query(Visit).filter(Visit.notes == notes).first()
     if visit is None:
         visit = Visit(patient_id=patient.id, notes=notes)
@@ -510,6 +516,7 @@ def _upsert_visit(
     visit.status = status
     visit.visit_date = date.today()
     visit.visit_time = visit_time
+    visit.created_at = created_at
     visit.department = department_key
     visit.department_id = doctor.department_id
     visit.source = "desk"
@@ -535,13 +542,15 @@ def _upsert_visit(
 def _upsert_daily_queue(db: Session, *, doctor: Any, queue_tag: str, cabinet: str) -> Any:
     from app.models.online_queue import DailyQueue
 
+    candidate_tags = QUEUE_TAG_ALIASES.get(queue_tag, (queue_tag,))
     queue = (
         db.query(DailyQueue)
         .filter(
             DailyQueue.day == date.today(),
             DailyQueue.specialist_id == doctor.id,
-            DailyQueue.queue_tag == queue_tag,
+            DailyQueue.queue_tag.in_(candidate_tags),
         )
+        .order_by(DailyQueue.id.asc())
         .first()
     )
     if queue is None:
@@ -552,6 +561,7 @@ def _upsert_daily_queue(db: Session, *, doctor: Any, queue_tag: str, cabinet: st
         )
         db.add(queue)
     queue.active = True
+    queue.queue_tag = queue_tag
     queue.opened_at = datetime.utcnow() - timedelta(hours=1)
     queue.cabinet_number = cabinet
     queue.cabinet_floor = 2
@@ -624,16 +634,17 @@ def _upsert_payment(
         db.add(payment)
         db.flush()
     payment.visit_id = visit.id
+    payment.created_at = visit.created_at or datetime.now()
     payment.amount = amount
     payment.currency = "UZS"
     payment.method = method
     payment.status = status
     payment.note = f"{DEMO_MARKER} {status} payment"
-    payment.paid_at = datetime.utcnow() if status in {"paid", "refunded"} else None
+    payment.paid_at = payment.created_at if status in {"paid", "refunded"} else None
     if status == "refunded":
         payment.refunded_amount = amount
         payment.refund_reason = "Demo refund scenario"
-        payment.refunded_at = datetime.utcnow()
+        payment.refunded_at = payment.created_at
         payment.refunded_by = cashier_id
     else:
         payment.refunded_amount = None
@@ -691,6 +702,16 @@ def seed_visits_queues_payments(
             service=services["S01"],
             status="closed",
             visit_time="11:00",
+        ),
+        "dentist_waiting": _upsert_visit(
+            db,
+            marker="visit-dentist-waiting",
+            patient=patients["DEMO-PAT-008"],
+            doctor=doctors["dentist@example.com"],
+            department_key="dental",
+            service=services["S01"],
+            status="open",
+            visit_time="11:30",
         ),
         "emr_draft": _upsert_visit(
             db,
@@ -771,6 +792,41 @@ def seed_visits_queues_payments(
         visit=visits["emr_signed"],
         service=services["K01"],
         status="served",
+    )
+
+    derma_queue = _upsert_daily_queue(
+        db,
+        doctor=doctors["derma@example.com"],
+        queue_tag="dermatology",
+        cabinet="301",
+    )
+    dentist_queue = _upsert_daily_queue(
+        db,
+        doctor=doctors["dentist@example.com"],
+        queue_tag="dental",
+        cabinet="401",
+    )
+    _commit(db)
+
+    _upsert_queue_entry(
+        db,
+        queue=derma_queue,
+        number=1,
+        marker="queue-derma-waiting",
+        patient=patients["DEMO-PAT-002"],
+        visit=visits["unpaid"],
+        service=services["D01"],
+        status="waiting",
+    )
+    _upsert_queue_entry(
+        db,
+        queue=dentist_queue,
+        number=1,
+        marker="queue-dentist-waiting",
+        patient=patients["DEMO-PAT-008"],
+        visit=visits["dentist_waiting"],
+        service=services["S01"],
+        status="waiting",
     )
 
     _upsert_payment(

--- a/frontend/src/components/QueueIntegration.jsx
+++ b/frontend/src/components/QueueIntegration.jsx
@@ -5,12 +5,36 @@ import { fetchAvailableSpecialists } from '../api/queue';
 import auth from '../stores/auth.js';
 import logger from '../utils/logger';
 
+const QUEUE_SPECIALTY_ALIASES = {
+  cardiology: ['cardiology', 'cardio'],
+  cardio: ['cardiology', 'cardio'],
+  dermatology: ['dermatology', 'derma'],
+  derma: ['dermatology', 'derma'],
+  dentistry: ['dentistry', 'dental', 'dentist', 'stomatology'],
+  dental: ['dentistry', 'dental', 'dentist', 'stomatology'],
+  dentist: ['dentistry', 'dental', 'dentist', 'stomatology'],
+};
+
+function normalizeQueueSpecialty(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function matchesQueueSpecialty(item, requestedSpecialty) {
+  const normalizedRequested = normalizeQueueSpecialty(requestedSpecialty);
+  if (!normalizedRequested) return false;
+
+  const aliases = QUEUE_SPECIALTY_ALIASES[normalizedRequested] || [normalizedRequested];
+  const itemSpecialty = normalizeQueueSpecialty(item?.specialty || item?.department);
+  return aliases.includes(itemSpecialty);
+}
+
 /**
  * Легкий адаптер, который подключает макос-панели к новому ModernQueueManager.
  * Вся бизнес-логика очереди вынесена на backend и в кастомные хуки.
  */
 const QueueIntegration = ({
   specialistId = '',
+  specialty = '',
   onPatientSelect,
   onStartVisit,
 }) => {
@@ -64,8 +88,17 @@ const QueueIntegration = ({
       }
     }
 
+    if (specialty) {
+      const matchedBySpecialty = availableSpecialists.find((item) =>
+        matchesQueueSpecialty(item, specialty)
+      );
+      if (matchedBySpecialty) {
+        return matchedBySpecialty;
+      }
+    }
+
     return availableSpecialists[0] || null;
-  }, [availableSpecialists, authProfile?.doctor_id, authProfile?.specialist_id, specialistId]);
+  }, [availableSpecialists, authProfile?.doctor_id, authProfile?.specialist_id, specialistId, specialty]);
 
   const queueDoctors = useMemo(() => (
     availableSpecialists.map((item) => ({
@@ -104,6 +137,7 @@ const QueueIntegration = ({
 QueueIntegration.propTypes = {
   specialist: PropTypes.string,
   department: PropTypes.string,
+  specialty: PropTypes.string,
   onPatientSelect: PropTypes.func,
   onStartVisit: PropTypes.func,
   specialistId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/frontend/src/components/laboratory/LabQueueWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabQueueWorkbench.jsx
@@ -72,11 +72,11 @@ function historySeverityBadge(item) {
 
 export default function LabQueueWorkbench({
   appointments,
-  loading,
+  loading = false,
   onRefresh,
   onOpenAppointment,
-  selectedAppointment,
-  reportHistory
+  selectedAppointment = null,
+  reportHistory = []
 }) {
   return (
     <div style={{ display: 'grid', gap: '16px' }}>
@@ -241,10 +241,4 @@ LabQueueWorkbench.propTypes = {
   onOpenAppointment: PropTypes.func.isRequired,
   selectedAppointment: PropTypes.object,
   reportHistory: PropTypes.array
-};
-
-LabQueueWorkbench.defaultProps = {
-  loading: false,
-  selectedAppointment: null,
-  reportHistory: []
 };

--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -245,18 +245,18 @@ function buildLabPrintPayload(instance, appointment) {
 }
 
 export default function LabReportWorkbench({
-  selectedAppointment,
+  selectedAppointment = null,
   templates,
-  templateResolution,
-  templateResolutionLoading,
-  reportHistory,
-  recentReports,
-  activeInstance,
+  templateResolution = null,
+  templateResolutionLoading = false,
+  reportHistory = [],
+  recentReports = [],
+  activeInstance = null,
   onInstanceChange,
   onOpenInstance,
   onRefreshHistory,
-  onRefreshRecentReports,
-  onQueueChanged,
+  onRefreshRecentReports = undefined,
+  onQueueChanged = undefined,
   notify
 }) {
   const [selectedTemplateId, setSelectedTemplateId] = useState('');
@@ -1011,15 +1011,4 @@ LabReportWorkbench.propTypes = {
   onRefreshRecentReports: PropTypes.func,
   onQueueChanged: PropTypes.func,
   notify: PropTypes.func.isRequired
-};
-
-LabReportWorkbench.defaultProps = {
-  selectedAppointment: null,
-  templateResolution: null,
-  templateResolutionLoading: false,
-  reportHistory: [],
-  recentReports: [],
-  onRefreshRecentReports: undefined,
-  onQueueChanged: undefined,
-  activeInstance: null
 };

--- a/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
@@ -184,7 +184,7 @@ function hydrateVersion(version) {
 
 export default function LabTemplateWorkbench({
   templates,
-  selectedTemplate,
+  selectedTemplate = null,
   onSelectTemplate,
   onTemplatesChanged,
   notify
@@ -706,8 +706,4 @@ LabTemplateWorkbench.propTypes = {
   onSelectTemplate: PropTypes.func.isRequired,
   onTemplatesChanged: PropTypes.func.isRequired,
   notify: PropTypes.func.isRequired
-};
-
-LabTemplateWorkbench.defaultProps = {
-  selectedTemplate: null
 };

--- a/frontend/src/components/queue/QueueTable.jsx
+++ b/frontend/src/components/queue/QueueTable.jsx
@@ -6,10 +6,10 @@ import PropTypes from 'prop-types';
  * Displays the current queue entries in a table format
  */
 const QueueTable = ({
-    queueData,
-    effectiveDoctor,
-    loading,
-    t
+    queueData = null,
+    effectiveDoctor = null,
+    loading = false,
+    t = {}
 }) => {
     // If no queue data or no doctor selected
     if (!effectiveDoctor) {
@@ -271,14 +271,6 @@ QueueTable.propTypes = {
     onGenerateQR: PropTypes.func,
     loading: PropTypes.bool,
     t: PropTypes.object
-};
-
-QueueTable.defaultProps = {
-    queueData: null,
-    effectiveDoctor: null,
-    onGenerateQR: () => { },
-    loading: false,
-    t: {}
 };
 
 export default QueueTable;

--- a/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
+++ b/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
@@ -75,6 +75,19 @@ const getBackendActionAvailability = (row, action, flagName) => {
   return aliases.some((alias) => actions.has(alias));
 };
 
+const getEnhancedAppointmentRowKey = (row, index) => {
+  const parts = [
+    row?.record_type || row?.source_type || row?.source || row?.entity_type || 'appointment',
+    row?.appointment_id ?? row?.visit_id ?? row?.queue_entry_id ?? row?.queue_id ?? row?.payment_id ?? row?.id ?? 'no-id',
+    row?.session_id || row?.queue_number || row?.number || '',
+    row?.doctor_id || row?.specialist_id || row?.department_id || row?.department || '',
+    row?.appointment_time || row?.visit_time || row?.time || row?.start_time || '',
+    index
+  ];
+
+  return parts.map((part) => String(part)).join(':');
+};
+
 const EnhancedAppointmentsTable = ({
   data = [],
   loading = false,
@@ -1619,7 +1632,7 @@ const EnhancedAppointmentsTable = ({
 
               return (
                 <tr
-                  key={row.id}
+                  key={getEnhancedAppointmentRowKey(row, index)}
                   className="enhanced-table-row"
                   style={{
                     backgroundColor: selectedRows.has(row.id) ?

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -31,6 +31,7 @@ import EditPatientModal from '../components/common/EditPatientModal';
 import { queueService } from '../services/queue';
 import { printPanelTicket } from '../services/panelPrint';
 import EnhancedAppointmentsTable from '../components/tables/EnhancedAppointmentsTable';
+import QueueIntegration from '../components/QueueIntegration';
 import { getApiBaseUrl } from '../api/runtime';
 import { EMRContainerV2 } from '../components/emr-v2/EMRContainerV2';
 import AIChatWidget from '../components/ai/AIChatWidget';
@@ -1530,6 +1531,10 @@ const MacOSCardiologistPanelUnified = () => {
           }
 
           {/* Прием пациента */}
+          {activeTab === 'queue' &&
+          <QueueIntegration specialty="cardiology" />
+          }
+
           {activeTab === 'visit' && selectedPatient &&
           <div style={{
             width: '100%',

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -3336,6 +3336,7 @@ const DentistPanelUnified = () => {
         return (
           <QueueIntegration
             specialistId={user?.doctor_id || user?.specialist_id || ''}
+            specialty="dentistry"
             onPatientSelect={handlePatientSelect}
             onStartVisit={(appointment) => {
               setSelectedPatient(appointment);

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -25,6 +25,7 @@ import ServiceChecklist from '../components/ServiceChecklist';
 import ScheduleNextModal from '../components/common/ScheduleNextModal';
 import EditPatientModal from '../components/common/EditPatientModal';
 import EnhancedAppointmentsTable from '../components/tables/EnhancedAppointmentsTable';
+import QueueIntegration from '../components/QueueIntegration';
 import { EMRContainerV2 } from '../components/emr-v2/EMRContainerV2';
 import PhotoUploader from '../components/dermatology/PhotoUploader';
 import PhotoComparison from '../components/dermatology/PhotoComparison';
@@ -1562,6 +1563,10 @@ const DermatologistPanelUnified = () => {
           }
 
           {/* Прием пациента - EMR система */}
+          {activeTab === 'queue' &&
+          <QueueIntegration specialty="dermatology" />
+          }
+
           {activeTab === 'visit' && currentAppointment &&
           <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
               <MacOSCard style={{ padding: '24px' }}>


### PR DESCRIPTION
## Summary

- Improve PostgreSQL demo seed coverage for manual UI smoke: dermatology/dentistry doctor queues now have stable demo DailyQueue/OnlineQueueEntry data.
- Align cashier pending stats with pending-payment row status filtering.
- Repair frontend specialty queue tabs and remove React smoke warnings.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/demo-seed-ui-smoke-coverage` was created from the current `origin/main`; local `main` was restored to track `origin/main` after the protected direct push rejection.
- Clean workspace: inspected before and after edits; only tracked PR files were staged, while smoke/temp artifacts stayed untracked.
- Branch: `codex/demo-seed-ui-smoke-coverage`.
- Scope gate: allowed dev/demo seed, cashier stats consistency, and frontend smoke/rendering files; denied migrations, production setup, backend startup, auth policy, lab/EMR invariants, and unrelated cleanup.
- Red-check handling: failed PR body gate is being fixed in this same PR; any code/test failure will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: demo seed script, cashier stats endpoint, and existing frontend doctor queue tab consumers.
- Request shape: no new API request body or route shape; existing authenticated queue/cashier GET paths and manual seed CLI invocation remain unchanged.
- Response shape: existing cashier stats and queue JSON shapes are unchanged; seeded rows now populate existing fields for manual UI smoke.
- Status codes: no status-code contract changed; smoke preserved expected 403 behavior for doctor-like users on `/clinical/appointments`.
- Frontend consumer: cashier dashboard/payments/appointments, registrar queue/appointments, lab workbench tabs, and doctor specialty queue tabs for cardiology/dermatology/dentistry.
- Compatibility path or alias: specialty alias selection maps cardio/derma/dentist-style labels to canonical specialties without changing backend routes.
- Contract proof: local API checks showed registrar queues and doctor specialty queues populated; full 8-user browser smoke completed with zero console/API errors.

## RBAC / Permissions

- Roles allowed: existing demo roles admin, registrar, doctor, cashier, lab, cardio, derma, and dentist can log in through unchanged auth paths.
- Roles denied: unchanged role denials remain, including doctor-like users receiving forbidden on `/clinical/appointments` in smoke.
- Positive auth proof: full UI smoke logged in successfully as all 8 demo users.
- Negative auth proof: smoke observed expected forbidden secondary path behavior for doctor/cardio/derma/dentist users.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, Telegram, or realtime event type was changed.
- Payload version / ack behavior: not applicable - no realtime payload or acknowledgement contract was touched.
- Read/unread or delivery semantics: not applicable - no notification delivery or read-state semantics were touched.
- Reconnect/resync proof: not applicable - no reconnect or resync path was changed by this PR.

## Frontend Resilience

- Empty data proof: not applicable - this PR targets seeded non-empty demo data and does not change empty-state component logic.
- Partial data proof: not applicable - no optional API DTO shape changed; smoke covered populated seeded rows.
- Forbidden secondary path behavior: doctor-like demo users still hit expected forbidden behavior on `/clinical/appointments`.
- Missing draft/resource behavior: not applicable - no draft, EMR signing, lab finalization, or resource reopen path was changed.
- Stale route/deep-link behavior: specialty queue deep links `/doctor/cardiology?tab=queue`, `/doctor/dermatology?tab=queue`, and `/doctor/dentistry?tab=queue` rendered the expected seeded patients.

## Scope Gate

- Allowed paths: `backend/app/scripts/dev_seed.py`, `backend/app/api/v1/endpoints/cashier.py`, `frontend/src/components/QueueIntegration.jsx`, `frontend/src/components/tables/EnhancedAppointmentsTable.jsx`, `frontend/src/components/queue/QueueTable.jsx`, `frontend/src/components/laboratory/*.jsx`, and the three specialty panel files.
- Denied paths: Alembic migrations, production setup/bootstrap behavior, backend startup seed hooks, secrets, auth/RBAC policy, payment transitions, EMR/lab immutability, generated output, and unrelated route cleanup.
- Migration/docs/test impact: no migration was added; no production docs changed; validation used targeted compile, seed, API, lint, build, and browser smoke evidence.
- Rollback note: revert PR #1237 / commit `58674481` to remove the demo seed UI smoke coverage changes.

## Validation

- Targeted tests or smoke run: `py_compile`, demo seed twice on `clinic_dev`, registrar/doctor queue API checks, touched-file ESLint, `git diff --check`, `npm run build`, and full 8-user manual UI smoke.
- Result: all listed local checks passed; full UI smoke had all 8 logins OK with zero console errors and zero API errors.
- Not checked: production database, remote dev reset, Alembic migration upgrade for a new migration, real payment provider, notification delivery, Telegram, and websocket delivery.
