### PR TITLE
test(admin): add finance action smoke

### DIFF
--- a/frontend/e2e/authenticated-role-smoke.spec.js
+++ b/frontend/e2e/authenticated-role-smoke.spec.js
@@ -88,6 +88,14 @@ const AUTHENTICATED_ADMIN_ACTION_QA_ROUTES = [
     primaryActionText: /Создать запись|Create appointment/i,
     openedFormHeading: /Создать запись на прием|Создать запись|Create appointment/i,
   },
+  {
+    key: 'admin-finance-billing',
+    path: '/admin/finance?section=billing',
+    routeId: 'admin-finance',
+    primaryActionText: /Создать счет|Create invoice/i,
+    openedFormHeading: /Создать счет|Create invoice/i,
+    requiresFormElement: false,
+  },
 ];
 
 async function expectRenderedRolePanel(page, route) {
@@ -219,10 +227,14 @@ async function runAdminRouteActionSmoke(page, testInfo, route) {
   await primaryAction.click();
 
   await expect(
-    page.locator('h2, h3, [role="heading"]').filter({ hasText: route.openedFormHeading }).first(),
+    page.locator('h1, h2, h3, h4, h5, h6, [role="heading"]').filter({ hasText: route.openedFormHeading }).first(),
     `${route.key} primary action should open its form`
   ).toBeVisible();
-  await expect(page.locator('form').first()).toBeVisible();
+  if (route.requiresFormElement === false) {
+    await expect(page.locator('input, textarea, select').first()).toBeVisible();
+  } else {
+    await expect(page.locator('form').first()).toBeVisible();
+  }
   await expectNoHorizontalOverflow(page, route);
 
   const screenshotPath = testInfo.outputPath(`admin-route-action-${route.key}.png`);

--- a/frontend/e2e/support/authenticatedQa.js
+++ b/frontend/e2e/support/authenticatedQa.js
@@ -185,6 +185,10 @@ function buildQaApiPayload(pathname, profile, method) {
     return [];
   }
 
+  if (lowerPath === '/billing/invoices' || lowerPath === '/billing/payments') {
+    return [];
+  }
+
   if (lowerPath === '/services' || lowerPath === '/services/categories' || lowerPath === '/services/admin/doctors') {
     return [];
   }


### PR DESCRIPTION
﻿## Summary

- Added an authenticated Admin action smoke for `/admin/finance?section=billing`.
- Verifies the Finance billing route exposes the named `Создать счет` action and opens the invoice creation surface with visible controls.
- Added QA harness mocks for empty billing invoices/payments so the route can render deterministically without backend data.

## Cyclic Execution Evidence

- Fresh main sync: branch `test/admin-finance-action-smoke` was created after syncing `main` with `origin/main` following PR #1585.
- Clean workspace: only `frontend/e2e/authenticated-role-smoke.spec.js` and `frontend/e2e/support/authenticatedQa.js` are changed.
- Branch: `test/admin-finance-action-smoke`.
- Scope gate: test harness only; no application runtime, backend, DB, migration, deploy, or secret changes.
- Red-check handling: the first local smoke exposed a test selector gap (`h4` heading); fixed in this branch and reran successfully.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

not applicable - no API, websocket, event, or frontend consumer contract changed; this PR only extends authenticated browser QA coverage and deterministic mocks.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed; the existing authenticated QA harness still seeds the Admin session for Admin routes.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed. Local Playwright output still shows expected Vite proxy WS noise when no backend is attached, but the mocked UI flow passes.

## Frontend Resilience

- Empty data proof: `/billing/invoices` and `/billing/payments` return empty arrays in the QA harness, matching the Finance/Billing route's empty-list expectations.
- Partial data proof: not applicable - this action smoke targets opening the create-invoice surface, not rendering a partial invoice payload.
- Forbidden secondary path behavior: not applicable - no forbidden-path behavior changed.
- Missing draft/resource behavior: not applicable - no draft/resource persistence behavior changed.
- Stale route/deep-link behavior: route contract tests passed for the current registry/ownership mapping.

## Scope Gate

- Allowed paths: `frontend/e2e/authenticated-role-smoke.spec.js`; `frontend/e2e/support/authenticatedQa.js`.
- Denied paths: backend/runtime code; frontend runtime code under `frontend/src/**`; DB/migrations; deploy/secrets/workflows; docs outside this PR body.
- Migration/docs/test impact: test-only PR; no migration or docs impact.
- Rollback note: revert this commit to remove only the Finance action smoke and its QA mock additions.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `npm.cmd run test:e2e -- e2e/authenticated-role-smoke.spec.js --project=chromium --reporter=line` - 24 passed; `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js src/routing/__tests__/routeOwnershipEnforcement.test.js` - 41 passed; `npm.cmd run lint:check -- --quiet` - passed; `npm.cmd run build` - passed; `git diff --check` - passed.
- Result: local validation passed for the test-only Finance action smoke.
- Not checked: live backend Finance API behavior; this PR intentionally uses the authenticated QA harness and does not change runtime code.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.
