### PR TITLE
test(admin): add browser heading smoke

### DIFF
--- a/frontend/e2e/authenticated-role-smoke.spec.js
+++ b/frontend/e2e/authenticated-role-smoke.spec.js
@@ -6,6 +6,59 @@ import {
   installAuthenticatedQaHarness,
 } from './support/authenticatedQa.js';
 
+const AUTHENTICATED_ADMIN_ROUTE_FAMILY_QA_ROUTES = [
+  {
+    key: 'admin-overview-dashboard',
+    path: '/admin',
+    routeId: 'admin-dashboard',
+  },
+  {
+    key: 'admin-management-users',
+    path: '/admin/users',
+    routeId: 'admin-users',
+  },
+  {
+    key: 'admin-management-services',
+    path: '/admin/services',
+    routeId: 'admin-services',
+  },
+  {
+    key: 'admin-management-appointments',
+    path: '/admin/appointments',
+    routeId: 'admin-appointments',
+  },
+  {
+    key: 'admin-operations-system',
+    path: '/admin/system',
+    routeId: 'admin-system',
+  },
+  {
+    key: 'admin-integrations-webhooks',
+    path: '/admin/webhooks',
+    routeId: 'admin-webhooks',
+  },
+  {
+    key: 'admin-system-telegram',
+    path: '/admin/integrations/telegram',
+    routeId: 'admin-telegram-integration',
+  },
+  {
+    key: 'admin-system-notifications',
+    path: '/admin/notifications',
+    routeId: 'admin-notifications',
+  },
+  {
+    key: 'admin-system-finance',
+    path: '/admin/finance',
+    routeId: 'admin-finance',
+  },
+  {
+    key: 'admin-contextual-clinic-settings',
+    path: '/admin/clinic-settings?section=clinic-settings',
+    routeId: 'admin-clinic-settings',
+  },
+];
+
 async function expectRenderedRolePanel(page, route) {
   await expect(page).not.toHaveURL(/\/login$/);
   await expect(page).not.toHaveURL(/\/(?:forbidden|unauthorized)$/);
@@ -29,6 +82,16 @@ async function expectRouteSpecificEvidence(page, route) {
   if (route.summaryLabel) {
     await expect(page.getByRole('list', { name: route.summaryLabel })).toBeVisible();
   }
+}
+
+async function expectVisibleRouteHeading(page, route) {
+  const heading = page.locator('main').locator('h1, h2, h3, h4, h5, h6, [role="heading"]').filter({
+    hasText: /\S/,
+  }).first();
+
+  await expect(heading, `${route.key} should expose a browser-visible heading`).toBeVisible({
+    timeout: 15_000,
+  });
 }
 
 async function runAuthenticatedRouteSmoke(page, testInfo, route) {
@@ -56,6 +119,32 @@ async function runAuthenticatedRouteSmoke(page, testInfo, route) {
   expect(pageErrors).toEqual([]);
 }
 
+async function runAdminRouteFamilyHeadingSmoke(page, testInfo, route) {
+  const pageErrors = [];
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.message);
+  });
+
+  await installAuthenticatedQaHarness(page, { role: 'Admin' });
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto(route.path, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+
+  await expectRenderedRolePanel(page, route);
+  await expectVisibleRouteHeading(page, route);
+  await expectNoHorizontalOverflow(page, route);
+  await expect(page.locator('body')).not.toContainText('AdminPanel');
+
+  const screenshotPath = testInfo.outputPath(`admin-route-family-${route.key}.png`);
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  await testInfo.attach(`admin-route-family-${route.key}`, {
+    path: screenshotPath,
+    contentType: 'image/png',
+  });
+
+  expect(pageErrors).toEqual([]);
+}
+
 test.describe('Authenticated role UI QA harness', () => {
   for (const route of AUTHENTICATED_ROLE_QA_ROUTES) {
     test(`${route.key} route renders with seeded ${route.role} session`, async ({ page }, testInfo) => {
@@ -68,6 +157,14 @@ test.describe('Authenticated specialty UI QA harness', () => {
   for (const route of AUTHENTICATED_SPECIALTY_QA_ROUTES) {
     test(`${route.key} route renders with seeded ${route.role} session`, async ({ page }, testInfo) => {
       await runAuthenticatedRouteSmoke(page, testInfo, route);
+    });
+  }
+});
+
+test.describe('Authenticated admin route family heading smoke', () => {
+  for (const route of AUTHENTICATED_ADMIN_ROUTE_FAMILY_QA_ROUTES) {
+    test(`${route.key} renders route-specific chrome and heading`, async ({ page }, testInfo) => {
+      await runAdminRouteFamilyHeadingSmoke(page, testInfo, route);
     });
   }
 });

--- a/frontend/e2e/support/authenticatedQa.js
+++ b/frontend/e2e/support/authenticatedQa.js
@@ -166,6 +166,49 @@ function buildQaApiPayload(pathname, profile, method) {
     return { success: true, id: 'qa-write-disabled' };
   }
 
+  if (lowerPath === '/users/users') {
+    return {
+      users: [],
+      page: 1,
+      per_page: 20,
+      total: 0,
+      total_pages: 0,
+      success: true,
+    };
+  }
+
+  if (lowerPath === '/services' || lowerPath === '/services/categories' || lowerPath === '/services/admin/doctors') {
+    return [];
+  }
+
+  if (lowerPath === '/departments') {
+    return { success: true, data: [], count: 0 };
+  }
+
+  if (lowerPath === '/queues/profiles') {
+    return { success: true, profiles: [] };
+  }
+
+  if (lowerPath === '/webhooks' || lowerPath === '/webhooks/') {
+    return { success: true, items: [] };
+  }
+
+  if (lowerPath === '/webhooks/system/stats') {
+    return {
+      success: true,
+      total_webhooks: 0,
+      active_webhooks: 0,
+      recent_24h: {
+        total_calls: 0,
+        success_rate: 0,
+      },
+    };
+  }
+
+  if (lowerPath.startsWith('/webhooks/') && lowerPath.endsWith('/calls')) {
+    return { success: true, items: [] };
+  }
+
   if (lowerPath.includes('summary') || lowerPath.includes('stats') || lowerPath.includes('dashboard')) {
     return {
       success: true,


### PR DESCRIPTION
﻿## Summary

- Adds authenticated Playwright browser-heading smoke coverage for representative Admin route families.
- Verifies expected route shell IDs, visible headings, no horizontal overflow, and no legacy `AdminPanel` fallback text.
- Extends the existing QA API harness with empty admin payload shapes so data-heavy Admin routes can render without backend/runtime changes.

## Cyclic Execution Evidence

- Fresh main sync: branch was created from current `main` synced to `origin/main` before this test-only slice.
- Clean workspace: current working tree contains only `frontend/e2e/authenticated-role-smoke.spec.js` and `frontend/e2e/support/authenticatedQa.js` changes.
- Branch: `test/admin-browser-heading-smoke`.
- Scope gate: allowed only the authenticated e2e smoke spec and QA support mock; denied product runtime, route registry, RBAC, DB/migrations, deploy, and secrets.
- Red-check handling: any failing GitHub check will be fixed in this same PR before merge; no follow-up PR for red checks.

## Contract Impact

- Canonical surface: not applicable - this PR changes only Playwright e2e coverage and local QA API mock payloads.
- Request shape: not applicable - no production request shape changed.
- Response shape: not applicable - production API responses are unchanged; QA mock returns empty shapes only inside Playwright harness.
- Status codes: not applicable - no backend status code behavior changed.
- Frontend consumer: existing Admin route components are smoke-tested but not modified.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: route contract Vitest passed for `routeContract.test.js` and `routeOwnershipEnforcement.test.js`.

## RBAC / Permissions

- Roles allowed: Admin seeded session is used by the new route-family smoke; existing role smoke still covers Registrar/Admin/Patient/Doctor/Lab/Cashier.
- Roles denied: not applicable - no production role policy changed.
- Positive auth proof: Playwright authenticated smoke passed and reached each Admin route shell without login redirect.
- Negative auth proof: not checked - this PR adds positive browser-visible smoke only and does not alter guards or RBAC.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, chat, websocket, or realtime event changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no notification delivery semantics changed.
- Reconnect/resync proof: not checked - local Playwright emitted non-blocking Vite WS proxy `ECONNREFUSED` noise because backend was not running; the modified tests passed through QA mocks.

## Frontend Resilience

- Empty data proof: Admin users/services/webhooks/departments/queue profile routes receive explicit empty QA payloads and render in Playwright smoke.
- Partial data proof: not checked - this PR covers empty browser render smoke, not partial data permutations.
- Forbidden secondary path behavior: Playwright smoke asserts no login, forbidden, or unauthorized redirect for the seeded Admin session.
- Missing draft/resource behavior: not checked - no draft/resource flow changed.
- Stale route/deep-link behavior: `/admin/clinic-settings?section=clinic-settings` is included as a contextual Admin deep-link smoke route.

## Scope Gate

- Allowed paths: `frontend/e2e/authenticated-role-smoke.spec.js`; `frontend/e2e/support/authenticatedQa.js`.
- Denied paths: backend/frontend product runtime, route registry, RBAC/auth policy, DB/migrations, deploy, secrets.
- Migration/docs/test impact: test-only impact; no migrations or docs changed.
- Rollback note: revert this commit to remove only the extra Admin route-family Playwright smoke and QA mock payloads.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

Notes: `agent_gate.py` was run twice with known-root-cause e2e files. It returned broader route-ownership guidance, so this PR used a narrow override and stayed inside the approved e2e/support test scope.

## Validation

- Targeted tests or smoke run: `npm.cmd run test:e2e -- e2e/authenticated-role-smoke.spec.js --project=chromium --reporter=line`; `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js src/routing/__tests__/routeOwnershipEnforcement.test.js`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`.
- Result: Playwright 19 passed; Vitest 41 passed; lint passed; build passed; diff-check passed with CRLF normalization warnings only.
- Not checked: full backend suite and full frontend suite were not run because this is a narrow e2e/support test-only change.
