### PR TITLE
fix(emr): guard phrase suggestion endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/phrase_suggest.py
+++ b/backend/app/api/v1/endpoints/phrase_suggest.py
@@ -18,6 +18,10 @@ from app.services.phrase_suggest_api_service import PhraseSuggestApiService
 
 router = APIRouter()
 
+PHRASE_CLINICAL_ROLES = ("Admin", "Doctor", "cardio", "derma", "dentist")
+phrase_clinical_access = deps.require_roles(*PHRASE_CLINICAL_ROLES)
+phrase_admin_access = deps.require_roles("Admin")
+
 
 # ============================================
 # SCHEMAS
@@ -69,7 +73,8 @@ class IndexPhraseResponse(BaseModel):
 @router.post("/phrase-suggest", response_model=PhraseSuggestResponse)
 async def suggest_phrases(
     request: PhraseSuggestRequest,
-    db: Session = Depends(deps.get_db)
+    db: Session = Depends(deps.get_db),
+    _current_user=Depends(phrase_clinical_access),
 ) -> PhraseSuggestResponse:
     """
     Получить подсказки фраз из истории врача.
@@ -108,7 +113,8 @@ async def suggest_phrases(
 @router.post("/phrase-index", response_model=IndexPhraseResponse)
 async def index_phrases(
     request: IndexPhraseRequest,
-    db: Session = Depends(deps.get_db)
+    db: Session = Depends(deps.get_db),
+    _current_user=Depends(phrase_clinical_access),
 ) -> IndexPhraseResponse:
     """
     Проиндексировать фразы из EMR записи.
@@ -140,7 +146,8 @@ async def index_phrases(
 @router.get("/phrase-stats/{doctor_id}")
 async def get_phrase_stats(
     doctor_id: int,
-    db: Session = Depends(deps.get_db)
+    db: Session = Depends(deps.get_db),
+    _current_user=Depends(phrase_clinical_access),
 ) -> Dict[str, Any]:
     """
     Получить статистику фраз врача.
@@ -163,7 +170,8 @@ class ReadinessResponse(BaseModel):
 @router.get("/readiness/{doctor_id}", response_model=ReadinessResponse)
 async def check_readiness(
     doctor_id: int,
-    db: Session = Depends(deps.get_db)
+    db: Session = Depends(deps.get_db),
+    _current_user=Depends(phrase_clinical_access),
 ) -> ReadinessResponse:
     """
     Проверить готовность врача к автоподсказкам.
@@ -205,7 +213,8 @@ class TelemetryResponse(BaseModel):
 @router.post("/telemetry", response_model=TelemetryResponse)
 async def record_telemetry(
     request: TelemetryRequest,
-    db: Session = Depends(deps.get_db)
+    db: Session = Depends(deps.get_db),
+    _current_user=Depends(phrase_clinical_access),
 ) -> TelemetryResponse:
     """
     Записать событие показа/принятия подсказки.
@@ -242,7 +251,8 @@ class TelemetryStatsResponse(BaseModel):
 @router.get("/telemetry-stats/{doctor_id}", response_model=TelemetryStatsResponse)
 async def get_telemetry_stats(
     doctor_id: int,
-    db: Session = Depends(deps.get_db)
+    db: Session = Depends(deps.get_db),
+    _current_user=Depends(phrase_clinical_access),
 ) -> TelemetryStatsResponse:
     """
     Получить статистику telemetry врача.
@@ -279,7 +289,8 @@ class FieldPreferencesResponse(BaseModel):
 @router.get("/preferences/{doctor_id}", response_model=FieldPreferencesResponse)
 async def get_field_preferences(
     doctor_id: int,
-    db: Session = Depends(deps.get_db)
+    db: Session = Depends(deps.get_db),
+    _current_user=Depends(phrase_clinical_access),
 ) -> FieldPreferencesResponse:
     """
     Получить per-field preferences для врача.
@@ -304,7 +315,8 @@ async def get_field_preferences(
 @router.post("/preferences", response_model=FieldPreferencesResponse)
 async def update_field_preferences(
     request: FieldPreferencesRequest,
-    db: Session = Depends(deps.get_db)
+    db: Session = Depends(deps.get_db),
+    _current_user=Depends(phrase_clinical_access),
 ) -> FieldPreferencesResponse:
     """
     Обновить per-field preferences.
@@ -347,7 +359,8 @@ class BatchIndexResponse(BaseModel):
 @router.post("/batch-index", response_model=BatchIndexResponse)
 async def batch_index_emrs(
     request: BatchIndexRequest,
-    db: Session = Depends(deps.get_db)
+    db: Session = Depends(deps.get_db),
+    _current_user=Depends(phrase_admin_access),
 ) -> BatchIndexResponse:
     """
     Batch-индексация EMR всех врачей.
@@ -399,7 +412,8 @@ class DoctorIndexResponse(BaseModel):
 @router.post("/index-doctor", response_model=DoctorIndexResponse)
 async def index_doctor_emrs(
     request: DoctorIndexRequest,
-    db: Session = Depends(deps.get_db)
+    db: Session = Depends(deps.get_db),
+    _current_user=Depends(phrase_admin_access),
 ) -> DoctorIndexResponse:
     """
     Проиндексировать все EMR одного врача.

--- a/backend/tests/unit/test_phrase_suggest_api_service.py
+++ b/backend/tests/unit/test_phrase_suggest_api_service.py
@@ -7,6 +7,16 @@ import pytest
 from app.services.phrase_suggest_api_service import PhraseSuggestApiService
 
 
+def _phrase_suggest_payload(doctor_id: int) -> dict:
+    return {
+        "field": "diagnosis",
+        "currentText": "",
+        "cursorPosition": 0,
+        "doctorId": doctor_id,
+        "maxSuggestions": 5,
+    }
+
+
 @pytest.mark.unit
 class TestPhraseSuggestApiService:
     def test_get_phrase_stats_formats_output(self):
@@ -40,4 +50,47 @@ class TestPhraseSuggestApiService:
         assert result["totalAccepted"] == 3
         assert result["acceptanceRate"] == 30.0
         assert result["topAcceptedPhrases"][0]["field"] == "complaints"
+
+
+@pytest.mark.integration
+def test_phrase_suggest_requires_auth(client):
+    response = client.post(
+        "/api/v1/emr/phrase-suggest",
+        json=_phrase_suggest_payload(doctor_id=1),
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+def test_phrase_suggest_allows_clinical_user(client, cardio_auth_headers, cardio_user):
+    response = client.post(
+        "/api/v1/emr/phrase-suggest",
+        headers=cardio_auth_headers,
+        json=_phrase_suggest_payload(doctor_id=cardio_user.id),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "suggestions": [],
+        "field": "diagnosis",
+        "doctorId": cardio_user.id,
+    }
+
+
+@pytest.mark.integration
+def test_batch_index_is_admin_only(client, cardio_auth_headers, auth_headers):
+    doctor_response = client.post(
+        "/api/v1/emr/batch-index",
+        headers=cardio_auth_headers,
+        json={"limit": 1, "offset": 0},
+    )
+    assert doctor_response.status_code == 403
+
+    admin_response = client.post(
+        "/api/v1/emr/batch-index",
+        headers=auth_headers,
+        json={"limit": 1, "offset": 0},
+    )
+    assert admin_response.status_code == 200, admin_response.text
 


### PR DESCRIPTION
## Summary

- Require clinical/admin auth for EMR phrase suggestion, phrase indexing, readiness, preferences, and telemetry endpoints.
- Restrict batch EMR phrase indexing and per-doctor bulk indexing to Admin only.
- Add regression coverage for unauthenticated phrase-suggest access, clinical access, and admin-only batch indexing.

## Cyclic Execution Evidence

- Fresh main sync: fetched origin and branched from current origin/main commit 508bdc1.
- Clean workspace: inspected before edits; unrelated frontend/src/components/payment/PaymentWidget.jsx local edit was left unstaged and excluded from commit/PR.
- Branch: codex/phrase-suggest-auth-guard.
- Scope gate: allowed backend/app/api/v1/endpoints/phrase_suggest.py and backend/tests/unit/test_phrase_suggest_api_service.py; denied frontend, /api/v1/ui/*, BFF-lite, migrations, payment widget work, and unrelated cleanup.
- Red-check handling: PR Review Quality Gate body failure is being fixed in this same PR; any further red checks will be fixed before merge.

## Contract Impact

- Canonical surface: /api/v1/emr/phrase-suggest, /phrase-index, /readiness/{doctor_id}, /phrase-stats/{doctor_id}, /telemetry, /telemetry-stats/{doctor_id}, /preferences, /batch-index, and /index-doctor as mounted under /api/v1/emr.
- Request shape: unchanged JSON bodies and path params; now requires Bearer auth for all listed phrase endpoints.
- Response shape: unchanged response DTOs for authorized callers.
- Status codes: authorized clinical/admin callers preserve 200 behavior; unauthenticated callers now receive 401; non-admin callers receive 403 on bulk index endpoints.
- Frontend consumer: existing logged-in EMR autocomplete hook uses the same API client and endpoint paths.
- Compatibility path or alias: no compatibility alias changed; unauthenticated access was a security bug, not a supported compatibility path.
- Contract proof: focused regression tests cover unauthenticated phrase-suggest 401, clinical phrase-suggest 200, and doctor batch-index 403 plus CI backend tests.

## RBAC / Permissions

- Roles allowed: Admin, Doctor, cardio, derma, dentist for clinical phrase endpoints; Admin only for batch-index and index-doctor.
- Roles denied: unauthenticated users for all phrase endpoints; non-admin clinical users for batch-index and index-doctor.
- Positive auth proof: cardio auth test returns 200 for /api/v1/emr/phrase-suggest; admin auth test returns 200 for /api/v1/emr/batch-index.
- Negative auth proof: unauthenticated phrase-suggest test returns 401; cardio batch-index test returns 403.

## Notification / Realtime

not applicable - no notification, websocket, chat, queue broadcast, delivery, read/unread, reconnect, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: clinical phrase-suggest test returns stable empty suggestions array when no phrases exist.
- Partial data proof: not applicable - response shape and frontend consumer were not changed.
- Forbidden secondary path behavior: non-admin batch-index returns 403; existing hook already treats failed phrase calls as non-fatal suggestions unavailable.
- Missing draft/resource behavior: not applicable - this patch does not create, reopen, or route drafts/resources.
- Stale route/deep-link behavior: not applicable - no route state or deep-link behavior changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/phrase_suggest.py, backend/tests/unit/test_phrase_suggest_api_service.py.
- Denied paths: frontend, /api/v1/ui/*, BFF-lite, separate BFF service, migrations, generated output, unrelated payment widget work.
- Migration/docs/test impact: no migration or docs changes; targeted regression tests added to existing phrase suggest test file.
- Rollback note: revert commit f885540d to remove the auth dependency additions and regression tests.

## Validation

- Targeted tests or smoke run: py_compile for endpoint and test file; git diff --check; CI backend tests, CodeQL, security, scope, role-system, context boundary, and PR Required Gate.
- Result: local py_compile and diff checks passed; CI backend tests and required gates passed except the initial PR Review Quality Gate body issue fixed by this update.
- Not checked: local pytest, because scripts/run_backend_pytest.ps1 could not find a Python 3.11+ interpreter with pytest installed; no frontend build needed because no frontend files are in the PR.