### PR TITLE
refactor(admin): route all free directly

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -82,6 +82,7 @@ const FileManager = lazy(() => import('./components/files/FileManager.jsx'));
 const AdvancedUserManagement = lazy(() => import('./components/admin/AdvancedUserManagement.jsx'));
 const UserManagement = lazy(() => import('./components/admin/UserManagement.jsx'));
 const UnifiedUserManagement = lazy(() => import('./components/admin/UnifiedUserManagement.jsx'));
+const AllFreeApproval = lazy(() => import('./components/admin/AllFreeApproval.jsx'));
 const IntegrationDemo = lazy(() => import('./components/integration/IntegrationDemo.jsx'));
 
 const ROUTE_COMPONENTS = {
@@ -103,6 +104,7 @@ const ROUTE_COMPONENTS = {
   AdvancedUserManagement,
   UserManagement,
   UnifiedUserManagement,
+  AllFreeApproval,
   FileManager,
   UserSelect,
   RegistrarPanel,

--- a/frontend/src/routing/__tests__/routeContract.test.js
+++ b/frontend/src/routing/__tests__/routeContract.test.js
@@ -81,6 +81,10 @@ const ADMIN_MANAGEMENT_ROUTE_CHROME_HEADING_CONTRACT = {
   'admin-all-free': { path: '/admin/all-free', pageTitle: 'Admin All Free' },
 };
 
+const ADMIN_STANDALONE_MANAGEMENT_COMPONENT_CONTRACT = {
+  'admin-all-free': { path: '/admin/all-free', owner: 'admin.operations', component: 'AllFreeApproval', entry: 'direct' },
+};
+
 const ADMIN_CONTEXTUAL_ROUTE_CHROME_HEADING_CONTRACT = {
   'admin-benefit-settings': { path: '/admin/benefit-settings', pageTitle: 'Admin Benefit Settings' },
   'admin-wizard-settings': { path: '/admin/wizard-settings', pageTitle: 'Admin Wizard Settings' },
@@ -286,6 +290,23 @@ describe('route contract invariants', () => {
 
   it('keeps management routes on route-specific chrome headings', () => {
     assertRouteSpecificChromeHeadings(ADMIN_MANAGEMENT_ROUTE_CHROME_HEADING_CONTRACT);
+  });
+
+  it('keeps standalone admin management routes on direct component owners', () => {
+    const adminProfile = { role: 'Admin' };
+
+    Object.entries(ADMIN_STANDALONE_MANAGEMENT_COMPONENT_CONTRACT).forEach(([routeId, expected]) => {
+      const route = getRouteById(routeId);
+
+      expect(route).toBeTruthy();
+      expect(route.path).toBe(expected.path);
+      expect(route.owner).toBe(expected.owner);
+      expect(route.component).toBe(expected.component);
+      expect(route.component).not.toBe('AdminPanel');
+      expect(route.entry).toBe(expected.entry);
+      expect(route.layout.activeSidebarItem).toBe(routeId);
+      expect(isRouteAccessibleToProfile(route, adminProfile)).toBe(true);
+    });
   });
 
   it('keeps contextual admin routes on route-specific chrome headings', () => {

--- a/frontend/src/routing/routeRegistry.js
+++ b/frontend/src/routing/routeRegistry.js
@@ -639,7 +639,7 @@ export const ROUTE_REGISTRY = [
     nav: nav({ label: 'Заявки All Free', icon: 'exclamationmark.triangle', section: 'Управление', order: 70, sidebar: true }),
     title: 'Admin All Free',
     owner: 'admin.operations',
-    component: 'AdminPanel',
+    component: 'AllFreeApproval',
     legacyRedirectFrom: [],
     layout: layout({ sidebarPreset: 'admin', activeSidebarItem: 'admin-all-free', pageTitle: 'Admin All Free' }),
   },


### PR DESCRIPTION
﻿## Summary

- Routes `/admin/all-free` directly to the existing `AllFreeApproval` component instead of the broad `AdminPanel` switch.
- Registers `AllFreeApproval` as a lazy route component in the app route component map.
- Adds a route-contract guard for standalone admin management routes so `admin-all-free` cannot silently drift back to `AdminPanel`.
- Leaves the old `AdminPanel` switch case untouched as a compatibility path for later cleanup.

## Cyclic Execution Evidence

- Fresh main sync: `main` was synced with `origin/main` after PR #1552 merge before this branch was created.
- Clean workspace: clean before branch creation; final diff is limited to `frontend/src/App.jsx`, `frontend/src/routing/routeRegistry.js`, and `frontend/src/routing/__tests__/routeContract.test.js`.
- Branch: `refactor/admin-all-free-direct-route`.
- Scope gate: `agent_gate` was run with known root cause `frontend/src/App.jsx` and returned narrow override. The patch stayed inside route component map, route registry, and the existing route-contract test.
- Red-check handling: if GitHub Actions fail, fixes will be pushed to this same PR before merge.

## Contract Impact

not applicable - no API, websocket, event, backend, request, response, or route path contract changed; only frontend route component owner changed for one existing Admin route.

## RBAC / Permissions

not applicable - route auth, allowed roles, guards, sidebar entry, active sidebar item, and page title are unchanged.

## Notification / Realtime

not applicable - no notification, websocket, chat, realtime, or delivery behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - existing all-free component is unchanged.
- Partial data proof: not applicable - existing data loading paths are unchanged.
- Forbidden secondary path behavior: route auth/roles are unchanged.
- Missing draft/resource behavior: not applicable - no draft, appointment, resource, or saved-form state is read or written by this route owner change.
- Stale route/deep-link behavior: `npm run test:run -- src/routing/__tests__/routeContract.test.js` passed and guards `/admin/all-free` on the direct component owner.

## Scope Gate

- Allowed paths: `frontend/src/App.jsx`, `frontend/src/routing/routeRegistry.js`, `frontend/src/routing/__tests__/routeContract.test.js`.
- Denied paths: backend runtime, DB/migrations, RBAC/auth logic, admin component internals, deploy/secrets, generated artifacts.
- Migration/docs/test impact: no migration; no docs update; route-contract test updated to preserve standalone management component ownership.
- Rollback note: revert the registry component back to `AdminPanel`, remove the `AllFreeApproval` route component map entry, and remove the specific standalone component expectation.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm run test:run -- src/routing/__tests__/routeContract.test.js` -> 34 passed; `npm run lint:check -- --quiet --rule "no-warning-comments: off"` -> passed; `npm run build` -> passed; `git diff --check` -> passed.
- Result: local validation passed.
- Not checked: browser QA was not run for this route-owner-only slice; GitHub Actions pending on PR.
