### PR TITLE
fix(frontend): use canonical user preferences route

### DIFF
--- a/frontend/src/hooks/__tests__/useUserPreferences.contract.test.js
+++ b/frontend/src/hooks/__tests__/useUserPreferences.contract.test.js
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const useUserPreferencesPath = path.resolve(__dirname, '../useUserPreferences.js');
+
+const readSource = () => fs.readFileSync(useUserPreferencesPath, 'utf8');
+
+describe('useUserPreferences API contract', () => {
+  it('uses canonical user-management preferences paths', () => {
+    const source = readSource();
+
+    expect(source).toContain('`/users/users/${userId}/preferences`');
+    expect(source).toContain("'/users/me/preferences'");
+  });
+
+  it('does not call the stale /user-management preferences path', () => {
+    const source = readSource();
+
+    expect(source).not.toContain('/user-management/users/');
+  });
+});

--- a/frontend/src/hooks/useUserPreferences.js
+++ b/frontend/src/hooks/useUserPreferences.js
@@ -71,7 +71,7 @@ export const useUserPreferences = (userId = null, autoLoad = true) => {
 
             // Загрузка с сервера
             const endpoint = userId
-                ? `/user-management/users/${userId}/preferences`
+                ? `/users/users/${userId}/preferences`
                 : '/users/me/preferences';
 
             const response = await api.get(endpoint);
@@ -122,7 +122,7 @@ export const useUserPreferences = (userId = null, autoLoad = true) => {
 
         try {
             const endpoint = userId
-                ? `/user-management/users/${userId}/preferences`
+                ? `/users/users/${userId}/preferences`
                 : '/users/me/preferences';
 
             await api.put(endpoint, newPrefs);


### PR DESCRIPTION
## Summary
- Fixed `useUserPreferences(userId)` to call the canonical mounted user-management preferences endpoint.
- Added a frontend contract test that preserves `/users/users/{id}/preferences` and rejects the stale `/user-management/users/...` path.

## Cyclic Execution Evidence
- Fresh main sync: Started from local `main` synced to `origin/main` at merge commit `78e17e04`.
- Clean workspace: Workspace was clean before the branch; only `useUserPreferences.js` and its adjacent hook contract test were changed.
- Branch: `codex/user-preferences-canonical-paths`.
- Scope gate: `run_agent_gate.ps1` was run twice with known root cause. It misrouted to notification/routing files, so narrow override was limited to the confirmed hook plus adjacent source-level contract test.
- Red-check handling: CI will be watched on this PR; any red check will be fixed in this PR before continuing the cycle.

## Contract Impact
- Canonical surface: Existing backend user-management router is mounted under `/api/v1/users`; the user-specific preferences route is `/api/v1/users/users/{user_id}/preferences`.
- Request shape: Unchanged GET/PUT preference calls; only the frontend path prefix changed for explicit `userId` calls.
- Response shape: Unchanged.
- Status codes: Unchanged; the frontend no longer calls non-mounted `/user-management/users/{id}/preferences`, which would return 404.
- Frontend consumer: `useUserPreferences(userId)` now calls `/users/users/${userId}/preferences`; current-user preferences continue to call `/users/me/preferences`.
- Compatibility path or alias: No backend alias added; stale frontend path removed.
- Contract proof: `useUserPreferences.contract.test.js` asserts canonical paths and rejects `/user-management/users/`.

## RBAC / Permissions
- Roles allowed: Unchanged; backend user preferences permissions remain backend-owned.
- Roles denied: Unchanged; no backend auth or role code changed.
- Positive auth proof: Existing backend route ownership remains under user-management preferences endpoints; this frontend-only route string fix does not alter auth.
- Negative auth proof: Not rerun locally because backend permission behavior was unchanged.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: Preference response parsing and default preference fallback are unchanged.
- Partial data proof: Existing merge with `DEFAULT_EMR_PREFERENCES` is unchanged for partial responses.
- Forbidden secondary path behavior: The contract test asserts stale `/user-management/users/` secondary path is not present.
- Missing draft/resource behavior: not applicable, user preferences do not create or reopen drafts/resources.
- Stale route/deep-link behavior: Fixed stale explicit-user API route strings to canonical `/users/users/{id}/preferences` paths.

## Scope Gate
- Allowed paths: `frontend/src/hooks/useUserPreferences.js`; `frontend/src/hooks/__tests__/useUserPreferences.contract.test.js`.
- Denied paths: Backend runtime, routing registry, notification services/schemas/models, `/api/v1/ui/*`, separate BFF service, command wrappers, unrelated cleanup.
- Migration/docs/test impact: No migration or docs impact; one frontend contract test added.
- Rollback note: Revert this commit to restore previous frontend route strings if needed.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- useUserPreferences.contract`; `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`.
- Result: All passed locally.
- Not checked: Backend pytest not run because backend code and API schema were unchanged.