### PR TITLE
fix(force-majeure): guard deposit visit ownership

### DIFF
--- a/backend/app/repositories/force_majeure_api_repository.py
+++ b/backend/app/repositories/force_majeure_api_repository.py
@@ -12,6 +12,7 @@ from app.models.refund_deposit import (
     PatientDeposit,
     RefundRequest,
 )
+from app.models.visit import Visit
 
 
 class ForceMajeureApiRepository:
@@ -75,6 +76,9 @@ class ForceMajeureApiRepository:
 
     def get_patient_deposit(self, *, patient_id: int) -> PatientDeposit | None:
         return self.db.query(PatientDeposit).filter(PatientDeposit.patient_id == patient_id).first()
+
+    def get_visit(self, visit_id: int) -> Visit | None:
+        return self.db.query(Visit).filter(Visit.id == visit_id).first()
 
     def list_deposit_transactions(
         self,

--- a/backend/app/services/force_majeure_api_service.py
+++ b/backend/app/services/force_majeure_api_service.py
@@ -16,7 +16,6 @@ from app.models.refund_deposit import (
     RefundRequestStatus,
     RefundType,
 )
-from app.models.visit import Visit
 from app.repositories.force_majeure_api_repository import ForceMajeureApiRepository
 from app.services.force_majeure_service import get_force_majeure_service
 
@@ -298,11 +297,7 @@ class ForceMajeureApiService:
             raise ForceMajeureApiDomainError(400, "Депозит деактивирован")
 
         if request.visit_id is not None:
-            visit = (
-                self.repository.db.query(Visit)
-                .filter(Visit.id == request.visit_id)
-                .first()
-            )
+            visit = self.repository.get_visit(request.visit_id)
             if not visit:
                 raise ForceMajeureApiDomainError(404, "Visit not found")
             if visit.patient_id != request.patient_id:

--- a/backend/app/services/force_majeure_api_service.py
+++ b/backend/app/services/force_majeure_api_service.py
@@ -16,6 +16,7 @@ from app.models.refund_deposit import (
     RefundRequestStatus,
     RefundType,
 )
+from app.models.visit import Visit
 from app.repositories.force_majeure_api_repository import ForceMajeureApiRepository
 from app.services.force_majeure_service import get_force_majeure_service
 
@@ -295,6 +296,20 @@ class ForceMajeureApiService:
             )
         if not deposit.is_active:
             raise ForceMajeureApiDomainError(400, "Депозит деактивирован")
+
+        if request.visit_id is not None:
+            visit = (
+                self.repository.db.query(Visit)
+                .filter(Visit.id == request.visit_id)
+                .first()
+            )
+            if not visit:
+                raise ForceMajeureApiDomainError(404, "Visit not found")
+            if visit.patient_id != request.patient_id:
+                raise ForceMajeureApiDomainError(
+                    400,
+                    "Visit does not belong to deposit patient",
+                )
 
         deposit.balance -= amount
         self.repository.flush()

--- a/backend/tests/unit/test_force_majeure_api_service.py
+++ b/backend/tests/unit/test_force_majeure_api_service.py
@@ -256,3 +256,51 @@ class TestForceMajeureApiService:
                 current_user_id=1,
             )
         assert exc_info.value.status_code == 400
+
+    def test_use_deposit_for_payment_rejects_cross_patient_visit(self):
+        deposit = SimpleNamespace(
+            balance=Decimal("100"),
+            is_active=True,
+            patient=None,
+            id=1,
+            patient_id=2,
+            currency="UZS",
+            created_at=None,
+        )
+        state = {"flushed": False}
+
+        class Query:
+            def filter(self, *args, **kwargs):
+                return self
+
+            def first(self):
+                return SimpleNamespace(id=9, patient_id=99)
+
+        class Db:
+            def query(self, model):
+                return Query()
+
+        class Repository:
+            db = Db()
+
+            def get_patient_deposit(self, *, patient_id):
+                return deposit
+
+            def flush(self):
+                state["flushed"] = True
+
+        service = ForceMajeureApiService(db=None, repository=Repository())
+        with pytest.raises(ForceMajeureApiDomainError) as exc_info:
+            service.use_deposit_for_payment(
+                request=SimpleNamespace(
+                    patient_id=2,
+                    amount=40,
+                    visit_id=9,
+                    description=None,
+                ),
+                current_user_id=1,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert deposit.balance == Decimal("100")
+        assert state["flushed"] is False

--- a/backend/tests/unit/test_force_majeure_api_service.py
+++ b/backend/tests/unit/test_force_majeure_api_service.py
@@ -269,22 +269,12 @@ class TestForceMajeureApiService:
         )
         state = {"flushed": False}
 
-        class Query:
-            def filter(self, *args, **kwargs):
-                return self
-
-            def first(self):
-                return SimpleNamespace(id=9, patient_id=99)
-
-        class Db:
-            def query(self, model):
-                return Query()
-
         class Repository:
-            db = Db()
-
             def get_patient_deposit(self, *, patient_id):
                 return deposit
+
+            def get_visit(self, visit_id):
+                return SimpleNamespace(id=visit_id, patient_id=99)
 
             def flush(self):
                 state["flushed"] = True


### PR DESCRIPTION
﻿## Summary
- Reject `/api/v1/force-majeure/deposits/use` when `visit_id` belongs to a different patient than the debited deposit `patient_id`.
- Validate the visit before mutating deposit balance or creating a debit transaction.
- Keep ORM lookup in `ForceMajeureApiRepository` so the force-majeure service preserves the service/repository boundary.
- Add a targeted unit regression proving cross-patient visit use fails without flushing/mutating the balance.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `origin/main` after #1468 merge.
- Clean workspace: worktree was clean before this PR slice.
- Branch: `codex/force-majeure-deposit-visit-owner-guard`.
- Scope gate: local agent gate run with known root cause `backend/app/services/force_majeure_api_service.py`; CI then exposed the existing service/repository boundary, so the fix was kept in-scope by moving the visit lookup into the existing force-majeure repository and updating the targeted unit regression.
- Red-check handling: backend CI red was fixed in this PR; rerun checks are being watched before merge.

## Contract Impact
- Canonical surface: `POST /api/v1/force-majeure/deposits/use`, `ForceMajeureApiService.use_deposit_for_payment`, and `ForceMajeureApiRepository.get_visit`.
- Request shape: unchanged; `patient_id`, `amount`, optional `visit_id`, and optional `description` are unchanged.
- Response shape: unchanged for successful debit.
- Status codes: cross-patient `visit_id` now returns domain 400 before debit; missing visit returns domain 404.
- Frontend consumer: unchanged; no frontend files touched.
- Compatibility path or alias: none.
- Contract proof: `backend/tests/unit/test_force_majeure_api_service.py::test_use_deposit_for_payment_rejects_cross_patient_visit` plus `backend/tests/unit/test_service_repository_boundary.py::test_force_majeure_service_avoids_direct_session_calls`.

## RBAC / Permissions
- Roles allowed: unchanged, endpoint remains Admin/Cashier.
- Roles denied: unchanged; no dependency or role list changed.
- Positive auth proof: endpoint RBAC was not altered; service regression covers the ownership rule below the existing route dependency.
- Negative auth proof: no RBAC behavior changed; this PR is a backend ownership invariant only.

## Notification / Realtime
- Event type or websocket channel: no notification or websocket surface is touched by this deposit debit guard.
- Payload version / ack behavior: no notification payload, ack, or delivery contract is changed.
- Read/unread or delivery semantics: no read/unread or delivery semantics are touched.
- Reconnect/resync proof: no realtime reconnect path exists in this deposit debit flow; the regression is proven through synchronous service state before persistence.

## Frontend Resilience
- Empty data proof: no frontend empty-state path is touched.
- Partial data proof: no frontend partial-data path is touched.
- Forbidden secondary path behavior: no alternate frontend/API path added.
- Missing draft/resource behavior: missing visit is now rejected before debit; existing missing deposit/insufficient funds behavior is unchanged.
- Stale route/deep-link behavior: no frontend route or deep-link path is touched.

## Scope Gate
- Allowed paths: `backend/app/services/force_majeure_api_service.py`, `backend/app/repositories/force_majeure_api_repository.py`, `backend/tests/unit/test_force_majeure_api_service.py`.
- Denied paths: frontend, BFF/read-model/UI endpoints, migrations, unrelated billing/payment/deposit flows.
- Migration/docs/test impact: no migration or docs; targeted unit test added and service/repository boundary preserved.
- Rollback note: revert this PR to restore prior deposit debit behavior.

## Validation
- Targeted tests or smoke run: `py_compile` for service/repository/tests; `pytest backend/tests/unit/test_force_majeure_api_service.py backend/tests/unit/test_service_repository_boundary.py::test_force_majeure_service_avoids_direct_session_calls -q`; `git diff --check`.
- Result: passed locally (`8 passed`, diff hygiene passed with CRLF warning only).
- Not checked: full backend suite, frontend build, browser smoke.
