### PR TITLE
fix(webhooks): guard legacy payment notification owner

### DIFF
--- a/backend/app/services/payment_webhook_api_service.py
+++ b/backend/app/services/payment_webhook_api_service.py
@@ -286,7 +286,7 @@ class PaymentWebhookApiService:
 
     def _resolve_legacy_webhook_recipient(self, webhook: Any) -> tuple[User | None, dict[str, int | None]]:
         db = self.repository.db
-        patient_id = self._safe_int(getattr(webhook, "patient_id", None))
+        claimed_patient_id = self._safe_int(getattr(webhook, "patient_id", None))
         visit_id = self._safe_int(getattr(webhook, "visit_id", None))
         payment_id = None
 
@@ -303,17 +303,44 @@ class PaymentWebhookApiService:
 
         if payment_id is not None:
             payment = db.query(Payment).filter(Payment.id == payment_id).first()
-            if payment and visit_id is None:
-                visit_id = self._safe_int(getattr(payment, "visit_id", None))
+            if payment:
+                payment_visit_id = self._safe_int(getattr(payment, "visit_id", None))
+                if (
+                    visit_id is not None
+                    and payment_visit_id is not None
+                    and visit_id != payment_visit_id
+                ):
+                    return None, {
+                        "patient_id": claimed_patient_id,
+                        "visit_id": visit_id,
+                        "payment_id": payment_id,
+                    }
+                if visit_id is None:
+                    visit_id = payment_visit_id
 
-        if visit_id is not None and patient_id is None:
+        canonical_patient_id = None
+        if visit_id is not None:
             visit = db.query(Visit).filter(Visit.id == visit_id).first()
             if visit:
-                patient_id = self._safe_int(getattr(visit, "patient_id", None))
+                canonical_patient_id = self._safe_int(getattr(visit, "patient_id", None))
 
-        if patient_id is None:
+        if claimed_patient_id is None:
             raw_data = getattr(webhook, "raw_data", None)
-            patient_id = self._extract_patient_id_from_raw_data(raw_data)
+            claimed_patient_id = self._extract_patient_id_from_raw_data(raw_data)
+
+        if canonical_patient_id is not None:
+            if (
+                claimed_patient_id is not None
+                and claimed_patient_id != canonical_patient_id
+            ):
+                return None, {
+                    "patient_id": claimed_patient_id,
+                    "visit_id": visit_id,
+                    "payment_id": payment_id,
+                }
+            patient_id = canonical_patient_id
+        else:
+            patient_id = claimed_patient_id
 
         if patient_id is None:
             return None, {"patient_id": None, "visit_id": visit_id, "payment_id": payment_id}

--- a/backend/tests/integration/test_notification_catalog_slice3_legacy_webhooks.py
+++ b/backend/tests/integration/test_notification_catalog_slice3_legacy_webhooks.py
@@ -7,6 +7,7 @@ from app.core.security import get_password_hash
 from app.models.notification import NotificationDelivery, NotificationEvent
 from app.models.patient import Patient
 from app.models.user import User
+from app.models.visit import Visit
 
 
 def _payment_event_deliveries(db_session, *, recipient_id: int):
@@ -247,3 +248,53 @@ def test_legacy_payme_webhook_duplicate_callback_does_not_create_duplicate_deliv
 
     deliveries = _payment_event_deliveries(db_session, recipient_id=patient_user.id)
     assert len(deliveries) == 1
+
+
+def test_legacy_click_webhook_skips_conflicting_patient_and_visit_owner(
+    client,
+    db_session,
+    monkeypatch,
+):
+    wrong_user, wrong_patient = _create_patient_user(
+        db_session, username="legacy_webhook_conflict_wrong_patient"
+    )
+    owner_user, owner_patient = _create_patient_user(
+        db_session, username="legacy_webhook_conflict_owner_patient"
+    )
+    visit = Visit(
+        patient_id=owner_patient.id,
+        visit_date=date.today(),
+        status="open",
+        source="desk",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+
+    fake_webhook = SimpleNamespace(
+        id=951,
+        provider="click",
+        status="processed",
+        transaction_id="legacy-click-conflict-951",
+        patient_id=wrong_patient.id,
+        visit_id=visit.id,
+        raw_data={"patient_id": wrong_patient.id},
+    )
+
+    def _fake_process_click_webhook(self, data):
+        return True, "Webhook processed successfully", fake_webhook
+
+    monkeypatch.setattr(
+        "app.services.payment_webhook_api_service.PaymentWebhookApiRepository.process_click_webhook",
+        _fake_process_click_webhook,
+    )
+
+    response = client.post(
+        "/api/v1/webhooks/payment/click",
+        data={"merchant_trans_id": "legacy-click-conflict"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["webhook_id"] == 951
+    assert _payment_event_deliveries(db_session, recipient_id=wrong_user.id) == []
+    assert _payment_event_deliveries(db_session, recipient_id=owner_user.id) == []


### PR DESCRIPTION
﻿## Summary
- Stop legacy payment webhook notification delivery when webhook `patient_id` conflicts with the canonical patient resolved from `visit_id` or payment-derived visit.
- Prefer canonical visit/payment ownership over provider-supplied patient hints for recipient resolution.
- Add a regression proving a conflicting webhook is processed without creating a wrong-patient inbox delivery.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `origin/main` after #1470 merge commit `8953613a`.
- Clean workspace: detached `origin/main` worktree was clean before this slice.
- Branch: `codex/payment-webhook-recipient-owner-guard`.
- Scope gate: local agent gate run with known root cause `backend/app/services/payment_webhook_api_service.py`; narrow override used, then explicitly expanded only to the targeted legacy webhook regression test.
- Red-check handling: if CI returns red, this PR will be fixed in-place before merge.

## Contract Impact
- Canonical surface: legacy `POST /api/v1/webhooks/payment/click` / `payme` notification emission through `PaymentWebhookApiService._resolve_legacy_webhook_recipient`.
- Request shape: unchanged; provider webhook payloads are unchanged.
- Response shape: unchanged; conflicting ownership still returns the existing webhook processing response, but no canonical inbox delivery is emitted.
- Status codes: unchanged.
- Frontend consumer: patient inbox notifications become safer; no frontend API contract changed.
- Compatibility path or alias: none.
- Contract proof: `backend/tests/integration/test_notification_catalog_slice3_legacy_webhooks.py::test_legacy_click_webhook_skips_conflicting_patient_and_visit_owner`.

## RBAC / Permissions
- Roles allowed: unchanged; provider webhook endpoints do not gain new role behavior.
- Roles denied: unchanged.
- Positive auth proof: existing legacy webhook notification tests still pass for matching patient ownership.
- Negative auth proof: targeted regression proves a conflicting patient/visit owner does not create a wrong-recipient delivery.

## Notification / Realtime
- Event type or websocket channel: `payment_notification` inbox event from `payments_webhook_legacy`.
- Payload version / ack behavior: payload shape and webhook ack response are unchanged.
- Read/unread or delivery semantics: matching owner deliveries remain deduped; conflicting owner data now produces no delivery.
- Reconnect/resync proof: no websocket reconnect path changed; durable inbox delivery creation is the guarded side effect.

## Frontend Resilience
- Empty data proof: no frontend empty-state path is touched.
- Partial data proof: provider payloads missing canonical payment/visit owner still use existing patient-id fallback behavior.
- Forbidden secondary path behavior: no alternate endpoint or delivery path added.
- Missing draft/resource behavior: missing recipient still skips notification as before.
- Stale route/deep-link behavior: no frontend route or deep-link path is touched.

## Scope Gate
- Allowed paths: `backend/app/services/payment_webhook_api_service.py`, `backend/tests/integration/test_notification_catalog_slice3_legacy_webhooks.py`.
- Denied paths: frontend, BFF/read-model/UI endpoints, migrations, unrelated payment creation/status flows, provider webhook processing internals.
- Migration/docs/test impact: no migration or docs; targeted integration regression added.
- Rollback note: revert this PR to restore prior legacy webhook recipient resolution behavior.

## Validation
- Targeted tests or smoke run: `py_compile` for service/test; `pytest backend/tests/integration/test_notification_catalog_slice3_legacy_webhooks.py -q`; `pytest backend/tests/unit/test_payment_webhook_api_service.py -q`; `git diff --check`.
- Result: passed locally (`5 passed`, `6 passed`, diff hygiene passed with CRLF warning only).
- Not checked: full backend suite, frontend build, browser smoke.
