### PR TITLE
fix(payments): reject ambiguous payme order ids

### DIFF
--- a/backend/app/services/payment_webhook.py
+++ b/backend/app/services/payment_webhook.py
@@ -42,20 +42,35 @@ class PaymentWebhookService:
         return getattr(account, key, None)
 
     @staticmethod
-    def _extract_payme_account_targets(
+    def _resolve_payme_account_targets(
+        db: Session,
         account: Any,
-    ) -> tuple[int | None, int | None]:
+    ) -> tuple[int | None, int | None, bool]:
         appointment_id = PaymentWebhookService._optional_int(
             PaymentWebhookService._account_value(account, "appointment_id")
         )
         visit_id = PaymentWebhookService._optional_int(
             PaymentWebhookService._account_value(account, "visit_id")
         )
-        if appointment_id is None and visit_id is None:
-            appointment_id = PaymentWebhookService._optional_int(
-                PaymentWebhookService._account_value(account, "order_id")
+        if appointment_id is not None or visit_id is not None:
+            return appointment_id, visit_id, False
+
+        order_id = PaymentWebhookService._optional_int(
+            PaymentWebhookService._account_value(account, "order_id")
+        )
+        if order_id is None:
+            return None, None, False
+
+        target_type, target_id = (
+            PaymentWebhookService._resolve_numeric_appointment_or_visit_target(
+                db, order_id
             )
-        return appointment_id, visit_id
+        )
+        if target_type == "ambiguous":
+            return None, None, True
+        if target_type == "visit":
+            return None, target_id, False
+        return target_id, None, False
 
     @staticmethod
     def _payme_targets_cross_patient(
@@ -78,10 +93,10 @@ class PaymentWebhookService:
         return int(appointment_patient_id) != int(visit_patient_id)
 
     @staticmethod
-    def _resolve_click_merchant_target(
-        db: Session, merchant_trans_id: Any
+    def _resolve_numeric_appointment_or_visit_target(
+        db: Session, target_value: Any
     ) -> tuple[str | None, int | None]:
-        target_id = PaymentWebhookService._optional_int(merchant_trans_id)
+        target_id = PaymentWebhookService._optional_int(target_value)
         if target_id is None:
             return None, None
 
@@ -101,6 +116,14 @@ class PaymentWebhookService:
         if visit_exists:
             return "visit", target_id
         return "appointment", target_id
+
+    @staticmethod
+    def _resolve_click_merchant_target(
+        db: Session, merchant_trans_id: Any
+    ) -> tuple[str | None, int | None]:
+        return PaymentWebhookService._resolve_numeric_appointment_or_visit_target(
+            db, merchant_trans_id
+        )
 
     @staticmethod
     def verify_payme_signature(
@@ -224,10 +247,11 @@ class PaymentWebhookService:
                     appointment_id = None
                     visit_id = None
 
+                    ambiguous_order_id = False
                     if hasattr(webhook_data, "account") and webhook_data.account:
-                        appointment_id, visit_id = (
-                            PaymentWebhookService._extract_payme_account_targets(
-                                webhook_data.account
+                        appointment_id, visit_id, ambiguous_order_id = (
+                            PaymentWebhookService._resolve_payme_account_targets(
+                                db, webhook_data.account
                             )
                         )
                         logger.info(
@@ -237,10 +261,32 @@ class PaymentWebhookService:
                                 "webhook_record_id": webhook.id,
                                 "has_appointment_target": appointment_id is not None,
                                 "has_visit_target": visit_id is not None,
+                                "ambiguous_order_id": ambiguous_order_id,
                             },
                         )
 
                     # Приоритет: сначала ищем appointment_id, потом visit_id
+                    if ambiguous_order_id:
+                        repository.update_webhook(
+                            webhook.id,
+                            {
+                                "status": "failed",
+                                "processed_at": datetime.utcnow(),
+                                "error_message": (
+                                    "Ambiguous Payme account order_id matches both "
+                                    "Appointment.id and Visit.id"
+                                ),
+                            },
+                        )
+                        logger.warning(
+                            "payment_webhook_payme_ambiguous_account_order_id",
+                            extra={
+                                "payment_provider": "payme",
+                                "webhook_record_id": webhook.id,
+                            },
+                        )
+                        return True, "Webhook processed successfully", webhook
+
                     if (
                         appointment_id is not None
                         and visit_id is not None

--- a/backend/tests/unit/test_payment_webhook_service.py
+++ b/backend/tests/unit/test_payment_webhook_service.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+from datetime import date
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 
+from app.models.appointment import Appointment
+from app.models.patient import Patient
+from app.models.visit import Visit
 from app.services.payment_webhook import PaymentWebhookService
 
 
@@ -228,6 +232,151 @@ class TestPaymentWebhookService:
         assert failed_update["error_message"] == (
             "Payme account appointment_id and visit_id belong to different patients"
         )
+
+    def test_payme_numeric_order_id_resolver_detects_appointment_visit_collision(
+        self, db_session
+    ):
+        patient = Patient(last_name="Payme", first_name="Collision")
+        db_session.add(patient)
+        db_session.flush()
+        db_session.add_all(
+            [
+                Appointment(
+                    id=888,
+                    patient_id=patient.id,
+                    appointment_date=date(2026, 2, 14),
+                    status="scheduled",
+                ),
+                Visit(id=888, patient_id=patient.id, status="open"),
+            ]
+        )
+        db_session.commit()
+
+        target_type, target_id = (
+            PaymentWebhookService._resolve_numeric_appointment_or_visit_target(
+                db_session, 888
+            )
+        )
+
+        assert (target_type, target_id) == ("ambiguous", 888)
+
+    def test_payme_webhook_uses_visit_target_when_numeric_order_id_matches_visit_only(
+        self, db_session
+    ):
+        webhook = SimpleNamespace(id=99)
+        repository = SimpleNamespace(
+            get_provider_by_code=Mock(return_value=SimpleNamespace(secret_key="secret")),
+            get_webhook_by_webhook_id=Mock(return_value=None),
+            create_webhook=Mock(return_value=webhook),
+            create_transaction=Mock(return_value=SimpleNamespace(id=100)),
+            update_webhook=Mock(return_value=webhook),
+        )
+        data = {
+            "id": "payme-tx-1",
+            "state": 2,
+            "amount": 250000,
+            "account": {"order_id": "888"},
+        }
+
+        with (
+            patch(
+                "app.services.payment_webhook.PaymentWebhookProcessingRepository",
+                return_value=repository,
+            ),
+            patch.object(
+                PaymentWebhookService, "verify_payme_signature", return_value=True
+            ),
+            patch.object(
+                PaymentWebhookService,
+                "_resolve_numeric_appointment_or_visit_target",
+                return_value=("visit", 888),
+            ),
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_appointment",
+                return_value=(True, "appointment paid"),
+            ) as process_appointment,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_existing_visit",
+                return_value=(True, "visit paid"),
+            ) as process_visit,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.create_appointment_from_payment",
+                return_value=(True, "created", 501),
+            ) as create_appointment,
+        ):
+            success, message, result_webhook = PaymentWebhookService.process_payme_webhook(
+                db_session, data, "signature"
+            )
+
+        assert success is True
+        assert message == "Webhook processed successfully"
+        assert result_webhook is webhook
+        process_visit.assert_called_once_with(db_session, 888, webhook)
+        process_appointment.assert_not_called()
+        create_appointment.assert_not_called()
+
+    def test_payme_webhook_fails_ambiguous_numeric_order_id_without_mutating_record(
+        self, db_session
+    ):
+        webhook = SimpleNamespace(id=99)
+        repository = SimpleNamespace(
+            get_provider_by_code=Mock(return_value=SimpleNamespace(secret_key="secret")),
+            get_webhook_by_webhook_id=Mock(return_value=None),
+            create_webhook=Mock(return_value=webhook),
+            create_transaction=Mock(return_value=SimpleNamespace(id=100)),
+            update_webhook=Mock(return_value=webhook),
+        )
+        data = {
+            "id": "payme-tx-1",
+            "state": 2,
+            "amount": 250000,
+            "account": {"order_id": "888"},
+        }
+
+        with (
+            patch(
+                "app.services.payment_webhook.PaymentWebhookProcessingRepository",
+                return_value=repository,
+            ),
+            patch.object(
+                PaymentWebhookService, "verify_payme_signature", return_value=True
+            ),
+            patch.object(
+                PaymentWebhookService,
+                "_resolve_numeric_appointment_or_visit_target",
+                return_value=("ambiguous", 888),
+            ),
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_appointment",
+                return_value=(True, "appointment paid"),
+            ) as process_appointment,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.process_payment_for_existing_visit",
+                return_value=(True, "visit paid"),
+            ) as process_visit,
+            patch(
+                "app.services.payment_webhook.VisitPaymentIntegrationService.create_appointment_from_payment",
+                return_value=(True, "created", 501),
+            ) as create_appointment,
+        ):
+            success, message, result_webhook = PaymentWebhookService.process_payme_webhook(
+                db_session, data, "signature"
+            )
+
+        assert success is True
+        assert message == "Webhook processed successfully"
+        assert result_webhook is webhook
+        process_appointment.assert_not_called()
+        process_visit.assert_not_called()
+        create_appointment.assert_not_called()
+
+        _, failed_update = repository.update_webhook.call_args_list[-1].args
+        assert failed_update["status"] == "failed"
+        expected_error = (
+            "Ambiguous Payme account order_id matches both "
+            "Appointment.id and Visit.id"
+        )
+        assert failed_update["error_message"] == expected_error
 
     def test_click_webhook_uses_visit_target_when_merchant_id_matches_visit_only(
         self, db_session


### PR DESCRIPTION
## Summary
- Reject legacy Payme numeric account.order_id when the same id matches both Appointment.id and Visit.id.
- Route Payme visit-only numeric order_id through the existing visit payment path.
- Keep explicit Payme appointment_id / visit_id accounts unchanged and keep Click on the shared ambiguity resolver.

## Cyclic Execution Evidence
- Fresh main sync: branch codex/contract-scan-next-17 was created from fresh origin/main after PR #1565 merged.
- Clean workspace: inspected before edits; only payment_webhook.py and test_payment_webhook_service.py changed.
- Branch: codex/contract-scan-next-17.
- Scope gate: allowed legacy payment webhook service and targeted unit regressions; denied frontend, /api/v1/ui/*, BFF-lite, migrations, and unrelated payment services.
- Red-check handling: fix failed targeted tests or CI checks in this same PR before merge; current code checks are green except this PR body gate update.

## Contract Impact
- Canonical surface: legacy Payme webhook processing behind /api/v1/webhooks/payment/payme and /api/v1/payments/webhook/payme service path.
- Request shape: signed Payme callback body is unchanged; account.appointment_id and account.visit_id remain explicit targets, account.order_id remains legacy numeric fallback.
- Response shape: unchanged success tuple/API response; ambiguous order_id records the webhook as failed without mutating appointment or visit payment state.
- Status codes: unchanged endpoint success handling for accepted webhook payloads; invalid signature and duplicate behavior unchanged.
- Frontend consumer: not applicable - no frontend code consumes or changes this webhook contract directly.
- Compatibility path or alias: legacy order_id appointment fallback is preserved when no Visit.id collision exists; Click merchant_trans_id keeps the same ambiguity behavior via shared resolver.
- Contract proof: targeted unit tests cover Payme explicit targets, visit-only order_id, ambiguous order_id, and resolver DB collision; legacy webhook integration smoke remains green.

## RBAC / Permissions
- Roles allowed: not applicable - provider webhooks are signed provider callbacks, not user-role authenticated UI commands.
- Roles denied: not applicable - no RBAC surface changed for staff, doctor, patient, registrar, cashier, or admin users.
- Positive auth proof: Payme signature verification path remains covered by existing service unit tests.
- Negative auth proof: signature rejection behavior was not changed; existing invalid signature handling remains outside this targeted id-collision patch.

## Notification / Realtime
- Event type or websocket channel: not applicable - no notification event type or websocket channel changed.
- Payload version / ack behavior: not applicable - webhook response/ack shape is unchanged.
- Read/unread or delivery semantics: not applicable - no notification delivery state changed.
- Reconnect/resync proof: not applicable - no realtime reconnect or resync behavior touched.

## Frontend Resilience
- Empty data proof: not applicable - no frontend data rendering path changed.
- Partial data proof: not applicable - no frontend partial data state changed.
- Forbidden secondary path behavior: not applicable - no frontend fallback/secondary path changed.
- Missing draft/resource behavior: not applicable - no draft/resource reopen behavior touched.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior touched.

## Scope Gate
- Allowed paths: backend/app/services/payment_webhook.py, backend/tests/unit/test_payment_webhook_service.py.
- Denied paths: frontend, /api/v1/ui/*, BFF-lite, migrations, unrelated payment services, generated artifacts.
- Migration/docs/test impact: no migration or docs change; targeted unit regression tests updated.
- Rollback note: revert this commit to restore previous Payme order_id fallback behavior and remove the new unit tests.

## Validation
- Targeted tests or smoke run: py_compile for changed files; pytest tests/unit/test_payment_webhook_service.py; pytest tests/integration/test_legacy_payment_webhook_body_limits.py; pytest tests/integration/test_notification_catalog_slice3_legacy_webhooks.py tests/integration/test_legacy_payment_webhook_body_limits.py; git diff --check.
- Result: all local validation passed; GitHub backend, CodeQL, security, CI scope, context boundary, and PR Required Gate passed before this body-only update.
- Not checked: full frontend build/browser smoke because this PR does not touch frontend or UI contracts.