### PR TITLE
fix(lab): use registrar department queue contract

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -1404,6 +1404,18 @@ def get_today_queues(
         else:
             today = date.today()
 
+        department_filter: set[str] | None = None
+        if department:
+            normalized_department = str(department).strip().lower()
+            department_aliases = {
+                "lab": {"lab", "laboratory"},
+                "laboratory": {"lab", "laboratory"},
+            }
+            department_filter = department_aliases.get(
+                normalized_department,
+                {normalized_department},
+            )
+
         # Получаем все визиты на сегодня (новая система)
         visits = db.query(Visit).filter(Visit.visit_date == today).all()
 
@@ -2052,6 +2064,10 @@ def get_today_queues(
         queue_number = 1
 
         for specialty, data in queues_by_specialty.items():
+            specialty_key = str(specialty or "").strip().lower()
+            if department_filter and specialty_key not in department_filter:
+                continue
+
             doctor = data["doctor"]
             entries_list = data["entries"]
 

--- a/backend/tests/integration/test_registrar_all_appointments.py
+++ b/backend/tests/integration/test_registrar_all_appointments.py
@@ -206,6 +206,70 @@ class TestRegistrarAllAppointments:
         assert found_entry["patient_birth_year"] == 1985
         assert found_entry["address"] == "Clinic Street 1"
 
+    def test_today_queues_department_filter_limits_lab_rows(
+        self,
+        client,
+        db_session,
+        auth_headers,
+        test_patient,
+        test_doctor,
+    ):
+        cardio_queue = DailyQueue(
+            day=date.today(),
+            specialist_id=test_doctor.id,
+            queue_tag="cardiology",
+            active=True,
+        )
+        lab_queue = DailyQueue(
+            day=date.today(),
+            specialist_id=test_doctor.id,
+            queue_tag="lab",
+            active=True,
+        )
+        db_session.add_all([cardio_queue, lab_queue])
+        db_session.commit()
+        db_session.refresh(cardio_queue)
+        db_session.refresh(lab_queue)
+
+        cardio_entry = OnlineQueueEntry(
+            queue_id=cardio_queue.id,
+            number=1,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            source="desk",
+            status="waiting",
+        )
+        lab_entry = OnlineQueueEntry(
+            queue_id=lab_queue.id,
+            number=1,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            source="desk",
+            status="waiting",
+        )
+        db_session.add_all([cardio_entry, lab_entry])
+        db_session.commit()
+
+        response = client.get(
+            "/api/v1/registrar/queues/today?department=lab",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        specialties = {queue["specialty"] for queue in payload["queues"]}
+        entry_ids = {
+            entry["id"]
+            for queue in payload["queues"]
+            for entry in queue["entries"]
+        }
+
+        assert specialties == {"laboratory"}
+        assert lab_entry.id in entry_ids
+        assert cardio_entry.id not in entry_ids
+
     def test_start_queue_visit_uses_queue_entry_id_when_visit_id_collides(
         self,
         client,

--- a/frontend/src/pages/LabPanel.jsx
+++ b/frontend/src/pages/LabPanel.jsx
@@ -251,7 +251,9 @@ export default function LabPanel() {
       if (!token) {
         throw new Error('Требуется авторизация для загрузки лабораторной очереди.');
       }
-      const response = await fetch(`${API_V1_BASE}/registrar/queues/today`, {
+      const queueParams = new URLSearchParams({ department: 'lab' });
+      const queueUrl = `${API_V1_BASE}/registrar/queues/today?${queueParams.toString()}`;
+      const response = await fetch(queueUrl, {
         headers: {
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json'
@@ -262,7 +264,6 @@ export default function LabPanel() {
       }
       const payload = await response.json();
       const queueEntries = (payload?.queues || [])
-        .filter((queue) => ['lab', 'laboratory'].includes(queue.specialty))
         .flatMap((queue) => (queue.entries || []).map((entry) => formatAppointmentEntry(queue, entry)));
       const visitIds = queueEntries
         .map((item) => item.visit_id)

--- a/frontend/src/pages/__tests__/LabPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/LabPanel.contract.test.jsx
@@ -40,4 +40,17 @@ describe('LabPanel queue/report status contract', () => {
     expect(source).not.toContain('/api/v1/ui/');
     expect(source).not.toContain('/ui/lab');
   });
+
+  it('uses the backend registrar department contract for lab queue rows', () => {
+    const source = readLabPanelSource();
+    const loadBlock = extractBlock(
+      source,
+      'const loadLabAppointments = useCallback(async () => {',
+      'const loadTemplates = useCallback(async (preferredTemplateId = null) => {',
+    );
+
+    expect(loadBlock).toContain("new URLSearchParams({ department: 'lab' })");
+    expect(loadBlock).toContain('/registrar/queues/today?${queueParams.toString()}');
+    expect(loadBlock).not.toContain(".filter((queue) => ['lab', 'laboratory'].includes(queue.specialty))");
+  });
 });


### PR DESCRIPTION
## Summary

- Extend the existing registrar queue endpoint behavior so `GET /api/v1/registrar/queues/today?department=lab` returns only lab/laboratory queues.
- Update `LabPanel` to request the backend-owned lab department contract instead of filtering queue specialties in React.
- Add targeted backend and frontend contract coverage for the lab queue path.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` at `1f030f8d` after PR #1242 merged.
- Clean workspace: inspected before edits; only scoped lab endpoint consumer and targeted tests changed.
- Branch: `codex/lab-existing-endpoint-extension`.
- Scope gate: allowed existing registrar queue endpoint, LabPanel consumer, and targeted tests; denied `/api/v1/ui/*`, separate BFF service, command wrappers, migrations, broad LabPanel rewrite, and unrelated cleanup.
- Red-check handling: PR checks are being watched; any red code or contract check will be fixed in this PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/registrar/queues/today`.
- Request shape: existing authenticated GET with optional `department` query; this PR makes `department=lab` effective.
- Response shape: unchanged response schema; backend filters returned queue groups to lab/laboratory rows for the lab request.
- Status codes: unchanged from the existing registrar queue endpoint.
- Frontend consumer: `frontend/src/pages/LabPanel.jsx` lab workbench queue load.
- Compatibility path or alias: `lab` and `laboratory` are treated as aliases for the department filter; callers without `department` keep the existing all-queues response.
- Contract proof: backend regression test for `department=lab` filtering and frontend contract test proving LabPanel uses the backend department query instead of local specialty filtering.

## RBAC / Permissions

- Roles allowed: unchanged from the existing `/registrar/queues/today` dependency and policy.
- Roles denied: unchanged from the existing `/registrar/queues/today` dependency and policy.
- Positive auth proof: existing authenticated registrar integration test calls the endpoint successfully.
- Negative auth proof: not rechecked in this narrow PR because auth dependencies were not changed.

## Notification / Realtime

- Event type or websocket channel: not applicable; no notification or websocket path changed.
- Payload version / ack behavior: not applicable; no realtime payload or ack behavior changed.
- Read/unread or delivery semantics: not applicable; no notification delivery state changed.
- Reconnect/resync proof: not applicable; no reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: existing LabPanel queue path keeps using `(payload?.queues || [])` and `(queue.entries || [])`, so empty queue data remains safe.
- Partial data proof: `formatAppointmentEntry` continues to handle optional fields; this PR only changes the source query and removes local specialty filtering.
- Forbidden secondary path behavior: no secondary endpoint was added; LabPanel continues to use the existing registrar queue endpoint.
- Missing draft/resource behavior: not applicable; lab queue loading does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable; this queue load does not read route/deep-link state.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/registrar_integration.py`, `backend/tests/integration/test_registrar_all_appointments.py`, `frontend/src/pages/LabPanel.jsx`, `frontend/src/pages/__tests__/LabPanel.contract.test.jsx`.
- Denied paths: `/api/v1/ui/*`, separate BFF service, command wrappers, migrations, unrelated panels, generated output, and broad LabPanel rewrite.
- Migration/docs/test impact: no migration; no docs required for runtime contract; targeted backend and frontend tests updated.
- Rollback note: revert this commit to restore previous all-queues LabPanel fetch plus frontend specialty filtering.

## Validation

- Targeted tests or smoke run: `C:\final\backend\.venv\Scripts\python.exe -m py_compile backend/app/api/v1/endpoints/registrar_integration.py`; `C:\final\backend\.venv\Scripts\python.exe -m pytest backend/tests/integration/test_registrar_all_appointments.py::TestRegistrarAllAppointments::test_today_queues_department_filter_limits_lab_rows`; `C:\final\backend\.venv\Scripts\python.exe -m pytest backend/tests/integration/test_registrar_all_appointments.py`; `npm --prefix frontend run test:run -- LabPanel.contract`; `npm --prefix frontend run build`; `git diff --check`.
- Result: local targeted validation passed; `git diff --check` had no whitespace errors and only Git CRLF conversion warnings.
- Not checked: full manual browser smoke and full backend suite beyond the targeted registrar integration file.