### PR TITLE
fix(payments): reject conflicting payme targets

### DIFF
--- a/backend/app/services/payment_webhook.py
+++ b/backend/app/services/payment_webhook.py
@@ -58,6 +58,26 @@ class PaymentWebhookService:
         return appointment_id, visit_id
 
     @staticmethod
+    def _payme_targets_cross_patient(
+        db: Session, appointment_id: int, visit_id: int
+    ) -> bool:
+        from app.models.appointment import Appointment
+        from app.models.visit import Visit
+
+        appointment_patient_id = (
+            db.query(Appointment.patient_id)
+            .filter(Appointment.id == appointment_id)
+            .scalar()
+        )
+        visit_patient_id = (
+            db.query(Visit.patient_id).filter(Visit.id == visit_id).scalar()
+        )
+
+        if appointment_patient_id is None or visit_patient_id is None:
+            return False
+        return int(appointment_patient_id) != int(visit_patient_id)
+
+    @staticmethod
     def _resolve_click_merchant_target(
         db: Session, merchant_trans_id: Any
     ) -> tuple[str | None, int | None]:
@@ -221,6 +241,33 @@ class PaymentWebhookService:
                         )
 
                     # Приоритет: сначала ищем appointment_id, потом visit_id
+                    if (
+                        appointment_id is not None
+                        and visit_id is not None
+                        and PaymentWebhookService._payme_targets_cross_patient(
+                            db, appointment_id, visit_id
+                        )
+                    ):
+                        repository.update_webhook(
+                            webhook.id,
+                            {
+                                "status": "failed",
+                                "processed_at": datetime.utcnow(),
+                                "error_message": (
+                                    "Payme account appointment_id and visit_id "
+                                    "belong to different patients"
+                                ),
+                            },
+                        )
+                        logger.warning(
+                            "payment_webhook_payme_conflicting_account_targets",
+                            extra={
+                                "payment_provider": "payme",
+                                "webhook_record_id": webhook.id,
+                            },
+                        )
+                        return True, "Webhook processed successfully", webhook
+
                     if appointment_id:
                         # Обрабатываем платёж для существующей записи
                         success, message = (

--- a/backend/tests/unit/test_payment_webhook_service.py
+++ b/backend/tests/unit/test_payment_webhook_service.py
@@ -169,6 +169,66 @@ class TestPaymentWebhookService:
             )
             process_appointment.assert_not_called()
 
+    def test_payme_webhook_rejects_cross_patient_account_targets(self, db_session):
+        webhook = SimpleNamespace(id=99)
+        repository = SimpleNamespace(
+            get_provider_by_code=Mock(return_value=SimpleNamespace(secret_key="secret")),
+            get_webhook_by_webhook_id=Mock(return_value=None),
+            create_webhook=Mock(return_value=webhook),
+            create_transaction=Mock(return_value=SimpleNamespace(id=100)),
+            update_webhook=Mock(return_value=webhook),
+        )
+        data = {
+            "id": "payme-tx-1",
+            "state": 2,
+            "amount": 250000,
+            "account": {"appointment_id": "123", "visit_id": "789"},
+        }
+
+        with (
+            patch(
+                "app.services.payment_webhook.PaymentWebhookProcessingRepository",
+                return_value=repository,
+            ),
+            patch.object(
+                PaymentWebhookService, "verify_payme_signature", return_value=True
+            ),
+            patch.object(
+                PaymentWebhookService,
+                "_payme_targets_cross_patient",
+                return_value=True,
+            ) as targets_cross_patient,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_appointment",
+                return_value=(True, "appointment paid"),
+            ) as process_appointment,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_existing_visit",
+                return_value=(True, "visit paid"),
+            ) as process_visit,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.create_appointment_from_payment",
+                return_value=(True, "created", 501),
+            ) as create_appointment,
+        ):
+            success, message, result_webhook = PaymentWebhookService.process_payme_webhook(
+                db_session, data, "signature"
+            )
+
+        assert success is True
+        assert message == "Webhook processed successfully"
+        assert result_webhook is webhook
+        targets_cross_patient.assert_called_once_with(db_session, 123, 789)
+        process_appointment.assert_not_called()
+        process_visit.assert_not_called()
+        create_appointment.assert_not_called()
+
+        _, failed_update = repository.update_webhook.call_args_list[-1].args
+        assert failed_update["status"] == "failed"
+        assert failed_update["error_message"] == (
+            "Payme account appointment_id and visit_id belong to different patients"
+        )
+
     def test_click_webhook_uses_visit_target_when_merchant_id_matches_visit_only(
         self, db_session
     ):


### PR DESCRIPTION
## Summary
Fixes legacy Payme webhook target disambiguation. A signed successful legacy webhook containing both account.appointment_id and account.visit_id now refuses the mutation when those targets belong to different patients.

## Cyclic Execution Evidence
- Fresh main sync: Started from codex/current-main-view at origin/main f1566253 after git fetch and ff-only merge.
- Clean workspace: Verified clean status before branching and editing.
- Branch: codex/payme-webhook-target-conflict.
- Scope gate: gate_known_root_cause for backend/app/services/payment_webhook.py; adjacent unit regression added after first runtime slice compiled.
- Red-check handling: PR Review Quality Gate was red only for body shape; body updated. Code/runtime checks are being monitored before merge.

## Contract Impact
- Canonical surface: Legacy Payme webhook processing in backend/app/services/payment_webhook.py.
- Request shape: No shape change; protects existing account.appointment_id plus account.visit_id payloads.
- Response shape: No response shape change; returns the existing successful webhook envelope while marking the webhook record failed internally.
- Status codes: No HTTP status code change in the legacy endpoint wrapper.
- Frontend consumer: No frontend consumer changed; current Payme init emits order_id-only provider data.
- Compatibility path or alias: Single-target Payme payloads and non-conflicting dual-target payloads keep legacy behavior.
- Contract proof: Unit regression asserts cross-patient dual targets do not call appointment, visit, or create-appointment mutation handlers and record failed webhook status.

## RBAC / Permissions
- Roles allowed: Unchanged public provider webhook path guarded by existing Payme provider signature validation.
- Roles denied: Unchanged; no user-role gate added or removed.
- Positive auth proof: Existing signature validation path remains before this new guard in process_payme_webhook.
- Negative auth proof: Invalid/missing signature behavior is unchanged and remains covered by existing payment webhook tests.

## Notification / Realtime
- Event type or websocket channel: None added; no notification event or websocket channel changed.
- Payload version / ack behavior: No notification payload or ack shape changed.
- Read/unread or delivery semantics: No delivery/read state touched.
- Reconnect/resync proof: No realtime path is changed; the conflict path returns before patient notification dispatch.

## Frontend Resilience
- Empty data proof: No frontend data path changed.
- Partial data proof: No frontend partial-data rendering path changed.
- Forbidden secondary path behavior: No frontend secondary path changed; backend rejects the conflicting mutation before write.
- Missing draft/resource behavior: No draft/resource frontend behavior changed.
- Stale route/deep-link behavior: No route or deep-link behavior changed.

## Scope Gate
- Allowed paths: backend/app/services/payment_webhook.py; backend/tests/unit/test_payment_webhook_service.py.
- Denied paths: frontend, BFF-lite/ui endpoints, migrations, provider settings, provider manager refactors, broad payment flow rewrites.
- Migration/docs/test impact: No migration or docs impact; one adjacent unit test added.
- Rollback note: Revert this commit to restore previous legacy appointment-first behavior for conflicting Payme account targets.

## Validation
- Targeted tests or smoke run: py_compile backend/app/services/payment_webhook.py backend/tests/unit/test_payment_webhook_service.py; pytest tests/unit/test_payment_webhook_service.py; git diff --check.
- Result: py_compile passed; pytest passed with 11 tests; git diff --check passed with only CRLF working-copy warnings.
- Not checked: Full backend suite locally; GitHub backend tests are used as broader validation for this narrow backend service change.