### PR TITLE
fix(analytics): restrict KPI financial metrics

### DIFF
--- a/backend/app/api/v1/endpoints/analytics_kpi.py
+++ b/backend/app/api/v1/endpoints/analytics_kpi.py
@@ -15,6 +15,8 @@ from app.services.analytics import AnalyticsService
 
 router = APIRouter()
 
+FINANCIAL_ANALYTICS_ROLES = ["admin", "manager"]
+
 
 def _parse_date_range(start_date: str, end_date: str) -> tuple[datetime, datetime]:
     try:
@@ -171,7 +173,7 @@ async def get_kpi_metrics(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
     """Получить KPI метрики для аналитики."""
     start, end = _parse_date_range(start_date, end_date)
@@ -246,7 +248,7 @@ async def get_kpi_trends(
     department: Optional[str] = Query(None, description="Отделение"),
     metric: Optional[str] = Query(None, description="Конкретная метрика"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
     """Получить тренды KPI метрик."""
     start, end = _parse_date_range(start_date, end_date)
@@ -275,7 +277,7 @@ async def get_kpi_comparison(
     department: Optional[str] = Query(None, description="Отделение"),
     comparison_period: str = Query("previous", description="Период сравнения"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
     """Получить сравнение KPI с предыдущими периодами."""
     start, end = _parse_date_range(start_date, end_date)

--- a/backend/tests/integration/test_analytics_contracts.py
+++ b/backend/tests/integration/test_analytics_contracts.py
@@ -194,6 +194,28 @@ def test_doctor_cannot_read_legacy_revenue_analytics(
 @pytest.mark.parametrize(
     "path",
     [
+        "/api/v1/analytics/kpi-metrics",
+        "/api/v1/analytics/kpi-trends",
+        "/api/v1/analytics/kpi-comparison",
+    ],
+)
+def test_doctor_cannot_read_kpi_financial_analytics(
+    client: TestClient,
+    doctor_token: str,
+    path: str,
+) -> None:
+    response = client.get(
+        path,
+        headers=_auth_headers(doctor_token),
+        params={"start_date": "2026-03-08", "end_date": "2026-04-07"},
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
         "/api/v1/analytics/export/kpi/export/json",
         "/api/v1/analytics/export/comprehensive/export/json",
         "/api/v1/analytics/export/revenue/export/json",


### PR DESCRIPTION
## Summary

- Restrict KPI analytics endpoints to Admin/Manager because the payload includes clinic-wide revenue metrics.
- Protect `/analytics/kpi-metrics`, `/analytics/kpi-trends`, and `/analytics/kpi-comparison` without changing response shape for allowed users.
- Add Doctor-denied RBAC regression coverage for all three KPI routes.

## Cyclic Execution Evidence

- Fresh main sync: worktree branch created from `origin/main` at `9301b350`, then merged current `origin/main` at `ade01dae` before push.
- Clean workspace: inspected before edits; only scoped KPI endpoint and analytics contract test changed relative to current main.
- Branch: `codex/contract-scan-next-27`.
- Scope gate: known-root-cause gate restricted runtime slice to `analytics_kpi.py`; second gate restricted test slice to `test_analytics_contracts.py`.
- Red-check handling: any failed targeted test or CI check will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/analytics/kpi-metrics`, `GET /api/v1/analytics/kpi-trends`, and `GET /api/v1/analytics/kpi-comparison`.
- Request shape: authenticated GET with existing `start_date`, `end_date`, optional `department`, and existing optional KPI query params.
- Response shape: unchanged for allowed roles; authorization is enforced before returning revenue-containing KPI payloads.
- Status codes: Doctor/Nurse now receive 403 for KPI financial analytics; Admin/Manager can reach the existing 200 behavior.
- Frontend consumer: not applicable - no frontend files changed; forbidden callers receive the standard backend 403 contract.
- Compatibility path or alias: no route alias changed; advanced/predictive/visualization analytics routes remain intentionally out of this PR scope.
- Contract proof: targeted backend integration test covers Doctor 403 on all three KPI routes; existing admin legacy contract test covers Admin 200 on `/analytics/kpi-metrics`.

## RBAC / Permissions

- Roles allowed: Admin and Manager for KPI financial analytics.
- Roles denied: Doctor and Nurse are no longer accepted for KPI routes exposing revenue fields; Patient remains denied by existing coverage.
- Positive auth proof: `test_analytics_legacy_contracts_exist` returns 200 for Admin on `/api/v1/analytics/kpi-metrics`.
- Negative auth proof: `test_doctor_cannot_read_kpi_financial_analytics` returns 403 for all three KPI routes.

## Notification / Realtime

not applicable - no notification, websocket, chat, delivery, read/unread, reconnect, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed; allowed response shape is unchanged.
- Partial data proof: not applicable - no frontend or response-shape fallback changed.
- Forbidden secondary path behavior: forbidden KPI analytics now return 403 before data calculation for Doctor/Nurse.
- Missing draft/resource behavior: not applicable - analytics reads do not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link state changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/analytics_kpi.py`, `backend/tests/integration/test_analytics_contracts.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read models, frontend, advanced/predictive/visualization analytics routes, migrations/models.
- Migration/docs/test impact: no migration; targeted integration test updated.
- Rollback note: revert this commit to restore previous KPI analytics RBAC and remove the regression tests.

## Validation

- Targeted tests or smoke run: `py_compile` on changed files; `pytest backend/tests/integration/test_analytics_contracts.py -q`; `git diff --check`; post-merge `py_compile` and `git diff --check origin/main...HEAD`; GitHub checks.
- Result: local analytics contract suite passed 21 tests; diff checks passed.
- Not checked: browser/frontend behavior and remaining advanced/predictive/visualization analytics RBAC, intentionally left for subsequent narrow audit slices.