### PR TITLE
fix(admin): route doctor stats before ids

### DIFF
--- a/backend/app/api/v1/endpoints/admin_doctors.py
+++ b/backend/app/api/v1/endpoints/admin_doctors.py
@@ -173,6 +173,14 @@ def get_available_doctor_users(
     ]
 
 
+@router.get("/doctors/stats")
+def get_doctors_stats(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_roles("Admin")),
+):
+    return _get_doctors_stats_payload(db)
+
+
 @router.get("/doctors/{doctor_id}", response_model=DoctorOut)
 def get_doctor(
     doctor_id: int,
@@ -348,11 +356,7 @@ def get_specialties(
         raise _admin_doctors_http_error(exc, "get_specialties") from exc
 
 
-@router.get("/doctors/stats")
-def get_doctors_stats(
-    db: Session = Depends(get_db),
-    current_user: User = Depends(require_roles("Admin")),
-):
+def _get_doctors_stats_payload(db: Session):
     """Получить статистику по врачам."""
     try:
         return AdminDoctorsStatsService(db).get_doctors_stats()

--- a/backend/tests/integration/test_admin_linkage_cleanup.py
+++ b/backend/tests/integration/test_admin_linkage_cleanup.py
@@ -1,10 +1,40 @@
 from datetime import date
 
+from app.api.v1.endpoints import admin_doctors
 from app.core.security import get_password_hash
 from app.models.appointment import Appointment
 from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue
 from app.models.user import User
+
+
+def test_admin_doctors_stats_route_dispatches_before_doctor_id(
+    client,
+    auth_headers,
+    monkeypatch,
+):
+    class FakeAdminDoctorsStatsService:
+        def __init__(self, db):
+            self.db = db
+
+        def get_doctors_stats(self):
+            return {
+                "total": 2,
+                "active": 1,
+                "inactive": 1,
+                "by_specialty": {"cardiology": 1},
+            }
+
+    monkeypatch.setattr(
+        admin_doctors,
+        "AdminDoctorsStatsService",
+        FakeAdminDoctorsStatsService,
+    )
+
+    response = client.get("/api/v1/admin/doctors/stats", headers=auth_headers)
+
+    assert response.status_code == 200
+    assert response.json()["by_specialty"] == {"cardiology": 1}
 
 
 def test_available_doctor_users_excludes_already_linked_accounts(


### PR DESCRIPTION
## Summary
Fixes admin doctor route shadowing by registering `GET /api/v1/admin/doctors/stats` before `GET /api/v1/admin/doctors/{doctor_id}`.

## Bug / Impact
- Before this change, `/admin/doctors/stats` could be captured by `/{doctor_id}` and fail as an invalid integer doctor id instead of returning doctor statistics.
- Numeric doctor lookup remains available and unchanged.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `origin/main` at `03e130a7` after PR #1490 merge and route-shadow re-scan.
- Clean workspace: only admin doctor route order and focused route tests are changed.
- Branch: `codex/admin-doctors-static-route-order`.
- Scope gate: route ordering fix plus regression test only; no frontend, no schema, no service logic, no migration.
- Red-check handling: will fix any failed required checks in this PR before merge.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/doctors/stats` and `GET /api/v1/admin/doctors/{doctor_id}`.
- Request shape: unchanged; existing path and auth behavior are preserved.
- Response shape: unchanged; stats payload and doctor response model are preserved.
- Status codes: static route now dispatches to its intended handler; numeric doctor lookup remains registered.
- Frontend consumer: no frontend files touched; existing API URLs are preserved.
- Compatibility path or alias: no alias added; restores an already published static admin doctors route.
- Contract proof: integration test asserts `/doctors/stats` dispatches before `/{doctor_id}` and returns the mocked stats payload.

## RBAC / Permissions
- Roles allowed: unchanged; doctors stats still requires the existing Admin dependency.
- Roles denied: unchanged; no role policy was edited.
- Positive auth proof: existing authenticated test fixture reaches the static route and receives the intended payload.
- Negative auth proof: forbidden/unauthenticated policy is covered by existing dependency behavior; this PR only changes route order.

## Notification / Realtime
- Event type or websocket channel: none; route order only.
- Payload version / ack behavior: unchanged; no realtime payloads or acknowledgements changed.
- Read/unread or delivery semantics: unchanged; not a notification feature.
- Reconnect/resync proof: unchanged because no websocket path is touched.

## Frontend Resilience
- Empty data proof: test uses a minimal mocked stats payload and does not depend on seeded doctors.
- Partial data proof: route test asserts representative stats without depending on full service internals.
- Forbidden secondary path behavior: static `/doctors/stats` no longer falls through to `/{doctor_id}`.
- Missing draft/resource behavior: unchanged; no draft/resource workflow touched.
- Stale route/deep-link behavior: existing `/admin/doctors/stats` URL is preserved and now resolves to the intended handler.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_doctors.py`, `backend/tests/integration/test_admin_linkage_cleanup.py`.
- Denied paths: frontend, schemas, services, migrations, database models, unrelated route cleanup.
- Migration/docs/test impact: no migration or docs; one focused integration test added to the existing admin route test file.
- Rollback note: revert this commit to restore previous route order, though that would reintroduce static admin doctors route shadowing.

## Validation
- Targeted tests or smoke run: `py_compile` for touched Python files; `pytest backend/tests/integration/test_admin_linkage_cleanup.py backend/tests/unit/test_admin_doctors_stats_service.py backend/tests/test_openapi_contract.py -q`; `git diff --check`; local route-shadow scan.
- Result: compile passed; 30 focused/OpenAPI tests passed; diff check passed; `admin_doctors.py` disappeared from route-shadow scan output.
- Not checked: frontend build, because no frontend files changed.