### PR TITLE
fix(registrar): scope appointment queue fallback

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -2164,12 +2164,26 @@ def get_today_queues(
             try:
                 from sqlalchemy import text
 
-                if patient_id:
+                if patient_id and appointment_date and doctor_id is not None:
                     queue_entry_row = db.execute(
                         text(
-                            "SELECT queue_time FROM queue_entries WHERE patient_id = :patient_id AND visit_id IS NULL ORDER BY created_at DESC LIMIT 1"
+                            """
+                            SELECT qe.queue_time
+                            FROM queue_entries qe
+                            JOIN daily_queues dq ON qe.queue_id = dq.id
+                            WHERE qe.patient_id = :patient_id
+                              AND qe.visit_id IS NULL
+                              AND dq.day = :appointment_date
+                              AND dq.specialist_id = :doctor_id
+                            ORDER BY qe.created_at DESC
+                            LIMIT 1
+                            """
                         ),
-                        {"patient_id": patient_id},
+                        {
+                            "patient_id": patient_id,
+                            "appointment_date": appointment_date,
+                            "doctor_id": doctor_id,
+                        },
                     ).first()
                     if queue_entry_row and queue_entry_row.queue_time:
                         appointment_queue_time = queue_entry_row.queue_time
@@ -2932,13 +2946,32 @@ def get_today_queues(
                             if queue_entry_row:
                                 queue_entry_number = queue_entry_row.number
                                 queue_entry_time = queue_entry_row.queue_time
-                        elif entry_type == "appointment" and patient_id:
-                            # Для Appointment ищем по patient_id
+                        elif (
+                            entry_type == "appointment"
+                            and patient_id
+                            and appointment_date
+                            and doctor_id is not None
+                        ):
+                            # Для Appointment используем только queue entry того же пациента, дня и врача.
                             queue_entry_row = db.execute(
                                 text(
-                                    "SELECT number, queue_time FROM queue_entries WHERE patient_id = :patient_id AND visit_id IS NULL ORDER BY created_at DESC LIMIT 1"
+                                    """
+                                    SELECT qe.number, qe.queue_time
+                                    FROM queue_entries qe
+                                    JOIN daily_queues dq ON qe.queue_id = dq.id
+                                    WHERE qe.patient_id = :patient_id
+                                      AND qe.visit_id IS NULL
+                                      AND dq.day = :appointment_date
+                                      AND dq.specialist_id = :doctor_id
+                                    ORDER BY qe.created_at DESC
+                                    LIMIT 1
+                                    """
                                 ),
-                                {"patient_id": patient_id},
+                                {
+                                    "patient_id": patient_id,
+                                    "appointment_date": appointment_date,
+                                    "doctor_id": doctor_id,
+                                },
                             ).first()
                             if queue_entry_row:
                                 queue_entry_number = queue_entry_row.number

--- a/backend/tests/integration/test_registrar_all_appointments.py
+++ b/backend/tests/integration/test_registrar_all_appointments.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from zoneinfo import ZoneInfo
 
@@ -209,6 +209,80 @@ class TestRegistrarAllAppointments:
         assert found_entry["phone"] == test_patient.phone
         assert found_entry["patient_birth_year"] == 1985
         assert found_entry["address"] == "Clinic Street 1"
+
+    def test_today_queues_appointment_does_not_inherit_unrelated_patient_queue_time(
+        self,
+        client,
+        db_session,
+        auth_headers,
+        test_patient,
+        test_doctor,
+    ):
+        old_queue = DailyQueue(
+            day=date.today() - timedelta(days=1),
+            specialist_id=test_doctor.id,
+            queue_tag="cardiology_common",
+            active=True,
+        )
+        db_session.add(old_queue)
+        db_session.flush()
+
+        unrelated_queue_time = datetime(
+            2026, 4, 15, 8, 0, tzinfo=ZoneInfo("Asia/Tashkent")
+        )
+        unrelated_entry = OnlineQueueEntry(
+            queue_id=old_queue.id,
+            number=77,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            visit_id=None,
+            source="desk",
+            status="waiting",
+            queue_time=unrelated_queue_time,
+            created_at=datetime(
+                2026, 4, 16, 12, 0, tzinfo=ZoneInfo("Asia/Tashkent")
+            ),
+        )
+        appointment_created_at = datetime(
+            2026, 4, 16, 10, 0, tzinfo=ZoneInfo("Asia/Tashkent")
+        )
+        appointment = Appointment(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            appointment_date=date.today(),
+            appointment_time="11:00",
+            status="scheduled",
+            visit_type="paid",
+            payment_type="cash",
+            services=[],
+            notes="same patient but unrelated queue entry from another day",
+            created_at=appointment_created_at,
+        )
+        db_session.add_all([unrelated_entry, appointment])
+        db_session.commit()
+        db_session.refresh(appointment)
+
+        response = client.get(
+            f"/api/v1/registrar/queues/today?target_date={date.today().isoformat()}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        appointment_row = next(
+            entry
+            for queue in payload["queues"]
+            for entry in queue["entries"]
+            if entry["record_kind"] == "appointment" and entry["id"] == appointment.id
+        )
+
+        assert appointment_row["number"] != unrelated_entry.number
+        assert appointment_row["queue_position"] != unrelated_entry.number
+        assert appointment_row["queue_time"] != _serialize_registrar_datetime(
+            unrelated_queue_time
+        )
+        assert appointment_row["queue_time"] == appointment_row["created_at"]
 
     def test_today_queues_visit_rows_do_not_expose_fuzzy_appointment_id(
         self,


### PR DESCRIPTION
## Summary
Fixes a registrar queue display/order bug where appointment rows in `GET /api/v1/registrar/queues/today` could borrow queue number/time from an unrelated queue entry for the same patient.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `origin/main` at `8926fc63`.
- Clean workspace: inspected before edits; only scoped registrar endpoint and targeted integration test changed.
- Branch: `codex/registrar-appointment-queue-time-scope`.
- Scope gate: allowed `backend/app/api/v1/endpoints/registrar_integration.py` and `backend/tests/integration/test_registrar_all_appointments.py`; denied frontend, migrations, `/api/v1/ui/*`, BFF service, command wrappers, unrelated cleanup.
- Red-check handling: will fix any CI red checks in this PR before merge.

## Contract Impact
- Canonical surface: `GET /api/v1/registrar/queues/today`.
- Request shape: unchanged.
- Response shape: unchanged; appointment rows no longer borrow queue number/time from unrelated patient-only queue entries.
- Status codes: unchanged.
- Frontend consumer: RegistrarPanel queue view.
- Compatibility path or alias: none; this keeps the same endpoint path with no aliases touched.
- Contract proof: targeted integration regression proves appointment rows ignore unrelated prior-day queue entries for same patient.

## RBAC / Permissions
- Roles allowed: unchanged existing endpoint roles.
- Roles denied: unchanged existing endpoint guard.
- Positive auth proof: targeted test uses existing auth headers and gets 200.
- Negative auth proof: not checked locally because no auth/role guard changed.

## Notification / Realtime
- Event type or websocket channel: none changed; this endpoint is a synchronous registrar read endpoint.
- Payload version / ack behavior: unchanged because this PR does not emit notification, websocket, or ack payloads.
- Read/unread or delivery semantics: unchanged because this PR does not touch notification delivery or read state.
- Reconnect/resync proof: unchanged because registrar queue refresh still uses the existing REST endpoint and no realtime resync contract was modified.

## Frontend Resilience
- Empty data proof: unchanged because this PR does not alter frontend rendering or empty-state behavior.
- Partial data proof: unchanged because response shape is additive-neutral and existing fallback timing remains when no scoped queue entry exists.
- Forbidden secondary path behavior: unchanged because no secondary route, alias, or forbidden frontend path was touched.
- Missing draft/resource behavior: unchanged because this PR does not touch drafts, resources, or frontend deep-link resource loading.
- Stale route/deep-link behavior: unchanged because no frontend route, navigation, or deep-link handling changed.

## Scope Gate
- Allowed paths: endpoint and targeted integration test.
- Denied paths: frontend, migrations, `/api/v1/ui/*`, separate BFF service, command wrappers, generated output, unrelated cleanup.
- Migration/docs/test impact: no migration/docs; targeted integration test added.
- Rollback note: revert this PR to restore prior appointment queue fallback behavior and remove regression test.

## Bug and impact
Appointment rows could inherit `number` and `queue_time` from any latest `queue_entries` row with the same `patient_id` and `visit_id IS NULL`. If the patient had an unrelated queue entry from another day or doctor, the registrar queue could display the appointment with the wrong queue number/time and wrong backend-owned ordering position.

## Root cause
The appointment fallback lookup matched queue entries only by `patient_id`, without scoping to the appointment day and doctor/specialist.

## Fix
Scope appointment queue-entry fallback lookups through `daily_queues`, requiring the same patient, same appointment date, same specialist/doctor, and `visit_id IS NULL`. If no scoped queue entry exists, appointment rows continue to use their appointment fallback timing.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/registrar_integration.py`.
- Targeted tests or smoke run: `pytest backend/tests/integration/test_registrar_all_appointments.py::TestRegistrarAllAppointments::test_today_queues_appointment_does_not_inherit_unrelated_patient_queue_time -q`.
- Targeted tests or smoke run: `pytest backend/tests/integration/test_registrar_all_appointments.py::TestRegistrarAllAppointments::test_today_queues_serializes_queue_time_and_created_at backend/tests/integration/test_registrar_all_appointments.py::TestRegistrarAllAppointments::test_today_queues_appointment_does_not_inherit_unrelated_patient_queue_time -q`.
- Targeted tests or smoke run: `pytest backend/tests/integration/test_registrar_all_appointments.py -q`.
- Targeted tests or smoke run: `git diff --check`.
- Result: all passed locally; `git diff --check` emitted only the existing Windows LF-to-CRLF warning.
- Not checked: full backend suite and frontend build, because this PR touches one backend endpoint and one targeted backend integration test only.