### PR TITLE
fix(cashier): preserve receipt payment status

### DIFF
--- a/frontend/src/pages/CashierPanel.jsx
+++ b/frontend/src/pages/CashierPanel.jsx
@@ -186,7 +186,7 @@ const buildReceiptPrintPayload = (paymentRow) => {
       total: totalAmount,
       method: methodCode,
       method_name: resolvePaymentMethodLabel(paymentRow?.method),
-      status: paymentRow?.status || 'paid',
+      status: paymentRow?.status ?? null,
       paid_amount: totalAmount,
       change: 0
     },

--- a/frontend/src/pages/__tests__/CashierPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/CashierPanel.contract.test.jsx
@@ -47,4 +47,16 @@ describe('CashierPanel payment action contract', () => {
     expect(actionCellBlock).not.toContain("row.status ===");
     expect(actionCellBlock).not.toContain('payment_status');
   });
+
+  it('does not invent a paid status in receipt print payloads', () => {
+    const source = readCashierPanelSource();
+    const receiptBlock = extractSourceBlock(
+      source,
+      'const buildReceiptPrintPayload = (paymentRow) => {',
+      'const getPaymentStatusMeta = (status) => {',
+    );
+
+    expect(receiptBlock).toContain('status: paymentRow?.status ?? null');
+    expect(receiptBlock).not.toContain("status: paymentRow?.status || 'paid'");
+  });
 });


### PR DESCRIPTION
## Summary
- Preserve backend payment status in cashier receipt print payloads.
- Stop defaulting missing `paymentRow.status` to `paid` during receipt printing.
- Add a focused contract test that rejects the old paid-status fallback.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `origin/main` at `5185b36f` after PR #1264 merge.
- Clean workspace: isolated worktree was clean before this narrow patch.
- Branch: `codex/cashier-receipt-status-contract`.
- Scope gate: `agent_gate.py` was run twice; both runs returned one-sided source/test first-touch files, so this PR uses a narrow override for exactly `frontend/src/pages/CashierPanel.jsx` and `frontend/src/pages/__tests__/CashierPanel.contract.test.jsx`.
- Red-check handling: if CI fails, this same PR will be fixed before any next PR.

## Contract Impact
- Canonical surface: cashier payment rows from backend own payment `status` and `available_actions`/`can_*`.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `buildReceiptPrintPayload` in `CashierPanel.jsx`.
- Compatibility path or alias: none added.
- Contract proof: receipt payload now uses `paymentRow?.status ?? null`, and contract test rejects `paymentRow?.status || 'paid'`.

## RBAC / Permissions
- Roles allowed: unchanged; cashier action permissions remain backend-owned.
- Roles denied: unchanged.
- Positive auth proof: not re-run; frontend-only receipt payload patch.
- Negative auth proof: not re-run; no backend auth behavior changed.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: unchanged.

## Frontend Resilience
- Empty data proof: missing payment status now stays `null` instead of becoming `paid`.
- Partial data proof: receipt can still render amount/method/patient fields while preserving unknown status.
- Forbidden secondary path behavior: no secondary endpoint added.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/pages/CashierPanel.jsx`, `frontend/src/pages/__tests__/CashierPanel.contract.test.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, command wrappers, payment command semantics, unrelated cleanup.
- Migration/docs/test impact: no migration or docs; one frontend contract test added.
- Rollback note: revert this commit to restore the previous receipt status fallback.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- CashierPanel.contract`; `npm --prefix frontend run build`; `git diff --check`.
- Result: all passed. `git diff --check` emitted CRLF normalization warnings and exited 0.
- Not checked: backend tests, because no backend code or API schema changed.
