### PR TITLE
fix(queue): avoid default action status

### DIFF
--- a/frontend/src/components/queue/QueueManagementCard.jsx
+++ b/frontend/src/components/queue/QueueManagementCard.jsx
@@ -59,12 +59,20 @@ export const QueueActionButtons = ({
   } = styles;
 
   const entryId = entry?.queue_entry_id ?? null;
-  const status = entry.status || entry.queue_status || 'waiting';
+  const status = entry.status || entry.queue_status || null;
 
   if (!entryId) {
     logger.warn('[QueueActionButtons] Missing queue_entry_id, skipping queue action controls', {
       entry,
       status
+    });
+    return null;
+  }
+
+  if (!status) {
+    logger.warn('[QueueActionButtons] Missing queue status, skipping queue action controls', {
+      entry,
+      entryId
     });
     return null;
   }


### PR DESCRIPTION
## Summary
- Stop `QueueActionButtons` from defaulting a missing queue status to `waiting`.
- Missing backend status now suppresses queue command buttons instead of enabling waiting-state actions by frontend guess.
- No backend, API, command endpoint, BFF-lite, or `/api/v1/ui/*` changes.

## Cyclic Execution Evidence
- Fresh main sync: isolated worktree `C:\tmp\final-queue-actions-status-contract` was created from `origin/main` at `113eec4f` after PR #1248 was merged.
- Clean workspace: the isolated worktree was clean before the patch and contains only `frontend/src/components/queue/QueueManagementCard.jsx` in this PR.
- Branch: `codex/queue-actions-status-contract`.
- Scope gate: `agent_gate.py` ran with known root cause `frontend/src/components/queue/QueueManagementCard.jsx` and returned narrow override with that file as the only first-touch file.
- Red-check handling: no CI red checks existed before PR creation; any red check will be fixed in this PR before merge.

## Contract Impact
- Canonical surface: `QueueActionButtons` rendering of queue command controls for a queue entry.
- Request shape: unchanged; no API request body, query parameter, or endpoint changed.
- Response shape: unchanged; the frontend still consumes existing backend-provided `status` or `queue_status` fields.
- Status codes: unchanged; no backend route or command status code changed.
- Frontend consumer: queue action buttons used by existing specialty/queue panels.
- Compatibility path or alias: unchanged; no route alias, legacy endpoint, or fallback API path was added.
- Contract proof: queue status remains backend-owned data; if backend omits status, React does not invent `waiting` and therefore does not expose waiting-state commands.

## RBAC / Permissions
- Roles allowed: unchanged; users who already can view queue action controls keep the same controls when backend provides a valid status.
- Roles denied: unchanged; no new route, permission, API call, or action path is introduced.
- Positive auth proof: valid rows with backend status still render their existing action controls.
- Negative auth proof: rows missing backend status render no queue command controls, so missing data cannot grant an action surface.

## Notification / Realtime
- Event type or websocket channel: unchanged; no websocket, notification, polling, or queue event code was touched.
- Payload version / ack behavior: unchanged; no realtime payload version or acknowledgement behavior was introduced or modified.
- Read/unread or delivery semantics: unchanged; this component has no notification delivery/read state changes in this PR.
- Reconnect/resync proof: after refresh or realtime resync, rows with backend status render actions as before, while rows without backend status stay command-disabled.

## Frontend Resilience
- Empty data proof: no queue entry or missing `queue_entry_id` still returns `null` as before.
- Partial data proof: rows with `queue_entry_id` but missing `status`/`queue_status` now return `null` instead of acting as `waiting`.
- Forbidden secondary path behavior: no fallback API, command wrapper, or secondary command route was added.
- Missing draft/resource behavior: no draft/resource behavior applies; no queue resource is created from this display/control component.
- Stale route/deep-link behavior: no route, query parameter, or deep-link handling changed.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run build` in the isolated worktree.
- Result: passed after installing frontend dependencies in the isolated worktree with `npm --prefix frontend ci`.
- Diff hygiene: `git diff --check` passed.
- Not checked: backend tests were not run because this PR does not touch backend code, API contracts, schemas, migrations, or command services.

## Scope Gate
- Allowed paths: `frontend/src/components/queue/QueueManagementCard.jsx` only.
- Denied paths: backend, API schemas, `/api/v1/ui/*`, QueueJoin, DisplayBoard, Registrar, specialty panels, queue backend services, command endpoints.
- Migration/docs/test impact: no migrations, docs, or tests changed; validation is frontend build because the gate limited first-touch scope to one runtime file.
- Rollback note: revert commit `bb555e27` to restore the previous `waiting` fallback.
