### PR TITLE
docs(admin): map notification route channels

### DIFF
--- a/docs/admin/ADMIN_NOTIFICATION_ROUTE_CHANNELS.md
+++ b/docs/admin/ADMIN_NOTIFICATION_ROUTE_CHANNELS.md
@@ -1,0 +1,98 @@
+# Admin Notification Route Channel Map
+
+Date: 2026-06-01
+
+This file defines admin notification route ownership before any runtime route
+merge, redirect, or sidebar change. It exists because several notification UI
+surfaces look related but operate different channels, backends, and risk
+profiles.
+
+## Current Decision
+
+Keep notification channels separate until a later implementation PR proves a
+safe consolidation path with route tests and browser smoke.
+
+## Channel Matrix
+
+| Channel / surface | Current route | Current component | Backend/API owner | Current status | Boundary |
+| --- | --- | --- | --- | --- | --- |
+| Email and SMS operations | `/admin/notifications` | `components/notifications/EmailSMSManager.jsx` | `/api/v1/email-sms/*` | Canonical sidebar route | Owns email/SMS tests, templates, statistics, and bulk messaging. It must not silently absorb push/registrar policy. |
+| FCM push operations | no public admin route yet | `components/admin/UnifiedNotifications.jsx` -> `FCMManager` | `/api/v1/fcm/*` | Hidden/unrouted admin surface | Owns FCM status, user device tokens, and push test/send tools. Do not expose without push-channel route tests and Admin browser smoke. |
+| Registrar operational alerts | no public admin route yet | `components/admin/UnifiedNotifications.jsx` -> `RegistrarNotificationManager` | `/api/v1/registrar/notifications/*` | Hidden/unrouted admin surface | Owns registrar system alerts, daily summaries, registrar stats, and registrar-only recipient targeting. Do not merge with Email/SMS templates. |
+| In-app notification center | role panels / notification center providers | `NotificationCenterContext`, `NotificationWebSocketContext`, `RoleNotificationCenter` | `/api/v1/notifications/*`, `/api/v1/ws/notifications/connect` | Runtime delivery/read-state surface | Owns inbox, unread counts, websocket delivery, read/seen/archive semantics. Admin route work must not change delivery semantics casually. |
+| Telegram patient/admin notifications | Telegram admin routes and bot/webhook surfaces | `TelegramManager`, `TelegramSettings`, Telegram bot/webhook code | `/api/v1/telegram*`, Telegram webhook/services | Separate Telegram ownership | Owns Telegram consent, token/security, webhook, bot UX, and patient chat delivery. It is not part of Email/SMS/FCM route consolidation. |
+| User notification preferences | user/profile management routes | user management/profile settings | `/api/v1/users/{id}/notifications`, preferences services | User preference policy | Owns per-user channel preferences, quiet hours, weekend notification rules, and anti-noise settings. It must be checked before bulk-send or runtime policy changes. |
+
+## Route Policy
+
+- `/admin/notifications` remains the canonical visible admin route for Email/SMS.
+- Do not create `/admin/fcm-notifications` or `/admin/registrar-notifications`
+  as runtime routes until a dedicated PR adds:
+  - route registry entries;
+  - Admin-only access proof;
+  - direct-route browser smoke;
+  - no 4xx/5xx on initial load;
+  - clear visible heading/content proof;
+  - route contract tests.
+- Do not make `UnifiedNotifications` the sidebar route until the route owner
+  and default tab are explicit.
+- Do not route Telegram notification settings through this channel map.
+  Telegram token/security and webhook work follows the Telegram ownership map
+  and DevBrain Telegram guardrails.
+- Do not change notification delivery/read-state behavior from an admin route
+  cleanup PR.
+
+## Required Validation Before Runtime Changes
+
+Before exposing, merging, redirecting, or renaming notification routes:
+
+1. Browser-smoke `/admin/notifications`.
+2. Browser-smoke the proposed FCM/registrar route or tab deep link.
+3. Confirm Admin auth works.
+4. Confirm non-Admin behavior is unchanged or out of scope with a stated reason.
+5. Check for initial-load API 4xx/5xx.
+6. Check console warnings/errors.
+7. Verify visible route heading and primary actions match the channel.
+8. Run route contract tests for the changed route family.
+9. Confirm delivery semantics remain unchanged:
+   - unread count;
+   - seen/read/archive;
+   - websocket reconnect/resync;
+   - user preferences / quiet hours / anti-noise policy.
+
+## Safe Next Slices
+
+### Slice A: Route Contract Guardrail
+
+Add tests proving:
+
+- `/admin/notifications` remains `EmailSMSManager`.
+- FCM and registrar notification surfaces are intentionally not public routes
+  until a route-map implementation PR exists.
+- `UnifiedNotifications` is an internal aggregator, not the canonical sidebar
+  owner.
+
+### Slice B: Optional Hidden Route Exposure
+
+If Admin needs direct URLs for FCM or registrar notifications, create a small PR
+that adds only one route at a time:
+
+- `/admin/fcm-notifications?section=fcm`
+- or `/admin/registrar-notifications?section=registrar-notifications`
+
+Each route must have a matching owner, test, browser smoke, and rollback note.
+
+### Slice C: Unified Notification Settings
+
+Only after the channel routes are proven, decide whether to create a single
+unified notifications landing page. It must show channel boundaries clearly and
+must not hide Email/SMS, FCM, registrar, Telegram, or user preference ownership.
+
+## Stop Conditions
+
+- Stop if a notification route change needs backend notification schema or
+  delivery policy changes.
+- Stop if channel ownership is unclear.
+- Stop if FCM credentials or live external messaging are required for local QA.
+- Stop if a route consolidation would remove Email/SMS, FCM, or registrar
+  primary actions without an explicit replacement.

--- a/docs/admin/ADMIN_ROUTE_OWNERSHIP.md
+++ b/docs/admin/ADMIN_ROUTE_OWNERSHIP.md
@@ -70,6 +70,7 @@ notification map:
 
 - `/admin/notifications`: current Email/SMS manager.
 - `UnifiedNotifications`: FCM and registrar notification surfaces.
+- Channel ownership details live in `docs/admin/ADMIN_NOTIFICATION_ROUTE_CHANNELS.md`.
 
 Do not merge them until each channel has owner, settings, runtime policy, and
 negative-noise validation.

--- a/docs/audits/admin-panel-deep-audit-2026-06-01/post-fix-status-2026-06-01.md
+++ b/docs/audits/admin-panel-deep-audit-2026-06-01/post-fix-status-2026-06-01.md
@@ -44,7 +44,8 @@ original audit as baseline evidence and records the small PRs merged afterward.
 - Notification route family:
   - `/admin/notifications` currently owns Email/SMS.
   - `UnifiedNotifications` owns FCM/registrar notification surfaces but has no dedicated route map.
-  - Do not expose or merge notification subroutes until a channel ownership map is written and browser-smoked.
+  - Channel ownership is tracked in `docs/admin/ADMIN_NOTIFICATION_ROUTE_CHANNELS.md`.
+  - Do not expose or merge notification subroutes until a route implementation PR is browser-smoked.
 - Telegram route family:
   - `/admin/integrations/telegram` remains the operational integration route.
   - `/admin/telegram-settings` now opens settings content.


### PR DESCRIPTION
﻿## Summary

- Add `docs/admin/ADMIN_NOTIFICATION_ROUTE_CHANNELS.md` as the channel ownership map for admin notification surfaces.
- Link the map from the Admin route ownership doc and the AdminPanel audit post-fix status.
- Keep this docs-only: no notification routes, runtime behavior, delivery policy, or backend contracts changed.

## Cyclic Execution Evidence

- Fresh main sync: branch was created from current `main` with local `main` matching `origin/main`.
- Clean workspace: only notification/admin docs changed before commit.
- Branch: `docs/admin-notification-route-channel-map`.
- Scope gate: allowed docs/admin and the AdminPanel audit status addendum; denied frontend/backend runtime, route registry, DB, notifications delivery code, CI, deploy, and secrets.
- Red-check handling: any failed GitHub check will be fixed in this same PR before merge.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

not applicable - docs-only ownership map with no API, websocket, event, route, request, response, or frontend consumer contract change.

## RBAC / Permissions

not applicable - docs-only ownership map with no route guard, role helper, endpoint permission, or auth-sensitive behavior change.

## Notification / Realtime

- Event type or websocket channel: not changed; this PR documents ownership boundaries only.
- Payload version / ack behavior: not changed.
- Read/unread or delivery semantics: not changed.
- Reconnect/resync proof: not changed; runtime delivery code was not touched.

## Frontend Resilience

not applicable - docs-only ownership map; no user-facing panel, data flow, empty state, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `docs/admin/ADMIN_NOTIFICATION_ROUTE_CHANNELS.md`, `docs/admin/ADMIN_ROUTE_OWNERSHIP.md`, `docs/audits/admin-panel-deep-audit-2026-06-01/post-fix-status-2026-06-01.md`.
- Denied paths: frontend/backend runtime, route registry, tests, DB/migrations, notification delivery code, deploy, secrets.
- Migration/docs/test impact: docs-only; no migration and no tests required.
- Rollback note: reverting this PR removes route-channel guidance only; product behavior is unchanged.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `git diff --cached --check`; docs-only diff inspection.
- Result: diff check passed; committed diff contains only admin/audit Markdown docs.
- Not checked: frontend/backend test suites; not relevant for a docs-only ownership map.
