### PR TITLE
Fix clinical visit detail display context

### DIFF
--- a/backend/app/api/v1/endpoints/visits.py
+++ b/backend/app/api/v1/endpoints/visits.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from datetime import date, datetime, timedelta
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
@@ -39,6 +39,16 @@ class VisitOut(BaseModel):
     notes: Optional[str] = None
     planned_date: Optional[date] = None  # <-- новая поддержка
     source: Optional[str] = None
+    patient_name: Optional[str] = None
+    patient_fio: Optional[str] = None
+    patient_phone: Optional[str] = None
+    patient_birth_year: Optional[int] = None
+    birth_year: Optional[int] = None
+    address: Optional[str] = None
+    patient: Optional[dict[str, Any]] = None
+    doctor_name: Optional[str] = None
+    room: Optional[str] = None
+    doctor: Optional[dict[str, Any]] = None
 
 
 class VisitServiceIn(BaseModel):

--- a/backend/app/services/visits_api_service.py
+++ b/backend/app/services/visits_api_service.py
@@ -34,6 +34,18 @@ class VisitsApiService:
         md = MetaData()
         return Table("visit_services", md, autoload_with=self.repository.get_bind())
 
+    def _patients(self) -> Table:
+        md = MetaData()
+        return Table("patients", md, autoload_with=self.repository.get_bind())
+
+    def _doctors(self) -> Table:
+        md = MetaData()
+        return Table("doctors", md, autoload_with=self.repository.get_bind())
+
+    def _users(self) -> Table:
+        md = MetaData()
+        return Table("users", md, autoload_with=self.repository.get_bind())
+
     def list_visits(
         self,
         *,
@@ -156,6 +168,86 @@ class VisitsApiService:
         ).mappings().first()
         if not visit_row:
             raise HTTPException(404, "Visit not found")
+        visit = dict(visit_row)
+
+        patient_id = visit.get("patient_id")
+        if patient_id:
+            patients_table = self._patients()
+            patient_row = self.repository.execute(
+                select(
+                    patients_table.c.id,
+                    patients_table.c.last_name,
+                    patients_table.c.first_name,
+                    patients_table.c.middle_name,
+                    patients_table.c.birth_date,
+                    patients_table.c.phone,
+                    patients_table.c.address,
+                ).where(patients_table.c.id == patient_id)
+            ).mappings().first()
+            if patient_row:
+                patient = dict(patient_row)
+                patient_name = " ".join(
+                    str(patient.get(key) or "").strip()
+                    for key in ("last_name", "first_name", "middle_name")
+                ).strip()
+                birth_date = patient.get("birth_date")
+                birth_year = getattr(birth_date, "year", None)
+                visit.update(
+                    {
+                        "patient_name": patient_name,
+                        "patient_fio": patient_name,
+                        "patient_phone": patient.get("phone"),
+                        "patient_birth_year": birth_year,
+                        "birth_year": birth_year,
+                        "address": patient.get("address"),
+                        "patient": {
+                            "id": patient.get("id"),
+                            "full_name": patient_name,
+                            "phone": patient.get("phone"),
+                            "birth_year": birth_year,
+                            "address": patient.get("address"),
+                        },
+                    }
+                )
+
+        doctor_id = visit.get("doctor_id")
+        if doctor_id:
+            doctors_table = self._doctors()
+            users_table = self._users()
+            doctor_row = self.repository.execute(
+                select(
+                    doctors_table.c.id,
+                    doctors_table.c.specialty,
+                    doctors_table.c.cabinet,
+                    users_table.c.full_name.label("doctor_full_name"),
+                    users_table.c.username.label("doctor_username"),
+                )
+                .select_from(
+                    doctors_table.outerjoin(
+                        users_table, users_table.c.id == doctors_table.c.user_id
+                    )
+                )
+                .where(doctors_table.c.id == doctor_id)
+            ).mappings().first()
+            if doctor_row:
+                doctor = dict(doctor_row)
+                doctor_name = (
+                    doctor.get("doctor_full_name")
+                    or doctor.get("doctor_username")
+                    or f"Doctor #{doctor_id}"
+                )
+                visit.update(
+                    {
+                        "doctor_name": doctor_name,
+                        "room": doctor.get("cabinet"),
+                        "doctor": {
+                            "id": doctor.get("id"),
+                            "name": doctor_name,
+                            "specialty": doctor.get("specialty"),
+                            "cabinet": doctor.get("cabinet"),
+                        },
+                    }
+                )
 
         services = (
             self.repository.execute(
@@ -166,7 +258,7 @@ class VisitsApiService:
             .mappings()
             .all()
         )
-        return {"visit": dict(visit_row), "services": [dict(item) for item in services]}
+        return {"visit": visit, "services": [dict(item) for item in services]}
 
     def add_service(self, *, visit_id: int, item) -> dict[str, Any]:
         visits_table = self._visits()

--- a/backend/tests/unit/test_visits_router_service_wiring.py
+++ b/backend/tests/unit/test_visits_router_service_wiring.py
@@ -93,6 +93,10 @@ def test_get_visit_endpoint_delegates_to_service(
                 "notes": "visit card",
                 "planned_date": None,
                 "source": "desk",
+                "patient_name": "Karimov Aziz",
+                "patient_fio": "Karimov Aziz",
+                "doctor_name": "Demo Cardiologist",
+                "room": "201",
             },
             "services": [
                 {
@@ -112,6 +116,8 @@ def test_get_visit_endpoint_delegates_to_service(
     payload = response.json()
     assert payload["visit"]["id"] == 42
     assert payload["visit"]["notes"] == "visit card"
+    assert payload["visit"]["patient_name"] == "Karimov Aziz"
+    assert payload["visit"]["doctor_name"] == "Demo Cardiologist"
     assert payload["services"][0]["name"] == "Consultation"
     assert captured["visit_id"] == 42
 

--- a/frontend/src/pages/VisitDetails.jsx
+++ b/frontend/src/pages/VisitDetails.jsx
@@ -6,6 +6,36 @@ import RescheduleDialog from '../components/RescheduleDialog';
 
 import { getErrorMessage } from '../utils/errorHandler';
 import logger from '../utils/logger';
+
+function normalizeVisitDetailPayload(data) {
+  if (!data) return null;
+  const baseVisit = data.visit && typeof data.visit === 'object' ? data.visit : data;
+  const services = Array.isArray(data.services) ? data.services : baseVisit.services;
+  return {
+    ...baseVisit,
+    services: Array.isArray(services) ? services : [],
+  };
+}
+
+function resolvePatientName(visit) {
+  return (
+    visit?.patient?.full_name ||
+    visit?.patient_fio ||
+    visit?.patient_name ||
+    (visit?.patient_id ? `Пациент #${visit.patient_id}` : '—')
+  );
+}
+
+function resolveDoctorName(visit) {
+  const doctorName = visit?.doctor?.name || visit?.doctor_name;
+  const cabinet = visit?.doctor?.cabinet || visit?.room;
+  if (doctorName && cabinet) return `${doctorName} / ${cabinet}`;
+  return doctorName || cabinet || (visit?.doctor_id ? `Врач #${visit.doctor_id}` : '—');
+}
+
+function resolveVisitSchedule(visit) {
+  return visit?.scheduled_at || visit?.planned_date || visit?.visit_date || null;
+}
 /**
  * VisitDetails page
  * - Shows visit information
@@ -30,7 +60,7 @@ function VisitDetails() {
     getVisit(id).
     then((data) => {
       if (!mounted) return;
-      setVisit(data || null);
+      setVisit(normalizeVisitDetailPayload(data));
     }).
     catch((err) => {
       logger.error('getVisit error:', err);
@@ -54,12 +84,13 @@ function VisitDetails() {
     setLoading(true);
     setError('');
     try {
-      const baseDate = visit.scheduled_at ? new Date(visit.scheduled_at) : new Date();
+      const scheduledAt = resolveVisitSchedule(visit);
+      const baseDate = scheduledAt ? new Date(scheduledAt) : new Date();
       const tomorrow = new Date(baseDate);
       tomorrow.setDate(baseDate.getDate() + 1);
       const iso = tomorrow.toISOString();
       const res = await rescheduleVisit(visit.id, iso);
-      setVisit((prev) => ({ ...(prev || {}), scheduled_at: iso, ...(res || {}) }));
+      setVisit((prev) => normalizeVisitDetailPayload({ ...(prev || {}), scheduled_at: iso, ...(res || {}) }));
     } catch (err) {
       logger.error('rescheduleTomorrow error:', err);
       setError(getErrorMessage(err, 'Не удалось перенести приём. Проверьте соединение и попробуйте снова.'));
@@ -110,7 +141,7 @@ function VisitDetails() {
         <div className="grid grid-cols-2 gap-4">
           <div>
             <div className="text-sm text-gray-500">Пациент</div>
-            <div className="font-medium">{visit.patient?.full_name || visit.patient_name || '—'}</div>
+            <div className="font-medium">{resolvePatientName(visit)}</div>
           </div>
           <div>
             <div className="text-sm text-gray-500">Статус</div>
@@ -118,11 +149,11 @@ function VisitDetails() {
           </div>
           <div>
             <div className="text-sm text-gray-500">Запланировано</div>
-            <div className="font-medium">{visit.scheduled_at ? new Date(visit.scheduled_at).toLocaleString() : '—'}</div>
+            <div className="font-medium">{resolveVisitSchedule(visit) ? new Date(resolveVisitSchedule(visit)).toLocaleString() : '—'}</div>
           </div>
           <div>
             <div className="text-sm text-gray-500">Врач / кабинет</div>
-            <div className="font-medium">{visit.doctor?.name || visit.room || '—'}</div>
+            <div className="font-medium">{resolveDoctorName(visit)}</div>
           </div>
         </div>
 

--- a/frontend/src/pages/__tests__/VisitDetails.contract.test.jsx
+++ b/frontend/src/pages/__tests__/VisitDetails.contract.test.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getVisitMock, rescheduleVisitMock } = vi.hoisted(() => ({
+  getVisitMock: vi.fn(),
+  rescheduleVisitMock: vi.fn(),
+}));
+
+vi.mock('../../api', () => ({
+  getVisit: getVisitMock,
+  rescheduleVisit: rescheduleVisitMock,
+}));
+
+vi.mock('../../components/RescheduleDialog', () => ({
+  default: () => null,
+}));
+
+import VisitDetails from '../VisitDetails.jsx';
+
+function renderVisitDetails() {
+  return render(
+    <MemoryRouter initialEntries={['/clinical/visits/1']}>
+      <Routes>
+        <Route path="/clinical/visits/:id" element={<VisitDetails />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('VisitDetails contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders backend visit detail wrapper with patient and doctor display fields', async () => {
+    getVisitMock.mockResolvedValue({
+      visit: {
+        id: 1,
+        patient_id: 1,
+        patient_name: 'Karimov Aziz',
+        doctor_id: 2,
+        doctor_name: 'Demo Cardiologist',
+        room: '201',
+        status: 'open',
+        visit_date: '2026-05-25',
+      },
+      services: [{ name: 'Consultation', price: 125000, qty: 1 }],
+    });
+
+    renderVisitDetails();
+
+    expect(await screen.findByText('Karimov Aziz')).toBeInTheDocument();
+    expect(screen.getByText('Demo Cardiologist / 201')).toBeInTheDocument();
+    expect(screen.getByText('open')).toBeInTheDocument();
+    expect(getVisitMock).toHaveBeenCalledWith('1');
+  });
+});


### PR DESCRIPTION
﻿## Summary

- Fix clinical visit detail deep links so the page renders the visit payload returned by the existing visits adapter instead of treating the response wrapper as the visit itself.
- Add display-safe patient and doctor fields to the existing visit detail response, preserving the existing endpoint and wrapper shape.
- Add targeted backend/frontend regression coverage for visit detail display context.

## Cyclic Execution Evidence

- Fresh main sync: branch based on `origin/main` at `8b437587` before this fix cycle.
- Clean workspace: workspace was checked before editing; final commit contains only the listed visit detail files.
- Branch: `codex/clinical-visit-detail-smoke-fix`.
- Scope gate: limited to the clinical visit detail route/API contract; no BFF-lite, no `/api/v1/ui/*`, no seed reset, no route rewrite.
- Red-check handling: PR Review Quality Gate failed only because this PR body was missing required sections; runtime/code checks were already passing when this body was updated.

## Contract Impact

- Canonical surface: existing `GET /api/v1/visits/visits/{visit_id}` response consumed by `frontend/src/api/visits.js` and `frontend/src/pages/VisitDetails.jsx`.
- Request shape: unchanged.
- Response shape: additive display-safe fields on the existing visit object: `patient_name`, `patient_fio`, `patient_phone`, `patient_birth_year`, `birth_year`, `address`, nested `patient`, `doctor_name`, `room`, nested `doctor`.
- Status codes: unchanged.
- Frontend consumer: `VisitDetails.jsx` now normalizes the existing `{ visit, services }` wrapper before rendering patient/doctor/schedule fields.
- Compatibility path or alias: unchanged; no new endpoint and no `/api/v1/ui/*` path.
- Contract proof: `backend/tests/unit/test_visits_router_service_wiring.py`, `backend/tests/test_openapi_contract.py`, and `frontend/src/pages/__tests__/VisitDetails.contract.test.jsx`.

## RBAC / Permissions

- Roles allowed: unchanged; existing visit detail access behavior is preserved.
- Roles denied: unchanged.
- Positive auth proof: not rechecked separately; this PR does not change route guards, auth dependencies, or role helpers.
- Negative auth proof: not rechecked separately; no permission-sensitive code changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime behavior changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no delivery semantics changed.
- Reconnect/resync proof: not applicable - no realtime reconnect/resync path changed.

## Frontend Resilience

- Empty data proof: `VisitDetails.contract` covers the existing wrapped visit detail payload and verifies patient/doctor/status rendering from the normalized shape.
- Partial data proof: fallback render helpers support legacy flat fields and nested patient/doctor fields without requiring a new endpoint.
- Forbidden secondary path behavior: unchanged; no new secondary API path was added.
- Missing draft/resource behavior: unchanged; this PR does not alter 404 or missing-visit behavior.
- Stale route/deep-link behavior: `/clinical/visits/:id` now uses the existing visit detail contract correctly for deep-linked seeded visits.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/visits.py`, `backend/app/services/visits_api_service.py`, `backend/tests/unit/test_visits_router_service_wiring.py`, `frontend/src/pages/VisitDetails.jsx`, `frontend/src/pages/__tests__/VisitDetails.contract.test.jsx`.
- Denied paths: BFF/read-model routes, `/api/v1/ui/*`, QueueJoin, DisplayBoard, RegistrarPanel, seed/reset scripts, migrations, unrelated UI cleanup.
- Migration/docs/test impact: no migration; no docs change; targeted backend/frontend tests updated/added.
- Rollback note: revert this PR to return to the previous visit detail response/rendering behavior; no database or migration rollback is involved.

## Validation

- Targeted tests or smoke run: `npm --prefix frontend run test:run -- VisitDetails.contract`; pgAdmin Python + temp target `pytest backend/tests/unit/test_visits_router_service_wiring.py -q`; pgAdmin Python + temp target `pytest backend/tests/test_openapi_contract.py -q`; `npm --prefix frontend run build`; `py_compile` for changed backend files; direct `clinic_dev` service check for visit 1 patient/doctor/room; `git diff --cached --check`.
- Result: all listed validation passed locally; CI frontend build/unit/e2e/lint, CodeQL, Analyze, security, scope, lifecycle, and role checks were passing when this body was updated.
- Not checked: full manual 39-route role smoke was not rerun in this PR cycle; backend auth negative-path tests were not rerun because auth behavior was not changed.
