### PR TITLE
fix(emr): guard lab result notify ownership

### DIFF
--- a/backend/app/api/v1/endpoints/emr_lab_integration.py
+++ b/backend/app/api/v1/endpoints/emr_lab_integration.py
@@ -104,6 +104,37 @@ def _ensure_doctor_can_integrate_lab_results(
         raise HTTPException(status_code=403, detail="Access denied")
 
 
+def _ensure_lab_result_notification_scope(
+    db: Session,
+    *,
+    result_id: int,
+    patient_id: int,
+    doctor_id: int,
+    current_user: User,
+) -> None:
+    result_owner = (
+        db.query(LabOrder.patient_id)
+        .join(LabResult, LabResult.order_id == LabOrder.id)
+        .filter(LabResult.id == result_id)
+        .scalar()
+    )
+    if result_owner is None:
+        raise HTTPException(status_code=404, detail="Lab result not found")
+    if int(result_owner) != int(patient_id):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if current_user.role != "Doctor":
+        return
+    if current_user.is_superuser:
+        return
+
+    allowed_doctor_ids = _doctor_allowed_doctor_ids(db, current_user)
+    if int(doctor_id) not in allowed_doctor_ids:
+        raise HTTPException(status_code=403, detail="Access denied")
+    if int(patient_id) not in _doctor_allowed_patient_ids(db, current_user):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+
 @router.get("/patients/{patient_id}/lab-results")
 async def get_patient_lab_results(
     patient_id: int,
@@ -253,6 +284,13 @@ async def notify_doctor_about_lab_result(
     current_user: User = Depends(deps.require_roles("Admin", "Doctor", "Lab")),
 ) -> Any:
     """Уведомить врача о готовности лабораторного результата"""
+    _ensure_lab_result_notification_scope(
+        db,
+        result_id=result_id,
+        patient_id=patient_id,
+        doctor_id=doctor_id,
+        current_user=current_user,
+    )
     try:
         notification = await emr_lab_integration.notify_doctor_about_lab_results(
             db=db, patient_id=patient_id, doctor_id=doctor_id, result_id=result_id

--- a/backend/tests/test_lab_reporting_api.py
+++ b/backend/tests/test_lab_reporting_api.py
@@ -698,6 +698,98 @@ def test_admin_emr_lab_integrate_rejects_cross_patient_result(
 
 
 @pytest.mark.integration
+def test_emr_lab_notify_doctor_rejects_cross_patient_result(
+    client,
+    auth_headers,
+    db_session,
+    test_doctor,
+) -> None:
+    own_patient = _create_patient(db_session)
+    other_patient = _create_patient(db_session)
+    other_visit = _create_visit(
+        db_session,
+        patient_id=other_patient.id,
+        doctor_id=test_doctor.id,
+    )
+    other_result = _create_legacy_lab_result(
+        db_session,
+        patient_id=other_patient.id,
+        visit_id=other_visit.id,
+        test_code="glucose",
+        value="7",
+    )
+
+    response = client.post(
+        f"/api/v1/emr/lab/lab-results/{other_result.id}/notify-doctor",
+        params={"patient_id": own_patient.id, "doctor_id": test_doctor.id},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.integration
+def test_doctor_emr_lab_notify_doctor_is_limited_to_owned_patient(
+    client,
+    db_session,
+) -> None:
+    own_user, own_doctor = _create_doctor_user(db_session, label="notify_own")
+    _other_user, other_doctor = _create_doctor_user(
+        db_session,
+        label="notify_other",
+    )
+    own_patient = _create_patient(db_session)
+    other_patient = _create_patient(db_session)
+    own_visit = _create_visit(
+        db_session,
+        patient_id=own_patient.id,
+        doctor_id=own_doctor.id,
+    )
+    other_visit = _create_visit(
+        db_session,
+        patient_id=other_patient.id,
+        doctor_id=other_doctor.id,
+    )
+    own_result = _create_legacy_lab_result(
+        db_session,
+        patient_id=own_patient.id,
+        visit_id=own_visit.id,
+        test_code="hemoglobin",
+        value="130",
+    )
+    other_result = _create_legacy_lab_result(
+        db_session,
+        patient_id=other_patient.id,
+        visit_id=other_visit.id,
+        test_code="glucose",
+        value="7",
+    )
+    doctor_headers = _doctor_headers(client, own_user)
+
+    own_response = client.post(
+        f"/api/v1/emr/lab/lab-results/{own_result.id}/notify-doctor",
+        params={"patient_id": own_patient.id, "doctor_id": own_doctor.id},
+        headers=doctor_headers,
+    )
+    assert own_response.status_code == 200, own_response.text
+    assert own_response.json()["notification"]["result_id"] == own_result.id
+
+    foreign_result_response = client.post(
+        f"/api/v1/emr/lab/lab-results/{other_result.id}/notify-doctor",
+        params={"patient_id": other_patient.id, "doctor_id": own_doctor.id},
+        headers=doctor_headers,
+    )
+    assert foreign_result_response.status_code == 403
+
+    wrong_doctor_response = client.post(
+        f"/api/v1/emr/lab/lab-results/{own_result.id}/notify-doctor",
+        params={"patient_id": own_patient.id, "doctor_id": other_doctor.id},
+        headers=doctor_headers,
+    )
+    assert wrong_doctor_response.status_code == 403
+
+
+@pytest.mark.integration
 def test_lab_template_resolution_api_restricts_template_choices(
     client, auth_headers, db_session, test_patient, test_visit
 ):

--- a/backend/tests/unit/test_notification_endpoint_inventory.py
+++ b/backend/tests/unit/test_notification_endpoint_inventory.py
@@ -16,7 +16,6 @@ FRONTEND_WS_JSX = ROOT / "frontend" / "src" / "contexts" / "NotificationWebSocke
 FRONTEND_INBOX_JSX = ROOT / "frontend" / "src" / "components" / "notifications" / "NotificationInbox.jsx"
 FRONTEND_PROMPT_JSX = ROOT / "frontend" / "src" / "components" / "chat" / "NotificationPrompt.jsx"
 FRONTEND_ROLE_CENTER_JSX = ROOT / "frontend" / "src" / "components" / "notifications" / "RoleNotificationCenter.jsx"
-ADMIN_PANEL = ROOT / "frontend" / "src" / "pages" / "AdminPanel.jsx"
 CARDIO_PANEL = ROOT / "frontend" / "src" / "pages" / "CardiologistPanelUnified.jsx"
 DENTIST_PANEL = ROOT / "frontend" / "src" / "pages" / "DentistPanelUnified.jsx"
 DERMA_PANEL = ROOT / "frontend" / "src" / "pages" / "DermatologistPanelUnified.jsx"
@@ -151,7 +150,7 @@ def test_frontend_notifications_prompt_uses_safe_notification_checks() -> None:
 
 @pytest.mark.unit
 def test_role_panels_use_shared_notification_center_without_direct_toasts() -> None:
-    page_files = [ADMIN_PANEL, CARDIO_PANEL, DENTIST_PANEL, DERMA_PANEL, LAB_PANEL]
+    page_files = [CARDIO_PANEL, DENTIST_PANEL, DERMA_PANEL, LAB_PANEL]
 
     for path in page_files:
         content = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Fix EMR lab notify-doctor ownership guard before notification metadata is returned.
- Prevent raw `LabResult.id` from being used with a mismatched `patient_id` or inaccessible doctor context.
- Add targeted EMR/lab ownership regression tests and unblock the existing notification inventory test after `AdminPanel.jsx` was removed from main.

## Cyclic Execution Evidence

- Fresh main sync: worktree `C:\tmp\final-contract-scan-next-23` created from `origin/main`, then updated after `origin/main` advanced to `e74b66d8`.
- Clean workspace: primary checkout was left untouched; PR work stayed in isolated worktree branch `codex/contract-scan-next-23`.
- Branch: `codex/contract-scan-next-23`.
- Scope gate: allowed `backend/app/api/v1/endpoints/emr_lab_integration.py`, targeted `backend/tests/test_lab_reporting_api.py`, and CI-unblocking `backend/tests/unit/test_notification_endpoint_inventory.py`; denied frontend, `/api/v1/ui/*`, migrations, notification catalog rewrites, generated output.
- Red-check handling: PR Review Quality Gate body failures were fixed in this PR; backend CI exposed a stale inventory test referencing deleted `AdminPanel.jsx`, fixed in the same branch.

## Contract Impact

- Canonical surface: `POST /api/v1/emr/lab/lab-results/{result_id}/notify-doctor`.
- Request shape: unchanged path `result_id` plus query `patient_id` and `doctor_id`.
- Response shape: unchanged success response for valid owned result notifications.
- Frontend consumer: not applicable - no frontend caller, route, adapter, or screen changed.
- Status codes: now returns 403 when `LabResult -> LabOrder.patient_id` does not match `patient_id`, or when a Doctor user targets a patient/doctor outside their own allowed scope; 404 remains for missing lab result.
- Compatibility path or alias: none changed.
- Contract proof: targeted backend ownership regression tests for admin cross-patient result and doctor owned/foreign result cases.

## RBAC / Permissions

- Roles allowed: existing Admin, Doctor, Lab roles remain allowed by dependency.
- Roles denied: unchanged by dependency.
- Positive auth proof: Doctor owning the patient/result can call notify-doctor and receives 200.
- Negative auth proof: Doctor receives 403 for another patient result and for supplying another doctor id; Admin receives 403 when result owner does not match supplied patient id.

## Notification / Realtime

- Event type or websocket channel: not applicable - no event type, websocket channel, or Telegram template changed.
- Payload version / ack behavior: unchanged - guard runs before existing `EMRLabIntegrationService.notify_doctor_about_lab_results` payload creation and does not change ack/response shape for valid owned calls.
- Read/unread or delivery semantics: unchanged - no notification delivery state, read/unread state, or notification catalog behavior changed.
- Reconnect/resync proof: not applicable - no websocket/realtime reconnect or resync behavior changed.
- Safety note: wrong-patient metadata is rejected before any notification payload can be built.

## Frontend Resilience

not applicable - backend-only ownership guard and backend inventory test update; no frontend component, route, adapter, empty state, or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/emr_lab_integration.py`, `backend/tests/test_lab_reporting_api.py`, `backend/tests/unit/test_notification_endpoint_inventory.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite/read models, migrations, notification catalog/runtime rewrite, generated output.
- Migration/docs/test impact: no migration or docs; targeted backend tests updated.
- Rollback note: revert commit `add5aea2` to restore prior notify-doctor behavior and remove the regression/inventory test updates.

## Validation

- Targeted tests or smoke run: `pytest backend/tests/test_lab_reporting_api.py::test_emr_lab_notify_doctor_rejects_cross_patient_result backend/tests/test_lab_reporting_api.py::test_doctor_emr_lab_notify_doctor_is_limited_to_owned_patient`; `pytest backend/tests/test_lab_reporting_api.py::test_doctor_emr_lab_integrate_is_limited_to_owned_emr_and_patient_results backend/tests/test_lab_reporting_api.py::test_admin_emr_lab_integrate_rejects_cross_patient_result backend/tests/test_lab_reporting_api.py::test_emr_lab_notify_doctor_rejects_cross_patient_result backend/tests/test_lab_reporting_api.py::test_doctor_emr_lab_notify_doctor_is_limited_to_owned_patient`; `pytest backend/tests/unit/test_notification_endpoint_inventory.py::test_role_panels_use_shared_notification_center_without_direct_toasts`; `py_compile backend/app/api/v1/endpoints/emr_lab_integration.py backend/tests/test_lab_reporting_api.py backend/tests/unit/test_notification_endpoint_inventory.py`; `git diff --check`.
- Result: py_compile passed; 2 targeted notify tests passed; 4 adjacent EMR/lab ownership tests passed; stale inventory test passed after removing deleted AdminPanel reference; git diff --check had no whitespace errors and only printed Git's CRLF normalization warning for existing test files.
- Not checked: full backend suite and live notification delivery locally, because CI runs the full backend suite and this patch only gates endpoint ownership before the existing service call.
