### PR TITLE
refactor(admin): route users directly

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -81,6 +81,7 @@ const TwoFactorManager = lazy(() => import('./components/security/TwoFactorManag
 const FileManager = lazy(() => import('./components/files/FileManager.jsx'));
 const AdvancedUserManagement = lazy(() => import('./components/admin/AdvancedUserManagement.jsx'));
 const UserManagement = lazy(() => import('./components/admin/UserManagement.jsx'));
+const UnifiedUserManagement = lazy(() => import('./components/admin/UnifiedUserManagement.jsx'));
 const IntegrationDemo = lazy(() => import('./components/integration/IntegrationDemo.jsx'));
 
 const ROUTE_COMPONENTS = {
@@ -101,6 +102,7 @@ const ROUTE_COMPONENTS = {
   EmailSMSManager,
   AdvancedUserManagement,
   UserManagement,
+  UnifiedUserManagement,
   FileManager,
   UserSelect,
   RegistrarPanel,

--- a/frontend/src/routing/__tests__/routeContract.test.js
+++ b/frontend/src/routing/__tests__/routeContract.test.js
@@ -301,7 +301,7 @@ describe('route contract invariants', () => {
     expect(canonicalUsersRoute.path).toBe('/admin/users');
     expect(canonicalUsersRoute.owner).toBe('admin.users');
     expect(canonicalUsersRoute.entry).toBe('menu');
-    expect(canonicalUsersRoute.component).toBe('AdminPanel');
+    expect(canonicalUsersRoute.component).toBe('UnifiedUserManagement');
     expect(canonicalUsersRoute.layout.activeSidebarItem).toBe('admin-users');
     expect(isRouteAccessibleToProfile(canonicalUsersRoute, adminProfile)).toBe(true);
 

--- a/frontend/src/routing/routeRegistry.js
+++ b/frontend/src/routing/routeRegistry.js
@@ -537,7 +537,7 @@ export const ROUTE_REGISTRY = [
     nav: nav({ label: 'Пользователи', icon: 'users', section: 'Управление', order: 10, sidebar: true }),
     title: 'Admin Users',
     owner: 'admin.users',
-    component: 'AdminPanel',
+    component: 'UnifiedUserManagement',
     legacyRedirectFrom: [],
     layout: layout({ sidebarPreset: 'admin', activeSidebarItem: 'admin-users', pageTitle: 'Admin Users' }),
   },


### PR DESCRIPTION
﻿## Summary

- Routes canonical `/admin/users` directly to the existing `UnifiedUserManagement` component instead of the broad `AdminPanel` switch.
- Registers `UnifiedUserManagement` as a lazy route component in the app route component map.
- Updates the existing user route contract so canonical users and advanced users remain split between `UnifiedUserManagement` and `AdvancedUserManagement`.
- Leaves old `AdminPanel` switch cases untouched as compatibility paths for later cleanup.

## Cyclic Execution Evidence

- Fresh main sync: `main` was synced with `origin/main` after PR #1550 merge before this branch was created.
- Clean workspace: clean before branch creation; final diff is limited to `frontend/src/App.jsx`, `frontend/src/routing/routeRegistry.js`, and `frontend/src/routing/__tests__/routeContract.test.js`.
- Branch: `refactor/admin-users-direct-route`.
- Scope gate: `agent_gate` was run with known root cause `frontend/src/App.jsx` and returned narrow override. The patch stayed inside route component map, route registry, and the existing route-contract test.
- Red-check handling: if GitHub Actions fail, fixes will be pushed to this same PR before merge.

## Contract Impact

not applicable - no API, websocket, event, backend, request, response, or route path contract changed; only frontend route component owner changed for one existing Admin route.

## RBAC / Permissions

not applicable - route auth, allowed roles, guards, sidebar entry, active sidebar item, and page title are unchanged.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime, or delivery behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - existing user-management component is unchanged.
- Partial data proof: not applicable - existing data loading paths are unchanged.
- Forbidden secondary path behavior: route auth/roles are unchanged.
- Missing draft/resource behavior: not applicable - no draft, appointment, resource, or saved-form state is read or written by this route owner change.
- Stale route/deep-link behavior: `npm run test:run -- src/routing/__tests__/routeContract.test.js` passed and guards `/admin/users` plus the separate `/admin/advanced-users` ownership.

## Scope Gate

- Allowed paths: `frontend/src/App.jsx`, `frontend/src/routing/routeRegistry.js`, `frontend/src/routing/__tests__/routeContract.test.js`.
- Denied paths: backend runtime, DB/migrations, RBAC/auth logic, admin component internals, deploy/secrets, generated artifacts.
- Migration/docs/test impact: no migration; no docs update; route-contract test updated to preserve users vs advanced-users ownership.
- Rollback note: revert the registry component back to `AdminPanel` and remove the `UnifiedUserManagement` route component map entry.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm run test:run -- src/routing/__tests__/routeContract.test.js` -> 33 passed; `npm run lint:check -- --quiet --rule "no-warning-comments: off"` -> passed; `npm run build` -> passed; `git diff --check` -> passed.
- Result: local validation passed.
- Not checked: browser QA was not run for this route-owner-only slice; GitHub Actions pending on PR.
