### PR TITLE
fix(payments): route visit payment summary before ids

### DIFF
--- a/backend/app/api/v1/endpoints/visit_payments.py
+++ b/backend/app/api/v1/endpoints/visit_payments.py
@@ -15,6 +15,21 @@ from app.services.visit_payment_api_service import (
 router = APIRouter()
 
 
+@router.get("/visit-payments/summary", summary="Сводка по платежам визитов")
+def get_visit_payments_summary(
+    db: Session = Depends(get_db),
+    _: dict = Depends(require_roles("Admin", "Registrar")),
+):
+    """Получение сводки по платежам визитов"""
+    service = VisitPaymentApiService(db)
+    try:
+        return service.get_visit_payments_summary()
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Ошибка получения сводки: {str(e)}",
+        )
+
 @router.get("/visit-payments/{visit_id}", summary="Информация о платеже для визита")
 def get_visit_payment_info(
     visit_id: int,
@@ -84,23 +99,6 @@ def update_visit_payment_status(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Ошибка обновления статуса платежа: {str(e)}",
         )
-
-
-@router.get("/visit-payments/summary", summary="Сводка по платежам визитов")
-def get_visit_payments_summary(
-    db: Session = Depends(get_db),
-    _: dict = Depends(require_roles("Admin", "Registrar")),
-):
-    """Получение сводки по платежам визитов"""
-    service = VisitPaymentApiService(db)
-    try:
-        return service.get_visit_payments_summary()
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения сводки: {str(e)}",
-        )
-
 
 @router.post(
     "/visit-payments/{visit_id}/create-from-payment",

--- a/backend/tests/integration/test_visit_payments_router_order.py
+++ b/backend/tests/integration/test_visit_payments_router_order.py
@@ -1,0 +1,35 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import visit_payments
+
+
+def test_visit_payments_summary_route_dispatches_before_visit_id(monkeypatch):
+    class FakeVisitPaymentApiService:
+        def __init__(self, db):
+            self.db = db
+
+        def get_visit_payments_summary(self):
+            return {"total": 1, "paid": 1}
+
+    app = FastAPI()
+    app.include_router(visit_payments.router)
+    app.dependency_overrides[visit_payments.get_db] = lambda: object()
+
+    for route in app.routes:
+        if getattr(route, "path", "") == "/visit-payments/summary":
+            for dependency in route.dependant.dependencies:
+                app.dependency_overrides[dependency.call] = lambda: {
+                    "role": "Admin"
+                }
+
+    monkeypatch.setattr(
+        visit_payments,
+        "VisitPaymentApiService",
+        FakeVisitPaymentApiService,
+    )
+
+    response = TestClient(app).get("/visit-payments/summary")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"total": 1, "paid": 1}


### PR DESCRIPTION
## Summary
Fixes the unmounted visit-payments router ordering by declaring `GET /visit-payments/summary` before `GET /visit-payments/{visit_id}`.

## Bug / Impact
- This router is not currently mounted in `backend/app/api/v1/api.py`, so there is no current production API dispatch bug from this file.
- If mounted later, `/visit-payments/summary` would have been captured by `/{visit_id}` and failed as an invalid integer visit id.
- This removes the last route-shadow scanner hit from endpoint modules.

## Cyclic Execution Evidence
- Fresh main sync: branch created from current `origin/main` at `ad0ac534` after PR #1495 merge and route-shadow re-scan.
- Clean workspace: only visit-payments route order and focused local-router test are changed.
- Branch: `codex/visit-payments-static-route-order`.
- Scope gate: route ordering fix plus regression test only; no app mounting, no frontend, no schema, no service logic, no migration.
- Red-check handling: will fix any failed required checks in this PR before merge.

## Contract Impact
- Canonical surface: local `visit_payments.router` paths `GET /visit-payments/summary` and `GET /visit-payments/{visit_id}`.
- Request shape: unchanged; existing path and dependency behavior are preserved inside the router.
- Response shape: unchanged; summary payload remains service-owned.
- Status codes: static summary route now dispatches before the visit-id route if this router is mounted in the future.
- Frontend consumer: no frontend files touched; this router is currently unmounted.
- Compatibility path or alias: no alias added; only route declaration order changed.
- Contract proof: local FastAPI router test asserts `/visit-payments/summary` dispatches to the summary handler before `/{visit_id}`.

## RBAC / Permissions
- Roles allowed: unchanged; summary still uses the existing Admin/Registrar dependency.
- Roles denied: unchanged; no role policy was edited.
- Positive auth proof: local router test overrides the existing route dependency only to isolate dispatch order.
- Negative auth proof: forbidden/unauthenticated policy is covered by existing dependency behavior; this PR only changes route order.

## Notification / Realtime
- Event type or websocket channel: none; route order only.
- Payload version / ack behavior: unchanged; no realtime payloads or acknowledgements changed.
- Read/unread or delivery semantics: unchanged; not a notification feature.
- Reconnect/resync proof: unchanged because no websocket path is touched.

## Frontend Resilience
- Empty data proof: not changed; summary payload is service-owned.
- Partial data proof: test uses a minimal mocked summary payload.
- Forbidden secondary path behavior: static `/visit-payments/summary` no longer falls through to `/{visit_id}` in the router.
- Missing draft/resource behavior: unchanged; no draft/resource workflow touched.
- Stale route/deep-link behavior: no mounted frontend route is changed.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/visit_payments.py`, `backend/tests/integration/test_visit_payments_router_order.py`.
- Denied paths: app router mounting, frontend, schemas, services, migrations, database models, unrelated route cleanup.
- Migration/docs/test impact: no migration or docs; one focused local-router integration test added.
- Rollback note: revert this commit to restore previous route order, though that would reintroduce the future-mount shadow risk.

## Validation
- Targeted tests or smoke run: `py_compile` for touched Python files; `pytest backend/tests/integration/test_visit_payments_router_order.py backend/tests/test_openapi_contract.py -q`; `git diff --check`; local route-shadow scan.
- Result: compile passed; 25 focused/OpenAPI tests passed; diff check passed; local route-shadow scan now has no output across endpoint modules.
- Not checked: frontend build, because no frontend files changed.