### PR TITLE
fix(queue): do not invent queue open time

### DIFF
--- a/frontend/src/components/queue/ModernQueueManager.jsx
+++ b/frontend/src/components/queue/ModernQueueManager.jsx
@@ -461,7 +461,7 @@ const ModernQueueManager = ({
             </h3>
             {queueData &&
             <Badge variant={queueData.is_open ? 'success' : 'secondary'}>
-                {queueData.is_open ? t.receptionOpen : `Откроется в ${queueData.online_start_time || '09:00'}`}
+                {queueData.is_open ? t.receptionOpen : queueData.online_start_time ? `Откроется в ${queueData.online_start_time}` : 'Откроется'}
               </Badge>
             }
           </div>


### PR DESCRIPTION
## Summary
- Stop ModernQueueManager from displaying a frontend-invented `09:00` when backend `queueData.online_start_time` is missing.
- Keep backend-provided `online_start_time` as the only source for the visible queue open time.
- Show a neutral `Откроется` label when the backend time is absent.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `main` after PR #1298 merge commit `ba17e638`.
- Clean workspace: inspected before edits; only one queue component file changed.
- Branch: `codex/queue-manager-no-fake-open-time`
- Scope gate: `agent_gate` ran with known root cause `frontend/src/components/queue/ModernQueueManager.jsx` and returned narrow override for that file.
- Red-check handling: fix failed local or CI checks in this same PR before merge.

## Contract Impact
- Canonical surface: backend queue snapshot `queueData.online_start_time` remains the source of queue opening time.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: ModernQueueManager no longer shows guessed `09:00` when the backend omits opening time.
- Compatibility path or alias: none added.
- Contract proof: source scan confirms `online_start_time || '09:00'` is absent from queue components.

## RBAC / Permissions
- Roles allowed: unchanged by this frontend-only display patch.
- Roles denied: unchanged by this frontend-only display patch.
- Positive auth proof: not applicable - no auth code changed.
- Negative auth proof: not applicable - no route or permission logic changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime behavior changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no delivery state changed.
- Reconnect/resync proof: not applicable - no reconnect or resync path changed.

## Frontend Resilience
- Empty data proof: missing backend `online_start_time` now renders neutral text instead of a fake `09:00`.
- Partial data proof: existing backend `queueData.online_start_time` is still displayed when present.
- Forbidden secondary path behavior: no frontend-owned queue open time fallback is introduced.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: unchanged; queue routing is not modified.

## Scope Gate
- Allowed paths: `frontend/src/components/queue/ModernQueueManager.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, command wrappers, queue services, unrelated queue UI.
- Migration/docs/test impact: no migration or docs; no API tests required because no API contract changed.
- Rollback note: revert this commit to restore the old `09:00` display fallback, though that would reintroduce frontend-owned queue open time.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; source scan for removed queue open time fallback.
- Result: passed.
- Not checked: backend tests, OpenAPI tests, browser smoke; not required for frontend-only display fallback removal.