### PR TITLE
fix(specialized): restrict financial panel analytics

### DIFF
--- a/backend/app/api/v1/endpoints/specialized_panels.py
+++ b/backend/app/api/v1/endpoints/specialized_panels.py
@@ -17,6 +17,8 @@ from app.services.specialized_panels_api_service import (
 
 router = APIRouter()
 
+FINANCIAL_SPECIALIZED_PANEL_ROLES = ("Admin", "Manager")
+
 
 @router.get("/cardiology/patients")
 async def get_cardiology_patients(
@@ -60,7 +62,7 @@ async def get_cardiology_visits(
 async def get_cardiology_analytics(
     start_date: Optional[date] = Query(None),
     end_date: Optional[date] = Query(None),
-    current_user: User = Depends(require_roles("Admin", "Doctor")),
+    current_user: User = Depends(require_roles(*FINANCIAL_SPECIALIZED_PANEL_ROLES)),
     db: Session = Depends(get_db),
 ):
     """Получить аналитику кардиологического отделения"""
@@ -112,7 +114,7 @@ async def get_dentistry_visits(
 async def get_dentistry_analytics(
     start_date: Optional[date] = Query(None),
     end_date: Optional[date] = Query(None),
-    current_user: User = Depends(require_roles("Admin", "Doctor")),
+    current_user: User = Depends(require_roles(*FINANCIAL_SPECIALIZED_PANEL_ROLES)),
     db: Session = Depends(get_db),
 ):
     """Получить аналитику стоматологического отделения"""
@@ -157,7 +159,7 @@ async def get_specialized_patient_history(
 async def get_specialized_statistics(
     start_date: Optional[date] = Query(None),
     end_date: Optional[date] = Query(None),
-    current_user: User = Depends(require_roles("Admin", "Doctor")),
+    current_user: User = Depends(require_roles(*FINANCIAL_SPECIALIZED_PANEL_ROLES)),
     db: Session = Depends(get_db),
 ):
     """Получить общую статистику по специализированным отделениям"""

--- a/backend/tests/integration/test_specialized_panels_api_endpoints.py
+++ b/backend/tests/integration/test_specialized_panels_api_endpoints.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 import pytest
 
 
+@pytest.fixture
+def doctor_headers(client, test_doctor_user):
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": test_doctor_user.username, "password": "doctor123"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
 @pytest.mark.integration
 @pytest.mark.parametrize(
     ("path", "expected_key"),
@@ -24,3 +35,63 @@ def test_specialized_panel_endpoints_accept_list_role_dependencies(
     assert response.status_code == 200, response.text
     body = response.json()
     assert expected_key in body
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/specialized/dentistry/patients",
+        "/api/v1/specialized/dentistry/visits",
+        "/api/v1/specialized/cardiology/patients",
+        "/api/v1/specialized/cardiology/visits",
+    ],
+)
+def test_doctor_can_still_read_clinical_specialized_panel_lists(
+    client,
+    doctor_headers,
+    path: str,
+):
+    response = client.get(path, headers=doctor_headers)
+
+    assert response.status_code == 200, response.text
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/specialized/cardiology/analytics",
+        "/api/v1/specialized/dentistry/analytics",
+        "/api/v1/specialized/specialized/statistics",
+    ],
+)
+def test_doctor_cannot_read_specialized_financial_analytics(
+    client,
+    doctor_headers,
+    path: str,
+):
+    response = client.get(path, headers=doctor_headers)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("path", "expected_key"),
+    [
+        ("/api/v1/specialized/cardiology/analytics", "total_revenue"),
+        ("/api/v1/specialized/dentistry/analytics", "total_revenue"),
+        ("/api/v1/specialized/specialized/statistics", "total"),
+    ],
+)
+def test_admin_can_read_specialized_financial_analytics(
+    client,
+    auth_headers,
+    path: str,
+    expected_key: str,
+):
+    response = client.get(path, headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    assert expected_key in response.json()


### PR DESCRIPTION
## Summary

- Restrict revenue-bearing specialized panel analytics/statistics endpoints to Admin/Manager because they expose department revenue totals, daily revenue, and average visit value.
- Keep clinical specialized patient/visit/services/history routes Doctor-accessible.
- Add regression coverage proving Doctor is denied only on financial specialized analytics while Admin remains allowed.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current origin/main in isolated worktree C:\tmp\final-contract-scan-next-31 at 13689234.
- Clean workspace: inspected before edits; only scoped specialized panel endpoint and specialized panel integration test changed in PR diff.
- Branch: codex/contract-scan-next-31.
- Scope gate: allowed backend/app/api/v1/endpoints/specialized_panels.py and backend/tests/integration/test_specialized_panels_api_endpoints.py; denied frontend, DB, migrations, analytics namespace changes, patient/visit/services/history behavior changes, and generated artifacts.
- Red-check handling: fix any failed targeted tests or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: GET /api/v1/specialized/cardiology/analytics, /api/v1/specialized/dentistry/analytics, and /api/v1/specialized/specialized/statistics.
- Request shape: authenticated GET with existing optional start_date/end_date query parameters; no request body changes.
- Response shape: unchanged for authorized Admin/Manager callers.
- Status codes: Admin/Manager keep 200 on valid requests; Doctor now receives 403 for revenue-bearing specialized analytics/statistics endpoints.
- Frontend consumer: no frontend files touched; clinical specialized list endpoints remain Doctor-accessible.
- Compatibility path or alias: existing specialized route paths remain unchanged.
- Contract proof: targeted integration tests prove Doctor 403 for financial endpoints, Admin 200 for financial endpoints, and Doctor 200 for clinical list endpoints.

## RBAC / Permissions

- Roles allowed: Admin, Manager for specialized financial analytics/statistics; Admin, Doctor remain allowed for clinical specialized lists.
- Roles denied: Doctor for /cardiology/analytics, /dentistry/analytics, and /specialized/statistics financial aggregates.
- Positive auth proof: auth_headers Admin test asserts 200 and expected revenue/statistics keys for all three financial endpoints.
- Negative auth proof: doctor_headers test asserts 403 for all three financial endpoints and 200 for clinical patient/visit list endpoints.

## Notification / Realtime

not applicable - no notification, websocket, chat, task, email, Telegram, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: Admin-positive tests pass on the existing empty/minimal test dataset and assert stable top-level keys.
- Partial data proof: not applicable, no frontend parser or adapter changed.
- Forbidden secondary path behavior: forbidden behavior is backend-owned 403 for Doctor on the same financial specialized endpoints; clinical list endpoints remain available.
- Missing draft/resource behavior: not applicable, specialized analytics routes do not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable, no frontend route or deep-link behavior changed.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/specialized_panels.py and backend/tests/integration/test_specialized_panels_api_endpoints.py.
- Denied paths: frontend files, DB models, Alembic migrations, analytics namespace files, generated artifacts, and unrelated specialized panel routes.
- Migration/docs/test impact: no migration or docs change; targeted backend integration tests updated.
- Rollback note: revert the PR commit to restore the previous specialized analytics role allowlist and remove matching regression tests.

## Validation

- Targeted tests or smoke run: py_compile for changed files; pytest backend/tests/integration/test_specialized_panels_api_endpoints.py -q; git diff --check.
- Result: py_compile passed; targeted specialized panel integration suite passed with 14 passed; git diff --check passed.
- Not checked: full frontend build/e2e not run locally because no frontend code changed.