### PR TITLE
fix(telegram): guard integration appointment owner

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_integration.py
+++ b/backend/app/api/v1/endpoints/telegram_integration.py
@@ -10,7 +10,9 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
+from app.crud import patient as crud_patient
 from app.crud import telegram_config as crud_telegram
+from app.models.appointment import Appointment
 from app.models.user import User
 from app.services.telegram_service import (
     get_telegram_service,
@@ -18,6 +20,46 @@ from app.services.telegram_service import (
 )
 
 router = APIRouter()
+
+
+def _appointment_id_from_payload(appointment_data: Dict[str, Any]) -> int | None:
+    for key in ("appointment_id", "id"):
+        value = appointment_data.get(key)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid appointment_id",
+            )
+    return None
+
+
+def _ensure_appointment_reminder_belongs_to_phone(
+    db: Session,
+    *,
+    patient_phone: str,
+    appointment_data: Dict[str, Any],
+) -> None:
+    appointment_id = _appointment_id_from_payload(appointment_data)
+    if appointment_id is None:
+        return
+
+    appointment = db.query(Appointment).filter(Appointment.id == appointment_id).first()
+    if not appointment:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Appointment not found",
+        )
+
+    patient = crud_patient.find_patient(db, phone=patient_phone)
+    if not patient or appointment.patient_id != patient.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
 
 # ===================== УВЕДОМЛЕНИЯ =====================
 
@@ -96,6 +138,12 @@ async def send_appointment_reminder(
             }
 
         # Формируем данные для шаблона
+        _ensure_appointment_reminder_belongs_to_phone(
+            db,
+            patient_phone=patient_phone,
+            appointment_data=appointment_data,
+        )
+
         template_data = {
             "patient_name": appointment_data.get("patient_name", "Пациент"),
             "doctor_name": appointment_data.get("doctor_name", "Врач"),

--- a/backend/tests/unit/test_telegram_integration_appointment_owner.py
+++ b/backend/tests/unit/test_telegram_integration_appointment_owner.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+from app.api.v1.endpoints import telegram_integration
+
+
+@pytest.mark.asyncio
+async def test_appointment_reminder_preserves_no_id_payload(monkeypatch):
+    telegram_user = SimpleNamespace(chat_id=998877, language_code="ru")
+    background_tasks = BackgroundTasks()
+
+    monkeypatch.setattr(
+        telegram_integration.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: telegram_user,
+        raising=False,
+    )
+
+    response = await telegram_integration.send_appointment_reminder(
+        {
+            "patient_phone": "+998901234567",
+            "appointment_data": {
+                "patient_name": "Sensitive Patient",
+                "doctor_name": "Dr Privacy",
+                "date": "2026-05-31",
+                "time": "09:00",
+            },
+        },
+        background_tasks,
+        db=object(),
+        current_user=SimpleNamespace(role="Registrar"),
+    )
+
+    assert response["success"] is True
+    assert len(background_tasks.tasks) == 1
+
+
+@pytest.mark.asyncio
+async def test_appointment_reminder_rejects_other_patient_appointment(
+    monkeypatch,
+):
+    patient = SimpleNamespace(id=123, phone="+998901234567")
+    appointment = SimpleNamespace(id=456, patient_id=999)
+    telegram_user = SimpleNamespace(chat_id=998877, language_code="ru")
+    background_tasks = BackgroundTasks()
+
+    class FakeQuery:
+        def __init__(self, result):
+            self.result = result
+
+        def filter(self, *_args, **_kwargs):
+            return self
+
+        def first(self):
+            return self.result
+
+    class FakeDb:
+        def query(self, model):
+            if model is telegram_integration.Appointment:
+                return FakeQuery(appointment)
+            raise AssertionError(f"Unexpected query model: {model}")
+
+    monkeypatch.setattr(
+        telegram_integration.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: telegram_user,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_integration.crud_patient,
+        "find_patient",
+        lambda _db, phone: patient,
+        raising=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await telegram_integration.send_appointment_reminder(
+            {
+                "patient_phone": "+998901234567",
+                "appointment_data": {
+                    "appointment_id": 456,
+                    "patient_name": "Other Patient",
+                    "date": "2026-05-31",
+                    "time": "09:00",
+                },
+            },
+            background_tasks,
+            db=FakeDb(),
+            current_user=SimpleNamespace(role="Registrar"),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert background_tasks.tasks == []


### PR DESCRIPTION
## Summary

- Reject `/api/v1/telegram/appointment-reminder` when supplied `appointment_data.appointment_id` or `appointment_data.id` points to an appointment owned by a different patient phone.
- Preserve existing quick/manual reminder behavior for appointment reminder payloads that do not carry an appointment id.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` at `a6314edb`.
- Clean workspace: inspected before edits; only the legacy Telegram integration endpoint and focused unit test file changed.
- Branch: `codex/telegram-integration-appointment-owner-guard`.
- Scope gate: `agent_gate` was run with known root cause for `backend/app/api/v1/endpoints/telegram_integration.py`; it broadened Telegram first-touch files, so this PR uses a narrow override limited to the concrete legacy endpoint plus regression test.
- Red-check handling: any failed local or GitHub checks will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/telegram/appointment-reminder`; appointment ownership is backend-owned via `Appointment.patient_id -> Patient.phone`.
- Request shape: unchanged `patient_phone` plus `appointment_data`; when `appointment_data.appointment_id` or `appointment_data.id` is present, it must belong to the patient resolved from `patient_phone`.
- Response shape: unchanged for successful sends and legacy no-appointment-id payloads.
- Status codes: existing unregistered Telegram response remains; new supplied appointment id failures are `400` for invalid id, `404` for missing appointment, and `403` for appointment/patient-phone mismatch.
- Frontend consumer: existing Admin/Registrar callers keep the same request contract; this PR changes backend validation only.
- Compatibility path or alias: quick/manual reminder payloads without `appointment_id` or `id` remain accepted.
- Contract proof: unit tests prove no-id payloads still enqueue a background Telegram send, while mismatched appointment ids return `403` before any background send task is added.

## RBAC / Permissions

- Roles allowed: existing `Admin` and `Registrar` dependency remains unchanged.
- Roles denied: all other roles remain blocked by the existing `require_roles("Admin", "Registrar")` dependency.
- Positive auth proof: compatibility unit test exercises a Registrar-style no-id payload and verifies the background send is still queued.
- Negative auth proof: ownership unit test proves an allowed-role caller cannot send another patient's appointment reminder to the supplied patient phone; it fails with `403` before task enqueue.

## Notification / Realtime

- Event type or websocket channel: Telegram appointment reminder send path only; no websocket channel is changed.
- Payload version / ack behavior: Telegram template payload and success response contract remain unchanged for allowed sends.
- Read/unread or delivery semantics: mismatched appointment ids are blocked before background Telegram send task enqueue; delivery behavior for valid/legacy payloads is unchanged.
- Reconnect/resync proof: no scheduler, websocket, reconnect, or resync files changed; regression proof is scoped to preventing the wrong Telegram reminder send.

## Frontend Resilience

- Empty data proof: legacy payloads without an appointment id still pass the compatibility unit test.
- Partial data proof: partial appointment data with patient name/date/time continues to enqueue the Telegram send.
- Forbidden secondary path behavior: mismatched appointment owner now returns backend `403` before any Telegram send side effect.
- Missing draft/resource behavior: no draft/resource reopen path is touched; missing supplied appointment ids are handled as `404`.
- Stale route/deep-link behavior: frontend routes/deep links are untouched by this backend-only validation guard.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/telegram_integration.py`, `backend/tests/unit/test_telegram_integration_appointment_owner.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read models, frontend, schema rewrite, Telegram webhook/admin flow, notification service refactor, migrations.
- Migration/docs/test impact: no migration or docs changes; new focused unit test file added for the endpoint guard.
- Rollback note: revert commit `32fc3c78` to restore prior endpoint behavior and remove the regression tests.

## Validation

- Targeted tests or smoke run: `py_compile` for endpoint/test; focused Telegram integration appointment owner unit test file; `git diff --check`; staged diff check.
- Result: compile passed; focused unit tests passed `2 passed`; diff checks passed.
- Not checked: full backend suite, browser smoke, and live Telegram delivery were intentionally left out because this slice only changes server-side validation before the background Telegram send task is queued.
