### PR TITLE
fix(doctor): require explicit schedule-next time

### DIFF
--- a/frontend/src/components/common/ScheduleNextModal.jsx
+++ b/frontend/src/components/common/ScheduleNextModal.jsx
@@ -35,7 +35,7 @@ const ScheduleNextModal = ({
   const [formData, setFormData] = useState({
     patient_id: '',
     visit_date: '',
-    visit_time: '09:00',
+    visit_time: '',
     services: [{ service_id: '', quantity: 1 }],
     discount_mode: 'none',
     all_free: false,
@@ -241,7 +241,7 @@ const ScheduleNextModal = ({
     setFormData({
       patient_id: '',
       visit_date: '',
-      visit_time: '09:00',
+      visit_time: '',
       services: [{ service_id: '', quantity: 1 }],
       discount_mode: 'none',
       all_free: false,


### PR DESCRIPTION
## Summary
- Stop ScheduleNextModal from pre-filling next visit time with frontend-owned `09:00`.
- Keep `visit_time` empty until the user explicitly selects a time.
- Preserve the existing required time input and `/doctor/visits/schedule-next` command path.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `main` after PR #1299 merge commit `2b892be0`.
- Clean workspace: inspected before edits; only `ScheduleNextModal.jsx` changed.
- Branch: `codex/schedule-next-no-default-time`
- Scope gate: `agent_gate` ran with known root cause `frontend/src/components/common/ScheduleNextModal.jsx` and returned narrow override for that file.
- Red-check handling: fix failed local or CI checks in this same PR before merge.

## Contract Impact
- Canonical surface: backend `ScheduleNextVisitRequest.visit_time` is optional and accepts explicit client input; frontend no longer invents a schedule time.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: doctor/specialist schedule-next modal now requires explicit time selection instead of silently submitting `09:00`.
- Compatibility path or alias: none added.
- Contract proof: source scan confirms `visit_time: '09:00'` is absent from `ScheduleNextModal.jsx`.

## RBAC / Permissions
- Roles allowed: unchanged by this frontend-only form default patch.
- Roles denied: unchanged by this frontend-only form default patch.
- Positive auth proof: not applicable - no auth code changed.
- Negative auth proof: not applicable - no route or permission logic changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime behavior changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no delivery state changed.
- Reconnect/resync proof: not applicable - no reconnect or resync path changed.

## Frontend Resilience
- Empty data proof: schedule-next form starts with empty `visit_time`, so missing user choice is visible and blocked by the existing required input.
- Partial data proof: explicitly selected visit time is still submitted through the same form field.
- Forbidden secondary path behavior: no frontend-owned default appointment time is introduced.
- Missing draft/resource behavior: reset state also returns to empty `visit_time`, not `09:00`.
- Stale route/deep-link behavior: unchanged; no route code modified.

## Scope Gate
- Allowed paths: `frontend/src/components/common/ScheduleNextModal.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, command wrappers, doctor/specialist panels, unrelated form logic.
- Migration/docs/test impact: no migration or docs; no API tests required because no API contract changed.
- Rollback note: revert this commit to restore the old prefilled `09:00`, though that would reintroduce frontend-owned schedule time.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; source scan for removed `visit_time: '09:00'` fallback.
- Result: passed.
- Not checked: backend tests, OpenAPI tests, browser smoke; not required for frontend-only form default removal.