### PR TITLE
fix(cashier): pass payment status history filter

### DIFF
--- a/frontend/src/hooks/__tests__/usePayments.contract.test.jsx
+++ b/frontend/src/hooks/__tests__/usePayments.contract.test.jsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { usePayments } from '../usePayments';
+
+const api = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock('../../api/client', () => ({ api }));
+
+vi.mock('../../utils/logger', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    log: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('usePayments cashier payment history contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes the backend status query alias for payment history filters', async () => {
+    api.get.mockResolvedValueOnce({
+      data: {
+        items: [],
+        total: 0,
+        page: 1,
+        size: 20,
+        pages: 0,
+      },
+    });
+
+    const { result } = renderHook(() => usePayments());
+
+    await act(async () => {
+      await result.current.getPayments({
+        date_from: '2026-05-01',
+        date_to: '2026-05-25',
+        page: 2,
+        search: 'Karimov',
+        status: 'refunded',
+      });
+    });
+
+    expect(api.get).toHaveBeenCalledWith('/cashier/payments', {
+      params: {
+        page: 2,
+        size: 20,
+        date_from: '2026-05-01',
+        date_to: '2026-05-25',
+        search: 'Karimov',
+        status: 'refunded',
+      },
+    });
+  });
+});

--- a/frontend/src/hooks/usePayments.js
+++ b/frontend/src/hooks/usePayments.js
@@ -62,7 +62,7 @@ export const usePayments = () => {
     /**
      * Get payment history
      */
-    const getPayments = useCallback(async ({ date_from, date_to, page = 1, size = 20, search } = {}) => {
+    const getPayments = useCallback(async ({ date_from, date_to, page = 1, size = 20, search, status } = {}) => {
         setLoading(true);
         setError(null);
 
@@ -72,7 +72,8 @@ export const usePayments = () => {
                 size,
                 ...(date_from && { date_from }),
                 ...(date_to && { date_to }),
-                ...(search && { search })
+                ...(search && { search }),
+                ...(status && { status })
             };
 
             const response = await api.get('/cashier/payments', { params });


### PR DESCRIPTION
## Summary
- Fixes the cashier payment history status filter path so frontend requests include the backend `status` query alias.
- Adds a focused hook contract test proving `usePayments.getPayments` forwards the status filter.
- No backend, BFF-lite, command, or runtime architecture changes.

## Cyclic Execution Evidence
- Fresh main sync: Branch was created from merged `origin/main` at `caf1f466` in isolated worktree `C:\tmp\final-queue-actions-status-contract`.
- Clean workspace: Worktree was clean after #1260 merge before this branch was created; unrelated `C:\final` dirty files were not touched.
- Branch: `codex/cashier-payment-status-filter-contract`.
- Scope gate: Direct narrow execute; only read-only cashier payment history adapter behavior and focused test were allowed.
- Red-check handling: No red checks yet for this PR; if CI fails, the same PR will be fixed before any next slice.

## Contract Impact
- Canonical surface: Backend `GET /api/v1/cashier/payments` already owns the `status` query alias through `status_filter: Query(..., alias=status)`.
- Request shape: Frontend now sends optional `status` in the existing `/cashier/payments` query params.
- Response shape: No response shape changes.
- Status codes: No status-code behavior changes.
- Frontend consumer: `frontend/src/hooks/usePayments.js` now preserves the `status` argument passed from `CashierPanel`.
- Compatibility path or alias: Uses the existing backend `status` alias; no new endpoint or alias added.
- Contract proof: `usePayments.contract` asserts the exact request params sent to `/cashier/payments`.

## RBAC / Permissions
- Roles allowed: Existing backend `Admin` and `Cashier` permissions remain unchanged.
- Roles denied: No denied-role behavior changed because this is a frontend query-param pass-through fix.
- Positive auth proof: Not rerun locally because no auth dependency or backend route changed; existing endpoint auth remains canonical.
- Negative auth proof: Not rerun because RBAC was untouched and this PR only forwards an optional read filter.

## Notification / Realtime
- Event type or websocket channel: No notification event or websocket channel is involved.
- Payload version / ack behavior: No notification payload or ack behavior changed.
- Read/unread or delivery semantics: No notification read/unread semantics changed.
- Reconnect/resync proof: No realtime reconnect/resync behavior is involved in this read-only filter fix.

## Frontend Resilience
- Empty data proof: Hook test uses an empty paginated response and still verifies the request contract.
- Partial data proof: Existing optional params remain optional; only provided `status` is forwarded.
- Forbidden secondary path behavior: No secondary endpoint or local status fallback was added.
- Missing draft/resource behavior: No draft/resource path is involved; missing `status` still omits the query param.
- Stale route/deep-link behavior: No route or deep-link behavior changed.

## Scope Gate
- Allowed paths: `frontend/src/hooks/usePayments.js`, `frontend/src/hooks/__tests__/usePayments.contract.test.jsx`.
- Denied paths: No backend, migrations, BFF, `/api/v1/ui/*`, QueueJoin, DisplayBoard, Registrar, lab, or command behavior changes.
- Migration/docs/test impact: No migration or docs changes; one focused frontend hook contract test added.
- Rollback note: Revert this PR to restore previous hook params; no data/schema rollback is needed.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- usePayments.contract`; `npm --prefix frontend run build`; `git diff --check`.
- Result: All local checks passed.
- Not checked: Backend pytest and manual browser smoke were not run because backend and UI rendering were not changed.