### PR TITLE
fix(emr): guard visit ownership

### DIFF
--- a/backend/app/api/v1/endpoints/emr_v2.py
+++ b/backend/app/api/v1/endpoints/emr_v2.py
@@ -22,7 +22,9 @@ from sqlalchemy.orm import Session
 
 from app.api import deps
 from app.core.audit import extract_model_changes, log_critical_change
+from app.models.clinic import Doctor
 from app.models.user import User
+from app.models.visit import Visit
 from app.schemas.emr_v2 import (
     EMRAmendRequest,
     EMRConflictError,
@@ -67,12 +69,47 @@ EMR_V2_ALLOWED_ROLES = (
     "Laboratory",
 )
 
+EMR_V2_DOCTOR_ROLES = {
+    "Doctor",
+    "cardio",
+    "cardiology",
+    "Cardiologist",
+    "Cardio",
+    "derma",
+    "Dermatologist",
+    "dentist",
+    "Dentist",
+}
+
+
 def get_client_ip(request: Request) -> str | None:
     """Extract client IP from request"""
     forwarded = request.headers.get("X-Forwarded-For")
     if forwarded:
         return forwarded.split(",")[0].strip()
     return request.client.host if request.client else None
+
+
+def ensure_emr_visit_access(db: Session, visit_id: int, current_user: User) -> None:
+    """Prevent doctor-profile users from opening another doctor's visit EMR."""
+    if current_user.role == "Admin" or current_user.is_superuser:
+        return
+
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active == True)
+        .first()
+    )
+    if not doctor:
+        if current_user.role in EMR_V2_DOCTOR_ROLES:
+            raise HTTPException(status_code=403, detail="Access denied")
+        return
+
+    visit = db.query(Visit).filter(Visit.id == visit_id).first()
+    if not visit:
+        raise HTTPException(status_code=404, detail="Visit not found")
+    if visit.doctor_id != doctor.id:
+        raise HTTPException(status_code=403, detail="Access denied")
 
 
 # =============================================================================
@@ -148,6 +185,8 @@ async def get_emr(
     Returns the latest version of the EMR for the specified visit.
     Creates an audit log entry for the view action.
     """
+    ensure_emr_visit_access(db, visit_id, current_user)
+
     emr = emr_v2_service.get_by_visit(db, visit_id)
     if not emr:
         raise HTTPException(status_code=404, detail="EMR not found")
@@ -176,6 +215,8 @@ async def get_emr_history(
     
     Returns list of all revisions in descending order (newest first).
     """
+    ensure_emr_visit_access(db, visit_id, current_user)
+
     emr = emr_v2_service.get_by_visit(db, visit_id)
     if not emr:
         raise HTTPException(status_code=404, detail="EMR not found")
@@ -211,6 +252,8 @@ async def get_emr_version(
     
     Returns the complete data snapshot for the specified version.
     """
+    ensure_emr_visit_access(db, visit_id, current_user)
+
     emr = emr_v2_service.get_by_visit(db, visit_id)
     if not emr:
         raise HTTPException(status_code=404, detail="EMR not found")
@@ -235,6 +278,8 @@ async def compare_versions(
     
     Returns list of field changes between the two versions.
     """
+    ensure_emr_visit_access(db, visit_id, current_user)
+
     try:
         diff = emr_v2_service.get_diff(db, visit_id, v1, v2)
         return diff
@@ -283,6 +328,8 @@ async def save_emr(
     - If row_version mismatch and different user: returns 409 Conflict
     - If row_version mismatch but same user/session: allows (autosave)
     """
+    ensure_emr_visit_access(db, visit_id, current_user)
+
     try:
         existing_emr = emr_v2_service.get_by_visit(db, visit_id)
         old_data = None
@@ -342,6 +389,8 @@ async def sign_emr(
     Changes status to 'signed' and records signing timestamp.
     After signing, EMR can only be modified via the amend endpoint.
     """
+    ensure_emr_visit_access(db, visit_id, current_user)
+
     try:
         emr = emr_v2_service.sign(
             db,
@@ -410,6 +459,8 @@ async def amend_emr(
     Creates a new version with amendment, requires a reason (min 10 chars).
     Only available for EMRs with status 'signed'.
     """
+    ensure_emr_visit_access(db, visit_id, current_user)
+
     try:
         emr = emr_v2_service.amend(
             db,
@@ -450,6 +501,8 @@ async def restore_emr(
     Creates a new version with data from the target version.
     The restore is recorded in the revision history.
     """
+    ensure_emr_visit_access(db, visit_id, current_user)
+
     try:
         emr = emr_v2_service.restore(
             db,

--- a/backend/tests/unit/test_emr_v2_api.py
+++ b/backend/tests/unit/test_emr_v2_api.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 
 from app.api.v1.endpoints import emr_v2
+from app.core.security import get_password_hash
+from app.models.clinic import Doctor
+from app.models.emr_v2 import EMRRecord
+from app.models.patient import Patient
+from app.models.user import User
+from app.models.visit import Visit
 
 
 @pytest.mark.unit
@@ -36,3 +44,83 @@ def test_doctor_history_route_is_not_shadowed_by_visit_id(
     payload = response.json()
     assert payload["field_name"] == "complaints"
     assert payload["entries"][0]["content"] == "Chest pain"
+
+
+@pytest.mark.unit
+def test_doctor_cannot_save_emr_for_another_doctors_visit(client, db_session):
+    attacker_user = User(
+        id=9601,
+        username="emr_v2_attacker",
+        email="emr-v2-attacker@test.com",
+        hashed_password=get_password_hash("doctor123"),
+        role="Doctor",
+        is_active=True,
+    )
+    victim_user = User(
+        id=9603,
+        username="emr_v2_victim",
+        email="emr-v2-victim@test.com",
+        hashed_password=get_password_hash("doctor123"),
+        role="Doctor",
+        is_active=True,
+    )
+    attacker_doctor = Doctor(
+        id=9602,
+        user_id=attacker_user.id,
+        specialty="therapy",
+        active=True,
+    )
+    victim_doctor = Doctor(
+        id=9604,
+        user_id=victim_user.id,
+        specialty="therapy",
+        active=True,
+    )
+    patient = Patient(
+        first_name="EMR",
+        last_name="Owner",
+        phone="+998909601000",
+        birth_date=date(1990, 1, 1),
+    )
+    db_session.add_all(
+        [attacker_user, victim_user, attacker_doctor, victim_doctor, patient]
+    )
+    db_session.commit()
+    db_session.refresh(patient)
+
+    victim_visit = Visit(
+        patient_id=patient.id,
+        doctor_id=victim_doctor.id,
+        visit_date=date.today(),
+        visit_time="13:00",
+        status="open",
+        department="therapy",
+    )
+    db_session.add(victim_visit)
+    db_session.commit()
+    db_session.refresh(victim_visit)
+
+    login_response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": attacker_user.username, "password": "doctor123"},
+    )
+    assert login_response.status_code == 200
+    headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+    response = client.post(
+        f"/api/v1/v2/emr/{victim_visit.id}",
+        headers=headers,
+        json={
+            "data": {"complaints": "tampered"},
+            "row_version": 0,
+            "is_draft": True,
+        },
+    )
+
+    assert response.status_code == 403, response.text
+    assert (
+        db_session.query(EMRRecord)
+        .filter(EMRRecord.visit_id == victim_visit.id)
+        .count()
+        == 0
+    )


### PR DESCRIPTION
## Summary

- Add an EMR v2 visit ownership guard for mounted `visit_id` endpoints.
- Doctor-profile users can no longer read, save, sign, amend, restore, diff, or inspect revision history for another doctor's visit.
- Add a regression test proving a doctor cannot create an EMR draft on another doctor's visit.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` after PR #1345 merge commit `e6256b99`.
- Clean workspace: inspected before edits; only the scoped EMR v2 endpoint and targeted unit test changed.
- Branch: `codex/emr-v2-visit-owner-guard`.
- Scope gate: first gate allowed `backend/app/api/v1/endpoints/emr_v2.py`; second validation gate allowed `backend/tests/unit/test_emr_v2_api.py`; denied service rewrites, migrations, frontend changes, and unrelated EMR patient-list semantics.
- Red-check handling: any failed required CI checks will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `GET/POST /api/v1/v2/emr/{visit_id}` plus `/history`, `/version/{version}`, `/diff`, `/sign`, `/amend`, and `/restore`.
- Request shape: unchanged; no request body, query, or path parameter changes.
- Response shape: unchanged for authorized callers.
- Status codes: doctor-profile users now receive `403` when the target `Visit.doctor_id` belongs to a different `Doctor.id`; missing visits still return `404` for guarded doctor-profile users.
- Frontend consumer: existing EMR v2 callers keep the same endpoint and response shape; unauthorized cross-doctor access now fails instead of mutating or exposing records.
- Compatibility path or alias: Admin/superuser bypass is preserved; non-doctor compatibility roles without a Doctor profile are not changed in this narrow PR.
- Contract proof: targeted regression test posts to another doctor's `visit_id` and verifies `403` plus no `EMRRecord` creation.

## RBAC / Permissions

- Roles allowed: unchanged route dependency still allows the existing EMR v2 role list; authorized doctor-profile users may access their own visits, and Admin/superuser remains bypassed.
- Roles denied: doctor-profile users are denied when `Visit.doctor_id != current user's active Doctor.id`; doctor roles without an active Doctor row are denied instead of defaulting to broad access.
- Positive auth proof: the regression uses an authenticated Doctor token and reaches the mounted EMR v2 endpoint.
- Negative auth proof: the authenticated attacker doctor receives `403` and no EMR draft is created for the victim visit.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime event, payload ack, read/unread, delivery, reconnect, or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no list/empty-state response shape changed.
- Partial data proof: not applicable - no optional response fields or frontend rendering changed.
- Forbidden secondary path behavior: unauthorized cross-doctor `visit_id` access now returns `403`; no secondary fallback path was added.
- Missing draft/resource behavior: regression verifies a forbidden cross-doctor save does not create an EMR draft/resource.
- Stale route/deep-link behavior: stale or copied cross-doctor visit links now fail with `403` for doctor-profile users.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/emr_v2.py`; `backend/tests/unit/test_emr_v2_api.py`.
- Denied paths: EMR service rewrites, DB migrations, frontend files, `/api/v1/ui/*`, BFF-lite, generated output, and broad Lab/Admin/product role redesign.
- Migration/docs/test impact: no migration and no docs change; one targeted backend unit regression was added.
- Rollback note: revert this commit to remove the endpoint ownership guard and its regression test.

## Validation

- Targeted tests or smoke run: py_compile for endpoint and test; `git diff --check`; attempted local targeted backend pytest; GitHub CI required for executable pytest proof.
- Result: py_compile passed; `git diff --check` passed; local pytest was blocked by missing local Python 3.11+ environment with `pytest`.
- Not checked: local pytest execution and frontend browser smoke; `/api/v1/v2/emr/patient/{patient_id}` ownership semantics are intentionally not changed in this narrow PR and should be audited separately.