### PR TITLE
Fix PaymentWidget status polling contract

### DIFF
--- a/frontend/src/components/payment/PaymentWidget.jsx
+++ b/frontend/src/components/payment/PaymentWidget.jsx
@@ -256,7 +256,7 @@ const PaymentWidget = ({
     if (!paymentData?.payment_id) return;
 
     try {
-      const response = await apiClient.get(`/payments/${paymentData.payment_id}/status`);
+      const response = await apiClient.get(`/payments/${paymentData.payment_id}`);
 
       if (response.data?.status) {
         const nextStatus = normalizePaymentStatus(response.data.status);

--- a/frontend/src/components/payment/__tests__/PaymentWidget.contract.test.jsx
+++ b/frontend/src/components/payment/__tests__/PaymentWidget.contract.test.jsx
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(process.cwd(), 'src/components/payment');
+
+const readPaymentWidget = () =>
+  fs.readFileSync(path.join(ROOT, 'PaymentWidget.jsx'), 'utf8').replace(/\r\n/g, '\n');
+
+describe('PaymentWidget backend payment status contract', () => {
+  it('polls the canonical backend payment status route', () => {
+    const source = readPaymentWidget();
+
+    expect(source).toContain('apiClient.get(`/payments/${paymentData.payment_id}`)');
+    expect(source).not.toContain('apiClient.get(`/payments/${paymentData.payment_id}/status`)');
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes active Cashier `PaymentWidget` status polling to use the canonical backend route `GET /api/v1/payments/{payment_id}`.
- Removes the stale frontend-only `/payments/{payment_id}/status` suffix that has no mounted FastAPI route.
- Adds a focused source contract test so the stale suffix does not come back.

## Cyclic Execution Evidence

- Fresh main sync: branch was created from `origin/main`, then fast-forwarded to latest `origin/main` after #1435 landed.
- Clean workspace: work happened in `C:\tmp\final-contract-scan-cycle-1435`; unrelated dirty files in `C:\final` were not touched.
- Branch: `codex/contract-scan-cycle-1435`.
- Scope gate: `agent_gate` misrouted twice into routing files; used narrow override on confirmed root cause plus focused contract test only.
- Red-check handling: will fix any relevant red checks in this PR before merge.

## Contract Impact

- Canonical surface: backend `GET /api/v1/payments/{payment_id}` in `backend/app/api/v1/endpoints/payments.py`.
- Request shape: unchanged; frontend now calls the existing canonical payment id route.
- Response shape: unchanged; `PaymentWidget` still consumes backend `status`.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/components/payment/PaymentWidget.jsx`.
- Compatibility path or alias: no alias added; stale `/payments/{payment_id}/status` consumer was removed.
- Contract proof: `frontend/src/components/payment/__tests__/PaymentWidget.contract.test.jsx` asserts the canonical route and rejects the stale `/status` suffix.

## RBAC / Permissions

- Roles allowed: unchanged; backend route remains guarded by existing `Admin`, `Cashier`, `Registrar`, `Doctor`, `Patient` payment read roles.
- Roles denied: unchanged.
- Positive auth proof: no backend guard changed; frontend now reaches the already-protected existing route instead of an unmounted path.
- Negative auth proof: not rerun because this PR does not modify backend auth, route guards, or role helpers.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: unchanged; status check remains a no-op when `paymentData.payment_id` is absent.
- Partial data proof: unchanged; widget still only updates state when backend returns `response.data.status`.
- Forbidden secondary path behavior: stale `/payments/{payment_id}/status` path is covered by a contract test and no longer used.
- Missing draft/resource behavior: no draft/resource workflow exists in this payment widget polling path.
- Stale route/deep-link behavior: no route or deep-link behavior changed; only the active payment status API consumer changed.

## Scope Gate

- Allowed paths: `frontend/src/components/payment/PaymentWidget.jsx`, `frontend/src/components/payment/__tests__/PaymentWidget.contract.test.jsx`.
- Denied paths: backend routes/services/schemas, `/api/v1/ui/*`, BFF/read-model code, payment state rules, unrelated frontend cleanup.
- Migration/docs/test impact: no migration or docs; one focused frontend contract test added.
- Rollback note: revert this commit to restore previous frontend polling path.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- PaymentWidget`; `npm.cmd --prefix frontend run build`; `git diff --check`.
- Result: all passed.
- Not checked: backend pytest not run because this PR does not change backend behavior or schemas.
