### PR TITLE
fix(queue): scope full update sync

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -2430,15 +2430,35 @@ def full_update_online_entry(
                     patient.first_name,
                 )
 
-                # ✅ НОВОЕ: Синхронизируем все остальные queue_entries для этого пациента
-                # Это предотвращает дубликаты в UI (одна запись с данными, другие без)
+                # Keep duplicate service entries in the same visit/session aligned.
+                # Patient-wide sync can rewrite unrelated historical/future entries.
+                other_entry_filters = [
+                    OnlineQueueEntry.patient_id == entry.patient_id,
+                    OnlineQueueEntry.id
+                    != entry.id,  # Исключаем текущую запись (уже обновлена)
+                ]
+                if entry.visit_id:
+                    other_entry_filters.append(
+                        OnlineQueueEntry.visit_id == entry.visit_id
+                    )
+                elif entry.session_id:
+                    other_entry_filters.extend(
+                        [
+                            OnlineQueueEntry.visit_id.is_(None),
+                            OnlineQueueEntry.session_id == entry.session_id,
+                        ]
+                    )
+                else:
+                    other_entry_filters.extend(
+                        [
+                            OnlineQueueEntry.visit_id.is_(None),
+                            OnlineQueueEntry.queue_id == entry.queue_id,
+                        ]
+                    )
+
                 other_entries = (
                     db.query(OnlineQueueEntry)
-                    .filter(
-                    OnlineQueueEntry.patient_id == entry.patient_id,
-                        OnlineQueueEntry.id
-                        != entry.id,  # Исключаем текущую запись (уже обновлена)
-                    )
+                    .filter(*other_entry_filters)
                     .all()
                 )
 


### PR DESCRIPTION
## Summary
- Limit `/api/v1/queue/online-entry/{entry_id}/full-update` related-entry synchronization to the same visit/session instead of every queue entry for the same patient.
- Use the same boundary as the cancel-service fix: `visit_id`, otherwise `session_id`, otherwise the same `queue_id` fallback for no-visit entries.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `origin/main` at `c416f6c57b8a9d2ce80df86e0291689dbfb071ff` after PR #1437 was merged and local safe-view was fast-forwarded.
- Clean workspace: inspected before edits; only `backend/app/api/v1/endpoints/qr_queue.py` changed.
- Branch: `codex/queue-full-update-sync-scope`.
- Scope gate: repo gate run for queue-risky work with known root cause `backend/app/api/v1/endpoints/qr_queue.py`; first-touch allowed only this endpoint file.
- Red-check handling: any red CI or PR body gate failure will be fixed in this same PR before merge.

## Bug and impact
`full-update` could update every queue entry for the same patient, including unrelated historical or future entries. For unrelated entries with `visit_id`, it rebuilds `services` JSON from `VisitService`, which can reset queue-entry-only cancellation state and recalculate totals outside the current visit/session.

Concrete trigger: a patient has an older queue entry whose service JSON has `cancelled: true`; later, staff edits a different current queue entry for the same patient through `full-update`. The patient-wide sync reaches the old entry, rebuilds services from its Visit rows, and writes `cancelled: false` with a restored total.

## Root cause
The related-entry synchronization query used `patient_id` as the only grouping boundary. Patient identity is not a queue service session; one patient can have multiple independent queue entries across visits, days, and sessions.

## Fix
The sync query now stays inside the current service session boundary:
- same `visit_id` when present
- otherwise same `session_id` for QR/no-visit entries
- otherwise same `queue_id` as a narrow fallback

## Contract Impact
- Canonical surface: `PUT /api/v1/queue/online-entry/{entry_id}/full-update` in the mounted QR queue router.
- Request shape: unchanged full-update request body.
- Response shape: unchanged endpoint response shape.
- Status codes: unchanged; only the related-row synchronization scope is narrowed.
- Frontend consumer: existing queue full-update callers keep the same endpoint and payload contract.
- Compatibility path or alias: no route alias or compatibility endpoint changed.
- Contract proof: local compile proof plus CI backend checks; local targeted pytest was attempted but blocked by missing `DATABASE_URL` before collection.

## RBAC / Permissions
- Roles allowed: unchanged existing full-update endpoint role guard.
- Roles denied: unchanged; this PR does not modify auth dependencies or role checks.
- Positive auth proof: not locally checked because endpoint pytest could not collect without `DATABASE_URL`; RBAC code was not modified.
- Negative auth proof: not locally checked because endpoint pytest could not collect without `DATABASE_URL`; RBAC code was not modified.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: not applicable, no frontend rendering path changed.
- Partial data proof: not applicable, request/response shape unchanged.
- Forbidden secondary path behavior: not applicable, no secondary path changed.
- Missing draft/resource behavior: not applicable, this endpoint does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable, no route/deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/qr_queue.py`.
- Denied paths: frontend, migrations / DB schema, `/api/v1/ui/*`, unrelated queue flows, generated output.
- Migration/docs/test impact: no migration or docs changes; a new regression test was not added because the repo gate first-touch boundary allowed only `backend/app/api/v1/endpoints/qr_queue.py`.
- Rollback note: revert this commit to restore the previous patient-wide synchronization behavior if an operational dependency on that broad sync is discovered.

## Validation
- Targeted tests or smoke run: `scripts/run_python.ps1 -PythonArgs -m,py_compile,backend\\app\\api\\v1\\endpoints\\qr_queue.py`; `git diff --check`; attempted `scripts/run_backend_pytest.ps1 tests\\integration\\test_qr_queue_full_update.py`.
- Result: `py_compile` passed; `git diff --check` passed; targeted pytest did not run because backend import failed before collection with `DATABASE_URL must be set before creating the database engine`.
- Not checked: no completed local backend pytest in this workstation environment; no frontend validation because frontend is out of scope.