### PR TITLE
fix(lab): require explicit report creation

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Badge, Button, Card, CardContent, CardHeader, CardTitle, Icon } from '../ui/macos';
 import { labReportingApi } from '../../api/labReporting';
@@ -266,7 +266,6 @@ export default function LabReportWorkbench({
   const [busyAction, setBusyAction] = useState('');
   const [printFeedback, setPrintFeedback] = useState(null);
   const [historySeverityFilter, setHistorySeverityFilter] = useState('all');
-  const autoActionRef = useRef('');
 
   const publishedTemplates = useMemo(
     () => templates.filter((template) => template.published_version_id || template.draft_version_id),
@@ -280,7 +279,6 @@ export default function LabReportWorkbench({
   const serviceContextPresent = (templateResolution?.service_codes || []).length > 0;
   const templateOptions = serviceContextPresent ? resolvedTemplates : publishedTemplates;
   const resolutionHasBlockingGap = serviceContextPresent && resolvedTemplates.length === 0;
-  const resolvedVisitId = templateResolution?.visit_id || selectedAppointment?.visit_id || null;
   const singleAllowedTemplate =
     serviceContextPresent && templateOptions.length === 1 ? templateOptions[0] : null;
 
@@ -381,10 +379,6 @@ export default function LabReportWorkbench({
   }, [activeInstance]);
 
   useEffect(() => {
-    autoActionRef.current = '';
-  }, [selectedAppointment?.id, selectedAppointment?.appointment_id, resolvedVisitId]);
-
-  useEffect(() => {
     if (activeInstance || !selectedAppointment) {
       return;
     }
@@ -397,56 +391,6 @@ export default function LabReportWorkbench({
       return defaultTemplateId ? String(defaultTemplateId) : '';
     });
   }, [activeInstance, selectedAppointment, templateOptions, templateResolution?.default_template?.id]);
-
-  useEffect(() => {
-    if (
-      activeInstance
-      || !selectedAppointment
-      || !singleAllowedTemplate
-      || templateResolutionLoading
-      || resolutionHasBlockingGap
-      || saving
-    ) {
-      return;
-    }
-
-    const templateId = String(singleAllowedTemplate.id);
-    const existingInstance = reportHistory
-      .filter(
-        (item) =>
-          String(item.template?.id || item.template_id) === templateId
-          && String(item.visit_id || '') === String(resolvedVisitId || '')
-      )
-      .sort((left, right) => new Date(right.created_at).getTime() - new Date(left.created_at).getTime())[0];
-    const autoKey = `${selectedAppointment.id || selectedAppointment.appointment_id || 'patient'}:${resolvedVisitId || 'no-visit'}:${templateId}:${existingInstance?.id || 'new'}`;
-    if (autoActionRef.current === autoKey) {
-      return;
-    }
-    autoActionRef.current = autoKey;
-    setSelectedTemplateId(templateId);
-
-    if (existingInstance) {
-      notify('info', 'Открываю уже созданный бланк для этого визита.');
-      void onOpenInstance(existingInstance.id);
-      return;
-    }
-
-    void handleCreateInstance(templateId, {
-      successMessage: `Бланк "${singleAllowedTemplate.name}" создан автоматически.`
-    });
-  }, [
-    activeInstance,
-    handleCreateInstance,
-    notify,
-    onOpenInstance,
-    reportHistory,
-    resolvedVisitId,
-    resolutionHasBlockingGap,
-    saving,
-    selectedAppointment,
-    singleAllowedTemplate,
-    templateResolutionLoading
-  ]);
 
   function updateField(fieldKey, value) {
     setDraftValues((prev) => ({ ...prev, [fieldKey]: value }));
@@ -690,7 +634,7 @@ export default function LabReportWorkbench({
               )}
               {!templateResolutionLoading && singleAllowedTemplate && !resolutionHasBlockingGap && (
                 <Alert severity="info">
-                  Единственный допустимый бланк найден: <strong>{singleAllowedTemplate.name}</strong>. Открываю его автоматически.
+                  Единственный допустимый бланк найден: <strong>{singleAllowedTemplate.name}</strong>. Нажмите «Создать бланк», чтобы открыть его для заполнения.
                 </Alert>
               )}
               <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: '12px', alignItems: 'end' }}>

--- a/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
@@ -7,6 +7,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import LabReportWorkbench from '../LabReportWorkbench';
+import { labReportingApi } from '../../../api/labReporting';
 import { ThemeProvider } from '../../../contexts/ThemeContext.jsx';
 import { MacOSThemeProvider } from '../../../theme/macosTheme.jsx';
 
@@ -28,6 +29,7 @@ vi.mock('../../../api/labReporting', () => ({
 
 describe('LabReportWorkbench', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     localStorage.clear();
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
@@ -101,5 +103,76 @@ describe('LabReportWorkbench', () => {
     expect(source).toContain("const canRevise = hasLabReportAction(activeInstance, 'revise')");
     expect(source).not.toContain("activeInstance.status !== 'FINALIZED' && activeInstance.status !== 'PRINTED'");
     expect(source).not.toContain("activeInstance.status === 'FINALIZED' || activeInstance.status === 'PRINTED'");
+  });
+
+  it('does not auto-create or auto-open a report when exactly one template is allowed', async () => {
+    const onOpenInstance = vi.fn();
+    const notify = vi.fn();
+
+    render(
+      <MacOSThemeProvider>
+        <ThemeProvider>
+          <LabReportWorkbench
+            selectedAppointment={{
+              id: 17,
+              patient_id: 444,
+              visit_id: 728,
+              patient_fio: 'Test Patient',
+              service_codes: ['CBC'],
+              service_details: [{ id: 5, code: 'CBC', name: 'CBC' }],
+            }}
+            templates={[
+              {
+                id: 3,
+                name: 'CBC template',
+                family: 'hematology',
+                published_version_id: 33,
+              },
+            ]}
+            templateResolution={{
+              visit_id: 728,
+              service_codes: ['CBC'],
+              default_template: {
+                id: 3,
+                name: 'CBC template',
+                family: 'hematology',
+                published_version_id: 33,
+              },
+              allowed_templates: [
+                {
+                  id: 3,
+                  name: 'CBC template',
+                  family: 'hematology',
+                  published_version_id: 33,
+                },
+              ],
+              unmapped_service_codes: [],
+            }}
+            templateResolutionLoading={false}
+            reportHistory={[]}
+            recentReports={[]}
+            activeInstance={null}
+            onInstanceChange={vi.fn()}
+            onOpenInstance={onOpenInstance}
+            onRefreshHistory={vi.fn()}
+            onRefreshRecentReports={vi.fn()}
+            onQueueChanged={vi.fn()}
+            notify={notify}
+          />
+        </ThemeProvider>
+      </MacOSThemeProvider>
+    );
+
+    await screen.findByText((content) =>
+      content.includes('Единственный допустимый бланк найден')
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(labReportingApi.createInstance).not.toHaveBeenCalled();
+    expect(onOpenInstance).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalledWith(
+      'success',
+      expect.stringContaining('автоматически')
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Remove the Lab report workbench auto-create/auto-open side effect when backend template resolution returns exactly one allowed template.
- Keep backend-owned lab command rules on existing lab reporting endpoints; report creation now requires explicit user action.
- Add a targeted component test proving single-template resolution does not call `createInstance` or `onOpenInstance` automatically.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `main` at `92703402` after PR #1244 merge.
- Clean workspace: clean before branch; clean after commit.
- Branch: `codex/lab-command-contract-tightening`.
- Scope gate: `agent_gate.py` required a known-root-cause narrow override for `frontend/src/components/laboratory/LabReportWorkbench.jsx`; test file touched only for focused proof.
- Red-check handling: PR Review Quality Gate failed on PR body wording only; body updated without runtime code changes.

## Contract Impact
- Canonical surface: existing lab reporting command endpoints remain unchanged.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `LabReportWorkbench` no longer converts `singleAllowedTemplate` read-model state into an automatic create/open command.
- Compatibility path or alias: none.
- Contract proof: focused Vitest proves exactly-one allowed template does not auto-create or auto-open a report.

## RBAC / Permissions
- Roles allowed: unchanged; existing lab reporting endpoints continue enforcing roles backend-side.
- Roles denied: unchanged.
- Positive auth proof: no backend/API auth change; existing command endpoints remain the only mutation path.
- Negative auth proof: no backend/API auth change; this PR removes an automatic frontend trigger and does not weaken denied-role behavior.

## Notification / Realtime
- Event type or websocket channel: no realtime event or websocket channel is added, removed, or changed.
- Payload version / ack behavior: no realtime payload or ack behavior exists in this diff.
- Read/unread or delivery semantics: no notification delivery state is touched.
- Reconnect/resync proof: reconnect/resync behavior is unchanged because the diff only removes a React auto-command effect and does not touch websocket subscriptions, REST reload paths, or persisted delivery state.

## Frontend Resilience
- Empty data proof: unchanged.
- Partial data proof: single allowed template still displays an info alert and preselects the template; no mutation occurs until the user clicks create.
- Forbidden secondary path behavior: no new secondary path.
- Missing draft/resource behavior: unchanged; explicit create still uses existing lab reporting command endpoint and backend errors remain surfaced.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `LabReportWorkbench.jsx`, focused `LabReportWorkbench.test.jsx`.
- Denied paths: `/api/v1/ui/*`, backend endpoints/services, command wrappers, migrations, QueueJoin, DisplayBoard, unrelated cleanup.
- Migration/docs/test impact: no migration; targeted frontend test updated.
- Rollback note: revert this commit to restore automatic single-template create/open behavior.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- LabReportWorkbench`; `npm --prefix frontend run build`; `git diff --check`; `git diff --check HEAD~1 HEAD`.
- Result: all passed.
- Not checked: full backend suite; browser smoke; LabPanel status fallback cleanup is intentionally left for a separate first-touch PR.