### PR TITLE
fix(analytics): require admin for export surfaces

### DIFF
--- a/backend/app/api/v1/endpoints/analytics_export.py
+++ b/backend/app/api/v1/endpoints/analytics_export.py
@@ -9,17 +9,11 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user
+from app.api.deps import require_roles
 from app.db.session import get_db
-from app.services.advanced_analytics import (
-    AdvancedAnalyticsService,
-    get_advanced_analytics_service,
-)
+from app.services.advanced_analytics import get_advanced_analytics_service
 from app.services.analytics import AnalyticsService
-from app.services.analytics_export_service import (
-    AnalyticsExportService,
-    get_analytics_export_service,
-)
+from app.services.analytics_export_service import get_analytics_export_service
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -29,7 +23,7 @@ ANALYTICS_EXPORT_PUBLIC_ERROR = "Internal server error"
 
 @router.get("/formats")
 async def get_export_formats(
-    db: Session = Depends(get_db), current_user=Depends(get_current_user)
+    db: Session = Depends(get_db), current_user=Depends(require_roles("Admin"))
 ):
     """Получить список поддерживаемых форматов экспорта"""
     try:
@@ -55,7 +49,7 @@ async def export_kpi_report(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles("Admin")),
 ):
     """Экспорт отчета KPI в указанном формате"""
     try:
@@ -105,7 +99,7 @@ async def export_comprehensive_report(
         True, description="Включить предиктивную аналитику"
     ),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles("Admin")),
 ):
     """Экспорт комплексного отчета в указанном формате"""
     try:
@@ -176,7 +170,7 @@ async def export_doctor_performance_report(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles("Admin")),
 ):
     """Экспорт отчета по эффективности врачей в указанном формате"""
     try:
@@ -224,7 +218,7 @@ async def export_revenue_report(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_roles("Admin")),
 ):
     """Экспорт отчета по доходам в указанном формате"""
     try:

--- a/backend/tests/integration/test_analytics_contracts.py
+++ b/backend/tests/integration/test_analytics_contracts.py
@@ -134,3 +134,42 @@ def test_predictive_auxiliary_routes_are_alive(
     assert accuracy.status_code == 200, accuracy.text
     assert scenarios.status_code == 200, scenarios.text
     assert insights.status_code == 200, insights.text
+
+
+def test_admin_can_read_analytics_export_formats(
+    client: TestClient,
+    admin_token: str,
+) -> None:
+    response = client.get(
+        "/api/v1/analytics/export/formats",
+        headers=_auth_headers(admin_token),
+    )
+
+    assert response.status_code == 200, response.text
+    payload: dict[str, Any] = response.json()
+    assert "formats" in payload
+    assert "count" in payload
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/analytics/export/formats",
+        "/api/v1/analytics/export/comprehensive/export/json",
+        "/api/v1/analytics/export/revenue/export/json",
+        "/api/v1/analytics/export/doctors/performance/export/json",
+        "/api/v1/analytics/export/kpi/export/json",
+    ],
+)
+def test_patient_cannot_read_analytics_export_surfaces(
+    client: TestClient,
+    patient_token: str,
+    path: str,
+) -> None:
+    response = client.get(
+        path,
+        headers=_auth_headers(patient_token),
+        params={"start_date": "2026-03-08", "end_date": "2026-04-07"},
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Require Admin role for analytics export read/export surfaces that expose clinic KPI, revenue, doctor-performance, and comprehensive analytics data.
- Keep export response shapes unchanged and leave health endpoint public.
- Add backend regression coverage for Admin allow + Patient deny.

## Cyclic Execution Evidence
- Fresh main sync: safe worktree `C:\tmp\final-ssot-cycle-main` at `origin/main` `699ceae4` before branch creation.
- Clean workspace: branch started from clean detached main worktree.
- Branch: `codex/analytics-export-rbac-guard`.
- Scope gate: `agent_gate` first returned endpoint-only first-touch; second gate could not resolve files, so this PR uses a narrow override limited to `analytics_export.py` and the existing analytics contract test.
- Red-check handling: will fix this PR if CI reports a code-related failure.

## Contract Impact
- Canonical surface: `GET /api/v1/analytics/export/*`.
- Request shape: unchanged.
- Response shape: unchanged for authorized Admin users.
- Status codes: non-Admin authenticated users now receive `403` for export formats and export data endpoints.
- Frontend consumer: Admin analytics route only; no frontend runtime code changed.
- Compatibility path or alias: none added.
- Contract proof: `test_analytics_contracts.py` verifies Admin formats access and Patient denial for all analytics export surfaces.

## RBAC / Permissions
- Roles allowed: `Admin`.
- Roles denied: `Patient` and any non-Admin role through `require_roles(Admin)`.
- Positive auth proof: `test_admin_can_read_analytics_export_formats`.
- Negative auth proof: `test_patient_cannot_read_analytics_export_surfaces`.

## Notification / Realtime
- Event type or websocket channel: none; this PR touches only synchronous HTTP analytics export endpoints.
- Payload version / ack behavior: none; no notification payloads, websocket messages, or ack contracts are changed.
- Read/unread or delivery semantics: none; no notification records, unread counters, or delivery state are touched.
- Reconnect/resync proof: not needed for this backend-only RBAC patch because no realtime channel or cache resync path is involved.

## Frontend Resilience
- Empty data proof: authorized Admin export responses are unchanged; unauthorized non-Admin paths now stop at backend `403` before any export body is produced.
- Partial data proof: no frontend code or DTO fields changed; Admin consumers receive the same export payloads as before.
- Forbidden secondary path behavior: direct non-Admin calls to analytics export endpoints now return `403`.
- Missing draft/resource behavior: not touched; analytics export has no draft/resource lifecycle in this PR.
- Stale route/deep-link behavior: not touched; `/admin/analytics` routing remains Admin-scoped and no route aliases are changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/analytics_export.py`, `backend/tests/integration/test_analytics_contracts.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF/read-model code, migrations, unrelated analytics services.
- Migration/docs/test impact: no migration; focused backend integration test updated.
- Rollback note: revert this commit to restore previous authenticated-user export access.

## Validation
- Targeted tests or smoke run: `C:\Users\DrSapaev\AppData\Local\Programs\Python\Python311\python.exe -m pytest backend/tests/integration/test_analytics_contracts.py`.
- Result: 13 passed.
- Not checked: full backend suite and frontend build, because no frontend/runtime DTO shape changed.
- Hygiene: `git diff --check` passed.