### PR TITLE
fix(dynamic-pricing): guard package purchase ownership

### DIFF
--- a/backend/app/services/dynamic_pricing_service.py
+++ b/backend/app/services/dynamic_pricing_service.py
@@ -19,6 +19,7 @@ from app.models.dynamic_pricing import (
     PricingRuleType,
     ServicePackage,
 )
+from app.models.appointment import Appointment
 from app.models.service import Service
 from app.models.visit import Visit
 
@@ -382,6 +383,26 @@ class DynamicPricingService:
                 raise ValueError("Превышен лимит покупок для пациента")
 
         # Создаем покупку
+        if visit_id is not None:
+            visit = self.db.query(Visit).filter(Visit.id == visit_id).first()
+            if not visit:
+                raise ValueError("Visit not found")
+            if visit.patient_id != patient_id:
+                raise ValueError("Visit does not belong to package purchase patient")
+
+        if appointment_id is not None:
+            appointment = (
+                self.db.query(Appointment)
+                .filter(Appointment.id == appointment_id)
+                .first()
+            )
+            if not appointment:
+                raise ValueError("Appointment not found")
+            if appointment.patient_id != patient_id:
+                raise ValueError(
+                    "Appointment does not belong to package purchase patient"
+                )
+
         purchase = PackagePurchase(
             package_id=package_id,
             patient_id=patient_id,

--- a/backend/tests/integration/test_dynamic_pricing_api.py
+++ b/backend/tests/integration/test_dynamic_pricing_api.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
+from datetime import date
 from decimal import Decimal
 
 import pytest
 
-from app.models.dynamic_pricing import PricingRule, PricingRuleService, ServicePackage
+from app.models.appointment import Appointment
+from app.models.dynamic_pricing import (
+    PackagePurchase,
+    PricingRule,
+    PricingRuleService,
+    ServicePackage,
+)
+from app.models.patient import Patient
 from app.models.service import Service
+from app.models.visit import Visit
 
 
 def _login_admin(client, admin_user, admin_password):
@@ -155,4 +164,77 @@ def test_patient_cannot_read_dynamic_pricing_analytics(client, patient_token):
     )
 
     assert response.status_code == 403
+
+
+@pytest.mark.integration
+def test_purchase_package_rejects_cross_patient_visit_and_appointment(
+    client,
+    db_session,
+    admin_user,
+    admin_password,
+):
+    purchase_patient = Patient(
+        first_name="Package",
+        last_name="Owner",
+        phone="+998901110001",
+    )
+    other_patient = Patient(
+        first_name="Other",
+        last_name="Context",
+        phone="+998901110002",
+    )
+    db_session.add_all([purchase_patient, other_patient])
+    db_session.flush()
+
+    other_visit = Visit(patient_id=other_patient.id, status="open")
+    other_appointment = Appointment(
+        patient_id=other_patient.id,
+        appointment_date=date.today(),
+        appointment_time="10:00",
+        status="scheduled",
+    )
+    package = ServicePackage(
+        name="Cross Patient Guard Package",
+        package_price=Decimal("9000"),
+        original_price=Decimal("10000"),
+        savings_amount=Decimal("1000"),
+        savings_percentage=10,
+        is_active=True,
+    )
+    db_session.add_all([other_visit, other_appointment, package])
+    db_session.commit()
+    db_session.refresh(purchase_patient)
+    db_session.refresh(other_visit)
+    db_session.refresh(other_appointment)
+    db_session.refresh(package)
+
+    headers = _login_admin(client, admin_user, admin_password)
+
+    visit_response = client.post(
+        "/api/v1/dynamic-pricing/purchase-package",
+        json={
+            "package_id": package.id,
+            "patient_id": purchase_patient.id,
+            "visit_id": other_visit.id,
+        },
+        headers=headers,
+    )
+    appointment_response = client.post(
+        "/api/v1/dynamic-pricing/purchase-package",
+        json={
+            "package_id": package.id,
+            "patient_id": purchase_patient.id,
+            "appointment_id": other_appointment.id,
+        },
+        headers=headers,
+    )
+
+    assert visit_response.status_code == 400, visit_response.text
+    assert appointment_response.status_code == 400, appointment_response.text
+    assert (
+        db_session.query(PackagePurchase)
+        .filter(PackagePurchase.patient_id == purchase_patient.id)
+        .count()
+        == 0
+    )
 


### PR DESCRIPTION
## Summary
- Guard dynamic pricing package purchases so `visit_id` and `appointment_id` must belong to the requested purchase `patient_id` before persistence.
- Add an integration regression test for cross-patient visit/appointment context rejection through `/api/v1/dynamic-pricing/purchase-package`.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `origin/main` at `8383b847` after fetch.
- Clean workspace: worktree was clean before edits on `codex/dynamic-pricing-purchase-owner-guard`.
- Branch: `codex/dynamic-pricing-purchase-owner-guard`.
- Scope gate: local agent gate run with known root cause `backend/app/services/dynamic_pricing_service.py`; first patch kept to service, then explicitly extended to targeted integration regression test.
- Red-check handling: if CI returns red, this PR will be fixed in-place before merge.

## Contract Impact
- Canonical surface: `POST /api/v1/dynamic-pricing/purchase-package` and `DynamicPricingService.purchase_package`.
- Request shape: unchanged; still accepts `package_id`, `patient_id`, optional `visit_id`, optional `appointment_id`.
- Response shape: unchanged for successful purchases.
- Status codes: cross-patient `visit_id` or `appointment_id` now returns existing 400 bad request path instead of creating an inconsistent purchase.
- Frontend consumer: unchanged; no frontend files touched.
- Compatibility path or alias: none.
- Contract proof: `backend/tests/integration/test_dynamic_pricing_api.py::test_purchase_package_rejects_cross_patient_visit_and_appointment`.

## RBAC / Permissions
- Roles allowed: unchanged, Admin-only endpoint remains Admin-only.
- Roles denied: unchanged, patient RBAC test remains in the same dynamic pricing integration suite.
- Positive auth proof: regression test logs in as Admin and reaches the endpoint.
- Negative auth proof: existing `test_patient_cannot_create_dynamic_pricing_rule` and `test_patient_cannot_read_dynamic_pricing_analytics` still pass in the targeted suite.

## Notification / Realtime
- Event type or websocket channel: no notification or websocket surface is touched by this backend-only package purchase guard.
- Payload version / ack behavior: no notification payload, ack, or delivery contract is changed.
- Read/unread or delivery semantics: no read/unread or delivery semantics are touched.
- Reconnect/resync proof: no realtime reconnect path exists in this dynamic-pricing purchase flow; backend persistence is synchronously rejected before any event emission.

## Frontend Resilience
- Empty data proof: no frontend empty-state path is touched.
- Partial data proof: no frontend partial-data path is touched.
- Forbidden secondary path behavior: no alternate frontend/API path added.
- Missing draft/resource behavior: mismatched or missing visit/appointment contexts are rejected before purchase persistence.
- Stale route/deep-link behavior: no frontend route or deep-link path is touched.

## Scope Gate
- Allowed paths: `backend/app/services/dynamic_pricing_service.py`, `backend/tests/integration/test_dynamic_pricing_api.py`.
- Denied paths: frontend, BFF/read-model/UI endpoints, migrations, unrelated billing/payment flows.
- Migration/docs/test impact: no migration or docs; targeted integration test added.
- Rollback note: revert this PR to restore prior package purchase behavior.

## Validation
- Targeted tests or smoke run: `py_compile` for service/test; `pytest backend/tests/integration/test_dynamic_pricing_api.py -q`; `git diff --check`.
- Result: passed locally (`5 passed`, diff hygiene passed with CRLF warning only).
- Not checked: full backend suite, frontend build, browser smoke.