### PR TITLE
fix(queue): scope doctor position notifications

### DIFF
--- a/backend/app/api/v1/endpoints/queue_position.py
+++ b/backend/app/api/v1/endpoints/queue_position.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user, require_roles
 from app.db.session import get_db
+from app.models.clinic import Doctor
 from app.models.user import User
 from app.services.queue_position_api_service import (
     QueuePositionApiDomainError,
@@ -29,6 +30,43 @@ from app.services.queue_position_notifications import (
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+QUEUE_POSITION_DOCTOR_NOTIFY_ROLES = {
+    "doctor",
+    "cardio",
+    "cardiology",
+    "cardiologist",
+    "derma",
+    "dermatologist",
+    "dentist",
+}
+
+
+def _role_name(user: User) -> str:
+    role = getattr(user, "role", "")
+    return str(getattr(role, "value", role) or "")
+
+
+def _ensure_doctor_can_notify_entry(
+    db: Session,
+    *,
+    entry: Any,
+    current_user: User,
+) -> None:
+    if _role_name(current_user).strip().lower() not in QUEUE_POSITION_DOCTOR_NOTIFY_ROLES:
+        return
+
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+        .first()
+    )
+    queue = getattr(entry, "queue", None)
+    if not doctor or getattr(queue, "specialist_id", None) != doctor.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
 
 
 # ========================= СХЕМЫ =========================
@@ -138,6 +176,7 @@ async def send_position_notification(
         entry = QueuePositionApiService(db).get_position_entry(entry_id=request.entry_id)
     except QueuePositionApiDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    _ensure_doctor_can_notify_entry(db, entry=entry, current_user=current_user)
 
     service = get_queue_position_service(db)
     people_ahead = service._count_people_ahead(entry)
@@ -168,6 +207,7 @@ async def send_call_notification(
         entry = QueuePositionApiService(db).get_position_entry(entry_id=request.entry_id)
     except QueuePositionApiDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    _ensure_doctor_can_notify_entry(db, entry=entry, current_user=current_user)
 
     result = await get_queue_position_service(db).notify_patient_called(
         entry=entry,
@@ -223,6 +263,7 @@ async def send_diagnostics_return_notification(
         entry = QueuePositionApiService(db).get_diagnostics_entry_or_error(entry_id=entry_id)
     except QueuePositionApiDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    _ensure_doctor_can_notify_entry(db, entry=entry, current_user=current_user)
 
     # Doctor identity lives on the related User profile in the current schema.
     specialist_name = "врач"

--- a/backend/tests/integration/test_queue_position_notify.py
+++ b/backend/tests/integration/test_queue_position_notify.py
@@ -1,12 +1,142 @@
 from __future__ import annotations
 
 from datetime import date
+from uuid import uuid4
 
 import pytest
 
 from app.api.v1.endpoints import queue_position as queue_position_endpoint
+from app.core.security import get_password_hash
 from app.models.clinic import Doctor
 from app.models.online_queue import DailyQueue, OnlineQueueEntry
+from app.models.user import User
+
+
+def _create_doctor_user(db_session, *, label: str) -> tuple[User, Doctor]:
+    suffix = uuid4().hex[:10]
+    user = User(
+        username=f"queue_position_{label}_{suffix}",
+        email=f"queue-position-{label}-{suffix}@test.local",
+        full_name=f"Queue Position {label}",
+        hashed_password=get_password_hash("doctor123"),
+        role="Doctor",
+        is_active=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    doctor = Doctor(
+        user_id=user.id,
+        specialty="general",
+        active=True,
+        cabinet="101",
+    )
+    db_session.add(doctor)
+    db_session.commit()
+    db_session.refresh(doctor)
+    return user, doctor
+
+
+def _doctor_headers(client, user: User) -> dict[str, str]:
+    login_response = client.post(
+        "/api/v1/authentication/login",
+        json={"username": user.username, "password": "doctor123"},
+    )
+    assert login_response.status_code == 200
+    return {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+
+def _create_queue_entry(db_session, *, doctor: Doctor, status: str) -> OnlineQueueEntry:
+    queue = DailyQueue(
+        day=date.today(),
+        specialist_id=doctor.id,
+        queue_tag=f"queue-position-{doctor.id}",
+        active=True,
+    )
+    db_session.add(queue)
+    db_session.commit()
+    db_session.refresh(queue)
+
+    entry = OnlineQueueEntry(
+        queue_id=queue.id,
+        number=1,
+        patient_name="Guarded Patient",
+        phone="+998901555555",
+        source="desk",
+        status=status,
+    )
+    db_session.add(entry)
+    db_session.commit()
+    db_session.refresh(entry)
+    return entry
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("endpoint_kind", "entry_status"),
+    [
+        ("position", "waiting"),
+        ("call", "waiting"),
+        ("diagnostics-return", "diagnostics"),
+    ],
+)
+def test_doctor_cannot_send_queue_position_notification_for_other_doctor_entry(
+    client,
+    db_session,
+    monkeypatch,
+    endpoint_kind,
+    entry_status,
+):
+    actor_user, actor_doctor = _create_doctor_user(db_session, label=f"actor_{endpoint_kind}")
+    _other_user, other_doctor = _create_doctor_user(db_session, label=f"other_{endpoint_kind}")
+    entry = _create_queue_entry(db_session, doctor=other_doctor, status=entry_status)
+
+    calls: list[str] = []
+
+    class FakeQueuePositionService:
+        def _count_people_ahead(self, entry):
+            calls.append("count_people_ahead")
+            return 0
+
+        async def notify_position_update(self, entry, people_ahead):
+            calls.append("notify_position_update")
+            return {"success": True, "sent": True}
+
+        async def notify_patient_called(self, entry, cabinet_number):
+            calls.append("notify_patient_called")
+            return {"success": True, "sent": True}
+
+        async def notify_diagnostics_return_needed(self, entry, specialist_name):
+            calls.append("notify_diagnostics_return_needed")
+            return {"success": True, "sent": True}
+
+    monkeypatch.setattr(
+        queue_position_endpoint,
+        "get_queue_position_service",
+        lambda db: FakeQueuePositionService(),
+    )
+
+    headers = _doctor_headers(client, actor_user)
+    if endpoint_kind == "diagnostics-return":
+        response = client.post(
+            f"/api/v1/queue/position/notify/diagnostics-return/{entry.id}",
+            headers=headers,
+        )
+    else:
+        payload = {"entry_id": entry.id}
+        if endpoint_kind == "call":
+            payload["cabinet_number"] = "101"
+        response = client.post(
+            f"/api/v1/queue/position/notify/{endpoint_kind}",
+            headers=headers,
+            json=payload,
+        )
+
+    assert actor_doctor.id != other_doctor.id
+    assert response.status_code == 403
+    assert calls == []
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

Fixes a Doctor cross-queue notification side effect in `/api/v1/queue/position/notify/*`.

Before this change, Doctor users could call queue-position notification endpoints with an arbitrary `entry_id`. If the entry belonged to another doctor's queue, the API still sent patient-facing position/call/diagnostics-return notifications for that unrelated queue.

The fix adds a narrow Doctor ownership guard in `queue_position.py`: Doctor-like roles may notify only entries whose `DailyQueue.specialist_id` matches their active linked `Doctor.id`. Admin and Registrar access remains unchanged.

## Cyclic Execution Evidence

- Fresh main sync: worktree created from `origin/main` at `1651eb14`.
- Clean workspace: branch started clean; final diff is limited to `queue_position.py` and its integration test.
- Branch: `codex/contract-scan-audit-38`.
- Scope gate: local agent gate returned `narrow override` with known root cause `backend/app/api/v1/endpoints/queue_position.py`; `gate_misroute=yes`, `override_used=yes`.
- Red-check handling: no local red checks remain.

## Contract Impact

- Canonical surface: `/api/v1/queue/position/notify/position`, `/api/v1/queue/position/notify/call`, `/api/v1/queue/position/notify/diagnostics-return/{entry_id}`.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: Doctor users now receive `403` when the target queue entry belongs to another doctor.
- Frontend consumer: unchanged.
- Compatibility path or alias: no route aliases changed.
- Contract proof: integration test covers all three guarded notification paths and asserts the notification service is not invoked after a cross-doctor request.

## RBAC / Permissions

- Roles allowed: Admin/Registrar behavior preserved; Doctor allowed for own linked `Doctor.id` queue entries.
- Roles denied: Doctor users are denied for queue entries owned by another linked doctor.
- Positive auth proof: existing diagnostics-return Doctor-owner test remains green.
- Negative auth proof: new parametrized integration test verifies cross-doctor `403` for position, call, and diagnostics-return notifications.

## Notification / Realtime

- Event type or websocket channel: queue position/call/diagnostics patient notifications.
- Payload version / ack behavior: unchanged.
- Read/unread or delivery semantics: unchanged.
- Reconnect/resync proof: not applicable; this PR only gates manual notification triggers.

## Frontend Resilience

- Empty data proof: no frontend empty-state path changes; the guarded endpoints either send a notification for an owned entry or return `403` before any side effect.
- Partial data proof: no frontend partial-data path changes; request/response schemas are unchanged and the guard only gates cross-doctor side effects.
- Forbidden secondary path behavior: backend now returns `403` before notification side effects for cross-doctor entries.
- Missing draft/resource behavior: unchanged.
- Stale route/deep-link behavior: unchanged.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/queue_position.py`, `backend/tests/integration/test_queue_position_notify.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite, migrations, broad notification catalog/settings changes.
- Migration/docs/test impact: no migration; targeted integration test added.
- Rollback note: revert this commit to restore previous broad Doctor notification behavior.

## Validation

- Targeted tests or smoke run: `python -m py_compile backend\app\api\v1\endpoints\queue_position.py backend\tests\integration\test_queue_position_notify.py`; `pytest backend\tests\integration\test_queue_position_notify.py`; `pytest backend\tests\integration\test_queue_position_notify.py backend\tests\integration\test_qr_queue_full_update.py`; `git diff --check`.
- Result: compile passed; queue-position test passed `4 passed`; combined queue ownership run passed `16 passed`; `git diff --check` exited 0 with CRLF warning only.
- Not checked: full backend suite.
