### PR TITLE
Tighten lab template selection contract

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -383,14 +383,22 @@ export default function LabReportWorkbench({
       return;
     }
     const defaultTemplateId =
-      templateResolution?.default_template?.id || templateOptions[0]?.id || '';
+      templateResolution?.default_template?.id
+      || (!serviceContextPresent ? templateOptions[0]?.id : '')
+      || '';
     setSelectedTemplateId((current) => {
       if (current && templateOptions.some((template) => String(template.id) === String(current))) {
         return current;
       }
       return defaultTemplateId ? String(defaultTemplateId) : '';
     });
-  }, [activeInstance, selectedAppointment, templateOptions, templateResolution?.default_template?.id]);
+  }, [
+    activeInstance,
+    selectedAppointment,
+    serviceContextPresent,
+    templateOptions,
+    templateResolution?.default_template?.id
+  ]);
 
   function updateField(fieldKey, value) {
     setDraftValues((prev) => ({ ...prev, [fieldKey]: value }));
@@ -657,7 +665,7 @@ export default function LabReportWorkbench({
                 <Button
                   variant="primary"
                   onClick={() => handleCreateInstance()}
-                  disabled={saving || templateResolutionLoading || resolutionHasBlockingGap}
+                  disabled={saving || templateResolutionLoading || resolutionHasBlockingGap || !selectedTemplateId}
                 >
                   <Icon name="plus.rectangle.on.folder" size={16} />
                   {busyAction === 'create' ? 'Создаю...' : 'Создать бланк'}

--- a/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
@@ -182,4 +182,59 @@ describe('LabReportWorkbench', () => {
       expect.stringContaining('автоматически')
     );
   });
+
+  it('does not auto-select a service-scoped template unless backend provides default_template', async () => {
+    render(
+      <MacOSThemeProvider>
+        <ThemeProvider>
+          <LabReportWorkbench
+            selectedAppointment={{
+              id: 17,
+              patient_id: 444,
+              visit_id: 728,
+              patient_fio: 'Test Patient',
+              service_codes: ['CBC'],
+              service_details: [{ id: 5, code: 'CBC', name: 'CBC' }],
+            }}
+            templates={[
+              {
+                id: 3,
+                name: 'CBC template',
+                family: 'hematology',
+                published_version_id: 33,
+              },
+            ]}
+            templateResolution={{
+              visit_id: 728,
+              service_codes: ['CBC'],
+              default_template: null,
+              allowed_templates: [
+                {
+                  id: 3,
+                  name: 'CBC template',
+                  family: 'hematology',
+                  published_version_id: 33,
+                },
+              ],
+              unmapped_service_codes: [],
+            }}
+            templateResolutionLoading={false}
+            reportHistory={[]}
+            recentReports={[]}
+            activeInstance={null}
+            onInstanceChange={vi.fn()}
+            onOpenInstance={vi.fn()}
+            onRefreshHistory={vi.fn()}
+            onRefreshRecentReports={vi.fn()}
+            onQueueChanged={vi.fn()}
+            notify={vi.fn()}
+          />
+        </ThemeProvider>
+      </MacOSThemeProvider>
+    );
+
+    expect(screen.getByRole('combobox')).toHaveValue('');
+    expect(screen.getByRole('combobox').closest('div')?.querySelector('button')).toBeDisabled();
+    expect(labReportingApi.createInstance).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Tightens the lab report workbench template selection contract. In a service-scoped lab visit, React no longer auto-selects the first allowed template when the backend omits `default_template`; the lab user must explicitly choose a template, and create remains validated by the existing `/lab/report-instances` backend command.

## Cyclic Execution Evidence
- Fresh main sync: started from local `main` matching `origin/main` at `c687d815` after #1424 merge.
- Clean workspace: `git status --short --branch` was clean before branch creation.
- Branch: `codex/lab-command-contract-proof`.
- Scope gate: lab SSOT task used `final-ssot-contract-repair`, `final-openapi-contract-review`, and `final-bff-lite-read-model`; agent gate first pointed at `LabPanel.jsx`, then confirmed `LabReportWorkbench.jsx` as the narrow root-cause file.
- Red-check handling: local LabReportWorkbench/LabPanel contract tests, frontend build, and diff hygiene passed before PR.

## Contract Impact
- Canonical surface: existing `POST /api/v1/lab/template-resolutions/resolve` and `POST /api/v1/lab/report-instances` remain unchanged.
- Request shape: unchanged; `createInstance` still submits the selected `template_id` to the existing backend command.
- Response shape: unchanged; frontend now treats `templateResolution.default_template` as the only backend-owned default for service-scoped visits.
- Status codes: unchanged; backend continues to own lab create/finalization/template validation and error responses.
- Frontend consumer: `frontend/src/components/laboratory/LabReportWorkbench.jsx`.
- Compatibility path or alias: none; no backend route, alias, or `/api/v1/ui/*` endpoint added.
- Contract proof: `LabReportWorkbench.test.jsx` proves single allowed template is not auto-created/opened and is not auto-selected without backend `default_template`.

## RBAC / Permissions
- Roles allowed: unchanged; this remains the existing Lab workbench UI path.
- Roles denied: unchanged; no route guard, auth token, or backend authorization behavior changed.
- Positive auth proof: `LabReportWorkbench.test.jsx` proves the authorized lab UI consumer uses backend template-resolution facts before enabling create selection.
- Negative auth proof: no permission logic changed; backend lab command denial behavior remains owned by the existing lab reporting API.

## Notification / Realtime
not applicable - lab template selection/create UI tightening does not emit notification or realtime events.

## Frontend Resilience
- Empty data proof: create button stays disabled when no template is selected.
- Partial data proof: service-scoped allowed templates without backend `default_template` are displayed but not auto-selected.
- Forbidden secondary path behavior: no secondary endpoint added.
- Missing draft/resource behavior: no draft/version/finalization behavior changed.
- Stale route/deep-link behavior: no route changes.

## Scope Gate
- Allowed paths: `frontend/src/components/laboratory/LabReportWorkbench.jsx`, `frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx`.
- Denied paths: backend lab command semantics, lab finalization/template/version rules, `/api/v1/ui/*`, BFF-lite, unrelated LabPanel rewrites.
- Migration/docs/test impact: no migration; frontend LabReportWorkbench test updated.
- Rollback note: revert this PR to restore previous frontend auto-selection of the first service-scoped template option.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- LabReportWorkbench`; `npm.cmd --prefix frontend run test:run -- LabPanel.contract`; `npm.cmd --prefix frontend run test:run -- LabReportWorkbench LabPanel.contract`; `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`.
- Result: all passed.
- Not checked: backend suite was not run because no backend code or API shape changed.