### PR TITLE
fix(registrar): stop fuzzy visit appointment id

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -2868,28 +2868,10 @@ def get_today_queues(
                                         "price": 0
                                     })
 
-                # [OK] УПРОЩЕНО: Добавляем appointment_id для Visit (если был создан соответствующий Appointment)
-                # Используем проверки вместо try/except (Single Source of Truth)
+                # appointment_id must mean a real Appointment.id for this row.
+                # Visit rows do not have an explicit Appointment FK, so a fuzzy
+                # patient/date/doctor match can expose an unrelated appointment.
                 appointment_id_value = record_id if entry_type == "appointment" else None
-                if entry_type == "visit" and patient_id:
-                    # Проверяем, есть ли Appointment для этого Visit
-                    visit_date = getattr(entry_data, 'visit_date', None) or today
-                    doctor_id = getattr(entry_data, 'doctor_id', None)
-
-                    if visit_date and doctor_id:
-                        existing_appointment = (
-                            db.query(Appointment)
-                            .filter(
-                                and_(
-                                    Appointment.patient_id == patient_id,
-                                    Appointment.appointment_date == visit_date,
-                                    Appointment.doctor_id == doctor_id,
-                                )
-                            )
-                            .first()
-                        )
-                        if existing_appointment:
-                            appointment_id_value = existing_appointment.id
 
                 # ✅ ИСПРАВЛЕНО: Получаем РЕАЛЬНЫЙ номер и queue_time из queue_entries
                 # Используем Table reflection вместо ORM модели для избежания конфликта DailyQueue

--- a/backend/tests/integration/test_registrar_all_appointments.py
+++ b/backend/tests/integration/test_registrar_all_appointments.py
@@ -13,6 +13,7 @@ from app.models.online_queue import DailyQueue
 from app.models.online_queue import OnlineQueueEntry
 from app.models.payment import Payment
 from app.models.visit import Visit
+from app.models.visit import VisitService
 
 
 @pytest.mark.integration
@@ -208,6 +209,69 @@ class TestRegistrarAllAppointments:
         assert found_entry["phone"] == test_patient.phone
         assert found_entry["patient_birth_year"] == 1985
         assert found_entry["address"] == "Clinic Street 1"
+
+    def test_today_queues_visit_rows_do_not_expose_fuzzy_appointment_id(
+        self,
+        client,
+        db_session,
+        auth_headers,
+        test_patient,
+        test_doctor,
+        test_service,
+    ):
+        visit = Visit(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=date.today(),
+            visit_time="10:00",
+            status="waiting",
+            discount_mode="none",
+            department="cardiology",
+            source="desk",
+        )
+        unrelated_appointment = Appointment(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            appointment_date=date.today(),
+            appointment_time="11:00",
+            status="scheduled",
+            visit_type="paid",
+            payment_type="cash",
+            services=[],
+            notes="same patient/date/doctor but not linked to the visit",
+        )
+        db_session.add_all([visit, unrelated_appointment])
+        db_session.flush()
+        visit_service = VisitService(
+            visit_id=visit.id,
+            service_id=test_service.id,
+            code=test_service.code,
+            name=test_service.name,
+            qty=1,
+            price=test_service.price,
+            currency="UZS",
+        )
+        db_session.add(visit_service)
+        db_session.commit()
+        db_session.refresh(visit)
+        db_session.refresh(unrelated_appointment)
+
+        response = client.get(
+            f"/api/v1/registrar/queues/today?target_date={date.today().isoformat()}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        found_visit = next(
+            entry
+            for queue_payload in payload["queues"]
+            for entry in queue_payload["entries"]
+            if entry.get("record_kind") == "visit" and entry.get("id") == visit.id
+        )
+
+        assert found_visit["visit_id"] == visit.id
+        assert found_visit["appointment_id"] is None
 
     def test_today_queues_secondary_doctor_actions_are_backend_owned(self):
         user = type("UserStub", (), {"role": "cardio", "roles": []})()


### PR DESCRIPTION
## Summary
- Stop `/registrar/queues/today` from exposing a fuzzy-matched `Appointment.id` as `appointment_id` on `visit` rows.
- Add a regression test proving a same patient/date/doctor appointment does not become the visit row's `appointment_id` unless there is an explicit appointment row.

## Cyclic Execution Evidence
- Fresh main sync: branch is based on `origin/main` at `1d768c62d631c786bdfb082ab75b647bed53f4a4`.
- Clean workspace: created fresh worktree `C:\tmp\final-contract-scan-next-4` from `origin/main`; no unrelated files changed.
- Branch: `codex/registrar-visit-appointment-id-contract`.
- Scope gate: `final-ssot-contract-repair` used for Registrar/Queue contract leak; agent gate known-root-cause returned narrow override for `backend/app/api/v1/endpoints/registrar_integration.py`; test-only expansion stayed in existing targeted integration coverage.
- Red-check handling: any CI failure will be fixed in this PR before merge.

## Contract Impact
- Canonical surface: `/api/v1/registrar/queues/today` read model consumed by registrar and doctor panels.
- Request shape: unchanged.
- Response shape: `appointment_id` remains present, but visit rows now return `null` instead of a fuzzy patient/date/doctor appointment match.
- Status codes: unchanged.
- Frontend consumer: doctor panels can keep treating `appointment_id` as a real appointment id; no fallback to row id is added.
- Compatibility path or alias: removed unsafe fuzzy compatibility alias for visit rows.
- Contract proof: integration regression covers same patient/date/doctor visit plus unrelated appointment.

## RBAC / Permissions
- Roles allowed: unchanged existing registrar queue read permissions.
- Roles denied: unchanged; no role dependency modified.
- Positive auth proof: targeted regression uses `auth_headers` against the mounted registrar queues endpoint.
- Negative auth proof: not rerun locally; this PR does not alter auth dependencies or role lists.

## Notification / Realtime
- Not applicable - no notification, websocket, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: visit rows still include the `appointment_id` field with `null` when no real appointment row is represented.
- Partial data proof: same patient/date/doctor appointment no longer leaks into a visit row as partial compatibility data.
- Forbidden secondary path behavior: no secondary write path added; this prevents frontend appointment-flow writes from targeting unrelated appointments.
- Missing draft/resource behavior: unchanged; appointment-specific flows remain unavailable when no real appointment id exists.
- Stale route/deep-link behavior: route path and response field name are unchanged.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/registrar_integration.py`, `backend/tests/integration/test_registrar_all_appointments.py`.
- Denied paths: `/api/v1/ui/*`, frontend, migrations, BFF-lite, unrelated queue commands.
- Migration/docs/test impact: no migration or docs; targeted integration regression added.
- Rollback note: revert this commit to restore fuzzy patient/date/doctor appointment id exposure for visit rows.

## Validation
- Targeted tests or smoke run: `& .\scripts\run_python.ps1 -PythonArgs -m,py_compile,backend\app\api\v1\endpoints\registrar_integration.py,backend\tests\integration\test_registrar_all_appointments.py`; `git diff --check`; `& .\scripts\run_backend_pytest.ps1 backend\tests\integration\test_registrar_all_appointments.py`.
- Result: compile passed; diff check passed; local pytest blocked before collection because `DATABASE_URL must be set before creating the database engine`.
- Not checked: local DB-backed test execution, pending GitHub CI.