### PR TITLE
fix(appointments): remove frontend appointment business helpers

### DIFF
--- a/frontend/src/constants/appointmentStatus.js
+++ b/frontend/src/constants/appointmentStatus.js
@@ -45,52 +45,6 @@ export const STATUS_ICONS = {
   [APPOINTMENT_STATUS.CANCELLED]: '❌',
   [APPOINTMENT_STATUS.NO_SHOW]: '🚫'
 };
-
-// Проверка возможности перехода между статусами
-export const canTransitionTo = (fromStatus, toStatus) => {
-  const fromIndex = STATUS_FLOW.indexOf(fromStatus);
-  const toIndex = STATUS_FLOW.indexOf(toStatus);
-  
-  // Можно переходить только вперед по потоку или к отмене/неявке
-  if (toStatus === APPOINTMENT_STATUS.CANCELLED || toStatus === APPOINTMENT_STATUS.NO_SHOW) {
-    return fromStatus !== APPOINTMENT_STATUS.COMPLETED;
-  }
-  
-  return toIndex === fromIndex + 1;
-};
-
-// Получение следующего статуса в потоке
-export const getNextStatus = (currentStatus) => {
-  const currentIndex = STATUS_FLOW.indexOf(currentStatus);
-  return currentIndex < STATUS_FLOW.length - 1 ? STATUS_FLOW[currentIndex + 1] : null;
-};
-
-// Получение предыдущего статуса в потоке
-export const getPreviousStatus = (currentStatus) => {
-  const currentIndex = STATUS_FLOW.indexOf(currentStatus);
-  return currentIndex > 0 ? STATUS_FLOW[currentIndex - 1] : null;
-};
-
-// Проверка, можно ли начать прием (статус PAID)
-export const canStartVisit = (status) => {
-  return status === APPOINTMENT_STATUS.PAID;
-};
-
-// Проверка, можно ли завершить прием (есть EMR)
-export const canCompleteVisit = (status, hasEMR) => {
-  return status === APPOINTMENT_STATUS.IN_VISIT && hasEMR;
-};
-
-// Проверка, можно ли создать рецепт (есть EMR)
-export const canCreatePrescription = (status, hasEMR) => {
-  return (status === APPOINTMENT_STATUS.IN_VISIT || status === APPOINTMENT_STATUS.COMPLETED) && hasEMR;
-};
-
-// Проверка, можно ли отменить запись
-export const canCancel = (status) => {
-  return status !== APPOINTMENT_STATUS.COMPLETED;
-};
-
 // Получение прогресса в потоке (0-100%)
 export const getProgress = (status) => {
   const index = STATUS_FLOW.indexOf(status);


### PR DESCRIPTION
## Summary
- Remove unused frontend appointment business helper exports from `frontend/src/constants/appointmentStatus.js`.
- Keep appointment status constants, display labels/colors/icons, and `getProgress` as presentation-only helpers.
- No backend changes, no `/api/v1/ui/*`, no command wrappers, and no runtime command behavior changes.

## Cyclic Execution Evidence
- Started from current `origin/main` at `5ec8ffcd` after the previous SSOT cleanup PRs merged.
- Gate mode: `gate_known_root_cause` for `frontend/src/constants/appointmentStatus.js`; gate returned narrow override with this one first-touch file.
- Fixed local branch hygiene after the initial commit landed on local `main`: saved the commit to this feature branch and reset the local `main` pointer to `origin/main` without discarding the feature commit.
- Refreshed PR metadata after GitHub initially reported only the external GitGuardian check.

## Contract Impact
- Removes frontend-exported appointment transition/action predicates: `canTransitionTo`, `getNextStatus`, `getPreviousStatus`, `canStartVisit`, `canCompleteVisit`, `canCreatePrescription`, and `canCancel`.
- Prevents future imports from reintroducing frontend-owned appointment command availability.
- Appointment command availability remains backend-owned through existing status/action contracts in the active screens.

## RBAC / Permissions
- No RBAC or permission behavior changed.
- No role gates, auth checks, or backend permission policies touched.

## Notification / Realtime
- No notification, websocket, polling, or realtime behavior changed.

## Frontend Resilience
- Build still succeeds after removing the unused helper exports.
- Existing display-only status constants and progress helper remain available for UI rendering.

## Scope Gate
- Touched only `frontend/src/constants/appointmentStatus.js`.
- No backend changes.
- No `/api/v1/ui/*` endpoints.
- No separate BFF service.
- No command wrappers.
- No QueueJoin, DisplayBoard, Registrar, Lab, or unrelated cleanup.

## Validation
Targeted tests or smoke run:
- `npm.cmd --prefix frontend run build`
- `git diff --check`
- Source proof: `rg` import search found no remaining imports of the removed helper exports.

Result:
- Build passed.
- Diff check passed.
- Removed helpers are no longer exported from `appointmentStatus.js`.

Not checked:
- Backend tests were not run because this is a frontend-only dead export cleanup with no backend contract changes.