### PR TITLE
fix(payments): finalize existing payme transactions

### DIFF
--- a/backend/app/services/provider_webhook_service.py
+++ b/backend/app/services/provider_webhook_service.py
@@ -225,6 +225,16 @@ class ProviderWebhookService:
                 )
                 if method == "CheckPerformTransaction":
                     return {"result": {"allow": True}, "id": request_id}
+                payment_id = getattr(existing_transaction, "payment_id", None)
+                payment_status = None
+                if method in {"PerformTransaction", "CancelTransaction"}:
+                    with transaction_ctx(self.db):
+                        payment_status = self._apply_existing_payme_transaction_state(
+                            existing_transaction,
+                            method=method,
+                            params=params,
+                        )
+                        payment_id = getattr(existing_transaction, "payment_id", None)
                 if method == "CreateTransaction":
                     return {
                         "result": {
@@ -233,8 +243,8 @@ class ProviderWebhookService:
                             "state": 1,
                         },
                         "id": request_id,
-                        "payment_id": getattr(existing_transaction, "payment_id", None),
-                        "payment_status": None,
+                        "payment_id": payment_id,
+                        "payment_status": payment_status,
                         "payment_provider": "payme",
                     }
                 if method == "PerformTransaction":
@@ -245,8 +255,8 @@ class ProviderWebhookService:
                             "state": 2,
                         },
                         "id": request_id,
-                        "payment_id": getattr(existing_transaction, "payment_id", None),
-                        "payment_status": None,
+                        "payment_id": payment_id,
+                        "payment_status": payment_status,
                         "payment_provider": "payme",
                     }
                 if method == "CancelTransaction":
@@ -257,15 +267,15 @@ class ProviderWebhookService:
                             "state": -1,
                         },
                         "id": request_id,
-                        "payment_id": getattr(existing_transaction, "payment_id", None),
-                        "payment_status": None,
+                        "payment_id": payment_id,
+                        "payment_status": payment_status,
                         "payment_provider": "payme",
                     }
                 return {
                     "result": {},
                     "id": request_id,
-                    "payment_id": getattr(existing_transaction, "payment_id", None),
-                    "payment_status": None,
+                    "payment_id": payment_id,
+                    "payment_status": payment_status,
                     "payment_provider": "payme",
                 }
 
@@ -408,6 +418,42 @@ class ProviderWebhookService:
                 "error": {"code": -32603, "message": f"Internal server error: {exc}"},
                 "id": request_id,
             }
+
+    def _apply_existing_payme_transaction_state(
+        self,
+        transaction: Any,
+        *,
+        method: str,
+        params: dict[str, Any],
+    ) -> str | None:
+        if method == "PerformTransaction":
+            provider_status = "completed"
+        elif method == "CancelTransaction":
+            provider_status = "cancelled" if params.get("reason") == 1 else "refunded"
+        else:
+            return None
+
+        payment_status = self._map_provider_status_to_payment_status(provider_status)
+        transaction.status = provider_status
+        transaction.provider_data = {
+            **(transaction.provider_data or {}),
+            "method": method,
+            "transaction_id": params.get("id"),
+            "params": params,
+        }
+
+        payment_id = getattr(transaction, "payment_id", None)
+        if payment_id:
+            payment = self.repository.get_payment_by_id(payment_id)
+            if payment:
+                payment.status = payment_status
+                if payment_status == "paid" and not payment.paid_at:
+                    payment.paid_at = datetime.utcnow()
+                payment.provider_data = {
+                    **(payment.provider_data or {}),
+                    **(transaction.provider_data or {}),
+                }
+        return payment_status
 
     def process_kaspi_webhook(self, webhook_data: dict[str, Any]) -> dict[str, Any]:
         """Webhook для Kaspi Pay платежной системы."""

--- a/backend/tests/unit/test_provider_webhook_service.py
+++ b/backend/tests/unit/test_provider_webhook_service.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
 import pytest
 
 from app.services.provider_webhook_service import ProviderWebhookService
@@ -23,6 +26,56 @@ class TestProviderWebhookService:
         assert result["id"] == 123
         assert result["error"]["code"] == -32504
         assert result["error"]["message"] == "Missing Authorization header"
+
+    def test_payme_perform_existing_transaction_marks_payment_paid(self, db_session):
+        transaction = SimpleNamespace(
+            id=77,
+            payment_id=44,
+            webhook_id=33,
+            status="processing",
+            provider_data={"method": "CreateTransaction"},
+        )
+        payment = SimpleNamespace(
+            id=44,
+            status="processing",
+            paid_at=None,
+            provider_data={"order_id": "clinic_44_1700000000"},
+        )
+        repository = SimpleNamespace(
+            get_existing_transaction=Mock(return_value=transaction),
+            get_payment_by_id=Mock(return_value=payment),
+        )
+        manager = SimpleNamespace(
+            get_provider=Mock(
+                return_value=SimpleNamespace(
+                    validate_webhook_signature=Mock(return_value=True)
+                )
+            )
+        )
+        service = ProviderWebhookService(db_session, repository=repository)
+
+        with patch(
+            "app.services.provider_webhook_service.get_payment_manager",
+            return_value=manager,
+        ):
+            result = service.process_payme_webhook(
+                {
+                    "id": "request-1",
+                    "method": "PerformTransaction",
+                    "params": {"id": "payme-tx-1", "amount": 100000},
+                },
+                "Basic valid",
+            )
+
+        assert result["result"]["state"] == 2
+        assert result["payment_id"] == 44
+        assert result["payment_status"] == "paid"
+        assert transaction.status == "completed"
+        assert transaction.provider_data["method"] == "PerformTransaction"
+        assert payment.status == "paid"
+        assert payment.paid_at is not None
+        assert payment.provider_data["order_id"] == "clinic_44_1700000000"
+        assert payment.provider_data["transaction_id"] == "payme-tx-1"
 
     def test_extract_payment_id_from_order(self, db_session):
         service = ProviderWebhookService(db_session)


### PR DESCRIPTION
## Summary
- Fix Payme JSON-RPC idempotency so a repeated provider transaction id from CreateTransaction does not cause PerformTransaction to return success without marking the internal payment paid.
- Update the existing PaymentTransaction and linked Payment for PerformTransaction and CancelTransaction duplicate paths.
- Add a focused unit regression for the PerformTransaction existing-transaction path.

## Cyclic Execution Evidence
- Fresh main sync: branch created from origin/main at db6bb4df.
- Clean workspace: isolated worktree C:\tmp\final-payme-webhook-perform-idempotency.
- Branch: codex/payme-webhook-perform-idempotency.
- Scope gate: agent_gate known-root-cause for backend/app/services/provider_webhook_service.py, then separate known-root-cause gate for backend/tests/unit/test_provider_webhook_service.py.
- Red-check handling: fix red checks in this PR only.

## Contract Impact
- Canonical surface: /api/v1/payments/webhook/payme via ProviderWebhookService.
- Request shape: unchanged Payme JSON-RPC payloads.
- Response shape: unchanged public JSON-RPC response; internal notification metadata can now include payment_status=paid on the corrected path.
- Status codes: unchanged.
- Frontend consumer: no direct frontend consumer; the webhook remains a provider callback endpoint.
- Compatibility path or alias: no route changes.
- Contract proof: targeted unit test covers existing Payme transaction + PerformTransaction.

## RBAC / Permissions
- Roles allowed: provider webhook remains public but provider-authenticated through the existing Payme auth check.
- Roles denied: no user role is newly allowed or denied because this is not a user-session endpoint; invalid provider auth is still rejected by the existing missing-auth test path.
- Positive auth proof: existing provider signature/auth path is preserved.
- Negative auth proof: existing missing-auth unit test remains.

## Notification / Realtime
- Event type or websocket channel: unchanged existing payment webhook notification flow; this PR does not add a channel or event type.
- Payload version / ack behavior: unchanged Payme JSON-RPC acknowledgement shape; only internal payment_status metadata is corrected after duplicate PerformTransaction.
- Read/unread or delivery semantics: unchanged because payment webhooks do not introduce read/unread state in this path.
- Reconnect/resync proof: unchanged because clients resync from canonical payment status, which now becomes paid instead of staying processing.

## Frontend Resilience
- Empty data proof: backend-only webhook mutation; no frontend empty-state path is introduced.
- Partial data proof: missing payment_id still returns without crashing.
- Forbidden secondary path behavior: no frontend route or secondary forbidden path changes; provider-auth rejection remains on the backend webhook.
- Missing draft/resource behavior: missing linked payment remains a no-op for payment mutation.
- Stale route/deep-link behavior: no route/deep-link behavior changes because no frontend route is touched.

## Scope Gate
- Allowed paths: backend/app/services/provider_webhook_service.py, backend/tests/unit/test_provider_webhook_service.py.
- Denied paths: frontend, migrations, BFF/ui endpoints, provider configs, route registration.
- Migration/docs/test impact: no migration; one focused unit test.
- Rollback note: revert this commit to restore previous idempotent duplicate behavior.

## Validation
- Targeted tests or smoke run: py_compile for service and unit test; git diff --check; GitHub backend tests.
- Result: passed in CI; local py_compile and diff check passed.
- Not checked: local pytest could not run because no Python 3.11+ interpreter with pytest was available in this checkout.