### PR TITLE
fix(cardio): guard doctor blood test access

### DIFF
--- a/backend/app/api/v1/endpoints/cardio.py
+++ b/backend/app/api/v1/endpoints/cardio.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.api import deps
 from app.models.cardio_blood_test import CardioBloodTest
+from app.models.clinic import Doctor
 from app.models.patient import Patient
 from app.models.user import User
 from app.models.visit import Visit
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 CARDIO_ROLES = ("Admin", "Doctor", "cardio", "cardiology", "cardiologist", "Cardiologist")
 CARDIO_PUBLIC_ERROR = "Internal server error"
+CARDIO_ADMIN_ROLES = {"Admin"}
 
 
 def _raise_cardio_internal_error(operation: str, exc: Exception) -> NoReturn:
@@ -27,6 +29,57 @@ def _raise_cardio_internal_error(operation: str, exc: Exception) -> NoReturn:
         type(exc).__name__,
     )
     raise HTTPException(status_code=500, detail=CARDIO_PUBLIC_ERROR) from exc
+
+
+def _is_admin_user(user: User) -> bool:
+    return getattr(user, "role", None) in CARDIO_ADMIN_ROLES or bool(
+        getattr(user, "is_superuser", False)
+    )
+
+
+def _doctor_allowed_doctor_ids(db: Session, user: User) -> set[int]:
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    allowed_doctor_ids = {doctor.id}
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == user.id).first()
+    # Some legacy visit writers stored User.id in doctor_id. Allow that only
+    # when the value does not target another real Doctor row.
+    if not assigned_doctor:
+        allowed_doctor_ids.add(user.id)
+    return allowed_doctor_ids
+
+
+def _doctor_allowed_patient_ids(db: Session, user: User) -> set[int]:
+    allowed_doctor_ids = _doctor_allowed_doctor_ids(db, user)
+    rows = (
+        db.query(Visit.patient_id)
+        .filter(
+            Visit.doctor_id.in_(allowed_doctor_ids),
+            Visit.patient_id.isnot(None),
+        )
+        .all()
+    )
+    return {row[0] for row in rows if row[0] is not None}
+
+
+def _ensure_doctor_can_access_patient(db: Session, patient_id: int, user: User) -> None:
+    if _is_admin_user(user):
+        return
+    if patient_id not in _doctor_allowed_patient_ids(db, user):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+
+def _ensure_doctor_can_access_visit(db: Session, visit: Visit, user: User) -> None:
+    if _is_admin_user(user):
+        return
+    if visit.doctor_id not in _doctor_allowed_doctor_ids(db, user):
+        raise HTTPException(status_code=403, detail="Access denied")
 
 
 @router.get("/ecg", summary="ЭКГ исследования")
@@ -76,6 +129,15 @@ async def get_blood_tests(
     """
     try:
         query = db.query(CardioBloodTest)
+        if not _is_admin_user(user):
+            if patient_id is not None:
+                _ensure_doctor_can_access_patient(db, patient_id, user)
+            else:
+                allowed_patient_ids = _doctor_allowed_patient_ids(db, user)
+                if not allowed_patient_ids:
+                    return []
+                query = query.filter(CardioBloodTest.patient_id.in_(allowed_patient_ids))
+
         if patient_id is not None:
             query = query.filter(CardioBloodTest.patient_id == patient_id)
 
@@ -127,6 +189,11 @@ async def create_blood_test(
                     status_code=400,
                     detail="Визит не принадлежит выбранному пациенту",
                 )
+
+        if blood_test_data.visit_id is None:
+            _ensure_doctor_can_access_patient(db, blood_test_data.patient_id, user)
+        else:
+            _ensure_doctor_can_access_visit(db, visit, user)
 
         blood_test = CardioBloodTest(
             patient_id=blood_test_data.patient_id,

--- a/backend/tests/integration/test_cardio_api.py
+++ b/backend/tests/integration/test_cardio_api.py
@@ -1,12 +1,84 @@
 from __future__ import annotations
 
 from datetime import date
+from uuid import uuid4
 
 import pytest
 
 from app.core.security import get_password_hash
 from app.models.cardio_blood_test import CardioBloodTest
+from app.models.clinic import Doctor
+from app.models.patient import Patient
 from app.models.user import User
+from app.models.visit import Visit
+
+
+def _suffix() -> str:
+    return uuid4().hex[:10]
+
+
+def _create_doctor_user(db_session, *, label: str) -> tuple[User, Doctor]:
+    suffix = _suffix()
+    user = User(
+        username=f"cardio_guard_{label}_{suffix}",
+        email=f"cardio-guard-{label}-{suffix}@test.local",
+        full_name=f"Cardio Guard {label}",
+        hashed_password=get_password_hash("doctor123"),
+        role="Doctor",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    doctor = Doctor(
+        user_id=user.id,
+        specialty="cardiology",
+        active=True,
+    )
+    db_session.add(doctor)
+    db_session.commit()
+    db_session.refresh(doctor)
+    return user, doctor
+
+
+def _create_patient(db_session, *, label: str) -> Patient:
+    suffix = _suffix()
+    patient = Patient(
+        first_name=f"Cardio {label}",
+        last_name="OwnerGuard",
+        phone=f"+99890{suffix[:7]}",
+        birth_date=date(1990, 1, 1),
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+    return patient
+
+
+def _create_visit(db_session, *, patient: Patient, doctor: Doctor) -> Visit:
+    visit = Visit(
+        patient_id=patient.id,
+        doctor_id=doctor.id,
+        visit_date=date.today(),
+        status="open",
+        source="desk",
+        department="cardiology",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+    return visit
+
+
+def _doctor_headers(client, user: User) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": user.username, "password": "doctor123"},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
 
 
 @pytest.mark.integration
@@ -86,6 +158,81 @@ class TestCardioApi:
         assert response.status_code == 404
         assert response.json()["detail"] == "Пациент не найден"
 
+    def test_doctor_blood_tests_are_limited_to_owned_patients(
+        self,
+        client,
+        db_session,
+    ):
+        own_user, own_doctor = _create_doctor_user(db_session, label="own")
+        _other_user, other_doctor = _create_doctor_user(db_session, label="other")
+        own_patient = _create_patient(db_session, label="own")
+        other_patient = _create_patient(db_session, label="other")
+        own_visit = _create_visit(db_session, patient=own_patient, doctor=own_doctor)
+        other_visit = _create_visit(db_session, patient=other_patient, doctor=other_doctor)
+        own_test = CardioBloodTest(
+            patient_id=own_patient.id,
+            visit_id=own_visit.id,
+            doctor_id=own_user.id,
+            test_date=date.today(),
+            cholesterol_total=180,
+            interpretation="owned cardio result",
+        )
+        other_test = CardioBloodTest(
+            patient_id=other_patient.id,
+            visit_id=other_visit.id,
+            doctor_id=None,
+            test_date=date.today(),
+            cholesterol_total=250,
+            interpretation="foreign cardio result",
+        )
+        db_session.add_all([own_test, other_test])
+        db_session.commit()
+        db_session.refresh(own_test)
+        db_session.refresh(other_test)
+        headers = _doctor_headers(client, own_user)
+
+        list_response = client.get(
+            "/api/v1/cardio/blood-tests?limit=20",
+            headers=headers,
+        )
+        assert list_response.status_code == 200
+        listed_ids = {item["id"] for item in list_response.json()}
+        assert own_test.id in listed_ids
+        assert other_test.id not in listed_ids
+
+        foreign_read_response = client.get(
+            f"/api/v1/cardio/blood-tests?patient_id={other_patient.id}",
+            headers=headers,
+        )
+        assert foreign_read_response.status_code == 403
+
+        foreign_write_response = client.post(
+            "/api/v1/cardio/blood-tests",
+            json={
+                "patient_id": other_patient.id,
+                "visit_id": other_visit.id,
+                "test_date": date.today().isoformat(),
+                "cholesterol_total": 260,
+                "interpretation": "must not be written",
+            },
+            headers=headers,
+        )
+        assert foreign_write_response.status_code == 403
+
+        own_write_response = client.post(
+            "/api/v1/cardio/blood-tests",
+            json={
+                "patient_id": own_patient.id,
+                "visit_id": own_visit.id,
+                "test_date": date.today().isoformat(),
+                "cholesterol_total": 181,
+                "interpretation": "owned write",
+            },
+            headers=headers,
+        )
+        assert own_write_response.status_code == 201
+        assert own_write_response.json()["patient_id"] == own_patient.id
+
     def test_cardiologist_role_can_access_cardio_endpoints(
         self,
         client,
@@ -105,6 +252,16 @@ class TestCardioApi:
         db_session.add(cardiologist)
         db_session.commit()
         db_session.refresh(cardiologist)
+        doctor = Doctor(
+            user_id=cardiologist.id,
+            specialty="cardiology",
+            active=True,
+        )
+        db_session.add(doctor)
+        db_session.commit()
+        db_session.refresh(doctor)
+        test_visit.doctor_id = doctor.id
+        db_session.commit()
 
         login_response = client.post(
             "/api/v1/authentication/login",


### PR DESCRIPTION
## Summary
- Restrict `GET /api/v1/cardio/blood-tests` for non-admin doctor/cardio roles to patients tied to their own visits.
- Reject `POST /api/v1/cardio/blood-tests` when a doctor/cardio user targets another doctor's visit or patient.
- Add an integration regression covering list filtering, foreign patient read denial, foreign visit write denial, and owned write success.

## Cyclic Execution Evidence
- Fresh main sync: branched from `origin/main` at `cc822381` in isolated worktree `C:\tmp\final-cardio-audit`.
- Clean workspace: worktree was clean before edits; only cardio endpoint/test changed.
- Branch: `codex/cardio-blood-tests-doctor-guard`.
- Scope gate: `agent_gate` run with known root cause `backend/app/api/v1/endpoints/cardio.py`; returned narrow override. Test expansion was limited to `backend/tests/integration/test_cardio_api.py` for regression proof.
- Red-check handling: if CI is red, this PR remains the active fix scope; no follow-up PR until checks are green.

## Contract Impact
- Canonical surface: legacy mounted cardio blood-test endpoint under `/api/v1/cardio/blood-tests`.
- Request shape: unchanged; `patient_id`, optional `visit_id`, and lab values are unchanged.
- Response shape: unchanged `CardioBloodTestOut` list/object.
- Status codes: Admin behavior unchanged. Doctor/cardio foreign access now returns `403 Access denied`; missing patient/visit and patient/visit mismatch behavior stays unchanged.
- Frontend consumer: no frontend files touched; existing callers keep the same payload shape.
- Compatibility path or alias: no route aliases, BFF-lite endpoints, or `/api/v1/ui/*` paths added.
- Contract proof: integration test asserts owned rows remain visible/writable while foreign patient/visit access is denied.

## RBAC / Permissions
- Roles allowed: `Admin`/superuser keep broad access; `Doctor`, `cardio`, `cardiology`, `cardiologist`, `Cardiologist` can access only patients connected to their active `Doctor` profile visits.
- Roles denied: users outside `CARDIO_ROLES` remain blocked by existing `require_roles`; doctor/cardio users without an active doctor profile or without an owned visit for the target patient are denied.
- Positive auth proof: regression test creates an owned doctor/patient/visit and confirms list + create succeed.
- Negative auth proof: regression test creates a second doctor's patient/visit and confirms filtered read and write return 403.

## Notification / Realtime
- Event type or websocket channel: none involved; this endpoint performs synchronous DB read/write only.
- Payload version / ack behavior: no notification payloads, websocket ack, or background task contract exists on this path.
- Read/unread or delivery semantics: no delivery/read state is touched.
- Reconnect/resync proof: not part of this endpoint; DB state remains the source for subsequent reads.

## Frontend Resilience
- Empty data proof: doctors with no allowed patients return an empty list for unfiltered listing rather than seeing global data.
- Partial data proof: unfiltered doctor list is scoped to owned patient ids, so owned rows can appear while foreign rows are omitted.
- Forbidden secondary path behavior: explicit foreign `patient_id` and foreign `visit_id` write paths return 403.
- Missing draft/resource behavior: missing patient/visit behavior remains the existing 404 flow.
- Stale route/deep-link behavior: stale or foreign patient deep links now fail closed with 403 for doctor/cardio users.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/cardio.py`, `backend/tests/integration/test_cardio_api.py`.
- Denied paths: `/api/v1/ui/*`, frontend, BFF-lite, migrations, unrelated clinical modules.
- Migration/docs/test impact: no schema change; targeted integration test added.
- Rollback note: revert this commit to restore prior broad cardio blood-test access behavior.

## Validation
- Targeted tests or smoke run: `& 'C:\Program Files\PostgreSQL\17\pgAdmin 4\python\python.exe' -m py_compile backend\app\api\v1\endpoints\cardio.py backend\tests\integration\test_cardio_api.py`; `$env:DATABASE_URL='sqlite:///C:/tmp/cardio-audit-test.db'; $env:TESTING='1'; & C:\tmp\final-cardio-audit\scripts\run_backend_pytest.ps1 tests\integration\test_cardio_api.py`; `git diff --check`.
- Result: py_compile passed; targeted cardio pytest passed `4 passed`; `git diff --check` passed with only CRLF warnings.
- Not checked: full backend suite and CI are pending on GitHub.