### PR TITLE
fix(cashier): guard payment visit owner

### DIFF
--- a/backend/app/api/v1/endpoints/cashier.py
+++ b/backend/app/api/v1/endpoints/cashier.py
@@ -1186,6 +1186,14 @@ async def create_payment(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail="Визит не найден"
                 )
+            if (
+                payment_data.patient_id is not None
+                and visit.patient_id != payment_data.patient_id
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Cashier payment patient_id does not match visit ownership",
+                )
             patient_id = visit.patient_id
             
             # === ВАЛИДАЦИЯ ПЕРЕПЛАТЫ ===

--- a/backend/tests/integration/test_notification_catalog_slice2_cashier.py
+++ b/backend/tests/integration/test_notification_catalog_slice2_cashier.py
@@ -196,6 +196,42 @@ def test_cashier_create_payment_rejects_mismatched_visit_and_appointment(
     ) == []
 
 
+def test_cashier_create_payment_rejects_mismatched_patient_and_visit(
+    client,
+    db_session,
+    auth_headers,
+):
+    patient, _own_visit = _create_patient_visit(db_session, suffix="0104")
+    other_patient, other_visit = _create_patient_visit(db_session, suffix="0105")
+
+    response = client.post(
+        "/api/v1/cashier/payments",
+        json={
+            "patient_id": patient.id,
+            "visit_id": other_visit.id,
+            "amount": 45000,
+            "method": "cash",
+            "note": "mixed patient visit cashier payment",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == (
+        "Cashier payment patient_id does not match visit ownership"
+    )
+    assert (
+        db_session.query(Payment)
+        .filter(Payment.visit_id == other_visit.id)
+        .count()
+        == 0
+    )
+    assert _payment_event_deliveries(
+        db_session,
+        recipient_id=other_patient.user_id,
+    ) == []
+
+
 def test_cashier_grouped_payment_allocates_by_backend_remaining_debt(
     client,
     db_session,


### PR DESCRIPTION
﻿## Summary

- Guard direct cashier payment creation so an explicit `patient_id` must match the owner of `visit_id` before a paid `Payment` is created.
- Add a regression covering patient A context submitted with patient B's visit id.

## Cyclic Execution Evidence

- Fresh main sync: branch created from clean `codex/current-main-view` tracking current `origin/main` at `cacd0402`.
- Clean workspace: inspected before edits; only scoped cashier endpoint and targeted cashier integration test changed.
- Branch: `codex/cashier-payment-patient-owner-guard`.
- Scope gate: local dev-brain gate was run with known root cause `backend/app/api/v1/endpoints/cashier.py`; it returned execute/narrow override with `gate_misroute: no`, `override_used: yes`.
- Red-check handling: any failed local or CI check is fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/cashier/payments`.
- Request shape: unchanged; existing optional `patient_id` is now enforced when provided together with `visit_id`.
- Response shape: unchanged success response; mismatched patient/visit ownership returns the existing error envelope.
- Status codes: unchanged for valid payment creation; new concrete owner-conflict case returns `409` before mutation.
- Frontend consumer: unchanged cashier payment caller.
- Compatibility path or alias: not applicable, no route alias or `/api/v1/ui/*` compatibility path changed.
- Contract proof: targeted integration regression asserts no Payment row and no patient notification are created when `patient_id` and `visit_id` disagree.

## RBAC / Permissions

- Roles allowed: unchanged existing endpoint roles: Admin and Cashier.
- Roles denied: unchanged existing endpoint dependency behavior for all other roles.
- Positive auth proof: existing authenticated cashier create-payment test still passes for a valid visit.
- Negative auth proof: not checked in this patch because route dependencies and role policy were not changed.

## Notification / Realtime

- Event type or websocket channel: existing payment notification and cashier websocket behavior unchanged for valid payments.
- Payload version / ack behavior: unchanged for valid payments.
- Read/unread or delivery semantics: unchanged for valid payments.
- Reconnect/resync proof: not applicable, no websocket contract or reconnect behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no frontend data rendering path changed.
- Partial data proof: not applicable, no frontend data shape changed.
- Forbidden secondary path behavior: not applicable, no frontend secondary path changed.
- Missing draft/resource behavior: not applicable, no draft/resource reopen behavior changed.
- Stale route/deep-link behavior: not applicable, no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/cashier.py`; `backend/tests/integration/test_notification_catalog_slice2_cashier.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read-model endpoints, frontend files, migrations/models, route registry/aliases, unrelated registrar/doctor/force-majeure flows.
- Migration/docs/test impact: no migration or docs change; one targeted integration regression added.
- Rollback note: revert the cashier owner guard and the targeted regression.

## Validation

- Targeted tests or smoke run: py_compile for changed endpoint/test; targeted pytest `tests\integration\test_notification_catalog_slice2_cashier.py -k create_payment`; full cashier notification slice `tests\integration\test_notification_catalog_slice2_cashier.py`; `git diff --check`.
- Result: py_compile passed; selected create_payment tests passed 3/3; full cashier slice passed 9/9; `git diff --check` passed.
- Not checked: full backend suite, browser smoke, and frontend build because this PR changes only one backend cashier command endpoint plus a targeted integration regression.
