### PR TITLE
fix(doctor): gate queue actions by backend contract

### DIFF
--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -97,7 +97,8 @@ def _doctor_queue_available_actions(entry: OnlineQueueEntry) -> list[str]:
     status_value = (entry.status or "").strip().lower()
     actions_by_status = {
         "waiting": ["call", "no_show"],
-        "called": ["send_to_diagnostics", "complete", "no_show"],
+        "called": ["start_visit", "send_to_diagnostics", "no_show"],
+        "in_progress": ["complete"],
         "diagnostics": [
             "notify_diagnostics_return",
             "complete",
@@ -112,6 +113,7 @@ def _doctor_queue_action_flags(entry: OnlineQueueEntry) -> dict[str, bool]:
     actions = set(_doctor_queue_available_actions(entry))
     return {
         "can_call": "call" in actions,
+        "can_start_visit": "start_visit" in actions,
         "can_no_show": "no_show" in actions,
         "can_send_to_diagnostics": "send_to_diagnostics" in actions,
         "can_complete": "complete" in actions,
@@ -556,6 +558,15 @@ def start_patient_visit(
             )
 
         # Обновляем статус
+        if "start_visit" not in _doctor_queue_available_actions(queue_entry):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Start visit is not available for current queue status: "
+                    f"{queue_entry.status}"
+                ),
+            )
+
         queue_entry.status = "in_progress"
 
         # Создаем или обновляем визит в таблице visits
@@ -743,6 +754,15 @@ def complete_patient_visit(
                 )
 
             # Отмечаем запись очереди как обслуженную
+            if "complete" not in _doctor_queue_available_actions(queue_entry):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        "Complete visit is not available for current queue status: "
+                        f"{queue_entry.status}"
+                    ),
+                )
+
             queue_entry.status = "served"
             db.commit()
             db.refresh(queue_entry)

--- a/backend/tests/integration/test_doctor_general_queue.py
+++ b/backend/tests/integration/test_doctor_general_queue.py
@@ -71,7 +71,154 @@ class TestDoctorGeneralQueue:
         assert set(payload["entries"][0]["available_actions"]) == {"call", "no_show"}
         assert payload["entries"][0]["can_call"] is True
         assert payload["entries"][0]["can_no_show"] is True
+        assert payload["entries"][0]["can_start_visit"] is False
         assert payload["entries"][0]["can_complete"] is False
+
+    def test_general_queue_exposes_backend_owned_start_and_complete_actions(
+        self,
+        client,
+        db_session,
+        test_doctor_user,
+        test_patient,
+    ):
+        doctor = Doctor(
+            user_id=test_doctor_user.id,
+            specialty="general",
+            active=True,
+            cabinet="101",
+        )
+        db_session.add(doctor)
+        db_session.commit()
+        db_session.refresh(doctor)
+
+        queue = DailyQueue(
+            day=date.today(),
+            specialist_id=doctor.id,
+            queue_tag="general",
+            active=True,
+        )
+        db_session.add(queue)
+        db_session.commit()
+        db_session.refresh(queue)
+
+        called_entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=1,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            source="registrar",
+            status="called",
+        )
+        in_progress_entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=2,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            source="registrar",
+            status="in_progress",
+        )
+        db_session.add_all([called_entry, in_progress_entry])
+        db_session.commit()
+
+        login_response = client.post(
+            "/api/v1/authentication/login",
+            json={"username": test_doctor_user.username, "password": "doctor123"},
+        )
+        assert login_response.status_code == 200
+        headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+        response = client.get("/api/v1/doctor/general/queue/today", headers=headers)
+
+        assert response.status_code == 200
+        entries = response.json()["entries"]
+        called_payload = entries[0]
+        in_progress_payload = entries[1]
+
+        assert called_payload["status"] == "called"
+        assert "start_visit" in called_payload["available_actions"]
+        assert "complete" not in called_payload["available_actions"]
+        assert called_payload["can_start_visit"] is True
+        assert called_payload["can_complete"] is False
+
+        assert in_progress_payload["status"] == "in_progress"
+        assert set(in_progress_payload["available_actions"]) == {"complete"}
+        assert in_progress_payload["can_start_visit"] is False
+        assert in_progress_payload["can_complete"] is True
+
+    def test_queue_commands_reject_statuses_without_backend_action(
+        self,
+        client,
+        db_session,
+        test_doctor_user,
+        test_patient,
+    ):
+        doctor = Doctor(
+            user_id=test_doctor_user.id,
+            specialty="general",
+            active=True,
+            cabinet="101",
+        )
+        db_session.add(doctor)
+        db_session.commit()
+        db_session.refresh(doctor)
+
+        queue = DailyQueue(
+            day=date.today(),
+            specialist_id=doctor.id,
+            queue_tag="general",
+            active=True,
+        )
+        db_session.add(queue)
+        db_session.commit()
+        db_session.refresh(queue)
+
+        waiting_entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=1,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            source="registrar",
+            status="waiting",
+        )
+        called_entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=2,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            source="registrar",
+            status="called",
+        )
+        db_session.add_all([waiting_entry, called_entry])
+        db_session.commit()
+        db_session.refresh(waiting_entry)
+        db_session.refresh(called_entry)
+
+        login_response = client.post(
+            "/api/v1/authentication/login",
+            json={"username": test_doctor_user.username, "password": "doctor123"},
+        )
+        assert login_response.status_code == 200
+        headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+        start_response = client.post(
+            f"/api/v1/doctor/queue/{waiting_entry.id}/start-visit",
+            headers=headers,
+        )
+        complete_response = client.post(
+            f"/api/v1/doctor/queue/{called_entry.id}/complete",
+            headers=headers,
+        )
+
+        assert start_response.status_code == 400
+        assert complete_response.status_code == 400
+        db_session.refresh(waiting_entry)
+        db_session.refresh(called_entry)
+        assert waiting_entry.status == "waiting"
+        assert called_entry.status == "called"
 
     def test_general_queue_returns_empty_payload_without_configuration(
         self,
@@ -382,7 +529,7 @@ class TestDoctorGeneralQueue:
             patient_name=test_patient.short_name(),
             phone=test_patient.phone,
             source="registrar",
-            status="waiting",
+            status="in_progress",
         )
         db_session.add(entry)
         db_session.commit()

--- a/frontend/src/components/doctor/DoctorQueuePanel.jsx
+++ b/frontend/src/components/doctor/DoctorQueuePanel.jsx
@@ -26,6 +26,22 @@ import {
   MacOSAlert } from
 '../ui/macos';
 
+const QUEUE_ACTION_ALIASES = {
+  call: ['call'],
+  start_visit: ['start_visit', 'start', 'in_cabinet'],
+  complete: ['complete']
+};
+
+const hasBackendQueueAction = (entry, action, flagName) => {
+  if (flagName && entry?.[flagName] === true) {
+    return true;
+  }
+
+  const actions = Array.isArray(entry?.available_actions) ? entry.available_actions : [];
+  const aliases = QUEUE_ACTION_ALIASES[action] || [action];
+  return aliases.some((alias) => actions.includes(alias));
+};
+
 /**
  * Панель очереди для врача - показывает пациентов из регистратуры
  * Основа: passport.md стр. 1417-1427
@@ -102,6 +118,10 @@ const DoctorQueuePanel = ({
           number: 'A001',
           patient_name: 'Иван Иванов',
           status: 'waiting',
+          available_actions: ['call', 'no_show'],
+          can_call: true,
+          can_start_visit: false,
+          can_complete: false,
           source: 'online',
           phone: '+998 90 123-45-67',
           created_at: '2024-01-15T09:00:00Z'
@@ -111,6 +131,10 @@ const DoctorQueuePanel = ({
           number: 'A002',
           patient_name: 'Мария Петрова',
           status: 'waiting',
+          available_actions: ['call', 'no_show'],
+          can_call: true,
+          can_start_visit: false,
+          can_complete: false,
           source: 'desk',
           phone: '+998 90 765-43-21',
           created_at: '2024-01-15T09:15:00Z'
@@ -508,6 +532,9 @@ const DoctorQueuePanel = ({
             const status = statusConfig[entry.status] || statusConfig.waiting;
             const source = sourceConfig[entry.source] || sourceConfig.desk;
             const StatusIcon = status.icon;
+            const canCall = hasBackendQueueAction(entry, 'call', 'can_call');
+            const canStartVisit = hasBackendQueueAction(entry, 'start_visit', 'can_start_visit');
+            const canComplete = hasBackendQueueAction(entry, 'complete', 'can_complete');
 
             return (
               <div
@@ -630,7 +657,7 @@ const DoctorQueuePanel = ({
 
                       {/* Действия */}
                       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                        {entry.status === 'waiting' &&
+                        {canCall &&
                       <MacOSButton
                         onClick={(e) => {
                           e.stopPropagation();
@@ -642,7 +669,7 @@ const DoctorQueuePanel = ({
                           </MacOSButton>
                       }
 
-                        {entry.status === 'called' &&
+                        {canStartVisit &&
                       <MacOSButton
                         variant="outline"
                         onClick={(e) => {
@@ -655,7 +682,7 @@ const DoctorQueuePanel = ({
                           </MacOSButton>
                       }
 
-                        {entry.status === 'in_progress' &&
+                        {canComplete &&
                       <MacOSButton
                         variant="success"
                         onClick={(e) => {

--- a/frontend/src/components/doctor/__tests__/DoctorQueuePanel.test.jsx
+++ b/frontend/src/components/doctor/__tests__/DoctorQueuePanel.test.jsx
@@ -1,4 +1,6 @@
 /* eslint-disable react/prop-types */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { render, waitFor } from '@testing-library/react';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -122,6 +124,10 @@ describe('DoctorQueuePanel', () => {
                 number: 'A001',
                 patient_name: 'Ivan Ivanov',
                 status: 'waiting',
+                available_actions: ['call', 'no_show'],
+                can_call: true,
+                can_start_visit: false,
+                can_complete: false,
                 source: 'desk',
                 phone: '+998901234567',
                 created_at: '2026-03-30T08:00:00Z',
@@ -161,5 +167,114 @@ describe('DoctorQueuePanel', () => {
         url: expect.stringMatching(/^http:\/\/(?:localhost|127\.0\.0\.1):18000\/api\/v1\/doctor\/my-info$/),
       }),
     );
+  });
+
+  it('does not render queue command buttons from status alone', async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url.includes('/doctor/my-info')) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 7,
+            name: 'Dr. Test',
+            specialty: 'cardiology',
+            queue_settings: {
+              start_number: 'A001',
+              max_per_day: 20,
+              timezone: 'Asia/Tashkent',
+            },
+            doctor: {
+              cabinet: '101',
+            },
+          }),
+        };
+      }
+
+      if (url.includes('/doctor/cardiology/queue/today')) {
+        return {
+          ok: true,
+          json: async () => ({
+            queue_exists: true,
+            opened_at: '2026-03-30T00:00:00Z',
+            stats: {
+              total: 3,
+              waiting: 1,
+              called: 1,
+              served: 0,
+              online_entries: 0,
+            },
+            doctor: {
+              name: 'Dr. Test',
+              specialty: 'cardiology',
+              cabinet: '101',
+            },
+            entries: [
+              {
+                id: 11,
+                number: 'A001',
+                patient_name: 'Waiting Patient',
+                status: 'waiting',
+                available_actions: [],
+                can_call: false,
+                source: 'desk',
+                phone: '+998901234567',
+                created_at: '2026-03-30T08:00:00Z',
+              },
+              {
+                id: 12,
+                number: 'A002',
+                patient_name: 'Called Patient',
+                status: 'called',
+                available_actions: [],
+                can_start_visit: false,
+                source: 'desk',
+                phone: '+998901234568',
+                created_at: '2026-03-30T08:05:00Z',
+              },
+              {
+                id: 13,
+                number: 'A003',
+                patient_name: 'Progress Patient',
+                status: 'in_progress',
+                available_actions: [],
+                can_complete: false,
+                source: 'desk',
+                phone: '+998901234569',
+                created_at: '2026-03-30T08:10:00Z',
+              },
+            ],
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+
+    const { container } = render(<DoctorQueuePanel specialty="cardiology" />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/\/doctor\/cardiology\/queue\/today$/),
+        expect.any(Object),
+      );
+    });
+
+    expect(container.querySelectorAll('button')).toHaveLength(1);
+  });
+
+  it('keeps queue command visibility behind backend actions and flags', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/components/doctor/DoctorQueuePanel.jsx'),
+      'utf8',
+    );
+
+    expect(source).toContain("hasBackendQueueAction(entry, 'call', 'can_call')");
+    expect(source).toContain("hasBackendQueueAction(entry, 'start_visit', 'can_start_visit')");
+    expect(source).toContain("hasBackendQueueAction(entry, 'complete', 'can_complete')");
+    expect(source).not.toContain("entry.status === 'waiting' &&");
+    expect(source).not.toContain("entry.status === 'called' &&");
+    expect(source).not.toContain("entry.status === 'in_progress' &&");
   });
 });


### PR DESCRIPTION
## Summary

- Adds backend-owned `start_visit` / `can_start_visit` to doctor queue entries.
- Enforces `start-visit` and `complete` availability in the backend doctor queue endpoints.
- Updates `DoctorQueuePanel` so call/start/complete buttons render only from backend `available_actions` / `can_*` flags, not local `entry.status`.

## Cyclic Execution Evidence

- Fresh main sync: branch created from fresh `origin/main`, then rebased onto `origin/main` at `6b63831d` before push
- Clean workspace: worktree `C:\tmp\final-queue-actions-status-contract` was clean before branch work; unrelated dirty `C:\final` worktree was not touched
- Branch: `codex/doctor-queue-actions-contract`
- Scope gate: `agent_gate.py` ran with known root cause; initial frontend-only scope hit stop condition because backend lacked `can_start_visit`; second gate allowed narrow override for doctor queue contract files
- Red-check handling: fix any failed targeted test or CI check in this same PR before merge

## Contract Impact

- Canonical surface: `GET /api/v1/doctor/{specialty}/queue/today`, `POST /api/v1/doctor/queue/{entry_id}/start-visit`, `POST /api/v1/doctor/queue/{entry_id}/complete`
- Request shape: no request shape changes
- Response shape: additive `can_start_visit` boolean on doctor queue entries; `available_actions` now includes `start_visit` for called entries and `complete` for in-progress entries
- Status codes: `start-visit` now returns `400` when backend action availability does not allow start; `complete` now returns `400` when backend action availability does not allow complete for queue-entry flow
- Frontend consumer: `frontend/src/components/doctor/DoctorQueuePanel.jsx` consumes backend actions/flags for queue command buttons
- Compatibility path or alias: frontend accepts aliases `start_visit`, `start`, and `in_cabinet` for the start command, but does not fall back to status
- Contract proof: backend integration assertions cover action flags and invalid status rejection; frontend test/source proof covers removal of status-driven command visibility

## RBAC / Permissions

- Roles allowed: existing endpoint roles unchanged: Admin, Doctor, Registrar, Cashier, Receptionist, cardio/cardiology/Cardiologist, derma, dentist, Lab
- Roles denied: existing backend role and doctor ownership checks remain unchanged
- Positive auth proof: existing and updated `test_doctor_general_queue.py` authenticated doctor/cardiologist flows cover allowed access
- Negative auth proof: existing endpoint ownership checks remain unchanged; this PR adds backend action rejection for disallowed statuses, not role changes

## Notification / Realtime

- Event type or websocket channel: existing patient-call display websocket behavior unchanged
- Payload version / ack behavior: no realtime payload version or ack changes
- Read/unread or delivery semantics: not applicable - no notification inbox, read/unread, or delivery tracking behavior changed
- Reconnect/resync proof: queue refresh still reloads from the canonical doctor queue endpoint after commands; websocket reconnect behavior was not changed

## Frontend Resilience

- Empty data proof: existing empty queue rendering unchanged
- Partial data proof: if action fields are missing, command buttons are hidden instead of inferred from status
- Forbidden secondary path behavior: no secondary API path added; no `/api/v1/ui/*`
- Missing draft/resource behavior: not applicable - doctor queue command buttons do not create drafts or reopen draft resources
- Stale route/deep-link behavior: not applicable - this component does not read route/deep-link state for queue command availability

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/doctor_integration.py`, `backend/tests/integration/test_doctor_general_queue.py`, `frontend/src/components/doctor/DoctorQueuePanel.jsx`, `frontend/src/components/doctor/__tests__/DoctorQueuePanel.test.jsx`
- Denied paths: no `/api/v1/ui/*`, no BFF service, no unrelated panels, no migrations, no broad rewrite
- Migration/docs/test impact: no migration or docs changes; targeted backend/frontend tests updated
- Rollback note: revert this commit to restore prior doctor queue action mapping and frontend status-based button visibility

## Validation

- Targeted tests or smoke run: `C:\final\backend\.venv\Scripts\python.exe -m py_compile backend/app/api/v1/endpoints/doctor_integration.py`; `npm --prefix frontend run test:run -- src/components/doctor/__tests__/DoctorQueuePanel.test.jsx`; `npm --prefix frontend run build`; `git diff --check`
- Result: all listed local commands passed; CI backend tests also passed on PR #1255
- Not checked: local backend pytest did not start before push because this shell had no `DATABASE_URL`; CI backend test environment validated the added backend integration tests