### PR TITLE
fix(users): require admin for user list

### DIFF
--- a/backend/app/api/v1/endpoints/user_management.py
+++ b/backend/app/api/v1/endpoints/user_management.py
@@ -300,7 +300,7 @@ async def get_users(
     is_active: Optional[bool] = Query(None),
     search: Optional[str] = Query(None, min_length=1, max_length=100),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """Получить список пользователей"""
     try:

--- a/backend/tests/integration/test_admin_user_reserved_email.py
+++ b/backend/tests/integration/test_admin_user_reserved_email.py
@@ -31,3 +31,19 @@ def test_admin_user_create_accepts_reserved_test_domain(
     )
     assert saved_user is not None
     assert saved_user.email == "qa_admin_api@test.local"
+
+
+def test_admin_can_list_users(client, auth_headers):
+    response = client.get("/api/v1/users/users", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    assert "users" in response.json()
+
+
+def test_patient_cannot_list_users(client, patient_token):
+    response = client.get(
+        "/api/v1/users/users",
+        headers={"Authorization": f"Bearer {patient_token}"},
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Require Admin role on `GET /api/v1/users/users`, the user-management list endpoint.
- Preserve current-user preferences and Admin user creation behavior while blocking arbitrary authenticated users from enumerating user profiles, emails, preferences, and notification settings.
- Add regression coverage for Admin list access and Patient denial.

## Cyclic Execution Evidence
- Fresh main sync: branch was created from fresh `origin/main` at `e6e9ab9e` after PR #1397 merge.
- Clean workspace: branch started clean in `C:\tmp\final-owner-audit`; unrelated dirty `C:\final` worktree was not touched.
- Branch: `codex/user-list-admin-guard`.
- Scope gate: `agent_gate` returned a known-root-cause narrow override but misrouted into notification files; narrow override used for only `user_management.py` plus targeted existing integration test file.
- Red-check handling: no red checks yet; this PR will be fixed in-place if CI reports a failure.

## Contract Impact
- Canonical surface: mounted FastAPI user-management router at `/api/v1/users`, specifically `GET /users` under that prefix.
- Request shape: unchanged; no DTO/query/path parameters changed.
- Response shape: unchanged for Admin callers.
- Status codes: authenticated non-admin roles now receive `403` before user directory lookup runs.
- Frontend consumer: Admin user-management flow continues using `/users/users`; positive Admin list proof is included.
- Compatibility path or alias: no route alias added or removed.
- Contract proof: `test_admin_user_reserved_email.py` verifies Admin can list users and Patient cannot list users.

## RBAC / Permissions
- Roles allowed: Admin may list users.
- Roles denied: Patient and other non-admin roles are denied by `require_roles` before profile/preference/notification data is loaded.
- Positive auth proof: Admin token receives 200 from `/api/v1/users/users`.
- Negative auth proof: Patient token receives 403 from `/api/v1/users/users`.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel changed; only one HTTP route dependency changed.
- Payload version / ack behavior: no payload version or acknowledgement behavior changed.
- Read/unread or delivery semantics: no read/unread or delivery state changed.
- Reconnect/resync proof: no realtime reconnect/resync path changed; backend regression test covers the affected HTTP access path.

## Frontend Resilience
- Empty data proof: Admin list endpoint still returns a response with `users`; targeted test covers response envelope availability.
- Partial data proof: user list response serialization remains existing endpoint/service code; no frontend data-shaping path changed.
- Forbidden secondary path behavior: Patient-token forbidden path is covered by regression test with 403 assertion.
- Missing draft/resource behavior: authorized users still reach existing user-management service; denied users stop at RBAC before list lookup.
- Stale route/deep-link behavior: no frontend route or deep-link changed; `/api/v1/users/users` remains mounted for Admin.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/user_management.py`, `backend/tests/integration/test_admin_user_reserved_email.py`.
- Denied paths: notification services/schemas/models, `/api/v1/ui/*`, BFF-lite/read-model endpoints, frontend, migrations, user-management service internals.
- Migration/docs/test impact: no migration or docs; one existing backend integration test file extended.
- Rollback note: revert this commit to restore previous auth-only user list behavior.

## Validation
- Targeted tests or smoke run: `py_compile` touched files; `scripts/run_backend_pytest.ps1 tests\integration\test_admin_user_reserved_email.py`; `git diff --cached --check`.
- Result: `py_compile` passed; targeted test `3 passed`; diff check passed.
- Not checked: broad backend suite and frontend build were not run because the change is a narrow backend dependency/RBAC guard.