### PR TITLE
fix(visits): guard canonical appointment time match

### DIFF
--- a/backend/app/repositories/canonical_visit_repository.py
+++ b/backend/app/repositories/canonical_visit_repository.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import time
+
 from sqlalchemy.orm import Session
 
 from app.models.appointment import Appointment
@@ -22,6 +24,12 @@ class CanonicalVisitRepository:
             Visit.patient_id == appointment.patient_id,
             Visit.visit_date == appointment.appointment_date,
         )
+        appointment_times = self._time_match_values(appointment.appointment_time)
+        if not appointment_times:
+            query = query.filter(Visit.visit_time.is_(None))
+        else:
+            query = query.filter(Visit.visit_time.in_(appointment_times))
+
         if appointment.doctor_id is None:
             query = query.filter(Visit.doctor_id.is_(None))
         else:
@@ -33,3 +41,26 @@ class CanonicalVisitRepository:
         self.db.commit()
         self.db.refresh(visit)
         return visit
+
+    @staticmethod
+    def _time_match_values(value: str | time | None) -> tuple[str, ...]:
+        if value is None:
+            return ()
+        if isinstance(value, time):
+            normalized = value.strftime("%H:%M")
+            return (normalized, f"{normalized}:00")
+
+        text = str(value).strip()
+        parts = text.split(":")
+        values = [text] if text else []
+        if len(parts) >= 2:
+            try:
+                hour = int(parts[0])
+                minute = int(parts[1])
+            except ValueError:
+                return tuple(values)
+            if 0 <= hour <= 23 and 0 <= minute <= 59:
+                normalized = f"{hour:02d}:{minute:02d}"
+                values.extend([normalized, f"{normalized}:00"])
+
+        return tuple(dict.fromkeys(values))

--- a/backend/tests/unit/test_canonical_visit_repository.py
+++ b/backend/tests/unit/test_canonical_visit_repository.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from uuid import uuid4
+
+from app.models.appointment import Appointment
+from app.models.clinic import Doctor
+from app.models.patient import Patient
+from app.models.visit import Visit
+from app.repositories.canonical_visit_repository import CanonicalVisitRepository
+
+
+def _suffix() -> str:
+    return uuid4().hex[:10]
+
+
+def test_list_visits_for_appointment_requires_matching_time(db_session) -> None:
+    suffix = _suffix()
+    patient = Patient(
+        first_name="Canonical",
+        last_name=f"TimeGuard{suffix}",
+        phone=f"+99890{suffix[:7]}",
+        birth_date=date(1990, 1, 1),
+    )
+    doctor = Doctor(specialty="cardiology", active=True)
+    db_session.add_all([patient, doctor])
+    db_session.commit()
+    db_session.refresh(patient)
+    db_session.refresh(doctor)
+
+    appointment = Appointment(
+        patient_id=patient.id,
+        doctor_id=doctor.id,
+        appointment_date=date(2026, 3, 17),
+        appointment_time="10:00",
+        status="paid",
+        created_at=datetime(2026, 3, 17, 9, 0, 0),
+    )
+    wrong_time_visit = Visit(
+        patient_id=patient.id,
+        doctor_id=doctor.id,
+        visit_date=appointment.appointment_date,
+        visit_time="09:00",
+        status="open",
+        source="desk",
+        created_at=datetime(2026, 3, 17, 8, 30, 0),
+    )
+    matching_visit = Visit(
+        patient_id=patient.id,
+        doctor_id=doctor.id,
+        visit_date=appointment.appointment_date,
+        visit_time="10:00:00",
+        status="open",
+        source="desk",
+        created_at=datetime(2026, 3, 17, 9, 30, 0),
+    )
+    db_session.add_all([appointment, wrong_time_visit, matching_visit])
+    db_session.commit()
+    db_session.refresh(appointment)
+    db_session.refresh(wrong_time_visit)
+    db_session.refresh(matching_visit)
+
+    matches = CanonicalVisitRepository(db_session).list_visits_for_appointment(
+        appointment
+    )
+
+    assert [visit.id for visit in matches] == [matching_visit.id]
+
+
+def test_list_visits_for_appointment_does_not_match_timed_visit_when_appointment_time_missing(
+    db_session,
+) -> None:
+    suffix = _suffix()
+    patient = Patient(
+        first_name="Canonical",
+        last_name=f"NoTime{suffix}",
+        phone=f"+99891{suffix[:7]}",
+        birth_date=date(1990, 1, 1),
+    )
+    doctor = Doctor(specialty="cardiology", active=True)
+    db_session.add_all([patient, doctor])
+    db_session.commit()
+    db_session.refresh(patient)
+    db_session.refresh(doctor)
+
+    appointment = Appointment(
+        patient_id=patient.id,
+        doctor_id=doctor.id,
+        appointment_date=date(2026, 3, 18),
+        appointment_time=None,
+        status="paid",
+        created_at=datetime(2026, 3, 18, 9, 0, 0),
+    )
+    timed_visit = Visit(
+        patient_id=patient.id,
+        doctor_id=doctor.id,
+        visit_date=appointment.appointment_date,
+        visit_time="09:00",
+        status="open",
+        source="desk",
+    )
+    db_session.add_all([appointment, timed_visit])
+    db_session.commit()
+    db_session.refresh(appointment)
+    db_session.refresh(timed_visit)
+
+    matches = CanonicalVisitRepository(db_session).list_visits_for_appointment(
+        appointment
+    )
+
+    assert matches == []

--- a/backend/tests/unit/test_payment_create_service.py
+++ b/backend/tests/unit/test_payment_create_service.py
@@ -40,6 +40,7 @@ class TestPaymentCreateService:
             patient_id=test_patient.id,
             appointment_date=test_visit.visit_date or date.today(),
             doctor_id=test_visit.doctor_id,
+            appointment_time=test_visit.visit_time,
         )
         db_session.add(appointment)
         db_session.commit()
@@ -109,7 +110,7 @@ class TestPaymentCreateService:
             patient_id=test_patient.id,
             doctor_id=test_doctor.id,
             visit_date=visit_date,
-            visit_time="09:00",
+            visit_time="10:00",
             status="open",
             discount_mode="none",
             source="desk",


### PR DESCRIPTION
## Summary
Fixes canonical appointment-to-visit resolution so an appointment can no longer resolve to a different same-patient/same-doctor/same-date Visit when the appointment time differs.

## Bug and impact
CanonicalVisitRepository.list_visits_for_appointment matched existing visits by patient/date/doctor only. If a patient had one visit at 09:00 and a separate appointment at 10:00 for the same doctor/date, the 10:00 appointment could resolve to the 09:00 Visit. Downstream flows that call CanonicalVisitService.resolve_canonical_visit could then link EMR/lab/payment context to the wrong clinical visit.

## Root cause
The canonical resolver did not include ppointment_time/isit_time in its existing Visit candidate query.

## Fix
The repository now requires matching time when ppointment_time exists, with compatibility for HH:MM and HH:MM:SS stored values. Appointments without a time only match visits without a time. Payment-create unit tests were aligned so appointment-based payment resolution follows the tightened canonical contract.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current detached origin/main at 3eced8f8 after PR #1475 merge.
- Clean workspace: started clean; current diff is limited to canonical visit repository and targeted regression tests.
- Branch: codex/canonical-visit-time-guard.
- Scope gate: gent_gate returned narrow override with known root cause ackend/app/repositories/canonical_visit_repository.py; tests added after first patch compiled; payment-create tests updated only after CI exposed contract drift.
- Red-check handling: CI backend failure was fixed in this PR by updating affected payment-create tests to the new canonical resolver contract.

## Contract Impact
- Canonical surface: CanonicalVisitRepository.list_visits_for_appointment used by CanonicalVisitService.resolve_canonical_visit.
- Request shape: no API request shape changes.
- Response shape: no API response shape changes.
- Status codes: no endpoint status-code changes.
- Frontend consumer: no frontend files or consumers changed.
- Compatibility path or alias: accepts equivalent stored time formats HH:MM and HH:MM:SS; appointment without time does not match timed visits.
- Contract proof: regression tests prove wrong-time visit is excluded, compatible same-time format is accepted, payment-create appointment resolution supplies matching time, and same-time duplicate visit candidates remain ambiguous.

## RBAC / Permissions
- Roles allowed: unchanged; no endpoint authorization code touched.
- Roles denied: unchanged; no endpoint authorization code touched.
- Positive auth proof: existing appointment-flow owner guard suite still passes with this resolver change.
- Negative auth proof: existing appointment-flow owner guard suite still passes and continues rejecting foreign access paths.

## Notification / Realtime
- Event type or websocket channel: no notification or websocket event is emitted by this repository path.
- Payload version / ack behavior: unchanged because no realtime payload code changed.
- Read/unread or delivery semantics: unchanged because notification storage/read paths are not touched.
- Reconnect/resync proof: appointment-flow regression tests exercise resolver behavior without requiring websocket resync.

## Frontend Resilience
- Empty data proof: no frontend state changed; resolver returns no candidate instead of a wrong timed candidate.
- Partial data proof: appointment without time only matches untimed visits, preventing fallback to unrelated timed data.
- Forbidden secondary path behavior: wrong-time same-patient/same-doctor/same-date candidate is rejected by test.
- Missing draft/resource behavior: existing service behavior still creates missing canonical visits when allowed.
- Stale route/deep-link behavior: no route or deep-link behavior changed.

## Scope Gate
- Allowed paths: ackend/app/repositories/canonical_visit_repository.py, ackend/tests/unit/test_canonical_visit_repository.py, ackend/tests/unit/test_payment_create_service.py.
- Denied paths: endpoints, frontend, migrations, provider webhooks, notification code, unrelated services.
- Migration/docs/test impact: no migration needed; targeted backend tests added/updated.
- Rollback note: revert this PR to restore previous patient/date/doctor-only resolver behavior.

## Validation
- Targeted tests or smoke run: py_compile backend/app/repositories/canonical_visit_repository.py backend/tests/unit/test_canonical_visit_repository.py backend/tests/unit/test_payment_create_service.py; pytest backend/tests/unit/test_payment_create_service.py backend/tests/unit/test_canonical_visit_repository.py backend/tests/unit/test_canonical_visit_service.py -q; pytest backend/tests/integration/test_appointment_flow_owner_guard.py -q; git diff --check.
- Result: all targeted tests passed; git diff --check passed with repository CRLF warning only.
- Not checked: full backend suite and frontend build were not run locally because CI runs backend suite and this PR touches only backend repository/test files.