### PR TITLE
fix(payments): preserve visit ownership on status updates

### DIFF
--- a/backend/app/services/visit_payment_api_service.py
+++ b/backend/app/services/visit_payment_api_service.py
@@ -116,9 +116,13 @@ class VisitPaymentApiService:
         doctor_id: int | None,
         notes: str | None,
     ) -> dict[str, Any]:
+        if patient_id is not None or doctor_id is not None:
+            raise VisitPaymentApiDomainError(
+                status_code=400,
+                detail="Cannot change visit ownership through payment status update",
+            )
+
         visit_data = {
-            "patient_id": patient_id,
-            "doctor_id": doctor_id,
             "notes": notes or "Визит создан вручную",
             "payment_status": "paid",
         }

--- a/backend/app/services/visit_payment_integration.py
+++ b/backend/app/services/visit_payment_integration.py
@@ -18,6 +18,16 @@ logger = logging.getLogger(__name__)
 class VisitPaymentIntegrationService:
     """Сервис для интеграции визитов с платежами"""
 
+    IMMUTABLE_VISIT_PAYMENT_FIELDS = frozenset(
+        {
+            "id",
+            "patient_id",
+            "doctor_id",
+            "created_at",
+            "source",
+        }
+    )
+
     @staticmethod
     def _repo(db: Session) -> VisitPaymentIntegrationRepository:
         return VisitPaymentIntegrationRepository(db)
@@ -299,6 +309,20 @@ class VisitPaymentIntegrationService:
 
             # Добавляем дополнительные данные
             if additional_data:
+                forbidden_fields = (
+                    set(additional_data)
+                    & VisitPaymentIntegrationService.IMMUTABLE_VISIT_PAYMENT_FIELDS
+                )
+                if forbidden_fields:
+                    logger.warning(
+                        "Rejected visit payment ownership update visit_id=%s fields=%s",
+                        visit_id,
+                        sorted(forbidden_fields),
+                    )
+                    return (
+                        False,
+                        "Cannot change visit ownership through payment status update",
+                    )
                 update_data.update(additional_data)
 
             # Обновляем визит

--- a/backend/tests/unit/test_visit_payment_api_service.py
+++ b/backend/tests/unit/test_visit_payment_api_service.py
@@ -66,10 +66,49 @@ class TestVisitPaymentApiService:
             with pytest.raises(VisitPaymentApiDomainError) as exc_info:
                 service.create_visit_from_payment(
                     visit_id=77,
-                    patient_id=10,
-                    doctor_id=20,
+                    patient_id=None,
+                    doctor_id=None,
                     notes=None,
                 )
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.detail == "update failed"
+
+    def test_create_visit_from_payment_rejects_ownership_fields(self, db_session):
+        service = VisitPaymentApiService(db_session)
+        with patch(
+            "app.services.visit_payment_api_service.VisitPaymentIntegrationService.update_visit_payment_status"
+        ) as update_status:
+            with pytest.raises(VisitPaymentApiDomainError) as exc_info:
+                service.create_visit_from_payment(
+                    visit_id=77,
+                    patient_id=10,
+                    doctor_id=None,
+                    notes=None,
+                )
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == (
+            "Cannot change visit ownership through payment status update"
+        )
+        update_status.assert_not_called()
+
+    def test_create_visit_from_payment_passes_payment_fields_only(self, db_session):
+        service = VisitPaymentApiService(db_session)
+        with patch(
+            "app.services.visit_payment_api_service.VisitPaymentIntegrationService.update_visit_payment_status",
+            return_value=(True, "updated"),
+        ) as update_status:
+            result = service.create_visit_from_payment(
+                visit_id=77,
+                patient_id=None,
+                doctor_id=None,
+                notes="Paid from cashier",
+            )
+
+        assert result["success"] is True
+        _, kwargs = update_status.call_args
+        assert kwargs["additional_data"] == {
+            "notes": "Paid from cashier",
+            "payment_status": "paid",
+        }

--- a/backend/tests/unit/test_visit_payment_integration_service.py
+++ b/backend/tests/unit/test_visit_payment_integration_service.py
@@ -31,6 +31,26 @@ class TestVisitPaymentIntegrationService:
         assert success is False
         assert message == "Визит 10 не найден"
 
+    def test_update_visit_payment_status_rejects_ownership_fields(self, db_session):
+        repo = SimpleNamespace(
+            get_visit=lambda _visit_id: _FakeRow({"id": 10, "patient_id": 1}),
+            update_visit=Mock(),
+        )
+        with patch(
+            "app.services.visit_payment_integration.VisitPaymentIntegrationRepository",
+            return_value=repo,
+        ):
+            success, message = VisitPaymentIntegrationService.update_visit_payment_status(
+                db_session,
+                visit_id=10,
+                payment_status="paid",
+                additional_data={"patient_id": 99, "notes": "bad owner update"},
+            )
+
+        assert success is False
+        assert message == "Cannot change visit ownership through payment status update"
+        repo.update_visit.assert_not_called()
+
     def test_get_visit_payment_info_success(self, db_session):
         row = _FakeRow(
             {


### PR DESCRIPTION
﻿## Summary
- Reject `patient_id`/`doctor_id` on `/visit-payments/{visit_id}/create-from-payment` instead of letting payment status updates rewrite visit ownership.
- Harden `VisitPaymentIntegrationService.update_visit_payment_status` so `additional_data` cannot overwrite immutable visit ownership fields.
- Add focused unit tests for the API wrapper and integration helper.

## Cyclic Execution Evidence
- Fresh main sync: Started from fresh `origin/main` at `9262e63c` in `C:\tmp\final-contract-scan-next-3`.
- Clean workspace: Worktree was clean before creating `codex/visit-payment-preserve-visit-owner`; only allowed payment service/test files changed.
- Branch: `codex/visit-payment-preserve-visit-owner` contains one focused commit, `0d3dc5d2`.
- Scope gate: Gate was run with known root causes `backend/app/services/visit_payment_api_service.py` and `backend/app/services/visit_payment_integration.py`; tests were the only narrow extension for regression proof.
- Red-check handling: Any red CI/check on this PR will be fixed in this PR before merge.

## Contract Impact
- Canonical surface: Existing `POST /api/v1/visit-payments/{visit_id}/create-from-payment` and `VisitPaymentIntegrationService.update_visit_payment_status` remain the touched surfaces.
- Request shape: Route shape is unchanged, but ownership query params are now rejected if provided because they are unsafe for an existing `visit_id`.
- Response shape: Successful response shape is unchanged.
- Status codes: Requests attempting ownership mutation now fail with 400 instead of corrupting `visits.patient_id` or `visits.doctor_id`.
- Frontend consumer: No frontend usage was found for `create-from-payment`; no frontend change is required.
- Compatibility path or alias: No route alias or compatibility path changed.
- Contract proof: Unit tests prove ownership fields are rejected and normal payment-status fields still pass through.

## RBAC / Permissions
- Roles allowed: Existing endpoint dependency remains Admin/Registrar for `create-from-payment`.
- Roles denied: No role expansion; unauthorized roles remain blocked by existing router dependency.
- Positive auth proof: Not rerun locally because route dependency code is unchanged.
- Negative auth proof: Not rerun locally because this PR only changes service behavior after auth has passed.

## Notification / Realtime
- Event type or websocket channel: No notification or websocket channel is added or changed.
- Payload version / ack behavior: Not applicable because no realtime payload or ack path is touched.
- Read/unread or delivery semantics: Not applicable because notification state is untouched.
- Reconnect/resync proof: Not applicable because no websocket state is involved.

## Frontend Resilience
- Empty data proof: Missing visit behavior remains unchanged through the existing integration-service failure path.
- Partial data proof: Requests with partial ownership data now fail closed before any update.
- Forbidden secondary path behavior: Ownership can no longer be changed through `additional_data` on payment status update.
- Missing draft/resource behavior: Existing missing-visit path still returns a service failure rather than creating or mutating another resource.
- Stale route/deep-link behavior: No frontend route or deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/app/services/visit_payment_api_service.py`, `backend/app/services/visit_payment_integration.py`, and their focused unit tests.
- Denied paths: No `/api/v1/ui/*`, no frontend files, no migrations, no schemas, no route rewrites, no BFF-lite service.
- Migration/docs/test impact: No migration or docs change; targeted unit tests updated.
- Rollback note: Reverting this commit restores previous permissive `additional_data` ownership updates if needed.

## Bug and impact
`/visit-payments/{visit_id}/create-from-payment` accepted `patient_id` and `doctor_id` and passed them into `update_visit_payment_status` as `additional_data`. A registrar/admin could mark a payment while accidentally or maliciously rewriting the existing visit to another patient or doctor, corrupting medical ownership.

## Root cause
The payment status helper accepted arbitrary `additional_data` and merged it directly into the `visits` update payload. The wrapper also populated `patient_id` and `doctor_id` for an existing `visit_id`, mixing creation-style fields into an update command.

## Fix
Reject ownership query params in the wrapper and add a fail-closed immutable-field guard in `VisitPaymentIntegrationService.update_visit_payment_status` for `id`, `patient_id`, `doctor_id`, `created_at`, and `source`.

## Validation
- Targeted tests or smoke run: `py_compile backend/app/services/visit_payment_api_service.py backend/app/services/visit_payment_integration.py`; `pytest backend/tests/unit/test_visit_payment_api_service.py backend/tests/unit/test_visit_payment_integration_service.py -q`; `git diff --check`.
- Result: Compile passed; targeted unit tests passed 15/15; diff hygiene passed with Windows CRLF warnings only.
- Not checked: Full backend suite and frontend suite were not run locally because this patch is backend service-only and does not touch frontend/API schema files.
