### PR TITLE
fix(specialists): do not invent appointment time

### DIFF
--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -602,7 +602,7 @@ const MacOSCardiologistPanelUnified = () => {
                   specialty: queue.specialty,
                   created_at: entry.created_at,
                   appointment_date: entry.created_at ? entry.created_at.split('T')[0] : new Date().toISOString().split('T')[0],
-                  appointment_time: entry.visit_time || '09:00',
+                  appointment_time: entry.visit_time || '',
                   status: entry.status ?? null,
                   cost: entry.cost || 0
                 });

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -602,7 +602,7 @@ const DentistPanelUnified = () => {
                     specialty: queue.specialty,
                     created_at: entry.created_at,
                     appointment_date: entry.created_at ? entry.created_at.split('T')[0] : new Date().toISOString().split('T')[0],
-                    appointment_time: entry.visit_time || '09:00',
+                    appointment_time: entry.visit_time || '',
                     status: entry.status ?? null,
                     cost: entry.cost || 0
                   });

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -455,7 +455,7 @@ const DermatologistPanelUnified = () => {
                     specialty: queue.specialty,
                     created_at: entry.created_at,
                     appointment_date: entry.created_at ? entry.created_at.split('T')[0] : today,
-                    appointment_time: entry.visit_time || '09:00',
+                    appointment_time: entry.visit_time || '',
                     status: entry.status ?? null,
                     cost: entry.cost || 0,
                     visit_id: entry.visit_id || null


### PR DESCRIPTION
## Summary

- Stop Cardio, Derma, and Dentist queue row adaptation from inventing `09:00` when backend `entry.visit_time` is missing.
- Keep missing appointment time empty instead of showing false schedule data.
- Preserve existing queue-derived row mapping otherwise.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `main` after PR #1297 merge commit `762bc90d`.
- Clean workspace: inspected before edits; only specialist panel queue row adapters changed.
- Branch: `codex/specialists-no-fake-appointment-time`
- Scope gate: known-root-cause gates were run for `CardiologistPanelUnified.jsx`, `DermatologistPanelUnified.jsx`, and `DentistPanelUnified.jsx`; each returned a narrow frontend override with backend queue misroute recorded.
- Red-check handling: fix failed local or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: backend queue entry `visit_time` remains the source of specialist appointment display time.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: specialist workbench queue row display no longer shows guessed `09:00` for missing `visit_time`.
- Compatibility path or alias: none added.
- Contract proof: source scan confirms `entry.visit_time || '09:00'` is absent from touched specialist panels.

## RBAC / Permissions

- Roles allowed: unchanged by this frontend-only patch.
- Roles denied: unchanged by this frontend-only patch.
- Positive auth proof: not applicable - no auth code changed.
- Negative auth proof: not applicable - no route or permission logic changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime behavior changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no delivery state changed.
- Reconnect/resync proof: not applicable - no reconnect or resync path changed.

## Frontend Resilience

- Empty data proof: missing backend `visit_time` now remains empty instead of displaying `09:00`.
- Partial data proof: existing backend `entry.visit_time` is still passed through when present.
- Forbidden secondary path behavior: no frontend-owned fallback appointment time is introduced.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: unchanged; specialist routing is not modified.

## Scope Gate

- Allowed paths: `frontend/src/pages/CardiologistPanelUnified.jsx`, `frontend/src/pages/DermatologistPanelUnified.jsx`, `frontend/src/pages/DentistPanelUnified.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, LabPanel, DoctorPanel, command wrappers, unrelated specialist logic.
- Migration/docs/test impact: no migration or docs; no API tests required because no API contract changed.
- Rollback note: revert this commit to restore the old `09:00` display fallback, though that would reintroduce frontend-owned appointment time.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; source scan for removed `09:00` fallback in touched specialist panels.
- Result: passed.
- Not checked: backend tests, OpenAPI tests, browser smoke; not required for frontend-only display fallback removal.