### PR TITLE
fix(payments): bound webhook json bodies

### DIFF
--- a/backend/app/api/v1/endpoints/payment_webhooks.py
+++ b/backend/app/api/v1/endpoints/payment_webhooks.py
@@ -2,9 +2,11 @@
 API endpoints для обработки webhook от платежных провайдеров
 """
 
+import json
+from json import JSONDecodeError
 from typing import Any, Dict
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
@@ -16,6 +18,38 @@ from app.services.notifications import notification_sender_service
 from app.services.provider_webhook_service import ProviderWebhookService
 
 router = APIRouter()
+
+MAX_PAYMENT_WEBHOOK_BODY_BYTES = 256 * 1024
+
+
+async def _read_payment_webhook_json(request: Request) -> Dict[str, Any]:
+    chunks: list[bytes] = []
+    total_size = 0
+
+    async for chunk in request.stream():
+        total_size += len(chunk)
+        if total_size > MAX_PAYMENT_WEBHOOK_BODY_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail="Payment webhook payload is too large",
+            )
+        chunks.append(chunk)
+
+    try:
+        payload = json.loads(b"".join(chunks).decode("utf-8") or "{}")
+    except (JSONDecodeError, UnicodeDecodeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid payment webhook JSON",
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Payment webhook JSON must be an object",
+        )
+
+    return payload
 
 
 async def _emit_payment_notification_from_webhook_result(
@@ -107,7 +141,7 @@ async def click_webhook(
     request: Request, db: Session = Depends(get_db)
 ) -> Dict[str, Any]:
     """Webhook для Click платежной системы"""
-    webhook_data = await request.json()
+    webhook_data = await _read_payment_webhook_json(request)
     result = ProviderWebhookService(db).process_click_webhook(webhook_data)
     await _emit_payment_notification_from_webhook_result(
         db=db,
@@ -122,7 +156,7 @@ async def payme_webhook(
     request: Request, db: Session = Depends(get_db)
 ) -> Dict[str, Any]:
     """Webhook для Payme платежной системы (JSON-RPC)"""
-    webhook_data = await request.json()
+    webhook_data = await _read_payment_webhook_json(request)
     auth_header = request.headers.get("Authorization")
     result = ProviderWebhookService(db).process_payme_webhook(webhook_data, auth_header)
     await _emit_payment_notification_from_webhook_result(
@@ -138,7 +172,7 @@ async def kaspi_webhook(
     request: Request, db: Session = Depends(get_db)
 ) -> Dict[str, Any]:
     """Webhook для Kaspi Pay платежной системы"""
-    webhook_data = await request.json()
+    webhook_data = await _read_payment_webhook_json(request)
     result = ProviderWebhookService(db).process_kaspi_webhook(webhook_data)
     await _emit_payment_notification_from_webhook_result(
         db=db,

--- a/backend/tests/integration/test_payment_webhook_body_limits.py
+++ b/backend/tests/integration/test_payment_webhook_body_limits.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import payment_webhooks
+
+
+@pytest.mark.parametrize(
+    ("path", "method_name"),
+    [
+        ("/api/v1/payments/webhook/click", "process_click_webhook"),
+        ("/api/v1/payments/webhook/payme", "process_payme_webhook"),
+        ("/api/v1/payments/webhook/kaspi", "process_kaspi_webhook"),
+    ],
+)
+def test_public_payment_webhook_rejects_oversized_json_before_processing(
+    client: TestClient,
+    monkeypatch,
+    path: str,
+    method_name: str,
+) -> None:
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("provider webhook processor should not be called")
+
+    monkeypatch.setattr(payment_webhooks, "MAX_PAYMENT_WEBHOOK_BODY_BYTES", 3)
+    monkeypatch.setattr(
+        payment_webhooks.ProviderWebhookService,
+        method_name,
+        fail_if_called,
+    )
+
+    response = client.post(
+        path,
+        content=b'{"oversized": true}',
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"] == "Payment webhook payload is too large"


### PR DESCRIPTION
## Summary
- Bound public canonical payment webhook JSON body reads before provider processing.
- `/api/v1/payments/webhook/{click,payme,kaspi}` now rejects oversized JSON payloads while reading request stream in chunks.
- Added regression proving oversized bodies return 413 before `ProviderWebhookService` processing.

## Cyclic Execution Evidence
- Fresh main sync: branch was fast-forwarded to current `origin/main` before commit.
- Clean workspace: clean before commit; this PR touches only canonical payment webhook endpoint code and one targeted body-limit test.
- Branch: `codex/payment-webhook-body-limit`.
- Scope gate: `gate_known_root_cause` returned a narrow canonical payment webhook override; one targeted regression file was added after explicit scope report.
- Red-check handling: any red CI for this change will be fixed in this same PR.

## Contract Impact
- Canonical surface: `/api/v1/payments/webhook/click`, `/api/v1/payments/webhook/payme`, `/api/v1/payments/webhook/kaspi`.
- Request shape: unchanged JSON object payloads.
- Response shape: successful provider responses unchanged; oversized payloads now return 413 JSON detail before processing.
- Status codes: oversized canonical webhook JSON bodies now return 413.
- Frontend consumer: no frontend consumer; public provider webhook integrations keep the same JSON routes for normal-sized payloads.
- Compatibility path or alias: legacy `/api/v1/webhooks/payment/*` left unchanged in this PR and will be handled separately.
- Contract proof: `backend/tests/integration/test_payment_webhook_body_limits.py` plus existing slice2 online payment notification tests.

## RBAC / Permissions
- Roles allowed: unchanged; these canonical webhook routes remain public provider callback endpoints.
- Roles denied: unchanged; no auth dependency or role policy was edited.
- Positive auth proof: not applicable because these are intentionally unauthenticated provider callbacks; normal route behavior covered by existing webhook tests.
- Negative auth proof: not changed because no auth dependency exists or was edited.

## Notification / Realtime
- Event type or websocket channel: existing `payment_notification` emission remains unchanged for accepted normal-sized webhooks.
- Payload version / ack behavior: provider response payloads unchanged for normal-sized webhooks; oversized requests return explicit 413 before provider processing.
- Read/unread or delivery semantics: notification delivery semantics unchanged.
- Reconnect/resync proof: not involved; no websocket reconnect or resync behavior changed.

## Frontend Resilience
- Empty data proof: empty/invalid JSON behavior now returns explicit JSON validation error; frontend routes not involved.
- Partial data proof: test forces a 3-byte webhook body limit and verifies oversized bodies are rejected before processing.
- Forbidden secondary path behavior: unchanged; no secondary UI path or download behavior involved.
- Missing draft/resource behavior: not involved; no draft/resource flow was edited.
- Stale route/deep-link behavior: unchanged; no frontend route or deep-link path was edited.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/payment_webhooks.py`, `backend/tests/integration/test_payment_webhook_body_limits.py`.
- Denied paths: legacy payment webhook routes, payment provider services, payment models/schemas, frontend, migrations, notification sender internals.
- Migration/docs/test impact: no migrations or docs changed; one focused integration regression was added.
- Rollback note: revert this commit to restore previous canonical webhook body parsing behavior.

## Validation
- Targeted tests or smoke run: `scripts/run_backend_pytest.ps1 tests/integration/test_payment_webhook_body_limits.py tests/integration/test_notification_catalog_slice2_online_payments.py`.
- Result: local py_compile, targeted pytest, `git diff --check`, and `git diff --cached --check` passed; GitHub CI will be watched before merge.
- Not checked: broad frontend/browser suites were not run because this PR does not touch frontend routes, UI, or client code.