### PR TITLE
fix(registrar): keep aggregated queue entry ids explicit

### DIFF
--- a/frontend/src/utils/__tests__/registrarAggregation.test.js
+++ b/frontend/src/utils/__tests__/registrarAggregation.test.js
@@ -22,6 +22,8 @@ const makeAppointment = (overrides = {}) => ({
   visit_id: pickOverride(overrides, 'visit_id', overrides.id ?? 1),
   appointment_id: pickOverride(overrides, 'appointment_id', overrides.id ?? 1),
   queue_entry_id: overrides.queue_entry_id ?? null,
+  queue_id: overrides.queue_id ?? null,
+  canonical_record_id: overrides.canonical_record_id,
   visit_type: overrides.visit_type ?? null,
   payment_type: overrides.payment_type ?? null,
   payment_status: overrides.payment_status ?? 'pending',
@@ -206,6 +208,61 @@ describe('aggregatePatientsForAllDepartments', () => {
     expect(result[0].grouped_record_refs).toEqual([
       { record_kind: 'online_queue', record_id: 900001 },
     ]);
+  });
+
+  it('promotes only explicit queue entry identity from queue_numbers', () => {
+    const result = aggregatePatientsForAllDepartments([
+      makeAppointment({
+        id: 31,
+        record_kind: 'online_queue',
+        record_type: 'online_queue',
+        canonical_record_id: null,
+        visit_id: null,
+        appointment_id: null,
+        queue_entry_id: null,
+        queue_numbers: [
+          {
+            id: 31,
+            queue_id: 31,
+            queue_entry_id: 9001,
+            number: 4,
+          },
+        ],
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].queue_entry_id).toBe(9001);
+    expect(result[0].queue_entry_ids).toEqual([9001]);
+    expect(result[0].grouped_record_refs).toEqual([
+      { record_kind: 'online_queue', record_id: 9001 },
+    ]);
+  });
+
+  it('does not promote DailyQueue ids into online queue record refs', () => {
+    const result = aggregatePatientsForAllDepartments([
+      makeAppointment({
+        id: 31,
+        record_kind: 'online_queue',
+        record_type: 'online_queue',
+        canonical_record_id: null,
+        visit_id: null,
+        appointment_id: null,
+        queue_entry_id: null,
+        queue_numbers: [
+          {
+            id: 31,
+            queue_id: 31,
+            number: 4,
+          },
+        ],
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].queue_entry_id).toBeNull();
+    expect(result[0].queue_entry_ids).toEqual([]);
+    expect(result[0].grouped_record_refs).toEqual([]);
   });
 
   it('preserves the earliest queue_time when grouping all departments', () => {

--- a/frontend/src/utils/registrarAggregation.js
+++ b/frontend/src/utils/registrarAggregation.js
@@ -40,13 +40,59 @@ const pickCanonicalVisitId = (appointment) => appointment?.visit_id ?? appointme
 
 const pickCanonicalAppointmentId = (appointment) => appointment?.appointment_id ?? null;
 
+const hasQueueIdentityValue = (value) => value !== null && value !== undefined && value !== '';
+
+const pickQueueNumberEntryId = (queueNumber) => {
+  if (!queueNumber || typeof queueNumber !== 'object') return null;
+
+  const explicitQueueEntryId = queueNumber.original_queue_id ??
+    queueNumber.queue_entry_id ??
+    queueNumber.doctor_queue_entry_id ??
+    null;
+  if (hasQueueIdentityValue(explicitQueueEntryId)) {
+    return explicitQueueEntryId;
+  }
+
+  if (hasQueueIdentityValue(queueNumber.queue_id)) {
+    return null;
+  }
+
+  return hasQueueIdentityValue(queueNumber.id) ? queueNumber.id : null;
+};
+
+const pickCanonicalQueueEntryId = (appointment) => {
+  const explicitQueueEntryId = appointment?.queue_entry_id ??
+    appointment?.original_queue_id ??
+    appointment?.doctor_queue_entry_id ??
+    null;
+  if (hasQueueIdentityValue(explicitQueueEntryId)) {
+    return explicitQueueEntryId;
+  }
+
+  return pickQueueNumberEntryId(appointment?.queue_numbers?.[0]);
+};
+
+const pickOnlineQueueRecordId = (appointment) => {
+  const queueEntryId = pickCanonicalQueueEntryId(appointment);
+  if (hasQueueIdentityValue(queueEntryId)) {
+    return queueEntryId;
+  }
+  if (
+    hasQueueIdentityValue(appointment?.queue_id) ||
+    hasQueueIdentityValue(appointment?.queue_numbers?.[0]?.queue_id)
+  ) {
+    return null;
+  }
+  return appointment?.id;
+};
+
 const buildRecordRef = (appointment) => {
   const recordKind = normalizeRecordKind(appointment);
   const recordId = appointment?.canonical_record_id
     ?? (recordKind === 'visit' ? appointment?.visit_id : null)
-    ?? (recordKind === 'online_queue' ? appointment?.queue_entry_id : null)
+    ?? (recordKind === 'online_queue' ? pickOnlineQueueRecordId(appointment) : null)
     ?? (recordKind === 'appointment' ? appointment?.appointment_id : null)
-    ?? appointment?.id;
+    ?? (recordKind === 'online_queue' ? null : appointment?.id);
 
   if (!['visit', 'online_queue', 'appointment'].includes(recordKind)) return null;
   const numericId = Number(recordId);
@@ -134,7 +180,7 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
     if (!patientGroups[patientKey]) {
       const initialVisitId = pickCanonicalVisitId(appointment);
       const initialAppointmentId = pickCanonicalAppointmentId(appointment);
-      const initialQueueEntryId = appointment.queue_entry_id || appointment.queue_numbers?.[0]?.id || null;
+      const initialQueueEntryId = pickCanonicalQueueEntryId(appointment);
 
       patientGroups[patientKey] = {
         id: appointment.id,
@@ -193,7 +239,7 @@ export const aggregatePatientsForAllDepartments = (appointments = []) => {
 
       const nextVisitId = pickCanonicalVisitId(appointment);
       const nextAppointmentId = pickCanonicalAppointmentId(appointment);
-      const nextQueueEntryId = appointment.queue_entry_id || appointment.queue_numbers?.[0]?.id || null;
+      const nextQueueEntryId = pickCanonicalQueueEntryId(appointment);
 
       if (nextVisitId !== null && nextVisitId !== undefined) {
         patientGroups[patientKey].visit_ids.push(nextVisitId);


### PR DESCRIPTION
## Summary

- Fix registrar all-departments aggregation so queue-entry identity stays explicit.
- Prevent `queue_numbers[].id` / DailyQueue `queue_id` from becoming top-level `queue_entry_id` or online queue command refs.
- Add regression coverage for explicit `queue_entry_id` promotion and unsafe DailyQueue fallback rejection.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/contract-scan-next-9` created from current `origin/main` after PR #1549 merged.
- Clean workspace: isolated worktree `C:\tmp\final-contract-scan-next-9`; primary checkout was not used for edits.
- Branch: `codex/contract-scan-next-9`.
- Scope gate: allowed registrar aggregation utility and its targeted unit test; denied backend endpoints, `/api/v1/ui/*`, BFF-lite, migrations, generated output, and broad frontend rewrites.
- Red-check handling: any failing PR checks will be fixed in this PR before merge.

## Contract Impact

- Canonical surface: registrar record command refs for `online_queue` must carry `OnlineQueueEntry.id`, not DailyQueue id.
- Request shape: unchanged; no endpoint or payload shape change.
- Response shape: unchanged; aggregation now leaves unsafe queue-entry identity as `null` instead of fabricating it.
- Status codes: unchanged.
- Frontend consumer: all-departments registrar grouped rows and edit/action handoff data.
- Compatibility path or alias: legacy `id` fallback remains only when no separate `queue_id` namespace is present; explicit `queue_entry_id` / `original_queue_id` wins.
- Contract proof: unit tests cover queue_numbers with both DailyQueue id and explicit OnlineQueueEntry id, plus DailyQueue-only rows that must not produce command refs.

## RBAC / Permissions

not applicable - no backend role policy, auth dependency, permission check, or endpoint access behavior changed.

## Notification / Realtime

not applicable - no websocket, notification, chat, polling, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: missing queue-entry identity remains `null` and does not create a command ref.
- Partial data proof: queue number rows with `queue_id` but no `queue_entry_id` retain display data without becoming write targets.
- Forbidden secondary path behavior: not applicable, no secondary request path was added.
- Missing draft/resource behavior: aggregate edit rows without safe queue-entry identity cannot seed unsafe wizard cancel/update ids.
- Stale route/deep-link behavior: not applicable, no route state or deep-link behavior changed.

## Scope Gate

- Allowed paths: `frontend/src/utils/registrarAggregation.js`, `frontend/src/utils/__tests__/registrarAggregation.test.js`.
- Denied paths: backend endpoints/services, `/api/v1/ui/*`, BFF-lite, migrations, generated artifacts, unrelated panels.
- Migration/docs/test impact: no migration or docs change; targeted frontend unit tests updated.
- Rollback note: revert this commit to restore previous aggregation fallback behavior.

## Validation

- Targeted tests or smoke run: `C:\final\frontend\node_modules\.bin\vitest.cmd run src/utils/__tests__/registrarAggregation.test.js --config C:\tmp\vitest-no-setup.config.mjs --root C:\tmp\final-contract-scan-next-9\frontend`; `C:\final\frontend\node_modules\.bin\vitest.cmd run src/pages/__tests__/RegistrarPanel.contract.test.jsx --config C:\tmp\vitest-no-setup.config.mjs --root C:\tmp\final-contract-scan-next-9\frontend`; `C:\final\frontend\node_modules\.bin\vitest.cmd run src/components/wizard/__tests__/AppointmentWizardV2.contract.test.jsx --config C:\tmp\vitest-no-setup.config.mjs --root C:\tmp\final-contract-scan-next-9\frontend`; `git diff --check`.
- Result: passed locally.
- Not checked: full browser all-departments edit-mode smoke was not run; backend tests skipped because this PR does not change backend code.