### PR TITLE
fix(telegram): guard lab result notifications

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_notifications.py
+++ b/backend/app/api/v1/endpoints/telegram_notifications.py
@@ -19,7 +19,10 @@ from app.crud import (
     patient as crud_patient,
     telegram_config as crud_telegram,
 )
+from app.models.clinic import Doctor
+from app.models.lab import LabOrder
 from app.models.user import User
+from app.models.visit import Visit
 from app.services.telegram_bot import get_telegram_bot_service
 from app.services.telegram_templates import get_telegram_templates_service
 
@@ -91,6 +94,83 @@ def _safe_payment_template_data(payment_data: Dict[str, Any]) -> Dict[str, Any]:
         "transaction_id": PROTECTED_PAYMENT_REFERENCE,
         "receipt_link": _protected_payment_history_url(),
     }
+
+
+def _doctor_allowed_patient_ids(db: Session, current_user: User) -> set[int]:
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
+    allowed_doctor_ids = {doctor.id}
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == current_user.id).first()
+    # Some legacy visit writers stored User.id in doctor_id. Allow that only
+    # when the value does not target another real Doctor row.
+    if not assigned_doctor:
+        allowed_doctor_ids.add(current_user.id)
+
+    rows = (
+        db.query(Visit.patient_id)
+        .filter(
+            Visit.doctor_id.in_(allowed_doctor_ids),
+            Visit.patient_id.isnot(None),
+        )
+        .all()
+    )
+    return {row[0] for row in rows if row[0] is not None}
+
+
+def _ensure_doctor_can_send_patient_lab_results(
+    db: Session,
+    patient_id: int,
+    current_user: User,
+) -> None:
+    if current_user.role != "Doctor":
+        return
+    if current_user.is_superuser:
+        return
+    if patient_id not in _doctor_allowed_patient_ids(db, current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
+
+def _lab_result_patient_id(db: Session, result: Any) -> int | None:
+    direct_patient_id = getattr(result, "patient_id", None)
+    if direct_patient_id is not None:
+        return int(direct_patient_id)
+
+    order = getattr(result, "order", None)
+    order_patient_id = getattr(order, "patient_id", None)
+    if order_patient_id is not None:
+        return int(order_patient_id)
+
+    order_id = getattr(result, "order_id", None)
+    if order_id is None:
+        return None
+    return db.query(LabOrder.patient_id).filter(LabOrder.id == order_id).scalar()
+
+
+def _ensure_lab_results_belong_to_patient(
+    db: Session,
+    *,
+    patient_id: int,
+    lab_results: List[Any],
+) -> None:
+    for result in lab_results:
+        result_patient_id = _lab_result_patient_id(db, result)
+        if result_patient_id is not None and result_patient_id != patient_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Access denied",
+            )
 
 
 @router.post("/send-appointment-reminder")
@@ -200,6 +280,8 @@ async def send_lab_results(
             )
 
         # Ищем Telegram пользователя
+        _ensure_doctor_can_send_patient_lab_results(db, patient_id, current_user)
+
         telegram_user = crud_telegram.find_telegram_user_by_phone(db, patient.phone)
         if not telegram_user:
             return {
@@ -224,6 +306,12 @@ async def send_lab_results(
             )
 
         # Получаем сервис бота
+        _ensure_lab_results_belong_to_patient(
+            db,
+            patient_id=patient_id,
+            lab_results=lab_results,
+        )
+
         bot_service = await get_telegram_bot_service()
         if not bot_service.active:
             await bot_service.initialize(db)

--- a/backend/tests/unit/test_telegram_notifications_privacy.py
+++ b/backend/tests/unit/test_telegram_notifications_privacy.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import BackgroundTasks
+from fastapi import HTTPException
 
 from app.api.v1.endpoints import telegram_notifications
 
@@ -458,6 +459,106 @@ async def test_send_lab_results_respects_notification_preferences(monkeypatch):
     assert "Sensitive Patient" not in str(response)
     assert "998877" not in str(response)
     get_bot_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_lab_results_rejects_result_for_different_patient(monkeypatch):
+    patient = SimpleNamespace(
+        phone="+998901234567",
+        full_name="Sensitive Patient",
+    )
+    telegram_user = SimpleNamespace(
+        chat_id=998877,
+        language_code="ru",
+        notifications_enabled=True,
+        lab_notifications=True,
+    )
+    lab_result = SimpleNamespace(
+        patient_id=999,
+        test_code="CBC",
+        created_at=datetime(2026, 5, 18, 9, 0, 0),
+        is_abnormal=False,
+    )
+    get_bot_service = AsyncMock()
+
+    monkeypatch.setattr(
+        telegram_notifications.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: telegram_user,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_lab,
+        "get_lab_result",
+        lambda _db, _result_id: lab_result,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications,
+        "get_telegram_bot_service",
+        get_bot_service,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await telegram_notifications.send_lab_results(
+            patient_id=123,
+            lab_result_ids=[456],
+            background_tasks=BackgroundTasks(),
+            db=object(),
+            current_user=SimpleNamespace(role="Lab"),
+        )
+
+    assert exc_info.value.status_code == 403
+    get_bot_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_doctor_send_lab_results_rejects_unowned_patient(monkeypatch):
+    patient = SimpleNamespace(
+        phone="+998901234567",
+        full_name="Sensitive Patient",
+    )
+    find_telegram_user = AsyncMock()
+
+    monkeypatch.setattr(
+        telegram_notifications.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications,
+        "_doctor_allowed_patient_ids",
+        lambda _db, _current_user: {123},
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_telegram,
+        "find_telegram_user_by_phone",
+        find_telegram_user,
+        raising=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await telegram_notifications.send_lab_results(
+            patient_id=999,
+            lab_result_ids=[456],
+            background_tasks=BackgroundTasks(),
+            db=object(),
+            current_user=SimpleNamespace(
+                id=1,
+                role="Doctor",
+                is_superuser=False,
+            ),
+        )
+
+    assert exc_info.value.status_code == 403
+    find_telegram_user.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Block Telegram lab-result notifications when selected `lab_result_ids` belong to a different patient than the requested `patient_id`.
- Limit Doctor users to sending lab-result notifications only for patients tied to one of their visits.
- Add privacy/security unit regressions proving mismatch and unowned-patient requests fail before bot send/lookup.

## Cyclic Execution Evidence
- Fresh main sync: branch started from `origin/main` at `b0f00a07`.
- Clean workspace: clean before branch creation; only Telegram endpoint and one targeted privacy test file changed.
- Branch: `codex/telegram-lab-results-patient-guard`.
- Scope gate: `run_agent_gate.ps1` with known root cause `backend/app/api/v1/endpoints/telegram_notifications.py`; gate reported `gate_misroute=yes` and broad Telegram/catalog/frontend first-touch. Used narrow override because the concrete runtime root cause is localized to `send_lab_results`; test file expansion is validation only.
- Red-check handling: no red GitHub checks yet; any CI failure will be fixed in this PR.

## Contract Impact
- Canonical surface: `POST /api/v1/telegram-notifications/send-lab-results` legacy Telegram notification endpoint.
- Request shape: unchanged (`patient_id`, `lab_result_ids`).
- Response shape: unchanged for authorized and matching sends.
- Status codes: mismatched patient/result and unowned Doctor patient now return `403` before Telegram delivery.
- Frontend consumer: no frontend files changed.
- Compatibility path or alias: no route alias or prefix changed.
- Contract proof: `test_send_lab_results_rejects_result_for_different_patient` and `test_doctor_send_lab_results_rejects_unowned_patient`.

## RBAC / Permissions
- Roles allowed: Admin/Lab keep broad send capability when result ids match the requested patient; Doctor may send only for patients tied to their visits.
- Roles denied: existing dependency still denies other roles; Doctor is denied for unrelated patient ids.
- Positive auth proof: existing privacy tests still cover successful Lab notification send.
- Negative auth proof: new unit tests assert 403 before bot send for mismatched result and before Telegram lookup for unowned Doctor patient.

## Notification / Realtime
- Event type or websocket channel: Telegram bot `_send_message` is the delivery side effect.
- Payload version / ack behavior: payload shape is unchanged; invalid ownership now fails before `_send_message`.
- Read/unread or delivery semantics: no read/unread state is changed.
- Reconnect/resync proof: this is a synchronous send endpoint; clients can retry matching requests, while mismatched or unowned IDs fail closed.

## Frontend Resilience
- Empty data proof: existing no-result 404 behavior is preserved.
- Partial data proof: successful response keeps `success`, `message`, and `lab_results_count`.
- Forbidden secondary path behavior: invalid patient/result combinations return 403 before external send.
- Missing draft/resource behavior: no draft/resource workflow touched.
- Stale route/deep-link behavior: route unchanged; stale IDs that point outside ownership fail closed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/telegram_notifications.py`, `backend/tests/unit/test_telegram_notifications_privacy.py`.
- Denied paths: notification catalog/service rewrites, `admin_telegram.py`, `telegram_webhook.py`, frontend, migrations, `/api/v1/ui/*`, BFF-lite.
- Migration/docs/test impact: no migration or docs; one targeted unit regression slice added.
- Rollback note: revert this commit to restore previous Telegram lab-results send behavior.

## Validation
- Targeted tests or smoke run: `py_compile` on endpoint and test file; `git diff --check`; attempted `scripts/run_backend_pytest.ps1 backend\tests\unit\test_telegram_notifications_privacy.py`.
- Result: `py_compile` and `git diff --check` passed; local pytest could not run because no local Python 3.11 interpreter has `pytest` installed.
- Not checked: local pytest/full suite; GitHub CI is required for pytest coverage on this machine.