### PR TITLE
fix(registrar): guard doctor visit completion

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -43,6 +43,33 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+
+def _ensure_visit_doctor_access(db: Session, visit: Visit, current_user: User) -> None:
+    if current_user.role == "Admin" or current_user.is_superuser:
+        return
+    if current_user.role != "Doctor":
+        return
+
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor:
+        raise HTTPException(status_code=403, detail="Access denied")
+    if visit.doctor_id == doctor.id:
+        return
+
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == visit.doctor_id).first()
+    # Legacy writers sometimes stored User.id in Visit.doctor_id. Keep that
+    # compatibility only when the value is not another real Doctor row.
+    if not assigned_doctor and visit.doctor_id == current_user.id:
+        return
+    if assigned_doctor and assigned_doctor.user_id == current_user.id:
+        return
+
+    raise HTTPException(status_code=403, detail="Access denied")
+
 # ===================== СХЕМЫ ДЛЯ КОРЗИНЫ =====================
 
 
@@ -3029,6 +3056,8 @@ def complete_visit(
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Запись не найдена"
             )
+
+        _ensure_visit_doctor_access(db, visit, current_user)
 
         visit.status = "completed"
         db.commit()

--- a/backend/tests/integration/test_visit_status_owner_guard.py
+++ b/backend/tests/integration/test_visit_status_owner_guard.py
@@ -122,3 +122,30 @@ def test_doctor_cannot_add_service_to_other_doctor_visit(client, db_session) -> 
         .count()
         == 0
     )
+
+
+def test_doctor_cannot_complete_other_doctor_visit_from_registrar_endpoint(
+    client, db_session
+) -> None:
+    own_user, _own_doctor = _create_doctor_user(db_session, label="complete_own")
+    _other_user, other_doctor = _create_doctor_user(db_session, label="complete_other")
+    other_patient = _create_patient(db_session)
+    other_visit = Visit(
+        patient_id=other_patient.id,
+        doctor_id=other_doctor.id,
+        visit_date=date.today(),
+        status="open",
+        source="desk",
+    )
+    db_session.add(other_visit)
+    db_session.commit()
+    db_session.refresh(other_visit)
+
+    response = client.post(
+        f"/api/v1/registrar/visits/{other_visit.id}/complete",
+        headers=_doctor_headers(client, own_user),
+    )
+
+    assert response.status_code == 403
+    db_session.refresh(other_visit)
+    assert other_visit.status == "open"


### PR DESCRIPTION
﻿## Summary

- Guard `POST /api/v1/registrar/visits/{visit_id}/complete` so Doctor role can complete only visits owned by their active Doctor profile.
- Preserve Admin, Registrar, Cashier, Receptionist, and superuser behavior.
- Add a regression proving a cross-doctor completion attempt returns 403 and leaves the visit status unchanged.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` at `11ffa2e4` after PR #1352 merge
- Clean workspace: inspected before edits; only `backend/app/api/v1/endpoints/registrar_wizard.py` and the paired integration test changed
- Branch: `codex/registrar-complete-doctor-owner-guard`
- Scope gate: gate_known_root_cause returned narrow override anchored to `backend/app/api/v1/endpoints/registrar_wizard.py`; paired regression test was added as validation evidence only
- Red-check handling: fix failed targeted tests or CI checks in this same PR before merge

## Contract Impact

- Canonical surface: legacy mounted registrar route `POST /api/v1/registrar/visits/{visit_id}/complete`
- Request shape: unchanged path-only request
- Response shape: unchanged for allowed callers; Doctor cross-owner requests now return 403 before mutation
- Status codes: existing 404 preserved for missing visit; new 403 for Doctor role when visit is owned by another active Doctor profile
- Frontend consumer: unchanged; no frontend files touched
- Compatibility path or alias: Admin, Registrar, Cashier, Receptionist, and superuser behavior unchanged; Doctor legacy User.id-in-doctor_id compatibility remains only when it does not target another real Doctor row
- Contract proof: `backend/tests/integration/test_visit_status_owner_guard.py` covers cross-doctor 403 and unchanged visit status

## RBAC / Permissions

- Roles allowed: Admin, Registrar, Cashier, Receptionist unchanged; Doctor allowed for own active Doctor-profile visits
- Roles denied: Doctor denied for another Doctor's visit
- Positive auth proof: existing registrar/doctor endpoint coverage keeps authenticated allowed paths in CI
- Negative auth proof: new regression posts as one Doctor against another Doctor's visit and expects 403

## Notification / Realtime

- Event type or websocket channel: not applicable, this endpoint does not emit notification/websocket events
- Payload version / ack behavior: not applicable, no realtime payload or acknowledgement behavior changed
- Read/unread or delivery semantics: not applicable, no notification delivery state changed
- Reconnect/resync proof: not applicable, no realtime channel or client resync behavior changed

## Frontend Resilience

- Empty data proof: not applicable, this backend mutation does not render or consume empty frontend data
- Partial data proof: not applicable, no frontend data mapping changed
- Forbidden secondary path behavior: forbidden Doctor path returns 403 before changing visit status
- Missing draft/resource behavior: missing visit still returns 404
- Stale route/deep-link behavior: endpoint path and frontend routes are unchanged

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/registrar_wizard.py`, `backend/tests/integration/test_visit_status_owner_guard.py`
- Denied paths: frontend files, migrations, generated output, unrelated visit/appointment/payment endpoints
- Migration/docs/test impact: no migration and no docs; one paired integration regression added
- Rollback note: revert this commit to restore previous broad Doctor completion behavior

## Validation

- Targeted tests or smoke run: `py_compile` for touched endpoint/test passed via pgAdmin Python; `git diff --check` and `git diff --cached --check` passed
- Result: local compile/checks green; GitHub backend tests will provide full regression proof
- Not checked: local pytest unavailable because this checkout has no Python 3.11+ interpreter with `pytest`
