### PR TITLE
fix(telegram): bind staff confirmations to targets

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -1716,6 +1716,44 @@ def _validate_staff_action_target_request(
     return "command_executor_not_supported"
 
 
+def _staff_action_expected_target_binding(
+    command_key: str,
+    request: StaffActionConfirmRequest,
+) -> tuple[str, int] | None:
+    command = command_key.lower()
+    if command == "/call":
+        return None
+    if command == "/skip" and request.entry_id is not None:
+        return ("queue_entry", int(request.entry_id))
+    if command in {"/cancel_visit", "/move_visit"} and request.visit_id is not None:
+        return ("visit", int(request.visit_id))
+    if command in {"/payment_status", "/refund"} and request.payment_id is not None:
+        return ("payment", int(request.payment_id))
+    if command == "/change_schedule" and request.schedule_id is not None:
+        return ("schedule", int(request.schedule_id))
+    return None
+
+
+def _validate_staff_action_target_binding(
+    record: TelegramStaffConfirmationToken,
+    command_key: str,
+    request: StaffActionConfirmRequest,
+) -> str | None:
+    expected = _staff_action_expected_target_binding(command_key, request)
+    if expected is None:
+        return None
+
+    target_type, target_id = expected
+    expected_hash = _staff_runtime_reference_hash(target_type, target_id)
+    if not record.target_reference_hash:
+        return "target_binding_required"
+    if str(record.target_type or "") != target_type:
+        return "target_binding_mismatch"
+    if str(record.target_reference_hash) != expected_hash:
+        return "target_binding_mismatch"
+    return None
+
+
 @router.post("/telegram/ai-approval-alerts")
 async def send_telegram_ai_approval_alert(
     request: TelegramAiApprovalAlertRequest,
@@ -2022,6 +2060,26 @@ def confirm_staff_action(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=target_error,
+        )
+
+    target_binding_error = _validate_staff_action_target_binding(
+        record,
+        command_key,
+        request,
+    )
+    if target_binding_error:
+        _record_staff_action_execution_failure(
+            db,
+            record=record,
+            current_user=current_user,
+            operation_key=operation_key,
+            command_key=command_key,
+            reason=target_binding_error,
+        )
+        db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=target_binding_error,
         )
 
     consume_result = TelegramStaffConfirmationTokenService(db).consume_for_confirmation(

--- a/backend/tests/unit/test_telegram_staff_action_confirm_endpoint.py
+++ b/backend/tests/unit/test_telegram_staff_action_confirm_endpoint.py
@@ -2,9 +2,13 @@ from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from uuid import uuid4
 
+import pytest
+from fastapi import HTTPException
+
 from app.api.v1.endpoints.admin_telegram import (
     StaffActionConfirmRequest,
     confirm_staff_action,
+    _staff_runtime_reference_hash,
 )
 from app.models.clinic import Schedule
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
@@ -16,7 +20,15 @@ from app.services.telegram_staff_confirmation_token_service import (
 )
 
 
-def _issue_confirmation(db_session, *, user, operation_key: str, command_key: str):
+def _issue_confirmation(
+    db_session,
+    *,
+    user,
+    operation_key: str,
+    command_key: str,
+    target_type: str | None = None,
+    target_id: int | None = None,
+):
     return TelegramStaffConfirmationTokenService(db_session).issue_token(
         token_hash=f"staff_confirmation_token:{uuid4().hex}",
         staff_user_id=user.id,
@@ -24,8 +36,12 @@ def _issue_confirmation(db_session, *, user, operation_key: str, command_key: st
         operation_key=operation_key,
         command_key=command_key,
         action_payload_hash=f"staff_action_payload:{uuid4().hex}",
-        target_type="telegram_staff_action",
-        target_reference_hash=f"staff_action:{uuid4().hex}",
+        target_type=target_type or "telegram_staff_action",
+        target_reference_hash=(
+            _staff_runtime_reference_hash(target_type, target_id)
+            if target_type and target_id is not None
+            else f"staff_action:{uuid4().hex}"
+        ),
         idempotency_key_hash=f"staff_action_idempotency:{uuid4().hex}",
         expires_at=datetime.now(timezone.utc) + timedelta(minutes=2),
     )
@@ -74,6 +90,8 @@ def test_confirm_skip_executes_only_with_bound_queue_entry(
         user=registrar_user,
         operation_key="queue_call_or_skip_patient",
         command_key="/skip",
+        target_type="queue_entry",
+        target_id=entry.id,
     )
 
     result = confirm_staff_action(
@@ -126,12 +144,16 @@ def test_confirm_cancel_and_move_visit_use_bound_visit_payloads(
         user=admin_user,
         operation_key="visit_cancel_or_move",
         command_key="/cancel_visit",
+        target_type="visit",
+        target_id=cancel_visit.id,
     )
     move_record = _issue_confirmation(
         db_session,
         user=admin_user,
         operation_key="visit_cancel_or_move",
         command_key="/move_visit",
+        target_type="visit",
+        target_id=move_visit.id,
     )
 
     cancel_result = confirm_staff_action(
@@ -188,12 +210,16 @@ def test_confirm_payment_status_and_refund_use_bound_payment_payloads(
         user=admin_user,
         operation_key="payment_status_change",
         command_key="/payment_status",
+        target_type="payment",
+        target_id=status_payment.id,
     )
     refund_record = _issue_confirmation(
         db_session,
         user=admin_user,
         operation_key="refund_issue",
         command_key="/refund",
+        target_type="payment",
+        target_id=refund_payment.id,
     )
 
     status_result = confirm_staff_action(
@@ -241,6 +267,8 @@ def test_confirm_schedule_change_uses_bound_schedule_payload(
         user=admin_user,
         operation_key="doctor_schedule_change",
         command_key="/change_schedule",
+        target_type="schedule",
+        target_id=schedule.id,
     )
 
     result = confirm_staff_action(
@@ -259,3 +287,93 @@ def test_confirm_schedule_change_uses_bound_schedule_payload(
     assert schedule.start_time == time(10, 0)
     assert schedule.end_time == time(16, 0)
     _assert_consumed(db_session, record)
+
+
+def test_confirm_refund_rejects_mismatched_bound_payment_target(
+    db_session, admin_user, test_visit
+):
+    bound_payment = Payment(
+        visit_id=test_visit.id,
+        amount=Decimal("50000"),
+        currency="UZS",
+        method="cash",
+        status="paid",
+    )
+    other_payment = Payment(
+        visit_id=test_visit.id,
+        amount=Decimal("60000"),
+        currency="UZS",
+        method="cash",
+        status="paid",
+    )
+    db_session.add_all([bound_payment, other_payment])
+    db_session.flush()
+    record = _issue_confirmation(
+        db_session,
+        user=admin_user,
+        operation_key="refund_issue",
+        command_key="/refund",
+        target_type="payment",
+        target_id=bound_payment.id,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        confirm_staff_action(
+            record.id,
+            db_session,
+            admin_user,
+            StaffActionConfirmRequest(
+                payment_id=other_payment.id,
+                refund_amount=Decimal("60000"),
+            ),
+        )
+
+    db_session.refresh(record)
+    db_session.refresh(bound_payment)
+    db_session.refresh(other_payment)
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == "target_binding_mismatch"
+    assert record.consumed_at is None
+    assert bound_payment.status == "paid"
+    assert other_payment.status == "paid"
+    assert bound_payment.refunded_amount is None
+    assert other_payment.refunded_amount is None
+
+
+def test_confirm_refund_rejects_unbound_command_level_token(
+    db_session, admin_user, test_visit
+):
+    payment = Payment(
+        visit_id=test_visit.id,
+        amount=Decimal("50000"),
+        currency="UZS",
+        method="cash",
+        status="paid",
+    )
+    db_session.add(payment)
+    db_session.flush()
+    record = _issue_confirmation(
+        db_session,
+        user=admin_user,
+        operation_key="refund_issue",
+        command_key="/refund",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        confirm_staff_action(
+            record.id,
+            db_session,
+            admin_user,
+            StaffActionConfirmRequest(
+                payment_id=payment.id,
+                refund_amount=Decimal("50000"),
+            ),
+        )
+
+    db_session.refresh(record)
+    db_session.refresh(payment)
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == "target_binding_mismatch"
+    assert record.consumed_at is None
+    assert payment.status == "paid"
+    assert payment.refunded_amount is None


### PR DESCRIPTION
## Summary

- Fix Telegram protected staff action confirmations so target commands cannot mutate a different queue entry, visit, payment, or schedule than the confirmation record was bound to.
- Keep `/call` targetless because it operates on server-selected next patient, not a client-supplied record id.
- Add focused regression coverage for bound success, mismatched target rejection, and unbound command-level token rejection.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/contract-scan-next-13` was created from `origin/main`, then fast-forwarded to current `origin/main` before commit.
- Clean workspace: inspected before edits; only `backend/app/api/v1/endpoints/admin_telegram.py` and `backend/tests/unit/test_telegram_staff_action_confirm_endpoint.py` changed.
- Branch: `codex/contract-scan-next-13`.
- Scope gate: `agent_gate` used with known root cause `backend/app/api/v1/endpoints/admin_telegram.py`; allowed Telegram confirmation endpoint and targeted regression test, denied unrelated Telegram/frontend/runtime changes.
- Red-check handling: PR Review Quality Gate body failure is being fixed in this PR; runtime CI checks are green so far.

## Contract Impact

- Canonical surface: `POST /api/v1/admin/telegram/staff-actions/{confirmation_id}/confirm`.
- Request shape: unchanged body fields; targeted commands still use `entry_id`, `visit_id`, `payment_id`, or `schedule_id` as before.
- Response shape: unchanged success responses for correctly bound confirmations.
- Status codes: targeted commands now return `409 target_binding_mismatch` or `409 target_binding_required` when the confirmation record is not bound to the requested target.
- Frontend consumer: not changed in this PR.
- Compatibility path or alias: unbound command-level Telegram tokens are no longer allowed to execute targeted mutations; they must be reissued through a target-bound protected-app flow.
- Contract proof: focused unit tests cover successful bound commands, mismatched payment rejection, and unbound `/refund` token rejection.

## RBAC / Permissions

- Roles allowed: unchanged from `STAFF_BOT_CONFIRMATION_CONTRACT` for each operation.
- Roles denied: unchanged role gate still rejects users outside the operation role allowlist.
- Positive auth proof: existing focused tests confirm allowed roles execute bound skip, visit, payment, refund, and schedule commands.
- Negative auth proof: target-binding tests prove an allowed user with a valid command token still cannot mutate a different or unbound target.

## Notification / Realtime

not applicable - no notification, websocket, Telegram outbound text, or realtime delivery behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no frontend rendering path changed.
- Partial data proof: not applicable, no frontend rendering path changed.
- Forbidden secondary path behavior: target mismatch now fails closed with `409` before token consumption.
- Missing draft/resource behavior: not applicable, no draft/resource UI changed.
- Stale route/deep-link behavior: not applicable, no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/admin_telegram.py`, `backend/tests/unit/test_telegram_staff_action_confirm_endpoint.py`.
- Denied paths: migrations, broader Telegram webhook behavior, frontend components, generated output, unrelated queue/payment services.
- Migration/docs/test impact: no migration; targeted backend regression tests updated.
- Rollback note: revert the endpoint binding helper/check and the related test updates.

## Validation

- Targeted tests or smoke run: `py_compile`; `pytest tests/unit/test_telegram_staff_action_confirm_endpoint.py tests/unit/test_telegram_staff_action_adapter_service.py`; `npm.cmd --prefix frontend run build`; `git diff --check`.
- Result: backend targeted pytest `12 passed`; frontend build passed; `git diff --check` passed.
- Not checked: full end-to-end protected app confirmation UI flow, because no frontend file changed in this slice.