### PR TITLE
fix(admin): keep appointment status backend-owned

### DIFF
--- a/frontend/src/hooks/useAppointments.js
+++ b/frontend/src/hooks/useAppointments.js
@@ -33,16 +33,21 @@ const buildAppointmentPayload = (appointmentData, doctors = []) => {
     (doctor) => doctor.id === Number(appointmentData.doctorId)
   );
 
-  return {
+  const payload = {
     patient_id: Number(appointmentData.patientId),
     doctor_id: Number(appointmentData.doctorId),
     department: selectedDoctor?.specialty || null,
     appointment_date: appointmentData.appointmentDate,
     appointment_time: appointmentData.appointmentTime,
     notes: appointmentData.reason?.trim() || appointmentData.notes?.trim() || '',
-    status: appointmentData.status || 'pending',
     services: [],
   };
+
+  if (appointmentData.status) {
+    payload.status = appointmentData.status;
+  }
+
+  return payload;
 };
 
 const useAppointments = (doctors = []) => {


### PR DESCRIPTION
## Summary

- Stop forcing Admin appointment create/update payloads to `status=pending` when no explicit status is selected.
- Let backend `AppointmentCreate` own the initial appointment status default.
- Keep update status changes explicit only.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `main` after PR #1314 was merged and local `main` matched `origin/main`.
- Clean workspace: inspected before edits; only `frontend/src/hooks/useAppointments.js` changed.
- Branch: `codex/admin-appointments-backend-status-default`.
- Scope gate: `agent_gate` returned narrow override for `frontend/src/hooks/useAppointments.js`; no backend, UI route, migration, BFF, or unrelated cleanup touched.
- Red-check handling: failed PR Review Quality Gate is fixed in this PR by updating the PR body only; stale rerun used the old event payload, so this edit intentionally refreshes the PR body event.

## Contract Impact

- Canonical surface: `POST /api/v1/appointments` and `PUT /api/v1/appointments/{id}` payload mapping from the admin appointments hook.
- Request shape: omit `status` when the UI leaves backend default selected; include `status` only when explicitly selected.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: Admin appointments create/update flow through `useAppointments`.
- Compatibility path or alias: not applicable; no endpoint path changed.
- Contract proof: source diff confirms the hook no longer synthesizes `pending`; frontend build and CI frontend checks passed.

## RBAC / Permissions

- Roles allowed: unchanged; existing appointment endpoint/backend permissions are untouched.
- Roles denied: unchanged.
- Positive auth proof: not checked locally; no auth code changed.
- Negative auth proof: not checked locally; no auth code changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable; appointment list loading/rendering was not changed.
- Partial data proof: omitted `status` now follows backend DTO defaults instead of a frontend fallback.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: not applicable, no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable, no route or deep-link state changed.

## Scope Gate

- Allowed paths: `frontend/src/hooks/useAppointments.js`.
- Denied paths: backend, `/api/v1/ui/*`, separate BFF service, command wrappers, migrations, QueueJoin, DisplayBoard, broad AdminPanel rewrite, generated output.
- Migration/docs/test impact: no migration; no docs; no tests added because the gate first-touch scope was one hook file.
- Rollback note: revert commit `825e983a` to restore previous forced `pending` payload behavior.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; GitHub Frontend build/unit/lint, PR Required Gate, CodeQL, Analyze checks.
- Result: local build passed; diff check passed; CI runtime checks passed. PR Review Quality Gate should pass on the fresh edited-event run.
- Not checked: backend pytest, browser role smoke, auth matrix; no backend/auth/browser runtime code changed.