### PR TITLE
Fix Settings activation contract

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -65,7 +65,7 @@ export default function Settings() {void
   async function loadStatus() {
     try {
       const st = await api.get('/activation/status');
-      setStatus(st || null);
+      setStatus(st?.data ?? st ?? null);
     } catch {
       setStatus(null);
     }
@@ -75,7 +75,8 @@ export default function Settings() {void
     setBusyAct(true);
     setErrAct('');
     try {
-      const res = await api.post('/activation/activate', { body: { key } });
+      const response = await api.post('/activation/activate', { key });
+      const res = response?.data ?? response;
       if (!res?.ok) {
         setErrAct(res?.reason || 'Не удалось активировать');
       }

--- a/frontend/src/pages/__tests__/Settings.contract.test.jsx
+++ b/frontend/src/pages/__tests__/Settings.contract.test.jsx
@@ -16,4 +16,14 @@ describe('Settings generic key/value route contract', () => {
     expect(source).toContain("api.put('/settings', { category, key, value })");
     expect(source).not.toContain("api.put('/settings', { body: { category, key, value } })");
   });
+
+  it('uses activation response data and the canonical activate body', () => {
+    const source = fs.readFileSync(settingsPath, 'utf8');
+
+    expect(source).toContain("api.get('/activation/status')");
+    expect(source).toContain('setStatus(st?.data ?? st ?? null);');
+    expect(source).toContain("api.post('/activation/activate', { key })");
+    expect(source).toContain('const res = response?.data ?? response;');
+    expect(source).not.toContain("api.post('/activation/activate', { body: { key } })");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the Admin Settings license tab activation contract. `Settings.jsx` now reads axios `response.data` from `GET /activation/status` and sends the canonical `POST /activation/activate` body `{ key }` instead of the invalid `{ body: { key } }` wrapper.

## Cyclic Execution Evidence
- Fresh main sync: started after #1422 merge from local `main` matching `origin/main` at `3a8ba307`.
- Clean workspace: `git status --short --branch` was clean before branch creation.
- Branch: `codex/settings-activation-contract`.
- Scope gate: route/body contract task used `final-ssot-contract-repair` and `final-openapi-contract-review`; agent gate misrouted to broader frontend routing/dependency files, so narrow override was used for the confirmed `Settings.jsx` root cause.
- Red-check handling: local frontend contract test, build, and diff hygiene passed before PR.

## Contract Impact
- Canonical surface: existing `GET /api/v1/activation/status` and `POST /api/v1/activation/activate`.
- Request shape: `POST /activation/activate` now sends `{ key }`.
- Response shape: Settings license tab now reads axios `response.data` for status and activation results.
- Status codes: unchanged; backend owns activation validation and error responses.
- Frontend consumer: `frontend/src/pages/Settings.jsx` license tab.
- Compatibility path or alias: none; no backend alias or route change.
- Contract proof: `Settings.contract.test.jsx` asserts canonical activation request/response usage.

## RBAC / Permissions
- Roles allowed: unchanged; the existing Settings admin screen remains the only frontend consumer touched by this patch.
- Roles denied: unchanged; no route guard, token, or backend authorization behavior changed.
- Positive auth proof: `Settings.contract.test.jsx` proves the authorized Settings consumer calls the existing activation endpoints with the canonical response/body shape.
- Negative auth proof: no permissions logic changed; backend activation denial behavior remains owned by the existing activation API.

## Notification / Realtime
not applicable - activation status/activate flow does not emit notification or realtime events in this frontend contract patch.

## Frontend Resilience
- Empty data proof: failed status load still clears local status to `null`.
- Partial data proof: activation result remains guarded with optional access before showing backend reason.
- Forbidden secondary path behavior: no secondary endpoint added.
- Missing draft/resource behavior: no draft/resource workflow in this screen.
- Stale route/deep-link behavior: no route changes.

## Scope Gate
- Allowed paths: `frontend/src/pages/Settings.jsx`, `frontend/src/pages/__tests__/Settings.contract.test.jsx`.
- Denied paths: backend activation semantics, route aliases, `/api/v1/ui/*`, BFF-lite, unrelated Settings rewrites.
- Migration/docs/test impact: no migration; frontend contract test updated.
- Rollback note: revert this PR to restore the previous broken activation body/response handling in Settings license tab.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- Settings.contract`; `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`.
- Result: all passed.
- Not checked: full backend suite was not run because no backend code changed.