### PR TITLE
fix(payments): bound legacy webhook bodies

### DIFF
--- a/backend/app/api/v1/endpoints/payment_webhook.py
+++ b/backend/app/api/v1/endpoints/payment_webhook.py
@@ -1,6 +1,9 @@
 # app/api/v1/endpoints/payment_webhook.py
+import json
 import logging
+from json import JSONDecodeError
 from typing import Any, List
+from urllib.parse import parse_qsl
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy.orm import Session
@@ -20,6 +23,58 @@ from app.services.payment_webhook_api_service import (
 
 router = APIRouter(prefix="/webhooks", tags=["payment_webhooks"])
 logger = logging.getLogger(__name__)
+
+MAX_LEGACY_PAYMENT_WEBHOOK_BODY_BYTES = 256 * 1024
+
+
+async def _read_legacy_payment_webhook_body(request: Request) -> bytes:
+    chunks: list[bytes] = []
+    total_size = 0
+
+    async for chunk in request.stream():
+        total_size += len(chunk)
+        if total_size > MAX_LEGACY_PAYMENT_WEBHOOK_BODY_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail="Payment webhook payload is too large",
+            )
+        chunks.append(chunk)
+
+    return b"".join(chunks)
+
+
+async def _read_legacy_payment_webhook_json(request: Request) -> dict[str, Any]:
+    raw_body = await _read_legacy_payment_webhook_body(request)
+
+    try:
+        data = json.loads(raw_body.decode("utf-8") or "{}")
+    except (JSONDecodeError, UnicodeDecodeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid payment webhook JSON",
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Payment webhook JSON must be an object",
+        )
+
+    return data
+
+
+async def _read_legacy_payment_webhook_form(request: Request) -> dict[str, str]:
+    raw_body = await _read_legacy_payment_webhook_body(request)
+
+    try:
+        decoded_body = raw_body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid payment webhook form encoding",
+        ) from exc
+
+    return dict(parse_qsl(decoded_body, keep_blank_values=True))
 
 
 def _finalize_public_webhook_result(
@@ -126,7 +181,7 @@ async def payme_webhook(request: Request, db: Session = Depends(get_db)):
     service = PaymentWebhookApiService(db)
     try:
         # Получаем данные из запроса
-        data = await request.json()
+        data = await _read_legacy_payment_webhook_json(request)
 
         # Получаем подпись из заголовков
         signature = request.headers.get("X-Payme-Signature")
@@ -160,8 +215,7 @@ async def click_webhook(request: Request, db: Session = Depends(get_db)):
     service = PaymentWebhookApiService(db)
     try:
         # Получаем данные из формы
-        form_data = await request.form()
-        data = dict(form_data)
+        data = await _read_legacy_payment_webhook_form(request)
         return _finalize_public_webhook_result(
             provider="click",
             result=service.process_click_webhook(data=data),

--- a/backend/tests/integration/test_legacy_payment_webhook_body_limits.py
+++ b/backend/tests/integration/test_legacy_payment_webhook_body_limits.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import payment_webhook
+
+
+def test_legacy_payme_webhook_rejects_oversized_json_before_processing(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("legacy Payme webhook processor should not be called")
+
+    monkeypatch.setattr(payment_webhook, "MAX_LEGACY_PAYMENT_WEBHOOK_BODY_BYTES", 3)
+    monkeypatch.setattr(
+        payment_webhook.PaymentWebhookApiService,
+        "process_payme_webhook",
+        fail_if_called,
+    )
+
+    response = client.post(
+        "/api/v1/webhooks/payment/payme",
+        content=b'{"oversized": true}',
+        headers={
+            "Content-Type": "application/json",
+            "X-Payme-Signature": "test-signature",
+        },
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"] == "Payment webhook payload is too large"
+
+
+def test_legacy_click_webhook_rejects_oversized_form_before_processing(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("legacy Click webhook processor should not be called")
+
+    monkeypatch.setattr(payment_webhook, "MAX_LEGACY_PAYMENT_WEBHOOK_BODY_BYTES", 3)
+    monkeypatch.setattr(
+        payment_webhook.PaymentWebhookApiService,
+        "process_click_webhook",
+        fail_if_called,
+    )
+
+    response = client.post(
+        "/api/v1/webhooks/payment/click",
+        content=b"merchant_trans_id=oversized",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"] == "Payment webhook payload is too large"


### PR DESCRIPTION
## Summary
- Bound public legacy payment webhook body reads before legacy service processing.
- `/api/v1/webhooks/payment/payme` now reads JSON from the ASGI stream with a 256 KiB cap before parsing.
- `/api/v1/webhooks/payment/click` now reads urlencoded form bodies from the ASGI stream with the same cap before parsing.
- Added regression proving oversized legacy Payme/Click payloads return 413 before `PaymentWebhookApiService` processing.

## Cyclic Execution Evidence
- Fresh main sync: branch started from current `origin/main` after PR #1428 merge.
- Clean workspace: clean before this branch; this PR touches only the legacy payment webhook endpoint and one targeted body-limit test.
- Branch: `codex/legacy-payment-webhook-body-limit`.
- Scope gate: `gate_known_root_cause` returned a narrow override anchored on `backend/app/api/v1/endpoints/payment_webhook.py`; the regression test was added after the first endpoint-only compile slice passed.
- Red-check handling: any red CI for this change will be fixed in this same PR.

## Contract Impact
- Canonical surface: legacy `/api/v1/webhooks/payment/payme` and `/api/v1/webhooks/payment/click`.
- Request shape: Payme remains JSON object; Click remains urlencoded form fields.
- Response shape: successful and domain-result legacy responses unchanged; oversized payloads now return 413 JSON detail before processing.
- Status codes: oversized legacy webhook bodies now return 413.
- Frontend consumer: no frontend consumer; these are public provider callback endpoints.
- Compatibility path or alias: canonical `/api/v1/payments/webhook/*` was already handled in PR #1428 and is not changed here.
- Contract proof: `backend/tests/integration/test_legacy_payment_webhook_body_limits.py` plus existing legacy notification catalog tests.

## RBAC / Permissions
- Roles allowed: unchanged; these legacy webhook routes remain public provider callback endpoints.
- Roles denied: unchanged; no auth dependency or role policy was edited.
- Positive auth proof: not applicable because these are intentionally unauthenticated provider callbacks; normal callback behavior covered by legacy webhook tests.
- Negative auth proof: not changed because no auth dependency exists or was edited.

## Notification / Realtime
- Event type or websocket channel: existing legacy `payment_notification` emission remains unchanged for accepted normal-sized callbacks.
- Payload version / ack behavior: provider response payloads unchanged for normal-sized callbacks; oversized requests return explicit 413 before legacy service processing.
- Read/unread or delivery semantics: notification delivery semantics unchanged.
- Reconnect/resync proof: not involved; no websocket reconnect or resync behavior changed.

## Frontend Resilience
- Empty data proof: empty JSON/form bodies still parse to empty dictionaries as before the service layer sees them.
- Partial data proof: test forces a 3-byte webhook body limit and verifies oversized JSON/form bodies are rejected before processing.
- Forbidden secondary path behavior: unchanged; no secondary UI path or download behavior involved.
- Missing draft/resource behavior: not involved; no draft/resource flow was edited.
- Stale route/deep-link behavior: unchanged; no frontend route or deep-link path was edited.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/payment_webhook.py`, `backend/tests/integration/test_legacy_payment_webhook_body_limits.py`.
- Denied paths: canonical payment webhook routes, payment provider/service/repository internals, payment models/schemas, frontend, migrations, notification sender internals.
- Migration/docs/test impact: no migrations or docs changed; one focused integration regression was added.
- Rollback note: revert this commit to restore previous legacy webhook body parsing behavior.

## Validation
- Targeted tests or smoke run: `scripts/run_backend_pytest.ps1 tests/integration/test_legacy_payment_webhook_body_limits.py tests/integration/test_notification_catalog_slice3_legacy_webhooks.py`.
- Result: local py_compile, targeted pytest, `git diff --check`, and `git diff --cached --check` passed; GitHub CI will be watched before merge.
- Not checked: broad frontend/browser suites were not run because this PR does not touch frontend routes, UI, or client code.