### PR TITLE
fix(registrar): stop queue mark-paid visit fallback

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -2871,22 +2871,6 @@ def mark_queue_entry_as_paid(
             visit = db.query(Visit).filter(Visit.id == entry.visit_id).first()
             logger.info(f"mark_queue_entry_as_paid: Найден Visit {entry.visit_id} через entry.visit_id")
         
-        # 2. Если visit_id нет, ищем по patient_id и дате
-        if not visit and entry.patient_id:
-            from datetime import date
-            today = date.today()
-            visit = (
-                db.query(Visit)
-                .filter(
-                    Visit.patient_id == entry.patient_id,
-                    Visit.visit_date == today,
-                )
-                .order_by(Visit.created_at.desc())
-                .first()
-            )
-            if visit:
-                logger.info(f"mark_queue_entry_as_paid: Найден Visit {visit.id} через patient_id и дату")
-
         requested_method = (
             str(payment_req.method).strip().lower()
             if payment_req and payment_req.method

--- a/backend/tests/integration/test_registrar_record_actions.py
+++ b/backend/tests/integration/test_registrar_record_actions.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 
 import pytest
 
 from app.models.appointment import Appointment
+from app.models.online_queue import OnlineQueueEntry
+from app.models.payment import Payment
+from app.models.visit import Visit
 
 
 @pytest.mark.integration
@@ -59,6 +62,68 @@ def test_registrar_record_action_rejects_doctor_mark_paid(
     )
 
     assert response.status_code == 403
+
+
+@pytest.mark.integration
+def test_queue_mark_paid_without_visit_id_does_not_pay_unrelated_patient_visit(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_daily_queue,
+    test_patient,
+    test_doctor,
+):
+    unrelated_visit = Visit(
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        visit_date=date.today(),
+        visit_time="12:00",
+        status="open",
+        discount_mode="none",
+        department="cardiology",
+        created_at=datetime.utcnow(),
+    )
+    entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=99,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        visit_id=None,
+        source="online",
+        status="waiting",
+    )
+    db_session.add_all([unrelated_visit, entry])
+    db_session.commit()
+    db_session.refresh(unrelated_visit)
+    db_session.refresh(entry)
+
+    response = client.post(
+        "/api/v1/registrar/records/actions",
+        headers=registrar_auth_headers,
+        json={
+            "action": "mark_paid",
+            "record_kind": "online_queue",
+            "record_id": entry.id,
+            "method": "cash",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["results"][0]["payment_status"] == "paid"
+
+    db_session.refresh(entry)
+    db_session.refresh(unrelated_visit)
+    assert entry.discount_mode == "paid"
+    assert unrelated_visit.status == "open"
+    assert (
+        db_session.query(Payment)
+        .filter(Payment.visit_id == unrelated_visit.id)
+        .count()
+        == 0
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- Stop legacy registrar queue mark-paid from inferring a Visit by `patient_id + today` when `OnlineQueueEntry.visit_id` is missing.
- Preserve the existing queue-only paid marker for entries without an explicit Visit link.
- Add a regression test proving an unrelated same-patient same-day Visit is not paid.

## Cyclic Execution Evidence

- Fresh main sync: isolated worktree `C:\tmp\final-next-audit`, branch based on current `origin/main`; merged latest `origin/main` before PR.
- Clean workspace: inspected before edits; only scoped registrar endpoint and targeted registrar action test changed.
- Branch: `codex/queue-mark-paid-visit-fallback`
- Scope gate: allowed `backend/app/api/v1/endpoints/registrar_wizard.py` and `backend/tests/integration/test_registrar_record_actions.py`; denied frontend, migrations, billing-service refactors, generated output, and unrelated queue behavior.
- Red-check handling: CI failures will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/registrar/records/actions` with `action=mark_paid` for `record_kind=online_queue`; legacy delegated endpoint `POST /api/v1/registrar/queue/entry/{entry_id}/mark-paid`.
- Request shape: authenticated registrar/cashier/admin command; no new request fields.
- Response shape: unchanged queue marker response with `payment_status=paid` when no explicit Visit is linked.
- Status codes: unchanged.
- Frontend consumer: unchanged; RegistrarPanel already uses backend registrar record actions.
- Compatibility path or alias: queue entries with explicit `visit_id` still create/check Visit payments; entries without `visit_id` keep queue marker behavior only.
- Contract proof: integration regression test covers same-patient same-day unrelated Visit and queue entry without `visit_id`.

## RBAC / Permissions

- Roles allowed: unchanged Admin, Registrar, Cashier for mark-paid.
- Roles denied: unchanged; existing doctor mark-paid rejection test remains.
- Positive auth proof: regression uses `registrar_auth_headers` and succeeds.
- Negative auth proof: existing `test_registrar_record_action_rejects_doctor_mark_paid` remains in the targeted file.

## Notification / Realtime

not applicable - no notification, websocket, Telegram, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend data rendering changed.
- Partial data proof: not applicable - no frontend adapter or component changed.
- Forbidden secondary path behavior: backend no longer uses an inferred secondary Visit path when `visit_id` is missing.
- Missing draft/resource behavior: queue entry without linked Visit remains supported through queue marker only.
- Stale route/deep-link behavior: not applicable - no route behavior changed.

## Scope Gate

- Allowed paths: registrar wizard endpoint and registrar record action integration test.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite, billing services, migrations, generated output, unrelated queue endpoints.
- Migration/docs/test impact: no migration; targeted integration test added.
- Rollback note: revert the endpoint fallback deletion and regression test.

## Validation

- Targeted tests or smoke run: `py_compile` for `backend/app/api/v1/endpoints/registrar_wizard.py` and `backend/tests/integration/test_registrar_record_actions.py`; `git diff --check`; targeted pytest attempted with `scripts/run_backend_pytest.ps1 backend/tests/integration/test_registrar_record_actions.py`.
- Result: `py_compile` passed; `git diff --check` passed; local targeted pytest could not run because no Python 3.11+ interpreter with `pytest` is available in this Windows checkout; GitHub backend tests passed on PR.
- Not checked: local full backend suite and frontend browser smoke.