### PR TITLE
fix(emr): avoid doctor history admin crash

### DIFF
--- a/backend/app/api/v1/endpoints/emr_v2.py
+++ b/backend/app/api/v1/endpoints/emr_v2.py
@@ -179,7 +179,8 @@ async def get_doctor_history(
     Doctor can only access their own history.
     """
     # Security: doctor can only access their own history
-    if current_user.id != doctor_id and not current_user.has_role("Admin"):
+    is_admin = current_user.role == "Admin" or current_user.is_superuser
+    if current_user.id != doctor_id and not is_admin:
         raise HTTPException(status_code=403, detail="Access denied")
     
     history_service = EMRDoctorHistoryService(db)

--- a/backend/tests/unit/test_emr_v2_api.py
+++ b/backend/tests/unit/test_emr_v2_api.py
@@ -34,9 +34,10 @@ def test_doctor_history_route_is_not_shadowed_by_visit_id(
         "get_history_entries",
         fake_get_history_entries,
     )
+    other_doctor_id = admin_user.id + 1000
 
     response = client.get(
-        f"/api/v1/v2/emr/doctor-history?doctor_id={admin_user.id}&field_name=complaints&specialty=cardiology",
+        f"/api/v1/v2/emr/doctor-history?doctor_id={other_doctor_id}&field_name=complaints&specialty=cardiology",
         headers=auth_headers,
     )
 


### PR DESCRIPTION
## Summary

- Fix `GET /api/v1/v2/emr/doctor-history` so its Admin bypass does not call missing `User.has_role`.
- Use existing `User.role == Admin` / `is_superuser` fields, matching the EMR v2 owner guards.
- Update the route regression so Admin requests history for a different `doctor_id`, which would previously crash.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` after PR #1347 merge commit `22041af1`.
- Clean workspace: inspected before edits; only the scoped EMR v2 endpoint and targeted unit test changed.
- Branch: `codex/emr-v2-doctor-history-admin-check`.
- Scope gate: first gate allowed `backend/app/api/v1/endpoints/emr_v2.py`; second validation gate allowed `backend/tests/unit/test_emr_v2_api.py`; denied service rewrites, migrations, frontend changes, and broad role redesign.
- Red-check handling: any failed required CI checks will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/v2/emr/doctor-history`.
- Request shape: unchanged `doctor_id`, `field_name`, `specialty`, `search_text`, and `limit` query parameters.
- Response shape: unchanged `DoctorHistoryResponse`.
- Status codes: Admin/superuser cross-doctor request now returns the normal response instead of crashing; non-admin cross-doctor access remains `403`.
- Frontend consumer: existing doctor-history callers keep the same endpoint and response shape.
- Compatibility path or alias: no new alias or route path.
- Contract proof: targeted route regression now requests a different `doctor_id` as Admin and asserts `200` with returned history.

## RBAC / Permissions

- Roles allowed: unchanged route dependency; Admin/superuser bypass is implemented with existing User fields.
- Roles denied: non-admin users still cannot request another user's doctor-history.
- Positive auth proof: Admin token can request another `doctor_id` and receive `200`.
- Negative auth proof: no permission broadening beyond the pre-existing intended Admin bypass; non-admin guard condition remains in place.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime event, payload ack, read/unread, delivery, reconnect, or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - response shape unchanged and test returns one stubbed entry.
- Partial data proof: not applicable - no optional response fields changed.
- Forbidden secondary path behavior: non-admin cross-doctor access still uses the same forbidden path.
- Missing draft/resource behavior: not applicable - endpoint is read-only and creates no resource.
- Stale route/deep-link behavior: not applicable - no route/deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/emr_v2.py`; `backend/tests/unit/test_emr_v2_api.py`.
- Denied paths: EMR service rewrites, DB migrations, frontend files, `/api/v1/ui/*`, BFF-lite, generated output, and broad role redesign.
- Migration/docs/test impact: no migration and no docs change; one targeted route regression was strengthened.
- Rollback note: revert this commit to restore the previous `current_user.has_role(Admin)` guard and previous test input.

## Validation

- Targeted tests or smoke run: py_compile for endpoint and test; `git diff --check`; attempted local targeted backend pytest; GitHub CI required for executable pytest proof.
- Result: py_compile passed; `git diff --check` passed; local pytest was blocked by missing local Python 3.11+ environment with `pytest`.
- Not checked: local pytest execution and frontend browser smoke, because the change is backend-only and CI runs the backend tests.