### PR TITLE
fix(queue): bound full update aggregation

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -1331,41 +1331,47 @@ def full_update_online_entry(
                 entry.visit_id, computed_aggregated_ids
             )
         else:
-            # Если нет visit_id, используем поиск по patient_id/phone за текущий день
-            # (это случай первой регистрации или когда visit еще не создан)
+            # If there is no visit yet, aggregate only the current service
+            # session. Same-day patient/phone scans can treat unrelated queue
+            # entries as already having the requested services.
+            session_filters = [
+                DailyQueue.day == queue_day,
+                OnlineQueueEntry.visit_id == None,
+                OnlineQueueEntry.status.in_(["waiting", "called", "in_service"]),
+            ]
+            session_label = None
+
             if entry.patient_id:
-                patient_entries = (
-                    db.query(OnlineQueueEntry)
-                    .join(DailyQueue, OnlineQueueEntry.queue_id == DailyQueue.id)
-                    .filter(
-                        OnlineQueueEntry.patient_id == entry.patient_id,
-                        DailyQueue.day == queue_day,
-                        OnlineQueueEntry.visit_id == None, # ⭐ Только записи без визита (потенциально текущая сессия)
-                        OnlineQueueEntry.status.in_(["waiting", "called", "in_service"]),
-                    )
-                    .all()
-                )
-                computed_aggregated_ids = list(set([e.id for e in patient_entries] + [entry.id]))
-                logger.info(
-                    "[full_update_online_entry] ⭐ FIX 3: Вычислены aggregated_ids по patient_id=%d (no visit): %s",
-                    entry.patient_id, computed_aggregated_ids
-                )
+                session_filters.append(OnlineQueueEntry.patient_id == entry.patient_id)
+                session_label = "patient_id"
             elif entry.phone:
-                phone_entries = (
+                session_filters.append(OnlineQueueEntry.phone == entry.phone)
+                session_label = "phone"
+
+            if session_label:
+                if entry.session_id:
+                    session_filters.append(
+                        OnlineQueueEntry.session_id == entry.session_id
+                    )
+                    boundary_label = "session_id"
+                else:
+                    session_filters.append(OnlineQueueEntry.queue_id == entry.queue_id)
+                    boundary_label = "queue_id"
+
+                session_entries = (
                     db.query(OnlineQueueEntry)
                     .join(DailyQueue, OnlineQueueEntry.queue_id == DailyQueue.id)
-                    .filter(
-                        OnlineQueueEntry.phone == entry.phone,
-                        DailyQueue.day == queue_day,
-                        OnlineQueueEntry.visit_id == None,
-                        OnlineQueueEntry.status.in_(["waiting", "called", "in_service"]),
-                    )
+                    .filter(*session_filters)
                     .all()
                 )
-                computed_aggregated_ids = list(set([e.id for e in phone_entries] + [entry.id]))
+                computed_aggregated_ids = list(
+                    set([e.id for e in session_entries] + [entry.id])
+                )
                 logger.info(
-                    "[full_update_online_entry] ⭐ FIX 3: Вычислены aggregated_ids по phone=%s (no visit): %s",
-                    entry.phone, computed_aggregated_ids
+                    "[full_update_online_entry] computed %d aggregated ids by %s bounded by %s (no visit)",
+                    len(computed_aggregated_ids),
+                    session_label,
+                    boundary_label,
                 )
         
         # Используем computed_aggregated_ids, frontend's aggregated_ids только как fallback

--- a/backend/tests/integration/test_qr_queue_full_update.py
+++ b/backend/tests/integration/test_qr_queue_full_update.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from datetime import date
+import json
+from datetime import date, datetime, timezone
 
 import pytest
 
-from app.models.online_queue import OnlineQueueEntry
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.visit import Visit, VisitService
 
 
@@ -90,3 +91,88 @@ def test_full_update_all_free_without_visit_id_does_not_reuse_unrelated_visit(
     linked_visit = db_session.query(Visit).filter(Visit.id == entry.visit_id).one()
     assert linked_visit.discount_mode == "all_free"
     assert linked_visit.approval_status == "pending"
+
+
+@pytest.mark.integration
+def test_full_update_without_visit_id_ignores_unrelated_same_day_patient_entries(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_daily_queue,
+    test_patient,
+    test_service,
+):
+    unrelated_queue = DailyQueue(
+        day=date.today(),
+        specialist_id=test_daily_queue.specialist_id,
+        queue_tag=f"unrelated-{test_daily_queue.id}",
+        active=True,
+    )
+    db_session.add(unrelated_queue)
+    db_session.flush()
+
+    unrelated_entry = OnlineQueueEntry(
+        queue_id=unrelated_queue.id,
+        number=10,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        visit_id=None,
+        session_id=None,
+        source="online",
+        status="waiting",
+        services=json.dumps(
+            [
+                {
+                    "service_id": test_service.id,
+                    "name": test_service.name,
+                    "code": test_service.code,
+                    "quantity": 1,
+                    "price": int(test_service.price or 0),
+                    "cancelled": False,
+                }
+            ],
+            ensure_ascii=False,
+        ),
+    )
+    current_entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=11,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        visit_id=None,
+        session_id=None,
+        source="online",
+        status="waiting",
+        queue_time=datetime(2026, 5, 31, 9, 30, tzinfo=timezone.utc),
+        services=json.dumps([], ensure_ascii=False),
+    )
+    db_session.add_all([unrelated_entry, current_entry])
+    db_session.commit()
+    db_session.refresh(current_entry)
+
+    response = client.put(
+        f"/api/v1/queue/online-entry/{current_entry.id}/full-update",
+        headers=registrar_auth_headers,
+        json={
+            "patient_data": {
+                "patient_name": test_patient.short_name(),
+                "phone": test_patient.phone,
+                "birth_year": 1990,
+                "address": test_patient.address,
+            },
+            "visit_type": "paid",
+            "discount_mode": "none",
+            "services": [{"service_id": test_service.id, "quantity": 1}],
+            "all_free": False,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+
+    db_session.refresh(current_entry)
+    db_session.refresh(unrelated_entry)
+    current_services = json.loads(current_entry.services)
+    assert [service["service_id"] for service in current_services] == [test_service.id]
+    assert unrelated_entry.queue_id == unrelated_queue.id


### PR DESCRIPTION
## Summary
- Bound `/api/v1/queue/online-entry/{entry_id}/full-update` computed aggregation for no-visit queue entries to the current service session.
- Added a regression test where an unrelated same-day patient queue entry already has the same service and must not suppress the current entry's service update.

## Cyclic Execution Evidence
- Fresh main sync: `origin/main` fetched and worktree started from `5d6d35d2aaefc69e802f06a59bfc6e976e90f72d`.
- Clean workspace: QR branch contains one commit; unrelated local `backend/app/api/v1/endpoints/telemetry.py` change remained unstaged and is not included.
- Branch: `codex/qr-full-update-session-aggregate`.
- Scope gate: agent gate rerun with known root cause returned narrow override for `backend/app/api/v1/endpoints/qr_queue.py`; test-only expansion is limited to existing targeted integration coverage.
- Red-check handling: any CI failure will be fixed in this PR before merge.

## Contract Impact
- Canonical surface: legacy QR queue full-update endpoint in the existing FastAPI backend.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: existing registrar/QR full-update callers keep the same payload contract.
- Compatibility path or alias: none added.
- Contract proof: regression test covers independent same-day patient entries without `visit_id`.

## RBAC / Permissions
- Roles allowed: unchanged existing `Admin`, `Registrar`, `Doctor`, `cardio`, `derma`, `dentist` guard.
- Roles denied: unchanged; any role outside the existing dependency remains denied by the existing dependency.
- Positive auth proof: targeted regression uses `registrar_auth_headers` against the mounted endpoint.
- Negative auth proof: not rerun locally; this PR does not alter auth dependencies or role lists.

## Notification / Realtime
- Not applicable - no notification, websocket, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: current entry starts with empty `services=[]` in regression and still receives its requested service.
- Partial data proof: unrelated same-day entry has only a service payload and no visit/session; it no longer affects current aggregation.
- Forbidden secondary path behavior: no secondary route or fallback endpoint added.
- Missing draft/resource behavior: no draft/resource contract changed; missing entry behavior remains existing 404 path.
- Stale route/deep-link behavior: route path and path params are unchanged, so existing deep links keep the same endpoint contract.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/qr_queue.py`, `backend/tests/integration/test_qr_queue_full_update.py`.
- Denied paths: `/api/v1/ui/*`, frontend, migrations, telemetry, unrelated queue flows.
- Migration/docs/test impact: no migration or docs; targeted integration regression added.
- Rollback note: revert this commit to restore previous patient/day aggregation behavior.

## Validation
- Targeted tests or smoke run: `& .\scripts\run_python.ps1 -PythonArgs -m,py_compile,backend\app\api\v1\endpoints\qr_queue.py,backend\tests\integration\test_qr_queue_full_update.py`; `git diff --check -- backend/app/api/v1/endpoints/qr_queue.py backend/tests/integration/test_qr_queue_full_update.py`; `& .\scripts\run_backend_pytest.ps1 backend\tests\integration\test_qr_queue_full_update.py`.
- Result: compile passed; diff check passed; local pytest blocked before collection because `DATABASE_URL must be set before creating the database engine`.
- Not checked: local DB-backed test execution, pending GitHub CI.