### PR TITLE
fix(emr): guard lab result patient ownership

### DIFF
--- a/backend/app/services/emr_lab_integration.py
+++ b/backend/app/services/emr_lab_integration.py
@@ -9,8 +9,9 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from app.crud import lab_result
+from app.models.appointment import Appointment
 from app.models.emr import EMR
-from app.models.lab import LabResult
+from app.models.lab import LabOrder, LabResult
 
 logger = logging.getLogger(__name__)
 
@@ -82,11 +83,32 @@ class EMRLabIntegrationService:
             if not emr_record:
                 raise ValueError("EMR не найден")
 
+            appointment = (
+                db.query(Appointment)
+                .filter(Appointment.id == emr_record.appointment_id)
+                .first()
+            )
+            if not appointment:
+                raise ValueError("EMR appointment not found")
+
             # Получаем лабораторные результаты
             lab_results = []
             for result_id in lab_result_ids:
                 result = lab_result.get_lab_result(db, result_id)
                 if result:
+                    order = (
+                        db.query(LabOrder)
+                        .filter(LabOrder.id == result.order_id)
+                        .first()
+                    )
+                    if not order:
+                        raise ValueError(
+                            f"Lab order for result {result_id} not found"
+                        )
+                    if order.patient_id != appointment.patient_id:
+                        raise ValueError(
+                            "Lab result patient does not match EMR appointment patient"
+                        )
                     lab_results.append(result)
 
             # Обновляем EMR с лабораторными данными

--- a/backend/tests/test_lab_reporting_api.py
+++ b/backend/tests/test_lab_reporting_api.py
@@ -636,6 +636,71 @@ def test_doctor_emr_lab_integrate_is_limited_to_owned_emr_and_patient_results(
 
 
 @pytest.mark.integration
+def test_admin_emr_lab_integrate_rejects_cross_patient_result(
+    client,
+    auth_headers,
+    db_session,
+) -> None:
+    _own_user, own_doctor = _create_doctor_user(db_session, label="admin_integrate_own")
+    _other_user, other_doctor = _create_doctor_user(
+        db_session,
+        label="admin_integrate_other",
+    )
+    own_patient = _create_patient(db_session)
+    other_patient = _create_patient(db_session)
+    own_visit = _create_visit(
+        db_session,
+        patient_id=own_patient.id,
+        doctor_id=own_doctor.id,
+    )
+    other_visit = _create_visit(
+        db_session,
+        patient_id=other_patient.id,
+        doctor_id=other_doctor.id,
+    )
+    own_emr = _create_emr(
+        db_session,
+        appointment_id=_create_appointment(
+            db_session,
+            patient_id=own_patient.id,
+            doctor_id=own_doctor.id,
+        ).id,
+    )
+    own_result = _create_legacy_lab_result(
+        db_session,
+        patient_id=own_patient.id,
+        visit_id=own_visit.id,
+        test_code="hemoglobin",
+        value="130",
+    )
+    other_result = _create_legacy_lab_result(
+        db_session,
+        patient_id=other_patient.id,
+        visit_id=other_visit.id,
+        test_code="glucose",
+        value="7",
+    )
+
+    own_response = client.post(
+        f"/api/v1/emr/lab/emr/{own_emr.id}/integrate-lab-results",
+        json=[own_result.id],
+        headers=auth_headers,
+    )
+    assert own_response.status_code == 200, own_response.text
+    db_session.refresh(own_emr)
+    assert own_emr.lab_results["hemoglobin"][0]["id"] == own_result.id
+
+    cross_patient_response = client.post(
+        f"/api/v1/emr/lab/emr/{own_emr.id}/integrate-lab-results",
+        json=[other_result.id],
+        headers=auth_headers,
+    )
+    assert cross_patient_response.status_code == 404
+    db_session.refresh(own_emr)
+    assert "glucose" not in own_emr.lab_results
+
+
+@pytest.mark.integration
 def test_lab_template_resolution_api_restricts_template_choices(
     client, auth_headers, db_session, test_patient, test_visit
 ):


### PR DESCRIPTION
## Summary
- Adds a service-level ownership guard before EMR/lab integration writes lab results into `EMR.lab_results`.
- Ensures every selected `LabResult` belongs to a `LabOrder.patient_id` matching the EMR appointment patient.
- Adds an integration regression test for Admin path, where endpoint-level Doctor-only ownership checks do not run.

## Cyclic Execution Evidence
- Fresh main sync: branch was created from `origin/main` at `0fc3110c` in `C:\tmp\final-contract-scan-next-3`.
- Clean workspace: worktree was clean before the patch; current diff is limited to the two files listed under Scope Gate.
- Branch: `codex/emr-lab-result-patient-guard`.
- Scope gate: local gate ran with known root cause `backend/app/services/emr_lab_integration.py`; service slice stayed narrow and the test slice was explicitly limited to the existing lab reporting integration test file.
- Red-check handling: if a code check fails, this PR will be fixed in-place; current red-check handling already inspected the PR Review Quality Gate log and updated this body instead of changing runtime code.

## Contract Impact
- Canonical surface: `POST /api/v1/emr/lab/emr/{emr_id}/integrate-lab-results` and `EMRLabIntegrationService.integrate_lab_results_with_emr`.
- Request shape: unchanged JSON array of lab result ids.
- Response shape: unchanged success response for valid same-patient results.
- Status codes: valid same-patient requests remain `200`; cross-patient lab result selection now follows the existing `ValueError` to HTTP error path instead of mutating the EMR.
- Frontend consumer: no frontend consumer changes; this is backend-only protection.
- Compatibility path or alias: no aliases or compatibility routes are changed.
- Contract proof: `test_doctor_emr_lab_integrate_is_limited_to_owned_emr_and_patient_results` plus new `test_admin_emr_lab_integrate_rejects_cross_patient_result` prove same-patient success and cross-patient rejection.

## RBAC / Permissions
- Roles allowed: existing endpoint roles are unchanged: Admin and Doctor.
- Roles denied: existing endpoint role denial behavior is unchanged for roles outside Admin/Doctor.
- Positive auth proof: targeted tests prove Doctor same-patient integration and Admin same-patient integration still succeed.
- Negative auth proof: targeted tests prove Doctor foreign EMR/result access is rejected and Admin cross-patient result integration is rejected before persistence.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel is touched.
- Payload version / ack behavior: no realtime payload, ack, delivery, or version behavior exists on this path.
- Read/unread or delivery semantics: no notification read/unread or delivery state is touched.
- Reconnect/resync proof: no websocket or realtime resync path is involved; the patch only rejects invalid EMR/lab ownership before persistence.

## Frontend Resilience
- Empty data proof: no frontend empty-state code is touched; backend valid empty `lab_result_ids` behavior is unchanged.
- Partial data proof: no frontend partial-data path is touched; backend now rejects mismatched selected results before any merge into EMR JSON.
- Forbidden secondary path behavior: no secondary frontend path is introduced; the existing backend endpoint enforces the invariant for all callers.
- Missing draft/resource behavior: missing EMR and missing EMR appointment continue to fail through the existing error path.
- Stale route/deep-link behavior: no route or deep-link behavior is touched.

## Scope Gate
- Allowed paths: `backend/app/services/emr_lab_integration.py`, `backend/tests/test_lab_reporting_api.py`.
- Denied paths: no frontend, no `/api/v1/ui/*`, no separate BFF service, no migrations, no schemas, no queue/payment/role logic, no command wrappers.
- Migration/docs/test impact: no migration or docs impact; one backend integration regression test was added.
- Rollback note: reverting this PR restores previous behavior but reopens the wrong-patient EMR lab result mutation risk.

## Bug and impact
An Admin could integrate a lab result from patient B into patient A's EMR because `EMRLabIntegrationService.integrate_lab_results_with_emr` only loaded requested result ids and merged them into the target EMR JSON. This is a wrong-record medical data mutation.

## Root cause
Doctor callers had endpoint-level ownership checks, but the service itself did not verify that each lab result's `LabOrder.patient_id` matched the patient of the EMR's appointment.

## Fix
- Resolve the target EMR appointment patient in the service.
- Resolve each lab result's owning lab order.
- Reject any result whose order patient does not match the EMR appointment patient before updating `EMR.lab_results`.

## Validation
- Targeted tests or smoke run: `py_compile` for `backend/app/services/emr_lab_integration.py`; targeted pytest for the existing Doctor EMR/lab integration test and the new Admin cross-patient regression test; `git diff --check`.
- Result: all local validation passed. Targeted pytest result was `2 passed, 1 warning`.
- Not checked: full backend suite and frontend build were not run locally because this backend-only patch touches no frontend code; GitHub CI ran the broader required backend and quality gates.