### PR TITLE
fix(payments): require auth for test init

### DIFF
--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -266,9 +266,12 @@ def cancel_payment(
 
 @router.post("/test-init", response_model=PaymentInitResponse)
 def test_init_payment(
-    payment_request: PaymentInitRequest, db: Session = Depends(get_db)
+    payment_request: PaymentInitRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(deps.require_roles("Admin", "Registrar", "Cashier")),
 ) -> PaymentInitResponse:
-    """Тестовая инициализация платежа БЕЗ аутентификации"""
+    """Test payment initialization for authorized payment staff."""
+    # Runtime write path: keep this aligned with /payments/init RBAC.
     service = PaymentTestInitService(db, get_payment_manager())
     try:
         result = service.init_test_payment(

--- a/backend/tests/integration/test_payment_init_e2e.py
+++ b/backend/tests/integration/test_payment_init_e2e.py
@@ -98,6 +98,43 @@ class TestPaymentInitE2E:
         assert data["payment_url"]
         self._assert_payment_created(db_session, data["payment_id"], "kaspi", "KZT")
 
+    def test_test_init_requires_auth(self, client, test_visit, db_session):
+        before_count = db_session.query(Payment).count()
+
+        response = client.post(
+            "/api/v1/payments/test-init",
+            json={
+                "visit_id": test_visit.id,
+                "amount": 150000,
+                "currency": "UZS",
+                "provider": "click",
+                "description": "unauth test init",
+            },
+        )
+
+        assert response.status_code == 401
+        assert db_session.query(Payment).count() == before_count
+
+    def test_test_init_allows_authorized_payment_staff(
+        self, client, auth_headers, test_visit, db_session
+    ):
+        response = client.post(
+            "/api/v1/payments/test-init",
+            headers=auth_headers,
+            json={
+                "visit_id": test_visit.id,
+                "amount": 150000,
+                "currency": "UZS",
+                "provider": "click",
+                "description": "authorized test init",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        self._assert_payment_created(db_session, data["payment_id"], "click", "UZS")
+
     def test_visit_payments_list_includes_new_payment(
         self, client, auth_headers, test_visit, db_session
     ):


### PR DESCRIPTION
## Summary

- Require the same Admin/Registrar/Cashier RBAC on /api/v1/payments/test-init that /api/v1/payments/init already uses.
- Keep the request/response contract unchanged for authorized staff.
- Add regression coverage for unauthenticated rejection and authorized test-init success.

## Cyclic Execution Evidence

- Fresh main sync: fetched origin and branched from current origin/main commit e72dbb58.
- Clean workspace: inspected before edits; working tree contained only scoped backend changes before commit.
- Branch: codex/payment-test-init-auth-guard.
- Scope gate: allowed backend/app/api/v1/endpoints/payments.py and backend/tests/integration/test_payment_init_e2e.py; denied frontend, /api/v1/ui/*, BFF-lite, migrations, provider rewrites, and unrelated payment widget work.
- Red-check handling: any failed CI checks will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: POST /api/v1/payments/test-init.
- Request shape: unchanged PaymentInitRequest JSON body.
- Response shape: unchanged PaymentInitResponse for authorized callers.
- Status codes: authorized Admin/Registrar/Cashier callers preserve 200 success path; unauthenticated callers now receive 401; forbidden roles follow require_roles behavior.
- Frontend consumer: PaymentWidget demo-token path is the only frontend reference; runtime staff payment initialization continues to use /payments/init.
- Compatibility path or alias: no alias changed; unauthenticated DB-write test-init access was not a safe production compatibility contract.
- Contract proof: targeted tests cover unauthenticated test-init 401 with no Payment row created and authorized test-init 200 with Payment row created.

## RBAC / Permissions

- Roles allowed: Admin, Registrar, Cashier.
- Roles denied: unauthenticated users; all other roles denied by require_roles unless superuser.
- Positive auth proof: auth_headers test returns 200 for /api/v1/payments/test-init and creates a click Payment.
- Negative auth proof: no-token test returns 401 and Payment count remains unchanged.

## Notification / Realtime

not applicable - no notification, websocket, queue broadcast, delivery, read/unread, reconnect, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - endpoint is a write path and response shape did not change.
- Partial data proof: unchanged Pydantic request validation handles missing/invalid request fields.
- Forbidden secondary path behavior: unauthorized demo-token/test-init path now fails closed instead of creating a Payment row.
- Missing draft/resource behavior: unchanged service behavior for missing visit_id; this PR only adds auth before service execution.
- Stale route/deep-link behavior: not applicable - no route state or deep-link behavior changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/payments.py, backend/tests/integration/test_payment_init_e2e.py.
- Denied paths: frontend, /api/v1/ui/*, BFF-lite, separate BFF service, migrations, payment provider internals, generated output.
- Migration/docs/test impact: no migration or docs changes; targeted backend regression tests added.
- Rollback note: revert commit aac9c971 to remove the RBAC dependency and tests.

## Validation

- Targeted tests or smoke run: py_compile for endpoint and payment init test file; git diff --check; CI backend tests and PR gates after opening.
- Result: local py_compile and diff checks passed; local pytest unavailable; CI pending at PR creation.
- Not checked: local pytest, because scripts/run_backend_pytest.ps1 could not find a Python 3.11+ interpreter with pytest installed; no frontend build run because no frontend files changed.