### PR TITLE
fix(notifications): prefer delivery status source

### DIFF
--- a/frontend/src/contexts/NotificationCenterContext.jsx
+++ b/frontend/src/contexts/NotificationCenterContext.jsx
@@ -290,7 +290,7 @@ function normalizeNotification(input, source = 'api') {
       input.department_key || input.departmentKey || input.department
     ),
     channel: input.channel || 'in_app_inbox',
-    status: input.status || input.delivery_status || input.deliveryStatus || null,
+    status: input.delivery_status || input.deliveryStatus || input.status || null,
     deliveryStatus:
       input.delivery_status || input.deliveryStatus || input.status || null,
     isRead: Boolean(


### PR DESCRIPTION
## Summary
- Prefer canonical notification `delivery_status` / `deliveryStatus` over legacy-compatible `status` when normalizing notification delivery state.
- Keep websocket payloads, read/unread behavior, and notification APIs unchanged.

## Cyclic Execution Evidence
- Fresh main sync: branch `codex/notification-delivery-status-source-ssot` was created from synced `main` at `86cb5c68`.
- Clean workspace: `git status --short --branch` was clean before this one-file patch.
- Branch: `codex/notification-delivery-status-source-ssot`.
- Scope gate: repo gate ran with known root cause `frontend/src/contexts/NotificationCenterContext.jsx`; it reported a narrow override and included the touched frontend normalizer in first-touch files.
- Red-check handling: no red checks existed before opening this PR; any red check will be fixed in this PR before merge.

## Contract Impact
- Canonical surface: notification delivery state normalization in `NotificationCenterContext`.
- Request shape: unchanged; no notification request body, query, or endpoint selection changed.
- Response shape: unchanged; backend still emits existing fields.
- Status codes: unchanged; no API status-code behavior changed.
- Frontend consumer: normalized notification items now prefer canonical delivery status when both canonical and legacy fields are present.
- Compatibility path or alias: legacy `status` remains supported only when canonical `delivery_status` / `deliveryStatus` is absent.
- Contract proof: `backend/app/schemas/notification.py` documents `delivery_status` as canonical and `status` as legacy-compatible delivery status; diff changes only source priority.

## RBAC / Permissions
- Roles allowed: unchanged for roles already receiving notifications.
- Roles denied: unchanged; no auth, role policy, route guard, or permission check changed.
- Positive auth proof: existing authorized notification consumers continue using the same provider and payload fields.
- Negative auth proof: denied-role behavior is unchanged because this PR does not touch API calls, guards, or backend auth.

## Notification / Realtime
- Event type or websocket channel: unchanged; no event name or websocket channel changed.
- Payload version / ack behavior: unchanged; payload schema is not changed, only frontend source priority.
- Read/unread or delivery semantics: unchanged; mark seen/read/archive optimistic paths are not changed.
- Reconnect/resync proof: unchanged; sync and websocket replacement paths continue passing through the same normalizer.

## Frontend Resilience
- Empty data proof: if canonical and legacy delivery status are absent, normalized status remains `null`.
- Partial data proof: if canonical delivery status exists, it wins even when legacy `status` differs.
- Forbidden secondary path behavior: legacy `status` no longer overrides canonical delivery status.
- Missing draft/resource behavior: unchanged; notifications do not create draft/resource state here.
- Stale route/deep-link behavior: unchanged; deep links and routes are not touched.

## Scope Gate
- Allowed paths: `frontend/src/contexts/NotificationCenterContext.jsx`.
- Denied paths: backend runtime code, migrations, websocket endpoints, notification APIs, role policy, docs, tests, and `/api/v1/ui/*`.
- Migration/docs/test impact: no migration or docs impact; tests were not edited because the patch is a one-line source-priority repair.
- Rollback note: revert this single commit to restore legacy `status` priority.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; backend notification `py_compile` via `scripts/run_python.ps1`; `git diff --check`.
- Result: frontend build passed; backend notification py_compile passed; diff check passed with the existing Windows LF/CRLF warning for the touched JSX file.
- Not checked: manual realtime browser smoke was not run because websocket contracts and runtime endpoints were not changed.