### PR TITLE
refactor(admin): clarify advanced user route

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -66,6 +66,7 @@ const TelegramMiniAppPatientShell = lazy(() => import('./pages/TelegramMiniAppPa
 const EmailSMSManager = lazy(() => import('./components/notifications/EmailSMSManager.jsx'));
 const TwoFactorManager = lazy(() => import('./components/security/TwoFactorManager.jsx'));
 const FileManager = lazy(() => import('./components/files/FileManager.jsx'));
+const AdvancedUserManagement = lazy(() => import('./components/admin/AdvancedUserManagement.jsx'));
 const UserManagement = lazy(() => import('./components/admin/UserManagement.jsx'));
 const IntegrationDemo = lazy(() => import('./components/integration/IntegrationDemo.jsx'));
 
@@ -85,6 +86,7 @@ const ROUTE_COMPONENTS = {
   Audit,
   TelegramManager,
   EmailSMSManager,
+  AdvancedUserManagement,
   UserManagement,
   FileManager,
   UserSelect,

--- a/frontend/src/components/admin/AdvancedUserManagement.jsx
+++ b/frontend/src/components/admin/AdvancedUserManagement.jsx
@@ -1,0 +1,18 @@
+import UserManagement from './UserManagement';
+import { MacOSAlert } from '../ui/macos';
+
+const AdvancedUserManagement = () => {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <MacOSAlert
+        type="info"
+        title="Расширенное управление пользователями"
+        description="Этот экран сохраняет прямой legacy-доступ к базовой таблице пользователей. Для повседневных задач используйте раздел Пользователи, где собраны связанные действия управления аккаунтами."
+      />
+
+      <UserManagement />
+    </div>
+  );
+};
+
+export default AdvancedUserManagement;

--- a/frontend/src/routing/__tests__/routeContract.test.js
+++ b/frontend/src/routing/__tests__/routeContract.test.js
@@ -220,7 +220,7 @@ describe('route contract invariants', () => {
     expect(advancedUsersRoute.path).toBe('/admin/advanced-users');
     expect(advancedUsersRoute.owner).toBe('admin.users');
     expect(advancedUsersRoute.entry).toBe('direct');
-    expect(advancedUsersRoute.component).toBe('UserManagement');
+    expect(advancedUsersRoute.component).toBe('AdvancedUserManagement');
     expect(advancedUsersRoute.legacyRedirectFrom).toContain('/advanced-users');
     expect(advancedUsersRoute.layout.activeSidebarItem).toBe('admin-advanced-users');
     expect(isRouteAccessibleToProfile(advancedUsersRoute, adminProfile)).toBe(true);

--- a/frontend/src/routing/routeRegistry.js
+++ b/frontend/src/routing/routeRegistry.js
@@ -945,7 +945,7 @@ export const ROUTE_REGISTRY = [
     nav: nav({ label: 'Расширенные пользователи', icon: 'users', section: 'Система', order: 110, sidebar: true }),
     title: 'Admin Advanced Users',
     owner: 'admin.users',
-    component: 'UserManagement',
+    component: 'AdvancedUserManagement',
     legacyRedirectFrom: ['/advanced-users'],
     layout: layout({ sidebarPreset: 'admin', activeSidebarItem: 'admin-advanced-users', pageTitle: 'Admin Advanced Users' }),
   },


### PR DESCRIPTION
﻿## Summary

- Adds a small `AdvancedUserManagement` wrapper for `/admin/advanced-users` so the advanced/legacy user route is explicit instead of looking like a duplicate canonical user screen.
- Keeps `/admin/users` as the day-to-day canonical user route through `AdminPanel` / `UnifiedUserManagement`.
- Updates the route contract test to guard the split.

## Cyclic Execution Evidence

- Fresh main sync: started from `main` at `f1566253`, matching `origin/main`.
- Clean workspace: `git status --short --branch` was clean before branching.
- Branch: `refactor/admin-advanced-users-wrapper`.
- Scope gate: frontend admin routing/component wrapper only; no backend, DB, RBAC, API, payment, queue, Telegram, deploy, or secrets changes.
- Red-check handling: any red CI check will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `/admin/users` remains the canonical day-to-day user management route.
- Request shape: not applicable - no API request shape changed.
- Response shape: not applicable - no API response shape changed.
- Status codes: not applicable - no endpoint behavior changed.
- Frontend consumer: `/admin/advanced-users` now resolves to `AdvancedUserManagement`, which wraps the existing `UserManagement` component with an explanatory notice.
- Compatibility path or alias: `/advanced-users` legacy redirect remains unchanged.
- Contract proof: `src/routing/__tests__/routeContract.test.js` asserts `/admin/users` and `/admin/advanced-users` remain separate routes with the intended components and active sidebar items.

## RBAC / Permissions

- Roles allowed: unchanged, Admin only for both admin user routes.
- Roles denied: unchanged by this PR.
- Positive auth proof: local preview browser smoke rendered both `/admin/users` and `/admin/advanced-users` with a seeded Admin profile and mocked user API data.
- Negative auth proof: not checked - route guards and role lists were not changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not checked - this slice does not alter the underlying user table empty state.
- Partial data proof: not checked - this slice does not alter user table data normalization.
- Forbidden secondary path behavior: unchanged by route registry role/auth settings.
- Missing draft/resource behavior: not applicable - no draft/resource flow changed.
- Stale route/deep-link behavior: `/admin/advanced-users` and legacy `/advanced-users` remain registered; route contract covers the direct advanced route.

## Scope Gate

- Allowed paths: `frontend/src/components/admin/AdvancedUserManagement.jsx`, `frontend/src/App.jsx`, `frontend/src/routing/routeRegistry.js`, `frontend/src/routing/__tests__/routeContract.test.js`.
- Denied paths: backend, DB migrations, RBAC helpers, API clients, payment/queue/Telegram/notification runtime, deploy/secrets.
- Migration/docs/test impact: no migration; one route contract test update; no docs required for this runtime wrapper.
- Rollback note: revert the wrapper, route component id, App component mapping, and test expectation to restore the previous direct `UserManagement` route.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: route contract Vitest, frontend lint check, frontend build, `git diff --check`, and local production-preview browser smoke for `/admin/users` and `/admin/advanced-users` with seeded Admin profile and mocked user API data.
- Result: passed locally.
- Not checked: negative RBAC browser path, because this PR does not change roles or route guards.
