### PR TITLE
refactor(admin): remove legacy panel registration

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,7 +37,6 @@ const Audit = lazy(() => import('./pages/Audit.jsx'));
 const Scheduler = lazy(() => import('./pages/Scheduler.jsx'));
 const Appointments = lazy(() => import('./pages/Appointments.jsx'));
 const VisitDetails = lazy(() => import('./pages/VisitDetails.jsx'));
-const AdminPanel = lazy(() => import('./pages/AdminPanel.jsx'));
 const RegistrarPanel = lazy(() => import('./pages/RegistrarPanel.jsx'));
 const DoctorPanel = lazy(() => import('./pages/DoctorPanel.jsx'));
 const CardiologistPanelUnified = lazy(() => import('./pages/CardiologistPanelUnified.jsx'));
@@ -101,7 +100,6 @@ const ROUTE_COMPONENTS = {
   PaymentCancel,
   DisplayBoardUnified,
   Setup,
-  AdminPanel,
   AnalyticsPage,
   Settings,
   Audit,

--- a/frontend/src/routing/__tests__/routeContract.test.js
+++ b/frontend/src/routing/__tests__/routeContract.test.js
@@ -156,6 +156,14 @@ describe('route contract invariants', () => {
     });
   });
 
+  it('keeps admin routes off the legacy AdminPanel component owner', () => {
+    const legacyAdminPanelRoutes = ROUTE_REGISTRY.filter(
+      (route) => route.group === 'admin' && route.component === 'AdminPanel'
+    );
+
+    expect(legacyAdminPanelRoutes).toEqual([]);
+  });
+
   it('keeps internal demo routes out of navigation', () => {
     getInternalDemoRoutes().forEach((route) => {
       expect(route.nav).toBe(false);


### PR DESCRIPTION
## Summary

- Remove the unused `AdminPanel` lazy registration from `App.jsx` after all admin routes have direct component owners.
- Add a route contract invariant proving no admin route renders the legacy `AdminPanel` component owner.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` after PR #1569 merged.
- Clean workspace: inspected before edits; only scoped frontend routing files changed.
- Branch: `refactor/admin-remove-legacy-panel-registration`
- Scope gate: `agent_gate` returned `narrow_override` for the `App.jsx` cleanup and a second `narrow_override` for the route contract regression.
- Red-check handling: fix failed local or GitHub checks in this same PR before merge.

## Contract Impact

- Canonical surface: frontend route component registry in `App.jsx` and `ROUTE_REGISTRY` route ownership.
- Request shape: unchanged; no HTTP request shape changed.
- Response shape: unchanged; no API response shape changed.
- Status codes: unchanged; no backend endpoint changed.
- Frontend consumer: route rendering now no longer carries a dead `AdminPanel` fallback registration.
- Compatibility path or alias: no route path or alias changed.
- Contract proof: route contract test asserts admin routes do not use `AdminPanel`.

## RBAC / Permissions

- Roles allowed: unchanged; existing route registry role rules remain in force.
- Roles denied: unchanged; no auth or route guard logic changed.
- Positive auth proof: existing route contract tests still verify Admin access for admin route slices.
- Negative auth proof: not re-run in this cleanup because no RBAC rule changed.

## Notification / Realtime

not applicable - no notification, websocket, polling, queue, payment, Telegram, EMR, lab, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no rendered screen state changed.
- Partial data proof: not applicable, no data rendering path changed.
- Forbidden secondary path behavior: unchanged, route guards still own forbidden handling.
- Missing draft/resource behavior: not applicable, no draft/resource flow changed.
- Stale route/deep-link behavior: route registry remains the source of truth; the new invariant prevents stale admin route owner fallback.

## Scope Gate

- Allowed paths: `frontend/src/App.jsx`, `frontend/src/routing/__tests__/routeContract.test.js`.
- Denied paths: backend runtime, database migrations, API contracts, RBAC/auth logic, admin screen behavior.
- Migration/docs/test impact: no migration; no docs update; route contract test updated.
- Rollback note: restore `AdminPanel` lazy registration and remove the no-legacy-owner invariant.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js`; `npm.cmd run lint:check -- --quiet --rule "no-warning-comments: off"`; `npm.cmd run build`; `git diff --check`.
- Result: route contract passed with 39 tests; lint passed; build passed; diff-check passed with CRLF warnings only.
- Not checked: browser click-through, because this removes a dead route registration and does not change any route path or rendered route owner.
