### PR TITLE
fix(display): scope doctor queue calls

### DIFF
--- a/backend/app/api/v1/endpoints/display_websocket.py
+++ b/backend/app/api/v1/endpoints/display_websocket.py
@@ -134,6 +134,7 @@ async def call_patient_to_board(
         return await DisplayWebSocketApiService(db).call_patient(
             entry_id=entry_id,
             board_ids=board_ids,
+            current_user=current_user,
         )
     except DisplayWebSocketApiDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
@@ -354,6 +355,7 @@ async def quick_call_next_patient(
         return await DisplayWebSocketApiService(db).quick_call_next(
             specialty=specialty,
             board_id=board_id,
+            current_user=current_user,
         )
     except DisplayWebSocketApiDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc

--- a/backend/app/repositories/display_websocket_api_repository.py
+++ b/backend/app/repositories/display_websocket_api_repository.py
@@ -41,6 +41,13 @@ class DisplayWebSocketApiRepository:
             .first()
         )
 
+    def get_active_doctor_by_user_id(self, user_id: int) -> Doctor | None:
+        return (
+            self.db.query(Doctor)
+            .filter(Doctor.user_id == user_id, Doctor.active.is_(True))
+            .first()
+        )
+
     def get_daily_queue_for_specialist(
         self,
         *,

--- a/backend/app/services/display_websocket_api_service.py
+++ b/backend/app/services/display_websocket_api_service.py
@@ -32,11 +32,48 @@ class DisplayWebSocketApiService:
         self.repository = repository or DisplayWebSocketApiRepository(db)
         self._manager_provider = manager_provider
 
+    @staticmethod
+    def _role_name(current_user: object) -> str:
+        role = getattr(current_user, "role", "")
+        return str(getattr(role, "value", role) or "").strip().lower()
+
+    @staticmethod
+    def _same_specialty(left: str | None, right: str | None) -> bool:
+        return str(left or "").strip().lower() == str(right or "").strip().lower()
+
+    def _current_doctor_or_403(self, current_user: object) -> object:
+        doctor = self.repository.get_active_doctor_by_user_id(
+            getattr(current_user, "id", None)
+        )
+        if not doctor:
+            raise DisplayWebSocketApiDomainError(
+                status_code=403,
+                detail="Doctor profile is required to call queue patients",
+            )
+        return doctor
+
+    def _ensure_doctor_can_call_queue(
+        self,
+        *,
+        current_user: object,
+        queue: object,
+    ) -> None:
+        if self._role_name(current_user) != "doctor":
+            return
+
+        doctor = self._current_doctor_or_403(current_user)
+        if getattr(queue, "specialist_id", None) != getattr(doctor, "id", None):
+            raise DisplayWebSocketApiDomainError(
+                status_code=403,
+                detail="Doctor can only call patients from their own queue",
+            )
+
     async def call_patient(
         self,
         *,
         entry_id: int,
         board_ids: list[str],
+        current_user: object,
     ) -> dict:
         queue_entry = self.repository.get_queue_entry(entry_id)
         if not queue_entry:
@@ -44,6 +81,11 @@ class DisplayWebSocketApiService:
                 status_code=404,
                 detail="Запись в очереди не найдена",
             )
+
+        self._ensure_doctor_can_call_queue(
+            current_user=current_user,
+            queue=queue_entry.queue,
+        )
 
         queue_entry.status = "called"
         queue_entry.called_at = datetime.utcnow()
@@ -112,20 +154,32 @@ class DisplayWebSocketApiService:
         *,
         specialty: str,
         board_id: str | None,
+        current_user: object,
     ) -> dict:
-        doctor = self.repository.get_active_doctor_by_specialty(specialty)
+        if self._role_name(current_user) == "doctor":
+            doctor = self._current_doctor_or_403(current_user)
+            if not self._same_specialty(getattr(doctor, "specialty", None), specialty):
+                raise DisplayWebSocketApiDomainError(
+                    status_code=403,
+                    detail="Doctor can only quick-call patients for their own specialty",
+                )
+        else:
+            doctor = self.repository.get_active_doctor_by_specialty(specialty)
         if not doctor:
             raise DisplayWebSocketApiDomainError(
                 status_code=404,
                 detail=f"Врач специальности {specialty} не найден",
             )
 
-        doctor_user_id = doctor.user_id if doctor.user_id else None
-        daily_queue = None
-        if doctor_user_id:
-            daily_queue = self.repository.get_daily_queue_for_specialist(
-                day=date.today(),
-                specialist_id=doctor_user_id,
+        daily_queue = self.repository.get_daily_queue_for_specialist(
+            day=date.today(),
+            specialist_id=doctor.id,
+        )
+
+        if daily_queue:
+            self._ensure_doctor_can_call_queue(
+                current_user=current_user,
+                queue=daily_queue,
             )
 
         if not daily_queue:
@@ -145,4 +199,5 @@ class DisplayWebSocketApiService:
         return await self.call_patient(
             entry_id=next_entry.id,
             board_ids=[board_id] if board_id else [],
+            current_user=current_user,
         )

--- a/backend/tests/unit/test_display_websocket_api_service.py
+++ b/backend/tests/unit/test_display_websocket_api_service.py
@@ -27,9 +27,93 @@ class TestDisplayWebSocketApiService:
         service = DisplayWebSocketApiService(db=None, repository=repository)
 
         with pytest.raises(DisplayWebSocketApiDomainError) as exc_info:
-            await service.call_patient(entry_id=1, board_ids=[])
+            await service.call_patient(
+                entry_id=1,
+                board_ids=[],
+                current_user=SimpleNamespace(id=1, role="Admin"),
+            )
 
         assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_doctor_calls_patient_by_linked_doctor_id_not_user_id(self):
+        entry = SimpleNamespace(
+            id=10,
+            number=4,
+            patient_name="Patient",
+            status="waiting",
+            called_at=None,
+            queue=SimpleNamespace(
+                specialist_id=7,
+                specialist=SimpleNamespace(
+                    user=SimpleNamespace(full_name="Dr Linked"),
+                    cabinet="12",
+                ),
+            ),
+        )
+        manager = SimpleNamespace(
+            connections=[],
+            broadcast_patient_call=AsyncMock(),
+        )
+
+        class Repository:
+            def get_queue_entry(self, entry_id):
+                return entry
+
+            def get_active_doctor_by_user_id(self, user_id):
+                return SimpleNamespace(id=7, user_id=100, specialty="cardio")
+
+            def save(self):
+                return None
+
+        service = DisplayWebSocketApiService(
+            db=None,
+            repository=Repository(),
+            manager_provider=lambda: manager,
+        )
+
+        result = await service.call_patient(
+            entry_id=10,
+            board_ids=[],
+            current_user=SimpleNamespace(id=100, role="Doctor"),
+        )
+
+        assert result["success"] is True
+        assert entry.status == "called"
+        manager.broadcast_patient_call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_doctor_cannot_call_patient_when_only_user_id_matches_queue(self):
+        entry = SimpleNamespace(
+            id=10,
+            number=4,
+            patient_name="Patient",
+            status="waiting",
+            called_at=None,
+            queue=SimpleNamespace(specialist_id=100),
+        )
+
+        class Repository:
+            def get_queue_entry(self, entry_id):
+                return entry
+
+            def get_active_doctor_by_user_id(self, user_id):
+                return SimpleNamespace(id=7, user_id=100, specialty="cardio")
+
+            def save(self):
+                raise AssertionError("foreign queue must not be mutated")
+
+        service = DisplayWebSocketApiService(db=None, repository=Repository())
+
+        with pytest.raises(DisplayWebSocketApiDomainError) as exc_info:
+            await service.call_patient(
+                entry_id=10,
+                board_ids=[],
+                current_user=SimpleNamespace(id=100, role="Doctor"),
+            )
+
+        assert exc_info.value.status_code == 403
+        assert entry.status == "waiting"
 
     def test_get_department_queue_state_payload_builds_counts(self):
         entry = SimpleNamespace(
@@ -69,12 +153,22 @@ class TestDisplayWebSocketApiService:
         service = DisplayWebSocketApiService(db=None, repository=repository)
 
         with pytest.raises(DisplayWebSocketApiDomainError) as exc_info:
-            await service.quick_call_next(specialty="cardio", board_id=None)
+            await service.quick_call_next(
+                specialty="cardio",
+                board_id=None,
+                current_user=SimpleNamespace(id=1, role="Admin"),
+            )
 
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_quick_call_next_delegates_to_call_patient(self):
+    async def test_quick_call_next_uses_doctor_id_for_queue_lookup(self):
+        specialist_ids = []
+
+        def get_daily_queue_for_specialist(day, specialist_id):
+            specialist_ids.append(specialist_id)
+            return SimpleNamespace(id=20, specialist_id=specialist_id)
+
         repository = SimpleNamespace(
             get_queue_entry=lambda entry_id: None,
             save=lambda: None,
@@ -83,15 +177,85 @@ class TestDisplayWebSocketApiService:
                 id=4,
                 user_id=9,
             ),
-            get_daily_queue_for_specialist=lambda day, specialist_id: SimpleNamespace(
-                id=20,
-            ),
+            get_daily_queue_for_specialist=get_daily_queue_for_specialist,
             get_next_waiting_entry=lambda queue_id: SimpleNamespace(id=33),
         )
         service = DisplayWebSocketApiService(db=None, repository=repository)
         service.call_patient = AsyncMock(return_value={"success": True})
 
-        result = await service.quick_call_next(specialty="cardio", board_id="b1")
+        current_user = SimpleNamespace(id=1, role="Admin")
+        result = await service.quick_call_next(
+            specialty="cardio",
+            board_id="b1",
+            current_user=current_user,
+        )
 
         assert result["success"] is True
-        service.call_patient.assert_awaited_once_with(entry_id=33, board_ids=["b1"])
+        assert specialist_ids == [4]
+        service.call_patient.assert_awaited_once_with(
+            entry_id=33,
+            board_ids=["b1"],
+            current_user=current_user,
+        )
+
+    @pytest.mark.asyncio
+    async def test_doctor_quick_call_uses_linked_doctor_id_not_user_id(self):
+        specialist_ids = []
+
+        def get_daily_queue_for_specialist(day, specialist_id):
+            specialist_ids.append(specialist_id)
+            return SimpleNamespace(id=20, specialist_id=specialist_id)
+
+        class Repository:
+            def get_active_doctor_by_user_id(self, user_id):
+                return SimpleNamespace(id=7, user_id=100, specialty="cardio")
+
+            def get_active_doctor_by_specialty(self, specialty):
+                raise AssertionError("doctor users must use their linked profile")
+
+            def get_daily_queue_for_specialist(self, day, specialist_id):
+                return get_daily_queue_for_specialist(day, specialist_id)
+
+            def get_next_waiting_entry(self, queue_id):
+                return SimpleNamespace(id=33)
+
+        service = DisplayWebSocketApiService(db=None, repository=Repository())
+        service.call_patient = AsyncMock(return_value={"success": True})
+        current_user = SimpleNamespace(id=100, role="Doctor")
+
+        result = await service.quick_call_next(
+            specialty="cardio",
+            board_id="b1",
+            current_user=current_user,
+        )
+
+        assert result["success"] is True
+        assert specialist_ids == [7]
+        service.call_patient.assert_awaited_once_with(
+            entry_id=33,
+            board_ids=["b1"],
+            current_user=current_user,
+        )
+
+    @pytest.mark.asyncio
+    async def test_doctor_cannot_quick_call_other_specialty(self):
+        class Repository:
+            def get_active_doctor_by_specialty(self, specialty):
+                return SimpleNamespace(id=4, user_id=9, specialty=specialty)
+
+            def get_active_doctor_by_user_id(self, user_id):
+                return SimpleNamespace(id=7, user_id=100, specialty="derma")
+
+            def get_daily_queue_for_specialist(self, day, specialist_id):
+                raise AssertionError("foreign specialty must not be queried")
+
+        service = DisplayWebSocketApiService(db=None, repository=Repository())
+
+        with pytest.raises(DisplayWebSocketApiDomainError) as exc_info:
+            await service.quick_call_next(
+                specialty="cardio",
+                board_id="b1",
+                current_user=SimpleNamespace(id=100, role="Doctor"),
+            )
+
+        assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary

- Restrict display-board Doctor queue-call commands to the Doctor profile linked to the authenticated user.
- Resolve `/display/quick/call-next` queues by `Doctor.id`, matching `DailyQueue.specialist_id`, instead of `Doctor.user_id`.
- Preserve Admin/Registrar behavior for display-board call commands.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` at `3dda1d75` after PR #1591.
- Clean workspace: inspected before edits; only display websocket endpoint, service, repository, and targeted unit tests changed.
- Branch: `codex/contract-scan-audit-34`.
- Scope gate: allowed display websocket endpoint/service/repository and targeted display tests; denied `/api/v1/ui/*`, BFF-lite, frontend, migrations, and unrelated queue services.
- Red-check handling: PR Review Quality Gate failed on missing body fields; I fixed the body in this same PR before merge.

## Contract Impact

- Canonical surface: `/api/v1/display/call-patient` and `/api/v1/display/quick/call-next`.
- Request shape: authenticated POST; `call-patient` keeps `entry_id`/`board_ids` body, `quick/call-next` keeps `specialty` and optional `board_id` query params.
- Response shape: unchanged existing success, call_data, queue_empty, 403, and 404 shapes.
- Status codes: Doctor foreign queue/specialty now returns 403 before mutation; existing missing entry/queue/doctor paths remain 404.
- Frontend consumer: existing display-board and queue call controls; no frontend contract or route changed.
- Compatibility path or alias: Admin/Registrar keep existing cross-queue display control; Doctor path is narrowed to the linked `Doctor.id` queue.
- Contract proof: targeted display websocket service tests cover linked Doctor.id allow, user-id collision deny, foreign specialty deny, and Admin queue lookup.

## RBAC / Permissions

- Roles allowed: Admin and Registrar can use existing display-board call controls; Doctor can call only their linked `DailyQueue`.
- Roles denied: Doctor is denied for queues/specialties not linked to `Doctor.user_id == current_user.id`.
- Positive auth proof: unit tests prove Doctor user id 100 linked to Doctor id 7 can call queue `specialist_id=7`.
- Negative auth proof: unit tests prove the same Doctor user id 100 cannot call queue `specialist_id=100` and cannot quick-call another specialty.

## Notification / Realtime

- Event type or websocket channel: existing display-board patient-call broadcast via `broadcast_patient_call`.
- Payload version / ack behavior: unchanged; no new ack/version contract.
- Read/unread or delivery semantics: not applicable - display-board call broadcast has no read/unread state and delivery semantics are unchanged.
- Reconnect/resync proof: existing queue-state websocket behavior unchanged; covered by `test_queue_time_websocket_e2e.py`.

## Frontend Resilience

- Empty data proof: unchanged `queue_empty` response for no waiting entries.
- Partial data proof: response shape and broadcast payload fields unchanged.
- Forbidden secondary path behavior: Doctor receives 403 before foreign queue mutation.
- Missing draft/resource behavior: missing queue entry and missing queue still return existing 404 paths.
- Stale route/deep-link behavior: no frontend route changes.

## Scope Gate

- Allowed paths: display websocket endpoint, display websocket API service/repository, display websocket service tests.
- Denied paths: `/api/v1/ui/*`, BFF-lite, frontend, migrations, unrelated queue services.
- Migration/docs/test impact: no migration or docs change; targeted tests updated for Doctor queue-call ownership.
- Rollback note: revert the four changed display websocket files to restore previous display call behavior.

## Validation

- Targeted tests or smoke run: py_compile; `test_display_websocket_api_service.py`; `test_service_repository_boundary.py`; `test_queue_time_websocket_e2e.py`; `git diff --check`.
- Result: 63 passed locally; `git diff --check` exited 0 with CRLF warnings only.
- Not checked: full browser display-board smoke; no frontend files changed and backend response shape is unchanged.
