### PR TITLE
fix(admin): require explicit appointment schedule

### DIFF
--- a/frontend/src/components/admin/AppointmentModal.jsx
+++ b/frontend/src/components/admin/AppointmentModal.jsx
@@ -27,7 +27,7 @@ const AppointmentModal = ({
     appointmentDate: '',
     appointmentTime: '',
     duration: 30,
-    status: 'pending',
+    status: '',
     reason: '',
     notes: '',
     phone: '',
@@ -50,25 +50,20 @@ const AppointmentModal = ({
           appointmentDate: appointment.appointmentDate || '',
           appointmentTime: appointment.appointmentTime || '',
           duration: appointment.duration || 30,
-          status: appointment.status || 'pending',
+          status: appointment.status || '',
           reason: appointment.reason || appointment.notes || '',
           notes: appointment.notes || '',
           phone: appointment.phone || '',
           email: appointment.email || ''
         });
       } else {
-        // Устанавливаем завтрашний день по умолчанию
-        const tomorrow = new Date();
-        tomorrow.setDate(tomorrow.getDate() + 1);
-        const tomorrowStr = tomorrow.toISOString().split('T')[0];
-
         setFormData({
           patientId: '',
           doctorId: '',
-          appointmentDate: tomorrowStr,
-          appointmentTime: '09:00',
+          appointmentDate: '',
+          appointmentTime: '',
           duration: 30,
-          status: 'pending',
+          status: '',
           reason: '',
           notes: '',
           phone: '',
@@ -131,12 +126,14 @@ const AppointmentModal = ({
         appointmentDate: formData.appointmentDate,
         appointmentTime: formData.appointmentTime,
         duration: parseInt(formData.duration),
-        status: formData.status,
         reason: formData.reason.trim(),
         notes: formData.notes.trim() || null,
         phone: formData.phone.trim() || null,
         email: formData.email.trim() || null
       };
+      if (formData.status) {
+        appointmentData.status = formData.status;
+      }
 
       await onSave(appointmentData);
       onClose();
@@ -399,6 +396,7 @@ const AppointmentModal = ({
               value={formData.status}
               onChange={(e) => handleChange('status', e.target.value)}
               options={[
+              { value: '', label: 'По умолчанию backend' },
               { value: 'pending', label: 'Ожидает' },
               { value: 'confirmed', label: 'Подтверждена' },
               { value: 'paid', label: 'Оплачена' },


### PR DESCRIPTION
## Summary

- Stop the admin appointment modal from pre-filling new appointments with tomorrow at `09:00`.
- Stop new appointment creation from forcing frontend default status `pending`.
- Preserve edit behavior while omitting `status` from create/update payloads unless the user explicitly selects one.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `main` after PR #1294 merge commit `d028bf1f`.
- Clean workspace: inspected before edits; only `AppointmentModal.jsx` changed.
- Branch: `codex/admin-appointment-no-implicit-defaults`
- Scope gate: `agent_gate` known-root-cause narrow override for `frontend/src/components/admin/AppointmentModal.jsx`.
- Red-check handling: fix failed local or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: backend `/appointments` create contract and `AppointmentCreate.status` default remain backend-owned.
- Request shape: unchanged except frontend omits `status` when no explicit status is selected.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: Admin appointment modal requires explicit date/time selection and no longer silently creates appointments at a guessed slot.
- Compatibility path or alias: none added.
- Contract proof: source scan confirms no `tomorrow`, `09:00`, or `status: 'pending'` default remains in `AppointmentModal.jsx`.

## RBAC / Permissions

- Roles allowed: unchanged by this frontend-only patch.
- Roles denied: unchanged by this frontend-only patch.
- Positive auth proof: not applicable - no auth code changed.
- Negative auth proof: not applicable - no route or permission logic changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime behavior changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no delivery state changed.
- Reconnect/resync proof: not applicable - no reconnect or resync path changed.

## Frontend Resilience

- Empty data proof: new modal opens with blank date/time/status and existing validation blocks submit until required schedule fields are selected.
- Partial data proof: edit mode keeps existing appointment values; missing edit status remains blank instead of converting to `pending`.
- Forbidden secondary path behavior: no fallback appointment slot or frontend-owned status is submitted.
- Missing draft/resource behavior: not applicable - no persisted draft behavior changed.
- Stale route/deep-link behavior: unchanged; admin appointment routing is not modified.

## Scope Gate

- Allowed paths: `frontend/src/components/admin/AppointmentModal.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, appointment API adapters, command wrappers, unrelated admin components.
- Migration/docs/test impact: no migration or docs; no API tests required because no API contract changed.
- Rollback note: revert this commit to restore previous pre-filled appointment defaults, though that would reintroduce frontend-owned slot/status defaults.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; source scan for removed implicit date/time/status defaults.
- Result: passed.
- Not checked: backend tests, OpenAPI tests, browser smoke; not required for single-file frontend contract hardening with unchanged backend API.