### PR TITLE
Fix settings route contract

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -107,6 +107,7 @@ from app.api.v1.endpoints import (
     schedule,
     services,
     setup,
+    settings as settings_ep,
     simple_auth,
     sms_providers,
     specialized_panels,
@@ -419,6 +420,7 @@ api_router.include_router(health_ep.router, tags=["health"])
 api_router.include_router(observability.router, tags=["observability"])
 api_router.include_router(activation_ep.router, tags=["activation"])
 api_router.include_router(setup.router, tags=["setup"])
+api_router.include_router(settings_ep.router, tags=["settings"])
 api_router.include_router(
     authentication.router, prefix="/authentication", tags=["authentication"]
 )

--- a/backend/app/api/v1/endpoints/settings.py
+++ b/backend/app/api/v1/endpoints/settings.py
@@ -1,17 +1,26 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db
+from app.api.deps import get_db, require_roles
+from app.models.user import User
 from app.schemas.setting import Setting as SettingSchema
 from app.services.setting_api_service import SettingApiDomainError, SettingApiService
 
 router = APIRouter()
 
 
+class SettingUpsertIn(BaseModel):
+    category: str = Field(..., min_length=1, max_length=50)
+    key: str = Field(..., min_length=1, max_length=100)
+    value: str = Field("", max_length=500)
+
+
 @router.get("/settings", response_model=list[SettingSchema])
 def get_settings(
     category: str = Query(..., description="Category of settings"),
     db: Session = Depends(get_db),
+    current_user: User = Depends(require_roles("Admin")),
 ):
     """
     Return list of settings for given category.
@@ -20,6 +29,26 @@ def get_settings(
     service = SettingApiService(db)
     try:
         return service.get_settings(category=category)
+    except SettingApiDomainError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=exc.detail
+        ) from exc
+
+
+@router.put("/settings", response_model=SettingSchema)
+def upsert_setting(
+    payload: SettingUpsertIn,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_roles("Admin")),
+):
+    """Create or update one generic key/value setting for the admin settings page."""
+    service = SettingApiService(db)
+    try:
+        return service.upsert_setting(
+            category=payload.category,
+            key=payload.key,
+            value=payload.value,
+        )
     except SettingApiDomainError as exc:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=exc.detail

--- a/backend/app/repositories/setting_api_repository.py
+++ b/backend/app/repositories/setting_api_repository.py
@@ -17,3 +17,19 @@ class SettingApiRepository:
     def list_by_category(self, *, category: str) -> list[Setting]:
         stmt = select(Setting).where(Setting.category == category)
         return self.db.execute(stmt).scalars().all()
+
+    def upsert(self, *, category: str, key: str, value: str) -> Setting:
+        stmt = select(Setting).where(
+            Setting.category == category,
+            Setting.key == key,
+        )
+        row = self.db.execute(stmt).scalar_one_or_none()
+        if row is None:
+            row = Setting(category=category, key=key, value=value)
+            self.db.add(row)
+        else:
+            row.value = value
+
+        self.db.commit()
+        self.db.refresh(row)
+        return row

--- a/backend/app/services/setting_api_service.py
+++ b/backend/app/services/setting_api_service.py
@@ -40,3 +40,16 @@ class SettingApiService:
                 status_code=500,
                 detail="Internal server error",
             ) from exc
+
+    def upsert_setting(self, *, category: str, key: str, value: str):
+        try:
+            return self.repository.upsert(category=category, key=key, value=value)
+        except Exception as exc:
+            logger.warning(
+                "Setting upsert failed error_type=%s",
+                type(exc).__name__,
+            )
+            raise SettingApiDomainError(
+                status_code=500,
+                detail="Internal server error",
+            ) from exc

--- a/backend/tests/integration/test_settings_api_contract.py
+++ b/backend/tests/integration/test_settings_api_contract.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from app.models.setting import Setting
+
+
+@pytest.mark.integration
+def test_settings_get_and_put_are_admin_contract(client, auth_headers, db_session):
+    db_session.add(Setting(category="printer", key="paper", value="A4"))
+    db_session.commit()
+
+    read_response = client.get(
+        "/api/v1/settings",
+        params={"category": "printer"},
+        headers=auth_headers,
+    )
+
+    assert read_response.status_code == 200, read_response.text
+    assert read_response.json() == [
+        {"category": "printer", "key": "paper", "value": "A4"}
+    ]
+
+    update_response = client.put(
+        "/api/v1/settings",
+        json={"category": "printer", "key": "paper", "value": "A5"},
+        headers=auth_headers,
+    )
+
+    assert update_response.status_code == 200, update_response.text
+    assert update_response.json() == {
+        "category": "printer",
+        "key": "paper",
+        "value": "A5",
+    }
+
+    reread_response = client.get(
+        "/api/v1/settings",
+        params={"category": "printer"},
+        headers=auth_headers,
+    )
+
+    assert reread_response.status_code == 200, reread_response.text
+    assert reread_response.json() == [
+        {"category": "printer", "key": "paper", "value": "A5"}
+    ]
+
+
+@pytest.mark.integration
+def test_settings_put_is_admin_only(client, registrar_auth_headers):
+    response = client.put(
+        "/api/v1/settings",
+        json={"category": "printer", "key": "paper", "value": "A5"},
+        headers=registrar_auth_headers,
+    )
+
+    assert response.status_code == 403

--- a/backend/tests/unit/test_setting_api_repository.py
+++ b/backend/tests/unit/test_setting_api_repository.py
@@ -23,3 +23,15 @@ class TestSettingApiRepository:
 
         assert {row.key for row in rows} == {"device_name", "paper"}
 
+    def test_upsert_creates_and_updates_category_key(self, db_session):
+        repository = SettingApiRepository(db_session)
+
+        created = repository.upsert(category="printer", key="paper", value="A4")
+        updated = repository.upsert(category="printer", key="paper", value="A5")
+
+        rows = db_session.query(Setting).filter(Setting.category == "printer").all()
+        assert created.id == updated.id
+        assert len(rows) == 1
+        assert rows[0].key == "paper"
+        assert rows[0].value == "A5"
+

--- a/backend/tests/unit/test_setting_api_service.py
+++ b/backend/tests/unit/test_setting_api_service.py
@@ -18,6 +18,15 @@ class TestSettingApiService:
 
         assert result == expected
 
+    def test_upsert_setting_delegates_to_repository(self):
+        expected = SimpleNamespace(category="printer", key="paper", value="A5")
+        repository = SimpleNamespace(upsert=lambda category, key, value: expected)
+        service = SettingApiService(db=None, repository=repository)
+
+        result = service.upsert_setting(category="printer", key="paper", value="A5")
+
+        assert result == expected
+
     def test_get_settings_wraps_repository_error_without_leaking_detail(self):
         def _boom(category: str):
             raise RuntimeError("db broken internal diagnostic")
@@ -27,6 +36,19 @@ class TestSettingApiService:
 
         with pytest.raises(SettingApiDomainError) as exc_info:
             service.get_settings(category="printer")
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.detail == "Internal server error"
+
+    def test_upsert_setting_wraps_repository_error_without_leaking_detail(self):
+        def _boom(category: str, key: str, value: str):
+            raise RuntimeError("constraint diagnostic")
+
+        repository = SimpleNamespace(upsert=_boom)
+        service = SettingApiService(db=None, repository=repository)
+
+        with pytest.raises(SettingApiDomainError) as exc_info:
+            service.upsert_setting(category="printer", key="paper", value="A5")
 
         assert exc_info.value.status_code == 500
         assert exc_info.value.detail == "Internal server error"

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -149,12 +149,13 @@ export default function Settings() {void
     try {
       // Ожидаем форму {items:[{key,value}]} или массив объектов
       const res = await api.get('/settings', { params: { category } });
+      const data = res?.data ?? res;
       let arr = [];
-      if (Array.isArray(res?.items)) arr = res.items;else
-      if (Array.isArray(res)) arr = res;else
-      if (res && typeof res === 'object') {
+      if (Array.isArray(data?.items)) arr = data.items;else
+      if (Array.isArray(data)) arr = data;else
+      if (data && typeof data === 'object') {
         // возможный словарь
-        arr = Object.entries(res).map(([k, v]) => ({ key: k, value: v }));
+        arr = Object.entries(data).map(([k, v]) => ({ key: k, value: v }));
       }
       setItems(arr.map((x) => ({ key: x.key ?? x.name ?? '', value: x.value ?? '' })));
     } catch (e) {
@@ -167,7 +168,7 @@ export default function Settings() {void
 
   async function saveKV(category, key, value) {
     try {
-      await api.put('/settings', { body: { category, key, value } });
+      await api.put('/settings', { category, key, value });
       await loadCat(category);
     } catch (e) {
       alert(e?.data?.detail || e?.message || 'Ошибка сохранения');

--- a/frontend/src/pages/__tests__/Settings.contract.test.jsx
+++ b/frontend/src/pages/__tests__/Settings.contract.test.jsx
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const settingsPath = path.resolve(__dirname, '../Settings.jsx');
+
+describe('Settings generic key/value route contract', () => {
+  it('uses the published settings endpoint with axios response data and canonical PUT body', () => {
+    const source = fs.readFileSync(settingsPath, 'utf8');
+
+    expect(source).toContain("api.get('/settings', { params: { category } })");
+    expect(source).toContain('const data = res?.data ?? res;');
+    expect(source).toContain("api.put('/settings', { category, key, value })");
+    expect(source).not.toContain("api.put('/settings', { body: { category, key, value } })");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the active Admin Settings generic key/value contract by publishing the existing backend `/api/v1/settings` route, adding the missing admin-only `PUT /api/v1/settings` upsert contract, and aligning `Settings.jsx` with axios response/body shape.

## Cyclic Execution Evidence
- Fresh main sync: started from local `main` matching `origin/main` at `a267098c`.
- Clean workspace: `git status --short --branch` was clean before branch creation.
- Branch: `codex/settings-route-contract`.
- Scope gate: route-contract work used `final-ssot-contract-repair` + `final-openapi-contract-review`; agent gate misrouted to frontend routing, so narrow override was used for the confirmed active settings API contract.
- Red-check handling: local targeted backend/frontend checks and OpenAPI contract check passed before PR.

## Contract Impact
- Canonical surface: `GET /api/v1/settings?category=...` and `PUT /api/v1/settings` for generic admin key/value settings.
- Request shape: `PUT /settings` accepts `{ category, key, value }` JSON.
- Response shape: `GET` returns `[{ category, key, value }]`; `PUT` returns `{ category, key, value }`.
- Status codes: admin requests return `200`; non-admin `PUT` returns `403`; validation remains FastAPI/Pydantic-owned.
- Frontend consumer: `frontend/src/pages/Settings.jsx` now reads `response.data` and sends the canonical PUT body.
- Compatibility path or alias: no alias added; this publishes the existing intended `/settings` contract.
- Contract proof: backend integration test covers GET/PUT/admin-only behavior; frontend source contract test covers request shape.

## RBAC / Permissions
- Roles allowed: Admin for generic settings GET/PUT.
- Roles denied: Registrar denied for generic settings write.
- Positive auth proof: `test_settings_get_and_put_are_admin_contract` passes with `auth_headers`.
- Negative auth proof: `test_settings_put_is_admin_only` asserts registrar receives `403`.

## Notification / Realtime
not applicable - settings key/value changes do not emit notifications or websocket events in the current contract.

## Frontend Resilience
- Empty data proof: existing Settings page keeps empty array fallback when response cannot be converted to rows.
- Partial data proof: frontend still maps `key ?? name` and `value ?? ''` for partial row shapes.
- Forbidden secondary path behavior: write denial remains backend-owned; frontend shows the existing save error path.
- Missing draft/resource behavior: no draft/resource workflow in this screen.
- Stale route/deep-link behavior: `/admin/settings` stays the active route; no route registry changes.

## Scope Gate
- Allowed paths: settings endpoint/router/service/repository, settings tests, `Settings.jsx`, frontend contract test.
- Denied paths: `/api/v1/ui/*`, BFF-lite, separate BFF service, unrelated admin settings rewrites, migrations.
- Migration/docs/test impact: no migration; uses existing `settings` table/model; tests added for route and contract behavior.
- Rollback note: revert this PR to unpublish generic `/settings` and return the UI to previous failing 404/405 behavior.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- Settings.contract`; `C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -File C:\final\scripts\run_backend_pytest.ps1 tests\unit\test_setting_api_repository.py tests\unit\test_setting_api_service.py tests\integration\test_settings_api_contract.py`; `C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -File C:\final\scripts\run_backend_pytest.ps1 tests\test_openapi_contract.py`; `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`.
- Result: all passed.
- Not checked: full backend suite and browser smoke were not run for this narrow route-contract PR.