### PR TITLE
fix(reports): restore admin report API contract

### DIFF
--- a/backend/app/api/v1/endpoints/reports.py
+++ b/backend/app/api/v1/endpoints/reports.py
@@ -4,9 +4,11 @@ API endpoints для системы отчетов
 
 import logging
 from datetime import date, datetime, timedelta
+from pathlib import Path
 from typing import Any, Dict, List, NoReturn, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -244,6 +246,98 @@ async def generate_financial_report(
         )
 
 
+@router.post("/queue", response_model=ReportResponse)
+async def generate_queue_report(
+    request: QueueReportRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _: None = Depends(require_roles([Roles.ADMIN, Roles.REGISTRAR, Roles.MANAGER])),
+):
+    """Generate a queue report."""
+    try:
+        reporting_service = get_reporting_service(db)
+
+        result = reporting_service.generate_queue_report(
+            start_date=request.start_date,
+            end_date=request.end_date,
+            doctor_id=request.doctor_id,
+            format=request.format,
+        )
+
+        if "error" in result:
+            log_report_service_error("queue_report")
+            return ReportResponse(
+                success=False,
+                report_type="queue_report",
+                generated_at=datetime.now().isoformat(),
+                format=request.format,
+                error="Queue report generation failed",
+            )
+
+        return ReportResponse(
+            success=True,
+            report_type="queue_report",
+            generated_at=result.get("generated_at", datetime.now().isoformat()),
+            format=result.get("format", request.format),
+            data=result.get("data"),
+            filename=result.get("filename"),
+            filepath=result.get("filepath"),
+            size=result.get("size"),
+        )
+
+    except Exception as e:
+        raise_report_internal_error(
+            "queue-report", "Queue report generation failed", e
+        )
+
+
+@router.post("/doctor-performance", response_model=ReportResponse)
+async def generate_doctor_performance_report(
+    request: DoctorPerformanceReportRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _: None = Depends(require_roles([Roles.ADMIN, Roles.MANAGER])),
+):
+    """Generate a doctor performance report."""
+    try:
+        reporting_service = get_reporting_service(db)
+
+        result = reporting_service.generate_doctor_performance_report(
+            start_date=request.start_date,
+            end_date=request.end_date,
+            doctor_id=request.doctor_id,
+            format=request.format,
+        )
+
+        if "error" in result:
+            log_report_service_error("doctor_performance_report")
+            return ReportResponse(
+                success=False,
+                report_type="doctor_performance_report",
+                generated_at=datetime.now().isoformat(),
+                format=request.format,
+                error="Doctor performance report generation failed",
+            )
+
+        return ReportResponse(
+            success=True,
+            report_type="doctor_performance_report",
+            generated_at=result.get("generated_at", datetime.now().isoformat()),
+            format=result.get("format", request.format),
+            data=result.get("data"),
+            filename=result.get("filename"),
+            filepath=result.get("filepath"),
+            size=result.get("size"),
+        )
+
+    except Exception as e:
+        raise_report_internal_error(
+            "doctor-performance-report",
+            "Doctor performance report generation failed",
+            e,
+        )
+
+
 @router.get("/daily-summary")
 async def get_daily_summary(
     target_date: Optional[date] = Query(
@@ -357,4 +451,44 @@ async def list_report_files(
     except Exception as e:
         raise_report_internal_error(
             "report-files", "Ошибка получения списка файлов отчетов", e
+        )
+
+
+@router.get("/download/{filename}")
+async def download_report_file(
+    filename: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _: None = Depends(require_roles([Roles.ADMIN, Roles.REGISTRAR, Roles.MANAGER])),
+):
+    """Download a generated report file."""
+    try:
+        reporting_service = get_reporting_service(db)
+        reports_dir = Path(reporting_service.reports_dir).resolve()
+        if not reports_dir.is_dir():
+            raise HTTPException(status_code=404, detail="Report file not found")
+
+        report_path = next(
+            (
+                candidate.resolve()
+                for candidate in reports_dir.iterdir()
+                if candidate.is_file() and candidate.name == filename
+            ),
+            None,
+        )
+
+        if report_path is None or report_path.parent != reports_dir:
+            raise HTTPException(status_code=404, detail="Report file not found")
+
+        return FileResponse(
+            path=str(report_path),
+            filename=report_path.name,
+            media_type="application/octet-stream",
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise_report_internal_error(
+            "download-report", "Report file download failed", e
         )

--- a/backend/tests/integration/test_reports_api_contract.py
+++ b/backend/tests/integration/test_reports_api_contract.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def test_advertised_report_types_have_backend_routes(client, auth_headers, monkeypatch):
+    from app.api.v1.endpoints import reports
+
+    class FakeReportingService:
+        def generate_queue_report(self, **kwargs):
+            return {
+                "format": kwargs["format"],
+                "data": {"report_type": "queue_report"},
+                "filename": "queue.csv",
+                "size": 10,
+            }
+
+        def generate_doctor_performance_report(self, **kwargs):
+            return {
+                "format": kwargs["format"],
+                "data": {"report_type": "doctor_performance_report"},
+                "filename": "doctor.xlsx",
+                "size": 20,
+            }
+
+    monkeypatch.setattr(
+        reports,
+        "get_reporting_service",
+        lambda db: FakeReportingService(),
+    )
+
+    queue_response = client.post(
+        "/api/v1/reports/queue",
+        headers=auth_headers,
+        json={"format": "json"},
+    )
+    assert queue_response.status_code == 200, queue_response.text
+    assert queue_response.json()["report_type"] == "queue_report"
+
+    doctor_response = client.post(
+        "/api/v1/reports/doctor-performance",
+        headers=auth_headers,
+        json={"format": "json"},
+    )
+    assert doctor_response.status_code == 200, doctor_response.text
+    assert doctor_response.json()["report_type"] == "doctor_performance_report"
+
+
+def test_report_download_matches_files_contract_and_blocks_path_traversal(
+    client,
+    auth_headers,
+    monkeypatch,
+    tmp_path,
+):
+    from app.api.v1.endpoints import reports
+
+    report_file = tmp_path / "daily.csv"
+    report_file.write_bytes(b"patient,total\nA,1\n")
+    hidden_dir = tmp_path / "hidden"
+    hidden_dir.mkdir()
+    hidden_file = hidden_dir / "secret.csv"
+    hidden_file.write_text("secret", encoding="utf-8")
+
+    monkeypatch.setattr(
+        reports,
+        "get_reporting_service",
+        lambda db: SimpleNamespace(reports_dir=str(tmp_path)),
+    )
+
+    response = client.get(
+        "/api/v1/reports/download/daily.csv",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    assert response.content == b"patient,total\nA,1\n"
+    assert "daily.csv" in response.headers["content-disposition"]
+
+    traversal_response = client.get(
+        "/api/v1/reports/download/hidden%2Fsecret.csv",
+        headers=auth_headers,
+    )
+    assert traversal_response.status_code == 404
+    assert b"secret" not in traversal_response.content
+
+
+def test_patient_cannot_download_admin_report_files(client, patient_token, monkeypatch, tmp_path):
+    from app.api.v1.endpoints import reports
+
+    (tmp_path / "daily.csv").write_text("patient,total\nA,1\n", encoding="utf-8")
+    monkeypatch.setattr(
+        reports,
+        "get_reporting_service",
+        lambda db: SimpleNamespace(reports_dir=str(tmp_path)),
+    )
+
+    response = client.get(
+        "/api/v1/reports/download/daily.csv",
+        headers={"Authorization": f"Bearer {patient_token}"},
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Adds missing backend routes already advertised or used by Admin Reports: POST /api/v1/reports/queue, POST /api/v1/reports/doctor-performance, and GET /api/v1/reports/download/{filename}.
- Keeps reporting service as SSOT and preserves role guards; no frontend runtime changes.
- Adds targeted contract tests for advertised report routes, secure file download, traversal rejection, and Patient denial.

## Cyclic Execution Evidence
- Fresh main sync: branch was created from origin/main in safe worktree C:\tmp\final-ssot-cycle-main.
- Clean workspace: worktree was clean before edits; only reports endpoint and targeted test changed.
- Branch: codex/reports-download-route.
- Scope gate: gate returned narrow override for backend reports route ownership; test-file override used because the gate omitted the targeted backend test file.
- Red-check handling: PR checks are monitored; infra/body failures are fixed in this PR cycle before merge.

## Contract Impact
- Canonical surface: existing FastAPI reports router under /api/v1/reports and ReportingService methods.
- Request shape: queue and doctor-performance routes reuse existing QueueReportRequest and DoctorPerformanceReportRequest.
- Response shape: report generation routes reuse existing ReportResponse; download returns FileResponse for generated files.
- Status codes: successful report routes return 200; missing or path-traversal report files return 404; unauthorized roles return 403 through existing role dependency.
- Frontend consumer: frontend Admin Reports already calls /reports/download/{filename} and maps queue_report/doctor_performance_report to these routes.
- Compatibility path or alias: no legacy alias added; this restores the backend side of the already-consumed reports contract.
- Contract proof: backend integration test covers advertised routes, file download bytes, traversal rejection, and Patient denial.

## RBAC / Permissions
- Roles allowed: Admin, Registrar, Manager for queue report and report download; Admin and Manager for doctor-performance report.
- Roles denied: Patient is denied report file download.
- Positive auth proof: targeted backend test uses admin auth to generate queue/doctor reports and download an existing file.
- Negative auth proof: targeted backend test asserts Patient receives 403 for report download.

## Notification / Realtime
- Not applicable - reports endpoints do not publish notifications or realtime events.

## Frontend Resilience
- Not applicable - frontend already called these routes; this PR restores the backend contract without frontend changes.

## Scope Gate
- Allowed paths: backend/app/api/v1/endpoints/reports.py and backend/tests/integration/test_reports_api_contract.py.
- Denied paths: frontend runtime, /api/v1/ui/*, BFF-lite, separate BFF service, migrations, command wrappers, unrelated cleanup.
- Migration/docs/test impact: no migration or docs change; one targeted backend integration test added.
- Rollback note: revert this commit to remove only the additive reports routes and their tests.

## Validation
- Targeted tests or smoke run: py_compile reports endpoint/test; backend reports API contract test; backend OpenAPI contract test; git diff --check.
- Result: py_compile passed; reports API contract test 3 passed; OpenAPI contract test 13 passed; git diff --check passed with CRLF warning only.
- Not checked: frontend build was not run because no frontend files changed.