### PR TITLE
refactor(admin): route services directly

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -69,6 +69,7 @@ const PhoneVerificationManager = lazy(() => import('./components/admin/PhoneVeri
 const ActivationSystem = lazy(() => import('./components/admin/ActivationSystem.jsx'));
 const ClinicManagement = lazy(() => import('./components/admin/ClinicManagement.jsx'));
 const QueueCabinetManagement = lazy(() => import('./components/admin/QueueCabinetManagement.jsx'));
+const AdminServices = lazy(() => import('./components/admin/AdminServices.jsx'));
 const UnifiedSettings = lazy(() => import('./components/admin/UnifiedSettings.jsx'));
 const SystemManagement = lazy(() => import('./components/admin/SystemManagement.jsx'));
 const CloudPrintingManager = lazy(() => import('./components/admin/CloudPrintingManager.jsx'));
@@ -136,6 +137,7 @@ const ROUTE_COMPONENTS = {
   ActivationSystem,
   ClinicManagement,
   QueueCabinetManagement,
+  AdminServices,
   UnifiedSettings,
   SystemManagement,
   CloudPrintingManager,

--- a/frontend/src/components/admin/AdminServices.jsx
+++ b/frontend/src/components/admin/AdminServices.jsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { FolderTree, Package } from 'lucide-react';
+
+import { MacOSLoadingSkeleton } from '../ui/macos';
+import { useTheme } from '../../contexts/ThemeContext';
+
+const LazyQueueProfilesManager = React.lazy(() => import('./QueueProfilesManager'));
+const LazyServiceCatalog = React.lazy(() => import('./ServiceCatalog'));
+
+const SERVICE_TABS = [
+  { key: 'catalog', label: 'Справочник услуг', icon: Package },
+  { key: 'queue-profiles', label: 'Вкладки регистратуры', icon: FolderTree },
+];
+
+const getInitialServicesTab = (search) => {
+  const params = new URLSearchParams(search);
+  return params.get('servicesTab') || localStorage.getItem('servicesTab') || 'catalog';
+};
+
+const AdminServices = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { isDark } = useTheme();
+  const [servicesTab, setServicesTab] = useState(() => getInitialServicesTab(location.search));
+
+  useEffect(() => {
+    localStorage.setItem('servicesTab', servicesTab);
+  }, [servicesTab]);
+
+  const selectTab = (tabKey) => {
+    setServicesTab(tabKey);
+    const params = new URLSearchParams(location.search);
+    params.set('servicesTab', tabKey);
+    navigate({
+      pathname: location.pathname,
+      search: `?${params.toString()}`,
+    }, { replace: true });
+  };
+
+  return (
+    <div>
+      <div style={{
+        display: 'flex',
+        gap: '8px',
+        marginBottom: '24px',
+        borderBottom: '1px solid var(--mac-border)',
+        paddingBottom: '0',
+      }}>
+        {SERVICE_TABS.map((tab) => {
+          const TabIcon = tab.icon;
+          const isActive = servicesTab === tab.key;
+          return (
+            <button
+              type="button"
+              key={tab.key}
+              aria-label={tab.label}
+              onClick={() => selectTab(tab.key)}
+              style={{
+                padding: '12px 20px',
+                background: 'transparent',
+                border: 'none',
+                borderBottom: isActive ? '2px solid var(--mac-accent)' : '2px solid transparent',
+                color: isActive ? 'var(--mac-accent)' : 'var(--mac-text-secondary)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                fontSize: '14px',
+                fontWeight: isActive ? '600' : '500',
+                transition: 'all 0.2s ease',
+                fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+              }}
+              onMouseEnter={(event) => {
+                if (!isActive) {
+                  event.currentTarget.style.color = 'var(--mac-text-primary)';
+                }
+              }}
+              onMouseLeave={(event) => {
+                if (!isActive) {
+                  event.currentTarget.style.color = 'var(--mac-text-secondary)';
+                }
+              }}
+            >
+              <TabIcon size={18} />
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {servicesTab === 'catalog' && (
+        <React.Suspense fallback={<MacOSLoadingSkeleton style={{ height: '384px' }} />}>
+          <LazyServiceCatalog />
+        </React.Suspense>
+      )}
+      {servicesTab === 'queue-profiles' && (
+        <React.Suspense fallback={<MacOSLoadingSkeleton style={{ height: '384px' }} />}>
+          <LazyQueueProfilesManager theme={isDark ? 'dark' : 'light'} />
+        </React.Suspense>
+      )}
+    </div>
+  );
+};
+
+export default AdminServices;

--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -72,13 +72,7 @@ import {
   Trash2,
 
   DollarSign,
-  AlertCircle,
-
-
-
-
-
-  FolderTree } from
+  AlertCircle } from
 'lucide-react';
 
 // ✅ УЛУЧШЕНИЕ: Универсальные хуки для устранения дублирования
@@ -158,6 +152,7 @@ import SystemManagement from '../components/admin/SystemManagement';
 import CloudPrintingManager from '../components/admin/CloudPrintingManager';
 import MedicalEquipmentManager from '../components/admin/MedicalEquipmentManager';
 import QueueCabinetManagement from '../components/admin/QueueCabinetManagement';
+import AdminServices from '../components/admin/AdminServices';
 import { getApiOrigin } from '../api/runtime';
 
 
@@ -171,7 +166,6 @@ import '../styles/admin-styles.css';
 
 const LazyGraphQLExplorer = React.lazy(() => import('../components/admin/GraphQLExplorer'));
 const LazyQueueProfilesManager = React.lazy(() => import('../components/admin/QueueProfilesManager'));
-const LazyServiceCatalog = React.lazy(() => import('../components/admin/ServiceCatalog'));
 const LazyUnifiedReports = React.lazy(() => import('../components/admin/UnifiedReports'));
 const LazyWaitTimeAnalytics = React.lazy(() => import('../components/analytics/WaitTimeAnalytics'));
 
@@ -520,21 +514,6 @@ const AdminPanel = () => {
   useEffect(() => {
     localStorage.setItem('settingsSubTab', settingsSubTab);
   }, [settingsSubTab]);
-
-  // Состояние для вкладок секции Services
-  const [servicesTab, setServicesTab] = useState(() => {
-    const params = new URLSearchParams(location.search);
-    const tabFromUrl = params.get('servicesTab');
-    if (tabFromUrl) {
-      return tabFromUrl;
-    }
-    return localStorage.getItem('servicesTab') || 'catalog';
-  });
-
-  // Сохраняем выбранную вкладку services
-  useEffect(() => {
-    localStorage.setItem('servicesTab', servicesTab);
-  }, [servicesTab]);
 
   // Состояние для логотипа
   const [, setLogoFile] = useState(null);
@@ -2631,86 +2610,8 @@ const AdminPanel = () => {
             <LazyGraphQLExplorer />
           </React.Suspense>
         );
-      case 'services':{
-          // Вкладки для секции Services
-          // ⭐ SSOT: DepartmentManagement удалён - QueueProfilesManager теперь единственный источник для вкладок регистратуры
-          const serviceTabs = [
-          { key: 'catalog', label: 'Справочник услуг', icon: Package },
-          { key: 'queue-profiles', label: 'Вкладки регистратуры', icon: FolderTree } // ⭐ SSOT: Dynamic queue tabs
-          ];
-
-          return (
-            <div>
-            {/* Вкладки */}
-            <div style={{
-                display: 'flex',
-                gap: '8px',
-                marginBottom: '24px',
-                borderBottom: '1px solid var(--mac-border)',
-                paddingBottom: '0'
-              }}>
-              {serviceTabs.map((tab) => {
-                  const TabIcon = tab.icon;
-                  const isActive = servicesTab === tab.key;
-                  return (
-                    <button
-                      type="button"
-                      key={tab.key}
-                      aria-label={tab.label}
-                      onClick={() => {
-                        setServicesTab(tab.key);
-                        // Обновляем URL
-                        const params = new URLSearchParams(location.search);
-                        params.set('servicesTab', tab.key);
-                        navigate(`?${params.toString()}`, { replace: true });
-                      }}
-                      style={{
-                        padding: '12px 20px',
-                        background: 'transparent',
-                        border: 'none',
-                        borderBottom: isActive ? '2px solid var(--mac-accent)' : '2px solid transparent',
-                        color: isActive ? 'var(--mac-accent)' : 'var(--mac-text-secondary)',
-                        cursor: 'pointer',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '8px',
-                        fontSize: '14px',
-                        fontWeight: isActive ? '600' : '500',
-                        transition: 'all 0.2s ease',
-                        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
-                      }}
-                      onMouseEnter={(e) => {
-                        if (!isActive) {
-                          e.currentTarget.style.color = 'var(--mac-text-primary)';
-                        }
-                      }}
-                      onMouseLeave={(e) => {
-                        if (!isActive) {
-                          e.currentTarget.style.color = 'var(--mac-text-secondary)';
-                        }
-                      }}>
-
-                    <TabIcon size={18} />
-                    {tab.label}
-                  </button>);
-
-                })}
-            </div>
-
-            {/* Содержимое вкладок */}
-            {servicesTab === 'catalog' && (
-              <React.Suspense fallback={<MacOSLoadingSkeleton style={{ height: '384px' }} />}>
-                <LazyServiceCatalog />
-              </React.Suspense>
-            )}
-            {servicesTab === 'queue-profiles' && (
-              <React.Suspense fallback={<MacOSLoadingSkeleton style={{ height: '384px' }} />}>
-                <LazyQueueProfilesManager theme={isDark ? 'dark' : 'light'} />
-              </React.Suspense>
-            )}
-          </div>);
-
-        }
+      case 'services':
+        return <AdminServices />;
       case 'departments':
         // ⭐ DEPRECATED: Redirect to SSOT queue-profiles
         return (

--- a/frontend/src/routing/__tests__/routeContract.test.js
+++ b/frontend/src/routing/__tests__/routeContract.test.js
@@ -82,6 +82,7 @@ const ADMIN_MANAGEMENT_ROUTE_CHROME_HEADING_CONTRACT = {
 };
 
 const ADMIN_STANDALONE_MANAGEMENT_COMPONENT_CONTRACT = {
+  'admin-services': { path: '/admin/services', owner: 'admin.catalog', component: 'AdminServices', entry: 'direct' },
   'admin-all-free': { path: '/admin/all-free', owner: 'admin.operations', component: 'AllFreeApproval', entry: 'direct' },
 };
 

--- a/frontend/src/routing/routeRegistry.js
+++ b/frontend/src/routing/routeRegistry.js
@@ -571,7 +571,7 @@ export const ROUTE_REGISTRY = [
     nav: nav({ label: 'Услуги', icon: 'list', section: 'Управление', order: 30, sidebar: true }),
     title: 'Admin Services',
     owner: 'admin.catalog',
-    component: 'AdminPanel',
+    component: 'AdminServices',
     legacyRedirectFrom: [],
     layout: layout({ sidebarPreset: 'admin', activeSidebarItem: 'admin-services', pageTitle: 'Admin Services' }),
   },


### PR DESCRIPTION
﻿## Summary

- Add `AdminServices` as a dedicated admin services route wrapper.
- Route `/admin/services` directly to `AdminServices` while preserving the old `AdminPanel` services switch as a compatibility path.
- Preserve both services tabs: Service Catalog and Queue Profiles, including `servicesTab` query/localStorage behavior.

## Cyclic Execution Evidence

- Fresh main sync: local `main` was synced after PR #1558 merged.
- Clean workspace: branch started from clean `main`.
- Branch: `refactor/admin-services-direct-route`.
- Scope gate: `agent_gate` accepted explicit first-touch files after the DevBrain gate fix: `AdminServices.jsx`, `App.jsx`, `routeRegistry.js`, and route contract coverage.
- Red-check handling: will fix any red GitHub Actions check in this PR branch before merge.

## Contract Impact

- Canonical surface: frontend admin route registry for `/admin/services`.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `/admin/services` now resolves to `AdminServices`; legacy `AdminPanel` services case delegates to the same component.
- Compatibility path or alias: old `AdminPanel` section rendering remains compatible through `return <AdminServices />`.
- Contract proof: `src/routing/__tests__/routeContract.test.js` now asserts `/admin/services` is a direct `AdminServices` route.

## RBAC / Permissions

- Roles allowed: unchanged; `/admin/services` remains Admin-only in route registry.
- Roles denied: unchanged through existing route guard behavior.
- Positive auth proof: route contract test still verifies admin accessibility for standalone management routes.
- Negative auth proof: not checked locally because no route guard or RBAC helper changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: existing `ServiceCatalog` and `QueueProfilesManager` empty-state handling is preserved; this PR only moves their tab wrapper.
- Partial data proof: not applicable because no service API response handling changed.
- Forbidden secondary path behavior: route guard behavior unchanged.
- Missing draft/resource behavior: not applicable because this route does not use drafts/resources in the moved wrapper.
- Stale route/deep-link behavior: `?servicesTab=catalog` and `?servicesTab=queue-profiles` continue to select the same tabs.

## Scope Gate

- Allowed paths: `frontend/src/components/admin/AdminServices.jsx`, `frontend/src/App.jsx`, `frontend/src/pages/AdminPanel.jsx`, `frontend/src/routing/routeRegistry.js`, `frontend/src/routing/__tests__/routeContract.test.js`.
- Denied paths: backend/runtime code, DB/migrations, RBAC/auth helpers, unrelated admin route families, deploy/secrets/generated artifacts.
- Migration/docs/test impact: no migration; one route contract test expectation updated.
- Rollback note: revert this commit to route `/admin/services` through `AdminPanel` again.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js`; `npm.cmd run lint:check -- --quiet --rule "no-warning-comments: off"`; `npm.cmd run build`; `git diff --check`.
- Result: route contract passed 34 tests; lint passed; production build passed; diff check passed.
- Not checked: browser `/admin/services` smoke; GitHub Actions pending after PR creation.
