### PR TITLE
fix(telegram): guard payment confirmation owner

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_notifications.py
+++ b/backend/app/api/v1/endpoints/telegram_notifications.py
@@ -21,6 +21,7 @@ from app.crud import (
 )
 from app.models.clinic import Doctor
 from app.models.lab import LabOrder
+from app.models.payment import Payment
 from app.models.user import User
 from app.models.visit import Visit
 from app.services.telegram_bot import get_telegram_bot_service
@@ -171,6 +172,46 @@ def _ensure_lab_results_belong_to_patient(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Access denied",
             )
+
+
+def _payment_id_from_payload(payment_data: Dict[str, Any]) -> int | None:
+    for key in ("payment_id", "id"):
+        value = payment_data.get(key)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid payment_id",
+            )
+    return None
+
+
+def _ensure_payment_confirmation_belongs_to_patient(
+    db: Session,
+    *,
+    patient_id: int,
+    payment_data: Dict[str, Any],
+) -> None:
+    payment_id = _payment_id_from_payload(payment_data)
+    if payment_id is None:
+        return
+
+    payment = db.query(Payment).filter(Payment.id == payment_id).first()
+    if not payment:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Payment not found",
+        )
+
+    visit = db.query(Visit).filter(Visit.id == payment.visit_id).first()
+    if not visit or visit.patient_id != patient_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
 
 
 @router.post("/send-appointment-reminder")
@@ -378,6 +419,12 @@ async def send_payment_confirmation(
             )
 
         # Ищем Telegram пользователя
+        _ensure_payment_confirmation_belongs_to_patient(
+            db,
+            patient_id=patient_id,
+            payment_data=payment_data,
+        )
+
         telegram_user = crud_telegram.find_telegram_user_by_phone(db, patient.phone)
         if not telegram_user:
             return {

--- a/backend/tests/unit/test_telegram_notifications_privacy.py
+++ b/backend/tests/unit/test_telegram_notifications_privacy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from fastapi import BackgroundTasks
@@ -702,6 +702,62 @@ async def test_send_payment_confirmation_message_omits_raw_payment_identifiers(
         "https://clinic.example.com/telegram/mini-app/patient?section=payments"
         in telegram_payload
     )
+
+
+@pytest.mark.asyncio
+async def test_send_payment_confirmation_rejects_payment_for_different_patient(
+    monkeypatch,
+):
+    patient = SimpleNamespace(
+        phone="+998901234567",
+        full_name="Sensitive Patient",
+    )
+    payment = SimpleNamespace(id=456, visit_id=10)
+    visit = SimpleNamespace(id=10, patient_id=999)
+    find_telegram_user = Mock()
+
+    class FakeQuery:
+        def __init__(self, result):
+            self.result = result
+
+        def filter(self, *_args, **_kwargs):
+            return self
+
+        def first(self):
+            return self.result
+
+    class FakeDb:
+        def query(self, model):
+            if model is telegram_notifications.Payment:
+                return FakeQuery(payment)
+            if model is telegram_notifications.Visit:
+                return FakeQuery(visit)
+            raise AssertionError(f"Unexpected query model: {model}")
+
+    monkeypatch.setattr(
+        telegram_notifications.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications.crud_telegram,
+        "find_telegram_user_by_phone",
+        find_telegram_user,
+        raising=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await telegram_notifications.send_payment_confirmation(
+            patient_id=123,
+            payment_data={"payment_id": 456, "amount": 125000},
+            background_tasks=BackgroundTasks(),
+            db=FakeDb(),
+            current_user=SimpleNamespace(role="Cashier"),
+        )
+
+    assert exc_info.value.status_code == 403
+    find_telegram_user.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Reject `/api/v1/telegram-notifications/send-payment-confirmation` when supplied `payment_data.payment_id` or `payment_data.id` points to a payment whose visit belongs to another patient.
- Preserve existing legacy behavior for payment confirmation payloads that do not carry a payment id.

## Cyclic Execution Evidence

- Fresh main sync: safe worktree branch was based on current `origin/main` at `d616621b`.
- Clean workspace: inspected before edits; only `telegram_notifications.py` and the existing Telegram privacy unit test file changed.
- Branch: `codex/telegram-payment-confirmation-owner-guard`.
- Scope gate: `agent_gate` was run with known root cause; it broadened first-touch files, so this PR uses a narrow override limited to endpoint guard plus privacy regression test.
- Red-check handling: PR Review Quality Gate first failed on missing required PR-body field labels; this body update fixes that in the same PR, and any further red checks will be handled here before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/telegram-notifications/send-payment-confirmation`; payment ownership is backend-owned via `Payment.visit_id -> Visit.patient_id`.
- Request shape: unchanged `patient_id` plus `payment_data`; when `payment_data.payment_id` or `payment_data.id` is present, it must belong to the supplied patient.
- Response shape: unchanged for successful sends and legacy no-payment-id payloads.
- Status codes: existing patient `404` remains; new supplied payment id failures are `400` for invalid id, `404` for missing payment, and `403` for payment/patient mismatch.
- Frontend consumer: existing Admin/Cashier callers keep the same request contract; this PR changes backend validation only.
- Compatibility path or alias: legacy payment confirmation payloads without `payment_id` or `id` remain accepted.
- Contract proof: targeted unit regression proves a mismatched payment id returns `403` before Telegram lookup; full Telegram privacy unit file still passes.

## RBAC / Permissions

- Roles allowed: existing `Admin` and `Cashier` dependency remains unchanged.
- Roles denied: all other roles remain blocked by the existing `require_roles("Admin", "Cashier")` dependency.
- Positive auth proof: existing payment-confirmation unit tests still exercise successful Cashier-style calls through the endpoint function.
- Negative auth proof: new ownership test proves an allowed-role caller cannot send a payment confirmation for another patient's payment; it fails with `403` before Telegram lookup/send.

## Notification / Realtime

- Event type or websocket channel: Telegram payment confirmation send path only; no websocket channel is changed.
- Payload version / ack behavior: Telegram template payload and success response contract remain unchanged for allowed sends.
- Read/unread or delivery semantics: mismatched payment ids are blocked before Telegram user lookup and bot service send; delivery behavior for valid/legacy payloads is unchanged.
- Reconnect/resync proof: no scheduler, websocket, reconnect, or resync files changed; regression proof is scoped to preventing the wrong Telegram send.

## Frontend Resilience

- Empty data proof: legacy payloads without a payment id still pass existing payment confirmation tests.
- Partial data proof: existing safe-template defaults continue to pass for partial payment data.
- Forbidden secondary path behavior: mismatched payment owner now returns backend `403` before any Telegram lookup/send side effect.
- Missing draft/resource behavior: no draft/resource reopen path is touched; missing supplied payment ids are handled as `404`.
- Stale route/deep-link behavior: frontend routes/deep links are untouched, and the protected payment history link test still passes.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_notifications.py`, `backend/tests/unit/test_telegram_notifications_privacy.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read models, frontend, schema rewrite, notification service refactor, Telegram bot UX, migrations.
- Migration/docs/test impact: no migration or docs changes; one targeted unit regression added to the existing privacy test file.
- Rollback note: revert commit `d2584798` to restore prior endpoint behavior and remove the regression test.

## Validation

- Targeted tests or smoke run: `py_compile` for endpoint/test; five focused payment-confirmation privacy tests; full `tests\unit\test_telegram_notifications_privacy.py`; `git diff --check`.
- Result: compile passed; focused payment-confirmation set passed `5 passed`; full privacy file passed `15 passed`; diff check passed.
- Not checked: full backend suite, browser smoke, and live Telegram delivery were intentionally left out because this slice only changes server-side validation before the Telegram send call.
