### PR TITLE
fix(force-majeure): guard refund visit owner

### DIFF
--- a/backend/app/services/force_majeure_service.py
+++ b/backend/app/services/force_majeure_service.py
@@ -27,6 +27,7 @@ from app.models.refund_deposit import (
     RefundRequestStatus,
     RefundType,
 )
+from app.models.visit import Visit
 from app.services.fcm_service import get_fcm_service
 
 logger = logging.getLogger(__name__)
@@ -370,6 +371,14 @@ class ForceMajeureService:
         """Получить платёж для записи"""
         if not entry.visit_id:
             return None
+
+        visit = self.db.query(Visit).filter(Visit.id == entry.visit_id).first()
+        if not visit:
+            return None
+        if visit.patient_id != entry.patient_id:
+            raise ForceMajeureError(
+                "Queue entry visit does not belong to the queue patient"
+            )
 
         return self.db.query(Payment).filter(
             Payment.visit_id == entry.visit_id,

--- a/backend/tests/unit/test_force_majeure_api_service.py
+++ b/backend/tests/unit/test_force_majeure_api_service.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
 
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.patient import Patient
+from app.models.payment import Payment
+from app.models.refund_deposit import DepositTransaction, PatientDeposit, RefundType
+from app.models.visit import Visit
 from app.repositories.force_majeure_api_repository import ForceMajeureApiRepository
 from app.services.force_majeure_api_service import (
     ForceMajeureApiDomainError,
     ForceMajeureApiService,
 )
+from app.services.force_majeure_service import ForceMajeureService
 
 
 @pytest.mark.unit
@@ -124,6 +129,96 @@ class TestForceMajeureApiService:
         )
 
         assert [entry.id for entry in entries] == [scoped_entry.id]
+
+    def test_cancel_with_refund_rejects_entry_linked_to_other_patient_visit(
+        self,
+        db_session,
+        test_doctor,
+        test_patient,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "app.services.force_majeure_service.get_fcm_service",
+            lambda: object(),
+        )
+
+        queue = DailyQueue(
+            day=date.today(),
+            specialist_id=test_doctor.id,
+            queue_tag="cardiology_common",
+            active=True,
+        )
+        other_patient = Patient(
+            first_name="Other",
+            last_name="Patient",
+            phone="+998901113333",
+        )
+        db_session.add_all([queue, other_patient])
+        db_session.flush()
+
+        other_visit = Visit(
+            patient_id=other_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=date.today(),
+            visit_time="14:00",
+            status="open",
+            discount_mode="none",
+            department="cardiology",
+            created_at=datetime.utcnow(),
+        )
+        db_session.add(other_visit)
+        db_session.flush()
+
+        payment = Payment(
+            visit_id=other_visit.id,
+            amount=Decimal("120.00"),
+            currency="UZS",
+            method="cash",
+            status="paid",
+        )
+        entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=1,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            visit_id=other_visit.id,
+            source="online",
+            status="waiting",
+        )
+        db_session.add_all([payment, entry])
+        db_session.commit()
+        db_session.refresh(entry)
+        db_session.refresh(other_visit)
+
+        result = ForceMajeureService(db_session).cancel_entries_with_refund(
+            entries=[entry],
+            reason="Doctor emergency",
+            refund_type=RefundType.DEPOSIT,
+            performed_by_id=1,
+            send_notifications=False,
+        )
+
+        assert result["cancelled"] == 0
+        assert result["failed"] == 1
+        assert "does not belong" in result["errors"][0]["error"]
+
+        db_session.refresh(entry)
+        db_session.refresh(other_visit)
+        assert entry.status == "waiting"
+        assert other_visit.status == "open"
+        assert (
+            db_session.query(PatientDeposit)
+            .filter(PatientDeposit.patient_id == test_patient.id)
+            .count()
+            == 0
+        )
+        assert (
+            db_session.query(DepositTransaction)
+            .filter(DepositTransaction.payment_id == payment.id)
+            .count()
+            == 0
+        )
 
     def test_cancel_queue_with_refund_rejects_invalid_type(self, monkeypatch):
         monkeypatch.setattr(


### PR DESCRIPTION
﻿## Summary

- Guard force-majeure refund/deposit lookup so `OnlineQueueEntry.visit_id` must resolve to a `Visit` owned by the same queue patient before any paid `Payment` is used.
- Add a regression covering a corrupted queue entry for patient A pointing at patient B's paid visit/payment.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` at `4d722635` in `C:\tmp\final-contract-scan-next-5`.
- Clean workspace: inspected before edits; only scoped force-majeure service and targeted test changed.
- Branch: `codex/force-majeure-refund-visit-owner`.
- Scope gate: local dev-brain gate returned execute/narrow override with known root cause `backend/app/services/force_majeure_service.py`; denied UI, BFF-lite, migrations, route aliases, and unrelated queue/payment paths.
- Red-check handling: any failed local or CI check is fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/force-majeure/cancel-with-refund` runtime path through `ForceMajeureService.cancel_entries_with_refund`.
- Request shape: unchanged existing cancel-with-refund request.
- Response shape: unchanged existing per-entry result envelope.
- Status codes: unchanged; ownership mismatch uses existing per-entry failure reporting.
- Frontend consumer: unchanged existing force-majeure caller; no frontend files changed.
- Compatibility path or alias: not applicable, no route alias or `/api/v1/ui/*` compatibility path changed.
- Contract proof: targeted regression asserts no cancellation, no patient deposit, and no deposit transaction when queue patient and linked visit owner differ.

## RBAC / Permissions

- Roles allowed: unchanged existing force-majeure endpoint dependency policy.
- Roles denied: unchanged existing force-majeure endpoint dependency policy.
- Positive auth proof: not checked in this service-level patch because route dependencies were not changed.
- Negative auth proof: not checked in this service-level patch because route dependencies were not changed.

## Notification / Realtime

- Event type or websocket channel: not applicable, no notification or websocket contract changed.
- Payload version / ack behavior: not applicable, no realtime payload changed.
- Read/unread or delivery semantics: not applicable, no delivery state changed.
- Reconnect/resync proof: not applicable, no reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no frontend data rendering path changed.
- Partial data proof: not applicable, no frontend data shape changed.
- Forbidden secondary path behavior: not applicable, no frontend secondary path changed.
- Missing draft/resource behavior: not applicable, no draft/resource reopen behavior changed.
- Stale route/deep-link behavior: not applicable, no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/services/force_majeure_service.py`; `backend/tests/unit/test_force_majeure_api_service.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read-model endpoints, frontend files, migrations/models unrelated to this guard, route registry/aliases.
- Migration/docs/test impact: no migration or docs change; one targeted unit regression added.
- Rollback note: revert the service owner guard and the targeted unit regression.

## Validation

- Targeted tests or smoke run: py_compile for changed backend files; targeted pytest `tests\unit\test_force_majeure_api_service.py`; `git diff --check`.
- Result: py_compile passed; targeted pytest passed with 8 tests; `git diff --check` passed.
- Not checked: full backend suite, browser smoke, and frontend build because this PR changes only backend force-majeure service behavior plus a unit regression.
