### PR TITLE
fix(telegram): bound enhanced webhook body

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook_enhanced.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook_enhanced.py
@@ -2,7 +2,9 @@
 Расширенный webhook endpoint для Telegram бота
 """
 
+import json
 import logging
+from json import JSONDecodeError
 from typing import Any, Dict, NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -18,6 +20,37 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 WEBHOOK_SECRET_HEADER = "x-telegram-bot-api-secret-token"
 TELEGRAM_ENHANCED_PUBLIC_ERROR = "Internal server error"
+MAX_TELEGRAM_ENHANCED_WEBHOOK_BODY_BYTES = 256 * 1024
+
+
+async def _read_telegram_enhanced_webhook_json(request: Request) -> Dict[str, Any]:
+    chunks: list[bytes] = []
+    total_size = 0
+
+    async for chunk in request.stream():
+        total_size += len(chunk)
+        if total_size > MAX_TELEGRAM_ENHANCED_WEBHOOK_BODY_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail="Telegram webhook payload is too large",
+            )
+        chunks.append(chunk)
+
+    try:
+        update_data = json.loads(b"".join(chunks).decode("utf-8") or "{}")
+    except (JSONDecodeError, UnicodeDecodeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Telegram webhook JSON",
+        ) from exc
+
+    if not isinstance(update_data, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Telegram webhook JSON must be an object",
+        )
+
+    return update_data
 
 
 def _validate_webhook_secret(request: Request, db: Session) -> None:
@@ -69,9 +102,10 @@ def _telegram_enhanced_test_failure(exc: Exception) -> Dict[str, Any]:
 async def telegram_webhook_enhanced(request: Request, db: Session = Depends(get_db)):
     """Обработка webhook от Telegram для расширенного бота"""
     try:
-        # Получаем данные от Telegram
-        update_data = await request.json()
         _validate_webhook_secret(request, db)
+
+        # Получаем данные от Telegram
+        update_data = await _read_telegram_enhanced_webhook_json(request)
 
         # Получаем экземпляр расширенного бота
         bot = get_enhanced_telegram_bot()

--- a/backend/tests/integration/test_telegram_enhanced_webhook_body_limits.py
+++ b/backend/tests/integration/test_telegram_enhanced_webhook_body_limits.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import telegram_webhook_enhanced
+from app.models.telegram_config import TelegramConfig
+
+
+def _configure_telegram_webhook(db_session, *, secret: str = "topsecret") -> None:
+    db_session.add(
+        TelegramConfig(
+            bot_token="bot-token",
+            webhook_secret=secret,
+            active=True,
+        )
+    )
+    db_session.commit()
+
+
+def test_enhanced_telegram_webhook_rejects_invalid_secret_before_json_parse(
+    client: TestClient,
+    db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_called():
+        raise AssertionError("enhanced Telegram bot should not be resolved")
+
+    _configure_telegram_webhook(db_session)
+    monkeypatch.setattr(
+        telegram_webhook_enhanced,
+        "get_enhanced_telegram_bot",
+        fail_if_called,
+    )
+
+    response = client.post(
+        "/api/v1/telegram/webhook/enhanced",
+        content=b"{not-json",
+        headers={
+            "Content-Type": "application/json",
+            "x-telegram-bot-api-secret-token": "wrong-secret",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Invalid Telegram webhook secret"
+
+
+def test_enhanced_telegram_webhook_rejects_oversized_json_before_dispatch(
+    client: TestClient,
+    db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_called():
+        raise AssertionError("enhanced Telegram bot should not be resolved")
+
+    _configure_telegram_webhook(db_session)
+    monkeypatch.setattr(
+        telegram_webhook_enhanced,
+        "get_enhanced_telegram_bot",
+        fail_if_called,
+    )
+    monkeypatch.setattr(
+        telegram_webhook_enhanced,
+        "MAX_TELEGRAM_ENHANCED_WEBHOOK_BODY_BYTES",
+        3,
+    )
+
+    response = client.post(
+        "/api/v1/telegram/webhook/enhanced",
+        content=b'{"update_id": 42}',
+        headers={
+            "Content-Type": "application/json",
+            "x-telegram-bot-api-secret-token": "topsecret",
+        },
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"] == "Telegram webhook payload is too large"


### PR DESCRIPTION
## Summary
- Bound mounted enhanced Telegram webhook body reads before enhanced bot dispatch.
- `/api/v1/telegram/webhook/enhanced` now validates the configured Telegram webhook secret before reading/parsing JSON.
- Added regression proving invalid secrets reject before JSON parse and oversized valid-secret bodies return 413 before resolving the enhanced bot.

## Cyclic Execution Evidence
- Fresh main sync: branch started from current `origin/main` after PR #1433 merge.
- Clean workspace: clean before this branch; this PR touches only the enhanced Telegram webhook endpoint and one targeted regression test.
- Branch: `codex/telegram-enhanced-webhook-body-limit`.
- Scope gate: known-root-cause gate for `backend/app/api/v1/endpoints/telegram_webhook_enhanced.py` returned `gate_misroute: yes`, `override_used: yes`, still carrying unrelated Telegram admin/frontend owners. This PR intentionally uses the narrow mounted endpoint slice only.
- Red-check handling: any red CI for this change will be fixed in this same PR.

## Contract Impact
- Canonical surface: `/api/v1/telegram/webhook/enhanced`.
- Request shape: unchanged Telegram JSON update object for valid secret requests.
- Response shape: successful webhook response unchanged; invalid secret still returns 403; oversized valid-secret payloads now return 413 before dispatch.
- Status codes: valid-secret oversized webhook bodies now return 413; malformed JSON now returns 400 after secret validation.
- Frontend consumer: no frontend consumer; this is a Telegram provider callback endpoint.
- Compatibility path or alias: `/api/v1/telegram/bot/webhook` was already handled in PR #1433 and is not changed here.
- Contract proof: `backend/tests/integration/test_telegram_enhanced_webhook_body_limits.py`.

## RBAC / Permissions
- Roles allowed: unchanged; this webhook remains a public Telegram callback protected by `x-telegram-bot-api-secret-token`.
- Roles denied: unchanged; admin Telegram management routes were not edited.
- Positive auth proof: valid secret reaches body parsing path; oversized valid-secret payload is rejected with 413 before bot resolution by targeted test.
- Negative auth proof: invalid secret with invalid JSON returns 403 before JSON parsing by targeted test.

## Notification / Realtime
- Event type or websocket channel: none changed.
- Payload version / ack behavior: normal enhanced Telegram webhook ack behavior unchanged for accepted requests; oversized requests now receive explicit 413.
- Read/unread or delivery semantics: not involved.
- Reconnect/resync proof: not involved; no websocket reconnect or resync behavior changed.

## Frontend Resilience
- Empty data proof: empty body still parses to `{}` after valid secret, then enhanced bot validation handles update shape as before.
- Partial data proof: test forces a 3-byte body limit and verifies oversized JSON is rejected before bot resolution.
- Forbidden secondary path behavior: invalid secret is rejected before JSON parse.
- Missing draft/resource behavior: not involved.
- Stale route/deep-link behavior: unchanged; no frontend route or deep-link path was edited.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/telegram_webhook_enhanced.py`, `backend/tests/integration/test_telegram_enhanced_webhook_body_limits.py`.
- Denied paths: basic Telegram bot webhook endpoint, old Telegram patient webhook endpoint, admin Telegram manager, frontend Telegram manager, Telegram storage/config/migrations.
- Migration/docs/test impact: no migrations or docs changed; one focused integration regression was added.
- Rollback note: revert this commit to restore previous enhanced Telegram webhook body parsing order.

## Validation
- Targeted tests or smoke run: `scripts/run_backend_pytest.ps1 tests/integration/test_telegram_enhanced_webhook_body_limits.py`.
- Result: local py_compile for `telegram_webhook_enhanced.py`, gate-listed adjacent Telegram files, and the new test passed; targeted pytest passed; `git diff --check` and `git diff --cached --check` passed. Local frontend build was not rerun because this checkout already failed to resolve `vite` during PR #1433 validation and this PR does not touch frontend.
- Not checked: local frontend build due missing `vite`; broad browser/frontend suites were not run because this PR does not touch frontend code.