### PR TITLE
fix(confirmation): claim visit before queue allocation

### DIFF
--- a/backend/app/services/visit_confirmation_service.py
+++ b/backend/app/services/visit_confirmation_service.py
@@ -32,6 +32,7 @@ CANONICAL_ACTIVE_CONFIRMATION_STATUSES = (
     "in_service",
     "diagnostics",
 )
+CONFIRMATION_PROCESSING_STATUS = "confirmation_processing"
 
 TELEGRAM_TICKET_QR_PREFIX = "tq"
 TELEGRAM_TICKET_QR_HASH_PREFIX = "ticket_qr:"
@@ -161,6 +162,36 @@ class VisitConfirmationService:
         self.security_service = ConfirmationSecurityService(db)
         self.queue_facade = QueueContextFacade(QueueDomainServiceContractAdapter(db))
 
+    def _claim_pending_visit_for_confirmation(self, token: str) -> Visit | None:
+        updated = (
+            self.repository.db.query(Visit)
+            .filter(
+                Visit.confirmation_token == token,
+                Visit.status == "pending_confirmation",
+            )
+            .update(
+                {Visit.status: CONFIRMATION_PROCESSING_STATUS},
+                synchronize_session=False,
+            )
+        )
+        if updated == 0:
+            return None
+        if updated != 1:
+            raise VisitConfirmationDomainError(
+                status_code=409,
+                detail="Ambiguous confirmation token",
+            )
+
+        self.repository.db.flush()
+        return (
+            self.repository.db.query(Visit)
+            .filter(
+                Visit.confirmation_token == token,
+                Visit.status == CONFIRMATION_PROCESSING_STATUS,
+            )
+            .first()
+        )
+
     def confirm_by_telegram(
         self,
         *,
@@ -200,7 +231,7 @@ class VisitConfirmationService:
                     ),
                 )
 
-            visit = self.repository.get_pending_visit_by_token(token)
+            visit = self._claim_pending_visit_for_confirmation(token)
             if not visit:
                 self.security_service.record_confirmation_attempt(
                     visit_id=0,
@@ -289,7 +320,7 @@ class VisitConfirmationService:
                     detail=security_check.reason,
                 )
 
-            visit = self.repository.get_pending_visit_by_token(token)
+            visit = self._claim_pending_visit_for_confirmation(token)
             if not visit:
                 self.security_service.record_confirmation_attempt(
                     visit_id=0,

--- a/backend/tests/characterization/test_confirmation_split_flow_concurrency.py
+++ b/backend/tests/characterization/test_confirmation_split_flow_concurrency.py
@@ -8,11 +8,16 @@ import pytest
 from sqlalchemy.orm import sessionmaker
 
 from app.models.clinic import Doctor
+from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.patient import Patient
 from app.models.user import User
 from app.models.visit import Visit
 from app.repositories.visit_confirmation_repository import VisitConfirmationRepository
 from app.services.confirmation_security import ConfirmationSecurityService
+from app.services.visit_confirmation_service import (
+    VisitConfirmationDomainError,
+    VisitConfirmationService,
+)
 
 
 def _make_pending_confirmation_visit(
@@ -157,6 +162,80 @@ def test_parallel_confirmation_pending_lookup_can_observe_same_pending_visit(tes
     finally:
         cleanup = session_local()
         try:
+            cleanup.query(Visit).filter(Visit.id == visit_id).delete()
+            cleanup.query(Patient).filter(Patient.id == patient_id).delete()
+            cleanup.query(Doctor).filter(Doctor.id == doctor_id).delete()
+            cleanup.query(User).filter(User.id == user_id).delete()
+            cleanup.commit()
+        finally:
+            cleanup.close()
+
+
+@pytest.mark.integration
+@pytest.mark.queue
+@pytest.mark.confirmation
+def test_parallel_telegram_confirmation_claim_allows_only_one_mutation(test_db):
+    token, visit_id, patient_id, doctor_id, user_id = _make_pending_confirmation_visit(
+        test_db,
+        suffix=uuid.uuid4().hex[:8],
+    )
+    session_local = sessionmaker(bind=test_db, autocommit=False, autoflush=False)
+    barrier = threading.Barrier(2)
+    successes: list[int] = []
+    failures: list[int] = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        session = session_local()
+        try:
+            barrier.wait()
+            service = VisitConfirmationService(session)
+            try:
+                result = service.confirm_by_telegram(
+                    token=token,
+                    telegram_user_id="123456789",
+                    source_ip="127.0.0.1",
+                    user_agent="Mozilla/5.0",
+                )
+                with lock:
+                    successes.append(int(result["visit_id"]))
+            except VisitConfirmationDomainError:
+                with lock:
+                    failures.append(1)
+        finally:
+            session.close()
+
+    try:
+        threads = [threading.Thread(target=worker), threading.Thread(target=worker)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        verify = session_local()
+        try:
+            visit = verify.query(Visit).filter(Visit.id == visit_id).one()
+            entries = (
+                verify.query(OnlineQueueEntry)
+                .filter(OnlineQueueEntry.visit_id == visit_id)
+                .all()
+            )
+            assert successes == [visit_id]
+            assert failures == [1]
+            assert visit.status == "open"
+            assert len(entries) == 1
+            assert entries[0].source == "confirmation"
+        finally:
+            verify.close()
+    finally:
+        cleanup = session_local()
+        try:
+            cleanup.query(OnlineQueueEntry).filter(
+                OnlineQueueEntry.visit_id == visit_id
+            ).delete()
+            cleanup.query(DailyQueue).filter(
+                DailyQueue.specialist_id == doctor_id
+            ).delete()
             cleanup.query(Visit).filter(Visit.id == visit_id).delete()
             cleanup.query(Patient).filter(Patient.id == patient_id).delete()
             cleanup.query(Doctor).filter(Doctor.id == doctor_id).delete()


### PR DESCRIPTION
## Summary

- Add an atomic confirmation claim before Telegram/PWA visit confirmation mutates visit state or allocates queue entries.
- Prevent concurrent same-token confirmations from both reaching queue allocation.
- Add a service-level concurrency regression that proves one request succeeds and one request fails without creating duplicate queue rows.

## Cyclic Execution Evidence

- Fresh main sync: branch `codex/contract-scan-next-14` created from current `origin/main` at `b6c7405b`.
- Clean workspace: inspected before edits; only visit confirmation service and targeted confirmation concurrency test changed.
- Branch: `codex/contract-scan-next-14`.
- Scope gate: `agent_gate` used with known root cause `backend/app/services/visit_confirmation_service.py`; second gate included the regression test path before test edits.
- Red-check handling: any failed CI check for this PR will be fixed in this same branch before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/telegram/visits/confirm` and PWA confirmation service path.
- Request shape: unchanged token-based confirmation request.
- Response shape: unchanged successful confirmation response.
- Status codes: concurrent/replayed confirmations now fail closed before queue allocation once the pending visit has already been claimed.
- Frontend consumer: not changed in this PR.
- Compatibility path or alias: sequential replay behavior remains rejected; the change hardens concurrent replay.
- Contract proof: characterization test covers parallel Telegram confirmation with one mutation and one rejected attempt.

## RBAC / Permissions

- Roles allowed: not applicable - patient/Telegram token confirmation path, no role allowlist changed.
- Roles denied: not applicable - no auth/RBAC policy changed.
- Positive auth proof: one valid token confirmation still succeeds and opens the visit.
- Negative auth proof: a second concurrent request with the same valid token cannot mutate visit/queue state.

## Notification / Realtime

not applicable - no notification, websocket, Telegram outbound text, or realtime delivery behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no frontend rendering path changed.
- Partial data proof: not applicable, no frontend rendering path changed.
- Forbidden secondary path behavior: concurrent replay now fails before a second queue mutation.
- Missing draft/resource behavior: not applicable, no draft/resource UI changed.
- Stale route/deep-link behavior: not applicable, no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/services/visit_confirmation_service.py`, `backend/tests/characterization/test_confirmation_split_flow_concurrency.py`.
- Denied paths: migrations, queue allocator internals, Telegram webhook/frontend, generated output, unrelated confirmation/security services.
- Migration/docs/test impact: no migration; targeted characterization test updated.
- Rollback note: revert atomic claim helper and the added concurrency regression.

## Validation

- Targeted tests or smoke run: `py_compile`; `pytest tests/characterization/test_confirmation_split_flow_concurrency.py tests/characterization/test_confirmation_split_flow_characterization.py`; `git diff --check`.
- Result: targeted pytest `7 passed`; `py_compile` passed; `git diff --check` passed.
- Not checked: full browser flow and full backend suite, because this slice only changes backend confirmation orchestration and targeted characterization coverage.