### PR TITLE
fix(emr-lab): guard doctor patient result reads

### DIFF
--- a/backend/app/api/v1/endpoints/emr_lab_integration.py
+++ b/backend/app/api/v1/endpoints/emr_lab_integration.py
@@ -9,10 +9,52 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.api import deps
+from app.models.clinic import Doctor
 from app.models.user import User
+from app.models.visit import Visit
 from app.services.emr_lab_integration import emr_lab_integration
 
 router = APIRouter()
+
+
+def _doctor_allowed_patient_ids(db: Session, current_user: User) -> set[int]:
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    allowed_doctor_ids = {doctor.id}
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == current_user.id).first()
+    # Some legacy visit writers stored User.id in doctor_id. Allow that only
+    # when the value does not target another real Doctor row.
+    if not assigned_doctor:
+        allowed_doctor_ids.add(current_user.id)
+
+    rows = (
+        db.query(Visit.patient_id)
+        .filter(
+            Visit.doctor_id.in_(allowed_doctor_ids),
+            Visit.patient_id.isnot(None),
+        )
+        .all()
+    )
+    return {row[0] for row in rows if row[0] is not None}
+
+
+def _ensure_doctor_can_read_patient_lab_data(
+    db: Session,
+    patient_id: int,
+    current_user: User,
+) -> None:
+    if current_user.role != "Doctor":
+        return
+    if current_user.is_superuser:
+        return
+    if patient_id not in _doctor_allowed_patient_ids(db, current_user):
+        raise HTTPException(status_code=403, detail="Access denied")
 
 
 @router.get("/patients/{patient_id}/lab-results")
@@ -25,6 +67,7 @@ async def get_patient_lab_results(
     current_user: User = Depends(deps.require_roles("Admin", "Doctor")),
 ) -> Any:
     """Получить лабораторные результаты пациента"""
+    _ensure_doctor_can_read_patient_lab_data(db, patient_id, current_user)
     try:
         # Парсим даты
         parsed_date_from = None
@@ -98,6 +141,7 @@ async def get_abnormal_lab_results(
     current_user: User = Depends(deps.require_roles("Admin", "Doctor")),
 ) -> Any:
     """Получить аномальные лабораторные результаты пациента"""
+    _ensure_doctor_can_read_patient_lab_data(db, patient_id, current_user)
     try:
         date_from = datetime.utcnow() - timedelta(days=days)
 
@@ -135,6 +179,7 @@ async def get_lab_summary_for_emr(
     current_user: User = Depends(deps.require_roles("Admin", "Doctor")),
 ) -> Any:
     """Получить сводку лабораторных данных для EMR"""
+    _ensure_doctor_can_read_patient_lab_data(db, patient_id, current_user)
     try:
         summary = await emr_lab_integration.generate_lab_summary_for_emr(
             db=db, patient_id=patient_id, emr_id=emr_id
@@ -229,6 +274,7 @@ async def get_lab_results_trends(
     current_user: User = Depends(deps.require_roles("Admin", "Doctor")),
 ) -> Any:
     """Получить тренды лабораторных результатов пациента"""
+    _ensure_doctor_can_read_patient_lab_data(db, patient_id, current_user)
     try:
         date_from = datetime.utcnow() - timedelta(days=period_days)
 

--- a/backend/tests/test_lab_reporting_api.py
+++ b/backend/tests/test_lab_reporting_api.py
@@ -8,6 +8,7 @@ import pytest
 from app.core.security import get_password_hash
 from app.models.appointment import Appointment
 from app.models.clinic import Doctor
+from app.models.lab import LabOrder, LabResult
 from app.models.patient import Patient
 from app.models.service import Service
 from app.models.user import User
@@ -105,6 +106,38 @@ def _create_lab_report_instance(
     )
     assert response.status_code == 200, response.text
     return response.json()
+
+
+def _create_legacy_lab_result(
+    db_session,
+    *,
+    patient_id: int,
+    visit_id: int,
+    test_code: str,
+    value: str,
+) -> LabResult:
+    order = LabOrder(
+        patient_id=patient_id,
+        visit_id=visit_id,
+        status="done",
+    )
+    db_session.add(order)
+    db_session.commit()
+    db_session.refresh(order)
+
+    result = LabResult(
+        order_id=order.id,
+        test_code=test_code,
+        test_name=test_code.title(),
+        value=value,
+        unit="g/L",
+        ref_range="120-160",
+        abnormal=False,
+    )
+    db_session.add(result)
+    db_session.commit()
+    db_session.refresh(result)
+    return result
 
 
 @pytest.mark.integration
@@ -353,6 +386,77 @@ def test_doctor_lab_report_reads_are_limited_to_own_visits(
         headers=doctor_headers,
     )
     assert other_pdf.status_code == 403
+
+
+@pytest.mark.integration
+def test_doctor_emr_lab_reads_are_limited_to_own_patients(
+    client,
+    db_session,
+) -> None:
+    own_user, own_doctor = _create_doctor_user(db_session, label="emr_own")
+    _other_user, other_doctor = _create_doctor_user(db_session, label="emr_other")
+    own_patient = _create_patient(db_session)
+    other_patient = _create_patient(db_session)
+    own_visit = _create_visit(
+        db_session,
+        patient_id=own_patient.id,
+        doctor_id=own_doctor.id,
+    )
+    other_visit = _create_visit(
+        db_session,
+        patient_id=other_patient.id,
+        doctor_id=other_doctor.id,
+    )
+    own_result = _create_legacy_lab_result(
+        db_session,
+        patient_id=own_patient.id,
+        visit_id=own_visit.id,
+        test_code="hemoglobin",
+        value="130",
+    )
+    _create_legacy_lab_result(
+        db_session,
+        patient_id=other_patient.id,
+        visit_id=other_visit.id,
+        test_code="hemoglobin",
+        value="80",
+    )
+    doctor_headers = _doctor_headers(client, own_user)
+
+    own_results = client.get(
+        f"/api/v1/emr/lab/patients/{own_patient.id}/lab-results",
+        headers=doctor_headers,
+    )
+    assert own_results.status_code == 200, own_results.text
+    own_payload = own_results.json()
+    assert own_payload["patient_id"] == own_patient.id
+    assert {item["id"] for item in own_payload["results"]} == {own_result.id}
+
+    other_results = client.get(
+        f"/api/v1/emr/lab/patients/{other_patient.id}/lab-results",
+        headers=doctor_headers,
+    )
+    assert other_results.status_code == 403
+
+    other_abnormal_results = client.get(
+        f"/api/v1/emr/lab/patients/{other_patient.id}/abnormal-lab-results",
+        headers=doctor_headers,
+    )
+    assert other_abnormal_results.status_code == 403
+
+    other_trends = client.get(
+        "/api/v1/emr/lab/lab-results/trends",
+        params={"patient_id": other_patient.id, "test_type": "hemoglobin"},
+        headers=doctor_headers,
+    )
+    assert other_trends.status_code == 403
+
+    other_summary = client.get(
+        "/api/v1/emr/lab/emr/123/lab-summary",
+        params={"patient_id": other_patient.id},
+        headers=doctor_headers,
+    )
+    assert other_summary.status_code == 403
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- Block Doctor users from reading legacy EMR lab data for patients outside their own visits.
- Apply the guard to `/api/v1/emr/lab/patients/{patient_id}/lab-results`, abnormal results, trends, and EMR lab summary.
- Add a regression covering own-patient success and foreign-patient 403s for the legacy `LabOrder`/`LabResult` path.

## Cyclic Execution Evidence
- Fresh main sync: audit worktree started from `origin/main` at `b3a05275`.
- Clean workspace: clean before branch creation; only this endpoint and one test file changed.
- Branch: `codex/doctor-emr-lab-read-guard`.
- Scope gate: `run_agent_gate.ps1` with known root cause `backend/app/api/v1/endpoints/emr_lab_integration.py`; result was execute/narrow override with endpoint first-touch. Test file expansion was narrow validation only.
- Red-check handling: no red GitHub checks yet; any CI failure will be fixed in this PR.

## Contract Impact
- Canonical surface: legacy mounted FastAPI surface `/api/v1/emr/lab/*` backed by `LabResult -> LabOrder.patient_id` and `Visit.doctor_id` ownership.
- Request shape: unchanged.
- Response shape: unchanged for authorized Admin and own-patient Doctor reads.
- Status codes: foreign-patient Doctor reads now return `403`; existing validation and server-error behavior otherwise unchanged.
- Frontend consumer: no frontend files changed.
- Compatibility path or alias: no route alias or prefix changed.
- Contract proof: `test_doctor_emr_lab_reads_are_limited_to_own_patients` covers own-patient 200 and foreign-patient 403s.

## RBAC / Permissions
- Roles allowed: Admin keeps existing broad read behavior; Doctor may read only patients linked to one of that doctor's visits.
- Roles denied: existing auth dependency still denies roles outside Admin/Doctor; Doctor is denied for unrelated patient ids.
- Positive auth proof: regression asserts Doctor can read own patient's legacy EMR lab results.
- Negative auth proof: regression asserts Doctor receives 403 for unrelated patient lab results, abnormal results, trends, and summary.

## Notification / Realtime
- Event type or websocket channel: no notification or websocket event is emitted by these synchronous read endpoints.
- Payload version / ack behavior: no payload version or ack contract is involved because this is request/response read-only access.
- Read/unread or delivery semantics: no delivery state is mutated.
- Reconnect/resync proof: clients resync by repeating the same GET; route and allowed response shape are unchanged.

## Frontend Resilience
- Empty data proof: own-patient endpoint still returns the existing `results` array shape and count fields.
- Partial data proof: no response fields were removed or renamed.
- Forbidden secondary path behavior: foreign-patient Doctor requests now fail closed with 403 before service reads.
- Missing draft/resource behavior: no draft/resource workflow is touched.
- Stale route/deep-link behavior: route paths are unchanged; stale unauthorized patient links now fail closed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/emr_lab_integration.py`, `backend/tests/test_lab_reporting_api.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite, frontend, migrations, service rewrites, broad lab reporting refactors.
- Migration/docs/test impact: no migration or docs; one targeted backend regression added.
- Rollback note: revert this commit to restore previous Doctor behavior on the legacy EMR-lab reads.

## Validation
- Targeted tests or smoke run: `py_compile` on endpoint and test file; attempted `scripts/run_backend_pytest.ps1 backend\tests\test_lab_reporting_api.py`.
- Result: `py_compile` passed; local pytest could not run because no local Python 3.11 interpreter has `pytest` installed.
- Not checked: full backend suite locally; GitHub CI is required for pytest coverage on this machine.