### PR TITLE
fix(auth): use canonical refresh route

### DIFF
--- a/frontend/src/api/__tests__/authRefreshRoute.contract.test.js
+++ b/frontend/src/api/__tests__/authRefreshRoute.contract.test.js
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { API_ENDPOINTS } from '../endpoints.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const apiDir = path.resolve(__dirname, '..');
+
+const readSource = (fileName) => fs.readFileSync(path.join(apiDir, fileName), 'utf8');
+
+describe('auth refresh API contract', () => {
+  it('uses the canonical authentication refresh route for proactive refresh', () => {
+    const clientSource = readSource('client.js');
+
+    expect(clientSource).toContain("buildApiUrl('/authentication/refresh')");
+    expect(clientSource).not.toContain("buildApiUrl('/auth/refresh')");
+  });
+
+  it('uses the canonical authentication refresh route in endpoint constants', () => {
+    expect(API_ENDPOINTS.AUTH.REFRESH).toBe('/authentication/refresh');
+  });
+
+  it('does not keep stale refresh route exceptions in interceptors', () => {
+    const interceptorsSource = readSource('interceptors.js');
+
+    expect(interceptorsSource).toContain("requestUrl.includes('/authentication/refresh')");
+    expect(interceptorsSource).not.toContain("requestUrl.includes('/auth/refresh')");
+  });
+});

--- a/frontend/src/api/__tests__/interceptors.test.js
+++ b/frontend/src/api/__tests__/interceptors.test.js
@@ -79,7 +79,7 @@ describe('shouldClearAuthOnUnauthorized', () => {
   it('does not clear auth for auth endpoints or when no token exists', () => {
     expect(
       shouldClearAuthOnUnauthorized({
-        config: { url: '/auth/refresh' },
+        config: { url: '/authentication/refresh' },
         response: { status: 401 },
       }, true)
     ).toBe(false);

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -90,7 +90,7 @@ async function refreshTokenIfNeeded() {
   refreshPromise = (async () => {
     try {
       logger.log('🔄 Token expiring soon, refreshing...');
-      const response = await axios.post(buildApiUrl('/auth/refresh'), {
+      const response = await axios.post(buildApiUrl('/authentication/refresh'), {
         refresh_token: refreshToken
       });
 

--- a/frontend/src/api/endpoints.js
+++ b/frontend/src/api/endpoints.js
@@ -10,7 +10,7 @@ export const API_ENDPOINTS = {
     LOGIN: '/auth/login',
     LOGOUT: '/auth/logout',
     ME: '/auth/me',
-    REFRESH: '/auth/refresh',
+    REFRESH: '/authentication/refresh',
     REGISTER: '/auth/register',
     FORGOT_PASSWORD: '/auth/forgot-password',
     RESET_PASSWORD: '/auth/reset-password',

--- a/frontend/src/api/interceptors.js
+++ b/frontend/src/api/interceptors.js
@@ -44,7 +44,6 @@ export function shouldClearAuthOnUnauthorized(error, hasToken = tokenManager.has
   const requestUrl = String(error?.config?.url || '');
   if (
     requestUrl.includes('/auth/login') ||
-    requestUrl.includes('/auth/refresh') ||
     requestUrl.includes('/auth/csrf-token') ||
     requestUrl.includes('/authentication/login') ||
     requestUrl.includes('/authentication/refresh')


### PR DESCRIPTION
## Summary
- Fixed proactive token refresh and auth endpoint constants to use the canonical authentication refresh route.
- Removed the stale `/auth/refresh` exemption from API interceptor auth-clearing logic.
- Added a frontend contract test locking refresh calls to `/authentication/refresh`.

## Cyclic Execution Evidence
- Fresh main sync: Started from detached `origin/main` at merge commit `13323923` after PR #1411 was merged.
- Clean workspace: Workspace was clean before the branch; only API auth-refresh client/constant/interceptor files and adjacent tests were changed.
- Branch: `codex/auth-refresh-canonical-route`.
- Scope gate: `run_agent_gate.ps1` was run with known root causes for `frontend/src/api/client.js`, `frontend/src/api/endpoints.js`, and `frontend/src/api/interceptors.js`. It returned narrow override; routing files suggested by one gate output were intentionally not touched.
- Red-check handling: CI will be watched on this PR; any red check will be fixed in this PR before continuing the cycle.

## Contract Impact
- Canonical surface: Existing backend authentication router exposes `POST /api/v1/authentication/refresh`.
- Request shape: Unchanged refresh payload: `refresh_token`.
- Response shape: Unchanged; frontend still expects `access_token`.
- Status codes: Unchanged; the frontend no longer calls non-mounted `/api/v1/auth/refresh`, which would return 404.
- Frontend consumer: `client.js` proactive refresh and `API_ENDPOINTS.AUTH.REFRESH` now use `/authentication/refresh`; interceptor retry flow was already canonical.
- Compatibility path or alias: No backend alias added; stale frontend refresh path removed.
- Contract proof: `authRefreshRoute.contract.test.js` asserts the canonical route and rejects the stale route in refresh call sites/guards.

## RBAC / Permissions
- Roles allowed: Unchanged; backend refresh auth/session requirements remain backend-owned.
- Roles denied: Unchanged; no backend auth or role code changed.
- Positive auth proof: Existing backend authentication route ownership remains under the mounted authentication endpoint; this frontend-only route string fix does not alter auth.
- Negative auth proof: Not rerun locally because backend permission behavior was unchanged.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: Refresh response handling is unchanged and still tolerates missing `access_token` by returning null/no retry token.
- Partial data proof: Refresh payload construction is unchanged.
- Forbidden secondary path behavior: The contract test asserts stale `/auth/refresh` is not used by proactive refresh or interceptor refresh exemptions.
- Missing draft/resource behavior: not applicable, token refresh does not use drafts/resources.
- Stale route/deep-link behavior: Fixed stale refresh API route strings to canonical `/authentication/refresh`.

## Scope Gate
- Allowed paths: `frontend/src/api/client.js`; `frontend/src/api/endpoints.js`; `frontend/src/api/interceptors.js`; `frontend/src/api/__tests__/interceptors.test.js`; `frontend/src/api/__tests__/authRefreshRoute.contract.test.js`.
- Denied paths: Backend runtime, routing registry/selectors, `/api/v1/ui/*`, separate BFF service, command wrappers, unrelated auth endpoint cleanup.
- Migration/docs/test impact: No migration or docs impact; one frontend contract test added and one API interceptor test updated.
- Rollback note: Revert this commit to restore previous frontend refresh route strings if needed.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- authRefreshRoute interceptors`; `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`; `rg -n /auth/refresh|/authentication/refresh frontend/src/api frontend/src/components frontend/src/pages frontend/src/hooks frontend/src/contexts -S`.
- Result: All passed locally; stale `/auth/refresh` remains only inside negative contract test assertions.
- Not checked: Backend pytest not run because backend code and API schema were unchanged.