### PR TITLE
fix(cardio): avoid stale payment status fallback

### DIFF
--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -488,7 +488,7 @@ const MacOSCardiologistPanelUnified = () => {
         number: nextAppointmentId || prev?.number || patientIdFromUrl,
         source: 'appointments',
         status: matchingAppointment.status ?? prev?.status ?? null,
-        payment_status: matchingAppointment.payment_status ?? prev?.payment_status ?? null,
+        payment_status: matchingAppointment.payment_status ?? null,
         discount_mode: matchingAppointment.discount_mode || prev?.discount_mode,
         specialty: matchingAppointment.specialty || prev?.specialty || 'cardiology'
       };


### PR DESCRIPTION
## Summary
- Removes CardiologistPanel selected-patient fallback from missing matchingAppointment.payment_status to previous selected patient payment_status.
- Cardiology selected patient state now uses the backend appointment row payment_status or null.
- No backend changes, no /api/v1/ui/*, no BFF-lite, no command wrapper.

## Cyclic Execution Evidence
- Fresh main sync: branch was created from clean main after #1383 merged and git fetch origin --prune confirmed main matched origin/main at 40e2b1ea.
- Clean workspace: pre-branch status was clean; PR changes exactly one tracked runtime file.
- Branch: codex/cardio-payment-status-source-ssot.
- Scope gate: agent_gate ran with known root cause frontend/src/pages/CardiologistPanelUnified.jsx; result allowed narrow override limited to that file.
- Red-check handling: no red checks yet; if CI fails, fixes will stay in this PR and within the stated scope.

## Contract Impact
- Canonical surface: cardiology appointments/doctor queue data that provides matchingAppointment.payment_status to CardiologistPanel.
- Request shape: unchanged; no API calls or request payloads changed.
- Response shape: unchanged; frontend no longer substitutes previous local selected-patient payment_status when the current backend row omits payment_status.
- Status codes: unchanged; no endpoint or error handling changed.
- Frontend consumer: frontend/src/pages/CardiologistPanelUnified.jsx selected-patient enrichment from matching appointment rows.
- Compatibility path or alias: removed stale local previous-state fallback for payment_status; missing backend payment status is represented as null.
- Contract proof: re-measure found payment_status: matchingAppointment.payment_status ?? prev?.payment_status ?? null; local patch narrows it to matchingAppointment.payment_status ?? null and frontend build passed.

## RBAC / Permissions
- Roles allowed: unchanged; no route or backend permission policy changed.
- Roles denied: unchanged; no auth gates or denial paths changed.
- Positive auth proof: unchanged by this PR; frontend build passed with existing imports/routes.
- Negative auth proof: unchanged by this PR; no permission behavior was modified.

## Notification / Realtime
- Event type or websocket channel: unchanged; no websocket or notification channel touched.
- Payload version / ack behavior: unchanged; no realtime payloads or acknowledgements changed.
- Read/unread or delivery semantics: unchanged; no notification delivery/read semantics touched.
- Reconnect/resync proof: unchanged; no reconnect or resync logic touched.

## Frontend Resilience
- Empty data proof: if the matching appointment row lacks payment_status, selected patient payment_status becomes null instead of stale previous state.
- Partial data proof: appointment_id, visit_id, patient display fields, status, discount_mode, and specialty merge behavior remain unchanged.
- Forbidden secondary path behavior: previous selectedPatient.payment_status is no longer a secondary source for current appointment payment status.
- Missing draft/resource behavior: unchanged; no EMR, visit draft, or resource creation behavior changed.
- Stale route/deep-link behavior: improved for deep-link enrichment because stale payment status is not retained across selected-patient merges.

## Scope Gate
- Allowed paths: frontend/src/pages/CardiologistPanelUnified.jsx only.
- Denied paths: backend, /api/v1/ui/*, separate BFF service, Registrar, QueueJoin, DisplayBoard, payment services, queue services, lab, Telegram, migrations, docs, and unrelated cleanup.
- Migration/docs/test impact: no migration or docs changes; no tests added because gate first-touch allowed one runtime file and the change is a one-line stale fallback removal.
- Rollback note: revert commit 7c5eb206 to restore previous fallback if needed.

## Validation
- Targeted tests or smoke run: rg confirmed old fallback removed; git diff --check; npm.cmd --prefix frontend run build.
- Result: frontend build passed; git diff --check passed with existing LF/CRLF warning only.
- Not checked: backend pytest and browser smoke were not run because no backend contract, route, or UI layout changed.