### PR TITLE
fix(lab): guard doctor report reads

### DIFF
--- a/backend/app/api/v1/endpoints/lab_reporting.py
+++ b/backend/app/api/v1/endpoints/lab_reporting.py
@@ -6,6 +6,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
+from app.models.clinic import Doctor
+from app.models.visit import Visit
 from app.schemas.lab_reporting import (
     LabCatalogAnalyteOut,
     LabCatalogReferenceRangeOut,
@@ -41,6 +43,47 @@ router = APIRouter(prefix="/lab", tags=["lab-reporting"])
 
 def _handle_domain_error(exc: LabReportingDomainError) -> None:
     raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+
+def _doctor_allowed_visit_ids(
+    db: Session,
+    current_user,
+    requested_visit_ids: list[int] | None = None,
+) -> list[int]:
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    allowed_doctor_ids = {doctor.id}
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == current_user.id).first()
+    # Some legacy visit writers stored User.id in doctor_id. Allow that only
+    # when the value does not target another real Doctor row.
+    if not assigned_doctor:
+        allowed_doctor_ids.add(current_user.id)
+
+    query = db.query(Visit.id).filter(Visit.doctor_id.in_(allowed_doctor_ids))
+    if requested_visit_ids:
+        requested_ids = {int(visit_id) for visit_id in requested_visit_ids}
+        allowed_ids = {row[0] for row in query.filter(Visit.id.in_(requested_ids)).all()}
+        if allowed_ids != requested_ids:
+            raise HTTPException(status_code=403, detail="Access denied")
+        return sorted(allowed_ids)
+
+    return [row[0] for row in query.all()]
+
+
+def _ensure_doctor_can_read_lab_instance(db: Session, instance, current_user) -> None:
+    if getattr(current_user, "role", None) != "Doctor":
+        return
+    if getattr(current_user, "is_superuser", False):
+        return
+    if not instance.visit_id:
+        raise HTTPException(status_code=403, detail="Access denied")
+    _doctor_allowed_visit_ids(db, current_user, requested_visit_ids=[instance.visit_id])
 
 
 def _template_summary_out(template) -> LabReportTemplateSummaryOut:
@@ -383,11 +426,22 @@ def list_lab_report_instances(
     user=Depends(require_roles("Admin", "Lab", "Doctor")),
 ):
     service = LabReportingService(db)
+    scoped_visit_ids = visit_ids
+    if getattr(user, "role", None) == "Doctor" and not getattr(
+        user, "is_superuser", False
+    ):
+        scoped_visit_ids = _doctor_allowed_visit_ids(
+            db,
+            user,
+            requested_visit_ids=visit_ids,
+        )
+        if not scoped_visit_ids:
+            return []
     return [
         _instance_summary_out(service, instance)
         for instance in service.list_instances(
             patient_id=patient_id,
-            visit_ids=visit_ids,
+            visit_ids=scoped_visit_ids,
             status=status,
             limit=limit,
             offset=offset,
@@ -420,7 +474,9 @@ def get_lab_report_instance(
 ):
     service = LabReportingService(db)
     try:
-        return _instance_out(service, service.get_instance(instance_id))
+        instance = service.get_instance(instance_id)
+        _ensure_doctor_can_read_lab_instance(db, instance, user)
+        return _instance_out(service, instance)
     except LabReportingDomainError as exc:
         _handle_domain_error(exc)
 
@@ -521,6 +577,7 @@ def download_lab_report_pdf(
     service = LabReportingService(db)
     try:
         instance = service.get_instance(instance_id)
+        _ensure_doctor_can_read_lab_instance(db, instance, user)
         if instance.status not in {"FINALIZED", "PRINTED"}:
             raise LabReportingDomainError(409, "Only finalized reports can be exported to PDF")
         materialized_sections = service.materialize_instance(instance)

--- a/backend/tests/test_lab_reporting_api.py
+++ b/backend/tests/test_lab_reporting_api.py
@@ -1,12 +1,110 @@
 from __future__ import annotations
 
 from datetime import date
+from uuid import uuid4
 
 import pytest
 
+from app.core.security import get_password_hash
 from app.models.appointment import Appointment
+from app.models.clinic import Doctor
+from app.models.patient import Patient
 from app.models.service import Service
+from app.models.user import User
+from app.models.visit import Visit
 from app.models.visit import VisitService
+
+
+def _suffix() -> str:
+    return uuid4().hex[:10]
+
+
+def _create_doctor_user(db_session, *, label: str) -> tuple[User, Doctor]:
+    suffix = _suffix()
+    user = User(
+        username=f"lab_report_{label}_{suffix}",
+        email=f"lab-report-{label}-{suffix}@test.local",
+        full_name=f"Lab Report {label}",
+        hashed_password=get_password_hash("doctor123"),
+        role="Doctor",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    doctor = Doctor(
+        user_id=user.id,
+        specialty="therapy",
+        active=True,
+    )
+    db_session.add(doctor)
+    db_session.commit()
+    db_session.refresh(doctor)
+    return user, doctor
+
+
+def _create_patient(db_session) -> Patient:
+    suffix = _suffix()
+    patient = Patient(
+        first_name="Lab",
+        last_name=f"Report{suffix}",
+        phone=f"+99890{suffix[:7]}",
+        birth_date=date(1990, 1, 1),
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+    return patient
+
+
+def _doctor_headers(client, user: User) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": user.username, "password": "doctor123"},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _create_visit(db_session, *, patient_id: int, doctor_id: int) -> Visit:
+    visit = Visit(
+        patient_id=patient_id,
+        doctor_id=doctor_id,
+        visit_date=date.today(),
+        status="open",
+        source="desk",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+    return visit
+
+
+def _create_lab_report_instance(
+    client,
+    *,
+    auth_headers: dict[str, str],
+    patient_id: int,
+    visit_id: int,
+) -> dict:
+    templates_response = client.get("/api/v1/lab/templates", headers=auth_headers)
+    assert templates_response.status_code == 200
+    cbc_template = next(
+        template for template in templates_response.json() if template["code"] == "cbc_oak"
+    )
+    response = client.post(
+        "/api/v1/lab/report-instances",
+        headers=auth_headers,
+        json={
+            "patient_id": patient_id,
+            "visit_id": visit_id,
+            "template_id": cbc_template["id"],
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
 
 
 @pytest.mark.integration
@@ -186,6 +284,75 @@ def test_lab_reporting_api_flow(client, auth_headers, db_session, test_patient, 
     )
     assert print_twice_response.status_code == 200
     assert print_twice_response.json()["status"] == "PRINTED"
+
+
+@pytest.mark.integration
+def test_doctor_lab_report_reads_are_limited_to_own_visits(
+    client,
+    auth_headers,
+    db_session,
+) -> None:
+    own_user, own_doctor = _create_doctor_user(db_session, label="own")
+    _other_user, other_doctor = _create_doctor_user(db_session, label="other")
+    own_patient = _create_patient(db_session)
+    other_patient = _create_patient(db_session)
+    own_visit = _create_visit(
+        db_session,
+        patient_id=own_patient.id,
+        doctor_id=own_doctor.id,
+    )
+    other_visit = _create_visit(
+        db_session,
+        patient_id=other_patient.id,
+        doctor_id=other_doctor.id,
+    )
+    own_instance = _create_lab_report_instance(
+        client,
+        auth_headers=auth_headers,
+        patient_id=own_patient.id,
+        visit_id=own_visit.id,
+    )
+    other_instance = _create_lab_report_instance(
+        client,
+        auth_headers=auth_headers,
+        patient_id=other_patient.id,
+        visit_id=other_visit.id,
+    )
+    doctor_headers = _doctor_headers(client, own_user)
+
+    own_detail = client.get(
+        f"/api/v1/lab/report-instances/{own_instance['id']}",
+        headers=doctor_headers,
+    )
+    assert own_detail.status_code == 200, own_detail.text
+
+    other_detail = client.get(
+        f"/api/v1/lab/report-instances/{other_instance['id']}",
+        headers=doctor_headers,
+    )
+    assert other_detail.status_code == 403
+
+    list_response = client.get(
+        "/api/v1/lab/report-instances",
+        headers=doctor_headers,
+    )
+    assert list_response.status_code == 200, list_response.text
+    listed_ids = {item["id"] for item in list_response.json()}
+    assert own_instance["id"] in listed_ids
+    assert other_instance["id"] not in listed_ids
+
+    other_visit_list = client.get(
+        "/api/v1/lab/report-instances",
+        params=[("visit_ids", str(other_visit.id))],
+        headers=doctor_headers,
+    )
+    assert other_visit_list.status_code == 403
+
+    other_pdf = client.get(
+        f"/api/v1/lab/report-instances/{other_instance['id']}/pdf",
+        headers=doctor_headers,
+    )
+    assert other_pdf.status_code == 403
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- Guard Doctor reads of generic lab report instances by visit ownership.
- Prevent Doctor users from reading other doctors' lab report detail, list entries, or PDF export by numeric report id.
- Preserve Admin and Lab behavior, and keep the guarded legacy `Visit.doctor_id == User.id` compatibility path.

## Cyclic Execution Evidence
- Fresh main sync: worktree was based on `origin/main` at `a6054d07 fix(visits): guard doctor visit reads (#1360)`.
- Clean workspace: branch started from a clean detached `origin/main` audit view; staged diff contains only the lab endpoint and its focused integration test.
- Branch: `codex/doctor-lab-report-read-guard`.
- Scope gate: `agent_gate` was run with known root cause `backend/app/api/v1/endpoints/lab_reporting.py`; runtime first-touch stayed in that file. Test scope was deliberately expanded only to `backend/tests/test_lab_reporting_api.py` for regression proof.
- Red-check handling: if CI is red, this PR will be fixed in place before merge.

## Contract Impact
- Canonical surface: `/api/v1/lab/report-instances`, `/api/v1/lab/report-instances/{instance_id}`, `/api/v1/lab/report-instances/{instance_id}/pdf`.
- Request shape: unchanged query/path parameters.
- Response shape: unchanged lab report summary/detail/PDF response shapes for authorized users.
- Status codes: Doctor now receives `403` for other-doctor visit-linked report detail, explicit other-doctor `visit_ids` filters, and other-doctor report PDF.
- Frontend consumer: Doctor-facing lab report consumers must use reports linked to the current doctor's visits; Admin/Lab reporting workflows are unchanged.
- Compatibility path or alias: preserves legacy `Visit.doctor_id == User.id` only when that value does not identify another real `Doctor` row.
- Contract proof: `backend/tests/test_lab_reporting_api.py` asserts Doctor can read own visit-linked lab report but cannot read/list/PDF another doctor's report.

## RBAC / Permissions
- Roles allowed: Admin and Lab unchanged; Doctor allowed only for lab report instances linked to their own visit ids.
- Roles denied: Doctor reading another doctor's lab report detail, list-by-foreign-visit, and PDF.
- Positive auth proof: integration test asserts Doctor receives `200` for own visit-linked report detail and own report appears in list.
- Negative auth proof: integration test asserts `403` for other-doctor detail, other-doctor `visit_ids` list filter, and other-doctor PDF; unscoped Doctor list excludes the other report.

## Notification / Realtime
- Event type or websocket channel: none; this change only affects synchronous lab report HTTP reads.
- Payload version / ack behavior: none; no notification payloads or acknowledgement contracts changed.
- Read/unread or delivery semantics: none; no notification delivery state changed.
- Reconnect/resync proof: no websocket channel or reconnect path is touched; clients resync by refetching the unchanged HTTP lab report endpoints.

## Frontend Resilience
- Empty data proof: Doctor with no owned visits receives an empty report instance list instead of unscoped data.
- Partial data proof: unscoped Doctor list is narrowed to owned visit-linked instances while keeping the same summary item shape.
- Forbidden secondary path behavior: explicit other-doctor detail/list/PDF paths now return `403`.
- Missing draft/resource behavior: missing report instance behavior remains the existing service `404`.
- Stale route/deep-link behavior: stale Doctor deep links to another doctor's report now return `403` rather than exposing PHI.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/lab_reporting.py`, `backend/tests/test_lab_reporting_api.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read-model endpoints, frontend files, migrations, unrelated lab write workflows, appointment/visit/payment endpoints.
- Migration/docs/test impact: no migration; focused integration test added.
- Rollback note: revert this commit to restore previous generic Doctor lab report read behavior, though that would reopen the PHI leak.

## Validation
- Targeted tests or smoke run: `py_compile` for changed endpoint/test; `git diff --check`; `git diff --cached --check`; attempted `scripts/run_backend_pytest.ps1 backend/tests/test_lab_reporting_api.py`.
- Result: `py_compile` passed; diff checks passed with CRLF warnings only; local pytest could not run because no local Python 3.11 interpreter has `pytest` installed.
- Not checked: full backend suite and browser/frontend flows; GitHub CI is expected to run the integration tests.
