### PR TITLE
fix(analytics): restrict financial exports

### DIFF
--- a/backend/app/api/v1/endpoints/analytics_export.py
+++ b/backend/app/api/v1/endpoints/analytics_export.py
@@ -25,12 +25,14 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 ANALYTICS_EXPORT_PUBLIC_ERROR = "Internal server error"
+CLINICAL_ANALYTICS_EXPORT_ROLES = ["admin", "doctor", "nurse"]
+FINANCIAL_ANALYTICS_EXPORT_ROLES = ["admin", "manager"]
 
 
 @router.get("/formats")
 async def get_export_formats(
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(CLINICAL_ANALYTICS_EXPORT_ROLES)),
 ):
     """Получить список поддерживаемых форматов экспорта"""
     try:
@@ -56,7 +58,7 @@ async def export_kpi_report(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ANALYTICS_EXPORT_ROLES)),
 ):
     """Экспорт отчета KPI в указанном формате"""
     try:
@@ -106,7 +108,7 @@ async def export_comprehensive_report(
         True, description="Включить предиктивную аналитику"
     ),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ANALYTICS_EXPORT_ROLES)),
 ):
     """Экспорт комплексного отчета в указанном формате"""
     try:
@@ -177,7 +179,7 @@ async def export_doctor_performance_report(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(CLINICAL_ANALYTICS_EXPORT_ROLES)),
 ):
     """Экспорт отчета по эффективности врачей в указанном формате"""
     try:
@@ -225,7 +227,7 @@ async def export_revenue_report(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ANALYTICS_EXPORT_ROLES)),
 ):
     """Экспорт отчета по доходам в указанном формате"""
     try:

--- a/backend/tests/integration/test_analytics_contracts.py
+++ b/backend/tests/integration/test_analytics_contracts.py
@@ -18,6 +18,16 @@ def admin_token(client: TestClient, admin_user: User, admin_password: str) -> st
     return response.json()["access_token"]
 
 
+@pytest.fixture
+def doctor_token(client: TestClient, test_doctor_user: User) -> str:
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": test_doctor_user.username, "password": "doctor123"},
+    )
+    assert response.status_code == 200
+    return response.json()["access_token"]
+
+
 def _auth_headers(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
@@ -158,3 +168,38 @@ def test_patient_cannot_read_staff_analytics_extension_routes(
     )
 
     assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/analytics/export/kpi/export/json",
+        "/api/v1/analytics/export/comprehensive/export/json",
+        "/api/v1/analytics/export/revenue/export/json",
+    ],
+)
+def test_doctor_cannot_export_clinic_financial_analytics(
+    client: TestClient,
+    doctor_token: str,
+    path: str,
+) -> None:
+    response = client.get(
+        path,
+        headers=_auth_headers(doctor_token),
+        params={"start_date": "2026-03-08", "end_date": "2026-04-07"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_admin_can_export_revenue_analytics(
+    client: TestClient,
+    admin_token: str,
+) -> None:
+    response = client.get(
+        "/api/v1/analytics/export/revenue/export/json",
+        headers=_auth_headers(admin_token),
+        params={"start_date": "2026-03-08", "end_date": "2026-04-07"},
+    )
+
+    assert response.status_code == 200, response.text


### PR DESCRIPTION
## Summary

- Restrict clinic-wide financial analytics export endpoints to Admin/Manager.
- Keep export format discovery and doctor-performance export on the existing clinical analytics role set.
- Add RBAC regression coverage for Doctor denial on KPI/comprehensive/revenue exports and Admin revenue export access.

## Cyclic Execution Evidence

- Fresh main sync: worktree branch created from current `origin/main` at `5e7911c9`.
- Clean workspace: inspected before edits; only scoped export endpoint and analytics contract test changed.
- Branch: `codex/contract-scan-next-25`.
- Scope gate: agent gate restricted runtime first-touch to `analytics_export.py`; second gate restricted test slice to `test_analytics_contracts.py`.
- Red-check handling: PR Review Quality Gate body failure is being fixed in this same PR; any later red check will be fixed here before merge.

## Contract Impact

- Canonical surface: `/api/v1/analytics/export/{kpi,comprehensive,revenue}/export/{format}`.
- Request shape: authenticated GET with existing `start_date`, `end_date`, optional `department`, and existing `format` path parameter.
- Response shape: unchanged export response body and `Content-Disposition`; only authorization changes before handler execution.
- Status codes: Doctor/Nurse now receive 403 for financial/KPI/comprehensive exports; Admin/Manager can reach the existing export behavior.
- Frontend consumer: not applicable - no frontend files changed and frontend callers receive the same 403 auth contract as other forbidden API calls.
- Compatibility path or alias: no route alias changed; non-export analytics routes intentionally remain out of this PR scope.
- Contract proof: targeted backend integration test covers Doctor 403 on all three protected export routes and Admin 200 on revenue export.

## RBAC / Permissions

- Roles allowed: Admin and Manager for financial/KPI/comprehensive exports.
- Roles denied: Doctor and Nurse are no longer accepted for those clinic-wide financial export surfaces; Patient remains denied by existing coverage.
- Positive auth proof: `test_admin_can_export_revenue_analytics` returns 200.
- Negative auth proof: `test_doctor_cannot_export_clinic_financial_analytics` returns 403 for KPI, comprehensive, and revenue export endpoints.

## Notification / Realtime

not applicable - no notification, websocket, chat, delivery, read/unread, reconnect, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed; backend export behavior for allowed users is unchanged.
- Partial data proof: not applicable - no frontend or response-shape fallback changed.
- Forbidden secondary path behavior: forbidden financial exports now return 403 before data export for Doctor/Nurse.
- Missing draft/resource behavior: not applicable - analytics exports do not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link state changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/analytics_export.py`, `backend/tests/integration/test_analytics_contracts.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read models, frontend, non-export analytics JSON/visualization routes, migrations/models.
- Migration/docs/test impact: no migration; targeted integration test updated.
- Rollback note: revert this commit to restore previous export RBAC and remove the regression tests.

## Validation

- Targeted tests or smoke run: `py_compile` on changed files; `pytest backend/tests/integration/test_analytics_contracts.py -q`; `git diff --check`; GitHub backend/quality/security checks.
- Result: local analytics contract suite passed 16 tests; `git diff --check` passed; GitHub backend tests, CodeQL, security, role-system, PR Required Gate, and quality checks are green except this body-only gate retry.
- Not checked: browser/frontend behavior and non-export analytics JSON/visualization RBAC, intentionally left for the next audit slice.