### PR TITLE
fix(doctor): require queue entry ids for queue commands

### DIFF
--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -67,6 +67,16 @@ function countAppointmentsByStatuses(appointments, statuses) {
   return appointments.filter((appointment) => statuses.includes(appointment.status)).length;
 }
 
+function resolveDoctorQueueEntryId(row) {
+  const explicitQueueEntryId = row?.doctor_queue_entry_id ?? row?.queue_entry_id ?? null;
+  if (explicitQueueEntryId !== null && explicitQueueEntryId !== undefined) {
+    return explicitQueueEntryId;
+  }
+
+  const recordKind = String(row?.record_kind ?? row?.record_type ?? row?.type ?? '').trim().toLowerCase();
+  return recordKind === 'online_queue' && row?.id !== null && row?.id !== undefined ? row.id : null;
+}
+
 /**
  * Унифицированная панель кардиолога
  * Объединяет: очередь + специализированные функции + AI + ЭКГ/ЭхоКГ
@@ -546,6 +556,7 @@ const MacOSCardiologistPanelUnified = () => {
             if (queue.entries) {
               queue.entries.forEach((entry) => {
                 const appointmentId = entry.appointment_id || null;
+                const doctorQueueEntryId = resolveDoctorQueueEntryId(entry);
                 const recordKey = `${entry.patient_id}_${entry.canonical_record_id || entry.id}_${queue.specialty}`;
 
                 // Пропускаем дубликаты (один и тот же пациент с одним и тем же appointment_id в одной специальности)
@@ -575,10 +586,12 @@ const MacOSCardiologistPanelUnified = () => {
                   payment_status: entry.payment_status || 'pending',
                   available_actions: entry.available_actions || [],
                   can_mark_paid: Boolean(entry.can_mark_paid),
-                  can_start_visit: Boolean(entry.can_start_visit),
+                  can_start_visit: Boolean(entry.can_start_visit) && doctorQueueEntryId !== null,
                   can_print_ticket: Boolean(entry.can_print_ticket),
-                  can_complete: Boolean(entry.can_complete),
+                  can_complete: Boolean(entry.can_complete) && doctorQueueEntryId !== null,
                   can_cancel: Boolean(entry.can_cancel),
+                  queue_entry_id: entry.queue_entry_id ?? null,
+                  doctor_queue_entry_id: doctorQueueEntryId,
                   canonical_record_id: entry.canonical_record_id || entry.id,
                   record_kind: entry.record_kind,
                   source_kind: entry.source_kind,
@@ -811,6 +824,7 @@ const MacOSCardiologistPanelUnified = () => {
         patient_name: row.patient_fio,
         phone: row.patient_phone,
         number: row.id,
+        doctor_queue_entry_id: resolveDoctorQueueEntryId(row),
         source: 'appointments',
         status: row.status || 'waiting',
         payment_status: row.payment_status || 'pending',
@@ -857,6 +871,7 @@ const MacOSCardiologistPanelUnified = () => {
             patient_name: row.patient_fio,
             phone: row.patient_phone,
             number: row.id,
+            doctor_queue_entry_id: resolveDoctorQueueEntryId(row),
             source: 'appointments',
             status: row.status || 'waiting',
             payment_status: row.payment_status || 'pending',
@@ -876,8 +891,14 @@ const MacOSCardiologistPanelUnified = () => {
       case 'call':
         // Вызвать пациента
         try {
+          const queueEntryId = resolveDoctorQueueEntryId(row);
+          if (queueEntryId === null) {
+            logger.warn('[Cardiology] Cannot start visit without OnlineQueueEntry id', row);
+            setMessage({ type: 'error', text: 'Cannot start visit without a queue entry id' });
+            break;
+          }
           const token = tokenManager.getAccessToken();
-          const response = await fetch(`${API_V1_BASE}/doctor/queue/${row.id}/start-visit`, {
+          const response = await fetch(`${API_V1_BASE}/doctor/queue/${queueEntryId}/start-visit`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -933,6 +954,7 @@ const MacOSCardiologistPanelUnified = () => {
               patient_name: row.patient_fio,
               phone: row.patient_phone,
               number: row.id,
+              doctor_queue_entry_id: resolveDoctorQueueEntryId(row),
               source: 'appointments',
               status: 'in_cabinet',
               payment_status: row.payment_status,
@@ -996,6 +1018,11 @@ const MacOSCardiologistPanelUnified = () => {
 
     try {
       setLoading(true);
+      const queueEntryId = resolveDoctorQueueEntryId(selectedPatient);
+      if (queueEntryId === null) {
+        setMessage({ type: 'error', text: 'Cannot complete visit without a queue entry id' });
+        return;
+      }
 
       const visitPayload = {
         patient_id: selectedPatient.patient?.id || selectedPatient.patient_id || selectedPatient.id,
@@ -1005,7 +1032,7 @@ const MacOSCardiologistPanelUnified = () => {
         services: selectedServices,
         notes: visitData.notes
       };
-      await queueService.completeVisit(selectedPatient.id, visitPayload);
+      await queueService.completeVisit(queueEntryId, visitPayload);
       setMessage({ type: 'success', text: 'Прием завершен успешно' });
 
       // Очищаем форму и возвращаемся в очередь

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -107,6 +107,16 @@ function normalizeNumericId(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function resolveDoctorQueueEntryId(row) {
+  const explicitQueueEntryId = row?.doctor_queue_entry_id ?? row?.queue_entry_id ?? null;
+  if (explicitQueueEntryId !== null && explicitQueueEntryId !== undefined) {
+    return explicitQueueEntryId;
+  }
+
+  const recordKind = String(row?.record_kind ?? row?.record_type ?? row?.type ?? '').trim().toLowerCase();
+  return recordKind === 'online_queue' && row?.id !== null && row?.id !== undefined ? row.id : null;
+}
+
 function buildPatientsFromAppointments(appointments) {
   const patientsById = new Map();
 
@@ -554,6 +564,7 @@ const DentistPanelUnified = () => {
             data.queues.forEach((queue) => {
               if (queue.entries) {
                 queue.entries.forEach((entry) => {
+                  const doctorQueueEntryId = resolveDoctorQueueEntryId(entry);
                   allAppointments.push({
                     id: entry.id,
                     appointment_id: entry.appointment_id || null,
@@ -575,10 +586,12 @@ const DentistPanelUnified = () => {
                     payment_status: entry.payment_status || 'pending',
                     available_actions: entry.available_actions || [],
                     can_mark_paid: Boolean(entry.can_mark_paid),
-                    can_start_visit: Boolean(entry.can_start_visit),
+                    can_start_visit: Boolean(entry.can_start_visit) && doctorQueueEntryId !== null,
                     can_print_ticket: Boolean(entry.can_print_ticket),
-                    can_complete: Boolean(entry.can_complete),
+                    can_complete: Boolean(entry.can_complete) && doctorQueueEntryId !== null,
                     can_cancel: Boolean(entry.can_cancel),
+                    queue_entry_id: entry.queue_entry_id ?? null,
+                    doctor_queue_entry_id: doctorQueueEntryId,
                     canonical_record_id: entry.canonical_record_id || entry.id,
                     record_kind: entry.record_kind,
                     source_kind: entry.source_kind,
@@ -708,6 +721,7 @@ const DentistPanelUnified = () => {
         patient_name: row.patient_fio,
         phone: row.patient_phone,
         number: row.id,
+        doctor_queue_entry_id: resolveDoctorQueueEntryId(row),
         source: 'appointments'
       };
       setSelectedPatient(patientData);
@@ -726,8 +740,14 @@ const DentistPanelUnified = () => {
       case 'call':
         // Вызвать пациента
         try {
+          const queueEntryId = resolveDoctorQueueEntryId(row);
+          if (queueEntryId === null) {
+            logger.warn('[Dentist] Cannot start visit without OnlineQueueEntry id', row);
+            notify.error('Cannot start visit without a queue entry id');
+            break;
+          }
           const token = tokenManager.getAccessToken();
-          const response = await fetch(`${API_V1_BASE}/doctor/queue/${row.id}/start-visit`, {
+          const response = await fetch(`${API_V1_BASE}/doctor/queue/${queueEntryId}/start-visit`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -775,6 +795,7 @@ const DentistPanelUnified = () => {
             patient_name: row.patient_fio,
             phone: row.patient_phone,
             number: row.id,
+            doctor_queue_entry_id: resolveDoctorQueueEntryId(row),
             source: 'appointments',
             status: 'in_cabinet'
           };

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -79,6 +79,16 @@ function countAppointmentsByStatuses(appointments, statuses) {
   return appointments.filter((appointment) => statuses.includes(appointment.status)).length;
 }
 
+function resolveDoctorQueueEntryId(row) {
+  const explicitQueueEntryId = row?.doctor_queue_entry_id ?? row?.queue_entry_id ?? null;
+  if (explicitQueueEntryId !== null && explicitQueueEntryId !== undefined) {
+    return explicitQueueEntryId;
+  }
+
+  const recordKind = String(row?.record_kind ?? row?.record_type ?? row?.type ?? '').trim().toLowerCase();
+  return recordKind === 'online_queue' && row?.id !== null && row?.id !== undefined ? row.id : null;
+}
+
 function getRecentDermatologyCache(cacheEntry, fallbackValue) {
   if (cacheEntry.lastAttemptAt && Date.now() - cacheEntry.lastAttemptAt < DERMATOLOGY_REQUEST_COOLDOWN_MS) {
     return cacheEntry.data ?? fallbackValue;
@@ -408,6 +418,7 @@ const DermatologistPanelUnified = () => {
             queuesData.queues.forEach((queue) => {
               if (queue.entries) {
                 queue.entries.forEach((entry) => {
+                  const doctorQueueEntryId = resolveDoctorQueueEntryId(entry);
                   allAppointments.push({
                     id: entry.id,
                     appointment_id: entry.appointment_id || null,
@@ -428,10 +439,12 @@ const DermatologistPanelUnified = () => {
                     payment_status: entry.payment_status || 'pending',
                     available_actions: entry.available_actions || [],
                     can_mark_paid: Boolean(entry.can_mark_paid),
-                    can_start_visit: Boolean(entry.can_start_visit),
+                    can_start_visit: Boolean(entry.can_start_visit) && doctorQueueEntryId !== null,
                     can_print_ticket: Boolean(entry.can_print_ticket),
-                    can_complete: Boolean(entry.can_complete),
+                    can_complete: Boolean(entry.can_complete) && doctorQueueEntryId !== null,
                     can_cancel: Boolean(entry.can_cancel),
+                    queue_entry_id: entry.queue_entry_id ?? null,
+                    doctor_queue_entry_id: doctorQueueEntryId,
                     canonical_record_id: entry.canonical_record_id || entry.id,
                     record_kind: entry.record_kind,
                     source_kind: entry.source_kind,
@@ -585,6 +598,7 @@ const DermatologistPanelUnified = () => {
         patient_name: row.patient_fio,
         phone: row.patient_phone,
         number: row.id,
+        doctor_queue_entry_id: resolveDoctorQueueEntryId(row),
         source: 'appointments',
         status: row.status || 'waiting',
         specialty: row.specialty || 'dermatology'
@@ -606,8 +620,14 @@ const DermatologistPanelUnified = () => {
       case 'call':
         // Вызвать пациента
         try {
+          const queueEntryId = resolveDoctorQueueEntryId(row);
+          if (queueEntryId === null) {
+            logger.warn('[Dermatology] Cannot start visit without OnlineQueueEntry id', row);
+            notify.error('Cannot start visit without a queue entry id');
+            break;
+          }
           const token = tokenManager.getAccessToken();
-          const response = await fetch(`${API_V1_BASE}/doctor/queue/${row.id}/start-visit`, {
+          const response = await fetch(`${API_V1_BASE}/doctor/queue/${queueEntryId}/start-visit`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -659,6 +679,7 @@ const DermatologistPanelUnified = () => {
             patient_name: row.patient_fio,
             phone: row.patient_phone,
             number: row.id,
+            doctor_queue_entry_id: resolveDoctorQueueEntryId(row),
             source: 'appointments',
             status: 'in_cabinet',
             specialty: row.specialty || 'dermatology'
@@ -1171,7 +1192,7 @@ const DermatologistPanelUnified = () => {
   // Унифицированная обработка сохранения визита
   const handleSaveVisit = async () => {
     // Определяем ID записи: приоритет selectedPatient, потом currentAppointment
-    const entryId = selectedPatient?.id || currentAppointment?.id;
+    const entryId = resolveDoctorQueueEntryId(selectedPatient) ?? resolveDoctorQueueEntryId(currentAppointment);
     if (!entryId) {
       logger.error('[Dermатology] handleSaveVisit: нет entryId');
       notify.error('Не выбран пациент для завершения приема');

--- a/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
@@ -35,10 +35,11 @@ describe('Doctor panels SSOT contract', () => {
       expect(source).toContain('payment_type: entry.payment_type');
       expect(source).toContain('available_actions: entry.available_actions || []');
       expect(source).toContain('can_mark_paid: Boolean(entry.can_mark_paid)');
-      expect(source).toContain('can_start_visit: Boolean(entry.can_start_visit)');
+      expect(source).toContain('can_start_visit: Boolean(entry.can_start_visit) && doctorQueueEntryId !== null');
       expect(source).toContain('can_print_ticket: Boolean(entry.can_print_ticket)');
-      expect(source).toContain('can_complete: Boolean(entry.can_complete)');
+      expect(source).toContain('can_complete: Boolean(entry.can_complete) && doctorQueueEntryId !== null');
       expect(source).toContain('can_cancel: Boolean(entry.can_cancel)');
+      expect(source).toContain('doctor_queue_entry_id: doctorQueueEntryId');
     }
   });
 
@@ -58,11 +59,16 @@ describe('Doctor panels SSOT contract', () => {
     expect(actionBlock).not.toContain("rowPaymentStatus === 'paid' :");
   });
 
-  it('routes start visit commands through the doctor command surface', () => {
+  it('routes queue commands through the doctor command surface using only OnlineQueueEntry ids', () => {
     for (const filePath of DOCTOR_PANEL_FILES) {
       const source = read(filePath);
 
-      expect(source).toContain('/doctor/queue/${row.id}/start-visit');
+      expect(source).toContain('function resolveDoctorQueueEntryId(row)');
+      expect(source).toContain("recordKind === 'online_queue'");
+      expect(source).toContain('/doctor/queue/${queueEntryId}/start-visit');
+      expect(source).not.toContain('/doctor/queue/${row.id}/start-visit');
+      expect(source).not.toContain('completeVisit(selectedPatient.id');
+      expect(source).not.toContain('const entryId = selectedPatient?.id || currentAppointment?.id');
       expect(source).not.toContain('/registrar/queue/${row.id}/start-visit');
     }
   });


### PR DESCRIPTION
## Summary
- Require a real `OnlineQueueEntry` id before specialty doctor panels issue `/doctor/queue/{entry_id}` commands.
- Preserve the queue entry id separately as `doctor_queue_entry_id` and stop using generic row ids for start/complete queue commands.
- Update the doctor panels contract test to lock the queue-command id boundary.

## Cyclic Execution Evidence
- Fresh main sync: branch based on `origin/main` at `113eec4f`.
- Clean workspace: scoped stage contains only the three doctor panels and `DoctorPanels.contract.test.jsx`; unrelated local docs/dev-brain edits were left unstaged.
- Branch: `codex/doctor-panels-queue-entry-id-guard`.
- Scope gate: `agent_gate.py` required narrow override per known first-touch file; applied as one same-class frontend caller slice.
- Red-check handling: no red checks observed before PR creation.

## Contract Impact
- Canonical surface: `/doctor/queue/{entry_id}/start-visit` and `queueService.completeVisit(entry_id, ...)` require `OnlineQueueEntry.id`.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: Cardiologist, Dermatologist, and Dentist specialty panels.
- Compatibility path or alias: no new endpoint, no BFF-lite path, no `/api/v1/ui/*`.
- Contract proof: `DoctorPanels.contract.test.jsx` now asserts queue commands use `queueEntryId`, not `row.id`, and complete does not use generic selected row ids.

## RBAC / Permissions
- Roles allowed: not changed.
- Roles denied: not changed.
- Positive auth proof: not applicable; auth headers unchanged.
- Negative auth proof: not applicable; no permission model change.

## Notification / Realtime
- Event type or websocket channel: no websocket or notification channel is changed; existing queue refresh behavior remains the only update path.
- Payload version / ack behavior: no realtime payload or ack contract is changed by this frontend id guard.
- Read/unread or delivery semantics: no notification delivery, read, or unread state is touched.
- Reconnect/resync proof: no reconnect path is touched; queue rows are still reloaded through the existing `/registrar/queues/today` fetch.

## Frontend Resilience
- Empty data proof: existing queue empty handling unchanged.
- Partial data proof: rows without `queue_entry_id` and not typed `online_queue` no longer show start/complete queue actions and refuse direct queue command execution.
- Forbidden secondary path behavior: raw `/doctor/queue/${row.id}/start-visit` and registrar fallback paths are contract-tested absent.
- Missing draft/resource behavior: no draft or saved-resource path participates in these queue commands; missing queue-entry context now blocks the command locally.
- Stale route/deep-link behavior: unchanged; save/complete now requires preserved queue entry context.

## Scope Gate
- Allowed paths: `frontend/src/pages/CardiologistPanelUnified.jsx`, `frontend/src/pages/DermatologistPanelUnified.jsx`, `frontend/src/pages/DentistPanelUnified.jsx`, `frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx`.
- Denied paths: backend endpoints, DB/Alembic, `/api/v1/ui/*`, BFF-lite, unrelated panels, generated artifacts.
- Migration/docs/test impact: no migration or docs; one existing frontend contract test updated.
- Rollback note: revert this PR to restore prior doctor panel queue-command id behavior.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- src/pages/__tests__/DoctorPanels.contract.test.jsx`; `npm.cmd --prefix frontend run build`; `git diff --check -- <changed files>`.
- Result: all passed locally.
- Not checked: backend pytest, browser smoke, full frontend E2E.
