### PR TITLE
fix(price-overrides): expose backend-owned actions

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -1140,7 +1140,16 @@ class PriceOverrideListResponse(BaseModel):
     reason: str
     details: Optional[str]
     status: str
+    available_actions: List[str]
+    can_approve: bool
+    can_reject: bool
     created_at: datetime
+
+
+def _price_override_available_actions(override_status: str) -> List[str]:
+    if override_status == "pending":
+        return ["approve", "reject"]
+    return []
 
 
 @router.get(
@@ -1169,6 +1178,7 @@ def get_pending_price_overrides(
 
         result = []
         for override in overrides:
+            available_actions = _price_override_available_actions(override.status)
             # Получаем данные визита и пациента
             visit = db.query(Visit).filter(Visit.id == override.visit_id).first()
             patient_name = None
@@ -1191,6 +1201,9 @@ def get_pending_price_overrides(
                     reason=override.reason,
                     details=override.details,
                     status=override.status,
+                    available_actions=available_actions,
+                    can_approve="approve" in available_actions,
+                    can_reject="reject" in available_actions,
                     created_at=override.created_at,
                 )
             )

--- a/backend/tests/unit/test_registrar_price_override_actions.py
+++ b/backend/tests/unit/test_registrar_price_override_actions.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from decimal import Decimal
+
+from app.api.v1.endpoints.registrar_wizard import (
+    PriceOverrideListResponse,
+    _price_override_available_actions,
+)
+
+
+def _price_override_response(status: str) -> PriceOverrideListResponse:
+    available_actions = _price_override_available_actions(status)
+    return PriceOverrideListResponse(
+        id=1,
+        visit_id=2,
+        service_id=3,
+        service_name="Consultation",
+        doctor_name="Demo Doctor",
+        doctor_specialty="dermatology",
+        patient_name="Demo Patient",
+        original_price=Decimal("100000.00"),
+        new_price=Decimal("120000.00"),
+        reason="requested discount change",
+        details=None,
+        status=status,
+        available_actions=available_actions,
+        can_approve="approve" in available_actions,
+        can_reject="reject" in available_actions,
+        created_at=datetime(2026, 1, 1),
+    )
+
+
+def test_pending_price_override_actions_are_backend_owned() -> None:
+    row = _price_override_response("pending")
+
+    assert row.available_actions == ["approve", "reject"]
+    assert row.can_approve is True
+    assert row.can_reject is True
+
+
+def test_processed_price_override_actions_fail_closed() -> None:
+    for status in ("approved", "rejected", "unknown"):
+        row = _price_override_response(status)
+
+        assert row.available_actions == []
+        assert row.can_approve is False
+        assert row.can_reject is False

--- a/frontend/src/components/registrar/PriceOverrideApproval.jsx
+++ b/frontend/src/components/registrar/PriceOverrideApproval.jsx
@@ -18,6 +18,31 @@ import { getApiBaseUrl } from '../../api/runtime';
 import logger from '../../utils/logger';
 const API_BASE = getApiBaseUrl();
 
+const PRICE_OVERRIDE_ACTION_CAN_FIELD = {
+  approve: 'can_approve',
+  reject: 'can_reject'
+};
+
+const hasBackendPriceOverrideAction = (override, action) => {
+  const normalizedAction = String(action || '').trim().toLowerCase();
+  if (!normalizedAction) {
+    return false;
+  }
+
+  if (Array.isArray(override?.available_actions)) {
+    return override.available_actions.some(
+      (availableAction) => String(availableAction || '').trim().toLowerCase() === normalizedAction
+    );
+  }
+
+  const canField = PRICE_OVERRIDE_ACTION_CAN_FIELD[normalizedAction];
+  if (canField && Object.prototype.hasOwnProperty.call(override || {}, canField)) {
+    return Boolean(override[canField]);
+  }
+
+  return false;
+};
+
 /**
  * Компонент для одобрения/отклонения изменений цен врачами
  */
@@ -280,8 +305,9 @@ const PriceOverrideApproval = () => {void
               </div>
 
               {/* Действия */}
-              {override.status === 'pending' &&
+              {(hasBackendPriceOverrideAction(override, 'approve') || hasBackendPriceOverrideAction(override, 'reject')) &&
           <div className="flex gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+                  {hasBackendPriceOverrideAction(override, 'approve') &&
                   <button
               onClick={() => handleApproval(override.id, 'approve')}
               disabled={isProcessing}
@@ -290,7 +316,9 @@ const PriceOverrideApproval = () => {void
                     <CheckCircle size={16} />
                     Одобрить
                   </button>
-                  
+            }
+
+                  {hasBackendPriceOverrideAction(override, 'reject') &&
                   <button
               onClick={() => {
                 setSelectedOverride(override);
@@ -302,6 +330,7 @@ const PriceOverrideApproval = () => {void
                     <XCircle size={16} />
                     Отклонить
                   </button>
+            }
                 </div>
           }
             </div>

--- a/frontend/src/pages/__tests__/PriceOverrideApproval.contract.test.jsx
+++ b/frontend/src/pages/__tests__/PriceOverrideApproval.contract.test.jsx
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sourcePath = path.resolve(
+  process.cwd(),
+  'src/components/registrar/PriceOverrideApproval.jsx'
+);
+
+const readSource = () => fs.readFileSync(sourcePath, 'utf8');
+
+const sourceSlice = (source, startMarker, endMarker) => {
+  const start = source.indexOf(startMarker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf(endMarker, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+};
+
+describe('PriceOverrideApproval action contract', () => {
+  it('renders approve and reject actions from backend-owned action fields', () => {
+    const source = readSource();
+    const helper = sourceSlice(
+      source,
+      'const hasBackendPriceOverrideAction = (override, action) => {',
+      '/**'
+    );
+
+    expect(helper).toContain('override?.available_actions');
+    expect(helper).toContain('PRICE_OVERRIDE_ACTION_CAN_FIELD');
+    expect(helper).toContain('return false;');
+
+    const actionRendering = sourceSlice(
+      source,
+      "{(hasBackendPriceOverrideAction(override, 'approve')",
+      '{showApprovalModal && selectedOverride &&'
+    );
+
+    expect(actionRendering).toContain("hasBackendPriceOverrideAction(override, 'approve')");
+    expect(actionRendering).toContain("hasBackendPriceOverrideAction(override, 'reject')");
+    expect(actionRendering).not.toContain("override.status === 'pending'");
+  });
+});


### PR DESCRIPTION
﻿## Summary

- Extend the registrar price override list response with backend-owned action availability fields.
- Make the registrar price override approval UI render approve/reject buttons from backend action fields, not local status logic.
- Add targeted backend and frontend contract tests.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/price-override-actions-ssot` was created from fresh `origin/main` in `C:\tmp\final-ssot-cycle-main`; `C:\final` was intentionally left untouched because it has unrelated dirty Telegram work.
- Clean workspace: inspected before edits; only price override endpoint/consumer/tests were changed, with ignored `frontend/dist` and `frontend/node_modules` build artifacts not staged.
- Branch: `codex/price-override-actions-ssot`.
- Scope gate: allowed paths were `backend/app/api/v1/endpoints/registrar_wizard.py`, `frontend/src/components/registrar/PriceOverrideApproval.jsx`, and targeted backend/frontend tests; denied paths included `/api/v1/ui/*`, migrations, QueueJoin, DisplayBoard, unrelated registrar flows, and command wrappers.
- Red-check handling: all runtime checks passed; the only red check was PR Review Quality Gate body formatting, fixed by this PR body update without code changes.

## Contract Impact

- Canonical surface: `GET /api/v1/registrar/price-overrides` remains the existing canonical read surface for registrar price override approvals.
- Request shape: unchanged authenticated query request with existing `status_filter` and `limit` parameters.
- Response shape: additive fields `available_actions`, `can_approve`, and `can_reject` are included per row; processed rows fail closed with no actions.
- Status codes: unchanged; this PR does not alter route auth, errors, or command status codes.
- Frontend consumer: `PriceOverrideApproval` now renders approve/reject controls from backend action fields while status remains presentation-only for badge text/color.
- Compatibility path or alias: no new compatibility path or alias; existing endpoint is extended additively and the UI also accepts explicit `can_*` fields if `available_actions` is absent.
- Contract proof: backend unit test covers pending/processed action shape; frontend contract test proves buttons are not gated by `override.status === 'pending'`.

## RBAC / Permissions

- Roles allowed: unchanged existing `Admin` and `Registrar` read access for price overrides.
- Roles denied: unchanged existing role guard behavior for other roles.
- Positive auth proof: not rerun as a role integration test because this PR does not modify auth dependencies; existing CI role-system-check passed.
- Negative auth proof: not rerun as a role integration test because this PR does not modify auth dependencies; existing CI role-system-check passed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime channel changed.
- Payload version / ack behavior: not applicable - no notification or websocket payload changed.
- Read/unread or delivery semantics: not applicable - no notification delivery semantics changed.
- Reconnect/resync proof: not applicable - no realtime reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: existing empty-list rendering path is unchanged; no command buttons render without rows.
- Partial data proof: UI fails closed if neither `available_actions` nor explicit `can_*` action fields are present.
- Forbidden secondary path behavior: no secondary endpoint/path was added; approve/reject still use the existing backend command endpoint.
- Missing draft/resource behavior: not applicable - price override approval does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - component does not depend on route/deep-link state.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/registrar_wizard.py`, `frontend/src/components/registrar/PriceOverrideApproval.jsx`, `backend/tests/unit/test_registrar_price_override_actions.py`, `frontend/src/pages/__tests__/PriceOverrideApproval.contract.test.jsx`.
- Denied paths: `/api/v1/ui/*`, separate BFF service, migrations, QueueJoin, DisplayBoard, unrelated registrar command flows, generated output, and broad cleanup.
- Migration/docs/test impact: no migration and no docs change; targeted backend/frontend tests added.
- Rollback note: revert this PR to remove additive action fields and return the UI to prior status-based rendering; no data migration rollback is needed.

## Validation

- Targeted tests or smoke run: backend unit test, OpenAPI contract test, frontend contract test, frontend build, and `git diff --check`.
- Result: `backend/tests/unit/test_registrar_price_override_actions.py` passed 2 tests; `backend/tests/test_openapi_contract.py` passed 13 tests; `PriceOverrideApproval.contract` passed 1 test; frontend build passed; GitHub runtime CI and PR Required Gate passed.
- Not checked: full manual browser smoke for registrar price override approval modal; no running seeded backend/frontend session was used in this slice.
