### PR TITLE
fix(registrar): guard queue visit read model owner

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -1522,8 +1522,33 @@ def get_today_queues(
 
         from app.models.appointment import Appointment
         from app.models.clinic import Doctor
+        from app.models.online_queue import DailyQueue, OnlineQueueEntry
         from app.models.patient import Patient
         from app.models.visit import Visit
+
+        def _same_patient_queue_entry_for_visit_id(
+            visit_id: int | None,
+            patient_id: int | None,
+        ) -> OnlineQueueEntry | None:
+            if visit_id is None or patient_id is None:
+                return None
+            return (
+                db.query(OnlineQueueEntry)
+                .filter(
+                    OnlineQueueEntry.visit_id == visit_id,
+                    OnlineQueueEntry.patient_id == patient_id,
+                )
+                .order_by(OnlineQueueEntry.id.asc())
+                .first()
+            )
+
+        def _same_patient_queue_entry_for_visit(
+            visit: Visit,
+        ) -> OnlineQueueEntry | None:
+            return _same_patient_queue_entry_for_visit_id(
+                visit.id,
+                visit.patient_id,
+            )
 
         # [OK] УПРОЩЕНО: Валидация формата даты перед парсингом (Single Source of Truth)
         # Если дата не указана, используем сегодня
@@ -1593,11 +1618,7 @@ def get_today_queues(
 
             # ⭐ PHASE 1.1: Пропускаем Visit если есть связанный OnlineQueueEntry
             # Очередь должна читаться ТОЛЬКО из OnlineQueueEntry (SSOT)
-            from sqlalchemy import text
-            has_queue_entry = db.execute(
-                text("SELECT 1 FROM queue_entries WHERE visit_id = :visit_id LIMIT 1"),
-                {"visit_id": visit.id}
-            ).first()
+            has_queue_entry = _same_patient_queue_entry_for_visit(visit)
             if has_queue_entry:
                 # ⚠️ НЕ добавляем в seen_visit_ids - пусть OQE обрабатывается
                 logger.debug(
@@ -1735,14 +1756,7 @@ def get_today_queues(
                 # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
                 visit_queue_time = None
                 try:
-                    from sqlalchemy import text
-
-                    queue_entry_row = db.execute(
-                        text(
-                            "SELECT queue_time FROM queue_entries WHERE visit_id = :visit_id LIMIT 1"
-                        ),
-                        {"visit_id": visit.id},
-                    ).first()
+                    queue_entry_row = _same_patient_queue_entry_for_visit(visit)
                     if queue_entry_row and queue_entry_row.queue_time:
                         visit_queue_time = queue_entry_row.queue_time
                 except Exception:
@@ -1776,14 +1790,7 @@ def get_today_queues(
                 # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
                 visit_queue_time = None
                 try:
-                    from sqlalchemy import text
-
-                    queue_entry_row = db.execute(
-                        text(
-                            "SELECT queue_time FROM queue_entries WHERE visit_id = :visit_id LIMIT 1"
-                        ),
-                        {"visit_id": visit.id},
-                    ).first()
+                    queue_entry_row = _same_patient_queue_entry_for_visit(visit)
                     if queue_entry_row and queue_entry_row.queue_time:
                         visit_queue_time = queue_entry_row.queue_time
                 except Exception:
@@ -1820,14 +1827,7 @@ def get_today_queues(
                 # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
                 visit_queue_time = None
                 try:
-                    from sqlalchemy import text
-
-                    queue_entry_row = db.execute(
-                        text(
-                            "SELECT queue_time FROM queue_entries WHERE visit_id = :visit_id LIMIT 1"
-                        ),
-                        {"visit_id": visit.id},
-                    ).first()
+                    queue_entry_row = _same_patient_queue_entry_for_visit(visit)
                     if queue_entry_row and queue_entry_row.queue_time:
                         visit_queue_time = queue_entry_row.queue_time
                 except Exception:
@@ -1875,14 +1875,7 @@ def get_today_queues(
             # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
             visit_queue_time = None
             try:
-                from sqlalchemy import text
-
-                queue_entry_row = db.execute(
-                    text(
-                        "SELECT queue_time FROM queue_entries WHERE visit_id = :visit_id LIMIT 1"
-                    ),
-                    {"visit_id": visit.id},
-                ).first()
+                queue_entry_row = _same_patient_queue_entry_for_visit(visit)
                 if queue_entry_row and queue_entry_row.queue_time:
                     visit_queue_time = queue_entry_row.queue_time
             except Exception:
@@ -2702,10 +2695,7 @@ def get_today_queues(
                         visit = entry_data
                         # ✅ SSOT FIX: Для QR-визитов нужно получить данные из OnlineQueueEntry
                         # Frontend использует этот ID для вызова full-update endpoint
-                        queue_entry_for_visit = db.execute(
-                            text("SELECT id, number, queue_time, updated_at, total_amount FROM queue_entries WHERE visit_id = :visit_id LIMIT 1"),
-                            {"visit_id": visit.id}
-                        ).first()
+                        queue_entry_for_visit = _same_patient_queue_entry_for_visit(visit)
                         if queue_entry_for_visit:
                             record_id = queue_entry_for_visit.id
                             # ⭐ PHASE 1 FIX: Сохраняем данные из OQE для использования позже
@@ -2950,12 +2940,10 @@ def get_today_queues(
                             )
                         elif entry_type == "visit":
                             # Ищем запись по visit_id
-                            queue_entry_row = db.execute(
-                                text(
-                                    "SELECT number, queue_time, updated_at FROM queue_entries WHERE visit_id = :visit_id LIMIT 1"
-                                ),
-                                {"visit_id": record_id},
-                            ).first()
+                            queue_entry_row = _same_patient_queue_entry_for_visit_id(
+                                record_id,
+                                patient_id,
+                            )
                             if queue_entry_row:
                                 queue_entry_number = queue_entry_row.number
                                 queue_entry_time = queue_entry_row.queue_time

--- a/backend/tests/integration/test_registrar_all_appointments.py
+++ b/backend/tests/integration/test_registrar_all_appointments.py
@@ -352,6 +352,97 @@ class TestRegistrarAllAppointments:
         assert found_visit["visit_id"] == visit.id
         assert found_visit["appointment_id"] is None
 
+    def test_today_queues_visit_ignores_other_patient_queue_entry_with_same_visit_id(
+        self,
+        client,
+        db_session,
+        auth_headers,
+        test_patient,
+        test_doctor,
+        test_service,
+    ):
+        other_patient = Patient(
+            first_name="Other",
+            last_name="QueueOwner",
+            phone="+998901119091",
+        )
+        queue = DailyQueue(
+            day=date.today(),
+            specialist_id=test_doctor.id,
+            queue_tag="cardiology_common",
+            active=True,
+        )
+        visit = Visit(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=date.today(),
+            visit_time="10:30",
+            status="waiting",
+            discount_mode="none",
+            department="cardiology",
+            source="desk",
+        )
+        db_session.add_all([other_patient, queue, visit])
+        db_session.flush()
+
+        visit_service = VisitService(
+            visit_id=visit.id,
+            service_id=test_service.id,
+            code=test_service.code,
+            name=test_service.name,
+            qty=1,
+            price=test_service.price,
+            currency="UZS",
+        )
+        stale_entry = OnlineQueueEntry(
+            queue_id=queue.id,
+            number=88,
+            patient_id=other_patient.id,
+            patient_name=other_patient.short_name(),
+            phone=other_patient.phone,
+            visit_id=visit.id,
+            source="online",
+            status="waiting",
+            queue_time=datetime(2026, 4, 16, 8, 0, tzinfo=ZoneInfo("Asia/Tashkent")),
+        )
+        db_session.add_all([visit_service, stale_entry])
+        db_session.commit()
+        db_session.refresh(visit)
+        db_session.refresh(stale_entry)
+
+        response = client.get(
+            f"/api/v1/registrar/queues/today?target_date={date.today().isoformat()}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        entries = [
+            entry for queue_payload in payload["queues"] for entry in queue_payload["entries"]
+        ]
+        found_visit = next(
+            (
+                entry
+                for entry in entries
+                if entry.get("record_kind") == "visit"
+                and entry.get("visit_id") == visit.id
+            ),
+            None,
+        )
+
+        assert found_visit is not None
+        assert found_visit["patient_id"] == test_patient.id
+        assert found_visit["queue_entry_id"] is None
+        assert found_visit["number"] != stale_entry.number
+        assert all(entry.get("queue_entry_id") != stale_entry.id for entry in entries)
+        assert all(
+            not (
+                entry.get("record_kind") == "online_queue"
+                and entry.get("id") == stale_entry.id
+            )
+            for entry in entries
+        )
+
     def test_today_queues_secondary_doctor_actions_are_backend_owned(self):
         user = type("UserStub", (), {"role": "cardio", "roles": []})()
 


### PR DESCRIPTION
## Summary

- Guard `/registrar/queues/today` queue-entry lookups by `Visit.patient_id` whenever a row is selected by `visit_id`.
- Prevent stale/cross-patient queue rows from suppressing a Visit row or exposing another patient's `queue_entry_id`.
- Add regression coverage for the cross-patient `visit_id` collision scenario.

## Cyclic Execution Evidence

- Fresh main sync: safe worktree fast-forwarded to fresh `origin/main` before this slice.
- Clean workspace: inspected before edits; only scoped registrar endpoint and targeted integration test changed.
- Branch: `codex/registrar-queue-visit-owner-read-model`.
- Scope gate: code gate and test gate both returned `narrow override`; allowed only `backend/app/api/v1/endpoints/registrar_integration.py` and `backend/tests/integration/test_registrar_all_appointments.py`; denied frontend, `/api/v1/ui/*`, BFF-lite, migrations, and unrelated queue services.
- Red-check handling: initial PR Review Quality Gate failed because body lacked required sections; fixed body in the same PR and will fix any remaining CI failures in this PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/registrar/queues/today` legacy registrar queue read model.
- Request shape: authenticated request with existing `target_date` and optional `department` query params; no request body change.
- Response shape: existing fields preserved; `queue_entry_id`, queue number, and queue time are now only taken from queue rows owned by the same patient as the Visit.
- Status codes: unchanged existing endpoint behavior; this patch does not add or remove status codes.
- Frontend consumer: existing RegistrarPanel/Lab/Doctor panels that read `/registrar/queues/today` continue using the same fields.
- Compatibility path or alias: no alias or endpoint path changed; legacy read model remains compatibility surface.
- Contract proof: integration regression proves a cross-patient stale queue row with the same `visit_id` does not suppress the Visit row or expose the stale queue entry id.

## RBAC / Permissions

- Roles allowed: unchanged existing endpoint roles: Admin, Registrar, Cashier, Doctor, Lab, cardio, cardiology, derma, dentist.
- Roles denied: unchanged; no role policy was widened.
- Positive auth proof: targeted integration test calls the endpoint with existing `auth_headers` and receives 200.
- Negative auth proof: not checked in this slice because RBAC policy was not changed; existing role guard remains in place.

## Notification / Realtime

- Event type or websocket channel: not applicable - no event, websocket, Telegram, SMS/email, or realtime channel changed.
- Payload version / ack behavior: not applicable - synchronous HTTP read model only.
- Read/unread or delivery semantics: not applicable - no delivery semantics changed.
- Reconnect/resync proof: not applicable - no realtime reconnect/resync path changed.

## Frontend Resilience

- Empty data proof: not checked in this slice; empty queue behavior is unchanged.
- Partial data proof: regression covers partial/stale data where a queue row has the same `visit_id` but the wrong patient owner.
- Forbidden secondary path behavior: not applicable - no secondary frontend path or fallback command added.
- Missing draft/resource behavior: not applicable - no draft/resource workflow changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/registrar_integration.py`, `backend/tests/integration/test_registrar_all_appointments.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite, migrations, command wrappers, unrelated queue services.
- Migration/docs/test impact: no migration or docs change; one targeted integration regression added.
- Rollback note: revert this PR to restore previous `visit_id`-only queue lookup behavior and remove the regression test.

## Risk / Impact

- Scope is limited to the mounted legacy registrar queue read model and its integration test.
- The behavioral change only narrows `visit_id` queue lookups to the same patient owner.
- Regression risk is mainly duplicate display behavior for legitimate same-patient queue links; covered by the existing registrar queue suite.

## Validation

- Targeted tests or smoke run: `py_compile`, `test_registrar_all_appointments.py`, and `git diff --check`.
- Result: `py_compile` passed; `tests/integration/test_registrar_all_appointments.py` passed (`11 passed, 1 warning`); `git diff --check` passed.
- Not checked: full backend suite and frontend build, because this slice is a narrow backend read-model guard with no frontend changes.