### PR TITLE
fix(price-overrides): guard doctor visit ownership

### DIFF
--- a/backend/app/repositories/derma_api_repository.py
+++ b/backend/app/repositories/derma_api_repository.py
@@ -27,6 +27,9 @@ class DermaApiRepository:
     def get_doctor_by_user_id(self, user_id: int) -> Doctor | None:
         return self.db.query(Doctor).filter(Doctor.user_id == user_id).first()
 
+    def get_doctor(self, doctor_id: int) -> Doctor | None:
+        return self.db.query(Doctor).filter(Doctor.id == doctor_id).first()
+
     def create_price_override(
         self,
         *,

--- a/backend/app/services/dental_api_service.py
+++ b/backend/app/services/dental_api_service.py
@@ -44,6 +44,17 @@ class DentalApiService:
         service_id = getattr(service, "id", None)
         return str(service_id) if service_id is not None else None
 
+    def _visit_belongs_to_doctor(self, *, visit, doctor, user_id: int) -> bool:
+        visit_doctor_id = getattr(visit, "doctor_id", None)
+        if visit_doctor_id == getattr(doctor, "id", None):
+            return True
+
+        get_doctor = getattr(self.repository, "get_doctor", None)
+        assigned_doctor = get_doctor(user_id) if get_doctor else None
+        # Some legacy visit writers stored User.id in doctor_id. Allow that only
+        # when the value does not target another real Doctor row.
+        return assigned_doctor is None and visit_doctor_id == user_id
+
     async def create_dental_price_override(self, *, override_data, user: User) -> DoctorPriceOverride:
         visit = self.repository.get_visit(override_data.visit_id)
         if not visit:
@@ -66,6 +77,9 @@ class DentalApiService:
                 403,
                 "Только стоматолог может указывать цену после лечения",
             )
+
+        if not self._visit_belongs_to_doctor(visit=visit, doctor=doctor, user_id=user.id):
+            raise DentalApiDomainError(403, "Access denied")
 
         price_override = DoctorPriceOverride(
             visit_id=override_data.visit_id,

--- a/backend/app/services/derma_api_service.py
+++ b/backend/app/services/derma_api_service.py
@@ -26,6 +26,17 @@ class DermaApiService:
     ):
         self.repository = repository or DermaApiRepository(db)
 
+    def _visit_belongs_to_doctor(self, *, visit, doctor, user_id: int) -> bool:
+        visit_doctor_id = getattr(visit, "doctor_id", None)
+        if visit_doctor_id == getattr(doctor, "id", None):
+            return True
+
+        get_doctor = getattr(self.repository, "get_doctor", None)
+        assigned_doctor = get_doctor(user_id) if get_doctor else None
+        # Some legacy visit writers stored User.id in doctor_id. Allow that only
+        # when the value does not target another real Doctor row.
+        return assigned_doctor is None and visit_doctor_id == user_id
+
     def create_price_override(self, *, override_data, user_id: int):
         visit = self.repository.get_visit(override_data.visit_id)
         if not visit:
@@ -48,6 +59,9 @@ class DermaApiService:
                 403,
                 "Только дерматолог-косметолог может изменять цены процедур",
             )
+
+        if not self._visit_belongs_to_doctor(visit=visit, doctor=doctor, user_id=user_id):
+            raise DermaApiDomainError(403, "Access denied")
 
         return self.repository.create_price_override(
             visit_id=override_data.visit_id,

--- a/backend/tests/unit/test_dental_api_service.py
+++ b/backend/tests/unit/test_dental_api_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
@@ -28,6 +29,88 @@ class TestDentalApiService:
                 user=SimpleNamespace(id=5),
             )
         assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_create_dental_price_override_rejects_foreign_visit(self):
+        class Repository:
+            def get_visit(self, visit_id):
+                return SimpleNamespace(id=visit_id, doctor_id=99)
+
+            def get_service(self, service_id):
+                return SimpleNamespace(
+                    id=service_id,
+                    allow_doctor_price_override=True,
+                    price=Decimal("120"),
+                )
+
+            def get_doctor_by_user_id(self, user_id):
+                return SimpleNamespace(id=7, specialty="dental")
+
+            def get_doctor(self, doctor_id):
+                return None
+
+        service = DentalApiService(db=None, repository=Repository())
+        with pytest.raises(DentalApiDomainError) as exc_info:
+            await service.create_dental_price_override(
+                override_data=SimpleNamespace(
+                    visit_id=1,
+                    service_id=2,
+                    new_price=Decimal("100"),
+                    reason="reason",
+                    details=None,
+                ),
+                user=SimpleNamespace(id=10),
+            )
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_create_dental_price_override_accepts_owned_visit(self):
+        class Repository:
+            def get_visit(self, visit_id):
+                return SimpleNamespace(id=visit_id, patient_id=20, doctor_id=7)
+
+            def get_service(self, service_id):
+                return SimpleNamespace(
+                    id=service_id,
+                    allow_doctor_price_override=True,
+                    price=Decimal("120"),
+                )
+
+            def get_doctor_by_user_id(self, user_id):
+                return SimpleNamespace(id=7, specialty="dental", user=None)
+
+            def get_doctor(self, doctor_id):
+                return None
+
+            def add(self, obj):
+                self.created = obj
+
+            def commit(self):
+                pass
+
+            def refresh(self, obj):
+                obj.id = 55
+
+            def list_registrars(self):
+                return []
+
+        repository = Repository()
+        service = DentalApiService(db=None, repository=repository)
+
+        result = await service.create_dental_price_override(
+            override_data=SimpleNamespace(
+                visit_id=1,
+                service_id=2,
+                new_price=Decimal("100"),
+                reason="reason",
+                details=None,
+            ),
+            user=SimpleNamespace(id=10),
+        )
+
+        assert result is repository.created
+        assert result.doctor_id == 7
 
     def test_get_dental_price_overrides_raises_when_doctor_missing(self):
         class Repository:

--- a/backend/tests/unit/test_derma_api_service.py
+++ b/backend/tests/unit/test_derma_api_service.py
@@ -46,7 +46,7 @@ class TestDermaApiService:
 
         class Repository:
             def get_visit(self, visit_id):
-                return SimpleNamespace(id=visit_id)
+                return SimpleNamespace(id=visit_id, doctor_id=7)
 
             def get_service(self, service_id):
                 return SimpleNamespace(
@@ -57,6 +57,9 @@ class TestDermaApiService:
 
             def get_doctor_by_user_id(self, user_id):
                 return SimpleNamespace(id=7, specialty="dermatology")
+
+            def get_doctor(self, doctor_id):
+                return None
 
             def create_price_override(self, **kwargs):
                 return created
@@ -74,3 +77,37 @@ class TestDermaApiService:
         )
 
         assert result is created
+
+    def test_create_price_override_rejects_foreign_visit(self):
+        class Repository:
+            def get_visit(self, visit_id):
+                return SimpleNamespace(id=visit_id, doctor_id=99)
+
+            def get_service(self, service_id):
+                return SimpleNamespace(
+                    id=service_id,
+                    allow_doctor_price_override=True,
+                    price=Decimal("120"),
+                )
+
+            def get_doctor_by_user_id(self, user_id):
+                return SimpleNamespace(id=7, specialty="dermatology")
+
+            def get_doctor(self, doctor_id):
+                return None
+
+        service = DermaApiService(db=None, repository=Repository())
+
+        with pytest.raises(DermaApiDomainError) as exc_info:
+            service.create_price_override(
+                override_data=SimpleNamespace(
+                    visit_id=1,
+                    service_id=2,
+                    new_price=Decimal("100"),
+                    reason="manual",
+                    details=None,
+                ),
+                user_id=10,
+            )
+
+        assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary
- Reject derma and dental doctor price overrides when the requested `visit_id` belongs to another doctor.
- Preserve the existing specialty checks, approval flows, notification behavior, and response shapes.
- Add unit regressions for foreign visit denial and owned dental visit success.

## Cyclic Execution Evidence
- Fresh main sync: branched from fresh `origin/main` at `e19d65fd` in isolated worktree `C:\tmp\final-clinical-audit`.
- Clean workspace: worktree was clean before edits; only price override service/repository unit-test files changed.
- Branch: `codex/price-override-visit-owner-guard`.
- Scope gate: `agent_gate` run with known root cause `backend/app/services/dental_api_service.py`; returned narrow override. Expansion was limited to same-class derma service/repository and service unit tests.
- Red-check handling: if CI is red, this PR remains the active fix scope; no unrelated follow-up PR until checks are green.

## Contract Impact
- Canonical surface: service layer behind `/api/v1/dental/price-override` and `/api/v1/derma/price-override`.
- Request shape: unchanged; `visit_id`, `service_id`, price, reason, and details stay the same.
- Response shape: unchanged price override response DTOs.
- Status codes: missing visit/service and invalid specialty behavior unchanged; foreign doctor visit now returns `403 Access denied` before writing a `DoctorPriceOverride` or sending dental notifications.
- Frontend consumer: no frontend files touched; existing callers keep the same payload shape.
- Compatibility path or alias: no route aliases, BFF-lite endpoints, or `/api/v1/ui/*` paths added.
- Contract proof: unit tests assert foreign visits are denied and an owned dental visit still creates an override.

## RBAC / Permissions
- Roles allowed: existing endpoint role gates remain unchanged; eligible dental/derma doctors can create overrides only for visits owned by their `Doctor.id`.
- Roles denied: same-role doctors targeting another doctor's visit are denied with 403.
- Positive auth proof: dental service unit test confirms an owned `visit.doctor_id == doctor.id` still creates an override.
- Negative auth proof: dental and derma service unit tests confirm foreign `visit.doctor_id` returns 403.

## Notification / Realtime
- Event type or websocket channel: dental price override may send registrar Telegram notifications after creation.
- Payload version / ack behavior: no notification payload shape changed; guard runs before creation/notification for foreign visits.
- Read/unread or delivery semantics: existing delivery state behavior is untouched.
- Reconnect/resync proof: these endpoints do not maintain websocket sessions; after reconnect or refresh, clients read persisted `DoctorPriceOverride` rows from existing list endpoints.

## Frontend Resilience
- Empty data proof: read endpoints are unchanged.
- Partial data proof: list/get override flows remain scoped by existing doctor-id filters.
- Forbidden secondary path behavior: foreign visit create path now fails closed with 403.
- Missing draft/resource behavior: missing visit/service behavior remains the existing 404 flow.
- Stale route/deep-link behavior: stale or foreign visit ids now fail closed before write side effects.

## Scope Gate
- Allowed paths: `backend/app/services/dental_api_service.py`, `backend/app/services/derma_api_service.py`, `backend/app/repositories/derma_api_repository.py`, `backend/tests/unit/test_dental_api_service.py`, `backend/tests/unit/test_derma_api_service.py`.
- Denied paths: endpoints DTOs, `/api/v1/ui/*`, frontend, BFF-lite, migrations, approval flow rewrites.
- Migration/docs/test impact: no schema change; targeted unit tests added.
- Rollback note: revert this commit to restore prior price override behavior.

## Validation
- Targeted tests or smoke run: `& 'C:\Program Files\PostgreSQL\17\pgAdmin 4\python\python.exe' -m py_compile backend\app\services\dental_api_service.py backend\app\services\derma_api_service.py backend\app\repositories\derma_api_repository.py backend\tests\unit\test_dental_api_service.py backend\tests\unit\test_derma_api_service.py`; `$env:DATABASE_URL='sqlite:///C:/tmp/price-override-audit-test.db'; $env:TESTING='1'; & C:\tmp\final-clinical-audit\scripts\run_backend_pytest.ps1 tests\unit\test_dental_api_service.py tests\unit\test_derma_api_service.py`; `git diff --check`.
- Result: py_compile passed; targeted unit tests passed `8 passed`; `git diff --check` passed with only CRLF warnings.
- Not checked: full backend suite and CI are pending on GitHub.
