### PR TITLE
fix(cashier): gate payment actions by backend contract

### DIFF
--- a/backend/app/api/v1/endpoints/cashier.py
+++ b/backend/app/api/v1/endpoints/cashier.py
@@ -44,6 +44,38 @@ def _preserve_cashier_visit_status(raw_status: str | None) -> str:
     return raw_status
 
 
+def _cashier_payment_status(payment: Payment) -> str:
+    return str(payment.status or "").strip().lower()
+
+
+def _cashier_payment_available_amount(payment: Payment) -> Decimal:
+    return Decimal(str(payment.amount or 0)) - Decimal(str(payment.refunded_amount or 0))
+
+
+def _cashier_payment_action_contract(payment: Payment) -> dict[str, Any]:
+    payment_status = _cashier_payment_status(payment)
+    can_confirm = payment_status not in {"paid", "completed", "cancelled", "refunded", "void"}
+    can_cancel = payment_status not in {"cancelled", "refunded", "void"}
+    can_refund = payment_status in {"paid", "completed"} and _cashier_payment_available_amount(payment) > 0
+    can_print_receipt = True
+
+    action_flags = {
+        "confirm": can_confirm,
+        "cancel": can_cancel,
+        "refund": can_refund,
+        "print_receipt": can_print_receipt,
+    }
+    return {
+        "available_actions": [
+            action for action, allowed in action_flags.items() if allowed
+        ],
+        "can_confirm": can_confirm,
+        "can_cancel": can_cancel,
+        "can_refund": can_refund,
+        "can_print_receipt": can_print_receipt,
+    }
+
+
 # ===================== МОДЕЛИ ДЛЯ КАССИРА =====================
 
 class PendingPaymentItem(BaseModel):
@@ -80,6 +112,11 @@ class PaymentHistoryItem(BaseModel):
     paid_at: Optional[datetime] = None
     note: Optional[str] = None
     cashier_name: Optional[str] = None
+    available_actions: List[str] = Field(default_factory=list)
+    can_confirm: bool = False
+    can_cancel: bool = False
+    can_refund: bool = False
+    can_print_receipt: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -802,6 +839,7 @@ async def get_payments(
                 paid_at=payment.paid_at if hasattr(payment, 'paid_at') else None,
                 note=payment.note if hasattr(payment, 'note') else None,
                 cashier_name=None,
+                **_cashier_payment_action_contract(payment),
             ))
             
         import math
@@ -1003,7 +1041,7 @@ async def cancel_payment(
             detail="Платеж не найден"
         )
     
-    if payment.status == "cancelled":
+    if _cashier_payment_status(payment) in {"cancelled", "refunded", "void"}:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Платеж уже отменен"
@@ -1141,10 +1179,12 @@ async def confirm_payment(
     if not payment:
          raise HTTPException(status_code=404, detail="Платеж не найден")
     
-    if payment.status == 'paid':
+    payment_status = _cashier_payment_status(payment)
+
+    if payment_status in {'paid', 'completed'}:
          return {"success": True, "message": "Платеж уже оплачен"}
 
-    if payment.status == 'cancelled':
+    if payment_status in {'cancelled', 'refunded', 'void'}:
          raise HTTPException(status_code=400, detail="Нельзя подтвердить отмененный платеж")
 
     # Обновляем статус платежа

--- a/backend/tests/integration/test_notification_catalog_slice2_cashier.py
+++ b/backend/tests/integration/test_notification_catalog_slice2_cashier.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date
+from decimal import Decimal
 
 from app.core.security import get_password_hash
 from app.models.notification import NotificationDelivery, NotificationEvent
@@ -8,6 +9,45 @@ from app.models.patient import Patient
 from app.models.payment import Payment
 from app.models.user import User
 from app.models.visit import Visit
+
+
+def _create_patient_visit(db_session, *, suffix: str) -> tuple[Patient, Visit]:
+    patient_user = User(
+        username=f"cashier_actions_patient_{suffix}",
+        email=f"cashier_actions_patient_{suffix}@test.local",
+        full_name=f"Cashier Actions Patient {suffix}",
+        hashed_password=get_password_hash("patient123"),
+        role="Patient",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(patient_user)
+    db_session.commit()
+    db_session.refresh(patient_user)
+
+    patient = Patient(
+        first_name=f"Action{suffix}",
+        last_name="Patient",
+        phone=f"+99890120{suffix.zfill(4)[-4:]}",
+        birth_date=date(1990, 1, 1),
+        user_id=patient_user.id,
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+
+    visit = Visit(
+        patient_id=patient.id,
+        status="waiting",
+        discount_mode="none",
+        approval_status="none",
+        source="desk",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+
+    return patient, visit
 
 
 def _payment_event_deliveries(db_session, *, recipient_id: int):
@@ -152,3 +192,111 @@ def test_cashier_cancel_payment_creates_cancelled_payment_notification(
     assert event.payload_snapshot["metadata"]["change_type"] == "cancelled"
     assert event.payload_snapshot["metadata"]["payment_status"] == "cancelled"
     assert event.payload_snapshot["metadata"]["reason"] == "patient requested cancel"
+
+
+def test_cashier_payment_history_exposes_backend_owned_actions(
+    client,
+    db_session,
+    auth_headers,
+):
+    _, visit = _create_patient_visit(db_session, suffix="0001")
+    pending_payment = Payment(
+        visit_id=visit.id,
+        amount=Decimal("30000"),
+        method="cash",
+        status="pending",
+    )
+    paid_payment = Payment(
+        visit_id=visit.id,
+        amount=Decimal("50000"),
+        method="cash",
+        status="paid",
+    )
+    refunded_payment = Payment(
+        visit_id=visit.id,
+        amount=Decimal("70000"),
+        method="cash",
+        status="refunded",
+        refunded_amount=Decimal("70000"),
+    )
+    db_session.add_all([pending_payment, paid_payment, refunded_payment])
+    db_session.commit()
+
+    response = client.get("/api/v1/cashier/payments?size=10", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    rows = {item["id"]: item for item in response.json()["items"]}
+
+    pending_row = rows[pending_payment.id]
+    assert pending_row["can_confirm"] is True
+    assert pending_row["can_cancel"] is True
+    assert pending_row["can_refund"] is False
+    assert pending_row["can_print_receipt"] is True
+    assert set(pending_row["available_actions"]) == {"confirm", "cancel", "print_receipt"}
+
+    paid_row = rows[paid_payment.id]
+    assert paid_row["can_confirm"] is False
+    assert paid_row["can_cancel"] is True
+    assert paid_row["can_refund"] is True
+    assert paid_row["can_print_receipt"] is True
+    assert set(paid_row["available_actions"]) == {"cancel", "refund", "print_receipt"}
+
+    refunded_row = rows[refunded_payment.id]
+    assert refunded_row["can_confirm"] is False
+    assert refunded_row["can_cancel"] is False
+    assert refunded_row["can_refund"] is False
+    assert refunded_row["can_print_receipt"] is True
+    assert refunded_row["available_actions"] == ["print_receipt"]
+
+
+def test_cashier_confirm_refunded_payment_is_rejected_without_mutation(
+    client,
+    db_session,
+    auth_headers,
+):
+    _, visit = _create_patient_visit(db_session, suffix="0002")
+    payment = Payment(
+        visit_id=visit.id,
+        amount=Decimal("40000"),
+        method="cash",
+        status="refunded",
+        refunded_amount=Decimal("40000"),
+    )
+    db_session.add(payment)
+    db_session.commit()
+    db_session.refresh(payment)
+
+    response = client.post(
+        f"/api/v1/cashier/payments/{payment.id}/confirm",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400, response.text
+    db_session.refresh(payment)
+    assert payment.status == "refunded"
+
+
+def test_cashier_confirm_completed_payment_does_not_downgrade_status(
+    client,
+    db_session,
+    auth_headers,
+):
+    _, visit = _create_patient_visit(db_session, suffix="0003")
+    payment = Payment(
+        visit_id=visit.id,
+        amount=Decimal("45000"),
+        method="cash",
+        status="completed",
+    )
+    db_session.add(payment)
+    db_session.commit()
+    db_session.refresh(payment)
+
+    response = client.post(
+        f"/api/v1/cashier/payments/{payment.id}/confirm",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    db_session.refresh(payment)
+    assert payment.status == "completed"

--- a/frontend/src/pages/CashierPanel.jsx
+++ b/frontend/src/pages/CashierPanel.jsx
@@ -251,7 +251,7 @@ const hasBackendPaymentAction = (paymentRow, action) => {
     return Boolean(paymentRow[canField]);
   }
 
-  return true;
+  return false;
 };
 
 const CashierPanel = () => {void
@@ -1419,6 +1419,7 @@ const CashierPanel = () => {void
                                   size="sm"
                                   variant="outline"
                                   onClick={() => confirmPayment(row.id)}
+                                  disabled={!hasBackendPaymentAction(row, 'confirm')}
                                   aria-label={`Confirm ${getPaymentActionContext(row)}`}>
                                   ✅ Принять
                                 </Button>
@@ -1447,6 +1448,7 @@ const CashierPanel = () => {void
                           size="sm"
                           variant="outline"
                           onClick={() => handlePrintReceipt(row)}
+                          disabled={!hasBackendPaymentAction(row, 'print_receipt')}
                           aria-label={`Print receipt for ${getPaymentActionContext(row)}`}
                           title="Печать чека">
 

--- a/frontend/src/pages/__tests__/CashierPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/CashierPanel.contract.test.jsx
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cashierPanelPath = path.resolve(__dirname, '../CashierPanel.jsx');
+
+const readCashierPanelSource = () => fs.readFileSync(cashierPanelPath, 'utf8');
+
+const extractSourceBlock = (source, startMarker, endMarker) => {
+  const start = source.indexOf(startMarker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf(endMarker, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+};
+
+describe('CashierPanel payment action contract', () => {
+  it('fails closed when backend payment action fields are missing', () => {
+    const source = readCashierPanelSource();
+    const helperBlock = extractSourceBlock(
+      source,
+      'const hasBackendPaymentAction = (paymentRow, action) => {',
+      'const CashierPanel = () => {',
+    );
+
+    expect(helperBlock).toContain('paymentRow?.available_actions');
+    expect(helperBlock).toContain('PAYMENT_ACTION_CAN_FIELD');
+    expect(helperBlock).toContain('return false;');
+    expect(helperBlock).not.toContain('return true;');
+  });
+
+  it('renders all payment history commands from backend-provided actions or can flags', () => {
+    const source = readCashierPanelSource();
+    const actionCellBlock = extractSourceBlock(
+      source,
+      "onClick={() => confirmPayment(row.id)}",
+      '<td colSpan="7"',
+    );
+
+    expect(actionCellBlock).toContain("disabled={!hasBackendPaymentAction(row, 'confirm')}");
+    expect(actionCellBlock).toContain("disabled={!hasBackendPaymentAction(row, 'cancel')}");
+    expect(actionCellBlock).toContain("disabled={!hasBackendPaymentAction(row, 'refund')}");
+    expect(actionCellBlock).toContain("disabled={!hasBackendPaymentAction(row, 'print_receipt')}");
+    expect(actionCellBlock).not.toContain("row.status ===");
+    expect(actionCellBlock).not.toContain('payment_status');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes cashier payment history command availability so React no longer enables payment commands when backend action fields are missing.
- Adds backend-owned `available_actions` and `can_*` flags to `GET /api/v1/cashier/payments` rows.
- Prevents manual confirm from mutating `refunded`, `cancelled`, or `void` payments, and avoids downgrading `completed` payments to `paid`.

## Cyclic Execution Evidence
- Fresh main sync: Branch was created from `origin/main` at `9a87b295` in isolated worktree `C:\tmp\final-queue-actions-status-contract`.
- Clean workspace: Worktree was clean before branch creation; unrelated dirty files in `C:\final` were not touched.
- Branch: `codex/cashier-payment-actions-contract`.
- Scope gate: Narrow override after two incomplete gate passes; allowed files were cashier payment endpoint, `CashierPanel`, and focused backend/frontend tests only.
- Red-check handling: PR Review Quality Gate failed on missing body fields only; this body update fills the required fields without runtime code changes.

## Contract Impact
- Canonical surface: `backend/app/api/v1/endpoints/cashier.py` owns cashier payment history DTO and cashier payment command endpoints.
- Request shape: No request shape changes; existing `GET /api/v1/cashier/payments`, `POST /confirm`, `POST /cancel`, `POST /refund`, and receipt routes remain.
- Response shape: `PaymentHistoryItem` now includes additive `available_actions`, `can_confirm`, `can_cancel`, `can_refund`, and `can_print_receipt`.
- Status codes: Confirm still returns 200 for already settled `paid/completed`; confirm now returns 400 for terminal `cancelled/refunded/void` instead of mutating them.
- Frontend consumer: `frontend/src/pages/CashierPanel.jsx` disables confirm/cancel/refund/receipt unless backend action contract allows the command.
- Compatibility path or alias: No endpoint alias or compatibility path added; existing cashier routes are extended additively.
- Contract proof: Backend integration tests assert action flags by payment status and no refunded/completed confirm mutation; frontend contract test asserts fail-closed action rendering.

## RBAC / Permissions
- Roles allowed: Existing `Admin` and `Cashier` dependencies remain on cashier payment history and command endpoints.
- Roles denied: No role policy changed; roles outside `Admin/Cashier` remain denied by the existing endpoint dependency.
- Positive auth proof: Targeted cashier integration tests use authenticated `auth_headers` and successfully exercise payment history and confirm endpoints.
- Negative auth proof: Not rerun in this PR because RBAC dependencies were not changed; existing role matrix coverage remains the owner for denied-role behavior.

## Notification / Realtime
- Event type or websocket channel: Existing payment notification event paths are unchanged for successful cancel/refund/confirm mutations; no websocket channel added.
- Payload version / ack behavior: No notification payload version, ack, or delivery contract was changed.
- Read/unread or delivery semantics: No read/unread notification behavior was changed; invalid confirm attempts now stop before mutation and notification emission.
- Reconnect/resync proof: No realtime reconnect/resync path is involved because this PR changes REST payment action contract only.

## Frontend Resilience
- Empty data proof: `CashierPanel.contract` verifies missing backend action facts fail closed instead of enabling commands.
- Partial data proof: Helper still accepts either `available_actions` or explicit `can_*` fields, so partial backend action contracts remain supported.
- Forbidden secondary path behavior: No secondary action endpoint or local status fallback was added; buttons use backend action facts only.
- Missing draft/resource behavior: Missing payment action fields disable commands rather than treating missing data as allowed.
- Stale route/deep-link behavior: No route or deep-link behavior changed; payment history rows keep existing IDs and command routes.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/cashier.py`, `backend/tests/integration/test_notification_catalog_slice2_cashier.py`, `frontend/src/pages/CashierPanel.jsx`, `frontend/src/pages/__tests__/CashierPanel.contract.test.jsx`.
- Denied paths: No `/api/v1/ui/*`, BFF service, migrations, QueueJoin, DisplayBoard, Registrar, lab, routing, or unrelated cleanup.
- Migration/docs/test impact: No migrations or docs changed; focused backend/frontend tests were added or updated.
- Rollback note: Revert this PR to restore previous cashier payment DTO/buttons; no schema migration rollback is needed.

## Validation
- Targeted tests or smoke run: `py_compile cashier.py`; cashier integration pytest; OpenAPI contract pytest; `CashierPanel.contract` Vitest; frontend build; `git diff --check`.
- Result: All local checks passed; GitHub runtime checks passed except the original body-format gate before this body correction.
- Not checked: Full manual browser smoke and negative RBAC matrix were not rerun because UI routing and RBAC dependencies were unchanged.