### PR TITLE
fix(wizard): await removed queue cancellation

### DIFF
--- a/frontend/src/components/wizard/AppointmentWizardV2.jsx
+++ b/frontend/src/components/wizard/AppointmentWizardV2.jsx
@@ -71,6 +71,44 @@ const resolveOnlineQueueEntryId = (record, recordKind, effectiveSource) => {
   return record.queue_entry_id ?? getFirstQueueNumberId(record) ?? record.id ?? null;
 };
 
+const getRemovedQueueEntryIds = (originalQueueIds, cartItems = []) => {
+  const currentQueueIds = new Set(
+    cartItems
+      .map((item) => item.original_queue_id)
+      .filter((id) => id)
+  );
+
+  return Array.from(originalQueueIds || []).filter((id) => !currentQueueIds.has(id));
+};
+
+const cancelRemovedQueueEntries = async (originalQueueIds, cartItems, contextLabel) => {
+  const removedQueueIds = getRemovedQueueEntryIds(originalQueueIds, cartItems);
+  if (removedQueueIds.length === 0) {
+    logger.log(`[AppointmentWizardV2] no removed queue entries to cancel (${contextLabel})`);
+    return;
+  }
+
+  logger.log(`[AppointmentWizardV2] cancelling removed queue entries (${contextLabel}): ${removedQueueIds.join(', ')}`);
+  const results = await Promise.allSettled(
+    removedQueueIds.map((id) => api.post(`/online-queue/entries/${id}/cancel`))
+  );
+  const failedIds = results
+    .map((result, index) => ({ result, id: removedQueueIds[index] }))
+    .filter(({ result }) => result.status === 'rejected')
+    .map(({ id }) => id);
+
+  if (failedIds.length > 0) {
+    logger.error('[AppointmentWizardV2] failed to cancel removed queue entries', {
+      contextLabel,
+      failedIds
+    });
+    toast.warning('Не удалось отменить часть удаленных записей очереди. Обновите очередь.');
+    return;
+  }
+
+  logger.log(`[AppointmentWizardV2] removed queue entries cancelled (${contextLabel})`);
+};
+
 const normalizeServiceSelectionValue = (serviceValue) => {
   if (serviceValue == null) return '';
 
@@ -2185,9 +2223,7 @@ const AppointmentWizardV2 = ({
 
             if (removedQueueIds.length > 0) {
               logger.log(`🗑️ Найдены удаленные записи очереди (Update Path): ${removedQueueIds.join(', ')}`);
-              // Non-blocking cleanup
-              Promise.all(removedQueueIds.map((id) => api.post(`/online-queue/entries/${id}/cancel`))).
-              catch((e) => logger.error('❌ Ошибка отмены записей:', e));
+              await cancelRemovedQueueEntries(originalQueueIds, wizardData.cart.items, 'patient-update');
             }
 
             onComplete?.({ success: true, message: 'Данные пациента обновлены' });
@@ -2262,9 +2298,7 @@ const AppointmentWizardV2 = ({
 
         if (removedQueueIds.length > 0) {
           logger.log(`🗑️ Найдены удаленные записи очереди (Cart Path): ${removedQueueIds.join(', ')}`);
-          // Non-blocking cleanup
-          Promise.all(removedQueueIds.map((id) => api.post(`/online-queue/entries/${id}/cancel`))).
-          catch((e) => logger.error('❌ Ошибка отмены записей:', e));
+          await cancelRemovedQueueEntries(originalQueueIds, wizardData.cart.items, 'cart-update');
         }
 
         onComplete?.(result);


### PR DESCRIPTION
## Summary

- Await removed online queue cancellation attempts in AppointmentWizardV2 patient-update/cart-update paths before closing the wizard.
- Keep queue state transition owned by the existing backend cancel endpoint.
- No /api/v1/ui/* endpoint, no BFF-lite, no backend changes.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current origin/main at a06461b2.
- Clean workspace: inspected before edits; only `frontend/src/components/wizard/AppointmentWizardV2.jsx` changed.
- Branch: codex/wizard-removed-queue-cancel-proof.
- Scope gate: repo gate returned narrow override; allowed only AppointmentWizardV2.jsx and denied backend, tests, generated output, BFF, and broad wizard rewrite.
- Red-check handling: PR Review Quality Gate failed on body field shape; fixing PR body in same PR, and any further red checks will be handled in this PR before merge.

## Contract Impact

- Canonical surface: existing POST `/online-queue/entries/{id}/cancel` remains the queue cancellation command surface.
- Request shape: unchanged existing cancel request; wizard only sends the existing entry id path parameter.
- Response shape: unchanged; frontend waits for request settlement and does not depend on a new DTO.
- Status codes: unchanged backend-owned success/failure behavior for the existing cancel endpoint.
- Frontend consumer: AppointmentWizardV2 removed-service cleanup after patient-update and cart-update success paths.
- Compatibility path or alias: no compatibility alias or secondary endpoint added.
- Contract proof: local frontend production build passed and source proof shows fire-and-forget cancellation removed from the two updated paths.

## RBAC / Permissions

- Roles allowed: unchanged; whatever roles the existing backend cancel endpoint allows remain authoritative.
- Roles denied: unchanged; backend endpoint still denies unauthorized roles.
- Positive auth proof: not applicable - this PR does not change auth, route registration, or backend permissions.
- Negative auth proof: not applicable - this PR does not change auth, route registration, or backend permissions.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime channel changed.
- Payload version / ack behavior: not applicable - no realtime payload or ack contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery/read state changed.
- Reconnect/resync proof: not applicable - no reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: helper returns without API calls when there are no removed queue ids.
- Partial data proof: partial cancellation failures are logged with failed ids and surfaced as a warning while preserving the main successful update/create flow.
- Forbidden secondary path behavior: no secondary cancel path is added; only the existing backend cancel endpoint is used.
- Missing draft/resource behavior: unchanged; draft cleanup and onComplete/onClose sequencing remain in the same success paths.
- Stale route/deep-link behavior: not applicable - AppointmentWizardV2 removed-queue cleanup does not read route or deep-link state.

## Scope Gate

- Allowed paths: `frontend/src/components/wizard/AppointmentWizardV2.jsx`.
- Denied paths: backend routes/services, tests outside gate, generated output, `/api/v1/ui/*`, separate BFF service, command wrappers, broad wizard rewrite.
- Migration/docs/test impact: no migration; no docs; tests not changed because gate allowed only the wizard file.
- Rollback note: revert the single frontend wizard commit to restore previous fire-and-forget cleanup behavior.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`.
- Result: both passed locally.
- Not checked: backend tests and browser smoke were not run because no backend contract or UI layout code changed; focused frontend tests were not added because gate first-touch allowed only AppointmentWizardV2.jsx.