### PR TITLE
fix(admin): use canonical user export routes

### DIFF
--- a/frontend/src/components/admin/UserExportManager.jsx
+++ b/frontend/src/components/admin/UserExportManager.jsx
@@ -82,7 +82,7 @@ const UserExportManager = () => {
   const loadExportFiles = async () => {
     setLoading(true);
     try {
-      const response = await api.get('/user-management/users/export/files');
+      const response = await api.get('/users/users/export/files');
       setExportFiles(response.data.files || []);
     } catch (error) {
       logger.error('Ошибка загрузки файлов экспорта:', error);
@@ -111,7 +111,7 @@ const UserExportManager = () => {
         include_audit_logs: exportForm.include_audit_logs
       };
 
-      const response = await api.post('/user-management/users/export', exportData);
+      const response = await api.post('/users/users/export', exportData);
 
       if (response.data.success) {
         toast.success(response.data.message);
@@ -133,7 +133,7 @@ const UserExportManager = () => {
 
   const handleDownload = async (filename) => {
     try {
-      const response = await api.get(`/user-management/users/export/download/${filename}`, {
+      const response = await api.get(`/users/users/export/download/${filename}`, {
         responseType: 'blob'
       });
 
@@ -158,7 +158,7 @@ const UserExportManager = () => {
     if (!confirm(`Удалить файл ${filename}?`)) return;
 
     try {
-      await api.delete(`/user-management/users/export/files/${filename}`);
+      await api.delete(`/users/users/export/files/${filename}`);
       toast.success(`Файл ${filename} удален`);
       loadExportFiles();
     } catch (error) {

--- a/frontend/src/components/admin/__tests__/UserExportManager.contract.test.jsx
+++ b/frontend/src/components/admin/__tests__/UserExportManager.contract.test.jsx
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const userExportManagerPath = path.resolve(__dirname, '../UserExportManager.jsx');
+
+const readSource = () => fs.readFileSync(userExportManagerPath, 'utf8');
+
+describe('UserExportManager API contract', () => {
+  it('uses the canonical user-management router paths mounted under /users', () => {
+    const source = readSource();
+
+    expect(source).toContain("api.get('/users/users/export/files')");
+    expect(source).toContain("api.post('/users/users/export', exportData)");
+    expect(source).toContain('api.get(`/users/users/export/download/${filename}`,');
+    expect(source).toContain('api.delete(`/users/users/export/files/${filename}`)');
+  });
+
+  it('does not call the stale /user-management compatibility path', () => {
+    const source = readSource();
+
+    expect(source).not.toContain('/user-management/users/export');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed Admin UserExportManager export/list/download/delete calls to use the canonical backend mount under `/users/users/export`.
- Added a frontend contract test locking out the stale `/user-management/users/export` path.

## Cyclic Execution Evidence
- Fresh main sync: Started from `main` at `7edeebff` after `git fetch origin --prune`.
- Clean workspace: Workspace was clean before the branch; only `UserExportManager` and its adjacent contract test were changed.
- Branch: `codex/user-export-canonical-paths`.
- Scope gate: `run_agent_gate.ps1` ran with known root cause. It returned narrow override; after two runs omitted the required test file, override was limited to the component plus adjacent contract test.
- Red-check handling: CI was watched on this PR; any red check will be fixed in this PR before continuing the cycle.

## Contract Impact
- Canonical surface: Existing backend user-management router is mounted under `/api/v1/users`; existing admin user consumers use `/users/users`.
- Request shape: Unchanged.
- Response shape: Unchanged.
- Status codes: Unchanged; the frontend no longer calls the non-mounted `/user-management/users/export` path that would return 404.
- Frontend consumer: Admin `UserExportManager` now calls `/users/users/export`, `/users/users/export/files`, `/users/users/export/download/{filename}`, and `/users/users/export/files/{filename}`.
- Compatibility path or alias: No backend alias added; stale frontend path removed.
- Contract proof: `UserExportManager.contract.test.jsx` asserts canonical paths and rejects `/user-management/users/export`.

## RBAC / Permissions
- Roles allowed: Unchanged; backend export endpoints remain Admin-only via existing role checks.
- Roles denied: Unchanged; non-Admin denial remains backend-owned and was not modified.
- Positive auth proof: Existing backend route ownership remains under Admin-only user-management endpoints; this frontend-only route string fix does not alter auth.
- Negative auth proof: Not rerun locally because backend permission behavior was unchanged.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: Export file listing still uses `response.data.files || []`, so an empty backend list renders as an empty local list.
- Partial data proof: Response parsing is unchanged; this PR only corrects endpoint paths.
- Forbidden secondary path behavior: The test asserts the stale `/user-management/users/export` secondary path is not present.
- Missing draft/resource behavior: not applicable, user export does not use drafts; missing files continue through existing catch/toast behavior.
- Stale route/deep-link behavior: Fixed stale API route strings to the canonical `/users/users/export...` paths.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/UserExportManager.jsx`; `frontend/src/components/admin/__tests__/UserExportManager.contract.test.jsx`.
- Denied paths: Backend runtime, `/api/v1/ui/*`, separate BFF service, command wrappers, unrelated cleanup.
- Migration/docs/test impact: No migration or docs impact; one frontend contract test added.
- Rollback note: Revert this commit to restore previous frontend route strings if needed.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- UserExportManager.contract`; `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`.
- Result: All passed locally; CI runtime checks passed before the PR body template correction.
- Not checked: Backend pytest not run because backend code and API schema were unchanged.