### PR TITLE
fix(payments): use canonical visit for appointment payments

### DIFF
--- a/backend/app/services/payment_create_service.py
+++ b/backend/app/services/payment_create_service.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date
 from decimal import Decimal
 from typing import Any
 
 from app.models.enums import PaymentStatus
 from app.repositories.payment_create_repository import PaymentCreateRepository
 from app.services.billing_service import BillingService
+from app.services.canonical_visit_service import (
+    CanonicalVisitResolutionError,
+    CanonicalVisitService,
+)
 
 
 @dataclass
@@ -62,16 +65,18 @@ class PaymentCreateService:
         if not appointment_id:
             return None
 
-        appointment = self.repository.get_appointment(appointment_id)
-        if not appointment:
+        try:
+            return CanonicalVisitService(self.repository.db).resolve_canonical_visit(
+                appointment_id,
+                create_if_missing=False,
+            )
+        except CanonicalVisitResolutionError as exc:
+            if exc.status_code == 409:
+                raise PaymentCreateDomainError(
+                    status_code=exc.status_code,
+                    detail=exc.detail,
+                ) from exc
             return None
-
-        appointment_date = appointment.appointment_date or date.today()
-        visit = self.repository.get_visit_by_patient_and_date(
-            patient_id=appointment.patient_id,
-            visit_date=appointment_date,
-        )
-        return visit.id if visit else None
 
     def _sync_visit_paid_state(self, *, visit_id: int) -> None:
         visit = self.repository.get_visit(visit_id)

--- a/backend/tests/unit/test_payment_create_service.py
+++ b/backend/tests/unit/test_payment_create_service.py
@@ -5,8 +5,9 @@ from datetime import date
 import pytest
 
 from app.models.appointment import Appointment
+from app.models.clinic import Doctor
 from app.models.payment import Payment
-from app.models.visit import VisitService
+from app.models.visit import Visit, VisitService
 from app.services.payment_create_service import (
     PaymentCreateDomainError,
     PaymentCreateService,
@@ -37,6 +38,7 @@ class TestPaymentCreateService:
         appointment = Appointment(
             patient_id=test_patient.id,
             appointment_date=test_visit.visit_date or date.today(),
+            doctor_id=test_visit.doctor_id,
         )
         db_session.add(appointment)
         db_session.commit()
@@ -56,6 +58,93 @@ class TestPaymentCreateService:
         assert payment is not None
         assert payment.visit_id == test_visit.id
         assert result["status"] == "paid"
+
+    def test_create_payment_from_appointment_uses_canonical_visit_not_first_same_day(
+        self, db_session, test_patient, test_visit
+    ):
+        matching_doctor = Doctor(specialty="dermatology", active=True)
+        db_session.add(matching_doctor)
+        db_session.flush()
+        matching_visit = Visit(
+            patient_id=test_patient.id,
+            doctor_id=matching_doctor.id,
+            visit_date=test_visit.visit_date or date.today(),
+            visit_time="12:00",
+            status="open",
+            discount_mode="none",
+            source="desk",
+        )
+        appointment = Appointment(
+            patient_id=test_patient.id,
+            doctor_id=matching_doctor.id,
+            appointment_date=matching_visit.visit_date,
+            appointment_time="12:00",
+        )
+        db_session.add_all([matching_visit, appointment])
+        db_session.commit()
+        db_session.refresh(matching_visit)
+        db_session.refresh(appointment)
+
+        service = PaymentCreateService(db_session)
+        result = service.create_payment(
+            visit_id=None,
+            appointment_id=appointment.id,
+            amount=75_000.0,
+            currency="UZS",
+            method="cash",
+            note="canonical appointment payment",
+        )
+
+        payment = db_session.query(Payment).filter(Payment.id == result["payment_id"]).first()
+        assert payment is not None
+        assert payment.visit_id == matching_visit.id
+        assert payment.visit_id != test_visit.id
+
+    def test_create_payment_from_appointment_rejects_ambiguous_visit_candidates(
+        self, db_session, test_patient, test_doctor
+    ):
+        visit_date = date.today()
+        first_visit = Visit(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=visit_date,
+            visit_time="09:00",
+            status="open",
+            discount_mode="none",
+            source="desk",
+        )
+        second_visit = Visit(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=visit_date,
+            visit_time="10:00",
+            status="open",
+            discount_mode="none",
+            source="desk",
+        )
+        appointment = Appointment(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            appointment_date=visit_date,
+            appointment_time="10:00",
+        )
+        db_session.add_all([first_visit, second_visit, appointment])
+        db_session.commit()
+        db_session.refresh(appointment)
+
+        service = PaymentCreateService(db_session)
+        with pytest.raises(PaymentCreateDomainError) as exc_info:
+            service.create_payment(
+                visit_id=None,
+                appointment_id=appointment.id,
+                amount=75_000.0,
+                currency="UZS",
+                method="cash",
+                note="ambiguous appointment payment",
+            )
+
+        assert exc_info.value.status_code == 409
+        assert db_session.query(Payment).count() == 0
 
     def test_create_payment_marks_visit_paid_when_fully_covered(
         self, db_session, test_visit, test_service


### PR DESCRIPTION
﻿## Summary
- Fix cashier payment creation when the request uses `appointment_id` by resolving the target visit through the existing canonical appointment-to-visit resolver.
- Reject ambiguous appointment-to-visit matches instead of silently attaching payment to the first same-patient same-day visit.
- Add focused unit coverage for canonical resolution and ambiguity protection.

## Cyclic Execution Evidence
- Fresh main sync: Started from `origin/main` at `abc86af9` in `C:\tmp\final-contract-scan-next-3` before creating `codex/payment-create-canonical-appointment-visit`.
- Clean workspace: `git status --short --branch` was clean before edits and is clean after commit.
- Branch: `codex/payment-create-canonical-appointment-visit` contains one focused commit, `80004520`.
- Scope gate: Gate was run with known root cause `backend/app/services/payment_create_service.py`; the test file was the only narrow extension for regression proof.
- Red-check handling: Any red CI/check on this PR will be fixed in this PR; no follow-up PR is planned for this bug.

## Contract Impact
- Canonical surface: `POST /api/v1/payments/` keeps using `PaymentCreateService`; appointment-to-visit mapping now delegates to `CanonicalVisitService`.
- Request shape: Unchanged; clients still send `visit_id` or `appointment_id` plus amount/currency/method/note.
- Response shape: Unchanged; successful responses still return the existing payment response fields.
- Status codes: Existing success behavior is unchanged; ambiguous appointment-to-visit matches now fail closed with 409 instead of mutating an arbitrary visit.
- Frontend consumer: No frontend changes; the existing cashier flow can keep the same payload.
- Compatibility path or alias: No route alias or compatibility path changed.
- Contract proof: Unit tests cover direct visit payment, appointment payment canonical resolution, and ambiguous appointment rejection.

## RBAC / Permissions
- Roles allowed: Existing endpoint dependency remains Admin/Cashier for payment creation.
- Roles denied: No role expansion; non-Admin/non-Cashier behavior is unchanged by this service-only patch.
- Positive auth proof: Not rerun locally because endpoint auth wiring is unchanged; existing route dependency still enforces allowed roles.
- Negative auth proof: Not rerun locally because no dependency or router code changed; this PR only changes backend visit resolution after auth has passed.

## Notification / Realtime
- Event type or websocket channel: No notification or websocket event is added or changed.
- Payload version / ack behavior: Not applicable because payment create response schema is unchanged and no realtime ack path is touched.
- Read/unread or delivery semantics: Not applicable because this patch does not touch notification delivery state.
- Reconnect/resync proof: Not applicable because no websocket or realtime state is involved.

## Frontend Resilience
- Empty data proof: If no canonical visit exists for the appointment, the service still returns the existing no-target failure path instead of creating a new visit.
- Partial data proof: Appointment requests with multiple possible visits now fail closed with 409 rather than selecting partial/first data.
- Forbidden secondary path behavior: The old secondary resolver using only `patient_id + appointment_date` is removed from payment creation.
- Missing draft/resource behavior: Missing appointment/canonical visit still does not create payment; existing failure behavior is preserved.
- Stale route/deep-link behavior: No frontend route or deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/app/services/payment_create_service.py` and `backend/tests/unit/test_payment_create_service.py`.
- Denied paths: No `/api/v1/ui/*`, no frontend files, no migrations, no schemas, no route rewrites, no BFF-lite service.
- Migration/docs/test impact: No migration or docs change; targeted unit tests added for the payment create service.
- Rollback note: Reverting this one commit restores the prior local resolver behavior if needed.

## Bug and impact
Cashier payment creation accepted `appointment_id`, but resolved it to a visit using only `patient_id + appointment_date`. If the same patient had multiple visits on the same day, payment could be attached to the wrong visit and that unrelated visit could be marked paid.

## Root cause
`PaymentCreateService._resolve_visit_id` duplicated appointment-to-visit lookup logic and selected the first same-patient same-day visit. It ignored doctor matching and did not fail on multiple candidates, unlike the canonical resolver already used by appointment/EMR flows.

## Fix
Replace the local appointment resolver with `CanonicalVisitService.resolve_canonical_visit(..., create_if_missing=False)`. Ambiguous matches now return a 409 domain error instead of mutating an arbitrary visit.

## Validation
- Targeted tests or smoke run: `py_compile backend/app/services/payment_create_service.py`; `pytest backend/tests/unit/test_payment_create_service.py -q`; `pytest backend/tests/unit/test_payment_create_service.py backend/tests/unit/test_canonical_visit_service.py -q`; `git diff --check`.
- Result: Compile passed; payment create tests passed 5/5; payment create plus canonical resolver tests passed 9/9; diff hygiene passed with Windows CRLF warnings only.
- Not checked: Full backend suite and frontend suite were not run locally because this patch is backend service-only and has no frontend/API schema changes.
