### PR TITLE
fix(clinic): route expiring licenses before ids

### DIFF
--- a/backend/app/api/v1/endpoints/clinic_management.py
+++ b/backend/app/api/v1/endpoints/clinic_management.py
@@ -359,6 +359,16 @@ def get_licenses(
     )
 
 
+@router.get("/licenses/expiring", response_model=List[LicenseOut])
+def get_expiring_licenses(
+    *,
+    db: Session = Depends(get_db),
+    days_ahead: int = Query(30, ge=1, le=365),
+    current_user: User = Depends(require_admin),
+):
+    return _get_expiring_licenses_payload(db=db, days_ahead=days_ahead)
+
+
 @router.get("/licenses/{license_id}", response_model=LicenseOut)
 def get_license(
     *,
@@ -409,8 +419,7 @@ def delete_license(
         )
 
 
-@router.get("/licenses/expiring", response_model=List[LicenseOut])
-def get_expiring_licenses(
+def _get_expiring_licenses_payload(
     *,
     db: Session = Depends(get_db),
     days_ahead: int = Query(

--- a/backend/tests/integration/test_clinic_management_admin_access.py
+++ b/backend/tests/integration/test_clinic_management_admin_access.py
@@ -1,5 +1,7 @@
 import pytest
 
+from app.api.v1.endpoints import clinic_management
+
 
 def _login_admin(client, admin_user, admin_password):
     response = client.post(
@@ -28,6 +30,48 @@ def test_clinic_management_stats_and_health_are_admin_accessible(
     assert health_response.status_code == 200, health_response.text
     health = health_response.json()
     assert "status" in health
+
+
+@pytest.mark.integration
+def test_clinic_license_expiring_route_dispatches_before_license_id(
+    client,
+    admin_user,
+    admin_password,
+    monkeypatch,
+):
+    def _fake_expiring_licenses(*, db, days_ahead):
+        return [
+            {
+                "id": 7,
+                "name": "Expiring License",
+                "license_type": "software",
+                "license_key": "license-key",
+                "status": "active",
+                "issued_by": None,
+                "issued_date": None,
+                "expires_date": None,
+                "renewal_date": None,
+                "cost": None,
+                "features": None,
+                "restrictions": None,
+                "notes": None,
+                "created_at": None,
+                "updated_at": None,
+                "activations_count": 0,
+            }
+        ]
+
+    monkeypatch.setattr(
+        clinic_management.license_management,
+        "get_expiring_licenses",
+        _fake_expiring_licenses,
+    )
+    headers = _login_admin(client, admin_user, admin_password)
+
+    response = client.get("/api/v1/clinic/licenses/expiring", headers=headers)
+
+    assert response.status_code == 200, response.text
+    assert response.json()[0]["name"] == "Expiring License"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
Fixes clinic license route shadowing by registering `GET /api/v1/clinic/licenses/expiring` before `GET /api/v1/clinic/licenses/{license_id}`.

## Bug / Impact
- Before this change, `/clinic/licenses/expiring` could be captured by `/{license_id}` and fail as an invalid integer license id instead of returning expiring licenses.
- Numeric license lookup remains available and unchanged.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `origin/main` at `62e1b15d` after PR #1491 merge and route-shadow re-scan.
- Clean workspace: only clinic license route order and focused route tests are changed.
- Branch: `codex/clinic-license-static-route-order`.
- Scope gate: route ordering fix plus regression test only; no frontend, no schema, no service logic, no migration.
- Red-check handling: will fix any failed required checks in this PR before merge.

## Contract Impact
- Canonical surface: `GET /api/v1/clinic/licenses/expiring` and `GET /api/v1/clinic/licenses/{license_id}`.
- Request shape: unchanged; existing path and auth behavior are preserved.
- Response shape: unchanged; expiring license list payload and license response model are preserved.
- Status codes: static route now dispatches to its intended handler; numeric license lookup remains registered.
- Frontend consumer: no frontend files touched; existing API URLs are preserved.
- Compatibility path or alias: no alias added; restores an already published static clinic license route.
- Contract proof: integration test asserts `/licenses/expiring` dispatches before `/{license_id}` and returns a response-model-compatible license list.

## RBAC / Permissions
- Roles allowed: unchanged; expiring licenses still require the existing Admin dependency.
- Roles denied: unchanged; no role policy was edited.
- Positive auth proof: admin login test reaches the static route and receives the intended payload.
- Negative auth proof: forbidden/unauthenticated policy is covered by existing dependency behavior; this PR only changes route order.

## Notification / Realtime
- Event type or websocket channel: none; route order only.
- Payload version / ack behavior: unchanged; no realtime payloads or acknowledgements changed.
- Read/unread or delivery semantics: unchanged; not a notification feature.
- Reconnect/resync proof: unchanged because no websocket path is touched.

## Frontend Resilience
- Empty data proof: not changed; response model remains a list.
- Partial data proof: test uses a minimal response-model-compatible mocked license row.
- Forbidden secondary path behavior: static `/licenses/expiring` no longer falls through to `/{license_id}`.
- Missing draft/resource behavior: unchanged; no draft/resource workflow touched.
- Stale route/deep-link behavior: existing `/clinic/licenses/expiring` URL is preserved and now resolves to the intended handler.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/clinic_management.py`, `backend/tests/integration/test_clinic_management_admin_access.py`.
- Denied paths: frontend, schemas, services, migrations, database models, unrelated route cleanup.
- Migration/docs/test impact: no migration or docs; one focused integration test added to the existing clinic management admin access test file.
- Rollback note: revert this commit to restore previous route order, though that would reintroduce static clinic license route shadowing.

## Validation
- Targeted tests or smoke run: `py_compile` for touched Python files; `pytest backend/tests/integration/test_clinic_management_admin_access.py backend/tests/test_openapi_contract.py -q`; `git diff --check`; local route-shadow scan.
- Result: compile passed; 27 focused/OpenAPI tests passed; diff check passed; `clinic_management.py` disappeared from route-shadow scan output.
- Not checked: frontend build, because no frontend files changed.