### PR TITLE
fix(lab): reject cross-patient report context

### DIFF
--- a/backend/app/services/lab_reporting_service.py
+++ b/backend/app/services/lab_reporting_service.py
@@ -15,6 +15,7 @@ from typing import Any
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from app.models.appointment import Appointment
 from app.models.lab import (
     FINAL_INSTANCE_STATUSES,
     LabCatalogAnalyte,
@@ -464,11 +465,23 @@ class LabReportingService:
         if not patient:
             raise LabReportingDomainError(404, "Patient not found")
 
+        appointment_id = payload.get("appointment_id")
+        if appointment_id:
+            self._assert_appointment_belongs_to_patient(
+                appointment_id=int(appointment_id),
+                patient_id=int(patient.id),
+            )
+
         visit_id = self._resolve_visit_context(
             visit_id=payload.get("visit_id"),
-            appointment_id=payload.get("appointment_id"),
+            appointment_id=appointment_id,
             create_if_missing=True,
         )
+        if visit_id:
+            self._assert_visit_belongs_to_patient(
+                visit_id=int(visit_id),
+                patient_id=int(patient.id),
+            )
 
         template = self.get_template(payload["template_id"])
         version = self._resolve_instance_version(
@@ -1184,6 +1197,11 @@ class LabReportingService:
             order = self.repository.get_order(order_id)
             if not order:
                 raise LabReportingDomainError(404, "Lab order not found")
+            self._assert_order_belongs_to_context(
+                order=order,
+                patient_id=patient_id,
+                visit_id=visit_id,
+            )
             return order, False
         order = self.repository.find_order_by_visit_and_patient(
             visit_id=visit_id,
@@ -1203,6 +1221,55 @@ class LabReportingService:
                 notes="Auto-created from lab report workflow",
             )
         ), True
+
+    def _assert_appointment_belongs_to_patient(
+        self, *, appointment_id: int, patient_id: int
+    ) -> None:
+        appointment = self.db.get(Appointment, appointment_id)
+        if not appointment:
+            raise LabReportingDomainError(404, "Appointment not found")
+        if appointment.patient_id is None or int(appointment.patient_id) != int(
+            patient_id
+        ):
+            raise LabReportingDomainError(
+                409, "Appointment does not belong to selected patient"
+            )
+
+    def _assert_visit_belongs_to_patient(
+        self, *, visit_id: int, patient_id: int
+    ) -> None:
+        visit = self.repository.get_visit(visit_id)
+        if not visit:
+            raise LabReportingDomainError(404, "Visit not found")
+        if visit.patient_id is None or int(visit.patient_id) != int(patient_id):
+            raise LabReportingDomainError(
+                409, "Visit does not belong to selected patient"
+            )
+
+    def _assert_order_belongs_to_context(
+        self,
+        *,
+        order: LabOrder,
+        patient_id: int,
+        visit_id: int | None,
+    ) -> None:
+        if order.patient_id is not None and int(order.patient_id) != int(patient_id):
+            raise LabReportingDomainError(
+                409, "Lab order does not belong to selected patient"
+            )
+        if order.visit_id is not None:
+            self._assert_visit_belongs_to_patient(
+                visit_id=int(order.visit_id),
+                patient_id=int(patient_id),
+            )
+        if (
+            visit_id is not None
+            and order.visit_id is not None
+            and int(order.visit_id) != int(visit_id)
+        ):
+            raise LabReportingDomainError(
+                409, "Lab order does not belong to selected visit"
+            )
 
     def _emit_lab_new_study_notification(
         self,

--- a/backend/tests/unit/test_lab_reporting_service.py
+++ b/backend/tests/unit/test_lab_reporting_service.py
@@ -12,14 +12,16 @@ import app.services.lab_reporting_service as lab_reporting_service_module
 from app.models.appointment import Appointment
 from app.models.lab import (
     LabCatalogReferenceRange,
+    LabOrder,
     LabReportFieldDef,
     LabReportSection,
     LabReportTemplate,
     LabReportTemplateVersion,
 )
+from app.models.patient import Patient
 from app.models.service import Service
 from app.models.user import User
-from app.models.visit import VisitService
+from app.models.visit import Visit, VisitService
 from app.services.notifications import notification_sender_service
 from app.services.lab_reporting_service import (
     LabReportingDomainError,
@@ -402,6 +404,143 @@ class TestLabReportingService:
         assert instance.visit_id is not None
         assert service.repository.get_visit(instance.visit_id) is not None
         assert instance.template.code == "hba1c_panel"
+
+    def test_create_instance_rejects_visit_for_different_patient(
+        self, db_session, test_patient, test_doctor
+    ):
+        other_patient = Patient(
+            first_name="Other",
+            last_name="Patient",
+            phone="+998901111111",
+            birth_date=date(1985, 1, 1),
+        )
+        db_session.add(other_patient)
+        db_session.flush()
+        other_visit = Visit(
+            patient_id=other_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=date.today(),
+            visit_time="14:00",
+            status="open",
+            department="cardiology",
+        )
+        db_session.add(other_visit)
+        db_session.commit()
+
+        service = LabReportingService(db_session)
+        cbc_template = next(
+            template
+            for template in service.list_templates()
+            if template.code == "cbc_oak"
+        )
+
+        with pytest.raises(LabReportingDomainError) as exc:
+            service.create_instance(
+                {
+                    "patient_id": test_patient.id,
+                    "visit_id": other_visit.id,
+                    "template_id": cbc_template.id,
+                }
+            )
+
+        assert exc.value.status_code == 409
+        assert "Visit does not belong" in exc.value.detail
+
+    def test_create_instance_rejects_order_for_different_patient(
+        self, db_session, test_patient, test_doctor
+    ):
+        other_patient = Patient(
+            first_name="Order",
+            last_name="Owner",
+            phone="+998902222222",
+            birth_date=date(1986, 1, 1),
+        )
+        db_session.add(other_patient)
+        db_session.flush()
+        other_visit = Visit(
+            patient_id=other_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=date.today(),
+            visit_time="14:30",
+            status="open",
+            department="cardiology",
+        )
+        db_session.add(other_visit)
+        db_session.flush()
+        other_order = LabOrder(
+            patient_id=other_patient.id,
+            visit_id=other_visit.id,
+            status="ordered",
+        )
+        db_session.add(other_order)
+        db_session.commit()
+
+        service = LabReportingService(db_session)
+        cbc_template = next(
+            template
+            for template in service.list_templates()
+            if template.code == "cbc_oak"
+        )
+
+        with pytest.raises(LabReportingDomainError) as exc:
+            service.create_instance(
+                {
+                    "patient_id": test_patient.id,
+                    "order_id": other_order.id,
+                    "template_id": cbc_template.id,
+                }
+            )
+
+        assert exc.value.status_code == 409
+        assert "Lab order does not belong" in exc.value.detail
+
+    def test_create_instance_rejects_appointment_for_different_patient_before_visit_creation(
+        self, db_session, test_patient, test_doctor
+    ):
+        other_patient = Patient(
+            first_name="Appointment",
+            last_name="Owner",
+            phone="+998903333333",
+            birth_date=date(1987, 1, 1),
+        )
+        db_session.add(other_patient)
+        db_session.flush()
+        other_appointment = Appointment(
+            patient_id=other_patient.id,
+            doctor_id=test_doctor.id,
+            appointment_date=date.today(),
+            appointment_time="15:00",
+            status="scheduled",
+            services=["L24"],
+        )
+        db_session.add(other_appointment)
+        db_session.commit()
+
+        service = LabReportingService(db_session)
+        hba1c_template = next(
+            template
+            for template in service.list_templates()
+            if template.code == "hba1c_panel"
+        )
+
+        with pytest.raises(LabReportingDomainError) as exc:
+            service.create_instance(
+                {
+                    "patient_id": test_patient.id,
+                    "appointment_id": other_appointment.id,
+                    "template_id": hba1c_template.id,
+                    "service_codes": ["L24"],
+                }
+            )
+
+        assert exc.value.status_code == 409
+        assert "Appointment does not belong" in exc.value.detail
+        assert (
+            db_session.query(Visit)
+            .filter(Visit.patient_id == other_patient.id)
+            .count()
+            == 0
+        )
 
     def test_create_instance_rejects_template_outside_service_binding(
         self, db_session, test_patient, test_visit


### PR DESCRIPTION
## Summary
Fixes lab report creation so `patient_id`, `appointment_id`, `visit_id`, and `order_id` cannot be combined across different patients.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `origin/main` at `755fe523` after PR #1452 merged.
- Clean workspace: inspected before edits; only scoped lab reporting service and targeted unit tests changed.
- Branch: `codex/lab-report-visit-patient-scope`.
- Scope gate: `agent_gate` known-root-cause run targeted `backend/app/services/lab_reporting_service.py`; test scope was explicitly limited to `backend/tests/unit/test_lab_reporting_service.py` for regression proof.
- Red-check handling: will fix any CI red checks in this PR before merge.

## Contract Impact
- Canonical surface: `POST /api/v1/lab/report-instances` through `LabReportingService.create_instance`.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: incoherent cross-patient contexts now return existing domain-style 409 instead of creating inconsistent lab data.
- Frontend consumer: LabPanel/LabReportWorkbench normal coherent payloads are unchanged.
- Compatibility path or alias: none; this keeps the same endpoint path and service API shape.
- Contract proof: unit regressions cover mismatched visit, order, and appointment contexts.

## RBAC / Permissions
- Roles allowed: unchanged existing endpoint roles, Admin and Lab for report creation.
- Roles denied: unchanged existing endpoint guard.
- Positive auth proof: not rerun locally because endpoint auth was not changed and service-layer unit tests cover behavior below the route.
- Negative auth proof: not rerun locally because no auth/role dependency changed.

## Notification / Realtime
- Event type or websocket channel: none changed; lab notification emission remains only after a valid order/report context is accepted.
- Payload version / ack behavior: unchanged because this PR does not emit or version notification/websocket/ack payloads.
- Read/unread or delivery semantics: unchanged because notification delivery and read state were not touched.
- Reconnect/resync proof: unchanged because no realtime or client resync contract was modified.

## Frontend Resilience
- Empty data proof: unchanged because this PR does not alter frontend rendering or empty-state behavior.
- Partial data proof: unchanged because coherent lab creation payloads still use the same request/response shape.
- Forbidden secondary path behavior: unchanged because no secondary frontend route or alias was touched.
- Missing draft/resource behavior: unchanged because draft loading and missing-resource handling were not touched.
- Stale route/deep-link behavior: unchanged because no frontend routing or deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/app/services/lab_reporting_service.py`, `backend/tests/unit/test_lab_reporting_service.py`.
- Denied paths: frontend, migrations, `/api/v1/ui/*`, separate BFF service, command wrappers, generated output, unrelated cleanup.
- Migration/docs/test impact: no migration/docs; targeted unit regressions added.
- Rollback note: revert this PR to restore prior permissive lab context behavior and remove the mismatch regression tests.

## Bug and impact
A lab report create request could combine `patient_id` for patient A with `visit_id`, `appointment_id`, or `order_id` belonging to patient B. That could create a `LabReportInstance` and/or `LabOrder` with inconsistent patient/visit/order ownership, corrupting clinical lab records and tying results to the wrong visit context.

## Root cause
`LabReportingService.create_instance` checked that the patient and visit/order records existed, but it did not verify that the supplied visit, appointment-derived visit, or lab order belonged to the selected patient before creating the report instance.

## Fix
Validate appointment ownership before canonical visit creation, validate resolved/direct visit ownership before template/order creation, and validate supplied lab orders against the selected patient and visit context.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/services/lab_reporting_service.py backend/tests/unit/test_lab_reporting_service.py`.
- Targeted tests or smoke run: `pytest backend/tests/unit/test_lab_reporting_service.py::TestLabReportingService::test_create_instance_rejects_visit_for_different_patient backend/tests/unit/test_lab_reporting_service.py::TestLabReportingService::test_create_instance_rejects_order_for_different_patient backend/tests/unit/test_lab_reporting_service.py::TestLabReportingService::test_create_instance_rejects_appointment_for_different_patient_before_visit_creation -q`.
- Targeted tests or smoke run: six-test create-instance subset including happy paths and mismatch regressions.
- Targeted tests or smoke run: `pytest backend/tests/unit/test_lab_reporting_service.py -q`.
- Targeted tests or smoke run: `git diff --check`.
- Result: all passed locally; `git diff --check` emitted only Windows LF-to-CRLF warnings.
- Not checked: full backend suite and frontend build, because this PR touches one backend service and one targeted unit test file only.