### PR TITLE
fix(registrar): preserve queue entry ids in wizard edits

### DIFF
--- a/frontend/src/components/wizard/AppointmentWizardV2.jsx
+++ b/frontend/src/components/wizard/AppointmentWizardV2.jsx
@@ -65,18 +65,38 @@ const getWizardSourceKind = (record) => normalizeWizardContractValue(
   record?.source_kind ?? record?.source
 );
 
+const hasQueueIdentityValue = (value) => value !== null && value !== undefined && value !== '';
+
+const resolveExplicitQueueEntryId = (record, { allowLegacyId = true } = {}) => {
+  if (!record || typeof record !== 'object') return null;
+
+  const explicitQueueEntryId = record.original_queue_id ??
+    record.queue_entry_id ??
+    record.doctor_queue_entry_id ??
+    null;
+  if (hasQueueIdentityValue(explicitQueueEntryId)) {
+    return explicitQueueEntryId;
+  }
+
+  if (!allowLegacyId || hasQueueIdentityValue(record.queue_id)) {
+    return null;
+  }
+
+  return hasQueueIdentityValue(record.id) ? record.id : null;
+};
+
 const getFirstQueueNumberId = (record) => {
   if (!Array.isArray(record?.queue_numbers) || record.queue_numbers.length === 0) {
     return null;
   }
-  return record.queue_numbers[0]?.id ?? null;
+  return resolveExplicitQueueEntryId(record.queue_numbers[0]);
 };
 
 const resolveOnlineQueueEntryId = (record, recordKind, effectiveSource) => {
   if (!record || recordKind !== 'online_queue' || effectiveSource !== 'online') {
     return null;
   }
-  return record.queue_entry_id ?? getFirstQueueNumberId(record) ?? record.id ?? null;
+  return resolveExplicitQueueEntryId(record) ?? getFirstQueueNumberId(record);
 };
 
 const getRemovedQueueEntryIds = (originalQueueIds, cartItems = []) => {
@@ -1954,10 +1974,7 @@ const AppointmentWizardV2 = ({
             const serviceId = serviceDetail.service_id || serviceDetail.id || null;
             const serviceCode = serviceDetail.service_code || serviceDetail.code || null;
             const serviceName = serviceDetail.service_name || serviceDetail.name || null;
-            const queueId = serviceDetail.original_queue_id ||
-              serviceDetail.queue_entry_id ||
-              serviceDetail.queue_id ||
-              null;
+            const queueId = resolveExplicitQueueEntryId(serviceDetail, { allowLegacyId: false });
 
             if (serviceId) originalServiceIds.add(serviceId);
             if (queueId) originalQueueIds.add(queueId);
@@ -2058,7 +2075,8 @@ const AppointmentWizardV2 = ({
           initialData.queue_numbers.forEach((q) => {
             if (q && q.service_id) {
               originalServiceIds.add(q.service_id);
-              if (q.id) originalQueueIds.add(q.id); // ✅ Сохраняем ID записи очереди
+              const queueId = resolveExplicitQueueEntryId(q);
+              if (queueId) originalQueueIds.add(queueId); // ✅ Сохраняем ID записи очереди
               // Находим service_code и name по service_id
               const service = servicesData.find((s) => s.id === q.service_id);
               if (service) {

--- a/frontend/src/components/wizard/__tests__/AppointmentWizardV2.contract.test.jsx
+++ b/frontend/src/components/wizard/__tests__/AppointmentWizardV2.contract.test.jsx
@@ -57,6 +57,9 @@ describe('AppointmentWizardV2 registrar metadata contract', () => {
     expect(groupingBlock).toContain('original_queue_id: item.original_queue_id || null');
     expect(newServiceBlock).toContain('const hasExistingQueueIdentity = Boolean(serviceItem.original_queue_id);');
     expect(newServiceBlock).toContain('const isNewService = !hasExistingQueueIdentity');
+    expect(source).toContain('const resolveExplicitQueueEntryId = (record, { allowLegacyId = true } = {}) => {');
+    expect(source).toContain('if (!allowLegacyId || hasQueueIdentityValue(record.queue_id))');
+    expect(source).toContain('return resolveExplicitQueueEntryId(record) ?? getFirstQueueNumberId(record);');
   });
 
   it('maps service-array initial data back to queue_numbers before edit saves', () => {
@@ -167,6 +170,10 @@ describe('AppointmentWizardV2 registrar metadata contract', () => {
     expect(existingServicesBlock).toContain('Array.isArray(initialData.service_details)');
     expect(existingServicesBlock).toContain('const serviceId = serviceDetail.service_id || serviceDetail.id || null;');
     expect(existingServicesBlock).toContain('if (serviceId) originalServiceIds.add(serviceId);');
+    expect(existingServicesBlock).toContain('const queueId = resolveExplicitQueueEntryId(serviceDetail, { allowLegacyId: false });');
+    expect(existingServicesBlock).not.toContain('serviceDetail.queue_id ||');
+    expect(existingServicesBlock).toContain('const queueId = resolveExplicitQueueEntryId(q);');
+    expect(existingServicesBlock).not.toContain('if (q.id) originalQueueIds.add(q.id)');
     expect(existingServicesBlock).toContain('if (queueId) originalQueueIds.add(queueId);');
   });
 

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -232,8 +232,24 @@ const formatPreviewList = (value) => {
   return value || '';
 };
 
+const hasQueueIdentityValue = (value) => value !== null && value !== undefined && value !== '';
+
+const resolveWizardQueueEntryId = (assignment) => {
+  if (!assignment || typeof assignment !== 'object') return null;
+  const explicitQueueEntryId = assignment.queue_entry_id ??
+    assignment.original_queue_id ??
+    assignment.doctor_queue_entry_id ??
+    null;
+  if (hasQueueIdentityValue(explicitQueueEntryId)) return explicitQueueEntryId;
+
+  if (hasQueueIdentityValue(assignment.queue_id)) return null;
+
+  return hasQueueIdentityValue(assignment.id) ? assignment.id : null;
+};
+
 const normalizeWizardQueueAssignment = (assignment, visitId = null) => {
   if (!assignment || typeof assignment !== 'object') return null;
+  const queueEntryId = resolveWizardQueueEntryId(assignment);
   const queueNumber = assignment.queue_number ??
     assignment.number ??
     assignment.ticket_number ??
@@ -243,8 +259,8 @@ const normalizeWizardQueueAssignment = (assignment, visitId = null) => {
 
   return {
     ...assignment,
-    id: assignment.queue_id ?? assignment.queue_entry_id ?? assignment.id ?? null,
-    queue_entry_id: assignment.queue_entry_id ?? assignment.queue_id ?? assignment.id ?? null,
+    id: assignment.queue_id ?? queueEntryId ?? assignment.id ?? null,
+    queue_entry_id: queueEntryId,
     visit_id: assignment.visit_id ?? (visitId !== null && visitId !== undefined && visitId !== '' ? Number(visitId) : null),
     queue_number: queueNumber,
     number: queueNumber

--- a/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
@@ -85,8 +85,11 @@ describe('RegistrarPanel command contract', () => {
 
     expect(source).toContain('const buildPostWizardPaymentRow = (wizardResult) => {');
     expect(source).toContain('const normalizeWizardQueueAssignment = (assignment, visitId = null) => {');
+    expect(source).toContain('const resolveWizardQueueEntryId = (assignment) => {');
+    expect(source).toContain('if (hasQueueIdentityValue(assignment.queue_id)) return null;');
     expect(source).toContain('if (Array.isArray(queueNumbers))');
-    expect(source).toContain('queue_entry_id: assignment.queue_entry_id ?? assignment.queue_id ?? assignment.id ?? null');
+    expect(source).toContain('queue_entry_id: queueEntryId');
+    expect(source).not.toContain('queue_entry_id: assignment.queue_entry_id ?? assignment.queue_id ?? assignment.id ?? null');
     expect(source).toContain('number: queueNumber');
     expect(source).toContain('grouped_record_refs: visitIds.map');
     expect(source).toContain('queue_number: firstQueueNumber?.queue_number ?? null');


### PR DESCRIPTION
## Summary

- Stop registrar wizard edit flows from treating DailyQueue `queue_id` as cancelable `OnlineQueueEntry.id`.
- Preserve only explicit queue-entry identity (`original_queue_id`, `queue_entry_id`, `doctor_queue_entry_id`) for wizard update/cancel paths.
- Update targeted wizard and registrar panel contract tests.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/contract-scan-next-8` created from current `origin/main` after PR #1547 merged.
- Clean workspace: isolated worktree `C:\tmp\final-contract-scan-next-8`; primary checkout was not used for edits.
- Branch: `codex/contract-scan-next-8`.
- Scope gate: allowed registrar wizard/panel queue-entry identity helpers and targeted contract tests; denied backend endpoints, `/api/v1/ui/*`, BFF-lite, migrations, generated output, and broad UI rewrites.
- Red-check handling: any failing PR checks will be fixed in this PR before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/online-queue/entries/{entry_id}/cancel` and `/queue/online-entry/{entry_id}/full-update` expect `OnlineQueueEntry.id`.
- Request shape: unchanged endpoint paths and payloads.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: registrar `AppointmentWizardV2` edit/update/cancel flow and `RegistrarPanel` wizard queue assignment normalization.
- Compatibility path or alias: legacy `id` fallback remains only when no separate `queue_id` field is present; if `queue_id` exists, `id` is not promoted to queue-entry identity.
- Contract proof: wizard and registrar contract tests assert `queue_id` blocks unsafe fallback and explicit queue-entry fields are required for write identities.

## RBAC / Permissions

not applicable - no backend role policy, auth dependency, permission check, or endpoint access behavior changed.

## Notification / Realtime

not applicable - no websocket, notification, chat, polling, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: missing queue-entry identity now resolves to `null` instead of inventing a write id.
- Partial data proof: rows with `queue_id` but no `queue_entry_id` keep display queue data but do not become cancel/update targets.
- Forbidden secondary path behavior: not applicable, no secondary request path was added.
- Missing draft/resource behavior: edit-mode removed services without safe queue-entry identity are not canceled via an unsafe id.
- Stale route/deep-link behavior: not applicable, no route state or deep-link behavior changed.

## Scope Gate

- Allowed paths: `frontend/src/components/wizard/AppointmentWizardV2.jsx`, `frontend/src/pages/RegistrarPanel.jsx`, and their targeted contract tests.
- Denied paths: backend endpoints/services, `/api/v1/ui/*`, BFF-lite, migrations, generated artifacts, unrelated doctor/admin panels.
- Migration/docs/test impact: no migration or docs change; targeted frontend contract tests updated.
- Rollback note: revert this commit to restore previous fallback behavior.

## Validation

- Targeted tests or smoke run: `C:\final\frontend\node_modules\.bin\vitest.cmd run src/components/wizard/__tests__/AppointmentWizardV2.contract.test.jsx --config C:\tmp\vitest-no-setup.config.mjs --root C:\tmp\final-contract-scan-next-8\frontend`; `C:\final\frontend\node_modules\.bin\vitest.cmd run src/pages/__tests__/RegistrarPanel.contract.test.jsx --config C:\tmp\vitest-no-setup.config.mjs --root C:\tmp\final-contract-scan-next-8\frontend`; `C:\final\frontend\node_modules\.bin\vitest.cmd run src/utils/__tests__/serviceCodeResolver.test.js --config C:\tmp\vitest-no-setup.config.mjs --root C:\tmp\final-contract-scan-next-8\frontend`; `git diff --check`.
- Result: passed locally.
- Not checked: full browser registrar edit-mode smoke was not run; backend tests skipped because this PR does not change backend code.