### PR TITLE
fix(queue): claim QR join session before allocation

### DIFF
--- a/backend/app/services/qr_queue_service.py
+++ b/backend/app/services/qr_queue_service.py
@@ -41,6 +41,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+JOIN_SESSION_PROCESSING_STATUS = "joining"
+
 
 class QRQueueService:
     """Сервис для управления QR очередями"""
@@ -227,8 +229,8 @@ class QRQueueService:
 
         if patient:
             logger.info(
-                "[QRQueueService._find_or_create_patient] ✅ Найден существующий пациент ID=%d по телефону %s",
-                patient.id, phone
+                "[QRQueueService._find_or_create_patient] ✅ Найден существующий пациент ID=%d",
+                patient.id,
             )
             return patient
 
@@ -251,11 +253,47 @@ class QRQueueService:
         self.db.flush()
 
         logger.info(
-            "[QRQueueService._find_or_create_patient] ✅ Создан новый пациент ID=%d для QR-регистрации: %s, %s",
-            patient.id, patient_name, phone
+            "[QRQueueService._find_or_create_patient] ✅ Создан новый пациент ID=%d для QR-регистрации",
+            patient.id,
         )
 
         return patient
+
+    def _claim_pending_join_session(self, session_token: str) -> QueueJoinSession | None:
+        now_utc = datetime.utcnow()
+        pending_filter = (
+            QueueJoinSession.session_token == session_token,
+            QueueJoinSession.status == "pending",
+            QueueJoinSession.expires_at > now_utc,
+        )
+        query = self.db.query(QueueJoinSession).filter(*pending_filter)
+
+        if not hasattr(query, "update"):
+            session = query.first()
+            if session:
+                session.status = JOIN_SESSION_PROCESSING_STATUS
+                if hasattr(self.db, "flush"):
+                    self.db.flush()
+            return session
+
+        updated = query.update(
+            {QueueJoinSession.status: JOIN_SESSION_PROCESSING_STATUS},
+            synchronize_session=False,
+        )
+        if updated == 0:
+            return None
+        if updated != 1:
+            raise ValueError("Ambiguous queue join session")
+
+        self.db.flush()
+        return (
+            self.db.query(QueueJoinSession)
+            .filter(
+                QueueJoinSession.session_token == session_token,
+                QueueJoinSession.status == JOIN_SESSION_PROCESSING_STATUS,
+            )
+            .first()
+        )
 
     def _create_visit_for_qr(
         self,
@@ -316,8 +354,9 @@ class QRQueueService:
         self.db.flush()
 
         logger.info(
-            "[QRQueueService._create_visit_for_qr] ✅ Создан Visit ID=%d для QR-пациента %d с %d услугами",
-            visit.id, patient_id, len(services)
+            "[QRQueueService._create_visit_for_qr] ✅ Создан Visit ID=%d с %d услугами",
+            visit.id,
+            len(services),
         )
 
         return visit
@@ -867,17 +906,7 @@ class QRQueueService:
         """
         # Находим сессию
         # expires_at сохраняется в UTC (datetime.utcnow()), поэтому сравниваем с UTC
-        now_utc = datetime.utcnow()
-
-        session = (
-            self.db.query(QueueJoinSession)
-            .filter(
-                QueueJoinSession.session_token == session_token,
-                QueueJoinSession.status == "pending",
-                QueueJoinSession.expires_at > now_utc,
-            )
-            .first()
-        )
+        session = self._claim_pending_join_session(session_token)
 
         if not session:
             raise ValueError("Сессия не найдена или истекла")
@@ -890,6 +919,7 @@ class QRQueueService:
         )
 
         if not qr_token:
+            self.db.rollback()
             raise ValueError("QR токен не найден")
 
         # ⭐ FIX: Создаём или находим пациента (patient_id ВСЕГДА заполняется)
@@ -898,8 +928,7 @@ class QRQueueService:
 
         if not patient_id:
             logger.warning(
-                "[complete_join_session] ⚠️ Не удалось создать/найти пациента для %s, %s",
-                patient_name, phone
+                "[complete_join_session] ⚠️ Не удалось создать/найти пациента"
             )
 
         try:
@@ -913,6 +942,7 @@ class QRQueueService:
                 source="online",
             )
         except (QueueValidationError, QueueConflictError, QueueNotFoundError) as exc:
+            self.db.rollback()
             raise ValueError(str(exc)) from exc
 
         queue_entry = join_result["entry"]
@@ -980,17 +1010,7 @@ class QRQueueService:
             raise ValueError("Не выбраны специалисты для записи")
 
         # expires_at сохраняется в UTC (datetime.utcnow()), поэтому сравниваем с UTC
-        now_utc = datetime.utcnow()
-
-        session = (
-            self.db.query(QueueJoinSession)
-            .filter(
-                QueueJoinSession.session_token == session_token,
-                QueueJoinSession.status == "pending",
-                QueueJoinSession.expires_at > now_utc,
-            )
-            .first()
-        )
+        session = self._claim_pending_join_session(session_token)
 
         if not session:
             raise ValueError("Сессия не найдена или истекла")
@@ -1001,6 +1021,7 @@ class QRQueueService:
             .first()
         )
         if not qr_token:
+            self.db.rollback()
             raise ValueError("QR токен не найден")
 
         # ⭐ FIX: Создаём или находим пациента (patient_id ВСЕГДА заполняется)
@@ -1009,8 +1030,7 @@ class QRQueueService:
 
         if not patient_id:
             logger.warning(
-                "[complete_join_session_multiple] ⚠️ Не удалось создать/найти пациента для %s, %s",
-                patient_name, phone
+                "[complete_join_session_multiple] ⚠️ Не удалось создать/найти пациента"
             )
 
         entries: list[dict[str, Any]] = []
@@ -1056,6 +1076,10 @@ class QRQueueService:
                         "error": str(exc),
                     }
                 )
+
+        if errors and not entries:
+            self.db.rollback()
+            raise ValueError(errors[0]["error"])
 
         session.status = "joined"
         session.patient_name = patient_name

--- a/backend/tests/unit/test_qr_queue_service_allocator_boundary.py
+++ b/backend/tests/unit/test_qr_queue_service_allocator_boundary.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from app.models.online_queue import QueueJoinSession, QueueToken
 from app.services.qr_queue_service import QRQueueService
 
 
@@ -27,6 +28,46 @@ class _DbStub:
 
     def query(self, model):
         return _QueryStub(self._results.pop(0))
+
+
+class _ClaimQueryStub:
+    def __init__(self, model, session, qr_token):
+        self._model = model
+        self._session = session
+        self._qr_token = qr_token
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def update(self, values, synchronize_session=False):
+        if self._model is not QueueJoinSession:
+            return 0
+        if (
+            self._session.status == "pending"
+            and self._session.expires_at > datetime.utcnow()
+        ):
+            self._session.status = next(iter(values.values()))
+            return 1
+        return 0
+
+    def first(self):
+        if self._model is QueueJoinSession:
+            return self._session
+        if self._model is QueueToken:
+            return self._qr_token
+        return None
+
+
+class _ClaimDbStub:
+    def __init__(self, session, qr_token):
+        self._session = session
+        self._qr_token = qr_token
+        self.commit = Mock()
+        self.flush = Mock()
+        self.rollback = Mock()
+
+    def query(self, model):
+        return _ClaimQueryStub(model, self._session, self._qr_token)
 
 
 @pytest.mark.unit
@@ -154,3 +195,62 @@ def test_complete_join_session_multiple_uses_queue_domain_boundary(monkeypatch):
     assert first_call.kwargs["allocation_mode"] == "join_with_token"
     assert first_call.kwargs["specialist_id_override"] == 11
     assert second_call.kwargs["specialist_id_override"] == 22
+
+
+@pytest.mark.unit
+def test_complete_join_session_claim_rejects_replay_before_allocator(monkeypatch):
+    session = SimpleNamespace(
+        qr_token="qr-token",
+        status="pending",
+        expires_at=datetime.utcnow() + timedelta(hours=1),
+        patient_name=None,
+        phone=None,
+        telegram_id=None,
+        queue_entry_id=None,
+        queue_number=None,
+        joined_at=None,
+    )
+    qr_token = SimpleNamespace(
+        token="qr-token",
+        specialist_id=11,
+        department="cardiology",
+    )
+    db = _ClaimDbStub(session, qr_token)
+    domain_service = Mock()
+
+    def allocate_ticket(**kwargs):
+        assert session.status == "joining"
+        return {
+            "entry": SimpleNamespace(id=88, number=5),
+            "duplicate": True,
+            "queue_length_before": 2,
+            "estimated_wait_minutes": 15,
+            "specialist_name": "Dr. Boundary",
+        }
+
+    domain_service.allocate_ticket.side_effect = allocate_ticket
+
+    service = QRQueueService(db, queue_domain_service=domain_service)
+    monkeypatch.setattr(
+        service,
+        "_find_or_create_patient",
+        lambda patient_name, phone: SimpleNamespace(id=123),
+    )
+
+    service.complete_join_session(
+        session_token="session-token",
+        patient_name="Boundary Patient",
+        phone="+998904040404",
+        telegram_id=77,
+    )
+
+    with pytest.raises(ValueError, match="Сессия"):
+        service.complete_join_session(
+            session_token="session-token",
+            patient_name="Replay Patient",
+            phone="+998904040405",
+            telegram_id=78,
+        )
+
+    assert session.status == "joined"
+    assert domain_service.allocate_ticket.call_count == 1


### PR DESCRIPTION
## Summary
- Claim public QR queue join sessions with an atomic pending-to-joining update before queue allocation.
- Reject replayed completion attempts for the same session_token before they can create another OnlineQueueEntry.
- Add a focused unit regression covering the replay guard at the allocator boundary.
- Redact QR patient identifiers from touched service logs to satisfy CodeQL clear-text logging policy.

## Cyclic Execution Evidence
- Fresh main sync: branch codex/contract-scan-next-15 was created from origin/main at ef452905.
- Clean workspace: isolated worktree C:\tmp\final-contract-scan-next-15 had only this PR's two backend files modified before commit.
- Branch: codex/contract-scan-next-15, commit 43cf6043.
- Scope gate: gate_known_root_cause for backend/app/services/qr_queue_service.py, then a second narrow gate for backend/tests/unit/test_qr_queue_service_allocator_boundary.py.
- Red-check handling: PR Review Quality Gate body fields were filled; CodeQL clear-text logging alerts were fixed in the same PR by removing patient identifiers from touched logs.

## Contract Impact
- Canonical surface: existing public POST /api/v1/queue/join/complete handled by QRQueueService.
- Request shape: unchanged; session_token, patient_name, phone, telegram_id, and optional specialist_ids remain the same.
- Response shape: unchanged for successful single and multi join responses.
- Status codes: unchanged at endpoint level; consumed/replayed sessions continue to surface as the existing 400 ValueError path.
- Frontend consumer: frontend/src/pages/QueueJoin.jsx keeps using the same API adapter and payload.
- Compatibility path or alias: no route alias, /api/v1/ui/* endpoint, or BFF-lite path added.
- Contract proof: existing QR join integration/characterization tests passed, and the new unit regression proves replay is rejected before allocator mutation.

## RBAC / Permissions
- Roles allowed: unchanged; QR join/start and join/complete remain public QR endpoints.
- Roles denied: unchanged; no authenticated role policy was added or removed.
- Positive auth proof: existing public QR join tests still pass without auth headers.
- Negative auth proof: not applicable because this PR does not change an authenticated route or role gate.

## Notification / Realtime
- Event type or websocket channel: existing queue.created broadcast is unchanged for newly created entries.
- Payload version / ack behavior: unchanged; no websocket payload schema or ack path changed.
- Read/unread or delivery semantics: not applicable because queue join broadcasts do not use read/unread delivery state.
- Reconnect/resync proof: not checked; no realtime reconnect/resync code was touched.

## Frontend Resilience
- Empty data proof: not checked; no frontend rendering path changed.
- Partial data proof: not checked; backend response shape for success remains unchanged.
- Forbidden secondary path behavior: not applicable; no secondary frontend command path or fallback endpoint changed.
- Missing draft/resource behavior: consumed/missing session_token still returns the existing session-not-found-or-expired error path.
- Stale route/deep-link behavior: unchanged; QueueJoin keeps the same token route and localStorage behavior.

## Scope Gate
- Allowed paths: backend/app/services/qr_queue_service.py, backend/tests/unit/test_qr_queue_service_allocator_boundary.py.
- Denied paths: frontend, /api/v1/ui/*, BFF-lite, migrations, queue allocator rewrite, unrelated endpoint cleanup.
- Migration/docs/test impact: no migration or docs changes; one targeted unit regression added.
- Rollback note: reverting this commit restores previous session lookup behavior and removes the regression test.
- Stop conditions not hit.

## Validation
- Targeted tests or smoke run: py_compile for changed backend files; unit QR service boundary tests; QR join integration and queue allocator characterization tests; git diff --check.
- Result: py_compile passed; unit tests 3 passed; integration/characterization tests 8 passed before log redaction; py_compile/unit/git diff --check re-run after log redaction passed.
- Not checked: full frontend build and full backend suite locally; GitHub backend tests and PR Required Gate are expected to rerun after the amended push.
