### PR TITLE
fix(doctor): read visits by doctor owner

### DIFF
--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -137,6 +137,19 @@ def _ensure_visit_doctor_access(visit: Visit, current_user: User) -> None:
     )
 
 
+def _visit_filter_doctor_id(db: Session, current_user: User) -> int:
+    doctor = (
+        db.query(Doctor)
+        .filter(and_(Doctor.user_id == current_user.id, Doctor.active == True))
+        .first()
+    )
+    if doctor:
+        return doctor.id
+    if current_user.role == "Admin":
+        return current_user.id
+    return -1
+
+
 class ScheduleNextVisitService(BaseModel):
     service_id: int
     quantity: int = 1
@@ -1448,7 +1461,10 @@ def get_today_visits(
 ):
     """Получить сегодняшние визиты врача"""
     try:
-        visits = crud_visit.get_today_visits_by_doctor(db=db, doctor_id=current_user.id)
+        visits = crud_visit.get_today_visits_by_doctor(
+            db=db,
+            doctor_id=_visit_filter_doctor_id(db, current_user),
+        )
 
         result = []
         for visit in visits:
@@ -1730,7 +1746,7 @@ def get_visit_statistics(
 
         stats = crud_visit.get_visit_statistics(
             db=db,
-            doctor_id=current_user.id,
+            doctor_id=_visit_filter_doctor_id(db, current_user),
             date_from=date_from_obj,
             date_to=date_to_obj,
         )

--- a/backend/tests/integration/test_e2e_doctor_visit.py
+++ b/backend/tests/integration/test_e2e_doctor_visit.py
@@ -304,6 +304,78 @@ class TestDoctorVisitFlow:
             == 0
         )
 
+    def test_today_visits_uses_doctor_id_not_user_id_collision(
+        self,
+        client: TestClient,
+        db_session,
+    ):
+        attacker_user = User(
+            id=9501,
+            username="today_visit_attacker",
+            email="today-visit-attacker@test.com",
+            hashed_password=get_password_hash("doctor123"),
+            role="Doctor",
+            is_active=True,
+        )
+        victim_user = User(
+            id=9503,
+            username="today_visit_victim",
+            email="today-visit-victim@test.com",
+            hashed_password=get_password_hash("doctor123"),
+            role="Doctor",
+            is_active=True,
+        )
+        attacker_doctor = Doctor(
+            id=9502,
+            user_id=attacker_user.id,
+            specialty="therapy",
+            active=True,
+        )
+        victim_doctor = Doctor(
+            id=attacker_user.id,
+            user_id=victim_user.id,
+            specialty="therapy",
+            active=True,
+        )
+        patient = Patient(
+            first_name="Private",
+            last_name="Visit",
+            phone="+998909501000",
+            birth_date=date(1990, 1, 1),
+        )
+        db_session.add_all(
+            [attacker_user, victim_user, attacker_doctor, victim_doctor, patient]
+        )
+        db_session.commit()
+        db_session.refresh(patient)
+
+        victim_visit = Visit(
+            patient_id=patient.id,
+            doctor_id=victim_doctor.id,
+            visit_date=date.today(),
+            visit_time="12:00",
+            status="open",
+            department="therapy",
+        )
+        db_session.add(victim_visit)
+        db_session.commit()
+        db_session.refresh(victim_visit)
+
+        login_response = client.post(
+            "/api/v1/authentication/login",
+            json={"username": attacker_user.username, "password": "doctor123"},
+        )
+        assert login_response.status_code == 200
+        headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+        response = client.get("/api/v1/doctor/visits/today", headers=headers)
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["total_count"] == 0
+        assert all(item["id"] != victim_visit.id for item in payload["visits"])
+
     def test_doctor_can_start_visit(
         self, client: TestClient, doctor_auth_headers, doctor_with_queue, db_session
     ):


### PR DESCRIPTION
## Summary

- Fix legacy doctor visit read filters to use the authenticated user's active `Doctor.id` instead of `User.id`.
- Keep the existing Admin fallback behavior while preventing non-doctor users without a Doctor row from inheriting arbitrary doctor visits by numeric id collision.
- Add regression coverage for `User.id == other Doctor.id` on `/api/v1/doctor/visits/today`.

## Cyclic Execution Evidence

- Fresh main sync: branch created from fresh `origin/main` after PR #1344 merge commit `4a72527b`.
- Clean workspace: inspected before edits; only the scoped doctor endpoint and targeted integration test changed.
- Branch: `codex/doctor-visits-read-doctor-id`.
- Scope gate: allowed `backend/app/api/v1/endpoints/doctor_integration.py` and `backend/tests/integration/test_e2e_doctor_visit.py`; denied `/api/v1/ui/*`, BFF-lite, frontend changes, migrations, and broad authorization rewrites.
- Red-check handling: any failed required CI checks will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/doctor/visits/today` and `GET /api/v1/doctor/visits/statistics`.
- Request shape: unchanged authenticated request; no request body added or removed.
- Response shape: unchanged existing JSON response shape for both endpoints.
- Status codes: unchanged endpoint status behavior; this PR only changes which `doctor_id` value is used for read filtering.
- Frontend consumer: existing doctor panels and legacy callers keep the same endpoint and response shape.
- Compatibility path or alias: Admin fallback to prior `current_user.id` behavior is preserved in this narrow PR; no alias path added.
- Contract proof: targeted regression test proves a doctor user no longer reads another doctor's visit when `User.id == other Doctor.id`; backend CI also ran on GitHub.

## RBAC / Permissions

- Roles allowed: unchanged route dependency still allows the existing Admin, Doctor, Registrar, Cashier, Receptionist, cardio/cardiology/derma/dentist roles.
- Roles denied: unchanged route dependency still denies unauthenticated users and roles not listed by `require_roles`.
- Positive auth proof: authenticated attacker doctor receives `200` from `/api/v1/doctor/visits/today`.
- Negative auth proof: the same authenticated attacker doctor receives no victim visit rows despite `attacker User.id == victim Doctor.id`.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime event, payload ack, read/unread, delivery, reconnect, or resync behavior changed.

## Frontend Resilience

- Empty data proof: regression asserts the endpoint returns `success: true` and `total_count: 0` for the collision case.
- Partial data proof: not applicable - this PR does not alter response field optionality or frontend rendering.
- Forbidden secondary path behavior: not applicable - no secondary frontend path or fallback command was changed.
- Missing draft/resource behavior: not applicable - visits read endpoint does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/doctor_integration.py`; `backend/tests/integration/test_e2e_doctor_visit.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite, separate BFF service, frontend files, migrations, docs, generated output, and broad doctor/visit authorization rewrites.
- Migration/docs/test impact: no migration and no docs change; one targeted backend integration regression was added.
- Rollback note: revert this commit to restore the previous `current_user.id` read filter behavior and remove the regression test.

## Validation

- Targeted tests or smoke run: py_compile for endpoint and test; `git diff --check`; attempted local targeted backend pytest; GitHub backend CI.
- Result: py_compile passed; `git diff --check` passed; GitHub backend tests and `PR Required Gate` passed; local pytest was blocked by missing local Python 3.11+ environment with `pytest`.
- Not checked: local pytest execution and frontend browser smoke, because the change is backend-only and the local pytest environment lacks `pytest`.