### PR TITLE
fix(registrar): type batch entry mutations

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_batch.py
+++ b/backend/app/api/v1/endpoints/registrar_batch.py
@@ -85,6 +85,7 @@ async def get_patient_entries(
         "online_queue_entries": [
             {
                 "id": e.id,
+                "entry_type": "online_queue",
                 "number": e.number,
                 "status": e.status,
                 "queue_tag": e.queue_tag,
@@ -97,6 +98,7 @@ async def get_patient_entries(
         "visits": [
             {
                 "id": v.id,
+                "entry_type": "visit",
                 "status": v.status,
                 "doctor_id": v.doctor_id,
                 "visit_date": str(v.visit_date) if v.visit_date else None,
@@ -213,6 +215,7 @@ async def cancel_all_patient_entries(
     for entry in entries_data["online_queue_entries"]:
         cancel_actions.append({
             "id": entry.id,
+            "entry_type": "online_queue",
             "action": "cancel",
             "reason": reason
         })
@@ -220,6 +223,7 @@ async def cancel_all_patient_entries(
     for visit in entries_data["visits"]:
         cancel_actions.append({
             "id": visit.id,
+            "entry_type": "visit",
             "action": "cancel",
             "reason": reason
         })

--- a/backend/app/services/batch_patient_service.py
+++ b/backend/app/services/batch_patient_service.py
@@ -34,6 +34,8 @@ from app.services.service_mapping import (
 
 logger = logging.getLogger(__name__)
 
+EntryActionType = Literal["online_queue", "visit"]
+
 _BATCH_CREATE_RESOURCE_MAPPING = {
     "ecg": "ecg_resource",
     "echokg": "ecg_resource",
@@ -53,6 +55,7 @@ _BATCH_CREATE_RESOURCE_MAPPING = {
 class EntryAction(BaseModel):
     """Действие над одной записью в batch-операции"""
     id: int | None = None  # None для создания новой
+    entry_type: EntryActionType | None = None
     action: Literal["update", "cancel", "create"]
 
     # Для update/create:
@@ -266,29 +269,23 @@ class BatchPatientService:
         if not action.id:
             return EntryResult(id=0, status="error", error="ID required for cancel")
 
-        # Пробуем найти в OnlineQueueEntry
-        entry = self.db.query(OnlineQueueEntry).filter(
-            OnlineQueueEntry.id == action.id,
-            OnlineQueueEntry.patient_id == patient_id,
-        ).join(
-            DailyQueue, OnlineQueueEntry.queue_id == DailyQueue.id
-        ).filter(
-            DailyQueue.day == target_date,
-        ).first()
+        # Resolve within patient/date before mutating to avoid id collisions.
+        entry_type, target, error = self._resolve_existing_entry_target(
+            patient_id=patient_id,
+            target_date=target_date,
+            action=action,
+        )
+        if error:
+            return EntryResult(id=action.id, status="error", error=error)
 
-        if entry:
+        if entry_type == "online_queue":
+            entry = target
             entry.status = "cancelled"
             entry.cancel_reason = action.reason
             return EntryResult(id=action.id, status="cancelled")
 
-        # Пробуем найти в Visit
-        visit = self.db.query(Visit).filter(
-            Visit.id == action.id,
-            Visit.patient_id == patient_id,
-            Visit.visit_date == target_date,
-        ).first()
-
-        if visit:
+        if entry_type == "visit":
+            visit = target
             visit.status = "cancelled"
             return EntryResult(id=action.id, status="cancelled")
 
@@ -308,17 +305,17 @@ class BatchPatientService:
         if not action.id:
             return EntryResult(id=0, status="error", error="ID required for update")
 
-        # Пробуем найти в OnlineQueueEntry
-        entry = self.db.query(OnlineQueueEntry).filter(
-            OnlineQueueEntry.id == action.id,
-            OnlineQueueEntry.patient_id == patient_id,
-        ).join(
-            DailyQueue, OnlineQueueEntry.queue_id == DailyQueue.id
-        ).filter(
-            DailyQueue.day == target_date,
-        ).first()
+        # Resolve within patient/date before mutating to avoid id collisions.
+        entry_type, target, error = self._resolve_existing_entry_target(
+            patient_id=patient_id,
+            target_date=target_date,
+            action=action,
+        )
+        if error:
+            return EntryResult(id=action.id, status="error", error=error)
 
-        if entry:
+        if entry_type == "online_queue":
+            entry = target
             if action.service_id:
                 entry.service_id = action.service_id
             if action.service_code:
@@ -327,14 +324,8 @@ class BatchPatientService:
                 entry.status = action.status
             return EntryResult(id=action.id, status="updated")
 
-        # Пробуем найти в Visit
-        visit = self.db.query(Visit).filter(
-            Visit.id == action.id,
-            Visit.patient_id == patient_id,
-            Visit.visit_date == target_date,
-        ).first()
-
-        if visit:
+        if entry_type == "visit":
+            visit = target
             if action.doctor_id:
                 visit.doctor_id = action.doctor_id
             if action.status:
@@ -346,6 +337,68 @@ class BatchPatientService:
             status="error",
             error="Entry not found"
         )
+
+    def _resolve_existing_entry_target(
+        self,
+        patient_id: int,
+        target_date: date_type,
+        action: EntryAction,
+    ) -> tuple[EntryActionType | None, Any | None, str | None]:
+        entry = self._find_online_queue_entry_for_action(
+            patient_id=patient_id,
+            target_date=target_date,
+            action=action,
+        )
+        visit = self._find_visit_for_action(
+            patient_id=patient_id,
+            target_date=target_date,
+            action=action,
+        )
+
+        if action.entry_type == "online_queue":
+            if entry:
+                return "online_queue", entry, None
+            return None, None, "Entry not found"
+
+        if action.entry_type == "visit":
+            if visit:
+                return "visit", visit, None
+            return None, None, "Entry not found"
+
+        if entry and visit:
+            return None, None, "Ambiguous entry id; include entry_type"
+        if entry:
+            return "online_queue", entry, None
+        if visit:
+            return "visit", visit, None
+        return None, None, "Entry not found"
+
+    def _find_online_queue_entry_for_action(
+        self,
+        patient_id: int,
+        target_date: date_type,
+        action: EntryAction,
+    ) -> OnlineQueueEntry | None:
+        return self.db.query(OnlineQueueEntry).filter(
+            OnlineQueueEntry.id == action.id,
+            OnlineQueueEntry.patient_id == patient_id,
+        ).join(
+            DailyQueue, OnlineQueueEntry.queue_id == DailyQueue.id
+        ).filter(
+            DailyQueue.day == target_date,
+        ).first()
+
+    def _find_visit_for_action(
+        self,
+        patient_id: int,
+        target_date: date_type,
+        action: EntryAction,
+    ) -> Visit | None:
+        return self.db.query(Visit).filter(
+            Visit.id == action.id,
+            Visit.patient_id == patient_id,
+            Visit.visit_date == target_date,
+        ).first()
 
     def _create_entry(
         self,

--- a/backend/tests/characterization/test_registrar_batch_create_action_characterization.py
+++ b/backend/tests/characterization/test_registrar_batch_create_action_characterization.py
@@ -45,6 +45,7 @@ def _create_existing_entry(
     doctor_id: int,
     number: int,
     queue_tag: str,
+    entry_id: int | None = None,
     status: str = "waiting",
     source: str = "desk",
 ) -> OnlineQueueEntry:
@@ -59,6 +60,7 @@ def _create_existing_entry(
     db_session.refresh(queue)
 
     entry = OnlineQueueEntry(
+        id=entry_id,
         queue_id=queue.id,
         number=number,
         patient_id=patient_id,
@@ -71,6 +73,30 @@ def _create_existing_entry(
     db_session.commit()
     db_session.refresh(entry)
     return entry
+
+
+def _create_visit_with_id(
+    db_session,
+    *,
+    visit_id: int,
+    patient_id: int,
+    doctor_id: int,
+    status: str = "open",
+) -> Visit:
+    visit = Visit(
+        id=visit_id,
+        patient_id=patient_id,
+        doctor_id=doctor_id,
+        visit_date=date.today(),
+        visit_time="11:30",
+        status=status,
+        discount_mode="none",
+        department="cardiology",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+    return visit
 
 
 def _create_other_patient(db_session) -> Patient:
@@ -330,3 +356,147 @@ def test_registrar_batch_update_rejects_visit_for_other_patient(
     assert response.status_code == 400
     db_session.refresh(unrelated_visit)
     assert unrelated_visit.status == "open"
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_registrar_batch_update_rejects_ambiguous_untyped_entry_id(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+):
+    collision_id = 700000 + test_patient.id
+    queue_entry = _create_existing_entry(
+        db_session,
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        number=31,
+        queue_tag="cardiology",
+        entry_id=collision_id,
+        status="waiting",
+    )
+    visit = _create_visit_with_id(
+        db_session,
+        visit_id=collision_id,
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        status="open",
+    )
+    target_day = date.today().isoformat()
+
+    response = client.patch(
+        f"/api/v1/registrar/batch/patients/{test_patient.id}/entries/{target_day}",
+        headers=registrar_auth_headers,
+        json={
+            "entries": [
+                {
+                    "id": collision_id,
+                    "action": "update",
+                    "status": "cancelled",
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 400
+    db_session.refresh(queue_entry)
+    db_session.refresh(visit)
+    assert queue_entry.status == "waiting"
+    assert visit.status == "open"
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_registrar_batch_update_uses_typed_visit_when_ids_collide(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+):
+    collision_id = 710000 + test_patient.id
+    queue_entry = _create_existing_entry(
+        db_session,
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        number=32,
+        queue_tag="cardiology",
+        entry_id=collision_id,
+        status="waiting",
+    )
+    visit = _create_visit_with_id(
+        db_session,
+        visit_id=collision_id,
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        status="open",
+    )
+    target_day = date.today().isoformat()
+
+    response = client.patch(
+        f"/api/v1/registrar/batch/patients/{test_patient.id}/entries/{target_day}",
+        headers=registrar_auth_headers,
+        json={
+            "entries": [
+                {
+                    "id": collision_id,
+                    "entry_type": "visit",
+                    "action": "update",
+                    "status": "cancelled",
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    db_session.refresh(queue_entry)
+    db_session.refresh(visit)
+    assert queue_entry.status == "waiting"
+    assert visit.status == "cancelled"
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_registrar_batch_cancel_all_uses_typed_actions_when_ids_collide(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+):
+    collision_id = 720000 + test_patient.id
+    queue_entry = _create_existing_entry(
+        db_session,
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        number=33,
+        queue_tag="cardiology",
+        entry_id=collision_id,
+        status="waiting",
+    )
+    visit = _create_visit_with_id(
+        db_session,
+        visit_id=collision_id,
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        status="open",
+    )
+    target_day = date.today().isoformat()
+
+    response = client.delete(
+        f"/api/v1/registrar/batch/patients/{test_patient.id}/entries/{target_day}",
+        headers=registrar_auth_headers,
+        params={"reason": "collision bulk cancel"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["cancelled_count"] == 2
+    db_session.refresh(queue_entry)
+    db_session.refresh(visit)
+    assert queue_entry.status == "cancelled"
+    assert queue_entry.cancel_reason == "collision bulk cancel"
+    assert visit.status == "cancelled"


### PR DESCRIPTION
## Summary
- Adds typed registrar batch entry mutations for `OnlineQueueEntry` vs `Visit` records.
- Rejects ambiguous untyped same patient/date id collisions instead of mutating the queue entry first.
- Adds regression coverage for typed visit updates and typed bulk cancel when ids collide.

## Cyclic Execution Evidence
- Fresh main sync: started from clean `main...origin/main` at `03d322a2`; PR base advanced remotely after creation and will be updated if required.
- Clean workspace: confirmed before branch; only this PR's three files changed.
- Branch: `codex/registrar-batch-typed-entry-action`.
- Scope gate: `agent_gate.py` narrow overrides for service, endpoint, and test slices with known root-cause files.
- Red-check handling: backend test assertion and PR body gate failures were fixed in this same PR.

## Contract Impact
- Canonical surface: mounted registrar batch endpoints under `/api/v1/registrar/batch/*` and `BatchPatientService` mutation resolver.
- Request shape: adds optional `entry_type` to `EntryAction`: `online_queue` or `visit`; old untyped requests still work unless ambiguous.
- Response shape: `GET /patients/{patient_id}/entries/{date}` now returns `entry_type` for each online queue entry and visit.
- Status codes: ambiguous untyped update/cancel now returns 400 instead of mutating the queue entry first.
- Frontend consumer: no frontend files touched; existing array grouping already tells clients which collection an item came from.
- Compatibility path or alias: untyped legacy commands still resolve when exactly one scoped record matches.
- Contract proof: regression tests cover ambiguous untyped rejection, typed visit update, and typed bulk cancel with colliding ids.

## RBAC / Permissions
- Roles allowed: unchanged; Admin/Registrar for mutations, Admin/Registrar/Doctor for read.
- Roles denied: unchanged through existing `require_roles` dependencies.
- Positive auth proof: targeted tests use `registrar_auth_headers` on mounted endpoints.
- Negative auth proof: no auth policy changed; existing role dependency remains the denial boundary.

## Notification / Realtime
- Event type or websocket channel: no realtime event or websocket channel is touched by this backend batch resolver change.
- Payload version / ack behavior: no notification payloads or ack behavior are introduced or changed.
- Read/unread or delivery semantics: no notification delivery state is read or written.
- Reconnect/resync proof: no realtime reconnect path is involved; persistence is validated through DB state assertions after HTTP commands.

## Frontend Resilience
- Empty data proof: unchanged endpoint empty response path remains in `cancel_all_patient_entries` when no actions are built.
- Partial data proof: unchanged separate `online_queue_entries` and `visits` arrays; each row now carries its own type.
- Forbidden secondary path behavior: unchanged RBAC dependency guards the mutation endpoint.
- Missing draft/resource behavior: no draft/resource lookup path is involved in registrar batch mutation.
- Stale route/deep-link behavior: no route or deep-link behavior changes; the mounted URL shape is unchanged.

## Scope Gate
- Allowed paths: `backend/app/services/batch_patient_service.py`, `backend/app/api/v1/endpoints/registrar_batch.py`, `backend/tests/characterization/test_registrar_batch_create_action_characterization.py`.
- Denied paths: no `/api/v1/ui/*`, no BFF-lite, no frontend, no migrations, no unrelated queue rewrites.
- Migration/docs/test impact: no migration; targeted characterization tests updated.
- Rollback note: revert commit to restore previous queue-first legacy behavior.

## Validation
- Targeted tests or smoke run: `py_compile` on changed backend files; `git diff --check`; attempted targeted pytest locally; GitHub backend tests rerun after assertion fix.
- Result: local compile and diff-check pass. Initial GitHub backend failure was a test assertion on generic HTTP detail and was fixed in this PR.
- Not checked: full backend suite locally because no local Python interpreter with `pytest` is installed in this checkout.