### PR TITLE
fix(queue): scope qr doctor entry mutations

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -54,6 +54,59 @@ def _queue_phone_matches(left: Any, right: Any) -> bool:
     )
 
 # NOTE: Doctor импортируется внутри функций для избежания circular dependency
+QUEUE_DOCTOR_MUTATION_ROLES = {
+    "doctor",
+    "cardio",
+    "cardiology",
+    "cardiologist",
+    "derma",
+    "dermatologist",
+    "dentist",
+}
+
+
+def _role_name(user: User) -> str:
+    role = getattr(user, "role", "")
+    return str(getattr(role, "value", role) or "")
+
+
+def _ensure_doctor_can_mutate_specialist_queue(
+    db: Session,
+    *,
+    specialist_id: int | None,
+    current_user: User,
+) -> None:
+    if _role_name(current_user).strip().lower() not in QUEUE_DOCTOR_MUTATION_ROLES:
+        return
+
+    from app.models.clinic import Doctor
+
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor or specialist_id != doctor.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
+
+def _ensure_doctor_can_mutate_queue_entry(
+    db: Session,
+    *,
+    entry: Any,
+    current_user: User,
+) -> None:
+    queue = getattr(entry, "queue", None)
+    _ensure_doctor_can_mutate_specialist_queue(
+        db,
+        specialist_id=getattr(queue, "specialist_id", None),
+        current_user=current_user,
+    )
+
+
 from app.services.qr_queue_service import QRQueueService
 from app.services.queue_service import (
     queue_service,
@@ -247,6 +300,11 @@ def generate_qr_token(
     qr_service = QRQueueService(db)
 
     try:
+        _ensure_doctor_can_mutate_specialist_queue(
+            db,
+            specialist_id=request.specialist_id,
+            current_user=current_user,
+        )
         target_date = None
         if request.target_date:
             target_date = datetime.strptime(request.target_date, "%Y-%m-%d").date()
@@ -667,6 +725,11 @@ async def call_next_patient(
     
     try:
         # Парсим дату, если передана
+        _ensure_doctor_can_mutate_specialist_queue(
+            db,
+            specialist_id=specialist_id,
+            current_user=current_user,
+        )
         queue_date = None
         if target_date:
             from datetime import datetime
@@ -733,6 +796,8 @@ async def call_next_patient(
 
         return CallNextPatientResponse(**result)
         
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
@@ -818,6 +883,12 @@ async def restore_entry_to_next(
             detail="Запись в очереди не найдена"
         )
     
+    _ensure_doctor_can_mutate_queue_entry(
+        db,
+        entry=entry,
+        current_user=current_user,
+    )
+
     if entry.status not in ["no_show", "cancelled"]:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -871,6 +942,12 @@ async def mark_entry_no_show(
             detail="Запись в очереди не найдена"
         )
     
+    _ensure_doctor_can_mutate_queue_entry(
+        db,
+        entry=entry,
+        current_user=current_user,
+    )
+
     if entry.status not in ["waiting", "called"]:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -923,6 +1000,12 @@ def send_entry_to_diagnostics(
             detail="Запись в очереди не найдена"
         )
     
+    _ensure_doctor_can_mutate_queue_entry(
+        db,
+        entry=entry,
+        current_user=current_user,
+    )
+
     if entry.status not in ["called", "in_service"]:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -967,6 +1050,12 @@ def mark_entry_incomplete(
             detail="Запись в очереди не найдена"
         )
     
+    _ensure_doctor_can_mutate_queue_entry(
+        db,
+        entry=entry,
+        current_user=current_user,
+    )
+
     if entry.status not in ["called", "in_service", "diagnostics"]:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1142,6 +1231,12 @@ def update_online_entry(
             )
 
         # Обновляем данные в OnlineQueueEntry
+        _ensure_doctor_can_mutate_queue_entry(
+            db,
+            entry=entry,
+            current_user=current_user,
+        )
+
         if request.patient_name is not None:
             entry.patient_name = request.patient_name
 
@@ -1272,6 +1367,12 @@ def full_update_online_entry(
         )
 
         # 2. Обновляем данные пациента в OnlineQueueEntry
+        _ensure_doctor_can_mutate_queue_entry(
+            db,
+            entry=entry,
+            current_user=current_user,
+        )
+
         original_entry_discount_mode = entry.discount_mode
         patient_data = request.patient_data
         if patient_data.get('patient_name'):
@@ -3080,6 +3181,12 @@ def cancel_service_in_entry(
             )
 
         # Парсим текущие услуги
+        _ensure_doctor_can_mutate_queue_entry(
+            db,
+            entry=entry,
+            current_user=current_user,
+        )
+
         services_list = json.loads(entry.services) if entry.services else []
 
         # Проверяем, что услуги в новом формате (с service_id)

--- a/backend/tests/integration/test_qr_queue_full_update.py
+++ b/backend/tests/integration/test_qr_queue_full_update.py
@@ -3,13 +3,197 @@ from __future__ import annotations
 import json
 from datetime import date, datetime, timezone
 from decimal import Decimal
+from uuid import uuid4
 
 import pytest
 
+from app.core.security import get_password_hash
+from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
 from app.models.patient import Patient
 from app.models.payment_invoice import PaymentInvoice, PaymentInvoiceVisit
+from app.models.user import User
 from app.models.visit import Visit, VisitService
+
+
+def _create_queue_doctor(db_session, *, label: str) -> tuple[User, Doctor]:
+    suffix = uuid4().hex[:10]
+    user = User(
+        username=f"qr_owner_{label}_{suffix}",
+        email=f"qr-owner-{label}-{suffix}@test.local",
+        full_name=f"QR Owner {label}",
+        hashed_password=get_password_hash("doctor123"),
+        role="Doctor",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    doctor = Doctor(
+        user_id=user.id,
+        specialty="general",
+        active=True,
+        cabinet="401",
+    )
+    db_session.add(doctor)
+    db_session.commit()
+    db_session.refresh(doctor)
+    return user, doctor
+
+
+def _doctor_headers(client, user: User) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": user.username, "password": "doctor123"},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _create_queue_entry_for_doctor(
+    db_session,
+    *,
+    doctor: Doctor,
+    status: str = "waiting",
+) -> OnlineQueueEntry:
+    queue = DailyQueue(
+        day=date.today(),
+        specialist_id=doctor.id,
+        queue_tag=f"qr-owner-{doctor.id}",
+        active=True,
+    )
+    db_session.add(queue)
+    db_session.commit()
+    db_session.refresh(queue)
+
+    entry = OnlineQueueEntry(
+        queue_id=queue.id,
+        number=1,
+        patient_name="Guarded Patient",
+        phone="+998901555555",
+        source="online",
+        status=status,
+        services=json.dumps(
+            [
+                {
+                    "service_id": 1,
+                    "name": "Consultation",
+                    "quantity": 1,
+                    "price": 10000,
+                    "cancelled": False,
+                }
+            ],
+            ensure_ascii=False,
+        ),
+    )
+    db_session.add(entry)
+    db_session.commit()
+    db_session.refresh(entry)
+    return entry
+
+
+@pytest.mark.integration
+def test_doctor_cannot_generate_qr_token_for_other_doctor_queue(
+    client,
+    db_session,
+) -> None:
+    actor_user, actor_doctor = _create_queue_doctor(db_session, label="actor_token")
+    _other_user, other_doctor = _create_queue_doctor(db_session, label="other_token")
+
+    response = client.post(
+        "/api/v1/queue/admin/qr-tokens/generate",
+        headers=_doctor_headers(client, actor_user),
+        json={
+            "specialist_id": other_doctor.id,
+            "department": "general",
+        },
+    )
+
+    assert actor_doctor.id != other_doctor.id
+    assert response.status_code == 403
+
+
+@pytest.mark.integration
+def test_doctor_cannot_call_next_for_other_doctor_queue(
+    client,
+    db_session,
+) -> None:
+    actor_user, actor_doctor = _create_queue_doctor(db_session, label="actor_call")
+    _other_user, other_doctor = _create_queue_doctor(db_session, label="other_call")
+    entry = _create_queue_entry_for_doctor(db_session, doctor=other_doctor)
+
+    response = client.post(
+        f"/api/v1/queue/{other_doctor.id}/call-next",
+        headers=_doctor_headers(client, actor_user),
+    )
+
+    assert actor_doctor.id != other_doctor.id
+    assert response.status_code == 403
+    db_session.refresh(entry)
+    assert entry.status == "waiting"
+
+
+@pytest.mark.integration
+def test_doctor_can_call_next_for_own_doctor_queue(
+    client,
+    db_session,
+) -> None:
+    actor_user, actor_doctor = _create_queue_doctor(db_session, label="own_call")
+    entry = _create_queue_entry_for_doctor(db_session, doctor=actor_doctor)
+
+    response = client.post(
+        f"/api/v1/queue/{actor_doctor.id}/call-next",
+        headers=_doctor_headers(client, actor_user),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["success"] is True
+    db_session.refresh(entry)
+    assert entry.status == "called"
+    assert entry.called_by_user_id == actor_user.id
+
+
+@pytest.mark.integration
+def test_doctor_cannot_mark_other_doctor_queue_entry_no_show(
+    client,
+    db_session,
+) -> None:
+    actor_user, actor_doctor = _create_queue_doctor(db_session, label="actor_no_show")
+    _other_user, other_doctor = _create_queue_doctor(db_session, label="other_no_show")
+    entry = _create_queue_entry_for_doctor(db_session, doctor=other_doctor)
+
+    response = client.post(
+        f"/api/v1/queue/entry/{entry.id}/no-show",
+        headers=_doctor_headers(client, actor_user),
+    )
+
+    assert actor_doctor.id != other_doctor.id
+    assert response.status_code == 403
+    db_session.refresh(entry)
+    assert entry.status == "waiting"
+
+
+@pytest.mark.integration
+def test_doctor_cannot_update_other_doctor_online_entry(
+    client,
+    db_session,
+) -> None:
+    actor_user, actor_doctor = _create_queue_doctor(db_session, label="actor_update")
+    _other_user, other_doctor = _create_queue_doctor(db_session, label="other_update")
+    entry = _create_queue_entry_for_doctor(db_session, doctor=other_doctor)
+
+    response = client.put(
+        f"/api/v1/queue/online-entry/{entry.id}/update",
+        headers=_doctor_headers(client, actor_user),
+        json={"patient_name": "Tampered Patient"},
+    )
+
+    assert actor_doctor.id != other_doctor.id
+    assert response.status_code == 403
+    db_session.refresh(entry)
+    assert entry.patient_name == "Guarded Patient"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- Scope QR queue Doctor/specialist-role mutations to the caller's linked `Doctor.id`.
- Guard QR token generation, `call-next`, queue entry status commands, online-entry updates/full-updates, and service cancellation before they mutate an `OnlineQueueEntry` or create a queue token.
- Keep Admin and Registrar behavior broad and unchanged.

## Cyclic Execution Evidence

- Fresh main sync: worktree branch `codex/contract-scan-audit-37` started from `origin/main` at `77f5e2ae`.
- Clean workspace: inspected before edit; only `qr_queue.py` and targeted QR queue integration tests changed.
- Branch: `codex/contract-scan-audit-37`
- Scope gate: `agent_gate` known-root-cause narrow override for `backend/app/api/v1/endpoints/qr_queue.py`; gate_misroute=yes because it also suggested queue_time/model/service files, which were not runtime root cause files. Second narrow gate admitted `backend/tests/integration/test_qr_queue_full_update.py`.
- Red-check handling: first targeted pytest run caught `call-next` converting the new 403 into 500 via broad exception handling; fixed in the same PR by re-raising `HTTPException`, then reran targeted suites successfully.

## Contract Impact

- Canonical surface: `/api/v1/queue/admin/qr-tokens/generate`, `/api/v1/queue/{specialist_id}/call-next`, `/api/v1/queue/entry/{entry_id}/...`, `/api/v1/queue/online-entry/{entry_id}/...`.
- Request shape: unchanged.
- Response shape: unchanged for allowed records; cross-doctor Doctor/specialist-role mutations now return existing 403 error shape.
- Status codes: own Doctor queue mutations remain 200; Admin/Registrar broad paths remain unchanged; cross-doctor Doctor/specialist-role writes now return 403.
- Frontend consumer: existing queue/registrar/doctor callers continue to use the same endpoints and payloads.
- Compatibility path or alias: no endpoint aliases changed; only pre-mutation ownership validation added for Doctor-like roles.
- Contract proof: new tests cover cross-doctor QR token generation, call-next, no-show status mutation, online-entry update, plus positive own-Doctor call-next.

## RBAC / Permissions

- Roles allowed: Admin and Registrar remain broad; Doctor/cardio/cardiology/Cardiologist/derma/Dermatologist/dentist callers are allowed only when linked `Doctor.user_id` resolves to the target `DailyQueue.specialist_id`.
- Roles denied: Doctor-like callers without a linked active Doctor, or linked to a different `Doctor.id`, are denied before mutation.
- Positive auth proof: `test_doctor_can_call_next_for_own_doctor_queue` passes and verifies status/called_by mutation.
- Negative auth proof: new cross-doctor QR token, call-next, no-show, and online-entry update tests return 403 and preserve target records.

## Notification / Realtime

- Event type or websocket channel: unchanged for allowed mutations.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable; denied mutations happen before notification side effects.

## Frontend Resilience

- Empty data proof: unchanged; no frontend/read model change.
- Partial data proof: existing QR queue full-update tests still pass.
- Forbidden secondary path behavior: new 403 prevents Doctor-like callers from mutating another Doctor's queue through alternate QR queue endpoints.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged; stale/wrong entry ids now fail ownership for Doctor-like callers instead of mutating.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/qr_queue.py`, `backend/tests/integration/test_qr_queue_full_update.py`.
- Denied paths: queue service/model/queue_time logic, `/api/v1/ui/*`, BFF-lite, separate BFF service, frontend, migrations, unrelated registrar/doctor endpoints.
- Migration/docs/test impact: no migration or docs; targeted integration tests updated.
- Rollback note: revert this PR to restore prior broad Doctor QR queue write behavior.

## Validation

- Targeted tests or smoke run: `py_compile` for touched files; `pytest backend/tests/integration/test_qr_queue_full_update.py`; `pytest backend/tests/integration/test_qr_queue_full_update.py backend/tests/integration/test_legacy_queue_today_role_guard.py backend/tests/integration/test_qr_queue_join.py`; `git diff --check`.
- Result: passed locally; combined targeted run was 21 passed; `git diff --check` exit 0 with CRLF warning only.
- Not checked: full backend suite, frontend build.
