### PR TITLE
fix(cashier): require backend visit ids for payments

### DIFF
--- a/frontend/src/pages/CashierPanel.jsx
+++ b/frontend/src/pages/CashierPanel.jsx
@@ -234,13 +234,29 @@ const getPaymentActionContext = (paymentRow) => {
 };
 
 const getAppointmentPaymentActionContext = (appointment) => {
-  const appointmentId = appointment?.visit_id || appointment?.id || appointment?.patient_id || 'unknown';
+  const appointmentId = appointment?.visit_id || appointment?.patient_id || 'unknown';
   const patientName = appointment?.patient_name ||
     (appointment?.patient_last_name && appointment?.patient_first_name
       ? `${appointment.patient_last_name} ${appointment.patient_first_name}`
       : 'unknown patient');
   return `appointment ${appointmentId} for ${patientName}`;
 };
+
+const resolveCashierVisitIds = (appointment) => {
+  const groupedVisitIds = Array.isArray(appointment?.visit_ids)
+    ? appointment.visit_ids.filter((visitId) => visitId !== null && visitId !== undefined)
+    : [];
+
+  if (groupedVisitIds.length > 0) {
+    return [...new Set(groupedVisitIds)];
+  }
+
+  return appointment?.visit_id !== null && appointment?.visit_id !== undefined
+    ? [appointment.visit_id]
+    : [];
+};
+
+const resolveSingleCashierVisitId = (appointment) => resolveCashierVisitIds(appointment)[0] ?? null;
 
 const PAYMENT_ACTION_CAN_FIELD = {
   cancel: 'can_cancel',
@@ -569,9 +585,11 @@ const CashierPanel = () => {void
   const processPayment = async (appointment, paymentData) => {
     try {
       // Получаем все visit_id пациента
-      const visitIds = appointment.visit_ids && appointment.visit_ids.length > 0 ?
-      appointment.visit_ids :
-      [appointment.visit_id || appointment.id];
+      const visitIds = resolveCashierVisitIds(appointment);
+
+      if (visitIds.length === 0) {
+        throw new Error('Невозможно обработать оплату: backend не вернул visit_id.');
+      }
 
       // 1. Рассчитываем долг по каждому визиту на основе услуг
       const visitDebts = {};
@@ -1605,7 +1623,7 @@ const CashierPanel = () => {void
 
               {paymentWidget.selectedItem &&
               <PaymentWidget
-                visitId={paymentWidget.selectedItem.visit_id || paymentWidget.selectedItem.id}
+                visitId={resolveSingleCashierVisitId(paymentWidget.selectedItem)}
                 amount={paymentWidget.selectedItem.remaining_amount || paymentWidget.selectedItem.total_amount || paymentWidget.selectedItem.cost || 0}
                 currency="UZS"
                 description={`Оплата за ${paymentWidget.selectedItem.department || 'медицинские услуги'}`}


### PR DESCRIPTION
## Summary

- Stop CashierPanel from falling back from `visit_id` to generic row `id` when creating cash or online payments.
- Fail closed when backend queue/payment data does not provide a canonical visit id.
- No `/api/v1/ui/*`, no BFF-lite, no backend changes, no broad CashierPanel rewrite.

## Cyclic Execution Evidence

- Fresh main sync: branch created after fast-forwarding local main to origin/main at 54dd9497.
- Clean workspace: inspected before edits; only `frontend/src/pages/CashierPanel.jsx` changed.
- Branch: codex/cashier-visit-id-fail-closed.
- Scope gate: repo gate returned narrow override; allowed only CashierPanel.jsx and denied backend, tests, generated output, BFF, and broad cashier rewrite.
- Red-check handling: local validation passed; any red CI or PR gate will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: existing cashier/payment frontend consumers still call existing payment APIs through `usePayments` and PaymentWidget.
- Request shape: payment requests now use only backend-provided `visit_id` or `visit_ids`, never generic row `id` as a visit id.
- Response shape: unchanged; no API response DTO changed.
- Status codes: unchanged backend-owned payment endpoint behavior.
- Frontend consumer: CashierPanel cash payment distribution and online PaymentWidget launch.
- Compatibility path or alias: no compatibility alias or secondary endpoint added.
- Contract proof: source scan confirms removed `visit_id || id` payment fallbacks; frontend production build passed.

## RBAC / Permissions

- Roles allowed: unchanged; backend payment endpoints remain authoritative.
- Roles denied: unchanged; backend payment endpoints remain authoritative.
- Positive auth proof: not applicable - this PR does not change auth, route registration, or backend permissions.
- Negative auth proof: not applicable - this PR does not change auth, route registration, or backend permissions.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime channel changed.
- Payload version / ack behavior: not applicable - no realtime payload or ack contract changed.
- Read/unread or delivery semantics: not applicable - no notification delivery/read state changed.
- Reconnect/resync proof: not applicable - no reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: missing visit id now fails closed with a user-facing payment error instead of sending a guessed id.
- Partial data proof: grouped visit ids are deduplicated and filtered for null/undefined before payment allocation.
- Forbidden secondary path behavior: no secondary payment path is added; existing payment APIs remain the only command path.
- Missing draft/resource behavior: not applicable - CashierPanel payment flow does not use drafts.
- Stale route/deep-link behavior: not applicable - this payment flow does not read route/deep-link state for visit id selection.

## Scope Gate

- Allowed paths: `frontend/src/pages/CashierPanel.jsx`.
- Denied paths: backend routes/services, tests outside gate, generated output, `/api/v1/ui/*`, separate BFF service, command wrappers, broad CashierPanel rewrite.
- Migration/docs/test impact: no migration; no docs; tests not changed because gate allowed only the CashierPanel file.
- Rollback note: revert the single frontend commit to restore previous generic id fallback behavior.

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; source scan for removed payment `visit_id || id` fallbacks.
- Result: all passed locally.
- Not checked: backend tests and browser smoke were not run because no backend contract or UI layout code changed; focused frontend tests were not added because gate first-touch allowed only CashierPanel.jsx.