### PR TITLE
fix(queue): scope cancel service sync

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -2978,14 +2978,32 @@ def cancel_service_in_entry(
             new_total,
         )
 
-        # Синхронизируем с другими queue_entries этого пациента
+        # Sync only within the same visit/session; patient_id alone is too broad.
         if entry.patient_id:
+            other_entry_filters = [
+                OnlineQueueEntry.patient_id == entry.patient_id,
+                OnlineQueueEntry.id != entry.id,
+            ]
+            if entry.visit_id:
+                other_entry_filters.append(OnlineQueueEntry.visit_id == entry.visit_id)
+            elif entry.session_id:
+                other_entry_filters.extend(
+                    [
+                        OnlineQueueEntry.visit_id.is_(None),
+                        OnlineQueueEntry.session_id == entry.session_id,
+                    ]
+                )
+            else:
+                other_entry_filters.extend(
+                    [
+                        OnlineQueueEntry.visit_id.is_(None),
+                        OnlineQueueEntry.queue_id == entry.queue_id,
+                    ]
+                )
+
             other_entries = (
                 db.query(OnlineQueueEntry)
-                .filter(
-                OnlineQueueEntry.patient_id == entry.patient_id,
-                    OnlineQueueEntry.id != entry.id,
-                )
+                .filter(*other_entry_filters)
                 .all()
             )
 


### PR DESCRIPTION
## Summary
- Limit `/api/v1/queue/online-entry/{entry_id}/cancel-service` synchronization to the same visit/session instead of every queue entry for the same patient.
- Prefer `visit_id`; for QR entries without visits, use `session_id`; fallback only to the same `queue_id`.

## Cyclic Execution Evidence
- Fresh main sync: started from `origin/main` view at `fccffbb117c8c76a2b98566b8b54878210d0515e` in `C:\tmp\final-owner-audit2`.
- Clean workspace: inspected before edits; only `backend/app/api/v1/endpoints/qr_queue.py` changed.
- Branch: `codex/queue-cancel-service-scope`.
- Scope gate: repo gate run for queue-risky work with known root cause `backend/app/api/v1/endpoints/qr_queue.py`; first-touch allowed only this endpoint file.
- Red-check handling: PR Review Quality Gate body failures are being fixed in this same PR; any remaining red CI will be fixed here before merge.

## Bug and impact
Cancelling a service in one online queue entry could silently cancel the same `service_id` in unrelated queue entries for the same patient. A patient with a future or separate queue entry containing the same service could lose service state and have `total_amount` recalculated incorrectly.

## Root cause
The endpoint queried other entries by `patient_id` only, excluding just the current row. That made patient identity the synchronization boundary even though queue entries can represent different visits or queue sessions.

## Fix
The sync query now stays inside the service session boundary:
- same `visit_id` when present
- otherwise same `session_id` for QR/no-visit entries
- otherwise same `queue_id` as a narrow fallback

## Contract Impact
- Canonical surface: `POST /api/v1/queue/online-entry/{entry_id}/cancel-service` in the mounted QR queue router.
- Request shape: unchanged `service_id`, `cancel_reason`, and `was_paid` JSON body.
- Response shape: unchanged `CancelServiceResponse` with `success`, `message`, `cancelled_service`, and `new_total_amount`.
- Status codes: unchanged success/error codes; only the related-row synchronization scope is narrowed.
- Frontend consumer: existing queue service-cancel callers keep the same endpoint and payload contract.
- Compatibility path or alias: no route alias or compatibility endpoint changed.
- Contract proof: local compile proof plus CI backend checks; local targeted pytest was attempted but blocked by missing `DATABASE_URL` before collection.

## RBAC / Permissions
- Roles allowed: unchanged `Admin`, `Registrar`, and `Doctor`.
- Roles denied: unchanged; users outside the existing `require_roles(Admin, Registrar, Doctor)` guard remain denied.
- Positive auth proof: not locally checked because endpoint pytest could not collect without `DATABASE_URL`; RBAC dependency code was not modified.
- Negative auth proof: not locally checked because endpoint pytest could not collect without `DATABASE_URL`; RBAC dependency code was not modified.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: not applicable, no frontend rendering path changed.
- Partial data proof: not applicable, request/response shape unchanged.
- Forbidden secondary path behavior: not applicable, no secondary path changed.
- Missing draft/resource behavior: not applicable, this endpoint does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable, no route/deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/qr_queue.py`.
- Denied paths: frontend, migrations / DB schema, `/api/v1/ui/*`, unrelated queue flows, generated output.
- Migration/docs/test impact: no migration or docs changes; a new regression test was not added because the repo gate first-touch boundary allowed only `backend/app/api/v1/endpoints/qr_queue.py` and widening into tests was stopped and reported.
- Rollback note: revert this commit to restore the previous patient-wide synchronization behavior if an operational dependency on that broad sync is discovered.

## Validation
- Targeted tests or smoke run: `scripts/run_python.ps1 -PythonArgs -m,py_compile,backend\\app\\api\\v1\\endpoints\\qr_queue.py`; `git diff --check`; attempted `scripts/run_backend_pytest.ps1 tests\\integration\\test_qr_queue_full_update.py`.
- Result: `py_compile` passed; `git diff --check` passed; targeted pytest did not run because backend import failed before collection with `DATABASE_URL must be set before creating the database engine`.
- Not checked: no completed local backend pytest in this workstation environment; no frontend validation because frontend is out of scope.