### PR TITLE
Fix hosted payment API client contract

### DIFF
--- a/frontend/src/components/payment/PaymentClick.jsx
+++ b/frontend/src/components/payment/PaymentClick.jsx
@@ -11,15 +11,13 @@ import {
 'lucide-react';
 import MultipleTicketsPrinter from '../tickets/MultipleTicketsPrinter';
 import { useAsyncAction } from '../../hooks/useAsyncAction';
-import { getApiBaseUrl } from '../../api/runtime';
+import { api } from '../../api/client';
 import ModernDialog from '../dialogs/ModernDialog';
 import logger from '../../utils/logger';
 import { printPanelTicketInBrowser } from '../../services/panelPrint';
 import notify from '../../services/notify';
 import './PaymentClick.css';
 import PropTypes from 'prop-types';
-
-const API_BASE = getApiBaseUrl();
 
 const PaymentClick = ({
   isOpen,
@@ -88,23 +86,14 @@ const PaymentClick = ({
 
     await executeAction(
       async () => {
-        const response = await fetch(`${API_BASE}/registrar/invoice/init-payment`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            invoice_id: invoiceId,
-            provider: 'click',
-            return_url: `${window.location.origin}/payment/success`,
-            cancel_url: `${window.location.origin}/payment/cancel`
-          })
+        const response = await api.post('/registrar/invoice/init-payment', {
+          invoice_id: invoiceId,
+          provider: 'click',
+          return_url: `${window.location.origin}/payment/success`,
+          cancel_url: `${window.location.origin}/payment/cancel`
         });
 
-        if (!response.ok) {
-          const errorData = await response.json();
-          throw new Error(errorData.detail || 'Ошибка инициации платежа');
-        }
-
-        const data = await response.json();
+        const data = response.data;
 
         if (data.success) {
           setPaymentUrl(data.payment_url);
@@ -165,10 +154,10 @@ const PaymentClick = ({
   };
 
   const checkPaymentStatus = async () => {
-    const response = await fetch(`${API_BASE}/registrar/invoice/${invoiceId}/status`);
+    const response = await api.get(`/registrar/invoice/${invoiceId}/status`);
 
-    if (response.ok) {
-      const data = await response.json();
+    if (response.status >= 200 && response.status < 300) {
+      const data = response.data;
 
       if (data.status === 'paid') {
         clearPolling();

--- a/frontend/src/components/payment/PaymentPayMe.jsx
+++ b/frontend/src/components/payment/PaymentPayMe.jsx
@@ -11,15 +11,13 @@ import {
 'lucide-react';
 import MultipleTicketsPrinter from '../tickets/MultipleTicketsPrinter';
 import { useAsyncAction } from '../../hooks/useAsyncAction';
-import { getApiBaseUrl } from '../../api/runtime';
+import { api } from '../../api/client';
 import ModernDialog from '../dialogs/ModernDialog';
 import logger from '../../utils/logger';
 import { printPanelTicketInBrowser } from '../../services/panelPrint';
 import notify from '../../services/notify';
 import './PaymentPayMe.css';
 import PropTypes from 'prop-types';
-
-const API_BASE = getApiBaseUrl();
 
 const PaymentPayMe = ({
   isOpen,
@@ -88,23 +86,14 @@ const PaymentPayMe = ({
 
     await executeAction(
       async () => {
-        const response = await fetch(`${API_BASE}/registrar/invoice/init-payment`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            invoice_id: invoiceId,
-            provider: 'payme',
-            return_url: `${window.location.origin}/payment/success`,
-            cancel_url: `${window.location.origin}/payment/cancel`
-          })
+        const response = await api.post('/registrar/invoice/init-payment', {
+          invoice_id: invoiceId,
+          provider: 'payme',
+          return_url: `${window.location.origin}/payment/success`,
+          cancel_url: `${window.location.origin}/payment/cancel`
         });
 
-        if (!response.ok) {
-          const errorData = await response.json();
-          throw new Error(errorData.detail || 'Ошибка инициации платежа');
-        }
-
-        const data = await response.json();
+        const data = response.data;
 
         if (data.success) {
           setPaymentUrl(data.payment_url);
@@ -165,10 +154,10 @@ const PaymentPayMe = ({
   };
 
   const checkPaymentStatus = async () => {
-    const response = await fetch(`${API_BASE}/registrar/invoice/${invoiceId}/status`);
+    const response = await api.get(`/registrar/invoice/${invoiceId}/status`);
 
-    if (response.ok) {
-      const data = await response.json();
+    if (response.status >= 200 && response.status < 300) {
+      const data = response.data;
 
       if (data.status === 'paid') {
         clearPolling();

--- a/frontend/src/components/payment/__tests__/HostedPaymentProviders.contract.test.jsx
+++ b/frontend/src/components/payment/__tests__/HostedPaymentProviders.contract.test.jsx
@@ -9,6 +9,17 @@ const readProvider = (fileName) =>
 
 describe('hosted payment provider ticket contract', () => {
   for (const fileName of ['PaymentClick.jsx', 'PaymentPayMe.jsx']) {
+    it(`${fileName} uses the authenticated api client for protected registrar invoice endpoints`, () => {
+      const source = readProvider(fileName);
+
+      expect(source).toContain("import { api } from '../../api/client'");
+      expect(source).toContain("api.post('/registrar/invoice/init-payment'");
+      expect(source).toContain("api.get(`/registrar/invoice/${invoiceId}/status`");
+      expect(source).not.toContain('fetch(`${API_BASE}/registrar/invoice/init-payment');
+      expect(source).not.toContain('fetch(`${API_BASE}/registrar/invoice/${invoiceId}/status');
+      expect(source).not.toContain('response.json()');
+    });
+
     it(`${fileName} prints only backend-provided tickets`, () => {
       const source = readProvider(fileName);
 


### PR DESCRIPTION
## Summary

- Fix hosted Click/PayMe payment components to call protected registrar invoice endpoints through the shared authenticated `api` client.
- Keep backend invoice endpoints, roles, payloads, responses, provider selection, and ticket printing semantics unchanged.
- Extend the hosted payment provider contract test to prevent raw unauthenticated `fetch` from returning on these protected routes.

## Cyclic Execution Evidence

- Fresh main sync: worktree was created from `origin/main` at merge commit `8d7579fc`.
- Clean workspace: scoped branch contains only hosted payment provider components and their focused contract test.
- Branch: `codex/hosted-payment-auth-client-contract`.
- Scope gate: agent gate was run twice with known root-cause files; it misrouted into backend billing files, so repo-approved narrow override was used for the confirmed active frontend consumers only.
- Red-check handling: no red checks yet; if CI finds a code-related failure, it will be fixed in this PR.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

- Canonical surface: existing protected routes `POST /api/v1/registrar/invoice/init-payment` and `GET /api/v1/registrar/invoice/{invoice_id}/status`.
- Request shape: unchanged; Click and PayMe still submit the same invoice/provider/return/cancel payloads.
- Response shape: unchanged; frontend now reads the same payload through `response.data`.
- Status codes: unchanged; backend still owns auth, role, invoice, provider, and payment status decisions.
- Frontend consumer: `PaymentManager` renders `PaymentClick` and `PaymentPayMe` from the Registrar panel payment flow.
- Compatibility path or alias: no new endpoint, alias, wrapper, command executor, or `/api/v1/ui/*` path added.
- Contract proof: `HostedPaymentProviders.contract.test.jsx` asserts both provider components use `api.post`/`api.get` and no longer call registrar invoice routes with raw `fetch`.

## RBAC / Permissions

- Roles allowed: unchanged backend `Admin` and `Registrar` guards on registrar invoice payment endpoints.
- Roles denied: unchanged backend denial behavior for unauthenticated or unauthorized users.
- Positive auth proof: frontend now uses the shared `api` client, which attaches the existing Authorization header before calling the protected endpoints.
- Negative auth proof: raw unauthenticated `fetch` paths for hosted payment init/status were removed from the active provider components.

## Notification / Realtime

not applicable - hosted payment transport does not change notifications, websocket channels, delivery semantics, or realtime resync behavior.

## Frontend Resilience

- Empty data proof: unchanged; payment success still requires backend `success` and backend-provided ticket array is still guarded with `Array.isArray`.
- Partial data proof: unchanged; provider URLs, provider payment id, status, and tickets are still consumed from backend response fields.
- Forbidden secondary path behavior: unauthorized responses remain backend-owned and now travel through the shared API error path instead of unauthenticated raw fetch.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate

- Allowed paths: `frontend/src/components/payment/PaymentClick.jsx`, `frontend/src/components/payment/PaymentPayMe.jsx`, `frontend/src/components/payment/__tests__/HostedPaymentProviders.contract.test.jsx`.
- Denied paths: backend payment/billing/registrar endpoints, API schemas, BFF/read-model code, `/api/v1/ui/*`, command wrappers, unrelated payment manager cleanup.
- Migration/docs/test impact: no migration or docs change; one existing frontend contract test was extended.
- Rollback note: revert this commit to restore the previous raw-fetch transport behavior.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd --prefix frontend run test:run -- HostedPaymentProviders`; `npm.cmd --prefix frontend run build`; `git diff --check`
- Result: all passed locally.
- Not checked: backend pytest not run because no backend runtime code or API contract shape changed.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.
