### PR TITLE
fix(registrar): guard start visit owner

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -1431,6 +1431,16 @@ def start_queue_visit(
                 linked_visit = (
                     db.query(Visit).filter(Visit.id == queue_entry.visit_id).first()
                 )
+                if linked_visit and linked_visit.patient_id != queue_entry.patient_id:
+                    logger.warning(
+                        "start_queue_visit: entry visit owner mismatch entry_id=%d visit_id=%d",
+                        queue_entry.id,
+                        linked_visit.id,
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail="Queue entry visit does not belong to the queue patient",
+                    )
 
             changed_at = datetime.now(timezone.utc)
             queue_entry.status = "in_progress"

--- a/backend/tests/integration/test_registrar_all_appointments.py
+++ b/backend/tests/integration/test_registrar_all_appointments.py
@@ -11,6 +11,7 @@ from app.api.v1.endpoints.registrar_integration import _serialize_registrar_date
 from app.models.appointment import Appointment
 from app.models.online_queue import DailyQueue
 from app.models.online_queue import OnlineQueueEntry
+from app.models.patient import Patient
 from app.models.payment import Payment
 from app.models.visit import Visit
 from app.models.visit import VisitService
@@ -598,3 +599,66 @@ class TestRegistrarAllAppointments:
         db_session.refresh(unrelated_visit)
         assert entry.status == "in_progress"
         assert unrelated_visit.status == "pending_confirmation"
+
+    def test_start_queue_visit_rejects_entry_linked_to_other_patient_visit(
+        self,
+        client,
+        db_session,
+        auth_headers,
+        test_patient,
+        test_doctor,
+    ):
+        queue = DailyQueue(
+            day=date.today(),
+            specialist_id=test_doctor.id,
+            queue_tag="cardiology_common",
+            active=True,
+        )
+        other_patient = Patient(
+            first_name="Other",
+            last_name="Patient",
+            phone="+998901119001",
+        )
+        db_session.add_all([queue, other_patient])
+        db_session.flush()
+
+        other_visit = Visit(
+            patient_id=other_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=date.today(),
+            visit_time="10:00",
+            status="pending_confirmation",
+            discount_mode="none",
+            department="cardiology",
+            source="desk",
+        )
+        db_session.add(other_visit)
+        db_session.flush()
+
+        entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=1,
+            patient_id=test_patient.id,
+            patient_name=test_patient.short_name(),
+            phone=test_patient.phone,
+            visit_id=other_visit.id,
+            source="desk",
+            status="waiting",
+        )
+        db_session.add(entry)
+        db_session.commit()
+
+        response = client.post(
+            f"/api/v1/registrar/queue/{entry.id}/start-visit",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 409, response.text
+        assert response.json()["detail"] == (
+            "Queue entry visit does not belong to the queue patient"
+        )
+
+        db_session.refresh(entry)
+        db_session.refresh(other_visit)
+        assert entry.status == "waiting"
+        assert other_visit.status == "pending_confirmation"


### PR DESCRIPTION
﻿## Summary

- Guard legacy registrar start-visit so `OnlineQueueEntry.visit_id` must resolve to a `Visit` owned by the same queue patient before the Visit status is changed.
- Add a regression covering a corrupted queue entry for patient A pointing at patient B's visit.

## Cyclic Execution Evidence

- Fresh main sync: branch created from clean `codex/current-main-view` tracking current `origin/main` at `fd96e1eb`.
- Clean workspace: inspected before edits; only scoped registrar endpoint and targeted integration test changed.
- Branch: `codex/registrar-start-visit-owner-guard`.
- Scope gate: local dev-brain gate was run with known root cause `backend/app/api/v1/endpoints/registrar_integration.py`; it reported `gate_misroute: yes` and `override_used: yes`, so this PR kept the runtime edit to the confirmed mounted endpoint and added only the adjacent targeted regression.
- Red-check handling: any failed local or CI check is fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/registrar/queue/{entry_id}/start-visit`.
- Request shape: unchanged path-only queue entry id request.
- Response shape: unchanged success envelope; mismatched linked Visit now returns the existing error envelope.
- Status codes: unchanged for valid starts and missing queue entries; new concrete owner-conflict case returns `409` before mutation.
- Frontend consumer: unchanged registrar/doctor legacy queue action caller.
- Compatibility path or alias: not applicable, no route alias or `/api/v1/ui/*` compatibility path changed.
- Contract proof: targeted integration regression asserts no queue status mutation and no linked Visit status mutation when queue patient and linked Visit owner differ.

## RBAC / Permissions

- Roles allowed: unchanged existing endpoint roles: Admin, Registrar, Doctor, cardio/cardiology, derma, dentist, Lab.
- Roles denied: unchanged existing endpoint dependency behavior for all other roles.
- Positive auth proof: existing authenticated registrar integration tests call the endpoint successfully for valid queue entries.
- Negative auth proof: not checked in this patch because route dependencies and role policy were not changed.

## Notification / Realtime

- Event type or websocket channel: not applicable, this endpoint does not add or change notification/realtime dispatch in this patch.
- Payload version / ack behavior: not applicable, no realtime payload changed.
- Read/unread or delivery semantics: not applicable, no delivery state changed.
- Reconnect/resync proof: not applicable, no reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no frontend data rendering path changed.
- Partial data proof: not applicable, no frontend data shape changed.
- Forbidden secondary path behavior: not applicable, no frontend secondary path changed.
- Missing draft/resource behavior: not applicable, no draft/resource reopen behavior changed.
- Stale route/deep-link behavior: not applicable, no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/registrar_integration.py`; `backend/tests/integration/test_registrar_all_appointments.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read-model endpoints, frontend files, migrations/models, route registry/aliases, unrelated billing/payment flows.
- Migration/docs/test impact: no migration or docs change; one targeted integration regression added.
- Rollback note: revert the linked Visit owner guard and the targeted regression.

## Validation

- Targeted tests or smoke run: py_compile for changed endpoint/test plus gate-listed nearby billing files; targeted pytest `tests\integration\test_registrar_all_appointments.py -k start_queue_visit`; broader registrar targeted pytest `tests\integration\test_registrar_all_appointments.py tests\integration\test_registrar_record_actions.py`; `git diff --check`.
- Result: py_compile passed; selected start_queue_visit tests passed 2/2; broader registrar targeted tests passed 16/16; `git diff --check` passed.
- Not checked: full backend suite, browser smoke, and frontend build because this PR changes only one backend legacy endpoint plus a targeted integration regression.
