### PR TITLE
fix(cardiology): keep start status backend-owned

### DIFF
--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -907,11 +907,6 @@ const MacOSCardiologistPanelUnified = () => {
           });
 
           if (response.ok) {
-            // Обновляем статус в локальном состоянии
-            setAppointments((prev) => prev.map((a) =>
-            a.id === row.id ? { ...a, status: 'called' } : a
-            ));
-            // Вызываем обновление списка
             await loadMacOSCardiologyAppointments();
             setMessage({ type: 'success', text: `Пациент ${row.patient_fio} вызван` });
           }


### PR DESCRIPTION
## Summary

- Remove the cardiology panel's optimistic local `status: 'called'` mutation after `POST /doctor/queue/{entry_id}/start-visit`.
- Keep the existing backend refresh through `loadMacOSCardiologyAppointments()` as the source of canonical row status.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/cardiology-start-visit-backend-status` was created from current `main` at `b7411b8f`.
- Clean workspace: inspected before edits; only `frontend/src/pages/CardiologistPanelUnified.jsx` changed.
- Branch: `codex/cardiology-start-visit-backend-status`.
- Scope gate: agent gate allowed first-touch `frontend/src/pages/CardiologistPanelUnified.jsx`; denied backend changes, `/api/v1/ui/*`, BFF-lite, and broader doctor panel rewrites.
- Red-check handling: any red CI/checks on this PR will be fixed before merge or reported if infra-only.

## Contract Impact

- Canonical surface: `POST /api/v1/doctor/queue/{entry_id}/start-visit` followed by `GET /api/v1/registrar/queues/today` through the existing cardiology refresh path.
- Request shape: unchanged authenticated start-visit POST; no new request body.
- Response shape: unchanged; frontend no longer fabricates the row status before refresh.
- Status codes: unchanged.
- Frontend consumer: cardiology appointment action handler.
- Compatibility path or alias: none added.
- Contract proof: production build and source diff confirm the local status mutation was removed.

## RBAC / Permissions

- Roles allowed: unchanged; backend start-visit endpoint still enforces existing role checks.
- Roles denied: unchanged by this frontend-only patch.
- Positive auth proof: unchanged authenticated start-visit path remains in use.
- Negative auth proof: not applicable - no backend auth or permission logic changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, or realtime event changed.
- Payload version / ack behavior: not applicable - no payload or ack contract changed.
- Read/unread or delivery semantics: not applicable - this flow is not a notification inbox feature.
- Reconnect/resync proof: unchanged; row state is reloaded through the existing backend refresh call.

## Frontend Resilience

- Empty data proof: unchanged; this patch only removes an optimistic update after a successful command.
- Partial data proof: if refresh returns partial data, the panel still uses the existing backend DTO mapping.
- Forbidden secondary path behavior: no new endpoint or secondary command path added.
- Missing draft/resource behavior: not applicable - this flow does not create drafts/resources.
- Stale route/deep-link behavior: not applicable - this handler does not read route state.

## Scope Gate

- Allowed paths: `frontend/src/pages/CardiologistPanelUnified.jsx` only.
- Denied paths: backend endpoints/services, `/api/v1/ui/*`, separate BFF service, other doctor panels, migrations, generated output.
- Migration/docs/test impact: no migration; no docs; no API contract change.
- Rollback note: revert commit `baf627e9` to restore the old optimistic local status mutation.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`.
- Result: all passed locally.
- Not checked: backend tests and browser smoke, because this is a single frontend status ownership cleanup with no API behavior change.