### PR TITLE
fix(appointments): preserve queue status source

### DIFF
--- a/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
+++ b/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
@@ -1020,8 +1020,7 @@ const EnhancedAppointmentsTable = ({
             queueStatus = row.queue_numbers[0].status;
           }
         }
-        // Fallback: используем общий статус записи только если queue_numbers отсутствует
-        queueStatus = queueStatus || row.status || null;
+        queueStatus = queueStatus || null;
         const statusConfig = {
           waiting: {
             bg: 'var(--mac-warning, #ff9500)',
@@ -1081,7 +1080,7 @@ const EnhancedAppointmentsTable = ({
       // Fallback: Если есть номера очередей, но нет queue_number - показываем первый
       if (row.queue_numbers && Array.isArray(row.queue_numbers) && row.queue_numbers.length > 0) {
         const firstQueue = row.queue_numbers[0];
-        const queueStatus = firstQueue.status || row.status || null;
+        const queueStatus = firstQueue.status || null;
         const statusConfig = {
           waiting: {
             bg: 'var(--mac-warning, #ff9500)',


### PR DESCRIPTION
## Summary

- Preserve backend-owned queue status in `EnhancedAppointmentsTable`.
- Remove appointment `row.status` as a fallback source for queue-number badge status.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/appointments-table-queue-status-ssot` is based on current `origin/main` after PR #1376 was merged.
- Clean workspace: `git status --short --branch` was clean before validation; the PR changes only `frontend/src/components/tables/EnhancedAppointmentsTable.jsx`.
- Branch: `codex/appointments-table-queue-status-ssot`.
- Scope gate: repo gate ran with known root cause `frontend/src/components/tables/EnhancedAppointmentsTable.jsx`; allowed only that first-touch file and denied backend, migrations, DTOs, generated output, and unrelated frontend files.
- Red-check handling: PR Review Quality Gate failed on the earlier incomplete PR body; this same PR body has been updated and revalidated before merge.

## Contract Impact

- Canonical surface: queue status remains the backend-provided queue-specific display fact in appointment table rows.
- Request shape: unchanged; no request body, query, or endpoint selection changed.
- Response shape: unchanged; the frontend only stops borrowing appointment `row.status` as queue status when queue status is missing.
- Status codes: unchanged; no API status-code behavior changed.
- Frontend consumer: `EnhancedAppointmentsTable` queue-number badge rendering.
- Compatibility path or alias: not applicable - no compatibility endpoint, route alias, or fallback API path changed.
- Contract proof: diff is limited to queue-status display fallback removal, plus local `npm.cmd --prefix frontend run build`, `git diff --check origin/main..HEAD`, and repo gate evidence.

## RBAC / Permissions

- Roles allowed: unchanged; the table remains available through existing frontend routes and backend auth contracts.
- Roles denied: unchanged; this PR does not alter route guards, API auth, or role policies.
- Positive auth proof: not applicable - no authenticated request path changed.
- Negative auth proof: not applicable - no authorization denial path changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification event or websocket channel changed.
- Payload version / ack behavior: not applicable - no payload, ack, or version behavior changed.
- Read/unread or delivery semantics: not applicable - no delivery or read-state behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect or resync path changed.

## Frontend Resilience

- Empty data proof: missing queue status now falls through to the existing neutral unknown queue badge state instead of using appointment status.
- Partial data proof: rows with `queue_number_status` or `queue_numbers[0].status` continue using those queue-specific fields.
- Forbidden secondary path behavior: not applicable - no secondary fetch or command path changed.
- Missing draft/resource behavior: not applicable - appointment table display does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no route or deep-link handling changed.

## Scope Gate

- Allowed paths: `frontend/src/components/tables/EnhancedAppointmentsTable.jsx`.
- Denied paths: backend endpoints/services/schemas, migrations, queue ordering logic, appointment status contracts, generated output, docs, and unrelated frontend files.
- Migration/docs/test impact: no migration; no docs change; validation is frontend build plus diff/gate checks for this one-file display fix.
- Rollback note: revert commit `5e27fc18` to restore the previous appointment-status fallback.

## Validation

- Targeted tests or smoke run: repo gate with known root cause `frontend/src/components/tables/EnhancedAppointmentsTable.jsx`; `git diff --check origin/main..HEAD`; `npm.cmd --prefix frontend run build`; local PR review body gate against this body file.
- Result: repo gate returned narrow override for the single first-touch file; `git diff --check` passed; frontend build passed; local PR body gate passed for this body before publishing.
- Not checked: full manual browser walkthrough of the appointments table against live backend data.