### PR TITLE
Fix doctor visit empty state

### DIFF
--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -1669,6 +1669,20 @@ const MacOSCardiologistPanelUnified = () => {
           }
 
           {/* ЭКГ */}
+          {activeTab === 'visit' && !selectedPatient &&
+          <MacOSCard style={{ padding: '48px' }}>
+              <MacOSEmptyState
+              icon={Calendar}
+              title="Выберите визит"
+              description="Откройте прием из очереди или списка записей, либо используйте ссылку с visitId."
+              action={
+              <MacOSButton variant="outline" onClick={() => goToTab('appointments')} style={{ marginTop: '16px' }}>
+                    Перейти к записям
+                  </MacOSButton>
+              } />
+            </MacOSCard>
+          }
+
           {activeTab === 'ecg' &&
           <div style={{
             width: '100%',

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -1902,6 +1902,20 @@ const DermatologistPanelUnified = () => {
           }
 
           {/* Фото до/после */}
+          {activeTab === 'visit' && !currentAppointment && !selectedPatient &&
+          <MacOSCard style={{ padding: '48px' }}>
+              <MacOSEmptyState
+              icon={Calendar}
+              title="Выберите визит"
+              description="Откройте прием из очереди или списка записей, либо используйте ссылку с visitId."
+              action={
+              <MacOSButton variant="outline" onClick={() => handleTabChange('appointments')} style={{ marginTop: '16px' }}>
+                    Перейти к записям
+                  </MacOSButton>
+              } />
+            </MacOSCard>
+          }
+
           {activeTab === 'photos' && (currentAppointment || selectedPatient) &&
           <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
               <MacOSCard style={{ padding: '24px' }}>

--- a/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
@@ -88,6 +88,19 @@ describe('Doctor panels SSOT contract', () => {
     }
   });
 
+  it('renders a safe visit empty state when specialty visit tabs have no selected context', () => {
+    const cardiology = read('pages/CardiologistPanelUnified.jsx');
+    const dermatology = read('pages/DermatologistPanelUnified.jsx');
+
+    expect(cardiology).toContain("activeTab === 'visit' && !selectedPatient");
+    expect(cardiology).toContain('title="Выберите визит"');
+    expect(cardiology).toContain("goToTab('appointments')");
+
+    expect(dermatology).toContain("activeTab === 'visit' && !currentAppointment && !selectedPatient");
+    expect(dermatology).toContain('title="Выберите визит"');
+    expect(dermatology).toContain("handleTabChange('appointments')");
+  });
+
   it('keeps the active doctor queue page action visibility backend-owned', () => {
     const source = read('pages/DoctorPanel.jsx');
     const actionBlock = extractBlock(


### PR DESCRIPTION
﻿## Summary

- Add a visible empty state for cardiology and dermatology `?tab=visit` routes when no patient or visit context is selected.
- Keep the action path presentation-only: the button returns the doctor to existing appointments selection.
- Add a focused source-level contract test covering both specialty panels.

## Cyclic Execution Evidence

- Fresh main sync: branch created from synced `main` at `0b1b7731` after PR #1238 merged.
- Clean workspace: workspace was checked before editing; final diff contains only two doctor panel files and one existing frontend contract test.
- Branch: `codex/doctor-visit-empty-state`.
- Scope gate: narrow override from `agent_gate.py` for cardiology and dermatology visit-tab empty states; no backend, no command, no BFF, no route-registry edit.
- Red-check handling: no red checks yet; targeted local validation is green before opening PR.

## Contract Impact

- Canonical surface: no API, websocket, event, command, or backend contract changed.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `CardiologistPanelUnified.jsx` and `DermatologistPanelUnified.jsx` now render an empty state when `activeTab === 'visit'` has no selected context.
- Compatibility path or alias: unchanged; no new route and no `/api/v1/ui/*` path.
- Contract proof: `frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx` asserts the no-context visit tab renders a safe empty state and returns to appointments.

## RBAC / Permissions

- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: not applicable - no route guard, endpoint, role helper, or auth-sensitive behavior changed.
- Negative auth proof: not applicable - no permission-sensitive code changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime behavior changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no delivery semantics changed.
- Reconnect/resync proof: not applicable - no realtime reconnect/resync path changed.

## Frontend Resilience

- Empty data proof: cardiology and dermatology visit tabs now show `Выберите визит` instead of rendering an almost blank content area when URL state has no selected context.
- Partial data proof: existing valid selected-patient/current-appointment render paths are untouched.
- Forbidden secondary path behavior: unchanged; no fallback API or secondary command path added.
- Missing draft/resource behavior: unchanged; EMR/resource handling is untouched.
- Stale route/deep-link behavior: stale/no-context `?tab=visit` routes recover to a visible empty state with a path back to appointments.

## Scope Gate

- Allowed paths: `frontend/src/pages/CardiologistPanelUnified.jsx`, `frontend/src/pages/DermatologistPanelUnified.jsx`, `frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx`.
- Denied paths: backend, migrations, route registry, BFF/read-model routes, `/api/v1/ui/*`, command handlers, EMR business logic, QueueJoin, DisplayBoard, RegistrarPanel.
- Migration/docs/test impact: no migration; no docs; one focused frontend contract test added.
- Rollback note: revert this PR to restore the previous blank/no-context visit tab behavior; no database or backend rollback is involved.

## Validation

- Targeted tests or smoke run: `npm --prefix frontend run test:run -- DoctorPanels.contract`; `npm --prefix frontend run build`; `git diff --check`; `git diff --cached --check`.
- Result: all listed checks passed locally.
- Not checked: full 39-route role smoke was not rerun; browser visual screenshot was not captured in this slice.
