### PR TITLE
refactor(admin): extract telegram settings route

### DIFF
--- a/docs/admin/ADMIN_TELEGRAM_ROUTE_SURFACES.md
+++ b/docs/admin/ADMIN_TELEGRAM_ROUTE_SURFACES.md
@@ -22,7 +22,7 @@ Keep the Telegram admin routes separate:
 | Surface | Route | Component path | Owner | Entry | Owns |
 | --- | --- | --- | --- | --- | --- |
 | Operational integration | `/admin/integrations/telegram` | `frontend/src/components/TelegramManager.jsx` | `admin.telegram` | sidebar/menu | Bot status, webhook visibility/actions, templates, Telegram users, test messages, operational troubleshooting. |
-| Settings/configuration | `/admin/telegram-settings` | `frontend/src/pages/AdminPanel.jsx` -> `TelegramSettings` | `admin.telegram` | contextual/direct | Token/config form, webhook-info/settings stats, setup instructions, settings save/test actions. |
+| Settings/configuration | `/admin/telegram-settings` | `frontend/src/components/admin/TelegramSettings.jsx` | `admin.telegram` | contextual/direct | Token/config form, webhook-info/settings stats, setup instructions, settings save/test actions. |
 | Unified admin helper | no public route | `frontend/src/components/admin/UnifiedTelegramManagement.jsx` | internal helper | unrouted | Internal tab helper for bot/settings content. It is not the canonical sidebar route. |
 | Patient Mini App | `/telegram/mini-app/patient` | `frontend/src/pages/TelegramMiniAppPatientShell.jsx` | `telegram.mini_app` | public mini-app | Telegram WebApp patient UX. It must not inherit admin route assumptions. |
 

--- a/docs/audits/admin-panel-deep-audit-2026-06-01/post-fix-status-2026-06-01.md
+++ b/docs/audits/admin-panel-deep-audit-2026-06-01/post-fix-status-2026-06-01.md
@@ -38,6 +38,8 @@ original audit as baseline evidence and records the small PRs merged afterward.
   registrar notification surfaces remain internal until a dedicated route PR.
 - Telegram admin surface policy is documented in
   `docs/admin/ADMIN_TELEGRAM_ROUTE_SURFACES.md`.
+- `/admin/telegram-settings` is a direct `TelegramSettings` route, reducing one
+  contextual settings branch from the broad `AdminPanel.jsx` switch.
 - Admin sidebar grouping is now:
   - `Overview`: dashboard, analytics, reports
   - `Операции`: system, cloud printing, medical equipment
@@ -72,7 +74,9 @@ original audit as baseline evidence and records the small PRs merged afterward.
   follow `docs/admin/ADMIN_NOTIFICATION_ROUTE_CHANNELS.md`.
 - Telegram route consolidation remains optional and must follow
   `docs/admin/ADMIN_TELEGRAM_ROUTE_SURFACES.md`.
-- `AdminPanel.jsx` remains a broad route switch plus implementation container.
+- `AdminPanel.jsx` remains a broad route switch plus implementation container,
+  although `/admin/telegram-settings` has been extracted as the first small
+  contextual route slice.
 - Some routes still have weak heading semantics and should get route-specific heading checks before UI redesign.
 
 ## Recommended Next PR Slices

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -63,6 +63,7 @@ const UserProfile = lazy(() => import('./pages/UserProfile.jsx'));
 const ButtonShowcase = lazy(() => import('./components/buttons/ButtonShowcase.jsx'));
 const TelegramManager = lazy(() => import('./components/TelegramManager.jsx'));
 const TelegramMiniAppPatientShell = lazy(() => import('./pages/TelegramMiniAppPatientShell.jsx'));
+const TelegramSettings = lazy(() => import('./components/admin/TelegramSettings.jsx'));
 const EmailSMSManager = lazy(() => import('./components/notifications/EmailSMSManager.jsx'));
 const TwoFactorManager = lazy(() => import('./components/security/TwoFactorManager.jsx'));
 const FileManager = lazy(() => import('./components/files/FileManager.jsx'));
@@ -113,6 +114,7 @@ const ROUTE_COMPONENTS = {
   CSSTestPage,
   ButtonShowcase,
   TelegramMiniAppPatientShell,
+  TelegramSettings,
   UnauthorizedPage,
   ForbiddenPage,
   NotFoundPage,

--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -136,7 +136,6 @@ import AllFreeApproval from '../components/admin/AllFreeApproval';
 
 import AnalyticsInsights from '../components/ai/AnalyticsInsights';
 import UnifiedTelegramManagement from '../components/admin/UnifiedTelegramManagement';
-import TelegramSettings from '../components/admin/TelegramSettings';
 import UnifiedSettings from '../components/admin/UnifiedSettings';
 import UnifiedFinance from '../components/admin/UnifiedFinance';
 import UnifiedNotifications from '../components/admin/UnifiedNotifications';
@@ -184,8 +183,7 @@ const ADMIN_ROUTE_SECTION_PARAMS = {
   'queue-settings': 'queue-settings',
   'display-settings': 'display-settings',
   'ai-settings': 'ai-settings',
-  security: 'security',
-  'telegram-settings': 'settings'
+  security: 'security'
 };
 
 const getAppointmentPatientDisplayName = (appointment) => {
@@ -2607,8 +2605,6 @@ const AdminPanel = () => {
         return <UnifiedAITools />;
       case 'telegram-bot':
         return <UnifiedTelegramManagement />;
-      case 'telegram-settings':
-        return <TelegramSettings />;
       case 'fcm-notifications':
       case 'registrar-notifications':
         return <UnifiedNotifications />;

--- a/frontend/src/pages/__tests__/AdminPanel.routeState.contract.test.jsx
+++ b/frontend/src/pages/__tests__/AdminPanel.routeState.contract.test.jsx
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const adminPanelPath = path.resolve(__dirname, '../AdminPanel.jsx');
+const routeRegistryPath = path.resolve(__dirname, '../../routing/routeRegistry.js');
 
 const CONTEXTUAL_ROUTE_SECTION_MAP = {
   'benefit-settings': 'benefit-settings',
@@ -15,12 +16,15 @@ const CONTEXTUAL_ROUTE_SECTION_MAP = {
   'queue-settings': 'queue-settings',
   'display-settings': 'display-settings',
   'ai-settings': 'ai-settings',
-  security: 'security',
-  'telegram-settings': 'settings'
+  security: 'security'
 };
 
 function readAdminPanel() {
   return fs.readFileSync(adminPanelPath, 'utf8');
+}
+
+function readRouteRegistry() {
+  return fs.readFileSync(routeRegistryPath, 'utf8');
 }
 
 describe('AdminPanel route state contract', () => {
@@ -40,11 +44,14 @@ describe('AdminPanel route state contract', () => {
     expect(source).toContain('{ replace: true }');
   });
 
-  it('keeps Telegram settings on the settings surface, not the bot manager surface', () => {
-    const source = readAdminPanel();
+  it('keeps Telegram settings out of the broad AdminPanel switch', () => {
+    const adminPanelSource = readAdminPanel();
+    const routeRegistrySource = readRouteRegistry();
 
-    expect(source).toContain("'telegram-settings': 'settings'");
-    expect(source).toContain("case 'telegram-settings':");
-    expect(source).toContain('return <TelegramSettings />;');
+    expect(adminPanelSource).not.toContain("'telegram-settings': 'settings'");
+    expect(adminPanelSource).not.toContain("case 'telegram-settings':");
+    expect(adminPanelSource).not.toContain('return <TelegramSettings />;');
+    expect(routeRegistrySource).toContain("id: 'admin-telegram-settings'");
+    expect(routeRegistrySource).toContain("component: 'TelegramSettings'");
   });
 });

--- a/frontend/src/routing/__tests__/routeContract.test.js
+++ b/frontend/src/routing/__tests__/routeContract.test.js
@@ -273,7 +273,7 @@ describe('route contract invariants', () => {
     expect(telegramSettingsRoute.owner).toBe('admin.telegram');
     expect(telegramSettingsRoute.entry).toBe('direct');
     expect(telegramSettingsRoute.nav).toBe(false);
-    expect(telegramSettingsRoute.component).toBe('AdminPanel');
+    expect(telegramSettingsRoute.component).toBe('TelegramSettings');
     expect(isRouteAccessibleToProfile(telegramSettingsRoute, adminProfile)).toBe(true);
 
     expect(routedComponents.has('UnifiedTelegramManagement')).toBe(false);

--- a/frontend/src/routing/routeRegistry.js
+++ b/frontend/src/routing/routeRegistry.js
@@ -775,7 +775,7 @@ export const ROUTE_REGISTRY = [
     nav: false,
     title: 'Admin Telegram Settings',
     owner: 'admin.telegram',
-    component: 'AdminPanel',
+    component: 'TelegramSettings',
     legacyRedirectFrom: [],
     layout: layout({ sidebarPreset: 'admin', pageTitle: 'Admin Telegram Settings' }),
   },


### PR DESCRIPTION
﻿## Summary

- Routes `/admin/telegram-settings` directly to `TelegramSettings` instead of going through the broad `AdminPanel` switch.
- Keeps `/admin/integrations/telegram` on `TelegramManager` and keeps `UnifiedTelegramManagement` unrouted.
- Updates route-contract coverage and Telegram admin route docs/status evidence.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/admin-telegram-settings-route` started from `origin/main` at `12e07ab2` after PR #1524 merged.
- Clean workspace: inspected `git status --short --branch`; only scoped route/docs/test files are modified.
- Branch: `refactor/admin-telegram-settings-route`.
- Scope gate: allowed only `frontend/src/App.jsx`, `frontend/src/pages/AdminPanel.jsx`, `frontend/src/routing/routeRegistry.js`, `frontend/src/routing/__tests__/routeContract.test.js`, `docs/admin/ADMIN_TELEGRAM_ROUTE_SURFACES.md`, and the admin audit status doc.
- Red-check handling: if GitHub Actions fail, fix in this same branch before merge.

## Contract Impact

- Canonical surface: frontend route registry entry `/admin/telegram-settings`.
- Request shape: unchanged - no API request payloads changed.
- Response shape: unchanged - Telegram settings component still consumes the same existing API responses.
- Status codes: unchanged - no backend endpoints or handlers changed.
- Frontend consumer: `RouteRenderer` resolves `TelegramSettings` through `ROUTE_COMPONENTS` instead of rendering it via `AdminPanel` route switch.
- Compatibility path or alias: unchanged - `/admin/telegram-settings` path stays the same; no legacy redirects added or removed.
- Contract proof: `npm run test:run -- src/routing/__tests__/routeContract.test.js` passed with 24 route-contract tests.

## RBAC / Permissions

- Roles allowed: unchanged - Admin route access remains controlled by existing route registry role metadata.
- Roles denied: unchanged - non-admin users remain denied by existing route guards.
- Positive auth proof: route contract confirms Admin profile can access `/admin/telegram-settings`; preview smoke with Admin localStorage reached the route without `/login` or `/forbidden`.
- Negative auth proof: not applicable - this PR does not change role guards or denied-role policy.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, Telegram bot webhook, or realtime channel changed.
- Payload version / ack behavior: not applicable - no payload contract changed.
- Read/unread or delivery semantics: not applicable - no delivery/read state changed.
- Reconnect/resync proof: not applicable - no realtime connection behavior changed.

## Frontend Resilience

- Empty data proof: preview smoke mocked empty Telegram settings/stats responses and the direct route still rendered Telegram settings content.
- Partial data proof: existing component fallback state is preserved; this PR only changes route ownership and does not alter data normalization.
- Forbidden secondary path behavior: route contract and preview smoke confirm Admin path remains accessible; denied-role behavior is unchanged by this slice.
- Missing draft/resource behavior: not applicable - Telegram settings route does not use drafts/resources in this patch.
- Stale route/deep-link behavior: `/admin/telegram-settings` remains the same deep link and now maps directly to `TelegramSettings`.

## Scope Gate

- Allowed paths: `frontend/src/App.jsx`; `frontend/src/pages/AdminPanel.jsx`; `frontend/src/routing/routeRegistry.js`; `frontend/src/routing/__tests__/routeContract.test.js`; `docs/admin/ADMIN_TELEGRAM_ROUTE_SURFACES.md`; `docs/audits/admin-panel-deep-audit-2026-06-01/post-fix-status-2026-06-01.md`.
- Denied paths: backend runtime, database migrations, Telegram backend contracts, auth/RBAC helpers, deploy/secrets, unrelated admin panels.
- Migration/docs/test impact: no DB migration; docs updated for Telegram route surfaces; route-contract test updated.
- Rollback note: revert this commit to send `/admin/telegram-settings` back through `AdminPanel` without API or DB rollback.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `git diff --check`; `npm run test:run -- src/routing/__tests__/routeContract.test.js`; `npm run lint:check -- --quiet --rule "no-warning-comments: off"`; `npm run build`; `npm run test:run -- --coverage`; preview smoke for `/admin/telegram-settings` with mocked Telegram admin APIs.
- Result: all local checks passed; route contract reported 24 passed tests; targeted AdminPanel route-state contract reported 2 passed tests; full frontend unit run reported 105 passed files / 478 passed tests; build produced separate `TelegramSettings-Dg_qRqOR.js` lazy chunk and `AdminPanel-C5olU2fw.js` at 987.41 KiB.
- Not checked: full backend test suite and full authenticated browser route matrix, because this is a narrow frontend route ownership slice with no backend changes.

