### PR TITLE
fix(lab): expose template version actions

### DIFF
--- a/backend/app/api/v1/endpoints/lab_reporting.py
+++ b/backend/app/api/v1/endpoints/lab_reporting.py
@@ -111,12 +111,15 @@ def _template_summary_out(template) -> LabReportTemplateSummaryOut:
     )
 
 
-def _version_out(version) -> LabReportTemplateVersionOut:
+def _version_out(service: LabReportingService, version) -> LabReportTemplateVersionOut:
+    available_actions = service.template_version_available_actions(version)
     return LabReportTemplateVersionOut(
         id=version.id,
         template_id=version.template_id,
         version_no=version.version_no,
         status=version.status,
+        available_actions=available_actions,
+        **service.template_version_action_flags(version),
         layout_preset=version.layout_preset,
         page_settings=version.page_settings or {},
         branding_overrides=version.branding_overrides or {},
@@ -140,11 +143,14 @@ def _version_out(version) -> LabReportTemplateVersionOut:
     )
 
 
-def _template_out(template) -> LabReportTemplateOut:
+def _template_out(service: LabReportingService, template) -> LabReportTemplateOut:
     summary = _template_summary_out(template)
     return LabReportTemplateOut(
         **summary.model_dump(),
-        versions=[_version_out(version) for version in sorted(template.versions, key=lambda item: item.version_no)],
+        versions=[
+            _version_out(service, version)
+            for version in sorted(template.versions, key=lambda item: item.version_no)
+        ],
     )
 
 
@@ -169,7 +175,7 @@ def _instance_out(service: LabReportingService, instance) -> LabReportInstanceOu
         finalized_at=instance.finalized_at,
         printed_at=instance.printed_at,
         template=_template_summary_out(instance.template),
-        template_version=_version_out(instance.template_version),
+        template_version=_version_out(service, instance.template_version),
         sections=[
             LabReportRenderedSectionOut(
                 id=section["id"],
@@ -312,7 +318,7 @@ def create_lab_template(
     service = LabReportingService(db)
     try:
         template = service.create_template(payload.model_dump())
-        return _template_out(template)
+        return _template_out(service, template)
     except LabReportingDomainError as exc:
         _handle_domain_error(exc)
 
@@ -325,7 +331,7 @@ def get_lab_template(
 ):
     service = LabReportingService(db)
     try:
-        return _template_out(service.get_template(template_id))
+        return _template_out(service, service.get_template(template_id))
     except LabReportingDomainError as exc:
         _handle_domain_error(exc)
 
@@ -340,7 +346,7 @@ def create_lab_template_version(
     service = LabReportingService(db)
     try:
         version = service.create_template_version(template_id, payload.source_version_id)
-        return _version_out(version)
+        return _version_out(service, version)
     except LabReportingDomainError as exc:
         _handle_domain_error(exc)
 
@@ -356,7 +362,7 @@ def get_lab_template_version(
         version = service.repository.get_template_version(version_id)
         if not version:
             raise LabReportingDomainError(404, "Template version not found")
-        return _version_out(version)
+        return _version_out(service, version)
     except LabReportingDomainError as exc:
         _handle_domain_error(exc)
 
@@ -371,7 +377,7 @@ def update_lab_template_version(
     service = LabReportingService(db)
     try:
         version = service.update_template_version(version_id, payload.model_dump())
-        return _version_out(version)
+        return _version_out(service, version)
     except LabReportingDomainError as exc:
         _handle_domain_error(exc)
 
@@ -384,7 +390,7 @@ def publish_lab_template_version(
 ):
     service = LabReportingService(db)
     try:
-        return _version_out(service.publish_template_version(version_id))
+        return _version_out(service, service.publish_template_version(version_id))
     except LabReportingDomainError as exc:
         _handle_domain_error(exc)
 
@@ -397,7 +403,7 @@ def archive_lab_template_version(
 ):
     service = LabReportingService(db)
     try:
-        return _version_out(service.archive_template_version(version_id))
+        return _version_out(service, service.archive_template_version(version_id))
     except LabReportingDomainError as exc:
         _handle_domain_error(exc)
 
@@ -410,7 +416,7 @@ def clone_lab_template(
 ):
     service = LabReportingService(db)
     try:
-        return _template_out(service.clone_template(template_id))
+        return _template_out(service, service.clone_template(template_id))
     except LabReportingDomainError as exc:
         _handle_domain_error(exc)
 

--- a/backend/app/schemas/lab_reporting.py
+++ b/backend/app/schemas/lab_reporting.py
@@ -114,6 +114,10 @@ class LabReportTemplateVersionOut(BaseModel):
     template_id: int
     version_no: int
     status: str
+    available_actions: list[str] = Field(default_factory=list)
+    can_update: bool = False
+    can_publish: bool = False
+    can_create_draft: bool = False
     layout_preset: str
     page_settings: dict[str, Any]
     branding_overrides: dict[str, Any]

--- a/backend/app/services/lab_reporting_service.py
+++ b/backend/app/services/lab_reporting_service.py
@@ -318,6 +318,23 @@ class LabReportingService:
         logger.info("[LAB] create_template_version created version_id=%s", draft.id)
         return self.repository.get_template_version(draft.id)
 
+    def template_version_available_actions(
+        self, version: LabReportTemplateVersion,
+    ) -> list[str]:
+        if version.status == "DRAFT":
+            return ["update", "publish"]
+        return ["create_draft"]
+
+    def template_version_action_flags(
+        self, version: LabReportTemplateVersion,
+    ) -> dict[str, bool]:
+        available_actions = set(self.template_version_available_actions(version))
+        return {
+            "can_update": "update" in available_actions,
+            "can_publish": "publish" in available_actions,
+            "can_create_draft": "create_draft" in available_actions,
+        }
+
     def update_template_version(
         self, version_id: int, payload: dict[str, Any]
     ) -> LabReportTemplateVersion:

--- a/backend/tests/test_lab_reporting_api.py
+++ b/backend/tests/test_lab_reporting_api.py
@@ -176,6 +176,65 @@ def _create_emr(
 
 
 @pytest.mark.integration
+def test_lab_template_version_actions_are_backend_owned(client, auth_headers):
+    templates_response = client.get("/api/v1/lab/templates", headers=auth_headers)
+    assert templates_response.status_code == 200
+    cbc_template = next(
+        template for template in templates_response.json() if template["code"] == "cbc_oak"
+    )
+
+    detail_response = client.get(
+        f"/api/v1/lab/templates/{cbc_template['id']}", headers=auth_headers
+    )
+    assert detail_response.status_code == 200
+    template_detail = detail_response.json()
+    source_version_id = (
+        template_detail["draft_version_id"]
+        or template_detail["published_version_id"]
+        or template_detail["latest_version_id"]
+    )
+    source = next(
+        version
+        for version in template_detail["versions"]
+        if version["id"] == source_version_id
+    )
+
+    if source["status"] == "DRAFT":
+        assert set(source["available_actions"]) == {"update", "publish"}
+        assert source["can_update"] is True
+        assert source["can_publish"] is True
+        assert source["can_create_draft"] is False
+
+        publish_response = client.post(
+            f"/api/v1/lab/template-versions/{source['id']}/publish",
+            headers=auth_headers,
+        )
+        assert publish_response.status_code == 200
+        published = publish_response.json()
+    else:
+        published = source
+
+    assert published["status"] == "PUBLISHED"
+    assert published["available_actions"] == ["create_draft"]
+    assert published["can_update"] is False
+    assert published["can_publish"] is False
+    assert published["can_create_draft"] is True
+
+    new_draft_response = client.post(
+        f"/api/v1/lab/templates/{cbc_template['id']}/versions",
+        headers=auth_headers,
+        json={"source_version_id": published["id"]},
+    )
+    assert new_draft_response.status_code == 200
+    new_draft = new_draft_response.json()
+    assert new_draft["status"] == "DRAFT"
+    assert set(new_draft["available_actions"]) == {"update", "publish"}
+    assert new_draft["can_update"] is True
+    assert new_draft["can_publish"] is True
+    assert new_draft["can_create_draft"] is False
+
+
+@pytest.mark.integration
 def test_lab_reporting_api_flow(client, auth_headers, db_session, test_patient, test_visit):
     test_patient.sex = "M"
     test_patient.birth_date = date(1990, 1, 1)

--- a/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
@@ -93,6 +93,32 @@ function formatVersionStatus(status) {
   return versionStatusLabels[status] || status;
 }
 
+const TEMPLATE_VERSION_ACTION_CAN_FIELD = {
+  update: 'can_update',
+  publish: 'can_publish',
+  create_draft: 'can_create_draft'
+};
+
+function hasTemplateVersionAction(version, action) {
+  const normalizedAction = String(action || '').trim().toLowerCase();
+  if (!normalizedAction) {
+    return false;
+  }
+
+  if (Array.isArray(version?.available_actions)) {
+    return version.available_actions.some(
+      (availableAction) => String(availableAction || '').trim().toLowerCase() === normalizedAction
+    );
+  }
+
+  const flagName = TEMPLATE_VERSION_ACTION_CAN_FIELD[normalizedAction];
+  if (flagName && Object.prototype.hasOwnProperty.call(version || {}, flagName)) {
+    return Boolean(version[flagName]);
+  }
+
+  return false;
+}
+
 function parseJsonInput(value) {
   if (!value?.trim()) {
     return null;
@@ -266,8 +292,11 @@ export default function LabTemplateWorkbench({
     if (!selectedTemplate) {
       throw new Error('Сначала выберите шаблон');
     }
-    if (activeVersion?.status === 'DRAFT') {
+    if (hasTemplateVersionAction(activeVersion, 'update')) {
       return activeVersion.id;
+    }
+    if (!hasTemplateVersionAction(activeVersion, 'create_draft')) {
+      throw new Error('Сервер не разрешил создать черновик для этой версии шаблона');
     }
     const version = await labReportingApi.createTemplateVersion(selectedTemplate.id, activeVersion?.id || null);
     await onTemplatesChanged(selectedTemplate.id);

--- a/frontend/src/components/laboratory/__tests__/LabTemplateWorkbench.contract.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabTemplateWorkbench.contract.test.jsx
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(process.cwd(), 'src');
+const source = fs.readFileSync(
+  path.join(ROOT, 'components/laboratory/LabTemplateWorkbench.jsx'),
+  'utf8'
+);
+
+function sourceBlock(startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf(endMarker, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe('LabTemplateWorkbench template version command contract', () => {
+  it('uses backend-owned template version actions instead of status for draft creation', () => {
+    const helperBlock = sourceBlock(
+      'function hasTemplateVersionAction(version, action) {',
+      'function parseJsonInput(value) {'
+    );
+    const ensureDraftBlock = sourceBlock(
+      'async function ensureDraftVersion() {',
+      'async function handleSaveTemplate() {'
+    );
+
+    expect(helperBlock).toContain('version?.available_actions');
+    expect(helperBlock).toContain('TEMPLATE_VERSION_ACTION_CAN_FIELD');
+    expect(helperBlock).toContain('return false;');
+    expect(ensureDraftBlock).toContain("hasTemplateVersionAction(activeVersion, 'update')");
+    expect(ensureDraftBlock).toContain("hasTemplateVersionAction(activeVersion, 'create_draft')");
+    expect(ensureDraftBlock).toContain('labReportingApi.createTemplateVersion');
+    expect(ensureDraftBlock).not.toContain("activeVersion?.status === 'DRAFT'");
+  });
+});


### PR DESCRIPTION
## Summary
- Exposes backend-owned lab template version actions on existing LabReportTemplateVersionOut DTOs.
- Stops LabTemplateWorkbench from deciding update-vs-create-draft from activeVersion.status.
- Adds backend and frontend contract proof; no BFF-lite or /api/v1/ui/*.

## Cyclic Execution Evidence
- Fresh main sync: worktree C:\tmp\final-ssot-cycle-main was synced to origin/main at 2dbf0106 after #1390.
- Clean workspace: branch started from detached origin/main; only scoped lab template version files were changed.
- Branch: codex/lab-template-version-actions-ssot.
- Scope gate: agent_gate returned narrow override for LabTemplateWorkbench; backend DTO/service/endpoints were added as explicit union first-touch because frontend-only would preserve the SSOT leak.
- Red-check handling: local targeted checks were run before PR creation; CI red checks will be fixed in this PR if code-related.

## Contract Impact
- Canonical surface: existing /api/v1/lab/templates/{template_id}, /api/v1/lab/templates/{template_id}/versions, /api/v1/lab/template-versions/{version_id}, /publish, and /archive responses.
- Request shape: unchanged.
- Response shape: LabReportTemplateVersionOut now includes available_actions, can_update, can_publish, can_create_draft.
- Status codes: unchanged.
- Frontend consumer: frontend/src/components/laboratory/LabTemplateWorkbench.jsx uses backend available_actions/can_* instead of activeVersion.status for the update/create-draft decision.
- Compatibility path or alias: no alias, no /api/v1/ui/*, no separate BFF service.
- Contract proof: backend/tests/test_lab_reporting_api.py proves published versions expose create_draft and draft versions expose update/publish; frontend contract test proves React no longer branches on activeVersion.status === 'DRAFT'.

## RBAC / Permissions
- Roles allowed: unchanged existing Admin/Lab lab template version routes.
- Roles denied: unchanged existing backend require_roles enforcement.
- Positive auth proof: backend/tests/test_lab_reporting_api.py uses auth_headers against the protected lab template routes.
- Negative auth proof: not expanded in this PR; role policy was not changed.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: LabTemplateWorkbench still errors when no selected template is present; behavior unchanged.
- Partial data proof: hasTemplateVersionAction returns false when backend action fields are missing, so commands fail closed.
- Forbidden secondary path behavior: no fallback to status-based command decisions was kept.
- Missing draft/resource behavior: if backend does not allow create_draft, frontend shows the backend-contract denial error instead of creating a draft from local status logic.
- Stale route/deep-link behavior: not applicable, no route changes.

## Scope Gate
- Allowed paths: backend/app/api/v1/endpoints/lab_reporting.py; backend/app/schemas/lab_reporting.py; backend/app/services/lab_reporting_service.py; backend/tests/test_lab_reporting_api.py; frontend/src/components/laboratory/LabTemplateWorkbench.jsx; frontend/src/components/laboratory/__tests__/LabTemplateWorkbench.contract.test.jsx.
- Denied paths: /api/v1/ui/*, separate BFF service, unrelated Registrar/Queue/Cashier/Doctor/DisplayBoard code, migrations, runtime config.
- Migration/docs/test impact: no migration; OpenAPI shape updated through existing schema; targeted backend/frontend tests added.
- Rollback note: revert this PR to restore prior status-based frontend draft decision and remove additive DTO fields.

## Validation
- Targeted tests or smoke run: pytest backend/tests/test_lab_reporting_api.py -k template_version_actions; pytest backend/tests/test_lab_reporting_api.py; pytest backend/tests/test_openapi_contract.py; npm --prefix frontend run test:run -- LabTemplateWorkbench.contract; npm --prefix frontend run build; git diff --check; git diff --cached --check.
- Result: all passed locally.
- Not checked: full backend suite, full frontend test suite, browser smoke.