### PR TITLE
fix(table): remove dead frontend payment grouping

### DIFF
--- a/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
+++ b/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
@@ -175,52 +175,6 @@ const EnhancedAppointmentsTable = ({
     return SESSION_COLORS[Math.abs(hash) % SESSION_COLORS.length];
   }, []);
 
-  // ⭐ SSOT: Presentation-Only Grouping (1 patient = 1 visual row)
-  // This does NOT modify data - only groups for rendering
-  // All original entries are preserved in group.rows[]
-  void useMemo(() => {
-    if (!Array.isArray(data) || data.length === 0) return [];
-
-    const map = new Map();
-
-    data.forEach((entry) => {
-      const patientId = entry.patient_id || entry.id;
-
-      if (!map.has(patientId)) {
-        map.set(patientId, {
-          patient_id: patientId,
-          patient_fio: entry.patient_fio || entry.patient_name || 'Неизвестный пациент',
-          patient_phone: entry.patient_phone || entry.phone || '',
-          patient_birth_year: entry.patient_birth_year,
-          address: entry.address || '',
-          rows: [] // Original SSOT entries
-        });
-      }
-
-      // Push ORIGINAL entry (no modification)
-      map.get(patientId).rows.push(entry);
-    });
-
-    // Sort rows within each group by queue_time
-    const grouped = Array.from(map.values());
-    grouped.forEach((group) => {
-      group.rows.sort((a, b) => {
-        const timeA = a.queue_time ? new Date(a.queue_time).getTime() : 0;
-        const timeB = b.queue_time ? new Date(b.queue_time).getTime() : 0;
-        return timeA - timeB;
-      });
-
-      // Compute display values (presentation only)
-      group.status = group.rows[0]?.status || 'waiting';
-      group.cost = group.rows.reduce((sum, r) => sum + (r.cost || 0), 0);
-      group.payment_status = group.rows.every((r) => r.payment_status === 'paid') ? 'paid' : 'pending';
-      group.visit_type = group.rows[0]?.visit_type || 'paid';
-      group.entry_ids = group.rows.map((r) => r.id);
-    });
-
-    return grouped;
-  }, [data]);
-
   // ⭐ SSOT: Display helper for services with queue numbers
   // Format: "K01 (1), D01 (2), L10 (3)"
   void useCallback((rows) => {


### PR DESCRIPTION
## Summary

- Remove a dead `void useMemo` block in `EnhancedAppointmentsTable` that returned unused grouped rows.
- The removed dead block locally synthesized `group.status`, `group.payment_status`, and `group.visit_type` from frontend rows.
- No backend changes, no `/api/v1/ui/*`, no command wrappers, and no visible table behavior change.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `main == origin/main` at `bf4cf124` after PR #1331 merged.
- Clean workspace: inspected before edits; only `frontend/src/components/tables/EnhancedAppointmentsTable.jsx` changed.
- Branch: `codex/remove-dead-table-payment-grouping`.
- Scope gate: agent gate known-root-cause narrow override allowed only `frontend/src/components/tables/EnhancedAppointmentsTable.jsx`; denied backend, `/api/v1/ui/*`, command wrappers, and unrelated cleanup.
- Red-check handling: fix failed local/frontend or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: table rows should consume backend-provided payment/queue/status fields; this PR removes dead frontend-synthesized grouping fields only.
- Request shape: not applicable - no API request shape changed.
- Response shape: not applicable - no API response shape changed.
- Status codes: not applicable - no backend endpoint or status code behavior changed.
- Frontend consumer: `EnhancedAppointmentsTable` keeps existing active rendering paths; removed code returned an unused value.
- Compatibility path or alias: not applicable - no route, endpoint, or alias changed.
- Contract proof: source proof shows the dead `void useMemo` and `group.payment_status/status/visit_type` synthesis are gone; frontend production build passes.

## RBAC / Permissions

- Roles allowed: not applicable - no role access behavior changed.
- Roles denied: not applicable - no role access behavior changed.
- Positive auth proof: not applicable - no authenticated endpoint changed.
- Negative auth proof: not applicable - no authenticated endpoint changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, polling, or realtime behavior changed.
- Payload version / ack behavior: not applicable - no notification payload or acknowledgement behavior changed.
- Read/unread or delivery semantics: not applicable - no notification delivery state changed.
- Reconnect/resync proof: not applicable - no reconnect or realtime resync path changed.

## Frontend Resilience

- Empty data proof: not applicable - removed dead code did not feed rendered empty states.
- Partial data proof: build passed after removing dead grouping; active table data paths remain unchanged.
- Forbidden secondary path behavior: not applicable - no secondary path behavior changed.
- Missing draft/resource behavior: not applicable - table cleanup does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - table cleanup does not read route or deep-link state.

## Scope Gate

- Allowed paths: `frontend/src/components/tables/EnhancedAppointmentsTable.jsx` only.
- Denied paths: backend files, `/api/v1/ui/*`, command wrappers, QueueJoin, DisplayBoard, Registrar, Lab, migrations, docs, generated output, and unrelated cleanup.
- Migration/docs/test impact: no migration; no docs change; no test files changed because this removes dead unused code and build/source proof covers active consumers.
- Rollback note: revert this one commit to restore the previous dead grouping block if a missed dependency is found.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; source proof `rg` for removed dead grouping symbols.
- Result: build passed; diff check passed; source proof found no remaining `void useMemo` or `group.payment_status/status/visit_type` synthesis in `EnhancedAppointmentsTable.jsx`.
- Not checked: backend tests were not run because no backend code or API contract changed.