### PR TITLE
fix(queue): preserve paid visit state on all-free update

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -1272,6 +1272,7 @@ def full_update_online_entry(
         )
 
         # 2. Обновляем данные пациента в OnlineQueueEntry
+        original_entry_discount_mode = entry.discount_mode
         patient_data = request.patient_data
         if patient_data.get('patient_name'):
             entry.patient_name = patient_data['patient_name']
@@ -2298,13 +2299,6 @@ def full_update_online_entry(
                     "[full_update_online_entry] Обновление существующего Visit ID=%d",
                     visit.id,
                 )
-                visit.approval_status = (
-                    "pending"  # Сбрасываем статус на pending при обновлении
-                )
-                visit.discount_mode = "all_free"  # Убеждаемся, что режим правильный
-                visit.department = department  # Обновляем department
-                visit.doctor_id = doctor_id  # Обновляем doctor_id
-
                 # ⭐ ИСПРАВЛЕНИЕ #2: Проверяем есть ли оплаченный инвойс перед удалением услуг
                 from app.models.payment_invoice import (
                     PaymentInvoice,
@@ -2322,14 +2316,22 @@ def full_update_online_entry(
                 )
 
                 if has_paid_invoice:
-                    # ⚠️ Визит УЖЕ оплачен - НЕ удаляем существующие услуги!
-                    # Только добавляем новые услуги к уже существующим
+                    # ⚠️ Визит УЖЕ оплачен - НЕ меняем платежный режим/статус и НЕ удаляем существующие услуги.
+                    # Только добавляем новые услуги к уже существующим.
+                    entry.discount_mode = original_entry_discount_mode
                     logger.warning(
-                        "[full_update_online_entry] ⚠️ Visit %d имеет оплаченный инвойс - НЕ удаляем услуги, только добавляем новые",
+                        "[full_update_online_entry] ⚠️ Visit %d имеет оплаченный инвойс - НЕ меняем payment state и НЕ удаляем услуги, только добавляем новые",
                         visit.id,
                     )
                     deleted_count = 0
                 else:
+                    visit.approval_status = (
+                        "pending"  # Сбрасываем статус на pending при обновлении
+                    )
+                    visit.discount_mode = "all_free"  # Убеждаемся, что режим правильный
+                    visit.department = department  # Обновляем department
+                    visit.doctor_id = doctor_id  # Обновляем doctor_id
+
                     # ✅ Визит не оплачен - безопасно удалять и пересоздавать услуги
                     deleted_count = (
                         db.query(VisitService)
@@ -2350,9 +2352,9 @@ def full_update_online_entry(
                         entry.id,
                         visit.id,
                     )
-                
+
                 # ✅ ИСПРАВЛЕНО: Синхронизируем discount_mode в OnlineQueueEntry с Visit
-                if entry.discount_mode != "all_free":
+                if not has_paid_invoice and entry.discount_mode != "all_free":
                     entry.discount_mode = "all_free"
                     logger.info(
                         "[full_update_online_entry] Синхронизирован discount_mode в OnlineQueueEntry %d с Visit %d",

--- a/backend/tests/integration/test_qr_queue_full_update.py
+++ b/backend/tests/integration/test_qr_queue_full_update.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import json
 from datetime import date, datetime, timezone
+from decimal import Decimal
 
 import pytest
 
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.payment_invoice import PaymentInvoice, PaymentInvoiceVisit
 from app.models.visit import Visit, VisitService
 
 
@@ -258,3 +260,96 @@ def test_full_update_without_visit_id_matches_same_session_phone_digits(
     current_services = json.loads(current_entry.services)
     assert [service["service_id"] for service in current_services] == [test_service.id]
     assert current_services[0]["queue_time"] == existing_queue_time.isoformat()
+
+
+@pytest.mark.integration
+def test_full_update_all_free_preserves_paid_visit_payment_state(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_daily_queue,
+    test_patient,
+    test_doctor,
+    test_service,
+):
+    paid_visit = Visit(
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        visit_date=date.today(),
+        visit_time="10:30",
+        status="open",
+        discount_mode="none",
+        approval_status="approved",
+        department="cardiology",
+    )
+    db_session.add(paid_visit)
+    db_session.flush()
+    db_session.add(
+        VisitService(
+            visit_id=paid_visit.id,
+            service_id=test_service.id,
+            code=test_service.code,
+            name=test_service.name,
+            qty=1,
+            price=test_service.price,
+            currency="UZS",
+        )
+    )
+    paid_invoice = PaymentInvoice(
+        patient_id=test_patient.id,
+        total_amount=Decimal("100000.00"),
+        currency="UZS",
+        status="paid",
+        payment_method="cash",
+    )
+    db_session.add(paid_invoice)
+    db_session.flush()
+    db_session.add(
+        PaymentInvoiceVisit(
+            invoice_id=paid_invoice.id,
+            visit_id=paid_visit.id,
+            visit_amount=Decimal("100000.00"),
+        )
+    )
+    entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=31,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        visit_id=paid_visit.id,
+        source="online",
+        status="waiting",
+        discount_mode="none",
+    )
+    db_session.add(entry)
+    db_session.commit()
+    db_session.refresh(entry)
+    db_session.refresh(paid_visit)
+
+    response = client.put(
+        f"/api/v1/queue/online-entry/{entry.id}/full-update",
+        headers=registrar_auth_headers,
+        json={
+            "patient_data": {
+                "patient_name": test_patient.short_name(),
+                "phone": test_patient.phone,
+                "birth_year": 1990,
+                "address": test_patient.address,
+            },
+            "visit_type": "paid",
+            "discount_mode": "none",
+            "services": [{"service_id": test_service.id, "quantity": 1}],
+            "all_free": True,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+
+    db_session.refresh(entry)
+    db_session.refresh(paid_visit)
+    assert paid_visit.discount_mode == "none"
+    assert paid_visit.approval_status == "approved"
+    assert paid_visit.department == "cardiology"
+    assert paid_visit.doctor_id == test_doctor.id
+    assert entry.discount_mode == "none"


### PR DESCRIPTION
## Summary
- Prevent QR queue full-update from silently changing `Visit.discount_mode` / `Visit.approval_status` when the linked visit already has a paid invoice.
- Preserve the queue entry `discount_mode` in that paid-visit path.
- Add a regression test for paid invoice + `all_free=true` update.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `origin/main` at `f55505af`.
- Clean workspace: inspected before edits; only scoped backend endpoint and targeted integration test changed.
- Branch: `codex/queue-paid-visit-all-free-guard`.
- Scope gate: allowed `backend/app/api/v1/endpoints/qr_queue.py` and `backend/tests/integration/test_qr_queue_full_update.py`; denied frontend, migrations, `/api/v1/ui/*`, BFF service, command wrappers, and unrelated cleanup.
- Red-check handling: watched CI, fixed PR body quality gate failures in this same PR, and added a rerun commit only to refresh checks.

## Contract Impact
- Canonical surface: `PUT /api/v1/queue/online-entry/{entry_id}/full-update` existing backend endpoint.
- Request shape: unchanged; existing request body still accepts `all_free`, `discount_mode`, `patient_data`, and `services`.
- Response shape: unchanged; no fields added or removed.
- Status codes: unchanged; authorized successful update remains 200.
- Frontend consumer: unchanged existing queue/appointment wizard consumer of full-update.
- Compatibility path or alias: not applicable - no endpoint path or alias changes.
- Contract proof: targeted integration regression proves paid visit state is preserved when full-update receives `all_free=true`.

## RBAC / Permissions
- Roles allowed: unchanged existing endpoint roles, Admin/Registrar/Doctor.
- Roles denied: unchanged existing endpoint role guard denies unauthorized roles/users.
- Positive auth proof: targeted test uses existing `registrar_auth_headers` and receives 200.
- Negative auth proof: not checked locally because this PR does not change authorization or role guards.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification or websocket event changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no notification delivery behavior changed.
- Reconnect/resync proof: not applicable - no realtime reconnect/resync path changed.

## Frontend Resilience
- Empty data proof: not applicable - no frontend rendering path changed.
- Partial data proof: not applicable - no frontend data mapping changed.
- Forbidden secondary path behavior: not applicable - no frontend secondary path changed.
- Missing draft/resource behavior: not applicable - no draft/resource frontend behavior changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/qr_queue.py`; `backend/tests/integration/test_qr_queue_full_update.py`.
- Denied paths: frontend, migrations, `/api/v1/ui/*`, separate BFF service, command wrappers, generated output, unrelated cleanup.
- Migration/docs/test impact: no migration and no docs change; one targeted backend integration test added.
- Rollback note: revert this PR to restore prior full-update paid-visit behavior and remove the regression test.

## Bug and impact
A registrar/queue full-update with `all_free=true` could find an existing visit that already has a paid invoice, then change the visit to `discount_mode='all_free'` and `approval_status='pending'` before checking the paid invoice. That corrupts payment/visit state for an already-paid workflow.

## Root cause
`full_update_online_entry` checked `PaymentInvoice.status == 'paid'` only before deleting/recreating services. The mutation of visit payment-state fields happened earlier, and the queue entry discount mode was also forced to `all_free`.

## Fix
- Detect paid invoice before mutating existing visit state.
- When a paid invoice exists, do not alter visit discount/approval/department/doctor state and restore the queue entry discount mode.
- Keep the existing behavior of not deleting paid visit services.

## Validation
- Targeted tests or smoke run: `py_compile` for `qr_queue.py`; targeted `pytest backend/tests/integration/test_qr_queue_full_update.py -q`; `git diff --check`.
- Result: py_compile passed; targeted pytest passed with 4 passed and 1 warning; `git diff --check` passed with Windows LF-to-CRLF warning for the touched test file.
- Not checked: frontend build/tests because this PR has no frontend changes; full backend suite locally because CI runs broader backend checks and targeted QR full-update regression is the narrow local proof.