### PR TITLE
fix(queue): scope legacy doctor calls

### DIFF
--- a/backend/app/api/v1/endpoints/queue.py
+++ b/backend/app/api/v1/endpoints/queue.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 # from app.models.patient import Patient  # Временно отключено
 from app.api.deps import get_current_user, require_roles
 from app.db.session import get_db
+from app.models.clinic import Doctor
 from app.models.user import User
 from app.services.queue_api_service import QueueApiService
 from app.services.queue_service import (
@@ -49,6 +50,33 @@ QUEUE_STATUS_ROLES = (
     "dentist",
     "Dentist",
 )
+
+
+def _role_name(user: User) -> str:
+    role = getattr(user, "role", "")
+    return str(getattr(role, "value", role) or "")
+
+
+def _ensure_doctor_can_call_legacy_entry(
+    db: Session,
+    *,
+    entry,
+    current_user: User,
+) -> None:
+    if _role_name(current_user) != "Doctor":
+        return
+
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    queue = getattr(entry, "queue", None)
+    if not queue or getattr(queue, "specialist_id", None) != doctor.id:
+        raise HTTPException(status_code=403, detail="Access denied")
 
 
 # Pydantic схемы
@@ -463,6 +491,12 @@ def call_patient(
 
     if not entry:
         raise HTTPException(status_code=404, detail="Запись не найдена")
+
+    _ensure_doctor_can_call_legacy_entry(
+        db,
+        entry=entry,
+        current_user=current_user,
+    )
 
     if entry.status != "waiting":
         raise HTTPException(status_code=400, detail="Пациент уже вызван или обслужен")

--- a/backend/tests/integration/test_legacy_queue_today_role_guard.py
+++ b/backend/tests/integration/test_legacy_queue_today_role_guard.py
@@ -8,10 +8,20 @@ from sqlalchemy.orm import Session
 from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.patient import Patient
+from app.models.user import User
 
 
 def _auth_headers(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
+
+
+def _login_headers(client: TestClient, *, user: User, password: str) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": user.username, "password": password},
+    )
+    assert response.status_code == 200
+    return _auth_headers(response.json()["access_token"])
 
 
 def _seed_legacy_today_queue(
@@ -43,6 +53,38 @@ def _seed_legacy_today_queue(
     db_session.commit()
     db_session.refresh(queue)
     return queue
+
+
+def _seed_legacy_call_entry(
+    db_session: Session,
+    *,
+    doctor: Doctor,
+    patient: Patient,
+) -> OnlineQueueEntry:
+    queue = DailyQueue(
+        day=date.today(),
+        specialist_id=doctor.id,
+        queue_tag="cardiology_common",
+        active=True,
+    )
+    db_session.add(queue)
+    db_session.commit()
+    db_session.refresh(queue)
+
+    entry = OnlineQueueEntry(
+        queue_id=queue.id,
+        number=1,
+        patient_id=patient.id,
+        patient_name=patient.short_name(),
+        phone=patient.phone,
+        source="registrar",
+        status="waiting",
+        created_at=datetime.utcnow(),
+    )
+    db_session.add(entry)
+    db_session.commit()
+    db_session.refresh(entry)
+    return entry
 
 
 def test_registrar_can_read_legacy_today_queue(
@@ -83,3 +125,99 @@ def test_patient_cannot_read_legacy_today_queue(
     )
 
     assert response.status_code == 403
+
+
+def test_registrar_can_call_legacy_queue_entry(
+    client: TestClient,
+    db_session: Session,
+    registrar_token: str,
+    test_doctor: Doctor,
+    test_patient: Patient,
+) -> None:
+    entry = _seed_legacy_call_entry(
+        db_session,
+        doctor=test_doctor,
+        patient=test_patient,
+    )
+
+    response = client.post(
+        f"/api/v1/queue/legacy/call/{entry.id}",
+        headers=_auth_headers(registrar_token),
+    )
+
+    assert response.status_code == 200, response.text
+    db_session.refresh(entry)
+    assert entry.status == "called"
+    assert entry.called_at is not None
+
+
+def test_doctor_can_call_own_legacy_queue_entry_by_linked_doctor_id(
+    client: TestClient,
+    db_session: Session,
+    test_doctor_user: User,
+    test_patient: Patient,
+) -> None:
+    doctor = Doctor(
+        user_id=test_doctor_user.id,
+        specialty="cardiology",
+        active=True,
+    )
+    db_session.add(doctor)
+    db_session.commit()
+    db_session.refresh(doctor)
+    entry = _seed_legacy_call_entry(
+        db_session,
+        doctor=doctor,
+        patient=test_patient,
+    )
+
+    response = client.post(
+        f"/api/v1/queue/legacy/call/{entry.id}",
+        headers=_login_headers(client, user=test_doctor_user, password="doctor123"),
+    )
+
+    assert response.status_code == 200, response.text
+    db_session.refresh(entry)
+    assert entry.status == "called"
+
+
+def test_doctor_cannot_call_legacy_queue_when_only_user_id_matches_specialist_id(
+    client: TestClient,
+    db_session: Session,
+    test_doctor_user: User,
+    test_patient: Patient,
+) -> None:
+    foreign_doctor = Doctor(
+        id=test_doctor_user.id,
+        specialty="foreign",
+        active=True,
+    )
+    db_session.add(foreign_doctor)
+    db_session.commit()
+    db_session.refresh(foreign_doctor)
+
+    actor_doctor = Doctor(
+        user_id=test_doctor_user.id,
+        specialty="cardiology",
+        active=True,
+    )
+    db_session.add(actor_doctor)
+    db_session.commit()
+    db_session.refresh(actor_doctor)
+    assert actor_doctor.id != test_doctor_user.id
+
+    entry = _seed_legacy_call_entry(
+        db_session,
+        doctor=foreign_doctor,
+        patient=test_patient,
+    )
+
+    response = client.post(
+        f"/api/v1/queue/legacy/call/{entry.id}",
+        headers=_login_headers(client, user=test_doctor_user, password="doctor123"),
+    )
+
+    assert response.status_code == 403
+    db_session.refresh(entry)
+    assert entry.status == "waiting"
+    assert entry.called_at is None


### PR DESCRIPTION
## Summary

- Restrict legacy `/api/v1/queue/legacy/call/{entry_id}` Doctor calls to the Doctor profile linked to the authenticated user.
- Require Doctor callers to match `OnlineQueueEntry.queue.specialist_id == Doctor.id`, not `User.id`.
- Preserve Admin/Registrar legacy call behavior.

## Cyclic Execution Evidence

- Fresh main sync: branch fast-forwarded to `origin/main` at `8bdfe78e` before commit.
- Clean workspace: inspected before edits; only legacy queue endpoint and targeted legacy queue integration tests changed.
- Branch: `codex/contract-scan-audit-35`.
- Scope gate: allowed `backend/app/api/v1/endpoints/queue.py` and `backend/tests/integration/test_legacy_queue_today_role_guard.py`; denied `/api/v1/ui/*`, BFF-lite, frontend, migrations, and unrelated queue services.
- Red-check handling: any failed CI check will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `POST /api/v1/queue/legacy/call/{entry_id}`.
- Request shape: authenticated POST with `entry_id` path param; no request body change.
- Response shape: unchanged existing success payload and 403/404/400 error shape.
- Status codes: Doctor foreign queue now returns 403 before status mutation; missing entry remains 404; non-waiting entry remains 400 after ownership passes.
- Frontend consumer: existing legacy queue callers; no frontend file changed.
- Compatibility path or alias: endpoint remains mounted under `/queue/legacy`; Admin/Registrar behavior stays compatibility-wide, Doctor behavior is narrowed to linked queue ownership.
- Contract proof: targeted integration tests cover Registrar allow, Doctor linked-Doctor.id allow, and user-id collision deny.

## RBAC / Permissions

- Roles allowed: Admin and Registrar keep existing legacy call access; Doctor can call only entries in their own `DailyQueue`.
- Roles denied: Doctor is denied when the entry queue belongs to another Doctor, including when `specialist_id` collides with the Doctor user's `User.id`.
- Positive auth proof: integration test proves a Doctor user linked to `Doctor.id` can call an entry where `DailyQueue.specialist_id == Doctor.id`.
- Negative auth proof: integration test proves `DailyQueue.specialist_id == current_user.id` is not enough when the linked `Doctor.id` differs.

## Notification / Realtime

- Event type or websocket channel: existing legacy display-board `broadcast_patient_call` side effect remains unchanged after allowed calls.
- Payload version / ack behavior: unchanged; no new ack/version contract.
- Read/unread or delivery semantics: not applicable - display-board call broadcast has no read/unread state and delivery semantics are unchanged.
- Reconnect/resync proof: no websocket resync path changed; adjacent queue reorder/status guard tests still pass.

## Frontend Resilience

- Empty data proof: unchanged; missing entry remains 404.
- Partial data proof: response shape is unchanged for allowed calls.
- Forbidden secondary path behavior: Doctor receives 403 before foreign queue mutation.
- Missing draft/resource behavior: not applicable - endpoint does not create/reopen drafts/resources.
- Stale route/deep-link behavior: no frontend route changes.

## Scope Gate

- Allowed paths: legacy queue endpoint and targeted legacy queue role guard tests.
- Denied paths: frontend, BFF-lite, `/api/v1/ui/*`, migrations, unrelated queue services.
- Migration/docs/test impact: no migration or docs change; targeted integration tests updated.
- Rollback note: revert the two changed files to restore previous legacy Doctor call behavior.

## Validation

- Targeted tests or smoke run: py_compile; `test_legacy_queue_today_role_guard.py`; `test_queue_reorder_status_role_guard.py`; `test_queue_api_service.py`; `git diff --check`.
- Result: 10 passed locally; `git diff --check` exited 0 with CRLF warnings only.
- Not checked: full browser queue panel smoke; backend response shape is unchanged and no frontend files changed.
