### PR TITLE
fix(devbrain): allow explicit new frontend paths

### DIFF
--- a/ai/langgraph/scripts/agent_gate.py
+++ b/ai/langgraph/scripts/agent_gate.py
@@ -36,7 +36,7 @@ MODEL_ALIASES = {
 
 EXPLICIT_PATH_RE = re.compile(
     r"(?P<path>(?:[A-Za-z0-9_.-]+[\\/])+[A-Za-z0-9_.-]+\."
-    r"(?:py|js|jsx|ts|tsx|json|md|yml|yaml|toml|sh|ps1|bat|txt))"
+    r"(?:jsx|tsx|js|ts|py|json|yaml|yml|toml|ps1|bat|sh|md|txt))"
 )
 
 MIGRATION_TASK_RE = re.compile(
@@ -242,7 +242,18 @@ def unique_paths(paths: list[str]) -> list[str]:
 
 def explicit_paths(task: str, repo_root: Path, tracked: set[str]) -> list[str]:
     candidates = [match.group("path") for match in EXPLICIT_PATH_RE.finditer(task)]
-    return unique_existing(repo_root, tracked, candidates)
+    seen: set[str] = set()
+    result: list[str] = []
+    for path in candidates:
+        rel = normalize_rel_path(path)
+        if rel in seen:
+            continue
+        # Explicit first-touch paths may name a new file for extraction work.
+        # Allow that only when the parent directory already exists in checkout.
+        if path_exists(repo_root, rel, tracked) or (repo_root / rel).parent.exists():
+            seen.add(rel)
+            result.append(rel)
+    return result
 
 
 def rule_matches(task: str, repo_root: Path, tracked: set[str]) -> tuple[list[str], list[str]]:
@@ -506,7 +517,7 @@ def main(argv: list[str] | None = None) -> int:
     files.extend(matched_files)
     reasons.extend(matched_reasons)
 
-    initial_first_touch = unique_existing(repo_root, tracked, files)
+    initial_first_touch = unique_paths(files)
     known = normalize_rel_path(args.known_root_cause) if args.known_root_cause else None
     gate_misroute = False
     override_used = False
@@ -559,7 +570,7 @@ def main(argv: list[str] | None = None) -> int:
             reasons.append("known-root-cause override")
             initial_first_touch.insert(0, known)
 
-    first_touch = unique_existing(repo_root, tracked, initial_first_touch)
+    first_touch = unique_paths(initial_first_touch)
     if not first_touch:
         print(
             "Result: stop\n"


### PR DESCRIPTION
﻿## Summary

- Teach `agent_gate.py` to keep explicit new first-touch files when the parent directory exists.
- Fix explicit path parsing so `.jsx` / `.tsx` paths are not truncated to `.js` / `.ts`.
- Preserve existing DevBrain acceptance behavior while unblocking route/component extraction prompts.

## Cyclic Execution Evidence

- Fresh main sync: local `main` was synced after PR #1557 merged.
- Clean workspace: branch started from clean `main`.
- Branch: `tooling/agent-gate-explicit-new-files`.
- Scope gate: tooling-only DevBrain fix prompted by repeated gate misroutes on a planned admin route extraction.
- Red-check handling: will fix any red GitHub Actions check in this PR branch before merge.

## Contract Impact

not applicable - tooling-only DevBrain gate behavior; no product API, websocket, frontend route, or runtime consumer contract changed.

## RBAC / Permissions

not applicable - tooling-only DevBrain gate behavior; no route guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - tooling-only DevBrain gate behavior; no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - tooling-only DevBrain gate behavior; no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `ai/langgraph/scripts/agent_gate.py`.
- Denied paths: backend/frontend product runtime, DB/migrations, route registry, deploy/secrets/generated artifacts.
- Migration/docs/test impact: no migration, no docs, no test files changed.
- Rollback note: revert this commit to restore old explicit-path behavior.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `./scripts/devbrain_acceptance.ps1`; AdminServices extraction gate probe; `git diff --check`.
- Result: DevBrain acceptance passed 5/5 with 0 warnings/failures; AdminServices probe now resolves `frontend/src/components/admin/AdminServices.jsx`, `frontend/src/App.jsx`, and `frontend/src/routing/routeRegistry.js`; diff check passed.
- Not checked: product frontend/backend tests because this is a DevBrain tooling-only patch.
