### PR TITLE
fix(notifications): preserve missing delivery status

### DIFF
--- a/frontend/src/contexts/NotificationCenterContext.jsx
+++ b/frontend/src/contexts/NotificationCenterContext.jsx
@@ -290,9 +290,9 @@ function normalizeNotification(input, source = 'api') {
       input.department_key || input.departmentKey || input.department
     ),
     channel: input.channel || 'in_app_inbox',
-    status: input.status || input.delivery_status || input.deliveryStatus || 'pending',
+    status: input.status || input.delivery_status || input.deliveryStatus || null,
     deliveryStatus:
-      input.delivery_status || input.deliveryStatus || input.status || 'pending',
+      input.delivery_status || input.deliveryStatus || input.status || null,
     isRead: Boolean(
       input.is_read ?? input.isRead ?? input.read_at ?? input.readAt ?? false
     ),


### PR DESCRIPTION
## Summary
- Preserve missing notification delivery status instead of normalizing absent frontend payload status to pending.
- Keep backend-provided status and delivery_status values unchanged for API and websocket payloads.
- No backend, API, BFF, route, queue, lab, payment, or command behavior changes.

## Cyclic Execution Evidence
- Fresh main sync: branch was created from main at e4332206 after PR #1369 merged.
- Clean workspace: before this patch the branch had no unrelated local edits.
- Branch: codex/notification-status-fallback-ssot.
- Scope gate: agent gate was run with known root cause frontend/src/contexts/NotificationCenterContext.jsx; it reported narrow override and override_used=yes for this notification contract slice.
- Red-check handling: if CI or PR quality checks fail, this same PR will be updated rather than opening a follow-up.

## Contract Impact
- Canonical surface: NotificationDelivery.delivery_status remains owned by backend model/schema/service serialization.
- Request shape: unchanged; no request payloads were edited.
- Response shape: unchanged; no backend DTOs or OpenAPI schema were edited.
- Status codes: unchanged.
- Frontend consumer: NotificationCenterContext now preserves missing delivery status as null instead of inventing pending for malformed or legacy frontend payloads.
- Compatibility path or alias: no route, endpoint, websocket channel, alias, adapter path, or compatibility path changed.
- Contract proof: backend notification API and websocket serialization already send status and delivery_status; frontend fallback no longer creates a canonical delivery state when both fields are absent.

## RBAC / Permissions
- Roles allowed: unchanged because this PR only changes notification normalization fallback for absent status fields.
- Roles denied: unchanged because authorization checks, recipient scoping, route guards, and notification permissions were not edited.
- Positive auth proof: existing authorized users continue to consume the same notification API and websocket payloads.
- Negative auth proof: denied users remain governed by backend notification recipient scope checks; this PR introduces no secondary fetch or bypass path.

## Notification / Realtime
- Event type or websocket channel: unchanged; /api/v1/ws/notifications/connect behavior and event types are not edited.
- Payload version / ack behavior: unchanged; backend ack payloads still provide delivery_status, and frontend consumes backend-provided values.
- Read/unread or delivery semantics: backend-owned pending/seen/read/archived delivery status remains unchanged when present; absent status remains absent.
- Reconnect/resync proof: notification guardrail tests and NotificationCenterContext tests passed, and API/websocket resync paths were not changed.

## Frontend Resilience
- Empty data proof: a notification-like payload without status fields now keeps null delivery status instead of showing false pending state.
- Partial data proof: payloads with either status, delivery_status, or deliveryStatus still preserve that backend-provided value.
- Forbidden secondary path behavior: no secondary API path was introduced.
- Missing draft/resource behavior: unchanged; no draft/resource flow touched.
- Stale route/deep-link behavior: unchanged; route/deep-link handling was not edited.

## Scope Gate
- Allowed paths: frontend/src/contexts/NotificationCenterContext.jsx.
- Denied paths: backend runtime behavior, API routes, /api/v1/ui/*, BFF service, migrations, QueueJoin, DisplayBoard, registrar command logic, lab command logic, generated artifacts.
- Migration/docs/test impact: no migrations or docs changed; existing focused notification tests covered this slice.
- Rollback note: revert the single context diff to restore the prior frontend pending fallback.

## Validation
- Targeted tests or smoke run: npm.cmd --prefix frontend run test:run -- notificationGuardrails NotificationCenterContext; C:\final\backend\.venv\Scripts\python.exe -m py_compile backend/app/services/notifications.py backend/app/services/notifications_api_service.py backend/app/schemas/notification.py backend/app/models/notification.py; npm.cmd --prefix frontend run build; git diff --check.
- Result: all passed locally. The repo run_python.ps1 wrapper rejected the gate py_compile argument shape, so the same compile check was run directly through the backend venv Python.
- Not checked: backend pytest was not run because backend code, schemas, routes, and database contracts were not changed.