### PR TITLE
fix(printing): preserve missing printer status

### DIFF
--- a/frontend/src/components/admin/CloudPrintingManager.jsx
+++ b/frontend/src/components/admin/CloudPrintingManager.jsx
@@ -39,7 +39,7 @@ const getStatusText = (status) => {
     case 'busy': return 'Занят';
     case 'offline': return 'Не в сети';
     case 'error': return 'Ошибка';
-    default: return status;
+    default: return status || 'Статус неизвестен';
   }
 };
 
@@ -67,7 +67,7 @@ const normalizeLocalPrinter = (printer) => ({
     ]
       .filter(Boolean)
       .join(' • ') || 'Локальный системный принтер',
-  status: printer.status || 'offline',
+  status: printer.status || null,
   location: printer.device_path || printer.location || 'Локальный компьютер',
   capabilities: {
     printer_type: printer.printer_type || 'unknown',

--- a/frontend/src/components/dialogs/PrintDialog.jsx
+++ b/frontend/src/components/dialogs/PrintDialog.jsx
@@ -94,7 +94,7 @@ const PrintDialog = ({
       const normalizedPrinters = backendPrinters.map((printer) => ({
         id: printer.name || String(printer.id),
         name: printer.display_name || printer.name || 'Принтер',
-        status: printer.status || 'offline',
+        status: printer.status || null,
         type: printer.printer_type || 'unknown',
         isDefault: Boolean(printer.is_default),
       }));
@@ -516,7 +516,11 @@ const PrintDialog = ({
                           fontSize: '12px',
                           fontWeight: '500',
                           color:
-                            printer.status === 'online' ? '#10b981' : '#ef4444',
+                            printer.status === 'online'
+                              ? '#10b981'
+                              : printer.status
+                                ? '#ef4444'
+                                : '#64748b',
                         }}
                       >
                         {printer.status === 'online' ? (
@@ -524,10 +528,15 @@ const PrintDialog = ({
                             <Wifi size={14} />
                             Онлайн
                           </>
-                        ) : (
+                        ) : printer.status ? (
                           <>
                             <WifiOff size={14} />
                             Офлайн
+                          </>
+                        ) : (
+                          <>
+                            <WifiOff size={14} />
+                            Статус неизвестен
                           </>
                         )}
                       </div>


### PR DESCRIPTION
## Summary
- Preserve missing printer status instead of normalizing absent provider data to offline.
- Keep printing safely disabled unless the backend/provider status is explicitly online.
- No backend, API, BFF, route, queue, lab, payment, or command behavior changes.

## Cyclic Execution Evidence
- Fresh main sync: branch was created from main at b0f00a07 after PR #1372 merged.
- Clean workspace: before this patch the branch had no unrelated local edits.
- Branch: codex/printer-status-fallback-ssot.
- Scope gate: direct_execute was used because this is a local display-only fallback outside core clinical/business rule domains.
- Red-check handling: if CI or PR quality checks fail, this same PR will be updated rather than opening a follow-up.

## Contract Impact
- Canonical surface: printer status remains the value returned by print provider/backend payloads.
- Request shape: unchanged; no request payloads were edited.
- Response shape: unchanged; no backend DTOs or OpenAPI schema were edited.
- Status codes: unchanged.
- Frontend consumer: CloudPrintingManager and PrintDialog preserve missing printer status as null/unknown instead of claiming offline.
- Compatibility path or alias: no route, endpoint, alias, adapter, or compatibility path changed.
- Contract proof: UI still enables printing only for explicit online status; absent status no longer becomes a false offline state.

## RBAC / Permissions
- Roles allowed: unchanged; existing print/admin surfaces keep their current access paths.
- Roles denied: unchanged because route guards and backend permissions were not edited.
- Positive auth proof: authorized users continue to see the same printer list and can choose explicitly online printers.
- Negative auth proof: this PR introduces no secondary fetch, print path, or bypass path.

## Notification / Realtime
- Event type or websocket channel: unchanged; no notification or websocket path touched.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: unchanged because this PR does not affect realtime state or cache hydration.

## Frontend Resilience
- Empty data proof: printers with absent status now show an unknown status label instead of a false offline label.
- Partial data proof: printers with online, busy, offline, or error status still render those backend/provider values.
- Forbidden secondary path behavior: no secondary API path was introduced.
- Missing draft/resource behavior: unchanged; no draft/resource flow touched.
- Stale route/deep-link behavior: unchanged; route handling was not edited.

## Scope Gate
- Allowed paths: frontend/src/components/admin/CloudPrintingManager.jsx; frontend/src/components/dialogs/PrintDialog.jsx.
- Denied paths: backend runtime behavior, API routes, /api/v1/ui/*, BFF service, migrations, QueueJoin, DisplayBoard, registrar command logic, lab command logic, generated artifacts.
- Migration/docs/test impact: no migrations or docs changed; no focused printer status test harness exists in this slice.
- Rollback note: revert the two frontend diffs to restore the prior offline fallback.

## Validation
- Targeted tests or smoke run: npm.cmd --prefix frontend run build; git diff --check.
- Result: both passed locally.
- Not checked: backend tests were not run because backend code, schemas, routes, and database contracts were not changed.