### PR TITLE
fix(payments): guard patient payment reads

### DIFF
--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -30,8 +30,25 @@ from app.services.payment_test_init_service import (
     PaymentTestInitService,
 )
 from app.services.payment_provider_manager_factory import get_payment_manager
+from app.models.payment import Payment
+from app.models.visit import Visit
 
 router = APIRouter()
+
+
+def _ensure_patient_payment_access(db: Session, payment_id: int, current_user) -> None:
+    if getattr(current_user, "role", None) != "Patient":
+        return
+    if not getattr(current_user, "patient", None):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    payment = db.query(Payment).filter(Payment.id == payment_id).first()
+    if not payment:
+        raise HTTPException(status_code=404, detail="Платеж не найден")
+
+    visit = db.query(Visit).filter(Visit.id == payment.visit_id).first()
+    if not visit or visit.patient_id != current_user.patient.id:
+        raise HTTPException(status_code=403, detail="Access denied")
 
 # ===================== МОДЕЛИ ДЛЯ МОДУЛЯ ОПЛАТЫ =====================
 
@@ -232,6 +249,7 @@ def get_payment_status(
     current_user=Depends(deps.require_roles("Admin", "Cashier", "Registrar", "Doctor", "Patient")),
 ) -> PaymentStatusResponse:
     """Получение статуса платежа"""
+    _ensure_patient_payment_access(db, payment_id, current_user)
     service = PaymentReadService(db, get_payment_manager())
     try:
         return PaymentStatusResponse(**service.get_payment_status(payment_id=payment_id))
@@ -296,6 +314,7 @@ def generate_receipt(
     current_user=Depends(deps.get_current_user),
 ):
     """Генерация квитанции об оплате"""
+    _ensure_patient_payment_access(db, payment_id, current_user)
     service = PaymentReadService(db)
     try:
         return service.generate_receipt(payment_id=payment_id, format_type=format_type)
@@ -315,6 +334,7 @@ def download_receipt(
     current_user=Depends(deps.get_current_user),
 ):
     """Скачивание квитанции"""
+    _ensure_patient_payment_access(db, payment_id, current_user)
     service = PaymentReadService(db)
     try:
         pdf_bytes = service.build_receipt_pdf(payment_id=payment_id)

--- a/backend/tests/integration/test_payment_patient_access.py
+++ b/backend/tests/integration/test_payment_patient_access.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+from app.core.security import get_password_hash
+from app.models.patient import Patient
+from app.models.payment import Payment
+from app.models.user import User
+from app.models.visit import Visit
+
+
+def _suffix() -> str:
+    return uuid4().hex[:10]
+
+
+def _create_patient_user(db_session, *, label: str) -> tuple[User, Patient]:
+    suffix = _suffix()
+    user = User(
+        username=f"payment_patient_{label}_{suffix}",
+        email=f"payment-patient-{label}-{suffix}@test.local",
+        hashed_password=get_password_hash("patient123"),
+        role="Patient",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    patient = Patient(
+        user_id=user.id,
+        first_name="Payment",
+        last_name=f"Patient{label}{suffix}",
+        phone=f"+99893{suffix[:7]}",
+        birth_date=date(1990, 1, 1),
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+    return user, patient
+
+
+def _create_payment(db_session, *, patient: Patient) -> Payment:
+    visit = Visit(
+        patient_id=patient.id,
+        visit_date=date.today(),
+        status="open",
+        source="desk",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+
+    payment = Payment(
+        visit_id=visit.id,
+        amount=Decimal("125000.00"),
+        currency="UZS",
+        method="online",
+        status="paid",
+        provider="click",
+        provider_payment_id=f"provider-{_suffix()}",
+        provider_data={"private": "payload"},
+    )
+    db_session.add(payment)
+    db_session.commit()
+    db_session.refresh(payment)
+    return payment
+
+
+def _patient_headers(client, user: User) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": user.username, "password": "patient123"},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def test_patient_payment_reads_are_limited_to_own_visit(client, db_session) -> None:
+    own_user, own_patient = _create_patient_user(db_session, label="own")
+    _other_user, other_patient = _create_patient_user(db_session, label="other")
+    own_payment = _create_payment(db_session, patient=own_patient)
+    other_payment = _create_payment(db_session, patient=other_patient)
+    headers = _patient_headers(client, own_user)
+
+    own_response = client.get(f"/api/v1/payments/{own_payment.id}", headers=headers)
+    assert own_response.status_code == 200, own_response.text
+    assert own_response.json()["payment_id"] == own_payment.id
+
+    status_response = client.get(f"/api/v1/payments/{other_payment.id}", headers=headers)
+    assert status_response.status_code == 403
+
+    receipt_response = client.get(
+        f"/api/v1/payments/{other_payment.id}/receipt",
+        headers=headers,
+    )
+    assert receipt_response.status_code == 403


### PR DESCRIPTION
﻿## Summary

- Guard Patient-role reads for `GET /api/v1/payments/{payment_id}` and payment receipt endpoints.
- Patient users can read only payments whose linked visit belongs to their own Patient profile.
- Add a regression proving own payment status is readable while another patient's payment status and receipt are forbidden.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` at `74c5a787` after PR #1354 merge
- Clean workspace: inspected before edits; only `backend/app/api/v1/endpoints/payments.py` and one paired integration test changed
- Branch: `codex/payment-patient-self-access`
- Scope gate: gate_known_root_cause returned narrow override anchored to `backend/app/api/v1/endpoints/payments.py`; paired regression test was added as validation evidence only
- Red-check handling: fix failed targeted tests or CI checks in this same PR before merge

## Contract Impact

- Canonical surface: `GET /api/v1/payments/{payment_id}`, `GET /api/v1/payments/{payment_id}/receipt`, `GET /api/v1/payments/{payment_id}/receipt/download`
- Request shape: unchanged path-only payment id requests
- Response shape: unchanged for allowed callers; Patient cross-owner requests now return 403 before exposing payment or receipt data
- Status codes: existing 404 preserved for missing payment; new 403 for Patient role when payment's visit belongs to another patient
- Frontend consumer: unchanged; no frontend files touched
- Compatibility path or alias: Admin, Cashier, Registrar, Doctor, and other authenticated staff receipt behavior unchanged; only Patient role is narrowed to self-owned payments
- Contract proof: `backend/tests/integration/test_payment_patient_access.py` covers own status 200 plus cross-patient status/receipt 403

## RBAC / Permissions

- Roles allowed: staff behavior unchanged; Patient allowed for payments linked to their own Patient profile
- Roles denied: Patient denied for another Patient's payment and receipt
- Positive auth proof: new regression reads own payment status with a Patient token and expects 200
- Negative auth proof: new regression reads another patient's payment status and receipt with the same token and expects 403

## Notification / Realtime

- Event type or websocket channel: not applicable, payment read endpoints do not emit notification/websocket events
- Payload version / ack behavior: not applicable, no realtime payload or acknowledgement behavior changed
- Read/unread or delivery semantics: not applicable, no notification delivery state changed
- Reconnect/resync proof: not applicable, no realtime channel or client resync behavior changed

## Frontend Resilience

- Empty data proof: not applicable, this backend access guard does not render or consume empty frontend data
- Partial data proof: not applicable, no frontend data mapping changed
- Forbidden secondary path behavior: forbidden Patient path returns 403 before exposing payment status/provider data or receipt data
- Missing draft/resource behavior: missing payment still returns 404
- Stale route/deep-link behavior: endpoint paths and frontend routes are unchanged

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/payments.py`, `backend/tests/integration/test_payment_patient_access.py`
- Denied paths: frontend files, migrations, generated output, unrelated billing/cashier/provider endpoints
- Migration/docs/test impact: no migration and no docs; one paired integration regression added
- Rollback note: revert this commit to restore previous broad Patient payment-read behavior

## Validation

- Targeted tests or smoke run: `py_compile` for touched endpoint/test passed via pgAdmin Python; `git diff --check` and `git diff --cached --check` passed
- Result: local compile/checks green; GitHub backend tests will provide full regression proof
- Not checked: local pytest unavailable because this checkout has no Python 3.11+ interpreter with `pytest`
