### PR TITLE
Require fresh onboarding duplicate review

### DIFF
--- a/backend/app/services/patient_onboarding_service.py
+++ b/backend/app/services/patient_onboarding_service.py
@@ -550,10 +550,18 @@ class PatientOnboardingService:
 
     def _safe_duplicate_review_snapshot(
         self,
-        request_id: int,
+        row: PatientOnboardingRequest,
     ) -> dict[str, Any] | None:
-        log_row = self._latest_duplicate_review_log(request_id)
+        log_row = self._latest_duplicate_review_log(int(row.id))
         if log_row is None or not isinstance(log_row.payload, dict):
+            return None
+        reviewed_at = _as_aware_utc(log_row.created_at)
+        request_updated_at = _as_aware_utc(row.updated_at or row.created_at)
+        if (
+            reviewed_at is not None
+            and request_updated_at is not None
+            and reviewed_at < request_updated_at
+        ):
             return None
         payload = log_row.payload
         return {
@@ -635,7 +643,7 @@ class PatientOnboardingService:
         )
 
     def _registrar_request_payload(self, row: PatientOnboardingRequest) -> dict[str, Any]:
-        duplicate_snapshot = self._safe_duplicate_review_snapshot(int(row.id))
+        duplicate_snapshot = self._safe_duplicate_review_snapshot(row)
         return {
             **_request_payload(row),
             "telegramUserId": row.telegram_user_id,
@@ -979,9 +987,9 @@ class PatientOnboardingService:
 
     def _require_duplicate_review(
         self,
-        request_id: int,
+        row: PatientOnboardingRequest,
     ) -> dict[str, Any]:
-        snapshot = self._safe_duplicate_review_snapshot(request_id)
+        snapshot = self._safe_duplicate_review_snapshot(row)
         if snapshot is None:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -1013,7 +1021,7 @@ class PatientOnboardingService:
         self._validate_audit_actor(actor)
         row = self._get_reviewable(request_id)
         safe_note = _safe_note(payload.safe_note)
-        snapshot = self._require_duplicate_review(request_id)
+        snapshot = self._require_duplicate_review(row)
         candidate_ids = {
             str(item.get("candidate_id"))
             for item in snapshot.get("topCandidates") or []
@@ -1087,7 +1095,7 @@ class PatientOnboardingService:
         self._validate_audit_actor(actor)
         row = self._get_reviewable(request_id)
         safe_note = _safe_note(payload.safe_note)
-        snapshot = self._require_duplicate_review(request_id)
+        snapshot = self._require_duplicate_review(row)
         top_candidates = snapshot.get("topCandidates") or []
         high_confidence_exists = bool(snapshot.get("highConfidenceCandidateExists"))
         if high_confidence_exists and not payload.confirm_create_despite_duplicates:

--- a/backend/tests/unit/test_patient_onboarding_request_policy.py
+++ b/backend/tests/unit/test_patient_onboarding_request_policy.py
@@ -350,6 +350,72 @@ def test_onboarding_duplicate_search_keeps_exact_phone_match_beyond_page_limit(
 
 
 @pytest.mark.unit
+def test_onboarding_duplicate_review_is_invalid_after_patient_resubmits_request(
+    client,
+    db_session,
+    registrar_auth_headers,
+):
+    _add_mini_app_telegram_config(db_session)
+    patient = Patient(
+        last_name="Old",
+        first_name="Candidate",
+        phone="+998901110001",
+    )
+    db_session.add(patient)
+    telegram_user = _create_unlinked_telegram_user(db_session, chat_id=9107)
+    request_row = PatientOnboardingRequest(
+        telegram_user_id=telegram_user.id,
+        telegram_chat_id=telegram_user.chat_id,
+        status="pending_review",
+        language_code="ru",
+        contact_phone=patient.phone,
+        contact_name="Old Candidate",
+    )
+    db_session.add(request_row)
+    db_session.commit()
+    db_session.refresh(request_row)
+    stale_candidate_id = _search_candidate_id(
+        client,
+        request_id=request_row.id,
+        headers=registrar_auth_headers,
+        phone=patient.phone,
+        name="Old Candidate",
+    )
+
+    review_response = client.post(
+        f"/api/v1/telegram/onboarding/requests/{request_row.id}/request-more-info",
+        headers=registrar_auth_headers,
+        json={"reasonCode": "other", "safeNote": "Please confirm contact details."},
+    )
+    assert review_response.status_code == 200
+    resubmit_response = client.post(
+        "/api/v1/telegram/mini-app/onboarding/requests",
+        json={
+            "initData": _signed_mini_app_init_data(telegram_user.chat_id),
+            "section": "appointments",
+            "contactPhone": "+998909990002",
+            "contactName": "Updated Patient",
+        },
+    )
+    assert resubmit_response.status_code == 200
+
+    link_response = client.post(
+        f"/api/v1/telegram/onboarding/requests/{request_row.id}/link-existing",
+        headers=registrar_auth_headers,
+        json={
+            "candidateId": stale_candidate_id,
+            "safeNote": "Stale link attempt",
+            "reasonCode": "duplicate_suspected",
+        },
+    )
+
+    assert link_response.status_code == 409
+    assert link_response.json()["detail"]["reason"] == "duplicate_review_required"
+    db_session.refresh(telegram_user)
+    assert telegram_user.patient_id is None
+
+
+@pytest.mark.unit
 def test_registrar_lists_pending_onboarding_requests_with_safe_payload(
     client,
     db_session,


### PR DESCRIPTION
## Summary

- Invalidates Telegram onboarding duplicate-review snapshots that were created before the latest patient request update.
- Prevents stale `candidateId` values from authorizing link/create decisions after a patient resubmits a `needs_more_info` request.
- Adds a regression test proving a stale candidate cannot link Telegram to the old patient record.

## Cyclic Execution Evidence

- Fresh main sync: branch started from `origin/main` at `b5141900`.
- Clean workspace: inspected before edits; only onboarding service and targeted onboarding policy test changed.
- Branch: `codex/onboarding-fresh-duplicate-review`.
- Scope gate: `agent_gate` run with known root cause `backend/app/services/patient_onboarding_service.py`; narrow override kept runtime change in the service and added one targeted policy regression test for proof.
- Red-check handling: No PR checks existed before opening this PR; targeted local validation passed and any future red CI will be fixed in this PR.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

- Canonical surface: `POST /api/v1/telegram/onboarding/requests/{request_id}/link-existing` and `POST /api/v1/telegram/onboarding/requests/{request_id}/create-patient`.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: stale duplicate-review attempts now correctly return existing `409 duplicate_review_required`.
- Frontend consumer: `frontend/src/components/TelegramManager.jsx` already handles the existing review-required error contract.
- Compatibility path or alias: not applicable - no route or alias added.
- Contract proof: `tests/unit/test_patient_onboarding_request_policy.py` proves old search candidates cannot be reused after patient resubmission.

## RBAC / Permissions

- Roles allowed: unchanged; Admin and Registrar.
- Roles denied: unchanged; unauthenticated and non-staff callers remain denied by endpoint dependencies.
- Positive auth proof: existing onboarding policy tests cover registrar access.
- Negative auth proof: existing `test_registrar_onboarding_actions_require_staff_role` still passes.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no frontend runtime code changed; the existing 409 review-required contract is preserved.

## Scope Gate

- Allowed paths: `backend/app/services/patient_onboarding_service.py`, `backend/tests/unit/test_patient_onboarding_request_policy.py`.
- Denied paths: frontend runtime, Telegram webhook routes, patient creation service, migrations, `/api/v1/ui/*`, unrelated cleanup.
- Migration/docs/test impact: no migration; one targeted backend unit policy test added.
- Rollback note: revert this PR to allow previous duplicate-search snapshots to authorize later request revisions.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `py_compile` for the changed service/test files; targeted backend pytest for `tests/unit/test_patient_onboarding_request_policy.py`; `git diff --check`; local PR review gate.
- Result: py_compile passed; pytest passed with `16 passed, 1 warning`; diff check passed; PR review gate passed.
- Not checked: frontend build was not run because this patch does not change frontend code or API shape.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.
