### PR TITLE
fix(mobile): guard notification read ownership

### DIFF
--- a/backend/app/api/v1/endpoints/mobile_api.py
+++ b/backend/app/api/v1/endpoints/mobile_api.py
@@ -443,30 +443,28 @@ async def mark_notification_read(
 ):
     """Отметить уведомление как прочитанное"""
     try:
-        notification = crud_notification.get(db, id=notification_id)
+        notification = crud_notification.get_notification(
+            db, notification_id=notification_id
+        )
         if not notification:
-             raise HTTPException(status_code=404, detail="Уведомление не найдено")
-        
-        # Check ownership logic if needed, usually notification has user_id or recipient_id
-        # Assuming CRUD handles update safely or we check here
-        # crud_notification.update(db, db_obj=notification, obj_in={"is_read": True}) 
-        # But we need to know the field name, usually 'is_read' or 'read'
-        
-        # In MobileNotificationService it was: notification.read = True
-        # Let's assume 'read' or 'is_read'. Checking NotificationHistory model logic previously...
-        # NotificationHistory usually has 'status', but for 'read/unread' it might need a field.
-        # If NotificationHistory doesn't have read status, maybe we need to add it or it uses 'status'.
-        # MobileNotificationService used 'read' field.
-        
-        if hasattr(notification, 'read'):
-             success = MobileApiService(db).mark_notification_as_read(
-                 notification=notification
-             )
-        else:
-             # If no read field, maybe status='read'?
-             # crud_notification.update_status(db, notification_id, status='read')
-             success = True # Mocking success if field missing to avoid 500
+            raise HTTPException(status_code=404, detail="Уведомление не найдено")
 
+        recipient_type = (notification.recipient_type or "").lower()
+        recipient_id = notification.recipient_id
+        owns_notification = recipient_type == "user" and recipient_id == current_user.id
+        if not owns_notification and recipient_type == "patient":
+            patient = get_patient_by_user_id(db, user_id=current_user.id)
+            owns_notification = bool(patient and recipient_id == patient.id)
+
+        if not owns_notification:
+            raise HTTPException(status_code=404, detail="Уведомление не найдено")
+
+        if hasattr(notification, 'read'):
+            success = MobileApiService(db).mark_notification_as_read(
+                notification=notification
+            )
+        else:
+            success = True
 
         if not success:
             raise HTTPException(status_code=404, detail="Уведомление не найдено")

--- a/backend/tests/unit/test_mobile_api_notification_read.py
+++ b/backend/tests/unit/test_mobile_api_notification_read.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.endpoints import mobile_api
+
+
+@pytest.mark.asyncio
+async def test_mobile_notification_read_accepts_owned_user_notification(monkeypatch):
+    notification = SimpleNamespace(
+        id=10,
+        recipient_type="user",
+        recipient_id=123,
+        read=False,
+    )
+    calls = {"marked": False}
+
+    monkeypatch.setattr(
+        mobile_api.crud_notification,
+        "get_notification",
+        lambda _db, notification_id: notification,
+        raising=False,
+    )
+
+    class FakeMobileApiService:
+        def __init__(self, _db):
+            pass
+
+        def mark_notification_as_read(self, *, notification):
+            calls["marked"] = True
+            notification.read = True
+            return True
+
+    monkeypatch.setattr(mobile_api, "MobileApiService", FakeMobileApiService)
+
+    response = await mobile_api.mark_notification_read(
+        notification_id=10,
+        current_user=SimpleNamespace(id=123),
+        db=object(),
+    )
+
+    assert response["message"]
+    assert calls["marked"] is True
+    assert notification.read is True
+
+
+@pytest.mark.asyncio
+async def test_mobile_notification_read_rejects_other_patient_notification(
+    monkeypatch,
+):
+    notification = SimpleNamespace(
+        id=10,
+        recipient_type="patient",
+        recipient_id=999,
+        read=False,
+    )
+    calls = {"marked": False}
+
+    monkeypatch.setattr(
+        mobile_api.crud_notification,
+        "get_notification",
+        lambda _db, notification_id: notification,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        mobile_api,
+        "get_patient_by_user_id",
+        lambda _db, user_id: SimpleNamespace(id=123, user_id=user_id),
+    )
+
+    class FakeMobileApiService:
+        def __init__(self, _db):
+            pass
+
+        def mark_notification_as_read(self, *, notification):
+            calls["marked"] = True
+            return True
+
+    monkeypatch.setattr(mobile_api, "MobileApiService", FakeMobileApiService)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await mobile_api.mark_notification_read(
+            notification_id=10,
+            current_user=SimpleNamespace(id=77),
+            db=object(),
+        )
+
+    assert exc_info.value.status_code == 404
+    assert calls["marked"] is False


### PR DESCRIPTION
## Summary
Fixes legacy `POST /api/v1/mobile/notifications/{notification_id}/read` so it loads notifications through the existing notification CRUD helper and rejects notifications that do not belong to the authenticated user or linked patient.

## Cyclic Execution Evidence
- Fresh main sync: started from safe worktree synced to `origin/main` at `d065a400`.
- Clean workspace: branch was created from a clean worktree; only two files changed.
- Branch: `codex/mobile-notification-read-owner-guard`.
- Scope gate: local agent gate was run with known root cause `backend/app/api/v1/endpoints/mobile_api.py`; gate broadened, so this used narrow override and stayed inside endpoint + focused unit test.
- Red-check handling: if CI fails, this PR will be fixed in-place before merge.

## Contract Impact
- Canonical surface: legacy mobile notification read endpoint under `backend/app/api/v1/endpoints/mobile_api.py`.
- Request shape: unchanged, still `notification_id` path parameter with current authenticated user.
- Response shape: unchanged success message payload.
- Status codes: unchanged externally; missing or unauthorized notifications return 404.
- Frontend consumer: mobile legacy client path only.
- Compatibility path or alias: preserves no-op success for legacy notification rows without a mapped `read` attribute.
- Contract proof: new unit test covers accepted owned user notification and rejected patient notification owned by another patient.

## RBAC / Permissions
- Roles allowed: any authenticated mobile endpoint user may mark only their own `recipient_type=user` notification, or their linked patient notification.
- Roles denied: authenticated users cannot mark another user/patient notification as read.
- Positive auth proof: `test_mobile_notification_read_accepts_owned_user_notification` verifies owned user notification is marked.
- Negative auth proof: `test_mobile_notification_read_rejects_other_patient_notification` verifies foreign patient notification returns 404 and does not call the mark service.

## Notification / Realtime
- Event type or websocket channel: none changed.
- Payload version / ack behavior: none changed.
- Read/unread or delivery semantics: fixes crash on read request and adds recipient ownership guard before read mutation.
- Reconnect/resync proof: not applicable; endpoint-only mutation guard.

## Frontend Resilience
- Empty data proof: missing notification continues to return 404.
- Partial data proof: legacy notification rows without `read` attribute keep previous no-op success behavior after ownership validation.
- Forbidden secondary path behavior: foreign notification returns 404 without mutation.
- Missing draft/resource behavior: missing notification returns 404.
- Stale route/deep-link behavior: stale notification id returns 404.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/mobile_api.py`, `backend/tests/unit/test_mobile_api_notification_read.py`.
- Denied paths: `/api/v1/ui/*`, frontend, migrations, BFF-lite, broad notification model/service rewrites.
- Migration/docs/test impact: no migration or docs; added focused unit regression coverage.
- Rollback note: revert this single commit to restore prior endpoint behavior.

## Validation
- Targeted tests or smoke run: `scripts/run_python.ps1 -PythonArgs @('-m','py_compile','backend/app/api/v1/endpoints/mobile_api.py','backend/tests/unit/test_mobile_api_notification_read.py')`.
- Targeted tests or smoke run: `TESTING=1 DATABASE_URL=sqlite:///C:/tmp/mobile-notification-read-owner-guard-test.db scripts/run_backend_pytest.ps1 tests/unit/test_mobile_api_notification_read.py tests/unit/test_mobile_api_service.py`.
- Targeted tests or smoke run: `git diff --check`.
- Result: py_compile passed; 4 targeted pytest tests passed; diff check passed.
- Not checked: broad backend suite and mobile UI runtime smoke.