### PR TITLE
fix(payments): guard provider webhook amounts

### DIFF
--- a/backend/app/services/provider_webhook_service.py
+++ b/backend/app/services/provider_webhook_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -26,6 +27,50 @@ class ProviderWebhookService:
     ):
         self.db = db
         self.repository = repository or ProviderWebhookRepository(db)
+
+    @staticmethod
+    def _decimal_amount(value: Any) -> Decimal | None:
+        try:
+            return Decimal(str(value))
+        except (InvalidOperation, TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _amounts_match(cls, expected: Any, actual: Any) -> bool:
+        expected_amount = cls._decimal_amount(expected)
+        actual_amount = cls._decimal_amount(actual)
+        return (
+            expected_amount is not None
+            and actual_amount is not None
+            and expected_amount == actual_amount
+        )
+
+    def _result_amount_matches_payment(self, payment: Any, result: Any) -> bool:
+        provider_amount = (getattr(result, "provider_data", None) or {}).get("amount")
+        return self._amounts_match(getattr(payment, "amount", None), provider_amount)
+
+    def _payme_params_amount_matches_payment(
+        self,
+        payment: Any,
+        params: dict[str, Any],
+        transaction: Any | None = None,
+    ) -> bool:
+        raw_amount = params.get("amount")
+        if raw_amount is not None:
+            provider_amount = self._decimal_amount(raw_amount)
+            if provider_amount is None:
+                return False
+            provider_amount = provider_amount / Decimal("100")
+        else:
+            provider_amount = self._decimal_amount(
+                (getattr(transaction, "provider_data", None) or {}).get("amount")
+            )
+            if provider_amount is None:
+                return False
+        return self._amounts_match(
+            getattr(payment, "amount", None),
+            provider_amount,
+        )
 
     def process_click_webhook(self, webhook_data: dict[str, Any]) -> dict[str, Any]:
         """Webhook для Click платежной системы."""
@@ -102,6 +147,21 @@ class ProviderWebhookService:
                             )
 
                     if payment:
+                        if not self._result_amount_matches_payment(payment, result):
+                            webhook.status = "failed"
+                            webhook.error_message = "provider_amount_mismatch"
+                            return {
+                                "click_trans_id": webhook_data.get("click_trans_id"),
+                                "merchant_trans_id": webhook_data.get(
+                                    "merchant_trans_id"
+                                ),
+                                "merchant_prepare_id": webhook.id,
+                                "error": -1,
+                                "error_note": "Payment amount mismatch",
+                                "payment_id": payment.id,
+                                "payment_status": None,
+                                "payment_provider": "click",
+                            }
                         mapped_status = self._map_provider_status_to_payment_status(result.status)
                         payment.status = mapped_status
                         if payment.status == "paid":
@@ -235,6 +295,17 @@ class ProviderWebhookService:
                             params=params,
                         )
                         payment_id = getattr(existing_transaction, "payment_id", None)
+                if payment_status == "amount_mismatch":
+                    return {
+                        "error": {
+                            "code": -31001,
+                            "message": "Payment amount mismatch",
+                        },
+                        "id": request_id,
+                        "payment_id": payment_id,
+                        "payment_status": None,
+                        "payment_provider": "payme",
+                    }
                 if method == "CreateTransaction":
                     return {
                         "result": {
@@ -308,6 +379,19 @@ class ProviderWebhookService:
                             )
 
                     if payment:
+                        if not self._result_amount_matches_payment(payment, result):
+                            webhook.status = "failed"
+                            webhook.error_message = "provider_amount_mismatch"
+                            return {
+                                "error": {
+                                    "code": -31001,
+                                    "message": "Payment amount mismatch",
+                                },
+                                "id": request_id,
+                                "payment_id": payment.id,
+                                "payment_status": None,
+                                "payment_provider": "payme",
+                            }
                         mapped_status = self._map_provider_status_to_payment_status(result.status)
                         payment.status = mapped_status
                         if payment.status == "paid":
@@ -434,6 +518,17 @@ class ProviderWebhookService:
             return None
 
         payment_status = self._map_provider_status_to_payment_status(provider_status)
+        payment_id = getattr(transaction, "payment_id", None)
+        if payment_id:
+            payment = self.repository.get_payment_by_id(payment_id)
+            if payment:
+                if not self._payme_params_amount_matches_payment(
+                    payment,
+                    params,
+                    transaction,
+                ):
+                    return "amount_mismatch"
+
         transaction.status = provider_status
         transaction.provider_data = {
             **(transaction.provider_data or {}),
@@ -442,7 +537,6 @@ class ProviderWebhookService:
             "params": params,
         }
 
-        payment_id = getattr(transaction, "payment_id", None)
         if payment_id:
             payment = self.repository.get_payment_by_id(payment_id)
             if payment:
@@ -488,6 +582,17 @@ class ProviderWebhookService:
                     )
 
                 if payment:
+                    if not self._result_amount_matches_payment(payment, result):
+                        webhook.status = "failed"
+                        webhook.error_message = "provider_amount_mismatch"
+                        self.db.commit()
+                        return {
+                            "status": "error",
+                            "message": "Payment amount mismatch",
+                            "payment_id": payment.id,
+                            "payment_status": None,
+                            "payment_provider": "kaspi",
+                        }
                     mapped_status = self._map_provider_status_to_payment_status(result.status)
                     payment.status = mapped_status
                     if payment.status == "paid":

--- a/backend/tests/integration/test_e2e_clinic.py
+++ b/backend/tests/integration/test_e2e_clinic.py
@@ -322,12 +322,13 @@ def test_e2e_clinic_flow(
         from app.services.queue_service import queue_service
         now = queue_service.get_local_timestamp(db_session)
         order_id = f"clinic_{payment_id}_{int(now.timestamp())}"
+    payme_amount = int(payment_obj.amount * 100)
 
     # Создаем PayMe webhook payload (JSON-RPC формат) для CheckPerformTransaction
     check_payload = {
         "method": "CheckPerformTransaction",
         "params": {
-            "amount": 100000,
+            "amount": payme_amount,
             "account": {
                 "order_id": order_id,
             },
@@ -353,7 +354,7 @@ def test_e2e_clinic_flow(
     create_payload = {
         "method": "CreateTransaction",
         "params": {
-            "amount": 100000,
+            "amount": payme_amount,
             "account": {
                 "order_id": order_id,
             },

--- a/backend/tests/unit/test_provider_webhook_service.py
+++ b/backend/tests/unit/test_provider_webhook_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -37,6 +38,7 @@ class TestProviderWebhookService:
         )
         payment = SimpleNamespace(
             id=44,
+            amount=Decimal("1000"),
             status="processing",
             paid_at=None,
             provider_data={"order_id": "clinic_44_1700000000"},
@@ -76,6 +78,116 @@ class TestProviderWebhookService:
         assert payment.paid_at is not None
         assert payment.provider_data["order_id"] == "clinic_44_1700000000"
         assert payment.provider_data["transaction_id"] == "payme-tx-1"
+
+    def test_payme_perform_existing_transaction_rejects_amount_mismatch(
+        self, db_session
+    ):
+        transaction = SimpleNamespace(
+            id=77,
+            payment_id=44,
+            webhook_id=33,
+            status="processing",
+            provider_data={"method": "CreateTransaction"},
+        )
+        payment = SimpleNamespace(
+            id=44,
+            amount=Decimal("1000"),
+            status="processing",
+            paid_at=None,
+            provider_data={"order_id": "clinic_44_1700000000"},
+        )
+        repository = SimpleNamespace(
+            get_existing_transaction=Mock(return_value=transaction),
+            get_payment_by_id=Mock(return_value=payment),
+        )
+        manager = SimpleNamespace(
+            get_provider=Mock(
+                return_value=SimpleNamespace(
+                    validate_webhook_signature=Mock(return_value=True)
+                )
+            )
+        )
+        service = ProviderWebhookService(db_session, repository=repository)
+
+        with patch(
+            "app.services.provider_webhook_service.get_payment_manager",
+            return_value=manager,
+        ):
+            result = service.process_payme_webhook(
+                {
+                    "id": "request-1",
+                    "method": "PerformTransaction",
+                    "params": {"id": "payme-tx-1", "amount": 100},
+                },
+                "Basic valid",
+            )
+
+        assert result["error"]["code"] == -31001
+        assert result["error"]["message"] == "Payment amount mismatch"
+        assert result["payment_id"] == 44
+        assert result["payment_status"] is None
+        assert transaction.status == "processing"
+        assert transaction.provider_data == {"method": "CreateTransaction"}
+        assert payment.status == "processing"
+        assert payment.paid_at is None
+
+    def test_click_webhook_rejects_amount_mismatch_without_marking_payment_paid(
+        self, db_session
+    ):
+        webhook = SimpleNamespace(id=33, status="pending", processed_at=None)
+        payment = SimpleNamespace(
+            id=44,
+            amount=Decimal("1000"),
+            status="pending",
+            paid_at=None,
+            provider_data={},
+            visit_id=55,
+        )
+        repository = SimpleNamespace(
+            get_existing_transaction=Mock(return_value=None),
+            create_webhook=Mock(return_value=webhook),
+            get_payment_by_id=Mock(return_value=payment),
+            create_transaction=Mock(),
+        )
+        manager = SimpleNamespace(
+            get_provider=Mock(
+                return_value=SimpleNamespace(
+                    validate_webhook_signature=Mock(return_value=True)
+                )
+            ),
+            process_webhook=Mock(
+                return_value=SimpleNamespace(
+                    success=True,
+                    payment_id="clinic_44_1700000000",
+                    status="completed",
+                    provider_data={"amount": Decimal("1")},
+                )
+            ),
+        )
+        service = ProviderWebhookService(db_session, repository=repository)
+
+        with patch(
+            "app.services.provider_webhook_service.get_payment_manager",
+            return_value=manager,
+        ):
+            result = service.process_click_webhook(
+                {
+                    "click_trans_id": "click-1",
+                    "merchant_trans_id": "clinic_44_1700000000",
+                    "amount": 100,
+                    "sign_string": "valid",
+                }
+            )
+
+        assert result["error"] == -1
+        assert result["error_note"] == "Payment amount mismatch"
+        assert result["payment_id"] == 44
+        assert result["payment_status"] is None
+        assert webhook.status == "failed"
+        assert webhook.error_message == "provider_amount_mismatch"
+        assert payment.status == "pending"
+        assert payment.paid_at is None
+        repository.create_transaction.assert_not_called()
 
     def test_extract_payment_id_from_order(self, db_session):
         service = ProviderWebhookService(db_session)


### PR DESCRIPTION
## Summary
Fix provider webhook payment status mutation so Click/Payme/Kaspi callbacks cannot mark a local `Payment` paid/refunded/cancelled unless the provider amount matches the canonical `Payment.amount`.

## Bug and impact
A signed provider callback could reference a valid local payment order id (`clinic_<payment_id>_...` or provider payment id) while carrying a different amount. `ProviderWebhookService` trusted the target id and updated `Payment.status` without amount ownership/contract validation. Concrete trigger: local payment `id=44 amount=1000`, Payme `PerformTransaction` or Click complete callback resolves `clinic_44_...` with amount `1`; old code marked payment 44 as paid. Impact: underpayment can close a bill as paid and emit payment notifications.

## Root cause
Provider-specific parsers put the callback amount into `result.provider_data`, but `ProviderWebhookService` never compared it to `Payment.amount` before mutating payment status, `paid_at`, provider data, or creating a payment transaction. The Payme existing-transaction path also accepted duplicate `PerformTransaction` state changes without rechecking the amount stored during `CreateTransaction`.

## Fix
- Added Decimal-based amount comparison helpers inside `ProviderWebhookService`.
- Click, Payme, and Kaspi successful webhook paths now fail the webhook with `provider_amount_mismatch` before mutating `Payment` or creating a transaction.
- Payme duplicate/existing `PerformTransaction` / `CancelTransaction` path now checks the callback amount, or the amount stored on the existing transaction when Perform omits amount, against the local payment before mutating transaction/payment state.
- Updated the e2e Payme webhook simulation to send provider minor units derived from the canonical stored payment amount.
- Added unit regressions for Click new callback mismatch and Payme existing transaction mismatch.

## Cyclic Execution Evidence
- Fresh main sync: started from `origin/main` at `d065a400` after PR #1473 merge.
- Clean workspace: `git status --short --branch` was clean before edits.
- Branch: `codex/provider-webhook-amount-guard`.
- Scope gate: `agent_gate` with known root cause `backend/app/services/provider_webhook_service.py`; result `narrow override`, first-touch service file, then explicitly expanded to targeted unit/integration tests after CI showed the e2e Payme fixture needed provider-unit alignment.
- Red-check handling: CI red checks were handled in this PR by updating the Payme amount guard path and the e2e provider payload.

## Contract Impact
- Canonical surface: `backend/app/services/provider_webhook_service.py` for `/api/v1/payments/webhook/{click,payme,kaspi}` processing.
- Request shape: unchanged provider webhook payloads; tests now generate Payme payload amounts in the same minor-unit format the provider uses.
- Response shape: unchanged top-level provider response families; mismatched amount now returns existing error forms (`error` for Click/Payme, `status: error` for Kaspi) instead of success.
- Status codes: unchanged endpoint HTTP status behavior; provider-level error payload carries the rejection.
- Frontend consumer: no browser/frontend consumer; this is a server/provider-facing payment callback contract.
- Compatibility path or alias: no route aliases changed.
- Contract proof: targeted unit tests prove mismatched amounts do not mutate payment state or create transactions; e2e clinic flow proves valid Payme minor-unit payloads still pass.

## RBAC / Permissions
- Roles allowed: provider webhook endpoints remain provider callbacks protected by provider signature/auth validation, unchanged.
- Roles denied: no user role access added or broadened.
- Positive auth proof: valid mocked provider signature/auth paths still pass in provider webhook unit tests and e2e Payme flow.
- Negative auth proof: existing tests for missing Click signature and Payme Authorization still pass in `test_provider_webhook_service.py`.

## Notification / Realtime
- Event type or websocket channel: payment notifications from `payment_webhooks.py` are unchanged for valid callbacks.
- Payload version / ack behavior: no notification payload version change; mismatched callbacks return provider error and expose no public internal payment fields.
- Read/unread or delivery semantics: unchanged for valid callbacks; mismatched callbacks do not produce `payment_status`, so no payment notification is emitted.
- Reconnect/resync proof: webhook processing is durable database state, and valid callback notification emission is re-proved by `test_click_webhook_creates_payment_notification_and_hides_internal_fields`; no websocket reconnect behavior is part of this payment callback path.

## Frontend Resilience
- Empty data proof: no frontend path touched; provider callback error payloads stay server-facing.
- Partial data proof: valid callback path with internal fields stripped is covered by the notification integration test.
- Forbidden secondary path behavior: no secondary provider route added; existing provider paths now reject mismatched amount before payment mutation.
- Missing draft/resource behavior: missing payment behavior unchanged because the guard only runs after a local payment is resolved.
- Stale route/deep-link behavior: no frontend route or deep link touched.

## Scope Gate
- Allowed paths: `backend/app/services/provider_webhook_service.py`, `backend/tests/unit/test_provider_webhook_service.py`, `backend/tests/integration/test_e2e_clinic.py`.
- Denied paths: frontend, migrations, BFF/UI endpoints, unrelated payment services, provider protocol schemas.
- Migration/docs/test impact: no migration; targeted unit tests updated; e2e fixture amount aligned to provider minor units.
- Rollback note: revert this commit to restore previous amount-trusting webhook behavior, though that reopens the underpayment status bug.

## Validation
- Targeted tests or smoke run: `py_compile backend/app/services/provider_webhook_service.py backend/tests/unit/test_provider_webhook_service.py backend/tests/integration/test_e2e_clinic.py`; `pytest backend/tests/unit/test_provider_webhook_service.py -q`; `pytest backend/tests/integration/test_e2e_clinic.py::test_e2e_clinic_flow -q`; `pytest backend/tests/integration/test_notification_catalog_slice2_online_payments.py::test_click_webhook_creates_payment_notification_and_hides_internal_fields -q`; `git diff --check`.
- Result: py_compile passed; provider webhook unit suite `7 passed`; e2e clinic flow `1 passed`; notification integration test `1 passed`; diff check passed with CRLF warnings only.
- Not checked: full backend suite and real provider sandbox callbacks.