### PR TITLE
fix(doctor): avoid reusing another doctor visit

### DIFF
--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -601,11 +601,7 @@ def start_patient_visit(
             db=db,
             patient_id=queue_entry.patient_id,
             doctor_id=doctor.id,
-            department=(
-                queue_entry.queue.department
-                if hasattr(queue_entry, 'queue')
-                else "general"
-            ),
+            department=getattr(daily_queue, "queue_tag", None) or "general",
         )
 
         # Обновляем время начала приема

--- a/backend/app/crud/visit.py
+++ b/backend/app/crud/visit.py
@@ -387,17 +387,15 @@ def find_or_create_today_visit(
 ) -> Visit:
     """Найти или создать визит на сегодня"""
     # Ищем открытый визит на сегодня
-    visit = (
-        db.query(Visit)
-        .filter(
-            and_(
-                Visit.patient_id == patient_id,
-                Visit.visit_date == date.today(),
-                Visit.status == "open",
-            )
-        )
-        .first()
-    )
+    filters = [
+        Visit.patient_id == patient_id,
+        Visit.visit_date == date.today(),
+        Visit.status == "open",
+    ]
+    if doctor_id is not None:
+        filters.append(Visit.doctor_id == doctor_id)
+
+    visit = db.query(Visit).filter(and_(*filters)).first()
 
     if not visit:
         # Создаем новый визит

--- a/backend/tests/integration/test_doctor_general_queue.py
+++ b/backend/tests/integration/test_doctor_general_queue.py
@@ -220,6 +220,96 @@ class TestDoctorGeneralQueue:
         assert waiting_entry.status == "waiting"
         assert called_entry.status == "called"
 
+    def test_start_visit_does_not_reuse_another_doctors_open_visit(
+        self,
+        client,
+        db_session,
+        test_doctor_user,
+        test_patient,
+    ):
+        doctor = Doctor(
+            user_id=test_doctor_user.id,
+            specialty="general",
+            active=True,
+            cabinet="101",
+        )
+        other_doctor = Doctor(
+            user_id=None,
+            specialty="dermatology",
+            active=True,
+            cabinet="202",
+        )
+        db_session.add_all([doctor, other_doctor])
+        db_session.commit()
+        db_session.refresh(doctor)
+        db_session.refresh(other_doctor)
+
+        unrelated_visit = Visit(
+            patient_id=test_patient.id,
+            doctor_id=other_doctor.id,
+            visit_date=date.today(),
+            visit_time="08:00",
+            status="open",
+            notes="do not touch",
+            discount_mode="none",
+            source="desk",
+        )
+        queue = DailyQueue(
+            day=date.today(),
+            specialist_id=doctor.id,
+            queue_tag="general",
+            active=True,
+        )
+        db_session.add_all([unrelated_visit, queue])
+        db_session.commit()
+        db_session.refresh(unrelated_visit)
+        db_session.refresh(queue)
+
+        entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=1,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            source="registrar",
+            status="called",
+        )
+        db_session.add(entry)
+        db_session.commit()
+        db_session.refresh(entry)
+
+        login_response = client.post(
+            "/api/v1/authentication/login",
+            json={"username": test_doctor_user.username, "password": "doctor123"},
+        )
+        assert login_response.status_code == 200
+        headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+        response = client.post(
+            f"/api/v1/doctor/queue/{entry.id}/start-visit",
+            headers=headers,
+        )
+
+        assert response.status_code == 200, response.text
+        db_session.refresh(entry)
+        db_session.refresh(unrelated_visit)
+        created_visit = (
+            db_session.query(Visit)
+            .filter(
+                Visit.patient_id == test_patient.id,
+                Visit.visit_date == date.today(),
+                Visit.doctor_id == doctor.id,
+            )
+            .one()
+        )
+
+        assert entry.status == "in_progress"
+        assert created_visit.id != unrelated_visit.id
+        assert created_visit.notes is not None
+        assert unrelated_visit.status == "open"
+        assert unrelated_visit.visit_time == "08:00"
+        assert unrelated_visit.notes == "do not touch"
+
     def test_general_queue_returns_empty_payload_without_configuration(
         self,
         client,


### PR DESCRIPTION
## Summary
- Prevent doctor queue start/complete flows from reusing another doctor's open same-day `Visit` for the same patient.
- Fix the newly exposed doctor queue `start-visit` crash when a new visit must be created from a `DailyQueue` row.
- Add a regression test proving `start-visit` leaves the other doctor's visit untouched and creates/uses the current doctor's visit.

## Cyclic Execution Evidence
- Fresh main sync: branch was created from `origin/main` at `08c27c5ace5e8f84a23debdcb1a0b3c96f4f6b25` after PR #1447 was merged.
- Clean workspace: used safe worktree `C:\tmp\final-contract-scan-next-4`; no unrelated files changed.
- Branch: `codex/doctor-queue-visit-reuse-guard`.
- Scope gate: `agent_gate` known-root-cause narrow override for `backend/app/crud/visit.py`, second narrow override for `backend/tests/integration/test_doctor_general_queue.py`, and third narrow override for the CI-exposed `backend/app/api/v1/endpoints/doctor_integration.py` crash.
- Red-check handling: PR Review Quality Gate body failure and backend test failure are being fixed in this same PR before merge.

## Contract Impact
- Canonical surface: doctor queue command endpoints using `crud_visit.find_or_create_today_visit`, especially `/api/v1/doctor/queue/{entry_id}/start-visit` and the queue-entry complete path.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged for valid starts; the crash path now succeeds when a new same-doctor visit must be created.
- Frontend consumer: unchanged; existing doctor queue actions still call the same command endpoints with `OnlineQueueEntry.id`.
- Compatibility path or alias: preserved for callers that pass `doctor_id=None`; tightened only when a concrete doctor id is provided.
- Contract proof: integration regression covers same patient/date with an existing open visit for another doctor plus a current doctor's called queue entry.

## RBAC / Permissions
- Roles allowed: unchanged existing doctor queue command permissions.
- Roles denied: unchanged; no role dependency modified.
- Positive auth proof: regression logs in as `test_doctor_user` and calls the mounted doctor queue `start-visit` endpoint.
- Negative auth proof: not rerun locally; this PR does not alter auth dependencies or role lists.

## Notification / Realtime
- Not applicable - no notification, websocket, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: not applicable - command response shape is unchanged and this PR does not alter frontend rendering.
- Partial data proof: queue entry can still start without an existing same-doctor visit; backend creates the proper visit instead of mutating another doctor's partial/open visit.
- Forbidden secondary path behavior: no secondary frontend/backend path added; the fix keeps the command on the existing doctor queue surface.
- Missing draft/resource behavior: unchanged; if no same-doctor visit exists, a new visit is created as before.
- Stale route/deep-link behavior: unchanged; route path and identifier semantics remain `OnlineQueueEntry.id`.

## Scope Gate
- Allowed paths: `backend/app/crud/visit.py`, `backend/app/api/v1/endpoints/doctor_integration.py`, `backend/tests/integration/test_doctor_general_queue.py`.
- Denied paths: `/api/v1/ui/*`, frontend files, migrations/models/schema changes, unrelated queue/appointment flows.
- Migration/docs/test impact: no migration or docs; targeted integration regression added.
- Rollback note: revert this commit to restore patient/date-only open-visit reuse and the previous new-visit creation behavior.

## Validation
- Targeted tests or smoke run: `& .\scripts\run_python.ps1 -PythonArgs -m,py_compile,backend\\app\\crud\\visit.py,backend\\app\\api\\v1\\endpoints\\doctor_integration.py,backend\\tests\\integration\\test_doctor_general_queue.py`; `git diff --check`; `& .\scripts\run_backend_pytest.ps1 backend\\tests\\integration\\test_doctor_general_queue.py::TestDoctorGeneralQueue::test_start_visit_does_not_reuse_another_doctors_open_visit`.
- Result: compile passed; diff check passed; local targeted pytest blocked before collection because `DATABASE_URL must be set before creating the database engine`; first GitHub backend run exposed the fixed `DailyQueue.department` crash.
- Not checked: local DB-backed test execution; pending rerun of GitHub CI backend tests after the amend.