### PR TITLE
fix(doctor): authorize visits by doctor owner

### DIFF
--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -123,6 +123,20 @@ def _doctor_queue_action_flags(entry: OnlineQueueEntry) -> dict[str, bool]:
     }
 
 
+def _ensure_visit_doctor_access(visit: Visit, current_user: User) -> None:
+    if current_user.role == "Admin":
+        return
+
+    doctor = visit.doctor
+    if doctor and doctor.user_id == current_user.id:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="No access to this visit",
+    )
+
+
 class ScheduleNextVisitService(BaseModel):
     service_id: int
     quantity: int = 1
@@ -1517,11 +1531,7 @@ def get_visit_details(
             )
 
         # Проверяем права доступа
-        if current_user.role not in ["Admin"] and visit.doctor_id != current_user.id:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Нет доступа к этому визиту",
-            )
+        _ensure_visit_doctor_access(visit, current_user)
 
         # Получаем услуги визита
         visit_services = crud_visit.get_visit_services(db=db, visit_id=visit.id)
@@ -1600,11 +1610,7 @@ def add_service_to_visit(
             )
 
         # Проверяем права доступа
-        if current_user.role not in ["Admin"] and visit.doctor_id != current_user.id:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Нет доступа к этому визиту",
-            )
+        _ensure_visit_doctor_access(visit, current_user)
 
         # Проверяем, что услуга существует
         service = db.query(Service).filter(Service.id == service_id).first()
@@ -1664,11 +1670,7 @@ def remove_service_from_visit(
             )
 
         # Проверяем права доступа
-        if current_user.role not in ["Admin"] and visit.doctor_id != current_user.id:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Нет доступа к этому визиту",
-            )
+        _ensure_visit_doctor_access(visit, current_user)
 
         # Удаляем услугу
         visit_service = (

--- a/backend/tests/integration/test_e2e_doctor_visit.py
+++ b/backend/tests/integration/test_e2e_doctor_visit.py
@@ -225,6 +225,85 @@ class TestDoctorVisitFlow:
         assert db_session.get(VisitService, first_service.id) is not None
         assert db_session.get(VisitService, other_service.id) is not None
 
+    def test_add_visit_service_rejects_user_id_doctor_id_collision_bypass(
+        self,
+        client: TestClient,
+        db_session,
+        test_service,
+    ):
+        attacker_user = User(
+            id=9401,
+            username="visit_service_attacker",
+            email="visit-service-attacker@test.com",
+            hashed_password=get_password_hash("doctor123"),
+            role="Doctor",
+            is_active=True,
+        )
+        victim_user = User(
+            id=9403,
+            username="visit_service_victim",
+            email="visit-service-victim@test.com",
+            hashed_password=get_password_hash("doctor123"),
+            role="Doctor",
+            is_active=True,
+        )
+        attacker_doctor = Doctor(
+            id=9402,
+            user_id=attacker_user.id,
+            specialty="therapy",
+            active=True,
+        )
+        victim_doctor = Doctor(
+            id=attacker_user.id,
+            user_id=victim_user.id,
+            specialty="therapy",
+            active=True,
+        )
+        patient = Patient(
+            first_name="Visit",
+            last_name="Owner",
+            phone="+998909401000",
+            birth_date=date(1990, 1, 1),
+        )
+        db_session.add_all(
+            [attacker_user, victim_user, attacker_doctor, victim_doctor, patient]
+        )
+        db_session.commit()
+        db_session.refresh(patient)
+
+        victim_visit = Visit(
+            patient_id=patient.id,
+            doctor_id=victim_doctor.id,
+            visit_date=date.today(),
+            visit_time="11:00",
+            status="open",
+            department="therapy",
+        )
+        db_session.add(victim_visit)
+        db_session.commit()
+        db_session.refresh(victim_visit)
+
+        login_response = client.post(
+            "/api/v1/authentication/login",
+            json={"username": attacker_user.username, "password": "doctor123"},
+        )
+        assert login_response.status_code == 200
+        headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+        response = client.put(
+            f"/api/v1/doctor/visits/{victim_visit.id}/add-service",
+            params={"service_id": test_service.id},
+            headers=headers,
+        )
+
+        assert response.status_code == 403, response.text
+        assert (
+            db_session.query(VisitService)
+            .filter(VisitService.visit_id == victim_visit.id)
+            .count()
+            == 0
+        )
+
     def test_doctor_can_start_visit(
         self, client: TestClient, doctor_auth_headers, doctor_with_queue, db_session
     ):


### PR DESCRIPTION
## Summary

- Fix mounted doctor visit detail/add-service/delete-service authorization to compare Visit.doctor_id through Doctor.user_id.
- Add targeted regression coverage for a User.id / Doctor.id collision bypass.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current origin/main at bb3aae17 after PR #1343 merge.
- Clean workspace: inspected before edits; only scoped doctor endpoint and targeted integration test changed.
- Branch: codex/doctor-visit-access-doctor-id.
- Scope gate: agent_gate.py with known root cause returned narrow override; first slice stayed in backend/app/api/v1/endpoints/doctor_integration.py, then added targeted regression coverage. Denied frontend, /api/v1/ui/*, migrations, list/statistics semantics, and broad doctor routing refactors.
- Red-check handling: fix failed targeted tests or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: GET /api/v1/doctor/visits/{visit_id}; PUT /api/v1/doctor/visits/{visit_id}/add-service; DELETE /api/v1/doctor/visits/{visit_id}/services/{visit_service_id}.
- Request shape: unchanged route/query parameters.
- Response shape: unchanged for authorized callers.
- Status codes: unauthorized doctor/user-id collisions now return 403 instead of allowing access when User.id equals the Visit's Doctor.id.
- Frontend consumer: unchanged.
- Compatibility path or alias: no route alias changed; only invalid authorization is rejected.
- Contract proof: targeted backend integration regression asserts the collision user cannot add a service to another doctor's visit.

## RBAC / Permissions

- Roles allowed: unchanged existing route roles; doctor ownership check now uses Doctor.user_id for non-admin users.
- Roles denied: non-owner doctors are denied even if their User.id collides with another Doctor.id.
- Positive auth proof: existing doctor/admin flows remain covered by backend suite; this PR adds the negative collision proof.
- Negative auth proof: regression logs in as the non-owner doctor and receives 403 without creating a VisitService.

## Notification / Realtime

not applicable - no notification, websocket, chat, Telegram, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend or read-model behavior changed.
- Partial data proof: not applicable - no frontend or read-model behavior changed.
- Forbidden secondary path behavior: not applicable - endpoint now returns the correct 403 for unauthorized doctor ownership.
- Missing draft/resource behavior: not applicable - no drafts/resources are created by frontend code in this PR.
- Stale route/deep-link behavior: not applicable - no route state or deep-link handling changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/doctor_integration.py; backend/tests/integration/test_e2e_doctor_visit.py.
- Denied paths: frontend, /api/v1/ui/*, migrations, doctor list/statistics semantics, schedule-next ownership, shared auth dependency refactor.
- Migration/docs/test impact: no migration; targeted integration test added.
- Rollback note: revert this PR to restore the previous User.id-vs-Doctor.id access check and remove the regression test.

## Validation

- Targeted tests or smoke run: py_compile for backend/app/api/v1/endpoints/doctor_integration.py and backend/tests/integration/test_e2e_doctor_visit.py; git diff --check; attempted targeted backend pytest.
- Result: py_compile passed; git diff --check passed; targeted local pytest could not run because this checkout has no Python 3.11+ interpreter with pytest installed.
- Not checked: full local backend pytest; CI backend tests are expected to provide executable coverage.