### PR TITLE
fix(queue): require auth for legacy next ticket

### DIFF
--- a/backend/app/api/v1/endpoints/queues.py
+++ b/backend/app/api/v1/endpoints/queues.py
@@ -5,7 +5,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db
+from app.api.deps import get_db, require_roles
 from app.services.online_queue import DayStats, issue_next_ticket, load_stats
 
 router = APIRouter(tags=["queues"])
@@ -33,6 +33,7 @@ def next_ticket(
     d: Optional[str] = Query(None),
     date: Optional[str] = Query(None),
     db: Session = Depends(get_db),
+    _current_user=Depends(require_roles("Admin", "Registrar")),
 ):
     date_str = d or date
     if not date_str:

--- a/backend/tests/integration/test_legacy_queues_api.py
+++ b/backend/tests/integration/test_legacy_queues_api.py
@@ -1,0 +1,28 @@
+import pytest
+
+from app.models.setting import Setting
+
+
+@pytest.mark.integration
+def test_next_ticket_requires_auth_and_does_not_mutate_counters(client, db_session):
+    response = client.post(
+        "/api/v1/queues/next-ticket",
+        params={"department": "cardiology", "date": "2026-05-26"},
+    )
+
+    assert response.status_code == 401, response.text
+    assert db_session.query(Setting).filter(Setting.category == "queue").count() == 0
+
+
+@pytest.mark.integration
+def test_next_ticket_allows_registrar_staff(client, registrar_auth_headers):
+    response = client.post(
+        "/api/v1/queues/next-ticket",
+        params={"department": "cardiology", "date": "2026-05-26"},
+        headers=registrar_auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ticket"] == 1
+    assert body["stats"]["waiting"] == 1


### PR DESCRIPTION
## Summary

- Require Admin/Registrar auth for legacy POST /api/v1/queues/next-ticket.
- Preserve GET /api/v1/queues/stats behavior; only the counter-mutating write endpoint is guarded.
- Add regression coverage for unauthenticated rejection and authorized registrar ticket issuance.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current main at 2946f130.
- Clean workspace: inspected before edits; only legacy queues endpoint and targeted integration test changed.
- Branch: codex/queues-next-ticket-auth-guard.
- Scope gate: agent gate used known root cause backend/app/api/v1/endpoints/queues.py and returned narrow override; first slice limited to endpoint, then targeted test added for the same contract.
- Red-check handling: fix failed targeted tests or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: POST /api/v1/queues/next-ticket.
- Request shape: unchanged query params department plus d/date.
- Response shape: unchanged ticket/stats payload for authorized callers.
- Status codes: unauthenticated callers now receive 401 before legacy queue counters mutate.
- Frontend consumer: no current frontend source imports or calls /api/v1/queues/next-ticket.
- Compatibility path or alias: no route path changed; legacy write now requires staff auth.
- Contract proof: targeted integration test covers unauthenticated no-mutation and authorized registrar success.

## RBAC / Permissions

- Roles allowed: Admin, Registrar.
- Roles denied: unauthenticated callers and non-staff roles via require_roles.
- Positive auth proof: registrar token can issue the first ticket and returns waiting=1.
- Negative auth proof: unauthenticated request returns 401 and creates no queue Setting counters.

## Notification / Realtime

not applicable - no websocket or notification contract changed; authorized successful ticket issuance still uses the existing issue_next_ticket broadcast behavior.

## Frontend Resilience

- Empty data proof: not applicable - no frontend caller or rendering path changed.
- Partial data proof: not applicable - request/response fields are unchanged for authorized callers.
- Forbidden secondary path behavior: unauthenticated calls now stop at 401 instead of mutating counters.
- Missing draft/resource behavior: not applicable - endpoint does not create drafts or reopen resources.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link handling changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/queues.py and backend/tests/integration/test_legacy_queues_api.py.
- Denied paths: queue allocator service, QR join flows, registrar queue SSOT, frontend, migrations, /api/v1/ui/*, BFF-lite.
- Migration/docs/test impact: no migration or docs; targeted integration test added.
- Rollback note: revert this commit to restore public legacy next-ticket writes.

## Validation

- Targeted tests or smoke run: py_compile for backend/app/api/v1/endpoints/queues.py and backend/tests/integration/test_legacy_queues_api.py; git diff --check; targeted pytest attempted with project launcher.
- Result: py_compile passed; git diff --check passed; targeted pytest could not run locally because no Python 3.11 interpreter with pytest is installed in this checkout.
- Not checked: full backend suite locally; GitHub CI is expected to run backend tests for this PR.