### PR TITLE
fix(admin): do not invent benefit settings

### DIFF
--- a/frontend/src/components/admin/BenefitSettings.jsx
+++ b/frontend/src/components/admin/BenefitSettings.jsx
@@ -59,17 +59,6 @@ const BenefitSettings = () => {
     } catch (error) {
       logger.error('Error loading benefit settings:', error);
       setError(error.response?.data?.detail || 'Не удалось загрузить настройки льгот. Проверьте подключение к серверу.');
-      // Fallback данные при ошибке
-      const fallbackData = {
-        repeat_visit_days: 21,
-        repeat_visit_discount: 0,
-        benefit_consultation_free: true,
-        all_free_auto_approve: false,
-        updated_at: new Date().toISOString()
-      };
-      setSettings(fallbackData);
-      setOriginalSettings(fallbackData);
-      setLastUpdated(new Date());
       toast.error('Ошибка загрузки настроек льгот');
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- Remove frontend fallback benefit policy data when `/admin/benefit-settings` fails to load.
- Let the existing critical error state render on first-load failure instead of showing invented settings.
- Preserve the backend-owned fetch/save endpoints and admin benefit settings command path.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `main` after PR #1300 merge commit `386c5659`.
- Clean workspace: inspected before edits; only `BenefitSettings.jsx` changed.
- Branch: `codex/benefit-settings-no-fallback-policy`
- Scope gate: `agent_gate` ran with known root cause `frontend/src/components/admin/BenefitSettings.jsx` and returned narrow override for that file.
- Red-check handling: fix failed local or CI checks in this same PR before merge.

## Contract Impact
- Canonical surface: backend `/admin/benefit-settings` remains the only source for benefit policy settings.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: admin BenefitSettings no longer shows or saves locally invented policy values after an API load failure.
- Compatibility path or alias: none added.
- Contract proof: source scan confirms `fallbackData` and fallback settings writes are absent from `BenefitSettings.jsx`.

## RBAC / Permissions
- Roles allowed: unchanged by this frontend-only load-error patch.
- Roles denied: unchanged by this frontend-only load-error patch.
- Positive auth proof: not applicable - no auth code changed.
- Negative auth proof: not applicable - no route or permission logic changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime behavior changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no delivery state changed.
- Reconnect/resync proof: not applicable - no reconnect or resync path changed.

## Frontend Resilience
- Empty data proof: first-load failure now keeps `settings.updated_at` absent, allowing the existing critical empty/error state to render.
- Partial data proof: previously loaded backend settings remain visible if a later refresh fails.
- Forbidden secondary path behavior: no frontend-owned benefit policy fallback is introduced.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: unchanged; admin settings routing is not modified.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/BenefitSettings.jsx`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, command wrappers, benefit endpoint behavior, unrelated admin settings.
- Migration/docs/test impact: no migration or docs; no API tests required because no API contract changed.
- Rollback note: revert this commit to restore fallback policy data, though that would reintroduce frontend-owned benefit settings.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; source scan for removed `fallbackData` path.
- Result: passed.
- Not checked: backend tests, OpenAPI tests, browser smoke; not required for frontend-only load-error fallback removal.