### PR TITLE
fix(emr): filter patient history by owner

### DIFF
--- a/backend/app/api/v1/endpoints/emr_v2.py
+++ b/backend/app/api/v1/endpoints/emr_v2.py
@@ -90,16 +90,20 @@ def get_client_ip(request: Request) -> str | None:
     return request.client.host if request.client else None
 
 
+def get_current_active_doctor(db: Session, current_user: User) -> Doctor | None:
+    return (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active == True)
+        .first()
+    )
+
+
 def ensure_emr_visit_access(db: Session, visit_id: int, current_user: User) -> None:
     """Prevent doctor-profile users from opening another doctor's visit EMR."""
     if current_user.role == "Admin" or current_user.is_superuser:
         return
 
-    doctor = (
-        db.query(Doctor)
-        .filter(Doctor.user_id == current_user.id, Doctor.active == True)
-        .first()
-    )
+    doctor = get_current_active_doctor(db, current_user)
     if not doctor:
         if current_user.role in EMR_V2_DOCTOR_ROLES:
             raise HTTPException(status_code=403, detail="Access denied")
@@ -110,6 +114,33 @@ def ensure_emr_visit_access(db: Session, visit_id: int, current_user: User) -> N
         raise HTTPException(status_code=404, detail="Visit not found")
     if visit.doctor_id != doctor.id:
         raise HTTPException(status_code=403, detail="Access denied")
+
+
+def filter_patient_emrs_for_access(
+    db: Session,
+    emrs: list,
+    current_user: User,
+) -> list:
+    if current_user.role == "Admin" or current_user.is_superuser:
+        return emrs
+
+    doctor = get_current_active_doctor(db, current_user)
+    if not doctor:
+        if current_user.role in EMR_V2_DOCTOR_ROLES:
+            raise HTTPException(status_code=403, detail="Access denied")
+        return emrs
+
+    visit_ids = [emr.visit_id for emr in emrs]
+    if not visit_ids:
+        return emrs
+
+    allowed_visit_ids = {
+        row[0]
+        for row in db.query(Visit.id)
+        .filter(Visit.id.in_(visit_ids), Visit.doctor_id == doctor.id)
+        .all()
+    }
+    return [emr for emr in emrs if emr.visit_id in allowed_visit_ids]
 
 
 # =============================================================================
@@ -302,7 +333,7 @@ async def get_patient_emrs(
     Returns list of EMR summaries in descending order by creation date.
     """
     emrs = emr_v2_service.get_by_patient(db, patient_id, limit=limit)
-    return emrs
+    return filter_patient_emrs_for_access(db, emrs, current_user)
 
 
 # =============================================================================

--- a/backend/tests/unit/test_emr_v2_api.py
+++ b/backend/tests/unit/test_emr_v2_api.py
@@ -124,3 +124,107 @@ def test_doctor_cannot_save_emr_for_another_doctors_visit(client, db_session):
         .count()
         == 0
     )
+
+
+@pytest.mark.unit
+def test_patient_emr_history_filters_other_doctors_summaries(client, db_session):
+    attacker_user = User(
+        id=9701,
+        username="emr_history_attacker",
+        email="emr-history-attacker@test.com",
+        hashed_password=get_password_hash("doctor123"),
+        role="Doctor",
+        is_active=True,
+    )
+    victim_user = User(
+        id=9703,
+        username="emr_history_victim",
+        email="emr-history-victim@test.com",
+        hashed_password=get_password_hash("doctor123"),
+        role="Doctor",
+        is_active=True,
+    )
+    attacker_doctor = Doctor(
+        id=9702,
+        user_id=attacker_user.id,
+        specialty="therapy",
+        active=True,
+    )
+    victim_doctor = Doctor(
+        id=9704,
+        user_id=victim_user.id,
+        specialty="therapy",
+        active=True,
+    )
+    patient = Patient(
+        first_name="Shared",
+        last_name="Patient",
+        phone="+998909701000",
+        birth_date=date(1990, 1, 1),
+    )
+    db_session.add_all(
+        [attacker_user, victim_user, attacker_doctor, victim_doctor, patient]
+    )
+    db_session.commit()
+    db_session.refresh(patient)
+
+    attacker_visit = Visit(
+        patient_id=patient.id,
+        doctor_id=attacker_doctor.id,
+        visit_date=date.today(),
+        visit_time="14:00",
+        status="open",
+        department="therapy",
+    )
+    victim_visit = Visit(
+        patient_id=patient.id,
+        doctor_id=victim_doctor.id,
+        visit_date=date.today(),
+        visit_time="15:00",
+        status="open",
+        department="therapy",
+    )
+    db_session.add_all([attacker_visit, victim_visit])
+    db_session.commit()
+    db_session.refresh(attacker_visit)
+    db_session.refresh(victim_visit)
+
+    attacker_emr = EMRRecord(
+        patient_id=patient.id,
+        visit_id=attacker_visit.id,
+        version=1,
+        data={"complaints": "own"},
+        status="draft",
+        created_by=attacker_user.id,
+        row_version=1,
+    )
+    victim_emr = EMRRecord(
+        patient_id=patient.id,
+        visit_id=victim_visit.id,
+        version=1,
+        data={"complaints": "private"},
+        status="draft",
+        created_by=victim_user.id,
+        row_version=1,
+    )
+    db_session.add_all([attacker_emr, victim_emr])
+    db_session.commit()
+    db_session.refresh(attacker_emr)
+    db_session.refresh(victim_emr)
+
+    login_response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": attacker_user.username, "password": "doctor123"},
+    )
+    assert login_response.status_code == 200
+    headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+    response = client.get(
+        f"/api/v1/v2/emr/patient/{patient.id}",
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    visit_ids = {item["visit_id"] for item in response.json()}
+    assert attacker_visit.id in visit_ids
+    assert victim_visit.id not in visit_ids


### PR DESCRIPTION
## Summary

- Filter `GET /api/v1/v2/emr/patient/{patient_id}` for doctor-profile users so it only returns EMR summaries for visits owned by their active `Doctor.id`.
- Preserve Admin/superuser and non-doctor compatibility behavior in this narrow PR.
- Add regression coverage for a shared patient with EMRs from two different doctors.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` after PR #1346 merge commit `2a12f572`.
- Clean workspace: inspected before edits; only the scoped EMR v2 endpoint and targeted unit test changed.
- Branch: `codex/emr-v2-patient-history-owner-filter`.
- Scope gate: first gate allowed `backend/app/api/v1/endpoints/emr_v2.py`; second validation gate allowed `backend/tests/unit/test_emr_v2_api.py`; denied service rewrites, migrations, frontend changes, and broad role redesign.
- Red-check handling: any failed required CI checks will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/v2/emr/patient/{patient_id}`.
- Request shape: unchanged authenticated request with the same `patient_id` path parameter and `limit` query parameter.
- Response shape: unchanged list of `EMRRecordSummary` objects; unauthorized doctor-owned rows are filtered out for doctor-profile users.
- Status codes: authorized doctor-profile users still receive `200`; doctor roles without an active Doctor row receive `403`; Admin/superuser behavior is unchanged.
- Frontend consumer: existing EMR patient-history callers keep the same endpoint and response shape, but cannot use it to enumerate another doctor's EMR summaries.
- Compatibility path or alias: no new alias; non-doctor compatibility roles without a Doctor profile keep prior behavior.
- Contract proof: targeted regression creates one shared patient with attacker-owned and victim-owned EMRs, then proves the attacker sees only their own visit summary.

## RBAC / Permissions

- Roles allowed: unchanged route dependency still allows the existing EMR v2 role list; doctor-profile users receive only summaries for visits owned by their active Doctor profile.
- Roles denied: doctor roles without an active Doctor row are denied with `403`; other doctors' EMR summaries are omitted from the list.
- Positive auth proof: the regression uses an authenticated Doctor token and receives `200` from the mounted patient-history endpoint.
- Negative auth proof: the same response excludes the victim doctor's `visit_id` for the same patient.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime event, payload ack, read/unread, delivery, reconnect, or resync behavior changed.

## Frontend Resilience

- Empty data proof: the filter returns the same list shape and can naturally return an empty list when no owned EMRs are present.
- Partial data proof: regression proves mixed owned/unowned patient history returns a partial list containing only allowed summaries.
- Forbidden secondary path behavior: doctor roles without an active Doctor row receive `403`; no secondary fallback path was added.
- Missing draft/resource behavior: not applicable - this endpoint is read-only and creates no draft/resource.
- Stale route/deep-link behavior: stale/copied patient-history links no longer reveal other doctors' visit summaries to doctor-profile users.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/emr_v2.py`; `backend/tests/unit/test_emr_v2_api.py`.
- Denied paths: EMR service rewrites, DB migrations, frontend files, `/api/v1/ui/*`, BFF-lite, generated output, and broad Lab/Admin/product role redesign.
- Migration/docs/test impact: no migration and no docs change; one targeted backend unit regression was added.
- Rollback note: revert this commit to restore the previous unfiltered patient EMR summary list and remove the regression test.

## Validation

- Targeted tests or smoke run: py_compile for endpoint and test; `git diff --check`; attempted local targeted backend pytest; GitHub CI required for executable pytest proof.
- Result: py_compile passed; `git diff --check` passed; local pytest was blocked by missing local Python 3.11+ environment with `pytest`.
- Not checked: local pytest execution and frontend browser smoke, because the change is backend-only and CI runs the backend tests.