### PR TITLE
fix(files): guard upload context ownership

### DIFF
--- a/backend/app/services/file_system_service.py
+++ b/backend/app/services/file_system_service.py
@@ -26,6 +26,9 @@ from app.crud.file_system import (
     file_share,
     file_version,
 )
+from app.models.appointment import Appointment
+from app.models.emr import EMR
+from app.models.emr_v2 import EMRRecord
 from app.models.file_system import (
     File,
     FileShare,
@@ -34,6 +37,7 @@ from app.models.file_system import (
 from app.models.file_system import (
     FileStatus as FileStatusEnum,
 )
+from app.models.visit import Visit
 from app.schemas.file_system import (
     FileCreate,
     FileExportRequest,
@@ -242,6 +246,86 @@ class FileSystemService:
             db, user_id=user_id, additional_size=file_size, additional_files=1
         )
 
+    @staticmethod
+    def _coerce_optional_int(value: Any) -> int | None:
+        if value is None:
+            return None
+        return int(value)
+
+    def _validate_upload_context(
+        self, db: Session, file_data: FileUploadRequest
+    ) -> None:
+        context_patient_ids: dict[str, int] = {}
+
+        patient_id = self._coerce_optional_int(file_data.patient_id)
+        if patient_id is not None:
+            context_patient_ids["patient_id"] = patient_id
+
+        appointment_id = self._coerce_optional_int(file_data.appointment_id)
+        if appointment_id is not None:
+            appointment = db.get(Appointment, appointment_id)
+            if not appointment:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Appointment not found",
+                )
+            context_patient_ids["appointment_id"] = int(appointment.patient_id)
+
+        visit_id = self._coerce_optional_int(file_data.visit_id)
+        if visit_id is not None:
+            visit = db.get(Visit, visit_id)
+            if not visit:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Visit not found",
+                )
+            context_patient_ids["visit_id"] = int(visit.patient_id)
+
+        emr_id = self._coerce_optional_int(file_data.emr_id)
+        if emr_id is not None:
+            emr = db.get(EMR, emr_id)
+            if not emr:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="EMR not found",
+                )
+            appointment = db.get(Appointment, emr.appointment_id)
+            if not appointment:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="EMR appointment not found",
+                )
+            context_patient_ids["emr_id"] = int(appointment.patient_id)
+            if (
+                appointment_id is not None
+                and int(emr.appointment_id) != appointment_id
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="EMR does not belong to selected appointment",
+                )
+
+        emr_record_id = self._coerce_optional_int(file_data.emr_record_id)
+        if emr_record_id is not None:
+            emr_record = db.get(EMRRecord, emr_record_id)
+            if not emr_record:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="EMR record not found",
+                )
+            context_patient_ids["emr_record_id"] = int(emr_record.patient_id)
+            if visit_id is not None and int(emr_record.visit_id) != visit_id:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="EMR record does not belong to selected visit",
+                )
+
+        if len(set(context_patient_ids.values())) > 1:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="File context does not belong to a single patient",
+            )
+
     def upload_file(
         self,
         db: Session,
@@ -251,6 +335,8 @@ class FileSystemService:
     ) -> File:
         """Загрузить файл"""
         try:
+            self._validate_upload_context(db, file_data)
+
             file_content, file_size = self._read_upload_file_limited(
                 upload_file, self.max_file_size
             )

--- a/backend/tests/test_file_security.py
+++ b/backend/tests/test_file_security.py
@@ -10,9 +10,13 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from io import BytesIO
+from datetime import date
 
+from app.models.appointment import Appointment
 from app.models.file_system import File, FileVersion
+from app.models.patient import Patient
 from app.models.user import User
+from app.models.visit import Visit
 
 
 class TestFileSecurity:
@@ -176,6 +180,104 @@ class TestFileSecurity:
 
         # Patient не должен иметь доступ к загрузке
         assert response.status_code == 403
+
+    def test_file_upload_rejects_mismatched_patient_visit_context(
+        self,
+        client: TestClient,
+        db_session: Session,
+        auth_headers: dict[str, str],
+        test_patient,
+        test_doctor,
+    ):
+        other_patient = Patient(
+            first_name="Other",
+            last_name="Patient",
+            phone="+998901112233",
+            birth_date=date(1985, 1, 1),
+        )
+        db_session.add(other_patient)
+        db_session.commit()
+        db_session.refresh(other_patient)
+
+        other_visit = Visit(
+            patient_id=other_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=date.today(),
+            visit_time="11:00",
+            status="open",
+        )
+        db_session.add(other_visit)
+        db_session.commit()
+        db_session.refresh(other_visit)
+
+        file_obj = BytesIO(b"wrong patient visit context")
+        response = client.post(
+            "/api/v1/files/upload",
+            files={"file": ("context.txt", file_obj, "text/plain")},
+            data={
+                "file_type": "document",
+                "permission": "private",
+                "patient_id": str(test_patient.id),
+                "visit_id": str(other_visit.id),
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 409
+        patient_files = db_session.query(File).filter(
+            File.patient_id == test_patient.id
+        )
+        visit_files = db_session.query(File).filter(File.visit_id == other_visit.id)
+        assert patient_files.count() == 0
+        assert visit_files.count() == 0
+
+    def test_file_upload_rejects_mismatched_patient_appointment_context(
+        self,
+        client: TestClient,
+        db_session: Session,
+        auth_headers: dict[str, str],
+        test_patient,
+        test_doctor,
+    ):
+        other_patient = Patient(
+            first_name="Appointment",
+            last_name="Other",
+            phone="+998901112244",
+            birth_date=date(1986, 1, 1),
+        )
+        db_session.add(other_patient)
+        db_session.commit()
+        db_session.refresh(other_patient)
+
+        other_appointment = Appointment(
+            patient_id=other_patient.id,
+            doctor_id=test_doctor.id,
+            appointment_date=date.today(),
+            appointment_time="12:00",
+            status="scheduled",
+        )
+        db_session.add(other_appointment)
+        db_session.commit()
+        db_session.refresh(other_appointment)
+
+        file_obj = BytesIO(b"wrong appointment context")
+        response = client.post(
+            "/api/v1/files/upload",
+            files={"file": ("appointment-context.txt", file_obj, "text/plain")},
+            data={
+                "file_type": "document",
+                "permission": "private",
+                "patient_id": str(test_patient.id),
+                "appointment_id": str(other_appointment.id),
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 409
+        appointment_files = db_session.query(File).filter(
+            File.appointment_id == other_appointment.id
+        )
+        assert appointment_files.count() == 0
 
     def test_file_hash_consistency(
         self, client: TestClient, db_session: Session


### PR DESCRIPTION
## Summary
- Add a service-level ownership guard before file upload persistence.
- Reject uploads whose patient_id conflicts with appointment_id, visit_id, legacy emr_id, or EMR v2 emr_record_id context.
- Add HTTP regression tests for mismatched patient/visit and patient/appointment uploads.

## Cyclic Execution Evidence
- Fresh main sync: worktree C:\tmp\final-contract-scan-next-5 synced to origin/main at 8d9e144f before branching.
- Clean workspace: branch created after the narrow service/test patch from detached origin/main.
- Branch: codex/file-upload-context-owner-guard.
- Scope gate: agent_gate returned narrow override with first-touch service owner backend/app/services/file_system_service.py; test file added only for the targeted regression proof.
- Red-check handling: local pytest initially exposed test fixture/RBAC and non-mounted emr_record API assumptions; fixed in the same branch before PR.

## Contract Impact
- Canonical surface: POST /api/v1/files/upload through FileSystemService.upload_file.
- Request shape: unchanged multipart form fields; existing patient_id, appointment_id, visit_id, emr_id remain accepted.
- Response shape: unchanged on success.
- Status codes: new 409 Conflict for cross-patient context mismatch; 404 for missing referenced appointment/visit/EMR anchors.
- Frontend consumer: existing file upload callers can keep sending the same fields; invalid mixed-patient metadata now fails instead of persisting a misfiled medical document.
- Compatibility path or alias: no route, prefix, DTO, or alias changes.
- Contract proof: tests/test_file_security.py covers mismatched patient_id with visit_id and appointment_id via the mounted HTTP endpoint.

## RBAC / Permissions
- Roles allowed: unchanged Admin, Doctor, Nurse, Receptionist for upload.
- Roles denied: unchanged Patient upload denial remains covered by existing file security test.
- Positive auth proof: targeted tests use authenticated admin headers to reach the service guard.
- Negative auth proof: existing Patient upload denial test still passes.

## Notification / Realtime
- Event type or websocket channel: no notification or websocket path is touched; upload still emits no realtime event.
- Payload version / ack behavior: no realtime payload or ack contract exists on this upload command.
- Read/unread or delivery semantics: no notification read-state or delivery state is created by this endpoint.
- Reconnect/resync proof: no realtime client resync path exists here; the persistence guard runs synchronously before DB file row creation.

## Frontend Resilience
- Empty data proof: no list/rendering empty-state path is touched; invalid upload returns 409 before any file row can appear in a list.
- Partial data proof: upload still accepts partial context such as patient-only or visit-only; it only rejects contradictory anchors.
- Forbidden secondary path behavior: RBAC behavior unchanged and still tested.
- Missing draft/resource behavior: missing context anchors return 404 before persistence.
- Stale route/deep-link behavior: no route or deep-link behavior changes.

## Scope Gate
- Allowed paths: backend/app/services/file_system_service.py, backend/tests/test_file_security.py.
- Denied paths: frontend, /api/v1/ui/*, migrations, unrelated upload endpoints, file model/schema changes.
- Migration/docs/test impact: no migration or docs; targeted backend regression tests added.
- Rollback note: revert this commit to restore previous permissive upload-context behavior.

## Validation
- Targeted tests or smoke run: py_compile for service/test files; pytest tests/test_file_security.py; git diff --check.
- Result: py_compile passed; pytest 7 passed; git diff --check passed with Windows CRLF warning only.
- Not checked: full backend suite, frontend build.