### PR TITLE
fix(doctor): guard schedule-next patient ownership

### DIFF
--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -21,6 +21,7 @@ from app.crud import (
     online_queue as crud_queue,
     visit as crud_visit,
 )
+from app.models.appointment import Appointment
 from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.service import Service
@@ -56,6 +57,14 @@ DOCTOR_QUEUE_ALLOWED_TAGS: dict[str, list[str]] = {
     "lab": ["lab", "laboratory"],
     "laboratory": ["lab", "laboratory"],
     "general": ["general"],
+}
+
+DOCTOR_SCHEDULE_NEXT_ROLES = {
+    "doctor",
+    "cardio",
+    "cardiology",
+    "derma",
+    "dentist",
 }
 
 
@@ -148,6 +157,60 @@ def _visit_filter_doctor_id(db: Session, current_user: User) -> int:
     if current_user.role == "Admin":
         return current_user.id
     return -1
+
+
+def _doctor_schedule_patient_context_exists(
+    db: Session,
+    *,
+    patient_id: int,
+    doctor: Doctor,
+    current_user: User,
+) -> bool:
+    doctor_ids = {doctor.id}
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == current_user.id).first()
+    # Some legacy visit writers stored User.id in doctor_id. Preserve that
+    # compatibility only when current_user.id does not point to another Doctor row.
+    if not assigned_doctor:
+        doctor_ids.add(current_user.id)
+
+    visit_exists = (
+        db.query(Visit.id)
+        .filter(Visit.patient_id == patient_id, Visit.doctor_id.in_(doctor_ids))
+        .first()
+        is not None
+    )
+    if visit_exists:
+        return True
+
+    return (
+        db.query(Appointment.id)
+        .filter(
+            Appointment.patient_id == patient_id,
+            Appointment.doctor_id.in_(doctor_ids),
+        )
+        .first()
+        is not None
+    )
+
+
+def _ensure_schedule_next_patient_access(
+    db: Session,
+    *,
+    patient_id: int,
+    doctor: Doctor | None,
+    current_user: User,
+) -> None:
+    if current_user.role == "Admin":
+        return
+    if (current_user.role or "").strip().lower() not in DOCTOR_SCHEDULE_NEXT_ROLES:
+        return
+    if not doctor or not _doctor_schedule_patient_context_exists(
+        db,
+        patient_id=patient_id,
+        doctor=doctor,
+        current_user=current_user,
+    ):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
 
 
 class ScheduleNextVisitService(BaseModel):
@@ -1291,6 +1354,13 @@ async def schedule_next_visit(
             )
 
         # Проверяем существование услуг
+        _ensure_schedule_next_patient_access(
+            db,
+            patient_id=request.patient_id,
+            doctor=doctor,
+            current_user=current_user,
+        )
+
         service_ids = [s.service_id for s in request.services]
         services = db.query(Service).filter(Service.id.in_(service_ids)).all()
 

--- a/backend/tests/integration/test_e2e_visit_flow.py
+++ b/backend/tests/integration/test_e2e_visit_flow.py
@@ -4,10 +4,12 @@ E2E тесты для полного сценария работы с визит
 """
 from datetime import date, datetime, timedelta
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.patient import Patient
 from app.models.service import Service
 from app.models.visit import Visit, VisitService
 from app.services.morning_assignment import MorningAssignmentService
@@ -18,6 +20,89 @@ from app.services.morning_assignment import MorningAssignmentService
 @pytest.mark.queue
 class TestE2EVisitFlow:
     """E2E тесты для полного сценария работы с визитами"""
+
+    def test_doctor_cannot_schedule_next_visit_for_unassigned_patient(
+        self,
+        client,
+        db_session,
+        cardio_auth_headers,
+        test_doctor,
+        test_service,
+    ):
+        suffix = uuid4().hex[:10]
+        foreign_patient = Patient(
+            first_name="Foreign",
+            last_name="ScheduleNext",
+            phone=f"+99890{suffix[:7]}",
+            birth_date=date(1990, 1, 1),
+        )
+        db_session.add(foreign_patient)
+        db_session.commit()
+        db_session.refresh(foreign_patient)
+
+        response = client.post(
+            "/api/v1/doctor/visits/schedule-next",
+            json={
+                "patient_id": foreign_patient.id,
+                "service_ids": [test_service.id],
+                "visit_date": (date.today() + timedelta(days=1)).isoformat(),
+                "visit_time": "10:00",
+                "discount_mode": "none",
+                "all_free": False,
+                "confirmation_channel": "phone",
+            },
+            headers=cardio_auth_headers,
+        )
+
+        assert response.status_code == 403
+        assert (
+            db_session.query(Visit)
+            .filter(Visit.patient_id == foreign_patient.id)
+            .count()
+            == 0
+        )
+
+    def test_doctor_can_schedule_next_visit_for_assigned_patient(
+        self,
+        client,
+        db_session,
+        cardio_auth_headers,
+        test_patient,
+        test_doctor,
+        test_service,
+    ):
+        existing_visit = Visit(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=date.today(),
+            visit_time="09:00",
+            status="open",
+            discount_mode="none",
+            source="desk",
+        )
+        db_session.add(existing_visit)
+        db_session.commit()
+
+        response = client.post(
+            "/api/v1/doctor/visits/schedule-next",
+            json={
+                "patient_id": test_patient.id,
+                "service_ids": [test_service.id],
+                "visit_date": (date.today() + timedelta(days=1)).isoformat(),
+                "visit_time": "10:00",
+                "discount_mode": "none",
+                "all_free": False,
+                "confirmation_channel": "phone",
+            },
+            headers=cardio_auth_headers,
+        )
+
+        assert response.status_code == 200
+        scheduled_visit_id = response.json()["visit_id"]
+        scheduled_visit = db_session.get(Visit, scheduled_visit_id)
+        assert scheduled_visit is not None
+        assert scheduled_visit.patient_id == test_patient.id
+        assert scheduled_visit.doctor_id == test_doctor.id
 
     def test_complete_visit_flow_today(self, client, db_session, auth_headers, test_patient, test_service):
         """


### PR DESCRIPTION
## Summary
Guards POST /api/v1/doctor/visits/schedule-next so doctor-like roles cannot create a pending next visit for an arbitrary patient without existing doctor/patient context.

## Bug and impact
A doctor role with an active doctor profile could submit any existing patient_id to schedule-next. The endpoint then created a pending Visit and attempted a confirmation invitation. A guessed patient id could therefore create a false clinical workflow item for another patient.

## Root cause
The endpoint checked that the patient existed and that the caller had a Doctor profile, but did not verify that the patient belonged to the caller's assigned visit or appointment context.

## Fix
For doctor-like roles (Doctor, cardio, cardiology, derma, dentist), schedule-next now requires an existing Visit or Appointment for that patient and doctor. Admin behavior is unchanged. Existing legacy User.id-as-doctor_id compatibility is preserved only when current_user.id does not point to another Doctor row.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current origin/main at 7e3472f after PR #1476 merge.
- Clean workspace: started clean; current diff is limited to mounted doctor endpoint and targeted visit-flow tests.
- Branch: codex/doctor-schedule-next-owner-guard.
- Scope gate: gent_gate returned narrow override with known root cause ackend/app/api/v1/endpoints/doctor_integration.py; tests added after endpoint patch compiled.
- Red-check handling: if CI reports a code/test failure, this PR will be fixed in place before merge.

## Contract Impact
- Canonical surface: mounted doctor_integration.schedule_next_visit endpoint.
- Request shape: no request fields added or removed.
- Response shape: success response unchanged; unauthorized doctor/patient context now returns existing 403 error shape.
- Status codes: doctor-like caller without patient context changes from successful creation to 403; admin path remains unchanged.
- Frontend consumer: ScheduleNextModal request shape remains unchanged; denied doctor context receives a normal forbidden response.
- Compatibility path or alias: legacy visit records with User.id in Visit.doctor_id remain accepted when that id is not another Doctor row.
- Contract proof: integration tests prove unassigned doctor/patient schedule-next is denied without creating a Visit and assigned patient schedule-next still succeeds.

## RBAC / Permissions
- Roles allowed: Admin remains allowed; doctor-like roles are allowed only with existing patient context through their Visit or Appointment.
- Roles denied: doctor-like roles without existing patient context are denied with 403.
- Positive auth proof: 	est_doctor_can_schedule_next_visit_for_assigned_patient passes.
- Negative auth proof: 	est_doctor_cannot_schedule_next_visit_for_unassigned_patient passes and confirms no Visit is created.

## Notification / Realtime
- Event type or websocket channel: schedule-next still uses the existing visit confirmation invitation path after the ownership check passes.
- Payload version / ack behavior: unchanged because notification payload code is not touched.
- Read/unread or delivery semantics: unchanged because notification storage/read paths are not touched.
- Reconnect/resync proof: denied path returns before Visit creation and before confirmation invitation; accepted path is covered by visit-flow tests.

## Frontend Resilience
- Empty data proof: no frontend state changed; forbidden doctor context gets 403 instead of a fake pending visit.
- Partial data proof: existing doctor profile alone is insufficient; patient context must be present through Visit or Appointment.
- Forbidden secondary path behavior: test proves arbitrary patient id does not create a fallback Visit.
- Missing draft/resource behavior: missing doctor profile behavior remains unchanged; active doctor with no patient context now receives 403.
- Stale route/deep-link behavior: route and payload are unchanged.

## Scope Gate
- Allowed paths: ackend/app/api/v1/endpoints/doctor_integration.py, ackend/tests/integration/test_e2e_visit_flow.py.
- Denied paths: frontend, migrations, notification services, queue services, duplicate unmounted service adapters, unrelated doctor endpoints.
- Migration/docs/test impact: no migration needed; targeted backend integration tests added.
- Rollback note: revert this PR to restore previous schedule-next behavior.

## Validation
- Targeted tests or smoke run: py_compile backend/app/api/v1/endpoints/doctor_integration.py backend/tests/integration/test_e2e_visit_flow.py; pytest backend/tests/integration/test_e2e_visit_flow.py::TestE2EVisitFlow::test_doctor_cannot_schedule_next_visit_for_unassigned_patient backend/tests/integration/test_e2e_visit_flow.py::TestE2EVisitFlow::test_doctor_can_schedule_next_visit_for_assigned_patient -q; pytest backend/tests/integration/test_e2e_visit_flow.py -q; git diff --check.
- Result: all targeted tests passed; git diff --check passed with repository CRLF warning only.
- Not checked: full backend suite and frontend build were not run locally because CI runs backend suite and this PR touches only backend endpoint/test files.