### PR TITLE
docs: refresh devbrain main status

### DIFF
--- a/docs/devbrain/DEVBRAIN_STATUS.md
+++ b/docs/devbrain/DEVBRAIN_STATUS.md
@@ -23,6 +23,17 @@ Operational status file for the repository's DevBrain layers. Agents must verify
 | LlamaIndex | active local fallback | `ai/llamaindex` exists; smoke passed without external API; generated storage remains gitignored. |
 | LightRAG | active relationship fallback | `ai/lightrag` exists; relationship graph acceptance passed; generated graph storage remains gitignored. |
 
+## Current Main Acceptance
+
+- Main merge commit: `f4ea5b73dc13858c0baf2d8456bdc7a8f1096fe3`
+- Retrieval layer commit: `3e11d2c1bc9b9f01a2c26a6ea3bf2504b76387a7`
+- Inventory: `passed`
+- Guardrail acceptance: `pass: 5`, `warn: 0`, `fail: 0`
+- LlamaIndex: `active local fallback`
+- LightRAG: `active relationship fallback`
+- Unified DevBrain status: `portable accepted in this checkout`
+- Limitation: `not a production autonomous brain`
+
 ## Active / Documented / Dormant / Missing Status
 
 | Component | Status | Operational meaning |


### PR DESCRIPTION
﻿## Summary

- Refreshes the DevBrain status passport with the merged `main` acceptance commit from PR #1303.
- Keeps the retrieval/indexed commit separate from the current `main` merge commit.
- Documents the final accepted state: inventory passed, guardrail acceptance `pass: 5`, LlamaIndex active local fallback, LightRAG active relationship fallback.

## Cyclic Execution Evidence

- Fresh main sync: `HEAD` and `origin/main` both resolved to `f4ea5b73dc13858c0baf2d8456bdc7a8f1096fe3` before branching.
- Clean workspace: branch started from clean `main`.
- Branch: `docs/devbrain-main-status-refresh`.
- Scope gate: allowed only `docs/devbrain/DEVBRAIN_STATUS.md`; denied product runtime, AI runtime scripts, generated indexes/storage, secrets, and deployment settings.
- Red-check handling: no red checks observed before PR creation; if CI fails, the fix stays in this PR.

## Contract Impact

not applicable - docs-only status refresh; no API, websocket, event payload, frontend consumer contract, status code, or compatibility route changed.

## RBAC / Permissions

not applicable - docs-only status refresh; no route, endpoint, role guard, auth helper, or permission-sensitive product behavior changed.

## Notification / Realtime

not applicable - docs-only status refresh; no notification event, websocket channel, delivery semantics, read/unread behavior, or realtime product behavior changed.

## Frontend Resilience

not applicable - docs-only status refresh; no frontend panel, route, data flow, empty state, partial data state, or user-facing behavior changed.

## Scope Gate

- Allowed paths: `docs/devbrain/DEVBRAIN_STATUS.md`.
- Denied paths: backend/frontend product runtime, AI runtime scripts, ops runtime, production deploy settings, secrets, generated local indexes/storage, `.env`, `.venv`.
- Migration/docs/test impact: docs-only; no database migration, no schema change, no tests changed.
- Rollback note: revert this PR to remove the `Current Main Acceptance` status note; DevBrain tooling remains unchanged.

## Validation

- Targeted tests or smoke run: `git diff --check`; `git diff --name-only`.
- Result: passed; changed file list contains only `docs/devbrain/DEVBRAIN_STATUS.md`.
- Not checked: product backend/frontend test suites and DevBrain smoke scripts were not rerun because this PR only records the already-accepted merged status from PR #1303.

## Notes

This does not regenerate retrieval indexes. It only clarifies that `f4ea5b73dc13858c0baf2d8456bdc7a8f1096fe3` is the merged `main` acceptance commit while `3e11d2c1bc9b9f01a2c26a6ea3bf2504b76387a7` remains the retrieval/indexed commit.
