### PR TITLE
fix(patient): use backend saved form status

### DIFF
--- a/frontend/src/pages/PatientPanel.jsx
+++ b/frontend/src/pages/PatientPanel.jsx
@@ -733,7 +733,7 @@ const PatientFormsPreview = ({ status, preview, error, initData }) => {
             ...(submission.answers || currentForm.answers),
           },
           status: 'saved',
-          savedStatus: submission.status || nextStatus,
+          savedStatus: submission.status || '',
           error: '',
           message: submission.status === 'draft' ? 'Draft saved.' : 'Form submitted.',
           submittedAt: submission.submitted_at || '',


### PR DESCRIPTION
## Summary
- Removes the PatientPanel fallback that treated the client-requested patient form nextStatus as saved backend state.
- Patient form badges now use only submission.status returned by POST /api/v1/telegram/mini-app/forms/submissions.
- No backend changes, no /api/v1/ui/*, no BFF-lite, no command wrapper.

## Cyclic Execution Evidence
- Fresh main sync: branch was created from clean main after #1382 merged and git fetch origin --prune confirmed main matched origin/main at e19d65fd.
- Clean workspace: pre-branch status was clean; PR changes exactly one tracked runtime file.
- Branch: codex/patient-form-saved-status-source-ssot.
- Scope gate: agent_gate ran with known root cause frontend/src/pages/PatientPanel.jsx; result allowed narrow override for Telegram mixed frontend/backend ownership.
- Red-check handling: no red checks yet; if CI fails, fixes will stay in this PR and within the stated scope.

## Contract Impact
- Canonical surface: POST /api/v1/telegram/mini-app/forms/submissions.
- Request shape: unchanged; frontend still sends initData, patientId, formId, answers, and requested status.
- Response shape: unchanged; frontend now displays saved status only from response.data.submission.status.
- Status codes: unchanged; existing error handling remains based on backend response errors.
- Frontend consumer: frontend/src/pages/PatientPanel.jsx PatientFormsPreview handleSave.
- Compatibility path or alias: removed fallback from missing backend submission.status to requested nextStatus because that would make the client request look like persisted backend truth.
- Contract proof: inspected backend/app/services/telegram_mini_app_init_data.py; save_telegram_mini_app_patient_form_submission normalizes and persists submission.status, and _patient_form_submission_payload serializes status in the response.

## RBAC / Permissions
- Roles allowed: unchanged; Mini App access remains controlled by existing initData/patient scope validation.
- Roles denied: unchanged; no admin/staff role policies or denial paths changed.
- Positive auth proof: unchanged by this PR; backend endpoint references compiled and frontend build passed.
- Negative auth proof: unchanged by this PR; no permission checks or failure conditions changed.

## Notification / Realtime
- Event type or websocket channel: unchanged; no websocket or notification channel touched.
- Payload version / ack behavior: unchanged; no realtime payload or ack semantics changed.
- Read/unread or delivery semantics: unchanged; notification delivery/read state is outside this PR.
- Reconnect/resync proof: unchanged; no reconnect, resync, or polling logic touched.

## Frontend Resilience
- Empty data proof: if backend omits submission.status, PatientPanel shows no saved-status badge instead of displaying the requested status as persisted state.
- Partial data proof: answers, submitted_at, updated_at, message, and error handling remain unchanged.
- Forbidden secondary path behavior: client-requested nextStatus is no longer a secondary source for saved backend status.
- Missing draft/resource behavior: unchanged; the PR only removes a misleading saved-status fallback.
- Stale route/deep-link behavior: unchanged; no routing or Telegram initData entry behavior touched.

## Scope Gate
- Allowed paths: frontend/src/pages/PatientPanel.jsx only.
- Denied paths: backend runtime changes, /api/v1/ui/*, separate BFF service, TelegramManager/admin Telegram, migrations, queue/payment/lab/EMR/Registrar/DisplayBoard/QueueJoin, docs, and unrelated cleanup.
- Migration/docs/test impact: no migration or docs changes; no tests added because this is a one-line frontend contract narrowing and the build plus compile checks cover the touched surface.
- Rollback note: revert commit 987cca87 to restore the previous requested-status fallback if needed.

## Validation
- Targeted tests or smoke run: git diff --check; rg confirmed old savedStatus fallback removed; py_compile for backend/app/api/v1/endpoints/admin_telegram.py and backend/app/api/v1/endpoints/telegram_webhook.py; npm.cmd --prefix frontend run build.
- Result: all local checks passed; git diff --check reported only the existing LF/CRLF warning.
- Not checked: backend pytest and browser smoke were not run because no backend behavior, routing, or UI layout changed.