### PR TITLE
fix(registrar): append edit services without duplicate queues

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -28,6 +28,10 @@ from app.services.feature_flags import is_feature_enabled
 from app.services.registrar_wizard_queue_assignment_service import (
     RegistrarWizardQueueAssignmentService,
 )
+from app.services.registrar_edit_delta_service import (
+    RegistrarEditDeltaItem,
+    RegistrarEditDeltaService,
+)
 from app.services.notifications import notification_sender_service
 from app.services.online_queue_new_service import (
     OnlineQueueNewDomainError,
@@ -110,6 +114,43 @@ class CartResponse(BaseModel):
     created_visits: Optional[List[Dict[str, Any]]] = (
         None  # Информация о созданных визитах
     )
+
+
+class EditDeltaPatientData(BaseModel):
+    full_name: Optional[str] = None
+    phone: Optional[str] = None
+    birth_date: Optional[date] = None
+    sex: Optional[str] = None
+    address: Optional[str] = None
+
+
+class EditDeltaServiceItem(BaseModel):
+    service_id: int
+    quantity: int = Field(default=1, ge=1)
+    specialist_id: Optional[int] = None
+
+
+class EditDeltaRequest(BaseModel):
+    patient_id: int
+    target_date: date = Field(default_factory=date.today)
+    payment_method: str = Field(default="cash")
+    discount_mode: str = Field(default="none")
+    all_free: bool = Field(default=False)
+    patient_data: Optional[EditDeltaPatientData] = None
+    services: List[EditDeltaServiceItem] = Field(default_factory=list)
+    existing_queue_entry_ids: List[int] = Field(default_factory=list)
+
+
+class EditDeltaResponse(BaseModel):
+    success: bool
+    message: str
+    invoice_id: Optional[int] = None
+    visit_ids: List[int] = Field(default_factory=list)
+    total_amount: Decimal = Decimal("0")
+    queue_numbers: Dict[int, List[Dict[str, Any]]] = Field(default_factory=dict)
+    print_tickets: List[Dict[str, Any]] = Field(default_factory=list)
+    created_visits: List[Dict[str, Any]] = Field(default_factory=list)
+    updated_queue_entries: List[Dict[str, Any]] = Field(default_factory=list)
 
 
 class MarkPaidRequest(BaseModel):
@@ -1119,6 +1160,54 @@ def create_cart_appointments(
 
 
 # ===================== УПРАВЛЕНИЕ ИЗМЕНЕНИЯМИ ЦЕН =====================
+
+
+@router.post("/registrar/cart/edit-delta", response_model=EditDeltaResponse)
+def apply_registrar_cart_edit_delta(
+    request: EditDeltaRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_roles("Admin", "Registrar")),
+):
+    try:
+        result = RegistrarEditDeltaService(db).apply(
+            patient_id=request.patient_id,
+            services=[
+                RegistrarEditDeltaItem(
+                    service_id=item.service_id,
+                    quantity=item.quantity,
+                    specialist_id=item.specialist_id,
+                )
+                for item in request.services
+            ],
+            target_date=request.target_date,
+            payment_method=request.payment_method,
+            discount_mode=request.discount_mode,
+            all_free=request.all_free,
+            patient_data=(
+                request.patient_data.model_dump(exclude_none=True)
+                if request.patient_data
+                else None
+            ),
+            existing_queue_entry_ids=request.existing_queue_entry_ids,
+            current_user=current_user,
+        )
+        return EditDeltaResponse(**result)
+    except ValueError as exc:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc))
+    except HTTPException:
+        db.rollback()
+        raise
+    except Exception as exc:
+        logger.exception(
+            "REGISTRATION: edit delta failed",
+            extra={"error_class": exc.__class__.__name__},
+        )
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Ошибка обновления записи",
+        )
 
 
 class PriceOverrideApprovalRequest(BaseModel):
@@ -2467,6 +2556,47 @@ def _preserve_operational_status_on_payment(raw_status: str | None) -> str:
     return raw_status
 
 
+def _sync_payment_invoices_for_paid_visit(
+    db: Session,
+    *,
+    visit_id: int,
+    payment_method: str,
+) -> None:
+    """Mark linked registrar invoices paid once all their visits have paid Payment rows."""
+    from app.models.payment import Payment
+
+    links = (
+        db.query(PaymentInvoiceVisit)
+        .filter(PaymentInvoiceVisit.visit_id == visit_id)
+        .all()
+    )
+    for link in links:
+        invoice = link.invoice
+        if not invoice or invoice.status not in {"pending", "processing"}:
+            continue
+
+        visit_ids = [invoice_visit.visit_id for invoice_visit in invoice.visits]
+        if not visit_ids:
+            continue
+
+        paid_visit_ids = {
+            row[0]
+            for row in (
+                db.query(Payment.visit_id)
+                .filter(
+                    Payment.visit_id.in_(visit_ids),
+                    Payment.status == "paid",
+                )
+                .distinct()
+                .all()
+            )
+        }
+        if all(invoice_visit_id in paid_visit_ids for invoice_visit_id in visit_ids):
+            invoice.status = "paid"
+            invoice.payment_method = payment_method or invoice.payment_method
+            invoice.paid_at = datetime.utcnow()
+
+
 REGISTRAR_COMMAND_ROLE_BY_ACTION = {
     "mark_paid": {"admin", "registrar", "cashier"},
     "start_visit": {
@@ -2844,6 +2974,15 @@ def mark_visit_as_paid(
 
         # [FIX:PAYMENT_STATUS] Payment must not overwrite the operational visit/queue status.
         visit.status = _preserve_operational_status_on_payment(visit.status)
+        _sync_payment_invoices_for_paid_visit(
+            db,
+            visit_id=visit.id,
+            payment_method=(
+                existing_payment.method
+                if existing_payment and getattr(existing_payment, "method", None)
+                else requested_method
+            ),
+        )
         logger.info(
             "[FIX:PAYMENT_STATUS] Visit marked paid without changing operational status: visit_id=%d, status=%s",
             visit.id,
@@ -3025,6 +3164,15 @@ def mark_queue_entry_as_paid(
         visit.status = _preserve_operational_status_on_payment(visit.status)
         
         entry.status = _preserve_operational_status_on_payment(entry.status)
+        _sync_payment_invoices_for_paid_visit(
+            db,
+            visit_id=visit.id,
+            payment_method=(
+                existing_payment.method
+                if existing_payment and getattr(existing_payment, "method", None)
+                else requested_method
+            ),
+        )
         logger.info(
             "[FIX:PAYMENT_STATUS] Queue entry marked paid without changing operational status: entry_id=%d, visit_id=%d, entry_status=%s, visit_status=%s",
             entry.id,

--- a/backend/app/services/registrar_edit_delta_service.py
+++ b/backend/app/services/registrar_edit_delta_service.py
@@ -1,0 +1,677 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.crud.patient import normalize_patient_name
+from app.models.clinic import Doctor
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.patient import Patient
+from app.models.payment_invoice import PaymentInvoice, PaymentInvoiceVisit
+from app.models.service import Service
+from app.models.user import User
+from app.models.visit import Visit, VisitService
+from app.services.queue_service import queue_service
+from app.services.service_mapping import get_service_code, normalize_service_code
+
+
+ACTIVE_APPEND_STATUSES = ("waiting", "called", "in_service", "diagnostics")
+
+
+@dataclass(frozen=True)
+class RegistrarEditDeltaItem:
+    service_id: int
+    quantity: int = 1
+    specialist_id: int | None = None
+
+
+class RegistrarEditDeltaService:
+    """Append edit-mode service deltas without duplicating active queue rows."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def apply(
+        self,
+        *,
+        patient_id: int,
+        services: list[RegistrarEditDeltaItem],
+        target_date: date,
+        payment_method: str,
+        discount_mode: str,
+        all_free: bool,
+        patient_data: dict[str, Any] | None = None,
+        existing_queue_entry_ids: list[int] | None = None,
+        current_user: User | None = None,
+    ) -> dict[str, Any]:
+        patient = self.db.query(Patient).filter(Patient.id == patient_id).first()
+        if not patient:
+            raise ValueError(f"Patient {patient_id} not found")
+
+        if patient_data:
+            self._apply_patient_data(patient, patient_data)
+
+        queue_entry_ids = set(existing_queue_entry_ids or [])
+        queue_numbers: dict[int, list[dict[str, Any]]] = {}
+        visit_delta_amounts: dict[int, Decimal] = {}
+        updated_queue_entries: list[dict[str, Any]] = []
+        created_visit_payloads: dict[int, dict[str, Any]] = {}
+
+        for item in services:
+            service = self.db.query(Service).filter(Service.id == item.service_id).first()
+            if not service:
+                raise ValueError(f"Service {item.service_id} not found")
+
+            queue_tag = service.queue_tag or service.department_key
+            if not queue_tag:
+                raise ValueError(f"Service {service.id} has no queue tag")
+
+            requested_qty = max(int(item.quantity or 1), 1)
+            entry = self._find_active_entry(
+                patient_id=patient_id,
+                queue_tag=queue_tag,
+                target_date=target_date,
+                preferred_entry_ids=queue_entry_ids,
+            )
+
+            if entry:
+                delta = self._append_to_existing_entry(
+                    entry=entry,
+                    patient=patient,
+                    service=service,
+                    requested_qty=requested_qty,
+                    target_date=target_date,
+                    specialist_id=item.specialist_id,
+                    discount_mode=discount_mode,
+                    all_free=all_free,
+                    current_user=current_user,
+                )
+            else:
+                delta = self._create_new_queue_entry(
+                    patient=patient,
+                    service=service,
+                    requested_qty=requested_qty,
+                    target_date=target_date,
+                    specialist_id=item.specialist_id,
+                    discount_mode=discount_mode,
+                    all_free=all_free,
+                    current_user=current_user,
+                )
+
+            if delta["delta_amount"] > 0 and delta["visit_id"]:
+                visit_id = int(delta["visit_id"])
+                visit_delta_amounts[visit_id] = (
+                    visit_delta_amounts.get(visit_id, Decimal("0"))
+                    + delta["delta_amount"]
+                )
+                created_visit_payloads.setdefault(
+                    visit_id,
+                    {
+                        "visit_id": visit_id,
+                        "patient_name": patient.short_name(),
+                        "doctor_name": self._doctor_name(delta.get("doctor_id")),
+                        "visit_date": target_date.isoformat(),
+                        "visit_time": None,
+                        "status": "open",
+                        "department": service.department_key or service.queue_tag,
+                        "services": [],
+                        "confirmation_required": False,
+                        "confirmation_token": None,
+                    },
+                )
+                created_visit_payloads[visit_id]["services"].append(
+                    self._service_response_payload(
+                        service=service,
+                        quantity=delta["delta_quantity"],
+                        price=delta["unit_price"],
+                    )
+                )
+
+            if delta["visit_id"]:
+                queue_numbers.setdefault(int(delta["visit_id"]), [])
+                assignment = {
+                    "queue_tag": queue_tag,
+                    "queue_id": delta["queue_id"],
+                    "number": delta["number"],
+                    "status": delta["queue_status"],
+                    "queue_entry_id": delta["queue_entry_id"],
+                }
+                if assignment not in queue_numbers[int(delta["visit_id"])]:
+                    queue_numbers[int(delta["visit_id"])].append(assignment)
+
+            updated_queue_entries.append(
+                {
+                    "queue_entry_id": delta["queue_entry_id"],
+                    "queue_id": delta["queue_id"],
+                    "queue_tag": queue_tag,
+                    "number": delta["number"],
+                    "status": delta["queue_status"],
+                    "visit_id": delta["visit_id"],
+                    "delta_quantity": delta["delta_quantity"],
+                    "delta_amount": delta["delta_amount"],
+                }
+            )
+
+        total_amount = sum(visit_delta_amounts.values(), Decimal("0"))
+        invoice = self._apply_invoice_delta(
+            patient_id=patient_id,
+            payment_method=payment_method,
+            visit_delta_amounts=visit_delta_amounts,
+            total_amount=total_amount,
+        )
+
+        self.db.commit()
+
+        return {
+            "success": True,
+            "message": (
+                "Запись обновлена. Добавленные услуги сохранены в существующей очереди."
+                if total_amount > 0
+                else "Запись обновлена. Новых платных услуг не добавлено."
+            ),
+            "invoice_id": invoice.id if invoice else None,
+            "visit_ids": list(visit_delta_amounts.keys()),
+            "total_amount": total_amount,
+            "queue_numbers": queue_numbers,
+            "print_tickets": [],
+            "created_visits": list(created_visit_payloads.values()),
+            "updated_queue_entries": updated_queue_entries,
+        }
+
+    def _apply_patient_data(self, patient: Patient, patient_data: dict[str, Any]) -> None:
+        if patient_data.get("full_name"):
+            names = normalize_patient_name(full_name=patient_data["full_name"])
+            if names["last_name"]:
+                patient.last_name = names["last_name"]
+            if names["first_name"]:
+                patient.first_name = names["first_name"]
+            patient.middle_name = names["middle_name"]
+        for attr in ("phone", "address"):
+            if patient_data.get(attr) is not None:
+                setattr(patient, attr, patient_data[attr])
+        if patient_data.get("sex") is not None:
+            patient.sex = patient_data["sex"]
+        if patient_data.get("birth_date") is not None:
+            patient.birth_date = patient_data["birth_date"]
+
+    def _find_active_entry(
+        self,
+        *,
+        patient_id: int,
+        queue_tag: str,
+        target_date: date,
+        preferred_entry_ids: set[int],
+    ) -> OnlineQueueEntry | None:
+        entries = (
+            self.db.query(OnlineQueueEntry)
+            .join(DailyQueue, OnlineQueueEntry.queue_id == DailyQueue.id)
+            .filter(
+                OnlineQueueEntry.patient_id == patient_id,
+                OnlineQueueEntry.status.in_(ACTIVE_APPEND_STATUSES),
+                DailyQueue.day == target_date,
+                DailyQueue.queue_tag == queue_tag,
+                DailyQueue.active.is_(True),
+            )
+            .order_by(OnlineQueueEntry.queue_time.asc(), OnlineQueueEntry.id.asc())
+            .all()
+        )
+        if preferred_entry_ids:
+            preferred = [entry for entry in entries if entry.id in preferred_entry_ids]
+            if preferred:
+                return preferred[0]
+        return entries[0] if entries else None
+
+    def _append_to_existing_entry(
+        self,
+        *,
+        entry: OnlineQueueEntry,
+        patient: Patient,
+        service: Service,
+        requested_qty: int,
+        target_date: date,
+        specialist_id: int | None,
+        discount_mode: str,
+        all_free: bool,
+        current_user: User | None,
+    ) -> dict[str, Any]:
+        services = self._coerce_services(entry.services)
+        existing_payload = self._find_service_payload(services, service)
+        existing_qty = self._payload_quantity(existing_payload) if existing_payload else 0
+        delta_qty = max(requested_qty - existing_qty, 0) if existing_payload else requested_qty
+        unit_price = Decimal("0") if all_free else Decimal(str(service.price or 0))
+        delta_amount = unit_price * Decimal(delta_qty)
+
+        if delta_qty > 0:
+            if existing_payload:
+                existing_payload["quantity"] = requested_qty
+                existing_payload["qty"] = requested_qty
+            else:
+                services.append(
+                    self._entry_service_payload(
+                        service=service,
+                        quantity=requested_qty,
+                        unit_price=unit_price,
+                    )
+                )
+            entry.services = services
+            entry.service_codes = self._merged_service_codes(entry.service_codes, service)
+            entry.total_amount = int(Decimal(str(entry.total_amount or 0)) + delta_amount)
+
+        visit = self._ensure_entry_visit(
+            entry=entry,
+            patient=patient,
+            service=service,
+            target_date=target_date,
+            specialist_id=specialist_id,
+            discount_mode=discount_mode,
+            current_user=current_user,
+            create_only_if_needed=delta_qty > 0,
+        )
+
+        if visit and delta_qty > 0:
+            self._append_visit_service(
+                visit=visit,
+                service=service,
+                requested_qty=requested_qty,
+                delta_qty=delta_qty,
+                unit_price=unit_price,
+            )
+
+        return self._delta_result(
+            entry=entry,
+            service=service,
+            visit=visit,
+            delta_qty=delta_qty,
+            unit_price=unit_price,
+            delta_amount=delta_amount,
+        )
+
+    def _create_new_queue_entry(
+        self,
+        *,
+        patient: Patient,
+        service: Service,
+        requested_qty: int,
+        target_date: date,
+        specialist_id: int | None,
+        discount_mode: str,
+        all_free: bool,
+        current_user: User | None,
+    ) -> dict[str, Any]:
+        queue_tag = service.queue_tag or service.department_key
+        daily_queue = self._resolve_daily_queue(
+            service=service,
+            specialist_id=specialist_id,
+            queue_tag=queue_tag,
+            target_date=target_date,
+        )
+        unit_price = Decimal("0") if all_free else Decimal(str(service.price or 0))
+        delta_amount = unit_price * Decimal(requested_qty)
+        visit = self._create_visit(
+            patient=patient,
+            service=service,
+            target_date=target_date,
+            specialist_id=specialist_id or daily_queue.specialist_id,
+            discount_mode=discount_mode,
+            current_user=current_user,
+        )
+        self._append_visit_service(
+            visit=visit,
+            service=service,
+            requested_qty=requested_qty,
+            delta_qty=requested_qty,
+            unit_price=unit_price,
+        )
+        entry = queue_service.create_queue_entry(
+            self.db,
+            daily_queue=daily_queue,
+            patient_id=patient.id,
+            patient_name=patient.short_name(),
+            phone=patient.phone,
+            visit_id=visit.id,
+            source="desk",
+            status="waiting",
+            services=[
+                self._entry_service_payload(
+                    service=service,
+                    quantity=requested_qty,
+                    unit_price=unit_price,
+                )
+            ],
+            service_codes=self._merged_service_codes([], service),
+            total_amount=int(delta_amount),
+            auto_number=True,
+            commit=False,
+        )
+        return self._delta_result(
+            entry=entry,
+            service=service,
+            visit=visit,
+            delta_qty=requested_qty,
+            unit_price=unit_price,
+            delta_amount=delta_amount,
+        )
+
+    def _ensure_entry_visit(
+        self,
+        *,
+        entry: OnlineQueueEntry,
+        patient: Patient,
+        service: Service,
+        target_date: date,
+        specialist_id: int | None,
+        discount_mode: str,
+        current_user: User | None,
+        create_only_if_needed: bool,
+    ) -> Visit | None:
+        if entry.visit_id:
+            return self.db.query(Visit).filter(Visit.id == entry.visit_id).first()
+        if not create_only_if_needed:
+            return None
+        visit = self._create_visit(
+            patient=patient,
+            service=service,
+            target_date=target_date,
+            specialist_id=specialist_id or entry.queue.specialist_id,
+            discount_mode=discount_mode,
+            current_user=current_user,
+        )
+        entry.visit_id = visit.id
+        return visit
+
+    def _create_visit(
+        self,
+        *,
+        patient: Patient,
+        service: Service,
+        target_date: date,
+        specialist_id: int | None,
+        discount_mode: str,
+        current_user: User | None,
+    ) -> Visit:
+        visit = Visit(
+            patient_id=patient.id,
+            doctor_id=specialist_id,
+            visit_date=target_date,
+            visit_time=None,
+            department=service.department_key or service.queue_tag,
+            discount_mode=discount_mode or "none",
+            status="open",
+            approval_status="approved",
+            confirmed_at=datetime.utcnow(),
+            confirmed_by=f"registrar_{current_user.id}" if current_user else None,
+            source="desk",
+        )
+        self.db.add(visit)
+        self.db.flush()
+        return visit
+
+    def _append_visit_service(
+        self,
+        *,
+        visit: Visit,
+        service: Service,
+        requested_qty: int,
+        delta_qty: int,
+        unit_price: Decimal,
+    ) -> None:
+        existing = (
+            self.db.query(VisitService)
+            .filter(VisitService.visit_id == visit.id, VisitService.service_id == service.id)
+            .first()
+        )
+        code = self._service_code(service)
+        if existing:
+            existing.qty = max(existing.qty or 0, requested_qty)
+            existing.price = unit_price
+            existing.code = code
+            existing.name = service.name
+            existing.currency = service.currency or "UZS"
+            return
+        self.db.add(
+            VisitService(
+                visit_id=visit.id,
+                service_id=service.id,
+                code=code,
+                name=service.name,
+                qty=delta_qty,
+                price=unit_price,
+                currency=service.currency or "UZS",
+            )
+        )
+
+    def _resolve_daily_queue(
+        self,
+        *,
+        service: Service,
+        specialist_id: int | None,
+        queue_tag: str | None,
+        target_date: date,
+    ) -> DailyQueue:
+        existing = (
+            self.db.query(DailyQueue)
+            .filter(
+                DailyQueue.day == target_date,
+                DailyQueue.queue_tag == queue_tag,
+                DailyQueue.active.is_(True),
+            )
+            .order_by(DailyQueue.id.asc())
+            .first()
+        )
+        if existing:
+            return existing
+
+        resolved_specialist_id = specialist_id or service.doctor_id
+        if not resolved_specialist_id:
+            raise ValueError(
+                f"No active queue exists for queue_tag={queue_tag}; specialist_id is required"
+            )
+        return queue_service.get_or_create_daily_queue(
+            self.db,
+            day=target_date,
+            specialist_id=resolved_specialist_id,
+            queue_tag=queue_tag,
+            defaults={},
+        )
+
+    def _apply_invoice_delta(
+        self,
+        *,
+        patient_id: int,
+        payment_method: str,
+        visit_delta_amounts: dict[int, Decimal],
+        total_amount: Decimal,
+    ) -> PaymentInvoice | None:
+        if total_amount <= 0:
+            return None
+        visit_ids = list(visit_delta_amounts.keys())
+        invoice = (
+            self.db.query(PaymentInvoice)
+            .join(PaymentInvoiceVisit, PaymentInvoiceVisit.invoice_id == PaymentInvoice.id)
+            .filter(
+                PaymentInvoice.patient_id == patient_id,
+                PaymentInvoice.status == "pending",
+                PaymentInvoiceVisit.visit_id.in_(visit_ids),
+            )
+            .order_by(PaymentInvoice.created_at.desc())
+            .first()
+        )
+        if invoice:
+            invoice.total_amount = Decimal(str(invoice.total_amount or 0)) + total_amount
+        else:
+            invoice = PaymentInvoice(
+                patient_id=patient_id,
+                total_amount=total_amount,
+                currency="UZS",
+                status="pending",
+                payment_method=payment_method or "cash",
+                notes="edit-delta",
+            )
+            self.db.add(invoice)
+            self.db.flush()
+
+        for visit_id, visit_amount in visit_delta_amounts.items():
+            link = (
+                self.db.query(PaymentInvoiceVisit)
+                .filter(
+                    PaymentInvoiceVisit.invoice_id == invoice.id,
+                    PaymentInvoiceVisit.visit_id == visit_id,
+                )
+                .first()
+            )
+            if link:
+                link.visit_amount = Decimal(str(link.visit_amount or 0)) + visit_amount
+            else:
+                self.db.add(
+                    PaymentInvoiceVisit(
+                        invoice_id=invoice.id,
+                        visit_id=visit_id,
+                        visit_amount=visit_amount,
+                    )
+                )
+        return invoice
+
+    def _delta_result(
+        self,
+        *,
+        entry: OnlineQueueEntry,
+        service: Service,
+        visit: Visit | None,
+        delta_qty: int,
+        unit_price: Decimal,
+        delta_amount: Decimal,
+    ) -> dict[str, Any]:
+        return {
+            "queue_entry_id": entry.id,
+            "queue_id": entry.queue_id,
+            "number": entry.number,
+            "queue_status": entry.status,
+            "visit_id": visit.id if visit else entry.visit_id,
+            "doctor_id": visit.doctor_id if visit else None,
+            "service_id": service.id,
+            "delta_quantity": delta_qty,
+            "unit_price": unit_price,
+            "delta_amount": delta_amount,
+        }
+
+    def _coerce_services(self, services_value: Any) -> list[dict[str, Any]]:
+        if not services_value:
+            return []
+        if isinstance(services_value, list):
+            return [
+                dict(item) if isinstance(item, dict) else {"name": str(item)}
+                for item in services_value
+            ]
+        if isinstance(services_value, str):
+            try:
+                parsed = json.loads(services_value)
+                if isinstance(parsed, str):
+                    parsed = json.loads(parsed)
+                if isinstance(parsed, list):
+                    return [
+                        dict(item) if isinstance(item, dict) else {"name": str(item)}
+                        for item in parsed
+                    ]
+            except Exception:
+                return []
+        return []
+
+    def _find_service_payload(
+        self, services: list[dict[str, Any]], service: Service
+    ) -> dict[str, Any] | None:
+        target_code = self._service_code(service)
+        for payload in services:
+            payload_id = payload.get("service_id") or payload.get("id")
+            payload_code = payload.get("code") or payload.get("service_code")
+            if payload_id == service.id:
+                return payload
+            if target_code and payload_code and normalize_service_code(payload_code) == target_code:
+                return payload
+        return None
+
+    def _payload_quantity(self, payload: dict[str, Any] | None) -> int:
+        if not payload:
+            return 0
+        try:
+            return max(int(payload.get("quantity") or payload.get("qty") or 1), 1)
+        except (TypeError, ValueError):
+            return 1
+
+    def _entry_service_payload(
+        self,
+        *,
+        service: Service,
+        quantity: int,
+        unit_price: Decimal,
+    ) -> dict[str, Any]:
+        code = self._service_code(service)
+        return {
+            "id": service.id,
+            "service_id": service.id,
+            "code": code,
+            "service_code": code,
+            "name": service.name,
+            "service_name": service.name,
+            "quantity": quantity,
+            "qty": quantity,
+            "price": float(unit_price),
+        }
+
+    def _service_response_payload(
+        self,
+        *,
+        service: Service,
+        quantity: int,
+        price: Decimal,
+    ) -> dict[str, Any]:
+        code = self._service_code(service)
+        return {
+            "name": service.name,
+            "code": code,
+            "quantity": quantity,
+            "price": float(price),
+        }
+
+    def _merged_service_codes(self, existing_codes: Any, service: Service) -> list[str]:
+        codes: list[str] = []
+        if isinstance(existing_codes, list):
+            codes.extend(str(code) for code in existing_codes if code)
+        elif isinstance(existing_codes, str):
+            try:
+                parsed = json.loads(existing_codes)
+                if isinstance(parsed, list):
+                    codes.extend(str(code) for code in parsed if code)
+            except Exception:
+                if existing_codes:
+                    codes.append(existing_codes)
+        code = self._service_code(service)
+        if code:
+            codes.append(code)
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for code_value in codes:
+            normalized = normalize_service_code(code_value)
+            if normalized and normalized not in seen:
+                deduped.append(normalized)
+                seen.add(normalized)
+        return deduped
+
+    def _service_code(self, service: Service) -> str | None:
+        raw = service.service_code or service.code or get_service_code(service.id, self.db)
+        return normalize_service_code(raw) if raw else None
+
+    def _doctor_name(self, doctor_id: int | None) -> str:
+        if not doctor_id:
+            return "Без врача"
+        doctor = self.db.query(Doctor).filter(Doctor.id == doctor_id).first()
+        if not doctor:
+            return "Без врача"
+        user = getattr(doctor, "user", None)
+        if user:
+            return user.full_name or user.username or "Без врача"
+        return str(doctor.specialty or "Без врача")

--- a/backend/tests/characterization/test_registrar_edit_delta_characterization.py
+++ b/backend/tests/characterization/test_registrar_edit_delta_characterization.py
@@ -1,0 +1,595 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.payment import Payment
+from app.models.payment_invoice import PaymentInvoice, PaymentInvoiceVisit
+from app.models.service import Service
+from app.models.visit import Visit, VisitService
+from app.services.service_mapping import normalize_service_code
+
+
+def _create_service(
+    db_session,
+    *,
+    code: str,
+    name: str,
+    queue_tag: str,
+    price: Decimal = Decimal("25000"),
+    requires_doctor: bool = False,
+) -> Service:
+    service = Service(
+        code=code,
+        service_code=code,
+        name=name,
+        price=price,
+        active=True,
+        requires_doctor=requires_doctor,
+        queue_tag=queue_tag,
+        department_key=queue_tag,
+        is_consultation=requires_doctor,
+    )
+    db_session.add(service)
+    db_session.commit()
+    db_session.refresh(service)
+    return service
+
+
+def _create_queue(
+    db_session,
+    *,
+    specialist_id: int,
+    queue_tag: str,
+) -> DailyQueue:
+    queue = DailyQueue(
+        day=date.today(),
+        specialist_id=specialist_id,
+        queue_tag=queue_tag,
+        active=True,
+    )
+    db_session.add(queue)
+    db_session.commit()
+    db_session.refresh(queue)
+    return queue
+
+
+def _create_entry(
+    db_session,
+    *,
+    queue: DailyQueue,
+    patient,
+    service: Service,
+    status: str = "waiting",
+    visit_id: int | None = None,
+) -> OnlineQueueEntry:
+    entry = OnlineQueueEntry(
+        queue_id=queue.id,
+        number=9,
+        patient_id=patient.id,
+        patient_name=patient.short_name(),
+        phone=patient.phone,
+        visit_id=visit_id,
+        source="desk",
+        status=status,
+        queue_time=datetime.now(ZoneInfo("Asia/Tashkent")).replace(microsecond=0),
+        services=[
+            {
+                "id": service.id,
+                "service_id": service.id,
+                "code": service.service_code,
+                "name": service.name,
+                "quantity": 1,
+                "price": float(service.price or 0),
+            }
+        ],
+        service_codes=[service.service_code],
+        total_amount=int(service.price or 0),
+    )
+    db_session.add(entry)
+    db_session.commit()
+    db_session.refresh(entry)
+    return entry
+
+
+def _create_visit(db_session, *, patient, doctor_id: int | None, department: str) -> Visit:
+    visit = Visit(
+        patient_id=patient.id,
+        doctor_id=doctor_id,
+        visit_date=date.today(),
+        visit_time=None,
+        department=department,
+        discount_mode="none",
+        approval_status="approved",
+        status="open",
+        source="desk",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+    return visit
+
+
+def _post_edit_delta(client, registrar_auth_headers, *, patient_id: int, services: list[dict], entry_ids: list[int] | None = None):
+    return client.post(
+        "/api/v1/registrar/cart/edit-delta",
+        headers=registrar_auth_headers,
+        json={
+            "patient_id": patient_id,
+            "target_date": date.today().isoformat(),
+            "payment_method": "cash",
+            "discount_mode": "none",
+            "all_free": False,
+            "services": services,
+            "existing_queue_entry_ids": entry_ids or [],
+        },
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_edit_delta_appends_lab_service_to_waiting_queue_without_duplicate_row(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+):
+    original_service = _create_service(
+        db_session,
+        code="LAB-OLD-01",
+        name="Old Lab",
+        queue_tag="laboratory_general",
+    )
+    added_service = _create_service(
+        db_session,
+        code="LAB-NEW-01",
+        name="New Lab",
+        queue_tag="laboratory_general",
+    )
+    queue = _create_queue(
+        db_session,
+        specialist_id=test_doctor.id,
+        queue_tag="laboratory_general",
+    )
+    entry = _create_entry(
+        db_session,
+        queue=queue,
+        patient=test_patient,
+        service=original_service,
+        status="waiting",
+    )
+    preserved_queue_time = entry.queue_time
+
+    response = _post_edit_delta(
+        client,
+        registrar_auth_headers,
+        patient_id=test_patient.id,
+        services=[{"service_id": added_service.id, "quantity": 1}],
+        entry_ids=[entry.id],
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["invoice_id"] is not None
+    assert Decimal(str(payload["total_amount"])) == Decimal("25000")
+
+    entries = (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.patient_id == test_patient.id)
+        .all()
+    )
+    assert len(entries) == 1
+    db_session.refresh(entry)
+    assert entry.number == 9
+    assert entry.queue_time == preserved_queue_time
+    assert {svc["service_id"] for svc in entry.services} == {
+        original_service.id,
+        added_service.id,
+    }
+    assert set(entry.service_codes) == {
+        normalize_service_code("LAB-OLD-01"),
+        normalize_service_code("LAB-NEW-01"),
+    }
+    assert payload["queue_numbers"][str(entry.visit_id)][0]["number"] == 9
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_edit_delta_appends_to_diagnostics_queue_without_new_row(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+):
+    original_service = _create_service(
+        db_session,
+        code="DIAG-OLD-01",
+        name="Old Diagnostics",
+        queue_tag="laboratory_general",
+    )
+    added_service = _create_service(
+        db_session,
+        code="DIAG-NEW-01",
+        name="New Diagnostics",
+        queue_tag="laboratory_general",
+    )
+    queue = _create_queue(
+        db_session,
+        specialist_id=test_doctor.id,
+        queue_tag="laboratory_general",
+    )
+    entry = _create_entry(
+        db_session,
+        queue=queue,
+        patient=test_patient,
+        service=original_service,
+        status="diagnostics",
+    )
+
+    response = _post_edit_delta(
+        client,
+        registrar_auth_headers,
+        patient_id=test_patient.id,
+        services=[{"service_id": added_service.id, "quantity": 1}],
+        entry_ids=[entry.id],
+    )
+
+    assert response.status_code == 200, response.text
+    assert (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.patient_id == test_patient.id)
+        .count()
+        == 1
+    )
+    db_session.refresh(entry)
+    assert entry.status == "diagnostics"
+    assert {svc["service_id"] for svc in entry.services} == {
+        original_service.id,
+        added_service.id,
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_edit_delta_different_queue_type_creates_only_new_type_row(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+):
+    lab_service = _create_service(
+        db_session,
+        code="LAB-BASE-01",
+        name="Base Lab",
+        queue_tag="laboratory_general",
+    )
+    cardio_service = _create_service(
+        db_session,
+        code="CARD-NEW-01",
+        name="New Cardiology",
+        queue_tag="cardiology_common",
+        requires_doctor=True,
+    )
+    lab_queue = _create_queue(
+        db_session,
+        specialist_id=test_doctor.id,
+        queue_tag="laboratory_general",
+    )
+    lab_entry = _create_entry(
+        db_session,
+        queue=lab_queue,
+        patient=test_patient,
+        service=lab_service,
+    )
+
+    response = _post_edit_delta(
+        client,
+        registrar_auth_headers,
+        patient_id=test_patient.id,
+        services=[
+            {
+                "service_id": cardio_service.id,
+                "quantity": 1,
+                "specialist_id": test_doctor.id,
+            }
+        ],
+        entry_ids=[lab_entry.id],
+    )
+
+    assert response.status_code == 200, response.text
+    entries = (
+        db_session.query(OnlineQueueEntry)
+        .filter(OnlineQueueEntry.patient_id == test_patient.id)
+        .order_by(OnlineQueueEntry.id.asc())
+        .all()
+    )
+    assert len(entries) == 2
+    assert entries[0].id == lab_entry.id
+    assert entries[0].number == 9
+    new_entry = entries[1]
+    assert new_entry.id != lab_entry.id
+    assert new_entry.visit_id is not None
+    assert new_entry.services[0]["service_id"] == cardio_service.id
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_edit_delta_readding_same_service_is_noop_and_does_not_invoice(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+):
+    service = _create_service(
+        db_session,
+        code="LAB-SAME-01",
+        name="Same Lab",
+        queue_tag="laboratory_general",
+    )
+    queue = _create_queue(
+        db_session,
+        specialist_id=test_doctor.id,
+        queue_tag="laboratory_general",
+    )
+    entry = _create_entry(db_session, queue=queue, patient=test_patient, service=service)
+
+    response = _post_edit_delta(
+        client,
+        registrar_auth_headers,
+        patient_id=test_patient.id,
+        services=[{"service_id": service.id, "quantity": 1}],
+        entry_ids=[entry.id],
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["invoice_id"] is None
+    assert Decimal(str(payload["total_amount"])) == Decimal("0")
+    assert (
+        db_session.query(PaymentInvoice)
+        .filter(PaymentInvoice.patient_id == test_patient.id)
+        .count()
+        == 0
+    )
+    db_session.refresh(entry)
+    assert len(entry.services) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_edit_delta_pending_invoice_receives_delta(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+):
+    original_service = _create_service(
+        db_session,
+        code="INV-OLD-01",
+        name="Old Invoice Lab",
+        queue_tag="laboratory_general",
+    )
+    added_service = _create_service(
+        db_session,
+        code="INV-NEW-01",
+        name="New Invoice Lab",
+        queue_tag="laboratory_general",
+        price=Decimal("30000"),
+    )
+    visit = _create_visit(
+        db_session,
+        patient=test_patient,
+        doctor_id=test_doctor.id,
+        department="laboratory_general",
+    )
+    queue = _create_queue(
+        db_session,
+        specialist_id=test_doctor.id,
+        queue_tag="laboratory_general",
+    )
+    entry = _create_entry(
+        db_session,
+        queue=queue,
+        patient=test_patient,
+        service=original_service,
+        visit_id=visit.id,
+    )
+    invoice = PaymentInvoice(
+        patient_id=test_patient.id,
+        total_amount=Decimal("10000"),
+        currency="UZS",
+        status="pending",
+        payment_method="cash",
+    )
+    db_session.add(invoice)
+    db_session.flush()
+    db_session.add(
+        PaymentInvoiceVisit(
+            invoice_id=invoice.id,
+            visit_id=visit.id,
+            visit_amount=Decimal("10000"),
+        )
+    )
+    db_session.commit()
+
+    response = _post_edit_delta(
+        client,
+        registrar_auth_headers,
+        patient_id=test_patient.id,
+        services=[{"service_id": added_service.id, "quantity": 1}],
+        entry_ids=[entry.id],
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["invoice_id"] == invoice.id
+    db_session.refresh(invoice)
+    assert invoice.total_amount == Decimal("40000.00")
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_mark_paid_syncs_pending_edit_delta_invoice_after_visit_payment(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+):
+    service = _create_service(
+        db_session,
+        code="PAY-SYNC-01",
+        name="Payment Sync Lab",
+        queue_tag="laboratory_general",
+        price=Decimal("30000"),
+    )
+    visit = _create_visit(
+        db_session,
+        patient=test_patient,
+        doctor_id=test_doctor.id,
+        department="laboratory_general",
+    )
+    db_session.add(
+        VisitService(
+            visit_id=visit.id,
+            service_id=service.id,
+            code=service.service_code,
+            name=service.name,
+            qty=1,
+            price=service.price,
+            currency="UZS",
+        )
+    )
+    invoice = PaymentInvoice(
+        patient_id=test_patient.id,
+        total_amount=Decimal("30000"),
+        currency="UZS",
+        status="pending",
+        payment_method="cash",
+        notes="edit-delta",
+    )
+    db_session.add(invoice)
+    db_session.flush()
+    db_session.add(
+        PaymentInvoiceVisit(
+            invoice_id=invoice.id,
+            visit_id=visit.id,
+            visit_amount=Decimal("30000"),
+        )
+    )
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/registrar/records/actions",
+        headers=registrar_auth_headers,
+        json={
+            "action": "mark_paid",
+            "amount": 30000,
+            "method": "cash",
+            "records": [{"record_kind": "visit", "record_id": visit.id}],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["success_count"] == 1
+
+    db_session.refresh(invoice)
+    assert invoice.status == "paid"
+    assert invoice.paid_at is not None
+    assert (
+        db_session.query(Payment)
+        .filter(Payment.visit_id == visit.id, Payment.status == "paid")
+        .count()
+        == 1
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_edit_delta_paid_invoice_creates_supplemental_invoice(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+):
+    original_service = _create_service(
+        db_session,
+        code="PAID-OLD-01",
+        name="Old Paid Lab",
+        queue_tag="laboratory_general",
+    )
+    added_service = _create_service(
+        db_session,
+        code="PAID-NEW-01",
+        name="New Paid Lab",
+        queue_tag="laboratory_general",
+        price=Decimal("45000"),
+    )
+    visit = _create_visit(
+        db_session,
+        patient=test_patient,
+        doctor_id=test_doctor.id,
+        department="laboratory_general",
+    )
+    queue = _create_queue(
+        db_session,
+        specialist_id=test_doctor.id,
+        queue_tag="laboratory_general",
+    )
+    entry = _create_entry(
+        db_session,
+        queue=queue,
+        patient=test_patient,
+        service=original_service,
+        visit_id=visit.id,
+    )
+    paid_invoice = PaymentInvoice(
+        patient_id=test_patient.id,
+        total_amount=Decimal("10000"),
+        currency="UZS",
+        status="paid",
+        payment_method="cash",
+    )
+    db_session.add(paid_invoice)
+    db_session.flush()
+    db_session.add(
+        PaymentInvoiceVisit(
+            invoice_id=paid_invoice.id,
+            visit_id=visit.id,
+            visit_amount=Decimal("10000"),
+        )
+    )
+    db_session.commit()
+
+    response = _post_edit_delta(
+        client,
+        registrar_auth_headers,
+        patient_id=test_patient.id,
+        services=[{"service_id": added_service.id, "quantity": 1}],
+        entry_ids=[entry.id],
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["invoice_id"] != paid_invoice.id
+    invoices = (
+        db_session.query(PaymentInvoice)
+        .filter(PaymentInvoice.patient_id == test_patient.id)
+        .order_by(PaymentInvoice.id.asc())
+        .all()
+    )
+    assert [invoice.status for invoice in invoices] == ["paid", "pending"]
+    assert invoices[-1].total_amount == Decimal("45000.00")

--- a/frontend/src/api/__tests__/queue.test.js
+++ b/frontend/src/api/__tests__/queue.test.js
@@ -10,6 +10,7 @@ vi.mock('../client', () => ({
 
 import { api } from '../client';
 import {
+  applyRegistrarEditDelta,
   completeQueueJoinSession,
   fetchPublicQueueProfiles,
   fetchQrTokenInfo,
@@ -52,5 +53,35 @@ describe('queue API', () => {
 
     expect(api.post).toHaveBeenCalledWith('/queue/join/complete', payload);
     expect(data).toEqual({ success: true });
+  });
+
+  it('posts registrar edit deltas without create-like queue endpoints', async () => {
+    api.post.mockResolvedValueOnce({ data: { success: true, total_amount: 25000 } });
+
+    const data = await applyRegistrarEditDelta({
+      patientId: '42',
+      targetDate: '2026-05-31',
+      patientData: { full_name: 'Test Patient', sex: 'F' },
+      services: [
+        { service_id: '7', quantity: '2', specialist_id: null },
+        { service_id: 8, quantity: 1, specialist_id: '3' },
+      ],
+      existingQueueEntryIds: ['10', 11],
+    });
+
+    expect(api.post).toHaveBeenCalledWith('/registrar/cart/edit-delta', {
+      patient_id: 42,
+      target_date: '2026-05-31',
+      patient_data: { full_name: 'Test Patient', sex: 'F' },
+      payment_method: 'cash',
+      discount_mode: 'none',
+      all_free: false,
+      services: [
+        { service_id: 7, quantity: 2, specialist_id: null },
+        { service_id: 8, quantity: 1, specialist_id: 3 },
+      ],
+      existing_queue_entry_ids: [10, 11],
+    });
+    expect(data).toEqual({ success: true, total_amount: 25000 });
   });
 });

--- a/frontend/src/api/queue.js
+++ b/frontend/src/api/queue.js
@@ -117,6 +117,38 @@ export async function createQueueEntriesBatch({ patientId, source, services }) {
   return response.data;
 }
 
+export async function applyRegistrarEditDelta({
+  patientId,
+  targetDate,
+  patientData,
+  services,
+  paymentMethod = 'cash',
+  discountMode = 'none',
+  allFree = false,
+  existingQueueEntryIds = [],
+}) {
+  const payload = {
+    patient_id: Number(patientId),
+    target_date: targetDate,
+    patient_data: patientData || null,
+    payment_method: paymentMethod,
+    discount_mode: discountMode,
+    all_free: Boolean(allFree),
+    services: (services || []).map((service) => ({
+      service_id: Number(service.service_id),
+      quantity: Number(service.quantity || 1),
+      specialist_id: service.specialist_id === null || service.specialist_id === undefined
+        ? null
+        : Number(service.specialist_id),
+    })),
+    existing_queue_entry_ids: (existingQueueEntryIds || [])
+      .filter((id) => id !== null && id !== undefined && id !== '')
+      .map((id) => Number(id)),
+  };
+  const response = await api.post('/registrar/cart/edit-delta', payload);
+  return response.data;
+}
+
 /**
  * Обновление существующей QR-записи (вместо создания новой)
  * ⭐ SSOT: Этот endpoint обновляет существующую запись в очереди,

--- a/frontend/src/components/ui/macos/MacOSButton.jsx
+++ b/frontend/src/components/ui/macos/MacOSButton.jsx
@@ -49,7 +49,7 @@ const MacOSButton = ({
       border: '1px solid var(--mac-border)',
       hover: {
         backgroundColor: 'var(--mac-bg-tertiary)',
-        borderColor: 'var(--mac-border-hover)'
+        border: '1px solid var(--mac-border-hover)'
       },
       active: {
         backgroundColor: 'var(--mac-bg-quaternary)',
@@ -62,7 +62,7 @@ const MacOSButton = ({
       border: '1px solid var(--mac-accent-blue)',
       hover: {
         backgroundColor: 'var(--mac-accent-blue-hover)',
-        borderColor: 'var(--mac-accent-blue-hover)'
+        border: '1px solid var(--mac-accent-blue-hover)'
       },
       active: {
         backgroundColor: 'var(--mac-accent-blue-active)',
@@ -75,7 +75,7 @@ const MacOSButton = ({
       border: '1px solid var(--mac-border)',
       hover: {
         backgroundColor: 'var(--mac-bg-secondary)',
-        borderColor: 'var(--mac-border-hover)'
+        border: '1px solid var(--mac-border-hover)'
       },
       active: {
         backgroundColor: 'var(--mac-bg-tertiary)',
@@ -88,7 +88,7 @@ const MacOSButton = ({
       border: '1px solid var(--mac-border)',
       hover: {
         backgroundColor: 'var(--mac-bg-secondary)',
-        borderColor: 'var(--mac-border-hover)'
+        border: '1px solid var(--mac-border-hover)'
       },
       active: {
         backgroundColor: 'var(--mac-bg-tertiary)',
@@ -113,7 +113,7 @@ const MacOSButton = ({
       border: '1px solid var(--mac-error)',
       hover: {
         backgroundColor: 'var(--mac-error-hover)',
-        borderColor: 'var(--mac-error-hover)'
+        border: '1px solid var(--mac-error-hover)'
       },
       active: {
         backgroundColor: 'var(--mac-error-active)',
@@ -126,7 +126,7 @@ const MacOSButton = ({
       border: '1px solid var(--mac-success)',
       hover: {
         backgroundColor: 'var(--mac-success-hover)',
-        borderColor: 'var(--mac-success-hover)'
+        border: '1px solid var(--mac-success-hover)'
       },
       active: {
         backgroundColor: 'var(--mac-success-active)',

--- a/frontend/src/components/wizard/AppointmentWizardV2.jsx
+++ b/frontend/src/components/wizard/AppointmentWizardV2.jsx
@@ -31,7 +31,7 @@ import {
   isValidUzbekPhone,
   normalizeUzbekPhoneForApi
 } from '../../utils/phoneUtils';
-import { createQueueEntriesBatch, updateOnlineQueueEntry } from '../../api/queue';
+import { applyRegistrarEditDelta, createQueueEntriesBatch, updateOnlineQueueEntry } from '../../api/queue';
 import { api } from '../../api/client';
 import logger from '../../utils/logger';
 import tokenManager from '../../utils/tokenManager';
@@ -43,6 +43,14 @@ const API_BASE = '/api/v1';
 const PATIENT_NAME_PATTERN = /^[\p{L}\s\-']+$/u;
 const MIXED_REPEAT_WARNING = 'В текущей модели repeat применяется на весь checkout; для точного применения разделите оформление по специалистам.';
 const LEGACY_DRAFT_KEY = 'appointment_wizard_draft';
+
+const getLocalISODate = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
 
 const normalizeWizardContractValue = (value) => {
   if (value === null || value === undefined) return '';
@@ -150,6 +158,92 @@ const normalizeServiceSelectionName = (serviceValue) => {
   }
 
   return String(serviceValue).trim();
+};
+
+const normalizeGenderForForm = (value) => {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!normalized) return '';
+  if (['m', 'male', 'man', 'men', '1', 'м', 'муж', 'мужской', 'мужчина', 'erkak'].includes(normalized)) return 'male';
+  if (['f', 'female', 'woman', 'women', '2', 'ж', 'жен', 'женский', 'женщина', 'ayol'].includes(normalized)) return 'female';
+  return value;
+};
+
+const firstNonEmpty = (...values) => {
+  for (const value of values) {
+    if (value !== null && value !== undefined && String(value).trim() !== '') {
+      return value;
+    }
+  }
+  return '';
+};
+
+const resolvePatientGenderValue = (record) => firstNonEmpty(
+  record?.patient_gender,
+  record?.patient_sex,
+  record?.gender,
+  record?.sex,
+  record?.patient?.gender,
+  record?.patient?.sex
+);
+
+const genderToPatientSexForApi = (value) => {
+  const normalized = normalizeGenderForForm(value);
+  if (normalized === 'male') return 'M';
+  if (normalized === 'female') return 'F';
+  return null;
+};
+
+const resolveInitialPatientId = (initialData) => (
+  initialData?.patient_id ??
+  initialData?.patient?.id ??
+  null
+);
+
+const WIZARD_DEPARTMENT_FILTER_KEYS = {
+  cardio: ['cardio'],
+  cardiology: ['cardio', 'cardiology'],
+  echokg: ['cardio', 'echokg', 'ecg'],
+  ecg: ['cardio', 'echokg', 'ecg'],
+  derma: ['derma', 'dermatology'],
+  dermatology: ['derma', 'dermatology'],
+  dental: ['dental', 'dentistry', 'stomatology'],
+  dentistry: ['dental', 'dentistry', 'stomatology'],
+  stomatology: ['dental', 'dentistry', 'stomatology'],
+  lab: ['lab', 'laboratory'],
+  laboratory: ['lab', 'laboratory'],
+  procedures: ['procedures'],
+  procedure: ['procedures']
+};
+
+const getWizardDepartmentFilterKeys = (value) => {
+  const normalized = String(value || '').trim().toLowerCase();
+  return WIZARD_DEPARTMENT_FILTER_KEYS[normalized] || [];
+};
+
+const serviceCodeToWizardCategory = (value) => {
+  const prefix = String(value || '').trim().toUpperCase().charAt(0);
+  if (prefix === 'L') return 'laboratory';
+  if (prefix === 'P' || prefix === 'C') return 'procedures';
+  if (prefix === 'K' || prefix === 'D' || prefix === 'S') return 'specialists';
+  return null;
+};
+
+const activeTabToWizardCategory = (value) => {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (['lab', 'laboratory'].includes(normalized)) return 'laboratory';
+  if (['procedures', 'procedure'].includes(normalized)) return 'procedures';
+  return 'specialists';
+};
+
+const resolveInitialServiceCategory = (items = [], activeTabValue = '') => {
+  const firstItem = (Array.isArray(items) ? items : []).find(Boolean);
+  const itemCategory = serviceCodeToWizardCategory(
+    firstItem?.service_code ||
+    firstItem?.code ||
+    firstItem?._temp_name ||
+    firstItem?.service_name
+  );
+  return itemCategory || activeTabToWizardCategory(activeTabValue);
 };
 
 // Категории услуг
@@ -263,10 +357,24 @@ const AppointmentWizardV2 = ({
         // ✅ ИСПРАВЛЕНО: Правильная инициализация даты рождения
         const birthDate = initialData.patient_birth_date || (
         initialData.patient_birth_year ? `${initialData.patient_birth_year}-01-01` : '');
+        const initialCartItems = (() => {
+          logger.log('📦 AppointmentWizardV2: Using SSOT normalizeServicesFromInitialData');
+          const items = normalizeServicesFromInitialData(initialData, []);
+          logger.log('📦 Initialized cart with items:', items);
+          logger.log('📦 InitialData full structure:', initialData);
+
+          if (items.length > 0) {
+            logger.log(`✅ SSOT: Услуги извлечены из источника: ${items[0]._source}`);
+          }
+          return items;
+        })();
+        setActiveServiceCategory(resolveInitialServiceCategory(initialCartItems, activeTab));
+        setServiceSearchQuery('');
+        setShowAllServices(false);
 
         setWizardData({
           patient: {
-            id: initialData.patient_id || initialData.patient?.id || null, // ✅ ИСПРАВЛЕНО: Добавлена проверка patient?.id
+            id: resolveInitialPatientId(initialData),
             fio: initialData.patient_fio || initialData.patient_name || initialData.patient?.fio || '',
             birth_date: birthDate, // ✅ ИСПРАВЛЕНО: Приоритет полной даты
             phone: formatUzbekPhoneDisplay(
@@ -275,31 +383,13 @@ const AppointmentWizardV2 = ({
             address: initialData.address || initialData.patient?.address || '',
             gender: (() => {
               // ✅ ИСПРАВЛЕНО: Преобразование пола из формата БД (M/F/sex) в формат формы (male/female)
-              const genderValue = initialData.patient_gender ||
-              initialData.gender ||
-              initialData.patient?.gender ||
-              initialData.patient?.sex ||
-              initialData.sex ||
-              '';
-              if (genderValue === 'M' || genderValue === 'm' || genderValue === 'male') return 'male';
-              if (genderValue === 'F' || genderValue === 'f' || genderValue === 'female') return 'female';
-              return genderValue; // Если уже в формате male/female, оставляем как есть
+              const genderValue = resolvePatientGenderValue(initialData);
+              return normalizeGenderForForm(genderValue);
             })()
           },
           cart: {
             // ⭐ SSOT: Используем унифицированную функцию вместо 5 разных источников
-            items: (() => {
-              logger.log('📦 AppointmentWizardV2: Using SSOT normalizeServicesFromInitialData');
-              const items = normalizeServicesFromInitialData(initialData, []);
-              logger.log('📦 Initialized cart with items:', items);
-              logger.log('📦 InitialData full structure:', initialData);
-
-              // ✅ SSOT: Логируем источник
-              if (items.length > 0) {
-                logger.log(`✅ SSOT: Услуги извлечены из источника: ${items[0]._source}`);
-              }
-              return items;
-            })(),
+            items: initialCartItems,
             discount_mode: initialData.discount_mode || 'none', // ✅ ИСПРАВЛЕНО: Восстанавливаем скидки
             all_free: initialData.all_free || false,
             notes: initialData.notes || ''
@@ -316,10 +406,62 @@ const AppointmentWizardV2 = ({
         }
 
       } else {
+        setActiveServiceCategory(activeTabToWizardCategory(activeTab));
+        setServiceSearchQuery('');
+        setShowAllServices(false);
         // New appointment mode intentionally avoids persistent draft storage for patient PHI.
       }
     }
-  }, [isOpen, editMode, initialData]);
+  }, [isOpen, editMode, initialData, activeTab]);
+
+  useEffect(() => {
+    if (!isOpen || !editMode || wizardData.patient.gender) return;
+
+    const patientId = wizardData.patient.id || resolveInitialPatientId(initialData);
+    if (!patientId) return;
+
+    let cancelled = false;
+
+    const hydrateMissingEditGender = async () => {
+      const token = tokenManager.getAccessToken();
+      if (!token) return;
+
+      try {
+        const response = await fetch(`${API_BASE}/api/v1/patients/${patientId}`, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+
+        if (!response.ok) return;
+
+        const patient = await response.json();
+        const normalizedGender = normalizeGenderForForm(resolvePatientGenderValue(patient));
+        if (!normalizedGender || cancelled) return;
+
+        setWizardData((prev) => {
+          if (prev.patient.gender) return prev;
+          return {
+            ...prev,
+            patient: {
+              ...prev.patient,
+              id: prev.patient.id || patientId,
+              gender: normalizedGender
+            }
+          };
+        });
+      } catch (error) {
+        logger.warn('[AppointmentWizardV2] Failed to hydrate edit-mode patient gender', {
+          patientId,
+          error: error?.message || error
+        });
+      }
+    };
+
+    hydrateMissingEditGender();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, editMode, wizardData.patient.id, wizardData.patient.gender, initialData]);
 
   // ✅ ИСПРАВЛЕНО: Сброс состояния мастера при закрытии
   useEffect(() => {
@@ -334,6 +476,9 @@ const AppointmentWizardV2 = ({
       setFormattedBirthDate('');
       setRepeatEligibilityByItemId({});
       setIsRepeatEligibilityLoading(false);
+      setActiveServiceCategory('specialists');
+      setServiceSearchQuery('');
+      setShowAllServices(false);
     }
   }, [isOpen]);
 
@@ -596,10 +741,8 @@ const AppointmentWizardV2 = ({
         address: patient.address || '',
         gender: (() => {
           // ✅ ИСПРАВЛЕНО: Преобразование пола из формата БД (M/F/sex) в формат формы (male/female)
-          const genderValue = patient.gender || patient.sex || '';
-          if (genderValue === 'M' || genderValue === 'm' || genderValue === 'male') return 'male';
-          if (genderValue === 'F' || genderValue === 'f' || genderValue === 'female') return 'female';
-          return genderValue;
+          const genderValue = resolvePatientGenderValue(patient);
+          return normalizeGenderForForm(genderValue);
         })(), // ✅ Заполняем пол с преобразованием
         // Отдельные поля для обратной совместимости (если нужны)
         lastName: patient.last_name || '',
@@ -632,14 +775,7 @@ const AppointmentWizardV2 = ({
 
   const loadServices = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/registrar/services`, {
-        headers: {
-          'Authorization': `Bearer ${tokenManager.getAccessToken()}`,
-          'Content-Type': 'application/json'
-        }
-      });
-      if (response.ok) {
-        const data = await response.json();
+      const { data } = await api.get('/registrar/services');
 
         // Извлекаем все услуги из групп
         let allServices = [];
@@ -655,20 +791,21 @@ const AppointmentWizardV2 = ({
         // Также показываем услуги без department_key (общие услуги)
 
 
-        if (activeTab && activeTab !== 'all') {void
-          allServices.length;
-          allServices = allServices.filter((service) =>
-          service.department_key === activeTab || !service.department_key
-          );
+        const departmentFilterKeys = editMode ? [] : getWizardDepartmentFilterKeys(activeTab);
+        if (departmentFilterKeys.length > 0) {
+          const departmentFilterSet = new Set(departmentFilterKeys);
+          allServices = allServices.filter((service) => {
+            const departmentKey = String(service.department_key || service.departmentKey || '').trim().toLowerCase();
+            return !departmentKey || departmentFilterSet.has(departmentKey);
+          });
         }
 
         setServicesData(allServices);
         setFilteredServices(allServices);
-      }
     } catch (error) {
       logger.error('Ошибка загрузки услуг:', error);
     }
-  }, [activeTab]);
+  }, [activeTab, editMode]);
 
   // ===================== РЕЗОЛВИНГ УСЛУГ (SSOT) =====================
 
@@ -858,16 +995,8 @@ const AppointmentWizardV2 = ({
 
   const loadDoctors = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/registrar/doctors`, {
-        headers: {
-          'Authorization': `Bearer ${tokenManager.getAccessToken()}`,
-          'Content-Type': 'application/json'
-        }
-      });
-      if (response.ok) {
-        const data = await response.json();
-        setDoctorsData(data);
-      }
+      const { data } = await api.get('/registrar/doctors');
+      setDoctorsData(data);
     } catch (error) {
       logger.error('Ошибка загрузки врачей:', error);
     }
@@ -1420,10 +1549,18 @@ const AppointmentWizardV2 = ({
 
       // ✅ НОВОЕ: Локальная переменная для patient_id, которую будем заполнять по мере создания/поиска пациента
       let patientId = wizardData.patient.id;
+      const initialPatientId = resolveInitialPatientId(initialData);
+      if (editMode && initialPatientId && !patientId) {
+        patientId = initialPatientId;
+        logger.warn('[AppointmentWizardV2] Restored edit-mode patient_id from initialData before submit', {
+          patientId: initialPatientId
+        });
+      }
       const normalizedPhone = wizardData.patient.phone
         ? normalizeUzbekPhoneForApi(wizardData.patient.phone)
         : null;
       const normalizedPhoneDigits = normalizedPhone ? normalizedPhone.replace(/\D/g, '') : '';
+      const selectedPatientSex = genderToPatientSexForApi(wizardData.patient.gender);
 
       // === ШАГ 1: ОПРЕДЕЛЯЕМ ИЛИ НАХОДИМ patient_id ===
 
@@ -1481,10 +1618,11 @@ const AppointmentWizardV2 = ({
           logger.log('✅ Found existing patient:', foundPatient.id);
 
           // Обновляем данные пациента если нужно
+          const foundPatientSex = genderToPatientSexForApi(resolvePatientGenderValue(foundPatient));
           const needsUpdate =
           wizardData.patient.birth_date && wizardData.patient.birth_date !== foundPatient.birth_date ||
           wizardData.patient.address && wizardData.patient.address !== foundPatient.address ||
-          wizardData.patient.gender && wizardData.patient.gender !== foundPatient.sex;
+          selectedPatientSex && selectedPatientSex !== foundPatientSex;
 
           if (needsUpdate) {
             logger.log('🔄 Updating patient data...');
@@ -1492,7 +1630,7 @@ const AppointmentWizardV2 = ({
 
             if (wizardData.patient.birth_date) updateData.birth_date = wizardData.patient.birth_date;
             if (wizardData.patient.address) updateData.address = wizardData.patient.address;
-            if (wizardData.patient.gender) updateData.sex = wizardData.patient.gender;
+            if (selectedPatientSex) updateData.sex = selectedPatientSex;
 
             try {
               await fetch(`${API_BASE}/patients/${foundPatient.id}`, {
@@ -1517,7 +1655,7 @@ const AppointmentWizardV2 = ({
 
           const patientData = {
             full_name: wizardData.patient.fio.trim(),
-            gender: wizardData.patient.gender || null,
+            sex: selectedPatientSex,
             last_name: wizardData.patient.lastName || '',
             first_name: wizardData.patient.firstName || '',
             middle_name: wizardData.patient.middleName || null,
@@ -1570,7 +1708,7 @@ const AppointmentWizardV2 = ({
         // Подготовка данных пациента - отправляем полное ФИО, backend нормализует
         const patientData = {
           full_name: wizardData.patient.fio.trim(),
-          gender: wizardData.patient.gender, // ✅ Отправляем пол
+          sex: selectedPatientSex,
           // Для обратной совместимости также отправляем отдельные поля (если есть)
           last_name: wizardData.patient.lastName || '',
           first_name: wizardData.patient.firstName || '',
@@ -1670,6 +1808,34 @@ const AppointmentWizardV2 = ({
         });
         toast.error('Не удалось определить пациента. Пожалуйста, перезагрузите страницу и попробуйте ещё раз.');
         return;
+      }
+
+      const initialPatientSex = genderToPatientSexForApi(resolvePatientGenderValue(initialData));
+      if (editMode && patientId && selectedPatientSex && selectedPatientSex !== initialPatientSex) {
+        const patientResponse = await fetch(`${API_BASE}/patients/${patientId}`, {
+          method: 'PUT',
+          headers: {
+            'Authorization': `Bearer ${tokenManager.getAccessToken()}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ sex: selectedPatientSex })
+        });
+
+        if (!patientResponse.ok) {
+          const errorText = await patientResponse.text().catch(() => '');
+          logger.error('[AppointmentWizardV2] Failed to persist patient gender before edit submit', {
+            patientId,
+            status: patientResponse.status,
+            errorText
+          });
+          toast.error('Не удалось сохранить пол пациента. Проверьте доступ и попробуйте ещё раз.');
+          return;
+        }
+
+        logger.log('[AppointmentWizardV2] Persisted edit-mode patient gender before submit', {
+          patientId,
+          sex: selectedPatientSex
+        });
       }
 
       // ✅ НОВОЕ: Проверяем, редактируется ли запись в очереди (QR или desk) и есть ли новые услуги
@@ -1779,6 +1945,26 @@ const AppointmentWizardV2 = ({
         const originalServiceCodes = new Set();
         const originalServiceNames = new Set();
         // originalQueueIds moved to higher scope
+
+        if (Array.isArray(initialData.service_details) && initialData.service_details.length > 0) {
+          logger.log('📋 Извлечение исходных услуг из service_details:', initialData.service_details);
+          initialData.service_details.forEach((serviceDetail) => {
+            if (!serviceDetail) return;
+
+            const serviceId = serviceDetail.service_id || serviceDetail.id || null;
+            const serviceCode = serviceDetail.service_code || serviceDetail.code || null;
+            const serviceName = serviceDetail.service_name || serviceDetail.name || null;
+            const queueId = serviceDetail.original_queue_id ||
+              serviceDetail.queue_entry_id ||
+              serviceDetail.queue_id ||
+              null;
+
+            if (serviceId) originalServiceIds.add(serviceId);
+            if (queueId) originalQueueIds.add(queueId);
+            if (serviceCode) originalServiceCodes.add(String(serviceCode).toUpperCase().trim());
+            if (serviceName) originalServiceNames.add(String(serviceName).toLowerCase().trim());
+          });
+        }
 
         // ✅ ПРИОРИТЕТ 1: service_codes - наиболее надежный источник для записей типа visit
         if (Array.isArray(initialData.service_codes) && initialData.service_codes.length > 0) {
@@ -1973,7 +2159,9 @@ const AppointmentWizardV2 = ({
             }
 
             // Проверяем, является ли услуга новой
-            const isNewService = !originalServiceIds.has(serviceItem.service_id) &&
+            const hasExistingQueueIdentity = Boolean(serviceItem.original_queue_id);
+            const isNewService = !hasExistingQueueIdentity &&
+            !originalServiceIds.has(serviceItem.service_id) &&
             !originalServiceCodes.has((service.service_code || '').toUpperCase().trim()) &&
             !originalServiceNames.has((service.name || '').toLowerCase().trim());
 
@@ -1982,6 +2170,7 @@ const AppointmentWizardV2 = ({
               inServiceIds: originalServiceIds.has(serviceItem.service_id),
               inServiceCodes: originalServiceCodes.has((service.service_code || '').toUpperCase().trim()),
               inServiceNames: originalServiceNames.has((service.name || '').toLowerCase().trim()),
+              hasExistingQueueIdentity,
               hasDoctorId: !!visit.doctor_id
             });
 
@@ -2027,6 +2216,66 @@ const AppointmentWizardV2 = ({
 
         // ✅ ИСПРАВЛЕНИЕ: Проверяем наличие новых услуг (как с врачами, так и без)
         const hasNewServices = newServices.length > 0 || newServicesWithoutDoctor.length > 0;
+
+        if (editMode && hasNewServices) {
+          const editDeltaServices = [
+            ...newServices,
+            ...newServicesWithoutDoctor.map((item) => ({
+              service_id: item.service_id,
+              quantity: item.quantity,
+              specialist_id: null
+            }))
+          ];
+          const patientDataForEditDelta = {
+            full_name: wizardData.patient.fio || wizardData.patient.name,
+            phone: normalizedPhone,
+            birth_date: wizardData.patient.birth_date || wizardData.patient.birthDate || null,
+            sex: selectedPatientSex,
+            address: wizardData.patient.address || null
+          };
+          Object.keys(patientDataForEditDelta).forEach((key) => {
+            if (patientDataForEditDelta[key] === undefined) {
+              delete patientDataForEditDelta[key];
+            }
+          });
+
+          try {
+            logger.log('[AppointmentWizardV2] edit mode with new services; applying edit delta', {
+              serviceCount: editDeltaServices.length,
+              existingQueueEntryIds: Array.from(originalQueueIds)
+            });
+            const editDeltaResult = await applyRegistrarEditDelta({
+              patientId,
+              targetDate: getLocalISODate(),
+              patientData: patientDataForEditDelta,
+              paymentMethod: wizardData.payment.method,
+              discountMode: wizardData.cart.discount_mode,
+              allFree: wizardData.cart.all_free,
+              services: editDeltaServices,
+              existingQueueEntryIds: Array.from(originalQueueIds)
+            });
+
+            if (!editDeltaResult?.success) {
+              throw new Error(editDeltaResult?.message || 'Edit delta failed');
+            }
+
+            await cancelRemovedQueueEntries(originalQueueIds, wizardData.cart.items, 'edit-delta');
+            localStorage.removeItem(LEGACY_DRAFT_KEY);
+            toast.success('Запись обновлена');
+            onComplete?.(editDeltaResult);
+            onClose();
+            return;
+          } catch (editDeltaError) {
+            logger.error('[AppointmentWizardV2] edit delta failed', editDeltaError);
+            toast.error(editDeltaError?.response?.data?.detail || editDeltaError?.message || 'Не удалось обновить запись');
+            return;
+          }
+        }
+
+        if (editMode && !hasNewServices) {
+          logger.log('[AppointmentWizardV2] edit mode without new services; bypassing registrar/cart to avoid duplicate visits');
+          visits = [];
+        }
 
         if (hasNewServices) {
           logger.log(`✅ Найдены новые услуги для ${recordType}:`, {
@@ -2186,7 +2435,7 @@ const AppointmentWizardV2 = ({
           full_name: wizardData.patient.fio || wizardData.patient.name,
           phone: normalizedPhone,
           birth_date: wizardData.patient.birth_date || wizardData.patient.birthDate,
-          sex: wizardData.patient.gender === 'male' ? 'M' : wizardData.patient.gender === 'female' ? 'F' : null,
+          sex: selectedPatientSex,
           address: wizardData.patient.address
         };
 
@@ -2401,7 +2650,11 @@ const AppointmentWizardV2 = ({
 
       visits[key].services.push({
         service_id: item.service_id,
-        quantity: item.quantity
+        quantity: item.quantity,
+        original_queue_id: item.original_queue_id || null,
+        service_code: item.service_code || null,
+        service_name: item.service_name || item.name || null,
+        _source: item._source || null
       });
     });
 
@@ -2602,6 +2855,7 @@ const AppointmentWizardV2 = ({
       </div>
 
       <button
+      type="button"
       onClick={onClose}
       title="Закрыть"
       aria-label="Закрыть"
@@ -2649,6 +2903,7 @@ const AppointmentWizardV2 = ({
         {categories.map((cat) =>
       <button
         key={cat.id}
+        type="button"
         onClick={() => setActiveServiceCategory(cat.id)}
         style={{
           ...wizardSegmentButtonBase,
@@ -2691,6 +2946,7 @@ const AppointmentWizardV2 = ({
     }}>
         {/* Кнопка обновления */}
         <button
+        type="button"
         onClick={handleReloadServices}
         disabled={isReloadingServices}
         title="Обновить список услуг"
@@ -2727,6 +2983,7 @@ const AppointmentWizardV2 = ({
 
         {/* Кнопка закрытия */}
         <button
+        type="button"
         onClick={onClose}
         title="Закрыть"
         aria-label="Close appointment wizard"
@@ -2879,6 +3136,7 @@ const AppointmentWizardV2 = ({
               errors={errors}
               onReloadServices={loadServices}
               getServiceName={getServiceName} // ✅ SSOT: Передаем функцию для получения названий услуг
+              editMode={editMode}
               activeCategory={activeServiceCategory}
               setActiveCategory={setActiveServiceCategory}
               searchQuery={serviceSearchQuery}
@@ -2921,6 +3179,7 @@ const PatientStepV2 = ({
   phoneError
 }) => {
   const safeData = data || {};
+  const selectedGender = normalizeGenderForForm(safeData.gender);
 
   return (
     <div style={{
@@ -3079,18 +3338,19 @@ const PatientStepV2 = ({
             {['male', 'female'].map((gender) =>
             <button
               key={gender}
+              type="button"
               onClick={() => onUpdate('gender', gender)}
               style={{
                 flex: 1,
                 padding: '8px',
                 border: 'none',
                 borderRadius: 'var(--mac-radius-sm)',
-                background: safeData.gender === gender ? 'var(--mac-bg-primary)' : 'transparent',
-                color: safeData.gender === gender ? 'var(--mac-text-primary)' : 'var(--mac-text-secondary)',
-                boxShadow: safeData.gender === gender ? 'var(--mac-shadow-sm)' : 'none',
+                background: selectedGender === gender ? 'var(--mac-bg-primary)' : 'transparent',
+                color: selectedGender === gender ? 'var(--mac-text-primary)' : 'var(--mac-text-secondary)',
+                boxShadow: selectedGender === gender ? 'var(--mac-shadow-sm)' : 'none',
                 cursor: 'pointer',
                 fontSize: 'var(--mac-font-size-sm)',
-                fontWeight: safeData.gender === gender ? '600' : '400',
+                fontWeight: selectedGender === gender ? '600' : '400',
                 transition: 'all 0.2s ease'
               }}>
 
@@ -3180,6 +3440,7 @@ const PatientStepV2 = ({
                 {phoneError.message}
               </span>
               <button
+              type="button"
               onClick={() => onSelectPatient(phoneError.patient)}
               style={{
                 background: 'var(--mac-error)',
@@ -3437,6 +3698,7 @@ const CartStepV2 = ({
   // New props from parent
   activeCategory,
   searchQuery,
+  editMode = false,
   getServiceName, // ✅ SSOT: Функция для получения названий услуг
   onUpdateItem,
   repeatEligibilityByItemId,
@@ -3466,6 +3728,7 @@ const CartStepV2 = ({
     }
 
     // 2. Фильтрация по категории (если нет поиска)
+    // Edit mode loads every service, but category tabs still filter what is displayed.
     return filtered.filter((service) => {
       const normalizedCategory = service.category_code ? normalizeCategoryCode(service.category_code) : 'other';
       const isConsultation = service.name.toLowerCase().includes('консультация');
@@ -3870,8 +4133,8 @@ const CartStepV2 = ({
                     }}>
 
                         <option value="">Выберите врача</option>
-                        {doctorOptions.map((doctor) =>
-                    <option key={doctor.id} value={doctor.id}>
+                        {doctorOptions.map((doctor, index) =>
+                    <option key={`${doctor.id ?? 'doctor'}-${doctor.specialty ?? ''}-${index}`} value={doctor.id}>
                             {getDoctorDisplayName(doctor)}{doctor.specialty ? ` · ${doctor.specialty}` : ''}{doctor.cabinet ? ` · каб. ${doctor.cabinet}` : ''}
                           </option>)}
                       </select>
@@ -3949,6 +4212,7 @@ CartStepV2.propTypes = {
   errors: PropTypes.object,
   activeCategory: PropTypes.string,
   searchQuery: PropTypes.string,
+  editMode: PropTypes.bool,
   getServiceName: PropTypes.func,
   onUpdateItem: PropTypes.func,
   repeatEligibilityByItemId: PropTypes.object,

--- a/frontend/src/components/wizard/__tests__/AppointmentWizardV2.contract.test.jsx
+++ b/frontend/src/components/wizard/__tests__/AppointmentWizardV2.contract.test.jsx
@@ -1,0 +1,197 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const wizardPath = path.resolve(__dirname, '../AppointmentWizardV2.jsx');
+const serviceResolverPath = path.resolve(__dirname, '../../../utils/serviceCodeResolver.js');
+
+const readWizardSource = () => fs.readFileSync(wizardPath, 'utf8');
+const readServiceResolverSource = () => fs.readFileSync(serviceResolverPath, 'utf8');
+
+const extractSourceBlock = (source, startMarker, endMarker) => {
+  const start = source.indexOf(startMarker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf(endMarker, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+};
+
+describe('AppointmentWizardV2 registrar metadata contract', () => {
+  it('loads registrar services and doctors through the unified api client', () => {
+    const source = readWizardSource();
+    const servicesLoadBlock = extractSourceBlock(
+      source,
+      'const loadServices = useCallback(async () => {',
+      'const getServiceName = useCallback((item) => {',
+    );
+    const doctorsLoadBlock = extractSourceBlock(
+      source,
+      'const loadDoctors = useCallback(async () => {',
+      'useEffect(() => {',
+    );
+
+    expect(servicesLoadBlock).toContain("api.get('/registrar/services')");
+    expect(doctorsLoadBlock).toContain("api.get('/registrar/doctors')");
+    expect(servicesLoadBlock).not.toContain('fetch(`${API_BASE}/registrar/services`');
+    expect(doctorsLoadBlock).not.toContain('fetch(`${API_BASE}/registrar/doctors`');
+    expect(servicesLoadBlock).not.toContain("'Authorization': `Bearer ${tokenManager.getAccessToken()}`");
+    expect(doctorsLoadBlock).not.toContain("'Authorization': `Bearer ${tokenManager.getAccessToken()}`");
+  });
+
+  it('preserves existing queue identity when grouping edit-mode cart items', () => {
+    const source = readWizardSource();
+    const groupingBlock = extractSourceBlock(
+      source,
+      'const groupCartItemsByVisit = () => {',
+      'const getDepartmentByService = (serviceId) => {',
+    );
+    const newServiceBlock = extractSourceBlock(
+      source,
+      'const newServicesWithDoctorId = [];',
+      'const newServices = [];',
+    );
+
+    expect(groupingBlock).toContain('original_queue_id: item.original_queue_id || null');
+    expect(newServiceBlock).toContain('const hasExistingQueueIdentity = Boolean(serviceItem.original_queue_id);');
+    expect(newServiceBlock).toContain('const isNewService = !hasExistingQueueIdentity');
+  });
+
+  it('maps service-array initial data back to queue_numbers before edit saves', () => {
+    const source = readServiceResolverSource();
+
+    expect(source).toContain('const resolveOriginalQueueId = (serviceData = {}) => {');
+    expect(source).toContain('initialData.queue_numbers.find');
+    expect(source).toContain('}, resolveOriginalQueueId(serviceItem))');
+    expect(source).toContain('}, resolveOriginalQueueId({ name: serviceName, code: serviceCode }))');
+    expect(source).toContain('}, resolveOriginalQueueId({ code: normalizedCode || serviceCode, service_id: foundService?.id || null }))');
+  });
+
+  it('normalizes edit-mode gender and persists selected existing-patient gender before submit', () => {
+    const source = readWizardSource();
+    const initBlock = extractSourceBlock(
+      source,
+      'useEffect(() => {',
+      '  // Safeguard: Ensure wizardData structure is valid',
+    );
+    const patientIdBlock = extractSourceBlock(
+      source,
+      'let patientId = wizardData.patient.id;',
+      '// === ШАГ 1: ОПРЕДЕЛЯЕМ ИЛИ НАХОДИМ patient_id ===',
+    );
+
+    expect(source).toContain('const normalizeGenderForForm = (value) => {');
+    expect(source).toContain("['m', 'male', 'man', 'men', '1',");
+    expect(source).toContain("['f', 'female', 'woman', 'women', '2',");
+    expect(source).toContain('const resolvePatientGenderValue = (record) => firstNonEmpty(');
+    expect(source).toContain('record?.patient_sex');
+    expect(source).toContain('const genderToPatientSexForApi = (value) => {');
+    expect(source).toContain('const resolveInitialPatientId = (initialData) => (');
+    expect(initBlock).toContain('id: resolveInitialPatientId(initialData)');
+    expect(initBlock).toContain('const genderValue = resolvePatientGenderValue(initialData);');
+    expect(initBlock).toContain('return normalizeGenderForForm(genderValue);');
+    expect(initBlock).toContain('const hydrateMissingEditGender = async () => {');
+    expect(initBlock).toContain('fetch(`${API_BASE}/api/v1/patients/${patientId}`');
+    expect(initBlock).toContain('if (prev.patient.gender) return prev;');
+    expect(source).toContain('const selectedGender = normalizeGenderForForm(safeData.gender);');
+    expect(source).toContain('background: selectedGender === gender');
+    expect(source).toContain('const selectedPatientSex = genderToPatientSexForApi(wizardData.patient.gender);');
+    expect(source).toContain('sex: selectedPatientSex');
+    expect(source).not.toContain('gender: wizardData.patient.gender');
+    expect(patientIdBlock).toContain('const initialPatientId = resolveInitialPatientId(initialData);');
+    expect(patientIdBlock).toContain('patientId = initialPatientId;');
+    expect(source).toContain('body: JSON.stringify({ sex: selectedPatientSex })');
+  });
+
+  it('filters services only for real department tabs, not registrar view tabs', () => {
+    const source = readWizardSource();
+    const servicesLoadBlock = extractSourceBlock(
+      source,
+      'const loadServices = useCallback(async () => {',
+      'const getServiceName = useCallback((item) => {',
+    );
+
+    expect(source).toContain('const WIZARD_DEPARTMENT_FILTER_KEYS = {');
+    expect(source).toContain('const getWizardDepartmentFilterKeys = (value) => {');
+    expect(source).toContain("echokg: ['cardio', 'echokg', 'ecg']");
+    expect(servicesLoadBlock).toContain('const departmentFilterKeys = editMode ? [] : getWizardDepartmentFilterKeys(activeTab);');
+    expect(servicesLoadBlock).toContain('if (departmentFilterKeys.length > 0)');
+    expect(servicesLoadBlock).not.toContain("if (activeTab && activeTab !== 'all')");
+  });
+
+  it('loads all services in edit mode while keeping category tabs active', () => {
+    const source = readWizardSource();
+    const initBlock = extractSourceBlock(
+      source,
+      'useEffect(() => {',
+      '  // Safeguard: Ensure wizardData structure is valid',
+    );
+    const servicesLoadBlock = extractSourceBlock(
+      source,
+      'const loadServices = useCallback(async () => {',
+      'const getServiceName = useCallback((item) => {',
+    );
+    const displayedServicesBlock = extractSourceBlock(
+      source,
+      'const getDisplayedServices = () => {',
+      'const displayedServices = getDisplayedServices();',
+    );
+
+    expect(source).toContain('const serviceCodeToWizardCategory = (value) => {');
+    expect(source).toContain('const activeTabToWizardCategory = (value) => {');
+    expect(source).toContain('const resolveInitialServiceCategory = (items = [], activeTabValue = \'\') => {');
+    expect(initBlock).toContain('const initialCartItems = (() => {');
+    expect(initBlock).toContain('setActiveServiceCategory(resolveInitialServiceCategory(initialCartItems, activeTab));');
+    expect(initBlock).toContain('setActiveServiceCategory(activeTabToWizardCategory(activeTab));');
+    expect(initBlock).toContain("setServiceSearchQuery('');");
+    expect(source).toContain('editMode={editMode}');
+    expect(servicesLoadBlock).toContain('const departmentFilterKeys = editMode ? [] : getWizardDepartmentFilterKeys(activeTab);');
+    expect(displayedServicesBlock).not.toContain('if (editMode) {');
+    expect(displayedServicesBlock).toContain('switch (activeCategory)');
+    expect(displayedServicesBlock).toContain("case 'specialists':");
+    expect(displayedServicesBlock).toContain("case 'laboratory':");
+    expect(displayedServicesBlock).toContain("case 'procedures':");
+    expect(displayedServicesBlock).toContain("case 'other':");
+  });
+
+  it('treats service_details as existing services in edit mode to avoid duplicate queues', () => {
+    const source = readWizardSource();
+    const existingServicesBlock = extractSourceBlock(
+      source,
+      'const originalServiceCodes = new Set();',
+      'logger.log(\'📋 Исходные услуги определены:\'',
+    );
+
+    expect(existingServicesBlock).toContain('Array.isArray(initialData.service_details)');
+    expect(existingServicesBlock).toContain('const serviceId = serviceDetail.service_id || serviceDetail.id || null;');
+    expect(existingServicesBlock).toContain('if (serviceId) originalServiceIds.add(serviceId);');
+    expect(existingServicesBlock).toContain('if (queueId) originalQueueIds.add(queueId);');
+  });
+
+  it('does not call registrar cart for edit mode when no new services were added', () => {
+    const source = readWizardSource();
+    const editSaveBlock = extractSourceBlock(
+      source,
+      'const hasNewServices = newServices.length > 0 || newServicesWithoutDoctor.length > 0;',
+      'const cartData = {',
+    );
+
+    expect(editSaveBlock).toContain('if (editMode && hasNewServices) {');
+    expect(editSaveBlock).toContain('const editDeltaServices = [');
+    expect(editSaveBlock).toContain('applyRegistrarEditDelta({');
+    expect(editSaveBlock).toContain('existingQueueEntryIds: Array.from(originalQueueIds)');
+    expect(editSaveBlock).toContain('if (editMode && !hasNewServices) {');
+    expect(editSaveBlock).toContain('bypassing registrar/cart to avoid duplicate visits');
+    expect(editSaveBlock).toContain('visits = [];');
+    expect(editSaveBlock).toContain('if (visits.length === 0 && editMode) {');
+  });
+
+  it('uses stable unique keys for doctor options in cart rows', () => {
+    const source = readWizardSource();
+
+    expect(source).toContain('doctorOptions.map((doctor, index)');
+    expect(source).toContain("key={`${doctor.id ?? 'doctor'}-${doctor.specialty ?? ''}-${index}`}");
+  });
+});

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -209,6 +209,137 @@ const hasBackendPatientDisplayContract = (record) => {
   return hasName && hasPhone && hasBirthYear && hasAddress;
 };
 
+const normalizePatientGender = (record) => (
+  record?.patient_gender ??
+  record?.patient_sex ??
+  record?.gender ??
+  record?.sex ??
+  null
+);
+
+const hasBackendPatientGenderContract = (record) => {
+  const gender = normalizePatientGender(record);
+  return gender !== null && gender !== undefined && String(gender).trim() !== '';
+};
+
+const formatPreviewList = (value) => {
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      if (typeof item === 'string') return item;
+      return item?.name || item?.service_name || item?.code || item?.queue_name || item?.queue_tag || '';
+    }).filter(Boolean).join(', ');
+  }
+  return value || '';
+};
+
+const normalizeWizardQueueAssignment = (assignment, visitId = null) => {
+  if (!assignment || typeof assignment !== 'object') return null;
+  const queueNumber = assignment.queue_number ??
+    assignment.number ??
+    assignment.ticket_number ??
+    assignment.queue_position ??
+    assignment.queue_no ??
+    null;
+
+  return {
+    ...assignment,
+    id: assignment.queue_id ?? assignment.queue_entry_id ?? assignment.id ?? null,
+    queue_entry_id: assignment.queue_entry_id ?? assignment.queue_id ?? assignment.id ?? null,
+    visit_id: assignment.visit_id ?? (visitId !== null && visitId !== undefined && visitId !== '' ? Number(visitId) : null),
+    queue_number: queueNumber,
+    number: queueNumber
+  };
+};
+
+const flattenWizardQueueNumbers = (queueNumbers) => {
+  if (!queueNumbers) return [];
+
+  if (Array.isArray(queueNumbers)) {
+    return queueNumbers
+      .map((assignment) => normalizeWizardQueueAssignment(assignment, assignment?.visit_id))
+      .filter(Boolean);
+  }
+
+  if (typeof queueNumbers !== 'object') return [];
+
+  return Object.entries(queueNumbers).flatMap(([visitId, assignments]) => {
+    const assignmentList = Array.isArray(assignments) ? assignments : [assignments];
+    return assignmentList
+      .map((assignment) => normalizeWizardQueueAssignment(assignment, visitId))
+      .filter(Boolean);
+  });
+};
+
+const buildPostWizardPaymentRow = (wizardResult) => {
+  if (!wizardResult?.success) return null;
+
+  const visitIds = Array.isArray(wizardResult.visit_ids) ? wizardResult.visit_ids.filter(Boolean) : [];
+  if (visitIds.length === 0) return null;
+
+  const createdVisits = Array.isArray(wizardResult.created_visits) ? wizardResult.created_visits : [];
+  const firstVisit = createdVisits[0] || {};
+  const services = createdVisits.flatMap((visit) =>
+    (Array.isArray(visit.services) ? visit.services : [])
+      .map((service) => service?.name || service?.code)
+      .filter(Boolean)
+  );
+  const queueNumbers = flattenWizardQueueNumbers(wizardResult.queue_numbers);
+  const firstQueueNumber = queueNumbers.find((queueItem) => (
+    queueItem?.queue_number !== null &&
+    queueItem?.queue_number !== undefined &&
+    queueItem?.queue_number !== ''
+  ));
+  const printTickets = (Array.isArray(wizardResult.print_tickets) ? wizardResult.print_tickets : [])
+    .map((ticket, index) => {
+      if (!ticket || typeof ticket !== 'object') return null;
+      const queueNumber = ticket.queue_number ??
+        ticket.number ??
+        ticket.ticket_number ??
+        queueNumbers[index]?.queue_number ??
+        queueNumbers[index]?.number ??
+        null;
+      if (queueNumber === null || queueNumber === undefined || queueNumber === '') return null;
+      return {
+        ...ticket,
+        queue_number: queueNumber
+      };
+    })
+    .filter(Boolean);
+  const totalAmount = Number(wizardResult.total_amount ?? 0);
+
+  return {
+    id: visitIds[0],
+    canonical_record_id: visitIds[0],
+    record_kind: 'visit',
+    visit_id: visitIds[0],
+    visit_ids: visitIds,
+    grouped_record_refs: visitIds.map((visitId) => ({ record_kind: 'visit', record_id: Number(visitId) })),
+    available_actions: ['mark_paid', 'print_ticket'],
+    can_mark_paid: totalAmount > 0,
+    can_print_ticket: true,
+    invoice_id: wizardResult.invoice_id ?? null,
+    patient_fio: firstVisit.patient_name || 'Patient',
+    services,
+    queue_number: firstQueueNumber?.queue_number ?? null,
+    number: firstQueueNumber?.queue_number ?? null,
+    cost: totalAmount,
+    payment_amount: totalAmount,
+    payment_status: totalAmount > 0 ? 'pending' : 'paid',
+    payment_type: null,
+    queue_numbers: queueNumbers,
+    print_tickets: printTickets,
+    created_visits: createdVisits
+  };
+};
+
+const hasMultipleRecordRefs = (value) => Array.isArray(value) && value.filter(Boolean).length > 1;
+
+const isMultiRecordAggregateRow = (row) => (
+  hasMultipleRecordRefs(row?.grouped_record_refs) ||
+  hasMultipleRecordRefs(row?.grouped_records) ||
+  hasMultipleRecordRefs(row?.aggregated_ids)
+);
+
 // Современные диалоги
 import PaymentDialog from '../components/dialogs/PaymentDialog';
 import CancelDialog from '../components/dialogs/CancelDialog';
@@ -329,6 +460,7 @@ const RegistrarPanel = () => {
   useState(null);
   const [cancelDialog, setCancelDialog] = useState({ open: false, row: null, reason: '' });
   const [paymentDialog, setPaymentDialog] = useState({ open: false, row: null, paid: false, source: null });
+  const [recordPreviewDialog, setRecordPreviewDialog] = useState({ open: false, row: null });
   // ✅ State for rescheduling
   const [rescheduleData, setRescheduleData] = useState(null);
 
@@ -1181,7 +1313,7 @@ const RegistrarPanel = () => {
       let enrichedApt = { ...apt };
 
       // Обогащаем данными пациента
-      if (apt.patient_id && !hasBackendPatientDisplayContract(apt)) {
+      if (apt.patient_id && (!hasBackendPatientDisplayContract(apt) || !hasBackendPatientGenderContract(apt))) {
         const patient = await fetchPatientData(apt.patient_id);
         if (patient) {
           // ✅ ИСПРАВЛЕНО: Формируем patient_fio безопасно, используя все доступные поля
@@ -1201,11 +1333,15 @@ const RegistrarPanel = () => {
             patient_fio = `Пациент ID=${patient.id}`;
           }
 
+          const patientGender = normalizePatientGender(patient);
           enrichedApt = {
             ...enrichedApt,
             patient_fio: patient_fio.trim() || `Пациент ID=${patient.id}`,
             patient_phone: patient.phone,
             patient_birth_year: patient.birth_date ? new Date(patient.birth_date).getFullYear() : null,
+            patient_gender: patientGender,
+            gender: patientGender,
+            sex: patientGender,
             address: patient.address || 'Не указан' // Добавляем адрес из данных пациента
           };
         }
@@ -1363,6 +1499,9 @@ const RegistrarPanel = () => {
               patient_fio: fullEntry.patient_fio ?? fullEntry.patient_name ?? entry.patient_fio ?? entry.patient_name ?? 'Неизвестный пациент',
               patient_birth_year: fullEntry.patient_birth_year ?? fullEntry.birth_year ?? entry.patient_birth_year ?? entry.birth_year ?? null,
               patient_phone: fullEntry.patient_phone ?? fullEntry.phone ?? entry.patient_phone ?? entry.phone ?? '',
+              patient_gender: normalizePatientGender(fullEntry) ?? normalizePatientGender(entry),
+              gender: normalizePatientGender(fullEntry) ?? normalizePatientGender(entry),
+              sex: normalizePatientGender(fullEntry) ?? normalizePatientGender(entry),
               address: fullEntry.address ?? entry.address ?? '',
               services: Array.isArray(fullEntry.services) ? fullEntry.services : [],
               service_codes: Array.isArray(fullEntry.service_codes) ? fullEntry.service_codes : [],
@@ -2518,14 +2657,33 @@ const RegistrarPanel = () => {
 
 
   // Обработчик действий контекстного меню
+  const openRecordPreview = useCallback((row) => {
+    setRecordPreviewDialog({ open: true, row });
+  }, []);
+
+  const openRecordEditor = useCallback((row) => {
+    if (isMultiRecordAggregateRow(row)) {
+      logger.info('[RegistrarPanel] Opening edit wizard for aggregate all-departments row', {
+        patient: row?.patient_fio || row?.patient_name,
+        groupedRecords: row?.grouped_records?.length || 0,
+        recordRefs: row?.grouped_record_refs?.length || 0,
+        aggregatedIds: row?.aggregated_ids?.length || 0
+      });
+    }
+
+    logger.info('[RegistrarPanel] Opening edit wizard for:', row?.patient_fio || row?.patient_name);
+    setWizardEditMode(true);
+    setWizardInitialData(row);
+    setShowWizard(true);
+  }, []);
+
   const handleContextMenuAction = useCallback(async (action, row) => {
     switch (action) {
       case 'view':
-        setWizardEditMode(true);
-        setWizardInitialData(row);
-        setShowWizard(true);
+        openRecordPreview(row);
         break;
       case 'edit':
+        openRecordEditor(row);
         logger.info('Редактирование записи:', row);
         break;
       case 'in_cabinet':
@@ -2569,7 +2727,7 @@ const RegistrarPanel = () => {
         logger.info('Неизвестное действие:', action);
         break;
     }
-  }, [updateAppointmentStatus, handleStartVisit]);
+  }, [updateAppointmentStatus, handleStartVisit, openRecordPreview, openRecordEditor]);
 
   return (
     <div style={{ ...pageStyle, overflow: 'hidden' }} role="main" aria-label="Панель регистратора">
@@ -3228,15 +3386,11 @@ const RegistrarPanel = () => {
                       switch (action) {
                         case 'view':
                           logger.info('Просмотр записи:', row);
-                          setWizardEditMode(true);
-                          setWizardInitialData(row);
-                          setShowWizard(true);
+                          openRecordPreview(row);
                           break;
                         case 'edit':
                           logger.info('[RegistrarPanel] Открытие мастера редактирования для:', row.patient_fio || row.patient_name);
-                          setWizardEditMode(true);
-                          setWizardInitialData(row);
-                          setShowWizard(true);
+                          openRecordEditor(row);
                           break;
                         case 'payment':
                           logger.info('Открытие модального окна оплаты для записи (welcome):', row);
@@ -3570,15 +3724,11 @@ const RegistrarPanel = () => {
                 switch (action) {
                   case 'view':
                     logger.info('Просмотр записи:', row);
-                    setWizardEditMode(true);
-                    setWizardInitialData(row);
-                    setShowWizard(true);
+                    openRecordPreview(row);
                     break;
                   case 'edit':
                     logger.info('[RegistrarPanel] Открытие мастера редактирования для:', row.patient_fio || row.patient_name);
-                    setWizardEditMode(true);
-                    setWizardInitialData(row);
-                    setShowWizard(true);
+                    openRecordEditor(row);
                     break;
                   case 'payment':
                     logger.info('Открытие модального окна оплаты для записи:', row);
@@ -3680,6 +3830,66 @@ const RegistrarPanel = () => {
       {/* Мастер создания записи */}
 
       {/* Современные диалоги */}
+      <ModernDialog
+        isOpen={recordPreviewDialog.open}
+        onClose={() => setRecordPreviewDialog({ open: false, row: null })}
+        title="Просмотр записи"
+        maxWidth="36rem"
+        dialogStyle={{
+          backgroundColor: 'var(--mac-bg-primary)'
+        }}
+        actions={[
+          {
+            label: 'Закрыть',
+            variant: 'secondary',
+            onClick: () => setRecordPreviewDialog({ open: false, row: null })
+          },
+          {
+            label: 'Редактировать',
+            variant: 'primary',
+            onClick: () => {
+              const row = recordPreviewDialog.row;
+              setRecordPreviewDialog({ open: false, row: null });
+              if (row) openRecordEditor(row);
+            }
+          }
+        ]}>
+        {recordPreviewDialog.row && (
+          <div style={{ display: 'grid', gap: '12px', color: 'var(--mac-text-primary)' }}>
+            {[
+              ['Пациент', recordPreviewDialog.row.patient_fio || recordPreviewDialog.row.patient_name],
+              ['Телефон', recordPreviewDialog.row.patient_phone || recordPreviewDialog.row.phone],
+              ['Год рождения', recordPreviewDialog.row.patient_birth_year || recordPreviewDialog.row.birth_year],
+              ['Пол', normalizePatientGender(recordPreviewDialog.row)],
+              ['Отделение', recordPreviewDialog.row.queue_name || recordPreviewDialog.row.department || recordPreviewDialog.row.specialty],
+              ['Услуги', formatPreviewList(recordPreviewDialog.row.services || recordPreviewDialog.row.service_details)],
+              ['Очередь', formatPreviewList(recordPreviewDialog.row.queue_numbers)],
+              ['Статус', recordPreviewDialog.row.status || recordPreviewDialog.row.canonical_status],
+              ['Оплата', recordPreviewDialog.row.payment_status || recordPreviewDialog.row.payment_type],
+              ['Сумма', recordPreviewDialog.row.cost]
+            ].filter(([, value]) => value !== null && value !== undefined && value !== '').map(([label, value]) => (
+              <div
+                key={label}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'minmax(120px, 0.36fr) minmax(0, 1fr)',
+                  gap: '12px',
+                  alignItems: 'start',
+                  padding: '10px 12px',
+                  border: '1px solid var(--mac-separator)',
+                  borderRadius: 'var(--mac-radius-md)',
+                  background: 'var(--mac-bg-secondary)'
+                }}>
+                <span style={{ color: 'var(--mac-text-secondary)', fontSize: '13px' }}>{label}</span>
+                <span style={{ minWidth: 0, overflowWrap: 'anywhere', fontWeight: 500 }}>
+                  {String(value)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </ModernDialog>
+
       <CancelDialog
         isOpen={cancelDialog.open}
         onClose={() => setCancelDialog({ open: false, row: null, reason: '' })}
@@ -3724,10 +3934,14 @@ const RegistrarPanel = () => {
           }
         }}
         onPrintTicket={(appointment) => {
+          const printSource = {
+            ...(paymentDialog.row || {}),
+            ...(appointment || {})
+          };
           setPrintDialog({
             open: true,
             type: 'ticket',
-            data: appointment
+            data: printSource
           });
         }} />
 
@@ -3791,6 +4005,10 @@ const RegistrarPanel = () => {
         setIsProcessing={setIsProcessing}
         onComplete={async (wizardData) => {
           logger.info('AppointmentWizardV2 completed successfully:', wizardData);
+          const wasEditMode = wizardEditMode;
+          const postWizardPaymentRow = (!wasEditMode || Number(wizardData?.total_amount || 0) > 0)
+            ? buildPostWizardPaymentRow(wizardData)
+            : null;
 
           // Обновляем данные (работает и для создания, и для редактирования)
           try {
@@ -3809,10 +4027,17 @@ const RegistrarPanel = () => {
             setWizardEditMode(false); // ✨ Сброс режима
             setWizardInitialData(null); // ✨ Сброс данных
 
-            const message = wizardEditMode ?
+            const message = wasEditMode ?
             'Запись успешно обновлена!' :
             'Запись успешно создана!';
             notify.success(message);
+            if (postWizardPaymentRow) {
+              if (Number(postWizardPaymentRow.cost || 0) > 0) {
+                setPaymentDialog({ open: true, row: postWizardPaymentRow, paid: false, source: wasEditMode ? 'wizard-edit' : 'wizard-create' });
+              } else {
+                setPrintDialog({ open: true, type: 'ticket', data: postWizardPaymentRow });
+              }
+            }
           } catch (error) {
             logger.error('Error refreshing data after wizard completion:', error);
             // Не показываем ошибку пользователю, так как запись уже создана

--- a/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
@@ -38,15 +38,62 @@ describe('RegistrarPanel command contract', () => {
       'const loadAppointments = useCallback(async (options = {}) => {',
     );
 
-    expect(source).toContain('if (apt.patient_id && !hasBackendPatientDisplayContract(apt))');
+    expect(source).toContain('if (apt.patient_id && (!hasBackendPatientDisplayContract(apt) || !hasBackendPatientGenderContract(apt)))');
     expect(source).toContain('patient_fio: fullEntry.patient_fio ?? fullEntry.patient_name');
     expect(source).toContain('patient_birth_year: fullEntry.patient_birth_year ?? fullEntry.birth_year');
     expect(source).toContain('patient_phone: fullEntry.patient_phone ?? fullEntry.phone');
     expect(source).toContain('address: fullEntry.address ?? entry.address');
-    expect(enrichmentBlock).toContain('if (apt.patient_id && !hasBackendPatientDisplayContract(apt))');
+    expect(source).toContain('const gender = normalizePatientGender(record);');
+    expect(source).toContain("String(gender).trim() !== ''");
+    expect(enrichmentBlock).toContain('!hasBackendPatientGenderContract(apt)');
+    expect(enrichmentBlock).toContain('patient_gender: patientGender');
     expect(enrichmentBlock.indexOf('!hasBackendPatientDisplayContract(apt)')).toBeLessThan(
       enrichmentBlock.indexOf('fetchPatientData(apt.patient_id)'),
     );
+  });
+
+  it('keeps Registrar table view separate from edit mode', () => {
+    const source = readRegistrarPanelSource();
+
+    expect(source).toContain('const openRecordPreview = useCallback((row) => {');
+    expect(source).toContain('const openRecordEditor = useCallback((row) => {');
+    expect(source).toContain("case 'view':");
+    expect(source).toContain('openRecordPreview(row);');
+    expect(source).toContain("case 'edit':");
+    expect(source).toContain('openRecordEditor(row);');
+  });
+
+  it('allows edit mode for aggregate all-departments rows while keeping preview separate', () => {
+    const source = readRegistrarPanelSource();
+    const editBlock = extractSourceBlock(
+      source,
+      'const openRecordEditor = useCallback((row) => {',
+      'const handleContextMenuAction = useCallback(async (action, row) => {',
+    );
+
+    expect(source).toContain('const isMultiRecordAggregateRow = (row) => (');
+    expect(source).toContain('hasMultipleRecordRefs(row?.grouped_record_refs)');
+    expect(editBlock).toContain('if (isMultiRecordAggregateRow(row))');
+    expect(editBlock).toContain('Opening edit wizard for aggregate all-departments row');
+    expect(editBlock).not.toContain('openRecordPreview(row);');
+    expect(editBlock).not.toContain('notify.warning');
+    expect(editBlock).toContain('setShowWizard(true);');
+  });
+
+  it('restores post-wizard payment or ticket handoff for creates and paid edit deltas', () => {
+    const source = readRegistrarPanelSource();
+
+    expect(source).toContain('const buildPostWizardPaymentRow = (wizardResult) => {');
+    expect(source).toContain('const normalizeWizardQueueAssignment = (assignment, visitId = null) => {');
+    expect(source).toContain('if (Array.isArray(queueNumbers))');
+    expect(source).toContain('queue_entry_id: assignment.queue_entry_id ?? assignment.queue_id ?? assignment.id ?? null');
+    expect(source).toContain('number: queueNumber');
+    expect(source).toContain('grouped_record_refs: visitIds.map');
+    expect(source).toContain('queue_number: firstQueueNumber?.queue_number ?? null');
+    expect(source).toContain('print_tickets: printTickets');
+    expect(source).toContain('const postWizardPaymentRow = (!wasEditMode || Number(wizardData?.total_amount || 0) > 0)');
+    expect(source).toContain("source: wasEditMode ? 'wizard-edit' : 'wizard-create'");
+    expect(source).toContain("setPrintDialog({ open: true, type: 'ticket', data: postWizardPaymentRow });");
   });
 
   it('loads Registrar metadata departments through one registrar endpoint', () => {

--- a/frontend/src/utils/__tests__/registrarAggregation.test.js
+++ b/frontend/src/utils/__tests__/registrarAggregation.test.js
@@ -14,6 +14,9 @@ const makeAppointment = (overrides = {}) => ({
   patient_id: overrides.patient_id ?? 10,
   patient_fio: overrides.patient_fio ?? 'Тест Пациент',
   patient_birth_year: overrides.patient_birth_year ?? 1990,
+  patient_gender: pickOverride(overrides, 'patient_gender', null),
+  gender: pickOverride(overrides, 'gender', overrides.patient_gender ?? null),
+  sex: pickOverride(overrides, 'sex', overrides.gender ?? overrides.patient_gender ?? null),
   patient_phone: overrides.patient_phone ?? '+998900000000',
   address: overrides.address ?? 'Тестовый адрес',
   visit_id: pickOverride(overrides, 'visit_id', overrides.id ?? 1),
@@ -30,6 +33,7 @@ const makeAppointment = (overrides = {}) => ({
   queue_time: overrides.queue_time ?? '2026-04-15T09:45:00+05:00',
   services: overrides.services ?? [],
   service_codes: overrides.service_codes ?? [],
+  service_details: overrides.service_details ?? [],
   department: overrides.department ?? 'cardiology',
   doctor_specialty: overrides.doctor_specialty ?? null,
   queue_numbers: overrides.queue_numbers ?? [],
@@ -221,6 +225,93 @@ describe('aggregatePatientsForAllDepartments', () => {
     expect(result).toHaveLength(1);
     expect(result[0].queue_time).toBe('2026-04-15T09:30:00+05:00');
     expect(result[0].created_at).toBe('2026-04-15T09:31:00+05:00');
+  });
+
+  it('preserves service_details for all-departments edit mode identity', () => {
+    const result = aggregatePatientsForAllDepartments([
+      makeAppointment({
+        id: 1,
+        service_details: [{ service_id: 10, service_code: 'K01', service_name: 'Консультация кардиолога' }],
+      }),
+      makeAppointment({
+        id: 2,
+        service_details: [{ service_id: 20, service_code: 'L01', service_name: 'Общий анализ крови' }],
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].service_details).toEqual([
+      { service_id: 10, service_code: 'K01', service_name: 'Консультация кардиолога' },
+      { service_id: 20, service_code: 'L01', service_name: 'Общий анализ крови' },
+    ]);
+  });
+
+  it('preserves patient gender for all-departments edit mode identity', () => {
+    const result = aggregatePatientsForAllDepartments([
+      makeAppointment({
+        id: 1,
+        patient_id: 13,
+        patient_gender: 'F',
+        gender: 'F',
+        sex: 'F',
+        service_details: [{ service_id: 10, service_code: 'K01', service_name: 'Cardio consult' }],
+      }),
+      makeAppointment({
+        id: 2,
+        patient_id: 13,
+        patient_gender: null,
+        gender: null,
+        sex: null,
+        service_details: [{ service_id: 20, service_code: 'L01', service_name: 'Blood test' }],
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].patient_gender).toBe('F');
+    expect(result[0].gender).toBe('F');
+    expect(result[0].sex).toBe('F');
+  });
+
+  it('does not merge distinct backend patients with the same displayed name', () => {
+    const result = aggregatePatientsForAllDepartments([
+      makeAppointment({
+        id: 1,
+        patient_id: 101,
+        patient_fio: 'Same Display Name',
+        patient_phone: '+998901111111',
+        canonical_record_id: 301,
+        record_kind: 'visit',
+        visit_id: 301,
+        appointment_id: null,
+        services: ['Cardio consult'],
+        service_details: [{ service_id: 10, service_code: 'K01', service_name: 'Cardio consult' }],
+      }),
+      makeAppointment({
+        id: 2,
+        patient_id: 202,
+        patient_fio: 'Same Display Name',
+        patient_phone: '+998902222222',
+        canonical_record_id: 402,
+        record_kind: 'online_queue',
+        record_type: 'online_queue',
+        visit_id: null,
+        appointment_id: null,
+        queue_entry_id: 402,
+        services: ['Blood test'],
+        service_details: [{ service_id: 20, service_code: 'L01', service_name: 'Blood test' }],
+      }),
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((row) => row.patient_id)).toEqual([101, 202]);
+    expect(result[0].grouped_record_refs).toEqual([{ record_kind: 'visit', record_id: 301 }]);
+    expect(result[1].grouped_record_refs).toEqual([{ record_kind: 'online_queue', record_id: 402 }]);
+    expect(result[0].service_details).toEqual([
+      { service_id: 10, service_code: 'K01', service_name: 'Cardio consult' },
+    ]);
+    expect(result[1].service_details).toEqual([
+      { service_id: 20, service_code: 'L01', service_name: 'Blood test' },
+    ]);
   });
 });
 

--- a/frontend/src/utils/registrarAggregation.js
+++ b/frontend/src/utils/registrarAggregation.js
@@ -52,6 +52,40 @@ const buildRecordRef = (appointment) => {
   return { record_kind: recordKind, record_id: numericId };
 };
 
+const buildPatientGroupKey = (appointment, index = 0) => {
+  const patientId = appointment?.patient_id;
+  if (patientId !== null && patientId !== undefined && String(patientId).trim() !== '') {
+    return `patient:${patientId}`;
+  }
+
+  const fio = String(appointment?.patient_fio || '').trim().toLowerCase();
+  const phone = String(appointment?.patient_phone || appointment?.phone || '').replace(/\D/g, '');
+  const birth = String(
+    appointment?.patient_birth_date ||
+    appointment?.birth_date ||
+    appointment?.patient_birth_year ||
+    ''
+  ).trim();
+  if (fio || phone || birth) {
+    return `identity:${fio}|${phone}|${birth}`;
+  }
+
+  const recordRef = buildRecordRef(appointment);
+  if (recordRef) {
+    return `record:${recordRef.record_kind}:${recordRef.record_id}`;
+  }
+
+  return `row:${appointment?.id ?? index}`;
+};
+
+const pickPatientGender = (appointment) => (
+  appointment?.patient_gender ??
+  appointment?.patient_sex ??
+  appointment?.gender ??
+  appointment?.sex ??
+  null
+);
+
 export const aggregatePatientsForAllDepartments = (appointments = []) => {
   const patientGroups = {};
 
@@ -74,12 +108,13 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
     return nextTime < currentTime ? nextValue : currentValue;
   };
 
-  appointments.forEach((appointment) => {
-    const patientKey = appointment.patient_fio;
+  appointments.forEach((appointment, index) => {
+    const patientKey = buildPatientGroupKey(appointment, index);
     const normalizedDiscountMode = normalizeRegistrationMode(appointment.discount_mode);
     const normalizedPayment = normalizePaymentStatus(appointment.payment_status);
     const appointmentCost = getRecordAmount(appointment);
     const recordRef = buildRecordRef(appointment);
+    const patientGender = pickPatientGender(appointment);
 
     if (!patientGroups[patientKey]) {
       const initialVisitId = pickCanonicalVisitId(appointment);
@@ -97,6 +132,9 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
         patient_id: appointment.patient_id,
         patient_fio: appointment.patient_fio,
         patient_birth_year: appointment.patient_birth_year,
+        patient_gender: patientGender,
+        gender: patientGender,
+        sex: patientGender,
         patient_phone: appointment.patient_phone,
         address: appointment.address,
         visit_type: appointment.visit_type ?? null,
@@ -109,6 +147,7 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
         created_at: appointment.created_at,
         queue_time: appointment.queue_time,
         services: [],
+        service_details: Array.isArray(appointment.service_details) ? [...appointment.service_details] : [],
         departments: new Set(),
         doctors: new Set(),
         department: appointment.department,
@@ -159,6 +198,12 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
         if (!patientGroups[patientKey].queue_entry_id) {
           patientGroups[patientKey].queue_entry_id = nextQueueEntryId;
         }
+      }
+
+      if (!patientGroups[patientKey].patient_gender && patientGender) {
+        patientGroups[patientKey].patient_gender = patientGender;
+        patientGroups[patientKey].gender = patientGender;
+        patientGroups[patientKey].sex = patientGender;
       }
 
       patientGroups[patientKey].queue_time = pickEarlierTimestamp(
@@ -236,6 +281,38 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
         if (!patientGroups[patientKey].service_codes.includes(code)) {
           patientGroups[patientKey].service_codes.push(code);
         }
+      });
+    }
+
+    if (Array.isArray(appointment.service_details)) {
+      if (!patientGroups[patientKey].service_details) {
+        patientGroups[patientKey].service_details = [];
+      }
+      const existingServiceDetailKeys = new Set(
+        patientGroups[patientKey].service_details.map((serviceDetail) => (
+          serviceDetail?.service_id ??
+          serviceDetail?.id ??
+          serviceDetail?.service_code ??
+          serviceDetail?.code ??
+          serviceDetail?.service_name ??
+          serviceDetail?.name
+        )).filter((value) => value !== null && value !== undefined).map(String),
+      );
+
+      appointment.service_details.forEach((serviceDetail) => {
+        if (!serviceDetail) return;
+        const serviceDetailKey = serviceDetail.service_id ??
+          serviceDetail.id ??
+          serviceDetail.service_code ??
+          serviceDetail.code ??
+          serviceDetail.service_name ??
+          serviceDetail.name ??
+          null;
+        if (serviceDetailKey === null || serviceDetailKey === undefined || existingServiceDetailKeys.has(String(serviceDetailKey))) {
+          return;
+        }
+        patientGroups[patientKey].service_details.push(serviceDetail);
+        existingServiceDetailKeys.add(String(serviceDetailKey));
       });
     }
 

--- a/frontend/src/utils/serviceCodeResolver.js
+++ b/frontend/src/utils/serviceCodeResolver.js
@@ -380,6 +380,32 @@ export function normalizeServicesFromInitialData(initialData, servicesData = [])
         };
     };
 
+    const resolveOriginalQueueId = (serviceData = {}) => {
+        if (serviceData.original_queue_id || serviceData.queue_entry_id || serviceData.queue_id) {
+            return serviceData.original_queue_id || serviceData.queue_entry_id || serviceData.queue_id;
+        }
+        if (!Array.isArray(initialData.queue_numbers)) return null;
+
+        const serviceId = serviceData.service_id || serviceData.id || null;
+        const serviceCode = toServiceCode(serviceData.service_code || serviceData.code || serviceData.name || '');
+        const serviceName = String(serviceData.name || serviceData.service_name || '').toLowerCase().trim();
+
+        const match = initialData.queue_numbers.find((queueItem) => {
+            if (!queueItem) return false;
+            if (serviceId && queueItem.service_id && Number(queueItem.service_id) === Number(serviceId)) {
+                return true;
+            }
+            const queueCode = toServiceCode(queueItem.service_code || queueItem.code || queueItem.service_name || '');
+            if (serviceCode && queueCode && serviceCode === queueCode) {
+                return true;
+            }
+            const queueName = String(queueItem.service_name || queueItem.name || '').toLowerCase().trim();
+            return Boolean(serviceName && queueName && serviceName === queueName);
+        });
+
+        return match?.id || match?.queue_id || match?.queue_entry_id || null;
+    };
+
     /**
      * Helper: Дедупликация и сортировка услуг
      */
@@ -414,7 +440,10 @@ export function normalizeServicesFromInitialData(initialData, servicesData = [])
     if (Array.isArray(initialData.service_details) && initialData.service_details.length > 0) {
         initialData.service_details.forEach(svc => {
             if (svc) {
-                items.push(createCartItem({ ...svc, _source: 'service_details' }));
+                items.push(createCartItem(
+                    { ...svc, _source: 'service_details' },
+                    resolveOriginalQueueId(svc)
+                ));
             }
         });
         return finalizeItems(items);
@@ -442,7 +471,7 @@ export function normalizeServicesFromInitialData(initialData, servicesData = [])
                     price: serviceItem.price || foundService?.price || 0,
                     quantity: serviceItem.quantity || 1,
                     _source: 'services_array',
-                }));
+                }, resolveOriginalQueueId(serviceItem)));
             } else {
                 // Строка - legacy формат (код или название услуги)
                 const serviceName = serviceItem;
@@ -459,7 +488,7 @@ export function normalizeServicesFromInitialData(initialData, servicesData = [])
                     code: serviceCode || serviceName,
                     price: foundService?.price || 0,
                     _source: 'services_array',
-                }));
+                }, resolveOriginalQueueId({ name: serviceName, code: serviceCode })));
             }
         });
         return finalizeItems(items);
@@ -480,7 +509,7 @@ export function normalizeServicesFromInitialData(initialData, servicesData = [])
                     code: normalizedCode || serviceCode,
                     price: foundService?.price || 0,
                     _source: 'service_codes',
-                }));
+                }, resolveOriginalQueueId({ code: normalizedCode || serviceCode, service_id: foundService?.id || null })));
             }
         });
         return finalizeItems(items);


### PR DESCRIPTION
## Summary

- Add `RegistrarEditDeltaService` and `POST /api/v1/registrar/cart/edit-delta` for edit-mode service additions.
- Reuse active queue entries for existing queue types instead of duplicating rows.
- Keep the registrar wizard and panel in sync so paid edit deltas can continue into payment and print handling.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/registrar-edit-delta-flow` was cut from the current `origin/main` baseline before the registrar delta slice was committed.
- Clean workspace: inspected before the commit; only the registrar wizard/service, frontend adapters, and focused tests were part of the slice.
- Branch: `codex/registrar-edit-delta-flow`
- Scope gate: allowed backend registrar wizard/service, focused frontend adapters/tests, and registrar characterization coverage; denied migrations, RBAC, and unrelated doctor/lab/payment provider surfaces.
- Red-check handling: fix the PR review gate failure in this same PR before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/registrar/cart/edit-delta` in `backend/app/api/v1/endpoints/registrar_wizard.py`.
- Request shape: registrar edit payload with visit/cart context plus the service delta to append.
- Response shape: registrar wizard state that preserves the active edit flow and reflects queue/payment side effects.
- Status codes: `200` for accepted deltas, `400` for invalid or no-op edit requests, `403` for unauthorized access, and other endpoint validation failures as covered by tests.
- Frontend consumer: `frontend/src/components/wizard/AppointmentWizardV2.jsx`, `frontend/src/pages/RegistrarPanel.jsx`, and the queue/service adapters.
- Compatibility path or alias: the normal create-like cart flow remains for non-edit paths; this endpoint only handles edit-mode deltas.
- Contract proof: backend characterization coverage plus focused contract tests for `AppointmentWizardV2`, `RegistrarPanel`, `queue.js`, and `registrarAggregation`.

## RBAC / Permissions

- Roles allowed: registrar users with access to the registrar wizard flow.
- Roles denied: patient and other non-registrar callers that do not own the registrar workflow.
- Positive auth proof: registrar edit-mode requests can append services without duplicating active queue rows.
- Negative auth proof: invalid access is rejected and the no-change path does not fall through to create-like behavior.

## Notification / Realtime

not applicable - this slice does not add websocket channels, push notifications, or realtime delivery semantics.

## Frontend Resilience

- Empty data proof: the wizard and registrar panel still render with empty or unchanged service sets without forcing duplicate queue creation.
- Partial data proof: missing optional service metadata does not break queue aggregation or edit-mode rendering.
- Forbidden secondary path behavior: no-change edit saves do not call create-like cart flow.
- Missing draft/resource behavior: missing edit context is handled by the existing registrar guardrails instead of inventing new rows.
- Stale route/deep-link behavior: the wizard and panel keep the edit route state stable while service tabs are toggled.

## Scope Gate

- Allowed paths: backend registrar wizard/service, registrar characterization tests, frontend registrar wizard/panel/api adapters, and focused tests.
- Denied paths: migrations, RBAC, doctor/lab/payment provider runtime changes outside registrar delta sync, and deploy/secrets.
- Migration/docs/test impact: no migration; focused backend and frontend contract/characterization tests were added or updated.
- Rollback note: revert the registrar delta service/endpoint and the matching frontend adapter changes.

## Validation

- Targeted tests or smoke run: branch-level backend characterization, frontend contract tests, and registrar browser smoke from the edit flow slice.
- Result: passed in the branch validation run.
- Not checked: no fresh rerun in this pass, and unrelated suites remain out of scope.