### PR TITLE
Fix anonymous telemetry audit boundary

### DIFF
--- a/backend/app/api/v1/endpoints/telemetry.py
+++ b/backend/app/api/v1/endpoints/telemetry.py
@@ -25,9 +25,6 @@ from fastapi import APIRouter, BackgroundTasks
 from pydantic import BaseModel, Field
 
 from app.core.config import settings
-from app.crud import audit as crud_audit
-from app.db.session import SessionLocal
-
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/telemetry", tags=["Telemetry"])
@@ -77,19 +74,6 @@ ALLOWED_EVENTS = {
     'autosave.fail',
 
     # Telegram patient onboarding
-    'patient_onboarding_started',
-    'patient_onboarding_opened',
-    'patient_onboarding_submitted',
-    'patient_onboarding_pending_review',
-    'patient_onboarding_needs_more_info',
-    'registrar_onboarding_reviewed',
-    'patient_onboarding_linked_existing',
-    'patient_onboarding_created_patient',
-    'patient_onboarding_rejected',
-    'patient_onboarding_expired',
-}
-
-ONBOARDING_TELEMETRY_EVENTS = {
     'patient_onboarding_started',
     'patient_onboarding_opened',
     'patient_onboarding_submitted',
@@ -188,38 +172,12 @@ async def store_events(events: List[TelemetryEvent]):
     - Mixpanel
     - etc.
     """
-    db = None
-    try:
-        db = SessionLocal()
-        for event in events:
-            logger.info(
-                f"[Telemetry] {event.event} | "
-                f"session={event.session_id} | "
-                f"meta={event.meta}"
-            )
-            if event.event in ONBOARDING_TELEMETRY_EVENTS:
-                crud_audit.log(
-                    db,
-                    action=event.event,
-                    entity_type="telegram_onboarding_telemetry",
-                    payload={
-                        "role": str((event.meta or {}).get("role") or "")[:32],
-                        "scope": str((event.meta or {}).get("scope") or "")[:32],
-                        "section": str((event.meta or {}).get("section") or "")[:32],
-                        "language": str((event.meta or {}).get("language") or "")[:16],
-                        "success": bool((event.meta or {}).get("success", True)),
-                        "reason_code": str((event.meta or {}).get("reason_code") or "")[:64] or None,
-                        "timestamp": str((event.meta or {}).get("timestamp") or event.timestamp or "")[:64] or None,
-                    },
-                )
-        db.commit()
-    except Exception as exc:
-        if db is not None:
-            db.rollback()
-        logger.warning("[Telemetry] Failed to persist events error_type=%s", type(exc).__name__)
-    finally:
-        if db is not None:
-            db.close()
+    for event in events:
+        logger.info(
+            f"[Telemetry] {event.event} | "
+            f"session={event.session_id} | "
+            f"meta={event.meta}"
+        )
 
 
 # =============================================================================

--- a/backend/tests/unit/test_telemetry_onboarding_privacy.py
+++ b/backend/tests/unit/test_telemetry_onboarding_privacy.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from app.api.v1.endpoints.telemetry import ALLOWED_EVENTS, TelemetryEvent, store_events, validate_event
@@ -68,7 +70,10 @@ def test_patient_onboarding_telemetry_rejects_sensitive_payload_keys(blocked_key
 
 @pytest.mark.unit
 @pytest.mark.anyio
-async def test_patient_onboarding_telemetry_events_are_persisted_safely(db_session):
+async def test_patient_onboarding_telemetry_events_do_not_write_anonymous_audit_logs(
+    caplog,
+    db_session,
+):
     event = TelemetryEvent(
         event="patient_onboarding_opened",
         entity="telegram_mini_app",
@@ -82,22 +87,47 @@ async def test_patient_onboarding_telemetry_events_are_persisted_safely(db_sessi
         },
     )
 
-    from app.api.v1.endpoints import telemetry as telemetry_module
+    with caplog.at_level(logging.INFO, logger="app.api.v1.endpoints.telemetry"):
+        await store_events([event])
 
-    telemetry_module.SessionLocal = lambda: db_session
-    await store_events([event])
-
-    audit_row = (
+    audit_rows = (
         db_session.query(AuditLog)
-        .filter(
-            AuditLog.entity_type == "telegram_onboarding_telemetry",
-            AuditLog.action == "patient_onboarding_opened",
-        )
-        .order_by(AuditLog.id.desc())
-        .first()
+        .filter(AuditLog.entity_type == "telegram_onboarding_telemetry")
+        .all()
     )
-    assert audit_row is not None
-    assert audit_row.payload["role"] == "patient"
-    assert audit_row.payload["scope"] == "onboarding"
-    assert "entryToken" not in str(audit_row.payload)
-    assert "full_phone" not in str(audit_row.payload)
+    assert audit_rows == []
+    assert "patient_onboarding_opened" in caplog.text
+    assert "entryToken" not in caplog.text
+    assert "full_phone" not in caplog.text
+
+
+@pytest.mark.unit
+def test_anonymous_telemetry_endpoint_cannot_populate_audit_log(client, db_session):
+    response = client.post(
+        "/api/v1/telemetry",
+        json={
+            "events": [
+                {
+                    "event": "patient_onboarding_opened",
+                    "entity": "telegram_mini_app",
+                    "meta": {
+                        "role": "patient",
+                        "scope": "onboarding",
+                        "section": "appointments",
+                        "language": "ru",
+                        "success": True,
+                        "reason_code": None,
+                    },
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"accepted": 1, "rejected": 0}
+    assert (
+        db_session.query(AuditLog)
+        .filter(AuditLog.entity_type == "telegram_onboarding_telemetry")
+        .count()
+        == 0
+    )


### PR DESCRIPTION
## Summary

- Stops unauthenticated telemetry accepted by `POST /api/v1/telemetry` from writing rows into `AuditLog`.
- Keeps telemetry best-effort and log-only, matching the endpoint's documented boundary that telemetry is not hidden audit.
- Adds regression coverage proving anonymous onboarding telemetry cannot populate audit rows.

## Cyclic Execution Evidence

- Fresh main sync: branch is based on `origin/main` at `5d6d35d2`.
- Clean workspace: inspected before edits; only telemetry endpoint and targeted telemetry privacy tests changed.
- Branch: `codex/telemetry-audit-boundary`.
- Scope gate: `agent_gate` run with known root cause `backend/app/api/v1/endpoints/telemetry.py`; narrow override limited the first patch to the telemetry endpoint, then one targeted test file was updated for CI proof.
- Red-check handling: No PR checks existed before opening this PR; targeted local validation passed and any future red CI will be fixed in this PR.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

- Canonical surface: `POST /api/v1/telemetry`.
- Request shape: unchanged.
- Response shape: unchanged; accepted/rejected counts are preserved.
- Status codes: unchanged.
- Frontend consumer: unchanged.
- Compatibility path or alias: not applicable - no route or alias added.
- Contract proof: `tests/unit/test_telemetry_onboarding_privacy.py` asserts the endpoint still accepts safe onboarding telemetry while leaving `AuditLog` empty for anonymous telemetry events.

## RBAC / Permissions

- Roles allowed: unchanged; telemetry remains unauthenticated by design.
- Roles denied: unchanged.
- Positive auth proof: not applicable - this route intentionally has no auth dependency.
- Negative auth proof: targeted test proves anonymous telemetry cannot create audit rows.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telemetry.py`, `backend/tests/unit/test_telemetry_onboarding_privacy.py`.
- Denied paths: frontend, migrations, audit CRUD/model, Telegram onboarding service, `/api/v1/ui/*`, unrelated cleanup.
- Migration/docs/test impact: no migration; targeted tests updated.
- Rollback note: revert this PR to restore previous AuditLog persistence for anonymous onboarding telemetry.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `py_compile` for the changed endpoint/test files; targeted backend pytest for `tests/unit/test_telemetry_onboarding_privacy.py` plus `tests/unit/test_patient_onboarding_request_policy.py::test_onboarding_analytics_summary_returns_safe_dashboard_metrics`; `git diff --check`.
- Result: py_compile passed; pytest passed with `15 passed, 1 warning`; diff check passed.
- Not checked: full backend suite and frontend build were not run because this is a backend telemetry boundary patch with no frontend/runtime UI changes.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.
