### PR TITLE
fix(ai): bound legacy upload reads

### DIFF
--- a/backend/app/api/v1/endpoints/ai.py
+++ b/backend/app/api/v1/endpoints/ai.py
@@ -17,6 +17,9 @@ from ....services.mcp import get_mcp_manager
 
 logger = logging.getLogger(__name__)
 
+MAX_LEGACY_AI_UPLOAD_BYTES = 25 * 1024 * 1024
+AI_UPLOAD_READ_CHUNK_BYTES = 1024 * 1024
+
 LEGACY_AI_ACCESS = require_any_ai_permission(
     AIPermission.ADMIN_AI,
     AIPermission.DIAGNOSE,
@@ -26,6 +29,28 @@ LEGACY_AI_ACCESS = require_any_ai_permission(
 )
 
 router = APIRouter(dependencies=[Depends(LEGACY_AI_ACCESS)])
+
+
+async def _read_ai_upload_bounded(upload: UploadFile) -> bytes:
+    total_size = 0
+    chunks: list[bytes] = []
+
+    while True:
+        chunk = await upload.read(AI_UPLOAD_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        total_size += len(chunk)
+        if total_size > MAX_LEGACY_AI_UPLOAD_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=(
+                    "File too large "
+                    f"(maximum {MAX_LEGACY_AI_UPLOAD_BYTES // 1024 // 1024} MB)"
+                ),
+            )
+        chunks.append(chunk)
+
+    return b"".join(chunks)
 
 
 def _raise_ai_internal_error(exc: Exception) -> NoReturn:
@@ -217,7 +242,7 @@ async def analyze_skin(
             raise HTTPException(status_code=400, detail="Файл должен быть изображением")
 
         # Читаем изображение
-        image_data = await image.read()
+        image_data = await _read_ai_upload_bounded(image)
 
         # Парсим метаданные если есть
         metadata_dict = None
@@ -363,7 +388,7 @@ async def analyze_xray_image(
     """Анализ рентгеновского снимка"""
     try:
         # Читаем изображение
-        image_data = await image.read()
+        image_data = await _read_ai_upload_bounded(image)
 
         # Парсим метаданные
         metadata_dict = None
@@ -397,7 +422,7 @@ async def analyze_ultrasound_image(
     """Анализ УЗИ изображения"""
     try:
         # Читаем изображение
-        image_data = await image.read()
+        image_data = await _read_ai_upload_bounded(image)
 
         # Парсим метаданные
         metadata_dict = None
@@ -431,7 +456,7 @@ async def analyze_dermatoscopy_image(
     """Анализ дерматоскопического изображения"""
     try:
         # Читаем изображение
-        image_data = await image.read()
+        image_data = await _read_ai_upload_bounded(image)
 
         # Парсим метаданные
         metadata_dict = None
@@ -466,7 +491,7 @@ async def analyze_medical_image_generic(
     """Универсальный анализ медицинского изображения"""
     try:
         # Читаем изображение
-        image_data = await image.read()
+        image_data = await _read_ai_upload_bounded(image)
 
         # Парсим метаданные
         metadata_dict = None
@@ -893,7 +918,7 @@ async def transcribe_audio(
             raise HTTPException(status_code=400, detail="Файл должен быть аудио")
 
         # Читаем аудио данные
-        audio_data = await audio_file.read()
+        audio_data = await _read_ai_upload_bounded(audio_file)
 
         # Ограничиваем размер файла (например, 25 МБ)
         if len(audio_data) > 25 * 1024 * 1024:

--- a/backend/tests/integration/test_ai_upload_limits.py
+++ b/backend/tests/integration/test_ai_upload_limits.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+from fastapi import HTTPException, UploadFile
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import ai
+
+
+def test_legacy_ai_image_upload_rejects_oversized_payload_before_provider_call(
+    client: TestClient,
+    cardio_auth_headers: dict[str, str],
+    monkeypatch,
+) -> None:
+    provider_called = False
+
+    async def fake_analyze_xray_image(*args, **kwargs):
+        nonlocal provider_called
+        provider_called = True
+        return {"ok": True}
+
+    monkeypatch.setattr(ai, "MAX_LEGACY_AI_UPLOAD_BYTES", 3)
+    monkeypatch.setattr(ai, "AI_UPLOAD_READ_CHUNK_BYTES", 2)
+    monkeypatch.setattr(
+        ai.ai_manager,
+        "analyze_xray_image",
+        fake_analyze_xray_image,
+        raising=False,
+    )
+
+    response = client.post(
+        "/api/v1/ai/analyze-xray",
+        headers=cardio_auth_headers,
+        files={"image": ("oversized.png", b"abcd", "image/png")},
+    )
+
+    assert response.status_code == 413
+    assert provider_called is False
+
+
+@pytest.mark.asyncio
+async def test_ai_upload_bounded_reader_rejects_oversized_payload(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(ai, "MAX_LEGACY_AI_UPLOAD_BYTES", 3)
+    monkeypatch.setattr(ai, "AI_UPLOAD_READ_CHUNK_BYTES", 2)
+    upload = UploadFile(file=io.BytesIO(b"abcd"), filename="voice.wav")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await ai._read_ai_upload_bounded(upload)
+
+    assert exc_info.value.status_code == 413


### PR DESCRIPTION
## Summary
- Bound legacy AI image/audio upload reads in `ai.py` before provider calls.
- Oversized payloads now return `413` while reading in chunks instead of loading the whole upload into memory.
- Added regression coverage for a mounted AI image route and the shared bounded reader used by image/audio callers.

## Cyclic Execution Evidence
- Fresh main sync: branch started from `main...origin/main` at `dba93bd3` after PR #1417 was merged.
- Clean workspace: clean before creating `codex/ai-upload-size-guard`; only legacy AI endpoint and one targeted test file changed.
- Branch: `codex/ai-upload-size-guard`.
- Scope gate: `gate_known_root_cause` returned a narrow `backend/app/api/v1/endpoints/ai.py` override; one regression test module was added after an explicit scope report.
- Red-check handling: if GitHub checks fail, fixes will stay in this PR branch before merge.

## Contract Impact
- Canonical surface: legacy `/api/v1/ai/skin-analyze`, `/api/v1/ai/analyze-xray`, `/api/v1/ai/analyze-ultrasound`, `/api/v1/ai/analyze-dermatoscopy`, `/api/v1/ai/analyze-medical-image`, and `/api/v1/ai/transcribe-audio` upload reads.
- Request shape: unchanged multipart upload fields and metadata/provider fields.
- Response shape: successful provider responses unchanged; oversized uploads now return FastAPI JSON error with HTTP `413`.
- Status codes: adds bounded `413 Payload Too Large` behavior before provider invocation; existing auth, content-type, metadata, and provider errors remain unchanged.
- Frontend consumer: existing AI upload callers keep the same routes and form fields and can surface the standard oversized-upload error.
- Compatibility path or alias: no route prefix, route alias, provider selection, or response DTO changed.
- Contract proof: `tests/integration/test_ai_upload_limits.py` exercises `/api/v1/ai/analyze-xray` through the mounted API and validates the shared bounded reader.

## RBAC / Permissions
- Roles allowed: unchanged; legacy AI router still uses `LEGACY_AI_ACCESS` from AI RBAC permissions.
- Roles denied: unchanged; no AI permission matrix or `require_any_ai_permission` behavior changed.
- Positive auth proof: regression test uses the existing `cardio` auth fixture, which has `ANALYZE_IMAGE`, and reaches the upload guard.
- Negative auth proof: denied-role behavior was not re-run because this patch does not touch auth dependencies or AI RBAC mapping.

## Notification / Realtime
- Event type or websocket channel: these legacy AI upload endpoints do not emit realtime notifications on the guarded path.
- Payload version / ack behavior: successful AI provider payloads remain unchanged; rejected uploads use normal HTTP error semantics.
- Read/unread or delivery semantics: no notification/message delivery state is created by these AI uploads.
- Reconnect/resync proof: rejected uploads do not create persistent AI artifacts requiring resync; successful paths are unchanged after the read completes.

## Frontend Resilience
- Empty data proof: empty-file behavior was intentionally left as existing provider/content validation behavior; this PR only bounds oversized reads.
- Partial data proof: tests reduce the read chunk to 2 bytes and prove a 4-byte upload is rejected once accumulated size crosses a 3-byte limit.
- Forbidden secondary path behavior: no secondary download/view path is introduced or changed.
- Missing draft/resource behavior: these AI uploads do not use drafts or resource records in this path.
- Stale route/deep-link behavior: route names and multipart field names are unchanged.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/ai.py`, `backend/tests/integration/test_ai_upload_limits.py`.
- Denied paths: frontend, migrations, AI RBAC matrix, AI providers, MCP services, prompt/provider behavior.
- Migration/docs/test impact: no migration or docs changes; added one targeted integration test module.
- Rollback note: revert this commit to restore previous unbounded upload reads; no schema or persisted-data migration is involved.

## Validation
- Targeted tests or smoke run: `py_compile` for touched files; `run_backend_pytest.ps1 tests\integration\test_ai_upload_limits.py`; `git diff --cached --check`.
- Result: compile passed; targeted AI upload tests passed `2 passed`; staged diff check passed.
- Not checked: full backend suite and frontend build were not run because the change is confined to legacy backend AI upload read bounds and the targeted mounted-route test passed.