### PR TITLE
fix(payments): guard payment invoice endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -425,7 +425,7 @@ def download_receipt(
 async def create_payment_invoice(
     request: PaymentInvoiceCreateRequest,
     db: Session = Depends(get_db),
-    current_user: Any = Depends(deps.get_current_user),
+    current_user: Any = Depends(deps.require_roles("Admin", "Registrar", "Cashier")),
 ):
     """Создание счета для оплаты из модуля оплаты"""
     service = PaymentInvoiceService(db)
@@ -451,7 +451,8 @@ async def create_payment_invoice(
 
 @router.get("/invoices/pending", response_model=List[PaymentInvoiceResponse])
 async def get_pending_invoices(
-    db: Session = Depends(get_db), current_user: Any = Depends(deps.get_current_user)
+    db: Session = Depends(get_db),
+    current_user: Any = Depends(deps.require_roles("Admin", "Registrar", "Cashier")),
 ):
     """Получение списка неоплаченных счетов"""
     service = PaymentInvoiceService(db)

--- a/backend/tests/integration/test_payment_invoice_role_guard.py
+++ b/backend/tests/integration/test_payment_invoice_role_guard.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.enums import PaymentStatus
+from app.models.payment_invoice import PaymentInvoice
+
+
+def test_registrar_can_create_and_list_payment_invoices(
+    client: TestClient,
+    registrar_auth_headers: dict[str, str],
+) -> None:
+    create_response = client.post(
+        "/api/v1/payments/invoice/create",
+        headers=registrar_auth_headers,
+        json={
+            "amount": 100000,
+            "currency": "UZS",
+            "provider": "click",
+            "description": "registrar payment invoice",
+        },
+    )
+    list_response = client.get(
+        "/api/v1/payments/invoices/pending",
+        headers=registrar_auth_headers,
+    )
+
+    assert create_response.status_code == 200
+    assert create_response.json()["amount"] == 100000.0
+    assert list_response.status_code == 200
+    assert any(
+        invoice["invoice_id"] == create_response.json()["invoice_id"]
+        for invoice in list_response.json()
+    )
+
+
+def test_patient_cannot_create_payment_invoice_for_arbitrary_patient(
+    client: TestClient,
+    db_session: Session,
+    patient_token: str,
+) -> None:
+    before_count = db_session.query(PaymentInvoice).count()
+
+    response = client.post(
+        "/api/v1/payments/invoice/create",
+        headers={"Authorization": f"Bearer {patient_token}"},
+        json={
+            "amount": 250000,
+            "currency": "UZS",
+            "provider": "click",
+            "description": "patient should not create invoice",
+            "patient_info": {"patient_id": 999999},
+        },
+    )
+
+    assert response.status_code == 403
+    assert db_session.query(PaymentInvoice).count() == before_count
+
+
+def test_patient_cannot_list_pending_payment_invoices(
+    client: TestClient,
+    db_session: Session,
+    patient_token: str,
+) -> None:
+    db_session.add(
+        PaymentInvoice(
+            patient_id=12345,
+            total_amount=Decimal("50000.00"),
+            currency="UZS",
+            provider="click",
+            status=PaymentStatus.PENDING.value,
+            payment_method="click",
+            notes="pending invoice not visible to patient role",
+        )
+    )
+    db_session.commit()
+
+    response = client.get(
+        "/api/v1/payments/invoices/pending",
+        headers={"Authorization": f"Bearer {patient_token}"},
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Require Admin/Registrar/Cashier roles on legacy payment invoice endpoints under `/api/v1/payments`.
- Keep the Registrar `PaymentManager` create/list flow working while blocking arbitrary authenticated Patient tokens.
- Add integration coverage for positive Registrar access and negative Patient create/list access.

## Cyclic Execution Evidence
- Fresh main sync: worktree was detached on fresh `origin/main` at `58de434d` after PR #1391 merge before branch creation.
- Clean workspace: branch started clean in `C:\tmp\final-owner-audit`; unrelated dirty `C:\final` worktree was not touched.
- Branch: `codex/payment-invoice-role-guard`.
- Scope gate: `agent_gate` returned known-root-cause narrow override for `backend/app/api/v1/endpoints/payments.py`; targeted test file was added as the narrow second slice for regression proof.
- Red-check handling: no red checks yet; this PR will be fixed in-place if CI reports a failure.

## Contract Impact
- Canonical surface: mounted FastAPI payments router at `/api/v1/payments/invoice/create` and `/api/v1/payments/invoices/pending`.
- Request shape: unchanged; no DTO/query/path parameters changed.
- Response shape: unchanged for allowed payment staff roles.
- Status codes: non-payment-staff authenticated roles now receive `403` before invoice creation or pending invoice list access.
- Frontend consumer: Registrar `PaymentManager` calls remain on the same endpoints and are covered by positive Registrar test.
- Compatibility path or alias: no route alias added or removed.
- Contract proof: `test_payment_invoice_role_guard.py` verifies Registrar create/list and Patient denial for create/list.

## RBAC / Permissions
- Roles allowed: Admin, Registrar, and Cashier may create payment invoices and list pending payment invoices.
- Roles denied: Patient and other non-payment-staff roles are denied by `require_roles` before creation or list queries run.
- Positive auth proof: Registrar token can create a payment invoice and then see it in pending invoices.
- Negative auth proof: Patient token receives 403 for creating an invoice with arbitrary `patient_info` and for listing pending invoices; test asserts no invoice row is created.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel changed; only HTTP route dependencies changed.
- Payload version / ack behavior: no payload version or acknowledgement behavior changed.
- Read/unread or delivery semantics: no read/unread or delivery state changed.
- Reconnect/resync proof: no realtime reconnect/resync path changed; backend regression test covers the affected HTTP access path.

## Frontend Resilience
- Empty data proof: pending invoice endpoint still returns a JSON list for allowed roles; Registrar create/list test exercises the list response.
- Partial data proof: payment invoice response serialization remains the existing response model; no frontend data-shaping path changed.
- Forbidden secondary path behavior: Patient-token forbidden create/list paths are covered by regression test with 403 assertions.
- Missing draft/resource behavior: authorized users still reach existing service behavior; denied users stop at RBAC before resource/list logic.
- Stale route/deep-link behavior: no frontend route or deep-link changed; legacy `/api/v1/payments/*` paths remain mounted.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/payments.py`, `backend/tests/integration/test_payment_invoice_role_guard.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read-model endpoints, frontend, migrations, payment service/repository internals.
- Migration/docs/test impact: no migration or docs; one targeted backend integration test added.
- Rollback note: revert this commit to restore previous auth-only behavior on payment invoice endpoints.

## Validation
- Targeted tests or smoke run: `scripts/run_backend_pytest.ps1 tests\integration\test_payment_invoice_role_guard.py`.
- Result: 3 passed.
- Not checked: broad backend suite and frontend build were not run because the change is a narrow backend dependency/RBAC guard.