### PR TITLE
fix(admin): stop showing mock security events

### DIFF
--- a/frontend/src/components/admin/SecuritySettings.jsx
+++ b/frontend/src/components/admin/SecuritySettings.jsx
@@ -82,73 +82,8 @@ const SecuritySettings = ({
     confirm: false
   });
 
-  // Моковые данные для активных сессий
-  const [activeSessions] = useState([
-  {
-    id: 1,
-    device: 'Chrome на Windows',
-    location: 'Ташкент, Узбекистан',
-    ip: '192.168.1.100',
-    lastActive: '2024-02-10T15:30:00Z',
-    current: true
-  },
-  {
-    id: 2,
-    device: 'Safari на iPhone',
-    location: 'Ташкент, Узбекистан',
-    ip: '192.168.1.101',
-    lastActive: '2024-02-10T14:15:00Z',
-    current: false
-  },
-  {
-    id: 3,
-    device: 'Firefox на Mac',
-    location: 'Самарканд, Узбекистан',
-    ip: '10.0.0.50',
-    lastActive: '2024-02-09T09:45:00Z',
-    current: false
-  }]
-  );
-
-  // Моковые данные для логов безопасности
-  const [securityLogs] = useState([
-  {
-    id: 1,
-    action: 'Вход в систему',
-    user: 'admin@clinic.uz',
-    ip: '192.168.1.100',
-    timestamp: '2024-02-10T15:30:00Z',
-    status: 'success',
-    details: 'Успешный вход с Chrome на Windows'
-  },
-  {
-    id: 2,
-    action: 'Неудачная попытка входа',
-    user: 'admin@clinic.uz',
-    ip: '192.168.1.105',
-    timestamp: '2024-02-10T15:25:00Z',
-    status: 'failed',
-    details: 'Неверный пароль'
-  },
-  {
-    id: 3,
-    action: 'Изменение пароля',
-    user: 'admin@clinic.uz',
-    ip: '192.168.1.100',
-    timestamp: '2024-02-10T14:00:00Z',
-    status: 'success',
-    details: 'Пароль успешно изменен'
-  },
-  {
-    id: 4,
-    action: 'Подозрительная активность',
-    user: 'unknown@example.com',
-    ip: '203.0.113.1',
-    timestamp: '2024-02-10T13:45:00Z',
-    status: 'blocked',
-    details: 'Множественные неудачные попытки входа'
-  }]
-  );
+  const [activeSessions] = useState([]);
+  const [securityLogs] = useState([]);
 
   // Инициализация формы
   useEffect(() => {
@@ -559,6 +494,7 @@ const SecuritySettings = ({
               <MacOSButton
               variant="outline"
               onClick={terminateAllOtherSessions}
+              disabled={activeSessions.length === 0}
               size="sm">
               
                 <Trash2 style={{ width: '16px', height: '16px', marginRight: '8px' }} />
@@ -567,6 +503,15 @@ const SecuritySettings = ({
             </div>
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              {activeSessions.length === 0 &&
+              <p style={{
+                fontSize: 'var(--mac-font-size-sm)',
+                color: 'var(--mac-text-secondary)',
+                margin: 0
+              }}>
+                Нет backend-данных об активных сессиях.
+              </p>
+              }
               {activeSessions.map((session) =>
             <div key={session.id} style={{
               display: 'flex',
@@ -774,6 +719,15 @@ const SecuritySettings = ({
             </h3>
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              {securityLogs.length === 0 &&
+              <p style={{
+                fontSize: 'var(--mac-font-size-sm)',
+                color: 'var(--mac-text-secondary)',
+                margin: 0
+              }}>
+                Нет backend-данных о событиях безопасности.
+              </p>
+              }
               {securityLogs.map((log) => {
               const StatusIcon = getStatusIcon(log.status);
               return (


### PR DESCRIPTION
## Summary

- Removes hardcoded demo active sessions and security audit logs from Admin SecuritySettings.
- Renders explicit empty backend-owned state when no session/audit data is provided.
- Disables terminate-all-sessions action when there are no backend-provided sessions.

## Cyclic Execution Evidence

- Fresh main sync: branch created from synced `main` at `42d345b5` after PR #1285 was merged and local cleanup completed.
- Clean workspace: inspected before edits; only `frontend/src/components/admin/SecuritySettings.jsx` changed.
- Branch: `codex/admin-security-settings-no-mock-truth`.
- Scope gate: repo gate ran with known root cause and returned narrow override limited to `frontend/src/components/admin/SecuritySettings.jsx`.
- Red-check handling: PR Review Quality Gate failed on PR body shape only; body is updated in the same PR, no application code change needed.

## Contract Impact

- Canonical surface: Admin security settings frontend component; no backend API surface changed.
- Request shape: not applicable - no request shape changed because this PR adds no API call or endpoint.
- Response shape: not applicable - no response shape changed because this PR adds no API call or endpoint.
- Status codes: not applicable - no HTTP status handling changed.
- Frontend consumer: `AdminPanel -> UnifiedSettings -> SecuritySettings` now consumes empty backend-owned session/audit state instead of hardcoded demo rows.
- Compatibility path or alias: not applicable - no route, alias, or compatibility path changed.
- Contract proof: local build passed and source scan confirms removed mock security values do not remain in `SecuritySettings.jsx`.

## RBAC / Permissions

- Roles allowed: unchanged; this PR does not alter route access or role policy.
- Roles denied: unchanged; this PR does not alter route access or role policy.
- Positive auth proof: not applicable - no backend auth path changed.
- Negative auth proof: not applicable - no backend auth path changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, or realtime channel changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no notification delivery/read state changed.
- Reconnect/resync proof: not applicable - no realtime reconnect/resync behavior changed.

## Frontend Resilience

- Empty data proof: empty active sessions and security logs render explicit backend-data-empty messages.
- Partial data proof: unchanged; existing form settings merge behavior still tolerates missing settings keys.
- Forbidden secondary path behavior: not applicable - this component has no secondary fetch path for sessions/audit rows.
- Missing draft/resource behavior: not applicable - this component does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - this component does not read deep-link route state.

## Scope Gate

- Allowed paths: `frontend/src/components/admin/SecuritySettings.jsx`.
- Denied paths: backend files, API adapters, `/api/v1/ui/*`, BFF service files, unrelated admin components, migrations, generated output.
- Migration/docs/test impact: no migration, no docs change, no test file change; local build and source scan cover this narrow one-file fallback cleanup.
- Rollback note: revert this PR to restore the previous SecuritySettings component behavior.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check -- frontend/src/components/admin/SecuritySettings.jsx`; `rg` scan for removed mock security values in `SecuritySettings.jsx`.
- Result: passed locally; CI frontend build/lint/unit/security/analyze checks are passing, pending the refreshed PR Review Quality Gate.
- Not checked: backend tests, because no backend code or API contract changed; browser smoke, because this is a narrow admin component empty-state fallback and the frontend build passed.

## Risk / rollback

- Low runtime risk: the component still preserves existing settings form behavior, but stops presenting demo security data as operational truth.
- Rollback is reverting this single PR.