### PR TITLE
test(admin): guard contextual route sections

### DIFF
--- a/frontend/src/pages/__tests__/AdminPanel.routeState.contract.test.jsx
+++ b/frontend/src/pages/__tests__/AdminPanel.routeState.contract.test.jsx
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const adminPanelPath = path.resolve(__dirname, '../AdminPanel.jsx');
+
+const CONTEXTUAL_ROUTE_SECTION_MAP = {
+  'benefit-settings': 'benefit-settings',
+  'wizard-settings': 'wizard-settings',
+  'payment-providers': 'payment-providers',
+  'clinic-settings': 'clinic-settings',
+  'queue-settings': 'queue-settings',
+  'display-settings': 'display-settings',
+  'ai-settings': 'ai-settings',
+  security: 'security',
+  'telegram-settings': 'settings'
+};
+
+function readAdminPanel() {
+  return fs.readFileSync(adminPanelPath, 'utf8');
+}
+
+describe('AdminPanel route state contract', () => {
+  it('keeps direct contextual routes mapped to their intended section params', () => {
+    const source = readAdminPanel();
+
+    expect(source).toContain('const ADMIN_ROUTE_SECTION_PARAMS = {');
+
+    Object.entries(CONTEXTUAL_ROUTE_SECTION_MAP).forEach(([routeSection, expectedParam]) => {
+      const key = /^[a-zA-Z_$][\w$]*$/.test(routeSection) ? routeSection : `'${routeSection}'`;
+      expect(source).toContain(`${key}: '${expectedParam}'`);
+    });
+
+    expect(source).toContain('params.set(\'section\', canonicalSectionParam);');
+    expect(source).toContain('navigate({');
+    expect(source).toContain('pathname: location.pathname');
+    expect(source).toContain('{ replace: true }');
+  });
+
+  it('keeps Telegram settings on the settings surface, not the bot manager surface', () => {
+    const source = readAdminPanel();
+
+    expect(source).toContain("'telegram-settings': 'settings'");
+    expect(source).toContain("case 'telegram-settings':");
+    expect(source).toContain('return <TelegramSettings />;');
+  });
+});


### PR DESCRIPTION
﻿## Summary

- Add a focused AdminPanel route-state guardrail test.
- Lock direct contextual admin routes to their intended `section` query mapping.
- Guard `/admin/telegram-settings` so it stays on Telegram settings instead of the bot-manager surface.

## Cyclic Execution Evidence

- Fresh main sync: branch was created from current `main` after PR #1508 was merged and local `main` matched `origin/main`.
- Clean workspace: only `frontend/src/pages/__tests__/AdminPanel.routeState.contract.test.jsx` changed before commit.
- Branch: `test/admin-route-state-guardrail`.
- Scope gate: allowed one frontend contract test only; denied runtime UI changes, backend, DB, route registry, RBAC, and notification route-map changes.
- Red-check handling: any failed GitHub check will be fixed in this same PR before merge.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

not applicable - no API, websocket, event, route, request, response, or product contract changed; this PR adds a guardrail test for an existing frontend route-state adapter.

## RBAC / Permissions

not applicable - no route guard, role helper, endpoint permission, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed; notification route-map consolidation remains a later separate decision.

## Frontend Resilience

- Empty data proof: not changed; test-only PR.
- Partial data proof: not changed; test-only PR.
- Forbidden secondary path behavior: not changed; test-only PR.
- Missing draft/resource behavior: not changed; test-only PR.
- Stale route/deep-link behavior: browser route-state smoke confirmed contextual admin routes deep-link to the intended screens, and this test now protects that mapping.

## Scope Gate

- Allowed paths: `frontend/src/pages/__tests__/AdminPanel.routeState.contract.test.jsx`.
- Denied paths: product runtime code, route registry, backend, DB/migrations, deploy, secrets, docs.
- Migration/docs/test impact: test-only; no migration and no docs.
- Rollback note: reverting the test does not change runtime behavior, but removes protection against route-state regressions.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `cd frontend; npm run test:run -- src/pages/__tests__/AdminPanel.routeState.contract.test.jsx`; `cd frontend; npm run lint:check -- --quiet --rule "no-warning-comments: off"`; `cd frontend; npm run build`; browser route-state smoke for `/admin/security`, `/admin/payment-providers`, `/admin/queue-settings`, `/admin/display-settings`, `/admin/ai-settings`, `/admin/telegram-settings`; `git diff --check`.
- Result: targeted Vitest passed with 2 tests; lint passed; build passed; browser smoke showed contextual routes redirect to their intended `?section=...` screens with no 4xx/5xx and no relevant console warnings; `git diff --check` passed.
- Not checked: full backend suite; not relevant for a frontend test-only guardrail PR.
