### PR TITLE
fix(mobile): list owned notifications safely

### DIFF
--- a/backend/app/api/v1/endpoints/mobile_api.py
+++ b/backend/app/api/v1/endpoints/mobile_api.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import JSONResponse
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
@@ -22,6 +23,7 @@ from app.crud import (
 )
 from app.crud.patient import get_patient_by_user_id
 from app.db.session import get_db
+from app.models.notification import NotificationHistory
 from app.schemas.mobile import (
     AppointmentUpcomingOut,
     BookAppointmentRequest,
@@ -58,6 +60,38 @@ def compress_json_response(data: dict) -> Response:
         )
     else:
         return JSONResponse(content=data)
+
+
+def _get_mobile_notification_rows(
+    db: Session,
+    *,
+    user_id: int,
+    patient_id: int | None,
+    limit: int,
+    offset: int,
+) -> list[NotificationHistory]:
+    ownership_filters = [
+        and_(
+            NotificationHistory.recipient_type == "user",
+            NotificationHistory.recipient_id == user_id,
+        )
+    ]
+    if patient_id is not None:
+        ownership_filters.append(
+            and_(
+                NotificationHistory.recipient_type == "patient",
+                NotificationHistory.recipient_id == patient_id,
+            )
+        )
+
+    return (
+        db.query(NotificationHistory)
+        .filter(or_(*ownership_filters))
+        .order_by(NotificationHistory.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
 
 
 @router.post("/mobile/auth/login", response_model=MobileLoginResponse)
@@ -412,8 +446,13 @@ async def get_mobile_notifications(
 ):
     """История уведомлений для мобильного приложения"""
     try:
-        notifications = crud_notification.get_user_notifications(
-            db, user_id=current_user.id, limit=limit
+        patient = get_patient_by_user_id(db, user_id=current_user.id)
+        notifications = _get_mobile_notification_rows(
+            db,
+            user_id=current_user.id,
+            patient_id=patient.id if patient else None,
+            limit=limit,
+            offset=offset,
         )
 
         return [
@@ -422,9 +461,9 @@ async def get_mobile_notifications(
                 "title": notif.subject, # Subject as title
                 "message": notif.content,
                 "type": notif.notification_type,
-                "data": notif.metadata,
+                "data": notif.notification_metadata or {},
                 "sent_at": notif.created_at,
-                "read": notif.is_read if hasattr(notif, 'is_read') else False, # Assuming is_read field exists or logic needed
+                "read": False,
             }
             for notif in notifications
         ]

--- a/backend/tests/unit/test_mobile_api_notification_read.py
+++ b/backend/tests/unit/test_mobile_api_notification_read.py
@@ -9,6 +9,67 @@ from app.api.v1.endpoints import mobile_api
 
 
 @pytest.mark.asyncio
+async def test_mobile_notifications_list_uses_owned_rows_and_model_fields(
+    monkeypatch,
+):
+    notification = SimpleNamespace(
+        id=10,
+        subject="Visit reminder",
+        content="Tomorrow at 10:00",
+        notification_type="appointment",
+        notification_metadata={"appointment_id": 42},
+        created_at="2026-05-31T10:00:00",
+    )
+    calls = {}
+
+    def fail_stale_crud(*_args, **_kwargs):
+        raise AssertionError("stale user_id NotificationHistory helper used")
+
+    def fake_rows(_db, *, user_id, patient_id, limit, offset):
+        calls.update(
+            {
+                "user_id": user_id,
+                "patient_id": patient_id,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+        return [notification]
+
+    monkeypatch.setattr(
+        mobile_api.crud_notification,
+        "get_user_notifications",
+        fail_stale_crud,
+    )
+    monkeypatch.setattr(
+        mobile_api,
+        "get_patient_by_user_id",
+        lambda _db, user_id: SimpleNamespace(id=9, user_id=user_id),
+    )
+    monkeypatch.setattr(mobile_api, "_get_mobile_notification_rows", fake_rows)
+
+    response = await mobile_api.get_mobile_notifications(
+        current_user=SimpleNamespace(id=55),
+        db=object(),
+        limit=7,
+        offset=2,
+    )
+
+    assert calls == {"user_id": 55, "patient_id": 9, "limit": 7, "offset": 2}
+    assert response == [
+        {
+            "id": 10,
+            "title": "Visit reminder",
+            "message": "Tomorrow at 10:00",
+            "type": "appointment",
+            "data": {"appointment_id": 42},
+            "sent_at": "2026-05-31T10:00:00",
+            "read": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_mobile_notification_read_accepts_owned_user_notification(monkeypatch):
     notification = SimpleNamespace(
         id=10,


### PR DESCRIPTION
## Summary
Fixes legacy `GET /api/v1/mobile/notifications` so it no longer crashes on stale `NotificationHistory.user_id` / `is_read` assumptions and only lists notifications owned by the authenticated user or their linked patient.

## Cyclic Execution Evidence
- Fresh main sync: branch started from safe worktree synced to `origin/main` at `83e9520f`.
- Clean workspace: started clean after PR #1474 merge and sync.
- Branch: `codex/mobile-notification-list-contract`.
- Scope gate: local agent gate was run with known root cause `backend/app/api/v1/endpoints/mobile_api.py`; gate returned broad notification-stack first-touch, so narrow override stayed in mounted endpoint + focused unit test.
- Red-check handling: if CI fails, this PR will be fixed in-place before merge.

## Contract Impact
- Canonical surface: legacy mobile notification list endpoint under `backend/app/api/v1/endpoints/mobile_api.py` backed by `NotificationHistory.recipient_type/recipient_id`.
- Request shape: unchanged, still authenticated `GET /api/v1/mobile/notifications` with `limit` and `offset` query parameters.
- Response shape: unchanged list of dicts with `id`, `title`, `message`, `type`, `data`, `sent_at`, and `read`.
- Status codes: unchanged externally; successful owned lists return 200, unexpected failures remain 500.
- Frontend consumer: mobile legacy client path only.
- Compatibility path or alias: preserves legacy `read: false` fallback because `NotificationHistory` has no mapped read column.
- Contract proof: unit test proves endpoint does not call stale CRUD helper and serializes existing model fields, including `notification_metadata`.

## RBAC / Permissions
- Roles allowed: authenticated mobile users can list notifications addressed to their `recipient_type=user` user id or to their linked `recipient_type=patient` patient id.
- Roles denied: notifications for other users/patients are excluded by backend query ownership filters.
- Positive auth proof: new unit test verifies current user id and linked patient id are passed to the owned-row query path.
- Negative auth proof: ownership is enforced by endpoint query construction; no caller-provided recipient id is accepted by the request.

## Notification / Realtime
- Event type or websocket channel: none changed.
- Payload version / ack behavior: none changed.
- Read/unread or delivery semantics: list endpoint no longer uses missing `is_read`; read remains false for legacy history rows.
- Reconnect/resync proof: mobile list resync now uses server-owned recipient filters instead of stale user-id field assumptions.

## Frontend Resilience
- Empty data proof: owned-row query returns an empty list when there are no owned notifications.
- Partial data proof: missing notification metadata serializes as `{}`.
- Forbidden secondary path behavior: foreign recipient rows are not selected because there is no request-controlled recipient selector.
- Missing draft/resource behavior: this endpoint has no draft/resource dependency; missing linked patient simply limits results to `recipient_type=user` rows instead of crashing.
- Stale route/deep-link behavior: mounted route path remains unchanged and stale clients keep receiving the same list shape.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/mobile_api.py`, `backend/tests/unit/test_mobile_api_notification_read.py`.
- Denied paths: `/api/v1/ui/*`, frontend, migrations, notification model/schema rewrites, canonical notification platform service rewrites, BFF-lite.
- Migration/docs/test impact: no migration or docs; extended focused unit regression coverage.
- Rollback note: revert this single commit to restore prior list behavior.

## Validation
- Targeted tests or smoke run: `scripts/run_python.ps1 -PythonArgs @('-m','py_compile','backend/app/api/v1/endpoints/mobile_api.py','backend/tests/unit/test_mobile_api_notification_read.py')`.
- Targeted tests or smoke run: `TESTING=1 DATABASE_URL=sqlite:///C:/tmp/mobile-notification-list-contract-test.db scripts/run_backend_pytest.ps1 tests/unit/test_mobile_api_notification_read.py tests/unit/test_mobile_api_service.py`.
- Targeted tests or smoke run: `git diff --check`.
- Result: py_compile passed; 5 targeted pytest tests passed; diff check passed.
- Not checked: broad backend suite and mobile UI runtime smoke.