### PR TITLE
fix(queue): resolve doctor reorder ownership

### DIFF
--- a/backend/app/repositories/queue_reorder_api_repository.py
+++ b/backend/app/repositories/queue_reorder_api_repository.py
@@ -6,6 +6,7 @@ from datetime import date
 
 from sqlalchemy.orm import Session
 
+from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.services.queue_status import REORDER_ACTIVE_RAW_STATUSES
 
@@ -46,6 +47,13 @@ class QueueReorderApiRepository:
                 OnlineQueueEntry.id == entry_id,
                 OnlineQueueEntry.status.in_(self.ACTIVE_ENTRY_STATUSES),
             )
+            .first()
+        )
+
+    def get_active_doctor_by_user_id(self, user_id: int) -> Doctor | None:
+        return (
+            self.db.query(Doctor)
+            .filter(Doctor.user_id == user_id, Doctor.active == True)
             .first()
         )
 

--- a/backend/app/services/queue_reorder_api_service.py
+++ b/backend/app/services/queue_reorder_api_service.py
@@ -29,6 +29,14 @@ class QueueReorderApiService:
         self.repository = repository or QueueReorderApiRepository(db)
         self.domain_service = domain_service or QueueDomainService(db)
 
+    def _ensure_doctor_can_mutate_queue(self, *, current_user, queue) -> None:
+        if current_user.role != "Doctor":
+            return
+
+        doctor = self.repository.get_active_doctor_by_user_id(current_user.id)
+        if not doctor or queue.specialist_id != doctor.id:
+            raise QueueReorderApiDomainError(403, "Нет прав для изменения этой очереди")
+
     @staticmethod
     def _queue_info(queue, entries: list) -> dict:
         return {
@@ -71,8 +79,7 @@ class QueueReorderApiService:
         if not queue:
             raise QueueReorderApiDomainError(404, "Очередь не найдена")
 
-        if current_user.role == "Doctor" and queue.specialist_id != current_user.id:
-            raise QueueReorderApiDomainError(403, "Нет прав для изменения этой очереди")
+        self._ensure_doctor_can_mutate_queue(current_user=current_user, queue=queue)
 
         entries = self.repository.list_active_entries(queue_id=queue_id)
         if not entries:
@@ -127,8 +134,7 @@ class QueueReorderApiService:
         if not queue:
             raise QueueReorderApiDomainError(404, "Очередь не найдена")
 
-        if current_user.role == "Doctor" and queue.specialist_id != current_user.id:
-            raise QueueReorderApiDomainError(403, "Нет прав для изменения этой очереди")
+        self._ensure_doctor_can_mutate_queue(current_user=current_user, queue=queue)
 
         all_entries = self.repository.list_active_entries(queue_id=entry.queue_id)
         if new_position > len(all_entries):

--- a/backend/tests/unit/test_queue_reorder_api_service.py
+++ b/backend/tests/unit/test_queue_reorder_api_service.py
@@ -12,6 +12,31 @@ from app.services.queue_reorder_api_service import (
 
 @pytest.mark.unit
 class TestQueueReorderApiService:
+    @staticmethod
+    def _queue(*, specialist_id: int):
+        return SimpleNamespace(
+            id=1,
+            day=SimpleNamespace(isoformat=lambda: "2026-01-01"),
+            specialist=SimpleNamespace(user=SimpleNamespace(full_name="Doctor")),
+            specialist_id=specialist_id,
+            active=True,
+            opened_at=None,
+        )
+
+    @staticmethod
+    def _entry(*, entry_id: int, number: int):
+        return SimpleNamespace(
+            id=entry_id,
+            queue_id=1,
+            number=number,
+            patient_name=f"Patient {entry_id}",
+            phone="1",
+            status="waiting",
+            source="online",
+            created_at=SimpleNamespace(isoformat=lambda: "2026-01-01T00:00:00"),
+            called_at=None,
+        )
+
     def test_reorder_queue_raises_when_queue_missing(self):
         class Repository:
             def get_queue(self, queue_id):
@@ -27,6 +52,60 @@ class TestQueueReorderApiService:
             )
 
         assert exc_info.value.status_code == 404
+
+    def test_doctor_reorders_queue_by_linked_doctor_id_not_user_id(self):
+        queue = self._queue(specialist_id=7)
+        entries = [self._entry(entry_id=10, number=1), self._entry(entry_id=11, number=2)]
+
+        class Repository:
+            def get_queue(self, queue_id):
+                return queue
+
+            def list_active_entries(self, *, queue_id):
+                return entries
+
+            def get_active_doctor_by_user_id(self, user_id):
+                return SimpleNamespace(id=7)
+
+            def commit(self):
+                return None
+
+        service = QueueReorderApiService(
+            db=None,
+            repository=Repository(),
+        )
+        updated_count, _ = service.reorder_queue(
+            queue_id=1,
+            entry_orders=[{"entry_id": 10, "new_position": 2}],
+            current_user=SimpleNamespace(id=100, role="Doctor"),
+        )
+
+        assert updated_count == 1
+        assert entries[0].number == 2
+
+    def test_doctor_cannot_reorder_queue_when_only_user_id_matches_specialist_id(self):
+        queue = self._queue(specialist_id=100)
+
+        class Repository:
+            def get_queue(self, queue_id):
+                return queue
+
+            def get_active_doctor_by_user_id(self, user_id):
+                return SimpleNamespace(id=7)
+
+        service = QueueReorderApiService(
+            db=None,
+            repository=Repository(),
+        )
+
+        with pytest.raises(QueueReorderApiDomainError) as exc_info:
+            service.reorder_queue(
+                queue_id=1,
+                entry_orders=[{"entry_id": 10, "new_position": 2}],
+                current_user=SimpleNamespace(id=100, role="Doctor"),
+            )
+
+        assert exc_info.value.status_code == 403
 
     def test_move_queue_entry_returns_unchanged_message(self):
         queue = SimpleNamespace(


### PR DESCRIPTION
## Summary

- Fix the queue reorder Doctor ownership guard to compare `DailyQueue.specialist_id` with the authenticated user's linked `Doctor.id`, not `User.id`.
- Keep the Doctor lookup behind the repository boundary and add unit regressions for the id-collision case: own Doctor queue allowed when ids differ, wrong queue denied when only `User.id` matches `specialist_id`.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` at `e8acf2e5`; `git fetch origin main` confirmed no newer base before commit.
- Clean workspace: isolated worktree `C:\tmp\final-contract-scan-audit-33`; final diff contains only queue reorder service, queue reorder repository, and focused unit tests.
- Branch: `codex/contract-scan-audit-33`
- Scope gate: `agent_gate` returned known-root-cause narrow override for `backend/app/services/queue_reorder_api_service.py`, separate gate-ok for `backend/tests/unit/test_queue_reorder_api_service.py`, and a follow-up repository gate for `backend/app/repositories/queue_reorder_api_repository.py`; first service gate recorded gate_misroute and scope was held to confirmed root-cause/boundary/test files.
- Red-check handling: GitHub backend tests first failed on the service/repository boundary; the fix was amended into this same PR and targeted boundary tests pass locally.

## Contract Impact

- Canonical surface: `/api/v1/queue/reorder/reorder` and `/api/v1/queue/reorder/move-entry` through `QueueReorderApiService`.
- Request shape: unchanged request bodies and path/query contracts.
- Response shape: unchanged for allowed Admin, Registrar, and correctly linked Doctor callers.
- Status codes: Doctor whose linked `Doctor.id` does not own the queue now receives 403 even if `User.id` collides with `DailyQueue.specialist_id`.
- Frontend consumer: not applicable - no frontend files changed; existing callers keep the same request/response shape.
- Compatibility path or alias: not applicable - no route aliases added, removed, or remapped.
- Contract proof: `test_doctor_reorders_queue_by_linked_doctor_id_not_user_id` and `test_doctor_cannot_reorder_queue_when_only_user_id_matches_specialist_id`.

## RBAC / Permissions

- Roles allowed: Admin, Registrar, and Doctor only for queues owned by that user's linked `Doctor.id`.
- Roles denied: Doctor for queues whose `specialist_id` belongs to another Doctor row; existing non-allowed role behavior unchanged.
- Positive auth proof: unit regression allows Doctor user id 100 to mutate queue specialist id 7 when linked Doctor id is 7.
- Negative auth proof: unit regression denies Doctor user id 100 from mutating queue specialist id 100 when linked Doctor id is 7.

## Notification / Realtime

- Event type or websocket channel: not applicable - no notification, websocket, Telegram, or realtime channel changed.
- Payload version / ack behavior: not applicable - no realtime payload or acknowledgement contract changed.
- Read/unread or delivery semantics: not applicable - no delivery/read state behavior changed.
- Reconnect/resync proof: not applicable - no reconnect or resync behavior touched.

## Frontend Resilience

- Empty data proof: not applicable - no frontend rendering path changed.
- Partial data proof: not applicable - allowed queue reorder response shape is unchanged.
- Forbidden secondary path behavior: wrong Doctor ownership returns 403 at the service guard before mutation.
- Missing draft/resource behavior: not applicable - queue reorder does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - no route or deep-link behavior changed.

## Scope Gate

- Allowed paths: `backend/app/services/queue_reorder_api_service.py`, `backend/app/repositories/queue_reorder_api_repository.py`, `backend/tests/unit/test_queue_reorder_api_service.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite, migrations, queue ordering algorithms outside the ownership guard, Telegram.
- Migration/docs/test impact: no migration or docs changes; focused unit regressions added.
- Rollback note: revert this commit to restore the previous `specialist_id != current_user.id` guard behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend/app/services/queue_reorder_api_service.py backend/app/repositories/queue_reorder_api_repository.py backend/tests/unit/test_queue_reorder_api_service.py`; `pytest backend\tests\unit\test_queue_reorder_api_service.py backend\tests\unit\test_service_repository_boundary.py backend\tests\integration\test_queue_reorder_status_role_guard.py -q`; `git diff --check`.
- Result: py_compile passed; targeted unit, boundary, and integration status tests passed, 61 passed; diff check exited 0 with CRLF warning only.
- Not checked: full backend suite and frontend build were not run locally because this is a backend queue ownership guard patch with focused tests; GitHub backend suite is rerunning after the in-PR boundary fix.
