### PR TITLE
fix(messages): avoid chat file upload collisions

### DIFF
--- a/backend/app/services/messages_api_service.py
+++ b/backend/app/services/messages_api_service.py
@@ -7,6 +7,7 @@ import hashlib
 import logging
 import os
 import re
+import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -59,6 +60,11 @@ def _find_chat_upload_file(filename: str) -> Path:
             return resolved_path
 
     raise HTTPException(status_code=404, detail="Файл не найден")
+
+
+def _build_chat_storage_filename(*, user_id: int, original_filename: str) -> str:
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    return f"{timestamp}_{user_id}_{uuid.uuid4().hex}_{original_filename}"
 
 
 async def _read_upload_bounded(
@@ -563,7 +569,10 @@ class MessagesApiService:
 
         content = await _read_upload_bounded(file, max_bytes=MAX_CHAT_UPLOAD_BYTES)
         original_filename = os.path.basename(file.filename or "file")
-        safe_filename = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{original_filename}"
+        safe_filename = _build_chat_storage_filename(
+            user_id=current_user.id,
+            original_filename=original_filename,
+        )
         upload_dir = "uploads/chat"
         os.makedirs(upload_dir, exist_ok=True)
         file_path = os.path.join(upload_dir, safe_filename)
@@ -630,7 +639,6 @@ from typing import List
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse
-from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user, get_db
@@ -813,18 +821,26 @@ async def download_chat_file(
     filename = _safe_chat_storage_filename(filename)
     file_record = db.query(FileModel).filter(FileModel.filename == filename).first()
     if file_record:
-        message = db.query(Message).filter(Message.file_id == file_record.id).first()
+        candidate_messages = (
+            db.query(Message).filter(Message.file_id == file_record.id).all()
+        )
     else:
-        message = db.query(Message).filter(
-            or_(
-                Message.content.contains(f"/download/{filename}"),
-                Message.content.contains(f"name={filename}"),
-            )
-        ).first()
+        candidate_messages = (
+            db.query(Message)
+            .filter(Message.content.contains(f"/download/{filename}"))
+            .all()
+        )
 
-    if not message or (
-        current_user.id != message.sender_id and current_user.id != message.recipient_id
-    ):
+    message = next(
+        (
+            item
+            for item in candidate_messages
+            if current_user.id == item.sender_id or current_user.id == item.recipient_id
+        ),
+        None,
+    )
+
+    if not message:
         raise HTTPException(status_code=403, detail="Нет доступа к этому файлу")
 
     file_path = _find_chat_upload_file(filename)

--- a/backend/tests/integration/test_messages_upload_limits.py
+++ b/backend/tests/integration/test_messages_upload_limits.py
@@ -1,9 +1,27 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 from fastapi.testclient import TestClient
 
+from app.api.deps import get_current_user
+from app.main import app
+from app.models.message import Message
 from app.models.user import User
 from app.services import messages_api_service
+
+
+class _FixedDatetime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        value = cls(2026, 1, 1, 12, 0, 0)
+        if tz is not None:
+            return value.replace(tzinfo=tz)
+        return value
+
+    @classmethod
+    def utcnow(cls):
+        return cls(2026, 1, 1, 12, 0, 0)
 
 
 def test_chat_file_upload_rejects_oversized_payload_before_write(
@@ -50,3 +68,78 @@ def test_voice_message_rejects_oversized_payload_before_write(
 
     assert response.status_code == 413
     assert not (tmp_path / "uploads").exists()
+
+
+def test_chat_file_upload_uses_collision_resistant_storage_name(
+    client: TestClient,
+    patient_token: str,
+    test_doctor_user: User,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(messages_api_service, "datetime", _FixedDatetime)
+
+    first_response = client.post(
+        "/api/v1/messages/upload",
+        headers={"Authorization": f"Bearer {patient_token}"},
+        data={"recipient_id": str(test_doctor_user.id)},
+        files={"file": ("report.pdf", b"first", "application/pdf")},
+    )
+    second_response = client.post(
+        "/api/v1/messages/upload",
+        headers={"Authorization": f"Bearer {patient_token}"},
+        data={"recipient_id": str(test_doctor_user.id)},
+        files={"file": ("report.pdf", b"second", "application/pdf")},
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert first_response.json()["content"] != second_response.json()["content"]
+
+    uploaded_files = sorted((tmp_path / "uploads" / "chat").iterdir())
+    assert {item.read_bytes() for item in uploaded_files} == {b"first", b"second"}
+
+
+def test_chat_file_download_authorizes_any_matching_message_candidate(
+    client: TestClient,
+    db_session,
+    admin_user: User,
+    registrar_user: User,
+    test_doctor_user: User,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    filename = "20260101_120000_report.pdf"
+    upload_dir = tmp_path / "uploads" / "chat"
+    upload_dir.mkdir(parents=True)
+    (upload_dir / filename).write_bytes(b"report")
+
+    download_url = f"/api/v1/messages/download/{filename}?name=report.pdf"
+    db_session.add(
+        Message(
+            sender_id=admin_user.id,
+            recipient_id=registrar_user.id,
+            message_type="file",
+            content=download_url,
+        )
+    )
+    db_session.add(
+        Message(
+            sender_id=admin_user.id,
+            recipient_id=test_doctor_user.id,
+            message_type="file",
+            content=download_url,
+        )
+    )
+    db_session.commit()
+
+    app.dependency_overrides[get_current_user] = lambda: test_doctor_user
+    try:
+        response = client.get(f"/api/v1/messages/download/{filename}")
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 200
+    assert response.content == b"report"


### PR DESCRIPTION
## Summary

- Fix chat attachment storage names so same-second uploads with the same original filename do not write to the same disk path.
- Fix chat attachment download authorization so legacy duplicate filename references check all matching message candidates instead of a single first row.
- Add regression tests for silent overwrite prevention and legacy duplicate-filename authorization.

## Cyclic Execution Evidence

- Fresh main sync: isolated worktree C:\tmp\final-contract-scan-next-24 was created from current origin/main at fe280dec.
- Clean workspace: inspected before edits; only backend/app/services/messages_api_service.py and backend/tests/integration/test_messages_upload_limits.py changed.
- Branch: codex/contract-scan-next-24.
- Scope gate: agent_gate run with known root cause backend/app/services/messages_api_service.py; it returned narrow override. Test scope was expanded only to the existing targeted message upload integration test file.
- Red-check handling: PR Review Quality Gate failure was handled in this same PR by updating the PR body; code checks were green.

## Contract Impact

- Canonical surface: POST /api/v1/messages/upload and GET /api/v1/messages/download/{filename}.
- Request shape: unchanged; upload still accepts multipart recipient_id and file, download still accepts filename plus optional name query.
- Response shape: unchanged; upload still returns the message payload, download still returns the file response.
- Status codes: unchanged for normal callers; unauthorized download still returns 403.
- Frontend consumer: no frontend code changed; existing download URL shape remains compatible.
- Compatibility path or alias: legacy YYYYMMDD_HHMMSS_original filenames remain valid for download.
- Contract proof: targeted integration tests cover unique storage names and duplicate legacy filename authorization.

## RBAC / Permissions

- Roles allowed: unchanged; message endpoints still use authenticated current user and conversation participation checks.
- Roles denied: unchanged; users outside the sender/recipient pair still receive 403 for chat file downloads.
- Positive auth proof: regression test confirms a participant can download when their matching message is not the first DB candidate.
- Negative auth proof: existing endpoint branch still raises 403 when no matching message candidate belongs to the current user; no permission broadening was added.

## Notification / Realtime

- Event type or websocket channel: unchanged existing message_received notification and chat websocket broadcast behavior after upload.
- Payload version / ack behavior: unchanged; upload response/download URL shape is stable, and no ack protocol changed.
- Read/unread or delivery semantics: unchanged; message delivery/read state is not modified by this PR.
- Reconnect/resync proof: unchanged; clients still resync through existing conversation/message endpoints, no websocket routing change.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed.
- Partial data proof: not applicable - no frontend data normalization changed.
- Forbidden secondary path behavior: unchanged 403 behavior for non-participants.
- Missing draft/resource behavior: not applicable - chat uploads do not create drafts/resources.
- Stale route/deep-link behavior: not applicable - no route state changed.

## Scope Gate

- Allowed paths: message API service and targeted message upload integration tests.
- Denied paths: frontend, migrations, auth core, notification services, generated output, unrelated file/report/payment endpoints.
- Migration/docs/test impact: no migration; targeted tests updated.
- Rollback note: revert this PR to restore prior chat attachment filename and download lookup behavior.

## Validation

- Targeted tests or smoke run: py_compile for changed Python files; pytest backend/tests/integration/test_messages_upload_limits.py -q; pytest backend/tests/unit/test_messages_router_service_wiring.py backend/tests/architecture/test_w2a_router_boundaries.py -q; git diff --check; GitHub CI backend/code/security gates.
- Result: local tests passed (4 integration tests, 7 wiring/boundary tests); GitHub backend tests, code quality, CodeQL, security, PR Required Gate passed.
- Not checked: full frontend build/browser smoke, because this PR changes only backend chat attachment storage/download behavior and no frontend code.
