### PR TITLE
fix(appointments): scope legacy collection access

### DIFF
--- a/backend/app/api/v1/endpoints/appointments.py
+++ b/backend/app/api/v1/endpoints/appointments.py
@@ -37,6 +37,7 @@ APPOINTMENT_DOCTOR_ROLES = {
     "Dentist",
 }
 APPOINTMENT_PATIENT_ROLES = {"Patient"}
+APPOINTMENT_PENDING_PAYMENT_ROLES = {"Admin", "Registrar", "Cashier"}
 
 
 def _appointments_http_error(exc: Exception, operation: str) -> HTTPException:
@@ -102,6 +103,98 @@ def _ensure_appointment_record_access(
         if patient:
             return
 
+    raise HTTPException(status_code=403, detail="Access denied")
+
+
+def _appointment_doctor_scope_ids(db: Session, current_user: User) -> set[int]:
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    allowed_ids = {doctor.id}
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == current_user.id).first()
+    if not assigned_doctor:
+        allowed_ids.add(current_user.id)
+    return allowed_ids
+
+
+def _appointment_patient_scope_id(db: Session, current_user: User) -> int:
+    current_patient = getattr(current_user, "patient", None)
+    if getattr(current_patient, "id", None) is not None:
+        return current_patient.id
+
+    patient = db.query(Patient).filter(Patient.user_id == current_user.id).first()
+    if not patient:
+        raise HTTPException(status_code=403, detail="Access denied")
+    return patient.id
+
+
+def _scope_appointment_list_filters(
+    db: Session,
+    *,
+    patient_id: int | None,
+    doctor_id: int | None,
+    current_user: User,
+) -> tuple[int | None, int | None]:
+    role = getattr(current_user, "role", None)
+    if role in APPOINTMENT_BROAD_ACCESS_ROLES or getattr(
+        current_user, "is_superuser", False
+    ):
+        return patient_id, doctor_id
+
+    if role in APPOINTMENT_DOCTOR_ROLES:
+        if doctor_id is None:
+            raise HTTPException(status_code=403, detail="Access denied")
+        if doctor_id not in _appointment_doctor_scope_ids(db, current_user):
+            raise HTTPException(status_code=403, detail="Access denied")
+        return patient_id, doctor_id
+
+    if role in APPOINTMENT_PATIENT_ROLES:
+        own_patient_id = _appointment_patient_scope_id(db, current_user)
+        if patient_id is not None and patient_id != own_patient_id:
+            raise HTTPException(status_code=403, detail="Access denied")
+        return own_patient_id, doctor_id
+
+    raise HTTPException(status_code=403, detail="Access denied")
+
+
+def _ensure_appointment_create_access(
+    db: Session,
+    appointment_in: appointment_schemas.AppointmentCreate,
+    current_user: User,
+) -> None:
+    role = getattr(current_user, "role", None)
+    if role in APPOINTMENT_BROAD_ACCESS_ROLES or getattr(
+        current_user, "is_superuser", False
+    ):
+        return
+
+    if role in APPOINTMENT_DOCTOR_ROLES:
+        if appointment_in.doctor_id not in _appointment_doctor_scope_ids(
+            db, current_user
+        ):
+            raise HTTPException(status_code=403, detail="Access denied")
+        return
+
+    if role in APPOINTMENT_PATIENT_ROLES:
+        if appointment_in.patient_id != _appointment_patient_scope_id(
+            db, current_user
+        ):
+            raise HTTPException(status_code=403, detail="Access denied")
+        return
+
+    raise HTTPException(status_code=403, detail="Access denied")
+
+
+def _ensure_pending_payment_access(current_user: User) -> None:
+    if getattr(current_user, "role", None) in APPOINTMENT_PENDING_PAYMENT_ROLES:
+        return
+    if getattr(current_user, "is_superuser", False):
+        return
     raise HTTPException(status_code=403, detail="Access denied")
 
 
@@ -178,6 +271,13 @@ def list_appointments(
     Получить список записей на прием с возможностью фильтрации и пагинации
     """
     from app.models.patient import Patient
+
+    patient_id, doctor_id = _scope_appointment_list_filters(
+        db,
+        patient_id=patient_id,
+        doctor_id=doctor_id,
+        current_user=current_user,
+    )
 
     appointments = appointment_crud.get_appointments(
         db,
@@ -272,6 +372,8 @@ def create_appointment(
     Создать новую запись на прием
     """
     # Проверяем, не занято ли время у врача
+    _ensure_appointment_create_access(db, appointment_in, current_user)
+
     if appointment_crud.is_time_slot_occupied(
         db,
         doctor_id=appointment_in.doctor_id,
@@ -299,6 +401,8 @@ async def get_pending_payments(
     Получить объединенный список записей (appointments и visits), ожидающие оплаты
     Группирует visits одного пациента в одну запись
     """
+    _ensure_pending_payment_access(current_user)
+
     try:
         from collections import defaultdict
 
@@ -782,6 +886,8 @@ async def get_pending_payments(
     Получить объединенный список записей (appointments и visits), ожидающие оплаты
     Группирует visits одного пациента в одну запись
     """
+    _ensure_pending_payment_access(current_user)
+
     try:
         from collections import defaultdict
 

--- a/backend/tests/integration/test_appointment_flow_owner_guard.py
+++ b/backend/tests/integration/test_appointment_flow_owner_guard.py
@@ -194,6 +194,77 @@ def test_patient_can_read_own_legacy_appointment(
     assert response.json()["id"] == own_appointment.id
 
 
+def test_patient_legacy_appointment_list_is_limited_to_own_records(
+    client,
+    db_session,
+) -> None:
+    own_user, own_patient = _create_patient_user(db_session, label="own_list")
+    _other_user, other_patient = _create_patient_user(db_session, label="other_list")
+    own_appointment = Appointment(
+        patient_id=own_patient.id,
+        appointment_date=date.today(),
+        appointment_time="09:00",
+        status="scheduled",
+    )
+    other_appointment = Appointment(
+        patient_id=other_patient.id,
+        appointment_date=date.today(),
+        appointment_time="09:30",
+        status="scheduled",
+    )
+    db_session.add_all([own_appointment, other_appointment])
+    db_session.commit()
+    db_session.refresh(own_appointment)
+    db_session.refresh(other_appointment)
+
+    response = client.get(
+        "/api/v1/appointments/",
+        headers=_patient_headers(client, own_user),
+    )
+
+    assert response.status_code == 200
+    appointment_ids = {item["id"] for item in response.json()}
+    assert own_appointment.id in appointment_ids
+    assert other_appointment.id not in appointment_ids
+
+
+def test_patient_cannot_create_legacy_appointment_for_another_patient(
+    client,
+    db_session,
+) -> None:
+    own_user, _own_patient = _create_patient_user(db_session, label="own_create")
+    _other_user, other_patient = _create_patient_user(db_session, label="other_create")
+    before_count = db_session.query(Appointment).count()
+
+    response = client.post(
+        "/api/v1/appointments/",
+        json={
+            "patient_id": other_patient.id,
+            "appointment_date": date.today().isoformat(),
+            "appointment_time": "14:00",
+            "status": "scheduled",
+        },
+        headers=_patient_headers(client, own_user),
+    )
+
+    assert response.status_code == 403
+    assert db_session.query(Appointment).count() == before_count
+
+
+def test_patient_cannot_read_legacy_pending_payments(
+    client,
+    db_session,
+) -> None:
+    own_user, _own_patient = _create_patient_user(db_session, label="pending")
+
+    response = client.get(
+        "/api/v1/appointments/pending-payments",
+        headers=_patient_headers(client, own_user),
+    )
+
+    assert response.status_code == 403
+
+
 def test_patient_cannot_update_other_patient_legacy_appointment(
     client,
     db_session,


### PR DESCRIPTION
## Summary
- Scope legacy appointment collection routes so auth-only users cannot enumerate, create, or inspect payment-workqueue records outside their ownership.
- `GET /api/v1/appointments/` now preserves Admin/Registrar broad access, requires Doctor own `doctor_id`, and auto-scopes Patient callers to their linked `patient_id`.
- `POST /api/v1/appointments/` now requires Admin/Registrar broad access, Doctor assigned-doctor scope, or Patient own-patient scope.
- `/api/v1/appointments/pending-payments` now requires Admin/Registrar/Cashier instead of any authenticated user.

## Cyclic Execution Evidence
- Fresh main sync: work started after PR #1387 merge from `origin/main` at `2bec7990` in clean worktree `C:\tmp\final-owner-audit`.
- Clean workspace: branch began clean; unrelated dirty `C:\final` Telegram/onboarding files were not touched.
- Branch: `codex/appointments-collection-owner-guard`.
- Scope gate: `agent_gate` misrouted into billing files; used narrow override because confirmed root cause is `backend/app/api/v1/endpoints/appointments.py`.
- Red-check handling: local targeted checks passed before PR creation; any red GitHub check will be fixed in this PR.

## Contract Impact
- Canonical surface: existing legacy appointments router mounted via `appointments.router` in `backend/app/api/v1/api.py`.
- Request shape: unchanged query parameters for list/pending-payments and unchanged `AppointmentCreate` body for create.
- Response shape: unchanged response schema for allowed list/create/pending-payments calls.
- Status codes: cross-owner list/create and unauthorized pending-payment access now return `403 Access denied`; allowed requests keep existing success behavior.
- Frontend consumer: existing URLs and payload shapes stay stable; only forbidden over-broad access now fails closed.
- Compatibility path or alias: legacy direct `/api/v1/appointments/*` paths remain mounted; appointment-flow paths are unchanged.
- Contract proof: `test_appointment_flow_owner_guard.py` covers Patient own list visibility, denial for other-patient create, and denial for pending-payment queue access.

## RBAC / Permissions
- Roles allowed: Admin/Registrar broad for appointment collection and create; Cashier for pending-payments; Doctor for explicitly scoped own doctor records; Patient for linked own patient records.
- Roles denied: Patient cannot enumerate other patients through the collection route, create an appointment for another patient, or read pending-payment workqueue data.
- Positive auth proof: targeted test confirms linked Patient can still read own appointment and list includes own appointment.
- Negative auth proof: targeted tests confirm other-patient read/update/delete denial from #1387 plus new collection create/list/pending-payment denial cases.

## Notification / Realtime
- Event type or websocket channel: this patch does not emit, rename, or remove any notification or websocket events.
- Payload version / ack behavior: realtime payload versions and ack semantics are unchanged.
- Read/unread or delivery semantics: notification delivery and read/unread state are untouched.
- Reconnect/resync proof: these HTTP routes do not keep websocket sessions; clients resync via existing persisted appointment list/detail routes after refresh.

## Frontend Resilience
- Empty data proof: Patient list calls without matching own rows naturally return an empty list through the existing list response shape.
- Partial data proof: allowed responses still use the existing appointment serializers and pending-payment dict shape.
- Forbidden secondary path behavior: cross-owner collection and workqueue access now gets explicit `403` instead of leaked rows or unauthorized writes.
- Missing draft/resource behavior: no draft resource path is changed by this patch.
- Stale route/deep-link behavior: stale collection filters pointing to another patient/doctor now fail closed with `403`.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/appointments.py`; `backend/tests/integration/test_appointment_flow_owner_guard.py` for targeted regression proof.
- Denied paths: no frontend, no BFF-lite, no `/api/v1/ui/*`, no migrations, no billing model/service rewrites, no Telegram/onboarding files.
- Migration/docs/test impact: no migrations or docs; one focused integration test file extended.
- Rollback note: revert this commit to restore previous auth-only collection/create/pending-payment behavior.

## Validation
- Targeted tests or smoke run: `py_compile` on touched Python files; `scripts/run_backend_pytest.ps1 tests\integration\test_appointment_flow_owner_guard.py`; `git diff --check`.
- Result: compile passed; targeted pytest passed `8 passed`; diff check passed with CRLF warnings only.
- Not checked: full backend suite and frontend build were not run locally because this is a narrow backend RBAC patch; GitHub CI will run required checks.
