### PR TITLE
fix(analytics): restrict legacy revenue metrics

### DIFF
--- a/backend/app/api/v1/endpoints/analytics.py
+++ b/backend/app/api/v1/endpoints/analytics.py
@@ -15,6 +15,8 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 ANALYTICS_PUBLIC_ERROR = "Internal server error"
+CLINICAL_ANALYTICS_ROLES = ["admin", "doctor", "nurse"]
+FINANCIAL_ANALYTICS_ROLES = ["admin", "manager"]
 
 
 def _build_payment_provider_payload(
@@ -48,7 +50,7 @@ def _build_payment_provider_payload(
 
 @router.get("/quick-stats")
 async def get_quick_stats(
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(CLINICAL_ANALYTICS_ROLES)),
     db: Session = Depends(get_db),
 ):
     """Получение быстрой статистики"""
@@ -61,7 +63,7 @@ async def get_quick_stats(
 
 @router.get("/dashboard")
 async def get_dashboard_data(
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(CLINICAL_ANALYTICS_ROLES)),
     db: Session = Depends(get_db),
 ):
     """Получение данных для дашборда"""
@@ -75,7 +77,7 @@ async def get_dashboard_data(
 @router.get("/trends")
 async def get_trends_analytics(
     days: int = Query(30, ge=1, le=365, description="Количество дней для анализа"),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(CLINICAL_ANALYTICS_ROLES)),
     db: Session = Depends(get_db),
 ):
     """Получение трендов за последние N дней через SSOT"""
@@ -101,7 +103,7 @@ async def get_appointment_flow_analytics(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: str | None = Query(None, description="Отделение"),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(CLINICAL_ANALYTICS_ROLES)),
     db: Session = Depends(get_db),
 ):
     """Legacy-compatible analytics route for appointment flow."""
@@ -124,7 +126,7 @@ async def get_revenue_breakdown_analytics(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: str | None = Query(None, description="Отделение"),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
     db: Session = Depends(get_db),
 ):
     """Legacy-compatible analytics route for revenue breakdown."""
@@ -147,7 +149,7 @@ async def get_payment_provider_analytics(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: str | None = Query(None, description="Отделение"),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
     db: Session = Depends(get_db),
 ):
     """Legacy-compatible analytics route for provider summary."""

--- a/backend/tests/integration/test_analytics_contracts.py
+++ b/backend/tests/integration/test_analytics_contracts.py
@@ -173,6 +173,27 @@ def test_patient_cannot_read_staff_analytics_extension_routes(
 @pytest.mark.parametrize(
     "path",
     [
+        "/api/v1/analytics/revenue-breakdown",
+        "/api/v1/analytics/payment-providers",
+    ],
+)
+def test_doctor_cannot_read_legacy_revenue_analytics(
+    client: TestClient,
+    doctor_token: str,
+    path: str,
+) -> None:
+    response = client.get(
+        path,
+        headers=_auth_headers(doctor_token),
+        params={"start_date": "2026-03-08", "end_date": "2026-04-07"},
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
         "/api/v1/analytics/export/kpi/export/json",
         "/api/v1/analytics/export/comprehensive/export/json",
         "/api/v1/analytics/export/revenue/export/json",


### PR DESCRIPTION
## Summary

- Restrict legacy non-export revenue analytics endpoints to Admin/Manager.
- Keep operational analytics routes such as quick stats, dashboard, trends, and appointment flow on the existing clinical role set.
- Add RBAC regression coverage for Doctor denial on revenue breakdown and payment-provider analytics.

## Cyclic Execution Evidence

- Fresh main sync: worktree branch created from current `origin/main` at `6701a410`.
- Clean workspace: inspected before edits; only scoped legacy analytics endpoint and analytics contract test changed.
- Branch: `codex/contract-scan-next-26`.
- Scope gate: broad non-export analytics gate could not resolve first-touch; known-root-cause gate restricted runtime slice to `analytics.py`, and a second gate restricted test slice to `test_analytics_contracts.py`.
- Red-check handling: any failed targeted test or CI check will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/analytics/revenue-breakdown` and `GET /api/v1/analytics/payment-providers`.
- Request shape: authenticated GET with existing `start_date`, `end_date`, and optional `department` query parameters.
- Response shape: unchanged for allowed roles; authorization is enforced before returning clinic-wide revenue/provider totals.
- Status codes: Doctor/Nurse now receive 403 for legacy revenue analytics; Admin/Manager can reach the existing 200 behavior.
- Frontend consumer: not applicable - no frontend files changed; forbidden callers receive the standard backend 403 contract.
- Compatibility path or alias: no route alias changed; KPI/predictive/visualization/advanced analytics surfaces remain intentionally out of this PR scope.
- Contract proof: targeted backend integration test covers Doctor 403 on both protected legacy routes; existing admin legacy contract test covers Admin 200 and response keys for both routes.

## RBAC / Permissions

- Roles allowed: Admin and Manager for legacy revenue breakdown/payment-provider analytics.
- Roles denied: Doctor and Nurse are no longer accepted for these clinic-wide financial metrics; Patient remains denied by existing coverage.
- Positive auth proof: `test_analytics_legacy_contracts_exist` returns 200 for Admin on both routes.
- Negative auth proof: `test_doctor_cannot_read_legacy_revenue_analytics` returns 403 for both routes.

## Notification / Realtime

not applicable - no notification, websocket, chat, delivery, read/unread, reconnect, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed; allowed response shape is unchanged.
- Partial data proof: not applicable - no frontend or response-shape fallback changed.
- Forbidden secondary path behavior: forbidden legacy revenue analytics now return 403 before data calculation for Doctor/Nurse.
- Missing draft/resource behavior: not applicable - analytics reads do not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link state changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/analytics.py`, `backend/tests/integration/test_analytics_contracts.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read models, frontend, KPI/predictive/visualization/advanced analytics routes, migrations/models.
- Migration/docs/test impact: no migration; targeted integration test updated.
- Rollback note: revert this commit to restore previous legacy revenue analytics RBAC and remove the regression tests.

## Validation

- Targeted tests or smoke run: `py_compile` on changed files; `pytest backend/tests/integration/test_analytics_contracts.py -q`; `git diff --check`; GitHub checks.
- Result: local analytics contract suite passed 18 tests; `git diff --check` passed.
- Not checked: browser/frontend behavior and remaining non-export KPI/predictive/visualization/advanced analytics RBAC, intentionally left for subsequent narrow audit slices.