### PR TITLE
fix(queue): guard qr visit aggregation by owner

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -1337,18 +1337,31 @@ def full_update_online_entry(
         
         if entry.visit_id:
             # ⭐ FIX 4: Если есть visit_id, ищем строго по нему (это одна сессия обслуживания)
+            visit_entry_filters = [
+                OnlineQueueEntry.visit_id == entry.visit_id,
+                OnlineQueueEntry.status.in_(["waiting", "called", "in_service"]),
+            ]
+            if entry.patient_id is not None:
+                visit_entry_filters.append(
+                    OnlineQueueEntry.patient_id == entry.patient_id
+                )
+            else:
+                visit_entry_filters.append(OnlineQueueEntry.id == entry.id)
+                logger.warning(
+                    "[full_update_online_entry] visit-linked entry %d has no patient_id; using current entry only for aggregation",
+                    entry.id,
+                )
             visit_entries = (
                 db.query(OnlineQueueEntry)
-                .filter(
-                    OnlineQueueEntry.visit_id == entry.visit_id,
-                    OnlineQueueEntry.status.in_(["waiting", "called", "in_service"]),
-                )
+                .filter(*visit_entry_filters)
                 .all()
             )
             computed_aggregated_ids = [e.id for e in visit_entries]
             logger.info(
-                "[full_update_online_entry] ⭐ FIX 4: Вычислены aggregated_ids по visit_id=%d: %s",
-                entry.visit_id, computed_aggregated_ids
+                "[full_update_online_entry] computed aggregated_ids by visit_id=%d and patient_id=%s: %s",
+                entry.visit_id,
+                entry.patient_id,
+                computed_aggregated_ids,
             )
         else:
             # If there is no visit yet, aggregate only the current service

--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -1358,10 +1358,8 @@ def full_update_online_entry(
             )
             computed_aggregated_ids = [e.id for e in visit_entries]
             logger.info(
-                "[full_update_online_entry] computed aggregated_ids by visit_id=%d and patient_id=%s: %s",
-                entry.visit_id,
-                entry.patient_id,
-                computed_aggregated_ids,
+                "[full_update_online_entry] computed %d aggregated ids by visit_id with same-patient guard",
+                len(computed_aggregated_ids),
             )
         else:
             # If there is no visit yet, aggregate only the current service

--- a/backend/tests/integration/test_qr_queue_full_update.py
+++ b/backend/tests/integration/test_qr_queue_full_update.py
@@ -184,6 +184,110 @@ def test_full_update_all_free_rejects_entry_linked_to_other_patient_visit(
 
 
 @pytest.mark.integration
+def test_full_update_visit_id_aggregation_ignores_other_patient_queue_entry(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_daily_queue,
+    test_patient,
+    test_doctor,
+    test_service,
+):
+    other_patient = Patient(
+        last_name="Other",
+        first_name="Queue",
+        phone="+998900001112",
+    )
+    db_session.add(other_patient)
+    db_session.flush()
+    other_visit = Visit(
+        patient_id=other_patient.id,
+        doctor_id=test_doctor.id,
+        visit_date=date.today(),
+        visit_time="12:00",
+        status="open",
+        discount_mode="none",
+        approval_status="none",
+        department="cardiology",
+    )
+    db_session.add(other_visit)
+    db_session.flush()
+
+    other_queue_time = datetime(2026, 5, 31, 7, 0, tzinfo=timezone.utc)
+    current_queue_time = datetime(2026, 5, 31, 10, 0, tzinfo=timezone.utc)
+    other_entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=80,
+        patient_id=other_patient.id,
+        patient_name="Other Queue",
+        phone=other_patient.phone,
+        visit_id=other_visit.id,
+        source="online",
+        status="waiting",
+        queue_time=other_queue_time,
+        services=json.dumps(
+            [
+                {
+                    "service_id": test_service.id,
+                    "name": test_service.name,
+                    "code": test_service.code,
+                    "quantity": 1,
+                    "price": int(test_service.price or 0),
+                    "queue_time": other_queue_time.isoformat(),
+                    "cancelled": False,
+                }
+            ],
+            ensure_ascii=False,
+        ),
+    )
+    current_entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=81,
+        patient_id=test_patient.id,
+        patient_name=test_patient.short_name(),
+        phone=test_patient.phone,
+        visit_id=other_visit.id,
+        source="online",
+        status="waiting",
+        queue_time=current_queue_time,
+        services=json.dumps([], ensure_ascii=False),
+    )
+    db_session.add_all([other_entry, current_entry])
+    db_session.commit()
+    db_session.refresh(current_entry)
+
+    response = client.put(
+        f"/api/v1/queue/online-entry/{current_entry.id}/full-update",
+        headers=registrar_auth_headers,
+        json={
+            "patient_data": {
+                "patient_name": test_patient.short_name(),
+                "phone": test_patient.phone,
+                "birth_year": 1990,
+                "address": test_patient.address,
+            },
+            "visit_type": "paid",
+            "discount_mode": "none",
+            "services": [{"service_id": test_service.id, "quantity": 1}],
+            "all_free": False,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+
+    db_session.refresh(current_entry)
+    db_session.refresh(other_entry)
+    current_services = json.loads(current_entry.services)
+    other_services = json.loads(other_entry.services)
+    assert [service["service_id"] for service in current_services] == [test_service.id]
+    assert current_services[0]["queue_time"] == current_queue_time.replace(
+        tzinfo=None
+    ).isoformat()
+    assert current_services[0]["queue_time"] != other_queue_time.isoformat()
+    assert other_services[0]["queue_time"] == other_queue_time.isoformat()
+
+
+@pytest.mark.integration
 def test_full_update_without_visit_id_ignores_unrelated_same_day_patient_entries(
     client,
     db_session,


### PR DESCRIPTION
## Summary

- Guard QR full-update visit_id aggregation by the edited queue entry owner.
- Prevent stale cross-patient `OnlineQueueEntry.visit_id` links from contributing services or queue_time to another patient's QR update.
- Add an integration regression for the mounted `/api/v1/queue/online-entry/{entry_id}/full-update` path.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `codex/current-main-view` after PR #1533 was merged and fast-forwarded to `origin/main`.
- Clean workspace: inspected before edits; only the mounted QR queue endpoint and targeted QR full-update regression test changed.
- Branch: `codex/qr-full-update-visit-aggregation-owner`.
- Scope gate: `gate_known_root_cause` on `backend/app/api/v1/endpoints/qr_queue.py`, then a second narrow gate for `backend/tests/integration/test_qr_queue_full_update.py`.
- Red-check handling: CodeQL flagged clear-text logging of `patient_id`; fixed in the same PR by removing owner IDs from the new log line, then reran local targeted validation.

## Contract Impact

- Canonical surface: `PUT /api/v1/queue/online-entry/{entry_id}/full-update`.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: unchanged.
- Compatibility path or alias: existing QR full-update behavior remains, but `visit_id` aggregation now only uses same-patient queue entries.
- Contract proof: integration regression proves a cross-patient queue row with the same `visit_id` does not donate queue_time/services to the edited entry.

## RBAC / Permissions

- Roles allowed: unchanged from existing endpoint (`Admin`, `Registrar`, `Doctor`, `cardio`, `derma`, `dentist`).
- Roles denied: unchanged.
- Positive auth proof: targeted integration uses registrar auth headers.
- Negative auth proof: not applicable - no auth policy changed; this narrows internal data ownership.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: existing QR full-update tests still cover empty service state.
- Partial data proof: existing QR full-update tests still cover visit-less entries and phone/session matching.
- Forbidden secondary path behavior: not applicable, no secondary path added.
- Missing draft/resource behavior: not applicable, no drafts/resources changed.
- Stale route/deep-link behavior: not applicable, no frontend routing changed.

## Scope Gate

- Allowed paths: mounted QR queue endpoint and targeted QR full-update integration tests.
- Denied paths: `/api/v1/ui/*`, BFF-lite, frontend, migrations, generated output, unrelated queue fairness/order code.
- Migration/docs/test impact: no migration; one targeted integration test added.
- Rollback note: revert this endpoint guard and the added regression test.

## Validation

- Targeted tests or smoke run: `scripts/run_python.ps1 py_compile backend/app/api/v1/endpoints/qr_queue.py backend/tests/integration/test_qr_queue_full_update.py`; `TESTING=1 DATABASE_URL=sqlite:///./test_codex_qr_full_update.db scripts/run_backend_pytest.ps1 tests/integration/test_qr_queue_full_update.py`; `git diff --check`.
- Result: py_compile passed; QR full-update integration passed with 6 passed before PR open and again after the CodeQL logging fix; diff check passed.
- Not checked: full backend suite locally; GitHub CI will run required checks before merge.
