### PR TITLE
fix(visits): guard queue updates by visit owner

### DIFF
--- a/backend/app/api/v1/endpoints/visits.py
+++ b/backend/app/api/v1/endpoints/visits.py
@@ -7,7 +7,7 @@ from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
-from sqlalchemy import MetaData, select, Table
+from sqlalchemy import MetaData, select, Table, text
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
@@ -76,6 +76,33 @@ def _visits(db: Session) -> Table:
 def _vservices(db: Session) -> Table:
     md = MetaData()
     return Table("visit_services", md, autoload_with=db.get_bind())
+
+
+def _update_queue_entries_for_visit_owner(
+    db: Session,
+    *,
+    visit_id: int,
+    patient_id: int | None,
+    status_value: str,
+) -> None:
+    if patient_id is None:
+        return
+
+    db.execute(
+        text(
+            """
+            UPDATE queue_entries
+            SET status = :status_value
+            WHERE visit_id = :visit_id
+              AND patient_id = :patient_id
+            """
+        ),
+        {
+            "status_value": status_value,
+            "visit_id": visit_id,
+            "patient_id": patient_id,
+        },
+    )
 
 
 def _ensure_visit_doctor_access(db: Session, visit: Visit, current_user) -> None:
@@ -237,10 +264,11 @@ def set_status(
     # [FIX] Также обновляем статус в очереди, если есть связанная запись
     if status_new == "canceled":
         try:
-            from sqlalchemy import text
-            db.execute(
-                text("UPDATE queue_entries SET status = 'canceled' WHERE visit_id = :visit_id"),
-                {"visit_id": visit_id}
+            _update_queue_entries_for_visit_owner(
+                db,
+                visit_id=visit_id,
+                patient_id=visit.patient_id,
+                status_value="canceled",
             )
         except Exception as e:
             # Ошибка обновления очереди не должна блокировать обновление визита
@@ -319,8 +347,15 @@ def reschedule_visit(
         from sqlalchemy import text
         # Помечаем старую запись очереди как перенесенную
         db.execute(
-            text("UPDATE queue_entries SET status = 'rescheduled' WHERE visit_id = :visit_id"),
-            {"visit_id": visit_id}
+            text(
+                """
+                UPDATE queue_entries
+                SET status = 'rescheduled'
+                WHERE visit_id = :visit_id
+                  AND patient_id = :patient_id
+                """
+            ),
+            {"visit_id": visit_id, "patient_id": vrow.get("patient_id")}
         )
     except Exception:
         pass
@@ -373,8 +408,15 @@ def reschedule_visit_tomorrow(visit_id: int, db: Session = Depends(get_db)):
         from sqlalchemy import text
         # Помечаем старую запись очереди как перенесенную
         db.execute(
-            text("UPDATE queue_entries SET status = 'rescheduled' WHERE visit_id = :visit_id"),
-            {"visit_id": visit_id}
+            text(
+                """
+                UPDATE queue_entries
+                SET status = 'rescheduled'
+                WHERE visit_id = :visit_id
+                  AND patient_id = :patient_id
+                """
+            ),
+            {"visit_id": visit_id, "patient_id": vrow.get("patient_id")}
         )
     except Exception:
         pass

--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -18,6 +18,7 @@ from app.crud.clinic import get_queue_settings
 from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue, OnlineQueueEntry, QueueToken
 from app.models.user import User
+from app.models.visit import Visit
 from app.services.queue_session import (
     get_or_create_session_id,
 )
@@ -1135,11 +1136,18 @@ class QueueBusinessService:
         *,
         visit_id: int,
     ) -> OnlineQueueEntry:
+        visit = db.query(Visit).filter(Visit.id == visit_id).first()
+        if not visit:
+            raise QueueNotFoundError(f"Visit {visit_id} not found")
+        if visit.patient_id is None:
+            raise QueueConflictError(f"Visit {visit_id} has no patient owner")
+
         active_statuses = {"waiting", "called", "in_service", "diagnostics"}
         entries = (
             db.query(OnlineQueueEntry)
             .filter(
                 OnlineQueueEntry.visit_id == visit_id,
+                OnlineQueueEntry.patient_id == visit.patient_id,
                 OnlineQueueEntry.status.in_(active_statuses),
             )
             .order_by(

--- a/backend/app/services/visits_api_service.py
+++ b/backend/app/services/visits_api_service.py
@@ -46,6 +46,32 @@ class VisitsApiService:
         md = MetaData()
         return Table("users", md, autoload_with=self.repository.get_bind())
 
+    def _update_queue_entries_for_visit_owner(
+        self,
+        *,
+        visit_id: int,
+        patient_id: int | None,
+        status_value: str,
+    ) -> None:
+        if patient_id is None:
+            return
+
+        self.repository.execute(
+            text(
+                """
+                UPDATE queue_entries
+                SET status = :status_value
+                WHERE visit_id = :visit_id
+                  AND patient_id = :patient_id
+                """
+            ),
+            {
+                "status_value": status_value,
+                "visit_id": visit_id,
+                "patient_id": patient_id,
+            },
+        )
+
     def list_visits(
         self,
         *,
@@ -301,11 +327,10 @@ class VisitsApiService:
 
         if status_new == "canceled":
             try:
-                self.repository.execute(
-                    text(
-                        "UPDATE queue_entries SET status = 'canceled' WHERE visit_id = :visit_id"
-                    ),
-                    {"visit_id": visit_id},
+                self._update_queue_entries_for_visit_owner(
+                    visit_id=visit_id,
+                    patient_id=visit.patient_id,
+                    status_value="canceled",
                 )
             except Exception:
                 pass
@@ -345,11 +370,10 @@ class VisitsApiService:
             raise HTTPException(404, "Visit not found")
 
         try:
-            self.repository.execute(
-                text(
-                    "UPDATE queue_entries SET status = 'rescheduled' WHERE visit_id = :visit_id"
-                ),
-                {"visit_id": visit_id},
+            self._update_queue_entries_for_visit_owner(
+                visit_id=visit_id,
+                patient_id=visit_row.get("patient_id"),
+                status_value="rescheduled",
             )
         except Exception:
             pass

--- a/backend/tests/unit/test_queue_time_window.py
+++ b/backend/tests/unit/test_queue_time_window.py
@@ -8,6 +8,8 @@ from zoneinfo import ZoneInfo
 import app.services.queue_service as queue_service
 from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.patient import Patient
+from app.models.visit import Visit
 from app.services.queue_service import QueueBusinessService
 
 
@@ -153,6 +155,39 @@ def _queue_with_entries(db_session, *, target_day: date):
     return daily_queue, first, second
 
 
+def _link_entry_to_visit(
+    db_session,
+    entry: OnlineQueueEntry,
+    *,
+    doctor_id: int,
+    target_day: date,
+    phone: str,
+) -> Visit:
+    patient = Patient(
+        first_name="Queue",
+        last_name="Owner",
+        phone=phone,
+    )
+    db_session.add(patient)
+    db_session.flush()
+
+    visit = Visit(
+        patient_id=patient.id,
+        doctor_id=doctor_id,
+        visit_date=target_day,
+        visit_time="09:00",
+        status="open",
+        department="cardiology",
+    )
+    db_session.add(visit)
+    db_session.flush()
+
+    entry.patient_id = patient.id
+    entry.visit_id = visit.id
+    db_session.flush()
+    return visit
+
+
 def test_staff_call_next_patient_preserves_queue_time(db_session, monkeypatch):
     target_day = date(2026, 1, 1)
     _freeze_datetime(monkeypatch, datetime(2026, 1, 1, 9, 0))
@@ -206,23 +241,28 @@ def test_staff_skip_queue_entry_preserves_queue_time(db_session):
 
 def test_staff_cancel_visit_queue_link_preserves_queue_time(db_session):
     target_day = date(2026, 1, 1)
-    _daily_queue, first, _second = _queue_with_entries(
+    daily_queue, first, _second = _queue_with_entries(
         db_session,
         target_day=target_day,
     )
-    first.visit_id = 1001
-    db_session.flush()
+    visit = _link_entry_to_visit(
+        db_session,
+        first,
+        doctor_id=daily_queue.specialist_id,
+        target_day=target_day,
+        phone="+998901001001",
+    )
 
     result = QueueBusinessService().staff_cancel_visit_queue_link(
         db_session,
-        visit_id=1001,
+        visit_id=visit.id,
         actor_user_id=42,
         commit=False,
     )
 
     assert result["success"] is True
     assert result["action"] == "staff_cancel_visit_queue_link"
-    assert result["visit_id"] == 1001
+    assert result["visit_id"] == visit.id
     assert result["previous_status"] == "waiting"
     assert result["status"] == "cancelled"
     assert result["queue_time_preserved"] is True
@@ -232,23 +272,28 @@ def test_staff_cancel_visit_queue_link_preserves_queue_time(db_session):
 
 def test_staff_move_visit_queue_link_preserves_queue_time(db_session):
     target_day = date(2026, 1, 1)
-    _daily_queue, first, _second = _queue_with_entries(
+    daily_queue, first, _second = _queue_with_entries(
         db_session,
         target_day=target_day,
     )
-    first.visit_id = 1002
-    db_session.flush()
+    visit = _link_entry_to_visit(
+        db_session,
+        first,
+        doctor_id=daily_queue.specialist_id,
+        target_day=target_day,
+        phone="+998901001002",
+    )
 
     result = QueueBusinessService().staff_move_visit_queue_link(
         db_session,
-        visit_id=1002,
+        visit_id=visit.id,
         actor_user_id=42,
         commit=False,
     )
 
     assert result["success"] is True
     assert result["action"] == "staff_move_visit_queue_link"
-    assert result["visit_id"] == 1002
+    assert result["visit_id"] == visit.id
     assert result["previous_status"] == "waiting"
     assert result["status"] == "rescheduled"
     assert result["queue_time_preserved"] is True

--- a/backend/tests/unit/test_telegram_staff_action_adapter_service.py
+++ b/backend/tests/unit/test_telegram_staff_action_adapter_service.py
@@ -6,6 +6,7 @@ import pytest
 from app.models.audit import AuditLog
 from app.models.clinic import Schedule
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.patient import Patient
 from app.models.payment import Payment
 from app.models.visit import Visit
 from app.services.telegram_staff_action_adapter_service import (
@@ -38,6 +39,22 @@ def _linked_queue_entry(db_session, *, visit_id: int, test_doctor, test_patient)
     return entry
 
 
+def _other_patient_queue_entry(db_session, *, visit_id: int, test_doctor):
+    other_patient = Patient(
+        first_name="Other",
+        last_name="Queue",
+        phone="+998901239998",
+    )
+    db_session.add(other_patient)
+    db_session.flush()
+    return _linked_queue_entry(
+        db_session,
+        visit_id=visit_id,
+        test_doctor=test_doctor,
+        test_patient=other_patient,
+    )
+
+
 def _audit_actions(db_session) -> list[str]:
     return [
         row.action
@@ -55,6 +72,11 @@ def test_staff_cancel_visit_adapter_mutates_visit_and_queue_with_audit(
         test_doctor=test_doctor,
         test_patient=test_patient,
     )
+    wrong_owner_entry = _other_patient_queue_entry(
+        db_session,
+        visit_id=test_visit.id,
+        test_doctor=test_doctor,
+    )
     db_session.flush()
 
     result = TelegramStaffActionAdapterService(db_session).staff_cancel_visit(
@@ -68,6 +90,7 @@ def test_staff_cancel_visit_adapter_mutates_visit_and_queue_with_audit(
     assert result["action"] == "staff_cancel_visit"
     assert test_visit.status == "cancelled"
     assert entry.status == "cancelled"
+    assert wrong_owner_entry.status == "waiting"
     assert result["queue"]["queue_time_preserved"] is True
     assert _audit_actions(db_session) == [
         "staff_action_confirmed",
@@ -97,6 +120,11 @@ def test_staff_move_visit_adapter_updates_date_and_preserves_queue_time(
         test_doctor=test_doctor,
         test_patient=test_patient,
     )
+    wrong_owner_entry = _other_patient_queue_entry(
+        db_session,
+        visit_id=test_visit.id,
+        test_doctor=test_doctor,
+    )
     original_queue_time = entry.queue_time
     db_session.flush()
 
@@ -112,6 +140,7 @@ def test_staff_move_visit_adapter_updates_date_and_preserves_queue_time(
     assert result["success"] is True
     assert test_visit.visit_date == new_date
     assert entry.status == "rescheduled"
+    assert wrong_owner_entry.status == "waiting"
     assert entry.queue_time == original_queue_time
     assert result["queue"]["queue_time_preserved"] is True
     assert _audit_actions(db_session) == [

--- a/backend/tests/unit/test_visits_router_service_wiring.py
+++ b/backend/tests/unit/test_visits_router_service_wiring.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timedelta
 
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.patient import Patient
+from app.models.visit import Visit
 from app.services.visits_api_service import VisitsApiService
 
 
@@ -246,3 +249,122 @@ def test_add_service_endpoint_delegates_to_service(
     assert captured["visit_id"] == test_visit.id
     assert captured["item"].code == "CONSULT"
     assert captured["item"].price == 125000
+
+
+def _create_cross_patient_queue_link(db_session, *, visit: Visit, doctor):
+    other_patient = Patient(
+        first_name="Other",
+        last_name="Queue",
+        phone="+998901239999",
+    )
+    db_session.add(other_patient)
+    db_session.flush()
+
+    queue = DailyQueue(
+        day=date.today(),
+        specialist_id=doctor.id,
+        queue_tag=f"visit_owner_guard_{visit.id}",
+        active=True,
+    )
+    db_session.add(queue)
+    db_session.flush()
+
+    own_entry = OnlineQueueEntry(
+        queue_id=queue.id,
+        visit_id=visit.id,
+        number=1,
+        patient_id=visit.patient_id,
+        patient_name="Visit Owner",
+        phone="+998901230001",
+        source="desk",
+        status="waiting",
+        queue_time=datetime.utcnow().replace(microsecond=0),
+    )
+    wrong_owner_entry = OnlineQueueEntry(
+        queue_id=queue.id,
+        visit_id=visit.id,
+        number=2,
+        patient_id=other_patient.id,
+        patient_name="Wrong Owner",
+        phone="+998901230002",
+        source="desk",
+        status="waiting",
+        queue_time=datetime.utcnow().replace(microsecond=0),
+    )
+    db_session.add_all([own_entry, wrong_owner_entry])
+    db_session.commit()
+    return own_entry, wrong_owner_entry
+
+
+def test_visit_service_cancel_updates_only_same_patient_queue_link(
+    db_session,
+    test_visit,
+    test_doctor,
+) -> None:
+    own_entry, wrong_owner_entry = _create_cross_patient_queue_link(
+        db_session,
+        visit=test_visit,
+        doctor=test_doctor,
+    )
+
+    VisitsApiService(db_session).set_status(
+        visit_id=test_visit.id,
+        status_new="canceled",
+    )
+
+    db_session.refresh(own_entry)
+    db_session.refresh(wrong_owner_entry)
+    assert own_entry.status == "canceled"
+    assert wrong_owner_entry.status == "waiting"
+
+
+def test_visit_endpoint_cancel_updates_only_same_patient_queue_link(
+    client,
+    auth_headers,
+    db_session,
+    test_visit,
+    test_doctor,
+) -> None:
+    own_entry, wrong_owner_entry = _create_cross_patient_queue_link(
+        db_session,
+        visit=test_visit,
+        doctor=test_doctor,
+    )
+
+    response = client.post(
+        f"/api/v1/visits/visits/{test_visit.id}/status",
+        params={"status_new": "canceled"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    db_session.refresh(own_entry)
+    db_session.refresh(wrong_owner_entry)
+    assert own_entry.status == "canceled"
+    assert wrong_owner_entry.status == "waiting"
+
+
+def test_visit_endpoint_reschedule_updates_only_same_patient_queue_link(
+    client,
+    auth_headers,
+    db_session,
+    test_visit,
+    test_doctor,
+) -> None:
+    own_entry, wrong_owner_entry = _create_cross_patient_queue_link(
+        db_session,
+        visit=test_visit,
+        doctor=test_doctor,
+    )
+
+    response = client.post(
+        f"/api/v1/visits/visits/{test_visit.id}/reschedule",
+        params={"new_date": (date.today() + timedelta(days=1)).isoformat()},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    db_session.refresh(own_entry)
+    db_session.refresh(wrong_owner_entry)
+    assert own_entry.status == "rescheduled"
+    assert wrong_owner_entry.status == "waiting"


### PR DESCRIPTION
## Summary

- Guard visit-linked queue updates by the owning Visit.patient_id.
- Keep legacy visit cancel/reschedule and Telegram staff visit queue actions from mutating cross-patient queue rows that share a stale visit_id.
- Update queue time tests so staff visit queue-link scenarios create the real Visit owner required by the guard.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/visit-queue-owner-guard` was created from current `origin/main`.
- Clean workspace: inspected before edits; only scoped visit endpoint/service, queue service, and targeted tests changed.
- Branch: `codex/visit-queue-owner-guard`.
- Scope gate: local agent gate twice returned single-file narrow overrides for two confirmed runtime roots; used a minimal `narrow_override` over the combined owner-guard slice.
- Red-check handling: GitHub backend tests failed on existing queue-time unit fixtures that used visit_id without a Visit row; fixed in this same PR and reran targeted validation.

## Contract Impact

- Canonical surface: mounted legacy visit cancel/reschedule queue sync plus QueueBusinessService staff visit queue-link adapter.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged for valid owned links; missing or ambiguous links still fail through existing queue errors.
- Frontend consumer: not applicable, backend-only runtime guard.
- Compatibility path or alias: legacy visit routes remain, but queue side-effects are now constrained to the Visit owner.
- Contract proof: unit regressions cover same-patient mutation and cross-patient non-mutation.

## RBAC / Permissions

- Roles allowed: unchanged from existing endpoints/adapters.
- Roles denied: unchanged.
- Positive auth proof: existing route/service tests continue to exercise authenticated visit flows.
- Negative auth proof: not applicable - no auth policy changed; this PR narrows data ownership inside existing authorized commands.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no frontend/read-model behavior changed.
- Partial data proof: not applicable, no frontend/read-model behavior changed.
- Forbidden secondary path behavior: not applicable, no secondary path added.
- Missing draft/resource behavior: not applicable, no drafts/resources changed.
- Stale route/deep-link behavior: not applicable, no frontend routing changed.

## Scope Gate

- Allowed paths: visit endpoint/service owner guard, queue service staff visit-link lookup, targeted visit/Telegram/queue-time tests.
- Denied paths: `/api/v1/ui/*`, BFF-lite, frontend, migrations, generated output, unrelated queue ordering/fairness changes.
- Migration/docs/test impact: no migration; targeted tests updated.
- Rollback note: revert the owner-guard code and targeted tests in this PR.

## Validation

- Targeted tests or smoke run: `scripts/run_python.ps1 py_compile` for changed Python files/tests; `scripts/run_backend_pytest.ps1 tests/unit/test_visits_router_service_wiring.py tests/unit/test_telegram_staff_action_adapter_service.py tests/unit/test_queue_time_window.py`; `scripts/run_backend_pytest.ps1 tests/integration/test_registrar_record_actions.py`; `git diff --check`.
- Result: local targeted unit suite passed with 23 passed; previous integration registrar suite passed with 6 passed; diff check passed with CRLF warnings only.
- Not checked: full backend suite locally; GitHub CI will run the full required backend gate before merge.
