### PR TITLE
fix(analytics): restrict financial visualizations

### DIFF
--- a/backend/app/api/v1/endpoints/analytics_visualization.py
+++ b/backend/app/api/v1/endpoints/analytics_visualization.py
@@ -22,6 +22,8 @@ from app.services.analytics_visualization_service import (
 
 router = APIRouter()
 
+FINANCIAL_ANALYTICS_ROLES = ["admin", "manager"]
+
 
 @router.get("/dashboard")
 async def get_dashboard_visualization(
@@ -29,7 +31,7 @@ async def get_dashboard_visualization(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
     """Получить визуализацию для дашборда"""
     try:
@@ -91,7 +93,7 @@ async def get_kpi_visualization(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
     """Получить визуализацию KPI метрик"""
     try:
@@ -238,7 +240,7 @@ async def get_revenue_analytics_visualization(
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
     department: Optional[str] = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
     """Получить визуализацию аналитики доходов"""
     try:
@@ -291,7 +293,7 @@ async def get_comprehensive_visualization(
         True, description="Включить предиктивную аналитику"
     ),
     db: Session = Depends(get_db),
-    current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
+    current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
     """Получить полную визуализацию для комплексного отчета"""
     try:

--- a/backend/tests/integration/test_analytics_contracts.py
+++ b/backend/tests/integration/test_analytics_contracts.py
@@ -260,6 +260,29 @@ def test_doctor_cannot_read_advanced_financial_analytics(
     assert response.status_code == 403
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/analytics/visualization/dashboard",
+        "/api/v1/analytics/visualization/kpi",
+        "/api/v1/analytics/visualization/revenue",
+        "/api/v1/analytics/visualization/comprehensive",
+    ],
+)
+def test_doctor_cannot_read_financial_analytics_visualizations(
+    client: TestClient,
+    doctor_token: str,
+    path: str,
+) -> None:
+    response = client.get(
+        path,
+        headers=_auth_headers(doctor_token),
+        params={"start_date": "2026-03-08", "end_date": "2026-04-07"},
+    )
+
+    assert response.status_code == 403
+
+
 def test_admin_can_read_advanced_revenue_analytics(
     client: TestClient,
     admin_token: str,
@@ -272,6 +295,20 @@ def test_admin_can_read_advanced_revenue_analytics(
 
     assert response.status_code == 200, response.text
     assert "total_revenue" in response.json()
+
+
+def test_admin_can_read_revenue_analytics_visualization(
+    client: TestClient,
+    admin_token: str,
+) -> None:
+    response = client.get(
+        "/api/v1/analytics/visualization/revenue",
+        headers=_auth_headers(admin_token),
+        params={"start_date": "2026-03-08", "end_date": "2026-04-07"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert "revenue_data" in response.json()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Restrict financial analytics visualization endpoints to Admin/Manager because they expose clinic-wide revenue charts, KPI revenue data, or comprehensive financial data.
- Add Doctor 403 regression coverage for dashboard, KPI, revenue, and comprehensive visualization routes.
- Add Admin-positive coverage for revenue visualization to prove authorized access remains live.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current origin/main in isolated worktree C:\tmp\final-contract-scan-next-30 at dfababe0.
- Clean workspace: inspected before edits; only scoped analytics visualization endpoint and analytics contract test changed in PR diff.
- Branch: codex/contract-scan-next-30.
- Scope gate: allowed backend/app/api/v1/endpoints/analytics_visualization.py and backend/tests/integration/test_analytics_contracts.py; denied /api/v1/ui/*, BFF-lite, frontend, DB, migrations, and unrelated analytics surfaces.
- Red-check handling: fix any failed targeted tests or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: GET /api/v1/analytics/visualization/dashboard, /kpi, /revenue, and /comprehensive.
- Request shape: authenticated GET with existing start_date/end_date query parameters and optional existing department/include_predictive parameters; no request body changes.
- Response shape: unchanged for authorized Admin/Manager callers.
- Status codes: Admin/Manager keep 200 on valid requests; Doctor/Nurse now receive 403 for financial visualization routes.
- Frontend consumer: unchanged; no frontend files touched and authorized response shape remains stable.
- Compatibility path or alias: no alias or compatibility path changed.
- Contract proof: targeted integration contract tests prove Doctor 403 and Admin 200 for revenue visualization.

## RBAC / Permissions

- Roles allowed: admin, manager.
- Roles denied: doctor, nurse, patient for financial analytics visualization endpoints.
- Positive auth proof: admin_token test asserts /api/v1/analytics/visualization/revenue returns 200 with revenue_data.
- Negative auth proof: new parametrized doctor_token test asserts 403 for dashboard, KPI, revenue, and comprehensive visualization endpoints.

## Notification / Realtime

not applicable - no notification, websocket, chat, task, email, Telegram, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no frontend rendering path changed and authorized response shape is unchanged.
- Partial data proof: not applicable, no frontend parser or adapter changed.
- Forbidden secondary path behavior: forbidden behavior is backend-owned 403 for Doctor/Nurse on the same visualization endpoints; no secondary frontend path changed.
- Missing draft/resource behavior: not applicable, analytics visualization routes do not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable, no frontend route or deep-link behavior changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/analytics_visualization.py and backend/tests/integration/test_analytics_contracts.py.
- Denied paths: /api/v1/ui/*, BFF-lite, separate BFF service, frontend files, DB models, Alembic migrations, generated artifacts, and unrelated analytics surfaces.
- Migration/docs/test impact: no migration or docs change; targeted backend integration contract tests updated.
- Rollback note: revert the PR commit to restore the previous visualization role allowlist and remove the matching regression tests.

## Validation

- Targeted tests or smoke run: py_compile for changed files; pytest backend/tests/integration/test_analytics_contracts.py -q; git diff --check.
- Result: py_compile passed; targeted analytics contract suite passed with 36 passed; git diff --check passed.
- Not checked: full frontend build/e2e not run locally because no frontend code changed.