### PR TITLE
fix(admin): keep report catalog backend-owned

### DIFF
--- a/frontend/src/components/admin/ReportGenerator.jsx
+++ b/frontend/src/components/admin/ReportGenerator.jsx
@@ -27,14 +27,6 @@ import PropTypes from 'prop-types';
 import { toast } from 'react-toastify';
 import logger from '../../utils/logger';
 
-const DEFAULT_REPORT_TYPES = [
-  'patient_report',
-  'appointments_report',
-  'financial_report',
-  'queue_report',
-  'doctor_performance_report'
-];
-
 const REPORT_ENDPOINTS = {
   patient_report: 'patient',
   appointments_report: 'appointments',
@@ -134,19 +126,9 @@ const ReportGenerator = ({
           return;
         }
 
-        if (normalized.length > 0) {
-          setAvailableReportTypes(normalized);
-          if (!selectedReportType && !internalSelectedReportType) {
-            setInternalSelectedReportType(normalized[0].type);
-          }
-        } else {
-          const fallback = DEFAULT_REPORT_TYPES
-            .map(normalizeReportType)
-            .filter(Boolean);
-          setAvailableReportTypes(fallback);
-          if (!selectedReportType && !internalSelectedReportType && fallback[0]) {
-            setInternalSelectedReportType(fallback[0].type);
-          }
+        setAvailableReportTypes(normalized);
+        if (!normalized.some((type) => type.type === internalSelectedReportType)) {
+          setInternalSelectedReportType('');
         }
       } catch (error) {
         logger.warn('Не удалось загрузить доступные отчеты для генератора:', error);
@@ -155,12 +137,9 @@ const ReportGenerator = ({
           return;
         }
 
-        const fallback = DEFAULT_REPORT_TYPES
-          .map(normalizeReportType)
-          .filter(Boolean);
-        setAvailableReportTypes(fallback);
-        if (!selectedReportType && !internalSelectedReportType && fallback[0]) {
-          setInternalSelectedReportType(fallback[0].type);
+        setAvailableReportTypes([]);
+        if (!selectedReportType) {
+          setInternalSelectedReportType('');
         }
       }
     };

--- a/frontend/src/components/admin/ReportsManager.jsx
+++ b/frontend/src/components/admin/ReportsManager.jsx
@@ -44,7 +44,7 @@ const ReportsManager = () => {
 
   // Состояние для генерации отчетов
   const [reportForm, setReportForm] = useState({
-    type: 'patient_report',
+    type: '',
     format: 'excel',
     start_date: '',
     end_date: '',
@@ -67,18 +67,17 @@ const ReportsManager = () => {
   const loadAvailableReports = async () => {
     try {
       const response = await api.get('/reports/available-reports');
-      setAvailableReports(response.data?.reports || []);
+      const reports = response.data?.reports || [];
+      setAvailableReports(reports);
+      setReportForm((prev) => ({
+        ...prev,
+        type: reports.some((report) => report.type === prev.type) ? prev.type : ''
+      }));
     } catch (error) {
-      logger.error('Ошибка загрузки доступных отчетов:', error);
-      setError('Не удалось загрузить данные'); // Set error state
-      // Set default reports if API fails
-      setAvailableReports([
-      { type: 'patient_report', name: 'Отчет по пациентам' },
-      { type: 'appointments_report', name: 'Отчет по записям' },
-      { type: 'financial_report', name: 'Финансовый отчет' },
-      { type: 'queue_report', name: 'Отчет по очереди' },
-      { type: 'doctor_performance_report', name: 'Отчет по врачам' }]
-      );
+      logger.error('Failed to load available reports:', error);
+      setError('Failed to load report catalog');
+      setAvailableReports([]);
+      setReportForm((prev) => ({ ...prev, type: '' }));
     }
   };
 
@@ -114,10 +113,14 @@ const ReportsManager = () => {
   };
 
   const generateReport = async () => {
+    const endpoint = getReportEndpoint(reportForm.type);
+    if (!reportForm.type || !endpoint) {
+      toast.error('Select an available report type');
+      return;
+    }
+
     setLoading(true);
     try {
-      const endpoint = getReportEndpoint(reportForm.type);
-
       const response = await api.post(`/reports/${endpoint}`, {
         start_date: reportForm.start_date || null,
         end_date: reportForm.end_date || null,
@@ -153,7 +156,7 @@ const ReportsManager = () => {
       'queue_report': 'queue',
       'doctor_performance_report': 'doctor-performance'
     };
-    return endpoints[type] || 'patient';
+    return endpoints[type] || null;
   };
 
 
@@ -316,7 +319,7 @@ const ReportsManager = () => {
           title={loading ? 'Generating report' : 'Generate report'}
           aria-label={loading ? 'Generating report' : 'Generate report'}
           onClick={generateReport}
-          disabled={loading}
+          disabled={loading || !reportForm.type}
           style={{
             width: '100%',
             height: '44px',


### PR DESCRIPTION
## Summary

- Remove frontend-invented fallback report catalogs from active admin report generation components.
- Require backend-provided `/reports/available-reports` entries before report generation can be selected.
- Stop unknown report types in `ReportsManager` from silently routing to the patient report endpoint.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `main` at `78914ddc` after fetching `origin`.
- Clean workspace: inspected before edits; only admin report generation frontend files changed.
- Branch: `codex/admin-reports-backend-catalog-only`
- Scope gate: `agent_gate` known-root-cause narrow override for `ReportsManager.jsx`; second known-root-cause gate for active sibling `ReportGenerator.jsx` after evidence showed the same live fallback path.
- Red-check handling: fix failed local or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: backend `/reports/available-reports` remains the source of available report types.
- Request shape: unchanged; existing `/reports/{endpoint}` POST payloads are preserved.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: Admin `UnifiedReports` children no longer invent report capabilities when the backend catalog is missing or empty.
- Compatibility path or alias: none added; removed silent fallback to patient report for unknown `ReportsManager` types.
- Contract proof: source scan confirms `DEFAULT_REPORT_TYPES`, default fallback catalog, and `endpoints[type] || 'patient'` are absent from touched components.

## RBAC / Permissions

- Roles allowed: unchanged by this frontend-only patch.
- Roles denied: unchanged by this frontend-only patch.
- Positive auth proof: not applicable - no auth code changed.
- Negative auth proof: not applicable - no route or permission logic changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime behavior changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no delivery state changed.
- Reconnect/resync proof: not applicable - no reconnect or resync path changed.

## Frontend Resilience

- Empty data proof: empty report catalog now leaves no selected report type and disables generation instead of fabricating patient/appointments/financial/queue/doctor reports.
- Partial data proof: existing selected type is preserved only if it remains present in the backend-provided catalog.
- Forbidden secondary path behavior: unknown `ReportsManager` type no longer falls back to `/reports/patient`.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: unchanged; admin reports routing is not modified.

## Scope Gate

- Allowed paths: `frontend/src/components/admin/ReportsManager.jsx`, `frontend/src/components/admin/ReportGenerator.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, API adapters, command wrappers, unrelated admin components.
- Migration/docs/test impact: no migration or docs; no API tests required because no API contract changed.
- Rollback note: revert this commit to restore previous fallback catalog behavior, though that would reintroduce frontend-owned report capabilities.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; source scan for removed fallback report catalog and fallback patient routing.
- Result: passed.
- Not checked: backend tests, OpenAPI tests, browser smoke; not required for frontend-only fallback removal with unchanged API contract.