### PR TITLE
fix(appointments): route static GET paths before ids

### DIFF
--- a/backend/app/api/v1/endpoints/appointments.py
+++ b/backend/app/api/v1/endpoints/appointments.py
@@ -635,23 +635,6 @@ async def get_pending_payments(
         raise _appointments_http_error(e, "list_appointments") from e
 
 
-@router.get("/{appointment_id}", response_model=appointment_schemas.Appointment)
-def get_appointment(
-    *,
-    db: Session = Depends(deps.get_db),
-    appointment_id: int,
-    current_user: User = Depends(deps.get_current_user),
-):
-    """
-    Получить запись на прием по ID
-    """
-    appointment = appointment_crud.get(db, id=appointment_id)
-    if not appointment:
-        raise HTTPException(status_code=404, detail="Запись не найдена")
-    _ensure_appointment_record_access(db, appointment, current_user)
-    return appointment
-
-
 @router.put("/{appointment_id}", response_model=appointment_schemas.Appointment)
 def update_appointment(
     *,
@@ -1283,3 +1266,20 @@ async def get_pending_payments(
 
     except Exception as e:
         raise _appointments_http_error(e, "get_pending_payments") from e
+
+
+@router.get("/{appointment_id}", response_model=appointment_schemas.Appointment)
+def get_appointment(
+    *,
+    db: Session = Depends(deps.get_db),
+    appointment_id: int,
+    current_user: User = Depends(deps.get_current_user),
+):
+    """
+    Получить запись на прием по ID
+    """
+    appointment = appointment_crud.get(db, id=appointment_id)
+    if not appointment:
+        raise HTTPException(status_code=404, detail="Запись не найдена")
+    _ensure_appointment_record_access(db, appointment, current_user)
+    return appointment

--- a/backend/tests/integration/test_appointments_static_routes.py
+++ b/backend/tests/integration/test_appointments_static_routes.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+from app.api.v1.endpoints import appointments
+
+
+def test_appointments_stats_route_dispatches_before_appointment_id(
+    client, auth_headers, monkeypatch
+):
+    monkeypatch.setattr(
+        appointments,
+        "load_stats",
+        lambda db, *, department, date_str: SimpleNamespace(
+            is_open=True,
+            start_number=10,
+            last_ticket=12,
+            waiting=2,
+            serving=1,
+            done=9,
+        ),
+    )
+
+    response = client.get(
+        "/api/v1/appointments/stats",
+        params={"department": "cardiology", "date": "2026-06-01"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "department": "cardiology",
+        "date_str": "2026-06-01",
+        "is_open": True,
+        "start_number": 10,
+        "last_ticket": 12,
+        "waiting": 2,
+        "serving": 1,
+        "done": 9,
+    }
+
+
+def test_appointments_qrcode_route_dispatches_before_appointment_id(
+    client, auth_headers
+):
+    response = client.get(
+        "/api/v1/appointments/qrcode",
+        params={"department": "cardiology", "date": "2026-06-01"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "format": "text",
+        "data": "cardiology::2026-06-01",
+    }
+
+
+def test_numeric_appointment_id_route_remains_available(client, auth_headers):
+    response = client.get("/api/v1/appointments/999999", headers=auth_headers)
+
+    assert response.status_code == 404


### PR DESCRIPTION
﻿## Summary
Fixes appointment route shadowing by registering `GET /api/v1/appointments/{appointment_id}` after static GET routes such as `/appointments/stats` and `/appointments/qrcode`.

## Bug / Impact
- Before this change, `/appointments/stats` and `/appointments/qrcode` could be captured by `/{appointment_id}` and fail path validation instead of returning their intended payloads.
- Existing numeric appointment lookup remains available; no appointment command behavior is changed.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `origin/main` at `fa1f957c` after re-fetching and re-scanning route shadows.
- Clean workspace: only appointments route order and focused route tests are changed.
- Branch: `codex/appointments-static-route-order`.
- Scope gate: route ordering fix plus regression tests only; no frontend, no schema, no service logic, no migration.
- Red-check handling: will fix any failed required checks in this PR before merge.

## Contract Impact
- Canonical surface: `GET /api/v1/appointments/stats`, `GET /api/v1/appointments/qrcode`, and `GET /api/v1/appointments/{appointment_id}`.
- Request shape: unchanged; existing query parameters and path parameters are preserved.
- Response shape: unchanged; static route payloads and appointment response model are preserved.
- Status codes: `/stats` and `/qrcode` now return 200 for authenticated users with valid params; numeric missing appointment still returns 404.
- Frontend consumer: no frontend files touched; existing API constants keep the same URLs.
- Compatibility path or alias: no alias added; restores already published static appointment routes.
- Contract proof: new integration tests assert `/stats` and `/qrcode` dispatch before `/{appointment_id}` and numeric id lookup remains reachable.

## RBAC / Permissions
- Roles allowed: unchanged; these routes still use the existing authenticated user dependencies.
- Roles denied: unauthenticated access remains denied by existing auth dependency.
- Positive auth proof: admin `auth_headers` receives 200 from `/appointments/stats` and `/appointments/qrcode`.
- Negative auth proof: numeric missing appointment returns 404 through the id route, proving static route ordering did not remove id route behavior.

## Notification / Realtime
- Event type or websocket channel: none; route order only.
- Payload version / ack behavior: unchanged; no realtime payloads or acknowledgements changed.
- Read/unread or delivery semantics: unchanged; not a notification feature.
- Reconnect/resync proof: unchanged because no websocket path is touched.

## Frontend Resilience
- Empty data proof: stats test uses a minimal mocked stats payload and returns the expected shape.
- Partial data proof: qrcode route returns its lightweight text payload without appointment-id validation.
- Forbidden secondary path behavior: static `/stats` and `/qrcode` no longer fall through to `/{appointment_id}`.
- Missing draft/resource behavior: unchanged; no draft/resource workflow touched.
- Stale route/deep-link behavior: existing `/appointments/stats` and `/appointments/qrcode` URLs are preserved and now resolve to intended handlers.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/appointments.py`, `backend/tests/integration/test_appointments_static_routes.py`.
- Denied paths: frontend, schemas, services, migrations, database models, unrelated route cleanup.
- Migration/docs/test impact: no migration or docs; one focused integration test file added.
- Rollback note: revert this commit to restore previous route order, though that would reintroduce static appointment route shadowing.

## Validation
- Targeted tests or smoke run: `py_compile` for touched Python files; `pytest backend/tests/integration/test_appointments_static_routes.py backend/tests/integration/test_appointment_flow_owner_guard.py -q`; `pytest backend/tests/test_openapi_contract.py backend/tests/integration/test_appointments_static_routes.py -q`; `git diff --check`; local route-shadow scan for `appointments.py`.
- Result: compile passed; 11 focused appointment tests passed; 27 OpenAPI+route tests passed; diff check passed; appointments route shadows disappeared from scan output.
- Not checked: frontend build, because no frontend files changed.
