### PR TITLE
fix(discounts): require admin for discount benefits

### DIFF
--- a/backend/app/api/v1/endpoints/discount_benefits.py
+++ b/backend/app/api/v1/endpoints/discount_benefits.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user, get_db
+from app.api.deps import get_db, require_roles
 from app.models.discount_benefits import BenefitType, DiscountType
 from app.models.user import User
 from app.services.discount_benefits_api_service import (
@@ -157,7 +157,7 @@ class RedeemPointsRequest(BaseModel):
 async def create_discount(
     discount_data: DiscountCreate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Создать скидку"""
     service = DiscountBenefitsService(db)
@@ -179,7 +179,7 @@ async def get_discounts(
     active_only: bool = Query(True),
     service_ids: Optional[List[int]] = Query(None),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Получить список скидок"""
     discounts = DiscountBenefitsApiService(db).get_discounts(
@@ -215,7 +215,7 @@ async def update_discount(
     discount_id: int,
     discount_data: DiscountUpdate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Обновить скидку"""
     service = DiscountBenefitsApiService(db)
@@ -234,7 +234,7 @@ async def update_discount(
 async def delete_discount(
     discount_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Удалить скидку"""
     service = DiscountBenefitsApiService(db)
@@ -250,7 +250,7 @@ async def delete_discount(
 async def apply_discount(
     request: ApplyDiscountRequest,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Применить скидку"""
     service = DiscountBenefitsService(db)
@@ -285,7 +285,7 @@ async def apply_discount(
 async def create_benefit(
     benefit_data: BenefitCreate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Создать льготу"""
     service = DiscountBenefitsService(db)
@@ -306,7 +306,7 @@ async def create_benefit(
 async def get_benefits(
     active_only: bool = Query(True),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Получить список льгот"""
     benefits = DiscountBenefitsApiService(db).list_benefits(active_only=active_only)
@@ -335,7 +335,7 @@ async def get_benefits(
 async def assign_benefit_to_patient(
     request: PatientBenefitCreate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Назначить льготу пациенту"""
     service = DiscountBenefitsService(db)
@@ -365,7 +365,7 @@ async def verify_patient_benefit(
     patient_benefit_id: int,
     notes: Optional[str] = None,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Верифицировать льготу пациента"""
     service = DiscountBenefitsService(db)
@@ -386,7 +386,7 @@ async def get_patient_benefits(
     patient_id: int,
     active_only: bool = Query(True),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Получить льготы пациента"""
     service = DiscountBenefitsService(db)
@@ -420,7 +420,7 @@ async def get_patient_benefits(
 async def apply_benefit(
     request: ApplyBenefitRequest,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Применить льготу"""
     service = DiscountBenefitsService(db)
@@ -455,7 +455,7 @@ async def apply_benefit(
 async def create_loyalty_program(
     program_data: LoyaltyProgramCreate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Создать программу лояльности"""
     service = DiscountBenefitsService(db)
@@ -476,7 +476,7 @@ async def create_loyalty_program(
 async def get_loyalty_programs(
     active_only: bool = Query(True),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Получить программы лояльности"""
     programs = DiscountBenefitsApiService(db).list_loyalty_programs(
@@ -505,7 +505,7 @@ async def enroll_patient_in_loyalty(
     patient_id: int,
     program_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Записать пациента в программу лояльности"""
     service = DiscountBenefitsService(db)
@@ -524,7 +524,7 @@ async def enroll_patient_in_loyalty(
 async def earn_loyalty_points(
     request: EarnPointsRequest,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Начислить баллы лояльности"""
     service = DiscountBenefitsService(db)
@@ -552,7 +552,7 @@ async def earn_loyalty_points(
 async def redeem_loyalty_points(
     request: RedeemPointsRequest,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Списать баллы лояльности"""
     service = DiscountBenefitsService(db)
@@ -581,7 +581,7 @@ async def get_loyalty_balance(
     patient_id: int,
     program_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Получить баланс баллов пациента"""
     service = DiscountBenefitsService(db)
@@ -597,7 +597,7 @@ async def get_loyalty_balance(
 async def calculate_total_discount(
     request: DiscountCalculationRequest,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Рассчитать общую скидку для пациента"""
     service = DiscountBenefitsService(db)
@@ -621,7 +621,7 @@ async def get_discount_analytics(
     start_date: Optional[datetime] = Query(None),
     end_date: Optional[datetime] = Query(None),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Получить аналитику по скидкам"""
     service = DiscountBenefitsService(db)
@@ -635,7 +635,7 @@ async def get_benefit_analytics(
     start_date: Optional[datetime] = Query(None),
     end_date: Optional[datetime] = Query(None),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Получить аналитику по льготам"""
     service = DiscountBenefitsService(db)
@@ -648,7 +648,7 @@ async def get_benefit_analytics(
 async def get_loyalty_analytics(
     program_id: Optional[int] = Query(None),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Получить аналитику по программе лояльности"""
     service = DiscountBenefitsService(db)

--- a/backend/tests/integration/test_discount_benefits_role_guard.py
+++ b/backend/tests/integration/test_discount_benefits_role_guard.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.discount_benefits import Discount
+
+
+def test_admin_can_list_discount_benefits(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    response = client.get("/api/v1/discount-benefits/discounts", headers=auth_headers)
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+
+def test_patient_cannot_create_discount_benefit_config(
+    client: TestClient,
+    db_session: Session,
+    patient_token: str,
+) -> None:
+    before_count = db_session.query(Discount).count()
+
+    response = client.post(
+        "/api/v1/discount-benefits/discounts",
+        headers={"Authorization": f"Bearer {patient_token}"},
+        json={
+            "name": "patient-created-discount",
+            "discount_type": "percentage",
+            "value": 99,
+            "min_amount": 0,
+        },
+    )
+
+    assert response.status_code == 403
+    assert db_session.query(Discount).count() == before_count
+
+
+def test_patient_cannot_read_discount_benefit_analytics(
+    client: TestClient,
+    patient_token: str,
+) -> None:
+    response = client.get(
+        "/api/v1/discount-benefits/analytics/discounts",
+        headers={"Authorization": f"Bearer {patient_token}"},
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Require Admin role on legacy `/api/v1/discount-benefits/*` financial discount/benefit/loyalty endpoints.
- Preserve Admin finance manager read access while blocking arbitrary authenticated users from creating discount config or reading discount analytics.
- Add integration coverage for positive Admin list access and negative Patient create/analytics access.

## Cyclic Execution Evidence
- Fresh main sync: worktree was detached on fresh `origin/main` at `f16054c3` after PR #1392 merge before branch creation.
- Clean workspace: branch started clean in `C:\tmp\final-owner-audit`; unrelated dirty `C:\final` worktree was not touched.
- Branch: `codex/discount-benefits-role-guard`.
- Scope gate: `agent_gate` returned known-root-cause narrow override for `backend/app/api/v1/endpoints/discount_benefits.py`; targeted test file was added as the narrow second slice for regression proof.
- Red-check handling: no red checks yet; this PR will be fixed in-place if CI reports a failure.

## Contract Impact
- Canonical surface: mounted FastAPI discount-benefits router at `/api/v1/discount-benefits`.
- Request shape: unchanged; no DTO/query/path parameters changed.
- Response shape: unchanged for Admin callers.
- Status codes: non-admin authenticated roles now receive `403` before financial discount/benefit/loyalty read or mutation logic runs.
- Frontend consumer: Admin finance `DiscountBenefitsManager` remains on the same endpoints and is represented by positive Admin list proof.
- Compatibility path or alias: no route alias added or removed.
- Contract proof: `test_discount_benefits_role_guard.py` verifies Admin list access and Patient denial for discount creation and analytics.

## RBAC / Permissions
- Roles allowed: Admin may access discount-benefits configuration, application, loyalty, and analytics endpoints.
- Roles denied: Patient and other non-admin roles are denied by `require_roles` before finance configuration or analytics logic runs.
- Positive auth proof: Admin token can list `/api/v1/discount-benefits/discounts` with 200.
- Negative auth proof: Patient token receives 403 for creating a discount config and for reading discount analytics; test asserts no discount row is created.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel changed; only HTTP route dependencies changed.
- Payload version / ack behavior: no payload version or acknowledgement behavior changed.
- Read/unread or delivery semantics: no read/unread or delivery state changed.
- Reconnect/resync proof: no realtime reconnect/resync path changed; backend regression test covers the affected HTTP access path.

## Frontend Resilience
- Empty data proof: Admin discount list still returns success JSON even when no discounts exist; targeted test covers this path.
- Partial data proof: discount-benefits response serialization remains existing endpoint code; no frontend data-shaping path changed.
- Forbidden secondary path behavior: Patient-token forbidden create/analytics paths are covered by regression test with 403 assertions.
- Missing draft/resource behavior: authorized users still reach existing service behavior; denied users stop at RBAC before resource or analytics lookup.
- Stale route/deep-link behavior: no frontend route or deep-link changed; legacy `/api/v1/discount-benefits/*` paths remain mounted.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/discount_benefits.py`, `backend/tests/integration/test_discount_benefits_role_guard.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read-model endpoints, frontend, migrations, discount-benefits service/repository internals.
- Migration/docs/test impact: no migration or docs; one targeted backend integration test added.
- Rollback note: revert this commit to restore previous auth-only behavior on discount-benefits endpoints.

## Validation
- Targeted tests or smoke run: `scripts/run_backend_pytest.ps1 tests\integration\test_discount_benefits_role_guard.py`.
- Result: 3 passed.
- Not checked: broad backend suite and frontend build were not run because the change is a narrow backend dependency/RBAC guard.