### PR TITLE
test(admin): guard notification route ownership

### DIFF
--- a/frontend/src/routing/__tests__/routeContract.test.js
+++ b/frontend/src/routing/__tests__/routeContract.test.js
@@ -231,6 +231,27 @@ describe('route contract invariants', () => {
     expect(getRouteChromeState('/admin/advanced-users', '', adminProfile).activeSidebarItem).toBe('admin-advanced-users');
   });
 
+  it('keeps admin notification channels separated until routed deliberately', () => {
+    const adminProfile = { role: 'Admin' };
+    const notificationsRoute = getRouteById('admin-notifications');
+    const publicNotificationPaths = new Set(ROUTE_REGISTRY.map((route) => route.path));
+    const publicNotificationComponents = new Set(ROUTE_REGISTRY.map((route) => route.component));
+
+    expect(notificationsRoute).toBeTruthy();
+    expect(notificationsRoute.path).toBe('/admin/notifications');
+    expect(notificationsRoute.owner).toBe('admin.notifications');
+    expect(notificationsRoute.entry).toBe('menu');
+    expect(notificationsRoute.component).toBe('EmailSMSManager');
+    expect(notificationsRoute.legacyRedirectFrom).toContain('/notifications');
+    expect(notificationsRoute.layout.activeSidebarItem).toBe('admin-notifications');
+    expect(isRouteAccessibleToProfile(notificationsRoute, adminProfile)).toBe(true);
+    expect(getRouteChromeState('/admin/notifications', '', adminProfile).activeSidebarItem).toBe('admin-notifications');
+
+    expect(publicNotificationPaths.has('/admin/fcm-notifications')).toBe(false);
+    expect(publicNotificationPaths.has('/admin/registrar-notifications')).toBe(false);
+    expect(publicNotificationComponents.has('UnifiedNotifications')).toBe(false);
+  });
+
   it('keeps clinical contextual routes registered and out of default sidebar navigation', () => {
     const doctorProfile = { role: 'Doctor' };
     const clinicalChrome = getRouteChromeState('/clinical/search', '', doctorProfile);


### PR DESCRIPTION
﻿## Summary

- Adds a route contract guardrail for the admin notification route family.
- Confirms `/admin/notifications` remains the visible Email/SMS admin route using `EmailSMSManager`.
- Confirms FCM and registrar notification surfaces remain unrouted/internal until a dedicated route implementation PR adds tests and browser smoke.

## Cyclic Execution Evidence

- Fresh main sync: started from `main` at `456a482b`, matching `origin/main` after #1522 merge.
- Clean workspace: branch was created from a clean synced `main`.
- Branch: `test/admin-notification-route-ownership`.
- Scope gate: route contract test only; no runtime component, backend, DB, RBAC, API, deploy, or secrets changes.
- Red-check handling: any red CI check will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `/admin/notifications` remains the canonical visible admin route for Email/SMS operations.
- Request shape: not applicable - no API request shape changed.
- Response shape: not applicable - no API response shape changed.
- Status codes: not applicable - no endpoint behavior changed.
- Frontend consumer: no runtime consumer changed; test guards `EmailSMSManager` as the current route component.
- Compatibility path or alias: `/notifications` legacy redirect remains unchanged.
- Contract proof: `src/routing/__tests__/routeContract.test.js` now asserts no public `/admin/fcm-notifications`, no public `/admin/registrar-notifications`, and no `UnifiedNotifications` route component.

## RBAC / Permissions

- Roles allowed: unchanged, Admin only for `/admin/notifications`.
- Roles denied: unchanged by this PR.
- Positive auth proof: route contract asserts Admin accessibility for `/admin/notifications`.
- Negative auth proof: not checked - route guards and role lists were not changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no delivery channel changed.
- Payload version / ack behavior: not applicable - no payload changed.
- Read/unread or delivery semantics: unchanged; this PR only guards route ownership.
- Reconnect/resync proof: not checked - websocket behavior was not changed.

## Frontend Resilience

- Empty data proof: not applicable - no panel rendering changed.
- Partial data proof: not applicable - no data normalization changed.
- Forbidden secondary path behavior: unchanged; no route guard changed.
- Missing draft/resource behavior: not applicable - no draft/resource flow changed.
- Stale route/deep-link behavior: route contract confirms the proposed FCM/registrar notification paths are intentionally absent until implemented deliberately.

## Scope Gate

- Allowed paths: `frontend/src/routing/__tests__/routeContract.test.js` only.
- Denied paths: frontend runtime components, backend, DB migrations, API clients, RBAC helpers, notification delivery code, Telegram code, deploy/secrets.
- Migration/docs/test impact: test-only; no migration; no docs changed.
- Rollback note: revert the added route contract test to remove this guardrail.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `cd frontend; npm run test:run -- src/routing/__tests__/routeContract.test.js`; `cd frontend; npm run lint:check -- --quiet --rule "no-warning-comments: off"`; `cd frontend; npm run build`; `git diff --check`.
- Result: passed locally.
- Not checked: browser smoke, because this is a route contract guardrail with no runtime route/component changes.
