### PR TITLE
Fix specialist price override API client contract

### DIFF
--- a/frontend/src/components/dental/DentalPriceManager.jsx
+++ b/frontend/src/components/dental/DentalPriceManager.jsx
@@ -13,10 +13,9 @@ import {
 import { useTheme } from '../../contexts/ThemeContext';
 import { toast } from 'react-toastify';
 
-import { getApiBaseUrl } from '../../api/runtime';
+import { api } from '../../api/client';
 import logger from '../../utils/logger';
 import PropTypes from 'prop-types';
-const API_BASE = getApiBaseUrl();
 
 /**
  * Компонент для указания цены стоматологом после лечения
@@ -52,11 +51,10 @@ const DentalPriceManager = ({
   const loadPriceOverrides = useCallback(async () => {
     setLoadingOverrides(true);
     try {
-      const response = await fetch(`${API_BASE}/dental/price-overrides?visit_id=${visitId}`);
-      if (response.ok) {
-        const data = await response.json();
-        setPriceOverrides(data);
-      }
+      const response = await api.get('/dental/price-overrides', {
+        params: { visit_id: visitId }
+      });
+      setPriceOverrides(Array.isArray(response.data) ? response.data : []);
     } catch (error) {
       logger.error('Error loading price overrides:', error);
     } finally {
@@ -86,21 +84,17 @@ const DentalPriceManager = ({
 
     setIsLoading(true);
     try {
-      const response = await fetch(`${API_BASE}/dental/price-override`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          visit_id: visitId,
-          service_id: serviceId,
-          new_price: priceNum,
-          reason: reason,
-          details: details || null,
-          treatment_completed: true
-        })
+      const response = await api.post('/dental/price-override', {
+        visit_id: visitId,
+        service_id: serviceId,
+        new_price: priceNum,
+        reason: reason,
+        details: details || null,
+        treatment_completed: true
       });
 
-      if (response.ok) {
-        const result = await response.json();
+      if (response.status >= 200 && response.status < 300) {
+        const result = response.data;
         toast.success('Цена отправлена в регистратуру для подтверждения');
 
         // Обновляем список изменений
@@ -113,13 +107,10 @@ const DentalPriceManager = ({
 
         // Уведомляем родительский компонент
         onPriceSet?.(result);
-      } else {
-        const errorData = await response.json();
-        toast.error(errorData.detail || 'Ошибка указания цены');
       }
     } catch (error) {
       logger.error('Error setting price:', error);
-      toast.error('Ошибка указания цены');
+      toast.error(error?.response?.data?.detail || 'Ошибка указания цены');
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/components/dermatology/PriceOverrideManager.jsx
+++ b/frontend/src/components/dermatology/PriceOverrideManager.jsx
@@ -12,10 +12,9 @@ import {
 import { useTheme } from '../../contexts/ThemeContext';
 import { toast } from 'react-toastify';
 
-import { getApiBaseUrl } from '../../api/runtime';
+import { api } from '../../api/client';
 import logger from '../../utils/logger';
 import PropTypes from 'prop-types';
-const API_BASE = getApiBaseUrl();
 
 /**
  * Компонент для управления изменениями цен дерматологом
@@ -48,11 +47,10 @@ const PriceOverrideManager = ({
   const loadPriceOverrides = useCallback(async () => {
     setLoadingOverrides(true);
     try {
-      const response = await fetch(`${API_BASE}/derma/price-overrides?visit_id=${visitId}`);
-      if (response.ok) {
-        const data = await response.json();
-        setPriceOverrides(data);
-      }
+      const response = await api.get('/derma/price-overrides', {
+        params: { visit_id: visitId }
+      });
+      setPriceOverrides(Array.isArray(response.data) ? response.data : []);
     } catch (error) {
       logger.error('Error loading price overrides:', error);
     } finally {
@@ -82,20 +80,16 @@ const PriceOverrideManager = ({
 
     setIsLoading(true);
     try {
-      const response = await fetch(`${API_BASE}/derma/price-override`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          visit_id: visitId,
-          service_id: serviceId,
-          new_price: priceNum,
-          reason: reason,
-          details: details || null
-        })
+      const response = await api.post('/derma/price-override', {
+        visit_id: visitId,
+        service_id: serviceId,
+        new_price: priceNum,
+        reason: reason,
+        details: details || null
       });
 
-      if (response.ok) {
-        const result = await response.json();
+      if (response.status >= 200 && response.status < 300) {
+        const result = response.data;
         toast.success('Изменение цены отправлено на одобрение');
 
         // Обновляем список изменений
@@ -108,13 +102,10 @@ const PriceOverrideManager = ({
 
         // Уведомляем родительский компонент
         onPriceOverrideCreated?.(result);
-      } else {
-        const errorData = await response.json();
-        toast.error(errorData.detail || 'Ошибка создания изменения цены');
       }
     } catch (error) {
       logger.error('Error creating price override:', error);
-      toast.error('Ошибка создания изменения цены');
+      toast.error(error?.response?.data?.detail || 'Ошибка создания изменения цены');
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/components/dermatology/__tests__/PriceOverrideManagers.contract.test.jsx
+++ b/frontend/src/components/dermatology/__tests__/PriceOverrideManagers.contract.test.jsx
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(process.cwd(), 'src/components');
+
+const readComponent = (relativePath) =>
+  fs.readFileSync(path.join(ROOT, relativePath), 'utf8').replace(/\r\n/g, '\n');
+
+describe('specialist price override API client contract', () => {
+  it('uses the authenticated api client for dermatology price override endpoints', () => {
+    const source = readComponent('dermatology/PriceOverrideManager.jsx');
+
+    expect(source).toContain("import { api } from '../../api/client'");
+    expect(source).toContain("api.get('/derma/price-overrides'");
+    expect(source).toContain("api.post('/derma/price-override'");
+    expect(source).not.toContain('fetch(`${API_BASE}/derma/price-overrides');
+    expect(source).not.toContain('fetch(`${API_BASE}/derma/price-override');
+    expect(source).not.toContain('response.json()');
+  });
+
+  it('uses the authenticated api client for dental price override endpoints', () => {
+    const source = readComponent('dental/DentalPriceManager.jsx');
+
+    expect(source).toContain("import { api } from '../../api/client'");
+    expect(source).toContain("api.get('/dental/price-overrides'");
+    expect(source).toContain("api.post('/dental/price-override'");
+    expect(source).not.toContain('fetch(`${API_BASE}/dental/price-overrides');
+    expect(source).not.toContain('fetch(`${API_BASE}/dental/price-override');
+    expect(source).not.toContain('response.json()');
+  });
+});


### PR DESCRIPTION
## Summary

- Fix specialist price override components to use the shared authenticated `api` client instead of raw `fetch`.
- Keep backend price override endpoints, RBAC guards, payloads, and business rules unchanged.
- Add a focused contract test proving dermatology and dental price override calls stay on the authenticated client path.

## Cyclic Execution Evidence

- Fresh main sync: branch started from fresh `origin/main`, then fast-forwarded to `c416f6c5` before final validation.
- Clean workspace: scoped diff contains only the two active price override components plus one focused contract test.
- Branch: `codex/price-override-api-client-contract`.
- Scope gate: agent gate misrouted twice into routing/queue despite known root-cause files; used repo-approved narrow override limited to the confirmed active price override files.
- Red-check handling: no red checks yet; PR will be watched and fixed in this branch if CI reports a code-related failure.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

- Canonical surface: existing protected endpoints `GET /api/v1/derma/price-overrides`, `POST /api/v1/derma/price-override`, `GET /api/v1/dental/price-overrides`, and `POST /api/v1/dental/price-override`.
- Request shape: unchanged; frontend still sends the existing visit/service/price/reason/details payloads.
- Response shape: unchanged; frontend still consumes the existing response body from `response.data`.
- Status codes: unchanged; non-2xx remains backend-owned and is surfaced through the shared client error path.
- Frontend consumer: `PriceOverrideManager` and `DentalPriceManager`.
- Compatibility path or alias: no new endpoint, alias, wrapper, or `/api/v1/ui/*` path added.
- Contract proof: `PriceOverrideManagers.contract.test.jsx` asserts both consumers use `api.get`/`api.post` and no longer call the protected routes through raw `fetch`.

## RBAC / Permissions

- Roles allowed: unchanged backend role guards on dermatology and dental price override endpoints.
- Roles denied: unchanged backend denial behavior for unauthenticated or unauthorized users.
- Positive auth proof: frontend now uses the shared `api` client, which attaches the existing Authorization header to the already role-guarded endpoints.
- Negative auth proof: no backend guard was weakened; raw unauthenticated `fetch` path is removed from these active consumers.

## Notification / Realtime

not applicable - price override calls do not change notifications, websocket channels, delivery semantics, or realtime resync behavior.

## Frontend Resilience

- Empty data proof: list loaders preserve an empty array fallback when the response data is not an array.
- Partial data proof: request payloads and rendered data mapping are unchanged; only the transport client changed.
- Forbidden secondary path behavior: backend error `detail` remains surfaced through the shared client exception path.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate

- Allowed paths: `frontend/src/components/dermatology/PriceOverrideManager.jsx`, `frontend/src/components/dental/DentalPriceManager.jsx`, and the focused price override contract test.
- Denied paths: backend endpoints/services/schemas, `/api/v1/ui/*`, BFF/read-model code, price approval rules, routing, unrelated frontend cleanup.
- Migration/docs/test impact: no migration or docs change; one focused frontend contract test added.
- Rollback note: revert this commit to restore the previous raw-fetch transport behavior.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- PriceOverrideManagers`; `npm.cmd --prefix frontend run build`; `git diff --check`
- Result: all passed locally.
- Not checked: backend pytest not run because no backend runtime code or API contract shape changed.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.
