### PR TITLE
fix(billing): require billing roles on legacy endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/billing.py
+++ b/backend/app/api/v1/endpoints/billing.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
 from app.api import deps
+from app.core.security import require_roles
 from app.models.billing import InvoiceStatus, InvoiceType, PaymentMethod, RecurrenceType
 from app.models.user import User
 from app.services.billing_api_service import BillingApiDomainError, BillingApiService
@@ -20,6 +21,9 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 BILLING_PUBLIC_ERROR = "Internal server error"
+BILLING_VIEW_ROLES = ("Admin", "Registrar", "Cashier")
+BILLING_WRITE_ROLES = ("Admin", "Cashier")
+BILLING_ADMIN_ROLES = ("Admin",)
 
 
 def _billing_http_error(exc: Exception, operation: str) -> HTTPException:
@@ -181,7 +185,7 @@ class PaymentResponse(BaseModel):
 def create_invoice(
     invoice_data: InvoiceCreate,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_WRITE_ROLES)),
 ):
     """Создать счет"""
     service = BillingService(db)
@@ -241,7 +245,7 @@ def get_invoices(
     date_from: Optional[date] = None,
     date_to: Optional[date] = None,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_VIEW_ROLES)),
 ):
     """Получить список счетов"""
     return BillingApiService(db).list_invoices(
@@ -259,7 +263,7 @@ def get_invoices(
 def get_invoice(
     invoice_id: int,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_VIEW_ROLES)),
 ):
     """Получить счет по ID"""
     try:
@@ -273,7 +277,7 @@ def update_invoice(
     invoice_id: int,
     invoice_data: InvoiceUpdate,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_WRITE_ROLES)),
 ):
     """Обновить счет"""
     try:
@@ -289,7 +293,7 @@ def update_invoice(
 def delete_invoice(
     invoice_id: int,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_WRITE_ROLES)),
 ):
     """Удалить счет"""
     try:
@@ -304,7 +308,7 @@ def get_invoice_html(
     invoice_id: int,
     template_id: Optional[int] = None,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_VIEW_ROLES)),
 ):
     """Получить HTML счета"""
     service = BillingService(db)
@@ -323,7 +327,7 @@ def send_invoice(
     invoice_id: int,
     background_tasks: BackgroundTasks,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_WRITE_ROLES)),
 ):
     """Отправить счет пациенту"""
     service = BillingService(db)
@@ -338,7 +342,7 @@ def send_invoice(
 def record_payment(
     payment_data: PaymentCreate,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_WRITE_ROLES)),
 ):
     """Записать платеж"""
     service = BillingService(db)
@@ -366,7 +370,7 @@ def get_payments(
     date_from: Optional[date] = None,
     date_to: Optional[date] = None,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_VIEW_ROLES)),
 ):
     """Получить список платежей"""
     payments = BillingApiService(db).list_payments(
@@ -382,7 +386,7 @@ def get_payments(
 def auto_generate_invoice_for_visit(
     visit_id: int,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_WRITE_ROLES)),
 ):
     """Автоматически создать счет для визита"""
     service = BillingService(db)
@@ -402,7 +406,7 @@ def auto_generate_invoice_for_visit(
 def auto_generate_invoice_for_appointment(
     appointment_id: int,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_WRITE_ROLES)),
 ):
     """Автоматически создать счет для записи"""
     service = BillingService(db)
@@ -422,7 +426,7 @@ def auto_generate_invoice_for_appointment(
 def process_recurring_invoices(
     background_tasks: BackgroundTasks,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_ADMIN_ROLES)),
 ):
     """Обработать периодические счета"""
     service = BillingService(db)
@@ -437,7 +441,7 @@ def process_recurring_invoices(
 def send_payment_reminders(
     background_tasks: BackgroundTasks,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_WRITE_ROLES)),
 ):
     """Отправить напоминания об оплате"""
     service = BillingService(db)
@@ -451,7 +455,7 @@ def send_payment_reminders(
 @router.get("/settings")
 def get_billing_settings(
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_ADMIN_ROLES)),
 ):
     """Получить настройки биллинга"""
     service = BillingService(db)
@@ -484,7 +488,7 @@ def get_billing_settings(
 def update_billing_settings(
     settings_data: BillingSettingsUpdate,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_ADMIN_ROLES)),
 ):
     """Обновить настройки биллинга"""
     service = BillingService(db)
@@ -502,7 +506,7 @@ def get_billing_analytics(
     date_from: Optional[date] = None,
     date_to: Optional[date] = None,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(require_roles(*BILLING_VIEW_ROLES)),
 ):
     """Получить аналитику по счетам"""
     return BillingApiService(db).get_billing_analytics(

--- a/backend/tests/integration/test_billing_role_guard.py
+++ b/backend/tests/integration/test_billing_role_guard.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.billing import Invoice
+from app.models.patient import Patient
+
+
+def _create_invoice(db_session: Session, patient: Patient) -> Invoice:
+    invoice = Invoice(
+        invoice_number=f"TEST-{uuid4().hex[:12]}",
+        patient_id=patient.id,
+        subtotal=100000,
+        total_amount=100000,
+        balance=100000,
+        description="role guard invoice",
+    )
+    db_session.add(invoice)
+    db_session.commit()
+    db_session.refresh(invoice)
+    return invoice
+
+
+def test_admin_can_list_legacy_billing_invoices(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    response = client.get("/api/v1/billing/invoices", headers=auth_headers)
+
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+def test_patient_cannot_read_legacy_billing_invoice(
+    client: TestClient,
+    db_session: Session,
+    patient_token: str,
+    test_patient: Patient,
+) -> None:
+    invoice = _create_invoice(db_session, test_patient)
+
+    response = client.get(
+        f"/api/v1/billing/invoices/{invoice.id}",
+        headers={"Authorization": f"Bearer {patient_token}"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_patient_cannot_update_or_delete_legacy_billing_invoice(
+    client: TestClient,
+    db_session: Session,
+    patient_token: str,
+    test_patient: Patient,
+) -> None:
+    invoice = _create_invoice(db_session, test_patient)
+    headers = {"Authorization": f"Bearer {patient_token}"}
+
+    update_response = client.put(
+        f"/api/v1/billing/invoices/{invoice.id}",
+        json={"notes": "patient should not mutate billing"},
+        headers=headers,
+    )
+    delete_response = client.delete(
+        f"/api/v1/billing/invoices/{invoice.id}",
+        headers=headers,
+    )
+
+    assert update_response.status_code == 403
+    assert delete_response.status_code == 403
+
+
+def test_patient_cannot_run_legacy_billing_wide_actions(
+    client: TestClient,
+    patient_token: str,
+) -> None:
+    headers = {"Authorization": f"Bearer {patient_token}"}
+
+    settings_response = client.get("/api/v1/billing/settings", headers=headers)
+    reminders_response = client.post("/api/v1/billing/send-reminders", headers=headers)
+    payments_response = client.get("/api/v1/billing/payments", headers=headers)
+
+    assert settings_response.status_code == 403
+    assert reminders_response.status_code == 403
+    assert payments_response.status_code == 403


### PR DESCRIPTION
## Summary
- Require explicit billing roles on legacy `/api/v1/billing/*` endpoints instead of accepting any authenticated user.
- Keep invoice/payment read routes to Admin/Registrar/Cashier, invoice/payment write routes to Admin/Cashier, and billing settings/recurring processing to Admin.
- Add integration coverage proving Patient tokens cannot read/mutate legacy invoices or run billing-wide actions.

## Cyclic Execution Evidence
- Fresh main sync: worktree was detached on fresh `origin/main` at `99456141` before branch creation.
- Clean workspace: branch started clean in `C:\tmp\final-owner-audit`; unrelated dirty `C:\final` worktree was not touched.
- Branch: `codex/billing-role-guard`.
- Scope gate: `agent_gate` returned known-root-cause narrow override for `backend/app/api/v1/endpoints/billing.py`; test file was added as the narrow second slice for regression proof.
- Red-check handling: PR Review Quality Gate failed on exact body labels; this update fixes the same PR body in-place.

## Contract Impact
- Canonical surface: mounted legacy FastAPI billing router at `/api/v1/billing`.
- Request shape: unchanged; no DTO/query/path parameters changed.
- Response shape: unchanged for allowed billing roles.
- Status codes: non-billing authenticated roles now receive `403` before invoice/payment/settings data or mutations are reached.
- Frontend consumer: existing admin billing manager calls remain on the same endpoints; cashier runtime payment UI uses `/api/v1/cashier/*` and `/api/v1/payments/*`, not these legacy admin billing routes.
- Compatibility path or alias: no route alias added or removed.
- Contract proof: `test_billing_role_guard.py` verifies Admin list access and Patient denial for invoice read/update/delete plus billing-wide settings/reminders/payments routes.

## RBAC / Permissions
- Roles allowed: Admin/Registrar/Cashier may read billing lists/details; Admin/Cashier may mutate invoices/payments/send reminders; Admin may read/update settings and process recurring invoices.
- Roles denied: Patient and Doctor-like non-billing roles are denied by `require_roles` before legacy billing data or mutations are reached.
- Positive auth proof: Admin can list `/api/v1/billing/invoices` with 200.
- Negative auth proof: Patient token receives 403 for invoice read/update/delete and billing-wide actions.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel changed; only HTTP route dependencies changed.
- Payload version / ack behavior: no payload version or acknowledgement behavior changed.
- Read/unread or delivery semantics: no read/unread or delivery state changed.
- Reconnect/resync proof: no realtime reconnect/resync path changed; backend regression test covers the affected HTTP access path.

## Frontend Resilience
- Empty data proof: Admin invoice list still returns a JSON list; targeted test accepts the empty-list case.
- Partial data proof: billing response serialization remains the existing response models; no frontend data-shaping path changed.
- Forbidden secondary path behavior: Patient-token forbidden path is covered by regression test with 403 assertions.
- Missing draft/resource behavior: authorized users still reach existing service-level 404/400 behavior; denied users stop at RBAC before resource lookup.
- Stale route/deep-link behavior: no frontend route or deep-link changed; legacy `/api/v1/billing/*` paths remain mounted.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/billing.py`, `backend/tests/integration/test_billing_role_guard.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read-model endpoints, frontend, migrations, billing service/repository internals.
- Migration/docs/test impact: no migration or docs; one targeted backend integration test added.
- Rollback note: revert this commit to restore previous auth-only behavior on legacy billing endpoints.

## Validation
- Targeted tests or smoke run: `scripts/run_backend_pytest.ps1 tests\integration\test_billing_role_guard.py`.
- Result: 4 passed.
- Not checked: broad backend suite and frontend build were not run because the change is a narrow backend dependency/RBAC guard.