### PR TITLE
fix(payments): route reconcile all before provider

### DIFF
--- a/backend/app/api/v1/endpoints/payment_reconciliation.py
+++ b/backend/app/api/v1/endpoints/payment_reconciliation.py
@@ -19,6 +19,29 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
+@router.post("/reconcile/all")
+async def reconcile_all_providers(
+    start_date: date = Query(..., description="Start date for reconciliation"),
+    end_date: date = Query(..., description="End date for reconciliation"),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles("Admin")),
+) -> dict:
+    """
+    Reconcile all payment providers
+
+    ✅ SECURITY: Requires Admin role
+    """
+    service = PaymentReconciliationApiService(db)
+    try:
+        return service.reconcile_all_providers(
+            start_date=start_date,
+            end_date=end_date,
+        )
+    except PaymentReconciliationApiDomainError as exc:
+        logger.error("Error in reconcile_all_providers: %s", exc.detail)
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+
 @router.post("/reconcile/{provider}")
 async def reconcile_provider(
     provider: str,
@@ -41,29 +64,6 @@ async def reconcile_provider(
         )
     except PaymentReconciliationApiDomainError as exc:
         logger.error("Error in reconcile_provider: %s", exc.detail)
-        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
-
-
-@router.post("/reconcile/all")
-async def reconcile_all_providers(
-    start_date: date = Query(..., description="Start date for reconciliation"),
-    end_date: date = Query(..., description="End date for reconciliation"),
-    db: Session = Depends(get_db),
-    current_user=Depends(require_roles("Admin")),
-) -> dict:
-    """
-    Reconcile all payment providers
-
-    ✅ SECURITY: Requires Admin role
-    """
-    service = PaymentReconciliationApiService(db)
-    try:
-        return service.reconcile_all_providers(
-            start_date=start_date,
-            end_date=end_date,
-        )
-    except PaymentReconciliationApiDomainError as exc:
-        logger.error("Error in reconcile_all_providers: %s", exc.detail)
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
 

--- a/backend/tests/integration/test_payment_reconciliation_routes.py
+++ b/backend/tests/integration/test_payment_reconciliation_routes.py
@@ -1,0 +1,93 @@
+from app.core.security import get_password_hash
+from app.models.user import User
+
+
+def _cashier_headers(client, db_session):
+    cashier = db_session.query(User).filter(User.username == "route_cashier").first()
+    if cashier is None:
+        cashier = User(
+            username="route_cashier",
+            email="route.cashier@test.com",
+            hashed_password=get_password_hash("cashier123"),
+            role="Cashier",
+            is_active=True,
+            is_superuser=False,
+        )
+        db_session.add(cashier)
+        db_session.commit()
+        db_session.refresh(cashier)
+
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": cashier.username, "password": "cashier123"},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def test_reconcile_all_route_dispatches_to_all_provider_service(
+    client, auth_headers, monkeypatch
+):
+    calls = {"all": 0, "provider": []}
+
+    def fake_reconcile_all(self, *, start_date, end_date):
+        calls["all"] += 1
+        return {
+            "route": "all",
+            "providers": {},
+            "overall_summary": {"total_discrepancies": 0},
+        }
+
+    def fake_reconcile_provider(self, *, provider, start_date, end_date):
+        calls["provider"].append(provider)
+        return {"route": "provider", "provider": provider}
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.payment_reconciliation."
+        "PaymentReconciliationApiService.reconcile_all_providers",
+        fake_reconcile_all,
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.payment_reconciliation."
+        "PaymentReconciliationApiService.reconcile_provider",
+        fake_reconcile_provider,
+    )
+
+    response = client.post(
+        "/api/v1/payments/reconcile/all",
+        params={"start_date": "2026-05-01", "end_date": "2026-05-31"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["route"] == "all"
+    assert calls == {"all": 1, "provider": []}
+
+
+def test_reconcile_all_route_keeps_admin_only_permission(
+    client, db_session, monkeypatch
+):
+    def fake_reconcile_all(self, *, start_date, end_date):
+        return {"route": "all"}
+
+    def fake_reconcile_provider(self, *, provider, start_date, end_date):
+        return {"route": "provider", "provider": provider}
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.payment_reconciliation."
+        "PaymentReconciliationApiService.reconcile_all_providers",
+        fake_reconcile_all,
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.payment_reconciliation."
+        "PaymentReconciliationApiService.reconcile_provider",
+        fake_reconcile_provider,
+    )
+
+    response = client.post(
+        "/api/v1/payments/reconcile/all",
+        params={"start_date": "2026-05-01", "end_date": "2026-05-31"},
+        headers=_cashier_headers(client, db_session),
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
﻿## Summary
Fixes payment reconciliation route shadowing so `POST /api/v1/payments/reconcile/all` dispatches to the all-provider reconciliation service before the parameterized `/reconcile/{provider}` route can capture `all` as a provider name.

## Bug / Impact
- Before this change, `/payments/reconcile/all` could be routed as `provider="all"`, returning a single-provider result instead of reconciling supported providers.
- Because the parameterized provider route allows `Admin` and `Cashier`, the shadow also weakened the intended Admin-only boundary for all-provider reconciliation.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `origin/main` in `C:\tmp\final-contract-scan-next-3` after PR #1480 merge.
- Clean workspace: first inspected branch status; only payment reconciliation endpoint and focused integration test are changed.
- Branch: `codex/payment-reconcile-all-route`.
- Scope gate: route ordering fix plus regression tests only; no frontend, no schema, no migration, no unrelated cleanup.
- Red-check handling: will fix any failed required checks in this PR before merge.

## Contract Impact
- Canonical surface: `POST /api/v1/payments/reconcile/all` and `POST /api/v1/payments/reconcile/{provider}`.
- Request shape: unchanged query parameters `start_date` and `end_date`.
- Response shape: unchanged; `/reconcile/all` now reliably returns the all-provider service response.
- Status codes: unchanged for successful admin requests; Cashier now correctly receives 403 on `/reconcile/all` instead of falling through to provider reconciliation.
- Frontend consumer: no frontend files touched; existing consumers keep the same URL.
- Compatibility path or alias: no alias added; this restores the already published route behavior.
- Contract proof: new integration tests assert `/reconcile/all` calls `reconcile_all_providers` and does not call `reconcile_provider(provider="all")`.

## RBAC / Permissions
- Roles allowed: `Admin` for `/reconcile/all`; `Admin` and `Cashier` for `/reconcile/{provider}` remain unchanged.
- Roles denied: `Cashier` is denied on `/reconcile/all` by regression test.
- Positive auth proof: admin `auth_headers` test receives 200 from `/reconcile/all` with monkeypatched all-provider service.
- Negative auth proof: Cashier token receives 403 on `/reconcile/all`, proving the static route is no longer shadowed by the provider route.

## Notification / Realtime
- Event type or websocket channel: none; payment reconciliation routes do not emit realtime notifications in this change.
- Payload version / ack behavior: unchanged; no realtime payloads or acknowledgements changed.
- Read/unread or delivery semantics: unchanged; not a notification feature.
- Reconnect/resync proof: not affected because no websocket or notification path is touched.

## Frontend Resilience
- Empty data proof: mocked all-provider response with empty `providers` returns 200 through the correct route.
- Partial data proof: route dispatch is independent of provider contents; no frontend parsing changed.
- Forbidden secondary path behavior: Cashier cannot use `/reconcile/all` as a provider-route fallback.
- Missing draft/resource behavior: unchanged; this endpoint does not manage drafts/resources.
- Stale route/deep-link behavior: existing `/payments/reconcile/all` URL is preserved and now resolves to the intended handler.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/payment_reconciliation.py`, `backend/tests/integration/test_payment_reconciliation_routes.py`.
- Denied paths: frontend, schemas, services, migrations, database models, unrelated route cleanup.
- Migration/docs/test impact: no migration or docs; one focused integration test file added.
- Rollback note: revert this commit to restore previous route order, though that would reintroduce the all-provider shadowing bug.

## Validation
- Targeted tests or smoke run: `py_compile` for touched Python files; `pytest backend/tests/integration/test_payment_reconciliation_routes.py backend/tests/unit/test_payment_reconciliation_api_service.py -q`; `pytest backend/tests/test_openapi_contract.py backend/tests/integration/test_payment_reconciliation_routes.py -q`; `git diff --check`.
- Result: compile passed; 5 targeted tests passed; 26 OpenAPI+route tests passed; diff check passed.
- Not checked: frontend build, because no frontend files changed.
