### PR TITLE
fix(registrar): keep queue entry identity for edit removal

### DIFF
--- a/frontend/src/utils/__tests__/serviceCodeResolver.test.js
+++ b/frontend/src/utils/__tests__/serviceCodeResolver.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeServicesFromInitialData } from '../serviceCodeResolver';
+
+describe('normalizeServicesFromInitialData', () => {
+  it('uses explicit queue_entry_id instead of DailyQueue identifiers for edit cancellation', () => {
+    const [item] = normalizeServicesFromInitialData(
+      {
+        service_details: [
+          {
+            id: 5,
+            code: 'K01',
+            name: 'Cardiology consult',
+          },
+        ],
+        queue_numbers: [
+          {
+            id: 31,
+            queue_id: 31,
+            queue_entry_id: 9001,
+            service_id: 5,
+            service_code: 'K01',
+            service_name: 'Cardiology consult',
+          },
+        ],
+      },
+      [{ id: 5, service_code: 'K01', name: 'Cardiology consult' }],
+    );
+
+    expect(item.original_queue_id).toBe(9001);
+  });
+
+  it('does not treat a bare queue_id as an OnlineQueueEntry id', () => {
+    const [item] = normalizeServicesFromInitialData(
+      {
+        service_details: [
+          {
+            id: 7,
+            code: 'D01',
+            name: 'Dermatology consult',
+          },
+        ],
+        queue_numbers: [
+          {
+            id: 44,
+            queue_id: 44,
+            service_id: 7,
+            service_code: 'D01',
+            service_name: 'Dermatology consult',
+          },
+        ],
+      },
+      [{ id: 7, service_code: 'D01', name: 'Dermatology consult' }],
+    );
+
+    expect(item.original_queue_id).toBeNull();
+  });
+});

--- a/frontend/src/utils/serviceCodeResolver.js
+++ b/frontend/src/utils/serviceCodeResolver.js
@@ -380,9 +380,14 @@ export function normalizeServicesFromInitialData(initialData, servicesData = [])
         };
     };
 
+    const pickExplicitQueueEntryId = (value = {}) => (
+        value.original_queue_id ?? value.queue_entry_id ?? null
+    );
+
     const resolveOriginalQueueId = (serviceData = {}) => {
-        if (serviceData.original_queue_id || serviceData.queue_entry_id || serviceData.queue_id) {
-            return serviceData.original_queue_id || serviceData.queue_entry_id || serviceData.queue_id;
+        const explicitQueueEntryId = pickExplicitQueueEntryId(serviceData);
+        if (explicitQueueEntryId !== null && explicitQueueEntryId !== undefined && explicitQueueEntryId !== '') {
+            return explicitQueueEntryId;
         }
         if (!Array.isArray(initialData.queue_numbers)) return null;
 
@@ -403,7 +408,21 @@ export function normalizeServicesFromInitialData(initialData, servicesData = [])
             return Boolean(serviceName && queueName && serviceName === queueName);
         });
 
-        return match?.id || match?.queue_id || match?.queue_entry_id || null;
+        if (!match) return null;
+
+        const matchedQueueEntryId = pickExplicitQueueEntryId(match);
+        if (matchedQueueEntryId !== null && matchedQueueEntryId !== undefined && matchedQueueEntryId !== '') {
+            return matchedQueueEntryId;
+        }
+
+        // In current registrar DTOs `queue_id` is DailyQueue.id, not a
+        // cancelable OnlineQueueEntry.id. If both are present, never treat the
+        // row id as an entry id; it may collide with an unrelated queue entry.
+        if (match.queue_id !== null && match.queue_id !== undefined) {
+            return null;
+        }
+
+        return match.id ?? null;
     };
 
     /**


### PR DESCRIPTION
## Summary

- Fix registrar edit-mode service identity mapping for removed services.
- Prevent DailyQueue ids from being reused as OnlineQueueEntry cancel ids.
- Add focused resolver regression coverage for queue-entry identity preservation.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/contract-scan-next-7` created from current `origin/main` in isolated worktree `C:\tmp\final-contract-scan-next-7`.
- Clean workspace: inspected before edits; primary `C:\final` had unrelated user frontend changes, so all PR work stayed in the isolated worktree.
- Branch: `codex/contract-scan-next-7`.
- Scope gate: allowed `frontend/src/utils/serviceCodeResolver.js` and targeted resolver test; denied backend endpoints, unrelated panels, migrations, generated output, and broad frontend rewrites.
- Red-check handling: PR Review Quality Gate failed on body shape; this PR body update fixes that same PR before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/online-queue/entries/{entry_id}/cancel` expects `OnlineQueueEntry.id`.
- Request shape: unchanged cancel endpoint path id; no request body contract change.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: registrar appointment wizard edit-mode removed-service cancellation payload.
- Compatibility path or alias: legacy queue number row `id` is used only when there is no separate `queue_id`; explicit `queue_entry_id` / `original_queue_id` wins.
- Contract proof: targeted resolver tests prove `queue_entry_id` is preserved and bare `queue_id` is not treated as cancelable queue-entry identity.

## RBAC / Permissions

not applicable - no role policy, auth dependency, permission check, or backend endpoint access behavior changed.

## Notification / Realtime

not applicable - no websocket, notification, chat, polling, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: existing resolver keeps empty service input behavior unchanged through focused wizard contract tests.
- Partial data proof: resolver handles missing explicit queue-entry identity by returning `null` instead of inventing an unsafe cancel id.
- Forbidden secondary path behavior: not applicable, no secondary request path was added.
- Missing draft/resource behavior: removed services without a safe queue-entry id are not sent as cancelable persisted queue entries.
- Stale route/deep-link behavior: not applicable, no route state or deep-link behavior changed.

## Scope Gate

- Allowed paths: `frontend/src/utils/serviceCodeResolver.js`, `frontend/src/utils/__tests__/serviceCodeResolver.test.js`.
- Denied paths: backend endpoints/services, `/api/v1/ui/*`, BFF-lite, unrelated doctor/admin panels, migrations, generated artifacts.
- Migration/docs/test impact: no migration or docs change; added targeted frontend regression test.
- Rollback note: revert the resolver change and its focused test to restore prior behavior.

## Validation

- Targeted tests or smoke run: `C:\final\frontend\node_modules\.bin\vitest.cmd run src/utils/__tests__/serviceCodeResolver.test.js --config C:\tmp\vitest-no-setup.config.mjs --root C:\tmp\final-contract-scan-next-7\frontend`; `C:\final\frontend\node_modules\.bin\vitest.cmd run src/components/wizard/__tests__/AppointmentWizardV2.contract.test.jsx --config C:\tmp\vitest-no-setup.config.mjs --root C:\tmp\final-contract-scan-next-7\frontend`; `git diff --check`.
- Result: passed locally; GitHub frontend lint, unit tests, build, CodeQL, security scan, CI Scope, and PR Required Gate passed before this body-only correction.
- Not checked: full browser registrar edit-mode smoke was not run; backend tests skipped because this PR does not change backend code.