### PR TITLE
fix(doctor): guard visit service deletion parent

### DIFF
--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -1671,15 +1671,23 @@ def remove_service_from_visit(
             )
 
         # Удаляем услугу
-        success = crud_visit.remove_visit_service(
-            db=db, visit_service_id=visit_service_id
+        visit_service = (
+            db.query(VisitService)
+            .filter(
+                VisitService.id == visit_service_id,
+                VisitService.visit_id == visit.id,
+            )
+            .first()
         )
 
-        if not success:
+        if not visit_service:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Услуга в визите не найдена",
             )
+
+        db.delete(visit_service)
+        db.commit()
 
         return {"success": True, "message": "Услуга удалена из визита"}
 

--- a/backend/tests/integration/test_e2e_doctor_visit.py
+++ b/backend/tests/integration/test_e2e_doctor_visit.py
@@ -24,7 +24,7 @@ from app.models.emr import EMR
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.patient import Patient
 from app.models.user import User
-from app.models.visit import Visit
+from app.models.visit import Visit, VisitService
 
 
 # =============================================================================
@@ -186,6 +186,44 @@ class TestDoctorVisitFlow:
             data = response.json()
             # Проверяем что вызван пациент
             assert "patient" in data or "entry" in data or "number" in data
+
+    def test_delete_visit_service_rejects_child_from_different_visit(
+        self,
+        client: TestClient,
+        db_session,
+        auth_headers,
+        doctor_with_queue,
+        test_service,
+    ):
+        """Nested service delete must not trust visit_service_id alone."""
+        first_visit = doctor_with_queue["entries"][0]["visit"]
+        other_visit = doctor_with_queue["entries"][1]["visit"]
+
+        first_service = VisitService(
+            visit_id=first_visit.id,
+            service_id=test_service.id,
+            quantity=1,
+            price=test_service.price,
+        )
+        other_service = VisitService(
+            visit_id=other_visit.id,
+            service_id=test_service.id,
+            quantity=1,
+            price=test_service.price,
+        )
+        db_session.add_all([first_service, other_service])
+        db_session.commit()
+        db_session.refresh(first_service)
+        db_session.refresh(other_service)
+
+        response = client.delete(
+            f"/api/v1/doctor/visits/{first_visit.id}/services/{other_service.id}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404, response.text
+        assert db_session.get(VisitService, first_service.id) is not None
+        assert db_session.get(VisitService, other_service.id) is not None
 
     def test_doctor_can_start_visit(
         self, client: TestClient, doctor_auth_headers, doctor_with_queue, db_session


### PR DESCRIPTION
## Summary

- Fix mounted doctor visit service deletion so the child VisitService must belong to the route Visit.
- Add a targeted regression test proving a mismatched visit_service_id is rejected and not deleted.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current origin/main at af64b5cb after PR #1339 merge.
- Clean workspace: inspected before edits; only scoped doctor endpoint and targeted integration test changed.
- Branch: codex/doctor-visit-service-parent-guard.
- Scope gate: agent_gate.py with known root cause returned narrow override; first slice stayed in backend/app/api/v1/endpoints/doctor_integration.py, then added the targeted regression test. Denied frontend, /api/v1/ui/*, migrations, shared CRUD refactor, and unrelated doctor flow rewrites.
- Red-check handling: fix failed targeted tests or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: DELETE /api/v1/doctor/visits/{visit_id}/services/{visit_service_id}.
- Request shape: unchanged route parameters; no request body.
- Response shape: unchanged success response for valid deletes.
- Status codes: mismatched child service now returns 404 instead of deleting a service from another visit.
- Frontend consumer: unchanged.
- Compatibility path or alias: no alias changed; only invalid parent/child combinations are rejected.
- Contract proof: targeted backend integration regression asserts the mismatched child is not deleted.

## RBAC / Permissions

- Roles allowed: unchanged existing Admin/Doctor/cardio/cardiology/derma/dentist gate.
- Roles denied: unchanged existing endpoint role checks.
- Positive auth proof: regression uses authenticated staff headers to reach the endpoint.
- Negative auth proof: not applicable - this PR does not change role policy.

## Notification / Realtime

not applicable - no notification, websocket, chat, Telegram, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend or read-model behavior changed.
- Partial data proof: not applicable - no frontend or read-model behavior changed.
- Forbidden secondary path behavior: not applicable - no secondary frontend path changed.
- Missing draft/resource behavior: not applicable - no drafts/resources are created by frontend code in this PR.
- Stale route/deep-link behavior: not applicable - no route state or deep-link handling changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/doctor_integration.py; backend/tests/integration/test_e2e_doctor_visit.py.
- Denied paths: frontend, /api/v1/ui/*, migrations, shared crud_visit helper refactor, service duplicate routers, broad doctor access policy changes.
- Migration/docs/test impact: no migration; targeted integration test added.
- Rollback note: revert this PR to restore previous delete-by-child-id behavior and remove the regression test.

## Validation

- Targeted tests or smoke run: py_compile for backend/app/api/v1/endpoints/doctor_integration.py and backend/tests/integration/test_e2e_doctor_visit.py; git diff --check; attempted targeted backend pytest.
- Result: py_compile passed; git diff --check passed; targeted local pytest could not run because this checkout has no Python 3.11+ interpreter with pytest installed.
- Not checked: full local backend pytest; CI backend tests are expected to provide executable coverage.