### PR TITLE
fix(cashier): show unknown missing payment status

### DIFF
--- a/frontend/src/pages/CashierPanel.jsx
+++ b/frontend/src/pages/CashierPanel.jsx
@@ -200,16 +200,31 @@ const buildReceiptPrintPayload = (paymentRow) => {
 };
 
 const getPaymentStatusMeta = (status) => {
-  const normalizedStatus = String(status || 'pending').trim().toLowerCase();
+  const normalizedStatus = String(status || '').trim().toLowerCase();
   const statusMap = {
     paid: { variant: 'success', ariaLabel: 'Payment status: paid' },
     partial: { variant: 'info', ariaLabel: 'Payment status: partially paid' },
     cancelled: { variant: 'danger', ariaLabel: 'Payment status: cancelled' },
     refunded: { variant: 'danger', ariaLabel: 'Payment status: refunded' },
     pending: { variant: 'warning', ariaLabel: 'Payment status: pending' },
+    unknown: { variant: 'secondary', ariaLabel: 'Payment status: unknown' },
   };
 
-  return statusMap[normalizedStatus] || statusMap.pending;
+  return statusMap[normalizedStatus] || statusMap.unknown;
+};
+
+const getPaymentStatusLabel = (status) => {
+  const normalizedStatus = String(status || '').trim().toLowerCase();
+  const statusMap = {
+    paid: 'Оплачено',
+    partial: 'Частично',
+    cancelled: 'Отменён',
+    refunded: 'Возвращено',
+    pending: 'Ожидает',
+    unknown: 'Неизвестно',
+  };
+
+  return statusMap[normalizedStatus] || statusMap.unknown;
 };
 
 const getPaymentActionContext = (paymentRow) => {
@@ -1407,11 +1422,7 @@ const CashierPanel = () => {void
                                   variant={getPaymentStatusMeta(row.status).variant}
                                   role="status"
                                   aria-label={getPaymentStatusMeta(row.status).ariaLabel}>
-                                  {row.status === 'paid' ? 'Оплачено' :
-                          row.status === 'partial' ? 'Частично' :
-                          row.status === 'cancelled' ? 'Отменён' :
-                          row.status === 'refunded' ? 'Возвращено' :
-                          'Ожидает'}
+                                  {getPaymentStatusLabel(row.status)}
                                 </Badge>
                               </td>
                               <td style={{ padding: '12px 16px', display: 'flex', gap: '8px', flexWrap: 'wrap' }}>


### PR DESCRIPTION
## Summary

- Stop cashier payment history from displaying missing/unknown payment status as `pending`.
- Add neutral unknown status metadata and label for history rows where backend status is absent or unrecognized.
- Keep payment commands backend-owned through existing `available_actions` / `can_*` checks.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/cashier-payment-status-unknown` was created from current `main` after PR #1323 merged.
- Clean workspace: inspected before edits; only `CashierPanel.jsx` changed.
- Branch: `codex/cashier-payment-status-unknown`.
- Scope gate: agent gate limited first-touch to `frontend/src/pages/CashierPanel.jsx`; denied backend changes, `/api/v1/ui/*`, separate BFF service, command wrappers, and unrelated cleanup.
- Red-check handling: fix failed targeted/local/CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: backend-provided payment history row `status` consumed by `CashierPanel`.
- Request shape: unchanged; no request changed.
- Response shape: unchanged; no backend response fields added.
- Status codes: unchanged.
- Frontend consumer: payment history status badge in `CashierPanel`.
- Compatibility path or alias: known status labels remain; missing/unknown status now maps to neutral display instead of `pending`.
- Contract proof: missing backend payment status no longer creates a frontend-owned pending state.

## RBAC / Permissions

- Roles allowed: unchanged; this PR does not change backend authorization.
- Roles denied: unchanged; denied users still depend on backend authorization.
- Positive auth proof: not applicable - no backend auth route changed.
- Negative auth proof: not applicable - no backend auth route changed.

## Notification / Realtime

not applicable - no notification, websocket, payment broadcast, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: missing payment status renders neutral unknown styling rather than pretending the payment is pending.
- Partial data proof: known backend statuses still render their existing labels and badge variants.
- Forbidden secondary path behavior: not applicable - no fallback endpoint is introduced.
- Missing draft/resource behavior: not applicable - no draft/resource behavior changed.
- Stale route/deep-link behavior: not applicable - no routing/deep-link state changed.

## Scope Gate

- Allowed paths: `frontend/src/pages/CashierPanel.jsx`.
- Denied paths: backend code, `/api/v1/ui/*`, separate BFF service, migrations, generated output, unrelated payment modules.
- Migration/docs/test impact: no migration; no docs change; focused existing cashier contract test and build run locally.
- Rollback note: revert this PR to restore the previous missing-status-as-pending display fallback.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- CashierPanel.contract`; `npm.cmd --prefix frontend run build`; `git diff --check`.
- Result: all passed locally.
- Not checked: backend pytest, because this PR does not change backend code or API schemas.