### PR TITLE
fix(cashier): require backend direct payment action

### DIFF
--- a/frontend/src/pages/CashierPanel.jsx
+++ b/frontend/src/pages/CashierPanel.jsx
@@ -278,11 +278,7 @@ const isBackendGroupedCashierPayment = (appointment) =>
   appointment?.can_create_grouped_payment === true;
 
 const canCreateDirectCashierPayment = (appointment) => {
-  if (Object.prototype.hasOwnProperty.call(appointment || {}, 'can_create_direct_payment')) {
-    return appointment.can_create_direct_payment === true;
-  }
-
-  return resolveSingleCashierVisitId(appointment) !== null;
+  return appointment?.can_create_direct_payment === true;
 };
 
 const canCreateCashierPayment = (appointment) =>

--- a/frontend/src/pages/__tests__/CashierPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/CashierPanel.contract.test.jsx
@@ -101,4 +101,18 @@ describe('CashierPanel payment action contract', () => {
     expect(paymentWidgetBlock).toContain('canCreateDirectCashierPayment(paymentWidget.selectedItem)');
     expect(paymentWidgetBlock).not.toContain('can_create_grouped_payment');
   });
+
+  it('does not infer direct cashier payment availability from visit ids', () => {
+    const source = readCashierPanelSource();
+    const helperBlock = extractSourceBlock(
+      source,
+      'const canCreateDirectCashierPayment = (appointment) => {',
+      'const canCreateCashierPayment = (appointment) =>',
+    );
+
+    expect(helperBlock).toContain('appointment?.can_create_direct_payment === true');
+    expect(helperBlock).not.toContain('resolveSingleCashierVisitId');
+    expect(helperBlock).not.toContain('visit_id');
+    expect(helperBlock).not.toContain('visit_ids');
+  });
 });


### PR DESCRIPTION
## Summary
- Require backend-owned can_create_direct_payment before CashierPanel enables direct/online payment creation.
- Keep visit_id as payload data only after backend allows direct payment.
- Add a contract proof that direct payment availability is not inferred from visit ids.

## Cyclic Execution Evidence
- Fresh main sync: origin/main at e6e9ab9e before branch creation.
- Clean workspace: branch created from origin/main in C:\tmp\final-ssot-cycle-main.
- Branch: codex/cashier-payment-create-contract.
- Scope gate: gate_known_root_cause ran for CashierPanel; second pass missed the test proof file, so narrow_override was used only for CashierPanel.contract.test.jsx.
- Red-check handling: not applicable - PR checks have not run yet.

## Contract Impact
- Canonical surface: GET /api/v1/cashier/pending-payments already emits can_create_direct_payment and can_create_grouped_payment.
- Request shape: unchanged - no request DTO changed.
- Response shape: unchanged - no backend response DTO changed.
- Status codes: unchanged - no backend status handling changed.
- Frontend consumer: CashierPanel direct payment controls now fail closed unless can_create_direct_payment is true.
- Compatibility path or alias: removed frontend legacy inference from single visit_id for command availability.
- Contract proof: CashierPanel.contract asserts direct payment availability is not inferred from visit_id or visit_ids.

## RBAC / Permissions
- Roles allowed: unchanged - existing cashier/payment route permissions remain backend-owned.
- Roles denied: unchanged - no backend role policy changed.
- Positive auth proof: not applicable - frontend-only action gating change.
- Negative auth proof: not applicable - no backend authorization surface changed.

## Notification / Realtime
- Event type or websocket channel: not applicable - no event or websocket surface changed.
- Payload version / ack behavior: not applicable - no realtime payload behavior changed.
- Read/unread or delivery semantics: not applicable - no delivery state behavior changed.
- Reconnect/resync proof: not applicable - no reconnect or resync behavior changed.

## Frontend Resilience
- Empty data proof: canCreateDirectCashierPayment now returns false for null or missing backend flag.
- Partial data proof: rows with visit_id but missing can_create_direct_payment no longer enable direct payment.
- Forbidden secondary path behavior: grouped rows still use backend grouped payment contract and do not route through online widget.
- Missing draft/resource behavior: not applicable - no draft or resource loading behavior changed.
- Stale route/deep-link behavior: unchanged - no route or deep-link behavior changed.

## Scope Gate
- Allowed paths: frontend/src/pages/CashierPanel.jsx; frontend/src/pages/__tests__/CashierPanel.contract.test.jsx.
- Denied paths: backend runtime, /api/v1/ui/*, BFF service, command wrappers, unrelated cleanup.
- Migration/docs/test impact: frontend contract test updated; no migration or docs change.
- Rollback note: revert this commit to restore legacy visit_id inference if needed.

## Validation
- Targeted tests or smoke run: npm.cmd --prefix frontend run test:run -- CashierPanel.contract; npm.cmd --prefix frontend run build; git diff --check.
- Result: all passed locally.
- Not checked: backend pytest not run because no backend code or API contract changed.