### PR TITLE
fix(derma): guard doctor record access

### DIFF
--- a/backend/app/api/v1/endpoints/derma.py
+++ b/backend/app/api/v1/endpoints/derma.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.api import deps
+from app.models.clinic import Doctor
 from app.models.derma_examination import DermaExamination
 from app.models.derma_procedure import DermaProcedure
 from app.models.patient import Patient
@@ -26,6 +27,7 @@ from app.services.derma_api_service import DermaApiDomainError, DermaApiService
 router = APIRouter(prefix="/derma", tags=["derma"])
 logger = logging.getLogger(__name__)
 DERMA_ROLES = ("Admin", "Doctor", "derma", "dermatology")
+DERMA_ADMIN_ROLES = {"Admin"}
 
 
 class PriceOverrideRequest(BaseModel):
@@ -53,13 +55,13 @@ def _validate_derma_context(
     *,
     patient_id: int,
     visit_id: int | None,
-) -> None:
+) -> Visit | None:
     patient = db.get(Patient, patient_id)
     if patient is None:
         raise HTTPException(status_code=404, detail="Пациент не найден")
 
     if visit_id is None:
-        return
+        return None
 
     visit = db.get(Visit, visit_id)
     if visit is None:
@@ -69,6 +71,58 @@ def _validate_derma_context(
             status_code=400,
             detail="Визит не принадлежит выбранному пациенту",
         )
+    return visit
+
+
+def _is_admin_user(user: User) -> bool:
+    return getattr(user, "role", None) in DERMA_ADMIN_ROLES or bool(
+        getattr(user, "is_superuser", False)
+    )
+
+
+def _doctor_allowed_doctor_ids(db: Session, user: User) -> set[int]:
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    allowed_doctor_ids = {doctor.id}
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == user.id).first()
+    # Some legacy visit writers stored User.id in doctor_id. Allow that only
+    # when the value does not target another real Doctor row.
+    if not assigned_doctor:
+        allowed_doctor_ids.add(user.id)
+    return allowed_doctor_ids
+
+
+def _doctor_allowed_patient_ids(db: Session, user: User) -> set[int]:
+    allowed_doctor_ids = _doctor_allowed_doctor_ids(db, user)
+    rows = (
+        db.query(Visit.patient_id)
+        .filter(
+            Visit.doctor_id.in_(allowed_doctor_ids),
+            Visit.patient_id.isnot(None),
+        )
+        .all()
+    )
+    return {row[0] for row in rows if row[0] is not None}
+
+
+def _ensure_doctor_can_access_patient(db: Session, patient_id: int, user: User) -> None:
+    if _is_admin_user(user):
+        return
+    if patient_id not in _doctor_allowed_patient_ids(db, user):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+
+def _ensure_doctor_can_access_visit(db: Session, visit: Visit, user: User) -> None:
+    if _is_admin_user(user):
+        return
+    if visit.doctor_id not in _doctor_allowed_doctor_ids(db, user):
+        raise HTTPException(status_code=403, detail="Access denied")
 
 
 @router.get(
@@ -87,6 +141,15 @@ async def get_skin_examinations(
     """
     try:
         query = db.query(DermaExamination)
+        if not _is_admin_user(user):
+            if patient_id is not None:
+                _ensure_doctor_can_access_patient(db, patient_id, user)
+            else:
+                allowed_patient_ids = _doctor_allowed_patient_ids(db, user)
+                if not allowed_patient_ids:
+                    return []
+                query = query.filter(DermaExamination.patient_id.in_(allowed_patient_ids))
+
         if patient_id is not None:
             query = query.filter(DermaExamination.patient_id == patient_id)
 
@@ -132,11 +195,15 @@ async def create_skin_examination(
     Создать новый осмотр кожи
     """
     try:
-        _validate_derma_context(
+        visit = _validate_derma_context(
             db,
             patient_id=examination_data.patient_id,
             visit_id=examination_data.visit_id,
         )
+        if visit is None:
+            _ensure_doctor_can_access_patient(db, examination_data.patient_id, user)
+        else:
+            _ensure_doctor_can_access_visit(db, visit, user)
 
         examination = DermaExamination(
             patient_id=examination_data.patient_id,
@@ -194,6 +261,15 @@ async def get_cosmetic_procedures(
     """
     try:
         query = db.query(DermaProcedure)
+        if not _is_admin_user(user):
+            if patient_id is not None:
+                _ensure_doctor_can_access_patient(db, patient_id, user)
+            else:
+                allowed_patient_ids = _doctor_allowed_patient_ids(db, user)
+                if not allowed_patient_ids:
+                    return []
+                query = query.filter(DermaProcedure.patient_id.in_(allowed_patient_ids))
+
         if patient_id is not None:
             query = query.filter(DermaProcedure.patient_id == patient_id)
 
@@ -239,11 +315,15 @@ async def create_cosmetic_procedure(
     Создать новую косметическую процедуру
     """
     try:
-        _validate_derma_context(
+        visit = _validate_derma_context(
             db,
             patient_id=procedure_data.patient_id,
             visit_id=procedure_data.visit_id,
         )
+        if visit is None:
+            _ensure_doctor_can_access_patient(db, procedure_data.patient_id, user)
+        else:
+            _ensure_doctor_can_access_visit(db, visit, user)
 
         procedure = DermaProcedure(
             patient_id=procedure_data.patient_id,

--- a/backend/tests/integration/test_derma_api.py
+++ b/backend/tests/integration/test_derma_api.py
@@ -1,11 +1,85 @@
 from __future__ import annotations
 
 from datetime import date
+from uuid import uuid4
 
 import pytest
 
+from app.core.security import get_password_hash
+from app.models.clinic import Doctor
 from app.models.derma_examination import DermaExamination
 from app.models.derma_procedure import DermaProcedure
+from app.models.patient import Patient
+from app.models.user import User
+from app.models.visit import Visit
+
+
+def _suffix() -> str:
+    return uuid4().hex[:10]
+
+
+def _create_doctor_user(db_session, *, label: str) -> tuple[User, Doctor]:
+    suffix = _suffix()
+    user = User(
+        username=f"derma_guard_{label}_{suffix}",
+        email=f"derma-guard-{label}-{suffix}@test.local",
+        full_name=f"Derma Guard {label}",
+        hashed_password=get_password_hash("doctor123"),
+        role="Doctor",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    doctor = Doctor(
+        user_id=user.id,
+        specialty="dermatology",
+        active=True,
+    )
+    db_session.add(doctor)
+    db_session.commit()
+    db_session.refresh(doctor)
+    return user, doctor
+
+
+def _create_patient(db_session, *, label: str) -> Patient:
+    suffix = _suffix()
+    patient = Patient(
+        first_name=f"Derma {label}",
+        last_name="OwnerGuard",
+        phone=f"+99891{suffix[:7]}",
+        birth_date=date(1990, 1, 1),
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+    return patient
+
+
+def _create_visit(db_session, *, patient: Patient, doctor: Doctor) -> Visit:
+    visit = Visit(
+        patient_id=patient.id,
+        doctor_id=doctor.id,
+        visit_date=date.today(),
+        status="open",
+        source="desk",
+        department="dermatology",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+    return visit
+
+
+def _doctor_headers(client, user: User) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": user.username, "password": "doctor123"},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
 
 
 @pytest.mark.integration
@@ -118,6 +192,135 @@ class TestDermaApi:
         assert len(listed) == 1
         assert listed[0]["id"] == created["id"]
         assert listed[0]["patient_id"] == test_patient.id
+
+    def test_doctor_derma_records_are_limited_to_owned_patients(
+        self,
+        client,
+        db_session,
+    ):
+        own_user, own_doctor = _create_doctor_user(db_session, label="own")
+        _other_user, other_doctor = _create_doctor_user(db_session, label="other")
+        own_patient = _create_patient(db_session, label="own")
+        other_patient = _create_patient(db_session, label="other")
+        own_visit = _create_visit(db_session, patient=own_patient, doctor=own_doctor)
+        other_visit = _create_visit(db_session, patient=other_patient, doctor=other_doctor)
+        own_exam = DermaExamination(
+            patient_id=own_patient.id,
+            visit_id=own_visit.id,
+            doctor_id=own_user.id,
+            examination_date=date.today(),
+            skin_type="combination",
+            diagnosis="owned diagnosis",
+        )
+        other_exam = DermaExamination(
+            patient_id=other_patient.id,
+            visit_id=other_visit.id,
+            doctor_id=None,
+            examination_date=date.today(),
+            skin_type="dry",
+            diagnosis="foreign diagnosis",
+        )
+        own_procedure = DermaProcedure(
+            patient_id=own_patient.id,
+            visit_id=own_visit.id,
+            doctor_id=own_user.id,
+            procedure_date=date.today(),
+            procedure_type="laser",
+            total_cost=100000,
+        )
+        other_procedure = DermaProcedure(
+            patient_id=other_patient.id,
+            visit_id=other_visit.id,
+            doctor_id=None,
+            procedure_date=date.today(),
+            procedure_type="peel",
+            total_cost=200000,
+        )
+        db_session.add_all([own_exam, other_exam, own_procedure, other_procedure])
+        db_session.commit()
+        db_session.refresh(own_exam)
+        db_session.refresh(other_exam)
+        db_session.refresh(own_procedure)
+        db_session.refresh(other_procedure)
+        headers = _doctor_headers(client, own_user)
+
+        exams_response = client.get("/api/v1/derma/examinations?limit=20", headers=headers)
+        assert exams_response.status_code == 200
+        exam_ids = {item["id"] for item in exams_response.json()}
+        assert own_exam.id in exam_ids
+        assert other_exam.id not in exam_ids
+
+        procedures_response = client.get("/api/v1/derma/procedures?limit=20", headers=headers)
+        assert procedures_response.status_code == 200
+        procedure_ids = {item["id"] for item in procedures_response.json()}
+        assert own_procedure.id in procedure_ids
+        assert other_procedure.id not in procedure_ids
+
+        foreign_exam_read_response = client.get(
+            f"/api/v1/derma/examinations?patient_id={other_patient.id}",
+            headers=headers,
+        )
+        assert foreign_exam_read_response.status_code == 403
+
+        foreign_procedure_read_response = client.get(
+            f"/api/v1/derma/procedures?patient_id={other_patient.id}",
+            headers=headers,
+        )
+        assert foreign_procedure_read_response.status_code == 403
+
+        foreign_exam_write_response = client.post(
+            "/api/v1/derma/examinations",
+            json={
+                "patient_id": other_patient.id,
+                "visit_id": other_visit.id,
+                "examination_date": date.today().isoformat(),
+                "skin_type": "dry",
+                "diagnosis": "must not be written",
+            },
+            headers=headers,
+        )
+        assert foreign_exam_write_response.status_code == 403
+
+        foreign_procedure_write_response = client.post(
+            "/api/v1/derma/procedures",
+            json={
+                "patient_id": other_patient.id,
+                "visit_id": other_visit.id,
+                "procedure_date": date.today().isoformat(),
+                "procedure_type": "laser",
+                "total_cost": 300000,
+            },
+            headers=headers,
+        )
+        assert foreign_procedure_write_response.status_code == 403
+
+        own_exam_write_response = client.post(
+            "/api/v1/derma/examinations",
+            json={
+                "patient_id": own_patient.id,
+                "visit_id": own_visit.id,
+                "examination_date": date.today().isoformat(),
+                "skin_type": "combination",
+                "diagnosis": "owned write",
+            },
+            headers=headers,
+        )
+        assert own_exam_write_response.status_code == 201
+        assert own_exam_write_response.json()["patient_id"] == own_patient.id
+
+        own_procedure_write_response = client.post(
+            "/api/v1/derma/procedures",
+            json={
+                "patient_id": own_patient.id,
+                "visit_id": own_visit.id,
+                "procedure_date": date.today().isoformat(),
+                "procedure_type": "laser",
+                "total_cost": 110000,
+            },
+            headers=headers,
+        )
+        assert own_procedure_write_response.status_code == 201
+        assert own_procedure_write_response.json()["patient_id"] == own_patient.id
 
     def test_create_skin_examination_rejects_missing_patient(
         self,


### PR DESCRIPTION
## Summary
- Restrict `GET /api/v1/derma/examinations` and `GET /api/v1/derma/procedures` for non-admin doctor/derma roles to patients tied to their own visits.
- Reject `POST /api/v1/derma/examinations` and `POST /api/v1/derma/procedures` when a doctor/derma user targets another doctor's patient or visit.
- Add an integration regression covering both read paths, both foreign write paths, and owned write success.

## Cyclic Execution Evidence
- Fresh main sync: branched from `origin/main` at `989f349b` after PR #1378 merged, in isolated worktree `C:\tmp\final-cardio-audit`.
- Clean workspace: worktree was clean before edits; only derma endpoint/test changed.
- Branch: `codex/derma-records-doctor-guard`.
- Scope gate: `agent_gate` run with known root cause `backend/app/api/v1/endpoints/derma.py`; returned narrow override. Test expansion was limited to `backend/tests/integration/test_derma_api.py` for regression proof.
- Red-check handling: if CI is red, this PR remains the active fix scope; no unrelated follow-up PR until checks are green.

## Contract Impact
- Canonical surface: legacy mounted derma record endpoints under `/api/v1/derma/examinations` and `/api/v1/derma/procedures`.
- Request shape: unchanged; `patient_id`, optional `visit_id`, dates, and clinical fields are unchanged.
- Response shape: unchanged `DermaExaminationOut` / `DermaProcedureOut` list/object payloads.
- Status codes: Admin behavior unchanged. Doctor/derma foreign access now returns `403 Access denied`; missing patient/visit and patient/visit mismatch behavior stays unchanged.
- Frontend consumer: no frontend files touched; existing callers keep the same payload shape.
- Compatibility path or alias: no route aliases, BFF-lite endpoints, or `/api/v1/ui/*` paths added.
- Contract proof: integration test asserts owned examination/procedure rows remain visible/writable while foreign patient/visit access is denied.

## RBAC / Permissions
- Roles allowed: `Admin`/superuser keep broad access; `Doctor`, `derma`, and `dermatology` can access only patients connected to their active `Doctor` profile visits.
- Roles denied: users outside `DERMA_ROLES` remain blocked by existing `require_roles`; doctor/derma users without an active doctor profile or without an owned visit for the target patient are denied.
- Positive auth proof: regression test creates an owned doctor/patient/visit and confirms examination/procedure list + create succeed.
- Negative auth proof: regression test creates a second doctor's patient/visit and confirms explicit foreign reads and writes return 403.

## Notification / Realtime
- Event type or websocket channel: none involved; these endpoints perform synchronous DB read/write only.
- Payload version / ack behavior: no notification payloads, websocket ack, or background task contract exists on these paths.
- Read/unread or delivery semantics: no delivery/read state is touched.
- Reconnect/resync proof: not part of these endpoints; DB state remains the source for subsequent reads.

## Frontend Resilience
- Empty data proof: doctors with no allowed patients return an empty list for unfiltered listing rather than seeing global data.
- Partial data proof: unfiltered doctor lists are scoped to owned patient ids, so owned rows can appear while foreign rows are omitted.
- Forbidden secondary path behavior: explicit foreign `patient_id` and foreign `visit_id` write paths return 403.
- Missing draft/resource behavior: missing patient/visit behavior remains the existing 404 flow.
- Stale route/deep-link behavior: stale or foreign patient deep links now fail closed with 403 for doctor/derma users.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/derma.py`, `backend/tests/integration/test_derma_api.py`.
- Denied paths: `/api/v1/ui/*`, frontend, BFF-lite, migrations, unrelated clinical modules.
- Migration/docs/test impact: no schema change; targeted integration test added.
- Rollback note: revert this commit to restore prior broad derma examination/procedure access behavior.

## Validation
- Targeted tests or smoke run: `& 'C:\Program Files\PostgreSQL\17\pgAdmin 4\python\python.exe' -m py_compile backend\app\api\v1\endpoints\derma.py backend\tests\integration\test_derma_api.py`; `$env:DATABASE_URL='sqlite:///C:/tmp/derma-audit-test.db'; $env:TESTING='1'; & C:\tmp\final-cardio-audit\scripts\run_backend_pytest.ps1 tests\integration\test_derma_api.py`; `git diff --check`.
- Result: py_compile passed; targeted derma pytest passed `4 passed`; `git diff --check` passed with only CRLF warnings.
- Not checked: full backend suite and CI are pending on GitHub.