### PR TITLE
fix(tooling): add backend pytest launcher

### DIFF
--- a/.ai-factory/patches/2026-05-25-15.48.md
+++ b/.ai-factory/patches/2026-05-25-15.48.md
@@ -1,0 +1,27 @@
+# Backend pytest launcher avoids fragile local Python state
+
+**Date:** 2026-05-25 15:48
+**Files:** scripts/run_python.ps1, scripts/run_backend_pytest.ps1, AGENTS.md, CLAUDE.md, docs/TESTING.md
+**Severity:** medium
+
+## Problem
+
+Agents reported that local backend pytest could not run because `py` was unavailable, local virtualenv metadata pointed at old user Python paths, and pgAdmin Python did not have `pytest`.
+
+## Root Cause
+
+The repo had a general Python launcher, but it selected the first valid Python 3.11+ interpreter without considering whether the command needed a module such as `pytest`. The root `.venv` was valid Python but lacked pytest, while `backend\.venv` had pytest.
+
+## Solution
+
+Extended `scripts/run_python.ps1` with `-RequireModule` and added `backend\.venv` as a candidate. Added `scripts/run_backend_pytest.ps1`, which requires `pytest`, runs from `backend/`, and sets `PYTHONPATH` to the backend root.
+
+## Prevention
+
+- Use `scripts/run_backend_pytest.ps1` for local backend pytest on Windows.
+- Use module-aware interpreter selection for commands that require tooling packages.
+- Do not rely on bare `python`, `py`, or pgAdmin Python for backend tests.
+
+## Tags
+
+`#pytest` `#python-launcher` `#windows` `#backend-tests` `#tooling`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,7 @@ From `C:\final\ai\langgraph`:
 Current checkout note:
 
 - For local Python commands in this Windows checkout, prefer `C:\final\scripts\run_python.ps1` over bare `python` or `py` unless a tool already provides a narrower launcher.
+- For backend pytest in this Windows checkout, prefer `C:\final\scripts\run_backend_pytest.ps1 <tests...>`; it selects a Python 3.11+ interpreter with `pytest` installed and runs from `backend/` with `PYTHONPATH` set.
 - `scripts\run_agent_gate.ps1` is the verified launcher for `scripts\agent_gate.py`; do not rely on bare `python` or `py` in local shells.
 - `scripts\agent_gate.py` is the only verified local dev-brain Python entrypoint.
 - Do not run historical `scripts\dev_brain.py`, `scripts\planner_smoke.py`, `scripts\dossier_smoke.py`, or `scripts\handoff_smoke.py` unless those files are restored and verified in the current checkout.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ cd C:\final\ai\langgraph
 
 Use `scripts\run_agent_gate.ps1` instead of bare `python` or `py`; it validates Python 3.11+ and falls back around broken `.venv`/PATH launcher state.
 For other local Python commands in this Windows checkout, prefer `C:\final\scripts\run_python.ps1` over bare `python` or `py`.
+For backend pytest in this Windows checkout, prefer `C:\final\scripts\run_backend_pytest.ps1 <tests...>`.
 
 **Gate Rules:**
 - Execute only inside `First-touch files` from gate output

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2,6 +2,13 @@
 
 # Testing
 
+## Local Windows Python Launchers
+
+- General Python: `C:\final\scripts\run_python.ps1 <python args>`
+- Backend pytest: `C:\final\scripts\run_backend_pytest.ps1 <tests...>`
+
+Use these instead of bare `python`, `py`, or pgAdmin Python in local Windows shells. The backend pytest launcher selects a Python 3.11+ interpreter that has `pytest`, runs from `backend/`, and sets `PYTHONPATH` to the backend root.
+
 ## Targeted Checks Run During Recovery
 
 | Area | Representative checks |

--- a/scripts/run_backend_pytest.ps1
+++ b/scripts/run_backend_pytest.ps1
@@ -1,0 +1,31 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $PytestArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..")
+$pythonLauncher = Join-Path $repoRoot "scripts\run_python.ps1"
+$backendRoot = Join-Path $repoRoot "backend"
+
+if (-not (Test-Path -LiteralPath $pythonLauncher)) {
+    throw "Python launcher not found: $pythonLauncher"
+}
+
+if (-not (Test-Path -LiteralPath $backendRoot)) {
+    throw "Backend directory not found: $backendRoot"
+}
+
+$previous = Get-Location
+try {
+    Set-Location -LiteralPath $backendRoot
+    $env:PYTHONPATH = $backendRoot
+    & $pythonLauncher -RequireModule pytest -m pytest @PytestArgs
+    exit $LASTEXITCODE
+}
+finally {
+    Set-Location -LiteralPath $previous
+}

--- a/scripts/run_python.ps1
+++ b/scripts/run_python.ps1
@@ -1,4 +1,5 @@
 param(
+    [string[]] $RequireModule = @(),
     [Parameter(ValueFromRemainingArguments = $true)]
     [string[]] $PythonArgs
 )
@@ -25,11 +26,13 @@ function New-Candidate {
 function Test-PythonCandidate {
     param(
         [Parameter(Mandatory = $true)]
-        [pscustomobject] $Candidate
+        [pscustomobject] $Candidate,
+        [string[]] $RequiredModules = @()
     )
 
     try {
-        $probe = "import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 2)"
+        $modules = ($RequiredModules -join ",")
+        $probe = "import importlib.util, sys; modules = [name for name in r'''$modules'''.split(',') if name]; ok = sys.version_info >= (3, 11) and all(importlib.util.find_spec(name) is not None for name in modules); raise SystemExit(0 if ok else 2)"
         & $Candidate.Command @($Candidate.PrefixArgs) -c $probe *> $null
         return ($LASTEXITCODE -eq 0)
     }
@@ -76,6 +79,7 @@ $candidates = [System.Collections.Generic.List[object]]::new()
 Add-FileCandidate $candidates "REPO_PYTHON" $env:REPO_PYTHON
 Add-FileCandidate $candidates "AGENT_GATE_PYTHON" $env:AGENT_GATE_PYTHON
 Add-FileCandidate $candidates "repo .venv" (Join-Path $repoRoot ".venv\Scripts\python.exe")
+Add-FileCandidate $candidates "backend .venv" (Join-Path $repoRoot "backend\.venv\Scripts\python.exe")
 Add-CommandCandidate $candidates "py -3.11 launcher" "py.exe" @("-3.11")
 Add-CommandCandidate $candidates "py -3 launcher" "py.exe" @("-3")
 Add-CommandCandidate $candidates "PATH python.exe" "python.exe"
@@ -107,7 +111,7 @@ $uniqueCandidates = foreach ($candidate in $candidates) {
 }
 
 foreach ($candidate in $uniqueCandidates) {
-    if (Test-PythonCandidate $candidate) {
+    if (Test-PythonCandidate $candidate -RequiredModules $RequireModule) {
         Write-Host "[repo-python] Using Python: $($candidate.Label) ($($candidate.Command) $($candidate.PrefixArgs -join ' '))"
         & $candidate.Command @($candidate.PrefixArgs) @PythonArgs
         exit $LASTEXITCODE
@@ -119,11 +123,11 @@ $attempted = $uniqueCandidates | ForEach-Object {
 }
 
 Write-Error @"
-No working Python 3.11+ interpreter was found.
+No working Python 3.11+ interpreter was found$(if ($RequireModule.Count -gt 0) { " with required module(s): $($RequireModule -join ', ')" } else { "" }).
 
 Tried:
 $($attempted -join [Environment]::NewLine)
 
 Set REPO_PYTHON to a valid python.exe, set AGENT_GATE_PYTHON for gate-only runs,
-or recreate .venv with Python 3.11+.
+or recreate .venv/backend\.venv with Python 3.11+ and the required packages.
 "@


### PR DESCRIPTION
## Summary

- Add `scripts/run_backend_pytest.ps1` for local Windows backend pytest runs.
- Extend `scripts/run_python.ps1` with `-RequireModule` and include `backend\.venv` as a Python candidate.
- Document the backend pytest launcher in agent instructions and testing docs.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` and verified `origin/main` is an ancestor before push.
- Clean workspace: inspected with `git status --short --branch`; only scoped tooling/docs files were staged.
- Branch: `codex/backend-pytest-launcher`
- Scope gate: allowed local tooling/docs files; denied backend runtime, frontend runtime, migrations, generated output, secrets, and production settings.
- Red-check handling: fix any failed PR checks in this same PR before merge.

## Contract Impact

not applicable - local test tooling and documentation only, no API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `scripts/run_python.ps1`, `scripts/run_backend_pytest.ps1`, `AGENTS.md`, `CLAUDE.md`, `docs/TESTING.md`, `.ai-factory/patches/*`
- Denied paths: backend runtime, frontend runtime, migrations, generated output, secrets, production deploy settings
- Migration/docs/test impact: no migration; docs updated; local backend pytest smoke run
- Rollback note: revert this PR to restore previous Python launcher behavior and remove the backend pytest wrapper

## Validation

- Targeted tests or smoke run: `scripts/run_python.ps1 -c "import sys; print(sys.version_info[:2])"`; `scripts/run_python.ps1 -RequireModule pytest -c "import pytest, sys; print(pytest.__version__); print(sys.executable)"`; `scripts/run_backend_pytest.ps1 tests\unit\test_simple.py -q`; `git diff --check HEAD~1..HEAD`
- Result: passed locally; backend pytest launcher selected `backend\.venv` and `tests\unit\test_simple.py` passed (`4 passed`, `1 warning`)
- Not checked: full backend/frontend suites, because this PR only changes local tooling and docs
