### PR TITLE
test(admin): add appointments action smoke

### DIFF
--- a/frontend/e2e/authenticated-role-smoke.spec.js
+++ b/frontend/e2e/authenticated-role-smoke.spec.js
@@ -81,6 +81,13 @@ const AUTHENTICATED_ADMIN_ACTION_QA_ROUTES = [
     primaryActionText: /Добавить пациента|Add patient/i,
     openedFormHeading: /Добавить пациента|Add patient/i,
   },
+  {
+    key: 'admin-appointments',
+    path: '/admin/appointments',
+    routeId: 'admin-appointments',
+    primaryActionText: /Создать запись|Create appointment/i,
+    openedFormHeading: /Создать запись на прием|Создать запись|Create appointment/i,
+  },
 ];
 
 async function expectRenderedRolePanel(page, route) {

--- a/frontend/e2e/support/authenticatedQa.js
+++ b/frontend/e2e/support/authenticatedQa.js
@@ -181,6 +181,10 @@ function buildQaApiPayload(pathname, profile, method) {
     return [];
   }
 
+  if (lowerPath === '/admin/appointments') {
+    return [];
+  }
+
   if (lowerPath === '/services' || lowerPath === '/services/categories' || lowerPath === '/services/admin/doctors') {
     return [];
   }


### PR DESCRIPTION
﻿## Summary

- Adds `/admin/appointments` to the authenticated admin action smoke matrix.
- Verifies the Admin Appointments primary action opens the appointment form with named controls and no horizontal overflow.
- Adds a narrow QA API payload shape for `/admin/appointments` so the route renders from an empty list instead of a generic collection object.

## Cyclic Execution Evidence

- Fresh main sync: local `main` was synced with `origin/main` after PR #1583 before branching.
- Clean workspace: started from clean `main`; final diff is two E2E/QA harness files only.
- Branch: `test/admin-appointments-action-smoke`.
- Scope gate: allowed `frontend/e2e/authenticated-role-smoke.spec.js` and `frontend/e2e/support/authenticatedQa.js`; denied frontend runtime, backend, DB, migrations, deploy, and docs.
- Red-check handling: fix any failing CI in this same PR before merge.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

not applicable - test-only QA harness change; no API, websocket, event, request, or response contract changed.

## RBAC / Permissions

not applicable - no route guard, endpoint permission, auth helper, or role policy changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: `/admin/appointments` QA payload now returns an empty array, matching `useAppointments` expectations and exercising the empty-list Admin Appointments route.
- Partial data proof: not applicable - this smoke targets opening the primary create form, not row rendering.
- Forbidden secondary path behavior: not applicable - RBAC behavior unchanged and covered by existing route tests.
- Missing draft/resource behavior: not applicable - no persisted draft/resource is used.
- Stale route/deep-link behavior: route contract tests passed for admin route registry ownership.

## Scope Gate

- Allowed paths: `frontend/e2e/authenticated-role-smoke.spec.js`, `frontend/e2e/support/authenticatedQa.js`.
- Denied paths: backend/frontend runtime components, DB/migrations, deploy/secrets, production configs.
- Migration/docs/test impact: test-only E2E coverage; no migration or docs impact.
- Rollback note: remove the Appointments route entry and `/admin/appointments` QA payload branch to return to previous smoke coverage.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd run test:e2e -- e2e/authenticated-role-smoke.spec.js --project=chromium --reporter=line` -> 23 passed
  - `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js src/routing/__tests__/routeOwnershipEnforcement.test.js` -> 41 passed
  - `npm.cmd run lint:check -- --quiet` -> passed
  - `npm.cmd run build` -> passed
  - `git diff --check` -> passed with existing LF-to-CRLF warnings only
- Result: local validation passed.
- Not checked: backend tests, because this PR changes only frontend E2E smoke coverage and mock QA payloads.
