### PR TITLE
fix(payment): stop fabricating hosted payment tickets

### DIFF
--- a/frontend/src/components/payment/PaymentClick.jsx
+++ b/frontend/src/components/payment/PaymentClick.jsx
@@ -175,14 +175,13 @@ const PaymentClick = ({
         setPaymentState('success');
 
         // Получаем данные для печати талонов
-        await loadPrintTickets();
+        const tickets = Array.isArray(data.print_tickets) ? data.print_tickets : [];
+        setPrintTickets(tickets);
 
         notify.success('Платёж успешно завершён!');
 
         // Показываем принтер талонов если есть талоны для печати
-        if (printTickets.length > 0) {
-          setShowTicketPrinter(true);
-        }
+        setShowTicketPrinter(tickets.length > 0);
 
         if (onSuccess) {
           onSuccess(data);
@@ -204,45 +203,6 @@ const PaymentClick = ({
 
   // ===================== ПЕЧАТЬ ТАЛОНОВ =====================
 
-  const loadPrintTickets = async () => {
-    try {
-      // Получаем данные о талонах из последнего ответа API
-      // Данные должны приходить в onSuccess callback
-      // Пока оставляем mock данные для тестирования множественных талонов
-      const mockTickets = [
-      {
-        visit_id: 1,
-        queue_tag: 'cardiology_common',
-        queue_name: 'Кардиолог',
-        queue_number: 15,
-        queue_id: 1,
-        patient_id: 1,
-        patient_name: 'Юля Михайловна',
-        doctor_name: 'Д-р Петров',
-        department: 'Кардиология',
-        visit_date: new Date().toISOString().split('T')[0],
-        visit_time: '10:30'
-      },
-      {
-        visit_id: 1,
-        queue_tag: 'dermatology',
-        queue_name: 'Дерматолог',
-        queue_number: 8,
-        queue_id: 2,
-        patient_id: 1,
-        patient_name: 'Юля Михайловна',
-        doctor_name: 'Д-р Смирнова',
-        department: 'Дерматология',
-        visit_date: new Date().toISOString().split('T')[0],
-        visit_time: '10:30'
-      }];
-
-
-      setPrintTickets(mockTickets);
-    } catch (error) {
-      logger.error('Error loading print tickets:', error);
-    }
-  };
 
   const printTicket = (ticket) => {
     const opened = printPanelTicketInBrowser({

--- a/frontend/src/components/payment/PaymentPayMe.jsx
+++ b/frontend/src/components/payment/PaymentPayMe.jsx
@@ -175,14 +175,13 @@ const PaymentPayMe = ({
         setPaymentState('success');
 
         // Получаем данные для печати талонов
-        await loadPrintTickets();
+        const tickets = Array.isArray(data.print_tickets) ? data.print_tickets : [];
+        setPrintTickets(tickets);
 
         notify.success('Платёж успешно завершён!');
 
         // Показываем принтер талонов если есть талоны для печати
-        if (printTickets.length > 0) {
-          setShowTicketPrinter(true);
-        }
+        setShowTicketPrinter(tickets.length > 0);
 
         if (onSuccess) {
           onSuccess(data);
@@ -204,45 +203,6 @@ const PaymentPayMe = ({
 
   // ===================== ПЕЧАТЬ ТАЛОНОВ =====================
 
-  const loadPrintTickets = async () => {
-    try {
-      // Получаем данные о талонах из последнего ответа API
-      // Данные должны приходить в onSuccess callback
-      // Пока оставляем mock данные для тестирования множественных талонов
-      const mockTickets = [
-      {
-        visit_id: 1,
-        queue_tag: 'cardiology_common',
-        queue_name: 'Кардиолог',
-        queue_number: 15,
-        queue_id: 1,
-        patient_id: 1,
-        patient_name: 'Юля Михайловна',
-        doctor_name: 'Д-р Петров',
-        department: 'Кардиология',
-        visit_date: new Date().toISOString().split('T')[0],
-        visit_time: '10:30'
-      },
-      {
-        visit_id: 1,
-        queue_tag: 'dermatology',
-        queue_name: 'Дерматолог',
-        queue_number: 8,
-        queue_id: 2,
-        patient_id: 1,
-        patient_name: 'Юля Михайловна',
-        doctor_name: 'Д-р Смирнова',
-        department: 'Дерматология',
-        visit_date: new Date().toISOString().split('T')[0],
-        visit_time: '10:30'
-      }];
-
-
-      setPrintTickets(mockTickets);
-    } catch (error) {
-      logger.error('Error loading print tickets:', error);
-    }
-  };
 
   const printTicket = (ticket) => {
     const opened = printPanelTicketInBrowser({

--- a/frontend/src/components/payment/__tests__/HostedPaymentProviders.contract.test.jsx
+++ b/frontend/src/components/payment/__tests__/HostedPaymentProviders.contract.test.jsx
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(process.cwd(), 'src/components/payment');
+
+const readProvider = (fileName) =>
+  fs.readFileSync(path.join(ROOT, fileName), 'utf8').replace(/\r\n/g, '\n');
+
+describe('hosted payment provider ticket contract', () => {
+  for (const fileName of ['PaymentClick.jsx', 'PaymentPayMe.jsx']) {
+    it(`${fileName} prints only backend-provided tickets`, () => {
+      const source = readProvider(fileName);
+
+      expect(source).toContain('Array.isArray(data.print_tickets) ? data.print_tickets : []');
+      expect(source).toContain('setPrintTickets(tickets)');
+      expect(source).toContain('setShowTicketPrinter(tickets.length > 0)');
+
+      expect(source).not.toContain('mockTickets');
+      expect(source).not.toContain('cardiology_common');
+      expect(source).not.toContain('queue_number: 15');
+      expect(source).not.toContain('queue_number: 8');
+      expect(source).not.toContain('loadPrintTickets');
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Stop Click/PayMe hosted payment polling from fabricating printable queue tickets after an invoice becomes paid.
- Consume optional backend-provided print_tickets only and show the ticket printer only when that backend data exists.
- Add a source-level contract test that prevents reintroducing fake ticket data.

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main at ae5952d5.
- Clean workspace: isolated worktree C:\\tmp\\final-payment-ticket-print-contract inspected before edits.
- Branch: codex/payment-ticket-print-contract.
- Scope gate: agent gate used for PaymentClick.jsx and PaymentPayMe.jsx known root-cause slices; no backend, BFF, or unrelated files changed.
- Red-check handling: PR Review Quality Gate failure is being fixed in this same PR via PR body metadata only.

## Contract Impact

- Canonical surface: GET /api/v1/registrar/invoice/{invoice_id}/status may provide print_tickets as backend-owned ticket data.
- Request shape: unchanged hosted payment status poll, no request body.
- Response shape: frontend now treats print_tickets as optional backend data; missing print_tickets means no printable tickets.
- Status codes: unchanged.
- Frontend consumer: PaymentClick.jsx and PaymentPayMe.jsx.
- Compatibility path or alias: none added.
- Contract proof: HostedPaymentProviders.contract source-level test.

## RBAC / Permissions

not applicable - no endpoint, auth, role, or permission behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: missing print_tickets resolves to [] and does not open the ticket printer.
- Partial data proof: non-array print_tickets resolves to [] and does not fabricate tickets.
- Forbidden secondary path behavior: no secondary ticket-loading endpoint is used.
- Missing draft/resource behavior: not applicable, payment providers do not create drafts/resources here.
- Stale route/deep-link behavior: not applicable, payment providers do not read deep-link route state.

## Scope Gate

- Allowed paths: PaymentClick.jsx, PaymentPayMe.jsx, targeted payment provider contract test.
- Denied paths: backend endpoints, /api/v1/ui/*, separate BFF service, command wrappers, unrelated payment flows.
- Migration/docs/test impact: no migration; targeted frontend contract test added.
- Rollback note: revert this PR, though that would restore hardcoded fake printable tickets.

## Validation

- Targeted tests or smoke run: npm.cmd --prefix frontend run test:run -- HostedPaymentProviders.contract; npm.cmd --prefix frontend run build; git diff --check.
- Result: passed locally.
- Not checked: backend tests, because this PR has no backend changes.