### PR TITLE
fix(patients): guard patient self access

### DIFF
--- a/backend/app/api/v1/endpoints/patients.py
+++ b/backend/app/api/v1/endpoints/patients.py
@@ -20,6 +20,13 @@ from app.schemas import lab as lab_schemas
 router = APIRouter()
 
 
+def _ensure_patient_self_access(current_user: User, patient_id: int) -> None:
+    if current_user.role != "Patient":
+        return
+    if not current_user.patient or current_user.patient.id != patient_id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+
 @router.get("/appointments", response_model=List[appointment_schemas.Appointment])
 def get_my_appointments(
     db: Session = Depends(deps.get_db),
@@ -116,6 +123,7 @@ def get_patient(
     """
     Получить пациента по ID
     """
+    _ensure_patient_self_access(current_user, patient_id)
     patient = patient_crud.get(db, id=patient_id)
     if not patient:
         raise HTTPException(status_code=404, detail="Пациент не найден")
@@ -164,6 +172,7 @@ def get_patient_appointments(
     """
     Получить все записи пациента
     """
+    _ensure_patient_self_access(current_user, patient_id)
     patient = patient_crud.get(db, id=patient_id)
     if not patient:
         raise HTTPException(status_code=404, detail="Пациент не найден")

--- a/backend/tests/integration/test_rbac_matrix.py
+++ b/backend/tests/integration/test_rbac_matrix.py
@@ -7,6 +7,8 @@
 - Неавторизованные запросы (401)
 - Own-data тесты (Patient видит только свои данные)
 """
+from datetime import date
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -349,6 +351,58 @@ class TestOwnDataRBAC:
 
 
 # ===================== АУДИТ-ЛОГИ 403 =====================
+
+    def test_patient_route_ids_are_limited_to_own_patient(
+        self, client: TestClient, patient_token: str, db_session: Session
+    ):
+        patient_user = db_session.query(User).filter(User.username == "patient_test").one()
+        own_patient = Patient(
+            user_id=patient_user.id,
+            last_name="Own",
+            first_name="Patient",
+            phone="+998909801001",
+            birth_date=date(1990, 1, 1),
+        )
+        other_patient = Patient(
+            last_name="Other",
+            first_name="Patient",
+            phone="+998909801002",
+            birth_date=date(1991, 1, 1),
+        )
+        db_session.add_all([own_patient, other_patient])
+        db_session.commit()
+        db_session.refresh(own_patient)
+        db_session.refresh(other_patient)
+
+        other_appointment = Appointment(
+            patient_id=other_patient.id,
+            appointment_date=date.today(),
+            appointment_time="10:00",
+            status="scheduled",
+        )
+        db_session.add(other_appointment)
+        db_session.commit()
+
+        headers = {"Authorization": f"Bearer {patient_token}"}
+
+        own_response = client.get(
+            f"/api/v1/patients/{own_patient.id}",
+            headers=headers,
+        )
+        assert own_response.status_code == 200
+
+        other_response = client.get(
+            f"/api/v1/patients/{other_patient.id}",
+            headers=headers,
+        )
+        assert other_response.status_code == 403
+
+        appointments_response = client.get(
+            f"/api/v1/patients/{other_patient.id}/appointments",
+            headers=headers,
+        )
+        assert appointments_response.status_code == 403
+
 
 class TestAuditLog403:
     """Тесты логирования попыток несанкционированного доступа"""


### PR DESCRIPTION
## Summary

- Fix Patient-role IDOR on `GET /api/v1/patients/{patient_id}`.
- Fix Patient-role IDOR on `GET /api/v1/patients/{patient_id}/appointments`.
- Preserve existing staff-role behavior for Admin, Registrar, Doctor, Lab, Cashier, and Nurse.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` after PR #1348 merge commit `49b6da39`.
- Clean workspace: inspected before edits; only the scoped patients endpoint and targeted RBAC regression changed.
- Branch: `codex/patient-portal-patient-id-owner-guard`.
- Scope gate: first gate allowed `backend/app/api/v1/endpoints/patients.py`; second validation gate allowed `backend/tests/integration/test_rbac_matrix.py`; denied broader patient-service rewrites, frontend changes, migrations, and role redesign.
- Red-check handling: any failed required CI checks will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/patients/{patient_id}` and `GET /api/v1/patients/{patient_id}/appointments`.
- Request shape: unchanged authenticated GET requests with the same `patient_id` path parameter.
- Response shape: unchanged for authorized callers.
- Status codes: Patient role now receives `403` when the requested `patient_id` is not linked to the current user; staff-role behavior is unchanged.
- Frontend consumer: patient portal and staff screens keep the same endpoints and response shape; cross-patient patient-token access is denied.
- Compatibility path or alias: no alias or route path changed.
- Contract proof: targeted RBAC regression creates a linked own Patient row and an unrelated Patient row, proves own row returns `200`, and proves other row plus other appointments return `403`.

## RBAC / Permissions

- Roles allowed: staff roles keep prior access; Patient role can access only `current_user.patient.id`.
- Roles denied: Patient role is denied for unrelated `patient_id` values and for unrelated patient appointments.
- Positive auth proof: Patient token receives `200` for the linked own patient row.
- Negative auth proof: the same Patient token receives `403` for another patient row and another patient's appointments.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime event, payload ack, read/unread, delivery, reconnect, or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - response shape unchanged; forbidden cross-patient access now returns `403`.
- Partial data proof: not applicable - endpoints return single patient or appointment list without partial rendering changes.
- Forbidden secondary path behavior: both direct patient read and patient appointments read now share the same self-access guard for Patient role.
- Missing draft/resource behavior: not applicable - endpoints are read-only and create no draft/resource.
- Stale route/deep-link behavior: stale or copied patient links now fail with `403` for Patient role unless linked to the current user's patient row.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/patients.py`; `backend/tests/integration/test_rbac_matrix.py`.
- Denied paths: patient service rewrites, DB migrations, frontend files, `/api/v1/ui/*`, BFF-lite, generated output, and broad role redesign.
- Migration/docs/test impact: no migration and no docs change; one targeted backend RBAC regression was added.
- Rollback note: revert this commit to restore prior Patient-role access to arbitrary `patient_id` route parameters and remove the regression.

## Validation

- Targeted tests or smoke run: py_compile for endpoint and test; `git diff --check`; attempted local targeted backend pytest; GitHub CI required for executable pytest proof.
- Result: py_compile passed; `git diff --check` passed; local pytest was blocked by missing local Python 3.11+ environment with `pytest`.
- Not checked: local pytest execution and frontend browser smoke, because the change is backend-only and CI runs backend tests.