### PR TITLE
fix(qr): filter full-update aggregated ids

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -1410,13 +1410,76 @@ def full_update_online_entry(
                     boundary_label,
                 )
         
-        # Используем computed_aggregated_ids, frontend's aggregated_ids только как fallback
-        final_aggregated_ids = computed_aggregated_ids if computed_aggregated_ids else (request.aggregated_ids or [])
-        if not computed_aggregated_ids and request.aggregated_ids:
+        def _same_fallback_aggregation_scope(
+            candidate: OnlineQueueEntry,
+        ) -> bool:
+            if candidate.id == entry.id:
+                return True
+
+            if entry.visit_id:
+                if candidate.visit_id != entry.visit_id:
+                    return False
+                if entry.patient_id is None:
+                    return False
+                return candidate.patient_id == entry.patient_id
+
+            if candidate.visit_id is not None:
+                return False
+
+            if entry.patient_id is not None:
+                return candidate.patient_id == entry.patient_id
+
+            if entry.phone:
+                same_boundary = (
+                    candidate.session_id == entry.session_id
+                    if entry.session_id
+                    else candidate.queue_id == entry.queue_id
+                )
+                return same_boundary and _queue_phone_matches(candidate.phone, entry.phone)
+
+            return False
+
+        # Используем computed_aggregated_ids; frontend aggregated_ids are only
+        # an advisory fallback and must not cross queue-entry identity scopes.
+        if computed_aggregated_ids:
+            final_aggregated_ids = computed_aggregated_ids
+        elif request.aggregated_ids:
+            requested_aggregated_ids = [
+                int(aggregated_id)
+                for aggregated_id in request.aggregated_ids
+                if aggregated_id is not None
+            ]
+            fallback_entries = (
+                db.query(OnlineQueueEntry)
+                .filter(OnlineQueueEntry.id.in_(requested_aggregated_ids))
+                .all()
+                if requested_aggregated_ids
+                else []
+            )
+            safe_fallback_ids = [
+                candidate.id
+                for candidate in fallback_entries
+                if _same_fallback_aggregation_scope(candidate)
+            ]
+            if entry.id not in safe_fallback_ids:
+                safe_fallback_ids.append(entry.id)
+
+            ignored_fallback_ids = sorted(
+                set(requested_aggregated_ids) - set(safe_fallback_ids)
+            )
+            if ignored_fallback_ids:
+                logger.warning(
+                    "[full_update_online_entry] ignored frontend aggregated_ids outside current entry scope: %s",
+                    ignored_fallback_ids,
+                )
+
+            final_aggregated_ids = safe_fallback_ids
             logger.warning(
                 "[full_update_online_entry] ⚠️ Используем aggregated_ids из frontend (fallback): %s",
-                request.aggregated_ids
+                final_aggregated_ids
             )
+        else:
+            final_aggregated_ids = []
         
         # ⭐ DEBUG: Логируем начальное состояние
         logger.info(

--- a/backend/tests/integration/test_qr_queue_full_update.py
+++ b/backend/tests/integration/test_qr_queue_full_update.py
@@ -455,6 +455,84 @@ def test_full_update_without_visit_id_matches_same_session_phone_digits(
 
 
 @pytest.mark.integration
+def test_full_update_frontend_aggregated_ids_ignore_unrelated_queue_entry(
+    client,
+    db_session,
+    registrar_auth_headers,
+    test_daily_queue,
+    test_service,
+):
+    unrelated_entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=25,
+        patient_id=None,
+        patient_name="Unrelated Queue",
+        phone=None,
+        visit_id=None,
+        session_id=None,
+        source="online",
+        status="waiting",
+        queue_time=datetime(2026, 5, 31, 9, 0, tzinfo=timezone.utc),
+        services=json.dumps(
+            [
+                {
+                    "service_id": test_service.id,
+                    "name": test_service.name,
+                    "code": test_service.code,
+                    "quantity": 1,
+                    "price": int(test_service.price or 0),
+                    "cancelled": False,
+                }
+            ],
+            ensure_ascii=False,
+        ),
+    )
+    current_entry = OnlineQueueEntry(
+        queue_id=test_daily_queue.id,
+        number=26,
+        patient_id=None,
+        patient_name="Current Queue",
+        phone=None,
+        visit_id=None,
+        session_id=None,
+        source="online",
+        status="waiting",
+        queue_time=datetime(2026, 5, 31, 9, 5, tzinfo=timezone.utc),
+        services=json.dumps([], ensure_ascii=False),
+    )
+    db_session.add_all([unrelated_entry, current_entry])
+    db_session.commit()
+    db_session.refresh(unrelated_entry)
+    db_session.refresh(current_entry)
+
+    response = client.put(
+        f"/api/v1/queue/online-entry/{current_entry.id}/full-update",
+        headers=registrar_auth_headers,
+        json={
+            "patient_data": {
+                "patient_name": "Current Queue",
+                "birth_year": 1990,
+                "address": "Queue Street",
+            },
+            "visit_type": "paid",
+            "discount_mode": "none",
+            "services": [{"service_id": test_service.id, "quantity": 1}],
+            "all_free": False,
+            "aggregated_ids": [unrelated_entry.id, current_entry.id],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+
+    db_session.refresh(current_entry)
+    db_session.refresh(unrelated_entry)
+    current_services = json.loads(current_entry.services)
+    unrelated_services = json.loads(unrelated_entry.services)
+    assert [service["service_id"] for service in current_services] == [test_service.id]
+    assert [service["service_id"] for service in unrelated_services] == [test_service.id]
+
+
+@pytest.mark.integration
 def test_full_update_all_free_preserves_paid_visit_payment_state(
     client,
     db_session,


### PR DESCRIPTION
## Summary

- Filter QR full-update fallback `aggregated_ids` to the current `OnlineQueueEntry` identity scope.
- Prevent mixed frontend record ids from making an unrelated queue entry look like an existing service source.
- Add a regression test for collided/unrelated frontend-provided ids.

## Cyclic Execution Evidence

- Fresh main sync: worktree `C:\tmp\final-contract-scan-next-11` created from current `origin/main` at `c973244b`, then PR base advanced to current `main` without conflicting files.
- Clean workspace: inspected before edits; only `backend/app/api/v1/endpoints/qr_queue.py` and `backend/tests/integration/test_qr_queue_full_update.py` changed.
- Branch: `codex/contract-scan-next-11`.
- Scope gate: gate_known_root_cause returned backend-only narrow override for QR full-update; denied frontend, `/api/v1/ui/*`, BFF-lite, migrations, and unrelated queue flows.
- Red-check handling: PR Review Quality Gate body failure is being fixed in this same PR; any further red check will be fixed here before merge.

## Contract Impact

- Canonical surface: `PUT /api/v1/queue/online-entry/{entry_id}/full-update` in `backend/app/api/v1/endpoints/qr_queue.py`.
- Request shape: unchanged; authenticated JSON body still accepts `patient_data`, `visit_type`, `discount_mode`, `services`, `all_free`, and optional `aggregated_ids`.
- Response shape: unchanged; this PR only changes which fallback ids may be read while computing existing services.
- Status codes: unchanged for valid and invalid callers; no new 4xx/5xx path added for ignored advisory ids.
- Frontend consumer: existing registrar wizard/full-update callers remain compatible even if they send broad grouped `aggregated_ids`.
- Compatibility path or alias: frontend-provided `aggregated_ids` remains a compatibility fallback, but is now scoped server-side before use.
- Contract proof: backend integration test proves unrelated frontend aggregated ids do not suppress adding the requested service.

## RBAC / Permissions

- Roles allowed: unchanged existing `Admin`, `Registrar`, `Doctor`, `cardio`, `derma`, and `dentist` roles.
- Roles denied: unchanged existing authentication and role dependency behavior for all other callers.
- Positive auth proof: targeted regression used `registrar_auth_headers` and returned 200.
- Negative auth proof: not applicable - no role or permission policy changed; existing dependency coverage remains the authority.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification event or websocket channel changed.
- Payload version / ack behavior: not applicable - no realtime payload or ack behavior changed.
- Read/unread or delivery semantics: not applicable - no notification delivery state changed.
- Reconnect/resync proof: not applicable - no realtime reconnect or resync behavior changed.

## Frontend Resilience

- Empty data proof: backend always includes the current entry id when fallback ids are supplied, so an empty/unsafe fallback set does not drop current-entry service detection.
- Partial data proof: regression covers entries without patient id, phone, visit id, or session id while still adding the requested service.
- Forbidden secondary path behavior: not applicable - no frontend secondary path or alternate route changed.
- Missing draft/resource behavior: not applicable - no draft/resource creation or reopen flow changed.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: QR full-update backend endpoint and focused QR full-update integration test.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite, migrations, generated output, unrelated queue endpoints.
- Migration/docs/test impact: no migration or docs change; targeted integration test added.
- Rollback note: revert commit `80d9f9f6` to restore previous fallback behavior and remove the regression test.

## Validation

- Targeted tests or smoke run: `py_compile` for changed backend files; targeted QR full-update regression; full `test_qr_queue_full_update.py`; `git diff --check`.
- Result: all local validation passed, including `test_qr_queue_full_update.py` with 7 passed.
- Not checked: full backend suite locally; GitHub CI backend tests are the broad validation for this narrow backend slice.