### PR TITLE
fix(doctor): require explicit queue entry ids

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -2730,6 +2730,7 @@ def get_today_queues(
                         # entry_data это OnlineQueueEntry (обычный случай)
                         online_entry = entry_data
                         record_id = online_entry.id
+                        entry_wrapper["queue_entry_id"] = online_entry.id
                         patient_id = online_entry.patient_id
                         patient_name = online_entry.patient_name or "Неизвестный пациент"
                         phone = online_entry.phone or "Не указан"

--- a/backend/tests/integration/test_registrar_all_appointments.py
+++ b/backend/tests/integration/test_registrar_all_appointments.py
@@ -186,6 +186,7 @@ class TestRegistrarAllAppointments:
         assert found_entry["id"] == entry.id
         assert found_entry["canonical_record_id"] == entry.id
         assert found_entry["record_kind"] == "online_queue"
+        assert found_entry["queue_entry_id"] == entry.id
         assert found_entry["appointment_id"] is None
         assert found_entry["source_kind"] == "desk"
         assert found_entry["canonical_status"] == "waiting"

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -73,8 +73,7 @@ function resolveDoctorQueueEntryId(row) {
     return explicitQueueEntryId;
   }
 
-  const recordKind = String(row?.record_kind ?? row?.record_type ?? row?.type ?? '').trim().toLowerCase();
-  return recordKind === 'online_queue' && row?.id !== null && row?.id !== undefined ? row.id : null;
+  return null;
 }
 
 /**

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -113,8 +113,7 @@ function resolveDoctorQueueEntryId(row) {
     return explicitQueueEntryId;
   }
 
-  const recordKind = String(row?.record_kind ?? row?.record_type ?? row?.type ?? '').trim().toLowerCase();
-  return recordKind === 'online_queue' && row?.id !== null && row?.id !== undefined ? row.id : null;
+  return null;
 }
 
 function buildPatientsFromAppointments(appointments) {

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -85,8 +85,7 @@ function resolveDoctorQueueEntryId(row) {
     return explicitQueueEntryId;
   }
 
-  const recordKind = String(row?.record_kind ?? row?.record_type ?? row?.type ?? '').trim().toLowerCase();
-  return recordKind === 'online_queue' && row?.id !== null && row?.id !== undefined ? row.id : null;
+  return null;
 }
 
 function getRecentDermatologyCache(cacheEntry, fallbackValue) {

--- a/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
@@ -86,8 +86,9 @@ describe('Doctor panels SSOT contract', () => {
       const source = read(filePath);
 
       expect(source).toContain('function resolveDoctorQueueEntryId(row)');
-      expect(source).toContain("recordKind === 'online_queue'");
+      expect(source).toContain('const explicitQueueEntryId = row?.doctor_queue_entry_id ?? row?.queue_entry_id ?? null;');
       expect(source).toContain('/doctor/queue/${queueEntryId}/start-visit');
+      expect(source).not.toContain("recordKind === 'online_queue' && row?.id");
       expect(source).not.toContain('/doctor/queue/${row.id}/start-visit');
       expect(source).not.toContain('completeVisit(selectedPatient.id');
       expect(source).not.toContain('const entryId = selectedPatient?.id || currentAppointment?.id');


### PR DESCRIPTION
## Summary

- Make `/registrar/queues/today` expose explicit `queue_entry_id` for normal `OnlineQueueEntry` rows.
- Stop doctor panels from falling back from `online_queue` row `id` to `/doctor/queue/{entry_id}` command ids.
- Add contract coverage on both backend queue DTO and doctor-panel command identity.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/contract-scan-next-10` created from current `origin/main` after PR #1551 merged.
- Clean workspace: isolated worktree `C:\tmp\final-contract-scan-next-10`; primary checkout was not used for edits.
- Branch: `codex/contract-scan-next-10`.
- Scope gate: gate split backend/frontend first-touch incorrectly for one contract seam; used narrow override limited to runtime registrar DTO, doctor panels, and targeted tests.
- Red-check handling: any failing PR checks will be fixed in this PR before merge.

## Contract Impact

- Canonical surface: doctor queue commands require `OnlineQueueEntry.id` in `/doctor/queue/{entry_id}/...`.
- Request shape: unchanged endpoint paths and payloads.
- Response shape: `/registrar/queues/today` now sets `queue_entry_id` for normal `OnlineQueueEntry` rows; QR visit rows without an OQE remain `queue_entry_id: null`.
- Status codes: unchanged.
- Frontend consumer: Cardiologist/Dermatologist/Dentist panels no longer infer command ids from row `id`.
- Compatibility path or alias: legacy row `id` fallback is removed for doctor queue commands; explicit `doctor_queue_entry_id` / `queue_entry_id` is required.
- Contract proof: backend integration assertion covers `queue_entry_id == OnlineQueueEntry.id`; frontend contract test rejects `recordKind === 'online_queue' && row.id` fallback.

## RBAC / Permissions

not applicable - no backend role policy, auth dependency, permission check, or endpoint access behavior changed.

## Notification / Realtime

not applicable - no websocket, notification, chat, polling, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: rows missing explicit queue-entry identity disable doctor queue command paths instead of guessing.
- Partial data proof: normal OQE rows now receive explicit `queue_entry_id`; QR visit rows without OQE stay non-commandable.
- Forbidden secondary path behavior: not applicable, no secondary request path was added.
- Missing draft/resource behavior: not applicable, no draft/resource flow changed.
- Stale route/deep-link behavior: not applicable, no route state or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/registrar_integration.py`, `backend/tests/integration/test_registrar_all_appointments.py`, doctor panel files, and `DoctorPanels.contract.test.jsx`.
- Denied paths: `/api/v1/ui/*`, BFF-lite, migrations, unrelated panels, generated artifacts.
- Migration/docs/test impact: no migration or docs change; targeted backend/frontend contract tests updated.
- Rollback note: revert this commit to restore previous implicit row-id fallback.

## Validation

- Targeted tests or smoke run: `C:\Users\DrSapaev\AppData\Local\Programs\Python\Python311\python.exe -m py_compile C:\tmp\final-contract-scan-next-10\backend\app\api\v1\endpoints\registrar_integration.py`; `C:\final\frontend\node_modules\.bin\vitest.cmd run src/pages/__tests__/DoctorPanels.contract.test.jsx --config C:\tmp\vitest-no-setup.config.mjs` from `C:\tmp\final-contract-scan-next-10\frontend`; `git diff --check`.
- Result: passed locally.
- Not checked: targeted backend pytest could not start locally because `DATABASE_URL` is not set in this isolated shell; CI backend env will validate the integration suite.