### PR TITLE
fix(analytics): require staff roles for extension routes

### DIFF
--- a/backend/app/api/v1/endpoints/advanced_analytics.py
+++ b/backend/app/api/v1/endpoints/advanced_analytics.py
@@ -8,7 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user
+from app.api.deps import require_roles
 from app.db.session import get_db
 from app.services.advanced_analytics import get_advanced_analytics_service
 from app.services.analytics import AnalyticsService
@@ -22,7 +22,7 @@ async def get_kpi_metrics(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить ключевые показатели эффективности (KPI)"""
     try:
@@ -47,7 +47,7 @@ async def get_doctor_performance(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить показатели эффективности врачей"""
     try:
@@ -70,7 +70,7 @@ async def get_advanced_patient_analytics(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить расширенную аналитику пациентов"""
     try:
@@ -94,7 +94,7 @@ async def get_advanced_revenue_analytics(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить расширенную аналитику доходов"""
     try:
@@ -118,7 +118,7 @@ async def get_predictive_analytics(
         30, ge=1, le=365, description="Количество дней для прогноза"
     ),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить предиктивную аналитику и прогнозы"""
     analytics_service = get_advanced_analytics_service()
@@ -134,7 +134,7 @@ async def get_advanced_comprehensive_report(
         True, description="Включить предиктивную аналитику"
     ),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить расширенный комплексный отчет"""
     try:

--- a/backend/app/api/v1/endpoints/analytics_export.py
+++ b/backend/app/api/v1/endpoints/analytics_export.py
@@ -9,7 +9,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user
+from app.api.deps import require_roles
 from app.db.session import get_db
 from app.services.advanced_analytics import (
     AdvancedAnalyticsService,
@@ -29,7 +29,8 @@ ANALYTICS_EXPORT_PUBLIC_ERROR = "Internal server error"
 
 @router.get("/formats")
 async def get_export_formats(
-    db: Session = Depends(get_db), current_user=Depends(get_current_user)
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить список поддерживаемых форматов экспорта"""
     try:
@@ -55,7 +56,7 @@ async def export_kpi_report(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Экспорт отчета KPI в указанном формате"""
     try:
@@ -105,7 +106,7 @@ async def export_comprehensive_report(
         True, description="Включить предиктивную аналитику"
     ),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Экспорт комплексного отчета в указанном формате"""
     try:
@@ -176,7 +177,7 @@ async def export_doctor_performance_report(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Экспорт отчета по эффективности врачей в указанном формате"""
     try:
@@ -224,7 +225,7 @@ async def export_revenue_report(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Экспорт отчета по доходам в указанном формате"""
     try:

--- a/backend/app/api/v1/endpoints/analytics_kpi.py
+++ b/backend/app/api/v1/endpoints/analytics_kpi.py
@@ -8,7 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user
+from app.api.deps import require_roles
 from app.db.session import get_db
 from app.services.advanced_analytics import get_advanced_analytics_service
 from app.services.analytics import AnalyticsService
@@ -171,7 +171,7 @@ async def get_kpi_metrics(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить KPI метрики для аналитики."""
     start, end = _parse_date_range(start_date, end_date)
@@ -246,7 +246,7 @@ async def get_kpi_trends(
     department: Optional[str] = Query(None, description="Отделение"),
     metric: Optional[str] = Query(None, description="Конкретная метрика"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить тренды KPI метрик."""
     start, end = _parse_date_range(start_date, end_date)
@@ -275,7 +275,7 @@ async def get_kpi_comparison(
     department: Optional[str] = Query(None, description="Отделение"),
     comparison_period: str = Query("previous", description="Период сравнения"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить сравнение KPI с предыдущими периодами."""
     start, end = _parse_date_range(start_date, end_date)

--- a/backend/app/api/v1/endpoints/analytics_predictive.py
+++ b/backend/app/api/v1/endpoints/analytics_predictive.py
@@ -9,7 +9,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user
+from app.api.deps import require_roles
 from app.db.session import get_db
 from app.services.advanced_analytics import get_advanced_analytics_service
 from app.services.analytics import AnalyticsService
@@ -379,7 +379,7 @@ async def get_predictive_analytics(
     department: Optional[str] = Query(None, description="Отделение"),
     forecast_days: int = Query(30, description="Дни прогноза"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить предиктивную аналитику и прогнозы."""
     start, end = _parse_date_range(start_date, end_date)
@@ -428,7 +428,7 @@ async def get_prediction_accuracy(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить оценочную точность предыдущих прогнозов."""
     start, end = _parse_date_range(start_date, end_date)
@@ -462,7 +462,7 @@ async def get_scenario_analysis(
         "optimistic", description="Сценарий: optimistic, realistic, pessimistic"
     ),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить анализ сценариев развития."""
     start, end = _parse_date_range(start_date, end_date)
@@ -512,7 +512,7 @@ async def get_predictive_insights(
         "all", description="Тип инсайтов: all, revenue, patients, efficiency"
     ),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить инсайты и паттерны из предиктивной аналитики."""
     start, end = _parse_date_range(start_date, end_date)

--- a/backend/app/api/v1/endpoints/analytics_visualization.py
+++ b/backend/app/api/v1/endpoints/analytics_visualization.py
@@ -8,7 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user
+from app.api.deps import require_roles
 from app.db.session import get_db
 from app.services.advanced_analytics import (
     AdvancedAnalyticsService,
@@ -29,7 +29,7 @@ async def get_dashboard_visualization(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить визуализацию для дашборда"""
     try:
@@ -91,7 +91,7 @@ async def get_kpi_visualization(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить визуализацию KPI метрик"""
     try:
@@ -141,7 +141,7 @@ async def get_doctor_performance_visualization(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить визуализацию эффективности врачей"""
     try:
@@ -191,7 +191,7 @@ async def get_patient_analytics_visualization(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить визуализацию аналитики пациентов"""
     try:
@@ -238,7 +238,7 @@ async def get_revenue_analytics_visualization(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить визуализацию аналитики доходов"""
     try:
@@ -291,7 +291,7 @@ async def get_comprehensive_visualization(
         True, description="Включить предиктивную аналитику"
     ),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить полную визуализацию для комплексного отчета"""
     try:
@@ -355,7 +355,8 @@ async def get_comprehensive_visualization(
 
 @router.get("/chart-types")
 async def get_supported_chart_types(
-    db: Session = Depends(get_db), current_user=Depends(get_current_user)
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
     """Получить список поддерживаемых типов графиков"""
     return {

--- a/backend/tests/integration/test_analytics_contracts.py
+++ b/backend/tests/integration/test_analytics_contracts.py
@@ -134,3 +134,27 @@ def test_predictive_auxiliary_routes_are_alive(
     assert accuracy.status_code == 200, accuracy.text
     assert scenarios.status_code == 200, scenarios.text
     assert insights.status_code == 200, insights.text
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/analytics/kpi-metrics",
+        "/api/v1/analytics/predictive",
+        "/api/v1/analytics/advanced/revenue/advanced",
+        "/api/v1/analytics/export/revenue/export/json",
+        "/api/v1/analytics/visualization/revenue",
+    ],
+)
+def test_patient_cannot_read_staff_analytics_extension_routes(
+    client: TestClient,
+    patient_token: str,
+    path: str,
+) -> None:
+    response = client.get(
+        path,
+        headers=_auth_headers(patient_token),
+        params={"start_date": "2026-03-08", "end_date": "2026-04-07"},
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Require the same staff analytics role guard on mounted analytics extension routers that canonical `/api/v1/analytics/*` routes already use.
- Block arbitrary authenticated Patient users from KPI, predictive, advanced, export, and visualization analytics that expose clinic revenue, patient, doctor, queue, and forecast aggregates.
- Extend analytics contract tests with representative Patient-denial coverage across each affected extension router while preserving Admin positive contract coverage.

## Cyclic Execution Evidence
- Fresh main sync: branch was created from fresh `origin/main` at `699ceae4` after PR #1395 merge.
- Clean workspace: work happened in clean audit worktree `C:\tmp\final-owner-audit`; unrelated dirty `C:\final` worktree was not touched.
- Branch: `codex/analytics-extension-role-guard`.
- Scope gate: `agent_gate` was run twice with known root causes and narrowed to one file each time; narrow override used because the confirmed mounted bug spans sibling analytics extension routers with the same `get_current_user` pattern and the same canonical staff analytics contract.
- Red-check handling: no red checks yet; this PR will be fixed in-place if CI reports a failure.

## Contract Impact
- Canonical surface: mounted FastAPI analytics routers under `/api/v1/analytics`, aligned with existing guarded `backend/app/api/v1/endpoints/analytics.py` staff contract.
- Request shape: unchanged; no DTO/query/path parameters changed.
- Response shape: unchanged for allowed staff callers.
- Status codes: authenticated non-staff roles now receive `403` before KPI, predictive, advanced, export, or visualization analytics logic runs.
- Frontend consumer: existing analytics components continue using the same endpoints; Admin positive contract tests still pass.
- Compatibility path or alias: no route alias added or removed.
- Contract proof: `test_analytics_contracts.py` verifies existing Admin analytics contracts and Patient denial on representative extension routes.

## RBAC / Permissions
- Roles allowed: `admin`, `doctor`, and `nurse`, matching the existing canonical analytics route guard.
- Roles denied: Patient and other non-staff roles are denied by `require_roles` before analytics calculations/export/rendering logic runs.
- Positive auth proof: Admin token still receives 200 on legacy analytics contracts and predictive auxiliary routes.
- Negative auth proof: Patient token receives 403 for KPI, predictive, advanced revenue, export revenue, and visualization revenue routes.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel changed; only HTTP route dependencies changed.
- Payload version / ack behavior: no payload version or acknowledgement behavior changed.
- Read/unread or delivery semantics: no read/unread or delivery state changed.
- Reconnect/resync proof: no realtime reconnect/resync path changed; backend regression test covers the affected HTTP access path.

## Frontend Resilience
- Empty data proof: existing Admin analytics contract tests still pass against the seeded/empty-safe analytics fixture behavior.
- Partial data proof: analytics response construction remains existing endpoint/service code; no frontend data-shaping path changed.
- Forbidden secondary path behavior: Patient-token forbidden paths are covered by regression test with 403 assertions.
- Missing draft/resource behavior: authorized users still reach existing analytics services; denied users stop at RBAC before analytics lookup/export.
- Stale route/deep-link behavior: no frontend route or deep-link changed; mounted `/api/v1/analytics/*` paths remain available for allowed roles.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/analytics_kpi.py`, `backend/app/api/v1/endpoints/analytics_predictive.py`, `backend/app/api/v1/endpoints/advanced_analytics.py`, `backend/app/api/v1/endpoints/analytics_export.py`, `backend/app/api/v1/endpoints/analytics_visualization.py`, `backend/tests/integration/test_analytics_contracts.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read-model endpoints, frontend, migrations, analytics service internals, schemas, route aliases.
- Migration/docs/test impact: no migration or docs; one existing backend integration test file extended.
- Rollback note: revert this commit to restore previous auth-only behavior on analytics extension endpoints.

## Validation
- Targeted tests or smoke run: `py_compile` touched files; `scripts/run_backend_pytest.ps1 tests\integration\test_analytics_contracts.py`; `git diff --cached --check`.
- Result: `py_compile` passed; analytics contract tests `12 passed`; diff check passed.
- Not checked: broad backend suite and frontend build were not run because the change is a narrow backend dependency/RBAC guard.