### PR TITLE
fix(lab): do not invent appointment time

### DIFF
--- a/frontend/src/pages/LabPanel.jsx
+++ b/frontend/src/pages/LabPanel.jsx
@@ -51,7 +51,7 @@ function formatAppointmentEntry(queue, entry) {
     queue_status: entry.status || null,
     specialty: queue.specialty,
     created_at: entry.created_at,
-    appointment_time: entry.visit_time || '09:00',
+    appointment_time: entry.visit_time || '',
     status: entry.status || null,
     status_source: 'queue',
     latest_lab_report: latestLabReport,


### PR DESCRIPTION
## Summary

- Stop `LabPanel` queue row adaptation from inventing `09:00` when backend `entry.visit_time` is missing.
- Keep missing appointment time empty instead of showing false schedule data.
- Preserve existing queue row mapping otherwise.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `main` after PR #1296 merge commit `80d6bc03`.
- Clean workspace: inspected before edits; only `LabPanel.jsx` changed.
- Branch: `codex/lab-panel-no-fake-appointment-time`
- Scope gate: initial gate misrouted to backend queue internals; one retry with known root cause produced a narrow override including `LabPanel.jsx`, and this PR touches only that frontend file.
- Red-check handling: fix failed local or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: backend queue entry `visit_time` remains the source of lab appointment display time.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: Lab workbench queue row display no longer shows guessed `09:00` for missing `visit_time`.
- Compatibility path or alias: none added.
- Contract proof: source scan confirms `entry.visit_time || '09:00'` is absent from `LabPanel.jsx`.

## RBAC / Permissions

- Roles allowed: unchanged by this frontend-only patch.
- Roles denied: unchanged by this frontend-only patch.
- Positive auth proof: not applicable - no auth code changed.
- Negative auth proof: not applicable - no route or permission logic changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime behavior changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no delivery state changed.
- Reconnect/resync proof: not applicable - no reconnect or resync path changed.

## Frontend Resilience

- Empty data proof: missing backend `visit_time` now remains empty instead of displaying `09:00`.
- Partial data proof: existing backend `entry.visit_time` is still passed through when present.
- Forbidden secondary path behavior: no frontend-owned fallback appointment time is introduced.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: unchanged; lab routing is not modified.

## Scope Gate

- Allowed paths: `frontend/src/pages/LabPanel.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, specialist doctor panels, command wrappers, unrelated lab components.
- Migration/docs/test impact: no migration or docs; no API tests required because no API contract changed.
- Rollback note: revert this commit to restore the old `09:00` display fallback, though that would reintroduce frontend-owned appointment time.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; source scan for removed `09:00` fallback in `LabPanel.jsx`.
- Result: passed.
- Not checked: backend tests, OpenAPI tests, browser smoke; not required for one-line frontend display fallback removal.