### PR TITLE
fix(ui): allow node table headers

### DIFF
--- a/frontend/src/components/ui/macos/MacOSTable.jsx
+++ b/frontend/src/components/ui/macos/MacOSTable.jsx
@@ -294,7 +294,7 @@ MacOSTable.propTypes = {
   columns: PropTypes.arrayOf(
     PropTypes.shape({
       key: PropTypes.string,
-      title: PropTypes.string,
+      title: PropTypes.node,
       sortable: PropTypes.bool,
       render: PropTypes.func
     })


### PR DESCRIPTION
﻿## Summary

- Align `MacOSTable` PropTypes with existing supported usage: column titles may be React nodes.
- Fix the `/admin/services` console warning caused by the service catalog checkbox header.
- Keep table rendering, admin services behavior, API calls, and data flow unchanged.

## Cyclic Execution Evidence

- Fresh main sync: branch was created from current `origin/main` after the previous Admin audit PR merge.
- Clean workspace: only `frontend/src/components/ui/macos/MacOSTable.jsx` changed before commit.
- Branch: `fix/admin-services-table-title-node`.
- Scope gate: allowed `MacOSTable` PropTypes only; denied services runtime logic, backend, DB, routes, RBAC, and docs.
- Red-check handling: any failed GitHub check will be fixed in this same PR before merge.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

not applicable - no API, websocket, event, route, request, response, or external frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route guard, role helper, endpoint permission, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not changed; this patch only broadens the shared table header PropTypes contract.
- Partial data proof: not changed.
- Forbidden secondary path behavior: not changed.
- Missing draft/resource behavior: not changed.
- Stale route/deep-link behavior: `/admin/services` browser smoke still loads without 4xx/5xx responses.

## Scope Gate

- Allowed paths: `frontend/src/components/ui/macos/MacOSTable.jsx`.
- Denied paths: backend, DB/migrations, route registry, admin services business logic, tests, docs, deploy, secrets.
- Migration/docs/test impact: no migration; no docs; no test file changes needed for a PropTypes-only contract alignment.
- Rollback note: revert the one-line PropTypes change if an unexpected table-header compatibility issue appears.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `cd frontend; npm run lint:check -- --quiet --rule "no-warning-comments: off"`; `cd frontend; npm run build`; Playwright smoke for `http://localhost:5173/admin/services` with admin token on `clinic_dev`; `git diff --check`.
- Result: lint passed; build passed; browser smoke passed with no `Failed prop type` / `MacOSTable` warning and no 4xx/5xx responses; `git diff --check` passed.
- Not checked: full backend suite; not relevant for a one-line frontend PropTypes fix.
