### PR TITLE
fix(all-free): expose backend-owned actions

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -1321,6 +1321,15 @@ class AllFreeVisitResponse(BaseModel):
     notes: Optional[str]
     created_at: datetime
     approval_status: str
+    available_actions: List[str]
+    can_approve: bool
+    can_reject: bool
+
+
+def _all_free_available_actions(approval_status: str) -> List[str]:
+    if approval_status == "pending":
+        return ["approve", "reject"]
+    return []
 
 
 @router.get(
@@ -1347,6 +1356,7 @@ def get_all_free_requests(
 
         result = []
         for visit in visits:
+            available_actions = _all_free_available_actions(visit.approval_status)
             # Получаем услуги визита
             visit_services = (
                 db.query(VisitService).filter(VisitService.visit_id == visit.id).all()
@@ -1435,6 +1445,9 @@ def get_all_free_requests(
                     notes=visit.notes,
                     created_at=visit.created_at,
                     approval_status=visit.approval_status,
+                    available_actions=available_actions,
+                    can_approve="approve" in available_actions,
+                    can_reject="reject" in available_actions,
                 )
             )
 

--- a/backend/tests/unit/test_registrar_all_free_actions.py
+++ b/backend/tests/unit/test_registrar_all_free_actions.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from decimal import Decimal
+
+from app.api.v1.endpoints.registrar_wizard import (
+    AllFreeVisitResponse,
+    _all_free_available_actions,
+)
+
+
+def _all_free_response(approval_status: str) -> AllFreeVisitResponse:
+    available_actions = _all_free_available_actions(approval_status)
+    return AllFreeVisitResponse(
+        id=1,
+        patient_id=2,
+        patient_name="Demo Patient",
+        patient_phone="+998901234567",
+        services=["Consultation"],
+        total_original_amount=Decimal("150000.00"),
+        doctor_name="Demo Doctor",
+        doctor_specialty="cardiology",
+        visit_date=None,
+        visit_time=None,
+        notes=None,
+        created_at=datetime(2026, 1, 1),
+        approval_status=approval_status,
+        available_actions=available_actions,
+        can_approve="approve" in available_actions,
+        can_reject="reject" in available_actions,
+    )
+
+
+def test_pending_all_free_actions_are_backend_owned() -> None:
+    row = _all_free_response("pending")
+
+    assert row.available_actions == ["approve", "reject"]
+    assert row.can_approve is True
+    assert row.can_reject is True
+
+
+def test_processed_all_free_actions_fail_closed() -> None:
+    for approval_status in ("approved", "rejected", "none", "unknown"):
+        row = _all_free_response(approval_status)
+
+        assert row.available_actions == []
+        assert row.can_approve is False
+        assert row.can_reject is False

--- a/frontend/src/components/admin/AllFreeApproval.jsx
+++ b/frontend/src/components/admin/AllFreeApproval.jsx
@@ -21,6 +21,31 @@ import { toast } from 'react-toastify';
 import { api } from '../../api/client';
 
 import logger from '../../utils/logger';
+
+const ALL_FREE_ACTION_CAN_FIELD = {
+  approve: 'can_approve',
+  reject: 'can_reject'
+};
+
+const hasBackendAllFreeAction = (request, action) => {
+  const normalizedAction = String(action || '').trim().toLowerCase();
+  if (!normalizedAction) {
+    return false;
+  }
+
+  if (Array.isArray(request?.available_actions)) {
+    return request.available_actions.some(
+      (availableAction) => String(availableAction || '').trim().toLowerCase() === normalizedAction
+    );
+  }
+
+  const canField = ALL_FREE_ACTION_CAN_FIELD[normalizedAction];
+  if (canField && Object.prototype.hasOwnProperty.call(request || {}, canField)) {
+    return Boolean(request[canField]);
+  }
+
+  return false;
+};
 /**
  * Компонент для одобрения/отклонения заявок All Free в админке
  */
@@ -478,8 +503,9 @@ const AllFreeApproval = () => {void
             }
 
                 {/* Действия */}
-                {request.approval_status === 'pending' &&
+                {(hasBackendAllFreeAction(request, 'approve') || hasBackendAllFreeAction(request, 'reject')) &&
             <div className="flex gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+                    {hasBackendAllFreeAction(request, 'approve') &&
                     <Button
                 onClick={() => handleApproval(request.id, 'approve')}
                 disabled={isProcessing}
@@ -488,7 +514,9 @@ const AllFreeApproval = () => {void
                       <CheckCircle size={16} />
                       Одобрить
                     </Button>
-                    
+              }
+
+                    {hasBackendAllFreeAction(request, 'reject') &&
                     <Button
                 onClick={() => {
                   setSelectedRequest(request);
@@ -501,6 +529,7 @@ const AllFreeApproval = () => {void
                       <XCircle size={16} />
                       Отклонить
                     </Button>
+              }
                   </div>
             }
               </Card>

--- a/frontend/src/components/admin/__tests__/AllFreeApproval.contract.test.jsx
+++ b/frontend/src/components/admin/__tests__/AllFreeApproval.contract.test.jsx
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sourcePath = path.resolve(
+  process.cwd(),
+  'src/components/admin/AllFreeApproval.jsx'
+);
+
+const readSource = () => fs.readFileSync(sourcePath, 'utf8');
+
+const sourceSlice = (source, startMarker, endMarker) => {
+  const start = source.indexOf(startMarker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf(endMarker, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+};
+
+describe('AllFreeApproval action contract', () => {
+  it('renders approve and reject actions from backend-owned action fields', () => {
+    const source = readSource();
+    const helper = sourceSlice(
+      source,
+      'const hasBackendAllFreeAction = (request, action) => {',
+      '/**'
+    );
+
+    expect(helper).toContain('request?.available_actions');
+    expect(helper).toContain('ALL_FREE_ACTION_CAN_FIELD');
+    expect(helper).toContain('return false;');
+
+    const actionRendering = sourceSlice(
+      source,
+      "{(hasBackendAllFreeAction(request, 'approve')",
+      '{showApprovalModal && selectedRequest &&'
+    );
+
+    expect(actionRendering).toContain("hasBackendAllFreeAction(request, 'approve')");
+    expect(actionRendering).toContain("hasBackendAllFreeAction(request, 'reject')");
+    expect(actionRendering).not.toContain("request.approval_status === 'pending'");
+  });
+});


### PR DESCRIPTION
﻿## Summary

- Extend the existing All Free requests response with backend-owned action availability fields.
- Make `AllFreeApproval` render approve/reject buttons from backend action fields, not local `approval_status === pending` logic.
- Add targeted backend and frontend contract tests.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/all-free-actions-ssot` was created from fresh `origin/main` at merge commit `5284ec58` in `C:\tmp\final-ssot-cycle-main`; dirty unrelated `C:\final` worktree was not touched.
- Clean workspace: inspected before edits; only All Free endpoint/consumer/tests were changed, with ignored `frontend/dist` and `frontend/node_modules` build artifacts not staged.
- Branch: `codex/all-free-actions-ssot`.
- Scope gate: allowed paths were `backend/app/api/v1/endpoints/registrar_wizard.py`, `frontend/src/components/admin/AllFreeApproval.jsx`, and targeted backend/frontend tests; denied paths included `/api/v1/ui/*`, migrations, BFF, separate service, notifications, QueueJoin, DisplayBoard, and unrelated admin panels.
- Red-check handling: local targeted validation passed; any CI red check will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/admin/all-free-requests` remains the existing canonical read surface for All Free approval rows.
- Request shape: unchanged authenticated query request with existing `status_filter` and `limit` parameters.
- Response shape: additive fields `available_actions`, `can_approve`, and `can_reject` are included per row; processed rows fail closed with no actions.
- Status codes: unchanged; this PR does not alter route auth, errors, or approve/reject command status codes.
- Frontend consumer: `AllFreeApproval` now renders approve/reject controls from backend action fields while `approval_status` remains presentation-only for labels, counters, and badges.
- Compatibility path or alias: no new compatibility path or alias; existing endpoint is extended additively and the UI also accepts explicit `can_*` fields if `available_actions` is absent.
- Contract proof: backend unit test covers pending/processed action shape; frontend contract test proves buttons are not gated by `request.approval_status === 'pending'`.

## RBAC / Permissions

- Roles allowed: unchanged existing `Admin` read/approve access for All Free requests.
- Roles denied: unchanged existing role guard behavior for non-admin roles.
- Positive auth proof: not rerun as a role integration test because auth dependencies were not changed; existing CI role-system-check is expected to cover role wiring.
- Negative auth proof: not rerun as a role integration test because auth dependencies were not changed; existing CI role-system-check is expected to cover role wiring.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, chat, or realtime channel changed.
- Payload version / ack behavior: not applicable - no notification or websocket payload changed.
- Read/unread or delivery semantics: not applicable - no notification delivery semantics changed.
- Reconnect/resync proof: not applicable - no realtime reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: existing empty-list rendering path is unchanged; no command buttons render without rows.
- Partial data proof: UI fails closed if neither `available_actions` nor explicit `can_*` action fields are present.
- Forbidden secondary path behavior: no secondary endpoint/path was added; approve/reject still use the existing backend command endpoint.
- Missing draft/resource behavior: not applicable - All Free approval does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - component does not depend on route/deep-link state.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/registrar_wizard.py`, `frontend/src/components/admin/AllFreeApproval.jsx`, `backend/tests/unit/test_registrar_all_free_actions.py`, `frontend/src/components/admin/__tests__/AllFreeApproval.contract.test.jsx`.
- Denied paths: `/api/v1/ui/*`, separate BFF service, migrations, notification behavior, QueueJoin, DisplayBoard, unrelated registrar/admin flows, generated output, and broad cleanup.
- Migration/docs/test impact: no migration and no docs change; targeted backend/frontend tests added.
- Rollback note: revert this PR to remove additive action fields and return the UI to prior approval-status-based rendering; no data migration rollback is needed.

## Validation

- Targeted tests or smoke run: backend unit test, OpenAPI contract test, frontend contract test, frontend build, and `git diff --check`.
- Result: `backend/tests/unit/test_registrar_all_free_actions.py` passed 2 tests; `backend/tests/test_openapi_contract.py` passed 13 tests; `AllFreeApproval.contract` passed 1 test; frontend build passed; `git diff --check` passed.
- Not checked: full manual browser smoke for the All Free approval modal; no running seeded backend/frontend session was used in this slice.
