### PR TITLE
fix(telegram): keep mini app entry token auth section

### DIFF
--- a/frontend/src/pages/TelegramMiniAppPatientShell.jsx
+++ b/frontend/src/pages/TelegramMiniAppPatientShell.jsx
@@ -307,6 +307,12 @@ function getTelegramMiniAppEntryToken(search) {
   return token.trim();
 }
 
+function getTelegramMiniAppEntryTokenSection(search) {
+  const token = getTelegramMiniAppEntryToken(search);
+  const tokenSection = token.split('_')[1] || '';
+  return MINI_APP_SECTION_ALIASES[tokenSection.trim().toLowerCase()] || '';
+}
+
 function getTelegramMiniAppAuthPayload(search, section) {
   const initData = getTelegramMiniAppInitData();
   const selectedSection = section || getTelegramMiniAppSelectedSection(search);
@@ -319,9 +325,12 @@ function getTelegramMiniAppAuthPayload(search, section) {
 
   const entryToken = getTelegramMiniAppEntryToken(search);
   if (entryToken) {
+    const tokenSection = getTelegramMiniAppEntryTokenSection(search);
     return {
       entryToken,
-      section: selectedSection || undefined,
+      // Local HTTP fallback tokens are signed for the entry section. Keep auth
+      // pinned to that section while the Mini App UI switches panels.
+      section: tokenSection || selectedSection || undefined,
     };
   }
 


### PR DESCRIPTION
﻿## Summary

- Fix Telegram patient Mini App navigation when opened through local/http `entryToken` fallback.
- Keep UI section switching (`queue` -> `payments`, `forms`, `results`, etc.) separate from the signed token auth section.
- Preserve real Telegram Mini App `initData` behavior unchanged.

## Cyclic Execution Evidence

- Fresh main sync: started from current `origin/main` and created `codex/fix-telegram-miniapp-section-navigation`.
- Clean workspace: inspected before edits; only `frontend/src/pages/TelegramMiniAppPatientShell.jsx` changed.
- Branch: `codex/fix-telegram-miniapp-section-navigation`.
- Scope gate: agent gate first missed the Mini App shell, then known-root-cause retry approved narrow override for the patient Mini App shell and Telegram endpoint references.
- Red-check handling: PR Review Quality Gate failure is fixed in this same PR by updating this body; code checks remain in this PR.

## Contract Impact

- Canonical surface: Telegram patient Mini App route `/telegram/mini-app/patient` and backend `/api/v1/telegram/mini-app/*` auth payload.
- Request shape: unchanged fields; fallback requests still send `entryToken` and `section`.
- Response shape: unchanged manifest, cabinet summary, forms, appointments, and report payloads.
- Status codes: unchanged; backend still rejects invalid, expired, unlinked, inactive, or blocked tokens.
- Frontend consumer: `TelegramMiniAppPatientShell` now uses the signed token section for fallback auth while rendering the selected UI section from the URL.
- Compatibility path or alias: canonical section aliases remain unchanged; local/http fallback links keep working.
- Contract proof: targeted Mini App deep-link guardrail test, frontend build, and backend py_compile passed locally.

## RBAC / Permissions

- Roles allowed: linked patient scope only through Telegram `initData` or signed short-lived patient entry token.
- Roles denied: unlinked Telegram users, inactive/blocked links, staff/admin scopes, and invalid/expired tokens remain denied by backend.
- Positive auth proof: local fallback token keeps using the signed entry section so section switching no longer creates a false mismatch.
- Negative auth proof: no patient id, chat id, or internal id is added to URL or request body; backend token validation remains required.

## Notification / Realtime

not applicable - no Telegram notification delivery, polling, webhook, websocket, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: existing Mini App empty states remain unchanged for queue, payments, visits, forms, and results.
- Partial data proof: existing manifest/cabinet summary defensive reads remain unchanged.
- Forbidden secondary path behavior: invalid/expired tokens still show session unavailable/expired copy.
- Missing draft/resource behavior: appointment preview/create and form submission flows keep their current error handling.
- Stale route/deep-link behavior: stale fallback links keep the original signed auth section while allowing UI section changes inside the Mini App.

## Scope Gate

- Allowed paths: `frontend/src/pages/TelegramMiniAppPatientShell.jsx` only for the code patch; Telegram endpoint files were reference/validation targets.
- Denied paths: backend auth weakening, migrations, token storage, patient identifiers in URLs, notification delivery, unrelated UI.
- Migration/docs/test impact: no migration; no docs change; targeted existing guardrail test run without test file changes.
- Rollback note: revert the Mini App shell helper change to restore previous section-coupled fallback auth behavior.

## Validation

- Targeted tests or smoke run: `C:\final\scripts\run_python.ps1 -PythonArgs -m py_compile backend/app/api/v1/endpoints/admin_telegram.py backend/app/api/v1/endpoints/telegram_webhook.py`; `npm.cmd exec vitest -- run src/__tests__/telegramMiniAppDeepLinkGuardrails.test.js`; `npm.cmd run build`; `git diff --check`.
- Result: passed locally; GitHub frontend build/e2e/lint/unit, security scan, CodeQL, CI Scope, and PR Required Gate passed on PR #1366; current body also passes the local PR review gate validator.
- Not checked: live Telegram Desktop click-through after merge/reload; backend runtime restart is not required for this frontend-only patch.
