### PR TITLE
fix(doctor): keep call-next selection backend-owned

### DIFF
--- a/frontend/src/services/queue.js
+++ b/frontend/src/services/queue.js
@@ -68,6 +68,28 @@ function notifyQueueUpdate(specialty, action = 'update') {
   window.dispatchEvent(event);
 }
 
+function hasBackendQueueAction(entry, action, flagName) {
+  if (!entry) return false;
+  if (Array.isArray(entry.available_actions)) {
+    return entry.available_actions.includes(action);
+  }
+  if (flagName && Object.prototype.hasOwnProperty.call(entry, flagName)) {
+    return Boolean(entry[flagName]);
+  }
+  return false;
+}
+
+function selectNextCallEntry(queue) {
+  const entries = Array.isArray(queue?.entries) ? queue.entries : [];
+  const backendEntryId = queue?.next_call_entry_id;
+
+  if (backendEntryId !== undefined && backendEntryId !== null) {
+    return entries.find((entry) => entry.id === backendEntryId) || { id: backendEntryId };
+  }
+
+  return entries.find((entry) => hasBackendQueueAction(entry, 'call', 'can_call')) || null;
+}
+
 export const queueService = {
   // Очередь врача на сегодня по специальности
   getTodayQueue: async (specialty) => {
@@ -106,11 +128,11 @@ export const queueService = {
   callNextWaiting: async (specialty) => {
     const queue = await apiRequest(`/doctor/${encodeURIComponent(specialty)}/queue/today`);
     if (!queue?.entries?.length) return { success: false, message: 'Очередь пуста' };
-    const waiting = queue.entries.find((e) => e.status === 'waiting');
-    if (!waiting) return { success: false, message: 'Нет ожидающих пациентов' };
-    await apiRequest(`/doctor/queue/${waiting.id}/call`, { method: 'POST' });
+    const nextEntry = selectNextCallEntry(queue);
+    if (!nextEntry?.id) return { success: false, message: 'Нет ожидающих пациентов' };
+    await apiRequest(`/doctor/queue/${nextEntry.id}/call`, { method: 'POST' });
     // Уведомляем об обновлении
     notifyQueueUpdate(specialty, 'nextPatientCalled');
-    return { success: true, entry: waiting };
+    return { success: true, entry: nextEntry };
   }
 };


### PR DESCRIPTION
## Summary

- Remove frontend queue-order selection from `queueService.callNextWaiting`.
- Use backend-provided `next_call_entry_id` first.
- Fall back only to backend-computed `available_actions` / `can_call`, not raw queue status.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/doctor-queue-call-next-ssot` was created from current `main` at `d65e2ecf`.
- Clean workspace: inspected before edits; only `frontend/src/services/queue.js` changed.
- Branch: `codex/doctor-queue-call-next-ssot`.
- Scope gate: agent gate allowed first-touch `frontend/src/services/queue.js`; denied backend changes, `/api/v1/ui/*`, BFF-lite, and doctor panel rewrites.
- Red-check handling: PR Review Quality Gate body failure is being fixed in this PR metadata before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/doctor/{specialty}/queue/today` and `POST /api/v1/doctor/queue/{entry_id}/call`.
- Request shape: unchanged authenticated frontend requests; no new request body.
- Response shape: existing `next_call_entry_id`, `available_actions`, and `can_call` are consumed as backend-owned facts.
- Status codes: unchanged.
- Frontend consumer: `queueService.callNextWaiting`.
- Compatibility path or alias: legacy fallback now uses backend action fields if `next_call_entry_id` is absent.
- Contract proof: targeted doctor panel contract test plus frontend build; no API shape change.

## RBAC / Permissions

- Roles allowed: unchanged; backend doctor queue endpoints still enforce existing role checks.
- Roles denied: unchanged by this frontend-only patch.
- Positive auth proof: unchanged; existing authenticated queue call path remains in use.
- Negative auth proof: not applicable - no backend auth or permission logic changed.

## Notification / Realtime

- Event type or websocket channel: unchanged browser `CustomEvent('queueUpdated')` with action `nextPatientCalled` after successful call.
- Payload version / ack behavior: unchanged unversioned local event payload `{ specialty, action, timestamp }`; no ack contract exists.
- Read/unread or delivery semantics: not applicable - this is local UI refresh signaling, not a durable notification/read-state feature.
- Reconnect/resync proof: unchanged; resync still comes from reloading `GET /api/v1/doctor/{specialty}/queue/today`, now using backend-owned next-call facts.

## Frontend Resilience

- Empty data proof: empty queue still returns the existing safe `{ success: false }` result.
- Partial data proof: if `next_call_entry_id` is absent, selection can still use backend-computed `available_actions` / `can_call`.
- Forbidden secondary path behavior: no new endpoint or secondary command path added.
- Missing draft/resource behavior: not applicable - this flow does not create drafts/resources.
- Stale route/deep-link behavior: not applicable - this service does not read route state.

## Scope Gate

- Allowed paths: `frontend/src/services/queue.js` only.
- Denied paths: backend endpoints/services, `/api/v1/ui/*`, separate BFF service, doctor panel rewrites, migrations, generated output.
- Migration/docs/test impact: no migration; no docs; no runtime API contract change.
- Rollback note: revert commit `3fdb518e` to restore the old local waiting-status scan.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- DoctorPanels.contract`; `npm.cmd --prefix frontend run build`; `git diff --check`.
- Result: all passed locally.
- Not checked: backend tests, because this is frontend-only and does not change API behavior.