### PR TITLE
fix(doctor): scope legacy complete fallback

### DIFF
--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -146,6 +146,41 @@ def _ensure_visit_doctor_access(visit: Visit, current_user: User) -> None:
     )
 
 
+def _ensure_legacy_complete_doctor_access(
+    db: Session,
+    *,
+    record_doctor_id: int | None,
+    current_user: User,
+) -> None:
+    if current_user.role == "Admin":
+        return
+
+    if record_doctor_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No access to complete this record",
+        )
+
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == record_doctor_id).first()
+    if assigned_doctor:
+        if assigned_doctor.user_id == current_user.id:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No access to complete this record",
+        )
+
+    # Legacy writers sometimes stored User.id in doctor_id. Preserve that only
+    # when the value does not point at another real Doctor row.
+    if record_doctor_id == current_user.id:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="No access to complete this record",
+    )
+
+
 def _visit_filter_doctor_id(db: Session, current_user: User) -> int:
     doctor = (
         db.query(Doctor)
@@ -774,6 +809,11 @@ def complete_patient_visit(
                 )
                 visit = None
         if visit:
+            _ensure_legacy_complete_doctor_access(
+                db,
+                record_doctor_id=visit.doctor_id,
+                current_user=current_user,
+            )
             # Обновляем статус визита
             visit.status = "completed"
             visit.updated_at = datetime.now(timezone.utc)
@@ -813,6 +853,11 @@ def complete_patient_visit(
                 )
                 appointment = None
         if appointment:
+            _ensure_legacy_complete_doctor_access(
+                db,
+                record_doctor_id=appointment.doctor_id,
+                current_user=current_user,
+            )
             # Обновляем статус appointment
             appointment.status = "completed"
 

--- a/backend/tests/integration/test_doctor_general_queue.py
+++ b/backend/tests/integration/test_doctor_general_queue.py
@@ -581,8 +581,17 @@ class TestDoctorGeneralQueue:
         db_session,
         test_doctor_user,
         test_patient,
-        test_doctor,
     ):
+        doctor = Doctor(
+            user_id=test_doctor_user.id,
+            specialty="general",
+            active=True,
+            cabinet="101",
+        )
+        db_session.add(doctor)
+        db_session.commit()
+        db_session.refresh(doctor)
+
         other_patient = Patient(
             first_name="Unrelated",
             last_name="Visit",
@@ -608,7 +617,7 @@ class TestDoctorGeneralQueue:
         appointment = Appointment(
             id=collision_id,
             patient_id=test_patient.id,
-            doctor_id=test_doctor.id,
+            doctor_id=doctor.id,
             appointment_date=date.today(),
             appointment_time="12:30",
             status="paid",
@@ -930,6 +939,159 @@ class TestDoctorGeneralQueue:
         db_session.refresh(visit)
         assert visit.status == "completed"
         assert visit.discount_mode == "repeat"
+
+    def test_complete_visit_record_rejects_other_doctor_visit(
+        self,
+        client,
+        db_session,
+        test_doctor_user,
+    ):
+        actor_doctor = Doctor(
+            user_id=test_doctor_user.id,
+            specialty="general",
+            active=True,
+            cabinet="301",
+        )
+        other_user = User(
+            username="other_visit_doctor",
+            email="other.visit.doctor@test.com",
+            full_name="Other Visit Doctor",
+            hashed_password=get_password_hash("other123"),
+            role="Doctor",
+            is_active=True,
+            is_superuser=False,
+        )
+        other_patient = Patient(
+            first_name="Other",
+            last_name="Visit",
+            middle_name="Doctor",
+            phone="+998901333333",
+            birth_date=date(1984, 7, 7),
+            address="Other doctor visit address",
+        )
+        db_session.add_all([actor_doctor, other_user, other_patient])
+        db_session.commit()
+        db_session.refresh(actor_doctor)
+        db_session.refresh(other_user)
+        db_session.refresh(other_patient)
+
+        other_doctor = Doctor(
+            user_id=other_user.id,
+            specialty="general",
+            active=True,
+            cabinet="303",
+        )
+        db_session.add(other_doctor)
+        db_session.commit()
+        db_session.refresh(other_doctor)
+
+        visit = Visit(
+            patient_id=other_patient.id,
+            doctor_id=other_doctor.id,
+            visit_date=date.today(),
+            status="open",
+            discount_mode="none",
+        )
+        db_session.add(visit)
+        db_session.commit()
+        db_session.refresh(visit)
+
+        assert actor_doctor.id != other_doctor.id
+
+        login_response = client.post(
+            "/api/v1/authentication/login",
+            json={"username": test_doctor_user.username, "password": "doctor123"},
+        )
+        assert login_response.status_code == 200
+        headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+        response = client.post(
+            f"/api/v1/doctor/queue/{visit.id}/complete",
+            json={"patient_id": other_patient.id, "notes": "wrong doctor"},
+            headers=headers,
+        )
+
+        assert response.status_code == 403
+        db_session.refresh(visit)
+        assert visit.status == "open"
+
+    def test_complete_appointment_record_rejects_other_doctor_appointment(
+        self,
+        client,
+        db_session,
+        test_doctor_user,
+    ):
+        actor_doctor = Doctor(
+            user_id=test_doctor_user.id,
+            specialty="general",
+            active=True,
+            cabinet="302",
+        )
+        other_user = User(
+            username="other_appointment_doctor",
+            email="other.appointment.doctor@test.com",
+            full_name="Other Appointment Doctor",
+            hashed_password=get_password_hash("other123"),
+            role="Doctor",
+            is_active=True,
+            is_superuser=False,
+        )
+        other_patient = Patient(
+            first_name="Other",
+            last_name="Appointment",
+            middle_name="Doctor",
+            phone="+998901444444",
+            birth_date=date(1986, 8, 8),
+            address="Other doctor appointment address",
+        )
+        db_session.add_all([actor_doctor, other_user, other_patient])
+        db_session.commit()
+        db_session.refresh(actor_doctor)
+        db_session.refresh(other_user)
+        db_session.refresh(other_patient)
+
+        other_doctor = Doctor(
+            user_id=other_user.id,
+            specialty="general",
+            active=True,
+            cabinet="304",
+        )
+        db_session.add(other_doctor)
+        db_session.commit()
+        db_session.refresh(other_doctor)
+
+        appointment = Appointment(
+            patient_id=other_patient.id,
+            doctor_id=other_doctor.id,
+            appointment_date=date.today(),
+            appointment_time="14:30",
+            status="paid",
+            visit_type="paid",
+            payment_type="cash",
+            services=["consultation"],
+        )
+        db_session.add(appointment)
+        db_session.commit()
+        db_session.refresh(appointment)
+
+        assert actor_doctor.id != other_doctor.id
+
+        login_response = client.post(
+            "/api/v1/authentication/login",
+            json={"username": test_doctor_user.username, "password": "doctor123"},
+        )
+        assert login_response.status_code == 200
+        headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+        response = client.post(
+            f"/api/v1/doctor/queue/{appointment.id}/complete",
+            json={"patient_id": other_patient.id, "notes": "wrong doctor"},
+            headers=headers,
+        )
+
+        assert response.status_code == 403
+        db_session.refresh(appointment)
+        assert appointment.status == "paid"
 
     def test_doctor_stats_reads_daily_queue_by_doctor_id(
         self,


### PR DESCRIPTION
## Summary
- Add an ownership guard before the legacy `Visit` / `Appointment` fallback in `POST /api/v1/doctor/queue/{entry_id}/complete`.
- Preserve Admin access, assigned Doctor/ specialist-role access through `Doctor.user_id`, and the existing legacy `doctor_id == user.id` compatibility only when the id does not collide with a real `Doctor.id`.
- Add regression tests proving a Doctor cannot complete another Doctor's legacy Visit or Appointment by numeric id.

## Cyclic Execution Evidence

- Fresh main sync: worktree branch `codex/contract-scan-audit-36` started from `origin/main` at `f1f21175`.
- Clean workspace: inspected before edit; only this PR's two files changed.
- Branch: `codex/contract-scan-audit-36`
- Scope gate: `agent_gate` known-root-cause narrow override for `backend/app/api/v1/endpoints/doctor_integration.py`, then second narrow override for `backend/tests/integration/test_doctor_general_queue.py`.
- Red-check handling: first targeted pytest run exposed a fixture mismatch in an existing positive collision test; fixed the test data to use a Doctor linked to the authenticated user, then reran successfully.

## Contract Impact

- Canonical surface: mounted legacy doctor complete command `POST /api/v1/doctor/queue/{entry_id}/complete`.
- Request shape: unchanged.
- Response shape: unchanged for allowed records; forbidden cross-doctor legacy fallback now returns existing 403 error shape.
- Status codes: allowed own/admin completions remain 200; cross-doctor legacy Visit/Appointment completion is now 403.
- Frontend consumer: existing doctor queue/doctor panel callers remain on the same endpoint and request shape.
- Compatibility path or alias: legacy `Visit.id` / `Appointment.id` fallback remains; legacy `doctor_id == user.id` remains only when it does not target another real Doctor row.
- Contract proof: `test_complete_visit_record_rejects_other_doctor_visit`, `test_complete_appointment_record_rejects_other_doctor_appointment`, and existing collision/positive completion tests.

## RBAC / Permissions

- Roles allowed: Admin; users linked to the record's `Doctor.id` via `Doctor.user_id`; legacy owner where `doctor_id == current_user.id` and no real Doctor row owns that id.
- Roles denied: non-admin users not linked to the target Visit/Appointment doctor, including another Doctor with a different `Doctor.id`.
- Positive auth proof: existing own-doctor complete tests and cardiologist queue complete test still pass.
- Negative auth proof: new cross-doctor Visit and Appointment complete tests return 403 and preserve record status.

## Notification / Realtime

- Event type or websocket channel: none changed.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable; no realtime behavior changed.

## Frontend Resilience

- Empty data proof: unchanged; no frontend/read model change.
- Partial data proof: unchanged; endpoint still supports queue-entry and legacy fallback paths.
- Forbidden secondary path behavior: new 403 on cross-doctor legacy fallback prevents wrong-record mutation.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/doctor_integration.py`, `backend/tests/integration/test_doctor_general_queue.py`.
- Denied paths: `/api/v1/ui/*`, BFF-lite, separate BFF service, frontend, migrations, unrelated queue/registrar endpoints.
- Migration/docs/test impact: no migration or docs; targeted integration tests updated.
- Rollback note: revert this PR to restore prior legacy fallback behavior.

## Validation

- Targeted tests or smoke run: `py_compile` for touched files; `pytest backend/tests/integration/test_doctor_general_queue.py`; `pytest backend/tests/integration/test_doctor_general_queue.py backend/tests/integration/test_visit_status_owner_guard.py`; `git diff --check`.
- Result: passed locally; `git diff --check` exit 0 with CRLF warnings only.
- Not checked: full backend suite, frontend build.
