### PR TITLE
fix(pricing): require admin for dynamic pricing

### DIFF
--- a/backend/app/api/v1/endpoints/dynamic_pricing.py
+++ b/backend/app/api/v1/endpoints/dynamic_pricing.py
@@ -187,7 +187,7 @@ def _model_to_dict(model: BaseModel) -> dict[str, Any]:
 def create_pricing_rule(
     rule_data: PricingRuleCreate,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Создать правило ценообразования"""
     service = DynamicPricingApiService(db)
@@ -208,7 +208,7 @@ def get_pricing_rules(
     rule_type: PricingRuleType | None = None,
     is_active: bool | None = None,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Получить список правил ценообразования"""
     return DynamicPricingApiService(db).list_pricing_rules(
@@ -223,7 +223,7 @@ def get_pricing_rules(
 def get_pricing_rule(
     rule_id: int,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Получить правило ценообразования по ID"""
     try:
@@ -237,7 +237,7 @@ def update_pricing_rule(
     rule_id: int,
     rule_data: PricingRuleUpdate,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Обновить правило ценообразования"""
     service = DynamicPricingApiService(db)
@@ -257,7 +257,7 @@ def update_pricing_rule(
 def delete_pricing_rule(
     rule_id: int,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Удалить правило ценообразования"""
     service = DynamicPricingApiService(db)
@@ -274,7 +274,7 @@ def delete_pricing_rule(
 def calculate_price(
     request: PriceCalculationRequest,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Рассчитать цену с учетом правил ценообразования"""
     service = DynamicPricingApiService(db)
@@ -292,7 +292,7 @@ def calculate_price(
 def create_service_package(
     package_data: ServicePackageCreate,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Создать пакет услуг"""
     service = DynamicPricingApiService(db)
@@ -313,7 +313,7 @@ def get_service_packages(
     is_active: bool | None = None,
     patient_id: int | None = None,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Получить список пакетов услуг"""
     return DynamicPricingApiService(db).list_service_packages(
@@ -328,7 +328,7 @@ def get_service_packages(
 def get_service_package(
     package_id: int,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Получить пакет услуг по ID"""
     try:
@@ -342,7 +342,7 @@ def update_service_package(
     package_id: int,
     package_data: ServicePackageUpdate,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Обновить пакет услуг"""
     service = DynamicPricingApiService(db)
@@ -362,7 +362,7 @@ def update_service_package(
 def delete_service_package(
     package_id: int,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Удалить пакет услуг"""
     service = DynamicPricingApiService(db)
@@ -379,7 +379,7 @@ def delete_service_package(
 def purchase_package(
     request: PackagePurchaseRequest,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Купить пакет услуг"""
     service = DynamicPricingApiService(db)
@@ -409,7 +409,7 @@ def purchase_package(
 @router.post("/update-dynamic-prices")
 def update_dynamic_prices(
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Обновить динамические цены"""
     service = DynamicPricingApiService(db)
@@ -424,7 +424,7 @@ def get_pricing_analytics(
     start_date: datetime | None = Query(None),
     end_date: datetime | None = Query(None),
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Получить аналитику по ценообразованию"""
     service = DynamicPricingApiService(db)
@@ -440,7 +440,7 @@ def get_price_history(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.require_roles("Admin")),
 ):
     """Получить историю изменения цен для услуги"""
     return DynamicPricingApiService(db).get_price_history(

--- a/backend/tests/integration/test_dynamic_pricing_api.py
+++ b/backend/tests/integration/test_dynamic_pricing_api.py
@@ -95,3 +95,64 @@ def test_dynamic_pricing_rule_delete_cleans_linked_rows(
     db_session.delete(service)
     db_session.commit()
 
+
+@pytest.mark.integration
+def test_admin_can_list_dynamic_pricing_rules(client, admin_user, admin_password):
+    headers = _login_admin(client, admin_user, admin_password)
+
+    response = client.get("/api/v1/dynamic-pricing/pricing-rules", headers=headers)
+
+    assert response.status_code == 200, response.text
+    assert isinstance(response.json(), list)
+
+
+@pytest.mark.integration
+def test_patient_cannot_create_dynamic_pricing_rule(
+    client,
+    db_session,
+    patient_token,
+):
+    service = Service(
+        code="DP-RBAC-001",
+        service_code="DP-RBAC-001",
+        name="Dynamic Pricing RBAC Service",
+        price=Decimal("10000"),
+        currency="UZS",
+        active=True,
+    )
+    db_session.add(service)
+    db_session.commit()
+    db_session.refresh(service)
+    before_count = db_session.query(PricingRule).count()
+
+    response = client.post(
+        "/api/v1/dynamic-pricing/pricing-rules",
+        json={
+            "name": "Patient Dynamic Pricing Rule",
+            "description": "should be rejected",
+            "rule_type": "dynamic",
+            "discount_type": "percentage",
+            "discount_value": 99,
+            "min_quantity": 1,
+            "priority": 0,
+            "service_ids": [service.id],
+        },
+        headers={"Authorization": f"Bearer {patient_token}"},
+    )
+
+    assert response.status_code == 403
+    assert db_session.query(PricingRule).count() == before_count
+
+    db_session.delete(service)
+    db_session.commit()
+
+
+@pytest.mark.integration
+def test_patient_cannot_read_dynamic_pricing_analytics(client, patient_token):
+    response = client.get(
+        "/api/v1/dynamic-pricing/pricing-analytics",
+        headers={"Authorization": f"Bearer {patient_token}"},
+    )
+
+    assert response.status_code == 403
+


### PR DESCRIPTION
## Summary
- Require Admin role on legacy `/api/v1/dynamic-pricing/*` financial pricing endpoints.
- Preserve Admin finance `DynamicPricingManager` access while blocking arbitrary authenticated users from pricing config, package, purchase, update, analytics, and history routes.
- Extend dynamic-pricing integration coverage for positive Admin list access and negative Patient create/analytics access.

## Cyclic Execution Evidence
- Fresh main sync: worktree was detached on fresh `origin/main` at `03061236` after PR #1394 merge before branch creation.
- Clean workspace: branch started clean in `C:\tmp\final-owner-audit`; unrelated dirty `C:\final` worktree was not touched.
- Branch: `codex/dynamic-pricing-role-guard`.
- Scope gate: `agent_gate` returned known-root-cause narrow override for `backend/app/api/v1/endpoints/dynamic_pricing.py`; existing targeted integration test file was extended as the narrow second slice for regression proof.
- Red-check handling: no red checks yet; this PR will be fixed in-place if CI reports a failure.

## Contract Impact
- Canonical surface: mounted FastAPI dynamic-pricing router at `/api/v1/dynamic-pricing`.
- Request shape: unchanged; no DTO/query/path parameters changed.
- Response shape: unchanged for Admin callers.
- Status codes: non-admin authenticated roles now receive `403` before pricing config, package, purchase, update, analytics, or history logic runs.
- Frontend consumer: Admin finance `DynamicPricingManager` remains on the same endpoints and is represented by positive Admin list proof.
- Compatibility path or alias: no route alias added or removed.
- Contract proof: `test_dynamic_pricing_api.py` verifies Admin list access and Patient denial for pricing rule creation and analytics.

## RBAC / Permissions
- Roles allowed: Admin may access dynamic pricing configuration, package, purchase, update, analytics, and history endpoints.
- Roles denied: Patient and other non-admin roles are denied by `require_roles` before pricing mutation or analytics logic runs.
- Positive auth proof: Admin token can list `/api/v1/dynamic-pricing/pricing-rules` with 200.
- Negative auth proof: Patient token receives 403 for creating a pricing rule and for reading pricing analytics; test asserts no pricing rule row is created.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel changed; only HTTP route dependencies changed.
- Payload version / ack behavior: no payload version or acknowledgement behavior changed.
- Read/unread or delivery semantics: no read/unread or delivery state changed.
- Reconnect/resync proof: no realtime reconnect/resync path changed; backend regression test covers the affected HTTP access path.

## Frontend Resilience
- Empty data proof: Admin pricing rule list still returns a JSON list even when no rules exist; targeted test covers this path.
- Partial data proof: dynamic-pricing response serialization remains existing endpoint code; no frontend data-shaping path changed.
- Forbidden secondary path behavior: Patient-token forbidden create/analytics paths are covered by regression test with 403 assertions.
- Missing draft/resource behavior: authorized users still reach existing service behavior; denied users stop at RBAC before resource or analytics lookup.
- Stale route/deep-link behavior: no frontend route or deep-link changed; legacy `/api/v1/dynamic-pricing/*` paths remain mounted.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/dynamic_pricing.py`, `backend/tests/integration/test_dynamic_pricing_api.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read-model endpoints, frontend, migrations, dynamic-pricing service/repository internals.
- Migration/docs/test impact: no migration or docs; one existing backend integration test file extended.
- Rollback note: revert this commit to restore previous auth-only behavior on dynamic-pricing endpoints.

## Validation
- Targeted tests or smoke run: `scripts/run_backend_pytest.ps1 tests\integration\test_dynamic_pricing_api.py`.
- Result: 4 passed.
- Not checked: broad backend suite and frontend build were not run because the change is a narrow backend dependency/RBAC guard.