### PR TITLE
fix(doctor): preserve missing queue status facts

### DIFF
--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -487,8 +487,8 @@ const MacOSCardiologistPanelUnified = () => {
         phone: matchingAppointment.patient_phone || prev?.phone || '',
         number: nextAppointmentId || prev?.number || patientIdFromUrl,
         source: 'appointments',
-        status: matchingAppointment.status || prev?.status || 'waiting',
-        payment_status: matchingAppointment.payment_status || prev?.payment_status || 'pending',
+        status: matchingAppointment.status ?? prev?.status ?? null,
+        payment_status: matchingAppointment.payment_status ?? prev?.payment_status ?? null,
         discount_mode: matchingAppointment.discount_mode || prev?.discount_mode,
         specialty: matchingAppointment.specialty || prev?.specialty || 'cardiology'
       };
@@ -583,7 +583,7 @@ const MacOSCardiologistPanelUnified = () => {
                   services: entry.services || [],
                   service_codes: entry.service_codes || [],
                   payment_type: entry.payment_type || null,
-                  payment_status: entry.payment_status || 'pending',
+                  payment_status: entry.payment_status ?? null,
                   available_actions: entry.available_actions || [],
                   can_mark_paid: Boolean(entry.can_mark_paid),
                   can_start_visit: Boolean(entry.can_start_visit) && doctorQueueEntryId !== null,
@@ -595,15 +595,15 @@ const MacOSCardiologistPanelUnified = () => {
                   canonical_record_id: entry.canonical_record_id || entry.id,
                   record_kind: entry.record_kind,
                   source_kind: entry.source_kind,
-                  canonical_status: entry.canonical_status || entry.status,
-                  queue_status: entry.queue_status || entry.status,
+                  canonical_status: entry.canonical_status ?? null,
+                  queue_status: entry.queue_status ?? null,
                   queue_position: entry.queue_position,
                   doctor: entry.doctor_name || 'Врач',
                   specialty: queue.specialty,
                   created_at: entry.created_at,
                   appointment_date: entry.created_at ? entry.created_at.split('T')[0] : new Date().toISOString().split('T')[0],
                   appointment_time: entry.visit_time || '09:00',
-                  status: entry.status || 'waiting',
+                  status: entry.status ?? null,
                   cost: entry.cost || 0
                 });
               });
@@ -826,8 +826,8 @@ const MacOSCardiologistPanelUnified = () => {
         number: row.id,
         doctor_queue_entry_id: resolveDoctorQueueEntryId(row),
         source: 'appointments',
-        status: row.status || 'waiting',
-        payment_status: row.payment_status || 'pending',
+        status: row.status ?? null,
+        payment_status: row.payment_status ?? null,
         discount_mode: row.discount_mode,
         specialty: row.specialty || 'cardiology'
       };
@@ -873,8 +873,8 @@ const MacOSCardiologistPanelUnified = () => {
             number: row.id,
             doctor_queue_entry_id: resolveDoctorQueueEntryId(row),
             source: 'appointments',
-            status: row.status || 'waiting',
-            payment_status: row.payment_status || 'pending',
+            status: row.status ?? null,
+            payment_status: row.payment_status ?? null,
             discount_mode: row.discount_mode,
             specialty: row.specialty || 'cardiology'
           };

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -583,7 +583,7 @@ const DentistPanelUnified = () => {
                     services: entry.services || [],
                     service_codes: entry.service_codes || [],
                     payment_type: entry.payment_type || null,
-                    payment_status: entry.payment_status || 'pending',
+                    payment_status: entry.payment_status ?? null,
                     available_actions: entry.available_actions || [],
                     can_mark_paid: Boolean(entry.can_mark_paid),
                     can_start_visit: Boolean(entry.can_start_visit) && doctorQueueEntryId !== null,
@@ -595,15 +595,15 @@ const DentistPanelUnified = () => {
                     canonical_record_id: entry.canonical_record_id || entry.id,
                     record_kind: entry.record_kind,
                     source_kind: entry.source_kind,
-                    canonical_status: entry.canonical_status || entry.status,
-                    queue_status: entry.queue_status || entry.status,
+                    canonical_status: entry.canonical_status ?? null,
+                    queue_status: entry.queue_status ?? null,
                     queue_position: entry.queue_position,
                     doctor: entry.doctor_name || 'Врач',
                     specialty: queue.specialty,
                     created_at: entry.created_at,
                     appointment_date: entry.created_at ? entry.created_at.split('T')[0] : new Date().toISOString().split('T')[0],
                     appointment_time: entry.visit_time || '09:00',
-                    status: entry.status || 'waiting',
+                    status: entry.status ?? null,
                     cost: entry.cost || 0
                   });
                 });

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -436,7 +436,7 @@ const DermatologistPanelUnified = () => {
                     services: entry.services || [],
                     service_codes: entry.service_codes || [],
                     payment_type: entry.payment_type || null,
-                    payment_status: entry.payment_status || 'pending',
+                    payment_status: entry.payment_status ?? null,
                     available_actions: entry.available_actions || [],
                     can_mark_paid: Boolean(entry.can_mark_paid),
                     can_start_visit: Boolean(entry.can_start_visit) && doctorQueueEntryId !== null,
@@ -448,15 +448,15 @@ const DermatologistPanelUnified = () => {
                     canonical_record_id: entry.canonical_record_id || entry.id,
                     record_kind: entry.record_kind,
                     source_kind: entry.source_kind,
-                    canonical_status: entry.canonical_status || entry.status,
-                    queue_status: entry.queue_status || entry.status,
+                    canonical_status: entry.canonical_status ?? null,
+                    queue_status: entry.queue_status ?? null,
                     queue_position: entry.queue_position,
                     doctor: entry.doctor_name || 'Врач',
                     specialty: queue.specialty,
                     created_at: entry.created_at,
                     appointment_date: entry.created_at ? entry.created_at.split('T')[0] : today,
                     appointment_time: entry.visit_time || '09:00',
-                    status: entry.status || 'waiting',
+                    status: entry.status ?? null,
                     cost: entry.cost || 0,
                     visit_id: entry.visit_id || null
                   });
@@ -600,7 +600,7 @@ const DermatologistPanelUnified = () => {
         number: row.id,
         doctor_queue_entry_id: resolveDoctorQueueEntryId(row),
         source: 'appointments',
-        status: row.status || 'waiting',
+        status: row.status ?? null,
         specialty: row.specialty || 'dermatology'
       };
       setSelectedPatient(patientData);

--- a/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
@@ -31,8 +31,11 @@ describe('Doctor panels SSOT contract', () => {
       expect(source).not.toContain('appointmentMetaMap');
       expect(source).not.toContain('appointmentsDBData');
 
-      expect(source).toContain('payment_status: entry.payment_status');
+      expect(source).toContain('payment_status: entry.payment_status ?? null');
       expect(source).toContain('payment_type: entry.payment_type');
+      expect(source).toContain('queue_status: entry.queue_status ?? null');
+      expect(source).toContain('canonical_status: entry.canonical_status ?? null');
+      expect(source).toContain('status: entry.status ?? null');
       expect(source).toContain('available_actions: entry.available_actions || []');
       expect(source).toContain('can_mark_paid: Boolean(entry.can_mark_paid)');
       expect(source).toContain('can_start_visit: Boolean(entry.can_start_visit) && doctorQueueEntryId !== null');
@@ -40,6 +43,13 @@ describe('Doctor panels SSOT contract', () => {
       expect(source).toContain('can_complete: Boolean(entry.can_complete) && doctorQueueEntryId !== null');
       expect(source).toContain('can_cancel: Boolean(entry.can_cancel)');
       expect(source).toContain('doctor_queue_entry_id: doctorQueueEntryId');
+
+      expect(source).not.toContain("payment_status: entry.payment_status || 'pending'");
+      expect(source).not.toContain("status: entry.status || 'waiting'");
+      expect(source).not.toContain("payment_status: row.payment_status || 'pending'");
+      expect(source).not.toContain("status: row.status || 'waiting'");
+      expect(source).not.toContain('queue_status: entry.queue_status || entry.status');
+      expect(source).not.toContain('canonical_status: entry.canonical_status || entry.status');
     }
   });
 


### PR DESCRIPTION
## Summary
- Removes frontend-invented `pending` payment status and `waiting` queue/status fallbacks from specialty doctor queue adapters.
- Preserves missing backend status facts as `null` instead of reconstructing canonical state in React.
- Strengthens `DoctorPanels.contract` so these fallbacks cannot slip through again.

## Cyclic Execution Evidence
- Fresh main sync: Branch was created directly from `origin/main` at `03d322a2` in isolated worktree `C:\tmp\final-queue-actions-status-contract`.
- Clean workspace: Worktree was clean after #1261 merge before this branch; unrelated dirty files in `C:\final` were not touched.
- Branch: `codex/doctor-panels-status-passthrough`.
- Scope gate: Narrow override after gate identified only one of three symmetric specialty panel adapters; allowed files were the three doctor specialty panels and their focused contract test.
- Red-check handling: No red checks yet for this PR; if CI fails, fixes stay in this PR before the next slice.

## Contract Impact
- Canonical surface: `/api/v1/registrar/queues/today` remains the backend source of queue/payment/canonical status facts consumed by doctor panels.
- Request shape: No request shape changes.
- Response shape: No backend response shape changes; frontend now preserves missing `payment_status`, `status`, `queue_status`, and `canonical_status` as `null`.
- Status codes: No status-code behavior changes.
- Frontend consumer: Cardiology, dermatology, and dentistry panel row adapters stop inventing `pending`/`waiting` status values.
- Compatibility path or alias: No endpoint, alias, or BFF-lite path added.
- Contract proof: `DoctorPanels.contract` now asserts exact `?? null` passthrough and rejects prior fallback strings.

## RBAC / Permissions
- Roles allowed: Existing doctor/role access paths are unchanged.
- Roles denied: No denied-role behavior changed because this PR only changes local DTO adaptation of already-fetched rows.
- Positive auth proof: Not rerun locally because no endpoint, auth dependency, or role mapping changed.
- Negative auth proof: Not rerun because RBAC was untouched and existing role tests remain canonical.

## Notification / Realtime
- Event type or websocket channel: No notification event or websocket channel is involved.
- Payload version / ack behavior: No notification payload or ack behavior changed.
- Read/unread or delivery semantics: No notification read/unread semantics changed.
- Reconnect/resync proof: No realtime reconnect/resync behavior is involved in this static row-adapter contract fix.

## Frontend Resilience
- Empty data proof: Missing backend status fields now remain `null` instead of becoming misleading operational states.
- Partial data proof: Existing row fields still pass through when provided; only absent status facts stop being invented.
- Forbidden secondary path behavior: No secondary endpoint, local status decision, or command fallback was added.
- Missing draft/resource behavior: Missing queue/payment status facts are represented as unknown/null, not as actionable states.
- Stale route/deep-link behavior: No routes or deep links changed.

## Scope Gate
- Allowed paths: `frontend/src/pages/CardiologistPanelUnified.jsx`, `frontend/src/pages/DermatologistPanelUnified.jsx`, `frontend/src/pages/DentistPanelUnified.jsx`, `frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx`.
- Denied paths: No backend, migrations, BFF, `/api/v1/ui/*`, cashier, registrar, lab, queue command endpoint, or unrelated cleanup.
- Migration/docs/test impact: No migrations or docs changed; focused frontend contract test updated.
- Rollback note: Revert this PR to restore previous fallback display behavior; no data/schema rollback is needed.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- DoctorPanels.contract`; `npm --prefix frontend run build`; `git diff --check`.
- Result: All local checks passed.
- Not checked: Backend pytest and manual browser smoke were not run because backend and route behavior were not changed.