### PR TITLE
fix(users): route static user paths before ids

### DIFF
--- a/backend/app/api/v1/endpoints/user_management.py
+++ b/backend/app/api/v1/endpoints/user_management.py
@@ -337,33 +337,6 @@ async def get_users(
         )
 
 
-@router.get("/users/{user_id}", response_model=UserResponse)
-async def get_user(
-    user_id: int,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(require_staff),
-):
-    """Получить пользователя по ID"""
-    try:
-        service = get_user_management_service()
-        profile_data = service.get_user_profile(db, user_id)
-
-        if not profile_data:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Пользователь не найден"
-            )
-
-        return UserResponse(**profile_data)
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения пользователя: {str(e)}",
-        )
-
-
 @router.put("/users/{user_id}", response_model=UserResponse)
 async def update_user(
     user_id: int,
@@ -1092,3 +1065,30 @@ async def user_management_health_check():
         "supported_statuses": ["active", "inactive", "suspended", "pending", "locked"],
         "export_formats": ["csv", "excel", "json", "pdf"],
     }
+
+
+@router.get("/users/{user_id}", response_model=UserResponse)
+async def get_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_staff),
+):
+    """Получить пользователя по ID"""
+    try:
+        service = get_user_management_service()
+        profile_data = service.get_user_profile(db, user_id)
+
+        if not profile_data:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Пользователь не найден"
+            )
+
+        return UserResponse(**profile_data)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Ошибка получения пользователя: {str(e)}",
+        )

--- a/backend/tests/integration/test_user_management_static_routes.py
+++ b/backend/tests/integration/test_user_management_static_routes.py
@@ -1,0 +1,86 @@
+from app.api.v1.endpoints import user_management
+from app.main import app
+
+
+def _allow_staff_dependency(monkeypatch):
+    monkeypatch.setitem(
+        app.dependency_overrides,
+        user_management.require_staff,
+        lambda: type(
+            "StaffUser",
+            (),
+            {"id": 1, "role": "Admin", "is_active": True},
+        )(),
+    )
+
+
+class _FakeUserManagementService:
+    def get_user_stats(self, db):
+        return {
+            "total_users": 3,
+            "active_users": 2,
+            "inactive_users": 1,
+            "suspended_users": 0,
+            "locked_users": 0,
+            "users_by_role": {"Admin": 1, "Doctor": 1, "Patient": 1},
+            "users_with_profiles": 2,
+            "users_with_2fa": 1,
+            "recent_registrations": 1,
+            "recent_logins": 1,
+        }
+
+    def get_user_profile(self, db, user_id):
+        if user_id != 12345:
+            return None
+        return {
+            "id": 12345,
+            "username": "route_user",
+            "email": "route.user@test.com",
+            "full_name": "Route User",
+            "role": "Doctor",
+            "is_active": True,
+            "is_superuser": False,
+            "created_at": None,
+            "updated_at": None,
+            "profile": None,
+            "preferences": None,
+            "roles": [],
+            "groups": [],
+        }
+
+
+def test_user_stats_route_dispatches_before_user_id(client, monkeypatch):
+    _allow_staff_dependency(monkeypatch)
+    monkeypatch.setattr(
+        user_management,
+        "get_user_management_service",
+        lambda: _FakeUserManagementService(),
+    )
+
+    response = client.get("/api/v1/users/users/stats")
+
+    assert response.status_code == 200
+    assert response.json()["total_users"] == 3
+    assert response.json()["users_by_role"]["Admin"] == 1
+
+
+def test_user_health_route_dispatches_before_user_id(client):
+    response = client.get("/api/v1/users/users/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    assert response.json()["service"] == "user_management"
+
+
+def test_numeric_user_id_route_remains_available(client, monkeypatch):
+    _allow_staff_dependency(monkeypatch)
+    monkeypatch.setattr(
+        user_management,
+        "get_user_management_service",
+        lambda: _FakeUserManagementService(),
+    )
+
+    response = client.get("/api/v1/users/users/12345")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == 12345


### PR DESCRIPTION
﻿## Summary
Fixes user-management route shadowing by registering `GET /api/v1/users/users/{user_id}` after static GET routes such as `/users/users/stats` and `/users/users/health`.

## Bug / Impact
- Before this change, `/users/users/stats` and `/users/users/health` could be captured by `/{user_id}` and fail as invalid integer IDs instead of returning their intended payloads.
- Numeric user lookup remains available and unchanged.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `origin/main` at `7447629f` after PR #1488 merge and route-shadow re-scan.
- Clean workspace: only user-management route order and focused route tests are changed.
- Branch: `codex/user-management-static-route-order`.
- Scope gate: route ordering fix plus regression tests only; no frontend, no schema, no service logic, no migration.
- Red-check handling: will fix any failed required checks in this PR before merge.

## Contract Impact
- Canonical surface: `GET /api/v1/users/users/stats`, `GET /api/v1/users/users/health`, and `GET /api/v1/users/users/{user_id}`.
- Request shape: unchanged; existing path and auth behavior are preserved.
- Response shape: unchanged; static route payloads and user response model are preserved.
- Status codes: static routes now dispatch to their intended handlers; numeric user lookup still returns its user DTO when found.
- Frontend consumer: no frontend files touched; existing API URLs are preserved.
- Compatibility path or alias: no alias added; restores already published static user-management routes.
- Contract proof: new integration tests assert `/stats` and `/health` dispatch before `/{user_id}` and numeric id lookup remains reachable.

## RBAC / Permissions
- Roles allowed: unchanged; stats and user id lookup still depend on the existing staff dependency, health remains its existing health route.
- Roles denied: unchanged; no role policy was edited.
- Positive auth proof: test overrides the staff dependency to prove route dispatch and response contract without changing auth code.
- Negative auth proof: forbidden/unauthenticated policy is covered by existing dependency behavior; this PR only changes route order.

## Notification / Realtime
- Event type or websocket channel: none; route order only.
- Payload version / ack behavior: unchanged; no realtime payloads or acknowledgements changed.
- Read/unread or delivery semantics: unchanged; not a notification feature.
- Reconnect/resync proof: unchanged because no websocket path is touched.

## Frontend Resilience
- Empty data proof: stats test uses a minimal mocked stats payload and returns the expected shape.
- Partial data proof: health route returns its lightweight service status payload without user-id validation.
- Forbidden secondary path behavior: static `/stats` and `/health` no longer fall through to `/{user_id}`.
- Missing draft/resource behavior: unchanged; no draft/resource workflow touched.
- Stale route/deep-link behavior: existing `/users/users/stats` and `/users/users/health` URLs are preserved and now resolve to intended handlers.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/user_management.py`, `backend/tests/integration/test_user_management_static_routes.py`.
- Denied paths: frontend, schemas, services, migrations, database models, unrelated route cleanup.
- Migration/docs/test impact: no migration or docs; one focused integration test file added.
- Rollback note: revert this commit to restore previous route order, though that would reintroduce static user-management route shadowing.

## Validation
- Targeted tests or smoke run: `py_compile` for touched Python files; `pytest backend/tests/integration/test_user_management_static_routes.py backend/tests/integration/test_admin_user_reserved_email.py -q`; `pytest backend/tests/test_openapi_contract.py backend/tests/integration/test_user_management_static_routes.py -q`; `git diff --check`; local route-shadow scan.
- Result: compile passed; 6 focused user-management tests passed; 27 OpenAPI+route tests passed; diff check passed; user-management route shadows disappeared from scan output.
- Not checked: frontend build, because no frontend files changed.
