### PR TITLE
fix(setup): block initialize when admin exists

### DIFF
--- a/backend/app/services/setup_service.py
+++ b/backend/app/services/setup_service.py
@@ -38,6 +38,9 @@ class SetupService:
         return SetupStatusOut(initialized=self.is_initialized())
 
     def is_initialized(self) -> bool:
+        if self.repo.count_active_admins() > 0:
+            return True
+
         clinic_setting = self.repo.get_setting(CLINIC_IDENTITY_KEY)
         clinic_name = None
         if clinic_setting:
@@ -45,7 +48,6 @@ class SetupService:
         return bool(
             clinic_name
             and self.repo.count_branches() > 0
-            and self.repo.count_active_admins() > 0
         )
 
     def initialize(self, payload: SetupInitializeIn) -> SetupInitializeOut:

--- a/backend/tests/integration/test_setup_api.py
+++ b/backend/tests/integration/test_setup_api.py
@@ -115,3 +115,34 @@ def test_setup_initialize_rejects_second_run(client):
 
     second = client.post("/api/v1/setup/initialize", json=build_payload())
     assert second.status_code == 409, second.text
+
+
+@pytest.mark.integration
+def test_setup_initialize_rejects_when_active_admin_already_exists(client, db_session):
+    db_session.add(
+        User(
+            username="legacy_admin",
+            hashed_password="legacy-hash",
+            full_name="Legacy Admin",
+            email="legacy-admin@example.com",
+            role="Admin",
+            is_active=True,
+            is_superuser=True,
+        )
+    )
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/setup/initialize",
+        json=build_payload(
+            admin={
+                "username": "attacker_admin",
+                "password": "strongpass123",
+                "full_name": "Attacker Admin",
+                "email": "attacker@example.com",
+            }
+        ),
+    )
+
+    assert response.status_code == 409, response.text
+    assert db_session.query(User).filter(User.role == "Admin").count() == 1


### PR DESCRIPTION
## Summary

- Block public setup initialization as soon as an active Admin already exists.
- Keep first-run setup available for truly adminless deployments.
- Add regression coverage for a partial legacy state with an existing Admin and missing setup settings.

## Cyclic Execution Evidence

- Fresh main sync: branch created from fresh origin/main worktree at b12f936f.
- Clean workspace: inspected before edits; only setup service and targeted setup API test changed.
- Branch: codex/setup-initialize-admin-guard.
- Scope gate: agent gate used known root cause backend/app/services/setup_service.py and returned narrow override; allowed setup initialization guard first, then targeted regression test.
- Red-check handling: fix failed targeted tests or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: POST /api/v1/setup/initialize and GET /api/v1/setup/status.
- Request shape: unchanged setup initialization body.
- Response shape: unchanged setup status and initialization response models.
- Status codes: partial deployments with an existing active Admin now return 409 on public initialize instead of creating another Admin.
- Frontend consumer: first-run setup screen may see initialized=true when an active Admin exists, which is intentional safety behavior.
- Compatibility path or alias: no route alias changed.
- Contract proof: targeted setup API regression test added for existing active Admin partial state.

## RBAC / Permissions

- Roles allowed: unauthenticated setup remains allowed only before any active Admin exists.
- Roles denied: unauthenticated setup is denied by 409 once an active Admin exists.
- Positive auth proof: fresh adminless setup path remains covered by existing test_setup_initialize_creates_ssot_entities.
- Negative auth proof: new regression verifies an existing active Admin blocks unauthenticated creation of a second Admin.

## Notification / Realtime

not applicable - setup initialization does not publish notifications, websocket events, chat messages, or realtime updates.

## Frontend Resilience

- Empty data proof: existing fresh-install status test still covers initialized=false with no Admin, branch, or clinic setting.
- Partial data proof: new backend regression covers partial legacy state with Admin but missing setup settings.
- Forbidden secondary path behavior: not applicable - setup has no secondary frontend action path in this PR.
- Missing draft/resource behavior: not applicable - setup does not create drafts or reopen resources.
- Stale route/deep-link behavior: not applicable - no route or deep-link handling changed.

## Scope Gate

- Allowed paths: backend/app/services/setup_service.py and backend/tests/integration/test_setup_api.py.
- Denied paths: auth middleware, setup schemas, migrations, frontend, broader setup redesign, unrelated public endpoints.
- Migration/docs/test impact: no migration or docs; targeted setup API regression test updated.
- Rollback note: revert this commit to restore the previous setup initialization predicate.

## Validation

- Targeted tests or smoke run: py_compile for backend/app/services/setup_service.py and backend/tests/integration/test_setup_api.py; git diff --check; targeted pytest attempted with project launcher.
- Result: py_compile passed; git diff --check passed; targeted pytest could not run locally because no Python 3.11 interpreter with pytest is installed in this checkout.
- Not checked: full backend suite locally; GitHub CI is expected to run backend tests for this PR.