### PR TITLE
fix(emr): guard lab integration ownership

### DIFF
--- a/backend/app/services/emr_lab_integration.py
+++ b/backend/app/services/emr_lab_integration.py
@@ -9,8 +9,9 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from app.crud import lab_result
+from app.models.appointment import Appointment
 from app.models.emr import EMR
-from app.models.lab import LabResult
+from app.models.lab import LabOrder, LabResult
 
 logger = logging.getLogger(__name__)
 
@@ -83,10 +84,27 @@ class EMRLabIntegrationService:
                 raise ValueError("EMR не найден")
 
             # Получаем лабораторные результаты
+            appointment = (
+                db.query(Appointment)
+                .filter(Appointment.id == emr_record.appointment_id)
+                .first()
+            )
+            if not appointment:
+                raise ValueError("EMR appointment not found")
+
             lab_results = []
             for result_id in lab_result_ids:
                 result = lab_result.get_lab_result(db, result_id)
                 if result:
+                    result_patient_id = (
+                        db.query(LabOrder.patient_id)
+                        .filter(LabOrder.id == result.order_id)
+                        .scalar()
+                    )
+                    if result_patient_id != appointment.patient_id:
+                        raise ValueError(
+                            "Lab result does not belong to the target EMR patient"
+                        )
                     lab_results.append(result)
 
             # Обновляем EMR с лабораторными данными

--- a/backend/tests/test_lab_reporting_api.py
+++ b/backend/tests/test_lab_reporting_api.py
@@ -636,6 +636,68 @@ def test_doctor_emr_lab_integrate_is_limited_to_owned_emr_and_patient_results(
 
 
 @pytest.mark.integration
+def test_admin_emr_lab_integrate_rejects_cross_patient_result(
+    client,
+    auth_headers,
+    db_session,
+    test_doctor,
+) -> None:
+    own_patient = _create_patient(db_session)
+    other_patient = _create_patient(db_session)
+    own_visit = _create_visit(
+        db_session,
+        patient_id=own_patient.id,
+        doctor_id=test_doctor.id,
+    )
+    other_visit = _create_visit(
+        db_session,
+        patient_id=other_patient.id,
+        doctor_id=test_doctor.id,
+    )
+    own_emr = _create_emr(
+        db_session,
+        appointment_id=_create_appointment(
+            db_session,
+            patient_id=own_patient.id,
+            doctor_id=test_doctor.id,
+        ).id,
+    )
+    other_result = _create_legacy_lab_result(
+        db_session,
+        patient_id=other_patient.id,
+        visit_id=other_visit.id,
+        test_code="glucose",
+        value="7",
+    )
+    own_result = _create_legacy_lab_result(
+        db_session,
+        patient_id=own_patient.id,
+        visit_id=own_visit.id,
+        test_code="hemoglobin",
+        value="130",
+    )
+
+    foreign_result_response = client.post(
+        f"/api/v1/emr/lab/emr/{own_emr.id}/integrate-lab-results",
+        json=[other_result.id],
+        headers=auth_headers,
+    )
+    assert foreign_result_response.status_code == 404
+    db_session.refresh(own_emr)
+    assert own_emr.lab_results == {}
+
+    own_result_response = client.post(
+        f"/api/v1/emr/lab/emr/{own_emr.id}/integrate-lab-results",
+        json=[own_result.id],
+        headers=auth_headers,
+    )
+    assert own_result_response.status_code == 200, own_result_response.text
+    db_session.refresh(own_emr)
+    assert own_emr.lab_results["hemoglobin"][0]["id"] == own_result.id
+    assert "glucose" not in own_emr.lab_results
+
+
+@pytest.mark.integration
 def test_lab_template_resolution_api_restricts_template_choices(
     client, auth_headers, db_session, test_patient, test_visit
 ):


### PR DESCRIPTION
## Summary
- Add a service-level ownership guard before legacy EMR lab integration writes LabResult data into EMR.lab_results.
- Add an admin-path regression proving a LabResult from another patient's LabOrder is rejected and not persisted into the target EMR.

## Cyclic Execution Evidence
- Fresh main sync: started from safe worktree at origin/main merge commit 0fc3110c after PR #1460 was merged.
- Clean workspace: branch codex/emr-lab-result-owner-guard was created with no pre-existing local edits.
- Branch: codex/emr-lab-result-owner-guard.
- Scope gate: gate_known_root_cause selected for EMR/Lab risky domain; local gate returned narrow_override anchored to backend/app/services/emr_lab_integration.py.
- Red-check handling: no red local checks before PR creation; any failing GitHub checks will be fixed in this PR.

## Contract Impact
- Canonical surface: POST /api/v1/emr/lab/emr/{emr_id}/integrate-lab-results delegates the actual write to EMRLabIntegrationService.integrate_lab_results_with_emr.
- Request shape: unchanged; the body remains a list of LabResult ids.
- Response shape: unchanged for successful own-patient integrations.
- Status codes: existing endpoint ValueError mapping is preserved; a rejected mismatched result currently returns the endpoint's existing 404 error path and does not write data.
- Frontend consumer: no frontend files touched; consumers keep using the same endpoint and payload.
- Compatibility path or alias: legacy EMR/Lab endpoint remains mounted in place; no alias, redirect, or BFF-lite route was added.
- Contract proof: tests/test_lab_reporting_api.py covers the admin mismatch rejection and the existing doctor ownership path.

## RBAC / Permissions
- Roles allowed: Admin and Doctor remain the endpoint roles from the existing route dependency.
- Roles denied: unauthenticated or non-listed roles remain denied by the unchanged require_roles dependency.
- Positive auth proof: the admin regression then integrates an own-patient LabResult successfully with auth_headers.
- Negative auth proof: the same admin path rejects another patient's LabResult before EMR.lab_results mutation; existing doctor test still rejects foreign EMR and foreign result with 403.

## Notification / Realtime
- Event type or websocket channel: this command does not emit a notification or websocket event in the touched path.
- Payload version / ack behavior: no realtime payload or ack contract is created or changed.
- Read/unread or delivery semantics: no delivery state exists for this EMR lab integration write.
- Reconnect/resync proof: clients resync through normal EMR reads after the unchanged write contract; rejected writes leave the stored EMR JSON unchanged.

## Frontend Resilience
- Empty data proof: rejected cross-patient integration keeps EMR.lab_results as an empty object in the regression.
- Partial data proof: the patch validates each found LabResult before formatting and commit, so a mismatched result stops the write instead of partially merging foreign lab data.
- Forbidden secondary path behavior: no secondary frontend path was added; the backend service guard protects Admin and internal callers in addition to the existing Doctor endpoint guard.
- Missing draft/resource behavior: missing EMR still follows the existing ValueError path; missing LabResult ids keep the previous ignore behavior.
- Stale route/deep-link behavior: route shape is unchanged, so stale links continue to hit the same endpoint with stricter ownership validation.

## Scope Gate
- Allowed paths: backend/app/services/emr_lab_integration.py and backend/tests/test_lab_reporting_api.py.
- Denied paths: frontend files, /api/v1/ui/*, BFF-lite routes, schemas, models, migrations, and unrelated lab reporting flows.
- Migration/docs/test impact: no migration or docs changes; one existing API test module updated.
- Rollback note: revert this commit to restore prior service behavior; database schema and API shape are unchanged.

## Validation
- Targeted tests or smoke run: py_compile for the changed service/test, two focused EMR/Lab integration tests, and the full tests/test_lab_reporting_api.py module.
- Result: all local validation passed; full module was 12 passed.
- Not checked: full backend suite and frontend build were not run because the patch is a narrow backend service/test ownership guard.