### PR TITLE
fix(admin): preserve finance modal status

### DIFF
--- a/frontend/src/components/admin/FinanceModal.jsx
+++ b/frontend/src/components/admin/FinanceModal.jsx
@@ -41,7 +41,7 @@ const FinanceModal = ({
           patientId: transaction.patientId || '',
           doctorId: transaction.doctorId || '',
           paymentMethod: transaction.paymentMethod || 'cash',
-          status: transaction.status || 'completed',
+          status: transaction.status ?? '',
           transactionDate: transaction.transactionDate || '',
           notes: transaction.notes || '',
           reference: transaction.reference || ''
@@ -509,6 +509,7 @@ const FinanceModal = ({
                       borderColor: 'var(--border-color)'
                     }}
                   >
+                    <option value="">Статус не передан</option>
                     <option value="pending">Ожидает</option>
                     <option value="completed">Завершена</option>
                     <option value="cancelled">Отменена</option>

--- a/frontend/src/components/admin/__tests__/FinanceModal.test.jsx
+++ b/frontend/src/components/admin/__tests__/FinanceModal.test.jsx
@@ -4,6 +4,22 @@ import FinanceModal from '../FinanceModal.jsx';
 import { ThemeProvider } from '../../../contexts/ThemeContext.jsx';
 import { MacOSThemeProvider } from '../../../theme/macosTheme.jsx';
 
+const renderFinanceModal = (props = {}) => render(
+  <MacOSThemeProvider>
+    <ThemeProvider>
+      <FinanceModal
+        isOpen
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        loading={false}
+        patients={[]}
+        doctors={[]}
+        {...props}
+      />
+    </ThemeProvider>
+  </MacOSThemeProvider>
+);
+
 describe('FinanceModal', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -21,20 +37,7 @@ describe('FinanceModal', () => {
   });
 
   it('shows an integer UZS amount hint and no longer enforces a 1000-step browser constraint', () => {
-    render(
-      <MacOSThemeProvider>
-        <ThemeProvider>
-          <FinanceModal
-            isOpen
-            onClose={vi.fn()}
-            onSave={vi.fn()}
-            loading={false}
-            patients={[]}
-            doctors={[]}
-          />
-        </ThemeProvider>
-      </MacOSThemeProvider>
-    );
+    renderFinanceModal();
 
     const amountInput = screen.getByPlaceholderText('100000');
 
@@ -42,5 +45,24 @@ describe('FinanceModal', () => {
     expect(amountInput).toHaveAttribute('step', '1');
     expect(amountInput).toHaveAttribute('inputmode', 'numeric');
     expect(screen.getByText('Введите сумму целым числом в UZS. Например: 12500.')).toBeInTheDocument();
+  });
+
+  it('does not initialize an existing transaction with missing status as completed', () => {
+    renderFinanceModal({
+      transaction: {
+        id: 601,
+        type: 'income',
+        category: 'РљРѕРЅСЃСѓР»СЊС‚Р°С†РёСЏ',
+        amount: 90000,
+        description: 'Backend row without status',
+        paymentMethod: 'cash',
+        transactionDate: '2026-03-27',
+      },
+    });
+
+    const statusSelect = screen.getByDisplayValue('Статус не передан');
+
+    expect(statusSelect).toHaveValue('');
+    expect(statusSelect).not.toHaveValue('completed');
   });
 });


### PR DESCRIPTION
## Summary
- Preserve unknown finance transaction status when editing an existing transaction.
- Keep the new-transaction default unchanged, but stop converting an existing missing backend status into `completed`.
- Add a focused FinanceModal test for the missing-status edit path.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `origin/main` at `55029860` after the latest main update.
- Clean workspace: isolated worktree was clean before this narrow patch.
- Branch: `codex/admin-finance-modal-status-contract`.
- Scope gate: `agent_gate.py` was run twice; both runs returned one-sided source/test first-touch files, so this PR uses a narrow override for exactly `frontend/src/components/admin/FinanceModal.jsx` and `frontend/src/components/admin/__tests__/FinanceModal.test.jsx`.
- Red-check handling: if CI fails, this same PR will be fixed before any next PR.

## Contract Impact
- Canonical surface: admin finance API owns existing transaction `status`.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `FinanceModal` edit initialization for existing transactions.
- Compatibility path or alias: none added.
- Contract proof: component test confirms a transaction without backend status displays `?????? ?? ???????` and does not initialize as `completed`.

## RBAC / Permissions
- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: not re-run; frontend-only form initialization patch.
- Negative auth proof: not re-run; no backend auth behavior changed.

## Notification / Realtime
- Event type or websocket channel: unchanged.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: unchanged.

## Frontend Resilience
- Empty data proof: missing existing transaction status now stays empty/unknown in the form.
- Partial data proof: other transaction fields still initialize normally.
- Forbidden secondary path behavior: no secondary endpoint added.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/FinanceModal.jsx`, `frontend/src/components/admin/__tests__/FinanceModal.test.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, finance command semantics, unrelated cleanup.
- Migration/docs/test impact: no migration or docs; one frontend component test added.
- Rollback note: revert this commit to restore the previous edit-form status fallback.

## Validation
- Targeted tests or smoke run: `npm --prefix frontend run test:run -- FinanceModal`; `npm --prefix frontend run build`; `git diff --check`.
- Result: all passed. `git diff --check` emitted CRLF normalization warnings and exited 0.
- Not checked: backend tests, because no backend code or API schema changed.
