### PR TITLE
fix(appointments): keep appointment flow display-only

### DIFF
--- a/frontend/src/components/AppointmentFlow.jsx
+++ b/frontend/src/components/AppointmentFlow.jsx
@@ -1,43 +1,14 @@
-import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { CreditCard, User, FileText, Pill, CheckCircle, AlertCircle } from 'lucide-react';
-import { Card, Button, Badge } from './ui/native';
-import logger from '../utils/logger';
+import { Card, Badge } from './ui/native';
 import {
   APPOINTMENT_STATUS,
   STATUS_LABELS,
-  STATUS_COLORS,
-  canStartVisit } from
+  STATUS_COLORS } from
 
 '../constants/appointmentStatus';
 
-const AppointmentFlow = ({ appointment, onStartVisit, onPayment }) => {
-  const [isProcessing, setIsProcessing] = useState(false);
-
-  const handleStartVisit = async () => {
-    if (!canStartVisit(appointment?.status)) return;
-
-    setIsProcessing(true);
-    try {
-      await onStartVisit(appointment);
-    } catch (error) {
-      logger.error('AppointmentFlow: Start visit error:', error);
-    } finally {
-      setIsProcessing(false);
-    }
-  };
-
-  const handlePayment = async () => {
-    setIsProcessing(true);
-    try {
-      await onPayment(appointment);
-    } catch (error) {
-      logger.error('AppointmentFlow: Payment error:', error);
-    } finally {
-      setIsProcessing(false);
-    }
-  };
-
+const AppointmentFlow = ({ appointment }) => {
   const getStepIcon = (step) => {
     switch (step) {
       case 'payment':
@@ -92,25 +63,21 @@ const AppointmentFlow = ({ appointment, onStartVisit, onPayment }) => {
     id: 'payment',
     title: 'Оплата',
     description: 'Ожидание оплаты записи',
-    action: appointment?.status === APPOINTMENT_STATUS.PENDING ? 'Оплатить' : null
   },
   {
     id: 'visit',
     title: 'Начать прием',
     description: 'Отправить пациента к врачу',
-    action: canStartVisit(appointment?.status) ? 'Начать прием' : null
   },
   {
     id: 'emr',
     title: 'ЭМК',
     description: 'Электронная медицинская карта',
-    action: null
   },
   {
     id: 'prescription',
     title: 'Рецепт',
     description: 'Назначение препаратов',
-    action: null
   }];
 
 
@@ -163,17 +130,6 @@ const AppointmentFlow = ({ appointment, onStartVisit, onPayment }) => {
                   <p className="text-sm opacity-75">{step.description}</p>
                 </div>
                 
-                {step.action &&
-                <div className="flex-shrink-0">
-                    <Button
-                    size="sm"
-                    onClick={step.id === 'payment' ? handlePayment : handleStartVisit}
-                    disabled={isProcessing}>
-
-                      {isProcessing ? 'Обработка...' : step.action}
-                    </Button>
-                  </div>
-                }
               </div>
             </div>);
 
@@ -224,9 +180,7 @@ const AppointmentFlow = ({ appointment, onStartVisit, onPayment }) => {
 };
 
 AppointmentFlow.propTypes = {
-  appointment: PropTypes.object,
-  onStartVisit: PropTypes.func,
-  onPayment: PropTypes.func
+  appointment: PropTypes.object
 };
 
 export default AppointmentFlow;


### PR DESCRIPTION
## Summary

- Make AppointmentFlow presentation-only in the read-only Appointments page.
- Remove local status-derived Pay/Start Visit action buttons and no-op command handlers.
- Keep visual appointment progress/status labels only; no backend/API changes.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current origin/main at 0989fddf after PR #1326 was merged.
- Clean workspace: inspected before edits; only frontend/src/components/AppointmentFlow.jsx changed.
- Branch: codex/appointment-flow-display-only.
- Scope gate: agent gate allowed only AppointmentFlow.jsx; denied backend changes, /api/v1/ui/*, separate BFF service, command wrappers, and unrelated callers/tests.
- Red-check handling: fix any failed code or PR gate check in this same PR before merge.

## Contract Impact

- Canonical surface: no API contract changed.
- Request shape: not applicable - no request changed.
- Response shape: not applicable - no response changed.
- Status codes: unchanged.
- Frontend consumer: AppointmentFlow no longer presents command availability from appointment.status.
- Compatibility path or alias: not applicable - no route or endpoint alias changed.
- Contract proof: source inspection and build confirm no action buttons, handlers, canStartVisit import, or frontend command gating remain in AppointmentFlow.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: existing safe status/label fallbacks remain unchanged.
- Partial data proof: appointment without status still renders unknown/passive labels, not command buttons.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: not applicable, component no longer starts payment/visit flows.
- Stale route/deep-link behavior: not applicable, no route/deep-link behavior changed.

## Scope Gate

- Allowed paths: frontend/src/components/AppointmentFlow.jsx.
- Denied paths: backend runtime, frontend callers/tests outside the gate, /api/v1/ui/*, separate BFF service, command wrappers, migrations, generated output.
- Migration/docs/test impact: no migration; no test file changed because gate first-touch allowed only the component.
- Rollback note: revert this one-file commit to restore previous local action buttons.

## Validation

- Targeted tests or smoke run: npm.cmd --prefix frontend run build; git diff --check; rg source proof for removed action/handler markers.
- Result: passed locally.
- Not checked: backend pytest and frontend unit tests, because this is a one-file passive display component change with no API/backend surface.