### PR TITLE
fix(lab): use report instance contract in pickup view

### DIFF
--- a/frontend/src/pages/PatientPickupView.jsx
+++ b/frontend/src/pages/PatientPickupView.jsx
@@ -5,6 +5,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { api } from '../api';
+import { labReportingApi } from '../api/labReporting';
 import auth from '../stores/auth';
 import logger from '../utils/logger';
 import { openPrintableWindow } from '../utils/printWindow';
@@ -45,9 +46,6 @@ export default function PatientPickupView() {
     return 'Выдача результатов';
   };
 
-  const canPrint = ['registrar', 'receptionist', 'admin'].includes(userRole);
-  const canDownloadPDF = ['registrar', 'receptionist', 'cashier', 'admin'].includes(userRole);
-
   const [patient, setPatient] = useState(null);
   const [labResults, setLabResults] = useState([]);
   const [visits, setVisits] = useState([]);
@@ -68,8 +66,8 @@ export default function PatientPickupView() {
 
       // Load lab results
       try {
-        const labRes = await api.get('/lab', { params: { patient_id: patientId } });
-        setLabResults(labRes.data || []);
+        const labReportInstances = await labReportingApi.listInstances({ patient_id: patientId, limit: 100 });
+        setLabResults(labReportInstances || []);
       } catch {
         setLabResults([]);
       }
@@ -111,8 +109,25 @@ export default function PatientPickupView() {
       ordered: { icon: '⚪', label: 'Заказан', bg: '#f1f5f9', color: '#475569' },
       canceled: { icon: '🔴', label: 'Отменён', bg: '#fee2e2', color: '#991b1b' }
     };
+    const normalizedStatus = String(status || '').toUpperCase();
+    if (['FINALIZED', 'PRINTED'].includes(normalizedStatus)) return config.done;
+    if (['IN_PROGRESS', 'READY'].includes(normalizedStatus)) return config.in_progress;
+    if (normalizedStatus === 'DRAFT') return config.ordered;
     return config[status] || config.ordered;
   };
+
+  const hasLabReportAction = (labResult, action) => {
+    const actions = Array.isArray(labResult?.available_actions) ? labResult.available_actions : [];
+    if (actions.includes(action)) return true;
+    if (action === 'print') return labResult?.can_print === true;
+    return false;
+  };
+
+  const getLabDisplayName = (labResult) =>
+    labResult?.template?.name || labResult?.service_name || labResult?.name || labResult?.test_name || `Lab #${labResult?.id}`;
+
+  const getLabDisplayCode = (labResult) =>
+    labResult?.template?.code || labResult?.service_code || labResult?.test_code || '-';
 
   // Get status badge for visits
   const getVisitStatusBadge = (status) => {
@@ -143,7 +158,7 @@ export default function PatientPickupView() {
     const labHtml = labResults.length
       ? labResults.map((result) => `
         <tr>
-          <td>${result.name || result.test_name || '—'}</td>
+          <td>${getLabDisplayName(result)}</td>
           <td>${result.value || '—'}</td>
           <td>${getStatusBadge(result.status).label}</td>
         </tr>
@@ -211,8 +226,8 @@ export default function PatientPickupView() {
   // Handle download PDF
   const handleDownloadPDF = async (labResult) => {
     try {
-      const response = await api.get(`/lab/${labResult.id}/pdf`, { responseType: 'blob' });
-      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const blob = await labReportingApi.downloadPdf(labResult.id);
+      const url = window.URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
       link.download = `lab_result_${labResult.id}.pdf`;
@@ -475,14 +490,15 @@ export default function PatientPickupView() {
         <div style={styles.labList}>
                             {labResults.map((lab) => {
             const status = getStatusBadge(lab.status);
+            const canPrintLabReport = hasLabReportAction(lab, 'print');
             return (
               <div key={lab.id} style={styles.labItem}>
                                         <div style={styles.labInfo}>
                                             <div style={styles.labName}>
-                                                {lab.service_name || `Анализ #${lab.id}`}
+                                                {getLabDisplayName(lab)}
                                             </div>
                                             <div style={styles.labDate}>
-                                                Код: {lab.service_code || '—'} • Заказ #{lab.id}
+                                                Код: {getLabDisplayCode(lab)} • Заказ #{lab.id}
                                             </div>
                                         </div>
 
@@ -497,30 +513,26 @@ export default function PatientPickupView() {
                                             {status.icon} {status.label}
                                         </div>
 
-                                        {lab.status === 'done' && (canPrint || canDownloadPDF) &&
+                                        {canPrintLabReport &&
                 <div style={styles.actions}>
-                                                {canPrint &&
                   <button
                     type="button"
                     style={styles.actionButton}
                     onClick={() => handlePrint(lab)}
-                    aria-label={`Печать анализа ${lab.service_name || `#${lab.id}`}`}
+                    aria-label={`Печать анализа ${getLabDisplayName(lab)}`}
                     title="Печать">
                     
                                                         🖨️ Печать
                                                     </button>
-                  }
-                                                {canDownloadPDF &&
                   <button
                     type="button"
                     style={styles.actionButton}
                     onClick={() => handleDownloadPDF(lab)}
-                    aria-label={`Скачать PDF анализа ${lab.service_name || `#${lab.id}`}`}
+                    aria-label={`Скачать PDF анализа ${getLabDisplayName(lab)}`}
                     title="Скачать PDF">
                     
                                                         📄 PDF
                                                     </button>
-                  }
                                             </div>
                 }
                                     </div>);


### PR DESCRIPTION
﻿## Summary
- Switches PatientPickupView lab loading from stale `GET /api/v1/lab` to the existing lab report instance read contract.
- Switches PDF download from stale `/lab/{id}/pdf` to `labReportingApi.downloadPdf`, backed by `/api/v1/lab/report-instances/{id}/pdf`.
- Removes frontend-owned `status === 'done'` plus local role gating for lab print/PDF buttons; button visibility now follows backend `available_actions` / `can_print` on report instances.

## Cyclic Execution Evidence
- Fresh main sync: started from detached `origin/main` at `2eb0aeeb` in `C:\tmp\final-ssot-cycle-main`.
- Clean workspace: clean before branch creation; only `frontend/src/pages/PatientPickupView.jsx` changed.
- Branch: `codex/patient-pickup-lab-contract`.
- Scope gate: `agent_gate` returned narrow override with first-touch limited to `frontend/src/pages/PatientPickupView.jsx`.
- Red-check handling: visible GitHub checks are green; this edit fixes PR body gate wording only.

## Contract Impact
- Canonical surface: existing `GET /api/v1/lab/report-instances` and `GET /api/v1/lab/report-instances/{instance_id}/pdf`.
- Request shape: frontend now calls `labReportingApi.listInstances({ patient_id, limit: 100 })` and `labReportingApi.downloadPdf(instanceId)`.
- Response shape: consumes existing report instance `template`, `status`, `available_actions`, and `can_print` fields.
- Status codes: no backend changes; PDF endpoint continues to enforce backend status/role errors.
- Frontend consumer: `PatientPickupView` only.
- Compatibility path or alias: stale `/lab` and `/lab/{id}/pdf` frontend calls removed from this screen.
- Contract proof: source now gates lab print/PDF rendering through `available_actions` / `can_print`, not `status === 'done'` or local role arrays.

## RBAC / Permissions
- Roles allowed: unchanged; backend lab report endpoints remain the source of truth.
- Roles denied: unchanged; no frontend role expansion or backend permission change.
- Positive auth proof: existing backend lab reporting tests cover report instance PDF/read access.
- Negative auth proof: existing backend lab reporting tests include doctor isolation for report reads/PDF.

## Notification / Realtime
- Event type or websocket channel: none; this PR does not create, change, emit, or subscribe to notification events or websocket channels.
- Payload version / ack behavior: none; no realtime payload or acknowledgement contract is touched.
- Read/unread or delivery semantics: none; no notification delivery or unread state is touched.
- Reconnect/resync proof: no reconnect/resync path is involved because this is a REST read/PDF frontend contract change only.

## Frontend Resilience
- Empty data proof: failed lab report load still falls back to an empty lab result list.
- Partial data proof: display helpers preserve legacy `service_name` / `test_name` fallbacks while preferring report instance `template` data.
- Forbidden secondary path behavior: forbidden/stale lab reads no longer route through `/lab` or `/lab/{id}/pdf` in this screen.
- Missing draft/resource behavior: backend `can_print` false or missing hides print/PDF actions.
- Stale route/deep-link behavior: `/clinical/pickup/:patientId` remains unchanged.

## Scope Gate
- Allowed paths: `frontend/src/pages/PatientPickupView.jsx`.
- Denied paths: backend code, `/api/v1/ui/*`, lab service rules, router contracts, QueueJoin, DisplayBoard, RegistrarPanel, unrelated cleanup.
- Migration/docs/test impact: no migration, docs, or backend test changes; gate first-touch did not allow adding test files in this slice.
- Rollback note: revert this commit to restore the previous pickup screen behavior.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; source proof with `rg` confirmed no `api.get('/lab')`, no `/lab/${id}/pdf`, and no `lab.status === 'done'` gate remain in `PatientPickupView`.
- Result: passed locally; GitHub CodeQL/security checks are green.
- Not checked: backend pytest not run because there were no backend changes; no new frontend test file added because `agent_gate` limited first-touch to `frontend/src/pages/PatientPickupView.jsx`.
