### PR TITLE
fix(print): route template types before ids

### DIFF
--- a/backend/app/api/v1/endpoints/print_templates.py
+++ b/backend/app/api/v1/endpoints/print_templates.py
@@ -183,6 +183,13 @@ def create_print_template(
         )
 
 
+@router.get("/templates/types")
+def get_template_types(
+    current_user: User = Depends(require_roles("Admin", "Registrar", "Doctor"))
+):
+    return _print_template_types_payload()
+
+
 @router.get("/templates/{template_id}", response_model=PrintTemplateOut)
 def get_print_template(
     template_id: int,
@@ -419,10 +426,7 @@ def get_default_template(
         )
 
 
-@router.get("/templates/types")
-def get_template_types(
-    current_user: User = Depends(require_roles("Admin", "Registrar", "Doctor"))
-):
+def _print_template_types_payload():
     """
     Получить список доступных типов шаблонов
     """

--- a/backend/tests/integration/test_print_template_upload_limits.py
+++ b/backend/tests/integration/test_print_template_upload_limits.py
@@ -5,6 +5,25 @@ from fastapi.testclient import TestClient
 from app.api.v1.endpoints import print_templates
 
 
+def test_print_template_types_route_dispatches_before_template_id(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    response = client.get(
+        "/api/v1/print/templates/templates/types",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["template_types"][0]["code"] == "ticket"
+    assert {template_type["code"] for template_type in payload["template_types"]} >= {
+        "ticket",
+        "prescription",
+        "payment_receipt",
+    }
+
+
 def test_print_template_upload_rejects_oversized_payload_before_write(
     client: TestClient,
     auth_headers: dict[str, str],


### PR DESCRIPTION
## Summary
Fixes print-template route shadowing by registering `GET /api/v1/print/templates/templates/types` before `GET /api/v1/print/templates/templates/{template_id}`.

## Bug / Impact
- Before this change, `/print/templates/templates/types` could be captured by `/{template_id}` and fail as an invalid integer template id instead of returning available print template types.
- Numeric template lookup remains available and unchanged.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `origin/main` at `15416ead` after PR #1489 merge and route-shadow re-scan.
- Clean workspace: only print-template route order and focused route tests are changed.
- Branch: `codex/print-template-static-route-order`.
- Scope gate: route ordering fix plus regression test only; no frontend, no schema, no service logic, no migration.
- Red-check handling: will fix any failed required checks in this PR before merge.

## Contract Impact
- Canonical surface: `GET /api/v1/print/templates/templates/types` and `GET /api/v1/print/templates/templates/{template_id}`.
- Request shape: unchanged; existing path and auth behavior are preserved.
- Response shape: unchanged; template types payload and template response model are preserved.
- Status codes: static route now dispatches to its intended handler; numeric template lookup remains registered.
- Frontend consumer: no frontend files touched; existing API URLs are preserved.
- Compatibility path or alias: no alias added; restores an already published static print-template route.
- Contract proof: integration test asserts `/templates/types` dispatches before `/{template_id}` and returns the expected template type codes.

## RBAC / Permissions
- Roles allowed: unchanged; template types still require the existing Admin, Registrar, or Doctor dependency.
- Roles denied: unchanged; no role policy was edited.
- Positive auth proof: existing authenticated test fixture reaches the static route and receives the intended payload.
- Negative auth proof: forbidden/unauthenticated policy is covered by existing dependency behavior; this PR only changes route order.

## Notification / Realtime
- Event type or websocket channel: none; route order only.
- Payload version / ack behavior: unchanged; no realtime payloads or acknowledgements changed.
- Read/unread or delivery semantics: unchanged; not a notification feature.
- Reconnect/resync proof: unchanged because no websocket path is touched.

## Frontend Resilience
- Empty data proof: not applicable; template types route returns static metadata.
- Partial data proof: route test asserts representative template codes without depending on database rows.
- Forbidden secondary path behavior: static `/templates/types` no longer falls through to `/{template_id}`.
- Missing draft/resource behavior: unchanged; no draft/resource workflow touched.
- Stale route/deep-link behavior: existing `/print/templates/templates/types` URL is preserved and now resolves to the intended handler.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/print_templates.py`, `backend/tests/integration/test_print_template_upload_limits.py`.
- Denied paths: frontend, schemas, services, migrations, database models, unrelated route cleanup.
- Migration/docs/test impact: no migration or docs; one focused integration test added to the existing print-template route test file.
- Rollback note: revert this commit to restore previous route order, though that would reintroduce static print-template route shadowing.

## Validation
- Targeted tests or smoke run: `py_compile` for touched Python files; `pytest backend/tests/integration/test_print_template_upload_limits.py backend/tests/test_openapi_contract.py -q`; `git diff --check`; local route-shadow scan.
- Result: compile passed; 26 focused/OpenAPI tests passed; diff check passed; `print_templates.py` disappeared from route-shadow scan output.
- Not checked: frontend build, because no frontend files changed.