### PR TITLE
fix(email-sms): guard payment confirmation owner

### DIFF
--- a/backend/app/api/v1/endpoints/email_sms_enhanced.py
+++ b/backend/app/api/v1/endpoints/email_sms_enhanced.py
@@ -11,10 +11,52 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user, get_db, require_roles
 from app.crud import appointment as crud_appointment, patient as crud_patient
+from app.models.payment import Payment
 from app.models.user import User
+from app.models.visit import Visit
 from app.services.email_sms_enhanced import get_email_sms_enhanced_service
 
 router = APIRouter()
+
+
+def _payment_id_from_payload(payment_data: Dict[str, Any]) -> int | None:
+    for key in ("payment_id", "id"):
+        value = payment_data.get(key)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid payment_id",
+            )
+    return None
+
+
+def _ensure_payment_confirmation_belongs_to_patient(
+    db: Session,
+    *,
+    patient_id: int,
+    payment_data: Dict[str, Any],
+) -> None:
+    payment_id = _payment_id_from_payload(payment_data)
+    if payment_id is None:
+        return
+
+    payment = db.query(Payment).filter(Payment.id == payment_id).first()
+    if not payment:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Payment not found",
+        )
+
+    visit = db.query(Visit).filter(Visit.id == payment.visit_id).first()
+    if not visit or visit.patient_id != patient_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
 
 
 @router.post("/send-appointment-reminder-enhanced")
@@ -169,6 +211,12 @@ async def send_payment_confirmation_enhanced(
             )
 
         # Подготавливаем данные
+        _ensure_payment_confirmation_belongs_to_patient(
+            db,
+            patient_id=patient_id,
+            payment_data=payment_data,
+        )
+
         patient_data = {
             'id': patient.id,
             'full_name': patient.full_name

--- a/backend/tests/unit/test_email_sms_enhanced_payment_owner.py
+++ b/backend/tests/unit/test_email_sms_enhanced_payment_owner.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+from app.api.v1.endpoints import email_sms_enhanced
+
+
+@pytest.mark.asyncio
+async def test_send_payment_confirmation_enhanced_preserves_no_id_payload(
+    monkeypatch,
+):
+    patient = SimpleNamespace(
+        id=123,
+        phone="+998901234567",
+        email="patient@example.com",
+        full_name="Sensitive Patient",
+    )
+    service = SimpleNamespace(
+        send_payment_confirmation_enhanced=AsyncMock(
+            return_value={"success": True, "channels": {"email": {"success": True}}}
+        )
+    )
+
+    monkeypatch.setattr(
+        email_sms_enhanced.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        email_sms_enhanced,
+        "get_email_sms_enhanced_service",
+        Mock(return_value=service),
+    )
+
+    response = await email_sms_enhanced.send_payment_confirmation_enhanced(
+        patient_id=123,
+        payment_data={"amount": 125000},
+        channels=["email"],
+        template_data=None,
+        background_tasks=BackgroundTasks(),
+        db=object(),
+        current_user=SimpleNamespace(role="Cashier"),
+    )
+
+    assert response["success"] is True
+    service.send_payment_confirmation_enhanced.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_payment_confirmation_enhanced_rejects_other_patient_payment(
+    monkeypatch,
+):
+    patient = SimpleNamespace(
+        id=123,
+        phone="+998901234567",
+        email="patient@example.com",
+        full_name="Sensitive Patient",
+    )
+    payment = SimpleNamespace(id=456, visit_id=10)
+    visit = SimpleNamespace(id=10, patient_id=999)
+    get_service = Mock()
+
+    class FakeQuery:
+        def __init__(self, result):
+            self.result = result
+
+        def filter(self, *_args, **_kwargs):
+            return self
+
+        def first(self):
+            return self.result
+
+    class FakeDb:
+        def query(self, model):
+            if model is email_sms_enhanced.Payment:
+                return FakeQuery(payment)
+            if model is email_sms_enhanced.Visit:
+                return FakeQuery(visit)
+            raise AssertionError(f"Unexpected query model: {model}")
+
+    monkeypatch.setattr(
+        email_sms_enhanced.crud_patient,
+        "get_patient",
+        lambda _db, _patient_id: patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        email_sms_enhanced,
+        "get_email_sms_enhanced_service",
+        get_service,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await email_sms_enhanced.send_payment_confirmation_enhanced(
+            patient_id=123,
+            payment_data={"payment_id": 456, "amount": 125000},
+            channels=["email", "sms"],
+            template_data=None,
+            background_tasks=BackgroundTasks(),
+            db=FakeDb(),
+            current_user=SimpleNamespace(role="Cashier"),
+        )
+
+    assert exc_info.value.status_code == 403
+    get_service.assert_not_called()


### PR DESCRIPTION
## Summary

- Reject `/api/v1/email-sms/send-payment-confirmation-enhanced` when supplied `payment_data.payment_id` or `payment_data.id` points to a payment whose visit belongs to another patient.
- Preserve existing legacy behavior for payment confirmation payloads that do not carry a payment id.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` at `4e81f4a5`.
- Clean workspace: inspected before edits; only the email/SMS endpoint and a focused unit test file changed.
- Branch: `codex/email-sms-payment-confirmation-owner-guard`.
- Scope gate: `agent_gate` was run with known root cause for `backend/app/api/v1/endpoints/email_sms_enhanced.py`; first runtime slice stayed in that endpoint, then a test-only slice added focused regression coverage.
- Red-check handling: any failed local or GitHub checks will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/email-sms/send-payment-confirmation-enhanced`; payment ownership is backend-owned via `Payment.visit_id -> Visit.patient_id`.
- Request shape: unchanged `patient_id` plus `payment_data`; when `payment_data.payment_id` or `payment_data.id` is present, it must belong to the supplied patient.
- Response shape: unchanged for successful sends and legacy no-payment-id payloads.
- Status codes: existing patient `404` remains; new supplied payment id failures are `400` for invalid id, `404` for missing payment, and `403` for payment/patient mismatch.
- Frontend consumer: existing Admin/Cashier callers keep the same request contract; this PR changes backend validation only.
- Compatibility path or alias: legacy payment confirmation payloads without `payment_id` or `id` remain accepted.
- Contract proof: unit tests prove no-id payloads still call the email/SMS service, while mismatched payment ids return `403` before the service is called.

## RBAC / Permissions

- Roles allowed: existing `Admin` and `Cashier` dependency remains unchanged.
- Roles denied: all other roles remain blocked by the existing `require_roles("Admin", "Cashier")` dependency.
- Positive auth proof: compatibility unit test exercises a Cashier-style no-id payload and verifies the service is still called.
- Negative auth proof: ownership unit test proves an allowed-role caller cannot send email/SMS confirmation for another patient's payment; it fails with `403` before service call.

## Notification / Realtime

- Event type or websocket channel: email/SMS payment confirmation send path only; no websocket channel is changed.
- Payload version / ack behavior: email/SMS service payload and success response contract remain unchanged for allowed sends.
- Read/unread or delivery semantics: mismatched payment ids are blocked before email/SMS service send; delivery behavior for valid/legacy payloads is unchanged.
- Reconnect/resync proof: no scheduler, websocket, reconnect, or resync files changed; regression proof is scoped to preventing the wrong email/SMS send.

## Frontend Resilience

- Empty data proof: legacy payloads without a payment id still pass the compatibility unit test.
- Partial data proof: partial payment data with only `amount` continues to reach the email/SMS service.
- Forbidden secondary path behavior: mismatched payment owner now returns backend `403` before any email/SMS service side effect.
- Missing draft/resource behavior: no draft/resource reopen path is touched; missing supplied payment ids are handled as `404`.
- Stale route/deep-link behavior: frontend routes/deep links are untouched by this backend-only validation guard.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/email_sms_enhanced.py`, `backend/tests/unit/test_email_sms_enhanced_payment_owner.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read models, frontend, schema rewrite, notification service refactor, Telegram bot UX, migrations.
- Migration/docs/test impact: no migration or docs changes; new focused unit test file added for the endpoint guard.
- Rollback note: revert commit `f32fd322` to restore prior endpoint behavior and remove the regression tests.

## Validation

- Targeted tests or smoke run: `py_compile` for endpoint/test; focused email/SMS payment owner unit test file; `git diff --check`; staged diff check.
- Result: compile passed; focused unit tests passed `2 passed`; diff checks passed.
- Not checked: full backend suite, browser smoke, and live email/SMS delivery were intentionally left out because this slice only changes server-side validation before the email/SMS service call.
