### PR TITLE
fix(mobile): require password for phone login

### DIFF
--- a/backend/app/api/v1/endpoints/mobile_api.py
+++ b/backend/app/api/v1/endpoints/mobile_api.py
@@ -73,36 +73,24 @@ async def mobile_login(credentials: MobileLoginRequest, db: Session = Depends(ge
     try:
         # Поиск пользователя по телефону или Telegram ID
         user = None
+        patient = None
 
         if credentials.phone:
-            user = crud_user.get_user_by_phone(db, phone=credentials.phone)
+            patient = crud_patient.get_patient_by_phone(db, phone=credentials.phone)
+            user = patient.user if patient and patient.user else None
         elif credentials.telegram_id:
-            user = crud_user.get_user_by_telegram_id(
-                db, telegram_id=credentials.telegram_id
+            raise HTTPException(
+                status_code=400, detail="Telegram login requires a verified link"
             )
 
-        # Если пользователь не найден, создаем нового
         if not user:
-            if not credentials.phone:
-                raise HTTPException(
-                    status_code=400, detail="Номер телефона обязателен для регистрации"
-                )
+            raise HTTPException(status_code=401, detail="Invalid credentials")
 
-            # Создаем нового пациента
-            user_data = {
-                "phone": credentials.phone,
-                "telegram_id": credentials.telegram_id,
-                "role": "Patient",
-                "is_active": True,
-            }
+        if not credentials.password or not user.hashed_password:
+            raise HTTPException(status_code=401, detail="Invalid credentials")
 
-            user = crud_user.create_user(db, user_data)
-
-        # Проверяем пароль (если указан)
-        if credentials.password and not crud_user.verify_password(
-            credentials.password, user.hashed_password
-        ):
-            raise HTTPException(status_code=401, detail="Неверный пароль")
+        if not crud_user.verify_password(credentials.password, user.hashed_password):
+            raise HTTPException(status_code=401, detail="Invalid credentials")
 
         # Генерируем токен
         access_token = crud_user.create_access_token(data={"sub": user.username})
@@ -120,7 +108,7 @@ async def mobile_login(credentials: MobileLoginRequest, db: Session = Depends(ge
             user={
                 "id": user.id,
                 "username": user.username,
-                "phone": user.phone,
+                "phone": patient.phone if patient else None,
                 "role": user.role,
                 "is_active": user.is_active,
             },

--- a/backend/tests/integration/test_mobile_auth_login_guard.py
+++ b/backend/tests/integration/test_mobile_auth_login_guard.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.security import get_password_hash
+from app.models.patient import Patient
+from app.models.user import User
+
+
+MOBILE_LOGIN_PATH = "/api/v1/mobile/mobile/auth/login"
+
+
+def _create_mobile_user(db_session: Session) -> tuple[User, str, str]:
+    suffix = uuid4().hex[:10]
+    password = "mobile-secret-123"
+    phone = f"+99890{suffix[:7]}"
+    user = User(
+        username=f"mobile_patient_{suffix}",
+        email=f"mobile-patient-{suffix}@test.local",
+        hashed_password=get_password_hash(password),
+        role="Patient",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    patient = Patient(
+        user_id=user.id,
+        first_name="Mobile",
+        last_name=f"Patient{suffix}",
+        phone=phone,
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(user)
+    return user, password, phone
+
+
+def test_mobile_login_existing_phone_requires_password(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    _user, _password, phone = _create_mobile_user(db_session)
+
+    response = client.post(MOBILE_LOGIN_PATH, json={"phone": phone})
+
+    assert response.status_code == 401
+    assert "access_token" not in response.text
+
+
+def test_mobile_login_existing_phone_rejects_wrong_password(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    _user, _password, phone = _create_mobile_user(db_session)
+
+    response = client.post(
+        MOBILE_LOGIN_PATH,
+        json={"phone": phone, "password": "wrong-password"},
+    )
+
+    assert response.status_code == 401
+    assert "access_token" not in response.text
+
+
+def test_mobile_login_existing_phone_accepts_valid_password(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    user, password, phone = _create_mobile_user(db_session)
+
+    response = client.post(
+        MOBILE_LOGIN_PATH,
+        json={"phone": phone, "password": password},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["access_token"]
+    assert payload["user"]["id"] == user.id


### PR DESCRIPTION
## Summary
- Fixes mobile phone login so an existing patient-linked user is resolved through the canonical `Patient.phone -> Patient.user_id -> User` relationship instead of phantom `User.phone` / `User.telegram_id` fields.
- Requires a valid password before issuing a mobile access token for an existing account.
- Adds a focused regression test for missing password, wrong password, and valid password paths.

## Cyclic Execution Evidence
- Fresh main sync: started from `origin/main` in `C:\tmp\final-owner-audit2` after PR #1407 merged; fetched before branching.
- Clean workspace: branch `codex/mobile-login-require-password` was created from clean `main`.
- Branch: `codex/mobile-login-require-password`.
- Scope gate: `agent_gate` returned narrow override with known root cause `backend/app/api/v1/endpoints/mobile_api.py`; expansion was limited to one targeted integration test after the endpoint slice compiled.
- Red-check handling: no red GitHub checks yet; local targeted test initially exposed model/source-of-truth mismatch and was fixed in this PR.

## Contract Impact
- Canonical surface: `POST /api/v1/mobile/mobile/auth/login` in the existing FastAPI backend mobile router.
- Request shape: unchanged JSON fields; `phone` remains the phone login identifier and `password` is now required for an existing linked account.
- Response shape: unchanged successful token payload; `user.phone` is populated from canonical `Patient.phone`.
- Status codes: existing linked account without password or with wrong password returns `401`; unsupported telegram-only login returns `400` instead of crashing through a nonexistent user column.
- Frontend consumer: existing mobile/PWA login callers keep the same success payload when a password is supplied.
- Compatibility path or alias: no new route or alias; this patches the already-mounted legacy mobile path.
- Contract proof: integration test covers missing password, wrong password, and valid password on the mounted route.

## RBAC / Permissions
- Roles allowed: any existing linked patient account with the correct password can receive its own token as before.
- Roles denied: unauthenticated callers who only know a phone number cannot receive a token.
- Positive auth proof: `test_mobile_login_existing_phone_accepts_valid_password` verifies valid credentials return `200` and a token.
- Negative auth proof: missing and wrong password tests both return `401` with no token.

## Notification / Realtime
- Event type or websocket channel: mobile login emits no notification or websocket event; it is synchronous token issuance only.
- Payload version / ack behavior: no realtime payload or ack contract changes.
- Read/unread or delivery semantics: no notification state is read or mutated by this endpoint.
- Reconnect/resync proof: no websocket reconnect path is involved; the targeted HTTP regression test exercises the full mounted route.

## Frontend Resilience
- Empty data proof: unknown or unlinked phone returns `401` through the same invalid-credentials path instead of attempting broken auto-create.
- Partial data proof: linked patient must also have a linked active user with `hashed_password`; otherwise token issuance is denied.
- Forbidden secondary path behavior: telegram-only fallback now fails closed with `400` because there is no canonical `User.telegram_id` field in this model.
- Missing draft/resource behavior: no draft/resource state is involved; missing account linkage returns `401`.
- Stale route/deep-link behavior: the mounted route remains available; stale clients without password receive a controlled auth failure instead of a server error or token.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/mobile_api.py`, `backend/tests/integration/test_mobile_auth_login_guard.py`.
- Denied paths: no schemas, migrations, frontend, BFF/UI routes, auth service refactors, or mobile registration rewrite.
- Migration/docs/test impact: no migration or docs; one targeted integration test added.
- Rollback note: revert this commit to restore the prior mobile login behavior, including the previous crash/bypass risk.

## Validation
- Targeted tests or smoke run: `py_compile` for touched files; `scripts/run_backend_pytest.ps1 tests\integration\test_mobile_auth_login_guard.py`.
- Result: compile passed; targeted pytest passed `3 passed, 1 warning`.
- Not checked: broad backend suite, frontend build, and browser flows were not run because the change is confined to one backend auth endpoint and one targeted regression test.