### PR TITLE
fix(emr): restrict v2 write roles

### DIFF
--- a/backend/app/api/v1/endpoints/emr_v2.py
+++ b/backend/app/api/v1/endpoints/emr_v2.py
@@ -81,6 +81,11 @@ EMR_V2_DOCTOR_ROLES = {
     "Dentist",
 }
 
+EMR_V2_WRITE_ROLES = (
+    "Admin",
+    *EMR_V2_DOCTOR_ROLES,
+)
+
 
 def get_client_ip(request: Request) -> str | None:
     """Extract client IP from request"""
@@ -348,7 +353,7 @@ async def save_emr(
     payload: EMRSaveRequest,
     request: Request,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.require_roles(*EMR_V2_ALLOWED_ROLES)),
+    current_user: User = Depends(deps.require_roles(*EMR_V2_WRITE_ROLES)),
 ):
     """
     Save EMR with versioning.
@@ -413,7 +418,7 @@ async def sign_emr(
     payload: EMRSignRequest,
     request: Request,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.require_roles(*EMR_V2_ALLOWED_ROLES)),
+    current_user: User = Depends(deps.require_roles(*EMR_V2_WRITE_ROLES)),
 ):
     """
     Sign and finalize EMR.
@@ -483,7 +488,7 @@ async def amend_emr(
     payload: EMRAmendRequest,
     request: Request,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.require_roles(*EMR_V2_ALLOWED_ROLES)),
+    current_user: User = Depends(deps.require_roles(*EMR_V2_WRITE_ROLES)),
 ):
     """
     Amend a signed EMR.
@@ -525,7 +530,7 @@ async def restore_emr(
     payload: EMRRestoreRequest,
     request: Request,
     db: Session = Depends(deps.get_db),
-    current_user: User = Depends(deps.require_roles(*EMR_V2_ALLOWED_ROLES)),
+    current_user: User = Depends(deps.require_roles(*EMR_V2_WRITE_ROLES)),
 ):
     """
     Restore EMR to a specific version.

--- a/backend/tests/unit/test_emr_v2_api.py
+++ b/backend/tests/unit/test_emr_v2_api.py
@@ -128,6 +128,96 @@ def test_doctor_cannot_save_emr_for_another_doctors_visit(client, db_session):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("path_suffix", "payload"),
+    [
+        ("", {"data": {"complaints": "tampered"}, "row_version": 0, "is_draft": True}),
+        ("/sign", {"data": {"complaints": "tampered"}, "row_version": 0}),
+        (
+            "/amend",
+            {
+                "data": {"complaints": "tampered"},
+                "reason": "Unauthorized lab amendment",
+                "row_version": 0,
+            },
+        ),
+        ("/restore", {"target_version": 1, "reason": "Unauthorized lab restore"}),
+    ],
+)
+def test_lab_role_cannot_write_emr_v2_records(
+    client,
+    db_session,
+    path_suffix,
+    payload,
+):
+    label = path_suffix.replace("/", "_") or "_save"
+    lab_user = User(
+        username=f"emr_v2_lab_writer{label}",
+        email=f"emr-v2-lab-writer{label}@test.com",
+        hashed_password=get_password_hash("lab123"),
+        role="Lab",
+        is_active=True,
+    )
+    doctor_user = User(
+        username=f"emr_v2_doctor_owner{label}",
+        email=f"emr-v2-doctor-owner{label}@test.com",
+        hashed_password=get_password_hash("doctor123"),
+        role="Doctor",
+        is_active=True,
+    )
+    doctor = Doctor(
+        user_id=doctor_user.id,
+        specialty="therapy",
+        active=True,
+    )
+    patient = Patient(
+        first_name="EMR",
+        last_name="WriteGuard",
+        phone=f"+99890965{abs(hash(label)) % 10000:04d}",
+        birth_date=date(1990, 1, 1),
+    )
+    db_session.add_all([lab_user, doctor_user])
+    db_session.flush()
+    doctor.user_id = doctor_user.id
+    db_session.add_all([doctor, patient])
+    db_session.commit()
+    db_session.refresh(patient)
+
+    visit = Visit(
+        patient_id=patient.id,
+        doctor_id=doctor.id,
+        visit_date=date.today(),
+        visit_time="16:00",
+        status="open",
+        department="therapy",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+
+    login_response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": lab_user.username, "password": "lab123"},
+    )
+    assert login_response.status_code == 200
+    headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+    response = client.post(
+        f"/api/v1/v2/emr/{visit.id}{path_suffix}",
+        headers=headers,
+        json=payload,
+    )
+
+    assert response.status_code == 403, response.text
+    assert (
+        db_session.query(EMRRecord)
+        .filter(EMRRecord.visit_id == visit.id)
+        .count()
+        == 0
+    )
+
+
+@pytest.mark.unit
 def test_patient_emr_history_filters_other_doctors_summaries(client, db_session):
     attacker_user = User(
         id=9701,


### PR DESCRIPTION
## Summary
- Splits EMR v2 read roles from write roles.
- Keeps existing EMR v2 read surfaces unchanged for currently allowed roles.
- Restricts EMR v2 save/sign/amend/restore commands to Admin and doctor roles, excluding Lab/Laboratory.
- Adds regression coverage proving Lab cannot mutate EMR v2 records.

## Cyclic Execution Evidence
- Fresh main sync: branch was created from `origin/main` at `07f6592e` in `C:\tmp\final-contract-scan-next-3` after syncing past #1461.
- Clean workspace: worktree was clean before this patch; current diff is limited to the two files listed under Scope Gate.
- Branch: `codex/emr-v2-write-role-guard`.
- Scope gate: local gate ran with known root cause `backend/app/api/v1/endpoints/emr_v2.py`; endpoint role split stayed narrow and the test slice was explicitly limited to the existing EMR v2 API unit test file.
- Red-check handling: if a code check fails, this PR will be fixed in-place before merge; no unrelated follow-up PR will be opened for this scope.

## Contract Impact
- Canonical surface: EMR v2 command endpoints under `/api/v1/v2/emr/{visit_id}`: save, sign, amend, restore.
- Request shape: unchanged request bodies for all four command endpoints.
- Response shape: unchanged success responses for Admin and doctor-role callers.
- Status codes: Lab/Laboratory write attempts now return role-denied `403` instead of reaching EMR mutation code.
- Frontend consumer: no frontend code is changed; doctor/admin EMR consumers continue using the same endpoints.
- Compatibility path or alias: no route aliases or compatibility paths are changed.
- Contract proof: `test_lab_role_cannot_write_emr_v2_records` covers save/sign/amend/restore denial; existing doctor ownership test still covers doctor write denial for another doctor's visit.

## RBAC / Permissions
- Roles allowed: Admin plus doctor roles (`Doctor`, cardio/cardiology, Cardio/Cardiologist, derma/Dermatologist, dentist/Dentist) may call EMR v2 write endpoints, subject to existing visit access checks.
- Roles denied: Lab/Laboratory are no longer allowed to call EMR v2 write endpoints.
- Positive auth proof: existing EMR v2 tests still pass for allowed doctor behavior and route access.
- Negative auth proof: new parametrized test proves Lab receives `403` for save/sign/amend/restore and no `EMRRecord` is created.

## Notification / Realtime
- Event type or websocket channel: no notification event or websocket channel is touched.
- Payload version / ack behavior: no realtime payload, ack, delivery, or version behavior changes.
- Read/unread or delivery semantics: no notification read/unread or delivery state is touched.
- Reconnect/resync proof: no websocket or realtime resync path is involved; this is an HTTP RBAC dependency change before command execution.

## Frontend Resilience
- Empty data proof: no frontend empty-state code is touched.
- Partial data proof: no frontend partial-data behavior is touched; invalid Lab writes are rejected before mutation.
- Forbidden secondary path behavior: no secondary frontend path is introduced; all four backend command routes share the restricted write-role dependency.
- Missing draft/resource behavior: missing EMR/draft behavior for allowed roles is unchanged because the service code is not changed.
- Stale route/deep-link behavior: no route or deep-link behavior is touched.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/emr_v2.py`, `backend/tests/unit/test_emr_v2_api.py`.
- Denied paths: no frontend, no `/api/v1/ui/*`, no separate BFF service, no migrations, no schemas, no lab reporting rules, no queue/payment/registrar changes.
- Migration/docs/test impact: no migration or docs impact; one backend unit regression test was added.
- Rollback note: reverting this PR restores Lab/Laboratory access to EMR v2 write commands and reopens the unauthorized medical-record mutation risk.

## Bug and impact
EMR v2 command endpoints reused `EMR_V2_ALLOWED_ROLES`, which includes Lab/Laboratory for read use. Because Lab users do not have a doctor profile and are not doctor roles, `ensure_emr_visit_access` allowed them through. A Lab user could therefore save, sign, amend, or restore an EMR for any visit. That is unauthorized medical-record mutation.

## Root cause
Read and write surfaces shared one role tuple. The read tuple included Lab/Laboratory, but write endpoints need the stricter Admin/doctor role set.

## Fix
- Add `EMR_V2_WRITE_ROLES` containing Admin and existing doctor roles only.
- Use `EMR_V2_WRITE_ROLES` for save/sign/amend/restore dependencies.
- Leave read endpoint dependencies unchanged.

## Validation
- Targeted tests or smoke run: `py_compile` for `backend/app/api/v1/endpoints/emr_v2.py`; targeted pytest for doctor write ownership and Lab write denial; full `backend/tests/unit/test_emr_v2_api.py`; `git diff --check`.
- Result: all local validation passed. Full EMR v2 API unit file result was `7 passed, 1 warning`.
- Not checked: full backend suite and frontend build were not run locally because this backend-only RBAC patch touches no frontend code; GitHub CI will run required broader gates.