### PR TITLE
fix(frontend): gate context menu actions by backend

### DIFF
--- a/frontend/src/components/tables/AppointmentContextMenu.jsx
+++ b/frontend/src/components/tables/AppointmentContextMenu.jsx
@@ -14,6 +14,30 @@ import {
   Eye } from
 'lucide-react';
 
+const ACTION_ALIASES = {
+  in_cabinet: ['in_cabinet', 'in-cabinet', 'start_visit', 'start-visit', 'call'],
+  call: ['call', 'start_visit', 'start-visit'],
+  complete: ['complete', 'complete_visit', 'complete-visit'],
+  payment: ['payment', 'mark_paid', 'mark-paid'],
+  print: ['print', 'print_ticket', 'print-ticket'],
+  reschedule: ['reschedule', 'move', 'transfer'],
+  cancel: ['cancel', 'cancel_visit', 'cancel-visit']
+};
+
+const hasBackendAction = (row, action, flagName) => {
+  if (row && flagName && Object.prototype.hasOwnProperty.call(row, flagName)) {
+    return Boolean(row[flagName]);
+  }
+
+  if (!Array.isArray(row?.available_actions)) {
+    return false;
+  }
+
+  const actions = new Set(row.available_actions.map((item) => String(item).trim().toLowerCase()));
+  const aliases = ACTION_ALIASES[action] || [action];
+  return aliases.some((alias) => actions.has(alias));
+};
+
 const AppointmentContextMenu = ({
   row,
   position,
@@ -25,8 +49,6 @@ const AppointmentContextMenu = ({
   const [isVisible, setIsVisible] = useState(false);
 
   const isDark = theme === 'dark';
-  const status = (row.status || '').toLowerCase();
-  const paymentStatus = (row.payment_status || '').toLowerCase();
   const colors = {
     bg: isDark ? '#1f2937' : '#ffffff',
     border: isDark ? '#4b5563' : '#e5e7eb',
@@ -84,21 +106,21 @@ const AppointmentContextMenu = ({
     label: 'В кабинет',
     icon: User,
     color: colors.accent,
-    visible: status === 'confirmed' || status === 'queued'
+    visible: hasBackendAction(row, 'in_cabinet', 'can_start_visit')
   },
   {
     id: 'call',
     label: 'Вызвать',
     icon: Clock,
     color: colors.success,
-    visible: status === 'queued'
+    visible: hasBackendAction(row, 'call', 'can_start_visit')
   },
   {
     id: 'complete',
     label: 'Завершить',
     icon: CheckCircle,
     color: colors.success,
-    visible: status === 'in_cabinet'
+    visible: hasBackendAction(row, 'complete', 'can_complete')
   },
   { type: 'divider' },
   {
@@ -106,16 +128,14 @@ const AppointmentContextMenu = ({
     label: 'Оплата',
     icon: CreditCard,
     color: colors.success,
-    visible: (() => {
-      return status !== 'paid' && paymentStatus !== 'paid' && (status === 'paid_pending' || !paymentStatus);
-    })()
+    visible: hasBackendAction(row, 'payment', 'can_mark_paid')
   },
   {
     id: 'print',
     label: 'Печать талона',
     icon: Printer,
     color: colors.accent,
-    visible: paymentStatus === 'paid' || status === 'queued'
+    visible: hasBackendAction(row, 'print', 'can_print_ticket')
   },
   { type: 'divider' },
   {
@@ -123,14 +143,14 @@ const AppointmentContextMenu = ({
     label: 'Перенести',
     icon: Calendar,
     color: colors.warning,
-    visible: status !== 'done' && status !== 'in_cabinet'
+    visible: hasBackendAction(row, 'reschedule', 'can_reschedule')
   },
   {
     id: 'cancel',
     label: 'Отменить',
     icon: X,
     color: colors.error,
-    visible: status !== 'canceled' && status !== 'cancelled' && status !== 'done'
+    visible: hasBackendAction(row, 'cancel', 'can_cancel')
   },
   { type: 'divider' },
   {


### PR DESCRIPTION
## Summary
- Stop `AppointmentContextMenu` from inferring command visibility from `status` and `payment_status`.
- Context-menu commands now require backend-owned `available_actions` or `can_*` flags.
- No backend, API, command endpoint, BFF-lite, or `/api/v1/ui/*` changes.

## Cyclic Execution Evidence
- Fresh main sync: isolated worktree was on `origin/main` at `d4467fdb`, after PR #1251 was merged and verified.
- Clean workspace: the isolated worktree was clean before the patch and contains only `frontend/src/components/tables/AppointmentContextMenu.jsx` in this PR.
- Branch: `codex/context-menu-backend-actions`.
- Scope gate: `agent_gate.py` ran with known root cause `frontend/src/components/tables/AppointmentContextMenu.jsx` and returned narrow override with that file as the only first-touch file.
- Red-check handling: no CI red checks existed before PR creation; any red check will be fixed in this PR before merge.

## Contract Impact
- Canonical surface: frontend context-menu command visibility for appointment/queue rows.
- Request shape: unchanged; no API request body, query parameter, or endpoint changed.
- Response shape: unchanged; the frontend consumes existing backend-provided `available_actions` and `can_*` fields.
- Status codes: unchanged; no backend route or command status code changed.
- Frontend consumer: `RegistrarPanel` context menu via `AppointmentContextMenu`.
- Compatibility path or alias: unchanged; no route alias, legacy endpoint, or fallback API path was added.
- Contract proof: call/payment/print/cancel/reschedule/complete visibility no longer falls back to frontend-derived status/payment rules when backend action fields are missing.

## RBAC / Permissions
- Roles allowed: unchanged; users keep existing context-menu commands only when backend action fields authorize them.
- Roles denied: strengthened; missing backend action fields no longer allow frontend status/payment heuristics to expose command items.
- Positive auth proof: rows with matching `can_*` flags or `available_actions` still render corresponding context-menu commands.
- Negative auth proof: rows without backend action fields render no command menu items from this component, except presentation-only view/edit and local call-patient display behavior.

## Notification / Realtime
- Event type or websocket channel: unchanged; no websocket, notification, polling, or realtime code was touched.
- Payload version / ack behavior: unchanged; no realtime payload version or acknowledgement behavior was introduced or modified.
- Read/unread or delivery semantics: unchanged; this menu has no notification delivery/read state changes in this PR.
- Reconnect/resync proof: after refresh or realtime resync, command menu visibility follows the backend-provided action fields in the latest row DTO and is not reconstructed from stale status/payment values.

## Frontend Resilience
- Empty data proof: no route/data loading path changed.
- Partial data proof: rows missing action fields now safely omit command menu items instead of guessing from partial status/payment data.
- Forbidden secondary path behavior: no fallback API, command wrapper, or secondary command route was added.
- Missing draft/resource behavior: no draft/resource behavior applies; no resource is created from this rendering change.
- Stale route/deep-link behavior: no route, query parameter, or deep-link handling changed.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run build` in the isolated worktree.
- Result: passed locally with Vite production build completing successfully.
- Diff hygiene: `git diff --check` passed.
- Not checked: backend tests were not run because this PR does not touch backend code, API contracts, schemas, migrations, or command services.

## Scope Gate
- Allowed paths: `frontend/src/components/tables/AppointmentContextMenu.jsx` only.
- Denied paths: backend, API schemas, `/api/v1/ui/*`, QueueJoin, DisplayBoard, RegistrarPanel, specialty panels, queue/payment/visit backend services, command endpoints.
- Migration/docs/test impact: no migrations, docs, or tests changed; validation is frontend build because the gate limited first-touch scope to one runtime file.
- Rollback note: revert commit `064dd751` to restore the previous status/payment-driven context-menu visibility.
