### PR TITLE
fix(doctor): do not invent next visit time

### DIFF
--- a/frontend/src/pages/DoctorPanel.jsx
+++ b/frontend/src/pages/DoctorPanel.jsx
@@ -199,7 +199,7 @@ const DoctorPanel = () => {
       ? patients.find((patient) => Number(patient.id) === normalizedPatientId)
       : null;
     const visitDate = confirmation.visit_date || submittedFormData?.visit_date || '';
-    const visitTime = confirmation.visit_time || submittedFormData?.visit_time || '09:00';
+    const visitTime = confirmation.visit_time || submittedFormData?.visit_time || '';
 
     const nextAppointment = {
       id: result?.visit_id || Date.now(),


### PR DESCRIPTION
## Summary

- Stop `DoctorPanel` schedule-next confirmation from inventing `09:00` when neither backend confirmation nor submitted form data contains a visit time.
- Preserve existing confirmation and submitted-time precedence.
- Keep missing visit time empty so the UI does not show a false appointment time.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `main` after PR #1295 merge commit `c3968fcf`.
- Clean workspace: inspected before edits; only `DoctorPanel.jsx` changed.
- Branch: `codex/doctor-panel-no-fake-visit-time`
- Scope gate: `agent_gate` known-root-cause narrow override for `frontend/src/pages/DoctorPanel.jsx`.
- Red-check handling: fix failed local or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: backend schedule-next confirmation remains the source of `visit_time` when present.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: Doctor schedule-next UI no longer displays a guessed `09:00` time for missing backend/submitted time.
- Compatibility path or alias: none added.
- Contract proof: source scan confirms the `submittedFormData?.visit_time || '09:00'` fallback is absent from `DoctorPanel.jsx`.

## RBAC / Permissions

- Roles allowed: unchanged by this frontend-only patch.
- Roles denied: unchanged by this frontend-only patch.
- Positive auth proof: not applicable - no auth code changed.
- Negative auth proof: not applicable - no route or permission logic changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime behavior changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no delivery state changed.
- Reconnect/resync proof: not applicable - no reconnect or resync path changed.

## Frontend Resilience

- Empty data proof: missing visit time now remains empty instead of displaying `09:00`.
- Partial data proof: backend `confirmation.visit_time` and submitted `visit_time` are still used when present.
- Forbidden secondary path behavior: no frontend-owned fallback appointment time is introduced.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: unchanged; doctor routing is not modified.

## Scope Gate

- Allowed paths: `frontend/src/pages/DoctorPanel.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, specialist panels, LabPanel, command wrappers, unrelated doctor UI.
- Migration/docs/test impact: no migration or docs; no API tests required because no API contract changed.
- Rollback note: revert this commit to restore the old `09:00` display fallback, though that would reintroduce frontend-owned appointment time.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; source scan for removed `09:00` fallback in `DoctorPanel.jsx`.
- Result: passed.
- Not checked: backend tests, OpenAPI tests, browser smoke; not required for one-line frontend display fallback removal.