### PR TITLE
fix(discounts): validate benefit context ownership

### DIFF
--- a/backend/app/services/discount_benefits_service.py
+++ b/backend/app/services/discount_benefits_service.py
@@ -9,6 +9,8 @@ from typing import Any
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
+from app.models.appointment import Appointment
+from app.models.billing import Invoice
 from app.models.discount_benefits import (
     Benefit,
     BenefitApplication,
@@ -21,6 +23,7 @@ from app.models.discount_benefits import (
     PatientBenefit,
     PatientLoyalty,
 )
+from app.models.visit import Visit
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +33,41 @@ class DiscountBenefitsService:
 
     def __init__(self, db: Session):
         self.db = db
+
+    def _validate_patient_context(
+        self,
+        *,
+        patient_id: int,
+        appointment_id: int | None = None,
+        visit_id: int | None = None,
+        invoice_id: int | None = None,
+    ) -> None:
+        if appointment_id is not None:
+            appointment = (
+                self.db.query(Appointment)
+                .filter(Appointment.id == appointment_id)
+                .first()
+            )
+            if not appointment:
+                raise ValueError(f"Appointment {appointment_id} not found")
+            if appointment.patient_id != patient_id:
+                raise ValueError(
+                    "Patient context does not match appointment ownership"
+                )
+
+        if visit_id is not None:
+            visit = self.db.query(Visit).filter(Visit.id == visit_id).first()
+            if not visit:
+                raise ValueError(f"Visit {visit_id} not found")
+            if visit.patient_id != patient_id:
+                raise ValueError("Patient context does not match visit ownership")
+
+        if invoice_id is not None:
+            invoice = self.db.query(Invoice).filter(Invoice.id == invoice_id).first()
+            if not invoice:
+                raise ValueError(f"Invoice {invoice_id} not found")
+            if invoice.patient_id != patient_id:
+                raise ValueError("Patient context does not match invoice ownership")
 
     # === СКИДКИ ===
 
@@ -266,6 +304,13 @@ class DiscountBenefitsService:
         if not patient_benefit:
             raise ValueError("Льгота пациента не найдена")
 
+        self._validate_patient_context(
+            patient_id=patient_benefit.patient_id,
+            appointment_id=appointment_id,
+            visit_id=visit_id,
+            invoice_id=invoice_id,
+        )
+
         benefit_amount = self.calculate_benefit_discount(patient_benefit, amount)
         final_amount = amount - benefit_amount
 
@@ -387,6 +432,13 @@ class DiscountBenefitsService:
         if not program or amount < program.min_purchase_for_points:
             return 0
 
+        self._validate_patient_context(
+            patient_id=patient_id,
+            appointment_id=appointment_id,
+            visit_id=visit_id,
+            invoice_id=invoice_id,
+        )
+
         # Получить или создать запись лояльности пациента
         patient_loyalty = (
             self.db.query(PatientLoyalty)
@@ -469,6 +521,13 @@ class DiscountBenefitsService:
 
         if points > patient_loyalty.current_balance:
             raise ValueError("Недостаточно баллов")
+
+        self._validate_patient_context(
+            patient_id=patient_id,
+            appointment_id=appointment_id,
+            visit_id=visit_id,
+            invoice_id=invoice_id,
+        )
 
         # Рассчитать сумму скидки
         discount_amount = points * program.ruble_per_point

--- a/backend/tests/unit/test_discount_benefits_service_ownership.py
+++ b/backend/tests/unit/test_discount_benefits_service_ownership.py
@@ -1,0 +1,140 @@
+from datetime import date
+
+import pytest
+
+from app.models.appointment import Appointment
+from app.models.discount_benefits import (
+    Benefit,
+    LoyaltyProgram,
+    PatientBenefit,
+    PatientLoyalty,
+)
+from app.models.patient import Patient
+from app.services.discount_benefits_service import DiscountBenefitsService
+
+
+def _create_patient(db_session, *, first_name: str, phone: str) -> Patient:
+    patient = Patient(
+        first_name=first_name,
+        last_name="Owner",
+        phone=phone,
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+    return patient
+
+
+def _create_verified_patient_benefit(db_session, patient_id: int) -> PatientBenefit:
+    benefit = Benefit(
+        name="Ownership benefit",
+        benefit_type="employee",
+        discount_percentage=10,
+        is_active=True,
+    )
+    patient_benefit = PatientBenefit(
+        patient_id=patient_id,
+        benefit=benefit,
+        is_active=True,
+        verified=True,
+    )
+    db_session.add_all([benefit, patient_benefit])
+    db_session.commit()
+    db_session.refresh(patient_benefit)
+    return patient_benefit
+
+
+def _create_loyalty_program(db_session) -> LoyaltyProgram:
+    program = LoyaltyProgram(
+        name="Ownership points",
+        points_per_ruble=1,
+        min_purchase_for_points=0,
+        ruble_per_point=1,
+        min_points_to_redeem=1,
+        is_active=True,
+    )
+    db_session.add(program)
+    db_session.commit()
+    db_session.refresh(program)
+    return program
+
+
+def test_apply_benefit_rejects_visit_from_another_patient(
+    db_session, test_patient, test_visit
+):
+    other_patient = _create_patient(
+        db_session, first_name="BenefitOther", phone="+998901010101"
+    )
+    patient_benefit = _create_verified_patient_benefit(
+        db_session, other_patient.id
+    )
+
+    service = DiscountBenefitsService(db_session)
+    with pytest.raises(ValueError) as exc_info:
+        service.apply_benefit(
+            patient_benefit_id=patient_benefit.id,
+            amount=1000,
+            visit_id=test_visit.id,
+        )
+
+    assert str(exc_info.value) == (
+        "Patient context does not match visit ownership"
+    )
+
+
+def test_earn_loyalty_points_rejects_appointment_from_another_patient(
+    db_session, test_patient
+):
+    other_patient = _create_patient(
+        db_session, first_name="LoyaltyOther", phone="+998902020202"
+    )
+    appointment = Appointment(
+        patient_id=test_patient.id,
+        appointment_date=date(2026, 3, 27),
+    )
+    program = _create_loyalty_program(db_session)
+    db_session.add(appointment)
+    db_session.commit()
+    db_session.refresh(appointment)
+
+    service = DiscountBenefitsService(db_session)
+    with pytest.raises(ValueError) as exc_info:
+        service.earn_loyalty_points(
+            patient_id=other_patient.id,
+            program_id=program.id,
+            amount=1000,
+            appointment_id=appointment.id,
+        )
+
+    assert str(exc_info.value) == (
+        "Patient context does not match appointment ownership"
+    )
+
+
+def test_redeem_loyalty_points_rejects_visit_from_another_patient(
+    db_session, test_patient, test_visit
+):
+    other_patient = _create_patient(
+        db_session, first_name="RedeemOther", phone="+998903030303"
+    )
+    program = _create_loyalty_program(db_session)
+    patient_loyalty = PatientLoyalty(
+        patient_id=other_patient.id,
+        program_id=program.id,
+        current_balance=100,
+    )
+    db_session.add(patient_loyalty)
+    db_session.commit()
+
+    service = DiscountBenefitsService(db_session)
+    with pytest.raises(ValueError) as exc_info:
+        service.redeem_loyalty_points(
+            patient_id=other_patient.id,
+            program_id=program.id,
+            points=10,
+            visit_id=test_visit.id,
+        )
+
+    assert str(exc_info.value) == (
+        "Patient context does not match visit ownership"
+    )


### PR DESCRIPTION
## Summary
- Validate patient-owned benefit application context before creating benefit applications.
- Validate loyalty earn/redeem context before creating loyalty point transactions.
- Add focused regression tests for cross-patient visit and appointment contexts.

## Cyclic Execution Evidence
- Fresh main sync: branch created from origin/main at 8d9e144f.
- Clean workspace: inspected after #1458 merge; this PR touches only discount benefits service and focused unit tests.
- Branch: codex/discount-benefit-context-owner-guard.
- Scope gate: local agent gate run with known root cause backend/app/services/discount_benefits_service.py; narrow service-first override used, then one focused test file added for proof.
- Red-check handling: will fix any failing PR checks in this PR before merge.

## Contract Impact
- Canonical surface: DiscountBenefitsService benefit and loyalty ownership validation.
- Request shape: unchanged.
- Response shape: unchanged for valid requests.
- Status codes: endpoint exception translation remains existing 400 behavior for invalid service errors.
- Frontend consumer: unchanged.
- Compatibility path or alias: none.
- Contract proof: unit tests reject cross-patient visit/appointment context before creating benefit or loyalty records.

## RBAC / Permissions
- Roles allowed: unchanged.
- Roles denied: unchanged.
- Positive auth proof: existing Admin-only endpoints keep the same authorization surface.
- Negative auth proof: service regression tests cover invalid ownership context even after authorization succeeds.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel is touched by this service-only ownership guard.
- Payload version / ack behavior: no realtime payload or acknowledgement behavior changes because valid request responses are unchanged.
- Read/unread or delivery semantics: no notification delivery or read/unread semantics are touched by this discount benefits validation.
- Reconnect/resync proof: no websocket or realtime resync path is involved; the patch only rejects invalid patient context before persistence.

## Frontend Resilience
- Empty data proof: no frontend empty-state or fetch behavior is touched.
- Partial data proof: valid benefit and loyalty operations with owned context keep existing behavior.
- Forbidden secondary path behavior: invalid cross-patient visit or appointment context is rejected instead of persisted.
- Missing draft/resource behavior: missing referenced visit/appointment/invoice now raises the existing service error path before persistence.
- Stale route/deep-link behavior: no frontend route or deep-link behavior is touched.

## Scope Gate
- Allowed paths: backend/app/services/discount_benefits_service.py; backend/tests/unit/test_discount_benefits_service_ownership.py.
- Denied paths: frontend, migrations, API schema shape, BFF/read-model code, unrelated discount/benefit cleanup.
- Migration/docs/test impact: no migration or docs; focused unit tests added.
- Rollback note: revert this commit to restore previous permissive benefit/loyalty context behavior.

## Bug and impact
Admin benefit or loyalty operations could use patient A's benefit/loyalty account while attaching the resulting application or point transaction to patient B's visit or appointment. That corrupts financial/discount usage history and links patient-owned value to the wrong medical context.

## Root cause
DiscountBenefitsService accepted patient-owned identifiers and context identifiers independently. apply_benefit used PatientBenefit.patient_id, while earn/redeem loyalty used request patient_id, but none verified that the supplied appointment_id, visit_id, or invoice_id belonged to that same patient.

## Fix
Add a service-level patient context validator and call it before benefit applications and loyalty earn/redeem transactions are persisted.

## Validation
- Targeted tests or smoke run: `C:\Users\DrSapaev\AppData\Local\Programs\Python\Python311\python.exe -m py_compile backend/app/services/discount_benefits_service.py`; `C:\Users\DrSapaev\AppData\Local\Programs\Python\Python311\python.exe -m pytest backend/tests/unit/test_discount_benefits_service_ownership.py -q`; `git diff --check`.
- Result: py_compile passed; 3 tests passed; diff check passed.
- Not checked: broad backend suite, frontend build, browser smoke; not needed for this backend service-only guard.