### PR TITLE
fix(lab): include latest report summary in queue rows

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -190,6 +190,74 @@ def _serialize_registrar_datetime(value: Any) -> str | None:
     return str(value)
 
 
+def _is_newer_lab_report_instance(candidate: Any, current: Any | None) -> bool:
+    if current is None:
+        return True
+
+    def sort_key(instance: Any) -> tuple[float, int]:
+        created_at = getattr(instance, "created_at", None)
+        if isinstance(created_at, datetime):
+            timestamp = created_at.timestamp()
+        else:
+            timestamp = 0.0
+        return (timestamp, getattr(instance, "id", 0) or 0)
+
+    return sort_key(candidate) > sort_key(current)
+
+
+def _lab_report_summary_for_registrar(service: Any, instance: Any) -> dict[str, Any]:
+    sections = service.materialize_instance(instance)
+    severity = service.summarize_instance_severity(sections)
+    available_actions = service.instance_available_actions(instance)
+    template = getattr(instance, "template", None)
+    return {
+        "id": instance.id,
+        "status": instance.status,
+        "template_id": instance.template_id,
+        "template_version_id": instance.template_version_id,
+        "template_name": getattr(template, "name", None),
+        "created_at": _serialize_registrar_datetime(instance.created_at),
+        "finalized_at": _serialize_registrar_datetime(instance.finalized_at),
+        "printed_at": _serialize_registrar_datetime(instance.printed_at),
+        "flagged_findings_count": severity["flagged_findings_count"],
+        "critical_findings_count": severity["critical_findings_count"],
+        "max_flag_severity": severity["max_flag_severity"],
+        "available_actions": available_actions,
+        **service.instance_action_flags(instance),
+    }
+
+
+def _latest_lab_report_summaries_by_visit(
+    db: Session,
+    visit_ids: set[int],
+) -> dict[int, dict[str, Any]]:
+    if not visit_ids:
+        return {}
+
+    from app.services.lab_reporting_service import LabReportingService
+
+    service = LabReportingService(db)
+    instances = service.list_instances(
+        patient_id=None,
+        visit_ids=sorted(visit_ids),
+        status=None,
+        limit=max(len(visit_ids) * 20, 500),
+        offset=0,
+    )
+    latest_by_visit: dict[int, Any] = {}
+    for instance in instances:
+        visit_id = getattr(instance, "visit_id", None)
+        if not visit_id:
+            continue
+        if _is_newer_lab_report_instance(instance, latest_by_visit.get(visit_id)):
+            latest_by_visit[visit_id] = instance
+
+    return {
+        visit_id: _lab_report_summary_for_registrar(service, instance)
+        for visit_id, instance in latest_by_visit.items()
+    }
+
+
 def _resolve_payment_truth(
     db: Session,
     *,
@@ -2062,6 +2130,37 @@ def get_today_queues(
         # Формируем результат
         result = []
         queue_number = 1
+        include_lab_report_summary = bool(
+            department_filter and department_filter.intersection({"lab", "laboratory"})
+        )
+        visible_entry_wrappers = []
+        if include_lab_report_summary:
+            for specialty, data in queues_by_specialty.items():
+                specialty_key = str(specialty or "").strip().lower()
+                if department_filter and specialty_key not in department_filter:
+                    continue
+                visible_entry_wrappers.extend(data["entries"])
+
+        visible_visit_ids: set[int] = set()
+        for entry_wrapper in visible_entry_wrappers:
+            entry_type = entry_wrapper.get("type")
+            entry_data = entry_wrapper.get("data")
+            entry_visit_id = (
+                entry_wrapper.get("visit_id")
+                or getattr(entry_data, "visit_id", None)
+                or (
+                    getattr(entry_data, "id", None)
+                    if entry_type == "visit"
+                    else None
+                )
+            )
+            if entry_visit_id:
+                visible_visit_ids.add(entry_visit_id)
+
+        latest_lab_reports_by_visit = _latest_lab_report_summaries_by_visit(
+            db,
+            visible_visit_ids,
+        )
 
         for specialty, data in queues_by_specialty.items():
             specialty_key = str(specialty or "").strip().lower()
@@ -2878,6 +2977,11 @@ def get_today_queues(
                     or getattr(entry_data, "visit_id", None)
                     or (record_id if entry_type == "visit" else None)
                 )
+                latest_lab_report = (
+                    latest_lab_reports_by_visit.get(entry_visit_id)
+                    if entry_visit_id
+                    else None
+                )
                 payment_status, payment_type = _resolve_payment_truth(
                     db,
                     visit_id=entry_visit_id,
@@ -2938,6 +3042,7 @@ def get_today_queues(
                         "approval_status": getattr(
                             entry_data, "approval_status", None
                         ),
+                        "latest_lab_report": latest_lab_report,
                         "type": entry_type,  # ✅ ИСПРАВЛЕНО: Добавляем type для frontend (online_queue, visit, appointment)
                         "record_type": entry_type,  # Добавляем тип записи: 'visit' или 'appointment' (для совместимости)
                         "queue_entry_id": entry_wrapper.get("queue_entry_id"),  # ✅ SSOT FIX: ID OnlineQueueEntry для QR-записей

--- a/backend/tests/integration/test_registrar_all_appointments.py
+++ b/backend/tests/integration/test_registrar_all_appointments.py
@@ -270,6 +270,97 @@ class TestRegistrarAllAppointments:
         assert lab_entry.id in entry_ids
         assert cardio_entry.id not in entry_ids
 
+    def test_today_queues_lab_rows_include_latest_lab_report_summary(
+        self,
+        client,
+        db_session,
+        auth_headers,
+        test_patient,
+        test_doctor,
+        test_visit,
+    ):
+        lab_queue = DailyQueue(
+            day=date.today(),
+            specialist_id=test_doctor.id,
+            queue_tag="lab",
+            active=True,
+        )
+        db_session.add(lab_queue)
+        db_session.commit()
+        db_session.refresh(lab_queue)
+
+        lab_entry = OnlineQueueEntry(
+            queue_id=lab_queue.id,
+            number=1,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            visit_id=test_visit.id,
+            source="desk",
+            status="waiting",
+        )
+        db_session.add(lab_entry)
+        db_session.commit()
+
+        templates_response = client.get("/api/v1/lab/templates", headers=auth_headers)
+        assert templates_response.status_code == 200, templates_response.text
+        template = next(
+            item for item in templates_response.json() if item["code"] == "cbc_oak"
+        )
+
+        first_response = client.post(
+            "/api/v1/lab/report-instances",
+            headers=auth_headers,
+            json={
+                "patient_id": test_patient.id,
+                "visit_id": test_visit.id,
+                "template_id": template["id"],
+            },
+        )
+        assert first_response.status_code == 200, first_response.text
+
+        latest_response = client.post(
+            "/api/v1/lab/report-instances",
+            headers=auth_headers,
+            json={
+                "patient_id": test_patient.id,
+                "visit_id": test_visit.id,
+                "template_id": template["id"],
+            },
+        )
+        assert latest_response.status_code == 200, latest_response.text
+        latest = latest_response.json()
+
+        ready_response = client.post(
+            f"/api/v1/lab/report-instances/{latest['id']}/mark-ready",
+            headers=auth_headers,
+        )
+        assert ready_response.status_code == 200, ready_response.text
+
+        response = client.get(
+            "/api/v1/registrar/queues/today?department=lab",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        found_entry = next(
+            entry
+            for queue in payload["queues"]
+            for entry in queue["entries"]
+            if entry["id"] == lab_entry.id
+        )
+        latest_lab_report = found_entry["latest_lab_report"]
+
+        assert latest_lab_report["id"] == latest["id"]
+        assert latest_lab_report["status"] == "READY"
+        assert latest_lab_report["template_id"] == template["id"]
+        assert latest_lab_report["template_name"] == template["name"]
+        assert latest_lab_report["flagged_findings_count"] == 0
+        assert latest_lab_report["critical_findings_count"] == 0
+        assert latest_lab_report["can_finalize"] is True
+        assert "finalize" in latest_lab_report["available_actions"]
+
     def test_start_queue_visit_uses_queue_entry_id_when_visit_id_collides(
         self,
         client,

--- a/frontend/src/pages/LabPanel.jsx
+++ b/frontend/src/pages/LabPanel.jsx
@@ -31,6 +31,7 @@ function getLabPanelTabPanelId(tabId) {
 }
 
 function formatAppointmentEntry(queue, entry) {
+  const latestLabReport = entry.latest_lab_report || null;
   return {
     id: entry.id,
     appointment_id: entry.appointment_id || null,
@@ -53,29 +54,15 @@ function formatAppointmentEntry(queue, entry) {
     appointment_time: entry.visit_time || '09:00',
     status: entry.status || 'waiting',
     status_source: 'queue',
-    lab_report_status: null,
-    report_status_source: null,
-    report_instance_id: null,
-    report_template_name: '',
-    flagged_findings_count: 0,
-    critical_findings_count: 0,
-    max_flag_severity: null
+    latest_lab_report: latestLabReport,
+    lab_report_status: latestLabReport?.status || null,
+    report_status_source: latestLabReport ? 'lab-report' : null,
+    report_instance_id: latestLabReport?.id || null,
+    report_template_name: latestLabReport?.template_name || '',
+    flagged_findings_count: latestLabReport?.flagged_findings_count || 0,
+    critical_findings_count: latestLabReport?.critical_findings_count || 0,
+    max_flag_severity: latestLabReport?.max_flag_severity ?? null
   };
-}
-
-function pickLatestInstance(left, right) {
-  if (!left) {
-    return right;
-  }
-  if (!right) {
-    return left;
-  }
-  const leftTime = new Date(left.created_at || 0).getTime();
-  const rightTime = new Date(right.created_at || 0).getTime();
-  if (rightTime !== leftTime) {
-    return rightTime > leftTime ? right : left;
-  }
-  return (right.id || 0) > (left.id || 0) ? right : left;
 }
 
 function normalizeListPayload(payload) {
@@ -98,43 +85,6 @@ function isAbortLikeError(error) {
   const name = String(error?.name || '').toLowerCase();
   const message = String(error?.message || '').toLowerCase();
   return name === 'aborterror' || message.includes('aborted');
-}
-
-function mergeQueueEntriesWithLabInstances(queueEntries, labInstances) {
-  if (!queueEntries.length || !labInstances.length) {
-    return queueEntries;
-  }
-  const latestByVisit = new Map();
-  labInstances.forEach((instance) => {
-    if (!instance.visit_id) {
-      return;
-    }
-    latestByVisit.set(
-      instance.visit_id,
-      pickLatestInstance(latestByVisit.get(instance.visit_id), instance)
-    );
-  });
-  return queueEntries.map((appointment) => {
-    const linkedInstance = appointment.visit_id
-      ? latestByVisit.get(appointment.visit_id)
-      : null;
-    if (!linkedInstance) {
-      return appointment;
-    }
-    return {
-      ...appointment,
-      status: appointment.status,
-      queue_status: appointment.queue_status || appointment.status,
-      status_source: 'queue',
-      lab_report_status: linkedInstance.status || null,
-      report_status_source: 'lab-report',
-      report_instance_id: linkedInstance.id || null,
-      report_template_name: linkedInstance.template?.name || '',
-      flagged_findings_count: linkedInstance.flagged_findings_count || 0,
-      critical_findings_count: linkedInstance.critical_findings_count || 0,
-      max_flag_severity: linkedInstance.max_flag_severity ?? null
-    };
-  });
 }
 
 function buildTemplateResolutionPayload(appointment) {
@@ -265,34 +215,19 @@ export default function LabPanel() {
       const payload = await response.json();
       const queueEntries = (payload?.queues || [])
         .flatMap((queue) => (queue.entries || []).map((entry) => formatAppointmentEntry(queue, entry)));
-      const visitIds = queueEntries
-        .map((item) => item.visit_id)
-        .filter(Boolean);
-      let mergedEntries = queueEntries;
-      if (visitIds.length > 0) {
-        try {
-          const linkedInstances = await labReportingApi.listInstances({
-            visit_ids: visitIds,
-            limit: Math.min(Math.max(visitIds.length * 4, 100), 500)
-          });
-          mergedEntries = mergeQueueEntriesWithLabInstances(queueEntries, normalizeListPayload(linkedInstances));
-        } catch (linkError) {
-          logger.warn('[LabPanel] queue/report status sync failed', linkError);
-        }
-      }
-      setAppointments(mergedEntries);
+      setAppointments(queueEntries);
       setSelectedAppointment((current) => {
         if (!current) {
           return current;
         }
-        const refreshed = mergedEntries.find(
+        const refreshed = queueEntries.find(
           (item) =>
             item.id === current.id
             || (current.appointment_id && item.appointment_id === current.appointment_id)
         );
         return refreshed || current;
       });
-      logger.info('[LabPanel] loaded lab queue entries', mergedEntries.length);
+      logger.info('[LabPanel] loaded lab queue entries', queueEntries.length);
     } catch (error) {
       logger.error('[LabPanel] loadLabAppointments failed', error);
       notify(

--- a/frontend/src/pages/__tests__/LabPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/LabPanel.contract.test.jsx
@@ -18,20 +18,22 @@ const extractBlock = (source, startMarker, endMarker) => {
 };
 
 describe('LabPanel queue/report status contract', () => {
-  it('keeps queue status separate from lab report status when merging report instances', () => {
+  it('keeps queue status separate from backend-provided lab report summary', () => {
     const source = readLabPanelSource();
-    const mergeBlock = extractBlock(
+    const formatBlock = extractBlock(
       source,
-      'function mergeQueueEntriesWithLabInstances(queueEntries, labInstances) {',
-      'function buildTemplateResolutionPayload(appointment) {',
+      'function formatAppointmentEntry(queue, entry) {',
+      'function normalizeListPayload(payload) {',
     );
 
-    expect(mergeBlock).toContain('status: appointment.status');
-    expect(mergeBlock).toContain('queue_status: appointment.queue_status || appointment.status');
-    expect(mergeBlock).toContain("status_source: 'queue'");
-    expect(mergeBlock).toContain('lab_report_status: linkedInstance.status || null');
-    expect(mergeBlock).toContain("report_status_source: 'lab-report'");
-    expect(mergeBlock).not.toContain('status: linkedInstance.status || appointment.status');
+    expect(formatBlock).toContain('const latestLabReport = entry.latest_lab_report || null');
+    expect(formatBlock).toContain("status_source: 'queue'");
+    expect(formatBlock).toContain('queue_status: entry.status ||');
+    expect(formatBlock).toContain('lab_report_status: latestLabReport?.status || null');
+    expect(formatBlock).toContain("report_status_source: latestLabReport ? 'lab-report' : null");
+    const lines = formatBlock.split('\n').map((line) => line.trim());
+    expect(lines).not.toContain('status: latestLabReport?.status || entry.status,');
+    expect(lines).not.toContain('status: latestLabReport?.status || null,');
   });
 
   it('does not add BFF-lite endpoints for the lab queue contract repair', () => {
@@ -52,5 +54,18 @@ describe('LabPanel queue/report status contract', () => {
     expect(loadBlock).toContain("new URLSearchParams({ department: 'lab' })");
     expect(loadBlock).toContain('/registrar/queues/today?${queueParams.toString()}');
     expect(loadBlock).not.toContain(".filter((queue) => ['lab', 'laboratory'].includes(queue.specialty))");
+  });
+
+  it('does not fetch report instances by visit_ids to enrich normal queue rows', () => {
+    const source = readLabPanelSource();
+    const loadBlock = extractBlock(
+      source,
+      'const loadLabAppointments = useCallback(async () => {',
+      'const loadTemplates = useCallback(async (preferredTemplateId = null) => {',
+    );
+
+    expect(loadBlock).not.toContain('visit_ids');
+    expect(loadBlock).not.toContain('mergeQueueEntriesWithLabInstances');
+    expect(source).not.toContain('function mergeQueueEntriesWithLabInstances');
   });
 });


### PR DESCRIPTION
## Summary
- Extend existing `GET /api/v1/registrar/queues/today?department=lab` rows with display-safe `latest_lab_report` summary.
- Remove LabPanel's extra `/lab/report-instances?visit_ids=...` enrichment pass for normal lab queue rows.
- Keep queue status and lab report status separate: queue state remains queue-owned, report summary is display metadata.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `main` at `61454628` after PR #1243 merge.
- Clean workspace: clean before commit; clean after commit.
- Branch: `codex/lab-latest-report-existing-endpoint`.
- Scope gate: narrow override after gate split backend/frontend ownership; touched only lab queue contract files and targeted tests.
- Red-check handling: no red checks before PR creation; will fix this PR if CI reports code-related failures.

## Contract Impact
- Canonical surface: existing `GET /api/v1/registrar/queues/today` with `department=lab` query.
- Request shape: unchanged.
- Response shape: additive per-entry `latest_lab_report` object for lab/laboratory department queue rows; no new endpoint.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/pages/LabPanel.jsx` consumes backend-provided report summary when formatting lab queue rows.
- Compatibility path or alias: none added.
- Contract proof: backend integration test covers latest report summary and frontend contract test proves no normal-row `visit_ids` enrichment.

## RBAC / Permissions
- Roles allowed: unchanged existing registrar/lab queue endpoint behavior.
- Roles denied: unchanged existing auth behavior.
- Positive auth proof: existing authenticated integration test calls `/api/v1/registrar/queues/today?department=lab` successfully.
- Negative auth proof: not changed in this PR; auth dependencies untouched.

## Notification / Realtime
- Event type or websocket channel: none.
- Payload version / ack behavior: none.
- Read/unread or delivery semantics: none.
- Reconnect/resync proof: not applicable; this is REST read contract only.

## Frontend Resilience
- Empty data proof: unchanged queue normalization handles empty queues; no extra enrichment fetch is required.
- Partial data proof: `latest_lab_report` is nullable and LabPanel falls back to null report fields.
- Forbidden secondary path behavior: removed normal queue-row `/lab/report-instances?visit_ids=...` secondary enrichment.
- Missing draft/resource behavior: unchanged; patient history/recent reports still use lab reporting endpoints outside queue-row enrichment.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: registrar queues endpoint, registrar integration test, LabPanel, LabPanel contract test.
- Denied paths: `/api/v1/ui/*`, separate BFF service, command wrappers, migrations, QueueJoin, DisplayBoard, unrelated cleanup.
- Migration/docs/test impact: no migration; targeted tests updated; no runtime docs required.
- Rollback note: revert this commit to return LabPanel to previous separate report-instance enrichment behavior.

## Validation
- Targeted tests or smoke run: `C:\final\backend\.venv\Scripts\python.exe -m py_compile backend/app/api/v1/endpoints/registrar_integration.py`; `C:\final\backend\.venv\Scripts\python.exe -m pytest backend/tests/integration/test_registrar_all_appointments.py::TestRegistrarAllAppointments::test_today_queues_lab_rows_include_latest_lab_report_summary`; `C:\final\backend\.venv\Scripts\python.exe -m pytest backend/tests/integration/test_registrar_all_appointments.py`; `npm --prefix frontend run test:run -- LabPanel.contract`; `npm --prefix frontend run build`; `git diff --check`.
- Result: all passed.
- Not checked: full backend suite; browser smoke; GitHub CI pending.