### PR TITLE
fix(admin): use canonical qr token routes

### DIFF
--- a/frontend/src/components/admin/QRTokenManager.jsx
+++ b/frontend/src/components/admin/QRTokenManager.jsx
@@ -89,7 +89,7 @@ const QRTokenManager = () => {
   const loadTokens = async () => {
     try {
       setLoading(true);
-      const response = await fetch('/api/v1/admin/qr-tokens/active', {
+      const response = await fetch('/api/v1/queue/admin/qr-tokens/active', {
         headers: {
           'Authorization': `Bearer ${tokenManager.getAccessToken()}`
         }
@@ -111,7 +111,7 @@ const QRTokenManager = () => {
   const createToken = async () => {
     try {
       setError(null);
-      const response = await fetch('/api/v1/admin/qr-tokens/generate', {
+      const response = await fetch('/api/v1/queue/admin/qr-tokens/generate', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -146,7 +146,7 @@ const QRTokenManager = () => {
     }
 
     try {
-      const response = await fetch(`/api/v1/admin/qr-tokens/${token}`, {
+      const response = await fetch(`/api/v1/queue/admin/qr-tokens/${token}`, {
         method: 'DELETE',
         headers: {
           'Authorization': `Bearer ${tokenManager.getAccessToken()}`

--- a/frontend/src/components/admin/__tests__/QRTokenManager.contract.test.jsx
+++ b/frontend/src/components/admin/__tests__/QRTokenManager.contract.test.jsx
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const qrTokenManagerPath = path.resolve(__dirname, '../QRTokenManager.jsx');
+
+const readSource = () => fs.readFileSync(qrTokenManagerPath, 'utf8');
+
+describe('QRTokenManager API contract', () => {
+  it('uses the canonical QR queue admin paths mounted under /queue', () => {
+    const source = readSource();
+
+    expect(source).toContain("fetch('/api/v1/queue/admin/qr-tokens/active'");
+    expect(source).toContain("fetch('/api/v1/queue/admin/qr-tokens/generate'");
+    expect(source).toContain('fetch(`/api/v1/queue/admin/qr-tokens/${token}`');
+  });
+
+  it('does not call the stale admin QR token path', () => {
+    const source = readSource();
+
+    expect(source).not.toContain('/api/v1/admin/qr-tokens');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed Admin QR token manager list/create/delete calls to use the canonical QR queue mount under `/api/v1/queue/admin/qr-tokens`.
- Added a frontend contract test locking out the stale `/api/v1/admin/qr-tokens` path.

## Cyclic Execution Evidence
- Fresh main sync: Started from detached `origin/main` at merge commit `54fc73a2` because local `main` is occupied by another worktree.
- Clean workspace: Workspace was clean before the branch; only `QRTokenManager.jsx` and its adjacent contract test were changed.
- Branch: `codex/qr-token-manager-canonical-paths`.
- Scope gate: `run_agent_gate.ps1` ran with known root cause. It returned narrow override and included routing files, but this patch was constrained to the confirmed component plus adjacent contract test.
- Red-check handling: CI will be watched on this PR; any red check will be fixed in this PR before continuing the cycle.

## Contract Impact
- Canonical surface: Existing backend `qr_queue.router` is mounted under `/api/v1/queue`; QR admin routes are `/api/v1/queue/admin/qr-tokens/*`.
- Request shape: Unchanged GET/POST/DELETE QR token calls; only the frontend path prefix changed.
- Response shape: Unchanged.
- Status codes: Unchanged; the frontend no longer calls non-mounted `/api/v1/admin/qr-tokens/*`, which would return 404.
- Frontend consumer: Admin `QRTokenManager` now calls `/api/v1/queue/admin/qr-tokens/active`, `/api/v1/queue/admin/qr-tokens/generate`, and `/api/v1/queue/admin/qr-tokens/{token}`.
- Compatibility path or alias: No backend alias added; stale frontend path removed.
- Contract proof: `QRTokenManager.contract.test.jsx` asserts canonical paths and rejects `/api/v1/admin/qr-tokens`.

## RBAC / Permissions
- Roles allowed: Unchanged; backend QR token route role checks remain backend-owned.
- Roles denied: Unchanged; no backend auth or role code changed.
- Positive auth proof: Existing backend QR queue route ownership remains under the mounted QR queue endpoints; this frontend-only route string fix does not alter auth.
- Negative auth proof: Not rerun locally because backend permission behavior was unchanged.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: Token response parsing and empty-token rendering are unchanged.
- Partial data proof: Token rendering behavior is unchanged; this PR only corrects endpoint paths.
- Forbidden secondary path behavior: The contract test asserts stale `/api/v1/admin/qr-tokens` secondary path is not present.
- Missing draft/resource behavior: not applicable, QR token manager does not use drafts.
- Stale route/deep-link behavior: Fixed stale QR token API route strings to canonical `/api/v1/queue/admin/qr-tokens...` paths.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/QRTokenManager.jsx`; `frontend/src/components/admin/__tests__/QRTokenManager.contract.test.jsx`.
- Denied paths: Backend runtime, routing registry/selectors, `/api/v1/ui/*`, separate BFF service, command wrappers, unrelated cleanup.
- Migration/docs/test impact: No migration or docs impact; one frontend contract test added.
- Rollback note: Revert this commit to restore previous frontend route strings if needed.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- QRTokenManager.contract`; `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`; `rg -n /api/v1/admin/qr-tokens frontend/src -S`.
- Result: All passed locally; stale path remains only inside the negative contract test assertion.
- Not checked: Backend pytest not run because backend code and API schema were unchanged.