### PR TITLE
refactor(admin): route security settings directly

### DIFF
--- a/frontend/src/components/admin/UnifiedSettings.jsx
+++ b/frontend/src/components/admin/UnifiedSettings.jsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 
 import { api } from '../../api/client';
 import logger from '../../utils/logger';
@@ -24,9 +24,21 @@ const stripPasswordFields = (formData) => {
   return persistedSettings;
 };
 
+const ADMIN_SETTINGS_ROUTE_SECTION_MAP = {
+  '/admin/benefit-settings': 'benefit-settings',
+  '/admin/wizard-settings': 'wizard-settings',
+  '/admin/payment-providers': 'payment-providers',
+  '/admin/clinic-settings': 'clinic-settings',
+  '/admin/queue-settings': 'queue-settings',
+  '/admin/display-settings': 'display-settings',
+  '/admin/security': 'security',
+};
+
 const UnifiedSettings = () => {
+  const location = useLocation();
   const [searchParams] = useSearchParams();
-  const section = searchParams.get('section') || 'general';
+  const routeSection = ADMIN_SETTINGS_ROUTE_SECTION_MAP[location.pathname.replace(/\/$/, '')];
+  const section = routeSection || searchParams.get('section') || 'general';
   const [securitySettings, setSecuritySettings] = useState({});
   const [securityLoading, setSecurityLoading] = useState(false);
 

--- a/frontend/src/routing/routeRegistry.js
+++ b/frontend/src/routing/routeRegistry.js
@@ -911,7 +911,7 @@ export const ROUTE_REGISTRY = [
     nav: nav({ label: 'Безопасность', icon: 'lock', section: 'Система', order: 90, sidebar: true }),
     title: 'Admin Security',
     owner: 'admin.security',
-    component: 'AdminPanel',
+    component: 'UnifiedSettings',
     legacyRedirectFrom: [],
     layout: layout({ sidebarPreset: 'admin', activeSidebarItem: 'admin-security', pageTitle: 'Admin Security' }),
   },


### PR DESCRIPTION
﻿## Summary

- Route `/admin/security` directly to `UnifiedSettings` instead of the broad `AdminPanel` switch.
- Let `UnifiedSettings` derive the intended settings section from canonical `/admin/<section>` paths, with path ownership taking precedence over `?section=` query values.
- Preserve existing query-section behavior for legacy/query-driven settings entry points.

## Cyclic Execution Evidence

- Fresh main sync: `git fetch origin; git switch main; git pull --ff-only origin main` passed before branch creation.
- Clean workspace: `git status --short --branch` was clean on `main`.
- Branch: `refactor/admin-security-direct-settings`.
- Scope gate: routing SSOT strict mode used `ai/langgraph/scripts/run_agent_gate.ps1`; first run missed the component root cause, retry with `frontend/src/components/admin/UnifiedSettings.jsx` produced narrow override for `UnifiedSettings.jsx` + route registry only.
- Red-check handling: will fix any red GitHub Actions check in this PR branch before merge.

## Contract Impact

not applicable - no API, websocket, event payload, backend DTO, or request/response shape changed.

## RBAC / Permissions

- Roles allowed: unchanged; `/admin/security` remains `roles: ['Admin']` in the route registry.
- Roles denied: unchanged through existing route guard behavior.
- Positive auth proof: route contract tests still pass for admin route accessibility.
- Negative auth proof: not checked locally because no route guard or RBAC helper changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable because no data loading semantics changed outside `UnifiedSettings` section selection.
- Partial data proof: not applicable because no API response handling changed.
- Forbidden secondary path behavior: route guard behavior unchanged.
- Missing draft/resource behavior: not applicable because settings routes do not use draft/resource loading in this slice.
- Stale route/deep-link behavior: canonical `/admin/security` and contextual settings paths now resolve their own settings section even without `?section=`.

## Scope Gate

- Allowed paths: `frontend/src/components/admin/UnifiedSettings.jsx`, `frontend/src/routing/routeRegistry.js`.
- Denied paths: backend/runtime code, DB/migrations, RBAC/auth helpers, unrelated AdminPanel render functions, deploy/secrets/generated artifacts.
- Migration/docs/test impact: no migration, no docs, no test files changed.
- Rollback note: revert this commit to route `/admin/security` through `AdminPanel` again and remove path-derived section selection.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm run test:run -- src/routing/__tests__/routeContract.test.js src/pages/__tests__/AdminPanel.routeState.contract.test.jsx`; `npm run lint:check -- --quiet --rule "no-warning-comments: off"`; `npm run build`; `git diff --check`.
- Result: all local validation passed; route/admin contract tests passed 36 tests.
- Not checked: browser admin/security smoke; GitHub Actions pending after PR creation.
