### PR TITLE
fix(queue): show unknown missing queue status

### DIFF
--- a/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
+++ b/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
@@ -1067,7 +1067,7 @@ const EnhancedAppointmentsTable = ({
           }
         }
         // Fallback: используем общий статус записи только если queue_numbers отсутствует
-        queueStatus = queueStatus || row.status || 'waiting';
+        queueStatus = queueStatus || row.status || null;
         const statusConfig = {
           waiting: {
             bg: 'var(--mac-warning, #ff9500)',
@@ -1092,10 +1092,16 @@ const EnhancedAppointmentsTable = ({
             icon: '❌',
             text: 'Не явился',
             pulse: false
+          },
+          unknown: {
+            bg: 'var(--mac-text-secondary, #8e8e93)',
+            icon: '?',
+            text: 'Неизвестно',
+            pulse: false
           }
         };
 
-        const config = statusConfig[queueStatus] || statusConfig.waiting;
+        const config = statusConfig[queueStatus] || statusConfig.unknown;
 
         return (
           <span
@@ -1121,7 +1127,7 @@ const EnhancedAppointmentsTable = ({
       // Fallback: Если есть номера очередей, но нет queue_number - показываем первый
       if (row.queue_numbers && Array.isArray(row.queue_numbers) && row.queue_numbers.length > 0) {
         const firstQueue = row.queue_numbers[0];
-        const queueStatus = firstQueue.status || row.status || 'waiting';
+        const queueStatus = firstQueue.status || row.status || null;
         const statusConfig = {
           waiting: {
             bg: 'var(--mac-warning, #ff9500)',
@@ -1146,10 +1152,16 @@ const EnhancedAppointmentsTable = ({
             icon: '❌',
             text: 'Не явился',
             pulse: false
+          },
+          unknown: {
+            bg: 'var(--mac-text-secondary, #8e8e93)',
+            icon: '?',
+            text: 'Неизвестно',
+            pulse: false
           }
         };
 
-        const config = statusConfig[queueStatus] || statusConfig.waiting;
+        const config = statusConfig[queueStatus] || statusConfig.unknown;
 
         return (
           <span


### PR DESCRIPTION
## Summary

- Stop `EnhancedAppointmentsTable` from displaying missing queue status as `waiting`.
- Show a neutral `unknown` queue-status display when backend queue status is absent.
- Keep this frontend-only and display-only; no queue commands, backend endpoints, or DTOs changed.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/table-queue-status-unknown` was created from current `main` after PR #1322 merged.
- Clean workspace: inspected before edits; only `EnhancedAppointmentsTable.jsx` changed.
- Branch: `codex/table-queue-status-unknown`.
- Scope gate: agent gate limited first-touch to `frontend/src/components/tables/EnhancedAppointmentsTable.jsx`; denied backend changes, `/api/v1/ui/*`, separate BFF service, command wrappers, and unrelated cleanup.
- Red-check handling: fix failed targeted/local/CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: backend-provided row queue status facts consumed by `EnhancedAppointmentsTable`.
- Request shape: unchanged; no request changed.
- Response shape: unchanged; no backend response fields added.
- Status codes: unchanged.
- Frontend consumer: queue-number status badge in `EnhancedAppointmentsTable`.
- Compatibility path or alias: existing known status labels remain; missing/unknown status now maps to neutral display instead of `waiting`.
- Contract proof: missing backend queue status no longer creates a frontend-owned `waiting` state.

## RBAC / Permissions

- Roles allowed: unchanged; this PR does not change backend authorization.
- Roles denied: unchanged; denied users still depend on backend authorization.
- Positive auth proof: not applicable - no backend auth route changed.
- Negative auth proof: not applicable - no backend auth route changed.

## Notification / Realtime

not applicable - no notification, websocket, queue broadcast, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: missing queue status renders neutral unknown styling rather than pretending the queue entry is waiting.
- Partial data proof: backend status from `queue_number_status`, matching `queue_numbers`, first queue entry, or row status is still used when present.
- Forbidden secondary path behavior: not applicable - no fallback endpoint is introduced.
- Missing draft/resource behavior: not applicable - no draft/resource behavior changed.
- Stale route/deep-link behavior: not applicable - no routing/deep-link state changed.

## Scope Gate

- Allowed paths: `frontend/src/components/tables/EnhancedAppointmentsTable.jsx`.
- Denied paths: backend code, `/api/v1/ui/*`, separate BFF service, QueueJoin, DisplayBoard, migrations, generated output.
- Migration/docs/test impact: no migration; no docs change; build and diff hygiene run locally.
- Rollback note: revert this PR to restore the previous missing-status-as-waiting display fallback.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`.
- Result: all passed locally.
- Not checked: backend pytest and frontend unit tests, because the agent gate limited this first patch slice to one frontend display file and no backend/API/test files changed.