### PR TITLE
fix(mcp): require admin for management telemetry

### DIFF
--- a/backend/app/api/v1/endpoints/mcp.py
+++ b/backend/app/api/v1/endpoints/mcp.py
@@ -10,7 +10,7 @@ from typing import Any, NoReturn
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel
 
-from ....api.deps import get_current_user
+from ....api.deps import get_current_user, require_roles
 from ....models.user import User
 from ....services.mcp import get_mcp_manager
 
@@ -41,7 +41,7 @@ def raise_mcp_internal_error(action: str, exc: Exception) -> NoReturn:
 
 @router.get("/status")
 async def get_mcp_status(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ) -> dict[str, Any]:
     """Получить статус MCP системы"""
     try:
@@ -57,7 +57,7 @@ async def get_mcp_status(
 
 @router.get("/health")
 async def mcp_health_check(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ) -> dict[str, Any]:
     """Проверка здоровья MCP серверов"""
     try:
@@ -73,7 +73,7 @@ async def mcp_health_check(
 
 @router.get("/metrics")
 async def get_mcp_metrics(
-    server: str | None = None, current_user: User = Depends(get_current_user)
+    server: str | None = None, current_user: User = Depends(require_roles("Admin"))
 ) -> dict[str, Any]:
     """Получить метрики MCP"""
     try:
@@ -87,7 +87,7 @@ async def get_mcp_metrics(
 
 @router.get("/circuit-breaker")
 async def get_circuit_breaker_status(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles("Admin")),
 ) -> dict[str, Any]:
     """Получить статус circuit breaker для всех серверов"""
     try:
@@ -646,7 +646,7 @@ async def mcp_batch_process(
 
 @router.get("/capabilities")
 async def mcp_get_capabilities(
-    server: str | None = None, current_user: User = Depends(get_current_user)
+    server: str | None = None, current_user: User = Depends(require_roles("Admin"))
 ) -> dict[str, Any]:
     """Получить возможности MCP серверов"""
     try:

--- a/backend/tests/integration/test_mcp_management_rbac.py
+++ b/backend/tests/integration/test_mcp_management_rbac.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+
+class _FakeMCPClient:
+    async def health_check(self) -> dict[str, str]:
+        return {"overall": "healthy"}
+
+    async def get_server_capabilities(self, server: str | None = None) -> dict[str, object]:
+        return {"server": server, "capabilities": ["status"]}
+
+
+class _FakeMCPManager:
+    CIRCUIT_BREAKER_THRESHOLD = 5
+    CIRCUIT_BREAKER_COOLDOWN = 30
+
+    def __init__(self) -> None:
+        self.client = _FakeMCPClient()
+
+    def is_healthy(self) -> bool:
+        return True
+
+    def get_metrics(self) -> dict[str, int]:
+        return {"requests": 1}
+
+    def get_server_metrics(self, server: str) -> dict[str, object]:
+        return {"server": server, "requests": 1}
+
+    def get_circuit_breaker_status(self) -> dict[str, str]:
+        return {"complaint": "closed"}
+
+    async def get_capabilities(self) -> dict[str, list[str]]:
+        return {"servers": ["complaint"]}
+
+
+async def _fake_get_mcp_manager() -> _FakeMCPManager:
+    return _FakeMCPManager()
+
+
+def test_mcp_management_status_allows_admin(client, auth_headers, monkeypatch):
+    from app.api.v1.endpoints import mcp
+
+    monkeypatch.setattr(mcp, "get_mcp_manager", _fake_get_mcp_manager)
+
+    response = client.get("/api/v1/mcp/status", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["healthy"] is True
+    assert payload["metrics"] == {"requests": 1}
+    assert payload["capabilities"] == {"servers": ["complaint"]}
+
+
+def test_patient_cannot_read_mcp_management_telemetry(client, patient_token):
+    patient_headers = {"Authorization": f"Bearer {patient_token}"}
+
+    for path in (
+        "/api/v1/mcp/status",
+        "/api/v1/mcp/health",
+        "/api/v1/mcp/metrics",
+        "/api/v1/mcp/circuit-breaker",
+        "/api/v1/mcp/capabilities",
+    ):
+        response = client.get(path, headers=patient_headers)
+
+        assert response.status_code == 403, path


### PR DESCRIPTION
## Summary
- Require Admin role for MCP management telemetry endpoints: status, health, metrics, circuit-breaker, and capabilities.
- Leave clinical MCP endpoints unchanged in this PR.
- Add targeted RBAC tests proving Admin access and Patient denial.

## Cyclic Execution Evidence
- Fresh main sync: branch created from origin/main at b40252db after PR #1399 merge.
- Clean workspace: branch started clean in C:\tmp\final-ssot-cycle-main.
- Branch: codex/mcp-management-admin-guard.
- Scope gate: gate_known_root_cause selected backend/app/api/v1/endpoints/mcp.py; test proof file was added under narrow_override after the gate omitted validation coverage.
- Red-check handling: not applicable - PR checks have not run yet.

## Contract Impact
- Canonical surface: GET /api/v1/mcp/status, /health, /metrics, /circuit-breaker, /capabilities.
- Request shape: unchanged - no request DTO changed.
- Response shape: unchanged for Admin callers.
- Status codes: authenticated non-admin roles now receive 403 before MCP telemetry is loaded.
- Frontend consumer: MCP client receives 403 for non-admin management telemetry; clinical MCP usage remains unchanged.
- Compatibility path or alias: no route alias added or removed.
- Contract proof: test_mcp_management_rbac.py covers Admin /mcp/status access and Patient denial for the management telemetry endpoints.

## RBAC / Permissions
- Roles allowed: Admin for MCP management telemetry.
- Roles denied: Patient and other non-admin roles are denied by require_roles before telemetry/capability lookup.
- Positive auth proof: Admin token receives 200 from /api/v1/mcp/status with a monkeypatched MCP manager.
- Negative auth proof: Patient token receives 403 from /api/v1/mcp/status, /health, /metrics, /circuit-breaker, and /capabilities.

## Notification / Realtime
- Event type or websocket channel: not applicable - no event or websocket surface changed.
- Payload version / ack behavior: not applicable - no realtime payload behavior changed.
- Read/unread or delivery semantics: not applicable - no delivery state behavior changed.
- Reconnect/resync proof: not applicable - no reconnect or resync behavior changed.

## Frontend Resilience
- Empty data proof: not applicable - this PR changes backend authorization before telemetry payload creation.
- Partial data proof: not applicable - response payload shape is unchanged for Admin callers.
- Forbidden secondary path behavior: Patient-token forbidden path is covered for all affected MCP management endpoints.
- Missing draft/resource behavior: not applicable - no draft or resource loading behavior changed.
- Stale route/deep-link behavior: unchanged - all MCP management route paths remain mounted.

## Scope Gate
- Allowed paths: backend/app/api/v1/endpoints/mcp.py; backend/tests/integration/test_mcp_management_rbac.py.
- Denied paths: clinical MCP endpoint behavior, frontend MCP client, /api/v1/ui/*, BFF-lite/read-model endpoints, migrations, unrelated AI routes.
- Migration/docs/test impact: no migration or docs; one backend integration test file added.
- Rollback note: revert this commit to restore previous auth-only MCP telemetry access.

## Validation
- Targeted tests or smoke run: scripts/run_backend_pytest.ps1 tests\\integration\\test_mcp_management_rbac.py; python -m py_compile backend/app/api/v1/endpoints/mcp.py backend/tests/integration/test_mcp_management_rbac.py; git diff --check.
- Result: targeted pytest 2 passed; py_compile passed; diff check passed.
- Not checked: broad backend suite and frontend build were not run because the change is a narrow backend RBAC guard.