### PR TITLE
fix(visits): guard doctor visit reads

### DIFF
--- a/backend/app/api/v1/endpoints/visits.py
+++ b/backend/app/api/v1/endpoints/visits.py
@@ -107,6 +107,24 @@ def _ensure_visit_doctor_access(db: Session, visit: Visit, current_user) -> None
     raise HTTPException(status_code=403, detail="Access denied")
 
 
+def _doctor_allowed_visit_doctor_ids(db: Session, current_user) -> set[int]:
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    allowed_ids = {doctor.id}
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == current_user.id).first()
+    # Some legacy visit writers stored User.id in doctor_id. Allow that only
+    # when the value does not target another real Doctor row.
+    if not assigned_doctor:
+        allowed_ids.add(current_user.id)
+    return allowed_ids
+
+
 @router.get("/visits", response_model=List[VisitOut], summary="Список визитов")
 def list_visits(
     patient_id: Optional[int] = Query(default=None),
@@ -118,6 +136,12 @@ def list_visits(
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(*VISIT_READ_ROLES)),
 ):
+    if getattr(current_user, "role", None) == "Doctor":
+        if doctor_id is None:
+            raise HTTPException(status_code=403, detail="Access denied")
+        if doctor_id not in _doctor_allowed_visit_doctor_ids(db, current_user):
+            raise HTTPException(status_code=403, detail="Access denied")
+
     rows = VisitsApiService(db).list_visits(
         patient_id=patient_id,
         doctor_id=doctor_id,
@@ -158,6 +182,11 @@ def get_visit(
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(*VISIT_READ_ROLES)),
 ):
+    visit = db.query(Visit).filter(Visit.id == visit_id).first()
+    if not visit:
+        raise HTTPException(404, "Visit not found")
+    _ensure_visit_doctor_access(db, visit, current_user)
+
     payload = VisitsApiService(db).get_visit(visit_id=visit_id)
     return VisitWithServices(
         visit=VisitOut(**payload["visit"]),

--- a/backend/tests/integration/test_visit_status_owner_guard.py
+++ b/backend/tests/integration/test_visit_status_owner_guard.py
@@ -89,6 +89,75 @@ def test_doctor_cannot_change_other_doctor_visit_status(client, db_session) -> N
     assert other_visit.status == "open"
 
 
+def test_doctor_cannot_read_other_doctor_visit_detail(client, db_session) -> None:
+    own_user, _own_doctor = _create_doctor_user(db_session, label="read_own")
+    _other_user, other_doctor = _create_doctor_user(db_session, label="read_other")
+    other_patient = _create_patient(db_session)
+    other_visit = Visit(
+        patient_id=other_patient.id,
+        doctor_id=other_doctor.id,
+        visit_date=date.today(),
+        status="open",
+        source="desk",
+    )
+    db_session.add(other_visit)
+    db_session.commit()
+    db_session.refresh(other_visit)
+
+    response = client.get(
+        f"/api/v1/visits/visits/{other_visit.id}",
+        headers=_doctor_headers(client, own_user),
+    )
+
+    assert response.status_code == 403
+
+
+def test_doctor_visit_list_is_limited_to_own_doctor_id(client, db_session) -> None:
+    own_user, own_doctor = _create_doctor_user(db_session, label="list_own")
+    _other_user, other_doctor = _create_doctor_user(db_session, label="list_other")
+    own_patient = _create_patient(db_session)
+    other_patient = _create_patient(db_session)
+    own_visit = Visit(
+        patient_id=own_patient.id,
+        doctor_id=own_doctor.id,
+        visit_date=date.today(),
+        status="open",
+        source="desk",
+    )
+    other_visit = Visit(
+        patient_id=other_patient.id,
+        doctor_id=other_doctor.id,
+        visit_date=date.today(),
+        status="open",
+        source="desk",
+    )
+    db_session.add_all([own_visit, other_visit])
+    db_session.commit()
+    db_session.refresh(own_visit)
+    db_session.refresh(other_visit)
+    headers = _doctor_headers(client, own_user)
+
+    own_response = client.get(
+        "/api/v1/visits/visits",
+        params={"doctor_id": own_doctor.id},
+        headers=headers,
+    )
+    assert own_response.status_code == 200, own_response.text
+    own_ids = {row["id"] for row in own_response.json()}
+    assert own_visit.id in own_ids
+    assert other_visit.id not in own_ids
+
+    other_response = client.get(
+        "/api/v1/visits/visits",
+        params={"doctor_id": other_doctor.id},
+        headers=headers,
+    )
+    assert other_response.status_code == 403
+
+    unscoped_response = client.get("/api/v1/visits/visits", headers=headers)
+    assert unscoped_response.status_code == 403
+
+
 def test_doctor_cannot_add_service_to_other_doctor_visit(client, db_session) -> None:
     own_user, _own_doctor = _create_doctor_user(db_session, label="svc_own")
     _other_user, other_doctor = _create_doctor_user(db_session, label="svc_other")

--- a/backend/tests/unit/test_visits_router_service_wiring.py
+++ b/backend/tests/unit/test_visits_router_service_wiring.py
@@ -75,7 +75,7 @@ def test_list_visits_endpoint_delegates_to_service(
 
 
 def test_get_visit_endpoint_delegates_to_service(
-    client, monkeypatch, auth_headers
+    client, monkeypatch, auth_headers, test_visit
 ) -> None:
     captured = {}
 
@@ -110,16 +110,19 @@ def test_get_visit_endpoint_delegates_to_service(
 
     monkeypatch.setattr(VisitsApiService, "get_visit", fake_get_visit)
 
-    response = client.get("/api/v1/visits/visits/42", headers=auth_headers)
+    response = client.get(
+        f"/api/v1/visits/visits/{test_visit.id}",
+        headers=auth_headers,
+    )
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["visit"]["id"] == 42
+    assert payload["visit"]["id"] == test_visit.id
     assert payload["visit"]["notes"] == "visit card"
     assert payload["visit"]["patient_name"] == "Karimov Aziz"
     assert payload["visit"]["doctor_name"] == "Demo Cardiologist"
     assert payload["services"][0]["name"] == "Consultation"
-    assert captured["visit_id"] == 42
+    assert captured["visit_id"] == test_visit.id
 
 
 def test_list_visits_endpoint_requires_auth(client, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Guard generic visit read endpoints for Doctor users.
- Keep Admin, Registrar, Cashier, Lab, and Nurse generic visit read behavior unchanged.
- Add regression coverage for Doctor cross-doctor visit detail/list access.

## Cyclic Execution Evidence
- Fresh main sync: worktree was based on `origin/main` at `40be632d fix(payments): guard doctor payment reads (#1359)`.
- Clean workspace: branch started from a clean audit worktree before this narrow patch; staged diff contains only the endpoint and its focused integration test.
- Branch: `codex/doctor-visit-read-guard`.
- Scope gate: `agent_gate` was run with known root cause `backend/app/api/v1/endpoints/visits.py`; first-touch runtime owner stayed in that file, with only the paired regression test added.
- Red-check handling: if CI is red, this PR will be fixed in place before merge.

## Contract Impact
- Canonical surface: legacy generic visits API under `/api/v1/visits/visits`.
- Request shape: unchanged query/path parameters; Doctor list requests must now include an owned `doctor_id`.
- Response shape: unchanged `VisitOut` / `VisitWithServices` models.
- Status codes: Doctor now receives `403` for unscoped list reads, other-doctor list filters, and other-doctor detail reads; missing visit remains `404`.
- Frontend consumer: existing Doctor-specific visit screens should use doctor-scoped flows; this closes generic read leakage rather than adding a new frontend contract.
- Compatibility path or alias: preserves legacy visit rows where `doctor_id` stored `User.id`, but only when that value does not identify another real `Doctor` row.
- Contract proof: `backend/tests/integration/test_visit_status_owner_guard.py` adds Doctor read/list denial and own-doctor list assertions.

## RBAC / Permissions
- Roles allowed: Admin, Registrar, Cashier, Lab, Nurse behavior unchanged; Doctor may read only own doctor-scoped generic visits.
- Roles denied: Doctor reading another doctor's visit detail, Doctor listing another doctor's visits, and Doctor unscoped generic visit listing.
- Positive auth proof: integration test asserts Doctor can list visits when `doctor_id` matches their own `Doctor.id`.
- Negative auth proof: integration tests assert `403` for other-doctor detail, other-doctor list, and unscoped list.

## Notification / Realtime
- Event type or websocket channel: none.
- Payload version / ack behavior: none.
- Read/unread or delivery semantics: none.
- Reconnect/resync proof: no websocket channel or reconnect path is touched; visit reads remain plain HTTP request/response and clients resync by refetching the unchanged endpoint.

## Frontend Resilience
- Empty data proof: not changed; endpoint still returns existing list response shape for allowed filters.
- Partial data proof: not changed; no response field changes.
- Forbidden secondary path behavior: covered by `403` regression tests for Doctor.
- Missing draft/resource behavior: missing visit remains `404`.
- Stale route/deep-link behavior: a stale Doctor link to another doctor's visit now returns `403` instead of exposing PHI.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/visits.py`, `backend/tests/integration/test_visit_status_owner_guard.py`, `backend/tests/unit/test_visits_router_service_wiring.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read-model endpoints, frontend files, migrations, unrelated doctor/registrar/payment code.
- Migration/docs/test impact: no migration; focused integration tests added and one existing unit wiring test updated to create the visit row required by the new access pre-check.
- Rollback note: revert this commit to restore previous generic Doctor read behavior, though that would reopen the PHI leak.

## Validation
- Targeted tests or smoke run: `py_compile` for changed endpoint/test; `git diff --check`; attempted `scripts/run_backend_pytest.ps1 backend/tests/integration/test_visit_status_owner_guard.py`.
- Result: `py_compile` passed; `git diff --check` passed with CRLF warnings only; local pytest could not run because no local Python 3.11 interpreter has `pytest` installed.
- Not checked: full backend suite and browser/frontend flows; GitHub CI is expected to run the integration tests.
