### PR TITLE
fix(payment): guard click webhook id collisions

### DIFF
--- a/backend/app/services/payment_webhook.py
+++ b/backend/app/services/payment_webhook.py
@@ -58,6 +58,31 @@ class PaymentWebhookService:
         return appointment_id, visit_id
 
     @staticmethod
+    def _resolve_click_merchant_target(
+        db: Session, merchant_trans_id: Any
+    ) -> tuple[str | None, int | None]:
+        target_id = PaymentWebhookService._optional_int(merchant_trans_id)
+        if target_id is None:
+            return None, None
+
+        from app.models.appointment import Appointment
+        from app.models.visit import Visit
+
+        appointment_exists = (
+            db.query(Appointment.id).filter(Appointment.id == target_id).first()
+            is not None
+        )
+        visit_exists = (
+            db.query(Visit.id).filter(Visit.id == target_id).first() is not None
+        )
+
+        if appointment_exists and visit_exists:
+            return "ambiguous", target_id
+        if visit_exists:
+            return "visit", target_id
+        return "appointment", target_id
+
+    @staticmethod
     def verify_payme_signature(
         data: dict[str, Any], signature: str, secret_key: str
     ) -> bool:
@@ -351,20 +376,36 @@ class PaymentWebhookService:
             if status == "success":
                 try:
                     # Извлекаем ID записи или визита из данных вебхука
-                    appointment_id = None
-                    visit_id = None
-
-                    if hasattr(webhook_data, "merchant_trans_id"):
-                        # Пытаемся найти appointment_id или visit_id в merchant_trans_id
-                        try:
-                            # Предполагаем, что merchant_trans_id может быть appointment_id
-                            appointment_id = int(webhook_data.merchant_trans_id)
-                        except (ValueError, TypeError):
-                            # Если merchant_trans_id не является числом, пропускаем
-                            pass
+                    target_type, target_id = (
+                        PaymentWebhookService._resolve_click_merchant_target(
+                            db, webhook_data.merchant_trans_id
+                        )
+                    )
+                    appointment_id = target_id if target_type == "appointment" else None
+                    visit_id = target_id if target_type == "visit" else None
 
                     # Приоритет: сначала ищем appointment_id, потом visit_id
-                    if appointment_id:
+                    if target_type == "ambiguous":
+                        repository.update_webhook(
+                            webhook.id,
+                            {
+                                "status": "failed",
+                                "processed_at": datetime.utcnow(),
+                                "error_message": (
+                                    "Ambiguous Click merchant_trans_id matches both "
+                                    "Appointment.id and Visit.id"
+                                ),
+                            },
+                        )
+                        logger.warning(
+                            "payment_webhook_click_ambiguous_merchant_target",
+                            extra={
+                                "payment_provider": "click",
+                                "webhook_record_id": webhook.id,
+                                "merchant_trans_id": webhook_data.merchant_trans_id,
+                            },
+                        )
+                    elif appointment_id:
                         # Обрабатываем платёж для существующей записи
                         success, message = (
                             VisitPaymentIntegrationService.process_payment_for_appointment(

--- a/backend/tests/unit/test_payment_webhook_service.py
+++ b/backend/tests/unit/test_payment_webhook_service.py
@@ -10,6 +10,18 @@ import pytest
 from app.services.payment_webhook import PaymentWebhookService
 
 
+def _valid_click_webhook_data(merchant_trans_id: str = "888") -> dict[str, str]:
+    return {
+        "click_trans_id": "click-tx-1",
+        "service_id": "svc",
+        "merchant_trans_id": merchant_trans_id,
+        "amount": "750.00",
+        "action": "0",
+        "sign_time": "2026-02-14 10:00:00",
+        "sign_string": "sig",
+    }
+
+
 @pytest.mark.unit
 class TestPaymentWebhookService:
     def test_verify_payme_signature_true_for_valid_signature(self):
@@ -138,3 +150,117 @@ class TestPaymentWebhookService:
                 db_session, expected_visit_id, webhook
             )
             process_appointment.assert_not_called()
+
+    def test_click_webhook_uses_visit_target_when_merchant_id_matches_visit_only(
+        self, db_session
+    ):
+        webhook = SimpleNamespace(id=99)
+        repository = SimpleNamespace(
+            get_provider_by_code=Mock(
+                return_value=SimpleNamespace(secret_key="secret")
+            ),
+            get_webhook_by_webhook_id=Mock(return_value=None),
+            create_webhook=Mock(return_value=webhook),
+            create_transaction=Mock(return_value=SimpleNamespace(id=100)),
+            update_webhook=Mock(return_value=webhook),
+        )
+
+        with (
+            patch(
+                "app.services.payment_webhook.PaymentWebhookProcessingRepository",
+                return_value=repository,
+            ),
+            patch.object(
+                PaymentWebhookService, "verify_click_signature", return_value=True
+            ),
+            patch.object(
+                PaymentWebhookService,
+                "_resolve_click_merchant_target",
+                return_value=("visit", 888),
+            ),
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_appointment",
+                return_value=(True, "appointment paid"),
+            ) as process_appointment,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_existing_visit",
+                return_value=(True, "visit paid"),
+            ) as process_visit,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.create_appointment_from_payment",
+                return_value=(True, "created", 501),
+            ) as create_appointment,
+        ):
+            success, message, result_webhook = (
+                PaymentWebhookService.process_click_webhook(
+                    db_session, _valid_click_webhook_data()
+                )
+            )
+
+        assert success is True
+        assert message == "Webhook processed successfully"
+        assert result_webhook is webhook
+        process_visit.assert_called_once_with(db_session, 888, webhook)
+        process_appointment.assert_not_called()
+        create_appointment.assert_not_called()
+
+    def test_click_webhook_fails_ambiguous_merchant_id_without_mutating_record(
+        self, db_session
+    ):
+        webhook = SimpleNamespace(id=99)
+        repository = SimpleNamespace(
+            get_provider_by_code=Mock(
+                return_value=SimpleNamespace(secret_key="secret")
+            ),
+            get_webhook_by_webhook_id=Mock(return_value=None),
+            create_webhook=Mock(return_value=webhook),
+            create_transaction=Mock(return_value=SimpleNamespace(id=100)),
+            update_webhook=Mock(return_value=webhook),
+        )
+
+        with (
+            patch(
+                "app.services.payment_webhook.PaymentWebhookProcessingRepository",
+                return_value=repository,
+            ),
+            patch.object(
+                PaymentWebhookService, "verify_click_signature", return_value=True
+            ),
+            patch.object(
+                PaymentWebhookService,
+                "_resolve_click_merchant_target",
+                return_value=("ambiguous", 888),
+            ),
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_appointment",
+                return_value=(True, "appointment paid"),
+            ) as process_appointment,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_existing_visit",
+                return_value=(True, "visit paid"),
+            ) as process_visit,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.create_appointment_from_payment",
+                return_value=(True, "created", 501),
+            ) as create_appointment,
+        ):
+            success, message, result_webhook = (
+                PaymentWebhookService.process_click_webhook(
+                    db_session, _valid_click_webhook_data()
+                )
+            )
+
+        assert success is True
+        assert message == "Webhook processed successfully"
+        assert result_webhook is webhook
+        process_appointment.assert_not_called()
+        process_visit.assert_not_called()
+        create_appointment.assert_not_called()
+
+        _, failed_update = repository.update_webhook.call_args_list[-1].args
+        assert failed_update["status"] == "failed"
+        expected_error = (
+            "Ambiguous Click merchant_trans_id matches both "
+            "Appointment.id and Visit.id"
+        )
+        assert failed_update["error_message"] == expected_error


### PR DESCRIPTION
## Summary

- Guard the legacy Click payment webhook against Visit.id vs Appointment.id numeric collisions.
- Add regression coverage for visit-only Click targets and ambiguous Click merchant targets.

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main in isolated worktree C:\\tmp\\final-payment-webhook-click-id-guard and fast-forwarded to current origin/main before PR.
- Clean workspace: inspected before edits; scoped changes are only backend/app/services/payment_webhook.py and backend/tests/unit/test_payment_webhook_service.py.
- Branch: codex/payment-webhook-click-id-guard.
- Scope gate: agent_gate known-root-cause narrow override for service file, then separate narrow override for unit test file; denied frontend, /api/v1/ui/*, BFF-lite, migrations, generated output, and unrelated payment flows.
- Red-check handling: failed PR Review Quality Gate was body-template only; fixed by updating this PR body in the same PR.

## Contract Impact

- Canonical surface: mounted legacy POST /api/v1/webhooks/payment/click.
- Request shape: unchanged Click webhook payload; merchant_trans_id remains the incoming merchant transaction id.
- Response shape: unchanged process result contract.
- Status codes: unchanged endpoint behavior.
- Frontend consumer: not applicable - no frontend consumer changed.
- Compatibility path or alias: legacy Click webhook path preserved; appointment-only ids continue using the legacy appointment path.
- Contract proof: unit regressions cover visit-only merchant_trans_id routing and ambiguous Appointment.id/Visit.id collision blocking.

## RBAC / Permissions

not applicable - payment provider webhook auth/signature behavior and user role permissions were not changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no frontend view, route, resource draft, or client-side fallback behavior changed.

## Scope Gate

- Allowed paths: backend/app/services/payment_webhook.py; backend/tests/unit/test_payment_webhook_service.py.
- Denied paths: frontend, /api/v1/ui/*, BFF-lite/read-model endpoints, migrations, payment provider signature contracts, generated output, unrelated appointment/visit flows.
- Migration/docs/test impact: no migration; targeted unit tests updated.
- Rollback note: revert this commit to restore previous Click merchant_trans_id appointment-first behavior.

## Validation

- Targeted tests or smoke run: py_compile for backend/app/services/payment_webhook.py and backend/tests/unit/test_payment_webhook_service.py; git diff --check.
- Result: passed locally.
- Not checked: pytest backend/tests/unit/test_payment_webhook_service.py because local launcher found no Python 3.11+ interpreter with pytest installed; black --check because pgAdmin Python has no black module. CI should run with project dependencies.