### PR TITLE
fix(cashier): consume grouped payment contract

### DIFF
--- a/frontend/src/pages/CashierPanel.jsx
+++ b/frontend/src/pages/CashierPanel.jsx
@@ -243,6 +243,18 @@ const getAppointmentPaymentActionContext = (appointment) => {
 };
 
 const resolveCashierVisitIds = (appointment) => {
+  const paymentVisitIds = Array.isArray(appointment?.payment_visit_ids)
+    ? appointment.payment_visit_ids.filter((visitId) => visitId !== null && visitId !== undefined)
+    : [];
+
+  if (paymentVisitIds.length > 0) {
+    return [...new Set(paymentVisitIds)];
+  }
+
+  if (appointment?.payment_visit_id !== null && appointment?.payment_visit_id !== undefined) {
+    return [appointment.payment_visit_id];
+  }
+
   const groupedVisitIds = Array.isArray(appointment?.visit_ids)
     ? appointment.visit_ids.filter((visitId) => visitId !== null && visitId !== undefined)
     : [];
@@ -259,6 +271,55 @@ const resolveCashierVisitIds = (appointment) => {
 const resolveSingleCashierVisitId = (appointment) => {
   const visitIds = resolveCashierVisitIds(appointment);
   return visitIds.length === 1 ? visitIds[0] : null;
+};
+
+const isBackendGroupedCashierPayment = (appointment) =>
+  appointment?.payment_contract === 'grouped_visits' ||
+  appointment?.can_create_grouped_payment === true;
+
+const canCreateDirectCashierPayment = (appointment) => {
+  if (Object.prototype.hasOwnProperty.call(appointment || {}, 'can_create_direct_payment')) {
+    return appointment.can_create_direct_payment === true;
+  }
+
+  return resolveSingleCashierVisitId(appointment) !== null;
+};
+
+const canCreateCashierPayment = (appointment) =>
+  canCreateDirectCashierPayment(appointment) || appointment?.can_create_grouped_payment === true;
+
+const createGroupedCashierPayment = async (appointment, paymentData) => {
+  const token = tokenManager.getAccessToken();
+  if (!token) {
+    throw new Error('Missing access token for grouped cashier payment.');
+  }
+
+  const visitIds = resolveCashierVisitIds(appointment);
+  if (visitIds.length === 0 || appointment?.can_create_grouped_payment !== true) {
+    throw new Error('Backend did not provide a grouped cashier payment contract for this row.');
+  }
+
+  const response = await fetch(`${getApiOrigin()}/api/v1/cashier/payments/grouped`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      patient_id: appointment?.patient_id ?? null,
+      visit_ids: visitIds,
+      amount: paymentData.amount,
+      method: paymentData.method,
+      note: paymentData.note || 'Grouped cashier payment'
+    })
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(payload?.detail || 'Grouped cashier payment failed.');
+  }
+
+  return payload;
 };
 
 const PAYMENT_ACTION_CAN_FIELD = {
@@ -578,9 +639,8 @@ const CashierPanel = () => {void
   };
 
   const openPaymentWidget = (appointment) => {
-    const visitId = resolveSingleCashierVisitId(appointment);
-    if (!visitId) {
-      const message = 'Cannot start payment: backend must provide exactly one visit_id for this payment row.';
+    if (!canCreateDirectCashierPayment(appointment) || isBackendGroupedCashierPayment(appointment)) {
+      const message = 'Cannot start online payment: grouped cashier rows must use the backend grouped payment contract.';
       setPaymentError(message);
       notify.error(message);
       return;
@@ -594,21 +654,26 @@ const CashierPanel = () => {void
   // Теперь appointment содержит сгруппированные данные пациента (все его неоплаченные визиты)
   const processPayment = async (appointment, paymentData) => {
     try {
+      const groupedPayment = isBackendGroupedCashierPayment(appointment);
       const visitId = resolveSingleCashierVisitId(appointment);
 
-      if (!visitId) {
+      if (!groupedPayment && !visitId) {
         throw new Error('Cannot process payment: backend must provide exactly one visit_id or a backend-owned allocation contract.');
       }
 
-      const result = await paymentsHook.createPayment({
-        visit_id: visitId,
-        amount: paymentData.amount,
-        method: paymentData.method,
-        note: paymentData.note || 'Оплата медицинских услуг'
-      });
+      if (groupedPayment) {
+        await createGroupedCashierPayment(appointment, paymentData);
+      } else {
+        const result = await paymentsHook.createPayment({
+          visit_id: visitId,
+          amount: paymentData.amount,
+          method: paymentData.method,
+          note: paymentData.note || 'Оплата медицинских услуг'
+        });
 
-      if (!result.success) {
-        throw new Error(`Не удалось оплатить визит #${visitId}: ${result.error}`);
+        if (!result.success) {
+          throw new Error(`Не удалось оплатить визит #${visitId}: ${result.error}`);
+        }
       }
 
       notify.success(`Оплата успешно обработана! Сумма: ${format(paymentData.amount)}`);
@@ -1271,6 +1336,7 @@ const CashierPanel = () => {void
                             size="sm"
                             variant="outline"
                             onClick={() => openPaymentWidget(appointment)}
+                            disabled={!canCreateDirectCashierPayment(appointment) || isBackendGroupedCashierPayment(appointment)}
                             aria-label={`Start online payment for ${getAppointmentPaymentActionContext(appointment)}`}>
 
                                   💳 Онлайн
@@ -1280,6 +1346,7 @@ const CashierPanel = () => {void
                             onClick={() => {
                               paymentModal.openModal(appointment);
                             }}
+                            disabled={!canCreateCashierPayment(appointment)}
                             aria-label={`Take cash payment for ${getAppointmentPaymentActionContext(appointment)}`}>
 
                                   💵 Касса
@@ -1576,7 +1643,7 @@ const CashierPanel = () => {void
 
               {paymentWidget.selectedItem &&
               <PaymentWidget
-                visitId={resolveSingleCashierVisitId(paymentWidget.selectedItem)}
+                visitId={canCreateDirectCashierPayment(paymentWidget.selectedItem) ? resolveSingleCashierVisitId(paymentWidget.selectedItem) : null}
                 amount={paymentWidget.selectedItem.remaining_amount || paymentWidget.selectedItem.total_amount || paymentWidget.selectedItem.cost || 0}
                 currency="UZS"
                 description={`Оплата за ${paymentWidget.selectedItem.department || 'медицинские услуги'}`}

--- a/frontend/src/pages/__tests__/CashierPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/CashierPanel.contract.test.jsx
@@ -59,4 +59,46 @@ describe('CashierPanel payment action contract', () => {
     expect(receiptBlock).toContain('status: paymentRow?.status ?? null');
     expect(receiptBlock).not.toContain("status: paymentRow?.status || 'paid'");
   });
+
+  it('delegates grouped cashier payment allocation to the backend contract', () => {
+    const source = readCashierPanelSource();
+    const groupedContractBlock = extractSourceBlock(
+      source,
+      'const createGroupedCashierPayment = async (appointment, paymentData) => {',
+      'const PAYMENT_ACTION_CAN_FIELD = {',
+    );
+    const processPaymentBlock = extractSourceBlock(
+      source,
+      'const processPayment = async (appointment, paymentData) => {',
+      'const confirmPayment = async (paymentId) => {',
+    );
+
+    expect(groupedContractBlock).toContain('/api/v1/cashier/payments/grouped');
+    expect(groupedContractBlock).toContain('appointment?.can_create_grouped_payment !== true');
+    expect(groupedContractBlock).toContain('visit_ids: visitIds');
+    expect(processPaymentBlock).toContain('const groupedPayment = isBackendGroupedCashierPayment(appointment);');
+    expect(processPaymentBlock).toContain('await createGroupedCashierPayment(appointment, paymentData);');
+    expect(processPaymentBlock).toContain('paymentsHook.createPayment');
+    expect(processPaymentBlock).not.toContain('remaining_amount -');
+    expect(processPaymentBlock).not.toContain('remainingAmount');
+    expect(processPaymentBlock).not.toContain('Math.min');
+  });
+
+  it('does not route grouped cashier rows through the single-visit online widget', () => {
+    const source = readCashierPanelSource();
+    const onlineActionBlock = extractSourceBlock(
+      source,
+      'onClick={() => openPaymentWidget(appointment)}',
+      'aria-label={`Take cash payment',
+    );
+    const paymentWidgetBlock = extractSourceBlock(
+      source,
+      '<PaymentWidget',
+      'amount={paymentWidget.selectedItem.remaining_amount',
+    );
+
+    expect(onlineActionBlock).toContain('disabled={!canCreateDirectCashierPayment(appointment) || isBackendGroupedCashierPayment(appointment)}');
+    expect(paymentWidgetBlock).toContain('canCreateDirectCashierPayment(paymentWidget.selectedItem)');
+    expect(paymentWidgetBlock).not.toContain('can_create_grouped_payment');
+  });
 });


### PR DESCRIPTION
## Summary
- Updates CashierPanel to consume the backend grouped cashier payment contract added in #1363.
- Cash grouped rows now call `POST /api/v1/cashier/payments/grouped` instead of staying permanently fail-closed or splitting allocation in React.
- Online payment remains single-visit only; grouped rows are disabled for the single-visit online widget and must use the backend grouped cashier contract.

## Cyclic Execution Evidence
- Fresh main sync: started from local `main == origin/main` at `a48ef7c2` after #1363 merged.
- Clean workspace: inspected status before edits; only CashierPanel and its contract test changed.
- Branch: `codex/cashier-consume-grouped-payment-contract`.
- Scope gate: `agent_gate` narrow override first allowed `frontend/src/pages/CashierPanel.jsx`; second gate allowed `frontend/src/pages/__tests__/CashierPanel.contract.test.jsx`.
- Red-check handling: no red checks existed before opening this PR; local validation passed before push.

## Contract Impact
- Canonical surface: frontend consumes existing `GET /api/v1/cashier/pending-payments` fields and existing `POST /api/v1/cashier/payments/grouped`.
- Request shape: grouped cashier payment posts `patient_id`, `visit_ids`, `amount`, `method`, and `note` to the backend grouped endpoint.
- Response shape: frontend only needs success/failure from the grouped endpoint, then refreshes cashier data; backend allocation response shape is not reinterpreted in React.
- Status codes: non-2xx backend responses are surfaced as payment errors; frontend does not translate grouped overpay/no-debt into local allocation behavior.
- Frontend consumer: `frontend/src/pages/CashierPanel.jsx`.
- Compatibility path or alias: single-visit rows continue using `paymentsHook.createPayment`; legacy direct rows still fall back to exactly one visit id.
- Contract proof: `CashierPanel.contract.test.jsx` proves grouped rows call the backend endpoint and no local allocation math is present.

## RBAC / Permissions
- Roles allowed: unchanged; CashierPanel remains behind existing app role routing and backend grouped endpoint enforces `Admin`/`Cashier`.
- Roles denied: unchanged; no public route or bypass is added.
- Positive auth proof: frontend passes the existing access token to the backend grouped endpoint.
- Negative auth proof: not separately checked in this frontend PR because backend authorization was implemented and tested in #1363.

## Notification / Realtime
- Event type or websocket channel: unchanged; backend grouped endpoint emits existing cashier/payment updates.
- Payload version / ack behavior: unchanged; frontend refreshes through existing cashier data reload after success.
- Read/unread or delivery semantics: not applicable - no notification read/unread behavior changes.
- Reconnect/resync proof: existing refresh path is reused after payment success; no websocket reconnect behavior is changed.

## Frontend Resilience
- Empty data proof: if backend does not provide grouped contract fields, grouped action fails closed instead of allocating locally.
- Partial data proof: grouped payment requires backend `can_create_grouped_payment` and backend-provided visit ids before POST.
- Forbidden secondary path behavior: grouped rows are not routed through the single-visit online `PaymentWidget`.
- Missing draft/resource behavior: not applicable - cashier payments do not use draft resources.
- Stale route/deep-link behavior: not applicable - no route changes.

## Scope Gate
- Allowed paths: `frontend/src/pages/CashierPanel.jsx`; `frontend/src/pages/__tests__/CashierPanel.contract.test.jsx`.
- Denied paths: backend, BFF, `/api/v1/ui/*`, payment service rewrites, broad CashierPanel rewrite, unrelated cleanup.
- Migration/docs/test impact: no migrations or docs; targeted frontend contract test updated.
- Rollback note: revert this PR to return grouped rows to the prior frontend fail-closed behavior; backend grouped endpoint remains available.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- src/pages/__tests__/CashierPanel.contract.test.jsx`; `npm.cmd --prefix frontend run build`; `git diff --check`.
- Result: contract test passed `5 tests`; frontend build passed; `git diff --check` passed with only Windows LF-to-CRLF warnings.
- Not checked: backend tests, because no backend files changed in this PR.