### PR TITLE
fix(admin): align contextual route sections

### DIFF
--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -136,6 +136,7 @@ import AllFreeApproval from '../components/admin/AllFreeApproval';
 
 import AnalyticsInsights from '../components/ai/AnalyticsInsights';
 import UnifiedTelegramManagement from '../components/admin/UnifiedTelegramManagement';
+import TelegramSettings from '../components/admin/TelegramSettings';
 import UnifiedSettings from '../components/admin/UnifiedSettings';
 import UnifiedFinance from '../components/admin/UnifiedFinance';
 import UnifiedNotifications from '../components/admin/UnifiedNotifications';
@@ -174,6 +175,18 @@ const LazyQueueProfilesManager = React.lazy(() => import('../components/admin/Qu
 const LazyServiceCatalog = React.lazy(() => import('../components/admin/ServiceCatalog'));
 const LazyUnifiedReports = React.lazy(() => import('../components/admin/UnifiedReports'));
 const LazyWaitTimeAnalytics = React.lazy(() => import('../components/analytics/WaitTimeAnalytics'));
+
+const ADMIN_ROUTE_SECTION_PARAMS = {
+  'benefit-settings': 'benefit-settings',
+  'wizard-settings': 'wizard-settings',
+  'payment-providers': 'payment-providers',
+  'clinic-settings': 'clinic-settings',
+  'queue-settings': 'queue-settings',
+  'display-settings': 'display-settings',
+  'ai-settings': 'ai-settings',
+  security: 'security',
+  'telegram-settings': 'settings'
+};
 
 const getAppointmentPatientDisplayName = (appointment) => {
   const rawName =
@@ -1223,18 +1236,35 @@ const AdminPanel = () => {
   // Вычисляем текущую вкладку из URL параметров или пути
   const searchParams = new URLSearchParams(location.search);
   const sectionFromQuery = searchParams.get('section');
+  const pathParts = location.pathname.split('/').filter(Boolean);
+  const sectionFromPath = pathParts.length >= 2 && pathParts[0] === 'admin' ?
+    pathParts[1] || 'dashboard' :
+    'dashboard';
+  const canonicalSectionParam = ADMIN_ROUTE_SECTION_PARAMS[sectionFromPath];
 
   // Если секция указана в query параметре, используем её
   // Иначе пытаемся извлечь из пути URL
-  let current = sectionFromQuery;
+  let current = canonicalSectionParam ? sectionFromPath : sectionFromQuery;
   if (!current) {
-    const pathParts = location.pathname.split('/').filter(Boolean);
-    if (pathParts.length >= 2 && pathParts[0] === 'admin') {
-      current = pathParts[1] || 'dashboard';
-    } else {
-      current = 'dashboard';
-    }
+    current = sectionFromPath;
   }
+
+  useEffect(() => {
+    if (!canonicalSectionParam) {
+      return;
+    }
+
+    const params = new URLSearchParams(location.search);
+    if (params.get('section') === canonicalSectionParam) {
+      return;
+    }
+
+    params.set('section', canonicalSectionParam);
+    navigate({
+      pathname: location.pathname,
+      search: `?${params.toString()}`
+    }, { replace: true });
+  }, [canonicalSectionParam, location.pathname, location.search, navigate]);
 
   const dashboardKpis = [
     {
@@ -2576,8 +2606,9 @@ const AdminPanel = () => {
       case 'quality-control':
         return <UnifiedAITools />;
       case 'telegram-bot':
-      case 'telegram-settings':
         return <UnifiedTelegramManagement />;
+      case 'telegram-settings':
+        return <TelegramSettings />;
       case 'fcm-notifications':
       case 'registrar-notifications':
         return <UnifiedNotifications />;


### PR DESCRIPTION
## Summary

- Aligns direct AdminPanel contextual routes with their intended settings section instead of falling back to generic settings.
- Preserves legacy `/admin?section=...` behavior for generic admin flows while making direct contextual paths authoritative.
- Makes `/admin/telegram-settings` render Telegram settings instead of the Bot Manager tab.

## Cyclic Execution Evidence

- Fresh main sync: `git fetch origin`, `git checkout main`, and `git pull --ff-only origin main` completed before branching.
- Clean workspace: inspected with `git status --short --branch`; branch started clean from `origin/main`.
- Branch: `fix/admin-route-state-adapter`.
- Scope gate: allowed `frontend/src/pages/AdminPanel.jsx`; denied backend, DB/migrations, RBAC, API contracts, deploy/secrets, and unrelated admin refactors.
- Red-check handling: fix any failed GitHub check in this same PR before merge.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

- Canonical surface: AdminPanel route rendering for direct contextual admin paths.
- Request shape: not applicable - no API request body changed.
- Response shape: not applicable - no API response shape changed.
- Status codes: not applicable - no backend status behavior changed.
- Frontend consumer: `/admin/security`, `/admin/ai-settings`, `/admin/payment-providers`, `/admin/queue-settings`, `/admin/display-settings`, `/admin/wizard-settings`, `/admin/benefit-settings`, `/admin/clinic-settings`, and `/admin/telegram-settings`.
- Compatibility path or alias: legacy generic `?section=` deep links remain for `/admin` flows; direct contextual paths now set their canonical `section` query with `replace`.
- Contract proof: targeted browser smoke confirmed each direct contextual route lands on the intended section and does not render generic settings.

## RBAC / Permissions

not applicable - no route guard, endpoint permission, role helper, auth policy, or RBAC behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime payload, delivery, read/unread, reconnect, or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no empty-state data flow changed.
- Partial data proof: not applicable - no partial-data handling changed.
- Forbidden secondary path behavior: not applicable - no forbidden/auth fallback behavior changed.
- Missing draft/resource behavior: not applicable - no draft/resource behavior changed.
- Stale route/deep-link behavior: targeted browser smoke confirmed direct contextual admin routes normalize to the intended `section` query and render route-specific content.

## Scope Gate

- Allowed paths: `frontend/src/pages/AdminPanel.jsx`
- Denied paths: `backend/**`, DB migrations, `.github/**`, deploy/secrets, route registry ownership changes, unrelated admin components, generated artifacts
- Migration/docs/test impact: no migration; no docs; validation used existing route contract test, lint, build, and browser smoke.
- Rollback note: revert this commit to restore previous AdminPanel route section behavior.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `cd frontend; npm run test:run -- src/routing/__tests__/routeContract.test.js`; `cd frontend; npm run lint:check -- --quiet`; `cd frontend; npm run build`; `.\scripts\check_dev_clinic.ps1`; targeted Playwright browser smoke for contextual admin routes; `git diff --check`.
- Result: route contract tests passed, lint passed, build passed, dev clinic health passed, browser smoke passed, and `git diff --check` passed.
- Not checked: no destructive admin actions clicked; no backend tests run because this patch does not touch backend code.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.