### PR TITLE
fix(payment): use canonical receipt read endpoint

### DIFF
--- a/frontend/src/pages/PaymentSuccess.jsx
+++ b/frontend/src/pages/PaymentSuccess.jsx
@@ -116,8 +116,8 @@ const PaymentSuccess = () => {
 
   const generateReceipt = useCallback(async () => {
     try {
-      const response = await apiClient.post(`/payments/${paymentId}/receipt`, {
-        format: 'pdf'
+      const response = await apiClient.get(`/payments/${paymentId}/receipt`, {
+        params: { format_type: 'pdf' }
       });
 
       if (response.data?.receipt_url) {

--- a/frontend/src/pages/__tests__/PaymentSuccess.contract.test.jsx
+++ b/frontend/src/pages/__tests__/PaymentSuccess.contract.test.jsx
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const paymentSuccessPath = path.resolve(__dirname, '../PaymentSuccess.jsx');
+
+describe('PaymentSuccess receipt route contract', () => {
+  it('uses the backend canonical GET receipt endpoint with format_type query params', () => {
+    const source = fs.readFileSync(paymentSuccessPath, 'utf8');
+
+    expect(source).toContain('apiClient.get(`/payments/${paymentId}/receipt`');
+    expect(source).toContain("params: { format_type: 'pdf' }");
+    expect(source).not.toContain('apiClient.post(`/payments/${paymentId}/receipt`');
+    expect(source).not.toContain("format: 'pdf'");
+  });
+});

--- a/frontend/src/services/__tests__/paymentServiceRoutes.contract.test.js
+++ b/frontend/src/services/__tests__/paymentServiceRoutes.contract.test.js
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const paymentServicePath = path.resolve(__dirname, '../payment.js');
+
+describe('paymentService receipt route contract', () => {
+  it('uses the backend canonical GET receipt endpoint with format_type query params', () => {
+    const source = fs.readFileSync(paymentServicePath, 'utf8');
+
+    expect(source).toContain('api.get(`/payments/${paymentId}/receipt`');
+    expect(source).toContain('params: { format_type: format }');
+    expect(source).not.toContain('api.post(`/payments/${paymentId}/receipt`');
+    expect(source).not.toContain('format\\n      });');
+  });
+});

--- a/frontend/src/services/payment.js
+++ b/frontend/src/services/payment.js
@@ -67,10 +67,10 @@ export const paymentService = {
    */
   async generateReceipt(paymentId, format = 'pdf') {
     try {
-      const response = await api.post(`/payments/${paymentId}/receipt`, {
-        format
+      const response = await api.get(`/payments/${paymentId}/receipt`, {
+        params: { format_type: format }
       });
-      
+
       return {
         success: true,
         data: response.data


### PR DESCRIPTION
## Summary

- Change payment receipt generation callers from POST to canonical GET /payments/{payment_id}/receipt.
- Pass receipt format through backend-owned query param format_type.
- Add frontend source contract tests for PaymentSuccess and paymentService receipt routes.

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main at c223171b.
- Clean workspace: inspected before edits; only scoped payment receipt frontend callers and tests changed.
- Branch: codex/payment-receipt-canonical-get.
- Scope gate: allowed PaymentSuccess.jsx, payment.js, and focused frontend contract tests; denied backend runtime, /api/v1/ui/*, BFF-lite, payment business logic, and unrelated cleanup.
- Red-check handling: fix failed code-related checks in this same PR before merge.

## Contract Impact

- Canonical surface: GET /api/v1/payments/{payment_id}/receipt.
- Request shape: authenticated GET with format_type query parameter; no request body.
- Response shape: backend receipt payload including receipt_data and receipt_url when generation succeeds.
- Status codes: existing backend behavior remains 200 for allowed reads, 401 unauthenticated, 403 forbidden, 404 missing payment, and backend domain errors unchanged.
- Frontend consumer: PaymentSuccess receipt generation and exported paymentService.generateReceipt.
- Compatibility path or alias: no alias added; old frontend POST caller removed.
- Contract proof: focused frontend source contract tests prove GET receipt calls and reject POST drift.

## RBAC / Permissions

- Roles allowed: unchanged; backend receipt endpoint remains Admin, Cashier, Registrar, Doctor, Patient subject to existing payment access checks.
- Roles denied: unchanged; backend rejects unauthenticated users and unauthorized patient/doctor access.
- Positive auth proof: not rerun locally because this PR has no backend changes; existing backend route test/CI ownership remains authoritative.
- Negative auth proof: not rerun locally because this PR has no backend changes; existing backend access checks remain untouched.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime, delivery, read/unread, ack, reconnect, or resync behavior changed.

## Frontend Resilience

- Empty data proof: existing PaymentSuccess missing payment_id path remains unchanged.
- Partial data proof: existing receipt_url fallback remains unchanged; UI still falls back to text receipt if canonical receipt generation does not provide a URL.
- Forbidden secondary path behavior: existing catch path remains unchanged and logs receipt generation failure without blocking payment detail display.
- Missing draft/resource behavior: not applicable, receipt generation does not create drafts or reopen resources.
- Stale route/deep-link behavior: existing payment_id query handling remains unchanged.

## Scope Gate

- Allowed paths: frontend/src/pages/PaymentSuccess.jsx, frontend/src/services/payment.js, focused frontend contract tests.
- Denied paths: backend runtime, /api/v1/ui/*, BFF-lite, payment state transitions, receipt generation service internals, and unrelated cleanup.
- Migration/docs/test impact: no migration or docs; targeted frontend tests added.
- Rollback note: revert this commit to restore previous frontend receipt call behavior.

## Validation

- Targeted tests or smoke run: npm.cmd --prefix frontend run test:run -- PaymentSuccess.contract paymentServiceRoutes.contract; npm.cmd --prefix frontend run build; git diff --check; git diff --cached --check.
- Result: all passed locally.
- Not checked: backend pytest, because backend receipt endpoint and access checks were not changed.