### PR TITLE
fix(auth): use canonical password change route

### DIFF
--- a/frontend/src/components/admin/UnifiedSettings.jsx
+++ b/frontend/src/components/admin/UnifiedSettings.jsx
@@ -65,7 +65,7 @@ const UnifiedSettings = () => {
       });
 
       if (activeTab === 'password' && formData.currentPassword && formData.newPassword) {
-        await api.post('/auth/password-change', {
+        await api.post('/authentication/password-change', {
           current_password: formData.currentPassword,
           new_password: formData.newPassword,
         });

--- a/frontend/src/components/admin/__tests__/PasswordChangeRoute.contract.test.js
+++ b/frontend/src/components/admin/__tests__/PasswordChangeRoute.contract.test.js
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const unifiedSettingsPath = path.resolve(__dirname, '../UnifiedSettings.jsx');
+const changePasswordRequiredPath = path.resolve(
+  __dirname,
+  '../../../pages/auth/ChangePasswordRequired.jsx'
+);
+
+const readSource = (filePath) => fs.readFileSync(filePath, 'utf8');
+
+describe('password change API contract', () => {
+  it('uses the canonical authentication password-change route', () => {
+    const unifiedSettingsSource = readSource(unifiedSettingsPath);
+    const changePasswordRequiredSource = readSource(changePasswordRequiredPath);
+
+    expect(unifiedSettingsSource).toContain("api.post('/authentication/password-change'");
+    expect(changePasswordRequiredSource).toContain("api.post('/authentication/password-change'");
+  });
+
+  it('does not call the stale auth password-change route', () => {
+    const unifiedSettingsSource = readSource(unifiedSettingsPath);
+    const changePasswordRequiredSource = readSource(changePasswordRequiredPath);
+
+    expect(unifiedSettingsSource).not.toContain('/auth/password-change');
+    expect(changePasswordRequiredSource).not.toContain('/auth/password-change');
+  });
+});

--- a/frontend/src/pages/auth/ChangePasswordRequired.jsx
+++ b/frontend/src/pages/auth/ChangePasswordRequired.jsx
@@ -63,7 +63,7 @@ export default function ChangePasswordRequired({ currentPassword }) {
 
         try {
             setLoading(true);
-            await api.post('/auth/password-change', {
+            await api.post('/authentication/password-change', {
                 current_password: formData.currentPassword,
                 new_password: formData.newPassword
             });


### PR DESCRIPTION
## Summary
- Fixed password-change calls in forced-change and admin security settings flows to use the canonical authentication route.
- Added a frontend contract test locking out the stale `/auth/password-change` path.

## Cyclic Execution Evidence
- Fresh main sync: Started from detached `origin/main` at merge commit `d68e1461` because local `main` is occupied by another worktree.
- Clean workspace: Workspace was clean before the branch; only the two password-change call sites and one adjacent contract test were changed.
- Branch: `codex/password-change-canonical-route`.
- Scope gate: `run_agent_gate.ps1` was run with known root causes. It returned narrow override but only one root file at a time and included routing files, so this patch was constrained to confirmed password-change call sites plus source-level contract test.
- Red-check handling: CI will be watched on this PR; any red check will be fixed in this PR before continuing the cycle.

## Contract Impact
- Canonical surface: Existing backend authentication router exposes `POST /api/v1/authentication/password-change`.
- Request shape: Unchanged password-change payload: `current_password` and `new_password`.
- Response shape: Unchanged.
- Status codes: Unchanged; the frontend no longer calls non-mounted `/api/v1/auth/password-change`, which would return 404.
- Frontend consumer: `ChangePasswordRequired` and admin `UnifiedSettings` now call `/authentication/password-change` through the API client.
- Compatibility path or alias: No backend alias added; stale frontend path removed.
- Contract proof: `PasswordChangeRoute.contract.test.js` asserts the canonical route and rejects `/auth/password-change`.

## RBAC / Permissions
- Roles allowed: Unchanged; backend password-change auth/session requirements remain backend-owned.
- Roles denied: Unchanged; no backend auth or role code changed.
- Positive auth proof: Existing backend authentication route ownership remains under the mounted authentication endpoint; this frontend-only route string fix does not alter auth.
- Negative auth proof: Not rerun locally because backend permission behavior was unchanged.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: Password-change response handling is unchanged.
- Partial data proof: Password-change payload construction and error handling are unchanged.
- Forbidden secondary path behavior: The contract test asserts stale `/auth/password-change` is not present.
- Missing draft/resource behavior: not applicable, password change does not use drafts/resources.
- Stale route/deep-link behavior: Fixed stale password-change API route strings to canonical `/authentication/password-change`.

## Scope Gate
- Allowed paths: `frontend/src/pages/auth/ChangePasswordRequired.jsx`; `frontend/src/components/admin/UnifiedSettings.jsx`; `frontend/src/components/admin/__tests__/PasswordChangeRoute.contract.test.js`.
- Denied paths: Backend runtime, routing registry/selectors, `/api/v1/ui/*`, separate BFF service, command wrappers, unrelated cleanup.
- Migration/docs/test impact: No migration or docs impact; one frontend contract test added.
- Rollback note: Revert this commit to restore previous frontend route strings if needed.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- PasswordChangeRoute.contract`; `npm.cmd --prefix frontend run build`; `git diff --check`; `rg -n /auth/password-change|/authentication/password-change frontend/src -S`.
- Result: All passed locally; stale path remains only inside the negative contract test assertion.
- Not checked: Backend pytest not run because backend code and API schema were unchanged.