### PR TITLE
fix(visits): guard doctor status updates

### DIFF
--- a/backend/app/api/v1/endpoints/visits.py
+++ b/backend/app/api/v1/endpoints/visits.py
@@ -11,6 +11,7 @@ from sqlalchemy import MetaData, select, Table
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
+from app.models.clinic import Doctor
 from app.services.visits_api_service import VisitsApiService
 
 router = APIRouter()
@@ -74,6 +75,35 @@ def _visits(db: Session) -> Table:
 def _vservices(db: Session) -> Table:
     md = MetaData()
     return Table("visit_services", md, autoload_with=db.get_bind())
+
+
+def _ensure_visit_doctor_status_access(db: Session, visit, current_user) -> None:
+    if getattr(current_user, "role", None) == "Admin" or getattr(
+        current_user, "is_superuser", False
+    ):
+        return
+    if getattr(current_user, "role", None) != "Doctor":
+        return
+
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor:
+        raise HTTPException(status_code=403, detail="Access denied")
+    if visit.doctor_id == doctor.id:
+        return
+
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == visit.doctor_id).first()
+    # Some legacy visit writers stored User.id in doctor_id. Allow that only
+    # when the value does not target another real Doctor row.
+    if not assigned_doctor and visit.doctor_id == current_user.id:
+        return
+    if assigned_doctor and assigned_doctor.user_id == current_user.id:
+        return
+
+    raise HTTPException(status_code=403, detail="Access denied")
 
 
 @router.get("/visits", response_model=List[VisitOut], summary="Список визитов")
@@ -145,10 +175,14 @@ def add_service(visit_id: int, item: VisitServiceIn, db: Session = Depends(get_d
 
 @router.post(
     "/visits/{visit_id}/status",
-    dependencies=[Depends(require_roles("Admin", "Doctor", "Registrar"))],
     summary="Смена статуса визита",
 )
-def set_status(visit_id: int, status_new: str, db: Session = Depends(get_db)):
+def set_status(
+    visit_id: int,
+    status_new: str,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("Admin", "Doctor", "Registrar")),
+):
     if status_new not in {"open", "in_progress", "closed", "canceled"}:
         raise HTTPException(400, "Invalid status")
     # Use ORM for reliability
@@ -156,6 +190,7 @@ def set_status(visit_id: int, status_new: str, db: Session = Depends(get_db)):
     visit = db.query(Visit).filter(Visit.id == visit_id).first()
     if not visit:
         raise HTTPException(404, "Visit not found")
+    _ensure_visit_doctor_status_access(db, visit, current_user)
 
     visit.status = status_new
     if status_new == "in_progress" and hasattr(visit, "started_at"):

--- a/backend/tests/integration/test_visit_status_owner_guard.py
+++ b/backend/tests/integration/test_visit_status_owner_guard.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import date
+from uuid import uuid4
+
+from app.core.security import get_password_hash
+from app.models.clinic import Doctor
+from app.models.patient import Patient
+from app.models.user import User
+from app.models.visit import Visit
+
+
+def _suffix() -> str:
+    return uuid4().hex[:10]
+
+
+def _create_doctor_user(db_session, *, label: str) -> tuple[User, Doctor]:
+    suffix = _suffix()
+    user = User(
+        username=f"visit_status_{label}_{suffix}",
+        email=f"visit-status-{label}-{suffix}@test.local",
+        full_name=f"Visit Status {label}",
+        hashed_password=get_password_hash("doctor123"),
+        role="Doctor",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    doctor = Doctor(
+        user_id=user.id,
+        specialty="therapy",
+        active=True,
+    )
+    db_session.add(doctor)
+    db_session.commit()
+    db_session.refresh(doctor)
+    return user, doctor
+
+
+def _create_patient(db_session) -> Patient:
+    suffix = _suffix()
+    patient = Patient(
+        first_name="Visit",
+        last_name=f"Status{suffix}",
+        phone=f"+99891{suffix[:7]}",
+        birth_date=date(1990, 1, 1),
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+    return patient
+
+
+def _doctor_headers(client, user: User) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": user.username, "password": "doctor123"},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def test_doctor_cannot_change_other_doctor_visit_status(client, db_session) -> None:
+    own_user, _own_doctor = _create_doctor_user(db_session, label="own")
+    _other_user, other_doctor = _create_doctor_user(db_session, label="other")
+    other_patient = _create_patient(db_session)
+    other_visit = Visit(
+        patient_id=other_patient.id,
+        doctor_id=other_doctor.id,
+        visit_date=date.today(),
+        status="open",
+        source="desk",
+    )
+    db_session.add(other_visit)
+    db_session.commit()
+    db_session.refresh(other_visit)
+
+    response = client.post(
+        f"/api/v1/visits/visits/{other_visit.id}/status",
+        params={"status_new": "closed"},
+        headers=_doctor_headers(client, own_user),
+    )
+
+    assert response.status_code == 403
+    db_session.refresh(other_visit)
+    assert other_visit.status == "open"


### PR DESCRIPTION
## Summary
- Add a Doctor owner guard to POST /api/v1/visits/visits/{visit_id}/status before mutating Visit.status.
- Preserve Admin/Registrar behavior and the narrow legacy User.id-in-doctor_id compatibility path only when it does not target another real Doctor row.
- Add a regression proving one Doctor token cannot close another Doctor's visit and the status remains unchanged.

## Cyclic Execution Evidence
- Fresh main sync: branch created from origin/main at 44c6737c2bfde4826359cf0bf52e81459dae287c in C:\tmp\final-next-audit.
- Clean workspace: git status was clean after PR #1350 merge/sync; only the two listed PR files are changed.
- Branch: codex/visit-status-doctor-owner-guard.
- Scope gate: gate was run with known root cause backend/app/api/v1/endpoints/visits.py; it returned gate_misroute: yes with unrelated billing paths, so a narrow override was used for visits.py plus one targeted regression test.
- Red-check handling: if CI is red, fixes will stay in this PR before merge.

## Contract Impact
- Canonical surface: existing /api/v1/visits/visits/{visit_id}/status mutation route.
- Request shape: unchanged; status_new remains the same query parameter.
- Response shape: unchanged for allowed callers.
- Status codes: Doctor role now receives 403 Access denied for another doctor's Visit before status mutation.
- Frontend consumer: existing visit status callers; no frontend files changed.
- Compatibility path or alias: legacy Visit.doctor_id values that stored User.id remain allowed only when that value does not resolve to another real Doctor row.
- Contract proof: backend/tests/integration/test_visit_status_owner_guard.py asserts cross-doctor status update returns 403 and preserves the original Visit.status.

## RBAC / Permissions
- Roles allowed: Admin/superuser and Registrar keep prior behavior; matching active Doctor profile can still update its own visit status.
- Roles denied: Doctor is denied when Visit.doctor_id resolves to another Doctor row.
- Positive auth proof: existing backend visit status tests remain in the suite; the guard returns without changing Admin/Registrar behavior and allows matching Doctor ownership.
- Negative auth proof: new integration regression covers a Doctor token attempting to close another Doctor's visit and expects 403.

## Notification / Realtime
- Event type or websocket channel: not applicable, no notification or websocket events are emitted by this patch.
- Payload version / ack behavior: not applicable, no notification payload changed.
- Read/unread or delivery semantics: not applicable, no delivery state touched.
- Reconnect/resync proof: not applicable, no realtime channel touched.

## Frontend Resilience
- Empty data proof: not applicable, no frontend empty-state behavior changed.
- Partial data proof: not applicable, no frontend partial-data handling changed.
- Forbidden secondary path behavior: forbidden cross-doctor status updates now receive standard 403.
- Missing draft/resource behavior: unchanged; missing visit still returns 404 and invalid status still returns 400.
- Stale route/deep-link behavior: unchanged route; stale/cross-doctor action links now fail closed with 403.

## Scope Gate
- Allowed paths: backend/app/api/v1/endpoints/visits.py, backend/tests/integration/test_visit_status_owner_guard.py.
- Denied paths: /api/v1/ui/*, BFF-lite, frontend, migrations, billing/payment code, broad visits refactors.
- Migration/docs/test impact: no migration or docs change; one targeted backend integration test added.
- Rollback note: revert this commit to restore previous Doctor ability to update any visit status by visit_id.

## Validation
- Targeted tests or smoke run: py_compile for touched backend files passed; targeted backend pytest attempted locally and blocked by missing pytest environment.
- Result: local syntax and diff checks passed; GitHub CI will provide executable pytest proof.
- Not checked: local pytest could not run because no Python 3.11+ interpreter with pytest is available in this Windows checkout.