### PR TITLE
fix(messages): bound chat upload reads

### DIFF
--- a/backend/app/services/messages_api_service.py
+++ b/backend/app/services/messages_api_service.py
@@ -27,6 +27,8 @@ from app.services.notifications import notification_sender_service
 
 CHAT_UPLOAD_DIR = Path("uploads/chat")
 CHAT_STORAGE_FILENAME_RE = re.compile(r"^\d{8}_\d{6}_.+$")
+MAX_CHAT_UPLOAD_BYTES = 10 * 1024 * 1024
+UPLOAD_READ_CHUNK_BYTES = 1024 * 1024
 logger = logging.getLogger(__name__)
 
 
@@ -57,6 +59,29 @@ def _find_chat_upload_file(filename: str) -> Path:
             return resolved_path
 
     raise HTTPException(status_code=404, detail="Файл не найден")
+
+
+async def _read_upload_bounded(
+    upload: UploadFile,
+    *,
+    max_bytes: int,
+) -> bytes:
+    total_size = 0
+    chunks: list[bytes] = []
+
+    while True:
+        chunk = await upload.read(UPLOAD_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        total_size += len(chunk)
+        if total_size > max_bytes:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File too large (maximum {max_bytes // 1024 // 1024} MB)",
+            )
+        chunks.append(chunk)
+
+    return b"".join(chunks)
 
 
 class MessagesApiService:
@@ -414,11 +439,11 @@ class MessagesApiService:
         audio_file: UploadFile,
         current_user: User,
     ) -> MessageOut:
-        from app.utils.audio import get_audio_duration, validate_audio_file
+        from app.utils.audio import MAX_AUDIO_SIZE, get_audio_duration, validate_audio_file
         from app.ws.chat_ws import chat_manager
 
         recipient = self.validate_recipient(recipient_id=recipient_id, current_user=current_user)
-        content = await audio_file.read()
+        content = await _read_upload_bounded(audio_file, max_bytes=MAX_AUDIO_SIZE)
         format_name, mime_type = await validate_audio_file(content, audio_file.filename)
         duration = await get_audio_duration(content, format_name)
 
@@ -536,7 +561,7 @@ class MessagesApiService:
             current_user=current_user,
         )
 
-        content = await file.read()
+        content = await _read_upload_bounded(file, max_bytes=MAX_CHAT_UPLOAD_BYTES)
         original_filename = os.path.basename(file.filename or "file")
         safe_filename = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{original_filename}"
         upload_dir = "uploads/chat"

--- a/backend/tests/integration/test_messages_upload_limits.py
+++ b/backend/tests/integration/test_messages_upload_limits.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.models.user import User
+from app.services import messages_api_service
+
+
+def test_chat_file_upload_rejects_oversized_payload_before_write(
+    client: TestClient,
+    patient_token: str,
+    test_doctor_user: User,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(messages_api_service, "MAX_CHAT_UPLOAD_BYTES", 3)
+    monkeypatch.setattr(messages_api_service, "UPLOAD_READ_CHUNK_BYTES", 2)
+
+    response = client.post(
+        "/api/v1/messages/upload",
+        headers={"Authorization": f"Bearer {patient_token}"},
+        data={"recipient_id": str(test_doctor_user.id)},
+        files={"file": ("oversized.txt", b"abcd", "text/plain")},
+    )
+
+    assert response.status_code == 413
+    assert not (tmp_path / "uploads").exists()
+
+
+def test_voice_message_rejects_oversized_payload_before_write(
+    client: TestClient,
+    patient_token: str,
+    test_doctor_user: User,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from app.utils import audio
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(audio, "MAX_AUDIO_SIZE", 3)
+    monkeypatch.setattr(messages_api_service, "UPLOAD_READ_CHUNK_BYTES", 2)
+
+    response = client.post(
+        "/api/v1/messages/send-voice",
+        headers={"Authorization": f"Bearer {patient_token}"},
+        data={"recipient_id": str(test_doctor_user.id)},
+        files={"audio_file": ("voice.mp3", b"abcd", "audio/mpeg")},
+    )
+
+    assert response.status_code == 413
+    assert not (tmp_path / "uploads").exists()


### PR DESCRIPTION
## Summary
- Bound chat attachment and voice-message upload reads before validation or disk writes.
- Oversized uploads now return `413` before creating `uploads/` content.
- Added regression coverage for patient-to-doctor upload attempts that exceed the limit.

## Cyclic Execution Evidence
- Fresh main sync: started from `main...origin/main` at `b714d2c1` after the prior merged PR.
- Clean workspace: clean before creating `codex/messages-upload-size-guard`; only the messages service and one targeted test file changed.
- Branch: `codex/messages-upload-size-guard`.
- Scope gate: `gate_known_root_cause` returned a narrow service-file override; the test-file expansion was reported explicitly and kept to one regression test module.
- Red-check handling: if GitHub checks fail, fixes will stay in this PR branch before merge.

## Contract Impact
- Canonical surface: `/api/v1/messages/upload` and `/api/v1/messages/send-voice` via `backend/app/services/messages_api_service.py`.
- Request shape: unchanged multipart form fields, `recipient_id` plus `file` or `audio_file`.
- Response shape: successful responses unchanged; oversized payloads now return FastAPI JSON error with HTTP `413`.
- Status codes: adds bounded `413 Payload Too Large` behavior before disk write; existing auth, recipient, audio-format, and duration statuses remain unchanged.
- Frontend consumer: existing chat upload callers keep the same routes and request fields; they can surface the standard error response for oversized files.
- Compatibility path or alias: no route alias, prefix, or download URL contract changed.
- Contract proof: `tests/integration/test_messages_upload_limits.py` exercises both upload routes through the mounted API.

## RBAC / Permissions
- Roles allowed: unchanged; `MESSAGING_PERMISSIONS` still controls which authenticated roles can message which recipient roles.
- Roles denied: unchanged; no role matrix or dependency override was altered.
- Positive auth proof: regression tests use a real patient token and a valid Doctor recipient, proving the rejection is the size guard rather than auth failure.
- Negative auth proof: denied-role behavior was not re-run because this patch does not touch auth dependencies, recipient validation, or the permission matrix.

## Notification / Realtime
- Event type or websocket channel: oversized uploads are rejected before message creation, notification send, or `MessageEventType.NEW_MESSAGE` broadcast.
- Payload version / ack behavior: successful message event payloads remain unchanged; rejected uploads use normal HTTP error semantics.
- Read/unread or delivery semantics: no message row is created on rejected upload, so unread counts and delivery state remain unchanged.
- Reconnect/resync proof: rejected uploads leave no persistent message/file artifact to resync; successful upload resync paths are untouched.

## Frontend Resilience
- Empty data proof: empty-file behavior was intentionally left as the existing service behavior; this PR only bounds oversized reads.
- Partial data proof: tests reduce the read chunk to 2 bytes and prove a 4-byte upload is rejected once the accumulated size crosses a 3-byte limit.
- Forbidden secondary path behavior: `/api/v1/messages/download/{filename}` ownership checks are unchanged.
- Missing draft/resource behavior: chat uploads do not use draft/resource records in this path; the patch only changes pre-write upload reading.
- Stale route/deep-link behavior: route names and download URL shape are unchanged.

## Scope Gate
- Allowed paths: `backend/app/services/messages_api_service.py`, `backend/tests/integration/test_messages_upload_limits.py`.
- Denied paths: frontend, migrations, file-system canonical upload service, messaging permission matrix, WebSocket managers, notification services.
- Migration/docs/test impact: no migration or docs changes; added one targeted integration test module.
- Rollback note: revert this commit to restore previous unbounded read behavior; no schema or persisted-data migration is involved.

## Validation
- Targeted tests or smoke run: `py_compile` for touched files; `run_backend_pytest.ps1 tests\integration\test_messages_upload_limits.py`; `run_backend_pytest.ps1 tests\integration\test_messages_upload_limits.py tests\unit\test_messages_router_service_wiring.py tests\unit\test_messages_notification_catalog_slice1.py`; `git diff --cached --check`.
- Result: compile passed; targeted upload tests passed `2 passed`; related messages tests passed `5 passed`; diff check passed.
- Not checked: full backend suite and frontend build were not run because the change is confined to backend upload read bounds and related message-service tests passed.