### PR TITLE
fix(analytics): restrict advanced financial metrics

### DIFF
--- a/backend/app/api/v1/endpoints/advanced_analytics.py
+++ b/backend/app/api/v1/endpoints/advanced_analytics.py
@@ -15,6 +15,9 @@ from app.services.analytics import AnalyticsService
 
 router = APIRouter()
 
+CLINICAL_ADVANCED_ANALYTICS_ROLES = ["admin", "doctor", "nurse"]
+FINANCIAL_ADVANCED_ANALYTICS_ROLES = ["admin", "manager"]
+
 
 @router.get("/kpi")
 async def get_kpi_metrics(
@@ -22,7 +25,7 @@ async def get_kpi_metrics(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ADVANCED_ANALYTICS_ROLES)),
 ):
     """Получить ключевые показатели эффективности (KPI)"""
     try:
@@ -47,7 +50,7 @@ async def get_doctor_performance(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ADVANCED_ANALYTICS_ROLES)),
 ):
     """Получить показатели эффективности врачей"""
     try:
@@ -70,7 +73,7 @@ async def get_advanced_patient_analytics(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(CLINICAL_ADVANCED_ANALYTICS_ROLES)),
 ):
     """Получить расширенную аналитику пациентов"""
     try:
@@ -94,7 +97,7 @@ async def get_advanced_revenue_analytics(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ADVANCED_ANALYTICS_ROLES)),
 ):
     """Получить расширенную аналитику доходов"""
     try:
@@ -118,7 +121,7 @@ async def get_predictive_analytics(
         30, ge=1, le=365, description="Количество дней для прогноза"
     ),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ADVANCED_ANALYTICS_ROLES)),
 ):
     """Получить предиктивную аналитику и прогнозы"""
     analytics_service = get_advanced_analytics_service()
@@ -134,7 +137,7 @@ async def get_advanced_comprehensive_report(
         True, description="Включить предиктивную аналитику"
     ),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ADVANCED_ANALYTICS_ROLES)),
 ):
     """Получить расширенный комплексный отчет"""
     try:

--- a/backend/tests/integration/test_analytics_contracts.py
+++ b/backend/tests/integration/test_analytics_contracts.py
@@ -216,6 +216,44 @@ def test_doctor_cannot_read_kpi_financial_analytics(
 @pytest.mark.parametrize(
     "path",
     [
+        "/api/v1/analytics/advanced/kpi",
+        "/api/v1/analytics/advanced/doctors/performance",
+        "/api/v1/analytics/advanced/revenue/advanced",
+        "/api/v1/analytics/advanced/predictive",
+        "/api/v1/analytics/advanced/comprehensive/advanced",
+    ],
+)
+def test_doctor_cannot_read_advanced_financial_analytics(
+    client: TestClient,
+    doctor_token: str,
+    path: str,
+) -> None:
+    response = client.get(
+        path,
+        headers=_auth_headers(doctor_token),
+        params={"start_date": "2026-03-08", "end_date": "2026-04-07"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_admin_can_read_advanced_revenue_analytics(
+    client: TestClient,
+    admin_token: str,
+) -> None:
+    response = client.get(
+        "/api/v1/analytics/advanced/revenue/advanced",
+        headers=_auth_headers(admin_token),
+        params={"start_date": "2026-03-08", "end_date": "2026-04-07"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert "total_revenue" in response.json()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
         "/api/v1/analytics/export/kpi/export/json",
         "/api/v1/analytics/export/comprehensive/export/json",
         "/api/v1/analytics/export/revenue/export/json",


### PR DESCRIPTION
## Summary

- Restrict advanced analytics routes that expose revenue, KPI, predictive, comprehensive, or doctor-performance financial metrics to Admin/Manager.
- Keep non-financial advanced patient analytics on the existing clinical role set.
- Add Doctor-denied RBAC regression coverage for all protected advanced analytics routes plus Admin revenue access proof.

## Cyclic Execution Evidence

- Fresh main sync: worktree branch created from current `origin/main` at `6f4d8b0b`.
- Clean workspace: inspected before edits; only scoped advanced analytics endpoint and analytics contract test changed.
- Branch: `codex/contract-scan-next-28`.
- Scope gate: known-root-cause gate restricted runtime slice to `advanced_analytics.py`; second gate restricted test slice to `test_analytics_contracts.py`.
- Red-check handling: any failed targeted test or CI check will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/analytics/advanced/kpi`, `/doctors/performance`, `/revenue/advanced`, `/predictive`, and `/comprehensive/advanced`.
- Request shape: authenticated GET with existing query parameters; no request parameter or route alias changed.
- Response shape: unchanged for allowed roles; authorization is enforced before returning revenue-bearing advanced analytics payloads.
- Status codes: Doctor/Nurse now receive 403 for advanced financial analytics; Admin/Manager can reach the existing behavior.
- Frontend consumer: not applicable - no frontend files changed; forbidden callers receive the standard backend 403 contract.
- Compatibility path or alias: no route alias changed; visualization/predictive standalone analytics routes remain intentionally out of this PR scope.
- Contract proof: targeted backend integration test covers Doctor 403 on all protected advanced routes and Admin 200 on advanced revenue analytics.

## RBAC / Permissions

- Roles allowed: Admin and Manager for advanced financial analytics routes; Admin/Doctor/Nurse remain allowed for advanced patient analytics.
- Roles denied: Doctor and Nurse are no longer accepted for revenue-bearing advanced analytics; Patient remains denied by existing coverage.
- Positive auth proof: `test_admin_can_read_advanced_revenue_analytics` returns 200 and sees `total_revenue`.
- Negative auth proof: `test_doctor_cannot_read_advanced_financial_analytics` returns 403 for five protected advanced routes.

## Notification / Realtime

not applicable - no notification, websocket, chat, delivery, read/unread, reconnect, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed; allowed response shape is unchanged.
- Partial data proof: not applicable - no frontend or response-shape fallback changed.
- Forbidden secondary path behavior: forbidden advanced financial analytics now return 403 before data calculation for Doctor/Nurse.
- Missing draft/resource behavior: not applicable - analytics reads do not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link state changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/advanced_analytics.py`, `backend/tests/integration/test_analytics_contracts.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite/read models, frontend, visualization/standalone predictive analytics routes, migrations/models.
- Migration/docs/test impact: no migration; targeted integration test updated.
- Rollback note: revert this commit to restore previous advanced analytics RBAC and remove the regression tests.

## Validation

- Targeted tests or smoke run: `py_compile` on changed files; `pytest backend/tests/integration/test_analytics_contracts.py -q`; `git diff --check`; GitHub checks.
- Result: local analytics contract suite passed 27 tests; `git diff --check` passed.
- Not checked: browser/frontend behavior and remaining visualization/standalone predictive analytics RBAC, intentionally left for subsequent narrow audit slices.