### PR TITLE
fix(analytics): restrict ai usage telemetry

### DIFF
--- a/backend/app/api/v1/endpoints/ai_analytics.py
+++ b/backend/app/api/v1/endpoints/ai_analytics.py
@@ -144,7 +144,7 @@ async def get_ai_usage_analytics(
     user_id: Optional[int] = Query(None, description="Фильтр по пользователю"),
     ai_function: Optional[str] = Query(None, description="Фильтр по AI функции"),
     db: Session = Depends(get_db),
-    current_user: User = Depends(require_roles(["Admin", "Doctor"])),
+    current_user: User = Depends(require_roles(["Admin"])),
 ):
     """Получить аналитику использования AI за период"""
     try:
@@ -319,7 +319,7 @@ async def generate_training_dataset(
 async def get_ai_usage_summary(
     days: int = Query(30, ge=1, le=365, description="Количество дней для анализа"),
     db: Session = Depends(get_db),
-    current_user: User = Depends(require_roles(["Admin", "Doctor"])),
+    current_user: User = Depends(require_roles(["Admin"])),
 ):
     """Получить краткую сводку использования AI за последние дни"""
     try:
@@ -364,7 +364,7 @@ async def get_function_performance(
     function_name: str,
     days: int = Query(7, ge=1, le=90, description="Количество дней для анализа"),
     db: Session = Depends(get_db),
-    current_user: User = Depends(require_roles(["Admin", "Doctor"])),
+    current_user: User = Depends(require_roles(["Admin"])),
 ):
     """Получить детальную информацию о производительности конкретной AI функции"""
     try:

--- a/backend/tests/integration/test_analytics_contracts.py
+++ b/backend/tests/integration/test_analytics_contracts.py
@@ -283,6 +283,44 @@ def test_doctor_cannot_read_financial_analytics_visualizations(
     assert response.status_code == 403
 
 
+@pytest.mark.parametrize(
+    ("path", "params"),
+    [
+        (
+            "/api/v1/analytics/ai/usage-analytics",
+            {"start_date": "2026-03-08", "end_date": "2026-04-07"},
+        ),
+        ("/api/v1/analytics/ai/usage-summary", {"days": 30}),
+        ("/api/v1/analytics/ai/function-performance/diagnosis", {"days": 7}),
+    ],
+)
+def test_doctor_cannot_read_ai_usage_cost_telemetry(
+    client: TestClient,
+    doctor_token: str,
+    path: str,
+    params: dict[str, Any],
+) -> None:
+    response = client.get(path, headers=_auth_headers(doctor_token), params=params)
+
+    assert response.status_code == 403
+
+
+def test_admin_can_read_ai_usage_cost_summary(
+    client: TestClient,
+    admin_token: str,
+) -> None:
+    response = client.get(
+        "/api/v1/analytics/ai/usage-summary",
+        headers=_auth_headers(admin_token),
+        params={"days": 30},
+    )
+
+    assert response.status_code == 200, response.text
+    payload: dict[str, Any] = response.json()
+    assert "total_cost_usd" in payload
+    assert "daily_average_cost" in payload
+
+
 def test_admin_can_read_advanced_revenue_analytics(
     client: TestClient,
     admin_token: str,


### PR DESCRIPTION
## Summary

- Restrict `/api/v1/analytics/ai/usage-analytics`, `/usage-summary`, and `/function-performance/{function_name}` to Admin only.
- Add analytics contract regression coverage proving Doctor gets 403 and Admin can still read AI usage cost summary.

## Cyclic Execution Evidence

- Fresh main sync: `git fetch origin main` then `git merge origin/main` fast-forwarded this worktree to `68aff494` before final validation.
- Clean workspace: isolated worktree `C:\tmp\final-contract-scan-audit-32`; final diff contains only AI analytics endpoint and analytics contract tests.
- Branch: `codex/contract-scan-audit-32`
- Scope gate: `agent_gate` allowed endpoint-only known-root-cause narrow override, then separately allowed `backend/tests/integration/test_analytics_contracts.py` for tests.
- Red-check handling: local validation passed; CI code checks passed; PR Review Quality Gate body format was corrected in-place.

## Contract Impact

- Canonical surface: FastAPI analytics router mounted at `/api/v1/analytics/ai`.
- Request shape: unchanged query params for all affected routes.
- Response shape: unchanged for Admin; Doctor no longer receives response bodies for global AI cost/usage telemetry routes.
- Status codes: Doctor changes from allowed route result to 403 on the three telemetry routes.
- Frontend consumer: not applicable - no frontend files or frontend API consumers changed in this backend-only RBAC patch.
- Compatibility path or alias: not applicable - no route aliases added, removed, or remapped.
- Contract proof: `test_doctor_cannot_read_ai_usage_cost_telemetry` and `test_admin_can_read_ai_usage_cost_summary`.

## RBAC / Permissions

- Roles allowed: Admin.
- Roles denied: Doctor for global AI usage/cost telemetry.
- Positive auth proof: Admin `GET /api/v1/analytics/ai/usage-summary` returns 200 and includes `total_cost_usd` / `daily_average_cost`.
- Negative auth proof: Doctor receives 403 for `usage-analytics`, `usage-summary`, and `function-performance/{function_name}`.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification events, websocket channels, Telegram messages, or realtime channels changed.
- Payload version / ack behavior: not applicable - this RBAC patch does not alter any realtime payload or acknowledgement contract.
- Read/unread or delivery semantics: not applicable - no delivery, read state, or notification persistence behavior changed.
- Reconnect/resync proof: not applicable - no websocket or realtime reconnect/resync path is touched.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed; backend 403 is covered before response data is rendered.
- Partial data proof: not applicable - response shape for allowed Admin callers is unchanged.
- Forbidden secondary path behavior: Doctor forbidden behavior is covered by targeted backend contract tests returning 403.
- Missing draft/resource behavior: not applicable - these analytics routes do not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no frontend route or deep-link handling changed.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/ai_analytics.py`, `backend/tests/integration/test_analytics_contracts.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite, migrations, unrelated analytics services, Telegram.
- Migration/docs/test impact: no migration or docs changes; targeted backend contract tests updated.
- Rollback note: revert this commit to restore Doctor access to the three AI telemetry routes.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/api/v1/endpoints/ai_analytics.py backend/tests/integration/test_analytics_contracts.py`; `pytest backend\tests\integration\test_analytics_contracts.py -q`; `git diff --check`.
- Result: py_compile passed; analytics contract tests passed, 40 passed; diff check exited 0 with CRLF warning only; GitHub backend/CodeQL/security/role-system checks passed.
- Not checked: full backend suite and frontend build were not run locally because this is a backend RBAC-only patch with targeted CI coverage.
