### PR TITLE
fix(registrar): show created visit time in clinic timezone

### DIFF
--- a/backend/app/models/visit.py
+++ b/backend/app/models/visit.py
@@ -35,7 +35,9 @@ class Visit(Base):
     notes: Mapped[str | None] = mapped_column(String(512), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
     )
     updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, default=lambda: datetime.now(timezone.utc)

--- a/backend/tests/unit/test_visit_timestamp_defaults.py
+++ b/backend/tests/unit/test_visit_timestamp_defaults.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from datetime import timezone
+
+from app.models.visit import Visit
+
+
+def test_visit_created_at_default_is_timezone_aware_utc() -> None:
+    default_factory = Visit.__table__.c.created_at.default.arg
+
+    created_at = default_factory(None)
+
+    assert created_at.tzinfo is not None
+    assert created_at.utcoffset() == timezone.utc.utcoffset(created_at)

--- a/frontend/src/utils/__tests__/dateUtils.test.js
+++ b/frontend/src/utils/__tests__/dateUtils.test.js
@@ -43,5 +43,29 @@ describe('parseRegistrarTimestamp', () => {
     expect(display.showChanged).toBe(true);
     expect(display.changedTime).toBe('09:45:00');
   });
-});
 
+  it('honors backend display_time_kind when queue_time is only a fallback value', () => {
+    const display = getRegistrarTimestampDisplay({
+      display_time_kind: 'created_at',
+      queue_time: '2026-06-02T00:28:48+05:00',
+      created_at: '2026-06-02T00:28:48+05:00',
+    });
+
+    expect(display.primaryKind).toBe('created_at');
+    expect(display.primaryLabel).toBe('Создано');
+    expect(display.primaryDate).toBe('02.06.2026');
+    expect(display.primaryTime).toBe('00:28:48');
+  });
+
+  it('does not show changed timestamp for immediate post-create system updates', () => {
+    const display = getRegistrarTimestampDisplay({
+      display_time_kind: 'created_at',
+      created_at: '2026-06-02T00:28:48+05:00',
+      updated_at: '2026-06-02T00:28:54+05:00',
+    });
+
+    expect(display.showChanged).toBe(false);
+    expect(display.changedDate).toBe('');
+    expect(display.changedTime).toBe('');
+  });
+});

--- a/frontend/src/utils/dateUtils.js
+++ b/frontend/src/utils/dateUtils.js
@@ -63,17 +63,25 @@ export const formatRegistrarDateTime = (value, locale = 'ru-RU', options = {}) =
     return [date, time].filter(Boolean).join(' ');
 };
 
-const timestampsDiffer = (a, b) => {
+const REGISTRAR_CHANGED_TIMESTAMP_THRESHOLD_MS = 60 * 1000;
+const REGISTRAR_PRIMARY_TIME_KINDS = new Set(['queue_time', 'created_at']);
+
+const timestampsDiffer = (a, b, thresholdMs = REGISTRAR_CHANGED_TIMESTAMP_THRESHOLD_MS) => {
     const first = parseRegistrarTimestamp(a);
     const second = parseRegistrarTimestamp(b);
     if (!first || !second) return false;
-    return Math.abs(first.getTime() - second.getTime()) > 1000;
+    return Math.abs(first.getTime() - second.getTime()) > thresholdMs;
 };
 
 export const getRegistrarTimestampDisplay = (record = {}, locale = 'ru-RU') => {
-    const primaryValue = record.queue_time || record.created_at || null;
+    const requestedPrimaryKind = REGISTRAR_PRIMARY_TIME_KINDS.has(record.display_time_kind)
+        ? record.display_time_kind
+        : null;
+    const primaryKind = requestedPrimaryKind || (record.queue_time ? 'queue_time' : 'created_at');
+    const primaryValue = primaryKind === 'queue_time'
+        ? record.queue_time || record.created_at || null
+        : record.created_at || record.queue_time || null;
     const changedValue = record.last_changed_at || record.updated_at || null;
-    const primaryKind = record.queue_time ? 'queue_time' : 'created_at';
     const showChanged = Boolean(changedValue && primaryValue && timestampsDiffer(primaryValue, changedValue));
 
     return {


### PR DESCRIPTION
﻿## Summary

- Fixes newly created registrar visit timestamps by making `Visit.created_at` timezone-aware UTC instead of naive `datetime.utcnow`.
- Makes registrar timestamp display honor backend `display_time_kind`, so a created-at fallback is not labeled as queue time.
- Suppresses immediate post-create technical `updated_at` noise so a just-created row does not look manually edited.
- Adds targeted backend and frontend tests for the timestamp contract.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/registrar-created-time-display` was created from current `main` synced with `origin/main`.
- Clean workspace: started clean; current diff is limited to timestamp model/display code and targeted tests.
- Branch: `fix/registrar-created-time-display`.
- Scope gate: queue/registrar time display only; no schema migration, payment logic, queue ordering logic, RBAC, deploy, or data correction.
- Red-check handling: if GitHub Actions reports a failure, the fix will stay in this PR branch before merge.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

- Canonical surface: registrar queue/table timestamp display contract.
- Request shape: not applicable - no API request shape changed.
- Response shape: not applicable - existing fields are unchanged; frontend now respects existing `display_time_kind`.
- Status codes: not applicable - no endpoint status behavior changed.
- Frontend consumer: registrar/doctor queue timestamp display through `getRegistrarTimestampDisplay`.
- Compatibility path or alias: existing timestamp strings remain accepted, including timezone-aware, UTC, and legacy naive strings.
- Contract proof: backend registrar queue serialization test still passes; frontend date utils tests cover `display_time_kind` and immediate post-create update suppression.

## RBAC / Permissions

not applicable - no route guards, endpoint permissions, auth helpers, or role authorization behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - timestamp utility still returns empty display parts when no timestamp is present.
- Partial data proof: frontend test covers created-at fallback with `display_time_kind: created_at`.
- Forbidden secondary path behavior: not applicable - no forbidden/auth path changed.
- Missing draft/resource behavior: not applicable - no draft/resource loading changed.
- Stale route/deep-link behavior: not applicable - no routing changed.

## Scope Gate

- Allowed paths: `backend/app/models/visit.py`, `backend/tests/unit/test_visit_timestamp_defaults.py`, `frontend/src/utils/dateUtils.js`, `frontend/src/utils/__tests__/dateUtils.test.js`.
- Denied paths: DB migrations, queue allocation/order logic, registrar wizard behavior, payment logic, RBAC/auth, deploy/secrets, unrelated UI cleanup.
- Migration/docs/test impact: no migration; targeted backend/frontend tests added/updated.
- Rollback note: revert this PR to restore previous naive `Visit.created_at` default and timestamp display behavior.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: backend py_compile, backend timestamp/registrar tests, frontend date utils test, frontend lint, frontend build, diff check, and rollback-insert dev DB probe all passed.
  - `./scripts/run_python.ps1 -PythonArgs @('-m','py_compile','backend\\app\\models\\visit.py')` - passed.
  - `./scripts/run_backend_pytest.ps1 tests\\unit\\test_visit_timestamp_defaults.py tests\\unit\\test_registrar_time_serialization.py tests\\integration\\test_registrar_all_appointments.py::TestRegistrarAllAppointments::test_today_queues_serializes_queue_time_and_created_at -q` - passed, 5 tests.
  - `npm.cmd run test:run -- src/utils/__tests__/dateUtils.test.js` - passed, 7 tests.
  - `npm.cmd run lint:check -- --quiet` - passed.
  - `npm.cmd run build` - passed.
  - `git diff --check` - passed.
  - `scripts/start_dev_clinic.ps1` / `scripts/check_dev_clinic.ps1` - dev runtime restarted and health checks passed.
  - rollback-insert probe in `clinic_dev` showed new `Visit.created_at` within ~0 seconds of current `Asia/Tashkent` time, then rolled back.
- Result: local validation passed.
- Not checked: manual new patient registration through browser after this patch; existing dev DB rows created before the fix can still contain already-corrupted timestamps until data is corrected separately.
