### PR TITLE
Fix dermatology photo upload contract

### DIFF
--- a/frontend/src/components/dermatology/PhotoUploader.jsx
+++ b/frontend/src/components/dermatology/PhotoUploader.jsx
@@ -39,7 +39,7 @@ import { api } from '../../api/client';
 import logger from '../../utils/logger';
 import { convertHEICToJPEG, isHEICFile } from '../../utils/heicConverter';
 import PropTypes from 'prop-types';
-const PhotoUploader = ({ visitId, onDataUpdate }) => {
+const PhotoUploader = ({ patientId, visitId, onDataUpdate }) => {
   const [photos, setPhotos] = useState({
     before: [],
     after: []
@@ -102,12 +102,22 @@ const PhotoUploader = ({ visitId, onDataUpdate }) => {
 
           // Загружаем на сервер
           const formData = new FormData();
-          formData.append('file', processedFile);
-          formData.append('kind', fileType === 'before' ? 'photo_before' : 'photo_after');
-          formData.append('visit_id', visitId);
-          formData.append('metadata', JSON.stringify(metadata));
+          if (!patientId && !visitId) {
+            throw new Error('Photo upload requires patientId or visitId');
+          }
 
-          const response = await api.post(`/visits/${visitId}/files`, formData, {
+          formData.append('file', processedFile);
+          formData.append('file_type', 'image');
+          formData.append('title', processedFile.name);
+          formData.append('tags', `dermatology,photo,${fileType}`);
+          if (patientId) {
+            formData.append('patient_id', patientId);
+          }
+          if (visitId) {
+            formData.append('visit_id', visitId);
+          }
+
+          const response = await api.post('/files/upload', formData, {
             headers: { 'Content-Type': 'multipart/form-data' },
             onUploadProgress: (progressEvent) => {
               const percentCompleted = Math.round(
@@ -119,7 +129,7 @@ const PhotoUploader = ({ visitId, onDataUpdate }) => {
 
           const newPhoto = {
             id: response.data.id,
-            url: response.data.url,
+            url: response.data.url || (response.data.id ? `/api/v1/files/${response.data.id}/download` : preview),
             preview: preview,
             name: processedFile.name,
             size: processedFile.size,
@@ -643,6 +653,7 @@ const PhotoUploader = ({ visitId, onDataUpdate }) => {
 PhotoUploader.propTypes = {
   ...(PhotoUploader.propTypes || {}),
   onDataUpdate: PropTypes.any,
+  patientId: PropTypes.any,
   visitId: PropTypes.any,
 };
 

--- a/frontend/src/components/dermatology/__tests__/PhotoUploader.test.jsx
+++ b/frontend/src/components/dermatology/__tests__/PhotoUploader.test.jsx
@@ -81,7 +81,9 @@ class TestFileReader {
 }
 
 function renderUploader(props = {}) {
-  return render(<PhotoUploader visitId="visit-42" onDataUpdate={vi.fn()} {...props} />);
+  return render(
+    <PhotoUploader patientId="patient-7" visitId="visit-42" onDataUpdate={vi.fn()} {...props} />
+  );
 }
 
 function getBeforeUploadInput(container) {
@@ -123,16 +125,13 @@ describe('PhotoUploader HEIC upload boundary', () => {
     expect(convertHEICToJPEGMock).not.toHaveBeenCalled();
 
     const [url, formData, config] = apiPostMock.mock.calls[0];
-    expect(url).toBe('/visits/visit-42/files');
+    expect(url).toBe('/files/upload');
     expect(formData.get('file')).toBe(jpgFile);
-    expect(formData.get('kind')).toBe('photo_before');
+    expect(formData.get('file_type')).toBe('image');
+    expect(formData.get('title')).toBe('lesion.jpg');
+    expect(formData.get('tags')).toBe('dermatology,photo,before');
+    expect(formData.get('patient_id')).toBe('patient-7');
     expect(formData.get('visit_id')).toBe('visit-42');
-    expect(JSON.parse(formData.get('metadata'))).toEqual({
-      zone: '',
-      angle: 'front',
-      lighting: 'natural',
-      flash: false,
-    });
     expect(config.headers).toEqual({ 'Content-Type': 'multipart/form-data' });
     expect(onDataUpdate).toHaveBeenCalledTimes(1);
   });
@@ -157,6 +156,7 @@ describe('PhotoUploader HEIC upload boundary', () => {
 
     const [, formData] = apiPostMock.mock.calls[0];
     expect(formData.get('file')).toBe(convertedFile);
-    expect(formData.get('kind')).toBe('photo_before');
+    expect(formData.get('file_type')).toBe('image');
+    expect(formData.get('tags')).toBe('dermatology,photo,before');
   });
 });


### PR DESCRIPTION
## Summary

- Fix active Dermatology PhotoUploader upload path from nonexistent `/visits/{visitId}/files` to the canonical published `/files/upload` endpoint.
- Send backend-supported file form fields: `file`, `file_type=image`, `title`, `tags`, optional `patient_id`, and optional `visit_id`.
- Update the focused PhotoUploader contract test to prove the canonical upload request shape and HEIC conversion path.
- No BFF-lite, no `/api/v1/ui/*`, no backend router mount, no dormant dermatology photo table/migration work.

## Cyclic Execution Evidence

- Fresh main sync: `git fetch origin --prune`; branch created from current `main` after #1427 merge (`f3a98493`).
- Clean workspace: clean before branch; only two staged frontend files in this PR.
- Branch: `codex/dermatology-photo-upload-contract`.
- Scope gate: repo gate run twice with known root cause; it returned narrow override but split frontend/backend ownership. I used the documented narrow override path and avoided backend mount/migration expansion.
- Red-check handling: not applicable - new PR, no CI results yet.

## Contract Impact

- Canonical surface: existing `POST /api/v1/files/upload`.
- Request shape: PhotoUploader now sends `multipart/form-data` with `file`, `file_type=image`, `title`, `tags=dermatology,photo,<before|after>`, and optional `patient_id`/`visit_id`.
- Response shape: unchanged frontend expectation for local preview; uses returned `id` and falls back to `/api/v1/files/{id}/download` for persisted URL.
- Status codes: unchanged; backend file upload owns validation/auth/status behavior.
- Frontend consumer: `frontend/src/components/dermatology/PhotoUploader.jsx`, rendered by Dermatologist panel.
- Compatibility path or alias: removed frontend dependency on nonexistent `/visits/{visitId}/files`.
- Contract proof: `npm.cmd --prefix frontend run test:run -- PhotoUploader` asserts canonical upload URL and form fields.

## RBAC / Permissions

- Roles allowed: unchanged; existing `/files/upload` backend guard remains authoritative.
- Roles denied: unchanged; no route guard edited.
- Positive auth proof: route already covered by existing backend file upload contract; this PR changes only the frontend caller to that published route.
- Negative auth proof: not checked locally; no auth logic changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: PhotoUploader now stops before upload if both `patientId` and `visitId` are missing instead of calling a dead endpoint.
- Partial data proof: upload supports either `patient_id` or `visit_id` when present; Dermatologist panel already passes both when appointment context is available.
- Forbidden secondary path behavior: test proves PhotoUploader no longer calls `/visits/{visitId}/files`.
- Missing draft/resource behavior: not applicable - no draft/resource flow.
- Stale route/deep-link behavior: not applicable - no route/deep-link change.

## Scope Gate

- Allowed paths: `frontend/src/components/dermatology/PhotoUploader.jsx`; `frontend/src/components/dermatology/__tests__/PhotoUploader.test.jsx`.
- Denied paths: backend router mounts, migrations, dormant dermatology photo model/router, BFF/read-model endpoints, unrelated specialty panels.
- Migration/docs/test impact: no migration or docs changes; focused frontend test updated.
- Rollback note: revert this PR to restore the old frontend upload call, though that path is currently nonexistent.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- PhotoUploader`; `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`.
- Result: all passed.
- Not checked: backend pytest not run because no backend code changed; browser smoke not run.