### PR TITLE
🎨 Palette: Add ARIA label to Language Switcher button

### DIFF
--- a/frontend/src/components/LanguageSwitcher.jsx
+++ b/frontend/src/components/LanguageSwitcher.jsx
@@ -37,6 +37,7 @@ const LanguageSwitcher = ({ compact = false }) => {
                 size="small"
                 onClick={() => setIsOpen(!isOpen)}
                 title={t('common.language')}
+                aria-label={t('common.language')}
                 style={{
                     display: 'flex',
                     alignItems: 'center',


### PR DESCRIPTION
💡 What: Added an `aria-label` to the Language Switcher button component.
🎯 Why: The Language Switcher button in the header is an icon-only button without an accessible name. This prevents screen reader users from understanding its purpose.
📸 Before/After: Before, screen readers would only announce "Button". After, they announce the localized string for "Language" (e.g. "Язык").
♿ Accessibility: The addition provides a reliable accessible name for screen readers, matching the existing `title` attribute which provides a tooltip for mouse users.

---
*PR created automatically by Jules for task [7125286126952943902](https://jules.google.com/task/7125286126952943902) started by @drsapaev*