### PR TITLE
fix(emr-lab): guard doctor result integration

### DIFF
--- a/backend/app/api/v1/endpoints/emr_lab_integration.py
+++ b/backend/app/api/v1/endpoints/emr_lab_integration.py
@@ -9,7 +9,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.api import deps
+from app.models.appointment import Appointment
 from app.models.clinic import Doctor
+from app.models.emr import EMR
+from app.models.lab import LabOrder, LabResult
 from app.models.user import User
 from app.models.visit import Visit
 from app.services.emr_lab_integration import emr_lab_integration
@@ -17,7 +20,7 @@ from app.services.emr_lab_integration import emr_lab_integration
 router = APIRouter()
 
 
-def _doctor_allowed_patient_ids(db: Session, current_user: User) -> set[int]:
+def _doctor_allowed_doctor_ids(db: Session, current_user: User) -> set[int]:
     doctor = (
         db.query(Doctor)
         .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
@@ -32,7 +35,11 @@ def _doctor_allowed_patient_ids(db: Session, current_user: User) -> set[int]:
     # when the value does not target another real Doctor row.
     if not assigned_doctor:
         allowed_doctor_ids.add(current_user.id)
+    return allowed_doctor_ids
 
+
+def _doctor_allowed_patient_ids(db: Session, current_user: User) -> set[int]:
+    allowed_doctor_ids = _doctor_allowed_doctor_ids(db, current_user)
     rows = (
         db.query(Visit.patient_id)
         .filter(
@@ -54,6 +61,46 @@ def _ensure_doctor_can_read_patient_lab_data(
     if current_user.is_superuser:
         return
     if patient_id not in _doctor_allowed_patient_ids(db, current_user):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+
+def _ensure_doctor_can_integrate_lab_results(
+    db: Session,
+    emr_id: int,
+    lab_result_ids: list[int],
+    current_user: User,
+) -> None:
+    if current_user.role != "Doctor":
+        return
+    if current_user.is_superuser:
+        return
+
+    emr_record = db.query(EMR).filter(EMR.id == emr_id).first()
+    if not emr_record:
+        raise HTTPException(status_code=404, detail="EMR not found")
+
+    allowed_doctor_ids = _doctor_allowed_doctor_ids(db, current_user)
+    appointment = (
+        db.query(Appointment)
+        .filter(
+            Appointment.id == emr_record.appointment_id,
+            Appointment.doctor_id.in_(allowed_doctor_ids),
+        )
+        .first()
+    )
+    if not appointment:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    result_rows = (
+        db.query(LabResult.id, LabOrder.patient_id)
+        .join(LabOrder, LabResult.order_id == LabOrder.id)
+        .filter(LabResult.id.in_(lab_result_ids))
+        .all()
+    )
+    if any(
+        patient_id != appointment.patient_id
+        for _result_id, patient_id in result_rows
+    ):
         raise HTTPException(status_code=403, detail="Access denied")
 
 
@@ -115,6 +162,9 @@ async def integrate_lab_results_with_emr(
     current_user: User = Depends(deps.require_roles("Admin", "Doctor")),
 ) -> Any:
     """Интегрировать лабораторные результаты с EMR"""
+    _ensure_doctor_can_integrate_lab_results(
+        db, emr_id, lab_result_ids, current_user
+    )
     try:
         result = await emr_lab_integration.integrate_lab_results_with_emr(
             db=db, emr_id=emr_id, lab_result_ids=lab_result_ids

--- a/backend/tests/test_lab_reporting_api.py
+++ b/backend/tests/test_lab_reporting_api.py
@@ -8,6 +8,7 @@ import pytest
 from app.core.security import get_password_hash
 from app.models.appointment import Appointment
 from app.models.clinic import Doctor
+from app.models.emr import EMR
 from app.models.lab import LabOrder, LabResult
 from app.models.patient import Patient
 from app.models.service import Service
@@ -138,6 +139,40 @@ def _create_legacy_lab_result(
     db_session.commit()
     db_session.refresh(result)
     return result
+
+
+def _create_appointment(
+    db_session,
+    *,
+    patient_id: int,
+    doctor_id: int,
+) -> Appointment:
+    appointment = Appointment(
+        patient_id=patient_id,
+        doctor_id=doctor_id,
+        appointment_date=date.today(),
+        appointment_time="09:00",
+        status="scheduled",
+    )
+    db_session.add(appointment)
+    db_session.commit()
+    db_session.refresh(appointment)
+    return appointment
+
+
+def _create_emr(
+    db_session,
+    *,
+    appointment_id: int,
+) -> EMR:
+    emr = EMR(
+        appointment_id=appointment_id,
+        lab_results={},
+    )
+    db_session.add(emr)
+    db_session.commit()
+    db_session.refresh(emr)
+    return emr
 
 
 @pytest.mark.integration
@@ -457,6 +492,88 @@ def test_doctor_emr_lab_reads_are_limited_to_own_patients(
         headers=doctor_headers,
     )
     assert other_summary.status_code == 403
+
+
+@pytest.mark.integration
+def test_doctor_emr_lab_integrate_is_limited_to_owned_emr_and_patient_results(
+    client,
+    db_session,
+) -> None:
+    own_user, own_doctor = _create_doctor_user(db_session, label="integrate_own")
+    _other_user, other_doctor = _create_doctor_user(
+        db_session,
+        label="integrate_other",
+    )
+    own_patient = _create_patient(db_session)
+    other_patient = _create_patient(db_session)
+    own_visit = _create_visit(
+        db_session,
+        patient_id=own_patient.id,
+        doctor_id=own_doctor.id,
+    )
+    other_visit = _create_visit(
+        db_session,
+        patient_id=other_patient.id,
+        doctor_id=other_doctor.id,
+    )
+    own_emr = _create_emr(
+        db_session,
+        appointment_id=_create_appointment(
+            db_session,
+            patient_id=own_patient.id,
+            doctor_id=own_doctor.id,
+        ).id,
+    )
+    other_emr = _create_emr(
+        db_session,
+        appointment_id=_create_appointment(
+            db_session,
+            patient_id=other_patient.id,
+            doctor_id=other_doctor.id,
+        ).id,
+    )
+    own_result = _create_legacy_lab_result(
+        db_session,
+        patient_id=own_patient.id,
+        visit_id=own_visit.id,
+        test_code="hemoglobin",
+        value="130",
+    )
+    other_result = _create_legacy_lab_result(
+        db_session,
+        patient_id=other_patient.id,
+        visit_id=other_visit.id,
+        test_code="glucose",
+        value="7",
+    )
+    doctor_headers = _doctor_headers(client, own_user)
+
+    own_response = client.post(
+        f"/api/v1/emr/lab/emr/{own_emr.id}/integrate-lab-results",
+        json=[own_result.id],
+        headers=doctor_headers,
+    )
+    assert own_response.status_code == 200, own_response.text
+    db_session.refresh(own_emr)
+    assert own_emr.lab_results["hemoglobin"][0]["id"] == own_result.id
+
+    foreign_emr_response = client.post(
+        f"/api/v1/emr/lab/emr/{other_emr.id}/integrate-lab-results",
+        json=[own_result.id],
+        headers=doctor_headers,
+    )
+    assert foreign_emr_response.status_code == 403
+    db_session.refresh(other_emr)
+    assert other_emr.lab_results == {}
+
+    foreign_result_response = client.post(
+        f"/api/v1/emr/lab/emr/{own_emr.id}/integrate-lab-results",
+        json=[other_result.id],
+        headers=doctor_headers,
+    )
+    assert foreign_result_response.status_code == 403
+    db_session.refresh(own_emr)
+    assert "glucose" not in own_emr.lab_results
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- Block Doctor users from integrating legacy lab results into EMRs outside their appointment ownership.
- Also block attaching `lab_result_ids` whose `LabOrder.patient_id` does not match the target EMR appointment patient.
- Add a regression for own EMR success, foreign EMR denial, and foreign patient result denial.

## Cyclic Execution Evidence
- Fresh main sync: branch started after #1368 merge from `origin/main` at `b316d9fd`.
- Clean workspace: clean before branch creation; only endpoint and targeted test file changed.
- Branch: `codex/doctor-emr-lab-integrate-guard`.
- Scope gate: `run_agent_gate.ps1` with known root cause `backend/app/api/v1/endpoints/emr_lab_integration.py`; result was execute/narrow override with endpoint first-touch. Test file expansion is narrow validation only.
- Red-check handling: no red GitHub checks yet; any CI failure will be fixed in this PR.

## Contract Impact
- Canonical surface: legacy mounted FastAPI surface `POST /api/v1/emr/lab/emr/{emr_id}/integrate-lab-results` backed by `EMR.appointment_id`, `Appointment.patient_id/doctor_id`, and `LabResult -> LabOrder.patient_id`.
- Request shape: unchanged, still accepts the existing JSON list of lab result ids.
- Response shape: unchanged for authorized Admin and own-EMR Doctor writes.
- Status codes: foreign-EMR Doctor writes and foreign-patient lab result attachments now return `403`; missing EMR for Doctor returns `404` before mutation.
- Frontend consumer: no frontend files changed.
- Compatibility path or alias: no route alias or prefix changed.
- Contract proof: `test_doctor_emr_lab_integrate_is_limited_to_owned_emr_and_patient_results` covers success and fail-closed cases.

## RBAC / Permissions
- Roles allowed: Admin keeps existing behavior; Doctor may integrate only into EMRs for appointments assigned to that doctor and only with results for the same patient.
- Roles denied: existing auth dependency still denies roles outside Admin/Doctor; unrelated Doctor attempts now fail closed.
- Positive auth proof: regression asserts Doctor can integrate own patient's result into own EMR.
- Negative auth proof: regression asserts Doctor receives 403 for unrelated EMR and unrelated patient result id.

## Notification / Realtime
- Event type or websocket channel: no notification or websocket event is emitted by this synchronous legacy integration endpoint.
- Payload version / ack behavior: no payload version or ack contract is involved because this endpoint writes through normal request/response.
- Read/unread or delivery semantics: no delivery state is mutated.
- Reconnect/resync proof: clients resync by re-reading the EMR/lab data; route and successful response shape are unchanged.

## Frontend Resilience
- Empty data proof: no empty-state response shape changed.
- Partial data proof: authorized integration response keeps the existing `result` payload.
- Forbidden secondary path behavior: unauthorized Doctor paths now return 403 before `EMR.lab_results` mutation.
- Missing draft/resource behavior: missing EMR remains a 404-style failure and no draft workflow is touched.
- Stale route/deep-link behavior: route path is unchanged; stale/foreign IDs now fail closed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/emr_lab_integration.py`, `backend/tests/test_lab_reporting_api.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite, frontend, migrations, service rewrites, broad EMR/lab refactors.
- Migration/docs/test impact: no migration or docs; one targeted backend regression added.
- Rollback note: revert this commit to restore previous Doctor behavior on legacy EMR-lab integration.

## Validation
- Targeted tests or smoke run: `py_compile` on endpoint and test file; `git diff --check`; attempted `scripts/run_backend_pytest.ps1 backend\tests\test_lab_reporting_api.py`.
- Result: `py_compile` and `git diff --check` passed; local pytest could not run because no local Python 3.11 interpreter has `pytest` installed.
- Not checked: full backend suite locally; GitHub CI is required for pytest coverage on this machine.