### PR TITLE
fix(appointments): guard sensitive legacy updates

### DIFF
--- a/backend/app/api/v1/endpoints/appointments.py
+++ b/backend/app/api/v1/endpoints/appointments.py
@@ -38,6 +38,18 @@ APPOINTMENT_DOCTOR_ROLES = {
 }
 APPOINTMENT_PATIENT_ROLES = {"Patient"}
 APPOINTMENT_PENDING_PAYMENT_ROLES = {"Admin", "Registrar", "Cashier"}
+APPOINTMENT_RESTRICTED_UPDATE_FIELDS = {
+    "payment_amount",
+    "payment_currency",
+    "payment_processed_at",
+    "payment_provider",
+    "payment_transaction_id",
+    "payment_type",
+    "payment_webhook_id",
+    "services",
+    "status",
+    "visit_type",
+}
 
 
 def _appointments_http_error(exc: Exception, operation: str) -> HTTPException:
@@ -196,6 +208,21 @@ def _ensure_pending_payment_access(current_user: User) -> None:
     if getattr(current_user, "is_superuser", False):
         return
     raise HTTPException(status_code=403, detail="Access denied")
+
+
+def _ensure_appointment_update_fields_allowed(
+    appointment_in: appointment_schemas.AppointmentUpdate,
+    current_user: User,
+) -> None:
+    role = getattr(current_user, "role", None)
+    if role in APPOINTMENT_BROAD_ACCESS_ROLES or getattr(
+        current_user, "is_superuser", False
+    ):
+        return
+
+    update_fields = appointment_in.model_dump(exclude_unset=True).keys()
+    if APPOINTMENT_RESTRICTED_UPDATE_FIELDS.intersection(update_fields):
+        raise HTTPException(status_code=403, detail="Access denied")
 
 
 # Схема для ответа pending-payments
@@ -652,6 +679,7 @@ def update_appointment(
 
     # Проверяем, не занято ли новое время у врача
     _ensure_appointment_record_access(db, appointment, current_user)
+    _ensure_appointment_update_fields_allowed(appointment_in, current_user)
 
     if (
         appointment_in.appointment_date

--- a/backend/tests/integration/test_appointment_flow_owner_guard.py
+++ b/backend/tests/integration/test_appointment_flow_owner_guard.py
@@ -293,6 +293,83 @@ def test_patient_cannot_update_other_patient_legacy_appointment(
     assert other_appointment.notes == "original"
 
 
+def test_patient_cannot_mutate_own_legacy_appointment_payment_fields(
+    client,
+    db_session,
+) -> None:
+    own_user, own_patient = _create_patient_user(db_session, label="own_payment")
+    own_appointment = Appointment(
+        patient_id=own_patient.id,
+        appointment_date=date.today(),
+        appointment_time="12:30",
+        status="scheduled",
+        notes="original",
+        payment_amount=None,
+        payment_transaction_id=None,
+        payment_provider=None,
+    )
+    db_session.add(own_appointment)
+    db_session.commit()
+    db_session.refresh(own_appointment)
+
+    response = client.put(
+        f"/api/v1/appointments/{own_appointment.id}",
+        json={
+            "notes": "keep me out",
+            "status": "paid",
+            "payment_amount": 100000,
+            "payment_provider": "cash",
+            "payment_transaction_id": "patient-forged",
+        },
+        headers=_patient_headers(client, own_user),
+    )
+
+    assert response.status_code == 403
+    db_session.refresh(own_appointment)
+    assert own_appointment.status == "scheduled"
+    assert own_appointment.notes == "original"
+    assert own_appointment.payment_amount is None
+    assert own_appointment.payment_provider is None
+    assert own_appointment.payment_transaction_id is None
+
+
+def test_admin_can_update_legacy_appointment_payment_fields(
+    client,
+    auth_headers,
+    db_session,
+) -> None:
+    patient = _create_patient(db_session, label="admin_payment")
+    appointment = Appointment(
+        patient_id=patient.id,
+        appointment_date=date.today(),
+        appointment_time="15:00",
+        status="scheduled",
+        payment_amount=None,
+        payment_transaction_id=None,
+    )
+    db_session.add(appointment)
+    db_session.commit()
+    db_session.refresh(appointment)
+
+    response = client.put(
+        f"/api/v1/appointments/{appointment.id}",
+        json={
+            "status": "paid",
+            "payment_amount": 100000,
+            "payment_provider": "cash",
+            "payment_transaction_id": "admin-marked",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    db_session.refresh(appointment)
+    assert appointment.status == "paid"
+    assert appointment.payment_amount == 100000
+    assert appointment.payment_provider == "cash"
+    assert appointment.payment_transaction_id == "admin-marked"
+
+
 def test_patient_cannot_delete_other_patient_legacy_appointment(
     client,
     db_session,


### PR DESCRIPTION
﻿## Summary
- Reject non-admin/non-registrar legacy appointment updates that include backend-owned billing or workflow fields.
- Keep Admin/Registrar/superuser updates available for payment/status metadata.
- Add regression coverage for patient self-update privilege escalation.

## Bug and impact
A Patient user who owned an appointment could call `PUT /api/v1/appointments/{appointment_id}` and include `status`, `payment_amount`, `payment_provider`, or `payment_transaction_id`. The endpoint checked record ownership, then applied the full `AppointmentUpdate` through generic CRUD. That let a self-service user forge paid/workflow state on their own appointment.

## Root cause
`update_appointment` used `_ensure_appointment_record_access` as the only authorization gate. That gate proves the caller may access the record, but it did not distinguish presentation/reschedule fields from backend-owned billing/workflow fields.

## Fix
Add a narrow restricted field guard for `AppointmentUpdate`. Admin/Registrar/superuser can still update those fields; other record-scoped roles get 403 if the payload includes billing/workflow fields.

## Cyclic Execution Evidence
- Fresh main sync: safe worktree inspected before edits and branch created from current `origin/main` view.
- Clean workspace: only `backend/app/api/v1/endpoints/appointments.py` and `backend/tests/integration/test_appointment_flow_owner_guard.py` changed.
- Branch: `codex/appointments-update-sensitive-fields`.
- Scope gate: `agent_gate` run with known root cause `backend/app/api/v1/endpoints/appointments.py`; runtime edit stayed in that endpoint, with targeted regression tests added for the exploit.
- Red-check handling: PR Review Quality Gate body failure handled in this PR; other checks watched before merge.

## Contract Impact
- Canonical surface: `PUT /api/v1/appointments/{appointment_id}` legacy appointment update.
- Request shape: same `AppointmentUpdate` body; non-admin/non-registrar roles now get 403 if restricted billing/workflow fields are present.
- Response shape: unchanged for allowed updates.
- Status codes: 403 added for record-scoped callers attempting `status`, `visit_type`, `services`, or `payment_*` mutation.
- Frontend consumer: no frontend change; backend rejects unsafe payloads.
- Compatibility path or alias: Admin/Registrar/superuser legacy update path remains compatible.
- Contract proof: targeted integration tests cover patient rejection and admin allowed update.

## RBAC / Permissions
- Roles allowed: Admin, Registrar, superuser can mutate restricted appointment update fields.
- Roles denied: Patient and Doctor-style record-scoped roles are denied restricted billing/workflow field mutation through this generic endpoint.
- Positive auth proof: admin token can update status/payment fields in regression test.
- Negative auth proof: patient token owning the appointment receives 403 and no fields are mutated.

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience
- Empty data proof: not applicable, no frontend data rendering changed.
- Partial data proof: not applicable, no frontend data rendering changed.
- Forbidden secondary path behavior: backend now returns 403 for unsafe generic update payloads; no secondary frontend path changed.
- Missing draft/resource behavior: not applicable, no draft/resource behavior changed.
- Stale route/deep-link behavior: not applicable, no route behavior changed.

## Scope Gate
- Allowed paths: legacy appointment endpoint and targeted appointment owner-guard tests.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read models, frontend files, migrations, generated output, unrelated billing services.
- Migration/docs/test impact: no migration or docs; targeted integration tests updated.
- Rollback note: revert endpoint guard and its two regression tests.

## Validation
- Targeted tests or smoke run: `py_compile` for endpoint/test file; `tests/integration/test_appointment_flow_owner_guard.py`; `tests/integration/test_appointment_flow_owner_guard.py tests/integration/test_appointments_static_routes.py`; `git diff --check`.
- Result: local validation passed; GitHub checks green except initial PR body format gate, now corrected in this PR.
- Not checked: full backend suite locally; frontend/browser smoke not applicable.
