### PR TITLE
refactor(admin): route appointments directly

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -72,6 +72,7 @@ const ClinicManagement = lazy(() => import('./components/admin/ClinicManagement.
 const QueueCabinetManagement = lazy(() => import('./components/admin/QueueCabinetManagement.jsx'));
 const AdminDoctors = lazy(() => import('./components/admin/AdminDoctors.jsx'));
 const AdminPatients = lazy(() => import('./components/admin/AdminPatients.jsx'));
+const AdminAppointments = lazy(() => import('./components/admin/AdminAppointments.jsx'));
 const AdminServices = lazy(() => import('./components/admin/AdminServices.jsx'));
 const UnifiedFinance = lazy(() => import('./components/admin/UnifiedFinance.jsx'));
 const UnifiedSettings = lazy(() => import('./components/admin/UnifiedSettings.jsx'));
@@ -144,6 +145,7 @@ const ROUTE_COMPONENTS = {
   QueueCabinetManagement,
   AdminDoctors,
   AdminPatients,
+  AdminAppointments,
   AdminServices,
   UnifiedFinance,
   UnifiedSettings,

--- a/frontend/src/components/admin/AdminAppointments.jsx
+++ b/frontend/src/components/admin/AdminAppointments.jsx
@@ -1,0 +1,641 @@
+import { Calendar, Clock, Edit, Plus, RefreshCw, Search, Trash2 } from 'lucide-react';
+import PropTypes from 'prop-types';
+
+import AppointmentModal from './AppointmentModal';
+import useAppointments from '../../hooks/useAppointments';
+import useDoctors from '../../hooks/useDoctors';
+import usePatients from '../../hooks/usePatients';
+import useModal from '../../hooks/useModal.jsx';
+import notify from '../../services/notify';
+import {
+  MacOSBadge,
+  MacOSButton,
+  MacOSCard,
+  MacOSEmptyState,
+  MacOSInput,
+  MacOSLoadingSkeleton,
+  MacOSSelect,
+} from '../ui/macos';
+import logger from '../../utils/logger';
+
+const statusOptions = [
+  { value: '', label: 'Все статусы' },
+  { value: 'pending', label: 'Ожидает' },
+  { value: 'confirmed', label: 'Подтверждена' },
+  { value: 'paid', label: 'Оплачена' },
+  { value: 'in_visit', label: 'На приеме' },
+  { value: 'completed', label: 'Завершена' },
+  { value: 'cancelled', label: 'Отменена' },
+  { value: 'no_show', label: 'Не явился' },
+];
+
+const tableHeaderStyle = {
+  textAlign: 'left',
+  padding: '12px 16px',
+  color: 'var(--mac-text-secondary)',
+  fontWeight: 'var(--mac-font-weight-semibold)',
+  fontSize: 'var(--mac-font-size-sm)',
+};
+
+const textCellStyle = {
+  padding: '12px 16px',
+  fontSize: 'var(--mac-font-size-sm)',
+  color: 'var(--mac-text-secondary)',
+};
+
+const getAppointmentPatientDisplayName = (appointment) => {
+  const rawName =
+    appointment?.patientName ||
+    appointment?.patient_name ||
+    appointment?.patient?.full_name ||
+    appointment?.patient?.fio ||
+    appointment?.patient?.name ||
+    appointment?.patient?.first_name ||
+    appointment?.patient?.last_name ||
+    'Пациент';
+
+  const normalized = String(rawName).trim();
+  return normalized || 'Пациент';
+};
+
+const getAppointmentDoctorDisplayName = (appointment) => {
+  const rawName =
+    appointment?.doctorName ||
+    appointment?.doctor_name ||
+    appointment?.doctor?.full_name ||
+    appointment?.doctor?.name ||
+    appointment?.doctor?.user?.full_name ||
+    appointment?.doctor?.user?.username ||
+    'Врач';
+
+  const normalized = String(rawName).trim();
+  return normalized || 'Врач';
+};
+
+const getAppointmentDoctorSpecialization = (appointment) => {
+  const rawValue =
+    appointment?.doctorSpecialization ||
+    appointment?.doctor_specialization ||
+    appointment?.specialization ||
+    appointment?.doctor?.specialization ||
+    appointment?.doctor?.specialty ||
+    '';
+
+  return String(rawValue).trim();
+};
+
+const getAppointmentStatusLabel = (status) => {
+  const statusMap = {
+    pending: 'Ожидает оплаты',
+    scheduled: 'Запланирована',
+    confirmed: 'Подтверждена',
+    paid: 'Оплачена',
+    in_visit: 'На приеме',
+    completed: 'Завершена',
+    cancelled: 'Отменена',
+    no_show: 'Не явился',
+  };
+  return statusMap[status] || status || 'Не указан';
+};
+
+const getAppointmentStatusVariant = (status) => {
+  const variantMap = {
+    pending: 'warning',
+    scheduled: 'warning',
+    confirmed: 'info',
+    paid: 'success',
+    in_visit: 'primary',
+    completed: 'success',
+    cancelled: 'error',
+    no_show: 'secondary',
+  };
+  return variantMap[status] || 'secondary';
+};
+
+const getInitials = (value, fallback) =>
+  String(value || fallback)
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2) || fallback;
+
+const formatAppointmentDate = (value) => {
+  if (!value) {
+    return 'Дата не указана';
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return parsed.toLocaleDateString('ru-RU');
+};
+
+const getDoctorOptionLabel = (doctor) => {
+  const name = doctor.user?.full_name || doctor.name || doctor.user?.username || `Врач #${doctor.id}`;
+  const flags = [
+    doctor.active === false ? 'неактивен' : null,
+    doctor.user?.is_active === false ? 'аккаунт неактивен' : null,
+    doctor.cabinet ? `каб. ${doctor.cabinet}` : null,
+  ].filter(Boolean);
+
+  return flags.length > 0 ? `${name} • ${flags.join(' • ')}` : name;
+};
+
+const IconButton = ({ label, tone = 'default', onClick, children }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-label={label}
+    title={label}
+    style={{
+      width: '32px',
+      height: '32px',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 0,
+      border: '1px solid transparent',
+      borderRadius: 'var(--mac-radius-sm)',
+      color: tone === 'danger' ? 'var(--mac-error)' : 'var(--mac-text-secondary)',
+      backgroundColor: 'transparent',
+      cursor: 'pointer',
+      transition: 'background-color var(--mac-duration-normal) var(--mac-ease)',
+    }}
+    onMouseEnter={(event) => {
+      event.currentTarget.style.backgroundColor = 'var(--mac-bg-tertiary)';
+    }}
+    onMouseLeave={(event) => {
+      event.currentTarget.style.backgroundColor = 'transparent';
+    }}
+  >
+    {children}
+  </button>
+);
+
+IconButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  label: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+  tone: PropTypes.oneOf(['default', 'danger']),
+};
+
+const StatCard = ({ label, value, icon: Icon, color }) => (
+  <MacOSCard style={{ padding: '24px' }}>
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '16px' }}>
+      <div>
+        <p
+          style={{
+            fontSize: 'var(--mac-font-size-sm)',
+            fontWeight: 'var(--mac-font-weight-medium)',
+            color: 'var(--mac-text-secondary)',
+            margin: 0,
+          }}
+        >
+          {label}
+        </p>
+        <p
+          style={{
+            fontSize: 'var(--mac-font-size-2xl)',
+            fontWeight: 'var(--mac-font-weight-bold)',
+            color: 'var(--mac-text-primary)',
+            margin: '4px 0 0',
+          }}
+        >
+          {value}
+        </p>
+      </div>
+      <Icon aria-hidden="true" size={32} style={{ color }} />
+    </div>
+  </MacOSCard>
+);
+
+StatCard.propTypes = {
+  color: PropTypes.string.isRequired,
+  icon: PropTypes.elementType.isRequired,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.number.isRequired,
+};
+
+const AdminAppointments = () => {
+  const { allDoctors } = useDoctors();
+  const { patients } = usePatients();
+  const {
+    appointments,
+    loading,
+    error,
+    searchTerm,
+    setSearchTerm,
+    filterStatus,
+    setFilterStatus,
+    filterDate,
+    setFilterDate,
+    filterDoctor,
+    setFilterDoctor,
+    createAppointment,
+    updateAppointment,
+    deleteAppointment,
+    refresh,
+    getStatusStats,
+    getTodayAppointments,
+    getTomorrowAppointments,
+  } = useAppointments(allDoctors);
+  const appointmentModal = useModal();
+
+  const statusStats = getStatusStats();
+  const todayAppointments = getTodayAppointments();
+  const tomorrowAppointments = getTomorrowAppointments();
+  const filtersActive = Boolean(searchTerm || filterStatus || filterDate || filterDoctor);
+  const doctorOptions = [
+    { value: '', label: 'Все врачи' },
+    ...allDoctors.map((doctor) => ({
+      value: String(doctor.id),
+      label: getDoctorOptionLabel(doctor),
+    })),
+  ];
+
+  const handleCreateAppointment = () => {
+    appointmentModal.openModal(null);
+  };
+
+  const handleEditAppointment = (appointment) => {
+    appointmentModal.openModal(appointment);
+  };
+
+  const handleDeleteAppointment = async (appointment) => {
+    const patientName = getAppointmentPatientDisplayName(appointment);
+    const doctorName = getAppointmentDoctorDisplayName(appointment);
+    const confirmed = window.confirm(`Вы уверены, что хотите удалить запись "${patientName} - ${doctorName}"?`);
+
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      await deleteAppointment(appointment.id);
+    } catch (deleteError) {
+      logger.error('Ошибка удаления записи:', deleteError);
+      notify.error('Ошибка при удалении записи');
+    }
+  };
+
+  const handleSaveAppointment = async (appointmentData) => {
+    appointmentModal.setModalLoading(true);
+    try {
+      if (appointmentModal.selectedItem) {
+        await updateAppointment(appointmentModal.selectedItem.id, appointmentData);
+      } else {
+        await createAppointment(appointmentData);
+      }
+      appointmentModal.closeModal();
+    } catch (saveError) {
+      logger.error('Ошибка сохранения записи:', saveError);
+      throw saveError;
+    } finally {
+      appointmentModal.setModalLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+          gap: '16px',
+        }}
+      >
+        <StatCard label="Всего записей" value={appointments.length} icon={Calendar} color="var(--mac-accent)" />
+        <StatCard label="На сегодня" value={todayAppointments.length} icon={Clock} color="var(--mac-success)" />
+        <StatCard label="На завтра" value={tomorrowAppointments.length} icon={Calendar} color="var(--mac-text-primary)" />
+        <StatCard label="Ожидают" value={statusStats.pending || 0} icon={Clock} color="var(--mac-warning)" />
+      </div>
+
+      <MacOSCard
+        variant="default"
+        shadow="none"
+        style={{
+          background: 'var(--mac-bg-primary)',
+          border: '1px solid var(--mac-border)',
+          padding: '24px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '16px',
+            marginBottom: '24px',
+            flexWrap: 'wrap',
+          }}
+        >
+          <div>
+            <h2
+              style={{
+                fontSize: 'var(--mac-font-size-xl)',
+                fontWeight: 'var(--mac-font-weight-semibold)',
+                color: 'var(--mac-text-primary)',
+                margin: 0,
+              }}
+            >
+              Управление записями
+            </h2>
+            <p
+              style={{
+                margin: '6px 0 0',
+                color: 'var(--mac-text-secondary)',
+                fontSize: 'var(--mac-font-size-sm)',
+              }}
+            >
+              Административный обзор записей, врачей, кабинетов и статусов.
+            </p>
+          </div>
+          <MacOSButton onClick={handleCreateAppointment} startIcon={<Plus size={16} />}>
+            Создать запись
+          </MacOSButton>
+        </div>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'minmax(220px, 1fr) minmax(150px, 190px) minmax(150px, 190px) minmax(180px, 240px)',
+            gap: '12px',
+            marginBottom: '24px',
+          }}
+        >
+          <MacOSInput
+            type="text"
+            placeholder="Поиск записей..."
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            icon={Search}
+            iconPosition="left"
+            aria-label="Поиск записей"
+          />
+          <MacOSSelect
+            value={filterStatus}
+            onChange={(event) => setFilterStatus(event.target.value)}
+            options={statusOptions}
+            aria-label="Фильтр по статусу записи"
+          />
+          <MacOSInput
+            type="date"
+            value={filterDate}
+            onChange={(event) => setFilterDate(event.target.value)}
+            aria-label="Фильтр по дате записи"
+          />
+          <MacOSSelect
+            value={filterDoctor}
+            onChange={(event) => setFilterDoctor(event.target.value)}
+            options={doctorOptions}
+            aria-label="Фильтр по врачу"
+          />
+        </div>
+
+        <div style={{ overflowX: 'auto' }}>
+          {loading ? (
+            <MacOSLoadingSkeleton type="table" count={5} />
+          ) : error ? (
+            <MacOSEmptyState
+              icon={RefreshCw}
+              title="Ошибка загрузки записей"
+              description="Не удалось загрузить список записей. Проверьте соединение и попробуйте снова."
+              action={
+                <MacOSButton onClick={refresh} startIcon={<RefreshCw size={16} />}>
+                  Обновить
+                </MacOSButton>
+              }
+            />
+          ) : appointments.length === 0 ? (
+            <MacOSEmptyState
+              icon={Calendar}
+              title="Записи не найдены"
+              description={
+                filtersActive
+                  ? 'Попробуйте изменить параметры поиска.'
+                  : 'В системе пока нет записей.'
+              }
+              action={
+                <MacOSButton onClick={handleCreateAppointment} startIcon={<Plus size={16} />}>
+                  Создать первую запись
+                </MacOSButton>
+              }
+            />
+          ) : (
+            <table style={{ width: '100%', borderCollapse: 'collapse' }} aria-label="Таблица записей">
+              <thead>
+                <tr
+                  style={{
+                    backgroundColor: 'var(--mac-bg-secondary)',
+                    borderBottom: '1px solid var(--mac-border)',
+                  }}
+                >
+                  <th scope="col" style={tableHeaderStyle}>Пациент</th>
+                  <th scope="col" style={tableHeaderStyle}>Врач</th>
+                  <th scope="col" style={tableHeaderStyle}>Кабинет</th>
+                  <th scope="col" style={tableHeaderStyle}>Дата и время</th>
+                  <th scope="col" style={tableHeaderStyle}>Статус</th>
+                  <th scope="col" style={tableHeaderStyle}>Связность</th>
+                  <th scope="col" style={tableHeaderStyle}>Причина</th>
+                  <th scope="col" style={tableHeaderStyle}>Действия</th>
+                </tr>
+              </thead>
+              <tbody>
+                {appointments.map((appointment) => {
+                  const patientName = getAppointmentPatientDisplayName(appointment);
+                  const doctorName = getAppointmentDoctorDisplayName(appointment);
+                  const doctorSpecialization = getAppointmentDoctorSpecialization(appointment);
+                  const reason = appointment.reason || '';
+
+                  return (
+                    <tr
+                      key={appointment.id}
+                      style={{
+                        borderBottom: '1px solid var(--mac-border)',
+                        transition: 'background-color var(--mac-duration-normal) var(--mac-ease)',
+                      }}
+                      onMouseEnter={(event) => {
+                        event.currentTarget.style.backgroundColor = 'var(--mac-bg-secondary)';
+                      }}
+                      onMouseLeave={(event) => {
+                        event.currentTarget.style.backgroundColor = 'transparent';
+                      }}
+                    >
+                      <td aria-label={`Пациент ${patientName}`} style={{ padding: '12px 16px' }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                          <div
+                            aria-hidden="true"
+                            style={{
+                              width: '32px',
+                              height: '32px',
+                              borderRadius: '50%',
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              background: 'var(--mac-accent-blue)',
+                              color: 'var(--mac-text-on-accent)',
+                              fontSize: 'var(--mac-font-size-sm)',
+                              fontWeight: 'var(--mac-font-weight-medium)',
+                            }}
+                          >
+                            {getInitials(patientName, 'П')}
+                          </div>
+                          <div>
+                            <p
+                              style={{
+                                fontWeight: 'var(--mac-font-weight-medium)',
+                                color: 'var(--mac-text-primary)',
+                                margin: 0,
+                              }}
+                            >
+                              {patientName}
+                            </p>
+                            {appointment.phone ? (
+                              <p
+                                style={{
+                                  fontSize: 'var(--mac-font-size-sm)',
+                                  color: 'var(--mac-text-secondary)',
+                                  margin: '4px 0 0',
+                                }}
+                              >
+                                {appointment.phone}
+                              </p>
+                            ) : null}
+                          </div>
+                        </div>
+                      </td>
+                      <td style={{ padding: '12px 16px' }}>
+                        <p
+                          style={{
+                            fontWeight: 'var(--mac-font-weight-medium)',
+                            color: 'var(--mac-text-primary)',
+                            margin: 0,
+                          }}
+                        >
+                          {doctorName}
+                        </p>
+                        <p
+                          style={{
+                            fontSize: 'var(--mac-font-size-sm)',
+                            color: 'var(--mac-text-secondary)',
+                            margin: '4px 0 0',
+                          }}
+                        >
+                          {doctorSpecialization || '—'}
+                        </p>
+                        <div style={{ marginTop: '4px' }}>
+                          <MacOSBadge
+                            variant={
+                              appointment.doctor?.active === false || appointment.doctor?.user_active === false
+                                ? 'warning'
+                                : 'success'
+                            }
+                            size="sm"
+                          >
+                            {appointment.doctor?.active === false
+                              ? 'Врач неактивен'
+                              : appointment.doctor?.user_active === false
+                                ? 'Аккаунт врача неактивен'
+                                : 'Связь активна'}
+                          </MacOSBadge>
+                        </div>
+                      </td>
+                      <td style={{ padding: '12px 16px' }}>
+                        <p
+                          style={{
+                            fontWeight: 'var(--mac-font-weight-medium)',
+                            color: 'var(--mac-text-primary)',
+                            margin: 0,
+                          }}
+                        >
+                          {appointment.effectiveCabinet || '—'}
+                        </p>
+                        <p
+                          style={{
+                            fontSize: 'var(--mac-font-size-xs)',
+                            color: 'var(--mac-text-secondary)',
+                            margin: '4px 0 0',
+                          }}
+                        >
+                          {appointment.queueCabinet
+                            ? `Очередь: ${appointment.queueCabinet}`
+                            : appointment.doctorCabinet
+                              ? `Врач: ${appointment.doctorCabinet}`
+                              : 'Нет связанного кабинета'}
+                        </p>
+                      </td>
+                      <td style={textCellStyle}>
+                        <p style={{ margin: 0, fontWeight: 'var(--mac-font-weight-medium)' }}>
+                          {formatAppointmentDate(appointment.appointmentDate)}
+                        </p>
+                        <p style={{ margin: '4px 0 0' }}>
+                          {appointment.appointmentTime || 'Время не указано'} ({appointment.duration || 30} мин)
+                        </p>
+                      </td>
+                      <td style={{ padding: '12px 16px' }}>
+                        <MacOSBadge variant={getAppointmentStatusVariant(appointment.status)}>
+                          {getAppointmentStatusLabel(appointment.status)}
+                        </MacOSBadge>
+                      </td>
+                      <td style={{ padding: '12px 16px' }}>
+                        {appointment.hasIntegrityWarnings ? (
+                          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                            <MacOSBadge variant="warning">Требует проверки</MacOSBadge>
+                            <p
+                              style={{
+                                fontSize: 'var(--mac-font-size-xs)',
+                                color: 'var(--mac-text-secondary)',
+                                margin: 0,
+                              }}
+                            >
+                              {(appointment.integrityWarnings || []).join(', ')}
+                            </p>
+                          </div>
+                        ) : (
+                          <MacOSBadge variant="success">Связано</MacOSBadge>
+                        )}
+                      </td>
+                      <td style={textCellStyle}>
+                        {reason.length > 50 ? `${reason.substring(0, 50)}...` : reason || 'Не указана'}
+                      </td>
+                      <td aria-label={`Действия для записи ${patientName} - ${doctorName}`} style={{ padding: '12px 16px' }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                          <IconButton label="Редактировать запись" onClick={() => handleEditAppointment(appointment)}>
+                            <Edit size={16} />
+                          </IconButton>
+                          <IconButton
+                            label="Удалить запись"
+                            tone="danger"
+                            onClick={() => handleDeleteAppointment(appointment)}
+                          >
+                            <Trash2 size={16} />
+                          </IconButton>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </MacOSCard>
+
+      <AppointmentModal
+        isOpen={appointmentModal.isOpen}
+        onClose={appointmentModal.closeModal}
+        appointment={appointmentModal.selectedItem}
+        onSave={handleSaveAppointment}
+        loading={appointmentModal.loading}
+        doctors={allDoctors}
+        patients={patients}
+      />
+    </div>
+  );
+};
+
+export default AdminAppointments;

--- a/frontend/src/routing/__tests__/routeContract.test.js
+++ b/frontend/src/routing/__tests__/routeContract.test.js
@@ -441,6 +441,22 @@ describe('route contract invariants', () => {
     expect(getRouteChromeState('/admin/patients', '', adminProfile).activeSidebarItem).toBe('admin-patients');
   });
 
+  it('keeps admin appointments on its direct route owner', () => {
+    const adminProfile = { role: 'Admin' };
+    const appointmentsRoute = getRouteById('admin-appointments');
+
+    expect(appointmentsRoute).toBeTruthy();
+    expect(appointmentsRoute.path).toBe('/admin/appointments');
+    expect(appointmentsRoute.owner).toBe('admin.scheduling');
+    expect(appointmentsRoute.entry).toBe('direct');
+    expect(appointmentsRoute.component).toBe('AdminAppointments');
+    expect(appointmentsRoute.component).not.toBe('AdminPanel');
+    expect(appointmentsRoute.nav.sidebar).toBe(true);
+    expect(appointmentsRoute.layout.activeSidebarItem).toBe('admin-appointments');
+    expect(isRouteAccessibleToProfile(appointmentsRoute, adminProfile)).toBe(true);
+    expect(getRouteChromeState('/admin/appointments', '', adminProfile).activeSidebarItem).toBe('admin-appointments');
+  });
+
   it('keeps admin clinic management on its direct route owner', () => {
     const adminProfile = { role: 'Admin' };
     const clinicManagementRoute = getRouteById('admin-clinic-management');

--- a/frontend/src/routing/routeRegistry.js
+++ b/frontend/src/routing/routeRegistry.js
@@ -622,7 +622,7 @@ export const ROUTE_REGISTRY = [
     nav: nav({ label: 'Записи', icon: 'calendar', section: 'Управление', order: 60, sidebar: true }),
     title: 'Admin Appointments',
     owner: 'admin.scheduling',
-    component: 'AdminPanel',
+    component: 'AdminAppointments',
     legacyRedirectFrom: [],
     layout: layout({ sidebarPreset: 'admin', activeSidebarItem: 'admin-appointments', pageTitle: 'Admin Appointments' }),
   },


### PR DESCRIPTION
## Summary

- Route `/admin/appointments` to a dedicated `AdminAppointments` component instead of the legacy shared `AdminPanel` section switch.
- Preserve existing appointment create/edit/delete behavior through `useAppointments` and `AppointmentModal`.
- Add a route contract regression that prevents this route from drifting back to `AdminPanel`.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` before edits.
- Clean workspace: inspected before edits; only scoped frontend route/component/test files changed.
- Branch: `refactor/admin-appointments-direct-route`
- Scope gate: `agent_gate` returned `narrow_override` for this known direct route-owner slice; edits stayed inside allowed frontend route/component/test paths.
- Red-check handling: fix failed local or GitHub checks in this same PR before merge.

## Contract Impact

- Canonical surface: frontend route `/admin/appointments` and route registry id `admin-appointments`.
- Request shape: unchanged; the route still uses existing authenticated frontend calls from `useAppointments`.
- Response shape: unchanged; existing appointment DTO handling remains in `useAppointments` and `AppointmentModal`.
- Status codes: unchanged; no backend endpoint or status handling changed.
- Frontend consumer: admin appointments screen now consumes the route through `AdminAppointments`.
- Compatibility path or alias: no URL alias changed; only the route component owner changed from `AdminPanel` to `AdminAppointments`.
- Contract proof: `routeContract.test.js` asserts `/admin/appointments` keeps direct owner `AdminAppointments` and remains accessible to Admin.

## RBAC / Permissions

- Roles allowed: Admin through the existing route registry role configuration.
- Roles denied: all non-Admin roles remain denied by existing route access checks; no auth/RBAC code changed.
- Positive auth proof: route contract test asserts Admin profile can access `admin-appointments`.
- Negative auth proof: not re-run in this slice because RBAC rules were not changed; existing registry-level role rules remain the source of truth.

## Notification / Realtime

not applicable - no notification, websocket, polling, queue, payment, Telegram, EMR, lab, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: dedicated appointments screen renders a named empty state and create action when no appointments match filters.
- Partial data proof: display helpers tolerate missing patient, doctor, specialization, cabinet, reason, phone, date, and time fields.
- Forbidden secondary path behavior: not applicable, route access remains handled before this component renders.
- Missing draft/resource behavior: appointment modal close/save paths reuse existing modal state and do not create separate draft resources.
- Stale route/deep-link behavior: route registry still maps `/admin/appointments` to active sidebar item `admin-appointments`.

## Scope Gate

- Allowed paths: `frontend/src/App.jsx`, `frontend/src/components/admin/AdminAppointments.jsx`, `frontend/src/routing/routeRegistry.js`, `frontend/src/routing/__tests__/routeContract.test.js`.
- Denied paths: backend runtime, database migrations, RBAC/auth logic, appointment API contracts, unrelated admin routes.
- Migration/docs/test impact: no migration; no docs update; route contract test updated.
- Rollback note: revert the dedicated component, route registry owner change, App lazy registration, and route contract assertion.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js`; `npm.cmd run lint:check -- --quiet --rule "no-warning-comments: off"`; `npm.cmd run build`; `git diff --check`.
- Result: route contract passed with 38 tests; lint passed; build passed; diff-check passed with CRLF warnings only.
- Not checked: full authenticated browser click-through for appointment CRUD; no runtime contract changed in this route-owner slice.
