### PR TITLE
Route dental treatment plans through EMR draft

### DIFF
--- a/frontend/src/components/dental/TreatmentPlanner.jsx
+++ b/frontend/src/components/dental/TreatmentPlanner.jsx
@@ -36,6 +36,46 @@ import PropTypes from 'prop-types';
 
 const iconSize = 15;
 
+function clonePlainObject(value) {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function loadExistingEmrDraft(visitId) {
+  const response = await api.get(`/v2/emr/${visitId}`, {
+    silent: true,
+    validateStatus: (status) => status === 404 || (status >= 200 && status < 300),
+  });
+
+  return response.status === 404 ? null : response.data;
+}
+
+function buildTreatmentPlanEmrPayload(existingEmr, treatmentPlan) {
+  const data = clonePlainObject(existingEmr?.data);
+  const specialtyData = clonePlainObject(data.specialty_data);
+
+  return {
+    data: {
+      ...data,
+      specialty: data.specialty || 'dentistry',
+      specialty_data: {
+        ...specialtyData,
+        treatment_plan: clonePlainObject(treatmentPlan),
+      },
+      treatment_plan: clonePlainObject(treatmentPlan),
+    },
+    row_version: existingEmr?.row_version ?? 0,
+    is_draft: true,
+  };
+}
+
 const styles = {
   panel: {
     display: 'block',
@@ -266,7 +306,15 @@ const TreatmentPlanner = ({ visitId, onUpdate }) => {
 
   const savePlan = async () => {
     try {
-      await api.post(`/visits/${visitId}/treatment-plan`, treatmentPlan);
+      if (!visitId) {
+        throw new Error('Treatment plan save requires visitId');
+      }
+
+      const existingEmr = await loadExistingEmrDraft(visitId);
+      await api.post(
+        `/v2/emr/${visitId}`,
+        buildTreatmentPlanEmrPayload(existingEmr, treatmentPlan)
+      );
       onUpdate && onUpdate(treatmentPlan);
     } catch (error) {
       logger.error('Ошибка сохранения плана:', error);


### PR DESCRIPTION
## Summary

- Route active dental TreatmentPlanner saves away from nonexistent `/visits/{visitId}/treatment-plan`.
- Save treatment plan drafts through the existing EMR v2 visit contract: `GET /v2/emr/{visitId}` then `POST /v2/emr/{visitId}` with `specialty_data.treatment_plan` and backend `row_version`.
- Preserve existing local UI form state and `onUpdate` behavior after successful save.
- No backend changes, no BFF-lite, no `/api/v1/ui/*`, no ToothModal or dental router rewrite.

## Cyclic Execution Evidence

- Fresh main sync: started from `main == origin/main` after #1429 merge (`12bba5a5`).
- Clean workspace: clean before branch; one frontend file changed.
- Branch: `codex/dental-treatment-plan-emr-contract`.
- Scope gate: repo gate with known root cause returned narrow override for `TreatmentPlanner.jsx`; no expansion into backend/router/migration work.
- Red-check handling: not applicable - new PR, no CI results yet.

## Contract Impact

- Canonical surface: existing EMR v2 draft contract, `GET /api/v1/v2/emr/{visitId}` and `POST /api/v1/v2/emr/{visitId}`.
- Request shape: `POST /v2/emr/{visitId}` sends `{ data, row_version, is_draft: true }`; `data.specialty_data.treatment_plan` contains the UI treatment plan.
- Response shape: no new response shape consumed; backend EMR response remains authoritative.
- Status codes: unchanged; EMR v2 owns 404/access/locking/conflict behavior.
- Frontend consumer: `frontend/src/components/dental/TreatmentPlanner.jsx`, rendered from Dentist panel.
- Compatibility path or alias: removed frontend dependency on nonexistent `/visits/{visitId}/treatment-plan`.
- Contract proof: source check shows no stale `/treatment-plan` route remains; build passed.

## RBAC / Permissions

- Roles allowed: unchanged; EMR v2 route guard remains authoritative.
- Roles denied: unchanged; no route guard edited.
- Positive auth proof: not re-tested locally; this PR only switches the frontend caller to the existing EMR v2 guarded route.
- Negative auth proof: not checked locally; no auth logic changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: missing `visitId` now stops before issuing a dead API call and logs the existing save error path.
- Partial data proof: existing EMR `data.specialty_data` is cloned and preserved before adding `treatment_plan`.
- Forbidden secondary path behavior: `/visits/{visitId}/treatment-plan` is no longer present in `TreatmentPlanner.jsx`.
- Missing draft/resource behavior: `GET /v2/emr/{visitId}` treats 404 as no existing draft and saves with `row_version: 0`.
- Stale route/deep-link behavior: not applicable - no route/deep-link change.

## Scope Gate

- Allowed paths: `frontend/src/components/dental/TreatmentPlanner.jsx`.
- Denied paths: backend routers, migrations, dormant odontogram model/table, ToothModal, dental placeholder endpoints, BFF/read-model endpoints.
- Migration/docs/test impact: no migration/docs changes; no new test file because the gate-limited slice was one active component and build/source proof is the validation.
- Rollback note: revert this PR to restore the previous TreatmentPlanner save call, though that call targets a nonexistent route.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`; `rg -n visits/.*/treatment-plan|/treatment-plan|/v2/emr/ frontend/src/components/dental/TreatmentPlanner.jsx`.
- Result: build and diff checks passed; source check shows only `/v2/emr/{visitId}` remains.
- Not checked: frontend unit test not added in this narrow slice; backend pytest not run because no backend code changed; browser smoke not run.