### PR TITLE
docs(admin): record advanced user route fix

### DIFF
--- a/docs/audits/admin-panel-deep-audit-2026-06-01/post-fix-status-2026-06-01.md
+++ b/docs/audits/admin-panel-deep-audit-2026-06-01/post-fix-status-2026-06-01.md
@@ -20,6 +20,7 @@ original audit as baseline evidence and records the small PRs merged afterward.
 | #1514 | merged | overview navigation grouping plan | Documented the staged `Overview` / `Operations` / `Integrations` split. |
 | #1516 | merged | overview route section guardrail | Added route contract coverage before moving sidebar sections. |
 | #1518 | merged | overview sidebar regrouping | Moved system/cloud-printing/medical-equipment to `Операции` and webhooks/GraphQL to `Интеграции`. |
+| #1521 | merged | advanced user route wrapper | Made `/admin/advanced-users` explicit as an advanced/legacy surface wrapping `UserManagement`, while `/admin/users` remains the canonical day-to-day user route. |
 
 ## Current Verified Status
 
@@ -29,6 +30,9 @@ original audit as baseline evidence and records the small PRs merged afterward.
 - `/admin/graphql-explorer` no longer produces the `textareaStyle` unknown DOM prop warning.
 - `/admin/users` and `/admin/advanced-users` have route contract coverage for
   their intentional canonical vs advanced split.
+- `/admin/advanced-users` now renders an explicit advanced/legacy notice before
+  the shared user table, so it no longer looks like an unlabelled duplicate of
+  `/admin/users`.
 - Admin sidebar grouping is now:
   - `Overview`: dashboard, analytics, reports
   - `Операции`: system, cloud printing, medical equipment
@@ -48,10 +52,6 @@ original audit as baseline evidence and records the small PRs merged afterward.
 
 ### P1
 
-- User-management duplicate route family:
-  - `/admin/users` is the canonical day-to-day user management route.
-  - `/admin/advanced-users` remains an advanced/legacy route.
-  - Next fix must either make the relationship explicit in UI copy/tests or intentionally alias/wrap one route.
 - Notification route family:
   - `/admin/notifications` currently owns Email/SMS.
   - `UnifiedNotifications` owns FCM/registrar notification surfaces but has no dedicated route map.
@@ -77,9 +77,9 @@ original audit as baseline evidence and records the small PRs merged afterward.
 1. `docs(admin): add notification route channel map`
    - Docs/test-first decision.
    - No runtime route exposure yet.
-2. `test(admin): guard duplicate user route ownership`
-   - Add route contract around `/admin/users` and `/admin/advanced-users`.
-   - No consolidation until a small browser-smoked implementation plan exists.
+2. `docs(admin): plan Telegram operational/settings surface separation`
+   - Keep token/security ownership explicit before implementation.
+   - No runtime changes until the target surface is named.
 3. `refactor(admin): extract one AdminPanel route family`
    - Only after a specific family is selected.
    - One family per PR.


### PR DESCRIPTION
﻿## Summary

- Records merged PR #1521 in the AdminPanel deep audit post-fix status.
- Marks the `/admin/users` versus `/admin/advanced-users` ambiguity as resolved by the explicit advanced route wrapper.
- Updates the next recommended admin slices to focus on notification and Telegram route ownership.

## Cyclic Execution Evidence

- Fresh main sync: started from `main` at `6b938d3c`, matching `origin/main` after #1521 merge.
- Clean workspace: branch was created from a clean synced `main`.
- Branch: `docs/admin-user-route-evidence`.
- Scope gate: docs-only audit status update; no runtime, backend, frontend app code, DB, RBAC, deploy, or secrets changes.
- Red-check handling: any red CI check will be fixed in this same PR before merge.

## Contract Impact

not applicable - docs-only status update; no API, websocket, event, route, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - docs-only status update; no route guard, role helper, endpoint permission, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - docs-only status update; no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - docs-only status update; no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `docs/audits/admin-panel-deep-audit-2026-06-01/post-fix-status-2026-06-01.md` only.
- Denied paths: backend, frontend runtime, tests, DB migrations, CI, deploy, secrets, API clients, RBAC helpers.
- Migration/docs/test impact: docs-only; no migration; no tests changed.
- Rollback note: revert the one docs file to restore the previous audit backlog wording.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `git diff --check` and docs-only diff inspection.
- Result: passed locally.
- Not checked: frontend/backend tests, because this is a docs-only status update.
