### PR TITLE
fix(doctor): route visit statistics before ids

### DIFF
--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -1578,6 +1578,60 @@ def get_today_visits(
         )
 
 
+@router.get("/doctor/visits/statistics")
+def get_visit_statistics(
+    date_from: Optional[str] = Query(
+        None, description="Дата начала в формате YYYY-MM-DD"
+    ),
+    date_to: Optional[str] = Query(
+        None, description="Дата окончания в формате YYYY-MM-DD"
+    ),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(
+        require_roles("Admin", "Doctor", "cardio", "cardiology", "derma", "dentist")
+    ),
+):
+    """Получить статистику визитов врача"""
+    try:
+        from datetime import datetime
+
+        date_from_obj = None
+        date_to_obj = None
+
+        if date_from:
+            date_from_obj = datetime.strptime(date_from, "%Y-%m-%d").date()
+
+        if date_to:
+            date_to_obj = datetime.strptime(date_to, "%Y-%m-%d").date()
+
+        stats = crud_visit.get_visit_statistics(
+            db=db,
+            doctor_id=_visit_filter_doctor_id(db, current_user),
+            date_from=date_from_obj,
+            date_to=date_to_obj,
+        )
+
+        return {
+            "success": True,
+            "statistics": stats,
+            "period": {"date_from": date_from, "date_to": date_to},
+        }
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Ошибка получения статистики: {str(e)}",
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Ошибка назначения визита: {str(e)}",
+        )
+
 @router.get("/doctor/visits/{visit_id}")
 def get_visit_details(
     visit_id: int,
@@ -1774,59 +1828,4 @@ def remove_service_from_visit(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Ошибка удаления услуги: {str(e)}",
-        )
-
-
-@router.get("/doctor/visits/statistics")
-def get_visit_statistics(
-    date_from: Optional[str] = Query(
-        None, description="Дата начала в формате YYYY-MM-DD"
-    ),
-    date_to: Optional[str] = Query(
-        None, description="Дата окончания в формате YYYY-MM-DD"
-    ),
-    db: Session = Depends(get_db),
-    current_user: User = Depends(
-        require_roles("Admin", "Doctor", "cardio", "cardiology", "derma", "dentist")
-    ),
-):
-    """Получить статистику визитов врача"""
-    try:
-        from datetime import datetime
-
-        date_from_obj = None
-        date_to_obj = None
-
-        if date_from:
-            date_from_obj = datetime.strptime(date_from, "%Y-%m-%d").date()
-
-        if date_to:
-            date_to_obj = datetime.strptime(date_to, "%Y-%m-%d").date()
-
-        stats = crud_visit.get_visit_statistics(
-            db=db,
-            doctor_id=_visit_filter_doctor_id(db, current_user),
-            date_from=date_from_obj,
-            date_to=date_to_obj,
-        )
-
-        return {
-            "success": True,
-            "statistics": stats,
-            "period": {"date_from": date_from, "date_to": date_to},
-        }
-
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
-        )
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка назначения визита: {str(e)}",
         )

--- a/backend/tests/integration/test_doctor_integration_visit_routes.py
+++ b/backend/tests/integration/test_doctor_integration_visit_routes.py
@@ -1,0 +1,32 @@
+from app.api.v1.endpoints import doctor_integration
+
+
+def test_doctor_visit_statistics_route_dispatches_before_visit_id(
+    client,
+    auth_headers,
+    monkeypatch,
+):
+    def _fake_visit_statistics(*, db, doctor_id, date_from, date_to):
+        return {
+            "total": 3,
+            "completed": 2,
+            "doctor_id": doctor_id,
+            "date_from": str(date_from) if date_from else None,
+            "date_to": str(date_to) if date_to else None,
+        }
+
+    monkeypatch.setattr(
+        doctor_integration.crud_visit,
+        "get_visit_statistics",
+        _fake_visit_statistics,
+    )
+
+    response = client.get(
+        "/api/v1/doctor/visits/statistics",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["statistics"]["total"] == 3


### PR DESCRIPTION
## Summary
Fixes doctor visit route shadowing by registering `GET /api/v1/doctor/visits/statistics` before `GET /api/v1/doctor/visits/{visit_id}`.

## Bug / Impact
- Before this change, `/doctor/visits/statistics` could be captured by `/{visit_id}` and fail as an invalid integer visit id instead of returning visit statistics.
- Numeric visit detail lookup remains available and unchanged.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `origin/main` at `f33fd008` after PR #1492 merge and route-shadow re-scan.
- Clean workspace: only doctor visit route order and focused route tests are changed.
- Branch: `codex/doctor-visits-static-route-order`.
- Scope gate: route ordering fix plus regression test only; no frontend, no schema, no service logic, no migration.
- Red-check handling: will fix any failed required checks in this PR before merge.

## Contract Impact
- Canonical surface: `GET /api/v1/doctor/visits/statistics` and `GET /api/v1/doctor/visits/{visit_id}`.
- Request shape: unchanged; existing path, query params, and auth behavior are preserved.
- Response shape: unchanged; statistics payload and visit detail payload are preserved.
- Status codes: static route now dispatches to its intended handler; numeric visit detail lookup remains registered.
- Frontend consumer: no frontend files touched; existing API URLs are preserved.
- Compatibility path or alias: no alias added; restores an already published static doctor visit route.
- Contract proof: integration test asserts `/doctor/visits/statistics` dispatches before `/{visit_id}` and returns the expected statistics envelope.

## RBAC / Permissions
- Roles allowed: unchanged; visit statistics still requires the existing doctor/admin role dependency.
- Roles denied: unchanged; no role policy was edited.
- Positive auth proof: authenticated test fixture reaches the static route and receives the intended payload.
- Negative auth proof: forbidden/unauthenticated policy is covered by existing dependency behavior; this PR only changes route order.

## Notification / Realtime
- Event type or websocket channel: none; route order only.
- Payload version / ack behavior: unchanged; no realtime payloads or acknowledgements changed.
- Read/unread or delivery semantics: unchanged; not a notification feature.
- Reconnect/resync proof: unchanged because no websocket path is touched.

## Frontend Resilience
- Empty data proof: not changed; service result is passed through in the existing statistics envelope.
- Partial data proof: test uses a minimal mocked statistics payload without depending on seeded visits.
- Forbidden secondary path behavior: static `/doctor/visits/statistics` no longer falls through to `/{visit_id}`.
- Missing draft/resource behavior: unchanged; no draft/resource workflow touched.
- Stale route/deep-link behavior: existing `/doctor/visits/statistics` URL is preserved and now resolves to the intended handler.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/doctor_integration.py`, `backend/tests/integration/test_doctor_integration_visit_routes.py`.
- Denied paths: frontend, schemas, services, migrations, database models, unrelated route cleanup.
- Migration/docs/test impact: no migration or docs; one focused integration test added.
- Rollback note: revert this commit to restore previous route order, though that would reintroduce static doctor visit route shadowing.

## Validation
- Targeted tests or smoke run: `py_compile` for touched Python files; `pytest backend/tests/integration/test_doctor_integration_visit_routes.py backend/tests/test_openapi_contract.py -q`; `git diff --check`; local route-shadow scan.
- Result: compile passed; 25 focused/OpenAPI tests passed; diff check passed; `doctor_integration.py` disappeared from route-shadow scan output.
- Not checked: frontend build, because no frontend files changed.