### PR TITLE
fix(admin): align department overview route contract

### DIFF
--- a/backend/app/api/v1/endpoints/admin_departments.py
+++ b/backend/app/api/v1/endpoints/admin_departments.py
@@ -443,7 +443,7 @@ def list_departments(
     return {"success": True, "data": data, "count": len(departments)}
 
 
-@router.get("/overview", response_model=dict, include_in_schema=False)
+@router.get("/overview", response_model=dict)
 def get_departments_overview(
     db: Session = Depends(get_db), current_user: User = Depends(require_roles("Admin"))
 ):
@@ -851,8 +851,7 @@ def update_queue_settings(
 # ============================================================
 
 
-@router.get("/overview", response_model=dict)
-def get_departments_overview(
+def _legacy_departments_overview_payload(
     db: Session = Depends(get_db), current_user: User = Depends(require_roles("Admin"))
 ):
     """Получить обзор статистики всех отделений"""

--- a/backend/tests/integration/test_admin_departments_overview_route.py
+++ b/backend/tests/integration/test_admin_departments_overview_route.py
@@ -1,0 +1,27 @@
+from app.api.v1.endpoints import admin_departments
+
+
+def test_admin_departments_overview_uses_canonical_handler(
+    client,
+    auth_headers,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        admin_departments,
+        "_collect_department_overview",
+        lambda db: {
+            "departments": [{"key": "cardiology"}],
+            "totals": {"departments": 1},
+        },
+    )
+
+    response = client.get("/api/v1/admin/departments/overview", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "success": True,
+        "data": {
+            "departments": [{"key": "cardiology"}],
+            "totals": {"departments": 1},
+        },
+    }


### PR DESCRIPTION
## Summary
Aligns the admin departments overview route contract with the route that is actually served at runtime.

## Bug / Impact
- `/api/v1/admin/departments/overview` already dispatched to the first overview handler before `/{department_id}`.
- A second duplicate `/overview` declaration after `/{department_id}` was unreachable and created a misleading route-shadow scanner hit / OpenAPI contract mismatch.
- This preserves the existing runtime handler and removes the unreachable duplicate route decorator.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `origin/main` at `9e6fba3e` after PR #1494 merge and route-shadow re-scan.
- Clean workspace: only admin departments overview route contract and focused route test are changed.
- Branch: `codex/admin-departments-overview-route-contract`.
- Scope gate: route contract cleanup plus regression test only; no frontend, no schema, no service logic, no migration.
- Red-check handling: will fix any failed required checks in this PR before merge.

## Contract Impact
- Canonical surface: `GET /api/v1/admin/departments/overview`.
- Request shape: unchanged; existing path and auth behavior are preserved.
- Response shape: unchanged for the runtime-served handler; the same `_collect_department_overview` envelope remains active.
- Status codes: static route continues to dispatch before `/{department_id}`.
- Frontend consumer: no frontend files touched; existing API URL is preserved.
- Compatibility path or alias: no alias added; removes an unreachable duplicate declaration.
- Contract proof: integration test asserts `/admin/departments/overview` uses the canonical `_collect_department_overview` handler.

## RBAC / Permissions
- Roles allowed: unchanged; overview still requires the existing Admin dependency.
- Roles denied: unchanged; no role policy was edited.
- Positive auth proof: authenticated test fixture reaches the canonical overview handler and receives the expected envelope.
- Negative auth proof: forbidden/unauthenticated policy is covered by existing dependency behavior; this PR only changes route declaration ownership.

## Notification / Realtime
- Event type or websocket channel: none; route contract cleanup only.
- Payload version / ack behavior: unchanged; no realtime payloads or acknowledgements changed.
- Read/unread or delivery semantics: unchanged; not a notification feature.
- Reconnect/resync proof: unchanged because no websocket path is touched.

## Frontend Resilience
- Empty data proof: test uses a minimal mocked overview payload.
- Partial data proof: route test asserts the canonical envelope without depending on seeded departments.
- Forbidden secondary path behavior: `/overview` is no longer represented by an unreachable duplicate after `/{department_id}`.
- Missing draft/resource behavior: unchanged; no draft/resource workflow touched.
- Stale route/deep-link behavior: existing `/admin/departments/overview` URL is preserved and continues to resolve to the handler already used at runtime.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/admin_departments.py`, `backend/tests/integration/test_admin_departments_overview_route.py`.
- Denied paths: frontend, schemas, services, migrations, database models, unrelated route cleanup.
- Migration/docs/test impact: no migration or docs; one focused integration test added.
- Rollback note: revert this commit to restore the previous duplicate declaration, though that would reintroduce the route contract mismatch.

## Validation
- Targeted tests or smoke run: `py_compile` for touched Python files; `pytest backend/tests/integration/test_admin_departments_overview_route.py backend/tests/test_openapi_contract.py -q`; `git diff --check`; local route-shadow scan.
- Result: compile passed; 25 focused/OpenAPI tests passed; diff check passed; `admin_departments.py` disappeared from route-shadow scan output.
- Not checked: frontend build, because no frontend files changed.