### PR TITLE
test(api): guard static route ordering

### DIFF
--- a/backend/tests/test_openapi_contract.py
+++ b/backend/tests/test_openapi_contract.py
@@ -1,11 +1,16 @@
 """OpenAPI contract checks for critical clinic API flows."""
 
+import ast
 import warnings
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+
+HTTP_ROUTE_METHODS = {"get", "post", "put", "patch", "delete"}
+ENDPOINTS_DIR = Path(__file__).resolve().parents[1] / "app" / "api" / "v1" / "endpoints"
 
 
 def _get_openapi_schema(client: TestClient) -> dict:
@@ -143,4 +148,91 @@ def test_openapi_has_no_duplicate_operation_id_warnings() -> None:
     ]
     assert not duplicate_messages, "Duplicate OpenAPI operation IDs found:\n" + "\n".join(
         duplicate_messages
+    )
+
+
+def _decorator_route(decorator: ast.expr) -> tuple[str, str] | None:
+    if not isinstance(decorator, ast.Call):
+        return None
+    if not isinstance(decorator.func, ast.Attribute):
+        return None
+    if decorator.func.attr not in HTTP_ROUTE_METHODS:
+        return None
+
+    if decorator.args:
+        first_arg = decorator.args[0]
+        if isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str):
+            return decorator.func.attr.upper(), first_arg.value
+
+    for keyword in decorator.keywords:
+        if keyword.arg != "path":
+            continue
+        if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+            return decorator.func.attr.upper(), keyword.value.value
+
+    return None
+
+
+def _route_parts(route: str) -> list[str]:
+    stripped = route.strip("/")
+    return stripped.split("/") if stripped else []
+
+
+def _is_shadowed_static_route(previous_route: str, current_route: str) -> bool:
+    previous_parts = _route_parts(previous_route)
+    current_parts = _route_parts(current_route)
+    if len(previous_parts) != len(current_parts):
+        return False
+
+    saw_previous_param = False
+    for previous_part, current_part in zip(previous_parts, current_parts):
+        if previous_part == current_part:
+            continue
+        if (
+            previous_part.startswith("{")
+            and previous_part.endswith("}")
+            and not current_part.startswith("{")
+        ):
+            saw_previous_param = True
+            continue
+        return False
+
+    return saw_previous_param
+
+
+def test_fastapi_static_routes_are_declared_before_same_shape_parameter_routes() -> None:
+    """A later static route can be swallowed by an earlier same-shape path parameter."""
+
+    shadow_messages: list[str] = []
+
+    for endpoint_file in sorted(ENDPOINTS_DIR.glob("*.py")):
+        tree = ast.parse(
+            endpoint_file.read_text(encoding="utf-8"),
+            filename=str(endpoint_file),
+        )
+        routes: list[tuple[int, str, str]] = []
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for decorator in node.decorator_list:
+                route = _decorator_route(decorator)
+                if route is not None:
+                    method, route_path = route
+                    routes.append((decorator.lineno, method, route_path))
+
+        routes.sort()
+        for index, (line_number, method, route_path) in enumerate(routes):
+            for previous_line, previous_method, previous_route_path in routes[:index]:
+                if method != previous_method:
+                    continue
+                if not _is_shadowed_static_route(previous_route_path, route_path):
+                    continue
+                shadow_messages.append(
+                    f"{endpoint_file}:{line_number}: {method} {route_path} "
+                    f"is shadowed by {previous_route_path} at {previous_line}"
+                )
+
+    assert not shadow_messages, "Static routes declared after parameter routes:\n" + "\n".join(
+        shadow_messages
     )


### PR DESCRIPTION
## Summary

- Add an AST-based backend contract test for FastAPI endpoint route declaration order.
- Fail when a same-method static route is declared after an earlier same-shape parameter route in backend/app/api/v1/endpoints/*.py.
- Prevent the route-shadow bug class fixed across the recent cyclic PRs from reappearing.

## Cyclic Execution Evidence

- Fresh main sync: branch created from fresh origin/main at da1018d9 after PR #1496 was merged.
- Clean workspace: inspected before edits; only backend/tests/test_openapi_contract.py changed.
- Branch: codex/backend-route-shadow-contract.
- Scope gate: allowed one backend OpenAPI/route contract test; denied runtime endpoint changes, frontend changes, migrations, /api/v1/ui/*, and BFF work.
- Red-check handling: PR Review Quality Gate failed on missing PR body sections; body updated in this same PR before merge.

## Contract Impact

- Canonical surface: FastAPI route declarations under backend/app/api/v1/endpoints/*.py.
- Request shape: not applicable - test-only contract guard, no API request body changed.
- Response shape: not applicable - no runtime response DTO changed.
- Status codes: not applicable - no endpoint behavior changed.
- Frontend consumer: not applicable - no frontend consumer changed.
- Compatibility path or alias: not applicable - no route alias added or removed.
- Contract proof: backend/tests/test_openapi_contract.py now asserts no same-method static route is declared after an earlier same-shape parameter route.

## RBAC / Permissions

not applicable - test-only route ordering guard; no auth dependency, role matrix, or permission behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, Telegram, chat, queue realtime, or broadcast behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed.
- Partial data proof: not applicable - no frontend DTO consumption changed.
- Forbidden secondary path behavior: not applicable - no secondary frontend path changed.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - frontend routing was not changed.

## Scope Gate

- Allowed paths: backend/tests/test_openapi_contract.py.
- Denied paths: runtime backend endpoints, frontend files, migrations, generated output, docs, /api/v1/ui/*, separate BFF service.
- Migration/docs/test impact: no migration; one backend contract test added.
- Rollback note: revert the test-only commit to remove the guard; no runtime rollback is needed.

## Validation

- Targeted tests or smoke run: C:\\Users\\DrSapaev\\AppData\\Local\\Programs\\Python\\Python311\\python.exe -m py_compile backend\\tests\\test_openapi_contract.py; pytest backend\\tests\\test_openapi_contract.py -q with PYTHONPATH, TESTING=1, and sqlite test DATABASE_URL; git diff --check.
- Result: passed locally; CI backend tests, PR Required Gate, formatting, security, CodeQL, and parity checks passed before body update.
- Not checked: full browser smoke and full frontend build, because this is a backend test-only contract guard with no runtime/frontend code changes.