### PR TITLE
fix(queue): restrict reorder status to staff

### DIFF
--- a/backend/app/api/v1/endpoints/queue_reorder.py
+++ b/backend/app/api/v1/endpoints/queue_reorder.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, field_validator
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user, require_roles
+from app.api.deps import require_roles
 from app.db.session import get_db
 from app.models.user import User
 from app.services.queue_reorder_api_service import (
@@ -20,6 +20,21 @@ from app.services.queue_reorder_api_service import (
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+QUEUE_STATUS_ROLES = (
+    "Admin",
+    "Registrar",
+    "Doctor",
+    "Lab",
+    "Laboratory",
+    "cardio",
+    "cardiology",
+    "Cardiologist",
+    "derma",
+    "Dermatologist",
+    "dentist",
+    "Dentist",
+)
 
 
 class QueueReorderRequest(BaseModel):
@@ -148,7 +163,7 @@ async def get_queue_status_by_specialist(
     specialist_id: int,
     day: date,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles(*QUEUE_STATUS_ROLES)),
 ):
     """
     Получение текущего состояния очереди по специалисту и дню
@@ -175,7 +190,7 @@ async def get_queue_status_by_specialist(
 async def get_queue_status(
     queue_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles(*QUEUE_STATUS_ROLES)),
 ):
     """
     Получение текущего состояния очереди по ID

--- a/backend/tests/integration/test_queue_reorder_status_role_guard.py
+++ b/backend/tests/integration/test_queue_reorder_status_role_guard.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.clinic import Doctor
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.patient import Patient
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_queue_with_patient(
+    db_session: Session,
+    test_doctor: Doctor,
+    test_patient: Patient,
+) -> DailyQueue:
+    queue = DailyQueue(
+        day=date.today(),
+        specialist_id=test_doctor.id,
+        queue_tag="cardiology_common",
+        active=True,
+    )
+    db_session.add(queue)
+    db_session.commit()
+    db_session.refresh(queue)
+
+    entry = OnlineQueueEntry(
+        queue_id=queue.id,
+        number=1,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        source="registrar",
+        status="waiting",
+        created_at=datetime.utcnow(),
+    )
+    db_session.add(entry)
+    db_session.commit()
+    db_session.refresh(queue)
+    return queue
+
+
+def test_registrar_can_read_queue_reorder_status(
+    client: TestClient,
+    db_session: Session,
+    registrar_token: str,
+    test_doctor: Doctor,
+    test_patient: Patient,
+) -> None:
+    queue = _seed_queue_with_patient(db_session, test_doctor, test_patient)
+
+    response = client.get(
+        f"/api/v1/queue/reorder/status/{queue.id}",
+        headers=_auth_headers(registrar_token),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["queue_id"] == queue.id
+    assert payload["entries"][0]["patient_name"] == test_patient.short_name()
+    assert payload["entries"][0]["phone"] == test_patient.phone
+
+
+def test_patient_cannot_read_queue_reorder_status_by_queue_id(
+    client: TestClient,
+    db_session: Session,
+    patient_token: str,
+    test_doctor: Doctor,
+    test_patient: Patient,
+) -> None:
+    queue = _seed_queue_with_patient(db_session, test_doctor, test_patient)
+
+    response = client.get(
+        f"/api/v1/queue/reorder/status/{queue.id}",
+        headers=_auth_headers(patient_token),
+    )
+
+    assert response.status_code == 403
+
+
+def test_patient_cannot_read_queue_reorder_status_by_specialist(
+    client: TestClient,
+    db_session: Session,
+    patient_token: str,
+    test_doctor: Doctor,
+    test_patient: Patient,
+) -> None:
+    _seed_queue_with_patient(db_session, test_doctor, test_patient)
+
+    response = client.get(
+        "/api/v1/queue/reorder/status/by-specialist/",
+        headers=_auth_headers(patient_token),
+        params={"specialist_id": test_doctor.id, "day": date.today().isoformat()},
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Restrict `/api/v1/queue/reorder/status/{queue_id}` and `/api/v1/queue/reorder/status/by-specialist/` from auth-only access to clinic staff roles.
- Add regression coverage proving Registrar can read queue status while Patient is denied.

## Cyclic Execution Evidence
- Fresh main sync: started from `origin/main` at `5bc4bb8c` after PR #1402 was merged and local audit worktree was clean/detached.
- Clean workspace: inspected before editing; only `backend/app/api/v1/endpoints/queue_reorder.py` and `backend/tests/integration/test_queue_reorder_status_role_guard.py` are touched.
- Branch: `codex/queue-status-role-guard`
- Scope gate: `agent_gate` run with known root cause `backend/app/api/v1/endpoints/queue_reorder.py`; gate narrowed this PR to the reorder status router only.
- Red-check handling: if CI is red, this same PR will be fixed before any next cycle.

## Contract Impact
- Canonical surface: mounted queue reorder status endpoints under `/api/v1/queue/reorder/status*`.
- Request shape: unchanged; `queue_id`, `specialist_id`, and `day` inputs are unchanged.
- Response shape: unchanged for allowed staff roles.
- Status codes: Patient now receives `403` before queue entries with patient names/phones are loaded.
- Frontend consumer: legacy queue utility status readers; no frontend code changed.
- Compatibility path or alias: existing `/api/v1/queue/reorder/status*` paths preserved.
- Contract proof: targeted integration test covers Registrar positive read and Patient denial for both status paths.

## RBAC / Permissions
- Roles allowed: Admin, Registrar/Receptionist alias, Doctor, Lab/Laboratory, cardio/cardiology/Cardiologist, derma/Dermatologist, dentist/Dentist.
- Roles denied: Patient and any authenticated role outside the queue staff tuple.
- Positive auth proof: `test_registrar_can_read_queue_reorder_status` returns `200` and includes the seeded queue entry.
- Negative auth proof: `test_patient_cannot_read_queue_reorder_status_by_queue_id` and `test_patient_cannot_read_queue_reorder_status_by_specialist` return `403`.

## Notification / Realtime
- Event type or websocket channel: none; this PR changes only synchronous HTTP queue status reads.
- Payload version / ack behavior: unchanged; no queue websocket payload or acknowledgement contract is changed.
- Read/unread or delivery semantics: unchanged; queue status reads do not manage notification delivery state.
- Reconnect/resync proof: no reconnect path exists because this is stateless request/response HTTP, not websocket or realtime subscription behavior.

## Frontend Resilience
- Empty data proof: not changed; allowed staff still receives the existing queue status payload or existing service errors.
- Partial data proof: not changed; response shape and queue entry serialization are unchanged for allowed staff.
- Forbidden secondary path behavior: Patient now receives backend `403` for both queue-id and specialist/day status reads.
- Missing draft/resource behavior: no draft/resource workflow is touched; missing queues still follow the existing domain-service behavior for allowed staff.
- Stale route/deep-link behavior: existing status routes are preserved; only unauthorized Patient access is blocked before lookup.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/queue_reorder.py`, `backend/tests/integration/test_queue_reorder_status_role_guard.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite, separate BFF service, migrations, models, repositories, services, legacy queue router.
- Migration/docs/test impact: no migration/docs; one targeted backend integration test added.
- Rollback note: revert this PR to return queue reorder status reads to auth-only access if an emergency rollback is required.

## Validation
- Targeted tests or smoke run: `py_compile` touched files; `scripts/run_backend_pytest.ps1 tests\integration\test_queue_reorder_status_role_guard.py`; `git diff --cached --check`.
- Result: local validation passed; pytest `3 passed, 1 warning`.
- Not checked: broad backend suite, frontend build, browser smoke.