### PR TITLE
fix(admin): preserve finance transaction status

### DIFF
--- a/frontend/src/hooks/__tests__/useFinance.test.jsx
+++ b/frontend/src/hooks/__tests__/useFinance.test.jsx
@@ -77,6 +77,34 @@ describe('useFinance', () => {
     );
   });
 
+  it('preserves missing backend transaction status as unknown instead of completed', async () => {
+    api.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: 601,
+          type: 'income',
+          category: 'РљРѕРЅСЃСѓР»СЊС‚Р°С†РёСЏ',
+          amount: 90000,
+          description: 'Backend row without status',
+          patient_id: null,
+          doctor_id: null,
+          payment_method: 'cash',
+          transaction_date: '2026-03-27',
+          notes: null,
+          reference: 'FIN-601'
+        }
+      ]
+    });
+
+    const { result } = renderHook(() => useFinance());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.allTransactions).toHaveLength(1);
+    expect(result.current.allTransactions[0].status).toBeNull();
+    expect(result.current.allTransactions[0].status).not.toBe('completed');
+  });
+
   it('persists create, update, and delete mutations across reloads using cached finance state', async () => {
     api.get
       .mockResolvedValueOnce({ data: [] })

--- a/frontend/src/hooks/useFinance.js
+++ b/frontend/src/hooks/useFinance.js
@@ -16,7 +16,7 @@ const normalizeTransaction = (transaction = {}) => ({
   patientName: transaction.patient_name ?? transaction.patientName ?? null,
   doctorName: transaction.doctor_name ?? transaction.doctorName ?? null,
   paymentMethod: transaction.payment_method || transaction.paymentMethod || 'cash',
-  status: transaction.status || 'completed',
+  status: transaction.status ?? null,
   transactionDate: transaction.transaction_date || transaction.transactionDate || '',
   notes: transaction.notes || '',
   reference: transaction.reference || '',


### PR DESCRIPTION
## Summary
- Preserve missing admin finance transaction status as unknown/null.
- Stop normalizing absent backend `transaction.status` to `completed`.
- Add a focused hook test proving missing status does not become completed.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `origin/main` at `030b006d` after PR #1265 merge.
- Clean workspace: isolated worktree was clean before this narrow patch.
- Branch: `codex/admin-finance-status-contract`.
- Scope gate: `agent_gate.py` was run twice; both runs returned one-sided source/test first-touch files, so this PR uses a narrow override for exactly `frontend/src/hooks/useFinance.js` and `frontend/src/hooks/__tests__/useFinance.test.jsx`.
- Red-check handling: if CI fails, this same PR will be fixed before any next PR.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/finance/transactions` owns transaction `status`.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `normalizeTransaction` in `useFinance.js`.
- Compatibility path or alias: none added.
- Contract proof: hook test confirms a backend row without `status` remains `null` and is not converted to `completed`.

## RBAC / Permissions
- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: not re-run; frontend-only read normalization patch.
- Negative auth proof: not re-run; no backend auth behavior changed.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: unchanged.

## Frontend Resilience
- Empty data proof: missing `status` now remains `null` instead of a false completed state.
- Partial data proof: finance rows still retain amount/category/date fields while preserving unknown status.
- Forbidden secondary path behavior: no secondary endpoint added.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/hooks/useFinance.js`, `frontend/src/hooks/__tests__/useFinance.test.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, finance command semantics, unrelated cleanup.
- Migration/docs/test impact: no migration or docs; one frontend hook test added.
- Rollback note: revert this commit to restore the previous completed-status fallback.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- useFinance`; `npm --prefix frontend run build`; `git diff --check`.
- Result: all passed. `git diff --check` emitted CRLF normalization warnings and exited 0.
- Not checked: backend tests, because no backend code or API schema changed.
