### PR TITLE
fix(print): use canonical templates route

### DIFF
--- a/frontend/src/api/endpoints.js
+++ b/frontend/src/api/endpoints.js
@@ -156,7 +156,7 @@ export const API_ENDPOINTS = {
   // Печать (новое)
   PRINT: {
     PRINTERS: '/print/printers',
-    TEMPLATES: '/print/templates',
+    TEMPLATES: '/print/templates/templates',
     TICKET: '/print/ticket',
     PRESCRIPTION: '/print/prescription',
     CERTIFICATE: '/print/certificate',

--- a/frontend/src/services/__tests__/printServiceRoutes.contract.test.js
+++ b/frontend/src/services/__tests__/printServiceRoutes.contract.test.js
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { API_ENDPOINTS } from '../../api/endpoints.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const printServicePath = path.resolve(__dirname, '../print.js');
+
+const readPrintServiceSource = () => fs.readFileSync(printServicePath, 'utf8');
+
+describe('print service route contract', () => {
+  it('uses the canonical mounted print-template list route', () => {
+    const source = readPrintServiceSource();
+
+    expect(source).toContain("api.get('/print/templates/templates'");
+    expect(API_ENDPOINTS.PRINT.TEMPLATES).toBe('/print/templates/templates');
+  });
+
+  it('does not call the stale print-template list route', () => {
+    const source = readPrintServiceSource();
+
+    expect(source).not.toContain("api.get('/print/templates',");
+  });
+});

--- a/frontend/src/services/print.js
+++ b/frontend/src/services/print.js
@@ -148,7 +148,7 @@ export const printService = {
    */
   async getTemplates(templateType, language = 'ru') {
     try {
-      const response = await api.get('/print/templates', {
+      const response = await api.get('/print/templates/templates', {
         params: { template_type: templateType, language }
       });
       


### PR DESCRIPTION
## Summary
- Fixed the exported print service template-list call to use the canonical mounted backend route.
- Updated `API_ENDPOINTS.PRINT.TEMPLATES` to `/print/templates/templates`.
- Added a frontend contract test locking the print template route.

## Cyclic Execution Evidence
- Fresh main sync: Started from detached `origin/main` at merge commit `bb5ff44e` after PR #1414 was merged.
- Clean workspace: Workspace was clean before the branch; only print template route strings and one adjacent contract test were changed.
- Branch: `codex/print-templates-canonical-route`.
- Scope gate: `run_agent_gate.ps1` was run with known root causes for `frontend/src/services/print.js` and `frontend/src/api/endpoints.js`. One gate output tried to include routing files; those were intentionally not touched.
- Red-check handling: CI will be watched on this PR; any red check will be fixed in this PR before continuing the cycle.

## Contract Impact
- Canonical surface: Backend mounts `print_templates.router` at `/api/v1/print/templates`, and the list endpoint is `GET /templates`, making the full route `GET /api/v1/print/templates/templates`.
- Request shape: Unchanged query params: `template_type` and `language`.
- Response shape: Unchanged; frontend still returns `response.data` from the backend list response.
- Status codes: Unchanged; the frontend no longer calls non-mounted `/api/v1/print/templates`, which would return 404.
- Frontend consumer: `printService.getTemplates` and `API_ENDPOINTS.PRINT.TEMPLATES` now use `/print/templates/templates`.
- Compatibility path or alias: No backend alias added; stale frontend path removed.
- Contract proof: `printServiceRoutes.contract.test.js` asserts the canonical route and rejects the stale service call.

## RBAC / Permissions
- Roles allowed: Unchanged; backend print-template route still enforces Admin, Registrar, Doctor.
- Roles denied: Unchanged; no backend auth or role code changed.
- Positive auth proof: Existing backend role enforcement remains on the mounted print-template endpoint.
- Negative auth proof: Not rerun locally because backend permission behavior was unchanged.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: Existing response handling is unchanged.
- Partial data proof: Query param construction is unchanged.
- Forbidden secondary path behavior: The contract test asserts stale `/print/templates` service call is not present.
- Missing draft/resource behavior: not applicable, this is a read-only template list route.
- Stale route/deep-link behavior: Fixed stale print-template API route string to canonical `/print/templates/templates`.

## Scope Gate
- Allowed paths: `frontend/src/services/print.js`; `frontend/src/api/endpoints.js`; `frontend/src/services/__tests__/printServiceRoutes.contract.test.js`.
- Denied paths: Backend runtime, print template schema changes, routing registry/selectors, `/api/v1/ui/*`, separate BFF service, command wrappers, unrelated print cleanup.
- Migration/docs/test impact: No migration or docs impact; one frontend contract test added.
- Rollback note: Revert this commit to restore previous frontend print template route string if needed.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- printServiceRoutes`; `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`; `rg -n /print/templates frontend/src/services frontend/src/api frontend/src/components frontend/src/pages -S`.
- Result: All passed locally; stale `/print/templates` remains only inside the negative contract test assertion substring.
- Not checked: Backend pytest not run because backend code and API schema were unchanged.