### PR TITLE
fix(ui): keep textarea style prop off dom

### DIFF
--- a/frontend/src/components/ui/macos/MacOSTextarea.jsx
+++ b/frontend/src/components/ui/macos/MacOSTextarea.jsx
@@ -11,6 +11,7 @@ const MacOSTextarea = React.forwardRef(({
   autoResize = true,
   minRows = 3,
   maxRows = 10,
+  textareaStyle = {},
   ...props
 }, ref) => {
   const textareaRef = useRef(null);
@@ -56,7 +57,7 @@ const MacOSTextarea = React.forwardRef(({
   const currentSize = sizeStyles[size];
   const currentVariantStyle = variantStyles[currentVariant];
 
-  const textareaStyle = {
+  const textareaStyles = {
     width: '100%',
     borderRadius: 'var(--mac-radius-md)',
     fontSize: currentSize.fontSize,
@@ -73,7 +74,8 @@ const MacOSTextarea = React.forwardRef(({
       cursor: 'not-allowed',
       background: 'var(--mac-bg-tertiary)'
     }),
-    ...style
+    ...style,
+    ...textareaStyle
   };
 
   const handleFocus = (e) => {
@@ -113,7 +115,7 @@ const MacOSTextarea = React.forwardRef(({
     <textarea
       ref={internalRef}
       className={className}
-      style={textareaStyle}
+      style={textareaStyles}
       disabled={disabled}
       onFocus={handleFocus}
       onBlur={handleBlur}
@@ -136,6 +138,7 @@ MacOSTextarea.propTypes = {
   minRows: PropTypes.any,
   size: PropTypes.any,
   style: PropTypes.any,
+  textareaStyle: PropTypes.object,
   value: PropTypes.any,
   variant: PropTypes.any,
 };


### PR DESCRIPTION
﻿## Summary

- Teach `MacOSTextarea` to consume the existing `textareaStyle` styling prop instead of forwarding it to the DOM.
- Fix the `/admin/graphql-explorer` React unknown-prop warning without changing GraphQL behavior.
- Preserve existing textarea styling semantics by merging `style` and `textareaStyle` into the textarea style object.

## Cyclic Execution Evidence

- Fresh main sync: branch was created from `main` after PR #1507 was merged and local `main` matched `origin/main`.
- Clean workspace: only `frontend/src/components/ui/macos/MacOSTextarea.jsx` changed before commit.
- Branch: `fix/admin-graphql-textarea-prop`.
- Scope gate: allowed `MacOSTextarea` prop handling only; denied GraphQL query logic, backend, DB, route registry, RBAC, and admin navigation changes.
- Red-check handling: any failed GitHub check will be fixed in this same PR before merge.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

not applicable - no API, websocket, event, route, request, response, or external product contract changed.

## RBAC / Permissions

not applicable - no route guard, role helper, endpoint permission, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not changed; this patch only prevents a UI primitive prop from leaking to the DOM.
- Partial data proof: not changed.
- Forbidden secondary path behavior: not changed.
- Missing draft/resource behavior: not changed.
- Stale route/deep-link behavior: `/admin/graphql-explorer` browser smoke loads directly under Admin auth with no 4xx/5xx responses.

## Scope Gate

- Allowed paths: `frontend/src/components/ui/macos/MacOSTextarea.jsx`.
- Denied paths: backend, DB/migrations, GraphQL execution logic, route registry, admin navigation, docs, deploy, secrets.
- Migration/docs/test impact: no migration; no docs; no test file changes needed for a narrow shared component PropTypes/DOM-prop fix.
- Rollback note: revert this one component change if a textarea styling regression appears.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `cd frontend; npm run lint:check -- --quiet --rule "no-warning-comments: off"`; `cd frontend; npm run build`; Playwright smoke for `http://localhost:5173/admin/graphql-explorer` with admin token on `clinic_dev`; `git diff --check`.
- Result: lint passed; build passed; browser smoke passed with no React unknown-prop / `textareaStyle` / `MacOSTextarea` warning and no 4xx/5xx responses; `git diff --check` passed.
- Not checked: full backend suite; not relevant for a one-file frontend UI primitive fix.
