### PR TITLE
test(admin): add services action smoke

### DIFF
--- a/frontend/e2e/authenticated-role-smoke.spec.js
+++ b/frontend/e2e/authenticated-role-smoke.spec.js
@@ -59,6 +59,16 @@ const AUTHENTICATED_ADMIN_ROUTE_FAMILY_QA_ROUTES = [
   },
 ];
 
+const AUTHENTICATED_ADMIN_ACTION_QA_ROUTES = [
+  {
+    key: 'admin-services-catalog',
+    path: '/admin/services?servicesTab=catalog',
+    routeId: 'admin-services',
+    primaryActionText: /Р”РѕР±Р°РІРёС‚СЊ СѓСЃР»СѓРіСѓ|Добавить услугу|Add service/i,
+    openedFormHeading: /Р”РѕР±Р°РІР»РµРЅРёРµ СѓСЃР»СѓРіРё|Добавление услуги|Add service/i,
+  },
+];
+
 async function expectRenderedRolePanel(page, route) {
   await expect(page).not.toHaveURL(/\/login$/);
   await expect(page).not.toHaveURL(/\/(?:forbidden|unauthorized)$/);
@@ -145,6 +155,65 @@ async function runAdminRouteFamilyHeadingSmoke(page, testInfo, route) {
   expect(pageErrors).toEqual([]);
 }
 
+async function expectVisibleButtonsHaveNames(page, route) {
+  const unnamedButtons = await page.locator('main button:visible').evaluateAll((buttons) =>
+    buttons
+      .map((button, index) => {
+        const label = [
+          button.getAttribute('aria-label'),
+          button.getAttribute('title'),
+          button.textContent,
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .replace(/\s+/g, ' ')
+          .trim();
+
+        return label ? null : index;
+      })
+      .filter((index) => index !== null)
+  );
+
+  expect(unnamedButtons, `${route.key} should not render unnamed visible buttons`).toEqual([]);
+}
+
+async function runAdminRouteActionSmoke(page, testInfo, route) {
+  const pageErrors = [];
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.message);
+  });
+
+  await installAuthenticatedQaHarness(page, { role: 'Admin' });
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto(route.path, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+
+  await expectRenderedRolePanel(page, route);
+  await expectVisibleRouteHeading(page, route);
+  await expectVisibleButtonsHaveNames(page, route);
+  await expectNoHorizontalOverflow(page, route);
+
+  const primaryAction = page.locator('main button:visible').filter({ hasText: route.primaryActionText }).first();
+  await expect(primaryAction, `${route.key} primary action should be visible`).toBeVisible();
+  await primaryAction.click();
+
+  await expect(
+    page.locator('main').locator('h2, h3, [role="heading"]').filter({ hasText: route.openedFormHeading }).first(),
+    `${route.key} primary action should open its form`
+  ).toBeVisible();
+  await expect(page.locator('main form').first()).toBeVisible();
+  await expectNoHorizontalOverflow(page, route);
+
+  const screenshotPath = testInfo.outputPath(`admin-route-action-${route.key}.png`);
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  await testInfo.attach(`admin-route-action-${route.key}`, {
+    path: screenshotPath,
+    contentType: 'image/png',
+  });
+
+  expect(pageErrors).toEqual([]);
+}
+
 test.describe('Authenticated role UI QA harness', () => {
   for (const route of AUTHENTICATED_ROLE_QA_ROUTES) {
     test(`${route.key} route renders with seeded ${route.role} session`, async ({ page }, testInfo) => {
@@ -165,6 +234,14 @@ test.describe('Authenticated admin route family heading smoke', () => {
   for (const route of AUTHENTICATED_ADMIN_ROUTE_FAMILY_QA_ROUTES) {
     test(`${route.key} renders route-specific chrome and heading`, async ({ page }, testInfo) => {
       await runAdminRouteFamilyHeadingSmoke(page, testInfo, route);
+    });
+  }
+});
+
+test.describe('Authenticated admin route action smoke', () => {
+  for (const route of AUTHENTICATED_ADMIN_ACTION_QA_ROUTES) {
+    test(`${route.key} exposes named controls and opens the primary form`, async ({ page }, testInfo) => {
+      await runAdminRouteActionSmoke(page, testInfo, route);
     });
   }
 });


### PR DESCRIPTION
﻿## Summary

- Adds the first data-heavy Admin action smoke for `/admin/services?servicesTab=catalog`.
- Verifies the Services route renders named visible controls, opens the primary add-service form, and preserves horizontal layout.
- Keeps runtime UI, API, RBAC, route registry, backend, and database behavior unchanged.

## Cyclic Execution Evidence

- Fresh main sync: `main` was fetched and fast-forward checked against `origin/main` before creating `test/admin-services-action-smoke`.
- Clean workspace: branch started clean; current diff is one e2e spec file.
- Branch: `test/admin-services-action-smoke`.
- Scope gate: allowed only `frontend/e2e/authenticated-role-smoke.spec.js`; denied product runtime, route registry, QA API behavior outside existing harness shape, RBAC, DB/migrations, deploy, and secrets.
- Red-check handling: any failing GitHub check will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: existing Admin Services route smoke only; no runtime route or API contract changed.
- Request shape: not applicable - no production request shape changed.
- Response shape: not applicable - no production response shape changed.
- Status codes: not applicable - no endpoint behavior changed.
- Frontend consumer: existing `/admin/services` UI is exercised by Playwright but not modified.
- Compatibility path or alias: not applicable - no route alias or compatibility path changed.
- Contract proof: route contract Vitest passed for `routeContract.test.js` and `routeOwnershipEnforcement.test.js`.

## RBAC / Permissions

- Roles allowed: Admin seeded session for `/admin/services?servicesTab=catalog`.
- Roles denied: not applicable - no production role policy changed.
- Positive auth proof: Playwright authenticated smoke reached the Admin Services shell and opened the add-service form.
- Negative auth proof: not checked - this PR adds positive action smoke only and does not alter guards or RBAC.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, chat, websocket, or realtime event changed.
- Payload version / ack behavior: not applicable - no realtime payload changed.
- Read/unread or delivery semantics: not applicable - no notification delivery semantics changed.
- Reconnect/resync proof: not checked - local Playwright emitted non-blocking Vite WS proxy `ECONNREFUSED` noise because backend was not running; the modified test passed through QA mocks.

## Frontend Resilience

- Empty data proof: `/admin/services?servicesTab=catalog` renders with empty services/categories/doctors QA payloads.
- Partial data proof: not checked - this PR covers empty action smoke, not partial permutations.
- Forbidden secondary path behavior: Playwright smoke asserts no login, forbidden, or unauthorized redirect for the seeded Admin session.
- Missing draft/resource behavior: not applicable - no draft/resource flow changed.
- Stale route/deep-link behavior: direct deep link with `servicesTab=catalog` is smoke-tested.

## Scope Gate

- Allowed paths: `frontend/e2e/authenticated-role-smoke.spec.js`.
- Denied paths: frontend/backend product runtime, route registry, RBAC/auth policy, DB/migrations, deploy, secrets.
- Migration/docs/test impact: test-only impact; no migrations or docs changed.
- Rollback note: revert this commit to remove only the Admin Services action smoke.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd run test:e2e -- e2e/authenticated-role-smoke.spec.js --project=chromium --reporter=line`; `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js src/routing/__tests__/routeOwnershipEnforcement.test.js`; `npm.cmd run lint:check -- --quiet`; `npm.cmd run build`; `git diff --check`; PR review body gate.
- Result: Playwright 20 passed; Vitest 41 passed; lint passed; build passed; diff-check passed with CRLF normalization warning only; PR body gate passed locally.
- Not checked: full backend suite and full frontend suite were not run because this is a narrow e2e-only smoke addition.
