### PR TITLE
fix(cashier): use backend refund request actions

### DIFF
--- a/backend/app/api/v1/endpoints/force_majeure.py
+++ b/backend/app/api/v1/endpoints/force_majeure.py
@@ -69,6 +69,10 @@ class RefundRequestResponse(BaseModel):
     created_at: datetime
     processed_at: Optional[datetime] = None
     processed_by_name: Optional[str] = None
+    available_actions: List[str] = Field(default_factory=list)
+    can_approve: bool = False
+    can_reject: bool = False
+    can_complete: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/force_majeure_api_service.py
+++ b/backend/app/services/force_majeure_api_service.py
@@ -194,6 +194,15 @@ class ForceMajeureApiService:
         payload["processed_by_name"] = current_user.full_name
         return payload
 
+    @staticmethod
+    def _refund_request_available_actions(status: str | None) -> list[str]:
+        normalized_status = (status or "").strip().lower()
+        if normalized_status == RefundRequestStatus.PENDING.value:
+            return ["approve", "reject"]
+        if normalized_status == RefundRequestStatus.APPROVED.value:
+            return ["reject", "complete"]
+        return []
+
     def get_deposits(
         self,
         *,
@@ -298,6 +307,7 @@ class ForceMajeureApiService:
 
     def _serialize_refund_request(self, req) -> dict[str, Any]:
         processed_by_name = req.processor.full_name if req.processor else None
+        available_actions = self._refund_request_available_actions(req.status)
         return {
             "id": req.id,
             "patient_id": req.patient_id,
@@ -314,6 +324,10 @@ class ForceMajeureApiService:
             "created_at": req.created_at,
             "processed_at": req.processed_at,
             "processed_by_name": processed_by_name,
+            "available_actions": available_actions,
+            "can_approve": "approve" in available_actions,
+            "can_reject": "reject" in available_actions,
+            "can_complete": "complete" in available_actions,
         }
 
     def _serialize_deposit(self, deposit) -> dict[str, Any]:

--- a/backend/tests/unit/test_force_majeure_api_service.py
+++ b/backend/tests/unit/test_force_majeure_api_service.py
@@ -75,6 +75,48 @@ class TestForceMajeureApiService:
             )
         assert exc_info.value.status_code == 400
 
+    def test_refund_request_serialization_exposes_backend_owned_actions(self):
+        service = ForceMajeureApiService(db=None, repository=SimpleNamespace())
+
+        def make_request(status):
+            return SimpleNamespace(
+                status=status,
+                processed_by=None,
+                processed_at=None,
+                patient=None,
+                processor=None,
+                id=1,
+                patient_id=2,
+                payment_id=3,
+                original_amount=Decimal("10"),
+                refund_amount=Decimal("10"),
+                commission_amount=Decimal("0"),
+                refund_type="deposit",
+                reason="r",
+                is_automatic=False,
+                bank_card_number=None,
+                created_at=None,
+            )
+
+        pending = service._serialize_refund_request(make_request("pending"))
+        approved = service._serialize_refund_request(make_request("approved"))
+        rejected = service._serialize_refund_request(make_request("rejected"))
+
+        assert pending["available_actions"] == ["approve", "reject"]
+        assert pending["can_approve"] is True
+        assert pending["can_reject"] is True
+        assert pending["can_complete"] is False
+
+        assert approved["available_actions"] == ["reject", "complete"]
+        assert approved["can_approve"] is False
+        assert approved["can_reject"] is True
+        assert approved["can_complete"] is True
+
+        assert rejected["available_actions"] == []
+        assert rejected["can_approve"] is False
+        assert rejected["can_reject"] is False
+        assert rejected["can_complete"] is False
+
     def test_use_deposit_for_payment_checks_balance(self):
         deposit = SimpleNamespace(
             balance=Decimal("50"),

--- a/frontend/src/components/cashier/RefundRequestsTable.jsx
+++ b/frontend/src/components/cashier/RefundRequestsTable.jsx
@@ -81,6 +81,32 @@ const statusIconStyle = {
   gap: 'var(--mac-spacing-1)'
 };
 
+const REFUND_ACTION_CAN_FIELD = {
+  approve: 'can_approve',
+  reject: 'can_reject',
+  complete: 'can_complete'
+};
+
+const hasBackendRefundAction = (request, action) => {
+  const normalizedAction = String(action || '').trim().toLowerCase();
+  if (!normalizedAction) {
+    return false;
+  }
+
+  if (Array.isArray(request?.available_actions)) {
+    return request.available_actions.some(
+      (availableAction) => String(availableAction || '').trim().toLowerCase() === normalizedAction
+    );
+  }
+
+  const canField = REFUND_ACTION_CAN_FIELD[normalizedAction];
+  if (canField && Object.prototype.hasOwnProperty.call(request || {}, canField)) {
+    return Boolean(request[canField]);
+  }
+
+  return false;
+};
+
 const RefundRequestsTable = ({ onRefresh }) => {
   const [requests, setRequests] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -101,7 +127,7 @@ const RefundRequestsTable = ({ onRefresh }) => {
       const token = getAuthToken();
       const params = new URLSearchParams();
       if (filter !== 'all') {
-        params.append('status', filter);
+        params.append('status_filter', filter);
       }
 
       const response = await fetch(`/api/v1/force-majeure/refund-requests?${params}`, {
@@ -129,92 +155,48 @@ const RefundRequestsTable = ({ onRefresh }) => {
     loadRequests();
   }, [loadRequests]);
 
-  // Approve request
-  const handleApprove = async (requestId) => {
+  const processRefundRequest = async (requestId, action, extraPayload = {}) => {
     setProcessingId(requestId);
     try {
       const token = getAuthToken();
-      const response = await fetch(`/api/v1/force-majeure/refund-requests/${requestId}/approve`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        }
-      });
-
-      if (response.ok) {
-        logger.log('[RefundRequestsTable] Approved request:', requestId);
-        await loadRequests();
-        if (onRefresh) onRefresh();
-      } else {
-        const errorData = await response.json();
-        throw new Error(errorData.detail || 'Failed to approve');
-      }
-    } catch (err) {
-      logger.error('[RefundRequestsTable] Approve error:', err);
-      alert('Ошибка: ' + err.message);
-    } finally {
-      setProcessingId(null);
-    }
-  };
-
-  // Reject request
-  const handleReject = async (requestId, reason = 'Отклонено кассиром') => {
-    setProcessingId(requestId);
-    try {
-      const token = getAuthToken();
-      const response = await fetch(`/api/v1/force-majeure/refund-requests/${requestId}/reject`, {
+      const response = await fetch(`/api/v1/force-majeure/refund-requests/${requestId}/process`, {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ reason })
+        body: JSON.stringify({ action, ...extraPayload })
       });
 
       if (response.ok) {
-        logger.log('[RefundRequestsTable] Rejected request:', requestId);
+        logger.log('[RefundRequestsTable] Processed request:', { requestId, action });
         await loadRequests();
         if (onRefresh) onRefresh();
       } else {
         const errorData = await response.json();
-        throw new Error(errorData.detail || 'Failed to reject');
+        throw new Error(errorData.detail || 'Failed to process refund request');
       }
     } catch (err) {
-      logger.error('[RefundRequestsTable] Reject error:', err);
+      logger.error('[RefundRequestsTable] Process error:', err);
       alert('Ошибка: ' + err.message);
     } finally {
       setProcessingId(null);
     }
   };
 
+  // Approve request
+  const handleApprove = async (requestId) => {
+    await processRefundRequest(requestId, 'approve');
+  };
+
+  // Reject request
+  const handleReject = async (requestId, reason = 'Отклонено кассиром') => {
+    await processRefundRequest(requestId, 'reject', { rejection_reason: reason });
+  };
+
   // Complete request (mark as refunded)
   const handleComplete = async (requestId) => {
-    setProcessingId(requestId);
-    try {
-      const token = getAuthToken();
-      const response = await fetch(`/api/v1/force-majeure/refund-requests/${requestId}/complete`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        }
-      });
-
-      if (response.ok) {
-        logger.log('[RefundRequestsTable] Completed request:', requestId);
-        await loadRequests();
-        if (onRefresh) onRefresh();
-      } else {
-        const errorData = await response.json();
-        throw new Error(errorData.detail || 'Failed to complete');
-      }
-    } catch (err) {
-      logger.error('[RefundRequestsTable] Complete error:', err);
-      alert('Ошибка: ' + err.message);
-    } finally {
-      setProcessingId(null);
-    }
+    await processRefundRequest(requestId, 'complete');
   };
 
   const getStatusBadge = (status) => {
@@ -269,42 +251,47 @@ const RefundRequestsTable = ({ onRefresh }) => {
       );
     }
 
-    if (request.status === 'pending') {
+    const canApprove = hasBackendRefundAction(request, 'approve');
+    const canReject = hasBackendRefundAction(request, 'reject');
+    const canComplete = hasBackendRefundAction(request, 'complete');
+
+    if (canApprove || canReject || canComplete) {
       return (
         <div style={actionClusterStyle}>
-          <Button
-            variant="success"
-            size="small"
-            onClick={() => handleApprove(request.id)}
-            title="Одобрить"
-            aria-label={`Одобрить заявку на возврат ${request.id}`}
-          >
-            <Check size={14} aria-hidden="true" />
-          </Button>
-          <Button
-            variant="danger"
-            size="small"
-            onClick={() => handleReject(request.id)}
-            title="Отклонить"
-            aria-label={`Отклонить заявку на возврат ${request.id}`}
-          >
-            <X size={14} aria-hidden="true" />
-          </Button>
+          {canApprove && (
+            <Button
+              variant="success"
+              size="small"
+              onClick={() => handleApprove(request.id)}
+              title="Одобрить"
+              aria-label={`Одобрить заявку на возврат ${request.id}`}
+            >
+              <Check size={14} aria-hidden="true" />
+            </Button>
+          )}
+          {canReject && (
+            <Button
+              variant="danger"
+              size="small"
+              onClick={() => handleReject(request.id)}
+              title="Отклонить"
+              aria-label={`Отклонить заявку на возврат ${request.id}`}
+            >
+              <X size={14} aria-hidden="true" />
+            </Button>
+          )}
+          {canComplete && (
+            <Button
+              variant="primary"
+              size="small"
+              onClick={() => handleComplete(request.id)}
+              aria-label={`Отметить заявку на возврат ${request.id} как выплаченную`}
+            >
+              <CreditCard size={14} aria-hidden="true" />
+              Выплатить
+            </Button>
+          )}
         </div>
-      );
-    }
-
-    if (request.status === 'approved') {
-      return (
-        <Button
-          variant="primary"
-          size="small"
-          onClick={() => handleComplete(request.id)}
-          aria-label={`Отметить заявку на возврат ${request.id} как выплаченную`}
-        >
-          <CreditCard size={14} aria-hidden="true" />
-          Выплатить
-        </Button>
       );
     }
 

--- a/frontend/src/components/cashier/__tests__/RefundRequestsTable.contract.test.jsx
+++ b/frontend/src/components/cashier/__tests__/RefundRequestsTable.contract.test.jsx
@@ -1,0 +1,38 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(process.cwd(), 'src');
+const source = fs.readFileSync(path.join(ROOT, 'components/cashier/RefundRequestsTable.jsx'), 'utf8');
+
+describe('RefundRequestsTable command contract', () => {
+  it('uses the published refund request list filter query name', () => {
+    expect(source).toContain("params.append('status_filter', filter)");
+    expect(source).not.toContain("params.append('status', filter)");
+  });
+
+  it('uses the existing backend process command instead of invented action URLs', () => {
+    expect(source).toContain('/api/v1/force-majeure/refund-requests/${requestId}/process');
+    expect(source).toContain('body: JSON.stringify({ action, ...extraPayload })');
+
+    expect(source).not.toContain('/api/v1/force-majeure/refund-requests/${requestId}/approve');
+    expect(source).not.toContain('/api/v1/force-majeure/refund-requests/${requestId}/reject');
+    expect(source).not.toContain('/api/v1/force-majeure/refund-requests/${requestId}/complete');
+  });
+
+  it('renders refund commands only from backend-provided availability', () => {
+    expect(source).toContain('const hasBackendRefundAction =');
+    expect(source).toContain("hasBackendRefundAction(request, 'approve')");
+    expect(source).toContain("hasBackendRefundAction(request, 'reject')");
+    expect(source).toContain("hasBackendRefundAction(request, 'complete')");
+
+    const renderActionsBlock = source.slice(
+      source.indexOf('const renderActions = (request) => {'),
+      source.indexOf('const columns = [')
+    );
+
+    expect(renderActionsBlock).not.toContain("request.status === 'pending'");
+    expect(renderActionsBlock).not.toContain("request.status === 'approved'");
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes cashier refund request actions so the UI uses the existing backend `/process` command instead of non-existent `/approve`, `/reject`, and `/complete` URLs.
- Adds backend-owned refund request action availability fields and makes the frontend render commands only from `available_actions/can_*`.
- Corrects the refund request list filter query to the published `status_filter` contract.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/refund-requests-action-contract` was reset from `origin/main` at `2be3c956` after PR #1255.
- Clean workspace: isolated worktree `C:\tmp\final-queue-actions-status-contract`; unrelated dirty files in `C:\final` were not touched.
- Branch: `codex/refund-requests-action-contract`.
- Scope gate: `agent_gate.py` was run twice with known root causes; it narrowed to one side each time, so narrow_override was used for the confirmed refund request contract file set only.
- Red-check handling: local targeted tests, OpenAPI contract, frontend build, and `git diff --check` passed before PR creation.

## Contract Impact

- Canonical surface: existing `POST /api/v1/force-majeure/refund-requests/{request_id}/process` remains the only refund request command endpoint.
- Request shape: frontend now posts `{ action, ...extraPayload }` to `/process`; reject sends `rejection_reason`.
- Response shape: refund request DTO now includes additive backend-owned `available_actions`, `can_approve`, `can_reject`, and `can_complete`.
- Status codes: no endpoint status-code behavior changed; service transition rejections remain backend-owned.
- Frontend consumer: `RefundRequestsTable` renders approve/reject/complete only from `available_actions/can_*` and no longer calls invented `/approve`, `/reject`, or `/complete` URLs.
- Compatibility path or alias: list filtering now uses the published `status_filter` query name instead of the non-contract `status` query.
- Contract proof: backend unit test covers action fields; frontend contract test covers `/process`, backend-owned action rendering, and query name.

## RBAC / Permissions

- Roles allowed: unchanged endpoint dependency `Admin`, `Cashier`, `Manager` for refund request list/get/process.
- Roles denied: unchanged FastAPI `require_roles` behavior denies other roles.
- Positive auth proof: existing endpoint dependency path unchanged; no auth bypass introduced.
- Negative auth proof: role enforcement was not modified; branch protection backend/API checks passed on the unchanged dependency path.

## Notification / Realtime

- Event type or websocket channel: no realtime event or websocket channel is touched by this refund request contract patch.
- Payload version / ack behavior: no notification payload or acknowledgement behavior is changed.
- Read/unread or delivery semantics: no notification read/unread or delivery state exists in this component path.
- Reconnect/resync proof: after a successful `/process` command, the component still reloads refund requests through the REST list endpoint; no websocket resync path is involved.

## Frontend Resilience

- Empty data proof: existing empty-state branch remains unchanged and still renders when the refund request list is empty.
- Partial data proof: missing `available_actions` falls back only to explicit backend `can_*`; missing both hides commands instead of inferring from status.
- Forbidden secondary path behavior: obsolete `/approve`, `/reject`, `/complete` request paths are removed and source-tested absent.
- Missing draft/resource behavior: this table has no draft/resource object workflow; failed list/process requests keep the existing error handling path and do not invent fallback state.
- Stale route/deep-link behavior: this component has no route/deep-link parameters; cashier tab routing is untouched.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/force_majeure.py`, `backend/app/services/force_majeure_api_service.py`, `backend/tests/unit/test_force_majeure_api_service.py`, `frontend/src/components/cashier/RefundRequestsTable.jsx`, `frontend/src/components/cashier/__tests__/RefundRequestsTable.contract.test.jsx`.
- Denied paths: `/api/v1/ui/*`, separate BFF service, command wrappers, unrelated cashier/payment flows, migrations, broad UI cleanup.
- Migration/docs/test impact: no migration; additive API response fields; targeted backend/frontend tests added/updated.
- Rollback note: revert this commit to restore previous frontend behavior and remove additive refund request action fields.

## Validation

- Targeted tests or smoke run: `py_compile` for force_majeure endpoint/service; `pytest backend/tests/unit/test_force_majeure_api_service.py -q` with test SQLite env; `pytest backend/tests/test_openapi_contract.py -q` with test SQLite env; `npm --prefix frontend run test:run -- RefundRequestsTable.contract`; `npm --prefix frontend run build`; `git diff --check`.
- Result: all passed.
- Not checked: full local backend suite and browser role smoke were not run for this narrow contract PR; GitHub backend/frontend required checks passed.