### PR TITLE
fix(admin): restore service catalog list

### DIFF
--- a/backend/app/api/v1/endpoints/services.py
+++ b/backend/app/api/v1/endpoints/services.py
@@ -269,17 +269,33 @@ def _should_validate_service_code_alignment(
     return bool(routing_fields.intersection(change_set.keys()))
 
 
+def _coerce_department_value(row: Any) -> str | None:
+    department = getattr(row, "department", None)
+    if isinstance(department, str):
+        return department
+    if department is None:
+        return None
+
+    for attr in ("key", "name_ru", "name", "code"):
+        value = getattr(department, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value
+
+    return None
+
+
 def _row_to_out(r) -> ServiceOut:
     price = None
     try:
         price = float(r.price) if r.price is not None else None
     except Exception:
         price = None
+    department = _coerce_department_value(r)
     return ServiceOut(
         id=r.id,
         code=r.service_code or r.code,
         name=r.name,
-        department=r.department,
+        department=department,
         unit=r.unit,
         price=price,
         currency=r.currency,

--- a/backend/tests/unit/test_patient_onboarding_request_policy.py
+++ b/backend/tests/unit/test_patient_onboarding_request_policy.py
@@ -630,6 +630,12 @@ def test_onboarding_analytics_summary_returns_safe_dashboard_metrics(
     registrar_auth_headers,
 ):
     now = datetime.now(timezone.utc)
+    start_of_today = datetime.combine(
+        now.date(),
+        datetime.min.time(),
+        tzinfo=timezone.utc,
+    )
+    today_created_at = max(now - timedelta(minutes=30), start_of_today)
     pending_request = _create_onboarding_request(db_session, chat_id=9201, status="pending_review")
     needs_info_request = _create_onboarding_request(
         db_session,
@@ -648,8 +654,8 @@ def test_onboarding_analytics_summary_returns_safe_dashboard_metrics(
     pending_request.created_at = now - timedelta(hours=5)
     needs_info_request.created_at = now - timedelta(hours=3)
     needs_info_request.reviewed_at = now - timedelta(hours=1)
-    linked_request.created_at = now - timedelta(hours=2)
-    linked_request.reviewed_at = now - timedelta(minutes=30)
+    linked_request.created_at = today_created_at
+    linked_request.reviewed_at = max(now - timedelta(minutes=10), today_created_at)
     rejected_request.created_at = now - timedelta(hours=1)
     rejected_request.reviewed_at = now - timedelta(minutes=10)
     db_session.add_all(

--- a/backend/tests/unit/test_services_router_service_wiring.py
+++ b/backend/tests/unit/test_services_router_service_wiring.py
@@ -74,6 +74,46 @@ def test_get_service_endpoint_delegates_to_service(client, monkeypatch) -> None:
     assert captured["service_id"] == 42
 
 
+def test_list_services_serializes_department_relationship(client, monkeypatch) -> None:
+    captured = {}
+
+    def fake_list_services(self, **kwargs):
+        captured.update(kwargs)
+        return [
+            SimpleNamespace(
+                id=7,
+                code="K02",
+                service_code="K02",
+                name="Repeat consultation",
+                department=SimpleNamespace(key="cardio", name_ru="Кардиология"),
+                unit="service",
+                price=50000,
+                currency="UZS",
+                active=True,
+                category_id=3,
+                duration_minutes=20,
+                doctor_id=None,
+                category_code="K",
+                requires_doctor=True,
+                queue_tag="cardio",
+                is_consultation=True,
+                allow_doctor_price_override=False,
+                department_key="cardio",
+            )
+        ]
+
+    monkeypatch.setattr(ServicesApiService, "list_services", fake_list_services)
+
+    response = client.get("/api/v1/services", params={"active": "true"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload[0]["id"] == 7
+    assert payload[0]["department"] == "cardio"
+    assert payload[0]["department_key"] == "cardio"
+    assert captured["active"] is True
+
+
 
 def test_queue_groups_endpoint_delegates_to_queue_domain_service(
     client,


### PR DESCRIPTION
﻿## Summary

- Fixes `GET /api/v1/services` serialization when SQLAlchemy returns a `Department` relationship object instead of a legacy department string.
- Keeps the existing service catalog response shape and converts relationship-backed `department` values into a stable string key/name before Pydantic validation.
- Adds a regression test for the admin service catalog list path.
- Stabilizes an unrelated onboarding analytics unit fixture that fails near UTC midnight, because backend CI runs the full suite for backend changes.

## Cyclic Execution Evidence

- Fresh main sync: `git fetch origin`, `git switch main`, `git pull --ff-only origin main` before branch creation.
- Clean workspace: branch started clean; final diff is backend endpoint plus targeted backend tests only.
- Branch: `fix/admin-services-service-list`.
- Scope gate: narrow override after `agent_gate` misrouted this service-catalog fix to queue fairness; allowed service endpoint/test changes, then one CI-red test fixture stabilization in the same PR.
- Red-check handling: PR Review Quality Gate and backend full-suite CI were red; both are being fixed in this PR.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

- Canonical surface: `GET /api/v1/services`.
- Request shape: unchanged.
- Response shape: unchanged by design; `department` remains the documented optional string field, now safely serialized from ORM relationship objects.
- Status codes: fixes unintended 500 for valid service rows; successful service lists remain 200.
- Frontend consumer: Admin service catalog (`frontend/src/components/admin/ServiceCatalog.jsx`) and duplicate-code checks using `/services`.
- Compatibility path or alias: none changed.
- Contract proof: targeted unit regression plus live `clinic_dev` smoke returned 200 and service rows with string `department` and `department_key`.

## RBAC / Permissions

not applicable - this does not change route dependencies, role checks, auth helpers, or permissions.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not checked - this backend-only fix targets a non-empty service catalog serialization 500.
- Partial data proof: relationship-backed `department` values now serialize without failing the whole response.
- Forbidden secondary path behavior: not applicable - no RBAC/403 behavior changed.
- Missing draft/resource behavior: not applicable - no draft/resource lifecycle changed.
- Stale route/deep-link behavior: not applicable - no route/deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/services.py`, `backend/tests/unit/test_services_router_service_wiring.py`, `backend/tests/unit/test_patient_onboarding_request_policy.py` for CI-red fixture stabilization.
- Denied paths: frontend runtime, DB migrations, queue allocation/timing, RBAC/auth, payment, registrar workflow, deploy/secrets.
- Migration/docs/test impact: no migration; one service router regression test added; one onboarding analytics test fixture stabilized for midnight-safe CI.
- Rollback note: revert this PR to restore the prior service serializer behavior and prior test fixture timing.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

Note: `agent_gate` returned a queue-fairness misroute for this admin service catalog root cause, so this PR used the documented narrow override policy.

## Validation

- Targeted tests or smoke run: `./scripts/run_backend_pytest.ps1 tests/unit/test_services_router_service_wiring.py -q`; `./scripts/run_backend_pytest.ps1 tests/integration/test_admin_service_code_prefix_consistency.py -q`; `./scripts/run_backend_pytest.ps1 tests/unit/test_patient_onboarding_request_policy.py::test_onboarding_analytics_summary_returns_safe_dashboard_metrics -q`; `./backend/.venv/Scripts/python.exe -m py_compile backend/app/api/v1/endpoints/services.py`; `./scripts/check_dev_clinic.ps1`; direct `GET http://localhost:18000/api/v1/services?limit=5`; `git diff --check`; `python scripts/run_pr_review_gate_checks.py --body-file <temp-pr-body>`.
- Result: all listed local checks passed; direct service-list smoke returned 200 with five service rows.
- Not checked: full backend/frontend test suites locally and browser admin route walkthrough.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.
