### PR TITLE
fix(files): restrict json upload to staff

### DIFF
--- a/backend/app/api/v1/endpoints/file_upload_json.py
+++ b/backend/app/api/v1/endpoints/file_upload_json.py
@@ -6,18 +6,21 @@ import base64
 import hashlib
 import logging
 import os
+from binascii import Error as BinasciiError
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user
+from app.api.deps import require_roles
 from app.db.session import get_db
 from app.models.user import User
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+MAX_JSON_UPLOAD_BYTES = 10 * 1024 * 1024
+MAX_JSON_UPLOAD_BASE64_CHARS = ((MAX_JSON_UPLOAD_BYTES + 2) // 3) * 4
 
 
 class FileUploadRequest(BaseModel):
@@ -31,7 +34,9 @@ class FileUploadRequest(BaseModel):
 async def upload_file_json(
     request: FileUploadRequest,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(
+        require_roles("Admin", "Doctor", "Nurse", "Receptionist")
+    ),
 ):
     """Загрузка файла через JSON (base64)"""
     try:
@@ -42,10 +47,13 @@ async def upload_file_json(
             bool(request.description),
         )
 
+        if len(request.content) > MAX_JSON_UPLOAD_BASE64_CHARS:
+            raise HTTPException(status_code=413, detail="Uploaded file is too large")
+
         # Декодируем содержимое файла
         try:
-            content = base64.b64decode(request.content)
-        except Exception as e:
+            content = base64.b64decode(request.content, validate=True)
+        except BinasciiError as e:
             logger.warning(
                 "JSON file upload rejected during base64 decode (%s)",
                 type(e).__name__,
@@ -55,6 +63,11 @@ async def upload_file_json(
             ) from e
 
         file_size = len(content)
+        if file_size == 0:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty")
+        if file_size > MAX_JSON_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail="Uploaded file is too large")
+
         logger.info("JSON file upload decoded size_bytes=%s", file_size)
 
         # Создаем хеш файла

--- a/backend/tests/integration/test_file_upload_json_guard.py
+++ b/backend/tests/integration/test_file_upload_json_guard.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import base64
+
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import file_upload_json
+
+
+UPLOAD_JSON_PATH = "/api/v1/files/upload-json"
+
+
+def _payload(content: bytes) -> dict[str, str]:
+    return {
+        "filename": "note.txt",
+        "content": base64.b64encode(content).decode("ascii"),
+        "title": "Test note",
+    }
+
+
+def test_patient_cannot_use_legacy_json_upload(
+    client: TestClient,
+    patient_token: str,
+) -> None:
+    response = client.post(
+        UPLOAD_JSON_PATH,
+        headers={"Authorization": f"Bearer {patient_token}"},
+        json=_payload(b"hello"),
+    )
+
+    assert response.status_code == 403
+
+
+def test_staff_can_upload_small_json_file(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    response = client.post(
+        UPLOAD_JSON_PATH,
+        headers=auth_headers,
+        json=_payload(b"hello"),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["file_size"] == 5
+    assert (tmp_path / payload["file_path"]).is_file()
+
+
+def test_json_upload_rejects_oversized_payload_before_write(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(file_upload_json, "MAX_JSON_UPLOAD_BYTES", 3)
+    monkeypatch.setattr(file_upload_json, "MAX_JSON_UPLOAD_BASE64_CHARS", 4)
+
+    response = client.post(
+        UPLOAD_JSON_PATH,
+        headers=auth_headers,
+        json=_payload(b"abcd"),
+    )
+
+    assert response.status_code == 413
+    assert not (tmp_path / "uploads").exists()


### PR DESCRIPTION
## Summary
- Restricts the legacy JSON file upload route to the same staff roles used by the canonical file upload endpoint.
- Adds bounded, validated base64 decoding so oversized or malformed payloads fail before writing to disk.
- Adds a focused regression test for patient denial, staff upload, and oversized payload rejection.

## Cyclic Execution Evidence
- Fresh main sync: started from `origin/main` at `ed0913f7` after PR #1410 merged; fetched before branching.
- Clean workspace: branch `codex/file-upload-json-staff-guard` was created from clean `main`.
- Branch: `codex/file-upload-json-staff-guard`.
- Scope gate: `agent_gate` returned narrow override with known root cause `backend/app/api/v1/endpoints/file_upload_json.py`; expansion was limited to one targeted integration test after the endpoint slice compiled.
- Red-check handling: no red GitHub checks yet; local targeted tests passed before opening this PR.

## Contract Impact
- Canonical surface: `POST /api/v1/files/upload-json`, mounted under the existing file routes.
- Request shape: unchanged JSON fields `filename`, `content`, `title`, and `description`; `content` must now be valid base64 and within the decoded size limit.
- Response shape: unchanged successful JSON payload for allowed staff uploads.
- Status codes: Patient tokens now receive `403`; malformed base64 returns `400`; oversized payloads return `413`.
- Frontend consumer: staff callers that already send small valid base64 keep the same success response.
- Compatibility path or alias: no new route or alias; this hardens the existing legacy JSON upload path.
- Contract proof: integration test covers denied Patient access, successful staff upload, and pre-write oversized rejection.

## RBAC / Permissions
- Roles allowed: `Admin`, `Doctor`, `Nurse`, and `Receptionist`, matching the canonical `/files/upload` staff upload policy.
- Roles denied: `Patient` and other authenticated non-staff roles are denied before decoding or writing content.
- Positive auth proof: `test_staff_can_upload_small_json_file` verifies staff can upload a small file.
- Negative auth proof: `test_patient_cannot_use_legacy_json_upload` verifies Patient receives `403`.

## Notification / Realtime
- Event type or websocket channel: file JSON upload emits no notification or websocket event.
- Payload version / ack behavior: no realtime payload or ack contract changes.
- Read/unread or delivery semantics: no notification delivery state is read or mutated by this endpoint.
- Reconnect/resync proof: no websocket path is involved; HTTP regression tests exercise the mounted route.

## Frontend Resilience
- Empty data proof: empty decoded content returns `400` instead of creating an empty file.
- Partial data proof: malformed base64 returns `400` and never writes a file.
- Forbidden secondary path behavior: Patient-token access returns `403` before base64 decode.
- Missing draft/resource behavior: no draft/resource state is involved; invalid upload data is rejected synchronously.
- Stale route/deep-link behavior: the route remains mounted; unauthorized or oversized legacy calls receive controlled HTTP errors.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/file_upload_json.py`, `backend/tests/integration/test_file_upload_json_guard.py`.
- Denied paths: no canonical file service rewrite, storage migration, frontend, BFF/UI routes, or document model changes.
- Migration/docs/test impact: no migration or docs; one targeted integration test added.
- Rollback note: revert this commit to restore the prior any-authenticated-user JSON upload behavior and unbounded decode.

## Validation
- Targeted tests or smoke run: `py_compile` for touched files; `scripts/run_backend_pytest.ps1 tests\integration\test_file_upload_json_guard.py`.
- Result: compile passed; targeted pytest passed `3 passed, 1 warning`.
- Not checked: broad backend suite, frontend build, and browser flows were not run because the change is confined to one backend legacy upload endpoint and one targeted regression test.