### PR TITLE
fix(auth): use canonical service lifecycle routes

### DIFF
--- a/frontend/src/api/endpoints.js
+++ b/frontend/src/api/endpoints.js
@@ -8,7 +8,7 @@ export const API_ENDPOINTS = {
   // Аутентификация
   AUTH: {
     LOGIN: '/auth/login',
-    LOGOUT: '/auth/logout',
+    LOGOUT: '/authentication/logout',
     ME: '/auth/me',
     REFRESH: '/authentication/refresh',
     REGISTER: '/auth/register',

--- a/frontend/src/services/__tests__/authServiceRoutes.contract.test.js
+++ b/frontend/src/services/__tests__/authServiceRoutes.contract.test.js
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { API_ENDPOINTS } from '../../api/endpoints.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const authServicePath = path.resolve(__dirname, '../auth.js');
+
+const readAuthServiceSource = () => fs.readFileSync(authServicePath, 'utf8');
+
+describe('auth service route contract', () => {
+  it('uses canonical authentication endpoints for logout and refresh', () => {
+    const source = readAuthServiceSource();
+
+    expect(source).toContain("api.post('/authentication/logout')");
+    expect(source).toContain("api.post('/authentication/refresh'");
+  });
+
+  it('does not call stale auth lifecycle endpoints', () => {
+    const source = readAuthServiceSource();
+
+    expect(source).not.toContain("api.post('/auth/logout')");
+    expect(source).not.toContain("api.post('/auth/refresh'");
+  });
+
+  it('exports the canonical logout endpoint constant', () => {
+    expect(API_ENDPOINTS.AUTH.LOGOUT).toBe('/authentication/logout');
+    expect(API_ENDPOINTS.AUTH.REFRESH).toBe('/authentication/refresh');
+  });
+});

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -41,7 +41,7 @@ export const authService = {
    */
   async logout() {
     try {
-      await api.post('/auth/logout');
+      await api.post('/authentication/logout');
     } catch (error) {
       logger.warn('Ошибка выхода:', error);
     } finally {
@@ -59,7 +59,7 @@ export const authService = {
       const refreshToken = tokenManager.getRefreshToken();
       if (!refreshToken) return false;
 
-      const response = await api.post('/auth/refresh', {
+      const response = await api.post('/authentication/refresh', {
         refresh_token: refreshToken
       });
 


### PR DESCRIPTION
## Summary
- Fixed the exported auth service logout and refresh calls to use canonical authentication routes.
- Updated `API_ENDPOINTS.AUTH.LOGOUT` to the mounted authentication logout endpoint.
- Added a frontend contract test so stale auth lifecycle paths do not return in this service layer.

## Cyclic Execution Evidence
- Fresh main sync: Started from detached `origin/main` at merge commit `db7803fc` after PR #1412 was merged.
- Clean workspace: Workspace was clean before the branch; only auth service lifecycle route strings, endpoint constant, and one adjacent contract test were changed.
- Branch: `codex/auth-service-canonical-lifecycle-routes`.
- Scope gate: `run_agent_gate.ps1` was run with known root causes for `frontend/src/services/auth.js` and `frontend/src/api/endpoints.js`. It returned narrow override and no backend edits were made.
- Red-check handling: CI will be watched on this PR; any red check will be fixed in this PR before continuing the cycle.

## Contract Impact
- Canonical surface: Existing backend authentication router exposes `POST /api/v1/authentication/logout` and `POST /api/v1/authentication/refresh`.
- Request shape: Unchanged logout and refresh payload behavior; refresh still sends `refresh_token`.
- Response shape: Unchanged; refresh still expects `access_token`, logout still clears local state in `finally`.
- Status codes: Unchanged; the frontend service no longer calls non-mounted `/api/v1/auth/logout` or `/api/v1/auth/refresh`, which would return 404.
- Frontend consumer: `frontend/src/services/auth.js` and `API_ENDPOINTS.AUTH.LOGOUT` now use `/authentication/*` for logout/refresh lifecycle routes.
- Compatibility path or alias: No backend alias added; stale frontend lifecycle paths removed from this service.
- Contract proof: `authServiceRoutes.contract.test.js` asserts canonical logout/refresh and rejects stale service route calls.

## RBAC / Permissions
- Roles allowed: Unchanged; backend auth/session requirements remain backend-owned.
- Roles denied: Unchanged; no backend auth or role code changed.
- Positive auth proof: Existing backend authentication route ownership remains under the mounted authentication endpoint; this frontend-only route string fix does not alter auth.
- Negative auth proof: Not rerun locally because backend permission behavior was unchanged.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: Existing service response handling is unchanged.
- Partial data proof: Refresh still checks for `access_token`; logout still clears local tokens in `finally` even if the server call fails.
- Forbidden secondary path behavior: The contract test asserts stale `/auth/logout` and `/auth/refresh` service calls are not present.
- Missing draft/resource behavior: not applicable, auth lifecycle routes do not use drafts/resources.
- Stale route/deep-link behavior: Fixed stale auth service lifecycle API route strings to canonical `/authentication/*`.

## Scope Gate
- Allowed paths: `frontend/src/services/auth.js`; `frontend/src/api/endpoints.js`; `frontend/src/services/__tests__/authServiceRoutes.contract.test.js`.
- Denied paths: Backend runtime, login payload migration, routing registry/selectors, `/api/v1/ui/*`, separate BFF service, command wrappers, unrelated auth endpoint cleanup.
- Migration/docs/test impact: No migration or docs impact; one frontend contract test added.
- Rollback note: Revert this commit to restore previous frontend service route strings if needed.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- authServiceRoutes authRefreshRoute`; `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`; `rg -n /auth/logout|/auth/refresh|/authentication/logout|/authentication/refresh frontend/src/services frontend/src/api frontend/src/components frontend/src/pages frontend/src/hooks frontend/src/contexts -S`.
- Result: All passed locally; stale logout/refresh paths remain only inside negative contract test assertions.
- Not checked: Backend pytest not run because backend code and API schema were unchanged.