### PR TITLE
fix(payments): reject mixed target ids

### DIFF
--- a/backend/app/services/payment_create_service.py
+++ b/backend/app/services/payment_create_service.py
@@ -59,6 +59,18 @@ class PaymentCreateService:
     def _resolve_visit_id(
         self, *, visit_id: int | None, appointment_id: int | None
     ) -> int | None:
+        if visit_id and appointment_id:
+            resolved_appointment_visit_id = self._resolve_visit_id(
+                visit_id=None,
+                appointment_id=appointment_id,
+            )
+            if resolved_appointment_visit_id != visit_id:
+                raise PaymentCreateDomainError(
+                    status_code=409,
+                    detail="visit_id does not match appointment_id",
+                )
+            return visit_id
+
         if visit_id:
             return visit_id
 

--- a/backend/tests/unit/test_payment_create_service.py
+++ b/backend/tests/unit/test_payment_create_service.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.models.appointment import Appointment
 from app.models.clinic import Doctor
+from app.models.patient import Patient
 from app.models.payment import Payment
 from app.models.visit import Visit, VisitService
 from app.services.payment_create_service import (
@@ -145,6 +146,63 @@ class TestPaymentCreateService:
 
         assert exc_info.value.status_code == 409
         assert db_session.query(Payment).count() == 0
+
+    def test_create_payment_rejects_mismatched_visit_and_appointment_ids(
+        self, db_session, test_patient, test_doctor
+    ):
+        visit_date = date.today()
+        appointment_visit = Visit(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=visit_date,
+            visit_time="09:00",
+            status="open",
+            discount_mode="none",
+            source="desk",
+        )
+        appointment = Appointment(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            appointment_date=visit_date,
+            appointment_time="09:00",
+        )
+        other_patient = Patient(
+            first_name="Other",
+            last_name="PaymentOwner",
+            phone="+998901990001",
+            birth_date=date(1991, 1, 1),
+        )
+        db_session.add(other_patient)
+        db_session.flush()
+        other_visit = Visit(
+            patient_id=other_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=visit_date,
+            visit_time="10:00",
+            status="open",
+            discount_mode="none",
+            source="desk",
+        )
+        db_session.add_all([appointment_visit, appointment, other_visit])
+        db_session.commit()
+        db_session.refresh(appointment)
+        db_session.refresh(other_visit)
+
+        service = PaymentCreateService(db_session)
+        with pytest.raises(PaymentCreateDomainError) as exc_info:
+            service.create_payment(
+                visit_id=other_visit.id,
+                appointment_id=appointment.id,
+                amount=75_000.0,
+                currency="UZS",
+                method="cash",
+                note="mixed-id payment",
+            )
+
+        db_session.refresh(other_visit)
+        assert exc_info.value.status_code == 409
+        assert db_session.query(Payment).count() == 0
+        assert other_visit.status == "open"
 
     def test_create_payment_marks_visit_paid_when_fully_covered(
         self, db_session, test_visit, test_service


### PR DESCRIPTION
## Summary
- Reject `/api/v1/payments/` create requests when both `visit_id` and `appointment_id` are supplied but resolve to different visits.
- Add a focused unit regression proving no payment is created and the unrelated visit is not marked paid.

## Cyclic Execution Evidence
- Fresh main sync: started from safe worktree `C:\tmp\final-contract-scan-next-5` at `origin/main` commit `07f6592e` after `git fetch origin`.
- Clean workspace: created `codex/payment-create-mixed-id-guard` from clean `main`.
- Branch: `codex/payment-create-mixed-id-guard`.
- Scope gate: `gate_known_root_cause` selected for payment/status mutation; local gate returned narrow override anchored to `backend/app/services/payment_create_service.py`.
- Red-check handling: no red local checks before PR creation; any failing GitHub checks will be fixed in this PR.

## Contract Impact
- Canonical surface: `PaymentCreateService.create_payment` resolves the target visit before `BillingService.create_payment` persists the payment and syncs visit paid state.
- Request shape: unchanged; `visit_id` and `appointment_id` remain optional request fields.
- Response shape: unchanged for valid single-id and matching-id requests.
- Status codes: mismatched `visit_id` + `appointment_id` now returns the existing domain-error path with HTTP 409.
- Frontend consumer: no frontend files touched; current cashier UI sends the single backend-provided `visit_id` for direct payments.
- Compatibility path or alias: no route, alias, redirect, or BFF-lite endpoint was added.
- Contract proof: `backend/tests/unit/test_payment_create_service.py` covers mismatch rejection, existing appointment resolution, ambiguous appointment resolution, and paid-state sync.

## RBAC / Permissions
- Roles allowed: unchanged from the existing `/api/v1/payments/` route, currently Admin and Cashier.
- Roles denied: unchanged route dependency continues denying roles outside Admin/Cashier.
- Positive auth proof: existing service tests still cover valid payment creation through canonical appointment-to-visit resolution and direct visit payment.
- Negative auth proof: new regression rejects a request that combines an appointment for one canonical visit with a different visit id before any payment row is created.

## Notification / Realtime
- Event type or websocket channel: this service path does not define a websocket channel in the touched files.
- Payload version / ack behavior: no realtime payload or ack contract is changed.
- Read/unread or delivery semantics: no notification delivery state is changed by this patch.
- Reconnect/resync proof: rejected mixed-id payments leave the database without a new payment row, so normal payment/visit reads resync to unchanged state.

## Frontend Resilience
- Empty data proof: rejection path returns a domain error and leaves no payment row for the mismatched request.
- Partial data proof: the guard runs before `BillingService.create_payment` and before `_sync_visit_paid_state`, so there is no partial payment/status mutation.
- Forbidden secondary path behavior: no secondary client path was added; the service guard protects API and internal callers using the same service.
- Missing draft/resource behavior: existing missing appointment canonical resolution behavior is preserved; mismatched concrete ids now fail explicitly with 409.
- Stale route/deep-link behavior: route shape is unchanged; stale callers that send only one id keep existing behavior, while stale mixed-id callers fail closed.

## Scope Gate
- Allowed paths: `backend/app/services/payment_create_service.py` and `backend/tests/unit/test_payment_create_service.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite routes, schemas, models, migrations, billing refactors, and unrelated cashier grouped-payment logic.
- Migration/docs/test impact: no migration or docs changes; one existing unit test module updated.
- Rollback note: revert this commit to restore previous mixed-id behavior; database schema and API shape are unchanged.

## Validation
- Targeted tests or smoke run: py_compile for changed service/test, `backend/tests/unit/test_payment_create_service.py`, and `git diff --check`.
- Result: local validation passed; payment create unit suite was 6 passed.
- Not checked: full backend suite and frontend build were not run because this is a narrow backend service guard with focused unit coverage.