### PR TITLE
fix(queue): preserve role actions and clinic local time

### DIFF
--- a/backend/alembic/versions/0030_visit_queue_updated_at.py
+++ b/backend/alembic/versions/0030_visit_queue_updated_at.py
@@ -1,0 +1,47 @@
+"""Add updated_at to visits and queue entries.
+
+Revision ID: 0030_visit_queue_updated_at
+Revises: 0029_tg_patient_onboarding
+Create Date: 2026-06-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0030_visit_queue_updated_at"
+down_revision = "0029_tg_patient_onboarding"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "visits",
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "queue_entries",
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+    )
+    op.execute(
+        "UPDATE visits SET updated_at = COALESCE(updated_at, created_at, CURRENT_TIMESTAMP)"
+    )
+    op.execute(
+        "UPDATE queue_entries SET updated_at = COALESCE(updated_at, created_at, CURRENT_TIMESTAMP)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("queue_entries", "updated_at")
+    op.drop_column("visits", "updated_at")

--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -5,7 +5,7 @@ API endpoints для интеграции панелей врачей с сис�
 
 import logging
 import uuid
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -427,7 +427,12 @@ def get_doctor_queue_today(
                     "phone": entry.phone,
                     "source": entry.source,
                     "status": entry.status,
-                    "created_at": entry.created_at.isoformat(),
+                    "created_at": entry.created_at.isoformat() if entry.created_at else None,
+                    "queue_time": entry.queue_time.isoformat() if entry.queue_time else None,
+                    "updated_at": entry.updated_at.isoformat() if entry.updated_at else None,
+                    "last_changed_at": entry.updated_at.isoformat() if entry.updated_at else None,
+                    "display_time_kind": "queue_time" if entry.queue_time else "created_at",
+                    "timezone": "Asia/Tashkent",
                     "called_at": (
                         entry.called_at.isoformat() if entry.called_at else None
                     ),
@@ -545,8 +550,10 @@ def call_patient(
                 detail=f"Р’С‹Р·РІР°С‚СЊ РјРѕР¶РЅРѕ С‚РѕР»СЊРєРѕ waiting, С‚РµРєСѓС‰РёР№: {queue_entry.status}",
             )
 
+        changed_at = datetime.now(timezone.utc)
         queue_entry.status = "called"
-        queue_entry.called_at = datetime.utcnow()
+        queue_entry.called_at = changed_at
+        queue_entry.updated_at = changed_at
 
         db.commit()
         db.refresh(queue_entry)
@@ -583,6 +590,7 @@ def call_patient(
                 "number": queue_entry.number,
                 "status": queue_entry.status,
                 "called_at": queue_entry.called_at.isoformat(),
+                "updated_at": queue_entry.updated_at.isoformat() if queue_entry.updated_at else None,
             },
         }
 
@@ -657,7 +665,9 @@ def start_patient_visit(
                 ),
             )
 
+        changed_at = datetime.now(timezone.utc)
         queue_entry.status = "in_progress"
+        queue_entry.updated_at = changed_at
 
         # Создаем или обновляем визит в таблице visits
         visit = crud_visit.find_or_create_today_visit(
@@ -670,6 +680,8 @@ def start_patient_visit(
         # Обновляем время начала приема
         visit.visit_time = datetime.now().strftime("%H:%M")
         visit.notes = f"Прием начат в {datetime.now().strftime('%H:%M')}"
+
+        visit.updated_at = changed_at
 
         db.commit()
 
@@ -764,6 +776,7 @@ def complete_patient_visit(
         if visit:
             # Обновляем статус визита
             visit.status = "completed"
+            visit.updated_at = datetime.now(timezone.utc)
 
             # Payment state remains in Payment; completion must not rewrite
             # registration discount_mode.
@@ -838,7 +851,9 @@ def complete_patient_visit(
                     ),
                 )
 
+            changed_at = datetime.now(timezone.utc)
             queue_entry.status = "served"
+            queue_entry.updated_at = changed_at
             db.commit()
             db.refresh(queue_entry)
 
@@ -857,6 +872,7 @@ def complete_patient_visit(
                 )
                 # ✅ Обновляем статус визита на completed
                 visit.status = "completed"
+                visit.updated_at = changed_at
 
                 # ✅ ИСПРАВЛЕНО: Проверяем и сохраняем информацию об оплате, создаем платеж через SSOT
                 # Если визит был оплачен (есть записи в Payment или статус указывает на оплату)

--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -43,26 +43,21 @@ def _normalize_queue_status_for_registrar(raw_status: str | None) -> str:
 
 
 REGISTRAR_PAYMENT_ROLES = {"admin", "registrar", "cashier"}
-REGISTRAR_START_VISIT_ROLES = {
-    "admin",
-    "registrar",
+REGISTRAR_DOCTOR_ACTION_ROLES = {
     "doctor",
     "cardio",
     "cardiology",
+    "cardiologist",
     "derma",
+    "dermatologist",
     "dentist",
     "lab",
 }
+REGISTRAR_START_VISIT_ROLES = REGISTRAR_DOCTOR_ACTION_ROLES
 REGISTRAR_PRINT_TICKET_ROLES = {"admin", "registrar", "cashier", "doctor"}
-REGISTRAR_COMPLETE_ROLES = {"admin", "registrar", "doctor", "cashier", "receptionist"}
+REGISTRAR_COMPLETE_ROLES = REGISTRAR_DOCTOR_ACTION_ROLES
 REGISTRAR_CANCEL_ROLES = {"admin", "registrar", "cashier", "receptionist", "doctor"}
-REGISTRAR_DOCTOR_SECONDARY_ACTION_ROLES = {
-    "doctor",
-    "cardio",
-    "cardiology",
-    "derma",
-    "dentist",
-}
+REGISTRAR_DOCTOR_SECONDARY_ACTION_ROLES = REGISTRAR_DOCTOR_ACTION_ROLES
 REGISTRAR_START_STATUSES = {"waiting", "queued"}
 REGISTRAR_PRINT_STATUSES = {"waiting", "queued"}
 REGISTRAR_COMPLETE_STATUSES = {"called", "in_cabinet", "in_progress"}
@@ -1437,9 +1432,12 @@ def start_queue_visit(
                     db.query(Visit).filter(Visit.id == queue_entry.visit_id).first()
                 )
 
+            changed_at = datetime.now(timezone.utc)
             queue_entry.status = "in_progress"
+            queue_entry.updated_at = changed_at
             if linked_visit:
                 linked_visit.status = "in_progress"
+                linked_visit.updated_at = changed_at
 
             logger.info(
                 "start_queue_visit: started queue entry %d; linked_visit_id=%s; status=%s",
@@ -2695,7 +2693,7 @@ def get_today_queues(
                         # ✅ SSOT FIX: Для QR-визитов нужно получить данные из OnlineQueueEntry
                         # Frontend использует этот ID для вызова full-update endpoint
                         queue_entry_for_visit = db.execute(
-                            text("SELECT id, number, queue_time, total_amount FROM queue_entries WHERE visit_id = :visit_id LIMIT 1"),
+                            text("SELECT id, number, queue_time, updated_at, total_amount FROM queue_entries WHERE visit_id = :visit_id LIMIT 1"),
                             {"visit_id": visit.id}
                         ).first()
                         if queue_entry_for_visit:
@@ -2704,6 +2702,7 @@ def get_today_queues(
                             entry_wrapper["oqe_number"] = queue_entry_for_visit.number
                             entry_wrapper["oqe_total_amount"] = queue_entry_for_visit.total_amount or 0
                             entry_wrapper["oqe_queue_time"] = queue_entry_for_visit.queue_time
+                            entry_wrapper["oqe_updated_at"] = queue_entry_for_visit.updated_at
                         else:
                             record_id = visit.id
                         # Также сохраняем visit_id для обратной совместимости
@@ -2893,6 +2892,8 @@ def get_today_queues(
                 queue_entry_time = None  # По умолчанию нет queue_time
 
                 # Пробуем получить номер и queue_time из таблицы queue_entries через Table reflection
+                queue_entry_updated_at = None
+
                 if record_id:
                     try:
                         # Используем прямой SQL запрос через Table reflection (без импорта модели)
@@ -2908,6 +2909,7 @@ def get_today_queues(
                                 # ⭐ PHASE 1 FIX: Используем уже полученные данные из entry_wrapper
                                 queue_entry_number = entry_wrapper.get("oqe_number") or idx
                                 queue_entry_time = entry_wrapper.get("oqe_queue_time")
+                                queue_entry_updated_at = entry_wrapper.get("oqe_updated_at")
                             else:
                                 # ⭐ PHASE 1 FIX: Для OnlineQueueEntry номер и queue_time из entry_data
                                 queue_entry_number = (
@@ -2928,6 +2930,7 @@ def get_today_queues(
                                     and entry_data.queue_time
                                     else None
                                 )
+                                queue_entry_updated_at = getattr(entry_data, 'updated_at', None)
                             logger.debug(
                                 "get_today_queues: OnlineQueue номер: ID=%d, number=%d, queue_time=%s, patient=%s",
                                 record_id,
@@ -2939,13 +2942,14 @@ def get_today_queues(
                             # Ищем запись по visit_id
                             queue_entry_row = db.execute(
                                 text(
-                                    "SELECT number, queue_time FROM queue_entries WHERE visit_id = :visit_id LIMIT 1"
+                                    "SELECT number, queue_time, updated_at FROM queue_entries WHERE visit_id = :visit_id LIMIT 1"
                                 ),
                                 {"visit_id": record_id},
                             ).first()
                             if queue_entry_row:
                                 queue_entry_number = queue_entry_row.number
                                 queue_entry_time = queue_entry_row.queue_time
+                                queue_entry_updated_at = queue_entry_row.updated_at
                         elif (
                             entry_type == "appointment"
                             and patient_id
@@ -2956,7 +2960,7 @@ def get_today_queues(
                             queue_entry_row = db.execute(
                                 text(
                                     """
-                                    SELECT qe.number, qe.queue_time
+                                    SELECT qe.number, qe.queue_time, qe.updated_at
                                     FROM queue_entries qe
                                     JOIN daily_queues dq ON qe.queue_id = dq.id
                                     WHERE qe.patient_id = :patient_id
@@ -2976,6 +2980,7 @@ def get_today_queues(
                             if queue_entry_row:
                                 queue_entry_number = queue_entry_row.number
                                 queue_entry_time = queue_entry_row.queue_time
+                                queue_entry_updated_at = queue_entry_row.updated_at
                     except Exception as e:
                         # Логируем ошибку, но продолжаем работу с дефолтным номером
                         # Это не критично - порядковые номера работают как fallback
@@ -3050,6 +3055,15 @@ def get_today_queues(
                     entry_queue_time = entry_wrapper["queue_time"]
                 if not entry_queue_time:
                     entry_queue_time = entry_wrapper.get("created_at")
+                entry_updated_at = (
+                    queue_entry_updated_at
+                    or entry_wrapper.get("oqe_updated_at")
+                    or getattr(entry_data, "updated_at", None)
+                    or entry_wrapper.get("created_at")
+                )
+                entry_display_time_kind = (
+                    "queue_time" if queue_entry_time or entry_wrapper.get("queue_time") else "created_at"
+                )
 
                 entry_visit_id = (
                     entry_wrapper.get("visit_id")
@@ -3121,6 +3135,10 @@ def get_today_queues(
                             entry_wrapper.get("created_at")
                         ),
                         "queue_time": _serialize_registrar_datetime(entry_queue_time),
+                        "updated_at": _serialize_registrar_datetime(entry_updated_at),
+                        "last_changed_at": _serialize_registrar_datetime(entry_updated_at),
+                        "display_time_kind": entry_display_time_kind,
+                        "timezone": "Asia/Tashkent",
                         "called_at": None,
                         "visit_time": visit_time,
                         "discount_mode": discount_mode,
@@ -3149,6 +3167,7 @@ def get_today_queues(
                     else f"Специалист #{data['doctor_id']}"
                 ),
                 "specialty": specialty,
+                "timezone": "Asia/Tashkent",
                 "cabinet": doctor.cabinet if doctor else "N/A",
                 "integrity_warnings": list(dict.fromkeys(data.get("integrity_warnings", []))),
                 "has_integrity_warnings": bool(data.get("integrity_warnings")),
@@ -3172,6 +3191,7 @@ def get_today_queues(
             "queues": result,
             "total_queues": len(result),
             "date": today.isoformat(),
+            "timezone": "Asia/Tashkent",
         }
 
     except Exception as e:

--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -2623,6 +2623,7 @@ REGISTRAR_COMMAND_ROLE_BY_ACTION = {
 }
 
 REGISTRAR_SUPPORTED_RECORD_KINDS = {"visit", "online_queue", "appointment"}
+REGISTRAR_APPOINTMENT_WORKFLOW_ROLES = {"admin", "registrar", "receptionist"}
 
 
 def _registrar_user_role_names(user: User | None) -> set[str]:
@@ -2647,8 +2648,24 @@ def _normalize_registrar_record_kind(record_kind: str | None) -> str:
     return str(record_kind or "").strip().lower()
 
 
-def _ensure_registrar_command_role(user: User | None, action: str) -> None:
-    allowed_roles = REGISTRAR_COMMAND_ROLE_BY_ACTION.get(action)
+def _registrar_command_allowed_roles(
+    action: str,
+    record_kind: str | None = None,
+) -> set[str] | None:
+    if (
+        record_kind == "appointment"
+        and action in {"start_visit", "complete"}
+    ):
+        return REGISTRAR_APPOINTMENT_WORKFLOW_ROLES
+    return REGISTRAR_COMMAND_ROLE_BY_ACTION.get(action)
+
+
+def _ensure_registrar_command_role(
+    user: User | None,
+    action: str,
+    record_kind: str | None = None,
+) -> None:
+    allowed_roles = _registrar_command_allowed_roles(action, record_kind)
     if not allowed_roles:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -3326,7 +3343,6 @@ def run_registrar_record_action(
     """Run registrar-owned record commands through a single backend contract."""
 
     action = _normalize_registrar_action(request.action)
-    _ensure_registrar_command_role(current_user, action)
 
     records: list[RegistrarRecordRef] = []
     if request.records:
@@ -3355,6 +3371,13 @@ def run_registrar_record_action(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No registrar records provided",
+        )
+
+    for record in unique_records:
+        _ensure_registrar_command_role(
+            current_user,
+            action,
+            record.record_kind,
         )
 
     results = [

--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -5,7 +5,7 @@ API endpoints для мастера регистрации с поддержко
 
 import asyncio
 import logging
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
@@ -2600,8 +2600,6 @@ def _sync_payment_invoices_for_paid_visit(
 REGISTRAR_COMMAND_ROLE_BY_ACTION = {
     "mark_paid": {"admin", "registrar", "cashier"},
     "start_visit": {
-        "admin",
-        "registrar",
         "doctor",
         "cardio",
         "cardiology",
@@ -2611,7 +2609,16 @@ REGISTRAR_COMMAND_ROLE_BY_ACTION = {
         "dentist",
         "lab",
     },
-    "complete": {"admin", "registrar", "doctor", "cashier", "receptionist"},
+    "complete": {
+        "doctor",
+        "cardio",
+        "cardiology",
+        "cardiologist",
+        "derma",
+        "dermatologist",
+        "dentist",
+        "lab",
+    },
     "cancel": {"admin", "registrar", "cashier", "receptionist", "doctor"},
 }
 
@@ -2973,7 +2980,9 @@ def mark_visit_as_paid(
             )
 
         # [FIX:PAYMENT_STATUS] Payment must not overwrite the operational visit/queue status.
+        changed_at = datetime.now(timezone.utc)
         visit.status = _preserve_operational_status_on_payment(visit.status)
+        visit.updated_at = changed_at
         _sync_payment_invoices_for_paid_visit(
             db,
             visit_id=visit.id,
@@ -3077,6 +3086,7 @@ def mark_queue_entry_as_paid(
             )
             entry.status = _preserve_operational_status_on_payment(entry.status)
             entry.discount_mode = "paid"
+            entry.updated_at = datetime.now(timezone.utc)
             logger.info(
                 "[FIX:PAYMENT_STATUS] Queue entry marked paid without Visit: entry_id=%d, status=%s",
                 entry.id,
@@ -3161,9 +3171,12 @@ def mark_queue_entry_as_paid(
             )
 
         # [FIX:PAYMENT_STATUS] Payment is stored separately; queue operational status stays intact.
+        changed_at = datetime.now(timezone.utc)
         visit.status = _preserve_operational_status_on_payment(visit.status)
+        visit.updated_at = changed_at
         
         entry.status = _preserve_operational_status_on_payment(entry.status)
+        entry.updated_at = changed_at
         _sync_payment_invoices_for_paid_visit(
             db,
             visit_id=visit.id,
@@ -3234,6 +3247,7 @@ def complete_visit(
         _ensure_visit_doctor_access(db, visit, current_user)
 
         visit.status = "completed"
+        visit.updated_at = datetime.now(timezone.utc)
         db.commit()
         db.refresh(visit)
 
@@ -3265,6 +3279,7 @@ def start_visit(
             )
 
         visit.status = "in_progress"
+        visit.updated_at = datetime.now(timezone.utc)
         db.commit()
         db.refresh(visit)
 

--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -2927,8 +2927,6 @@ def mark_visit_as_paid(
 
             # [OK] ИСПРАВЛЕНО: Используем прямой SQL для создания платежа, чтобы обойти конфликт моделей
             # (BillingPayment и Payment используют одну таблицу, что вызывает проблемы)
-            from datetime import datetime, timezone
-
             from sqlalchemy import text
 
             currency = total_info.get("currency", "UZS")
@@ -3120,7 +3118,6 @@ def mark_queue_entry_as_paid(
             )
             payment_amount = float(total_info["total"])
 
-            from datetime import datetime, timezone
             from sqlalchemy import text
 
             currency = total_info.get("currency", "UZS")

--- a/backend/app/models/online_queue.py
+++ b/backend/app/models/online_queue.py
@@ -24,7 +24,7 @@ See also:
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
@@ -183,6 +183,9 @@ class OnlineQueueEntry(Base):
 
     created_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), index=True
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=lambda: datetime.now(timezone.utc)
     )
     called_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 

--- a/backend/app/models/visit.py
+++ b/backend/app/models/visit.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
@@ -36,6 +36,9 @@ class Visit(Base):
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=lambda: datetime.now(timezone.utc)
     )
 
     # ✅ ПОЛЯ ДЛЯ МАСТЕРА РЕГИСТРАЦИИ

--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -984,6 +984,7 @@ class QueueBusinessService:
             source=source,
             status=status,
             queue_time=queue_dt,
+            updated_at=queue_dt,
             total_amount=total_amount or 0,
             session_id=session_id,  # ⭐ NEW: Session grouping
         )
@@ -1074,8 +1075,10 @@ class QueueBusinessService:
 
         original_queue_time = entry.queue_time
         previous_status = entry.status
+        changed_at = self.get_local_timestamp(db)
         entry.status = "called"
-        entry.called_at = self.get_local_timestamp(db)
+        entry.called_at = changed_at
+        entry.updated_at = changed_at
         if commit:
             db.commit()
             db.refresh(entry)
@@ -1112,6 +1115,7 @@ class QueueBusinessService:
         original_queue_time = entry.queue_time
         previous_status = entry.status
         entry.status = "no_show"
+        entry.updated_at = self.get_local_timestamp(db)
         if commit:
             db.commit()
             db.refresh(entry)
@@ -1167,6 +1171,7 @@ class QueueBusinessService:
         original_queue_time = entry.queue_time
         previous_status = entry.status
         entry.status = "cancelled"
+        entry.updated_at = self.get_local_timestamp(db)
         if commit:
             db.commit()
             db.refresh(entry)
@@ -1192,6 +1197,7 @@ class QueueBusinessService:
         original_queue_time = entry.queue_time
         previous_status = entry.status
         entry.status = "rescheduled"
+        entry.updated_at = self.get_local_timestamp(db)
         if commit:
             db.commit()
             db.refresh(entry)

--- a/backend/app/services/registrar_edit_delta_service.py
+++ b/backend/app/services/registrar_edit_delta_service.py
@@ -246,6 +246,8 @@ class RegistrarEditDeltaService:
         unit_price = Decimal("0") if all_free else Decimal(str(service.price or 0))
         delta_amount = unit_price * Decimal(delta_qty)
 
+        changed_at = queue_service.get_local_timestamp(self.db)
+
         if delta_qty > 0:
             if existing_payload:
                 existing_payload["quantity"] = requested_qty
@@ -261,6 +263,7 @@ class RegistrarEditDeltaService:
             entry.services = services
             entry.service_codes = self._merged_service_codes(entry.service_codes, service)
             entry.total_amount = int(Decimal(str(entry.total_amount or 0)) + delta_amount)
+            entry.updated_at = changed_at
 
         visit = self._ensure_entry_visit(
             entry=entry,
@@ -274,6 +277,7 @@ class RegistrarEditDeltaService:
         )
 
         if visit and delta_qty > 0:
+            visit.updated_at = changed_at
             self._append_visit_service(
                 visit=visit,
                 service=service,
@@ -348,6 +352,7 @@ class RegistrarEditDeltaService:
             auto_number=True,
             commit=False,
         )
+        entry.updated_at = queue_service.get_local_timestamp(self.db)
         return self._delta_result(
             entry=entry,
             service=service,
@@ -382,6 +387,7 @@ class RegistrarEditDeltaService:
             current_user=current_user,
         )
         entry.visit_id = visit.id
+        entry.updated_at = queue_service.get_local_timestamp(self.db)
         return visit
 
     def _create_visit(
@@ -432,7 +438,9 @@ class RegistrarEditDeltaService:
             existing.code = code
             existing.name = service.name
             existing.currency = service.currency or "UZS"
+            visit.updated_at = queue_service.get_local_timestamp(self.db)
             return
+        visit.updated_at = queue_service.get_local_timestamp(self.db)
         self.db.add(
             VisitService(
                 visit_id=visit.id,

--- a/backend/tests/integration/test_registrar_all_appointments.py
+++ b/backend/tests/integration/test_registrar_all_appointments.py
@@ -191,13 +191,12 @@ class TestRegistrarAllAppointments:
         assert found_entry["queue_status"] == "waiting"
         assert found_entry["queue_position"] == entry.number
         assert found_entry["can_mark_paid"] is True
-        assert found_entry["can_start_visit"] is True
+        assert found_entry["can_start_visit"] is False
         assert found_entry["can_cancel"] is True
         assert found_entry["can_print_ticket"] is True
         assert found_entry["can_complete"] is False
         assert set(found_entry["available_actions"]) == {
             "mark_paid",
-            "start_visit",
             "print_ticket",
             "cancel",
         }
@@ -205,6 +204,11 @@ class TestRegistrarAllAppointments:
         assert found_entry["can_schedule_next"] is False
         assert found_entry["queue_time"] == _serialize_registrar_datetime(entry.queue_time)
         assert found_entry["created_at"] == _serialize_registrar_datetime(entry.created_at)
+        expected_changed_at = _serialize_registrar_datetime(entry.updated_at or entry.created_at)
+        assert found_entry["updated_at"] == expected_changed_at
+        assert found_entry["last_changed_at"] == expected_changed_at
+        assert found_entry["display_time_kind"] == "queue_time"
+        assert found_entry["timezone"] == "Asia/Tashkent"
         assert found_entry["patient_name"] == test_patient.short_name()
         assert found_entry["phone"] == test_patient.phone
         assert found_entry["patient_birth_year"] == 1985

--- a/frontend/src/components/doctor/DoctorQueuePanel.jsx
+++ b/frontend/src/components/doctor/DoctorQueuePanel.jsx
@@ -25,6 +25,10 @@ import {
   MacOSEmptyState,
   MacOSAlert } from
 '../ui/macos';
+import {
+  formatRegistrarTime,
+  getRegistrarTimestampDisplay,
+} from '../../utils/dateUtils';
 
 const QUEUE_ACTION_ALIASES = {
   call: ['call'],
@@ -535,6 +539,7 @@ const DoctorQueuePanel = ({
             const canCall = hasBackendQueueAction(entry, 'call', 'can_call');
             const canStartVisit = hasBackendQueueAction(entry, 'start_visit', 'can_start_visit');
             const canComplete = hasBackendQueueAction(entry, 'complete', 'can_complete');
+            const timeDisplay = getRegistrarTimestampDisplay(entry);
 
             return (
               <div
@@ -621,10 +626,8 @@ const DoctorQueuePanel = ({
                           fontSize: 'var(--mac-font-size-xs)',
                           color: 'var(--mac-text-tertiary)'
                         }}>
-                            {new Date(entry.created_at).toLocaleTimeString('ru-RU', {
-                            hour: '2-digit',
-                            minute: '2-digit'
-                          })}
+                            {timeDisplay.primaryLabel}: {timeDisplay.primaryTime || '—'}
+                            {timeDisplay.showChanged ? ` · ${timeDisplay.changedLabel}: ${timeDisplay.changedTime}` : ''}
                           </span>
                         </div>
                       </div>
@@ -647,10 +650,7 @@ const DoctorQueuePanel = ({
                         color: 'var(--mac-text-tertiary)',
                         marginTop: '4px'
                       }}>
-                            Вызван: {new Date(entry.called_at).toLocaleTimeString('ru-RU', {
-                          hour: '2-digit',
-                          minute: '2-digit'
-                        })}
+                            Вызван: {formatRegistrarTime(entry.called_at) || '—'}
                           </div>
                       }
                       </div>

--- a/frontend/src/components/queue/QueueTable.jsx
+++ b/frontend/src/components/queue/QueueTable.jsx
@@ -1,5 +1,6 @@
 import { Badge, Icon } from '../ui/macos';
 import PropTypes from 'prop-types';
+import { formatRegistrarTime } from '../../utils/dateUtils';
 
 /**
  * QueueTable Component
@@ -119,10 +120,7 @@ const QueueTable = ({
     const formatTime = (timestamp) => {
         if (!timestamp) return '—';
         try {
-            return new Date(timestamp).toLocaleTimeString('ru-RU', {
-                hour: '2-digit',
-                minute: '2-digit'
-            });
+            return formatRegistrarTime(timestamp) || 'вЂ”';
         } catch {
             return '—';
         }

--- a/frontend/src/components/tables/AppointmentContextMenu.jsx
+++ b/frontend/src/components/tables/AppointmentContextMenu.jsx
@@ -15,7 +15,7 @@ import {
 'lucide-react';
 
 const ACTION_ALIASES = {
-  in_cabinet: ['in_cabinet', 'in-cabinet', 'start_visit', 'start-visit', 'call'],
+  in_cabinet: ['in_cabinet', 'in-cabinet'],
   call: ['call', 'start_visit', 'start-visit'],
   complete: ['complete', 'complete_visit', 'complete-visit'],
   payment: ['payment', 'mark_paid', 'mark-paid'],

--- a/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
+++ b/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
@@ -36,7 +36,9 @@ import { QueueActionButtons } from '../queue/QueueManagementCard';
 import logger from '../../utils/logger';
 import {
   parseRegistrarTimestamp,
-  REGISTRAR_TIME_ZONE,
+  getRegistrarTimestampDisplay,
+  formatRegistrarDate,
+  formatRegistrarTime,
 } from '../../utils/dateUtils';
 
 // ⭐ SSOT: Centralized service code resolver
@@ -970,8 +972,8 @@ const EnhancedAppointmentsTable = ({
         if (row.payment_type) return t[row.payment_type] || row.payment_type;
         return paymentStatus === 'paid' ? t.unknownPayment : t.pendingPayment;
       })(),
-      row.created_at ? new Date(row.created_at).toLocaleDateString('ru-RU') : row.appointment_date || '',
-      row.created_at ? new Date(row.created_at).toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit', second: '2-digit' }) : row.appointment_time || '',
+      row.created_at ? formatRegistrarDate(row.created_at) : row.appointment_date || '',
+      row.created_at ? formatRegistrarTime(row.created_at, 'ru-RU', { includeSeconds: true }) : row.appointment_time || '',
       t[row.status] || row.status || '',
       (() => {
         if (row.cost_display === 'free') return t.paymentFree;
@@ -1578,10 +1580,10 @@ const EnhancedAppointmentsTable = ({
               const backendCanViewEmr = getBackendActionAvailability(row, 'view_emr', 'can_view_emr');
               const backendCanScheduleNext = getBackendActionAvailability(row, 'schedule_next', 'can_schedule_next');
               const canPay = !isDoctorView && backendCanPay === true;
-              const canCall = backendCanCall === true;
+              const canCall = isDoctorView && backendCanCall === true;
               const canPrint = backendCanPrint === true;
-              const canComplete = backendCanComplete === true;
-              const canViewEmr = backendCanViewEmr === true;
+              const canComplete = isDoctorView && backendCanComplete === true;
+              const canViewEmr = isDoctorView && backendCanViewEmr === true;
               const canScheduleNext = isDoctorView && backendCanScheduleNext === true;
 
               return (
@@ -1881,17 +1883,22 @@ const EnhancedAppointmentsTable = ({
                         {/* ✅ SSOT FIX: ONLY use queue_time. Compute earliest from all patient entries if needed. */}
                         {(() => {
                         // ⭐ SSOT: Use row.queue_time directly - no aggregation
-                        const displayDate = row.queue_time ? safeParseDate(row.queue_time) :
-                        row.created_at ? safeParseDate(row.created_at) : null;
+                        const timeDisplay = getRegistrarTimestampDisplay(row);
 
-                        if (displayDate) {
+                        if (timeDisplay.primaryDate || timeDisplay.primaryTime) {
                           return (
-                            <div>
+                            <div title={`Часовой пояс: ${timeDisplay.timeZone}`}>
+                                <div style={{
+                                fontSize: '11px',
+                                fontWeight: 600,
+                                color: 'var(--mac-text-secondary)',
+                                marginBottom: '2px'
+                              }}>
+                                  {timeDisplay.primaryLabel}
+                                </div>
                                 <div style={{ display: 'flex', alignItems: 'center', gap: '4px', justifyContent: 'center' }}>
                                   <Calendar size={12} style={{ color: 'var(--mac-text-secondary)' }} />
-                                  {displayDate.toLocaleDateString('ru-RU', {
-                                  timeZone: REGISTRAR_TIME_ZONE
-                                })}
+                                  {timeDisplay.primaryDate}
                                 </div>
                                 <div style={{
                                 display: 'flex',
@@ -1903,13 +1910,18 @@ const EnhancedAppointmentsTable = ({
                                 color: 'var(--mac-text-secondary)'
                               }}>
                                   <Clock size={10} />
-                                  {displayDate.toLocaleTimeString('ru-RU', {
-                                  hour: '2-digit',
-                                  minute: '2-digit',
-                                  second: '2-digit',
-                                  timeZone: REGISTRAR_TIME_ZONE
-                                })}
+                                  {timeDisplay.primaryTime}
                                 </div>
+                                {timeDisplay.showChanged &&
+                              <div style={{
+                                marginTop: '4px',
+                                fontSize: '11px',
+                                color: 'var(--mac-text-tertiary)',
+                                lineHeight: 1.35
+                              }}>
+                                    {timeDisplay.changedLabel}: {timeDisplay.changedDate} {timeDisplay.changedTime}
+                                  </div>
+                              }
                               </div>);
 
                         }

--- a/frontend/src/pages/CashierPanel.jsx
+++ b/frontend/src/pages/CashierPanel.jsx
@@ -18,6 +18,7 @@ import { printPanelReceiptInBrowser } from '../services/panelPrint';
 import logger from '../utils/logger';
 import tokenManager from '../utils/tokenManager';
 import { getErrorMessage } from '../utils/errorHandler';
+import { formatRegistrarDate, formatRegistrarTime, parseRegistrarTimestamp } from '../utils/dateUtils';
 import notify from '../services/notify';
 import {
   Dialog,
@@ -104,14 +105,14 @@ const resolvePaymentMethodLabel = (method) => {
 
 const extractReceiptDateTime = (paymentRow) => {
   const sourceTimestamp = paymentRow?.paid_at || paymentRow?.created_at || null;
-  const parsedDate = sourceTimestamp ? new Date(sourceTimestamp) : null;
+  const parsedDate = sourceTimestamp ? parseRegistrarTimestamp(sourceTimestamp) : null;
   const hasValidDate = parsedDate && !Number.isNaN(parsedDate.getTime());
 
   return {
-    date: paymentRow?.date || (hasValidDate ? parsedDate.toLocaleDateString('ru-RU') : ''),
+    date: paymentRow?.date || (hasValidDate ? formatRegistrarDate(parsedDate) : ''),
     time: paymentRow?.time || (
       hasValidDate
-        ? parsedDate.toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' })
+        ? formatRegistrarTime(parsedDate)
         : ''
     )
   };
@@ -941,9 +942,9 @@ const CashierPanel = () => {void
 
     paymentsList.forEach((payment) => {
       // Parse dates from backend
-      const dateObj = new Date(payment.created_at);
-      const dateKey = dateObj.toLocaleDateString('ru-RU');
-      const timeKey = dateObj.toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' });
+      const dateObj = parseRegistrarTimestamp(payment.created_at);
+      const dateKey = formatRegistrarDate(dateObj || payment.created_at);
+      const timeKey = formatRegistrarTime(dateObj || payment.created_at);
 
       const groupKey = `${payment.patient_id}_${dateKey}_${timeKey}`;
 
@@ -1285,22 +1286,13 @@ const CashierPanel = () => {void
                               <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
                                 <span style={{ fontWeight: '500' }}>
                                   {appointment.created_at ?
-                            new Date(appointment.created_at).toLocaleDateString('ru-RU', {
-                              day: '2-digit',
-                              month: '2-digit',
-                              year: 'numeric',
-                              timeZone: 'Asia/Tashkent'
-                            }) :
+                            formatRegistrarDate(appointment.created_at) :
                             appointment.appointment_date || '—'
                             }
                                 </span>
                                 <span style={{ fontSize: '12px', color: 'var(--mac-text-secondary)' }}>
                                   {appointment.created_at ?
-                            new Date(appointment.created_at).toLocaleTimeString('ru-RU', {
-                              hour: '2-digit',
-                              minute: '2-digit',
-                              timeZone: 'Asia/Tashkent'
-                            }) :
+                            formatRegistrarTime(appointment.created_at) :
                             appointment.appointment_time || '—'
                             }
                                 </span>

--- a/frontend/src/pages/DisplayBoardUnified.jsx
+++ b/frontend/src/pages/DisplayBoardUnified.jsx
@@ -21,6 +21,7 @@ import { useTheme } from '../contexts/ThemeContext';
 
 import logger from '../utils/logger';
 import PropTypes from 'prop-types';
+import { formatRegistrarTime } from '../utils/dateUtils';
 
 const DEFAULT_BOARD_STATS = { last_ticket: 0, waiting: 0, serving: 0, done: 0 };
 
@@ -492,10 +493,7 @@ export default function DisplayBoardUnified({
   // Форматирование времени (новое)
   const formatTime = (dateString) => {
     if (!dateString) return '';
-    return new Date(dateString).toLocaleTimeString('ru-RU', {
-      hour: '2-digit',
-      minute: '2-digit'
-    });
+    return formatRegistrarTime(dateString);
   };
 
   // Темы оформления (новое)
@@ -962,7 +960,7 @@ export default function DisplayBoardUnified({
 
         <div style={statCardStyle}>
           <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: currentTheme.textPrimary }}>
-            {new Date().toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' })}
+            {formatRegistrarTime(new Date().toISOString())}
           </div>
           <div style={{ color: currentTheme.textSecondary }}>Текущее время</div>
         </div>

--- a/frontend/src/pages/QueueJoin.jsx
+++ b/frontend/src/pages/QueueJoin.jsx
@@ -17,6 +17,7 @@ import {
   startQueueJoinSession,
   completeQueueJoinSession,
 } from '../api/queue';
+import { formatRegistrarTime } from '../utils/dateUtils';
 
 const formatSpecialistLabel = (specialist) => {
   const doctorName =
@@ -874,7 +875,7 @@ const QueueJoin = () => {
                             {entry.specialist_name || entry.department || `Мутахассис ${idx + 1}`}
                           </div>
                           <div style={{ fontSize: '12px', color: 'var(--mac-text-tertiary)', marginTop: '4px' }}>
-                            Вақт: {entry.queue_time ? new Date(entry.queue_time).toLocaleTimeString('uz-UZ', { hour: '2-digit', minute: '2-digit' }) : '—'}
+                            Вақт: {entry.queue_time ? formatRegistrarTime(entry.queue_time, 'uz-UZ') : '—'}
                           </div>
                         </div>
                       </div>

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -1424,7 +1424,8 @@ const RegistrarPanel = () => {
 
       // Используем новый эндпоинт для получения очередей на указанную дату
       // Если календарь открыт, используем historyDate, иначе сегодня
-      const dateParam = showCalendar && historyDate ? historyDate : getLocalDateString();
+      const urlDate = searchParams.get('date');
+      const dateParam = showCalendar && historyDate ? historyDate : urlDate || getLocalDateString();
       /* console.log('📅 Параметры для loadAppointments:', {
         source: callSource,
         showCalendar,
@@ -1515,6 +1516,10 @@ const RegistrarPanel = () => {
               record_type: fullEntry.record_type ?? fullEntry.type ?? entry.record_type ?? entry.type ?? null,
               created_at: fullEntry.created_at || null,
               queue_time: queueTime,
+              updated_at: fullEntry.updated_at || fullEntry.last_changed_at || null,
+              last_changed_at: fullEntry.last_changed_at || fullEntry.updated_at || null,
+              display_time_kind: fullEntry.display_time_kind || (fullEntry.queue_time ? 'queue_time' : 'created_at'),
+              timezone: fullEntry.timezone || data.timezone || 'Asia/Tashkent',
               discount_mode: fullEntry.discount_mode ?? null,
               approval_status: fullEntry.approval_status || null,
               available_actions: Array.isArray(fullEntry.available_actions) ? fullEntry.available_actions : [],
@@ -1532,7 +1537,10 @@ const RegistrarPanel = () => {
                 queue_name: queueName,
                 specialty: queueTag,
                 status: canonicalStatus,
-                queue_time: queueTime
+                queue_time: queueTime,
+                updated_at: fullEntry.updated_at || fullEntry.last_changed_at || null,
+                last_changed_at: fullEntry.last_changed_at || fullEntry.updated_at || null,
+                timezone: fullEntry.timezone || data.timezone || 'Asia/Tashkent'
               }],
               specialty: queueTag,
               queue_tag: queueTag,
@@ -1668,7 +1676,7 @@ const RegistrarPanel = () => {
       loadAppointmentsInFlightRef.current = false;
       if (!silent) setAppointmentsLoading(false);
     }
-  }, [enrichAppointmentsWithPatientData, showCalendar, historyDate, activeTab, demoAppointments, appointmentsCount]);
+  }, [enrichAppointmentsWithPatientData, showCalendar, historyDate, searchParams, activeTab, demoAppointments, appointmentsCount]);
 
   // Слушаем обновления отделений от админ-панели
   useEffect(() => {

--- a/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
@@ -67,10 +67,10 @@ describe('Doctor panels SSOT contract', () => {
     expect(actionBlock).toContain("getBackendActionAvailability(row, 'view_emr', 'can_view_emr')");
     expect(actionBlock).toContain("getBackendActionAvailability(row, 'schedule_next', 'can_schedule_next')");
     expect(actionBlock).toContain('const canPay = !isDoctorView && backendCanPay === true');
-    expect(actionBlock).toContain('const canCall = backendCanCall === true');
+    expect(actionBlock).toContain('const canCall = isDoctorView && backendCanCall === true');
     expect(actionBlock).toContain('const canPrint = backendCanPrint === true');
-    expect(actionBlock).toContain('const canComplete = backendCanComplete === true');
-    expect(actionBlock).toContain('const canViewEmr = backendCanViewEmr === true');
+    expect(actionBlock).toContain('const canComplete = isDoctorView && backendCanComplete === true');
+    expect(actionBlock).toContain('const canViewEmr = isDoctorView && backendCanViewEmr === true');
     expect(actionBlock).toContain('const canScheduleNext = isDoctorView && backendCanScheduleNext === true');
     expect(actionBlock).not.toContain('rowStatus');
     expect(actionBlock).not.toContain('rowPaymentStatus');

--- a/frontend/src/services/panelPrint.js
+++ b/frontend/src/services/panelPrint.js
@@ -8,6 +8,12 @@ import {
   TICKET_PRINT_SETTINGS_DEFAULTS,
 } from '../api/ticketPrintSettings';
 import logger from '../utils/logger';
+import {
+  formatRegistrarDate,
+  formatRegistrarDateTime,
+  formatRegistrarTime,
+  parseRegistrarTimestamp,
+} from '../utils/dateUtils';
 import { finalizePrintableWindow, openPrintableWindow } from '../utils/printWindow';
 
 function normalizePrintableDateString(value) {
@@ -33,8 +39,8 @@ function tryParsePrintableDate(value) {
   }
 
   for (const candidate of candidates) {
-    const parsed = new Date(candidate);
-    if (!Number.isNaN(parsed.getTime())) {
+    const parsed = parseRegistrarTimestamp(candidate);
+    if (parsed && !Number.isNaN(parsed.getTime())) {
       return parsed;
     }
   }
@@ -43,22 +49,15 @@ function tryParsePrintableDate(value) {
 }
 
 function formatPrintableDate(date) {
-  return date.toLocaleDateString('ru-RU', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  });
+  return formatRegistrarDate(date);
 }
 
 function formatPrintableTime(date) {
-  return date.toLocaleTimeString('ru-RU', {
-    hour: '2-digit',
-    minute: '2-digit'
-  });
+  return formatRegistrarTime(date);
 }
 
 function formatPrintableDateTime(date) {
-  return `${formatPrintableDate(date)} ${formatPrintableTime(date)}`;
+  return formatRegistrarDateTime(date);
 }
 
 function normalizeDateOnly(value) {
@@ -668,7 +667,7 @@ function renderPanelTicketMarkup(payload, settings, branding, issuedAt) {
 }
 
 function renderPanelTicketHtml(payloads, settings, branding) {
-  const issuedAt = new Date().toLocaleString('ru-RU');
+  const issuedAt = formatRegistrarDateTime(new Date().toISOString());
   const safePayloads = Array.isArray(payloads) && payloads.length > 0 ? payloads : [];
   const documentTitle = safePayloads.length > 1
     ? `Талоны (${safePayloads.length})`
@@ -957,7 +956,7 @@ export function buildPanelReceiptPrintableHtml(receiptPayload) {
   const patient = receiptPayload?.patient || {};
   const services = Array.isArray(receiptPayload?.services) ? receiptPayload.services : [];
   const currency = services[0]?.currency || 'UZS';
-  const issuedAt = new Date().toLocaleString('ru-RU');
+  const issuedAt = formatRegistrarDateTime(new Date().toISOString());
 
   const serviceRows = services.length > 0
     ? services.map((service) => `

--- a/frontend/src/utils/__tests__/dateUtils.test.js
+++ b/frontend/src/utils/__tests__/dateUtils.test.js
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseRegistrarTimestamp, REGISTRAR_TIME_ZONE } from '../dateUtils';
+import {
+  formatRegistrarDate,
+  formatRegistrarTime,
+  getRegistrarTimestampDisplay,
+  parseRegistrarTimestamp,
+  REGISTRAR_TIME_ZONE,
+} from '../dateUtils';
 
 describe('parseRegistrarTimestamp', () => {
   it('keeps timezone-aware timestamps stable', () => {
@@ -19,6 +25,23 @@ describe('parseRegistrarTimestamp', () => {
 
   it('exposes the clinic timezone constant used for rendering', () => {
     expect(REGISTRAR_TIME_ZONE).toBe('Asia/Tashkent');
+  });
+
+  it('formats UTC timestamps in clinic local time', () => {
+    expect(formatRegistrarDate('2026-05-31T19:00:00Z')).toBe('01.06.2026');
+    expect(formatRegistrarTime('2026-05-31T19:00:00Z')).toBe('00:00');
+  });
+
+  it('reports changed timestamps separately from queue time', () => {
+    const display = getRegistrarTimestampDisplay({
+      queue_time: '2026-05-31T09:15:00+05:00',
+      updated_at: '2026-05-31T09:45:00+05:00',
+    });
+
+    expect(display.primaryLabel).toBe('Очередь');
+    expect(display.primaryTime).toBe('09:15:00');
+    expect(display.showChanged).toBe(true);
+    expect(display.changedTime).toBe('09:45:00');
   });
 });
 

--- a/frontend/src/utils/dateUtils.js
+++ b/frontend/src/utils/dateUtils.js
@@ -35,6 +35,62 @@ export const parseRegistrarTimestamp = (value) => {
     return Number.isNaN(parsed.getTime()) ? null : parsed;
 };
 
+export const formatRegistrarDate = (value, locale = 'ru-RU') => {
+    const parsed = parseRegistrarTimestamp(value);
+    if (!parsed) return '';
+    return parsed.toLocaleDateString(locale, {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        timeZone: REGISTRAR_TIME_ZONE
+    });
+};
+
+export const formatRegistrarTime = (value, locale = 'ru-RU', options = {}) => {
+    const parsed = parseRegistrarTimestamp(value);
+    if (!parsed) return '';
+    return parsed.toLocaleTimeString(locale, {
+        hour: '2-digit',
+        minute: '2-digit',
+        ...(options.includeSeconds ? { second: '2-digit' } : {}),
+        timeZone: REGISTRAR_TIME_ZONE
+    });
+};
+
+export const formatRegistrarDateTime = (value, locale = 'ru-RU', options = {}) => {
+    const date = formatRegistrarDate(value, locale);
+    const time = formatRegistrarTime(value, locale, options);
+    return [date, time].filter(Boolean).join(' ');
+};
+
+const timestampsDiffer = (a, b) => {
+    const first = parseRegistrarTimestamp(a);
+    const second = parseRegistrarTimestamp(b);
+    if (!first || !second) return false;
+    return Math.abs(first.getTime() - second.getTime()) > 1000;
+};
+
+export const getRegistrarTimestampDisplay = (record = {}, locale = 'ru-RU') => {
+    const primaryValue = record.queue_time || record.created_at || null;
+    const changedValue = record.last_changed_at || record.updated_at || null;
+    const primaryKind = record.queue_time ? 'queue_time' : 'created_at';
+    const showChanged = Boolean(changedValue && primaryValue && timestampsDiffer(primaryValue, changedValue));
+
+    return {
+        timeZone: record.timezone || REGISTRAR_TIME_ZONE,
+        primaryKind,
+        primaryLabel: primaryKind === 'queue_time' ? 'Очередь' : 'Создано',
+        primaryValue,
+        primaryDate: formatRegistrarDate(primaryValue, locale),
+        primaryTime: formatRegistrarTime(primaryValue, locale, { includeSeconds: true }),
+        changedValue,
+        showChanged,
+        changedLabel: 'Изменено',
+        changedDate: showChanged ? formatRegistrarDate(changedValue, locale) : '',
+        changedTime: showChanged ? formatRegistrarTime(changedValue, locale, { includeSeconds: true }) : ''
+    };
+};
+
 /**
  * Converts a Date object to YYYY-MM-DD format string
  * @param {Date} date - The date to format (defaults to current date)
@@ -42,10 +98,14 @@ export const parseRegistrarTimestamp = (value) => {
  */
 export const getLocalDateString = (date = new Date()) => {
     const d = new Date(date);
-    const year = d.getFullYear();
-    const month = String(d.getMonth() + 1).padStart(2, '0');
-    const day = String(d.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
+    const parts = new Intl.DateTimeFormat('en-CA', {
+        timeZone: REGISTRAR_TIME_ZONE,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+    }).formatToParts(d);
+    const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+    return `${values.year}-${values.month}-${values.day}`;
 };
 
 /**

--- a/frontend/src/utils/registrarAggregation.js
+++ b/frontend/src/utils/registrarAggregation.js
@@ -1,3 +1,5 @@
+import { parseRegistrarTimestamp } from './dateUtils';
+
 export const normalizeRegistrationMode = (value) => {
   const normalized = String(value || 'none').toLowerCase();
   return ['none', 'repeat', 'benefit', 'all_free'].includes(normalized) ? normalized : 'none';
@@ -13,8 +15,8 @@ export const getRecordAmount = (appointment) => {
 export const getRegistrarPresentationSortTime = (record) => {
   const value = record?.queue_time || record?.created_at || null;
   if (!value) return 0;
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? 0 : date.getTime();
+  const date = parseRegistrarTimestamp(value);
+  return !date || Number.isNaN(date.getTime()) ? 0 : date.getTime();
 };
 
 export const compareRegistrarPresentationOrder = (a, b) => {
@@ -91,8 +93,8 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
 
   const toTime = (value) => {
     if (!value) return null;
-    const date = new Date(value);
-    return Number.isNaN(date.getTime()) ? null : date.getTime();
+    const date = parseRegistrarTimestamp(value);
+    return !date || Number.isNaN(date.getTime()) ? null : date.getTime();
   };
 
   const pickEarlierTimestamp = (currentValue, nextValue) => {
@@ -106,6 +108,19 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
     if (nextTime === null) return currentValue;
 
     return nextTime < currentTime ? nextValue : currentValue;
+  };
+
+  const pickLaterTimestamp = (currentValue, nextValue) => {
+    if (!currentValue) return nextValue || currentValue;
+    if (!nextValue) return currentValue;
+
+    const currentTime = toTime(currentValue);
+    const nextTime = toTime(nextValue);
+
+    if (currentTime === null) return nextValue;
+    if (nextTime === null) return currentValue;
+
+    return nextTime > currentTime ? nextValue : currentValue;
   };
 
   appointments.forEach((appointment, index) => {
@@ -146,6 +161,10 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
         appointment_date: appointment.appointment_date,
         created_at: appointment.created_at,
         queue_time: appointment.queue_time,
+        updated_at: appointment.updated_at || appointment.last_changed_at || appointment.created_at,
+        last_changed_at: appointment.last_changed_at || appointment.updated_at || appointment.created_at,
+        display_time_kind: appointment.display_time_kind || (appointment.queue_time ? 'queue_time' : 'created_at'),
+        timezone: appointment.timezone || 'Asia/Tashkent',
         services: [],
         service_details: Array.isArray(appointment.service_details) ? [...appointment.service_details] : [],
         departments: new Set(),
@@ -209,6 +228,14 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
       patientGroups[patientKey].queue_time = pickEarlierTimestamp(
         patientGroups[patientKey].queue_time,
         appointment.queue_time,
+      );
+      patientGroups[patientKey].updated_at = pickLaterTimestamp(
+        patientGroups[patientKey].updated_at,
+        appointment.updated_at || appointment.last_changed_at,
+      );
+      patientGroups[patientKey].last_changed_at = pickLaterTimestamp(
+        patientGroups[patientKey].last_changed_at,
+        appointment.last_changed_at || appointment.updated_at,
       );
 
       if (Array.isArray(appointment.queue_numbers)) {


### PR DESCRIPTION
﻿## Summary

- Add `updated_at` tracking for visits and queue entries through Alembic revision `0030_visit_queue_updated_at`.
- Preserve `queue_time` as fair queue time while exposing `updated_at`, `last_changed_at`, `display_time_kind`, and `timezone` for clinic-local display.
- Hide doctor-only call/start actions from registrar/admin aggregate tables while keeping doctor panel actions available.
- Centralize clinic-local time display around `Asia/Tashkent` formatters for registrar, queue, doctor, cashier, and print surfaces.

## Cyclic Execution Evidence

- Fresh main sync: branch was created from current `origin/main` after confirming local `main` matched remote.
- Clean workspace: initial diff was inspected as the intended role-action/time patch before branching.
- Branch: `fix/registrar-role-actions-local-time`.
- Scope gate: limited to queue/visit timestamp tracking, role-specific actions, frontend time formatting, and targeted tests.
- Red-check handling: GitHub backend failure was reproduced locally, fixed in the same PR, and pushed as a follow-up commit.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

- Canonical surface: `/api/v1/registrar/queues/today` queue DTO and queue/visit payment action responses.
- Request shape: unchanged; no new request fields are required.
- Response shape: extended queue rows with `updated_at`, `last_changed_at`, `display_time_kind`, and `timezone` while preserving existing fields.
- Status codes: unchanged for existing endpoints.
- Frontend consumer: registrar tables, doctor queue panels, cashier/payment rows, queue cards, and ticket preview time displays.
- Compatibility path or alias: existing `queue_time` remains the sort/fairness anchor; new timestamp fields are additive.
- Contract proof: targeted backend serialization test and frontend formatter/doctor-panel contract tests passed locally.

## RBAC / Permissions

- Roles allowed: Registrar/Admin/Cashier keep registrar-safe actions; Doctor/Specialist/Lab keep clinical queue actions where already allowed.
- Roles denied: Registrar/Admin aggregate rows no longer expose ambiguous doctor-only `call/start_visit` one-click actions.
- Positive auth proof: doctor panel tests verify call/clinical actions remain visible for doctor surfaces.
- Negative auth proof: action availability is filtered by role/surface and registrar aggregate rows do not show doctor-only call/start duplicates.

## Notification / Realtime

not applicable - this PR does not change notification channels, websocket payloads, chat delivery, read/unread state, or realtime reconnect behavior.

## Frontend Resilience

- Empty data proof: existing registrar/doctor table tests continue to cover rendering without removing primary controls.
- Partial data proof: time formatter handles naive timestamps, UTC/offset timestamps, and missing/invalid values without browser-timezone drift.
- Forbidden secondary path behavior: unchanged; this PR does not weaken route guards or RBAC boundaries.
- Missing draft/resource behavior: unchanged; no draft/resource lifecycle was modified.
- Stale route/deep-link behavior: `?date=YYYY-MM-DD` handling remains explicit and clinic-local date fallback is preserved.

## Scope Gate

- Allowed paths: backend queue/visit timestamp models, Alembic migration, registrar/doctor queue endpoints, frontend time/action rendering utilities, targeted tests.
- Denied paths: unrelated AdminPanel fixes, unrelated runtime refactors, production/deploy/secrets, DB reset/seed behavior.
- Migration/docs/test impact: one additive Alembic migration plus targeted backend/frontend tests; no destructive migration.
- Rollback note: revert the PR and downgrade migration `0030_visit_queue_updated_at` to remove only the additive `updated_at` columns.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `git diff --check`; targeted backend pytest; targeted frontend Vitest; frontend lint; frontend build; browser smoke on `/registrar` and `/doctor/cardiology`; red backend check reproduced and fixed with `tests/integration/test_registrar_record_actions.py::test_queue_mark_paid_without_visit_id_does_not_pay_unrelated_patient_visit`.
- Result: local targeted validation passed; PR checks are expected to rerun after the follow-up fix commit.
- Not checked: full backend suite and production deploy were not run locally because this is a scoped queue/time patch and deploy is outside scope.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.
