### PR TITLE
fix(queue): scope full update service detection

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -1429,22 +1429,39 @@ def full_update_online_entry(
         # ⭐ FIX: Если aggregated_ids не предоставлен или пустой, используем старую логику
         # Но ТОЛЬКО если мы ещё не нашли услуги через aggregated_ids
         if len(existing_service_ids) == 0:
-            if entry.patient_id and queue:
-                # ⭐ Запрашиваем ВСЕ записи этого пациента за этот день
+            if entry.patient_id:
+                # Limit fallback service detection to the same service session.
+                all_patient_entry_filters = [
+                    OnlineQueueEntry.patient_id == entry.patient_id,
+                ]
+                if entry.visit_id:
+                    all_patient_entry_filters.append(
+                        OnlineQueueEntry.visit_id == entry.visit_id
+                    )
+                elif entry.session_id:
+                    all_patient_entry_filters.extend(
+                        [
+                            OnlineQueueEntry.visit_id.is_(None),
+                            OnlineQueueEntry.session_id == entry.session_id,
+                        ]
+                    )
+                else:
+                    all_patient_entry_filters.extend(
+                        [
+                            OnlineQueueEntry.visit_id.is_(None),
+                            OnlineQueueEntry.queue_id == entry.queue_id,
+                        ]
+                    )
+
                 all_patient_entries = (
                     db.query(OnlineQueueEntry)
-                    .join(DailyQueue, OnlineQueueEntry.queue_id == DailyQueue.id)
-                    .filter(
-                        OnlineQueueEntry.patient_id == entry.patient_id,
-                        DailyQueue.day == queue.day
-                    )
+                    .filter(*all_patient_entry_filters)
                     .all()
                 )
-                
+
                 logger.info(
-                    "[full_update_online_entry] ⭐ FIX: Найдено %d записей пациента за %s",
+                    "[full_update_online_entry] ⭐ FIX: Найдено %d записей пациента в текущей сессии",
                     len(all_patient_entries),
-                    queue.day,
                 )
                 
                 for patient_entry in all_patient_entries:


### PR DESCRIPTION
## Summary
- Limit `/api/v1/queue/online-entry/{entry_id}/full-update` fallback service detection to the current visit/session instead of all same-day entries for the patient.
- Prevent unrelated same-day queue entries from making a requested service look like it already exists in the current session.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `origin/main` at `ede6e4677a2345e88de67b2b9ac5a3f7582c1233` after PR #1438 was merged and local safe-view was fast-forwarded.
- Clean workspace: inspected before edits; only `backend/app/api/v1/endpoints/qr_queue.py` changed.
- Branch: `codex/queue-full-update-service-scope`.
- Scope gate: repo gate run for queue-risky work with known root cause `backend/app/api/v1/endpoints/qr_queue.py`; first-touch allowed only this endpoint file.
- Red-check handling: any red CI or PR body gate failure will be fixed in this same PR before merge.

## Bug and impact
When `full-update` had no trusted aggregated ids, it scanned all queue entries for the patient on the same day to build `existing_service_ids`. A separate same-day visit/session containing the same `service_id` could make the current request treat that service as already present, risking a silently skipped service/billing entry.

Concrete trigger: a patient receives service X in one queue session earlier the same day, then returns or starts a separate queue session that also needs service X. The fallback sees service X in the old session and can suppress creation/update for the current session.

## Root cause
The fallback service-detection query used patient + day as the boundary. Same patient and same day is not the same service session.

## Fix
Fallback service detection now uses the current service session boundary:
- same `visit_id` when present
- otherwise same `session_id` for QR/no-visit entries
- otherwise same `queue_id` as a narrow fallback

## Contract Impact
- Canonical surface: `PUT /api/v1/queue/online-entry/{entry_id}/full-update` in the mounted QR queue router.
- Request shape: unchanged full-update request body.
- Response shape: unchanged endpoint response shape.
- Status codes: unchanged; only the internal existing-service detection scope is narrowed.
- Frontend consumer: existing queue full-update callers keep the same endpoint and payload contract.
- Compatibility path or alias: no route alias or compatibility endpoint changed.
- Contract proof: local compile proof plus CI backend checks; local targeted pytest was attempted but blocked by missing `DATABASE_URL` before collection.

## RBAC / Permissions
- Roles allowed: unchanged existing full-update endpoint role guard.
- Roles denied: unchanged; this PR does not modify auth dependencies or role checks.
- Positive auth proof: not locally checked because endpoint pytest could not collect without `DATABASE_URL`; RBAC code was not modified.
- Negative auth proof: not locally checked because endpoint pytest could not collect without `DATABASE_URL`; RBAC code was not modified.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: not applicable, no frontend rendering path changed.
- Partial data proof: not applicable, request/response shape unchanged.
- Forbidden secondary path behavior: not applicable, no secondary path changed.
- Missing draft/resource behavior: not applicable, this endpoint does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable, no route/deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/qr_queue.py`.
- Denied paths: frontend, migrations / DB schema, `/api/v1/ui/*`, unrelated queue flows, generated output.
- Migration/docs/test impact: no migration or docs changes; a new regression test was not added because the repo gate first-touch boundary allowed only `backend/app/api/v1/endpoints/qr_queue.py`.
- Rollback note: revert this commit to restore the previous patient-day fallback if an operational dependency on that broad service detection is discovered.

## Validation
- Targeted tests or smoke run: `scripts/run_python.ps1 -PythonArgs -m,py_compile,backend\\app\\api\\v1\\endpoints\\qr_queue.py`; `git diff --check`; attempted `scripts/run_backend_pytest.ps1 tests\\integration\\test_qr_queue_full_update.py`.
- Result: `py_compile` passed; `git diff --check` passed; targeted pytest did not run because backend import failed before collection with `DATABASE_URL must be set before creating the database engine`.
- Not checked: no completed local backend pytest in this workstation environment; no frontend validation because frontend is out of scope.