### PR TITLE
fix(files): bound replacement upload reads

### DIFF
--- a/backend/app/services/file_system_service.py
+++ b/backend/app/services/file_system_service.py
@@ -46,6 +46,8 @@ from app.schemas.file_system import (
 
 logger = logging.getLogger(__name__)
 
+FILE_READ_CHUNK_BYTES = 1024 * 1024
+
 
 class FileSystemService:
     """Сервис файловой системы"""
@@ -78,6 +80,29 @@ class FileSystemService:
 
         # Создаем директории если их нет
         self._ensure_directories()
+
+    def _read_upload_file_limited(
+        self, upload_file: UploadFile, max_bytes: int
+    ) -> tuple[bytes, int]:
+        chunks: list[bytes] = []
+        total_size = 0
+
+        while True:
+            chunk = upload_file.file.read(FILE_READ_CHUNK_BYTES)
+            if not chunk:
+                break
+
+            total_size += len(chunk)
+            if total_size > max_bytes:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail=(
+                        f"Файл слишком большой. Максимальный размер: {max_bytes} байт"
+                    ),
+                )
+            chunks.append(chunk)
+
+        return b"".join(chunks), total_size
 
     def _ensure_directories(self):
         """Создать необходимые директории"""
@@ -226,16 +251,9 @@ class FileSystemService:
     ) -> File:
         """Загрузить файл"""
         try:
-            # Читаем содержимое файла
-            file_content = upload_file.file.read()
-            file_size = len(file_content)
-
-            # Проверяем размер файла
-            if file_size > self.max_file_size:
-                raise HTTPException(
-                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                    detail=f"Файл слишком большой. Максимальный размер: {self.max_file_size} байт",
-                )
+            file_content, file_size = self._read_upload_file_limited(
+                upload_file, self.max_file_size
+            )
 
             # Проверяем квоту пользователя
             quota_ok, quota_message = self._check_file_quota(db, user_id, file_size)
@@ -474,16 +492,9 @@ class FileSystemService:
                 detail="Нет прав для замены содержимого файла",
             )
 
-        # Читаем новое содержимое
-        new_content = new_file.file.read()
-        new_size = len(new_content)
-
-        # Проверяем размер
-        if new_size > self.max_file_size:
-            raise HTTPException(
-                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                detail=f"Файл слишком большой. Максимальный размер: {self.max_file_size} байт",
-            )
+        new_content, new_size = self._read_upload_file_limited(
+            new_file, self.max_file_size
+        )
 
         # Вычисляем хеш нового содержимого
         new_hash = self._generate_file_hash(new_content)

--- a/backend/tests/integration/test_file_system_upload_limits.py
+++ b/backend/tests/integration/test_file_system_upload_limits.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
+from app.services import file_system_service
 from app.utils import file_validator
 from app.utils.file_validator import FileCategory
 
@@ -30,3 +31,38 @@ def test_canonical_file_upload_rejects_oversized_payload_before_write(
     assert response.status_code == 400
     assert "exceeds limit" in response.json()["detail"]
     assert not (tmp_path / "uploads").exists()
+
+
+def test_file_content_replace_rejects_oversized_payload_before_version_write(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(file_validator, "READ_CHUNK_BYTES", 2)
+    monkeypatch.setattr(
+        file_validator,
+        "SIZE_LIMITS",
+        {category: 100 for category in FileCategory},
+    )
+    monkeypatch.setattr(file_system_service, "FILE_READ_CHUNK_BYTES", 2)
+    monkeypatch.setattr(file_system_service.file_system_service, "max_file_size", 3)
+
+    create_response = client.post(
+        "/api/v1/files/upload",
+        headers=auth_headers,
+        data={"file_type": "document"},
+        files={"file": ("record.txt", b"ok", "text/plain")},
+    )
+    assert create_response.status_code == 200
+    file_id = create_response.json()["id"]
+
+    replace_response = client.put(
+        f"/api/v1/files/{file_id}/content",
+        headers=auth_headers,
+        files={"file": ("record.txt", b"abcd", "text/plain")},
+    )
+
+    assert replace_response.status_code == 413
+    assert "Файл слишком большой" in replace_response.json()["detail"]


### PR DESCRIPTION
## Summary
- Bound file-system service reads for canonical upload and replacement content paths.
- `PUT /api/v1/files/{file_id}/content` now rejects oversized replacement payloads while reading in chunks instead of buffering the whole request first.
- Added a regression covering create-small then replace-oversized.

## Cyclic Execution Evidence
- Fresh main sync: branch started from current main after PR #1419 (`c1bc9f0`).
- Clean workspace: clean before this branch; this PR touches only file-system service and the existing upload-limit regression file.
- Branch: `codex/file-replace-bounded-read`.
- Scope gate: `gate_known_root_cause` returned a narrow service override; one targeted regression was added after explicit scope report.
- Red-check handling: any red CI for this change will be fixed in this same PR.

## Contract Impact
- Canonical surface: `/api/v1/files/upload` and `/api/v1/files/{file_id}/content` through `FileSystemService`.
- Request shape: unchanged multipart upload/replacement fields.
- Response shape: success unchanged; oversized service-level failures continue to return the existing 413 error shape.
- Status codes: oversized service-level upload/replacement remains 413.
- Frontend consumer: unchanged route and fields; oversized replacement now gets the existing too-large error before any version/write work.
- Compatibility path or alias: unchanged; no alias, redirect, or compatibility endpoint was edited.
- Contract proof: `backend/tests/integration/test_file_system_upload_limits.py`.

## RBAC / Permissions
- Roles allowed: unchanged; existing endpoint dependencies still allow the same staff roles.
- Roles denied: unchanged; no auth or role dependency was edited.
- Positive auth proof: regression uses the existing authenticated test client headers.
- Negative auth proof: not rerun because the auth dependency was not touched.

## Notification / Realtime
- Event type or websocket channel: not involved; this file service path does not publish realtime events.
- Payload version / ack behavior: not involved; no notification payload or ack contract changed.
- Read/unread or delivery semantics: not involved; this is not a messaging delivery/read path.
- Reconnect/resync proof: not involved; no websocket reconnect or resync behavior changed.

## Frontend Resilience
- Empty data proof: not changed; this PR only changes oversized binary read enforcement in the backend service.
- Partial data proof: test forces 2-byte chunks with a 4-byte replacement over a 3-byte service limit and verifies 413.
- Forbidden secondary path behavior: unchanged; owner/admin authorization logic was not edited.
- Missing draft/resource behavior: not involved; no draft or missing-resource flow was edited.
- Stale route/deep-link behavior: unchanged; no frontend route or deep-link path was edited.

## Scope Gate
- Allowed paths: `backend/app/services/file_system_service.py`, `backend/tests/integration/test_file_system_upload_limits.py`.
- Denied paths: frontend, schemas/models, migrations, storage layout, quota policy, route dependencies, and download/preview behavior.
- Migration/docs/test impact: no migrations or docs changed; one focused integration regression was added.
- Rollback note: revert this commit to restore previous service read behavior.

## Validation
- Targeted tests or smoke run: `scripts/run_backend_pytest.ps1 tests/integration/test_file_system_upload_limits.py`.
- Result: local py_compile, targeted pytest, `git diff --check`, and `git diff --cached --check` passed; GitHub CI will be watched before merge.
- Not checked: broad frontend/browser suites were not run because this PR does not touch frontend routes, UI, or client upload code.
