### PR TITLE
fix(tooling): add resilient Python launchers

### DIFF
--- a/.ai-factory/PLAN.md
+++ b/.ai-factory/PLAN.md
@@ -58,9 +58,11 @@ Before any runtime/code task, print the `AGENTS.md` execution pre-work block.
 - Use `gate` for queue, EMR, RBAC, payment, Telegram, routing, frontend/backend contract, or multi-file UX work.
 - Use `gate_known_root_cause` only when the root-cause file is already confirmed.
 - Gate command for risky tasks:
-  `cd C:\final\ai\langgraph && python scripts\agent_gate.py "<task>"`
+  `cd C:\final\ai\langgraph && .\scripts\run_agent_gate.ps1 "<task>"`
 - Gate command with known root cause:
-  `cd C:\final\ai\langgraph && python scripts\agent_gate.py "<task>" --known-root-cause "<relative/path>"`
+  `cd C:\final\ai\langgraph && .\scripts\run_agent_gate.ps1 "<task>" --known-root-cause "<relative/path>"`
+- Use the launcher instead of bare `python` or `py`; it validates Python 3.11+ and skips broken local launcher state.
+- For other local Python commands in this Windows checkout, prefer `C:\final\scripts\run_python.ps1`.
 - If the gate emits a handoff, read and obey the generated `Ready-to-send execution prompt` before editing.
 - If the gate fails, stop and report instead of editing.
 
@@ -325,7 +327,7 @@ This backlog is evidence-led and must be refined as tasks uncover better facts.
 ### Phase 1B: STOP & SECURE (Blocking P0)
 
 - [x] Task 6: Audit auth router precedence and 2FA-bypass surfaces.
-  Run the gate before edits: `cd C:\final\ai\langgraph && python scripts\agent_gate.py "audit auth router precedence and bypass surfaces" --known-root-cause "backend/app/api/v1/api.py"`. Build an endpoint map for `/api/v1/auth/*`, `/api/v1/authentication/*`, and 2FA verification paths. Identify which endpoints can return `access_token` before OTP and which frontend/API docs call them. Do not edit code in this task unless the gate handoff explicitly permits a narrow first-touch file.
+  Run the gate before edits: `cd C:\final\ai\langgraph && .\scripts\run_agent_gate.ps1 "audit auth router precedence and bypass surfaces" --known-root-cause "backend/app/api/v1/api.py"`. Build an endpoint map for `/api/v1/auth/*`, `/api/v1/authentication/*`, and 2FA verification paths. Identify which endpoints can return `access_token` before OTP and which frontend/API docs call them. Do not edit code in this task unless the gate handoff explicitly permits a narrow first-touch file.
   Files: `backend/app/api/v1/api.py`, `backend/app/api/v1/endpoints/auth*.py`, `backend/app/api/v1/endpoints/minimal_auth.py`, `backend/app/api/v1/endpoints/simple_auth.py`, `backend/app/api/v1/endpoints/authentication.py`, `backend/app/api/deps.py`, `frontend/src/components/auth/LoginFormStyled.jsx`, `backend/tests/test_2fa_enforcement.py`
   LOGGING REQUIREMENTS: log route path, router owner, whether it returns `access_token`, 2FA requirement, canonical/legacy status, and validation target; do not log passwords or tokens.
 

--- a/.ai-factory/patches/2026-05-25-13.23.md
+++ b/.ai-factory/patches/2026-05-25-13.23.md
@@ -1,0 +1,28 @@
+# Robust agent gate Python launcher
+
+**Date:** 2026-05-25 13:23
+**Files:** scripts/run_python.ps1, ai/langgraph/scripts/run_agent_gate.ps1, ai/langgraph/scripts/agent_gate.py, AGENTS.md, CLAUDE.md, docs/runbooks/CODEX_SUPERPOWERS_GUARD.md, .ai-factory/PLAN.md
+**Severity:** medium
+
+## Problem
+
+Local gate instructions used bare `python scripts\agent_gate.py`. On Windows this can resolve to the Microsoft Store alias or a missing launcher, and `py` may be absent from the active shell. Agents then stop before the repository gate can run.
+
+## Root Cause
+
+The repo had verified Python entrypoints but no verified launcher contract. Shell-specific Python discovery was left to each agent, so PATH, `py`, `.venv`, and bundled interpreter differences caused repeat failures. The gate also generated validation commands with bare `python`, which could recreate the same failure after the gate succeeded.
+
+## Solution
+
+Added `scripts/run_python.ps1`, which validates Python 3.11+ candidates in a stable order and falls back around broken local launcher state. `ai/langgraph/scripts/run_agent_gate.ps1` now delegates to that launcher, and `agent_gate.py` emits launcher-based Python validation targets. Updated the active agent instructions and runbook to call launchers instead of bare `python` or `py`.
+
+## Prevention
+
+- Use repo-owned launchers for agent-critical tooling.
+- Do not document bare `python` for gate execution on Windows.
+- Do not emit bare `python` validation targets from local gate tooling.
+- Validate fallback interpreters with a real `-c` probe before running the gate.
+
+## Tags
+
+`#agent-gate` `#python-launcher` `#windows` `#dev-brain` `#tooling`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,15 +165,17 @@ Run the local gate only when the selected mode is `gate` or `gate_known_root_cau
 
 ```powershell
 cd C:\final\ai\langgraph
-python scripts\agent_gate.py "<user task>"
+.\scripts\run_agent_gate.ps1 "<user task>"
 ```
 
 - For `gate_known_root_cause`, run:
 
 ```powershell
 cd C:\final\ai\langgraph
-python scripts\agent_gate.py "<user task>" --known-root-cause "<relative/path.py>"
+.\scripts\run_agent_gate.ps1 "<user task>" --known-root-cause "<relative/path.py>"
 ```
+
+Use `scripts\run_agent_gate.ps1` instead of calling `python` or `py` directly. The launcher validates a Python 3.11+ interpreter, skips broken `.venv`/Windows Store aliases, and can fall back to the bundled pgAdmin Python.
 
 - If the gate says handoff is required, read the generated `Ready-to-send execution prompt` before editing.
 - Execute only inside the prompt's `First-touch files`.
@@ -296,13 +298,15 @@ EMR, Lab, Rollout-sensitive areas:
 From `C:\final\ai\langgraph`:
 
 ```powershell
-python scripts\agent_gate.py "<task>"
-python scripts\agent_gate.py "<task>" --known-root-cause "<relative/path.py>"
+.\scripts\run_agent_gate.ps1 "<task>"
+.\scripts\run_agent_gate.ps1 "<task>" --known-root-cause "<relative/path.py>"
 ```
 
 Current checkout note:
 
-- `scripts\agent_gate.py` is the only verified local dev-brain command.
+- For local Python commands in this Windows checkout, prefer `C:\final\scripts\run_python.ps1` over bare `python` or `py` unless a tool already provides a narrower launcher.
+- `scripts\run_agent_gate.ps1` is the verified launcher for `scripts\agent_gate.py`; do not rely on bare `python` or `py` in local shells.
+- `scripts\agent_gate.py` is the only verified local dev-brain Python entrypoint.
 - Do not run historical `scripts\dev_brain.py`, `scripts\planner_smoke.py`, `scripts\dossier_smoke.py`, or `scripts\handoff_smoke.py` unless those files are restored and verified in the current checkout.
 - For `plan`, `dossier`, or `handoff` modes, produce the artifact directly from repo-grounded evidence and use `agent_gate.py` only when an execution boundary is needed.
 - Use handoff as the default input contract for the next agent when a real code change is risky or multi-file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,11 +57,14 @@ For `gate` or `gate_known_root_cause` modes, run:
 
 ```powershell
 cd C:\final\ai\langgraph
-python scripts\agent_gate.py "<user task>"
+.\scripts\run_agent_gate.ps1 "<user task>"
 
 # Or with known root cause:
-python scripts\agent_gate.py "<user task>" --known-root-cause "<relative/path.py>"
+.\scripts\run_agent_gate.ps1 "<user task>" --known-root-cause "<relative/path.py>"
 ```
+
+Use `scripts\run_agent_gate.ps1` instead of bare `python` or `py`; it validates Python 3.11+ and falls back around broken `.venv`/PATH launcher state.
+For other local Python commands in this Windows checkout, prefer `C:\final\scripts\run_python.ps1` over bare `python` or `py`.
 
 **Gate Rules:**
 - Execute only inside `First-touch files` from gate output
@@ -533,19 +536,11 @@ From `C:\final\ai\langgraph`:
 
 ```powershell
 # Execution gate for risky tasks
-python scripts\agent_gate.py "<task>"
-python scripts\agent_gate.py "<task>" --known-root-cause "<path>"
-
-# Planning and analysis
-python scripts\dev_brain.py plan "<task>"
-python scripts\dev_brain.py dossier "<task>"
-python scripts\dev_brain.py handoff "<task>"
-
-# Smoke tests
-python scripts\planner_smoke.py
-python scripts\dossier_smoke.py
-python scripts\handoff_smoke.py
+.\scripts\run_agent_gate.ps1 "<task>"
+.\scripts\run_agent_gate.ps1 "<task>" --known-root-cause "<path>"
 ```
+
+Historical `dev_brain.py`, `planner_smoke.py`, `dossier_smoke.py`, and `handoff_smoke.py` commands are not verified in this checkout. Use the AGENTS.md plan/dossier/handoff rules directly unless those files are restored and validated.
 
 Use `handoff` as the default input contract for the next agent when a real code change is risky or multi-file.
 

--- a/ai/langgraph/scripts/agent_gate.py
+++ b/ai/langgraph/scripts/agent_gate.py
@@ -309,22 +309,39 @@ def migration_read_only_references(
     return unique_existing(repo_root, tracked, references)
 
 
-def migration_validation_targets(new_revision_pattern: str) -> list[str]:
+def powershell_quote(value: Path | str) -> str:
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def repo_location_command(repo_root: Path) -> str:
+    return f"Set-Location -LiteralPath {powershell_quote(repo_root)}"
+
+
+def python_launcher_command(repo_root: Path) -> str:
+    launcher = repo_root / "scripts" / "run_python.ps1"
+    return f"& {powershell_quote(launcher)}"
+
+
+def migration_validation_targets(repo_root: Path, new_revision_pattern: str) -> list[str]:
     placeholder = new_revision_pattern.replace("*", "<slug>")
+    python_launcher = python_launcher_command(repo_root)
     return [
-        f"python -m py_compile {placeholder}",
-        "cd backend; alembic heads",
-        "cd backend; alembic history --verbose",
-        "cd backend; alembic upgrade head  # against a disposable/test Postgres database",
+        f"{repo_location_command(repo_root)}; {python_launcher} -m py_compile {placeholder}",
+        f"Set-Location -LiteralPath {powershell_quote(repo_root / 'backend')}; alembic heads",
+        f"Set-Location -LiteralPath {powershell_quote(repo_root / 'backend')}; alembic history --verbose",
+        f"Set-Location -LiteralPath {powershell_quote(repo_root / 'backend')}; alembic upgrade head  # against a disposable/test Postgres database",
     ]
 
 
-def validation_targets(files: list[str]) -> list[str]:
+def validation_targets(repo_root: Path, files: list[str]) -> list[str]:
     targets: list[str] = []
     py_files = [path for path in files if path.endswith(".py")]
     if py_files:
         joined = " ".join(py_files)
-        targets.append(f"python -m py_compile {joined}")
+        targets.append(
+            f"{repo_location_command(repo_root)}; "
+            f"{python_launcher_command(repo_root)} -m py_compile {joined}"
+        )
 
     frontend_tests = [
         path.removeprefix("frontend/")
@@ -489,7 +506,7 @@ def main(argv: list[str] | None = None) -> int:
             tracked,
             list(REFERENCE_FILES) + read_only_references,
         )
-        validations = migration_validation_targets(new_revision)
+        validations = migration_validation_targets(repo_root, new_revision)
         stops = unique_paths(
             stop_conditions(first_touch) + list(MIGRATION_STOP_CONDITIONS)
         )
@@ -531,7 +548,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     references = unique_existing(repo_root, tracked, list(REFERENCE_FILES))
-    validations = validation_targets(first_touch)
+    validations = validation_targets(repo_root, first_touch)
     stops = stop_conditions(first_touch)
 
     print(

--- a/ai/langgraph/scripts/run_agent_gate.ps1
+++ b/ai/langgraph/scripts/run_agent_gate.ps1
@@ -1,0 +1,23 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $GateArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..\..\..")
+$pythonLauncher = Join-Path $repoRoot "scripts\run_python.ps1"
+$gateScript = Join-Path $scriptDir "agent_gate.py"
+
+if (-not (Test-Path -LiteralPath $pythonLauncher)) {
+    throw "Python launcher not found: $pythonLauncher"
+}
+
+if (-not (Test-Path -LiteralPath $gateScript)) {
+    throw "agent_gate.py not found next to this launcher: $gateScript"
+}
+
+& $pythonLauncher $gateScript @GateArgs
+exit $LASTEXITCODE

--- a/docs/runbooks/CODEX_SUPERPOWERS_GUARD.md
+++ b/docs/runbooks/CODEX_SUPERPOWERS_GUARD.md
@@ -72,17 +72,17 @@ For `gate` or `gate_known_root_cause`, run:
 
 ```powershell
 cd C:\final\ai\langgraph
-python scripts\agent_gate.py "<task>"
+.\scripts\run_agent_gate.ps1 "<task>"
 ```
 
 or:
 
 ```powershell
 cd C:\final\ai\langgraph
-python scripts\agent_gate.py "<task>" --known-root-cause "<relative/path.py>"
+.\scripts\run_agent_gate.ps1 "<task>" --known-root-cause "<relative/path.py>"
 ```
 
-If the gate cannot run, stop and report instead of improvising.
+Use the launcher instead of bare `python` or `py`; it validates Python 3.11+ and skips broken local launcher state. For other local Python commands in this Windows checkout, prefer `C:\final\scripts\run_python.ps1`. If the gate cannot run, stop and report instead of improvising.
 
 ## Skill Routing
 

--- a/scripts/run_python.ps1
+++ b/scripts/run_python.ps1
@@ -1,0 +1,129 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $PythonArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function New-Candidate {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Label,
+        [Parameter(Mandatory = $true)]
+        [string] $Command,
+        [string[]] $PrefixArgs = @()
+    )
+
+    [pscustomobject]@{
+        Label = $Label
+        Command = $Command
+        PrefixArgs = $PrefixArgs
+    }
+}
+
+function Test-PythonCandidate {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject] $Candidate
+    )
+
+    try {
+        $probe = "import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 2)"
+        & $Candidate.Command @($Candidate.PrefixArgs) -c $probe *> $null
+        return ($LASTEXITCODE -eq 0)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Add-FileCandidate {
+    param(
+        [System.Collections.Generic.List[object]] $Candidates,
+        [string] $Label,
+        [string] $Path
+    )
+
+    if ($Path -and (Test-Path -LiteralPath $Path)) {
+        $Candidates.Add((New-Candidate -Label $Label -Command $Path)) | Out-Null
+    }
+}
+
+function Add-CommandCandidate {
+    param(
+        [System.Collections.Generic.List[object]] $Candidates,
+        [string] $Label,
+        [string] $Name,
+        [string[]] $PrefixArgs = @()
+    )
+
+    $command = Get-Command $Name -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($command) {
+        $Candidates.Add((New-Candidate -Label $Label -Command $command.Source -PrefixArgs $PrefixArgs)) | Out-Null
+    }
+}
+
+if (-not $PythonArgs -or $PythonArgs.Count -eq 0) {
+    Write-Error "Usage: .\scripts\run_python.ps1 <python arguments>"
+    exit 64
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..")
+$candidates = [System.Collections.Generic.List[object]]::new()
+
+Add-FileCandidate $candidates "REPO_PYTHON" $env:REPO_PYTHON
+Add-FileCandidate $candidates "AGENT_GATE_PYTHON" $env:AGENT_GATE_PYTHON
+Add-FileCandidate $candidates "repo .venv" (Join-Path $repoRoot ".venv\Scripts\python.exe")
+Add-CommandCandidate $candidates "py -3.11 launcher" "py.exe" @("-3.11")
+Add-CommandCandidate $candidates "py -3 launcher" "py.exe" @("-3")
+Add-CommandCandidate $candidates "PATH python.exe" "python.exe"
+
+$programFilesRoots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
+foreach ($root in $programFilesRoots) {
+    $postgresRoot = Join-Path $root "PostgreSQL"
+    if (-not (Test-Path -LiteralPath $postgresRoot)) {
+        continue
+    }
+
+    Get-ChildItem -LiteralPath $postgresRoot -Directory -ErrorAction SilentlyContinue |
+        Sort-Object Name -Descending |
+        ForEach-Object {
+            Add-FileCandidate $candidates "pgAdmin bundled Python" (Join-Path $_.FullName "pgAdmin 4\python\python.exe")
+        }
+}
+
+foreach ($path in @("C:\Python311\python.exe", "C:\Program Files\Python311\python.exe")) {
+    Add-FileCandidate $candidates "common Python 3.11 path" $path
+}
+
+$seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$uniqueCandidates = foreach ($candidate in $candidates) {
+    $key = "$($candidate.Command)|$($candidate.PrefixArgs -join ' ')"
+    if ($seen.Add($key)) {
+        $candidate
+    }
+}
+
+foreach ($candidate in $uniqueCandidates) {
+    if (Test-PythonCandidate $candidate) {
+        Write-Host "[repo-python] Using Python: $($candidate.Label) ($($candidate.Command) $($candidate.PrefixArgs -join ' '))"
+        & $candidate.Command @($candidate.PrefixArgs) @PythonArgs
+        exit $LASTEXITCODE
+    }
+}
+
+$attempted = $uniqueCandidates | ForEach-Object {
+    "- $($_.Label): $($_.Command) $($_.PrefixArgs -join ' ')"
+}
+
+Write-Error @"
+No working Python 3.11+ interpreter was found.
+
+Tried:
+$($attempted -join [Environment]::NewLine)
+
+Set REPO_PYTHON to a valid python.exe, set AGENT_GATE_PYTHON for gate-only runs,
+or recreate .venv with Python 3.11+.
+"@


### PR DESCRIPTION
## Summary

- Add repo-owned Windows Python launcher for local tooling.
- Add a gate-specific launcher that delegates to the shared Python launcher.
- Update agent gate validation output and active agent docs so future runs avoid bare `python` / `py` launcher drift.

## Cyclic Execution Evidence

- Fresh main sync: branch rebased onto current `origin/main` before push.
- Clean workspace: inspected with `git status --short --branch`; staged only tooling/docs files for this PR.
- Branch: `codex/current-main-view`
- Scope gate: allowed local tooling/docs files; denied backend runtime, frontend runtime, migrations, generated output, and production settings.
- Red-check handling: PR Review Quality Gate failure is being fixed in this same PR by updating this PR body to the required template.

## Contract Impact

not applicable - local tooling and agent documentation only, no API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `scripts/run_python.ps1`, `ai/langgraph/scripts/*`, `AGENTS.md`, `CLAUDE.md`, `docs/runbooks/CODEX_SUPERPOWERS_GUARD.md`, `.ai-factory/PLAN.md`, `.ai-factory/patches/*`
- Denied paths: backend runtime, frontend runtime, migrations, generated output, secrets, production deploy settings
- Migration/docs/test impact: no migration; docs/runbooks updated; local Python launcher and gate smoke checks run
- Rollback note: revert this PR to restore the previous bare-python gate instructions and validation output

## Validation

- Targeted tests or smoke run: `scripts/run_python.ps1 -c "import sys; print(sys.version_info[:2])"`; `Set-Location -LiteralPath 'C:\final'; & 'C:\final\scripts\run_python.ps1' -m py_compile ai/langgraph/scripts/agent_gate.py`; `ai/langgraph/scripts/run_agent_gate.ps1` smoke via repo `.venv`; `ai/langgraph/scripts/run_agent_gate.ps1` smoke via `REPO_PYTHON` pgAdmin fallback; `git diff --check HEAD~1..HEAD`
- Result: passed locally after rebase onto `origin/main`
- Not checked: full backend/frontend suites, because this PR does not change product runtime behavior
