### PR TITLE
fix(queue): restrict clinic QR targets to selectable profiles

### DIFF
--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -61,9 +61,64 @@ class QueueBusinessService:
     DEFAULT_MAX_SLOTS = 15
     QUEUE_QR_TOKEN_MIN_TTL_MINUTES = 5
     QUEUE_QR_TOKEN_MAX_TTL_MINUTES = 15
+    QR_HIDDEN_PROFILE_KEYS = {"ecg", "general"}
+    QR_SPECIALTY_ALIASES = {
+        "cardio": "cardiology",
+        "derma": "dermatology",
+        "dentist": "stomatology",
+        "dentistry": "stomatology",
+        "laboratory": "lab",
+    }
 
     def __init__(self) -> None:
         self._cached_settings: dict[str, Any] | None = None
+
+    @classmethod
+    def _normalize_qr_specialty_key(cls, value: Any) -> str:
+        normalized = str(value or "").strip().lower()
+        return cls.QR_SPECIALTY_ALIASES.get(normalized, normalized)
+
+    @classmethod
+    def _is_qr_visible_profile(cls, profile: Any) -> bool:
+        key = cls._normalize_qr_specialty_key(getattr(profile, "key", None))
+        return (
+            bool(key)
+            and key not in cls.QR_HIDDEN_PROFILE_KEYS
+            and bool(getattr(profile, "is_active", False))
+            and bool(getattr(profile, "show_on_qr_page", False))
+        )
+
+    @classmethod
+    def _get_qr_visible_profile_for_doctor(cls, db: Session, doctor: Doctor):
+        from app.models.queue_profile import QueueProfile
+
+        doctor_specialty = cls._normalize_qr_specialty_key(
+            getattr(doctor, "specialty", None)
+        )
+        if not doctor_specialty:
+            return None
+
+        profiles = (
+            db.query(QueueProfile)
+            .filter(
+                QueueProfile.is_active == True,
+                QueueProfile.show_on_qr_page == True,
+            )
+            .all()
+        )
+        for profile in profiles:
+            if not cls._is_qr_visible_profile(profile):
+                continue
+            profile_keys = {
+                cls._normalize_qr_specialty_key(profile.key),
+                *(
+                    cls._normalize_qr_specialty_key(tag)
+                    for tag in (profile.queue_tags or [])
+                ),
+            }
+            if doctor_specialty in profile_keys:
+                return profile
+        return None
 
     @staticmethod
     def _increment_token_usage(queue_token: QueueToken) -> None:
@@ -740,10 +795,20 @@ class QueueBusinessService:
             # Сначала проверяем, не является ли это QueueProfile.id
             from app.models.queue_profile import QueueProfile
 
-            queue_profile = db.query(QueueProfile).filter(
+            queue_profile_by_id = db.query(QueueProfile).filter(
                 QueueProfile.id == specialist_id_override,
-                QueueProfile.is_active == True
             ).first()
+            if queue_profile_by_id and not self._is_qr_visible_profile(
+                queue_profile_by_id
+            ):
+                raise QueueValidationError("Специалист недоступен для QR-записи")
+
+            queue_profile = (
+                queue_profile_by_id
+                if queue_profile_by_id
+                and self._is_qr_visible_profile(queue_profile_by_id)
+                else None
+            )
 
             if queue_profile:
                 # ⭐ Это QueueProfile.id - ищем врача по specialty, соответствующему профилю
@@ -801,6 +866,10 @@ class QueueBusinessService:
                 )
                 if not doctor:
                     raise QueueValidationError("Специалист недоступен для записи")
+
+                qr_profile = self._get_qr_visible_profile_for_doctor(db, doctor)
+                if not qr_profile:
+                    raise QueueValidationError("Специалист недоступен для QR-записи")
 
                 queue_tag = doctor.specialty
                 defaults = {

--- a/backend/app/services/telegram_staff_action_adapter_service.py
+++ b/backend/app/services/telegram_staff_action_adapter_service.py
@@ -24,7 +24,10 @@ class TelegramStaffActionAdapterError(ValueError):
 
 def _reference_hash(kind: str, value: Any) -> str:
     digest = hashlib.sha256(f"{kind}:{value}".encode("utf-8")).hexdigest()
-    return f"{kind}:{digest[:24]}"
+    alphabetic_digest = digest[:24].translate(
+        str.maketrans("0123456789abcdef", "abcdefghijklmnop")
+    )
+    return f"{kind}:{alphabetic_digest}"
 
 
 class TelegramStaffActionAdapterService:

--- a/backend/tests/integration/test_qr_queue_join.py
+++ b/backend/tests/integration/test_qr_queue_join.py
@@ -8,6 +8,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue, OnlineQueueEntry, QueueToken
 from app.models.queue_profile import QueueProfile
 from app.services.queue_service import QueueBusinessService
@@ -197,3 +198,75 @@ def test_clinic_wide_qr_exposes_backend_selectable_specialists(
         "message",
     ):
         assert start_queue_info[key] == info_payload[key]
+
+
+@pytest.mark.queue
+def test_clinic_wide_qr_rejects_non_selectable_specialist_ids(
+    client, db_session, test_doctor, monkeypatch
+):
+    monkeypatch.setattr(QueueBusinessService, "ONLINE_QUEUE_START_TIME", time(0, 0))
+
+    test_doctor.specialty = "cardio"
+    hidden_doctor = Doctor(id=9001, specialty="ecg", active=True)
+    visible_profile = QueueProfile(
+        key="cardiology",
+        title="Cardiology",
+        title_ru="Cardiology",
+        queue_tags=["cardio", "cardiology", "cardiology_common"],
+        display_order=1,
+        is_active=True,
+        show_on_qr_page=True,
+    )
+    hidden_profile = QueueProfile(
+        key="ecg",
+        title="ECG",
+        title_ru="ECG",
+        queue_tags=["ecg", "echokg"],
+        display_order=2,
+        is_active=True,
+        show_on_qr_page=False,
+    )
+    db_session.add_all([hidden_doctor, visible_profile, hidden_profile])
+
+    token_value = "test-clinic-wide-hidden-specialist-token"
+    local_now = datetime.now(ZoneInfo("Asia/Tashkent")).replace(tzinfo=None)
+    token = QueueToken(
+        token=token_value,
+        day=date.today(),
+        specialist_id=None,
+        department="clinic",
+        is_clinic_wide=True,
+        expires_at=local_now + timedelta(hours=2),
+        active=True,
+    )
+    db_session.add(token)
+    db_session.commit()
+
+    start_resp = client.post("/api/v1/queue/join/start", json={"token": token_value})
+    assert start_resp.status_code == 200
+    hidden_doctor_resp = client.post(
+        "/api/v1/queue/join/complete",
+        json={
+            "session_token": start_resp.json()["session_token"],
+            "patient_name": "Hidden Doctor Patient",
+            "phone": "+998909991111",
+            "specialist_ids": [hidden_doctor.id],
+        },
+    )
+    assert hidden_doctor_resp.status_code == 400
+
+    start_resp = client.post("/api/v1/queue/join/start", json={"token": token_value})
+    assert start_resp.status_code == 200
+    hidden_profile_resp = client.post(
+        "/api/v1/queue/join/complete",
+        json={
+            "session_token": start_resp.json()["session_token"],
+            "patient_name": "Hidden Profile Patient",
+            "phone": "+998909992222",
+            "specialist_ids": [hidden_profile.id],
+        },
+    )
+    assert hidden_profile_resp.status_code == 400
+
+    entries = db_session.query(OnlineQueueEntry).all()
+    assert entries == []


### PR DESCRIPTION
## Summary
- Restrict clinic-wide QR join targets to backend-visible QR profiles.
- Reject hidden/non-QR QueueProfile IDs before they can fall back to a colliding Doctor ID.
- Reject legacy Doctor IDs whose specialty is not backed by a visible QR profile.
- Add an integration regression proving hidden doctor/profile IDs do not create OnlineQueueEntry rows.
- Fix the backend CI red-check by making protected Telegram staff action audit reference hashes alphabetic, so redacted hash text cannot accidentally contain a raw chat id string.

## Cyclic Execution Evidence
- Fresh main sync: branch codex/contract-scan-next-16 was created from origin/main at fe588ec3, the merge commit for PR #1562.
- Clean workspace: isolated worktree C:\tmp\final-contract-scan-next-16 had only this PR's queue service and targeted tests modified before commit; CI red-check handling added one protected Telegram audit adapter file.
- Branch: codex/contract-scan-next-16, commit 6a0b505a.
- Scope gate: gate_known_root_cause for backend/app/services/queue_service.py, second narrow gate for backend/tests/integration/test_qr_queue_join.py, and narrow override for backend/app/services/telegram_staff_action_adapter_service.py after CI exposed the audit redaction test failure.
- Red-check handling: backend CI failed on Telegram staff action audit payload redaction; fixed in this same PR and re-pushed for CI.

## Contract Impact
- Canonical surface: existing public POST /api/v1/queue/join/complete for clinic-wide QR tokens through QueueBusinessService.join_queue_with_token.
- Request shape: unchanged; specialist_ids remains a list of IDs submitted by QueueJoin.
- Response shape: unchanged for valid selectable specialists.
- Status codes: invalid hidden/non-selectable target IDs return the existing 400 ValueError path.
- Frontend consumer: frontend/src/pages/QueueJoin.jsx keeps rendering backend-provided selectable_specialists and sending selected IDs.
- Compatibility path or alias: no route alias, /api/v1/ui/* endpoint, BFF-lite path, or frontend fallback added.
- Contract proof: new integration test shows hidden Doctor.id and hidden QueueProfile.id are rejected and no OnlineQueueEntry is created.

## RBAC / Permissions
- Roles allowed: unchanged; clinic-wide QR join remains public QR flow.
- Roles denied: unchanged; no authenticated route or role gate changed.
- Positive auth proof: existing public QR join tests pass without auth headers.
- Negative auth proof: hidden/non-selectable public target IDs now fail with 400 and create no queue row.

## Notification / Realtime
- Event type or websocket channel: unchanged; valid queue.created broadcasts still happen in QRQueueService after successful allocation.
- Payload version / ack behavior: unchanged; no websocket payload schema or ack behavior changed.
- Read/unread or delivery semantics: not applicable because queue join does not use read/unread delivery state.
- Reconnect/resync proof: not checked; no realtime reconnect/resync code was touched.

## Frontend Resilience
- Empty data proof: not checked; no frontend rendering path changed.
- Partial data proof: not checked; backend response shape for valid success remains unchanged.
- Forbidden secondary path behavior: submitting a specialist ID not present in backend selectable_specialists now fails server-side.
- Missing draft/resource behavior: unchanged; session/token missing behavior remains the existing QR join error path.
- Stale route/deep-link behavior: unchanged; QueueJoin token route and localStorage behavior were not touched.

## Scope Gate
- Allowed paths: backend/app/services/queue_service.py, backend/tests/integration/test_qr_queue_join.py, backend/app/services/telegram_staff_action_adapter_service.py for the CI red-check fix.
- Denied paths: frontend, /api/v1/ui/*, BFF-lite, migrations, registrar/doctor endpoints, unrelated queue allocator cleanup.
- Migration/docs/test impact: no migration or docs changes; one targeted integration regression added.
- Rollback note: reverting this commit restores prior clinic-wide QR target acceptance, removes the regression test, and restores hex protected-action audit reference hashes.
- Stop conditions not hit.

## Validation
- Targeted tests or smoke run: py_compile for changed backend files; QR join integration test module; queue allocator characterization and QR service unit boundary tests; Telegram staff action adapter/confirm/runtime unit tests; git diff --check.
- Result: py_compile passed; tests/integration/test_qr_queue_join.py -> 4 passed; characterization/unit allocator tests -> 8 passed; Telegram staff action adapter/confirm/runtime tests -> 34 passed; combined QR/allocator run -> 12 passed; git diff --check passed.
- Not checked: full frontend build and full backend suite locally; GitHub backend tests and PR Required Gate are rerunning on PR.