### PR TITLE
fix(registrar): use typed bulk selection keys

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -142,6 +142,19 @@ const getRegistrarRecordRefs = (record) => {
   }, []);
 };
 
+const getRegistrarSelectionKey = (record) => {
+  const refs = getRegistrarRecordRefs(record);
+  if (refs.length > 0) {
+    return refs.map((ref) => `${ref.record_kind}:${ref.record_id}`).join('|');
+  }
+  return record?.id !== undefined && record?.id !== null ? `legacy:${record.id}` : null;
+};
+
+const findRegistrarRecordBySelectionKey = (records, selectionKey) => {
+  if (!selectionKey) return null;
+  return (records || []).find((record) => getRegistrarSelectionKey(record) === selectionKey) || null;
+};
+
 const hasOwn = (object, key) => Object.prototype.hasOwnProperty.call(object || {}, key);
 
 const hasBackendAction = (record, action) => {
@@ -1775,12 +1788,17 @@ const RegistrarPanel = () => {
     }
   };
 
-  const updateAppointmentStatus = useCallback(async (appointmentId, status, reason = '', sourceRecord = null) => {
+  const updateAppointmentStatus = useCallback(async (recordSelectionKey, status, reason = '', sourceRecord = null) => {
     try {
-      const record = sourceRecord || appointments.find((apt) => apt.id === appointmentId);
+      const record = sourceRecord || findRegistrarRecordBySelectionKey(appointments, recordSelectionKey);
       const requiredBackendAction = getRegistrarActionForStatus(status);
       if (!requiredBackendAction) {
-        logger.warn('RegistrarPanel: unsupported status command', { appointmentId, status, record });
+        logger.warn('RegistrarPanel: unsupported status command', { recordSelectionKey, status, record });
+        notify.error('Action is not available for this record');
+        return null;
+      }
+      if (!record) {
+        logger.warn('RegistrarPanel: selected record is missing for status command', { recordSelectionKey, status });
         notify.error('Action is not available for this record');
         return null;
       }
@@ -1809,12 +1827,22 @@ const RegistrarPanel = () => {
       if (!ok) return;
     }
 
+    const selectedRecords = Array.from(appointmentsSelected)
+      .map((selectionKey) => findRegistrarRecordBySelectionKey(filteredAppointmentsRef.current, selectionKey))
+      .filter(Boolean);
+
+    if (selectedRecords.length === 0) {
+      notify.error('Action is not available for this record');
+      setAppointmentsSelected(new Set());
+      return;
+    }
+
     const results = await Promise.allSettled(
-      Array.from(appointmentsSelected).map((id) => updateAppointmentStatus(id, action, reason))
+      selectedRecords.map((record) => updateAppointmentStatus(getRegistrarSelectionKey(record), action, reason, record))
     );
 
     const successCount = results.filter((r) => r.status === 'fulfilled' && r.value).length;
-    const failCount = results.length - successCount;
+    const failCount = appointmentsSelected.size - successCount;
 
     if (successCount > 0) notify.success(`Обновлено: ${successCount}`);
     if (failCount > 0) notify.error(`Ошибок: ${failCount}`);
@@ -1853,9 +1881,11 @@ const RegistrarPanel = () => {
           e.preventDefault();
           logger.info('Ctrl+A: Выбрать все записи');
           // ✅ ИСПРАВЛЕНО: Используем filteredAppointments из ref
-          const allIds = filteredAppointmentsRef.current.map((a) => a.id);
-          setAppointmentsSelected(new Set(allIds));
-          logger.info('Выбрано записей:', allIds.length);
+          const allSelectionKeys = filteredAppointmentsRef.current
+            .map((appointment) => getRegistrarSelectionKey(appointment))
+            .filter(Boolean);
+          setAppointmentsSelected(new Set(allSelectionKeys));
+          logger.info('Выбрано записей:', allSelectionKeys.length);
         } else if (e.key === 'd') {
           e.preventDefault();
           logger.info('Ctrl+D: Снять выделение');


### PR DESCRIPTION
## Summary

- Store Registrar bulk selection with backend typed record keys instead of generic row ids.
- Resolve bulk actions back to the selected typed records before posting `/registrar/records/actions`.
- Keep the fix scoped to `RegistrarPanel`; no backend, BFF-lite, or shared table API changes.

## Cyclic Execution Evidence

- Fresh main sync: branch created from clean `origin/main` at `4264c3f0` after `git fetch origin --prune`.
- Clean workspace: inspected before edits; only `frontend/src/pages/RegistrarPanel.jsx` changed.
- Branch: `codex/registrar-bulk-typed-selection`.
- Scope gate: `agent_gate.py` used with known root cause; first-touch file limited to `frontend/src/pages/RegistrarPanel.jsx`; denied backend, `/api/v1/ui/*`, shared table API, migrations, and generated output.
- Red-check handling: PR Review Quality Gate body failure is being fixed in this same PR before merge.

## Contract Impact

- Canonical surface: existing `/registrar/records/actions` command contract with typed `{record_kind, record_id}` records.
- Request shape: unchanged authenticated POST body with `action`, `records`, and optional payload such as `reason`.
- Response shape: unchanged registrar record action result payload.
- Status codes: unchanged; frontend-only selection identity fix.
- Frontend consumer: `RegistrarPanel` keyboard bulk selection and bulk status command path.
- Compatibility path or alias: no new alias; generic `row.id` remains presentation data only and is no longer the bulk command selection key.
- Contract proof: focused RegistrarPanel contract suite plus frontend production build passed locally.

## RBAC / Permissions

- Roles allowed: unchanged from existing registrar command endpoint policy.
- Roles denied: unchanged from existing registrar command endpoint policy.
- Positive auth proof: not applicable - frontend-only selection key change does not alter auth checks.
- Negative auth proof: not applicable - frontend-only selection key change does not alter auth checks.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime, read/unread, delivery, reconnect, or resync behavior changed.

## Frontend Resilience

- Empty data proof: selected bulk set clears and no command runs when no selected record resolves.
- Partial data proof: rows with canonical registrar refs use typed keys; rows without refs fall back to a legacy key instead of a raw numeric id.
- Forbidden secondary path behavior: not applicable - no secondary API path or fallback command endpoint added.
- Missing draft/resource behavior: not applicable - Registrar bulk status commands do not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - change does not read route or deep-link state.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`.
- Denied paths: backend endpoints, `/api/v1/ui/*`, BFF-lite, shared table API, migrations, generated output, unrelated panels.
- Migration/docs/test impact: no migration or docs; no test file edit because gate first-touch limited the patch to `RegistrarPanel`, but existing focused contract tests were run.
- Rollback note: revert this single frontend commit to restore previous numeric-id bulk selection behavior.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- src/pages/__tests__/RegistrarPanel.contract.test.jsx`; `npm.cmd --prefix frontend run build`; `git diff --check -- frontend/src/pages/RegistrarPanel.jsx`.
- Result: passed locally.
- Not checked: browser keyboard smoke against a live backend; backend tests not run because no backend code or API shape changed.