### PR TITLE
fix(telegram): auto-detect mini app frontend url

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -5,11 +5,14 @@ Webhook endpoint для обработки входящих сообщений �
 import hashlib
 import html
 import hmac
+import ipaddress
 import logging
 import secrets
+import socket
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Dict, NoReturn
+from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, ConfigDict, Field
@@ -1087,8 +1090,61 @@ def _append_patient_mini_app_entry_token(entry_url: str, token: str) -> str:
     return f"{entry_url}{separator}entryToken={token}"
 
 
+def _detect_local_lan_ip() -> str | None:
+    try:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        probe.settimeout(0)
+        try:
+            probe.connect(("8.8.8.8", 80))
+            local_ip = probe.getsockname()[0]
+        finally:
+            probe.close()
+    except OSError:
+        try:
+            local_ip = socket.gethostbyname(socket.gethostname())
+        except OSError:
+            return None
+
+    try:
+        parsed_ip = ipaddress.ip_address(local_ip)
+    except ValueError:
+        return None
+    if parsed_ip.is_loopback or parsed_ip.is_unspecified:
+        return None
+    return local_ip
+
+
+def _is_local_frontend_host(hostname: str | None) -> bool:
+    host = str(hostname or "").strip().lower()
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_private
+    except ValueError:
+        return False
+
+
+def _telegram_patient_frontend_url() -> str | None:
+    configured_url = str(getattr(settings, "FRONTEND_URL", "") or "").strip()
+    if not configured_url:
+        local_ip = _detect_local_lan_ip()
+        return f"http://{local_ip}:5173" if local_ip else None
+
+    parsed = urlsplit(configured_url)
+    if parsed.scheme != "http" or not _is_local_frontend_host(parsed.hostname):
+        return configured_url
+
+    local_ip = _detect_local_lan_ip()
+    if not local_ip:
+        return configured_url
+
+    port = parsed.port or 5173
+    netloc = f"{local_ip}:{port}"
+    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
+
+
 def _patient_entry_url(section: str | None = None) -> str | None:
-    frontend_url = str(getattr(settings, "FRONTEND_URL", "") or "").strip()
+    frontend_url = _telegram_patient_frontend_url()
     if not frontend_url:
         return None
 

--- a/backend/app/api/v1/endpoints/telegram_webhook.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook.py
@@ -1127,8 +1127,7 @@ def _is_local_frontend_host(hostname: str | None) -> bool:
 def _telegram_patient_frontend_url() -> str | None:
     configured_url = str(getattr(settings, "FRONTEND_URL", "") or "").strip()
     if not configured_url:
-        local_ip = _detect_local_lan_ip()
-        return f"http://{local_ip}:5173" if local_ip else None
+        return None
 
     parsed = urlsplit(configured_url)
     if parsed.scheme != "http" or not _is_local_frontend_host(parsed.hostname):


### PR DESCRIPTION
## Summary
- Auto-detect the current LAN IP for local Telegram Mini App patient links when configured `FRONTEND_URL` is a private/localhost HTTP URL.
- Keep public HTTPS frontend URLs unchanged for future domain/webhook deployment.
- Preserve the existing no-frontend fallback: if `FRONTEND_URL` is empty, the bot shows the localized services menu instead of a Mini App button.

## Cyclic Execution Evidence
- Fresh main sync: branch `codex/telegram-miniapp-auto-frontend-url` created from current `main` in this cycle.
- Clean workspace: inspected before edits; only `backend/app/api/v1/endpoints/telegram_webhook.py` changed.
- Branch: `codex/telegram-miniapp-auto-frontend-url`.
- Scope gate: repo gate routed this as Telegram endpoint/service first-touch; no frontend, migration, QR, payment, or queue files changed.
- Red-check handling: initial CI backend failure was fixed in the same PR by preserving the empty `FRONTEND_URL` fallback contract.

## Contract Impact
- Canonical surface: Telegram patient Mini App entry URL generation in `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Request shape: unchanged.
- Response shape: unchanged Telegram reply markup shape; only local URL host is rewritten for configured private/localhost frontend URLs.
- Status codes: unchanged.
- Frontend consumer: existing Mini App shell URL stays `/telegram/mini-app/patient?...`.
- Compatibility path or alias: empty `FRONTEND_URL` still falls back to localized bot menu; public HTTPS domain remains untouched.
- Contract proof: local smoke covers empty URL, stale private IP, localhost, public HTTPS, and fresh entryToken manifest validation.

## RBAC / Permissions
- Roles allowed: unchanged; linked Telegram patient access rules remain unchanged.
- Roles denied: unchanged.
- Positive auth proof: fresh signed `entryToken` manifest smoke returned HTTP 200 for linked patient.
- Negative auth proof: no new bypass added; empty `FRONTEND_URL` does not create a Mini App button.

## Notification / Realtime
not applicable - no notification delivery, websocket, polling loop, or realtime event contract changed.

## Frontend Resilience
- Empty data proof: not changed; Mini App shell build still passes.
- Partial data proof: not changed; URL rewrite does not alter manifest payload.
- Forbidden secondary path behavior: not changed; expired/invalid entryToken behavior remains backend-owned.
- Missing draft/resource behavior: not applicable, no draft/resource workflow changed.
- Stale route/deep-link behavior: stale private LAN host is replaced with current detected LAN IP; signed token and route query are preserved.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook.py`.
- Denied paths: migrations, frontend shell, QR queue service, payment services, generated output, secrets/env files.
- Migration/docs/test impact: no migration; no docs required; smoke and compile validation run.
- Rollback note: revert the two commits on this branch to return to configured `FRONTEND_URL` exactly as-is.

## Validation
- Targeted tests or smoke run: `backend/.venv/Scripts/python.exe -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; auto URL contract smoke; fresh Mini App entryToken manifest HTTP smoke; `npm.cmd run build`; `git diff --check`.
- Result: local validation passed. `scripts/run_backend_pytest.ps1` could not collect the targeted async test on this Windows checkout because `pytest.mark.asyncio` is not registered locally; CI Linux backend test is the authoritative check for that pytest path.
- Not checked: manual click inside Telegram after the second CI fix; backend and polling were restarted after the first live fix and will be restarted again locally after final verification.