### PR TITLE
fix(doctor): require backend call-next permission

### DIFF
--- a/frontend/src/hooks/useDoctorQueue.js
+++ b/frontend/src/hooks/useDoctorQueue.js
@@ -62,7 +62,7 @@ const useDoctorQueue = (specialty = 'general') => {
 
             setQueue(entries);
             setQueueControls({
-                canCallNext: Boolean(response.data?.can_call_next ?? nextCallEntryId),
+                canCallNext: response.data?.can_call_next === true,
                 nextCallEntryId
             });
             setStats({

--- a/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
@@ -154,9 +154,11 @@ describe('Doctor panels SSOT contract', () => {
     expect(source).toContain('const selectNextCallEntryId =');
     expect(source).toContain('queuePayload?.next_call_entry_id');
     expect(source).toContain("hasBackendQueueAction(entry, 'call', 'can_call')");
+    expect(source).toContain('canCallNext: response.data?.can_call_next === true');
     expect(source).toContain('canCallNext: queueControls.canCallNext');
     expect(callNextBlock).toContain('selectNextCallEntryId(currentQueue.data)');
     expect(callNextBlock).toContain('/doctor/queue/${nextCallEntryId}/call');
+    expect(source).not.toContain('canCallNext: Boolean(response.data?.can_call_next ?? nextCallEntryId)');
     expect(callNextBlock).not.toContain("entry.status === 'waiting'");
     expect(callNextBlock).not.toContain('waitingEntry');
   });


### PR DESCRIPTION
## Summary
- Make `useDoctorQueue` fail closed for the top-level call-next permission.
- Keep `next_call_entry_id` as the backend-provided command target, but stop using it as a permission fallback.
- Extend the existing doctor contract test to reject the old `can_call_next ?? nextCallEntryId` inference.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `origin/main` at `92c569ee` after PR #1262 merge.
- Clean workspace: worktree was clean before this narrow patch.
- Branch: `codex/doctor-call-next-contract`.
- Scope gate: `agent_gate.py` was run twice; both runs returned one-sided source/test first-touch files, so this PR uses a narrow override for exactly `frontend/src/hooks/useDoctorQueue.js` and `frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx`.
- Red-check handling: if CI fails, this same PR will be fixed before any next PR.

## Contract Impact
- Canonical surface: `GET /api/v1/doctor/{specialty}/queue/today` already returns top-level `can_call_next` and `next_call_entry_id`.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/hooks/useDoctorQueue.js`.
- Compatibility path or alias: none added.
- Contract proof: frontend now requires `response.data?.can_call_next === true` for the call-next button and the contract test rejects the old fallback.

## RBAC / Permissions
- Roles allowed: unchanged; backend doctor queue endpoint remains authoritative.
- Roles denied: unchanged.
- Positive auth proof: not re-run; frontend-only permission rendering patch.
- Negative auth proof: not re-run; no backend auth behavior changed.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: unchanged; queue reload still fetches the canonical REST contract.

## Frontend Resilience
- Empty data proof: missing `can_call_next` now disables call-next instead of enabling from `next_call_entry_id`.
- Partial data proof: `next_call_entry_id` can still be stored as the command target, but it no longer grants permission by itself.
- Forbidden secondary path behavior: no secondary endpoint added.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/hooks/useDoctorQueue.js`, `frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, QueueJoin, DisplayBoard, broad doctor panel rewrites, unrelated cleanup.
- Migration/docs/test impact: no migration or docs; one focused frontend contract test updated.
- Rollback note: revert this commit to restore the previous fallback behavior.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- DoctorPanels.contract`; `npm --prefix frontend run build`; `git diff --check`.
- Result: all passed. `git diff --check` only emitted existing CRLF normalization warnings and exited 0.
- Not checked: backend tests, because no backend code or API schema changed.
