### PR TITLE
fix(queue): keep action buttons backend-owned

### DIFF
--- a/frontend/src/components/queue/QueueManagementCard.jsx
+++ b/frontend/src/components/queue/QueueManagementCard.jsx
@@ -17,6 +17,35 @@ import {
 import api from '../../services/api';
 import logger from '../../utils/logger';
 
+const normalizeQueueAction = (action) => String(action || '').trim().toLowerCase().replace(/-/g, '_');
+
+const QUEUE_ACTION_ALIASES = {
+  no_show: ['no_show'],
+  restore_next: ['restore_next'],
+  send_to_diagnostics: ['send_to_diagnostics', 'diagnostics'],
+  notify_diagnostics_return: ['notify_diagnostics_return', 'call_from_diagnostics'],
+  incomplete: ['incomplete'],
+  complete: ['complete']
+};
+
+const QUEUE_COMPLETED_STATUSES = new Set(['served', 'completed', 'done']);
+const QUEUE_INCOMPLETE_STATUSES = new Set(['incomplete']);
+const QUEUE_CANCELLED_STATUSES = new Set(['cancelled']);
+
+const hasBackendQueueAction = (entry, action, flagName) => {
+  if (entry?.[flagName] === true) {
+    return true;
+  }
+
+  if (!Array.isArray(entry?.available_actions)) {
+    return false;
+  }
+
+  const availableActions = new Set(entry.available_actions.map(normalizeQueueAction));
+  const aliases = QUEUE_ACTION_ALIASES[action] || [action];
+  return aliases.some((alias) => availableActions.has(normalizeQueueAction(alias)));
+};
+
 /**
  * Кнопки действий для одной записи в очереди
  * @param {object} entry - Запись из очереди (appointment/queue entry)
@@ -69,14 +98,6 @@ export const QueueActionButtons = ({
     return null;
   }
 
-  if (!status) {
-    logger.warn('[QueueActionButtons] Missing queue status, skipping queue action controls', {
-      entry,
-      entryId
-    });
-    return null;
-  }
-
   const handleAction = async (action, payload = {}) => {
     if (loading) return;
     setLoading(true);
@@ -124,6 +145,104 @@ export const QueueActionButtons = ({
 
   // Кнопки в зависимости от статуса
   const renderButtons = () => {
+    const buttons = [];
+
+    if (hasBackendQueueAction(entry, 'no_show', 'can_no_show')) {
+      buttons.push(
+        <button
+          key="no-show"
+          style={{ ...actionButtonStyle, background: getColor('danger', 100), color: dangerColor }}
+          onClick={() => handleAction('no-show')}
+          disabled={loading}
+          aria-label="Отметить неявку"
+          title="Отметить неявку">
+
+                    <XCircle size={iconSize} />
+                </button>);
+    }
+
+    if (hasBackendQueueAction(entry, 'send_to_diagnostics', 'can_send_to_diagnostics')) {
+      buttons.push(
+        <button
+          key="diagnostics"
+          style={{ ...actionButtonStyle, background: getColor('info', 100), color: infoColor }}
+          onClick={() => handleAction('diagnostics')}
+          disabled={loading}
+          aria-label="Направить на обследование"
+          title="На обследование">
+
+                    <Stethoscope size={iconSize} />
+                </button>);
+    }
+
+    if (hasBackendQueueAction(entry, 'notify_diagnostics_return', 'can_notify_diagnostics_return')) {
+      buttons.push(
+        <button
+          key="call-from-diagnostics"
+          style={{ ...actionButtonStyle, background: getColor('info', 100), color: infoColor }}
+          onClick={() => handleAction('call-from-diagnostics')}
+          disabled={loading}
+          aria-label="Вернуть с диагностики и вызвать повторно"
+          title="Вернуть с диагностики (Вызвать повторно)">
+
+                    <Bell size={iconSize} />
+                </button>);
+    }
+
+    if (hasBackendQueueAction(entry, 'complete', 'can_complete')) {
+      buttons.push(
+        <button
+          key="complete"
+          style={{ ...actionButtonStyle, background: getColor('success', 100), color: successColor }}
+          onClick={() => handleAction('complete')}
+          disabled={loading}
+          aria-label="Завершить приём"
+          title="Завершить приём">
+
+                    <CheckCircle size={iconSize} />
+                </button>);
+    }
+
+    if (hasBackendQueueAction(entry, 'incomplete', 'can_incomplete')) {
+      buttons.push(
+        <button
+          key="incomplete"
+          style={{ ...actionButtonStyle, background: getColor('warning', 100), color: warningColor }}
+          onClick={() => handleAction('incomplete', { reason: 'Не вернулся с обследования' })}
+          disabled={loading}
+          aria-label="Отметить, что пациент не вернулся"
+          title="Не вернулся">
+
+                    <AlertCircle size={iconSize} />
+                </button>);
+    }
+
+    if (hasBackendQueueAction(entry, 'restore_next', 'can_restore_next')) {
+      buttons.push(
+        <button
+          key="restore-next"
+          style={{ ...actionButtonStyle, background: getColor('warning', 100), color: warningColor }}
+          onClick={() => handleAction('restore-next')}
+          disabled={loading}
+          aria-label="Восстановить пациента следующим в очереди"
+          title="Восстановить следующим">
+
+                    <RotateCcw size={iconSize} />
+                </button>);
+    }
+
+    if (buttons.length > 0) {
+      return <>{buttons}</>;
+    }
+
+    if (
+      !QUEUE_COMPLETED_STATUSES.has(status) &&
+      !QUEUE_INCOMPLETE_STATUSES.has(status) &&
+      !QUEUE_CANCELLED_STATUSES.has(status)
+    ) {
+      return null;
+    }
+
     switch (status) {
       case 'waiting':
         return (

--- a/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
+++ b/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
@@ -2176,7 +2176,15 @@ const EnhancedAppointmentsTable = ({
                         <QueueActionButtons
                           entry={{
                             queue_entry_id: row.queue_entry_id,
-                            status: row.status
+                            status: row.status,
+                            queue_status: row.queue_status,
+                            available_actions: row.available_actions,
+                            can_no_show: row.can_no_show,
+                            can_send_to_diagnostics: row.can_send_to_diagnostics,
+                            can_notify_diagnostics_return: row.can_notify_diagnostics_return,
+                            can_restore_next: row.can_restore_next,
+                            can_incomplete: row.can_incomplete,
+                            can_complete: getBackendActionAvailability(row, 'complete', 'can_complete')
                           }}
                           onStatusChange={(action, entry, result) => {
                             logger.log(`[EnhancedAppointmentsTable] Queue action: ${action}`, entry, result);


### PR DESCRIPTION
## Summary

- Make `QueueActionButtons` render queue command buttons only from backend-provided `available_actions` / `can_*` flags.
- Pass queue action facts from `EnhancedAppointmentsTable` into `QueueActionButtons` instead of passing only `status`.
- Keep `status` usage limited to passive terminal labels when no backend command is available.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/queue-action-buttons-ssot` was created from current `main` after PR #1320 was merged.
- Clean workspace: inspected before edits; only scoped queue button/table frontend files changed.
- Branch: `codex/queue-action-buttons-ssot`.
- Scope gate: allowed frontend queue action button contract repair; denied backend changes, `/api/v1/ui/*`, separate BFF service, command wrappers, and unrelated cleanup.
- Red-check handling: failed PR Review Quality Gate is being fixed in this same PR by completing the required PR body sections.

## Contract Impact

- Canonical surface: existing backend queue action contract carried by row `available_actions` and `can_*` flags.
- Request shape: unchanged; no API request shape changed.
- Response shape: unchanged; no backend response fields added.
- Status codes: unchanged.
- Frontend consumer: `EnhancedAppointmentsTable` / `QueueActionButtons`.
- Compatibility path or alias: action aliases normalize hyphen/underscore names for existing frontend action strings only.
- Contract proof: queue command buttons deny by default when backend action facts are absent; status no longer enables queue commands by itself.

## RBAC / Permissions

- Roles allowed: unchanged; this PR does not change backend authorization.
- Roles denied: unchanged; denied users still depend on backend authorization.
- Positive auth proof: not applicable - no backend auth route changed.
- Negative auth proof: not applicable - no backend auth route changed.

## Notification / Realtime

not applicable - no notification, websocket, queue broadcast, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: if `available_actions` / `can_*` are missing, queue command buttons are not rendered.
- Partial data proof: individual `can_*` flags or action names enable only the matching button.
- Forbidden secondary path behavior: not applicable - no fallback endpoint is introduced.
- Missing draft/resource behavior: not applicable - queue buttons do not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no routing/deep-link state changed.

## Scope Gate

- Allowed paths: `frontend/src/components/queue/QueueManagementCard.jsx`, `frontend/src/components/tables/EnhancedAppointmentsTable.jsx`.
- Denied paths: backend code, `/api/v1/ui/*`, separate BFF service, QueueJoin, DisplayBoard, migrations, generated output.
- Migration/docs/test impact: no migration; no docs change; existing focused frontend contract tests and build run locally.
- Rollback note: revert this PR to restore previous status-based queue action button rendering.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- DoctorPanels.contract QueueManager.contract`; `npm.cmd --prefix frontend run build`; `git diff --check`.
- Result: all passed locally.
- Not checked: backend pytest, because this PR does not change backend code or API schemas.