### PR TITLE
fix(webhooks): route system stats before webhook stats

### DIFF
--- a/backend/app/api/v1/endpoints/webhooks.py
+++ b/backend/app/api/v1/endpoints/webhooks.py
@@ -475,6 +475,30 @@ async def get_webhook_call(
 # ===================== СТАТИСТИКА =====================
 
 
+@router.get("/system/stats", response_model=SystemWebhookStats)
+async def get_system_webhook_stats(
+    *,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_roles([Roles.ADMIN, Roles.MANAGER])),
+):
+    """
+    Получает общую статистику системы webhook'ов
+
+    Требует роль: ADMIN или DEVELOPER
+    """
+    try:
+        webhook_service = get_webhook_service(db)
+        stats = webhook_service.get_system_webhook_stats()
+        return SystemWebhookStats(**stats)
+
+    except Exception as e:
+        logger.error(f"Ошибка получения системной статистики: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Ошибка получения статистики",
+        )
+
+
 @router.get("/{webhook_id}/stats", response_model=WebhookStats)
 async def get_webhook_stats(
     *,
@@ -507,30 +531,6 @@ async def get_webhook_stats(
 
     stats = crud_webhook.get_stats(db=db, id=webhook_id)
     return WebhookStats(**stats)
-
-
-@router.get("/system/stats", response_model=SystemWebhookStats)
-async def get_system_webhook_stats(
-    *,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(require_roles([Roles.ADMIN, Roles.MANAGER])),
-):
-    """
-    Получает общую статистику системы webhook'ов
-
-    Требует роль: ADMIN или DEVELOPER
-    """
-    try:
-        webhook_service = get_webhook_service(db)
-        stats = webhook_service.get_system_webhook_stats()
-        return SystemWebhookStats(**stats)
-
-    except Exception as e:
-        logger.error(f"Ошибка получения системной статистики: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Ошибка получения статистики",
-        )
 
 
 # ===================== МАССОВЫЕ ОПЕРАЦИИ =====================

--- a/backend/tests/integration/test_webhook_system_stats_route.py
+++ b/backend/tests/integration/test_webhook_system_stats_route.py
@@ -1,0 +1,50 @@
+from app.api.v1.endpoints import webhooks
+
+
+class _FakeWebhookService:
+    def get_system_webhook_stats(self):
+        return {
+            "total_webhooks": 7,
+            "active_webhooks": 5,
+            "inactive_webhooks": 2,
+            "recent_24h": {
+                "total_calls": 11,
+                "successful_calls": 9,
+                "failed_calls": 2,
+                "success_rate": 81.82,
+            },
+            "pending_retries": 1,
+            "unprocessed_events": 3,
+        }
+
+
+def test_system_stats_route_dispatches_before_webhook_id_stats(
+    client, auth_headers, monkeypatch
+):
+    monkeypatch.setattr(
+        webhooks,
+        "get_webhook_service",
+        lambda db: _FakeWebhookService(),
+    )
+
+    response = client.get("/api/v1/webhooks/system/stats", headers=auth_headers)
+
+    assert response.status_code == 200
+    assert response.json()["total_webhooks"] == 7
+    assert response.json()["recent_24h"]["successful_calls"] == 9
+
+
+def test_system_stats_route_keeps_admin_manager_only_permission(
+    client, registrar_auth_headers, monkeypatch
+):
+    def fail_if_called(db):
+        raise AssertionError("system stats service should not run for Registrar")
+
+    monkeypatch.setattr(webhooks, "get_webhook_service", fail_if_called)
+
+    response = client.get(
+        "/api/v1/webhooks/system/stats",
+        headers=registrar_auth_headers,
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
﻿## Summary
Fixes webhook route shadowing so `GET /api/v1/webhooks/system/stats` dispatches to the system webhook stats handler before the parameterized `/{webhook_id}/stats` route can capture `system` as a webhook id.

## Bug / Impact
- Before this change, the admin Webhook Manager call to `/webhooks/system/stats` could be captured by `/{webhook_id}/stats`, producing a path validation failure instead of system stats.
- This broke the system statistics section for webhook administration and hid operational webhook health data.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `origin/main` at `67c69d81` after PR #1481 merge.
- Clean workspace: only webhook endpoint route order and focused route test are changed.
- Branch: `codex/webhook-system-stats-route`.
- Scope gate: route ordering fix plus regression tests only; no frontend, no schema, no service logic, no migration.
- Red-check handling: will fix any failed required checks in this PR before merge.

## Contract Impact
- Canonical surface: `GET /api/v1/webhooks/system/stats` and `GET /api/v1/webhooks/{webhook_id}/stats`.
- Request shape: unchanged; both routes keep their existing request parameters.
- Response shape: unchanged; system stats still returns `SystemWebhookStats`.
- Status codes: Admin receives 200 for system stats; Registrar receives 403 for system stats; per-webhook stats route remains unchanged.
- Frontend consumer: no frontend files touched; `WebhookManager.jsx` keeps using `/webhooks/system/stats`.
- Compatibility path or alias: no alias added; restores the already published route behavior.
- Contract proof: new integration tests assert `/system/stats` dispatches to `get_system_webhook_stats` and is not captured by `/{webhook_id}/stats`.

## RBAC / Permissions
- Roles allowed: `Admin` and `Manager` for `/webhooks/system/stats`, unchanged.
- Roles denied: `Registrar` denied for `/webhooks/system/stats` by regression test.
- Positive auth proof: admin `auth_headers` receives 200 from `/webhooks/system/stats` with mocked system stats service.
- Negative auth proof: registrar `registrar_auth_headers` receives 403 and the system stats service is not called.

## Notification / Realtime
- Event type or websocket channel: none; route order only.
- Payload version / ack behavior: unchanged; no notification payloads or acknowledgements changed.
- Read/unread or delivery semantics: unchanged; not a notification delivery path.
- Reconnect/resync proof: unchanged because no websocket or realtime path is touched.

## Frontend Resilience
- Empty data proof: mocked stats route returns a valid empty-compatible stats shape through the correct route.
- Partial data proof: frontend consumer path is unchanged; response model remains backend-owned.
- Forbidden secondary path behavior: `/webhooks/system/stats` no longer falls through to the per-webhook stats route.
- Missing draft/resource behavior: unchanged; this endpoint does not manage drafts/resources.
- Stale route/deep-link behavior: existing `/webhooks/system/stats` URL is preserved and now resolves to the intended handler.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/webhooks.py`, `backend/tests/integration/test_webhook_system_stats_route.py`.
- Denied paths: frontend, schemas, services, migrations, database models, unrelated route cleanup.
- Migration/docs/test impact: no migration or docs; one focused integration test file added.
- Rollback note: revert this commit to restore previous route order, though that would reintroduce the system stats shadowing bug.

## Validation
- Targeted tests or smoke run: `py_compile` for touched Python files; `pytest backend/tests/integration/test_webhook_system_stats_route.py -q`; `pytest backend/tests/test_openapi_contract.py backend/tests/integration/test_webhook_system_stats_route.py -q`; `git diff --check`.
- Result: compile passed; 2 focused route tests passed; 26 OpenAPI+route tests passed; diff check passed.
- Not checked: frontend build, because no frontend files changed.
