### PR TITLE
fix(telegram): guard lab notification owner

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_integration.py
+++ b/backend/app/api/v1/endpoints/telegram_integration.py
@@ -13,6 +13,7 @@ from app.api.deps import get_db, require_roles
 from app.crud import patient as crud_patient
 from app.crud import telegram_config as crud_telegram
 from app.models.appointment import Appointment
+from app.models.lab import LabOrder, LabResult
 from app.models.user import User
 from app.services.telegram_service import (
     get_telegram_service,
@@ -60,6 +61,47 @@ def _ensure_appointment_reminder_belongs_to_phone(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Access denied",
         )
+
+def _lab_result_id_from_payload(lab_data: Dict[str, Any]) -> int | None:
+    for key in ("lab_results_id", "lab_result_id", "id"):
+        value = lab_data.get(key)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid lab_results_id",
+            )
+    return None
+
+
+def _ensure_lab_notification_belongs_to_phone(
+    db: Session,
+    *,
+    patient_phone: str,
+    lab_data: Dict[str, Any],
+) -> None:
+    lab_result_id = _lab_result_id_from_payload(lab_data)
+    if lab_result_id is None:
+        return
+
+    lab_result = db.query(LabResult).filter(LabResult.id == lab_result_id).first()
+    if not lab_result:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Lab result not found",
+        )
+
+    lab_order = db.query(LabOrder).filter(LabOrder.id == lab_result.order_id).first()
+    patient = crud_patient.find_patient(db, phone=patient_phone)
+    if not lab_order or not patient or lab_order.patient_id != patient.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
 
 # ===================== УВЕДОМЛЕНИЯ =====================
 
@@ -211,6 +253,12 @@ async def send_lab_results_notification(
             }
 
         # Формируем данные для шаблона
+        _ensure_lab_notification_belongs_to_phone(
+            db,
+            patient_phone=patient_phone,
+            lab_data=lab_data,
+        )
+
         template_data = {
             "patient_name": lab_data.get("patient_name", "Пациент"),
             "test_type": lab_data.get("test_type", "Лабораторное исследование"),

--- a/backend/tests/unit/test_telegram_integration_appointment_owner.py
+++ b/backend/tests/unit/test_telegram_integration_appointment_owner.py
@@ -95,3 +95,96 @@ async def test_appointment_reminder_rejects_other_patient_appointment(
 
     assert exc_info.value.status_code == 403
     assert background_tasks.tasks == []
+
+
+@pytest.mark.asyncio
+async def test_lab_results_notification_preserves_no_id_payload(monkeypatch):
+    telegram_user = SimpleNamespace(chat_id=998877, language_code="ru")
+    background_tasks = BackgroundTasks()
+
+    monkeypatch.setattr(
+        telegram_integration.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: telegram_user,
+        raising=False,
+    )
+
+    response = await telegram_integration.send_lab_results_notification(
+        {
+            "patient_phone": "+998901234567",
+            "lab_data": {
+                "patient_name": "Sensitive Patient",
+                "test_type": "CBC",
+                "collection_date": "2026-05-31",
+                "has_abnormalities": True,
+            },
+        },
+        background_tasks,
+        db=object(),
+        current_user=SimpleNamespace(role="Lab"),
+    )
+
+    assert response["success"] is True
+    assert len(background_tasks.tasks) == 1
+
+
+@pytest.mark.asyncio
+async def test_lab_results_notification_rejects_other_patient_result(
+    monkeypatch,
+):
+    patient = SimpleNamespace(id=123, phone="+998901234567")
+    lab_result = SimpleNamespace(id=456, order_id=789)
+    lab_order = SimpleNamespace(id=789, patient_id=999)
+    telegram_user = SimpleNamespace(chat_id=998877, language_code="ru")
+    background_tasks = BackgroundTasks()
+
+    class FakeQuery:
+        def __init__(self, result):
+            self.result = result
+
+        def filter(self, *_args, **_kwargs):
+            return self
+
+        def first(self):
+            return self.result
+
+    class FakeDb:
+        def query(self, model):
+            if model is telegram_integration.LabResult:
+                return FakeQuery(lab_result)
+            if model is telegram_integration.LabOrder:
+                return FakeQuery(lab_order)
+            raise AssertionError(f"Unexpected query model: {model}")
+
+    monkeypatch.setattr(
+        telegram_integration.crud_telegram,
+        "find_telegram_user_by_phone",
+        lambda _db, _phone: telegram_user,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_integration.crud_patient,
+        "find_patient",
+        lambda _db, phone: patient,
+        raising=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await telegram_integration.send_lab_results_notification(
+            {
+                "patient_phone": "+998901234567",
+                "lab_data": {
+                    "lab_results_id": 456,
+                    "patient_name": "Other Patient",
+                    "test_type": "Sensitive Lab",
+                    "collection_date": "2026-05-31",
+                    "has_abnormalities": True,
+                },
+            },
+            background_tasks,
+            db=FakeDb(),
+            current_user=SimpleNamespace(role="Lab"),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert background_tasks.tasks == []


### PR DESCRIPTION
## Summary
- Reject `/api/v1/telegram/lab-results-notification` when `lab_data` `id`/`lab_result_id`/`lab_results_id` resolves to a `LabResult` owned by a different patient than the supplied `patient_phone`.
- Preserve legacy/manual no-id payloads so quick/manual lab notifications continue to enqueue.
- Add regression coverage for no-id compatibility and cross-patient `LabResult` rejection.

## Cyclic Execution Evidence
- Fresh main sync: safe worktree started from `origin/main` at `52c76a95` before this slice.
- Clean workspace: `git status --short --branch` was clean before editing; only two allowed files changed.
- Branch: `codex/telegram-lab-notification-owner-guard`.
- Scope gate: `gate_known_root_cause` for `backend/app/api/v1/endpoints/telegram_integration.py`; gate returned narrow override/misroute into broader notification files, so this PR stayed in the confirmed endpoint + focused unit test slice.
- Red-check handling: PR Review Quality Gate initially failed because the PR body lacked required field labels; this body update adds those labels. Any further red checks will be fixed in this PR.

## Contract Impact
- Canonical surface: mounted runtime endpoint `/api/v1/telegram/lab-results-notification`; canonical owner is `LabResult -> LabOrder.patient_id` matched to `Patient.phone`.
- Request shape: existing `patient_phone` plus `lab_data`; optional `lab_data.id`, `lab_data.lab_result_id`, or `lab_data.lab_results_id` now triggers owner validation.
- Response shape: successful response is unchanged; no-id legacy/manual payloads keep the same success shape.
- Status codes: invalid lab id returns 400, missing `LabResult` returns 404, owner mismatch returns 403.
- Frontend consumer: no frontend files changed; existing callers that omit lab result ids keep working.
- Compatibility path or alias: no `/api/v1/ui/*`, BFF-lite, alias, or route migration added.
- Contract proof: targeted unit tests cover no-id compatibility and cross-patient `LabResult` rejection before background enqueue.

## RBAC / Permissions
- Roles allowed: existing route roles remain Admin, Lab, Doctor.
- Roles denied: unchanged by this PR; FastAPI `require_roles` still handles non-allowed roles.
- Positive auth proof: no-id payload test uses the existing route function and verifies enqueue still succeeds under a permitted Lab-style caller.
- Negative auth proof: mismatched lab-result owner test verifies 403 and no queued background task.

## Notification / Realtime
- Event type or websocket channel: Telegram `lab_results_ready` notification enqueue only; no websocket channel involved.
- Payload version / ack behavior: payload keys are unchanged; only pre-enqueue owner validation was added.
- Read/unread or delivery semantics: unchanged; no notification persistence/read-state logic touched.
- Reconnect/resync proof: not applicable because this endpoint queues a one-shot Telegram background task and has no reconnect/resync contract.

## Frontend Resilience
- Empty data proof: existing missing `patient_phone`/`lab_data` 400 branch is unchanged.
- Partial data proof: no-id manual payload test proves partial/manual `lab_data` still enqueues.
- Forbidden secondary path behavior: owner mismatch now returns 403 before background task creation.
- Missing draft/resource behavior: missing `LabResult` id now returns 404; no draft/resource flow exists here.
- Stale route/deep-link behavior: not applicable; no frontend route or deep-link behavior changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/telegram_integration.py`, `backend/tests/unit/test_telegram_integration_appointment_owner.py`.
- Denied paths: no `/api/v1/ui/*`, no BFF, no admin Telegram/webhook changes, no notification service rewrite, no migrations, no frontend.
- Migration/docs/test impact: no migrations or docs; focused unit test file updated with two regression tests.
- Rollback note: reverting this PR restores prior lab notification behavior only for the legacy Telegram integration endpoint.

## Validation
- Targeted tests or smoke run: `scripts/run_python.ps1 -PythonArgs @('-m','py_compile','backend/app/api/v1/endpoints/telegram_integration.py','backend/tests/unit/test_telegram_integration_appointment_owner.py')`; `TESTING=1 DATABASE_URL=sqlite:///C:/tmp/telegram-lab-notification-owner-guard-test.db scripts/run_backend_pytest.ps1 tests/unit/test_telegram_integration_appointment_owner.py`; `git diff --check`; `git diff --cached --check`.
- Result: py_compile passed; targeted pytest passed with `4 passed, 1 warning`; diff checks passed.
- Not checked: broad backend suite, frontend build/tests, live Telegram delivery, and live database migration because this is a two-file endpoint/unit-test guard with no frontend or schema change.