### PR TITLE
fix(visits): guard doctor service adds

### DIFF
--- a/backend/app/api/v1/endpoints/visits.py
+++ b/backend/app/api/v1/endpoints/visits.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
 from app.models.clinic import Doctor
+from app.models.visit import Visit
 from app.services.visits_api_service import VisitsApiService
 
 router = APIRouter()
@@ -77,7 +78,7 @@ def _vservices(db: Session) -> Table:
     return Table("visit_services", md, autoload_with=db.get_bind())
 
 
-def _ensure_visit_doctor_status_access(db: Session, visit, current_user) -> None:
+def _ensure_visit_doctor_access(db: Session, visit: Visit, current_user) -> None:
     if getattr(current_user, "role", None) == "Admin" or getattr(
         current_user, "is_superuser", False
     ):
@@ -166,10 +167,18 @@ def get_visit(
 
 @router.post(
     "/visits/{visit_id}/services",
-    dependencies=[Depends(require_roles("Admin", "Registrar", "Doctor", "Cashier"))],
     summary="Добавить услугу к визиту",
 )
-def add_service(visit_id: int, item: VisitServiceIn, db: Session = Depends(get_db)):
+def add_service(
+    visit_id: int,
+    item: VisitServiceIn,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("Admin", "Registrar", "Doctor", "Cashier")),
+):
+    visit = db.query(Visit).filter(Visit.id == visit_id).first()
+    if not visit:
+        raise HTTPException(404, "Visit not found")
+    _ensure_visit_doctor_access(db, visit, current_user)
     return VisitsApiService(db).add_service(visit_id=visit_id, item=item)
 
 
@@ -185,12 +194,10 @@ def set_status(
 ):
     if status_new not in {"open", "in_progress", "closed", "canceled"}:
         raise HTTPException(400, "Invalid status")
-    # Use ORM for reliability
-    from app.models.visit import Visit
     visit = db.query(Visit).filter(Visit.id == visit_id).first()
     if not visit:
         raise HTTPException(404, "Visit not found")
-    _ensure_visit_doctor_status_access(db, visit, current_user)
+    _ensure_visit_doctor_access(db, visit, current_user)
 
     visit.status = status_new
     if status_new == "in_progress" and hasattr(visit, "started_at"):

--- a/backend/tests/integration/test_visit_status_owner_guard.py
+++ b/backend/tests/integration/test_visit_status_owner_guard.py
@@ -7,7 +7,7 @@ from app.core.security import get_password_hash
 from app.models.clinic import Doctor
 from app.models.patient import Patient
 from app.models.user import User
-from app.models.visit import Visit
+from app.models.visit import Visit, VisitService
 
 
 def _suffix() -> str:
@@ -87,3 +87,38 @@ def test_doctor_cannot_change_other_doctor_visit_status(client, db_session) -> N
     assert response.status_code == 403
     db_session.refresh(other_visit)
     assert other_visit.status == "open"
+
+
+def test_doctor_cannot_add_service_to_other_doctor_visit(client, db_session) -> None:
+    own_user, _own_doctor = _create_doctor_user(db_session, label="svc_own")
+    _other_user, other_doctor = _create_doctor_user(db_session, label="svc_other")
+    other_patient = _create_patient(db_session)
+    other_visit = Visit(
+        patient_id=other_patient.id,
+        doctor_id=other_doctor.id,
+        visit_date=date.today(),
+        status="open",
+        source="desk",
+    )
+    db_session.add(other_visit)
+    db_session.commit()
+    db_session.refresh(other_visit)
+
+    response = client.post(
+        f"/api/v1/visits/visits/{other_visit.id}/services",
+        json={
+            "code": "CONSULT",
+            "name": "Consultation",
+            "price": 125000,
+            "qty": 1,
+        },
+        headers=_doctor_headers(client, own_user),
+    )
+
+    assert response.status_code == 403
+    assert (
+        db_session.query(VisitService)
+        .filter(VisitService.visit_id == other_visit.id)
+        .count()
+        == 0
+    )


### PR DESCRIPTION
﻿## Summary

- Guard `POST /api/v1/visits/visits/{visit_id}/services` so Doctor role can add services only to visits owned by their active Doctor profile.
- Reuse the existing visit Doctor-owner guard added for status changes.
- Add a regression proving a cross-doctor service add returns 403 and does not insert `visit_services` rows.

## Cyclic Execution Evidence

- Fresh main sync: started from `origin/main` at `54dd9497` after PR #1351 merge
- Clean workspace: inspected before edits; only `backend/app/api/v1/endpoints/visits.py` and the paired integration test changed
- Branch: `codex/visit-service-doctor-owner-guard`
- Scope gate: gate_known_root_cause returned narrow override anchored to `backend/app/api/v1/endpoints/visits.py`; paired regression test was added as validation evidence only
- Red-check handling: fix failed targeted tests or CI checks in this same PR before merge

## Contract Impact

- Canonical surface: legacy mounted visits router `POST /api/v1/visits/visits/{visit_id}/services`
- Request shape: unchanged path/body using `VisitServiceIn`
- Response shape: unchanged for allowed callers; Doctor cross-owner requests now return 403 before mutation
- Status codes: existing 404 preserved for missing visit; new 403 for Doctor role when visit is owned by another active Doctor profile
- Frontend consumer: unchanged; no frontend files touched
- Compatibility path or alias: Admin, Registrar, Cashier, and superuser behavior unchanged; Doctor legacy User.id-in-doctor_id compatibility remains only when it does not target another real Doctor row
- Contract proof: `backend/tests/integration/test_visit_status_owner_guard.py` covers cross-doctor 403 and no inserted service row

## RBAC / Permissions

- Roles allowed: Admin, Registrar, Cashier unchanged; Doctor allowed for own active Doctor-profile visits
- Roles denied: Doctor denied for another Doctor's visit
- Positive auth proof: existing routing/auth tests and status owner tests continue to exercise authenticated Doctor/Admin paths
- Negative auth proof: new regression posts as one Doctor against another Doctor's visit and expects 403

## Notification / Realtime

- Event type or websocket channel: not applicable, this backend mutation does not emit or alter notification/websocket events
- Payload version / ack behavior: not applicable, no realtime payload or acknowledgement behavior changed
- Read/unread or delivery semantics: not applicable, no notification delivery state changed
- Reconnect/resync proof: not applicable, no realtime channel or client resync behavior changed

## Frontend Resilience

- Empty data proof: not applicable, this backend mutation does not render or consume empty frontend data
- Partial data proof: not applicable, no frontend data mapping changed
- Forbidden secondary path behavior: forbidden Doctor path returns 403 before inserting a visit service
- Missing draft/resource behavior: missing visit still returns 404 before service insertion
- Stale route/deep-link behavior: endpoint path and frontend routes are unchanged

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/visits.py`, `backend/tests/integration/test_visit_status_owner_guard.py`
- Denied paths: frontend files, migrations, generated output, unrelated visit/appointment/payment endpoints
- Migration/docs/test impact: no migration and no docs; one paired integration regression added
- Rollback note: revert this commit to restore previous broad Doctor service-add behavior

## Validation

- Targeted tests or smoke run: `py_compile` for touched endpoint/test passed via pgAdmin Python; `git diff --check` and `git diff --cached --check` passed
- Result: local compile/checks green; GitHub backend tests are running for full regression proof
- Not checked: local pytest unavailable because this checkout has no Python 3.11+ interpreter with `pytest`
