### PR TITLE
fix(payments): guard doctor payment reads

### DIFF
--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -30,6 +30,7 @@ from app.services.payment_test_init_service import (
     PaymentTestInitService,
 )
 from app.services.payment_provider_manager_factory import get_payment_manager
+from app.models.clinic import Doctor
 from app.models.payment import Payment
 from app.models.visit import Visit
 
@@ -51,6 +52,63 @@ def _ensure_patient_payment_access(db: Session, payment_id: int, current_user) -
         raise HTTPException(status_code=403, detail="Access denied")
 
 # ===================== МОДЕЛИ ДЛЯ МОДУЛЯ ОПЛАТЫ =====================
+
+
+def _ensure_doctor_visit_payment_access(
+    db: Session, visit: Visit | None, current_user
+) -> None:
+    if not visit:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor:
+        raise HTTPException(status_code=403, detail="Access denied")
+    if visit.doctor_id == doctor.id:
+        return
+
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == visit.doctor_id).first()
+    # Legacy writers sometimes stored User.id in visits.doctor_id. Preserve that
+    # compatibility only when the value does not point to another Doctor row.
+    if not assigned_doctor and visit.doctor_id == current_user.id:
+        return
+    if assigned_doctor and assigned_doctor.user_id == current_user.id:
+        return
+
+    raise HTTPException(status_code=403, detail="Access denied")
+
+
+def _ensure_visit_payment_access(db: Session, visit_id: int, current_user) -> Visit:
+    visit = db.query(Visit).filter(Visit.id == visit_id).first()
+    if not visit:
+        raise HTTPException(status_code=404, detail="Visit not found")
+
+    role = getattr(current_user, "role", None)
+    if role == "Patient":
+        if not getattr(current_user, "patient", None):
+            raise HTTPException(status_code=403, detail="Access denied")
+        if visit.patient_id != current_user.patient.id:
+            raise HTTPException(status_code=403, detail="Access denied")
+    elif role == "Doctor":
+        _ensure_doctor_visit_payment_access(db, visit, current_user)
+
+    return visit
+
+
+def _ensure_payment_read_access(db: Session, payment_id: int, current_user) -> None:
+    if getattr(current_user, "role", None) not in {"Patient", "Doctor"}:
+        return
+
+    payment = db.query(Payment).filter(Payment.id == payment_id).first()
+    if not payment:
+        raise HTTPException(status_code=404, detail="Payment not found")
+
+    if not payment.visit_id:
+        raise HTTPException(status_code=403, detail="Access denied")
+    _ensure_visit_payment_access(db, payment.visit_id, current_user)
 
 
 class PaymentInvoiceCreateRequest(BaseModel):
@@ -230,6 +288,10 @@ def list_payments(
     current_user=Depends(deps.require_roles("Admin", "Cashier", "Registrar", "Doctor")),
 ) -> PaymentListResponse:
     """Получение списка платежей с фильтрацией (использует SSOT)"""
+    if getattr(current_user, "role", None) == "Doctor":
+        if visit_id is None:
+            raise HTTPException(status_code=403, detail="Access denied")
+        _ensure_visit_payment_access(db, visit_id, current_user)
     service = PaymentReadService(db)
     return PaymentListResponse(
         **service.list_payments(
@@ -249,7 +311,7 @@ def get_payment_status(
     current_user=Depends(deps.require_roles("Admin", "Cashier", "Registrar", "Doctor", "Patient")),
 ) -> PaymentStatusResponse:
     """Получение статуса платежа"""
-    _ensure_patient_payment_access(db, payment_id, current_user)
+    _ensure_payment_read_access(db, payment_id, current_user)
     service = PaymentReadService(db, get_payment_manager())
     try:
         return PaymentStatusResponse(**service.get_payment_status(payment_id=payment_id))
@@ -264,6 +326,7 @@ def get_visit_payments(
     current_user=Depends(deps.require_roles("Admin", "Cashier", "Registrar", "Doctor")),
 ) -> PaymentListResponse:
     """Получение всех платежей по визиту"""
+    _ensure_visit_payment_access(db, visit_id, current_user)
     service = PaymentReadService(db)
     return PaymentListResponse(**service.get_visit_payments(visit_id=visit_id))
 
@@ -311,10 +374,10 @@ def generate_receipt(
     payment_id: int,
     format_type: str = "pdf",
     db: Session = Depends(get_db),
-    current_user=Depends(deps.get_current_user),
+    current_user=Depends(deps.require_roles("Admin", "Cashier", "Registrar", "Doctor", "Patient")),
 ):
     """Генерация квитанции об оплате"""
-    _ensure_patient_payment_access(db, payment_id, current_user)
+    _ensure_payment_read_access(db, payment_id, current_user)
     service = PaymentReadService(db)
     try:
         return service.generate_receipt(payment_id=payment_id, format_type=format_type)
@@ -331,10 +394,10 @@ def generate_receipt(
 def download_receipt(
     payment_id: int,
     db: Session = Depends(get_db),
-    current_user=Depends(deps.get_current_user),
+    current_user=Depends(deps.require_roles("Admin", "Cashier", "Registrar", "Doctor", "Patient")),
 ):
     """Скачивание квитанции"""
-    _ensure_patient_payment_access(db, payment_id, current_user)
+    _ensure_payment_read_access(db, payment_id, current_user)
     service = PaymentReadService(db)
     try:
         pdf_bytes = service.build_receipt_pdf(payment_id=payment_id)

--- a/backend/tests/integration/test_payment_patient_access.py
+++ b/backend/tests/integration/test_payment_patient_access.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from uuid import uuid4
 
 from app.core.security import get_password_hash
+from app.models.clinic import Doctor
 from app.models.patient import Patient
 from app.models.payment import Payment
 from app.models.user import User
@@ -42,9 +43,38 @@ def _create_patient_user(db_session, *, label: str) -> tuple[User, Patient]:
     return user, patient
 
 
-def _create_payment(db_session, *, patient: Patient) -> Payment:
+def _create_doctor_user(db_session, *, label: str) -> tuple[User, Doctor]:
+    suffix = _suffix()
+    user = User(
+        username=f"payment_doctor_{label}_{suffix}",
+        email=f"payment-doctor-{label}-{suffix}@test.local",
+        full_name=f"Payment Doctor {label}",
+        hashed_password=get_password_hash("doctor123"),
+        role="Doctor",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    doctor = Doctor(
+        user_id=user.id,
+        specialty="therapy",
+        active=True,
+    )
+    db_session.add(doctor)
+    db_session.commit()
+    db_session.refresh(doctor)
+    return user, doctor
+
+
+def _create_payment(
+    db_session, *, patient: Patient, doctor: Doctor | None = None
+) -> Payment:
     visit = Visit(
         patient_id=patient.id,
+        doctor_id=doctor.id if doctor else None,
         visit_date=date.today(),
         status="open",
         source="desk",
@@ -78,6 +108,38 @@ def _patient_headers(client, user: User) -> dict[str, str]:
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
 
 
+def _doctor_headers(client, user: User) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": user.username, "password": "doctor123"},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _staff_headers(client, db_session, *, role: str) -> dict[str, str]:
+    suffix = _suffix()
+    password = "staff123"
+    user = User(
+        username=f"payment_staff_{role.lower()}_{suffix}",
+        email=f"payment-staff-{role.lower()}-{suffix}@test.local",
+        hashed_password=get_password_hash(password),
+        role=role,
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": user.username, "password": password},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
 def test_patient_payment_reads_are_limited_to_own_visit(client, db_session) -> None:
     own_user, own_patient = _create_patient_user(db_session, label="own")
     _other_user, other_patient = _create_patient_user(db_session, label="other")
@@ -97,3 +159,76 @@ def test_patient_payment_reads_are_limited_to_own_visit(client, db_session) -> N
         headers=headers,
     )
     assert receipt_response.status_code == 403
+
+
+def test_doctor_payment_reads_are_limited_to_own_visits(client, db_session) -> None:
+    own_user, own_doctor = _create_doctor_user(db_session, label="own")
+    _other_user, other_doctor = _create_doctor_user(db_session, label="other")
+    own_patient = _create_patient_user(db_session, label="doc_own_patient")[1]
+    other_patient = _create_patient_user(db_session, label="doc_other_patient")[1]
+    own_payment = _create_payment(
+        db_session, patient=own_patient, doctor=own_doctor
+    )
+    other_payment = _create_payment(
+        db_session, patient=other_patient, doctor=other_doctor
+    )
+    headers = _doctor_headers(client, own_user)
+
+    own_status_response = client.get(
+        f"/api/v1/payments/{own_payment.id}",
+        headers=headers,
+    )
+    assert own_status_response.status_code == 200, own_status_response.text
+    assert own_status_response.json()["payment_id"] == own_payment.id
+
+    other_status_response = client.get(
+        f"/api/v1/payments/{other_payment.id}",
+        headers=headers,
+    )
+    assert other_status_response.status_code == 403
+
+    other_receipt_response = client.get(
+        f"/api/v1/payments/{other_payment.id}/receipt",
+        headers=headers,
+    )
+    assert other_receipt_response.status_code == 403
+
+    other_receipt_download_response = client.get(
+        f"/api/v1/payments/{other_payment.id}/receipt/download",
+        headers=headers,
+    )
+    assert other_receipt_download_response.status_code == 403
+
+    other_visit_response = client.get(
+        f"/api/v1/payments/visit/{other_payment.visit_id}",
+        headers=headers,
+    )
+    assert other_visit_response.status_code == 403
+
+    filtered_list_response = client.get(
+        "/api/v1/payments/",
+        params={"visit_id": other_payment.visit_id},
+        headers=headers,
+    )
+    assert filtered_list_response.status_code == 403
+
+    unscoped_list_response = client.get("/api/v1/payments/", headers=headers)
+    assert unscoped_list_response.status_code == 403
+
+
+def test_non_payment_staff_cannot_read_payment_receipts(client, db_session) -> None:
+    patient = _create_patient_user(db_session, label="lab_receipt_patient")[1]
+    payment = _create_payment(db_session, patient=patient)
+    headers = _staff_headers(client, db_session, role="Lab")
+
+    receipt_response = client.get(
+        f"/api/v1/payments/{payment.id}/receipt",
+        headers=headers,
+    )
+    assert receipt_response.status_code == 403
+
+    download_response = client.get(
+        f"/api/v1/payments/{payment.id}/receipt/download",
+        headers=headers,
+    )
+    assert download_response.status_code == 403


### PR DESCRIPTION
## Summary

- Guarded legacy payment read/receipt endpoints so Doctor users can only read payments for visits assigned to their own Doctor row.
- Kept Admin/Cashier/Registrar payment-read behavior unchanged and preserved Patient self-access guard.
- Restricted receipt routes from generic authenticated access to explicit payment-read roles.

## Cyclic Execution Evidence

- Fresh main sync: started from fresh `origin/main` at `08e943fc fix(cors): auto-allow current dev lan origin (#1357)`.
- Clean workspace: branch created from detached fresh main after `git status --short --branch` showed no local changes.
- Branch: `codex/doctor-payment-read-guard`.
- Scope gate: `agent_gate` returned execute with known-root-cause override; used narrow override to touch only `backend/app/api/v1/endpoints/payments.py` plus paired regression test.
- Red-check handling: no red CI yet; will fix failures in this PR before merge.

## Contract Impact

- Canonical surface: legacy payment read endpoints in `backend/app/api/v1/endpoints/payments.py`.
- Request shape: unchanged path/query shapes for `/payments/{payment_id}`, `/payments/{payment_id}/receipt`, `/payments/{payment_id}/receipt/download`, `/payments/visit/{visit_id}`, and `/payments/?visit_id=...`.
- Response shape: unchanged successful payment status/list/receipt response bodies.
- Status codes: Doctor cross-visit and unscoped list now return 403; missing visit returns 404; existing successful staff/patient reads remain unchanged.
- Frontend consumer: existing cashier and patient payment flows keep their API shapes; no frontend file changed.
- Compatibility path or alias: legacy `visits.doctor_id == User.id` compatibility is preserved only when no real Doctor row owns that id.
- Contract proof: regression tests cover Patient self-access, Doctor own/cross-visit reads, Doctor unscoped list denial, and non-payment staff receipt denial.

## RBAC / Permissions

- Roles allowed: Admin/Cashier/Registrar retain payment reads; Patient can read own visit payments; Doctor can read payments for visits assigned to their Doctor row.
- Roles denied: Doctor cross-visit payment reads are denied; unscoped Doctor list is denied; Lab/non-payment roles are denied on receipt routes.
- Positive auth proof: `test_doctor_payment_reads_are_limited_to_own_visits` asserts Doctor can read own payment status.
- Negative auth proof: the same test asserts Doctor cannot read other payment status, visit payment list, receipt metadata, receipt download, or unscoped payment list; `test_non_payment_staff_cannot_read_payment_receipts` asserts Lab receives 403.

## Notification / Realtime

- Event type or websocket channel: not applicable because payment read guards do not emit notifications or websocket events.
- Payload version / ack behavior: not applicable because no notification/realtime payload changed.
- Read/unread or delivery semantics: not applicable because this PR does not touch notification delivery state.
- Reconnect/resync proof: not applicable because no realtime channel or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable because response shapes are unchanged and no frontend list rendering changed.
- Partial data proof: not applicable because no frontend data normalization changed.
- Forbidden secondary path behavior: backend now returns 403 for forbidden Doctor/non-payment staff payment reads; existing API error handling receives the same HTTP error class as prior Patient denial.
- Missing draft/resource behavior: not applicable because no draft/resource workflow changed.
- Stale route/deep-link behavior: not applicable because no route or deep-link changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/payments.py`, `backend/tests/integration/test_payment_patient_access.py`.
- Denied paths: `/api/v1/ui/*`, frontend files, BFF-lite/read models, billing services/models, migrations, notification/realtime code.
- Migration/docs/test impact: no migration; no docs; added targeted payment access regression tests.
- Rollback note: revert this PR to restore prior broad Doctor/generic-auth payment receipt reads.

## Validation

- Targeted tests or smoke run: `py_compile`, `git diff --check`, `git diff --cached --check`, attempted local `run_backend_pytest`, and GitHub backend CI.
- Result: local `py_compile` and diff checks passed; local pytest could not start because no local Python 3.11 interpreter has `pytest`; GitHub `🐍 Backend тесты` passed.
- Not checked: no frontend build/unit tests run locally because no frontend files changed and CI skipped frontend jobs for this backend-only scope.
