### PR TITLE
Route dental tooth saves through EMR draft

### DIFF
--- a/frontend/src/components/dental/ToothModal.jsx
+++ b/frontend/src/components/dental/ToothModal.jsx
@@ -3,7 +3,7 @@
  * Модальное окно для работы с зубом
  * Согласно MASTER_TODO_LIST строка 285
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Alert,
   Badge,
@@ -30,6 +30,49 @@ import logger from '../../utils/logger';
 import PropTypes from 'prop-types';
 
 const iconSize = 15;
+
+function clonePlainObject(value) {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function loadExistingEmrDraft(visitId) {
+  const response = await api.get(`/v2/emr/${visitId}`, {
+    silent: true,
+    validateStatus: (status) => status === 404 || (status >= 200 && status < 300),
+  });
+
+  return response.status === 404 ? null : response.data;
+}
+
+function buildToothEmrPayload(existingEmr, toothNumber, toothData) {
+  const data = clonePlainObject(existingEmr?.data);
+  const specialtyData = clonePlainObject(data.specialty_data);
+  const toothStatus = clonePlainObject(specialtyData.tooth_status);
+
+  toothStatus[toothNumber] = clonePlainObject(toothData);
+
+  return {
+    data: {
+      ...data,
+      specialty: data.specialty || 'dentistry',
+      specialty_data: {
+        ...specialtyData,
+        tooth_status: toothStatus,
+      },
+      tooth_status: toothStatus,
+    },
+    row_version: existingEmr?.row_version ?? 0,
+    is_draft: true,
+  };
+}
 
 const styles = {
   header: {
@@ -199,14 +242,13 @@ const MATERIALS = {
   GOLD: { id: 'gold', name: 'Золото', price: 500000 },
 };
 
-const ToothModal = ({ 
-  open, 
-  onClose, 
-  toothNumber, 
-  toothData = {}, 
+const ToothModal = ({
+  open,
+  onClose,
+  toothNumber,
+  toothData = {},
   onSave,
-  patientId,
-  visitId 
+  visitId
 }) => {
   const [formData, setFormData] = useState({
     status: '',
@@ -221,19 +263,6 @@ const ToothModal = ({
   const [history, setHistory] = useState([]);
   const [loading, setLoading] = useState(false);
 
-  // Загрузка истории процедур
-  const loadToothHistory = useCallback(async () => {
-    if (!toothNumber || !patientId) return;
-    
-    try {
-      const response = await api.get(`/patients/${patientId}/teeth/${toothNumber}/history`);
-      setHistory(response.data || []);
-    } catch (error) {
-      logger.error('Ошибка загрузки истории зуба:', error);
-      setHistory([]);
-    }
-  }, [patientId, toothNumber]);
-
   useEffect(() => {
     if (open && toothData) {
       setFormData({
@@ -246,10 +275,9 @@ const ToothModal = ({
         requiresFollowUp: toothData.requiresFollowUp || false,
       });
 
-      // Загружаем историю зуба
-      loadToothHistory();
+      setHistory([]);
     }
-  }, [loadToothHistory, open, toothData]);
+  }, [open, toothData]);
 
   // Добавление процедуры
   const addProcedure = (procedureId) => {
@@ -307,9 +335,12 @@ const ToothModal = ({
         updatedAt: new Date().toISOString(),
       };
       
-      // Сохраняем на сервере
       if (visitId) {
-        await api.post(`/visits/${visitId}/teeth/${toothNumber}`, dataToSave);
+        const existingEmr = await loadExistingEmrDraft(visitId);
+        await api.post(
+          `/v2/emr/${visitId}`,
+          buildToothEmrPayload(existingEmr, toothNumber, dataToSave)
+        );
       }
       
       onSave && onSave(toothNumber, dataToSave);


### PR DESCRIPTION
## Summary

- Remove active ToothModal calls to nonexistent dental tooth routes: `/patients/{patientId}/teeth/{tooth}/history` and `/visits/{visitId}/teeth/{tooth}`.
- Keep tooth history empty until a backend read contract exists instead of logging a 404 on every modal open.
- Save tooth edits through existing EMR v2 draft contract with `specialty_data.tooth_status[toothNumber]` and backend `row_version`.
- No backend changes, no BFF-lite, no `/api/v1/ui/*`, no odontogram migration/router work.

## Cyclic Execution Evidence

- Fresh main sync: started from `main == origin/main` after #1431 merge (`16d3164b`).
- Clean workspace: clean before branch; one frontend file changed.
- Branch: `codex/dental-toothmodal-emr-contract`.
- Scope gate: repo gate with known root cause returned first-touch `frontend/src/components/dental/ToothModal.jsx` only.
- Red-check handling: not applicable - new PR, no CI results yet.

## Contract Impact

- Canonical surface: existing EMR v2 draft contract, `GET /api/v1/v2/emr/{visitId}` and `POST /api/v1/v2/emr/{visitId}`.
- Request shape: `POST /v2/emr/{visitId}` sends `{ data, row_version, is_draft: true }`; `data.specialty_data.tooth_status[toothNumber]` contains the tooth edit.
- Response shape: no new response shape consumed; backend EMR response remains authoritative.
- Status codes: unchanged; EMR v2 owns 404/access/locking/conflict behavior.
- Frontend consumer: `frontend/src/components/dental/ToothModal.jsx`, rendered from Dentist panel.
- Compatibility path or alias: removed frontend dependency on nonexistent dental tooth routes.
- Contract proof: source check shows no stale `/patients/.../teeth` or `/visits/.../teeth` routes remain; build passed.

## RBAC / Permissions

- Roles allowed: unchanged; EMR v2 route guard remains authoritative.
- Roles denied: unchanged; no route guard edited.
- Positive auth proof: not re-tested locally; this PR only switches the frontend caller to the existing EMR v2 guarded route.
- Negative auth proof: not checked locally; no auth logic changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: history now remains empty when no backend read contract exists rather than making a dead request.
- Partial data proof: existing EMR `data.specialty_data.tooth_status` is cloned and preserved before the single tooth update is added.
- Forbidden secondary path behavior: dead tooth history/save routes are no longer present in `ToothModal.jsx`.
- Missing draft/resource behavior: `GET /v2/emr/{visitId}` treats 404 as no existing draft and saves with `row_version: 0`.
- Stale route/deep-link behavior: not applicable - no route/deep-link change.

## Scope Gate

- Allowed paths: `frontend/src/components/dental/ToothModal.jsx`.
- Denied paths: backend routers, migrations, dormant odontogram model/table, TreatmentPlanner, dental placeholder endpoints, BFF/read-model endpoints.
- Migration/docs/test impact: no migration/docs changes; no new test file because the gate-limited slice was one active component and build/source proof is the validation.
- Rollback note: revert this PR to restore the previous ToothModal API calls, though those calls target nonexistent routes.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`; `rg -n patients/.*/teeth|visits/.*/teeth|/v2/emr/ frontend/src/components/dental/ToothModal.jsx`.
- Result: build and diff checks passed; source check shows only `/v2/emr/{visitId}` remains.
- Not checked: frontend unit test not added in this narrow slice; backend pytest not run because no backend code changed; browser smoke not run.