### PR TITLE
fix(cors): auto-allow current dev lan origin

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,12 @@
 # --- BEGIN app/main.py ---
 from __future__ import annotations
 
+import ipaddress
 import logging
 import os
+import socket
 from contextlib import asynccontextmanager
+from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -27,10 +30,72 @@ API_V1_STR = os.getenv("API_V1_STR", "/api/v1")
 # Use settings for CORS configuration
 CORS_DISABLE = settings.CORS_DISABLE
 CORS_ALLOW_ALL = settings.CORS_ALLOW_ALL
-CORS_ORIGINS = settings.BACKEND_CORS_ORIGINS
 ENV = os.getenv("ENV", "dev").lower()
 IS_PROD = ENV in ("prod", "production")
 TESTING = os.getenv("TESTING", "0").lower() in ("1", "true", "yes")
+
+
+def _detect_local_lan_ip() -> str | None:
+    try:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        probe.settimeout(0)
+        try:
+            probe.connect(("8.8.8.8", 80))
+            local_ip = probe.getsockname()[0]
+        finally:
+            probe.close()
+    except OSError:
+        try:
+            local_ip = socket.gethostbyname(socket.gethostname())
+        except OSError:
+            return None
+
+    try:
+        parsed_ip = ipaddress.ip_address(local_ip)
+    except ValueError:
+        return None
+    if parsed_ip.is_loopback or parsed_ip.is_unspecified:
+        return None
+    return local_ip
+
+
+def _is_local_cors_host(hostname: str | None) -> bool:
+    host = str(hostname or "").strip().lower()
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_private
+    except ValueError:
+        return False
+
+
+def _with_dev_lan_cors_origins(origins: list[str]) -> list[str]:
+    if IS_PROD:
+        return origins
+
+    local_ip = _detect_local_lan_ip()
+    if not local_ip:
+        return origins
+
+    updated_origins = list(dict.fromkeys(origins))
+    ports: set[int] = set()
+    for origin in origins:
+        parsed = urlsplit(str(origin or "").strip())
+        if parsed.scheme != "http" or not _is_local_cors_host(parsed.hostname):
+            continue
+        try:
+            ports.add(parsed.port or 80)
+        except ValueError:
+            continue
+
+    for port in ports or {5173}:
+        local_origin = urlunsplit(("http", f"{local_ip}:{port}", "", "", ""))
+        if local_origin not in updated_origins:
+            updated_origins.append(local_origin)
+    return updated_origins
+
+
+CORS_ORIGINS = _with_dev_lan_cors_origins(settings.BACKEND_CORS_ORIGINS)
 
 # Fail fast on insecure CORS in production
 if IS_PROD and (CORS_DISABLE or CORS_ALLOW_ALL):


### PR DESCRIPTION
## Summary
- Add development-only automatic LAN CORS origins for local HTTP frontend origins.
- Preserve production CORS strictness and keep configured HTTPS origins unchanged.
- Make local Telegram Mini App links keep working after Wi-Fi/private IP changes without editing `CORS_ORIGINS` every time.

## Cyclic Execution Evidence
- Fresh main sync: branch `codex/dev-auto-lan-cors` created from synced `main` after PR #1356 was merged.
- Clean workspace: inspected before edits; only `backend/app/main.py` changed.
- Branch: `codex/dev-auto-lan-cors`.
- Scope gate: initial gate misrouted to Telegram files; one known-root-cause retry approved narrow override for `backend/app/main.py`.
- Red-check handling: PR Review Quality Gate failed on body wording only; body is being fixed in this same PR.

## Contract Impact
- Canonical surface: backend CORS middleware setup in `backend/app/main.py`.
- Request shape: unchanged.
- Response shape: unchanged except dev CORS headers can now include current LAN origin.
- Status codes: unchanged.
- Frontend consumer: existing Vite dev server and Telegram Mini App shell.
- Compatibility path or alias: configured CORS origins remain; current LAN origin is appended only in non-production.
- Contract proof: local helper smoke proves dev adds current LAN ports and production does not auto-add.

## RBAC / Permissions
- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: CORS preflight policy only; authenticated route permissions were not touched.
- Negative auth proof: production mode returns configured origins unchanged and still rejects insecure CORS_ALLOW_ALL/CORS_DISABLE startup as before.

## Notification / Realtime
not applicable - no Telegram message, websocket payload, polling loop, or realtime event changed.

## Frontend Resilience
- Empty data proof: no data view changed; CORS origin list changes before payload handling.
- Partial data proof: no frontend payload changed; partial API data behavior is unchanged.
- Forbidden secondary path behavior: forbidden/expired Mini App entryToken behavior is unchanged because this patch only affects CORS origin matching.
- Missing draft/resource behavior: no draft or resource is created, reopened, or resolved by this middleware; missing-resource handling remains in existing route handlers.
- Stale route/deep-link behavior: local private-IP Mini App deep links and API calls now share the current LAN origin in dev CORS.

## Scope Gate
- Allowed paths: `backend/app/main.py`.
- Denied paths: frontend package/dependency files, Telegram endpoints, migrations, generated output, secrets/env files.
- Migration/docs/test impact: no migration; no docs required; smoke and compile validation run.
- Rollback note: revert this PR to return to static configured `BACKEND_CORS_ORIGINS`/`CORS_ORIGINS` only.

## Validation
- Targeted tests or smoke run: `backend/.venv/Scripts/python.exe -m py_compile backend/app/main.py`; dev/prod LAN CORS helper smoke; `git diff --check`; `npm.cmd run build`; `npm.cmd audit --audit-level=moderate`.
- Result: compile, helper smoke, diff check, and frontend build passed. `npm audit` failed on existing moderate `qs` advisory unrelated to this CORS change and package files were not touched.
- Not checked: full manual browser CORS preflight after changing the machine IP.