### PR TITLE
docs(devbrain): add regression matrix checker

### DIFF
--- a/docs/devbrain/DEVBRAIN_STATUS.md
+++ b/docs/devbrain/DEVBRAIN_STATUS.md
@@ -25,8 +25,8 @@ Operational status file for the repository's DevBrain layers. Agents must verify
 
 ## Current Main Acceptance
 
-- Main merge commit: `f4ea5b73dc13858c0baf2d8456bdc7a8f1096fe3`
-- Retrieval layer commit: `3e11d2c1bc9b9f01a2c26a6ea3bf2504b76387a7`
+- Main merge commit: `13055c56eaba571cc86501cf3bdda65d8f160f9f`
+- Retrieval layer commit: `13055c56eaba571cc86501cf3bdda65d8f160f9f`
 - Inventory: `passed`
 - Guardrail acceptance: `pass: 5`, `warn: 0`, `fail: 0`
 - LlamaIndex: `active local fallback`
@@ -54,8 +54,8 @@ Operational status file for the repository's DevBrain layers. Agents must verify
   - `Test-Path ai/llamaindex/scripts/ingest.py`
   - `Test-Path ai/llamaindex/storage/devbrain_index.json`
   - `./ai/llamaindex/scripts/run_smoke.ps1`
-- Last indexed commit: `3e11d2c1bc9b9f01a2c26a6ea3bf2504b76387a7`
-- Last verification date: `2026-05-25T17:47:52+00:00`
+- Last indexed commit: `13055c56eaba571cc86501cf3bdda65d8f160f9f`
+- Last verification date: `2026-05-25T18:53:26+00:00`
 - Indexed document count: `1501`
 - Acceptance result: `simple locate smoke passed in no-key fallback mode`
 - Smoke query: `Where is runtime API/WS origin resolution implemented on the frontend?`
@@ -72,8 +72,8 @@ Operational status file for the repository's DevBrain layers. Agents must verify
   - `Test-Path ai/lightrag/scripts/ingest.py`
   - `Test-Path ai/lightrag/indexes/lightrag_graph/graph.json`
   - `./ai/lightrag/scripts/run_acceptance.ps1`
-- Last indexed commit: `3e11d2c1bc9b9f01a2c26a6ea3bf2504b76387a7`
-- Last verification date: `2026-05-25T17:47:58+00:00`
+- Last indexed commit: `13055c56eaba571cc86501cf3bdda65d8f160f9f`
+- Last verification date: `2026-05-25T18:53:26+00:00`
 - Indexed document count: `1499`
 - Relationship concept count: `9`
 - Relationship edge count: `4658`
@@ -86,7 +86,7 @@ LightRAG or LlamaIndex may be treated as active project retrieval only after all
 
 1. `simple locate`
    - Expected: reliably finds canonical files for a narrow known task.
-   - Status: `passed via LightRAG acceptance`.
+   - Status: `passed via ai/llamaindex smoke in no-key fallback mode`.
 2. `Telegram mixed-contract`
    - Expected: separates Bot API/UX/webhook work from token storage, security, and migration ownership.
    - Status: `passed via LightRAG acceptance`.
@@ -113,13 +113,31 @@ Use the local guardrail acceptance checker before changing DevBrain routing rule
 
 The checker is read-only. It runs `ai/langgraph/scripts/run_agent_gate.ps1` against critical routing scenarios and prints `PASS`, `WARN`, or `FAIL` per scenario. It does not require LlamaIndex or LightRAG, does not run product tests, and exits non-zero only when a core guardrail expectation is clearly violated.
 
+## How To Run Full DevBrain Regression Matrix
+
+Use the local regression matrix before trusting DevBrain for graph-heavy, risky, or ownership-sensitive work:
+
+```powershell
+.\scripts\devbrain_regression_matrix.ps1
+```
+
+The matrix is read-only. It runs inventory, guardrail acceptance, LlamaIndex simple locate, LightRAG registrar/payment, Alembic migration, notification anti-noise, and queue identity probes when the corresponding retrieval layers are active. It does not run ingest, does not require API keys, and does not update generated storage or status files.
+
+Excellent DevBrain status requires:
+
+- inventory green
+- acceptance green
+- retrieval freshness checked
+- graph-heavy probes return relevant anchors
+- no `STALE / NEEDS REINDEX` warning for trusted retrieval use
+
 ## Last Indexed Commit Placeholders
 
 | Retrieval layer | Last indexed commit | Last verified by | Notes |
 | --- | --- | --- | --- |
 | AI Factory file memory | `file-backed; no index` | `TBD` | Update relevant logs/dossiers manually. |
-| LlamaIndex | `3e11d2c1bc9b9f01a2c26a6ea3bf2504b76387a7` | `2026-05-25T17:47:52+00:00` | Active local fallback; smoke passed without external API. |
-| LightRAG | `3e11d2c1bc9b9f01a2c26a6ea3bf2504b76387a7` | `2026-05-25T17:47:58+00:00` | Active relationship fallback; acceptance passed without external API. |
+| LlamaIndex | `13055c56eaba571cc86501cf3bdda65d8f160f9f` | `2026-05-25T18:53:26+00:00` | Active local fallback; smoke passed without external API. |
+| LightRAG | `13055c56eaba571cc86501cf3bdda65d8f160f9f` | `2026-05-25T18:53:26+00:00` | Active relationship fallback; acceptance passed without external API. |
 
 ## Known Limitations
 

--- a/scripts/devbrain_regression_matrix.ps1
+++ b/scripts/devbrain_regression_matrix.ps1
@@ -1,0 +1,262 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..")
+$statusFile = Join-Path $repoRoot "docs\devbrain\DEVBRAIN_STATUS.md"
+
+$failCount = 0
+$warnCount = 0
+
+function Write-Section {
+    param([Parameter(Mandatory = $true)][string] $Title)
+
+    Write-Output ""
+    Write-Output "== $Title =="
+}
+
+function Add-Warn {
+    param([Parameter(Mandatory = $true)][string] $Message)
+
+    $script:warnCount += 1
+    Write-Output "WARN: $Message"
+}
+
+function Add-Fail {
+    param([Parameter(Mandatory = $true)][string] $Message)
+
+    $script:failCount += 1
+    Write-Output "FAIL: $Message"
+}
+
+function Invoke-MatrixStep {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Name,
+        [Parameter(Mandatory = $true)]
+        [scriptblock] $Step,
+        [switch] $WarnOnly
+    )
+
+    Write-Section $Name
+    try {
+        & $Step
+        Write-Output "PASS: $Name"
+    }
+    catch {
+        if ($WarnOnly) {
+            Add-Warn "$Name failed: $($_.Exception.Message)"
+        }
+        else {
+            Add-Fail "$Name failed: $($_.Exception.Message)"
+        }
+    }
+}
+
+function Test-StatusActive {
+    param([Parameter(Mandatory = $true)][string] $Pattern)
+
+    if (-not (Test-Path -LiteralPath $statusFile)) {
+        return $false
+    }
+
+    return Select-String -LiteralPath $statusFile -Pattern $Pattern -Quiet
+}
+
+function Test-LlamaIndexActive {
+    $root = Join-Path $repoRoot "ai\llamaindex"
+    $query = Join-Path $repoRoot "ai\llamaindex\scripts\run_query.ps1"
+    $index = Join-Path $repoRoot "ai\llamaindex\storage\devbrain_index.json"
+    return (
+        (Test-Path -LiteralPath $root) -and
+        (Test-Path -LiteralPath $query) -and
+        (Test-Path -LiteralPath $index) -and
+        (Test-StatusActive "Current status: ``active local fallback``")
+    )
+}
+
+function Test-LightRagActive {
+    $root = Join-Path $repoRoot "ai\lightrag"
+    $query = Join-Path $repoRoot "ai\lightrag\scripts\run_query.ps1"
+    $graph = Join-Path $repoRoot "ai\lightrag\indexes\lightrag_graph\graph.json"
+    return (
+        (Test-Path -LiteralPath $root) -and
+        (Test-Path -LiteralPath $query) -and
+        (Test-Path -LiteralPath $graph) -and
+        (Test-StatusActive "Current status: ``active relationship fallback``")
+    )
+}
+
+function Invoke-QueryProbe {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Layer,
+        [Parameter(Mandatory = $true)]
+        [string] $ScriptPath,
+        [Parameter(Mandatory = $true)]
+        [string] $Query,
+        [Parameter(Mandatory = $true)]
+        [string[]] $ExpectedPatterns
+    )
+
+    Write-Output "Query: $Query"
+    $outputLines = & $ScriptPath $Query
+    $exitCode = $LASTEXITCODE
+    $output = ($outputLines | ForEach-Object { $_.ToString() }) -join "`n"
+    Write-Output $output
+
+    if ($exitCode -ne 0) {
+        throw "$Layer query exited with code $exitCode"
+    }
+
+    foreach ($pattern in $ExpectedPatterns) {
+        if ($output -notmatch $pattern) {
+            Add-Warn "$Layer query did not show expected anchor pattern: $pattern"
+        }
+    }
+}
+
+function Get-RecordedIndexedCommits {
+    if (-not (Test-Path -LiteralPath $statusFile)) {
+        throw "DevBrain status file not found: $statusFile"
+    }
+
+    $text = Get-Content -Raw -LiteralPath $statusFile
+    $sectionMatches = [regex]::Matches(
+        $text,
+        "(?s)## (?<name>LlamaIndex|LightRAG) Status.*?- Last indexed commit: ``(?<commit>[0-9a-f]{40})``"
+    )
+
+    $commits = @{}
+    foreach ($match in $sectionMatches) {
+        $commits[$match.Groups["name"].Value] = $match.Groups["commit"].Value
+    }
+    return $commits
+}
+
+function Test-IndexedCommitFreshness {
+    Push-Location $repoRoot
+    try {
+        $head = (git rev-parse HEAD).Trim()
+        if ($LASTEXITCODE -ne 0) {
+            throw "git rev-parse HEAD failed"
+        }
+
+        Write-Output "HEAD: $head"
+        $commits = Get-RecordedIndexedCommits
+        foreach ($layer in @("LlamaIndex", "LightRAG")) {
+            if (-not $commits.ContainsKey($layer)) {
+                Add-Warn "$layer indexed commit is not recorded"
+                continue
+            }
+
+            $recorded = [string] $commits[$layer]
+            Write-Output "$layer recorded indexed commit: $recorded"
+            if ($recorded -eq $head) {
+                Write-Output "PASS: $layer index is fresh at HEAD"
+                continue
+            }
+
+            git merge-base --is-ancestor $recorded $head 2>$null
+            $isAncestor = $LASTEXITCODE -eq 0
+            if ($isAncestor) {
+                Add-Warn "STALE / NEEDS REINDEX: $layer indexed commit $recorded is behind HEAD $head"
+            }
+            else {
+                Add-Warn "STALE / NEEDS REINDEX: $layer indexed commit $recorded differs from HEAD $head"
+            }
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+Write-Output "DevBrain Regression Matrix"
+Write-Output ""
+Write-Output "This checker is read-only. It does not run ingest, does not require API keys, and does not update status files."
+
+Invoke-MatrixStep "Inventory" {
+    & (Join-Path $repoRoot "scripts\devbrain_inventory.ps1")
+    if (-not $?) {
+        throw "inventory command failed"
+    }
+}
+
+Invoke-MatrixStep "Guardrail acceptance" {
+    & (Join-Path $repoRoot "scripts\devbrain_acceptance.ps1")
+    if (-not $?) {
+        throw "acceptance command failed"
+    }
+}
+
+$llamaIndexActive = Test-LlamaIndexActive
+$lightRagActive = Test-LightRagActive
+
+if ($llamaIndexActive) {
+    Invoke-MatrixStep "LlamaIndex simple locate query" {
+        Invoke-QueryProbe `
+            -Layer "LlamaIndex" `
+            -ScriptPath (Join-Path $repoRoot "ai\llamaindex\scripts\run_query.ps1") `
+            -Query "Where is runtime API/WS origin resolution implemented on the frontend?" `
+            -ExpectedPatterns @("frontend/src/api/runtime\.js", "frontend/src/api/ws\.js")
+    } -WarnOnly
+}
+else {
+    Write-Section "LlamaIndex simple locate query"
+    Add-Warn "LlamaIndex is not active in this checkout; skipping query probe"
+}
+
+if ($lightRagActive) {
+    $lightRagQuery = Join-Path $repoRoot "ai\lightrag\scripts\run_query.ps1"
+    Invoke-MatrixStep "LightRAG registrar ownership query" {
+        Invoke-QueryProbe `
+            -Layer "LightRAG" `
+            -ScriptPath $lightRagQuery `
+            -Query "fix registrar payment status persistence ownership" `
+            -ExpectedPatterns @("registrar_payment_status", "backend/app/services/billing_service\.py", "backend/app/models/payment\.py")
+    } -WarnOnly
+
+    Invoke-MatrixStep "LightRAG Alembic ownership query" {
+        Invoke-QueryProbe `
+            -Layer "LightRAG" `
+            -ScriptPath $lightRagQuery `
+            -Query "add Alembic revision for existing TelegramStaffLinkToken model table telegram_staff_link_tokens" `
+            -ExpectedPatterns @("alembic_migration_ownership", "backend/alembic/versions", "backend/app/models")
+    } -WarnOnly
+
+    Invoke-MatrixStep "LightRAG notification anti-noise query" {
+        Invoke-QueryProbe `
+            -Layer "LightRAG" `
+            -ScriptPath $lightRagQuery `
+            -Query "implement notification preferences mute snooze DND runtime policy" `
+            -ExpectedPatterns @("notification_catalog_anti_noise", "backend/app/services/notifications\.py", "backend/app/schemas/notification\.py")
+    } -WarnOnly
+
+    Invoke-MatrixStep "LightRAG queue identity query" {
+        Invoke-QueryProbe `
+            -Layer "LightRAG" `
+            -ScriptPath $lightRagQuery `
+            -Query "fix queue specialist id Doctor.id canonical ownership" `
+            -ExpectedPatterns @("queue_identity_fairness", "backend/app/services/queue_service\.py", "backend/app/models/online_queue\.py")
+    } -WarnOnly
+}
+else {
+    Write-Section "LightRAG relationship queries"
+    Add-Warn "LightRAG is not active in this checkout; skipping relationship probes"
+}
+
+Invoke-MatrixStep "Retrieval freshness" {
+    Test-IndexedCommitFreshness
+} -WarnOnly
+
+Write-Output ""
+Write-Output "Summary:"
+Write-Output "- failures: $failCount"
+Write-Output "- warnings: $warnCount"
+
+if ($failCount -gt 0) {
+    exit 1
+}
+
+exit 0


### PR DESCRIPTION
﻿## Summary

- Adds a read-only DevBrain regression matrix checker for inventory, guardrail acceptance, LlamaIndex locate, and LightRAG ownership probes.
- Documents how to run the matrix and what `excellent` DevBrain status requires.
- Refreshes DevBrain status to the latest accepted `main` commit before this branch: `13055c56eaba571cc86501cf3bdda65d8f160f9f`.

## Cyclic Execution Evidence

- Fresh main sync: branch `docs/devbrain-regression-matrix` was created from clean `main` at `13055c56eaba571cc86501cf3bdda65d8f160f9f`.
- Clean workspace: inspected `git status --short --branch` before editing; only DevBrain docs/tooling files changed.
- Branch: `docs/devbrain-regression-matrix`.
- Scope gate: allowed `scripts/devbrain_regression_matrix.ps1` and `docs/devbrain/DEVBRAIN_STATUS.md`; denied backend/frontend product runtime, generated indexes/storage, secrets, deploy settings, and AI runtime behavior changes.
- Red-check handling: if checks fail, fixes stay in this PR.

## Contract Impact

not applicable - DevBrain docs/tooling only; no API, websocket, event payload, frontend consumer contract, status code, or compatibility route changed.

## RBAC / Permissions

not applicable - no route, endpoint, role guard, auth helper, or permission-sensitive product behavior changed.

## Notification / Realtime

not applicable - no notification event, websocket channel, delivery semantics, read/unread behavior, or realtime product behavior changed.

## Frontend Resilience

not applicable - no frontend panel, route, data flow, empty state, partial data state, or user-facing behavior changed.

## Scope Gate

- Allowed paths: `scripts/devbrain_regression_matrix.ps1`, `docs/devbrain/DEVBRAIN_STATUS.md`.
- Denied paths: backend/frontend product runtime, generated retrieval storage/indexes, `.env`, `.venv`, production deploy settings, secrets, DB schema, CI workflow behavior.
- Migration/docs/test impact: docs/tooling only; no database migration, schema change, product test change, or generated index commit.
- Rollback note: revert this PR to remove the matrix checker and its status-file usage docs; generated local retrieval storage is untouched and gitignored.

## Validation

- Targeted tests or smoke run: `./ai/llamaindex/scripts/run_smoke.ps1`; `./ai/lightrag/scripts/run_acceptance.ps1`; `./scripts/devbrain_regression_matrix.ps1`; `git diff --check` with intent-to-add for the new script.
- Result: LlamaIndex smoke passed with 1501 docs; LightRAG acceptance passed with 1499 docs, 9 concepts, and 4658 edges; regression matrix passed with `failures: 0`, `warnings: 0` before commit at the refreshed status commit; `git diff --check` passed.
- Not checked: product backend/frontend test suites were not run because this PR is DevBrain docs/tooling only and does not touch product runtime.

## Notes

A committed status snapshot cannot point at its own future commit. After this PR commit or merge, `devbrain_regression_matrix.ps1` may correctly emit `STALE / NEEDS REINDEX` until the local checkout reruns LlamaIndex smoke and LightRAG acceptance for the new `HEAD`. That warning is intentional and non-failing.
