### PR TITLE
fix(registrar): guard edit delta visit owner

### DIFF
--- a/backend/app/services/registrar_edit_delta_service.py
+++ b/backend/app/services/registrar_edit_delta_service.py
@@ -370,7 +370,15 @@ class RegistrarEditDeltaService:
         create_only_if_needed: bool,
     ) -> Visit | None:
         if entry.visit_id:
-            return self.db.query(Visit).filter(Visit.id == entry.visit_id).first()
+            visit = self.db.query(Visit).filter(Visit.id == entry.visit_id).first()
+            if visit:
+                if visit.patient_id != patient.id:
+                    raise ValueError(
+                        "Queue entry visit does not belong to the requested patient"
+                    )
+                return visit
+            if not create_only_if_needed:
+                return None
         if not create_only_if_needed:
             return None
         visit = self._create_visit(

--- a/backend/tests/characterization/test_registrar_edit_delta_characterization.py
+++ b/backend/tests/characterization/test_registrar_edit_delta_characterization.py
@@ -7,6 +7,7 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.patient import Patient
 from app.models.payment import Payment
 from app.models.payment_invoice import PaymentInvoice, PaymentInvoiceVisit
 from app.models.service import Service
@@ -435,6 +436,84 @@ def test_edit_delta_pending_invoice_receives_delta(
     assert payload["invoice_id"] == invoice.id
     db_session.refresh(invoice)
     assert invoice.total_amount == Decimal("40000.00")
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+def test_edit_delta_rejects_queue_entry_linked_to_other_patient_visit(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_patient,
+    test_doctor,
+):
+    original_service = _create_service(
+        db_session,
+        code="OWNER-OLD-01",
+        name="Owner Old Lab",
+        queue_tag="laboratory_general",
+    )
+    added_service = _create_service(
+        db_session,
+        code="OWNER-NEW-01",
+        name="Owner New Lab",
+        queue_tag="laboratory_general",
+        price=Decimal("30000"),
+    )
+    other_patient = Patient(
+        last_name="Other",
+        first_name="Patient",
+        phone="+998900000999",
+    )
+    db_session.add(other_patient)
+    db_session.commit()
+    db_session.refresh(other_patient)
+    other_visit = _create_visit(
+        db_session,
+        patient=other_patient,
+        doctor_id=test_doctor.id,
+        department="laboratory_general",
+    )
+    queue = _create_queue(
+        db_session,
+        specialist_id=test_doctor.id,
+        queue_tag="laboratory_general",
+    )
+    entry = _create_entry(
+        db_session,
+        queue=queue,
+        patient=test_patient,
+        service=original_service,
+        visit_id=other_visit.id,
+    )
+
+    response = _post_edit_delta(
+        client,
+        registrar_auth_headers,
+        patient_id=test_patient.id,
+        services=[{"service_id": added_service.id, "quantity": 1}],
+        entry_ids=[entry.id],
+    )
+
+    assert response.status_code == 400, response.text
+    assert "does not belong" in response.json()["detail"]
+    assert (
+        db_session.query(VisitService)
+        .filter(
+            VisitService.visit_id == other_visit.id,
+            VisitService.service_id == added_service.id,
+        )
+        .count()
+        == 0
+    )
+    assert (
+        db_session.query(PaymentInvoiceVisit)
+        .filter(PaymentInvoiceVisit.visit_id == other_visit.id)
+        .count()
+        == 0
+    )
+    db_session.refresh(entry)
+    assert {svc["service_id"] for svc in entry.services} == {original_service.id}
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
Fixes registrar edit-delta so an existing `OnlineQueueEntry.visit_id` is trusted only when the resolved `Visit.patient_id` matches the request `patient_id`.

## Cyclic Execution Evidence
- Fresh main sync: safe worktree fast-forwarded to `origin/main` at `fa1f957c` before branching.
- Clean workspace: branch started clean from `codex/current-main-view`.
- Branch: `codex/registrar-edit-delta-visit-owner`.
- Scope gate: local agent gate was run with known root cause `backend/app/services/registrar_edit_delta_service.py`; first runtime slice stayed in service, with a focused characterization regression added for proof.
- Red-check handling: if CI fails, this PR will be fixed in-place before merge.

## Contract Impact
- Canonical surface: mounted `POST /api/v1/registrar/cart/edit-delta` delegates queue/visit mutation to `RegistrarEditDeltaService`.
- Request shape: unchanged; still accepts `patient_id`, `services`, `target_date`, and optional `existing_queue_entry_ids`.
- Response shape: unchanged for valid requests.
- Status codes: valid same-patient queue/visit appends remain 200; mislinked queue entry to another patient's visit now returns 400 before mutation.
- Frontend consumer: registrar edit flow only.
- Compatibility path or alias: stale missing visit ids can still create a new visit when a real delta is needed; only cross-patient visit ids fail closed.
- Contract proof: characterization regression posts through the mounted route and proves a queue entry for patient A linked to patient B's visit is rejected.

## RBAC / Permissions
- Roles allowed: existing Admin/Registrar dependency remains unchanged.
- Roles denied: no role can append edit-delta services to a Visit owned by a different patient via a mislinked queue entry.
- Positive auth proof: existing edit-delta characterization tests still pass for same-patient appends, diagnostics rows, invoice deltas, and paid supplemental invoices.
- Negative auth proof: new regression verifies cross-patient queue-entry visit id returns 400 and creates no VisitService or PaymentInvoiceVisit for the foreign Visit.

## Notification / Realtime
- Event type or websocket channel: none changed.
- Payload version / ack behavior: none changed.
- Read/unread or delivery semantics: no notification read/delivery semantics changed.
- Reconnect/resync proof: registrar state can resync from unchanged response shape for valid records; rejected mislinked records do not mutate backend state.

## Frontend Resilience
- Empty data proof: existing no-new-service edit-delta test still returns zero invoice/amount without mutation.
- Partial data proof: existing tests cover missing new queue row when appending to active waiting/diagnostics entries.
- Forbidden secondary path behavior: cross-patient visit linkage now fails before secondary VisitService/invoice writes.
- Missing draft/resource behavior: missing existing visit ids are handled by the existing create-visit path when a delta is needed; this PR only blocks foreign existing visits.
- Stale route/deep-link behavior: route path and request contract are unchanged; stale clients get an explicit 400 for corrupted queue/visit linkage.

## Scope Gate
- Allowed paths: `backend/app/services/registrar_edit_delta_service.py`, `backend/tests/characterization/test_registrar_edit_delta_characterization.py`.
- Denied paths: frontend, `/api/v1/ui/*`, migrations, queue allocator fairness rewrites, appointment wizard rewrites, payment schema/model changes.
- Migration/docs/test impact: no migration or docs; added focused characterization regression.
- Rollback note: revert this single commit to restore prior edit-delta trust behavior.

## Validation
- Targeted tests or smoke run: `scripts/run_python.ps1 -PythonArgs @('-m','py_compile','backend/app/services/registrar_edit_delta_service.py','backend/tests/characterization/test_registrar_edit_delta_characterization.py')`.
- Targeted tests or smoke run: `TESTING=1 DATABASE_URL=sqlite:///C:/tmp/registrar-edit-delta-owner-test.db scripts/run_backend_pytest.ps1 tests/characterization/test_registrar_edit_delta_characterization.py`.
- Targeted tests or smoke run: `git diff --check`.
- Result: py_compile passed; edit-delta characterization suite passed 8 tests; diff check passed.
- Not checked: broad backend suite and frontend wizard runtime smoke.