### PR TITLE
fix(lab): preserve missing print status

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -202,7 +202,7 @@ function buildLabPrintPayload(instance, appointment) {
       patient_id: instance?.patient_id || appointmentSnapshot?.patient_id || null,
       template_id: instance?.template_id || null,
       template_name: templateName,
-      status: instance?.status || 'DRAFT',
+      status: instance?.status || null,
       created_at: instance?.created_at || null,
       finalized_at: instance?.finalized_at || null,
       printed_at: instance?.printed_at || null

--- a/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
@@ -105,6 +105,13 @@ describe('LabReportWorkbench', () => {
     expect(source).not.toContain("activeInstance.status === 'FINALIZED' || activeInstance.status === 'PRINTED'");
   });
 
+  it('does not invent draft status in the print payload when backend status is missing', () => {
+    const source = fs.readFileSync(workbenchPath, 'utf8');
+
+    expect(source).toContain('status: instance?.status || null');
+    expect(source).not.toContain("status: instance?.status || 'DRAFT'");
+  });
+
   it('does not auto-create or auto-open a report when exactly one template is allowed', async () => {
     const onOpenInstance = vi.fn();
     const notify = vi.fn();


### PR DESCRIPTION
## Summary
- Preserve missing backend lab report status as `null` in the print payload instead of inventing `DRAFT`.
- Keep lab finalization/print status ownership on backend report instance data.
- Add a focused contract test proving the print payload does not synthesize draft status when backend status is missing.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `main` at `c8bda151` after PR #1246 merge.
- Clean workspace: clean before branch; clean after commit.
- Branch: `codex/lab-print-payload-status-fallback`.
- Scope gate: `agent_gate.py --known-root-cause frontend/src/components/laboratory/LabReportWorkbench.jsx` returned narrow override; runtime edit stayed in `LabReportWorkbench.jsx`, test edit added focused proof only.
- Red-check handling: no red checks before PR creation; will fix this PR if CI reports code-related failures.

## Contract Impact
- Canonical surface: no backend/API surface changed; frontend print payload consumes existing lab report instance status.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `LabReportWorkbench` now treats missing `instance.status` as unknown/null in print payload instead of local `DRAFT` canonical default.
- Compatibility path or alias: none.
- Contract proof: `LabReportWorkbench` test asserts no fallback to `DRAFT` for missing backend status in print payload.

## RBAC / Permissions
- Roles allowed: unchanged existing lab report roles because this PR does not edit backend auth dependencies, route decorators, token handling, or API client authorization headers.
- Roles denied: unchanged denied-role behavior because no backend endpoint, role guard, route registration, or frontend role gate is modified.
- Positive auth proof: protected print/export flows still use the same existing report instance and PDF/print paths; only local payload formatting after an already loaded instance changed.
- Negative auth proof: unauthorized/forbidden behavior still terminates at the same backend endpoints before payload formatting because this diff does not add fallback endpoints, bypass routes, cached data sources, or alternate unauthenticated calls.

## Notification / Realtime
- Event type or websocket channel: no realtime event or websocket channel is added, removed, or changed.
- Payload version / ack behavior: no realtime payload or ack behavior exists in this diff.
- Read/unread or delivery semantics: no notification delivery state is touched.
- Reconnect/resync proof: reconnect/resync behavior is unchanged because the diff only changes local print payload formatting and does not touch websocket subscriptions, reload paths, or persisted delivery state.

## Frontend Resilience
- Empty data proof: unchanged.
- Partial data proof: missing report status remains nullable in print payload and is not turned into a false draft state.
- Forbidden secondary path behavior: no new secondary path and no new API calls.
- Missing draft/resource behavior: unchanged; print still requires an active report instance and backend command/export paths remain authoritative.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/components/laboratory/LabReportWorkbench.jsx`, focused `frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx`.
- Denied paths: `/api/v1/ui/*`, backend endpoints/services, command wrappers, migrations, QueueJoin, DisplayBoard, unrelated cleanup.
- Migration/docs/test impact: no migration; targeted frontend contract test updated.
- Rollback note: revert this commit to restore previous local `DRAFT` fallback in the print payload.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- LabReportWorkbench`; `npm --prefix frontend run build`; `git diff --check`.
- Result: all passed.
- Not checked: full backend suite; browser smoke.