### PR TITLE
fix(queue): restrict legacy today status to staff

### DIFF
--- a/backend/app/api/v1/endpoints/queue.py
+++ b/backend/app/api/v1/endpoints/queue.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 # from app.models.patient import Patient  # Временно отключено
-from app.api.deps import get_current_user
+from app.api.deps import get_current_user, require_roles
 from app.db.session import get_db
 from app.models.user import User
 from app.services.queue_api_service import QueueApiService
@@ -34,6 +34,21 @@ router = APIRouter()
 
 # Timezone для Узбекистана (UTC+5)
 TASHKENT_OFFSET = 5
+
+QUEUE_STATUS_ROLES = (
+    "Admin",
+    "Registrar",
+    "Doctor",
+    "Lab",
+    "Laboratory",
+    "cardio",
+    "cardiology",
+    "Cardiologist",
+    "derma",
+    "Dermatologist",
+    "dentist",
+    "Dentist",
+)
 
 
 # Pydantic схемы
@@ -357,7 +372,7 @@ def open_queue(
 def get_today_queue(
     specialist_id: int = Query(..., description="ID специалиста"),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles(*QUEUE_STATUS_ROLES)),
 ):
     """
     Получение текущей очереди на сегодня

--- a/backend/tests/integration/test_legacy_queue_today_role_guard.py
+++ b/backend/tests/integration/test_legacy_queue_today_role_guard.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.clinic import Doctor
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.patient import Patient
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_legacy_today_queue(
+    db_session: Session,
+    test_doctor: Doctor,
+    test_patient: Patient,
+) -> DailyQueue:
+    queue = DailyQueue(
+        day=date.today(),
+        specialist_id=test_doctor.id,
+        queue_tag="cardiology_common",
+        active=True,
+    )
+    db_session.add(queue)
+    db_session.commit()
+    db_session.refresh(queue)
+
+    entry = OnlineQueueEntry(
+        queue_id=queue.id,
+        number=1,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        source="registrar",
+        status="waiting",
+        created_at=datetime.utcnow(),
+    )
+    db_session.add(entry)
+    db_session.commit()
+    db_session.refresh(queue)
+    return queue
+
+
+def test_registrar_can_read_legacy_today_queue(
+    client: TestClient,
+    db_session: Session,
+    registrar_token: str,
+    test_doctor: Doctor,
+    test_patient: Patient,
+) -> None:
+    queue = _seed_legacy_today_queue(db_session, test_doctor, test_patient)
+
+    response = client.get(
+        "/api/v1/queue/legacy/today",
+        headers=_auth_headers(registrar_token),
+        params={"specialist_id": test_doctor.id},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["queue_id"] == queue.id
+    assert payload["entries"][0]["patient_name"] == test_patient.short_name()
+    assert payload["entries"][0]["phone"] == test_patient.phone
+
+
+def test_patient_cannot_read_legacy_today_queue(
+    client: TestClient,
+    db_session: Session,
+    patient_token: str,
+    test_doctor: Doctor,
+    test_patient: Patient,
+) -> None:
+    _seed_legacy_today_queue(db_session, test_doctor, test_patient)
+
+    response = client.get(
+        "/api/v1/queue/legacy/today",
+        headers=_auth_headers(patient_token),
+        params={"specialist_id": test_doctor.id},
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Restrict legacy `/api/v1/queue/legacy/today` from auth-only access to clinic staff roles.
- Add regression coverage proving Registrar can read the legacy today queue while Patient is denied.

## Cyclic Execution Evidence
- Fresh main sync: started from `origin/main` at `7edeebff` after PR #1404 was merged and local audit worktree was recreated clean/detached.
- Clean workspace: inspected before editing; only `backend/app/api/v1/endpoints/queue.py` and `backend/tests/integration/test_legacy_queue_today_role_guard.py` are touched.
- Branch: `codex/legacy-queue-today-role-guard`
- Scope gate: `agent_gate` run with known root cause `backend/app/api/v1/endpoints/queue.py`; this PR is limited to legacy `today` status read.
- Red-check handling: if CI is red, this same PR will be fixed before any next cycle.

## Contract Impact
- Canonical surface: mounted legacy queue endpoint `/api/v1/queue/legacy/today`.
- Request shape: unchanged; `specialist_id` query input is unchanged.
- Response shape: unchanged for allowed staff roles.
- Status codes: Patient now receives `403` before queue entries with patient names/phones are loaded.
- Frontend consumer: deprecated legacy queue status path; no frontend code changed.
- Compatibility path or alias: existing `/api/v1/queue/legacy/today` path preserved.
- Contract proof: targeted integration test covers Registrar positive read and Patient denial.

## RBAC / Permissions
- Roles allowed: Admin, Registrar/Receptionist alias, Doctor, Lab/Laboratory, cardio/cardiology/Cardiologist, derma/Dermatologist, dentist/Dentist.
- Roles denied: Patient and any authenticated role outside the queue staff tuple.
- Positive auth proof: `test_registrar_can_read_legacy_today_queue` returns `200` and includes the seeded queue entry.
- Negative auth proof: `test_patient_cannot_read_legacy_today_queue` returns `403`.

## Notification / Realtime
- Event type or websocket channel: none; this PR changes only a synchronous HTTP legacy queue read.
- Payload version / ack behavior: unchanged; no queue websocket payload or acknowledgement contract is changed.
- Read/unread or delivery semantics: unchanged; legacy queue reads do not manage notification delivery state.
- Reconnect/resync proof: no reconnect path exists because this is stateless request/response HTTP, not websocket or realtime subscription behavior.

## Frontend Resilience
- Empty data proof: not changed; allowed staff still receives existing missing/empty queue behavior.
- Partial data proof: not changed; response model and queue entry serialization are unchanged for allowed staff.
- Forbidden secondary path behavior: Patient now receives backend `403` for the legacy today queue read.
- Missing draft/resource behavior: no draft/resource workflow is touched; missing queues still follow the existing legacy behavior for allowed staff.
- Stale route/deep-link behavior: existing legacy route is preserved; only unauthorized Patient access is blocked before lookup.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/queue.py`, `backend/tests/integration/test_legacy_queue_today_role_guard.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite, separate BFF service, migrations, models, repositories, services, queue reorder router.
- Migration/docs/test impact: no migration/docs; one targeted backend integration test added.
- Rollback note: revert this PR to return legacy queue today reads to auth-only access if an emergency rollback is required.

## Validation
- Targeted tests or smoke run: `py_compile` touched files; `scripts/run_backend_pytest.ps1 tests\integration\test_legacy_queue_today_role_guard.py`; `git diff --cached --check`.
- Result: local validation passed; pytest `2 passed, 2 warnings`.
- Not checked: broad backend suite, frontend build, browser smoke.