### PR TITLE
Fix onboarding duplicate phone candidate search

### DIFF
--- a/backend/app/services/patient_onboarding_service.py
+++ b/backend/app/services/patient_onboarding_service.py
@@ -75,6 +75,13 @@ def _normalize_phone(value: str | None) -> str:
     return re.sub(r"\D", "", str(value or ""))
 
 
+def _phone_matches(search_digits: str, candidate_phone: str | None) -> bool:
+    candidate_digits = _normalize_phone(candidate_phone)
+    if not search_digits or not candidate_digits:
+        return False
+    return search_digits == candidate_digits or candidate_digits.endswith(search_digits)
+
+
 def _mask_phone(value: str | None) -> str | None:
     digits = _normalize_phone(value)
     if not digits:
@@ -360,7 +367,7 @@ class PatientOnboardingService:
                 if value
             ) or None
 
-        phone_match = bool(search_phone and patient_phone and search_phone == patient_phone)
+        phone_match = _phone_matches(search_phone, patient_phone)
         dob_match = bool(
             search_input.birth_date is not None
             and patient.birth_date is not None
@@ -416,7 +423,20 @@ class PatientOnboardingService:
         birth_date = search_payload.birth_date
 
         query = self.db.query(Patient).filter(Patient.is_deleted.is_not(True))
+        exact_phone_rows: list[Patient] = []
         if phone:
+            phone_rows = (
+                self.db.query(Patient)
+                .filter(
+                    Patient.is_deleted.is_not(True),
+                    Patient.phone.is_not(None),
+                )
+                .order_by(Patient.last_name.asc(), Patient.first_name.asc())
+                .all()
+            )
+            exact_phone_rows = [
+                patient for patient in phone_rows if _phone_matches(phone, patient.phone)
+            ]
             query = query.filter(Patient.phone.is_not(None))
         name_parts = [
             part.strip().lower()
@@ -442,6 +462,14 @@ class PatientOnboardingService:
             .limit(MAX_SEARCH_CANDIDATES)
             .all()
         )
+        if exact_phone_rows:
+            seen_ids = {int(patient.id) for patient in exact_phone_rows}
+            candidate_rows = exact_phone_rows + [
+                patient
+                for patient in candidate_rows
+                if int(patient.id) not in seen_ids
+            ]
+            candidate_rows = candidate_rows[:MAX_SEARCH_CANDIDATES]
         candidates = [
             self._candidate_for_patient(
                 request_row,

--- a/backend/tests/unit/test_patient_onboarding_request_policy.py
+++ b/backend/tests/unit/test_patient_onboarding_request_policy.py
@@ -310,6 +310,46 @@ def test_registrar_links_existing_patient_and_writes_audit(
 
 
 @pytest.mark.unit
+def test_onboarding_duplicate_search_keeps_exact_phone_match_beyond_page_limit(
+    client,
+    db_session,
+    registrar_auth_headers,
+):
+    target_phone = "+998901234321"
+    for index in range(45):
+        db_session.add(
+            Patient(
+                last_name=f"Alpha{index:02d}",
+                first_name="Filler",
+                phone=f"+99890000{index:04d}",
+            )
+        )
+    target = Patient(
+        last_name="Zulu",
+        first_name="Exact",
+        phone=target_phone,
+    )
+    db_session.add(target)
+    request_row = _create_onboarding_request(db_session, chat_id=9106)
+    request_row.contact_phone = target_phone
+    request_row.contact_name = "Unknown Caller"
+    db_session.commit()
+
+    response = client.post(
+        f"/api/v1/telegram/onboarding/requests/{request_row.id}/search-patients",
+        headers=registrar_auth_headers,
+        json={"phone": "901234321"},
+    )
+
+    assert response.status_code == 200
+    candidates = response.json()["candidates"]
+    assert candidates
+    assert candidates[0]["matchReasons"]["phone_match"] is True
+    assert candidates[0]["maskedPhone"].endswith("21")
+    assert len(candidates) <= 40
+
+
+@pytest.mark.unit
 def test_registrar_lists_pending_onboarding_requests_with_safe_payload(
     client,
     db_session,


### PR DESCRIPTION
## Summary

- Fixes Telegram onboarding duplicate search so exact normalized phone matches are kept before the 40-candidate page limit.
- Preserves the existing masked candidate response, staff-only review flow, and duplicate-review gate.
- Adds a regression test with more than 40 patients proving the exact phone match is still returned.

## Cyclic Execution Evidence

- Fresh main sync: branch started from `origin/main` at `85ea8d2b`.
- Clean workspace: inspected before edits; only onboarding service and targeted onboarding policy test changed.
- Branch: `codex/onboarding-phone-candidate-search`.
- Scope gate: `agent_gate` run with known root cause `backend/app/services/patient_onboarding_service.py`; narrow override kept runtime change in the service and added one targeted policy regression test for proof.
- Red-check handling: No PR checks existed before opening this PR; targeted local validation passed and any future red CI will be fixed in this PR.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

- Canonical surface: `POST /api/v1/telegram/onboarding/requests/{request_id}/search-patients`.
- Request shape: unchanged.
- Response shape: unchanged; candidates remain masked and use the existing DTO.
- Status codes: unchanged.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` continues to consume the same masked candidate response.
- Compatibility path or alias: not applicable - no route or alias added.
- Contract proof: `tests/unit/test_patient_onboarding_request_policy.py` proves an exact normalized phone match beyond the first 40 alphabetic patients remains visible to registrar review.

## RBAC / Permissions

- Roles allowed: unchanged; Admin and Registrar.
- Roles denied: unchanged; unauthenticated and non-staff callers remain denied by the endpoint dependency.
- Positive auth proof: existing onboarding policy tests cover registrar access.
- Negative auth proof: existing `test_registrar_onboarding_actions_require_staff_role` still passes.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no frontend runtime code changed; existing consumer contract is unchanged.

## Scope Gate

- Allowed paths: `backend/app/services/patient_onboarding_service.py`, `backend/tests/unit/test_patient_onboarding_request_policy.py`.
- Denied paths: frontend runtime, Telegram webhook routes, patient creation service, migrations, `/api/v1/ui/*`, unrelated cleanup.
- Migration/docs/test impact: no migration; one targeted backend unit policy test added.
- Rollback note: revert this PR to restore previous alphabetical candidate limiting behavior.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `py_compile` for the changed service/test files; targeted backend pytest for `tests/unit/test_patient_onboarding_request_policy.py`; `git diff --check`; local PR review gate.
- Result: py_compile passed; pytest passed with `15 passed, 1 warning`; diff check passed; PR review gate passed.
- Not checked: frontend build was not run because this patch does not change frontend code or API shape.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.
