### PR TITLE
Fix clinical search visit API contract

### DIFF
--- a/frontend/src/pages/Search.jsx
+++ b/frontend/src/pages/Search.jsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../api';
+import { getVisit } from '../api/visits';
 import { AppEmpty, AppError, Button } from '../components/ui/macos';
 
 // Modern Search Page with Full Functionality
@@ -42,9 +43,9 @@ export default function Search() {
 
         // Try to get visit by ID directly
         try {
-          const visitRes = await api.get(`/visits/${visitId}`);
-          if (visitRes.data && visitRes.data.visit) {
-            visitsData = [visitRes.data.visit];
+          const visitRes = await getVisit(visitId);
+          if (visitRes?.visit) {
+            visitsData = [visitRes.visit];
           }
         } catch {
           // Visit not found by ID, try by patient_id
@@ -52,7 +53,7 @@ export default function Search() {
 
         // Also get visits for patient with this ID
         try {
-          const patientVisitsRes = await api.get(`/visits?patient_id=${visitId}&limit=20`);
+          const patientVisitsRes = await api.get(`/visits/visits?patient_id=${visitId}&limit=20`);
           if (Array.isArray(patientVisitsRes.data)) {
             // Merge without duplicates
             const existingIds = new Set(visitsData.map(v => v.id));
@@ -72,7 +73,7 @@ export default function Search() {
         const patientIds = patientsData.slice(0, 5).map(p => p.id);
         for (const patientId of patientIds) {
           try {
-            const pvRes = await api.get(`/visits?patient_id=${patientId}&limit=5`);
+            const pvRes = await api.get(`/visits/visits?patient_id=${patientId}&limit=5`);
             if (Array.isArray(pvRes.data)) {
               const existingIds = new Set(visitsData.map(v => v.id));
               pvRes.data.forEach(v => {


### PR DESCRIPTION
## Summary

- Fixes active clinical global search visit lookups to use the published visits contract.
- Routes numeric visit detail lookup through the existing `getVisit()` frontend adapter.
- Updates patient visit list lookups from stale `/visits?...` to current `/visits/visits?...`.

## Cyclic Execution Evidence

- Fresh main sync: `git fetch origin --prune` on clean `main`, branch created from `origin/main`.
- Clean workspace: clean before branch; final diff is one frontend file.
- Branch: `codex/search-visit-route-contract`.
- Scope gate: `run_agent_gate.ps1` with known root cause `frontend/src/pages/Search.jsx`; gate returned narrow override for this routing contract repair.
- Red-check handling: no red checks yet; PR will be monitored after creation.

## Contract Impact

- Canonical surface: existing FastAPI visits router is mounted as `/api/v1/visits/visits...`; existing frontend adapter `frontend/src/api/visits.js` already uses that route.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `/clinical/search` now uses the canonical visit detail adapter and current list path.
- Compatibility path or alias: no backend alias added.
- Contract proof: source proof shows `Search.jsx` no longer calls stale short `/visits/{id}` or `/visits?patient_id=...`; frontend build passes.

## RBAC / Permissions

- Roles allowed: unchanged; backend visits route guards remain the source of truth.
- Roles denied: unchanged.
- Positive auth proof: frontend-only route correction; no route guard changed. Existing backend auth is still exercised by the same visits endpoints.
- Negative auth proof: not run because this PR does not change backend auth or permissions.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: existing catch paths remain; missing visit still falls back to patient visit lookup.
- Partial data proof: existing duplicate merge and patient-name fallback behavior unchanged.
- Forbidden secondary path behavior: no new fallback endpoint added; stale short visit paths removed from this screen.
- Missing draft/resource behavior: not applicable - no draft/resource flow changed.
- Stale route/deep-link behavior: active `/clinical/search` no longer uses stale visit API paths.

## Scope Gate

- Allowed paths: `frontend/src/pages/Search.jsx`.
- Denied paths: backend routes, `/api/v1/ui/*`, BFF-lite, broad route canonicalization, unrelated UI cleanup.
- Migration/docs/test impact: no migration or docs; no backend test needed because no backend contract changed.
- Rollback note: revert this commit to restore previous search request paths.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run build`; `git diff --check`; `git diff --cached --check`; source proof with `rg` for stale/current visit paths in `Search.jsx`.
- Result: passed.
- Not checked: backend pytest not run because backend code and API schema were not changed.
