### PR TITLE
fix(cashier): add backend grouped payment allocation

### DIFF
--- a/backend/app/api/v1/endpoints/cashier.py
+++ b/backend/app/api/v1/endpoints/cashier.py
@@ -95,6 +95,11 @@ class PendingPaymentItem(BaseModel):
     created_at: datetime
     queue_number: Optional[str] = None
     department: Optional[str] = None
+    payment_contract: str = "single_visit"
+    payment_visit_id: Optional[int] = None
+    payment_visit_ids: List[int] = Field(default_factory=list)
+    can_create_direct_payment: bool = True
+    can_create_grouped_payment: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -156,6 +161,35 @@ class PaymentResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class CreateGroupedPaymentRequest(BaseModel):
+    """Backend-owned allocation request for grouped cashier payment rows."""
+    visit_ids: List[int] = Field(..., min_length=1, description="Visit ids from a cashier grouped pending-payment row")
+    patient_id: Optional[int] = Field(None, description="Expected patient id for all grouped visits")
+    amount: Decimal = Field(..., gt=0, description="Total payment amount to allocate")
+    method: str = Field(default="cash", description="Payment method (cash, card)")
+    note: Optional[str] = Field(None, description="Payment note")
+
+
+class GroupedPaymentAllocationItem(BaseModel):
+    """One backend-owned payment allocation leg."""
+    visit_id: int
+    payment_id: int
+    amount: Decimal
+    remaining_before: Decimal
+    remaining_after: Decimal
+
+
+class GroupedPaymentResponse(BaseModel):
+    """Response for backend-owned grouped cashier payment allocation."""
+    patient_id: int
+    amount: Decimal
+    method: str
+    status: str
+    created_at: datetime
+    payments: List[PaymentResponse]
+    allocations: List[GroupedPaymentAllocationItem]
+
+
 class CancelPaymentRequest(BaseModel):
     """Запрос на отмену платежа"""
     reason: Optional[str] = None
@@ -208,6 +242,45 @@ def _decimal_to_float(value: Any) -> Optional[float]:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _cashier_visit_total_amount(visit: Visit) -> Decimal:
+    total_cost = Decimal("0")
+    if hasattr(visit, "services") and visit.services:
+        for visit_service in visit.services:
+            price = (
+                Decimal(str(visit_service.price))
+                if hasattr(visit_service, "price") and visit_service.price
+                else Decimal("0")
+            )
+            quantity = (
+                Decimal(str(visit_service.qty))
+                if hasattr(visit_service, "qty") and visit_service.qty
+                else Decimal("1")
+            )
+            total_cost += price * quantity
+
+    if total_cost == Decimal("0"):
+        if hasattr(visit, "total_price") and visit.total_price:
+            total_cost = Decimal(str(visit.total_price))
+        elif hasattr(visit, "total_amount") and visit.total_amount:
+            total_cost = Decimal(str(visit.total_amount))
+
+    return total_cost
+
+
+def _cashier_paid_amounts_by_visit_id(db: Session, visit_ids: list[int]) -> dict[int, Decimal]:
+    if not visit_ids:
+        return {}
+
+    paid_amounts = {visit_id: Decimal("0") for visit_id in visit_ids}
+    payments = db.query(Payment).filter(
+        Payment.visit_id.in_(visit_ids),
+        Payment.status.in_(["paid", "completed"]),
+    ).all()
+    for payment in payments:
+        paid_amounts[payment.visit_id] = paid_amounts.get(payment.visit_id, Decimal("0")) + Decimal(str(payment.amount or 0))
+    return paid_amounts
 
 
 async def _emit_payment_notification(
@@ -503,6 +576,8 @@ async def get_pending_payments(
         # Формируем результат
         result = []
         for group in paginated_groups:
+            group_visit_ids = group["visit_ids"]
+            direct_payment_allowed = len(group_visit_ids) == 1
             result.append(PendingPaymentItem(
                 id=group["visit_ids"][0] if group["visit_ids"] else 0,  # Первый visit_id для совместимости
                 patient_id=group["patient_id"],
@@ -519,6 +594,11 @@ async def get_pending_payments(
                 created_at=group["created_at"],
                 queue_number=group["queue_number"],
                 department=group["department"],
+                payment_contract="single_visit" if direct_payment_allowed else "grouped_visits",
+                payment_visit_id=group_visit_ids[0] if direct_payment_allowed else None,
+                payment_visit_ids=group_visit_ids,
+                can_create_direct_payment=direct_payment_allowed,
+                can_create_grouped_payment=not direct_payment_allowed,
             ))
         
         return {
@@ -857,6 +937,204 @@ async def get_payments(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Ошибка получения истории платежей: {str(e)}"
+        )
+
+
+@router.post("/payments/grouped", response_model=GroupedPaymentResponse)
+async def create_grouped_payment(
+    payment_data: CreateGroupedPaymentRequest,
+    db: Session = Depends(deps.get_db),
+    current_user = Depends(deps.require_roles("Admin", "Cashier")),
+):
+    """
+    Create cashier payments for a grouped pending-payment row.
+
+    Allocation is backend-owned: visits must belong to one patient, amount is
+    allocated oldest visit first by remaining backend-calculated debt, and
+    overpay is rejected instead of being assigned to an arbitrary visit.
+    """
+    normalized_visit_ids = list(dict.fromkeys(payment_data.visit_ids))
+    if not normalized_visit_ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="visit_ids is required",
+        )
+
+    visits = db.query(Visit).options(joinedload(Visit.services)).filter(
+        Visit.id.in_(normalized_visit_ids)
+    ).all()
+    visits_by_id = {visit.id: visit for visit in visits}
+    missing_visit_ids = [visit_id for visit_id in normalized_visit_ids if visit_id not in visits_by_id]
+    if missing_visit_ids:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Visits not found: {missing_visit_ids}",
+        )
+
+    patient_ids = {visit.patient_id for visit in visits if visit.patient_id is not None}
+    if len(patient_ids) != 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Grouped cashier payment requires visits from exactly one patient",
+        )
+
+    patient_id = next(iter(patient_ids))
+    if payment_data.patient_id is not None and payment_data.patient_id != patient_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Grouped cashier payment patient_id does not match visit ownership",
+        )
+
+    paid_amounts = _cashier_paid_amounts_by_visit_id(db, normalized_visit_ids)
+    allocation_candidates = []
+    for visit in visits:
+        total_amount = _cashier_visit_total_amount(visit)
+        paid_amount = paid_amounts.get(visit.id, Decimal("0"))
+        remaining_amount = total_amount - paid_amount
+        if remaining_amount > 0:
+            allocation_candidates.append({
+                "visit": visit,
+                "remaining_amount": remaining_amount,
+            })
+
+    allocation_candidates.sort(
+        key=lambda item: (
+            item["visit"].created_at or datetime.min,
+            item["visit"].id,
+        )
+    )
+
+    total_remaining = sum(
+        (item["remaining_amount"] for item in allocation_candidates),
+        Decimal("0"),
+    )
+    if total_remaining <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Grouped cashier payment has no remaining backend-calculated debt",
+        )
+    if payment_data.amount > total_remaining:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Grouped cashier payment amount exceeds backend-calculated remaining debt",
+        )
+
+    remaining_to_allocate = payment_data.amount
+    created_at = datetime.utcnow()
+    created_payments: list[Payment] = []
+    allocation_rows: list[tuple[Payment, Visit, Decimal, Decimal, Decimal]] = []
+
+    try:
+        for candidate in allocation_candidates:
+            if remaining_to_allocate <= 0:
+                break
+
+            visit = candidate["visit"]
+            remaining_before = candidate["remaining_amount"]
+            allocation_amount = min(remaining_to_allocate, remaining_before)
+            if allocation_amount <= 0:
+                continue
+
+            payment = Payment(
+                visit_id=visit.id,
+                amount=allocation_amount,
+                method=payment_data.method,
+                status="paid",
+                note=payment_data.note,
+                created_at=created_at,
+                paid_at=created_at,
+            )
+            db.add(payment)
+            db.flush()
+
+            remaining_after = remaining_before - allocation_amount
+            created_payments.append(payment)
+            allocation_rows.append((
+                payment,
+                visit,
+                allocation_amount,
+                remaining_before,
+                remaining_after,
+            ))
+            remaining_to_allocate -= allocation_amount
+
+        if remaining_to_allocate != Decimal("0"):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Grouped cashier payment could not allocate full amount",
+            )
+
+        db.commit()
+        for payment in created_payments:
+            db.refresh(payment)
+
+        for payment, visit, *_ in allocation_rows:
+            await _emit_payment_notification(
+                db=db,
+                payment=payment,
+                current_user=current_user,
+                change_type="paid",
+                patient_id=patient_id,
+                visit=visit,
+            )
+
+        try:
+            from app.ws.cashier_ws import broadcast_cashier_update
+            import asyncio
+
+            for payment in created_payments:
+                asyncio.create_task(broadcast_cashier_update("payment_created", {
+                    "payment_id": payment.id,
+                    "visit_id": payment.visit_id,
+                    "patient_id": patient_id,
+                    "amount": float(payment.amount),
+                    "method": payment.method,
+                    "status": payment.status,
+                }))
+        except Exception as ws_error:
+            logger.warning(f"WebSocket broadcast failed: {ws_error}")
+
+        return GroupedPaymentResponse(
+            patient_id=patient_id,
+            amount=payment_data.amount,
+            method=payment_data.method,
+            status="paid",
+            created_at=created_at,
+            payments=[
+                PaymentResponse(
+                    id=payment.id,
+                    visit_id=payment.visit_id,
+                    patient_id=patient_id,
+                    amount=payment.amount,
+                    method=payment.method,
+                    status=payment.status,
+                    created_at=payment.created_at,
+                    paid_at=payment.paid_at,
+                    note=payment.note,
+                )
+                for payment in created_payments
+            ],
+            allocations=[
+                GroupedPaymentAllocationItem(
+                    visit_id=visit.id,
+                    payment_id=payment.id,
+                    amount=allocation_amount,
+                    remaining_before=remaining_before,
+                    remaining_after=remaining_after,
+                )
+                for payment, visit, allocation_amount, remaining_before, remaining_after in allocation_rows
+            ],
+        )
+
+    except HTTPException:
+        db.rollback()
+        raise
+    except Exception as exc:
+        db.rollback()
+        logger.exception("Grouped cashier payment allocation failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Grouped cashier payment allocation failed: {str(exc)}",
         )
 
 

--- a/backend/tests/integration/test_notification_catalog_slice2_cashier.py
+++ b/backend/tests/integration/test_notification_catalog_slice2_cashier.py
@@ -8,7 +8,7 @@ from app.models.notification import NotificationDelivery, NotificationEvent
 from app.models.patient import Patient
 from app.models.payment import Payment
 from app.models.user import User
-from app.models.visit import Visit
+from app.models.visit import Visit, VisitService
 
 
 def _create_patient_visit(db_session, *, suffix: str) -> tuple[Patient, Visit]:
@@ -61,6 +61,21 @@ def _payment_event_deliveries(db_session, *, recipient_id: int):
         .order_by(NotificationDelivery.id.asc())
         .all()
     )
+
+
+def _add_visit_service(db_session, visit: Visit, *, price: str, service_id: int) -> VisitService:
+    service = VisitService(
+        visit_id=visit.id,
+        service_id=service_id,
+        code=f"CASH-{service_id}",
+        name=f"Cashier Service {service_id}",
+        qty=1,
+        price=Decimal(price),
+    )
+    db_session.add(service)
+    db_session.commit()
+    db_session.refresh(service)
+    return service
 
 
 def test_cashier_create_payment_creates_canonical_payment_notification(
@@ -126,6 +141,110 @@ def test_cashier_create_payment_creates_canonical_payment_notification(
     assert event.payload_snapshot["metadata"]["change_type"] == "paid"
     assert event.payload_snapshot["metadata"]["payment_status"] == "paid"
     assert event.payload_snapshot["metadata"]["visit_id"] == visit.id
+
+
+def test_cashier_grouped_payment_allocates_by_backend_remaining_debt(
+    client,
+    db_session,
+    auth_headers,
+):
+    patient, first_visit = _create_patient_visit(db_session, suffix="0101")
+    second_visit = Visit(
+        patient_id=patient.id,
+        status="waiting",
+        discount_mode="none",
+        approval_status="none",
+        source="desk",
+    )
+    db_session.add(second_visit)
+    db_session.commit()
+    db_session.refresh(second_visit)
+
+    _add_visit_service(db_session, first_visit, price="100000", service_id=101)
+    _add_visit_service(db_session, second_visit, price="50000", service_id=102)
+    existing_payment = Payment(
+        visit_id=first_visit.id,
+        amount=Decimal("40000"),
+        method="cash",
+        status="paid",
+    )
+    db_session.add(existing_payment)
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/cashier/payments/grouped",
+        json={
+            "patient_id": patient.id,
+            "visit_ids": [first_visit.id, second_visit.id],
+            "amount": 80000,
+            "method": "cash",
+            "note": "backend grouped allocation",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["patient_id"] == patient.id
+    assert payload["amount"] == "80000"
+    assert [item["visit_id"] for item in payload["allocations"]] == [
+        first_visit.id,
+        second_visit.id,
+    ]
+    assert [item["amount"] for item in payload["allocations"]] == ["60000.00", "20000.00"]
+    assert [item["remaining_after"] for item in payload["allocations"]] == ["0.00", "30000.00"]
+
+    payments = (
+        db_session.query(Payment)
+        .filter(Payment.visit_id.in_([first_visit.id, second_visit.id]))
+        .order_by(Payment.id.asc())
+        .all()
+    )
+    assert [(payment.visit_id, payment.amount, payment.status) for payment in payments] == [
+        (first_visit.id, Decimal("40000.00"), "paid"),
+        (first_visit.id, Decimal("60000.00"), "paid"),
+        (second_visit.id, Decimal("20000.00"), "paid"),
+    ]
+
+
+def test_cashier_grouped_payment_rejects_overpay_without_mutation(
+    client,
+    db_session,
+    auth_headers,
+):
+    patient, first_visit = _create_patient_visit(db_session, suffix="0102")
+    second_visit = Visit(
+        patient_id=patient.id,
+        status="waiting",
+        discount_mode="none",
+        approval_status="none",
+        source="desk",
+    )
+    db_session.add(second_visit)
+    db_session.commit()
+    db_session.refresh(second_visit)
+
+    _add_visit_service(db_session, first_visit, price="10000", service_id=201)
+    _add_visit_service(db_session, second_visit, price="15000", service_id=202)
+
+    response = client.post(
+        "/api/v1/cashier/payments/grouped",
+        json={
+            "patient_id": patient.id,
+            "visit_ids": [first_visit.id, second_visit.id],
+            "amount": 30000,
+            "method": "cash",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400, response.text
+    assert "exceeds backend-calculated remaining debt" in response.json()["detail"]
+    assert (
+        db_session.query(Payment)
+        .filter(Payment.visit_id.in_([first_visit.id, second_visit.id]))
+        .count()
+    ) == 0
 
 
 def test_cashier_cancel_payment_creates_cancelled_payment_notification(


### PR DESCRIPTION
## Summary
- Adds a backend-owned grouped cashier payment allocation endpoint for pending-payment rows with multiple visit ids.
- Exposes additive pending-payment contract hints so consumers can distinguish single-visit direct payment rows from grouped-visit rows.
- Rejects grouped overpay and allocates payment amount backend-side by remaining visit debt; no frontend code, no BFF-lite, and no `/api/v1/ui/*` endpoints are added.

## Cyclic Execution Evidence
- Fresh main sync: started from `origin/main` at `7fdc4be5` after PR #1361 merged.
- Clean workspace: inspected branch status before edits; only cashier endpoint and targeted cashier integration test are changed.
- Branch: `codex/cashier-backend-grouped-payment-allocation`.
- Scope gate: `agent_gate` narrow override approved `backend/app/api/v1/endpoints/cashier.py`; second gate approved targeted test file `backend/tests/integration/test_notification_catalog_slice2_cashier.py`.
- Red-check handling: no prior red checks on this branch; local targeted validation is green before PR open.

## Contract Impact
- Canonical surface: `POST /api/v1/cashier/payments/grouped` plus additive fields on `GET /api/v1/cashier/pending-payments` row DTOs.
- Request shape: grouped command accepts `visit_ids`, optional `patient_id`, `amount`, `method`, and optional `note`.
- Response shape: grouped command returns `patient_id`, `amount`, `method`, `status`, `created_at`, created `payments`, and backend allocation rows with `visit_id`, `payment_id`, `amount`, `remaining_before`, and `remaining_after`.
- Status codes: success is 200; validation/no-debt/overpay/patient mismatch return 400; missing visits return 404; existing `/cashier/payments` behavior is unchanged.
- Frontend consumer: not changed in this PR; prior PR #1361 fail-closes grouped rows until the frontend consumes this backend contract.
- Compatibility path or alias: existing `/cashier/payments`, `visit_id`, and `visit_ids` compatibility fields remain; new pending fields are additive: `payment_contract`, `payment_visit_id`, `payment_visit_ids`, `can_create_direct_payment`, `can_create_grouped_payment`.
- Contract proof: targeted cashier integration tests and OpenAPI contract tests pass locally.

## RBAC / Permissions
- Roles allowed: existing cashier route dependency allows `Admin` and `Cashier` via `deps.require_roles(Admin, Cashier)`.
- Roles denied: unchanged from cashier route dependency; no public or patient-facing route is added.
- Positive auth proof: targeted cashier integration tests call the endpoint with existing authenticated cashier headers and pass.
- Negative auth proof: not separately checked in this PR because route auth uses the existing cashier dependency pattern and no auth behavior was changed.

## Notification / Realtime
- Event type or websocket channel: grouped payments emit the existing payment notification path and cashier websocket `payment_created` event for each created payment.
- Payload version / ack behavior: unchanged existing payment notification/websocket payload style; no new realtime protocol is introduced.
- Read/unread or delivery semantics: unchanged; notifications are emitted through the existing canonical helper.
- Reconnect/resync proof: not applicable - cashier list resync still uses existing pending/payments endpoints; this PR does not change websocket reconnect behavior.

## Frontend Resilience
- Empty data proof: grouped endpoint rejects no-debt rows with 400 rather than creating zero/ambiguous payments.
- Partial data proof: missing visit ids return 404 and same-patient mismatch returns 400 before mutation.
- Forbidden secondary path behavior: frontend is not touched; #1361 already prevents local grouped allocation.
- Missing draft/resource behavior: not applicable - cashier payments do not use draft resources.
- Stale route/deep-link behavior: not applicable - no frontend route changes.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/cashier.py`; `backend/tests/integration/test_notification_catalog_slice2_cashier.py`.
- Denied paths: frontend files, `/api/v1/ui/*`, separate BFF service, migrations, broad payment refactors, unrelated cleanup.
- Migration/docs/test impact: no migrations or docs; targeted backend integration tests updated.
- Rollback note: revert this PR to remove the grouped endpoint and additive pending-payment fields; existing single-payment endpoint remains untouched.

## Validation
- Targeted tests or smoke run: `C:\final\scripts\run_python.ps1 -PythonArgs @('-m','py_compile','backend/app/api/v1/endpoints/cashier.py','backend/tests/integration/test_notification_catalog_slice2_cashier.py')`; `C:\final\scripts\run_backend_pytest.ps1 tests/integration/test_notification_catalog_slice2_cashier.py tests/test_openapi_contract.py`; `git diff --check`.
- Result: py_compile passed; backend pytest passed `20 passed, 1 warning`; `git diff --check` passed with only the existing Windows LF-to-CRLF warning for the touched test file.
- Not checked: frontend build/tests, because no frontend files changed in this backend-only contract PR.