### PR TITLE
fix(appointments): guard legacy appointment records

### DIFF
--- a/backend/app/api/v1/endpoints/appointments.py
+++ b/backend/app/api/v1/endpoints/appointments.py
@@ -11,6 +11,8 @@ from sqlalchemy.orm import Session
 from app.api import deps
 from app.crud.appointment import appointment as appointment_crud
 from app.models import appointment as appointment_models
+from app.models.clinic import Doctor
+from app.models.patient import Patient
 from app.models.setting import Setting
 from app.models.user import User
 from app.schemas import appointment as appointment_schemas
@@ -22,6 +24,19 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/appointments", tags=["appointments"])
 APPOINTMENTS_PUBLIC_ERROR = "Internal server error"
+APPOINTMENT_BROAD_ACCESS_ROLES = {"Admin", "Registrar"}
+APPOINTMENT_DOCTOR_ROLES = {
+    "Doctor",
+    "cardio",
+    "cardiology",
+    "Cardiologist",
+    "Cardio",
+    "derma",
+    "Dermatologist",
+    "dentist",
+    "Dentist",
+}
+APPOINTMENT_PATIENT_ROLES = {"Patient"}
 
 
 def _appointments_http_error(exc: Exception, operation: str) -> HTTPException:
@@ -34,6 +49,60 @@ def _appointments_http_error(exc: Exception, operation: str) -> HTTPException:
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         detail=APPOINTMENTS_PUBLIC_ERROR,
     )
+
+
+def _ensure_appointment_record_access(
+    db: Session,
+    appointment: Any,
+    current_user: User,
+) -> None:
+    role = getattr(current_user, "role", None)
+    if role in APPOINTMENT_BROAD_ACCESS_ROLES or getattr(
+        current_user, "is_superuser", False
+    ):
+        return
+
+    if role in APPOINTMENT_DOCTOR_ROLES:
+        doctor = (
+            db.query(Doctor)
+            .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+            .first()
+        )
+        if not doctor:
+            raise HTTPException(status_code=403, detail="Access denied")
+        if appointment.doctor_id == doctor.id:
+            return
+
+        assigned_doctor = (
+            db.query(Doctor).filter(Doctor.id == appointment.doctor_id).first()
+        )
+        # Some legacy appointment writers stored User.id in doctor_id. Allow it
+        # only when that value does not resolve to another real Doctor row.
+        if not assigned_doctor and appointment.doctor_id == current_user.id:
+            return
+        if assigned_doctor and assigned_doctor.user_id == current_user.id:
+            return
+
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if role in APPOINTMENT_PATIENT_ROLES:
+        patient_id = getattr(appointment, "patient_id", None)
+        if patient_id is None:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        current_patient = getattr(current_user, "patient", None)
+        if getattr(current_patient, "id", None) == patient_id:
+            return
+
+        patient = (
+            db.query(Patient)
+            .filter(Patient.id == patient_id, Patient.user_id == current_user.id)
+            .first()
+        )
+        if patient:
+            return
+
+    raise HTTPException(status_code=403, detail="Access denied")
 
 
 # Схема для ответа pending-payments
@@ -472,9 +541,10 @@ def get_appointment(
     """
     Получить запись на прием по ID
     """
-    appointment = appointment_crud.get_appointment(db, id=appointment_id)
+    appointment = appointment_crud.get(db, id=appointment_id)
     if not appointment:
         raise HTTPException(status_code=404, detail="Запись не найдена")
+    _ensure_appointment_record_access(db, appointment, current_user)
     return appointment
 
 
@@ -489,11 +559,13 @@ def update_appointment(
     """
     Обновить запись на прием
     """
-    appointment = appointment_crud.get_appointment(db, id=appointment_id)
+    appointment = appointment_crud.get(db, id=appointment_id)
     if not appointment:
         raise HTTPException(status_code=404, detail="Запись не найдена")
 
     # Проверяем, не занято ли новое время у врача
+    _ensure_appointment_record_access(db, appointment, current_user)
+
     if (
         appointment_in.appointment_date
         or appointment_in.appointment_time
@@ -514,7 +586,7 @@ def update_appointment(
                 status_code=400, detail="Это время уже занято у выбранного врача"
             )
 
-    appointment = appointment_crud.update_appointment(
+    appointment = appointment_crud.update(
         db=db, db_obj=appointment, obj_in=appointment_in
     )
     return appointment
@@ -530,11 +602,13 @@ def delete_appointment(
     """
     Отменить запись на прием
     """
-    appointment = appointment_crud.get_appointment(db, id=appointment_id)
+    appointment = appointment_crud.get(db, id=appointment_id)
     if not appointment:
         raise HTTPException(status_code=404, detail="Запись не найдена")
 
-    appointment_crud.delete_appointment(db=db, id=appointment_id)
+    _ensure_appointment_record_access(db, appointment, current_user)
+
+    appointment_crud.remove(db=db, id=appointment_id)
     return {"message": "Запись успешно отменена"}
 
 

--- a/backend/tests/integration/test_appointment_flow_owner_guard.py
+++ b/backend/tests/integration/test_appointment_flow_owner_guard.py
@@ -78,6 +78,43 @@ def _doctor_headers(client, user: User) -> dict[str, str]:
     return {"Authorization": f"Bearer {response.json()['access_token']}"}
 
 
+def _create_patient_user(db_session, *, label: str) -> tuple[User, Patient]:
+    suffix = _suffix()
+    user = User(
+        username=f"appt_patient_{label}_{suffix}",
+        email=f"appt-patient-{label}-{suffix}@test.local",
+        full_name=f"Appointment Patient {label}",
+        hashed_password=get_password_hash("patient123"),
+        role="Patient",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    patient = Patient(
+        user_id=user.id,
+        first_name=f"Patient {label}",
+        last_name="LegacyAppointmentGuard",
+        phone=f"+99891{suffix[:7]}",
+        birth_date=date(1990, 1, 1),
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+    return user, patient
+
+
+def _patient_headers(client, user: User) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": user.username, "password": "patient123"},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
 def test_doctor_cannot_read_other_doctor_appointment_flow_status(
     client,
     db_session,
@@ -107,3 +144,105 @@ def test_doctor_cannot_read_other_doctor_appointment_flow_status(
         .first()
     )
     assert leaked_visit is None
+
+
+def test_patient_cannot_read_other_patient_legacy_appointment(
+    client,
+    db_session,
+) -> None:
+    own_user, _own_patient = _create_patient_user(db_session, label="own_read")
+    _other_user, other_patient = _create_patient_user(db_session, label="other_read")
+    other_appointment = Appointment(
+        patient_id=other_patient.id,
+        appointment_date=date.today(),
+        appointment_time="11:00",
+        status="scheduled",
+    )
+    db_session.add(other_appointment)
+    db_session.commit()
+    db_session.refresh(other_appointment)
+
+    response = client.get(
+        f"/api/v1/appointments/{other_appointment.id}",
+        headers=_patient_headers(client, own_user),
+    )
+
+    assert response.status_code == 403
+
+
+def test_patient_can_read_own_legacy_appointment(
+    client,
+    db_session,
+) -> None:
+    own_user, own_patient = _create_patient_user(db_session, label="own_allow")
+    own_appointment = Appointment(
+        patient_id=own_patient.id,
+        appointment_date=date.today(),
+        appointment_time="10:30",
+        status="scheduled",
+    )
+    db_session.add(own_appointment)
+    db_session.commit()
+    db_session.refresh(own_appointment)
+
+    response = client.get(
+        f"/api/v1/appointments/{own_appointment.id}",
+        headers=_patient_headers(client, own_user),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["id"] == own_appointment.id
+
+
+def test_patient_cannot_update_other_patient_legacy_appointment(
+    client,
+    db_session,
+) -> None:
+    own_user, _own_patient = _create_patient_user(db_session, label="own_update")
+    _other_user, other_patient = _create_patient_user(db_session, label="other_update")
+    other_appointment = Appointment(
+        patient_id=other_patient.id,
+        appointment_date=date.today(),
+        appointment_time="12:00",
+        status="scheduled",
+        notes="original",
+    )
+    db_session.add(other_appointment)
+    db_session.commit()
+    db_session.refresh(other_appointment)
+
+    response = client.put(
+        f"/api/v1/appointments/{other_appointment.id}",
+        json={"notes": "tampered"},
+        headers=_patient_headers(client, own_user),
+    )
+
+    assert response.status_code == 403
+    db_session.refresh(other_appointment)
+    assert other_appointment.notes == "original"
+
+
+def test_patient_cannot_delete_other_patient_legacy_appointment(
+    client,
+    db_session,
+) -> None:
+    own_user, _own_patient = _create_patient_user(db_session, label="own_delete")
+    _other_user, other_patient = _create_patient_user(db_session, label="other_delete")
+    other_appointment = Appointment(
+        patient_id=other_patient.id,
+        appointment_date=date.today(),
+        appointment_time="13:00",
+        status="scheduled",
+    )
+    db_session.add(other_appointment)
+    db_session.commit()
+    db_session.refresh(other_appointment)
+    appointment_id = other_appointment.id
+
+    response = client.delete(
+        f"/api/v1/appointments/{appointment_id}",
+        headers=_patient_headers(client, own_user),
+    )
+
+    assert response.status_code == 403
+    assert db_session.get(Appointment, appointment_id) is not None


### PR DESCRIPTION
## Summary
- Guard legacy direct appointment record routes `GET/PUT/DELETE /api/v1/appointments/{appointment_id}` with record ownership checks.
- Preserve broad Admin/Registrar access, Doctor access only for assigned doctor records, and Patient access only for the linked patient record.
- Replace broken legacy CRUD method calls on these handlers with the mounted CRUD object methods so authorized requests no longer crash before access policy runs.

## Cyclic Execution Evidence
- Fresh main sync: work started in clean worktree `C:\tmp\final-owner-audit` from `origin/main` at `e576c998`.
- Clean workspace: branch began clean; `C:\final` dirty Telegram/onboarding changes were left untouched.
- Branch: `codex/appointments-owner-guard`.
- Scope gate: `agent_gate` returned narrow override for `backend/app/api/v1/endpoints/appointments.py`; I reported and then added one targeted regression test file for proof only.
- Red-check handling: local targeted pytest initially exposed the existing CRUD crash; the same PR fixes that runtime defect and the tests now pass.

## Contract Impact
- Canonical surface: existing legacy appointments router mounted as `appointments.router` in `backend/app/api/v1/api.py`.
- Request shape: unchanged path parameter `appointment_id`; unchanged JSON body for `PUT` using `AppointmentUpdate`.
- Response shape: unchanged `Appointment` response for allowed `GET/PUT`; unchanged delete success message for allowed `DELETE`.
- Status codes: unrelated/unauthorized record access now returns `403 Access denied`; missing records still return `404`; allowed calls keep prior success semantics.
- Frontend consumer: existing callers of `/api/v1/appointments/{appointment_id}` keep the same URL and payload shape; only cross-owner access is rejected.
- Compatibility path or alias: legacy direct appointment path remains mounted; appointment-flow routes under the same `/api/v1/appointments` prefix are unchanged.
- Contract proof: `test_appointment_flow_owner_guard.py` covers patient own read success and other-patient read/update/delete denial.

## RBAC / Permissions
- Roles allowed: Admin and Registrar broadly; Doctor only for assigned appointment doctor records including safe legacy User.id compatibility; Patient only for linked own patient records.
- Roles denied: Patient cannot read/update/delete another patient's direct legacy appointment record; other non-owner roles fall through to `403`.
- Positive auth proof: targeted test confirms a linked Patient can still read their own legacy appointment record.
- Negative auth proof: targeted tests confirm a linked Patient receives `403` for read, update, and delete against another patient's appointment; delete leaves the row present.

## Notification / Realtime
- Event type or websocket channel: no notification or websocket event contract changed by this patch.
- Payload version / ack behavior: no realtime payloads, ack semantics, or event versions are introduced or modified.
- Read/unread or delivery semantics: notification read/unread state and delivery persistence are untouched.
- Reconnect/resync proof: these endpoints do not maintain websocket sessions; after refresh, clients read persisted appointment rows through existing list/detail endpoints.

## Frontend Resilience
- Empty data proof: missing appointment behavior remains `404`, so empty/missing record handling is unchanged.
- Partial data proof: response schema for successful `GET/PUT` remains the existing `Appointment` schema.
- Forbidden secondary path behavior: forbidden cross-owner legacy path now returns explicit `403` instead of exposing or mutating the target record.
- Missing draft/resource behavior: no draft resources are involved; missing appointment resource behavior remains `404`.
- Stale route/deep-link behavior: stale direct appointment links to records outside the user's ownership now fail closed with `403`.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/appointments.py`; `backend/tests/integration/test_appointment_flow_owner_guard.py` for regression proof.
- Denied paths: no frontend, no BFF-lite, no `/api/v1/ui/*`, no migrations, no Telegram/onboarding work, no broad route rewrite.
- Migration/docs/test impact: no migration or docs changes; one focused integration test file updated.
- Rollback note: revert this commit to restore previous auth-only legacy appointment behavior and the previous broken CRUD method calls.

## Validation
- Targeted tests or smoke run: `py_compile` on touched Python files; `scripts/run_backend_pytest.ps1 tests\integration\test_appointment_flow_owner_guard.py`; `git diff --check`.
- Result: compile passed; targeted pytest passed `5 passed`; diff check passed with CRLF warnings only.
- Not checked: broad backend suite and frontend build were not run because this is a narrow backend endpoint/RBAC patch.
