### PR TITLE
fix(files): bound validator upload reads

### DIFF
--- a/backend/app/utils/file_validator.py
+++ b/backend/app/utils/file_validator.py
@@ -104,6 +104,8 @@ SIZE_LIMITS = {
     FileCategory.OTHER: 10 * 1024 * 1024,  # 10MB
 }
 
+READ_CHUNK_BYTES = 1024 * 1024
+
 
 # Allowed extensions by category
 ALLOWED_EXTENSIONS = {
@@ -251,9 +253,25 @@ async def validate_upload_file(
         Tuple of (is_valid, error_message, file_info)
     """
     try:
-        # Read file content
-        content = await upload_file.read()
-        file_size = len(content)
+        chunks: list[bytes] = []
+        file_size = 0
+        read_limit = max_size or max(SIZE_LIMITS.values())
+
+        while True:
+            chunk = await upload_file.read(READ_CHUNK_BYTES)
+            if not chunk:
+                break
+            file_size += len(chunk)
+            if file_size > read_limit:
+                await upload_file.seek(0)
+                return (
+                    False,
+                    f"File size {file_size} bytes exceeds limit {read_limit} bytes",
+                    None,
+                )
+            chunks.append(chunk)
+
+        content = b"".join(chunks)
 
         # Reset file pointer for later use
         await upload_file.seek(0)

--- a/backend/tests/integration/test_file_system_upload_limits.py
+++ b/backend/tests/integration/test_file_system_upload_limits.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.utils import file_validator
+from app.utils.file_validator import FileCategory
+
+
+def test_canonical_file_upload_rejects_oversized_payload_before_write(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(file_validator, "READ_CHUNK_BYTES", 2)
+    monkeypatch.setattr(
+        file_validator,
+        "SIZE_LIMITS",
+        {category: 3 for category in FileCategory},
+    )
+
+    response = client.post(
+        "/api/v1/files/upload",
+        headers=auth_headers,
+        data={"file_type": "document"},
+        files={"file": ("oversized.txt", b"abcd", "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert "exceeds limit" in response.json()["detail"]
+    assert not (tmp_path / "uploads").exists()


### PR DESCRIPTION
## Summary
- Bound canonical file validator upload reads before file type and size validation.
- Oversized canonical uploads now fail before the service storage/write path.
- Added a regression test for `/api/v1/files/upload`.

## Cyclic Execution Evidence
- Fresh main sync: branch started from current main after PR #1418 (`c223171b`).
- Clean workspace: clean before this branch; this PR touches only the validator and one targeted test.
- Branch: `codex/file-validator-bounded-read`.
- Scope gate: `gate_known_root_cause` returned a narrow validator override; one regression test module was added after explicit scope report.
- Red-check handling: any red CI for this change will be fixed in this same PR.

## Contract Impact
- Canonical surface: `/api/v1/files/upload` via `validate_upload_file`.
- Request shape: unchanged multipart `file` plus existing metadata fields.
- Response shape: success unchanged; oversized validation failure continues through the existing `File validation failed: ...` 400 path.
- Status codes: no route status contract changed to 413 in this narrow slice.
- Frontend consumer: unchanged route and fields; oversized uploads continue to use the existing validation error path.
- Compatibility path or alias: unchanged; no alias, redirect, or compatibility endpoint was edited.
- Contract proof: `backend/tests/integration/test_file_system_upload_limits.py`.

## RBAC / Permissions
- Roles allowed: unchanged; the existing endpoint dependency still allows the same staff roles.
- Roles denied: unchanged; no auth or role dependency was edited.
- Positive auth proof: regression uses the existing authenticated test client headers.
- Negative auth proof: not rerun because the auth dependency was not touched.

## Notification / Realtime
- Event type or websocket channel: not involved; this upload validator does not publish realtime events.
- Payload version / ack behavior: not involved; no notification payload or ack contract changed.
- Read/unread or delivery semantics: not involved; this is not a messaging delivery/read path.
- Reconnect/resync proof: not involved; no websocket reconnect or resync behavior changed.

## Frontend Resilience
- Empty data proof: not changed; this PR only changes oversized binary read enforcement before storage.
- Partial data proof: test forces chunked validation with a 4-byte upload over a 3-byte limit and verifies rejection.
- Forbidden secondary path behavior: unchanged; no secondary download or forbidden route was edited.
- Missing draft/resource behavior: not involved; no draft or missing-resource flow was edited.
- Stale route/deep-link behavior: unchanged; no frontend route or deep-link path was edited.

## Scope Gate
- Allowed paths: `backend/app/utils/file_validator.py`, `backend/tests/integration/test_file_system_upload_limits.py`.
- Denied paths: frontend, schemas/models, migrations, storage layout, quota policy, and service write logic.
- Migration/docs/test impact: no migrations or docs changed; one focused integration regression was added.
- Rollback note: revert this commit to restore the previous validator read behavior.

## Validation
- Targeted tests or smoke run: `scripts/run_backend_pytest.ps1 tests/integration/test_file_system_upload_limits.py`.
- Result: local py_compile, targeted pytest, and `git diff --cached --check` passed; GitHub CI is being watched before merge.
- Not checked: broad frontend/browser suites were not run because this PR does not touch frontend routes, UI, or client upload code.
