### PR TITLE
refactor(admin): route reports directly

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -75,6 +75,7 @@ const CloudPrintingManager = lazy(() => import('./components/admin/CloudPrinting
 const MedicalEquipmentManager = lazy(() => import('./components/admin/MedicalEquipmentManager.jsx'));
 const WebhookManager = lazy(() => import('./components/admin/WebhookManager.jsx'));
 const GraphQLExplorer = lazy(() => import('./components/admin/GraphQLExplorer.jsx'));
+const UnifiedReports = lazy(() => import('./components/admin/UnifiedReports.jsx'));
 const EmailSMSManager = lazy(() => import('./components/notifications/EmailSMSManager.jsx'));
 const TwoFactorManager = lazy(() => import('./components/security/TwoFactorManager.jsx'));
 const FileManager = lazy(() => import('./components/files/FileManager.jsx'));
@@ -137,6 +138,7 @@ const ROUTE_COMPONENTS = {
   MedicalEquipmentManager,
   WebhookManager,
   GraphQLExplorer,
+  UnifiedReports,
   UnauthorizedPage,
   ForbiddenPage,
   NotFoundPage,

--- a/frontend/src/routing/__tests__/routeContract.test.js
+++ b/frontend/src/routing/__tests__/routeContract.test.js
@@ -55,7 +55,7 @@ const ADMIN_CONTEXTUAL_SETTINGS_DIRECT_ROUTE_IDS = [
 const ADMIN_NAV_GROUPING_ROUTE_CONTRACT = {
   'admin-dashboard': { path: '/admin', owner: 'admin.operations', component: 'AdminPanel', entry: 'menu', section: 'Обзор' },
   'admin-analytics': { path: '/admin/analytics', owner: 'admin.analytics', component: 'AnalyticsPage', entry: 'menu', section: 'Обзор' },
-  'admin-reports': { path: '/admin/reports', owner: 'admin.reports', component: 'AdminPanel', entry: 'direct', section: 'Обзор' },
+  'admin-reports': { path: '/admin/reports', owner: 'admin.reports', component: 'UnifiedReports', entry: 'direct', section: 'Обзор' },
   'admin-system': { path: '/admin/system', owner: 'admin.system', component: 'SystemManagement', entry: 'direct', section: 'Операции' },
   'admin-cloud-printing': { path: '/admin/cloud-printing', owner: 'admin.operations', component: 'CloudPrintingManager', entry: 'direct', section: 'Операции' },
   'admin-medical-equipment': { path: '/admin/medical-equipment', owner: 'admin.operations', component: 'MedicalEquipmentManager', entry: 'direct', section: 'Операции' },

--- a/frontend/src/routing/routeRegistry.js
+++ b/frontend/src/routing/routeRegistry.js
@@ -452,7 +452,7 @@ export const ROUTE_REGISTRY = [
     nav: nav({ label: 'Отчеты', icon: 'file-text', section: 'Обзор', order: 40, sidebar: true }),
     title: 'Admin Reports',
     owner: 'admin.reports',
-    component: 'AdminPanel',
+    component: 'UnifiedReports',
     legacyRedirectFrom: [],
     layout: layout({ sidebarPreset: 'admin', activeSidebarItem: 'admin-reports', pageTitle: 'Admin Reports' }),
   },


### PR DESCRIPTION
﻿## Summary

- Routes `/admin/reports` directly to the existing `UnifiedReports` component instead of the broad `AdminPanel` switch.
- Registers `UnifiedReports` as a lazy route component in the app route component map.
- Updates the existing admin route contract test so the reports direct owner is guarded while path, role, owner, sidebar grouping, and page title stay unchanged.
- Leaves the old `AdminPanel` switch case untouched as a compatibility path for later cleanup.

## Cyclic Execution Evidence

- Fresh main sync: `main` was synced with `origin/main` after PR #1548 merge before this branch was created.
- Clean workspace: clean before branch creation; final diff is limited to `frontend/src/App.jsx`, `frontend/src/routing/routeRegistry.js`, and `frontend/src/routing/__tests__/routeContract.test.js`.
- Branch: `refactor/admin-reports-direct-route`.
- Scope gate: `agent_gate` was run with known root cause `frontend/src/App.jsx` and returned narrow override. The patch stayed inside route component map, route registry, and the existing route-contract test.
- Red-check handling: if GitHub Actions fail, fixes will be pushed to this same PR before merge.

## Contract Impact

not applicable - no API, websocket, event, backend, request, response, or route path contract changed; only frontend route component owner changed for one existing Admin route.

## RBAC / Permissions

not applicable - route auth, allowed roles, guards, sidebar entry, active sidebar item, and page title are unchanged.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime, or delivery behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - existing reports component is unchanged.
- Partial data proof: not applicable - existing data loading paths are unchanged.
- Forbidden secondary path behavior: route auth/roles are unchanged.
- Missing draft/resource behavior: not applicable - no draft, appointment, resource, or saved-form state is read or written by this route owner change.
- Stale route/deep-link behavior: `npm run test:run -- src/routing/__tests__/routeContract.test.js` passed and guards `/admin/reports` with the new direct component owner.

## Scope Gate

- Allowed paths: `frontend/src/App.jsx`, `frontend/src/routing/routeRegistry.js`, `frontend/src/routing/__tests__/routeContract.test.js`.
- Denied paths: backend runtime, DB/migrations, RBAC/auth logic, admin component internals, deploy/secrets, generated artifacts.
- Migration/docs/test impact: no migration; no docs update; route-contract test updated to preserve the route-owner contract.
- Rollback note: revert the registry component back to `AdminPanel` and remove the `UnifiedReports` route component map entry.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm run test:run -- src/routing/__tests__/routeContract.test.js` -> 33 passed; `npm run lint:check -- --quiet --rule "no-warning-comments: off"` -> passed; `npm run build` -> passed; `git diff --check` -> passed.
- Result: local validation passed.
- Not checked: browser QA was not run for this route-owner-only slice; GitHub Actions pending on PR.
