### PR TITLE
fix(dental): stop false-success placeholder writes

### DIFF
--- a/backend/app/api/v1/endpoints/dental.py
+++ b/backend/app/api/v1/endpoints/dental.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -16,6 +16,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/dental", tags=["dental"])
 
 DENTAL_CLINICIAN_ROLES = ("Admin", "Doctor", "dentist")
+DENTAL_PERSISTENCE_NOT_IMPLEMENTED_DETAIL = (
+    "Dental examination/treatment persistence is not implemented on this endpoint. "
+    "Use the canonical visit protocol or odontogram workflow until a durable dental "
+    "record contract is added."
+)
 
 
 class DentalPriceOverrideRequest(BaseModel):
@@ -67,12 +72,10 @@ async def create_dental_examination(
     """
     Создать новый стоматологический осмотр
     """
-    try:
-        return {"message": "Стоматологический осмотр создан", "id": 1}
-    except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка создания осмотра: {str(e)}"
-        )
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail=DENTAL_PERSISTENCE_NOT_IMPLEMENTED_DETAIL,
+    )
 
 
 @router.get("/treatments", summary="Планы лечения")
@@ -102,12 +105,10 @@ async def create_treatment_plan(
     """
     Создать новый план лечения
     """
-    try:
-        return {"message": "План лечения создан", "id": 1}
-    except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка создания плана лечения: {str(e)}"
-        )
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail=DENTAL_PERSISTENCE_NOT_IMPLEMENTED_DETAIL,
+    )
 
 
 @router.get("/prosthetics", summary="Протезирование")
@@ -137,12 +138,10 @@ async def create_prosthetic(
     """
     Создать новый протез
     """
-    try:
-        return {"message": "Протез создан", "id": 1}
-    except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Ошибка создания протеза: {str(e)}"
-        )
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail=DENTAL_PERSISTENCE_NOT_IMPLEMENTED_DETAIL,
+    )
 
 
 @router.get("/xray", summary="Рентгеновские снимки")

--- a/backend/tests/integration/test_dental_api.py
+++ b/backend/tests/integration/test_dental_api.py
@@ -40,7 +40,9 @@ def dentist_auth_headers(client, dentist_user):
 
 @pytest.mark.integration
 class TestDentalApi:
-    def test_dentist_role_can_create_examination(self, client, dentist_auth_headers):
+    def test_dentist_create_examination_does_not_report_false_success(
+        self, client, dentist_auth_headers
+    ):
         response = client.post(
             "/api/v1/dental/examinations",
             json={
@@ -51,8 +53,40 @@ class TestDentalApi:
             headers=dentist_auth_headers,
         )
 
-        assert response.status_code == 200
-        assert response.json()["message"] == "Стоматологический осмотр создан"
+        assert response.status_code == 501
+        assert "persistence is not implemented" in response.json()["detail"]
+
+    def test_dentist_create_treatment_does_not_report_false_success(
+        self, client, dentist_auth_headers
+    ):
+        response = client.post(
+            "/api/v1/dental/treatments",
+            json={
+                "patient_id": 451,
+                "treatment_date": "2026-03-22",
+                "treatment_type": "filling",
+            },
+            headers=dentist_auth_headers,
+        )
+
+        assert response.status_code == 501
+        assert "persistence is not implemented" in response.json()["detail"]
+
+    def test_dentist_create_prosthetic_does_not_report_false_success(
+        self, client, dentist_auth_headers
+    ):
+        response = client.post(
+            "/api/v1/dental/prosthetics",
+            json={
+                "patient_id": 451,
+                "prosthetic_date": "2026-03-22",
+                "prosthetic_type": "crown",
+            },
+            headers=dentist_auth_headers,
+        )
+
+        assert response.status_code == 501
+        assert "persistence is not implemented" in response.json()["detail"]
 
     def test_dentist_role_can_list_examinations(self, client, dentist_auth_headers):
         response = client.get(


### PR DESCRIPTION
## Summary
- Stop mounted dental placeholder create endpoints from returning successful `200` responses with fake `id: 1`.
- Return explicit `501` for `/api/v1/dental/examinations`, `/api/v1/dental/treatments`, and `/api/v1/dental/prosthetics` until a durable dental storage contract exists.
- Update integration tests so the false-success behavior cannot regress.

## Cyclic Execution Evidence
- Fresh main sync: started from detached `origin/main` at `a27ea9d5` after the previous green merge.
- Clean workspace: checked before creating `codex/dental-no-false-success`.
- Branch: `codex/dental-no-false-success`.
- Scope gate: `agent_gate` returned narrow override with root cause `backend/app/api/v1/endpoints/dental.py`.
- Red-check handling: this PR will be monitored and any red CI caused by this diff will be fixed here.

## Contract Impact
- Canonical surface: mounted FastAPI router `backend/app/api/v1/endpoints/dental.py`.
- Request shape: unchanged for the three create endpoints.
- Response shape: false success body is removed; unsupported writes now return HTTP `501` with an explicit detail message.
- Status codes: create endpoints move from fake `200` to `501` until durable persistence is implemented.
- Frontend consumer: `frontend/src/pages/DentistPanelUnified.jsx` only closes forms on `res.ok`, so failed persistence no longer appears as a successful save.
- Compatibility path or alias: no aliases added; `/api/v1/ui/*` untouched.
- Contract proof: `backend/tests/integration/test_dental_api.py` asserts all three placeholder creates reject instead of reporting success.

## RBAC / Permissions
- Roles allowed: existing route dependency remains `Admin`, `Doctor`, `dentist`.
- Roles denied: existing authentication and role dependency behavior unchanged.
- Positive auth proof: focused dental integration test authenticates `dentist` and reaches the endpoints.
- Negative auth proof: route dependency is unchanged; this PR does not widen access.

## Notification / Realtime
- Event type or websocket channel: no notification or websocket path touched.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: no realtime behavior in this patch.

## Frontend Resilience
- Empty data proof: existing dental list test still proves list endpoint returns an empty array.
- Partial data proof: create request shapes remain accepted by the router but rejected with an explicit backend status.
- Forbidden secondary path behavior: no secondary command path added.
- Missing draft/resource behavior: missing durable dental storage is now explicit `501`, not a fake saved draft.
- Stale route/deep-link behavior: dental routes remain mounted; unsupported writes are explicit.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/dental.py`, `backend/tests/integration/test_dental_api.py`.
- Denied paths: frontend runtime, migrations, `/api/v1/ui/*`, separate BFF, unrelated dental price override logic.
- Migration/docs/test impact: no migration; targeted integration tests updated.
- Rollback note: revert this commit to restore prior placeholder behavior if needed, but that reintroduces silent false success.

## Validation
- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/dental.py backend/tests/integration/test_dental_api.py`; `pytest backend/tests/integration/test_dental_api.py -q`; `git diff --check`.
- Result: py_compile passed; dental integration test passed (`4 passed`); `git diff --check` passed with CRLF warnings only.
- Not checked: frontend build, because frontend runtime was not changed.