### PR TITLE
fix(force-majeure): scope explicit queue entries

### DIFF
--- a/backend/app/repositories/force_majeure_api_repository.py
+++ b/backend/app/repositories/force_majeure_api_repository.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from datetime import date
+
 from sqlalchemy.orm import Session
 
-from app.models.online_queue import OnlineQueueEntry
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.refund_deposit import (
     DepositTransaction,
     PatientDeposit,
@@ -18,12 +20,22 @@ class ForceMajeureApiRepository:
     def __init__(self, db: Session):
         self.db = db
 
-    def list_pending_entries_by_ids(self, entry_ids: list[int]) -> list[OnlineQueueEntry]:
+    def list_pending_entries_by_ids(
+        self,
+        entry_ids: list[int],
+        *,
+        specialist_id: int,
+        target_date: date | None,
+    ) -> list[OnlineQueueEntry]:
+        queue_day = target_date or date.today()
         return (
             self.db.query(OnlineQueueEntry)
+            .join(DailyQueue, OnlineQueueEntry.queue_id == DailyQueue.id)
             .filter(
                 OnlineQueueEntry.id.in_(entry_ids),
                 OnlineQueueEntry.status.in_(["waiting", "called"]),
+                DailyQueue.specialist_id == specialist_id,
+                DailyQueue.day == queue_day,
             )
             .all()
         )

--- a/backend/app/services/force_majeure_api_service.py
+++ b/backend/app/services/force_majeure_api_service.py
@@ -39,7 +39,11 @@ class ForceMajeureApiService:
     def transfer_queue_to_tomorrow(self, *, request, current_user_id: int) -> dict[str, Any]:
         service = get_force_majeure_service(self.repository.db)
         if request.entry_ids:
-            entries = self.repository.list_pending_entries_by_ids(request.entry_ids)
+            entries = self.repository.list_pending_entries_by_ids(
+                request.entry_ids,
+                specialist_id=request.specialist_id,
+                target_date=request.target_date,
+            )
         else:
             entries = service.get_pending_entries(
                 specialist_id=request.specialist_id,
@@ -68,7 +72,11 @@ class ForceMajeureApiService:
             ) from exc
 
         if request.entry_ids:
-            entries = self.repository.list_pending_entries_by_ids(request.entry_ids)
+            entries = self.repository.list_pending_entries_by_ids(
+                request.entry_ids,
+                specialist_id=request.specialist_id,
+                target_date=request.target_date,
+            )
         else:
             entries = service.get_pending_entries(
                 specialist_id=request.specialist_id,

--- a/backend/tests/unit/test_force_majeure_api_service.py
+++ b/backend/tests/unit/test_force_majeure_api_service.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from datetime import date, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
 
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.repositories.force_majeure_api_repository import ForceMajeureApiRepository
 from app.services.force_majeure_api_service import (
     ForceMajeureApiDomainError,
     ForceMajeureApiService,
@@ -13,6 +16,115 @@ from app.services.force_majeure_api_service import (
 
 @pytest.mark.unit
 class TestForceMajeureApiService:
+    def test_transfer_entry_ids_are_scoped_to_requested_specialist_and_date(
+        self, monkeypatch
+    ):
+        captured = {}
+        selected_entries = [SimpleNamespace(id=11)]
+
+        class Repository:
+            db = object()
+
+            def list_pending_entries_by_ids(
+                self, entry_ids, *, specialist_id, target_date
+            ):
+                captured["entry_ids"] = entry_ids
+                captured["specialist_id"] = specialist_id
+                captured["target_date"] = target_date
+                return selected_entries
+
+        force_service = SimpleNamespace(
+            transfer_entries_to_tomorrow=lambda **kwargs: {
+                "success": True,
+                "transferred_ids": [entry.id for entry in kwargs["entries"]],
+            }
+        )
+        monkeypatch.setattr(
+            "app.services.force_majeure_api_service.get_force_majeure_service",
+            lambda db: force_service,
+        )
+
+        target_date = date.today()
+        service = ForceMajeureApiService(db=None, repository=Repository())
+        result = service.transfer_queue_to_tomorrow(
+            request=SimpleNamespace(
+                entry_ids=[11, 12],
+                specialist_id=77,
+                target_date=target_date,
+                reason="doctor emergency",
+                send_notifications=False,
+            ),
+            current_user_id=10,
+        )
+
+        assert result["success"] is True
+        assert captured == {
+            "entry_ids": [11, 12],
+            "specialist_id": 77,
+            "target_date": target_date,
+        }
+
+    def test_repository_filters_explicit_entry_ids_by_specialist_and_date(
+        self, db_session, test_doctor, test_patient
+    ):
+        today = date.today()
+        other_day = today + timedelta(days=1)
+        requested_queue = DailyQueue(
+            day=today,
+            specialist_id=test_doctor.id,
+            queue_tag="cardiology_common",
+            active=True,
+        )
+        other_specialist_queue = DailyQueue(
+            day=today,
+            specialist_id=test_doctor.id + 1000,
+            queue_tag="dermatology_common",
+            active=True,
+        )
+        other_day_queue = DailyQueue(
+            day=other_day,
+            specialist_id=test_doctor.id,
+            queue_tag="cardiology_common",
+            active=True,
+        )
+        db_session.add_all([requested_queue, other_specialist_queue, other_day_queue])
+        db_session.flush()
+
+        scoped_entry = OnlineQueueEntry(
+            queue_id=requested_queue.id,
+            number=1,
+            patient_id=test_patient.id,
+            patient_name="Scoped Patient",
+            status="waiting",
+            source="desk",
+        )
+        other_specialist_entry = OnlineQueueEntry(
+            queue_id=other_specialist_queue.id,
+            number=2,
+            patient_id=test_patient.id,
+            patient_name="Other Specialist",
+            status="waiting",
+            source="desk",
+        )
+        other_day_entry = OnlineQueueEntry(
+            queue_id=other_day_queue.id,
+            number=3,
+            patient_id=test_patient.id,
+            patient_name="Other Day",
+            status="waiting",
+            source="desk",
+        )
+        db_session.add_all([scoped_entry, other_specialist_entry, other_day_entry])
+        db_session.flush()
+
+        entries = ForceMajeureApiRepository(db_session).list_pending_entries_by_ids(
+            [scoped_entry.id, other_specialist_entry.id, other_day_entry.id],
+            specialist_id=test_doctor.id,
+            target_date=today,
+        )
+
+        assert [entry.id for entry in entries] == [scoped_entry.id]
+
     def test_cancel_queue_with_refund_rejects_invalid_type(self, monkeypatch):
         monkeypatch.setattr(
             "app.services.force_majeure_api_service.get_force_majeure_service",


### PR DESCRIPTION
## Summary
- Scope force-majeure explicit entry_ids to the requested specialist/date before transfer/cancel workflows mutate queue entries.
- Add regression coverage for service scope propagation and repository filtering.

## Cyclic Execution Evidence
- Fresh main sync: branch created in clean worktree from origin/main at 9262e63c.
- Clean workspace: C:\final was dirty with unrelated user work, so this PR used C:\tmp\final-contract-scan-next-5 only.
- Branch: codex/force-majeure-entry-scope.
- Scope gate: allowed force-majeure repository/service and targeted unit test; denied /api/v1/ui/*, BFF-lite, frontend, migrations, and broad queue refactors.
- Red-check handling: CI failures will be fixed in this PR before merge; PR Review Quality Gate body issue handled by editing this body.

## Contract Impact
- Canonical surface: force-majeure transfer and cancel-with-refund service path for explicit queue entry_ids.
- Request shape: unchanged; existing specialist_id, target_date, and entry_ids are preserved.
- Response shape: unchanged; workflows still return existing transfer/cancel/refund result dictionaries.
- Status codes: unchanged; no endpoint authorization or exception mapping changed.
- Frontend consumer: not applicable - no frontend files changed and existing callers keep the same request contract.
- Compatibility path or alias: explicit entry_ids remain supported, now narrowed to the same specialist/date scope as the all-pending path.
- Contract proof: targeted unit test proves service passes scope and repository filters out same-id-list entries from other specialist/date queues.

## RBAC / Permissions
- Roles allowed: unchanged; existing force-majeure endpoint permissions still apply.
- Roles denied: unchanged; no authorization policy changed.
- Positive auth proof: not applicable - this patch does not change auth gates; backend service regression covers the corrected mutation scope.
- Negative auth proof: not applicable - this patch does not change auth gates; denied-role behavior is outside the changed code path.

## Notification / Realtime
- Event type or websocket channel: unchanged; no notification or websocket channel changed.
- Payload version / ack behavior: unchanged; no payload schema or acknowledgement behavior changed.
- Read/unread or delivery semantics: unchanged; this patch only narrows which queue entries can be selected for mutation.
- Reconnect/resync proof: not applicable - no realtime reconnect or resync behavior changed.

## Frontend Resilience
- Empty data proof: not applicable - no frontend rendering path changed.
- Partial data proof: not applicable - no frontend data handling changed.
- Forbidden secondary path behavior: not applicable - no frontend fallback or secondary path changed.
- Missing draft/resource behavior: not applicable - no draft or resource reopen behavior changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link state changed.

## Bug and Impact
A force-majeure request for one specialist/date could include entry_ids from another active queue. The old explicit-id path filtered only by OnlineQueueEntry.id and waiting/called status, so transfer or cancel-with-refund could mutate an unrelated queue entry.

## Root Cause
The all-pending path was specialist/date scoped through get_pending_entries, but the explicit entry_ids path bypassed DailyQueue specialist/day scoping.

## Fix
The repository now joins DailyQueue and requires specialist_id plus target_date, and both service callers pass the request scope.

## Scope Gate
- Allowed paths: backend/app/repositories/force_majeure_api_repository.py, backend/app/services/force_majeure_api_service.py, backend/tests/unit/test_force_majeure_api_service.py.
- Denied paths: /api/v1/ui/*, BFF-lite, frontend, migrations, broad queue refactors.
- Migration/docs/test impact: no migration or docs change; targeted unit tests updated.
- Rollback note: revert the repository signature/scoping change, service call-site arguments, and the two added regression tests.

## Validation
- Targeted tests or smoke run: py_compile for changed backend files; backend tests/unit/test_force_majeure_api_service.py; git diff --check.
- Result: py_compile passed; targeted pytest passed 6 tests; git diff --check passed.
- Not checked: full browser smoke and unrelated frontend suites, because this is backend-only force-majeure mutation scoping.