### PR TITLE
fix(doctor): guard complete visit fallback by patient

### DIFF
--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -654,6 +654,16 @@ def complete_patient_visit(
         visit = None
         if not queue_entry:
             visit = db.query(Visit).filter(Visit.id == entry_id).first()
+            if (
+                visit
+                and requested_patient_id is not None
+                and visit.patient_id is not None
+                and visit.patient_id != requested_patient_id
+            ):
+                logger.warning(
+                    "complete_patient_visit: route id matched a Visit for a different patient than the request payload; trying appointment fallback"
+                )
+                visit = None
         if visit:
             # Обновляем статус визита
             visit.status = "completed"
@@ -697,6 +707,16 @@ def complete_patient_visit(
             appointment = (
                 db.query(Appointment).filter(Appointment.id == entry_id).first()
             )
+            if (
+                appointment
+                and requested_patient_id is not None
+                and appointment.patient_id is not None
+                and appointment.patient_id != requested_patient_id
+            ):
+                logger.warning(
+                    "complete_patient_visit: route id matched an Appointment for a different patient than the request payload"
+                )
+                appointment = None
         if appointment:
             # Обновляем статус appointment
             appointment.status = "completed"

--- a/backend/tests/integration/test_doctor_general_queue.py
+++ b/backend/tests/integration/test_doctor_general_queue.py
@@ -336,6 +336,74 @@ class TestDoctorGeneralQueue:
         assert appointment.status == "completed"
         assert entry.status == "diagnostics"
 
+    def test_complete_skips_unrelated_visit_when_appointment_id_collides(
+        self,
+        client,
+        db_session,
+        test_doctor_user,
+        test_patient,
+        test_doctor,
+    ):
+        other_patient = Patient(
+            first_name="Unrelated",
+            last_name="Visit",
+            middle_name="Collision",
+            phone="+998901222222",
+            birth_date=date(1982, 6, 6),
+            address="Unrelated visit address",
+        )
+        db_session.add(other_patient)
+        db_session.commit()
+        db_session.refresh(other_patient)
+
+        collision_id = 9003
+        unrelated_visit = Visit(
+            id=collision_id,
+            patient_id=other_patient.id,
+            doctor_id=None,
+            visit_date=date.today(),
+            status="open",
+            discount_mode="none",
+            source="desk",
+        )
+        appointment = Appointment(
+            id=collision_id,
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            appointment_date=date.today(),
+            appointment_time="12:30",
+            status="paid",
+            visit_type="paid",
+            payment_type="cash",
+            services=["consultation"],
+        )
+        db_session.add_all([unrelated_visit, appointment])
+        db_session.commit()
+
+        login_response = client.post(
+            "/api/v1/authentication/login",
+            json={"username": test_doctor_user.username, "password": "doctor123"},
+        )
+        assert login_response.status_code == 200
+        headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+        response = client.post(
+            f"/api/v1/doctor/queue/{collision_id}/complete",
+            json={"patient_id": test_patient.id, "notes": "appointment complete"},
+            headers=headers,
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["entry_id"] == collision_id
+        assert payload["status"] == "completed"
+
+        db_session.refresh(unrelated_visit)
+        db_session.refresh(appointment)
+        assert unrelated_visit.status == "open"
+        assert appointment.status == "completed"
+
     def test_cardiologist_role_can_complete_queue_entry(
         self,
         client,


### PR DESCRIPTION
## Summary

- Guard `/doctor/queue/{entry_id}/complete` legacy `Visit` fallback with request `patient_id` before mutating.
- Apply the same patient guard to the legacy `Appointment` fallback when a request payload supplies patient identity.
- Add a regression test for appointment-id / visit-id collision so an unrelated patient's Visit is not completed.

## Cyclic Execution Evidence

- Fresh main sync: branch created from clean `origin/main` at `6b63831d` after PR #1254 merge and `git fetch origin --prune`.
- Clean workspace: inspected before edits; only `backend/app/api/v1/endpoints/doctor_integration.py` and `backend/tests/integration/test_doctor_general_queue.py` changed.
- Branch: `codex/doctor-complete-visit-patient-guard`.
- Scope gate: `agent_gate.py` used with known root cause for endpoint, then a separate known-root-cause gate for the targeted test file; denied frontend, `/api/v1/ui/*`, BFF-lite, DB/Alembic, and unrelated doctor flows.
- Red-check handling: any red CI check on this PR will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: mounted `POST /api/v1/doctor/queue/{entry_id}/complete` endpoint.
- Request shape: unchanged; optional JSON payload may include `patient_id` and existing visit data.
- Response shape: unchanged success/error payloads.
- Status codes: unchanged for valid requests; mismatched legacy fallback candidates are skipped instead of being mutated.
- Frontend consumer: existing doctor queue complete callers; current frontend uses queue entry ids, while this patch protects the legacy fallback path.
- Compatibility path or alias: legacy Visit/Appointment fallback remains, but a supplied patient guard now prevents cross-patient id-collision mutation.
- Contract proof: new integration regression test covers appointment id colliding with another patient's Visit id.

## RBAC / Permissions

- Roles allowed: unchanged from existing doctor complete endpoint roles.
- Roles denied: unchanged from existing endpoint role dependency.
- Positive auth proof: regression test logs in as doctor and completes the intended appointment fallback.
- Negative auth proof: not applicable - this patch does not change role enforcement.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime, read/unread, delivery, reconnect, or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - backend-only guard, no frontend state shape changed.
- Partial data proof: if `patient_id` is absent, existing legacy fallback behavior is preserved for compatibility.
- Forbidden secondary path behavior: not applicable - no secondary API path added.
- Missing draft/resource behavior: not applicable - complete endpoint does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link state changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/doctor_integration.py`, `backend/tests/integration/test_doctor_general_queue.py`.
- Denied paths: frontend panels, `/api/v1/ui/*`, BFF-lite, service rewrites, migrations, generated output, unrelated endpoints.
- Migration/docs/test impact: no migration or docs; targeted integration test added.
- Rollback note: revert this single backend commit to restore previous unguarded legacy fallback behavior.

## Validation

- Targeted tests or smoke run: `powershell.exe -ExecutionPolicy Bypass -File .\\scripts\\run_python.ps1 -m py_compile backend/app/api/v1/endpoints/doctor_integration.py backend/tests/integration/test_doctor_general_queue.py`; `git diff --check -- backend/app/api/v1/endpoints/doctor_integration.py backend/tests/integration/test_doctor_general_queue.py`.
- Result: py_compile passed; diff check passed. Targeted pytest could not run locally because `py` is not installed, `backend/.venv` points to a missing Python executable, and the resilient fallback selected pgAdmin Python where `pytest` is not installed.
- Not checked: local pytest; GitHub backend CI is expected to run the integration suite.