### PR TITLE
fix(queue): guard full update visit owner

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -2251,11 +2251,9 @@ def full_update_online_entry(
                 if visit:
                     if visit.patient_id != patient_id_for_visit:
                         logger.warning(
-                            "[full_update_online_entry] entry visit owner mismatch entry_id=%d visit_id=%d entry_patient_id=%s visit_patient_id=%s",
+                            "[full_update_online_entry] entry visit owner mismatch entry_id=%d visit_id=%d",
                             entry.id,
                             visit.id,
-                            patient_id_for_visit,
-                            visit.patient_id,
                         )
                         raise HTTPException(
                             status_code=status.HTTP_409_CONFLICT,

--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -2249,6 +2249,18 @@ def full_update_online_entry(
             if entry.visit_id:
                 visit = db.query(Visit).filter(Visit.id == entry.visit_id).first()
                 if visit:
+                    if visit.patient_id != patient_id_for_visit:
+                        logger.warning(
+                            "[full_update_online_entry] entry visit owner mismatch entry_id=%d visit_id=%d entry_patient_id=%s visit_patient_id=%s",
+                            entry.id,
+                            visit.id,
+                            patient_id_for_visit,
+                            visit.patient_id,
+                        )
+                        raise HTTPException(
+                            status_code=status.HTTP_409_CONFLICT,
+                            detail="Queue entry visit does not belong to the queue patient",
+                        )
                     logger.info(
                         "[full_update_online_entry] Найден Visit по entry.visit_id: %d",
                         visit.id,

--- a/backend/tests/integration/test_qr_queue_full_update.py
+++ b/backend/tests/integration/test_qr_queue_full_update.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 import pytest
 
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.patient import Patient
 from app.models.payment_invoice import PaymentInvoice, PaymentInvoiceVisit
 from app.models.visit import Visit, VisitService
 
@@ -93,6 +94,93 @@ def test_full_update_all_free_without_visit_id_does_not_reuse_unrelated_visit(
     linked_visit = db_session.query(Visit).filter(Visit.id == entry.visit_id).one()
     assert linked_visit.discount_mode == "all_free"
     assert linked_visit.approval_status == "pending"
+
+
+@pytest.mark.integration
+def test_full_update_all_free_rejects_entry_linked_to_other_patient_visit(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_daily_queue,
+    test_patient,
+    test_doctor,
+    test_service,
+):
+    other_patient = Patient(
+        last_name="Other",
+        first_name="Queue",
+        phone="+998900001111",
+    )
+    db_session.add(other_patient)
+    db_session.flush()
+    other_visit = Visit(
+        patient_id=other_patient.id,
+        doctor_id=test_doctor.id,
+        visit_date=date.today(),
+        visit_time="12:00",
+        status="open",
+        discount_mode="none",
+        approval_status="none",
+        department="cardiology",
+    )
+    db_session.add(other_visit)
+    db_session.flush()
+    db_session.add(
+        VisitService(
+            visit_id=other_visit.id,
+            service_id=test_service.id,
+            code=test_service.code,
+            name=test_service.name,
+            qty=1,
+            price=test_service.price,
+            currency="UZS",
+        )
+    )
+    entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=78,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        visit_id=other_visit.id,
+        source="online",
+        status="waiting",
+    )
+    db_session.add(entry)
+    db_session.commit()
+    db_session.refresh(entry)
+    db_session.refresh(other_visit)
+
+    response = client.put(
+        f"/api/v1/queue/online-entry/{entry.id}/full-update",
+        headers=registrar_auth_headers,
+        json={
+            "patient_data": {
+                "patient_name": test_patient.short_name(),
+                "phone": test_patient.phone,
+                "birth_year": 1990,
+                "address": test_patient.address,
+            },
+            "visit_type": "paid",
+            "discount_mode": "none",
+            "services": [{"service_id": test_service.id, "quantity": 1}],
+            "all_free": True,
+        },
+    )
+
+    assert response.status_code == 409, response.text
+    assert "does not belong" in response.json()["detail"]
+
+    db_session.refresh(other_visit)
+    assert other_visit.discount_mode == "none"
+    assert other_visit.approval_status == "none"
+    assert other_visit.department == "cardiology"
+    assert (
+        db_session.query(VisitService)
+        .filter(VisitService.visit_id == other_visit.id)
+        .count()
+        == 1
+    )
 
 
 @pytest.mark.integration

--- a/backend/tests/unit/test_patient_onboarding_request_policy.py
+++ b/backend/tests/unit/test_patient_onboarding_request_policy.py
@@ -644,6 +644,7 @@ def test_onboarding_analytics_summary_returns_safe_dashboard_metrics(
         status="rejected",
         review_message="Please contact the clinic.",
     )
+    today_request = _create_onboarding_request(db_session, chat_id=9206, status="pending_review")
 
     pending_request.created_at = now - timedelta(hours=5)
     needs_info_request.created_at = now - timedelta(hours=3)
@@ -652,6 +653,7 @@ def test_onboarding_analytics_summary_returns_safe_dashboard_metrics(
     linked_request.reviewed_at = now - timedelta(minutes=30)
     rejected_request.created_at = now - timedelta(hours=1)
     rejected_request.reviewed_at = now - timedelta(minutes=10)
+    today_request.created_at = now
     db_session.add_all(
         [
             AuditLog(


### PR DESCRIPTION
## Summary
Fixes mounted QR full-update so `OnlineQueueEntry.visit_id` is trusted only when the resolved `Visit.patient_id` matches the queue entry patient before all-free Visit/VisitService mutation.

## Cyclic Execution Evidence
- Fresh main sync: safe worktree was on `origin/main` at `b5487e0e` before branching.
- Clean workspace: branch started clean from `codex/current-main-view`.
- Branch: `codex/qr-full-update-visit-owner`.
- Scope gate: local agent gate was run with known root cause `backend/app/api/v1/endpoints/qr_queue.py`; first runtime slice stayed in mounted endpoint, with a focused integration regression added for proof.
- Red-check handling: first CodeQL run flagged patient ids in the new owner-mismatch warning; fixed in-place by removing patient ids from the log. Second CI run exposed an unrelated UTC-boundary onboarding analytics fixture failure; fixed in-place with a test-only fixture stabilization.

## Contract Impact
- Canonical surface: mounted `PUT /api/v1/queue/online-entry/{entry_id}/full-update`.
- Request shape: unchanged; still accepts the existing full-update payload with patient data, services, discount fields, and all_free.
- Response shape: unchanged for valid same-patient updates.
- Status codes: valid same-patient updates remain 200; mislinked queue entry to another patient's Visit now returns 409 before mutation.
- Frontend consumer: registrar/queue full-update flow only.
- Compatibility path or alias: missing `entry.visit_id` and same-patient visit behavior are preserved; only foreign existing visit ids fail closed.
- Contract proof: integration regression posts through the mounted route and proves patient A's queue entry cannot mutate patient B's Visit.

## RBAC / Permissions
- Roles allowed: existing Admin/Registrar/Doctor/specialist role dependency remains unchanged.
- Roles denied: no allowed role can use a mislinked queue entry to mutate another patient's Visit or VisitService rows.
- Positive auth proof: existing QR full-update tests still pass for same-patient/no-visit matching, same-session phone matching, and paid Visit preservation.
- Negative auth proof: new regression verifies cross-patient `entry.visit_id` returns 409 and leaves the foreign Visit and VisitService unchanged.

## Notification / Realtime
- Event type or websocket channel: none changed.
- Payload version / ack behavior: none changed.
- Read/unread or delivery semantics: no notification read/delivery semantics changed.
- Reconnect/resync proof: valid queue full-update responses keep the same shape; rejected corrupted links do not mutate backend state.

## Frontend Resilience
- Empty data proof: existing no-visit test still creates a new owned Visit instead of reusing unrelated data.
- Partial data proof: existing same-session phone-digit test still handles partial queue identity data.
- Forbidden secondary path behavior: foreign Visit mutation path now returns 409 before secondary VisitService writes.
- Missing draft/resource behavior: missing `entry.visit_id` keeps existing create/find behavior; this PR only blocks foreign existing visits.
- Stale route/deep-link behavior: route path and request contract are unchanged; stale clients receive explicit 409 for corrupted queue/visit linkage.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/qr_queue.py`, `backend/tests/integration/test_qr_queue_full_update.py`, `backend/tests/unit/test_patient_onboarding_request_policy.py` for red-check fixture stabilization only.
- Denied paths: frontend, `/api/v1/ui/*`, migrations, queue allocator/fairness rewrites, unmounted duplicate service rewrites, payment schema/model changes, runtime onboarding analytics behavior.
- Migration/docs/test impact: no migration or docs; added focused integration regression and one test-only CI flake stabilization.
- Rollback note: revert the queue runtime commit to restore prior full-update trust behavior; the onboarding test fixture commit is independent and runtime-neutral.

## Validation
- Targeted tests or smoke run: `scripts/run_python.ps1 -PythonArgs @('-m','py_compile','backend/app/api/v1/endpoints/qr_queue.py','backend/tests/integration/test_qr_queue_full_update.py')`.
- Targeted tests or smoke run: `TESTING=1 DATABASE_URL=sqlite:///C:/tmp/qr-full-update-owner-test.db scripts/run_backend_pytest.ps1 tests/integration/test_qr_queue_full_update.py`.
- Targeted tests or smoke run: `scripts/run_python.ps1 -PythonArgs @('-m','py_compile','backend/app/api/v1/endpoints/qr_queue.py','backend/tests/integration/test_qr_queue_full_update.py','backend/tests/unit/test_patient_onboarding_request_policy.py')`.
- Targeted tests or smoke run: `TESTING=1 DATABASE_URL=sqlite:///C:/tmp/onboarding-analytics-test.db scripts/run_backend_pytest.ps1 tests/unit/test_patient_onboarding_request_policy.py::test_onboarding_analytics_summary_returns_safe_dashboard_metrics`.
- Targeted tests or smoke run: `git diff --check`.
- Result: py_compile passed; QR full-update integration suite passed 5 tests; onboarding analytics targeted unit passed; diff check passed.
- Not checked: broad backend suite locally and frontend wizard runtime smoke; GitHub CI is the broad check.