### PR TITLE
fix(cashier): reject mixed payment target ids

### DIFF
--- a/backend/app/api/v1/endpoints/cashier.py
+++ b/backend/app/api/v1/endpoints/cashier.py
@@ -19,6 +19,10 @@ from app.models.payment import Payment
 from app.models.visit import Visit
 from app.models.patient import Patient
 from app.models.user import User
+from app.services.canonical_visit_service import (
+    CanonicalVisitResolutionError,
+    CanonicalVisitService,
+)
 from app.services.payment_read_service import PaymentReadService
 from app.services.notifications import notification_sender_service
 
@@ -1153,8 +1157,30 @@ async def create_payment(
         visit = None
         
         if payment_data.visit_id:
+            def _ensure_appointment_matches_visit() -> None:
+                if not payment_data.appointment_id:
+                    return
+                if not visit:
+                    return
+                try:
+                    resolved_visit_id = CanonicalVisitService(db).resolve_canonical_visit(
+                        payment_data.appointment_id,
+                        create_if_missing=False,
+                    )
+                except CanonicalVisitResolutionError as exc:
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail="appointment_id does not match visit_id",
+                    ) from exc
+                if resolved_visit_id != visit.id:
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail="appointment_id does not match visit_id",
+                    )
+
             # ✅ FIX: Use lazy load to ensure consistency with get_pending_payments
             visit = db.query(Visit).filter(Visit.id == payment_data.visit_id).first()
+            _ensure_appointment_matches_visit()
             if not visit:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/tests/integration/test_notification_catalog_slice2_cashier.py
+++ b/backend/tests/integration/test_notification_catalog_slice2_cashier.py
@@ -4,6 +4,7 @@ from datetime import date
 from decimal import Decimal
 
 from app.core.security import get_password_hash
+from app.models.appointment import Appointment
 from app.models.notification import NotificationDelivery, NotificationEvent
 from app.models.patient import Patient
 from app.models.payment import Payment
@@ -141,6 +142,58 @@ def test_cashier_create_payment_creates_canonical_payment_notification(
     assert event.payload_snapshot["metadata"]["change_type"] == "paid"
     assert event.payload_snapshot["metadata"]["payment_status"] == "paid"
     assert event.payload_snapshot["metadata"]["visit_id"] == visit.id
+
+
+def test_cashier_create_payment_rejects_mismatched_visit_and_appointment(
+    client,
+    db_session,
+    auth_headers,
+):
+    patient, appointment_visit = _create_patient_visit(db_session, suffix="0102")
+    other_patient, other_visit = _create_patient_visit(db_session, suffix="0103")
+    appointment_visit.visit_date = date.today()
+    other_visit.visit_date = date.today()
+    db_session.add_all([appointment_visit, other_visit])
+    db_session.commit()
+
+    appointment = Appointment(
+        patient_id=patient.id,
+        appointment_date=appointment_visit.visit_date,
+        appointment_time=None,
+        doctor_id=None,
+        status="scheduled",
+    )
+    db_session.add(appointment)
+    db_session.commit()
+    db_session.refresh(appointment)
+    db_session.refresh(other_visit)
+    original_status = other_visit.status
+
+    response = client.post(
+        "/api/v1/cashier/payments",
+        json={
+            "visit_id": other_visit.id,
+            "appointment_id": appointment.id,
+            "amount": 45000,
+            "method": "cash",
+            "note": "mixed-id cashier payment",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 409
+    db_session.refresh(other_visit)
+    assert other_visit.status == original_status
+    assert (
+        db_session.query(Payment)
+        .filter(Payment.visit_id == other_visit.id)
+        .count()
+        == 0
+    )
+    assert _payment_event_deliveries(
+        db_session,
+        recipient_id=other_patient.user_id,
+    ) == []
 
 
 def test_cashier_grouped_payment_allocates_by_backend_remaining_debt(


### PR DESCRIPTION
## Summary
- Reject direct cashier payment requests when `appointment_id` is supplied but does not resolve to the same `visit_id` used for the payment.
- Add a cashier integration regression proving no payment row or payment notification is created for mismatched ids.

## Cyclic Execution Evidence
- Fresh main sync: continued from safe worktree `C:\tmp\final-contract-scan-next-5` at `origin/main` commit `34d36bce` after PR #1463 was merged.
- Clean workspace: created `codex/cashier-payment-mixed-id-guard` from clean `main`.
- Branch: `codex/cashier-payment-mixed-id-guard`.
- Scope gate: `gate_known_root_cause` selected for cashier payment mutation; local gate returned narrow override anchored to `backend/app/api/v1/endpoints/cashier.py`.
- Red-check handling: no red local checks before PR creation; any failing GitHub checks will be fixed in this PR.

## Contract Impact
- Canonical surface: `POST /api/v1/cashier/payments` direct payment branch owns cashier-created payment rows and payment notifications.
- Request shape: unchanged; `visit_id`, `appointment_id`, and `patient_id` fields remain accepted by the existing request model.
- Response shape: unchanged for valid direct payment requests.
- Status codes: mismatched `appointment_id` + `visit_id` now fail closed with HTTP 409 before payment creation.
- Frontend consumer: no frontend files touched; current CashierPanel direct payment path sends the backend-provided single `visit_id`.
- Compatibility path or alias: no route, alias, redirect, or BFF-lite endpoint was added.
- Contract proof: `backend/tests/integration/test_notification_catalog_slice2_cashier.py` covers normal direct payment notification and mismatch rejection.

## RBAC / Permissions
- Roles allowed: unchanged from the existing `/api/v1/cashier/payments` route, currently Admin and Cashier.
- Roles denied: unchanged route dependency continues denying roles outside Admin/Cashier.
- Positive auth proof: existing cashier create-payment notification regression still passes with `auth_headers`.
- Negative auth proof: new regression rejects a request combining an appointment for one visit with another visit id and proves no payment/notification mutation occurs.

## Notification / Realtime
- Event type or websocket channel: existing `payment_notification` event behavior is unchanged for valid payments.
- Payload version / ack behavior: no notification payload version or ack contract changed.
- Read/unread or delivery semantics: rejected mixed-id requests create no `NotificationDelivery`, preserving delivery state.
- Reconnect/resync proof: rejected requests leave payment storage unchanged, so normal cashier/patient payment reads resync to the pre-request state.

## Frontend Resilience
- Empty data proof: mismatch regression asserts zero payment rows for the unrelated visit and zero payment notification deliveries.
- Partial data proof: guard runs before `Payment(...)`, `db.add`, `db.commit`, and notification send, so no partial payment/status/notification mutation is possible for the mismatched request.
- Forbidden secondary path behavior: no secondary client path was added; the route-level guard protects the mounted cashier endpoint directly.
- Missing draft/resource behavior: missing `visit_id` and missing visit behavior remain unchanged; supplied but non-matching appointment context now fails explicitly.
- Stale route/deep-link behavior: route shape is unchanged; stale callers with mismatched mixed ids fail closed instead of paying the wrong visit.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/cashier.py` and `backend/tests/integration/test_notification_catalog_slice2_cashier.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite routes, schemas, models, migrations, payment provider integrations, and unrelated cashier grouped-payment allocation logic.
- Migration/docs/test impact: no migration or docs changes; one existing cashier integration test module updated.
- Rollback note: revert this commit to restore previous behavior; database schema and API shape are unchanged.

## Validation
- Targeted tests or smoke run: py_compile for changed endpoint/test, two focused cashier tests, full `backend/tests/integration/test_notification_catalog_slice2_cashier.py`, and `git diff --check`.
- Result: local validation passed; full cashier notification slice was 8 passed.
- Not checked: full backend suite and frontend build were not run because this is a narrow backend cashier route guard with focused integration coverage.