### PR TITLE
fix(mcp): bound imaging upload reads

### DIFF
--- a/backend/app/api/v1/endpoints/mcp.py
+++ b/backend/app/api/v1/endpoints/mcp.py
@@ -18,6 +18,32 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+MAX_MCP_IMAGE_UPLOAD_BYTES = 25 * 1024 * 1024
+MCP_IMAGE_READ_CHUNK_BYTES = 1024 * 1024
+
+
+async def _read_mcp_image_bounded(image: UploadFile) -> bytes:
+    chunks: list[bytes] = []
+    total_size = 0
+
+    while True:
+        chunk = await image.read(MCP_IMAGE_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+
+        total_size += len(chunk)
+        if total_size > MAX_MCP_IMAGE_UPLOAD_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=(
+                    "Image upload is too large "
+                    f"(maximum {MAX_MCP_IMAGE_UPLOAD_BYTES // 1024 // 1024} MB)"
+                ),
+            )
+        chunks.append(chunk)
+
+    return b"".join(chunks)
+
 
 def log_mcp_service_unavailable(action: str, exc: Exception) -> None:
     logger.warning(
@@ -518,7 +544,7 @@ async def mcp_analyze_image(
             raise HTTPException(status_code=400, detail="Файл должен быть изображением")
 
         # Читаем и кодируем изображение в base64
-        image_data = await image.read()
+        image_data = await _read_mcp_image_bounded(image)
         image_base64 = base64.b64encode(image_data).decode('utf-8')
 
         mcp_manager = await get_mcp_manager()
@@ -558,7 +584,7 @@ async def mcp_analyze_skin_lesion(
             raise HTTPException(status_code=403, detail="Недостаточно прав")
 
         # Читаем и кодируем изображение
-        image_data = await image.read()
+        image_data = await _read_mcp_image_bounded(image)
         image_base64 = base64.b64encode(image_data).decode('utf-8')
 
         # Парсим JSON данные

--- a/backend/tests/integration/test_mcp_upload_limits.py
+++ b/backend/tests/integration/test_mcp_upload_limits.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import mcp
+
+
+@pytest.mark.parametrize(
+    ("path", "data"),
+    [
+        ("/api/v1/mcp/imaging/analyze", {"image_type": "xray"}),
+        ("/api/v1/mcp/imaging/skin-lesion", {}),
+    ],
+)
+def test_mcp_imaging_rejects_oversized_payload_before_manager_call(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    monkeypatch,
+    path: str,
+    data: dict[str, str],
+) -> None:
+    async def fail_if_called():
+        raise AssertionError("MCP manager should not be called for oversized upload")
+
+    monkeypatch.setattr(mcp, "MCP_IMAGE_READ_CHUNK_BYTES", 2)
+    monkeypatch.setattr(mcp, "MAX_MCP_IMAGE_UPLOAD_BYTES", 3)
+    monkeypatch.setattr(mcp, "get_mcp_manager", fail_if_called)
+
+    response = client.post(
+        path,
+        headers=auth_headers,
+        data=data,
+        files={"image": ("oversized.png", b"abcd", "image/png")},
+    )
+
+    assert response.status_code == 413
+    assert "Image upload is too large" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- Bound MCP imaging upload reads before base64 encoding and MCP manager dispatch.
- `/api/v1/mcp/imaging/analyze` and `/api/v1/mcp/imaging/skin-lesion` now reject oversized images while reading in chunks.
- Added a regression proving oversized requests return 413 before `get_mcp_manager()` is called.

## Cyclic Execution Evidence
- Fresh main sync: branch started from current main after PR #1421 (`67dae483`).
- Clean workspace: clean before this branch; this PR touches only MCP endpoint code and one targeted MCP upload-limit test.
- Branch: `codex/mcp-imaging-bounded-read`.
- Scope gate: `gate_known_root_cause` returned a narrow MCP endpoint override; one targeted regression file was added after explicit scope report.
- Red-check handling: any red CI for this change will be fixed in this same PR.

## Contract Impact
- Canonical surface: `/api/v1/mcp/imaging/analyze` and `/api/v1/mcp/imaging/skin-lesion`.
- Request shape: unchanged multipart `image` plus existing form fields.
- Response shape: success unchanged; oversized image failures return a 413 JSON error detail before MCP processing.
- Status codes: oversized images now return 413 instead of continuing toward memory-heavy base64 encoding.
- Frontend consumer: unchanged route and fields; oversized images get an explicit too-large error before analysis starts.
- Compatibility path or alias: unchanged; no alias, redirect, or compatibility endpoint was edited.
- Contract proof: `backend/tests/integration/test_mcp_upload_limits.py`.

## RBAC / Permissions
- Roles allowed: unchanged; existing endpoint role checks still gate doctor/admin access.
- Roles denied: unchanged; no auth dependency or role policy was edited.
- Positive auth proof: regression uses the existing authenticated test client headers.
- Negative auth proof: not rerun because auth and role dependencies were not touched.

## Notification / Realtime
- Event type or websocket channel: not involved; MCP imaging upload does not publish realtime events.
- Payload version / ack behavior: not involved; no notification payload or ack contract changed.
- Read/unread or delivery semantics: not involved; this is not a messaging delivery/read path.
- Reconnect/resync proof: not involved; no websocket reconnect or resync behavior changed.

## Frontend Resilience
- Empty data proof: not changed; this PR only changes oversized backend image read enforcement.
- Partial data proof: test forces 2-byte chunks with a 4-byte image over a 3-byte MCP image limit and verifies 413.
- Forbidden secondary path behavior: unchanged; role checks were not edited.
- Missing draft/resource behavior: not involved; no draft or missing-resource flow was edited.
- Stale route/deep-link behavior: unchanged; no frontend route or deep-link path was edited.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/mcp.py`, `backend/tests/integration/test_mcp_upload_limits.py`.
- Denied paths: frontend, schemas/models, migrations, MCP manager/service internals, role policy, and non-imaging MCP endpoints.
- Migration/docs/test impact: no migrations or docs changed; one focused integration regression was added.
- Rollback note: revert this commit to restore the previous MCP imaging read behavior.

## Validation
- Targeted tests or smoke run: `scripts/run_backend_pytest.ps1 tests/integration/test_mcp_upload_limits.py`.
- Result: local py_compile, targeted pytest, `git diff --check`, and `git diff --cached --check` passed; GitHub CI will be watched before merge.
- Not checked: broad frontend/browser suites were not run because this PR does not touch frontend routes, UI, or client upload code.
