### PR TITLE
fix(print): bound template upload reads

### DIFF
--- a/backend/app/api/v1/endpoints/print_templates.py
+++ b/backend/app/api/v1/endpoints/print_templates.py
@@ -28,6 +28,31 @@ router = APIRouter()
 
 # Путь к шаблонам
 TEMPLATES_DIR = Path(__file__).parent.parent.parent / "templates" / "print"
+MAX_PRINT_TEMPLATE_UPLOAD_BYTES = 5 * 1024 * 1024
+PRINT_TEMPLATE_READ_CHUNK_BYTES = 1024 * 1024
+
+
+def _read_print_template_bounded(file: UploadFile) -> bytes:
+    chunks: list[bytes] = []
+    total_size = 0
+
+    while True:
+        chunk = file.file.read(PRINT_TEMPLATE_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+
+        total_size += len(chunk)
+        if total_size > MAX_PRINT_TEMPLATE_UPLOAD_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=(
+                    "Print template upload is too large "
+                    f"(maximum {MAX_PRINT_TEMPLATE_UPLOAD_BYTES // 1024 // 1024} MB)"
+                ),
+            )
+        chunks.append(chunk)
+
+    return b"".join(chunks)
 
 
 def _safe_template_type(value: str) -> str:
@@ -272,7 +297,7 @@ def upload_template_file(
         file_path = _template_path(filename)
 
         # Сохраняем файл
-        content = file.file.read()
+        content = _read_print_template_bounded(file)
 
         # Валидируем шаблон
         try:

--- a/backend/tests/integration/test_print_template_upload_limits.py
+++ b/backend/tests/integration/test_print_template_upload_limits.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import print_templates
+
+
+def test_print_template_upload_rejects_oversized_payload_before_write(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr(print_templates, "TEMPLATES_DIR", tmp_path)
+    monkeypatch.setattr(print_templates, "PRINT_TEMPLATE_READ_CHUNK_BYTES", 2)
+    monkeypatch.setattr(print_templates, "MAX_PRINT_TEMPLATE_UPLOAD_BYTES", 3)
+
+    response = client.post(
+        "/api/v1/print/templates/templates/upload/ticket",
+        headers=auth_headers,
+        files={"file": ("ticket.html", b"abcd", "text/html")},
+    )
+
+    assert response.status_code == 413
+    assert "Print template upload is too large" in response.json()["detail"]
+    assert not (tmp_path / "ticket_ru.j2").exists()


### PR DESCRIPTION
## Summary
- Bound Admin print-template upload reads before Jinja validation and disk write.
- `/api/v1/print/templates/templates/upload/{template_type}` now rejects oversized template files while reading in chunks.
- Added a regression proving oversized uploads return 413 and do not create a template file.

## Cyclic Execution Evidence
- Fresh main sync: branch started from current main after PR #1423 (`de6d5b5`).
- Clean workspace: clean before this branch; this PR touches only print-template endpoint code and one targeted upload-limit test.
- Branch: `codex/print-template-bounded-read`.
- Scope gate: `gate_known_root_cause` returned a narrow print-template endpoint override; one targeted regression file was added after explicit scope report.
- Red-check handling: any red CI for this change will be fixed in this same PR.

## Contract Impact
- Canonical surface: `/api/v1/print/templates/templates/upload/{template_type}`.
- Request shape: unchanged multipart `file` and existing language default.
- Response shape: success unchanged; oversized template failures return a 413 JSON error detail before validation/write.
- Status codes: oversized template uploads now return 413 instead of reading the whole file first.
- Frontend consumer: unchanged route and fields; oversized templates get an explicit too-large error.
- Compatibility path or alias: unchanged; no alias, redirect, or compatibility endpoint was edited.
- Contract proof: `backend/tests/integration/test_print_template_upload_limits.py`.

## RBAC / Permissions
- Roles allowed: unchanged; upload remains Admin-only.
- Roles denied: unchanged; no auth dependency or role policy was edited.
- Positive auth proof: regression uses the existing authenticated admin test client headers.
- Negative auth proof: not rerun because auth and role dependencies were not touched.

## Notification / Realtime
- Event type or websocket channel: not involved; template upload does not publish realtime events.
- Payload version / ack behavior: not involved; no notification payload or ack contract changed.
- Read/unread or delivery semantics: not involved; this is not a messaging delivery/read path.
- Reconnect/resync proof: not involved; no websocket reconnect or resync behavior changed.

## Frontend Resilience
- Empty data proof: not changed; this PR only changes oversized backend template read enforcement.
- Partial data proof: test forces 2-byte chunks with a 4-byte template over a 3-byte template limit and verifies 413.
- Forbidden secondary path behavior: unchanged; upload role checks were not edited.
- Missing draft/resource behavior: not involved; no draft or missing-resource flow was edited.
- Stale route/deep-link behavior: unchanged; no frontend route or deep-link path was edited.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/print_templates.py`, `backend/tests/integration/test_print_template_upload_limits.py`.
- Denied paths: frontend, schemas/models, migrations, print CRUD/storage model, role policy, and non-upload print endpoints.
- Migration/docs/test impact: no migrations or docs changed; one focused integration regression was added.
- Rollback note: revert this commit to restore the previous print-template read behavior.

## Validation
- Targeted tests or smoke run: `scripts/run_backend_pytest.ps1 tests/integration/test_print_template_upload_limits.py`.
- Result: local py_compile, targeted pytest, `git diff --check`, and `git diff --cached --check` passed; GitHub CI will be watched before merge.
- Not checked: broad frontend/browser suites were not run because this PR does not touch frontend routes, UI, or client upload code.
