### PR TITLE
fix(search): restrict global search to staff

### DIFF
--- a/backend/app/api/v1/endpoints/global_search.py
+++ b/backend/app/api/v1/endpoints/global_search.py
@@ -11,12 +11,28 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user, get_db
+from app.api.deps import get_db, require_roles
 from app.models.user import User
 from app.services.global_search_api_service import GlobalSearchApiService
 
 
 router = APIRouter(tags=["search"])
+
+GLOBAL_SEARCH_ROLES = (
+    "Admin",
+    "Registrar",
+    "Doctor",
+    "Cashier",
+    "Lab",
+    "Laboratory",
+    "cardio",
+    "cardiology",
+    "Cardiologist",
+    "derma",
+    "Dermatologist",
+    "dentist",
+    "Dentist",
+)
 
 
 # ============== Response Schemas ==============
@@ -70,7 +86,7 @@ async def global_search(
     q: str = Query(..., min_length=2, max_length=100, description="Search query"),
     limit: int = Query(default=5, ge=1, le=20, description="Max results per domain"),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles(*GLOBAL_SEARCH_ROLES)),
 ):
     """
     Global search across patients, visits, and lab results.
@@ -115,7 +131,7 @@ class LogClickRequest(BaseModel):
 async def log_search_click(
     request: LogClickRequest,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles(*GLOBAL_SEARCH_ROLES)),
 ):
     """
     Log when user clicks on a search result.

--- a/backend/tests/integration/test_global_search_role_guard.py
+++ b/backend/tests/integration/test_global_search_role_guard.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.patient import Patient
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_registrar_can_search_patient_directory(
+    client: TestClient,
+    db_session: Session,
+    registrar_token: str,
+) -> None:
+    patient = Patient(
+        first_name="Searchable",
+        last_name="Patient",
+        phone="+998901110000",
+        birth_date=date(1991, 2, 3),
+    )
+    db_session.add(patient)
+    db_session.commit()
+
+    response = client.get(
+        "/api/v1/global-search",
+        headers=_auth_headers(registrar_token),
+        params={"q": "Searchable", "limit": 5},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["total"] >= 1
+    assert any(result["id"] == patient.id for result in payload["patients"])
+
+
+def test_patient_cannot_search_global_patient_directory(
+    client: TestClient,
+    patient_token: str,
+) -> None:
+    response = client.get(
+        "/api/v1/global-search",
+        headers=_auth_headers(patient_token),
+        params={"q": "Patient", "limit": 5},
+    )
+
+    assert response.status_code == 403
+
+
+def test_patient_cannot_log_global_search_clicks(
+    client: TestClient,
+    patient_token: str,
+) -> None:
+    response = client.post(
+        "/api/v1/global-search/log-click",
+        headers=_auth_headers(patient_token),
+        json={"opened_type": "patient", "opened_id": 1, "query": "Patient"},
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Restrict mounted `/api/v1/global-search` and `/api/v1/global-search/log-click` from auth-only access to clinic staff roles.
- Add regression coverage proving Registrar can search while Patient is denied.

## Cyclic Execution Evidence
- Fresh main sync: started from `origin/main` at `b40252db` after PR #1399 was merged and local audit worktree was clean/detached.
- Clean workspace: inspected before editing; only `backend/app/api/v1/endpoints/global_search.py` and `backend/tests/integration/test_global_search_role_guard.py` are touched.
- Branch: `codex/global-search-role-guard`
- Scope gate: `agent_gate` run with known root cause `backend/app/api/v1/endpoints/global_search.py`; narrow override used for endpoint slice plus targeted regression test only.
- Red-check handling: if CI is red, this same PR will be fixed before any next cycle.

## Contract Impact
- Canonical surface: mounted legacy runtime endpoint `/api/v1/global-search` and click audit endpoint `/api/v1/global-search/log-click`.
- Request shape: unchanged; `q`, `limit`, and log-click JSON body are unchanged.
- Response shape: unchanged for allowed staff roles.
- Status codes: Patient now receives `403` instead of search results / click-log `200`.
- Frontend consumer: existing `GlobalSearchBar` staff header search; no frontend code changed.
- Compatibility path or alias: existing `/api/v1/global-search*` paths preserved.
- Contract proof: targeted integration test covers Registrar positive search and Patient denial.

## RBAC / Permissions
- Roles allowed: Admin, Registrar/Receptionist alias, Doctor, Cashier, Lab/Laboratory, cardio/cardiology/Cardiologist, derma/Dermatologist, dentist/Dentist.
- Roles denied: Patient and any other authenticated role not in the staff tuple.
- Positive auth proof: `test_registrar_can_search_patient_directory` returns `200` and includes the seeded patient.
- Negative auth proof: `test_patient_cannot_search_global_patient_directory` and `test_patient_cannot_log_global_search_clicks` return `403`.

## Notification / Realtime
- Event type or websocket channel: none; this PR changes only synchronous HTTP search endpoints.
- Payload version / ack behavior: unchanged; no event payload or acknowledgement contract exists for these endpoints.
- Read/unread or delivery semantics: unchanged; global search does not create notification delivery state.
- Reconnect/resync proof: no reconnect path exists because the changed surface is stateless request/response HTTP, not websocket or realtime subscription behavior.

## Frontend Resilience
- Empty data proof: not changed; existing empty-result behavior remains service-owned.
- Partial data proof: not changed; response model unchanged.
- Forbidden secondary path behavior: Patient now receives backend `403`; frontend already catches search errors and clears results.
- Missing draft/resource behavior: no draft or resource-loading path is touched; search still returns the same grouped response for allowed staff and only blocks unauthorized callers before lookup.
- Stale route/deep-link behavior: no route or deep-link behavior is touched; existing `/api/v1/global-search*` paths and frontend navigation targets are preserved for allowed staff.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/global_search.py`, `backend/tests/integration/test_global_search_role_guard.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite, separate BFF service, migrations, models, repositories, services.
- Migration/docs/test impact: no migration/docs; one targeted backend integration test added.
- Rollback note: revert this PR to return global search to auth-only access if an emergency rollback is required.

## Validation
- Targeted tests or smoke run: `py_compile` touched files; `scripts/run_backend_pytest.ps1 tests\integration\test_global_search_role_guard.py`; `git diff --cached --check`.
- Result: local validation passed; pytest `3 passed, 1 warning`.
- Not checked: broad backend suite, frontend build, browser smoke.