### PR TITLE
fix(auth): use canonical login route

### DIFF
--- a/frontend/src/api/__tests__/authLoginRoute.contract.test.js
+++ b/frontend/src/api/__tests__/authLoginRoute.contract.test.js
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { API_ENDPOINTS } from '../endpoints.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const apiDir = path.resolve(__dirname, '..');
+
+const readSource = (fileName) => fs.readFileSync(path.join(apiDir, fileName), 'utf8');
+
+describe('auth login API contract', () => {
+  it('uses the canonical authentication login route in the API helper', () => {
+    const clientSource = readSource('client.js');
+
+    expect(clientSource).toContain("api.post('/authentication/login'");
+    expect(clientSource).not.toContain("api.post('/auth/login'");
+  });
+
+  it('uses the canonical authentication login route in endpoint constants', () => {
+    expect(API_ENDPOINTS.AUTH.LOGIN).toBe('/authentication/login');
+  });
+});

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -334,7 +334,7 @@ async function login(username, password) {
     remember_me: false
   };
 
-  const resp = await api.post('/auth/login', credentials);
+  const resp = await api.post('/authentication/login', credentials);
 
   return resp.data;
 }

--- a/frontend/src/api/endpoints.js
+++ b/frontend/src/api/endpoints.js
@@ -7,7 +7,7 @@
 export const API_ENDPOINTS = {
   // Аутентификация
   AUTH: {
-    LOGIN: '/auth/login',
+    LOGIN: '/authentication/login',
     LOGOUT: '/authentication/logout',
     ME: '/auth/me',
     REFRESH: '/authentication/refresh',

--- a/frontend/src/services/__tests__/authServiceRoutes.contract.test.js
+++ b/frontend/src/services/__tests__/authServiceRoutes.contract.test.js
@@ -12,6 +12,18 @@ const authServicePath = path.resolve(__dirname, '../auth.js');
 const readAuthServiceSource = () => fs.readFileSync(authServicePath, 'utf8');
 
 describe('auth service route contract', () => {
+  it('uses canonical authentication endpoints for login', () => {
+    const source = readAuthServiceSource();
+
+    expect(source).toContain("api.post('/authentication/login'");
+  });
+
+  it('does not call the stale auth login endpoint', () => {
+    const source = readAuthServiceSource();
+
+    expect(source).not.toContain("api.post('/auth/login'");
+  });
+
   it('uses canonical authentication endpoints for logout and refresh', () => {
     const source = readAuthServiceSource();
 
@@ -27,6 +39,7 @@ describe('auth service route contract', () => {
   });
 
   it('exports the canonical logout endpoint constant', () => {
+    expect(API_ENDPOINTS.AUTH.LOGIN).toBe('/authentication/login');
     expect(API_ENDPOINTS.AUTH.LOGOUT).toBe('/authentication/logout');
     expect(API_ENDPOINTS.AUTH.REFRESH).toBe('/authentication/refresh');
   });

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -12,7 +12,7 @@ export const authService = {
    */
   async login(credentials) {
     try {
-      const response = await api.post('/auth/login', credentials);
+      const response = await api.post('/authentication/login', credentials);
       
       if (response.data.access_token) {
         // Сохраняем токен через tokenManager


### PR DESCRIPTION
## Summary
- Fixed old frontend login helpers to use the canonical authentication login route.
- Updated `API_ENDPOINTS.AUTH.LOGIN` to `/authentication/login`.
- Added frontend contract tests for API helper and service login route ownership.

## Cyclic Execution Evidence
- Fresh main sync: Started from detached `origin/main` at merge commit `ecd410ff` after PR #1413 was merged.
- Clean workspace: Workspace was clean before the branch; only auth login helper route strings, endpoint constant, and adjacent contract tests were changed.
- Branch: `codex/auth-login-canonical-route`.
- Scope gate: `run_agent_gate.ps1` was run with known root causes for `frontend/src/api/client.js`, `frontend/src/services/auth.js`, and `frontend/src/api/endpoints.js`. It returned narrow override and no backend edits were made.
- Red-check handling: CI will be watched on this PR; any red check will be fixed in this PR before continuing the cycle.

## Contract Impact
- Canonical surface: Existing backend authentication router exposes `POST /api/v1/authentication/login`.
- Request shape: Unchanged JSON login payload: `username`, `password`, `remember_me`.
- Response shape: Unchanged; callers still receive backend login response data.
- Status codes: Unchanged; old helpers no longer call legacy `/api/v1/auth/login`, which is disabled by default in this deployment path.
- Frontend consumer: `api/client.js` login helper, `frontend/src/services/auth.js`, and `API_ENDPOINTS.AUTH.LOGIN` now use `/authentication/login`.
- Compatibility path or alias: No backend alias added; frontend helpers moved to the mounted canonical route. The interceptor legacy `/auth/login` 401 guard remains because `/api/v1/auth/login` is still a mounted legacy route and this PR does not change 401-clearing behavior.
- Contract proof: `authLoginRoute.contract.test.js` and `authServiceRoutes.contract.test.js` assert canonical login route usage and reject stale outgoing helper calls.

## RBAC / Permissions
- Roles allowed: Unchanged; backend login/session requirements remain backend-owned.
- Roles denied: Unchanged; no backend auth or role code changed.
- Positive auth proof: `LoginFormStyled` already uses `/authentication/login`; this PR aligns older helpers with that canonical route.
- Negative auth proof: Not rerun locally because backend permission behavior was unchanged.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: Existing login response handling is unchanged.
- Partial data proof: Login payload construction remains unchanged.
- Forbidden secondary path behavior: Contract tests assert stale outgoing `/auth/login` helper calls are not present.
- Missing draft/resource behavior: not applicable, login does not use drafts/resources.
- Stale route/deep-link behavior: Fixed stale login API helper route strings to canonical `/authentication/login`.

## Scope Gate
- Allowed paths: `frontend/src/api/client.js`; `frontend/src/api/endpoints.js`; `frontend/src/services/auth.js`; `frontend/src/api/__tests__/authLoginRoute.contract.test.js`; `frontend/src/services/__tests__/authServiceRoutes.contract.test.js`.
- Denied paths: Backend runtime, interceptor behavior change, routing registry/selectors, `/api/v1/ui/*`, separate BFF service, command wrappers, unrelated auth endpoint cleanup.
- Migration/docs/test impact: No migration or docs impact; one frontend contract test added and one existing service contract test extended.
- Rollback note: Revert this commit to restore previous frontend helper route strings if needed.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- authLoginRoute authServiceRoutes`; `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`; `rg -n /auth/login|/authentication/login frontend/src/api frontend/src/services frontend/src/components/auth frontend/src/pages frontend/src/hooks frontend/src/contexts -S`.
- Result: All passed locally; remaining `/auth/login` runtime reference is only the non-outgoing interceptor compatibility guard for the still-mounted legacy route, plus negative contract test assertions.
- Not checked: Backend pytest not run because backend code and API schema were unchanged.