### PR TITLE
fix(billing): validate invoice context ownership

### DIFF
--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -86,6 +86,28 @@ class BillingService:
         """Создать счет"""
 
         # Получаем настройки биллинга
+        if visit_id is not None:
+            visit = self.db.query(Visit).filter(Visit.id == visit_id).first()
+            if not visit:
+                raise ValueError(f"Visit {visit_id} not found")
+            if visit.patient_id != patient_id:
+                raise ValueError(
+                    "Invoice patient_id does not match visit ownership"
+                )
+
+        if appointment_id is not None:
+            appointment = (
+                self.db.query(Appointment)
+                .filter(Appointment.id == appointment_id)
+                .first()
+            )
+            if not appointment:
+                raise ValueError(f"Appointment {appointment_id} not found")
+            if appointment.patient_id != patient_id:
+                raise ValueError(
+                    "Invoice patient_id does not match appointment ownership"
+                )
+
         settings = self.get_billing_settings()
 
         # Генерируем номер счета

--- a/backend/tests/unit/test_billing_service_timezone.py
+++ b/backend/tests/unit/test_billing_service_timezone.py
@@ -5,7 +5,9 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+from app.models.appointment import Appointment
 from app.models.billing import PaymentReminder
+from app.models.patient import Patient
 from app.services import billing_service as billing_module
 from app.services.billing_service import BillingService
 
@@ -51,3 +53,68 @@ class TestBillingServiceTimezone:
         assert invoice.due_date.tzinfo is None
         assert len(reminders) == 7
         assert all(reminder.scheduled_at.tzinfo is None for reminder in reminders)
+
+    def test_create_invoice_rejects_visit_from_another_patient(
+        self, db_session, test_patient, test_visit
+    ):
+        other_patient = Patient(
+            first_name="Other",
+            last_name="Patient",
+            phone="+998901111111",
+        )
+        db_session.add(other_patient)
+        db_session.commit()
+        db_session.refresh(other_patient)
+
+        service = BillingService(db_session)
+        with pytest.raises(ValueError) as exc_info:
+            service.create_invoice(
+                patient_id=other_patient.id,
+                visit_id=test_visit.id,
+                services=[
+                    {
+                        "description": "Wrong owner service",
+                        "quantity": 1,
+                        "unit_price": 1000,
+                    }
+                ],
+            )
+
+        assert str(exc_info.value) == (
+            "Invoice patient_id does not match visit ownership"
+        )
+
+    def test_create_invoice_rejects_appointment_from_another_patient(
+        self, db_session, test_patient
+    ):
+        other_patient = Patient(
+            first_name="Other",
+            last_name="Patient",
+            phone="+998902222222",
+        )
+        appointment = Appointment(
+            patient_id=test_patient.id,
+            appointment_date=datetime(2026, 3, 27).date(),
+        )
+        db_session.add_all([other_patient, appointment])
+        db_session.commit()
+        db_session.refresh(other_patient)
+        db_session.refresh(appointment)
+
+        service = BillingService(db_session)
+        with pytest.raises(ValueError) as exc_info:
+            service.create_invoice(
+                patient_id=other_patient.id,
+                appointment_id=appointment.id,
+                services=[
+                    {
+                        "description": "Wrong owner service",
+                        "quantity": 1,
+                        "unit_price": 1000,
+                    }
+                ],
+            )
+
+        assert str(exc_info.value) == (
+            "Invoice patient_id does not match appointment ownership"
+        )


### PR DESCRIPTION
## Summary
- Validate invoice visit ownership before creating billing invoices.
- Validate invoice appointment ownership before creating billing invoices.
- Add focused regression tests for cross-patient visit and appointment contexts.

## Cyclic Execution Evidence
- Fresh main sync: branch created from origin/main at 194a3f4c.
- Clean workspace: inspected before edit; only billing service and focused billing tests touched.
- Branch: codex/billing-invoice-owner-guard.
- Scope gate: local agent gate run with known root cause backend/app/services/billing_service.py; narrow override used for this confirmed billing ownership bug.
- Red-check handling: PR Review Quality Gate failure was metadata-only; PR body updated in-place and a fresh edited-event gate run was triggered, with no runtime code change.

## Contract Impact
- Canonical surface: BillingService.create_invoice ownership validation.
- Request shape: unchanged.
- Response shape: unchanged for valid requests.
- Status codes: API translation remains existing endpoint behavior; service now raises ValueError for invalid cross-owner visit/appointment context.
- Frontend consumer: unchanged.
- Compatibility path or alias: none.
- Contract proof: unit tests reject invoice creation when patient_id does not own provided visit_id or appointment_id.

## RBAC / Permissions
- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: unchanged; this service-level guard applies after existing caller authorization.
- Negative auth proof: service regression tests cover invalid ownership context regardless of caller.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel is touched by this backend service-only guard.
- Payload version / ack behavior: no realtime payload or acknowledgement behavior changes because invoice creation response shape is unchanged for valid requests.
- Read/unread or delivery semantics: no notification delivery or read/unread semantics are touched by this billing ownership validation.
- Reconnect/resync proof: no websocket or realtime resync path is involved; reconnect behavior remains unchanged because the patch only rejects invalid invoice context before persistence.

## Frontend Resilience
- Empty data proof: unchanged; no frontend empty-state or fetch behavior is touched.
- Partial data proof: unchanged; valid invoice creation with owned visit/appointment context keeps existing behavior.
- Forbidden secondary path behavior: invalid cross-patient invoice context is rejected instead of persisted.
- Missing draft/resource behavior: missing visit_id or appointment_id now raises the existing service error path instead of creating an invoice with a dangling context.
- Stale route/deep-link behavior: unchanged; no frontend route or deep-link behavior is touched.

## Scope Gate
- Allowed paths: backend/app/services/billing_service.py; backend/tests/unit/test_billing_service_timezone.py.
- Denied paths: frontend, migrations, API route shape, BFF/read-model code, unrelated billing cleanup.
- Migration/docs/test impact: no migration or docs; focused unit tests added.
- Rollback note: revert this commit to restore previous permissive invoice context behavior.

## Bug and impact
Creating an invoice with patient A and a visit_id or appointment_id belonging to patient B persisted a cross-owner invoice context. That can corrupt billing ownership and attach financial records to the wrong patient context.

## Root cause
BillingService.create_invoice accepted patient_id, visit_id, and appointment_id independently and wrote them directly to Invoice without verifying that the supplied visit or appointment belonged to the same patient.

## Fix
Lookup the supplied Visit and Appointment, reject missing records, and reject mismatched patient ownership before invoice creation.

## Validation
- Targeted tests or smoke run: `C:\Users\DrSapaev\AppData\Local\Programs\Python\Python311\python.exe -m py_compile backend/app/services/billing_service.py`; `C:\Users\DrSapaev\AppData\Local\Programs\Python\Python311\python.exe -m pytest backend/tests/unit/test_billing_service_timezone.py -q`; `git diff --check`.
- Result: py_compile passed; 3 tests passed; diff check passed.
- Not checked: broad backend suite, frontend build, browser smoke; not needed for this backend service-only guard.
