### PR TITLE
fix(queue): guard mark-paid visit owner

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -3087,6 +3087,17 @@ def mark_queue_entry_as_paid(
             visit = db.query(Visit).filter(Visit.id == entry.visit_id).first()
             logger.info(f"mark_queue_entry_as_paid: Найден Visit {entry.visit_id} через entry.visit_id")
         
+        if visit and visit.patient_id != entry.patient_id:
+            logger.warning(
+                "mark_queue_entry_as_paid: entry visit owner mismatch entry_id=%d visit_id=%d",
+                entry.id,
+                visit.id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Queue entry visit does not belong to the queue patient",
+            )
+
         requested_method = (
             str(payment_req.method).strip().lower()
             if payment_req and payment_req.method

--- a/backend/tests/integration/test_registrar_record_actions.py
+++ b/backend/tests/integration/test_registrar_record_actions.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.models.appointment import Appointment
 from app.models.online_queue import OnlineQueueEntry
+from app.models.patient import Patient
 from app.models.payment import Payment
 from app.models.visit import Visit
 
@@ -121,6 +122,70 @@ def test_queue_mark_paid_without_visit_id_does_not_pay_unrelated_patient_visit(
     assert (
         db_session.query(Payment)
         .filter(Payment.visit_id == unrelated_visit.id)
+        .count()
+        == 0
+    )
+
+
+@pytest.mark.integration
+def test_queue_mark_paid_rejects_entry_linked_to_other_patient_visit(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_daily_queue,
+    test_patient,
+    test_doctor,
+):
+    other_patient = Patient(
+        first_name="Other",
+        last_name="Patient",
+        phone="+998901119999",
+    )
+    db_session.add(other_patient)
+    db_session.flush()
+
+    other_visit = Visit(
+        patient_id=other_patient.id,
+        doctor_id=test_doctor.id,
+        visit_date=date.today(),
+        visit_time="12:30",
+        status="open",
+        discount_mode="none",
+        department="cardiology",
+        created_at=datetime.utcnow(),
+    )
+    db_session.add(other_visit)
+    db_session.flush()
+
+    entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=100,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        visit_id=other_visit.id,
+        source="online",
+        status="waiting",
+    )
+    db_session.add(entry)
+    db_session.commit()
+
+    response = client.post(
+        f"/api/v1/registrar/queue/entry/{entry.id}/mark-paid",
+        headers=registrar_auth_headers,
+        json={"method": "cash"},
+    )
+
+    assert response.status_code == 409, response.text
+    assert "does not belong" in response.json()["detail"]
+
+    db_session.refresh(entry)
+    db_session.refresh(other_visit)
+    assert entry.status == "waiting"
+    assert other_visit.status == "open"
+    assert (
+        db_session.query(Payment)
+        .filter(Payment.visit_id == other_visit.id)
         .count()
         == 0
     )


### PR DESCRIPTION
## Summary
Fixes registrar queue mark-paid so `OnlineQueueEntry.visit_id` is trusted only when the linked `Visit.patient_id` matches the queue entry patient before Payment/invoice/Visit mutation.

## Cyclic Execution Evidence
- Fresh main sync: safe worktree was fast-forwarded to `origin/main` at `e8f103de` before branching.
- Clean workspace: branch started clean from `codex/current-main-view`.
- Branch: `codex/queue-mark-paid-visit-owner`.
- Scope gate: local agent gate was run with known root cause `backend/app/api/v1/endpoints/registrar_wizard.py`; runtime slice stayed in the mounted registrar queue mark-paid endpoint, with a focused integration regression added for proof.
- Red-check handling: if CI fails, this PR will be fixed in-place before merge.

## Contract Impact
- Canonical surface: mounted `POST /api/v1/registrar/queue/entry/{entry_id}/mark-paid`.
- Request shape: unchanged; existing optional mark-paid payload remains accepted.
- Response shape: unchanged for valid same-patient queue/visit links and no-visit legacy marker path.
- Status codes: valid same-patient queue mark-paid remains 200; corrupted cross-patient `entry.visit_id` now returns 409 before payment mutation.
- Frontend consumer: registrar/cashier queue mark-paid action only.
- Compatibility path or alias: missing `entry.visit_id` behavior is preserved; only an existing foreign visit link fails closed.
- Contract proof: integration regression posts through the mounted route and proves patient A's queue entry cannot create payment rows for patient B's Visit.

## RBAC / Permissions
- Roles allowed: existing Admin/Registrar/Cashier dependency remains unchanged.
- Roles denied: no allowed role can use a mislinked queue entry to mark another patient's Visit paid.
- Positive auth proof: existing registrar record-action tests still pass for no-visit queue mark-paid, visit mark-paid role denial, cancellation, and start-visit id-collision coverage.
- Negative auth proof: new regression verifies cross-patient `entry.visit_id` returns 409 and leaves the foreign Visit unpaid/unchanged.

## Notification / Realtime
- Event type or websocket channel: none changed.
- Payload version / ack behavior: none changed.
- Read/unread or delivery semantics: no notification read/delivery semantics changed.
- Reconnect/resync proof: valid mark-paid responses keep the same shape; rejected corrupted links do not mutate backend payment state.

## Frontend Resilience
- Empty data proof: existing no-visit test still keeps legacy queue marker behavior without creating a Payment for unrelated Visit rows.
- Partial data proof: request body remains optional; default payment method behavior is unchanged.
- Forbidden secondary path behavior: foreign Visit payment path now returns 409 before Payment insert, invoice sync, or Visit updated_at mutation.
- Missing draft/resource behavior: missing `entry.visit_id` keeps existing fallback marker behavior.
- Stale route/deep-link behavior: route path and request contract are unchanged; stale clients receive explicit 409 for corrupted queue/visit linkage.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/registrar_wizard.py`, `backend/tests/integration/test_registrar_record_actions.py`.
- Denied paths: frontend, `/api/v1/ui/*`, migrations, payment schema/model changes, billing service rewrites, queue allocator/fairness rewrites, registrar read-model rewrites.
- Migration/docs/test impact: no migration or docs; added focused integration regression.
- Rollback note: revert this single commit to restore prior queue mark-paid trust behavior.

## Validation
- Targeted tests or smoke run: `scripts/run_python.ps1 -PythonArgs @('-m','py_compile','backend/app/api/v1/endpoints/registrar_wizard.py','backend/tests/integration/test_registrar_record_actions.py')`.
- Targeted tests or smoke run: `TESTING=1 DATABASE_URL=sqlite:///C:/tmp/queue-mark-paid-owner-test.db scripts/run_backend_pytest.ps1 tests/integration/test_registrar_record_actions.py`.
- Targeted tests or smoke run: `git diff --check`.
- Result: py_compile passed; registrar record-action integration suite passed 6 tests; diff check passed.
- Not checked: broad backend suite locally and frontend runtime smoke; GitHub CI is the broad check.