### PR TITLE
fix(files): hide soft-deleted records

### DIFF
--- a/backend/app/crud/file_system.py
+++ b/backend/app/crud/file_system.py
@@ -86,6 +86,8 @@ class CRUDFile:
             query = query.filter(File.file_type == file_type)
         if status:
             query = query.filter(File.status == status)
+        else:
+            query = query.filter(File.status != FileStatus.DELETED)
         if owner_id:
             query = query.filter(File.owner_id == owner_id)
         if patient_id:
@@ -107,7 +109,7 @@ class CRUDFile:
         self, db: Session, *, search_request: FileSearchRequest
     ) -> tuple[list[File], int, dict[str, Any]]:
         """Поиск файлов с фильтрацией"""
-        query = db.query(File)
+        query = db.query(File).filter(File.status != FileStatus.DELETED)
 
         # Текстовый поиск
         if search_request.query:
@@ -172,9 +174,11 @@ class CRUDFile:
         # Фасеты для фильтрации
         facets = {
             "file_types": db.query(File.file_type, func.count(File.id))
+            .filter(File.status != FileStatus.DELETED)
             .group_by(File.file_type)
             .all(),
             "permissions": db.query(File.permission, func.count(File.id))
+            .filter(File.status != FileStatus.DELETED)
             .group_by(File.permission)
             .all(),
             "size_ranges": self._get_size_ranges(db, query),

--- a/backend/app/repositories/file_system_api_repository.py
+++ b/backend/app/repositories/file_system_api_repository.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
+from app.models.file_system import FileStatus
+
 
 class FileSystemApiRepository:
     """Encapsulates DB primitives used by file_system endpoint wrappers."""
@@ -35,7 +37,7 @@ class FileSystemApiRepository:
         emr_record_id: int | None,
         folder_id: int | None,
     ) -> int:
-        query = self.db.query(file_model)
+        query = self.db.query(file_model).filter(file_model.status != FileStatus.DELETED)
 
         # owner_id=None означает "без фильтра по владельцу" (admin view)
         if owner_id is not None:

--- a/backend/app/services/file_system_service.py
+++ b/backend/app/services/file_system_service.py
@@ -461,7 +461,7 @@ class FileSystemService:
     ) -> File | None:
         """Получить файл"""
         db_file = file.get(db, id=file_id)
-        if not db_file:
+        if not db_file or self._is_deleted_file(db_file):
             return None
 
         # Проверяем права доступа
@@ -473,6 +473,10 @@ class FileSystemService:
             file_access_log.create(db, file_id=file_id, user_id=user_id, action="view")
 
         return db_file
+
+    def _is_deleted_file(self, file_obj: File) -> bool:
+        """Soft-deleted files must be hidden from normal file access paths."""
+        return file_obj.status == FileStatusEnum.DELETED
 
     def _check_file_access(
         self, db: Session, file_obj: File, user_id: int | None
@@ -572,6 +576,11 @@ class FileSystemService:
             )
 
         # Проверяем права доступа
+        if self._is_deleted_file(db_file):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Файл не найден"
+            )
+
         if db_file.owner_id != user_id and not self._is_admin(db, user_id):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -647,7 +656,7 @@ class FileSystemService:
     def delete_file(self, db: Session, file_id: int, user_id: int) -> bool:
         """Удалить файл"""
         db_file = file.get(db, id=file_id)
-        if not db_file:
+        if not db_file or self._is_deleted_file(db_file):
             return False
 
         # Проверяем права доступа
@@ -675,7 +684,7 @@ class FileSystemService:
         """Создать совместное использование файла"""
         # Проверяем права доступа
         db_file = file.get(db, id=file_id)
-        if not db_file or db_file.owner_id != user_id:
+        if not db_file or self._is_deleted_file(db_file) or db_file.owner_id != user_id:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Нет прав для создания совместного использования",

--- a/backend/tests/test_file_security.py
+++ b/backend/tests/test_file_security.py
@@ -13,7 +13,7 @@ from io import BytesIO
 from datetime import date
 
 from app.models.appointment import Appointment
-from app.models.file_system import File, FileVersion
+from app.models.file_system import File, FileStatus, FileVersion
 from app.models.patient import Patient
 from app.models.user import User
 from app.models.visit import Visit
@@ -404,4 +404,69 @@ class TestFileSecurity:
         assert version is not None
         assert version.file_hash is not None
         assert version.file_hash == original_hash
+
+    def test_soft_deleted_file_is_hidden_from_read_and_list_paths(
+        self, client: TestClient, db_session: Session, auth_headers: dict[str, str]
+    ):
+        file_obj = BytesIO(b"soft deleted clinical document")
+
+        upload_response = client.post(
+            "/api/v1/files/upload",
+            files={"file": ("soft-delete.txt", file_obj, "text/plain")},
+            data={
+                "file_type": "document",
+                "permission": "public",
+                "title": "soft-delete-contract-proof",
+            },
+            headers=auth_headers,
+        )
+        assert upload_response.status_code == 200
+        file_id = upload_response.json()["id"]
+
+        delete_response = client.delete(
+            f"/api/v1/files/{file_id}",
+            headers=auth_headers,
+        )
+        assert delete_response.status_code == 200
+
+        db_session.expire_all()
+        db_file = db_session.query(File).filter(File.id == file_id).one()
+        assert db_file.status == FileStatus.DELETED
+
+        assert (
+            client.get(f"/api/v1/files/{file_id}", headers=auth_headers).status_code
+            == 404
+        )
+        assert (
+            client.get(
+                f"/api/v1/files/{file_id}/download", headers=auth_headers
+            ).status_code
+            == 404
+        )
+        assert (
+            client.get(
+                f"/api/v1/files/{file_id}/preview", headers=auth_headers
+            ).status_code
+            == 404
+        )
+
+        list_response = client.get("/api/v1/files/", headers=auth_headers)
+        assert list_response.status_code == 200
+        listed_ids = {item["id"] for item in list_response.json()["files"]}
+        assert file_id not in listed_ids
+
+        search_response = client.post(
+            "/api/v1/files/search",
+            json={"query": "soft-delete-contract-proof"},
+            headers=auth_headers,
+        )
+        assert search_response.status_code == 200
+        assert search_response.json()["total"] == 0
+        assert search_response.json()["files"] == []
+
+        second_delete_response = client.delete(
+            f"/api/v1/files/{file_id}",
+            headers=auth_headers,
+        )
+        assert second_delete_response.status_code == 404
 


### PR DESCRIPTION
## Summary

- Hide soft-deleted files from normal read/download/preview/export service paths.
- Exclude soft-deleted files from /files/ list, search totals, and count totals.
- Prevent repeated DELETE from treating an already-deleted file as deletable again.
- Add regression coverage for deleted clinical file visibility.

## Cyclic Execution Evidence

- Fresh main sync: fetched origin before branching; base was origin/main at d8988bdd.
- Clean workspace: branch started from detached origin/main and only file-system backend/test files were touched.
- Branch: codex/files-hide-soft-deleted.
- Scope gate: agent_gate narrow overrides were run for service, CRUD, and count repository root-cause files.
- Red-check handling: any red CI check on this PR will be fixed in this same branch before merge.

## Bug and Impact

Soft-deleted clinical files remained reachable after DELETE because normal read paths loaded File rows by id without checking FileStatus.DELETED. A deleted public/private file could still be returned by detail/download/preview or remain visible in list/search/count, and a repeated DELETE could double-apply delete-side effects such as quota usage updates.

## Root Cause

DELETE is a soft delete that sets files.status = deleted, but file access helpers and list/search/count queries did not consistently exclude deleted rows.

## Fix

- FileSystemService.get_file now treats deleted files as missing.
- replace/share/delete service paths reject deleted files; repeated delete returns 404 through the endpoint.
- CRUD list/search and search facets exclude deleted rows by default.
- FileSystemApiRepository.count_files excludes deleted rows so /files/ pagination totals match visible rows.

## Contract Impact

- Canonical surface: existing /api/v1/files endpoints only.
- Request shape: unchanged.
- Response shape: unchanged for active files; deleted files now return hidden/missing behavior on normal read paths.
- Status codes: detail/download/preview and repeated delete return 404 for soft-deleted files.
- Frontend consumer: no frontend changes; existing consumers see deleted files disappear instead of remaining accessible.
- Compatibility path or alias: no aliases added or changed.
- Contract proof: backend regression test covers detail/download/preview/list/search/repeated-delete after soft delete.

## RBAC / Permissions

- Roles allowed: existing file roles are unchanged.
- Roles denied: existing role denials are unchanged.
- Positive auth proof: authenticated Admin upload/delete flow still succeeds before the file is hidden.
- Negative auth proof: the same authenticated user can no longer read/list/search/download/preview the soft-deleted file.

## Notification / Realtime

- Event type or websocket channel: no realtime channel is touched by this file-system fix.
- Payload version / ack behavior: no notification payload changes.
- Read/unread or delivery semantics: no notification semantics changed.
- Reconnect/resync proof: REST resync now omits soft-deleted files in list/search/count.

## Frontend Resilience

- Empty data proof: search for the deleted file returns total 0 and files [].
- Partial data proof: list still returns 200 and omits only the deleted file id.
- Forbidden secondary path behavior: direct detail/download/preview paths return 404 after delete.
- Missing draft/resource behavior: deleted file behaves as a missing resource.
- Stale route/deep-link behavior: stale file deep links now get 404 instead of stale content.

## Scope Gate

- Allowed paths: backend/app/services/file_system_service.py; backend/app/crud/file_system.py; backend/app/repositories/file_system_api_repository.py; backend/tests/test_file_security.py.
- Denied paths: frontend, migrations, unrelated file-system features, auth/RBAC redesign, storage migration.
- Migration/docs/test impact: no migration; targeted backend regression test added.
- Rollback note: revert this commit to restore previous soft-delete visibility behavior.

## Validation

- Targeted tests or smoke run: C:\Users\DrSapaev\AppData\Local\Programs\Python\Python311\python.exe -m py_compile backend\app\services\file_system_service.py backend\app\crud\file_system.py backend\app\repositories\file_system_api_repository.py backend\tests\test_file_security.py; pytest backend\tests\test_file_security.py backend\tests\unit\test_file_system_api_service.py -q.
- Result: py_compile passed; 10 pytest tests passed.
- Not checked: full backend suite and frontend build were not run because this is a narrow backend file visibility fix.
