### PR TITLE
ci: optimize PR lifecycle recommendation workflow

### DIFF
--- a/.github/workflows/pr-lifecycle-recommendation.yml
+++ b/.github/workflows/pr-lifecycle-recommendation.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
   issues: write
 
 concurrency:
@@ -54,24 +54,7 @@ jobs:
             --output-labels pr-lifecycle-labels.txt \
             --output-known-labels pr-lifecycle-known-labels.txt
 
-      - name: Refresh lifecycle labels
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          while IFS= read -r label; do
-            [ -z "$label" ] && continue
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" || true
-          done < pr-lifecycle-known-labels.txt
-
-          while IFS= read -r label; do
-            [ -z "$label" ] && continue
-            gh label create "$label" --repo "$REPO" --color "6f42c1" --description "Automated PR lifecycle recommendation" || true
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$label"
-          done < pr-lifecycle-labels.txt
-
-      - name: Upsert lifecycle recommendation comment
+      - name: Apply lifecycle labels and recommendation comment
         uses: actions/github-script@v9
         with:
           script: |
@@ -80,27 +63,69 @@ jobs:
             const body = fs.readFileSync("pr-lifecycle-comment.md", "utf8");
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-            const previous = comments.find((comment) =>
-              comment.user.type === "Bot" && comment.body && comment.body.includes(marker)
-            );
-            if (previous) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: previous.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+
+            const readLines = (path) =>
+              fs.readFileSync(path, "utf8")
+                .split(/\r?\n/)
+                .map((line) => line.trim())
+                .filter(Boolean);
+
+            const desiredLifecycleLabels = new Set(readLines("pr-lifecycle-labels.txt"));
+            const knownLifecycleLabels = new Set(readLines("pr-lifecycle-known-labels.txt"));
+            const issue = await github.rest.issues.get({ owner, repo, issue_number });
+            const currentLabels = issue.data.labels
+              .map((label) => typeof label === "string" ? label : label.name)
+              .filter(Boolean);
+            const nextLabels = [
+              ...currentLabels.filter((label) => !knownLifecycleLabels.has(label)),
+              ...desiredLifecycleLabels,
+            ];
+            const nextLabelSet = new Set(nextLabels);
+            const currentLabelSet = new Set(currentLabels);
+            const labelsChanged =
+              nextLabelSet.size !== currentLabelSet.size ||
+              [...nextLabelSet].some((label) => !currentLabelSet.has(label));
+
+            if (labelsChanged) {
+              await github.rest.issues.setLabels({
                 owner,
                 repo,
                 issue_number,
-                body,
+                labels: [...nextLabelSet],
               });
+            } else {
+              core.info("Lifecycle labels are already up to date.");
+            }
+
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              });
+              const previous = comments.find((comment) =>
+                comment.user.type === "Bot" && comment.body && comment.body.includes(marker)
+              );
+              if (previous) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: previous.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body,
+                });
+              }
+            } catch (error) {
+              if (error.status === 403) {
+                core.warning(`Skipping lifecycle recommendation comment: ${error.message}`);
+                return;
+              }
+              throw error;
             }

--- a/.github/workflows/pr-lifecycle-recommendation.yml
+++ b/.github/workflows/pr-lifecycle-recommendation.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 concurrency:


### PR DESCRIPTION
## Summary

- Replace shell lifecycle label refresh loops with one GitHub API label update.
- Stop creating lifecycle labels on every PR run.
- Keep lifecycle recommendation comments advisory when GitHub comment APIs return 403.
- Restore PR write permission required by GitHub for setting labels on pull requests.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/optimize-pr-lifecycle-workflow` was created from `origin/main`.
- Clean workspace: inspected before edits; only `.github/workflows/pr-lifecycle-recommendation.yml` changed.
- Branch: `codex/optimize-pr-lifecycle-workflow`.
- Scope gate: allowed PR lifecycle workflow only; denied application runtime, scripts, tests, docs, migrations, and generated output.
- Red-check handling: the first PR run exposed missing `pull_requests: write` for `issues.setLabels`; fixed in this same PR.

## Contract Impact

not applicable - CI-only workflow implementation change; no backend, frontend, API, payload, schema, route, or generated OpenAPI contract changed.

## RBAC / Permissions

- Roles allowed: not applicable - no application roles changed.
- Roles denied: not applicable - no application roles changed.
- Positive auth proof: GitHub Actions log showed `issues.setLabels` requires `issues=write; pull_requests=write` for PR labels.
- Negative auth proof: not applicable - no application authorization path changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime, or Telegram behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend UI changed.
- Partial data proof: not applicable - no frontend UI changed.
- Forbidden secondary path behavior: not applicable - no frontend route or fallback path changed.
- Missing draft/resource behavior: not applicable - no draft/resource UI changed.
- Stale route/deep-link behavior: not applicable - no route state changed.

## Scope Gate

- Allowed paths: `.github/workflows/pr-lifecycle-recommendation.yml`.
- Denied paths: application runtime, Python recommendation script, tests, docs, migrations, generated output, secrets, and production deploy settings.
- Migration/docs/test impact: no migration; no docs or test files changed; validation is workflow syntax/static checks plus live PR workflow run.
- Rollback note: revert this workflow commit to restore previous shell label refresh/comment behavior.

## Validation

- Targeted tests or smoke run: `git diff --check`; PyYAML parsed `.github/workflows/pr-lifecycle-recommendation.yml`; Node parsed the embedded `github-script` block; verified all lifecycle labels already exist in `drsapaev/final`; opened PR #1332 to smoke the workflow.
- Result: local validation passed; first PR run confirmed the label update needs `pull_requests: write`, now restored in this PR.
- Not checked: full application test suites, because this is a workflow-only change.