### PR TITLE
Route EchoForm saves through EMR contract

### DIFF
--- a/frontend/src/components/cardiology/EchoForm.jsx
+++ b/frontend/src/components/cardiology/EchoForm.jsx
@@ -118,7 +118,35 @@ function setNestedValue(source, path, value) {
   return result;
 }
 
-const EchoForm = ({ patientId, visitId, onSave, initialData = null }) => {
+async function loadExistingEmrDraft(visitId) {
+  try {
+    const response = await api.get(`/v2/emr/${visitId}`);
+    return response.data || null;
+  } catch (err) {
+    if (err?.response?.status === 404) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+function buildEchoEmrPayload(existingEmr, echoData) {
+  const currentData = existingEmr?.data || {};
+  return {
+    data: {
+      ...currentData,
+      specialty: currentData.specialty || 'cardiology',
+      specialty_data: {
+        ...(currentData.specialty_data || {}),
+        echo: echoData
+      }
+    },
+    row_version: existingEmr?.row_version ?? 0,
+    is_draft: true
+  };
+}
+
+const EchoForm = ({ visitId, onSave, onDataUpdate, initialData = null }) => {
   const [echoData, setEchoData] = useState(DEFAULT_ECHO_DATA);
 
   const [loading, setLoading] = useState(false);
@@ -162,17 +190,24 @@ const EchoForm = ({ patientId, visitId, onSave, initialData = null }) => {
       setLoading(true);
       setError('');
 
-      const response = await api.post('/cardiology/echo-results', {
-        patient_id: patientId,
-        visit_id: visitId,
-        echo_data: echoData
-      });
+      if (!visitId) {
+        if (onSave) {
+          onSave(echoData);
+          setSuccess('Результаты ЭхоКГ сохранены в черновике приема');
+          return;
+        }
+        throw new Error('visit_id is required to save Echo results');
+      }
+
+      const existingEmr = await loadExistingEmrDraft(visitId);
+      const response = await api.post(`/v2/emr/${visitId}`, buildEchoEmrPayload(existingEmr, echoData));
 
       if (response.status === 200) {
         setSuccess('Результаты ЭхоКГ сохранены успешно');
         if (onSave) {
-          onSave(response.data);
+          onSave(response.data?.data?.specialty_data?.echo || echoData);
         }
+        onDataUpdate?.(response.data);
       }
     } catch (err) {
       setError('Ошибка при сохранении результатов ЭхоКГ');
@@ -369,6 +404,7 @@ const EchoForm = ({ patientId, visitId, onSave, initialData = null }) => {
 EchoForm.propTypes = {
   ...(EchoForm.propTypes || {}),
   initialData: PropTypes.any,
+  onDataUpdate: PropTypes.func,
   onSave: PropTypes.any,
   patientId: PropTypes.any,
   visitId: PropTypes.any,

--- a/frontend/src/components/cardiology/__tests__/EchoForm.contract.test.jsx
+++ b/frontend/src/components/cardiology/__tests__/EchoForm.contract.test.jsx
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const echoFormPath = path.resolve(__dirname, '../EchoForm.jsx');
+
+const readEchoFormSource = () => fs.readFileSync(echoFormPath, 'utf8');
+
+describe('EchoForm EMR contract', () => {
+  it('saves Echo data through the existing EMR v2 draft contract', () => {
+    const source = readEchoFormSource();
+
+    expect(source).not.toContain('/cardiology/echo-results');
+    expect(source).toContain('api.get(`/v2/emr/${visitId}`)');
+    expect(source).toContain('api.post(`/v2/emr/${visitId}`, buildEchoEmrPayload(existingEmr, echoData))');
+    expect(source).toContain('specialty_data: {');
+    expect(source).toContain('echo: echoData');
+  });
+
+  it('preserves backend-owned EMR locking data instead of inventing command state', () => {
+    const source = readEchoFormSource();
+
+    expect(source).toContain('row_version: existingEmr?.row_version ?? 0');
+    expect(source).toContain('is_draft: true');
+    expect(source).not.toContain('available_actions');
+    expect(source).not.toContain('can_sign');
+    expect(source).not.toContain('can_amend');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the active cardiology Echo form save contract. `EchoForm` no longer posts to the nonexistent `/cardiology/echo-results`; it now saves Echo data through the existing EMR v2 draft endpoint and stores it under `specialty_data.echo`, keeping EMR access, versioning, locking, and audit backend-owned.

## Cyclic Execution Evidence
- Fresh main sync: started from local `main` matching `origin/main` at `fa33ddf5` after #1426 merge.
- Clean workspace: branch was created from clean main.
- Branch: `codex/echoform-emr-contract`.
- Scope gate: cardiology/EMR route contract task used `final-ssot-contract-repair` and `final-openapi-contract-review`; agent gate confirmed a narrow override rooted at `EchoForm.jsx` and warned route ownership was sensitive.
- Red-check handling: local EchoForm contract test, frontend build, and diff hygiene passed before PR.

## Contract Impact
- Canonical surface: existing `GET /api/v1/v2/emr/{visit_id}` and `POST /api/v1/v2/emr/{visit_id}`.
- Request shape: Echo save now posts `{ data, row_version, is_draft: true }` to the existing EMR v2 save contract.
- Response shape: unchanged; EchoForm reads saved echo from `response.data.data.specialty_data.echo` when available.
- Status codes: unchanged; EMR v2 continues to own 404, 409 conflict, validation, access, and audit behavior.
- Frontend consumer: `frontend/src/components/cardiology/EchoForm.jsx`, used by cardiology panel and EMR cardiology section.
- Compatibility path or alias: none; no backend alias or new route added.
- Contract proof: `EchoForm.contract.test.jsx` asserts the stale `/cardiology/echo-results` path is gone and the existing EMR v2 draft contract is used.

## RBAC / Permissions
- Roles allowed: unchanged; EMR v2 backend role/access checks remain canonical.
- Roles denied: unchanged; no frontend route guard or backend authorization code changed.
- Positive auth proof: EchoForm now calls the existing EMR v2 endpoint that already enforces visit access and allowed clinical roles.
- Negative auth proof: no permission bypass added; unauthorized/foreign visit behavior remains owned by EMR v2 backend checks.

## Notification / Realtime
not applicable - Echo form draft save does not emit notification or realtime events in this frontend contract patch.

## Frontend Resilience
- Empty data proof: when there is no `visitId` but parent `onSave` exists, the form updates the parent draft instead of calling a missing route.
- Partial data proof: existing EMR data is fetched and merged so other `specialty_data` keys are preserved.
- Forbidden secondary path behavior: no secondary compatibility endpoint or `/api/v1/ui/*` path added.
- Missing draft/resource behavior: a missing EMR draft is treated as a new draft with `row_version: 0` through the canonical EMR save contract.
- Stale route/deep-link behavior: no route changes.

## Scope Gate
- Allowed paths: `frontend/src/components/cardiology/EchoForm.jsx`, `frontend/src/components/cardiology/__tests__/EchoForm.contract.test.jsx`.
- Denied paths: backend EMR semantics, migrations, new cardio echo model/table, `/api/v1/ui/*`, route aliases, broad cardiology panel rewrites.
- Migration/docs/test impact: no migration; frontend contract test added.
- Rollback note: revert this PR to restore the broken `/cardiology/echo-results` post path.

## Validation
- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- EchoForm.contract`; `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`.
- Result: all passed.
- Not checked: backend suite was not run because this uses existing EMR v2 endpoints without backend code changes.