### PR TITLE
fix(graphql): require admin auth

### DIFF
--- a/backend/app/graphql/schema.py
+++ b/backend/app/graphql/schema.py
@@ -3,15 +3,21 @@
 """
 
 import strawberry
+from fastapi import Depends
 from strawberry.fastapi import GraphQLRouter
 
+from app.api.deps import require_roles
 from app.graphql.mutations import Mutation
 from app.graphql.resolvers import Query
 
 # Создаем GraphQL схему
 schema = strawberry.Schema(query=Query, mutation=Mutation)
+graphql_admin_required = require_roles("Admin")
 
 # Создаем GraphQL роутер для FastAPI
 graphql_router = GraphQLRouter(
-    schema, graphql_ide="graphiql", path="/graphql"  # Включаем GraphiQL интерфейс для разработки
+    schema,
+    graphql_ide="graphiql",
+    path="/graphql",
+    dependencies=[Depends(graphql_admin_required)],
 )

--- a/backend/tests/integration/test_graphql_api_smoke.py
+++ b/backend/tests/integration/test_graphql_api_smoke.py
@@ -1,15 +1,38 @@
+from types import SimpleNamespace
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from app.graphql.schema import graphql_router, schema
+from app.graphql.schema import graphql_admin_required, graphql_router, schema
 
 
-def test_graphql_schema_mount_serves_typename_smoke():
+def _app_with_graphql() -> FastAPI:
     app = FastAPI()
     app.include_router(graphql_router, prefix="/api")
+    return app
+
+
+def test_graphql_schema_mount_rejects_unauthenticated_request():
+    app = _app_with_graphql()
 
     schema_text = schema.as_str()
     assert "type Query" in schema_text
+
+    response = TestClient(app).post(
+        "/api/graphql",
+        json={"query": "query Smoke { __typename }"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_graphql_schema_mount_serves_typename_with_admin_dependency_override():
+    app = _app_with_graphql()
+    app.dependency_overrides[graphql_admin_required] = lambda: SimpleNamespace(
+        id=1,
+        role="Admin",
+        is_active=True,
+    )
 
     response = TestClient(app).post(
         "/api/graphql",

--- a/frontend/src/components/admin/GraphQLExplorer.jsx
+++ b/frontend/src/components/admin/GraphQLExplorer.jsx
@@ -281,10 +281,12 @@ const GraphQLExplorer = () => {
 
   const loadSchema = async () => {
     try {
+      const accessToken = tokenManager.getAccessToken();
       const response = await fetch('/api/graphql', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {})
         },
         body: JSON.stringify({
           query: `


### PR DESCRIPTION
## Summary

- Require backend Admin auth for the mounted GraphQL API at /api/graphql.
- Keep the admin GraphQL Explorer schema loading working by sending the existing Bearer token.
- Add GraphQL smoke coverage for unauthenticated rejection and authenticated dependency-override access.

## Cyclic Execution Evidence

- Fresh main sync: started from clean main tracking origin/main at 6d237a3e after PR #1270 merge.
- Clean workspace: inspected before edits; scoped changes are only backend/app/graphql/schema.py, backend/tests/integration/test_graphql_api_smoke.py, and frontend/src/components/admin/GraphQLExplorer.jsx.
- Branch: codex/graphql-admin-auth.
- Scope gate: agent_gate known-root-cause narrow override for schema file, separate test-file gate with gate_misroute=yes/override_used=yes, and separate frontend GraphQLExplorer gate with gate_misroute=no/override_used=yes.
- Red-check handling: fix failed targeted tests or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: /api/graphql mounted by backend/app/main.py.
- Request shape: GraphQL request body unchanged; Authorization Bearer token is now required by backend dependency.
- Response shape: authenticated GraphQL response unchanged; unauthenticated requests now receive 401 before query execution.
- Status codes: unauthenticated /api/graphql changes from 200 query execution to 401.
- Frontend consumer: admin GraphQL Explorer now sends Authorization for schema introspection as it already did for query execution.
- Compatibility path or alias: no alternate public GraphQL path added.
- Contract proof: integration smoke test rejects unauthenticated POST and verifies the schema still serves __typename when the Admin dependency is satisfied.

## RBAC / Permissions

- Roles allowed: Admin, plus existing require_roles superuser behavior.
- Roles denied: unauthenticated users; non-admin users through existing require_roles behavior.
- Positive auth proof: dependency-override smoke proves the router still executes GraphQL when admin dependency is satisfied.
- Negative auth proof: unauthenticated POST /api/graphql now returns 401.

## Notification / Realtime

not applicable - no notification, websocket subscription workflow, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no rendered data state changed.
- Partial data proof: not applicable - no schema rendering logic changed.
- Forbidden secondary path behavior: unauthenticated schema load now fails via backend 401 instead of executing introspection.
- Missing draft/resource behavior: not applicable - GraphQL Explorer does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no routing/deep-link behavior changed.

## Scope Gate

- Allowed paths: backend GraphQL router definition, GraphQL smoke test, admin GraphQL Explorer auth header for schema load.
- Denied paths: unrelated API routers, GraphQL resolver business logic, DB/Alembic, /api/v1/ui/*, BFF-lite/read-model endpoints, broad frontend redesign.
- Migration/docs/test impact: no migration; targeted integration smoke updated.
- Rollback note: revert this commit to restore public /api/graphql behavior and unauthenticated schema introspection.

## Validation

- Targeted tests or smoke run: py_compile for backend/app/graphql/schema.py and backend/tests/integration/test_graphql_api_smoke.py; git diff --check; npm.cmd --prefix frontend run build.
- Result: passed locally.
- Not checked: local pytest backend/tests/integration/test_graphql_api_smoke.py because the local Python launcher found no Python 3.11+ interpreter with pytest installed and both repo/backend venv launchers point to a missing Python executable. CI should run backend tests with project dependencies.