### PR TITLE
fix(lab): avoid auto-create visit wording

### DIFF
--- a/frontend/src/components/laboratory/LabQueueWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabQueueWorkbench.jsx
@@ -136,7 +136,7 @@ export default function LabQueueWorkbench({
                           {appointment.patient_fio || 'Пациент без имени'}
                         </div>
                       <div style={{ color: 'var(--mac-text-secondary)', fontSize: '14px' }}>
-                        Визит: {appointment.visit_id || 'будет создан автоматически'} | Телефон: {appointment.patient_phone || 'не указан'}
+                        Визит: {appointment.visit_id || 'не привязан'} | Телефон: {appointment.patient_phone || 'не указан'}
                       </div>
                     </div>
                       <Badge variant={getLabStatusVariant(appointment.status)}>


### PR DESCRIPTION
## Summary
- Replace the Lab queue missing-visit display text from `will be created automatically` semantics to the neutral label `not linked` (`?? ????????`).
- Keeps Lab queue workbench presentation-only: no frontend promise that a missing visit will be auto-created.
- No backend, command, API, BFF-lite, or `/api/v1/ui/*` changes.

## Cyclic Execution Evidence
- Fresh main sync: branch was created from `origin/main` at `8c5c95f9`, after PR #1247 was merged and `main == origin/main` was verified.
- Clean workspace: before the patch, tracked workspace state was clean; after the patch, only `frontend/src/components/laboratory/LabQueueWorkbench.jsx` is part of this PR.
- Branch: `codex/lab-queue-visit-display-contract`.
- Scope gate: `agent_gate.py` ran with known root cause `frontend/src/components/laboratory/LabQueueWorkbench.jsx` and returned narrow override with that file as the only first-touch file.
- Red-check handling: PR Review Quality Gate body failures are being fixed in this PR; runtime checks were not bypassed.

## Contract Impact
- Canonical surface: `frontend/src/components/laboratory/LabQueueWorkbench.jsx` display rendering for Lab queue rows.
- Request shape: unchanged; no API request body, query parameter, or endpoint changed.
- Response shape: unchanged; the frontend still consumes the existing backend-provided `visit_id` field.
- Status codes: unchanged; no backend route or command status code changed.
- Frontend consumer: Lab queue workbench card display only.
- Compatibility path or alias: unchanged; no route alias, legacy endpoint, or fallback API path was added.
- Contract proof: `visit_id` remains backend-owned data; React only renders a neutral missing-value label when the backend DTO has no linked visit.

## RBAC / Permissions
- Roles allowed: unchanged; existing Lab queue viewers keep the same access and actions.
- Roles denied: unchanged; users without existing Lab queue access receive no new route, API call, or action path.
- Positive auth proof: authorized Lab queue users see the same cards, buttons, and refresh behavior; only the missing-visit text changes.
- Negative auth proof: this PR does not add routes, permissions, role checks, API calls, or action buttons, so unauthorized users gain no new Lab access path.

## Notification / Realtime
- Event type or websocket channel: unchanged; no event type, channel, polling endpoint, or websocket code was touched.
- Payload version / ack behavior: unchanged; no realtime payload version or acknowledgement behavior was introduced or modified.
- Read/unread or delivery semantics: unchanged; the component has no notification delivery/read state changes in this PR.
- Reconnect/resync proof: existing refresh/realtime paths still pass the same appointment DTOs into `LabQueueWorkbench`; only local missing `visit_id` label rendering changes.

## Frontend Resilience
- Empty data proof: empty appointment lists still render the existing empty Lab queue alert; this PR does not touch that path.
- Partial data proof: rows missing `visit_id` now render `?? ????????` instead of promising automatic creation.
- Forbidden secondary path behavior: no secondary API path, fallback command, or hidden report creation path was added.
- Missing draft/resource behavior: no draft/report resource is created or opened from this display field.
- Stale route/deep-link behavior: no route, query parameter, or deep-link handling changed.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run build`.
- Result: passed locally with Vite production build completing successfully.
- Diff hygiene: `git diff --check` passed; Git reported only the existing LF-to-CRLF working-copy warning for the touched file.
- Not checked: backend tests were not run because this PR does not touch backend code, API contracts, schemas, migrations, or command services.

## Scope Gate
- Allowed paths: `frontend/src/components/laboratory/LabQueueWorkbench.jsx` only.
- Denied paths: backend, API schemas, `/api/v1/ui/*`, QueueJoin, DisplayBoard, Registrar, lab command services, report finalization/template/version logic.
- Migration/docs/test impact: no migrations, docs, or tests changed; validation is frontend build because the gate limited first-touch scope to one runtime display file.
- Rollback note: revert commit `a81750a4` to restore the previous label.
