### PR TITLE
fix(cashier): fail closed for grouped payment allocation

### DIFF
--- a/frontend/src/pages/CashierPanel.jsx
+++ b/frontend/src/pages/CashierPanel.jsx
@@ -256,7 +256,10 @@ const resolveCashierVisitIds = (appointment) => {
     : [];
 };
 
-const resolveSingleCashierVisitId = (appointment) => resolveCashierVisitIds(appointment)[0] ?? null;
+const resolveSingleCashierVisitId = (appointment) => {
+  const visitIds = resolveCashierVisitIds(appointment);
+  return visitIds.length === 1 ? visitIds[0] : null;
+};
 
 const PAYMENT_ACTION_CAN_FIELD = {
   cancel: 'can_cancel',
@@ -575,6 +578,13 @@ const CashierPanel = () => {void
   };
 
   const openPaymentWidget = (appointment) => {
+    const visitId = resolveSingleCashierVisitId(appointment);
+    if (!visitId) {
+      const message = 'Cannot start payment: backend must provide exactly one visit_id for this payment row.';
+      setPaymentError(message);
+      notify.error(message);
+      return;
+    }
     paymentWidget.openModal(appointment);
     setPaymentError(null);
     setPaymentSuccess(null);
@@ -584,78 +594,21 @@ const CashierPanel = () => {void
   // Теперь appointment содержит сгруппированные данные пациента (все его неоплаченные визиты)
   const processPayment = async (appointment, paymentData) => {
     try {
-      // Получаем все visit_id пациента
-      const visitIds = resolveCashierVisitIds(appointment);
+      const visitId = resolveSingleCashierVisitId(appointment);
 
-      if (visitIds.length === 0) {
-        throw new Error('Невозможно обработать оплату: backend не вернул visit_id.');
+      if (!visitId) {
+        throw new Error('Cannot process payment: backend must provide exactly one visit_id or a backend-owned allocation contract.');
       }
 
-      // 1. Рассчитываем долг по каждому визиту на основе услуг
-      const visitDebts = {};
-      const services = appointment.services || [];
-
-      // Инициализируем долги нулями
-      visitIds.forEach((id) => visitDebts[id] = 0);
-
-      // Суммируем стоимость услуг для каждого визита
-      services.forEach((s) => {
-        if (s.visit_id) {
-          visitDebts[s.visit_id] = (visitDebts[s.visit_id] || 0) + (s.price || 0) * (s.quantity || 1);
-        }
+      const result = await paymentsHook.createPayment({
+        visit_id: visitId,
+        amount: paymentData.amount,
+        method: paymentData.method,
+        note: paymentData.note || 'Оплата медицинских услуг'
       });
 
-      // 2. Распределяем сумму оплаты
-      let remaining = parseFloat(paymentData.amount);
-      const paymentsToMake = [];
-
-      for (const visitId of visitIds) {
-        if (remaining <= 0) break;
-
-        const debt = visitDebts[visitId] || 0;
-        const payAmount = Math.min(remaining, debt);
-
-        if (payAmount > 0) {
-          paymentsToMake.push({ visitId, amount: payAmount });
-          remaining -= payAmount;
-        } else if (debt === 0 && remaining > 0 && visitIds.length === 1) {
-          // Если единственный визит и долг 0, но платим - зачисляем
-          paymentsToMake.push({ visitId, amount: remaining });
-          remaining = 0;
-        }
-      }
-
-      // Если осталась сумма (переплата), закидываем на первый визит
-      if (remaining > 0) {
-        if (paymentsToMake.length > 0) {
-          paymentsToMake[0].amount += remaining;
-        } else if (visitIds.length > 0) {
-          paymentsToMake.push({ visitId: visitIds[0], amount: remaining });
-        }
-      }
-
-      // 3. Выполняем платежи последовательно
-      for (const p of paymentsToMake) {
-        const result = await paymentsHook.createPayment({
-          visit_id: p.visitId,
-          amount: p.amount,
-          method: paymentData.method,
-          note: paymentData.note || 'Оплата медицинских услуг'
-        });
-
-        if (!result.success) {
-          throw new Error(`Не удалось оплатить визит #${p.visitId}: ${result.error}`);
-        }
-      }
-
-      // Fallback если ничего не добавилось в paymentsToMake но сумма есть
-      if (paymentsToMake.length === 0 && parseFloat(paymentData.amount) > 0 && visitIds.length > 0) {
-        await paymentsHook.createPayment({
-          visit_id: visitIds[0],
-          amount: paymentData.amount,
-          method: paymentData.method,
-          note: paymentData.note
-        });
+      if (!result.success) {
+        throw new Error(`Не удалось оплатить визит #${visitId}: ${result.error}`);
       }
 
       notify.success(`Оплата успешно обработана! Сумма: ${format(paymentData.amount)}`);


### PR DESCRIPTION
## Summary
- Fail closed when cashier pending payment rows contain zero or multiple backend visit ids.
- Remove frontend-owned cash allocation across grouped `visit_ids`, service debt splitting, and overpay assignment to the first visit.
- Prevent online payment from silently using the first visit id from a grouped payment row.

## Cyclic Execution Evidence
- Fresh main sync: started from `main` synced to `origin/main` at `a6054d07` after PR #1358 was green/merged.
- Clean workspace: verified before creating `codex/cashier-payment-allocation-ssot`; final diff is one file.
- Branch: `codex/cashier-payment-allocation-ssot`.
- Scope gate: `agent_gate` returned narrow override with first-touch limited to `frontend/src/pages/CashierPanel.jsx`.
- Red-check handling: no prior red checks on this new PR; previous red PR #1358 was resolved before this cycle.

## Contract Impact
- Canonical surface: existing cashier payment creation path remains `/api/v1/cashier/payments` through `usePayments.createPayment`.
- Request shape: unchanged for valid single-visit rows: `{ visit_id, amount, method, note }`.
- Response shape: unchanged; frontend still consumes the existing `createPayment` hook result.
- Status codes: unchanged; no backend route or HTTP semantics changed.
- Frontend consumer: `CashierPanel` now requires exactly one backend-provided visit id before starting cash or online payment.
- Compatibility path or alias: no compatibility alias added; grouped rows now require a future backend-owned allocation contract instead of frontend guessing.
- Contract proof: local focused contract test and frontend build passed; diff removes `visitDebts`, `paymentsToMake`, and overpay-to-first-visit logic.

## RBAC / Permissions
- Roles allowed: not changed - backend cashier permissions remain canonical.
- Roles denied: not changed - no backend authorization path changed.
- Positive auth proof: not checked - frontend-only fail-closed change, no route permission change.
- Negative auth proof: not checked - frontend-only fail-closed change, no route permission change.

## Notification / Realtime
- Event type or websocket channel: not applicable - payment notification/realtime channels were not touched.
- Payload version / ack behavior: not applicable - no realtime payload was changed.
- Read/unread or delivery semantics: not applicable - no notification state was changed.
- Reconnect/resync proof: not applicable - no websocket or notification reconnect path was changed.

## Frontend Resilience
- Empty data proof: rows without a backend visit id now fail closed with an error instead of creating a guessed payment.
- Partial data proof: grouped rows with multiple visit ids now fail closed instead of allocating across visits in React.
- Forbidden secondary path behavior: online payment no longer falls back to the first id from `visit_ids`.
- Missing draft/resource behavior: not applicable - no draft/resource workflow touched.
- Stale route/deep-link behavior: not applicable - cashier route/deep-link handling was not changed.

## Scope Gate
- Allowed paths: `frontend/src/pages/CashierPanel.jsx`.
- Denied paths: backend endpoints/services, payment hook APIs, tests, BFF `/api/v1/ui/*`, unrelated frontend cleanup.
- Migration/docs/test impact: no migration or backend docs impact; no test file changed because gate first-touch was code-only.
- Rollback note: revert this commit to restore previous frontend grouped-payment allocation behavior.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- CashierPanel.contract`; `npm.cmd --prefix frontend run build`; `git diff --check`.
- Result: all passed. `git diff --check` only emitted the existing Windows LF-to-CRLF warning for `CashierPanel.jsx`.
- Not checked: backend pytest, because no backend code or API contract was changed.