### PR TITLE
Fix lab template abort resilience

### DIFF
--- a/frontend/src/pages/LabPanel.jsx
+++ b/frontend/src/pages/LabPanel.jsx
@@ -94,6 +94,12 @@ function normalizeListPayload(payload) {
   return [];
 }
 
+function isAbortLikeError(error) {
+  const name = String(error?.name || '').toLowerCase();
+  const message = String(error?.message || '').toLowerCase();
+  return name === 'aborterror' || message.includes('aborted');
+}
+
 function mergeQueueEntriesWithLabInstances(queueEntries, labInstances) {
   if (!queueEntries.length || !labInstances.length) {
     return queueEntries;
@@ -310,6 +316,10 @@ export default function LabPanel() {
         setSelectedTemplate(null);
       }
     } catch (error) {
+      if (isAbortLikeError(error)) {
+        logger.info('[LabPanel] loadTemplates aborted');
+        return;
+      }
       logger.error('[LabPanel] loadTemplates failed', error);
       notify(
         'error',


### PR DESCRIPTION
﻿## Summary

- Suppress `loadTemplates failed` error logging/notification when the lab template fetch is aborted during navigation or tab changes.
- Keep real `/lab/templates` failures on the existing error path.
- No backend, lab template workflow, report finalization, or API contract changes.

## Cyclic Execution Evidence

- Fresh main sync: branch created from synced `main` at `662a22e8` after PR #1239 merged.
- Clean workspace: workspace was checked before editing; final diff contains only `frontend/src/pages/LabPanel.jsx`.
- Branch: `codex/lab-template-abort-resilience`.
- Scope gate: `agent_gate.py` known-root-cause narrow override for `LabPanel.jsx`; no backend, no template business rules, no BFF, no unrelated lab work.
- Red-check handling: no red checks yet; targeted local validation is green before opening PR.

## Contract Impact

- Canonical surface: no API, websocket, event, command, or backend contract changed.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `LabPanel.jsx` treats abort-like template load errors as non-error navigation noise.
- Compatibility path or alias: unchanged; no new endpoint and no `/api/v1/ui/*` path.
- Contract proof: existing `LabPanel.contract` still passes and confirms no BFF-lite endpoint was introduced.

## RBAC / Permissions

- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: not applicable - no route guard, endpoint, role helper, or auth-sensitive behavior changed.
- Negative auth proof: not applicable - no permission-sensitive code changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime behavior changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no delivery semantics changed.
- Reconnect/resync proof: not applicable - no realtime reconnect/resync path changed.

## Frontend Resilience

- Empty data proof: unchanged; lab templates still resolve to the existing template state when the request completes.
- Partial data proof: unchanged; selected template handling is untouched.
- Forbidden secondary path behavior: unchanged; no fallback API path added.
- Missing draft/resource behavior: unchanged; template/report draft behavior is untouched.
- Stale route/deep-link behavior: abort-like navigation cancellation no longer appears as an application error.

## Scope Gate

- Allowed paths: `frontend/src/pages/LabPanel.jsx`.
- Denied paths: backend, migrations, lab reporting services, template/finalization rules, `/api/v1/ui/*`, QueueJoin, DisplayBoard, RegistrarPanel, doctor panels.
- Migration/docs/test impact: no migration; no docs; existing focused frontend contract test run.
- Rollback note: revert this PR to restore previous behavior where aborted lab template loads logged and notified as errors.

## Validation

- Targeted tests or smoke run: `npm --prefix frontend run test:run -- LabPanel.contract`; `npm --prefix frontend run build`; `git diff --check`; `git diff --cached --check`.
- Result: all listed checks passed locally.
- Not checked: full manual role smoke was not rerun; browser console smoke for `/lab` was not captured in this slice.
