### PR TITLE
fix(notifications): scope doctor appointment reminders

### DIFF
--- a/backend/app/api/v1/endpoints/email_sms_enhanced.py
+++ b/backend/app/api/v1/endpoints/email_sms_enhanced.py
@@ -11,12 +11,52 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user, get_db, require_roles
 from app.crud import appointment as crud_appointment, patient as crud_patient
+from app.models.clinic import Doctor
 from app.models.payment import Payment
 from app.models.user import User
 from app.models.visit import Visit
 from app.services.email_sms_enhanced import get_email_sms_enhanced_service
 
 router = APIRouter()
+
+
+def _doctor_allowed_doctor_ids(db: Session, current_user: User) -> set[int]:
+    doctor = (
+        db.query(Doctor)
+        .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
+        .first()
+    )
+    if not doctor:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
+    allowed_doctor_ids = {doctor.id}
+    assigned_doctor = db.query(Doctor).filter(Doctor.id == current_user.id).first()
+    # Some legacy visit writers stored User.id in doctor_id. Allow that only
+    # when the value does not target another real Doctor row.
+    if not assigned_doctor:
+        allowed_doctor_ids.add(current_user.id)
+    return allowed_doctor_ids
+
+
+def _ensure_doctor_can_send_appointment_reminder(
+    db: Session,
+    appointment: Any,
+    current_user: User,
+) -> None:
+    if current_user.role != "Doctor":
+        return
+    if current_user.is_superuser:
+        return
+    if getattr(appointment, "doctor_id", None) not in _doctor_allowed_doctor_ids(
+        db, current_user
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
 
 
 def _payment_id_from_payload(payment_data: Dict[str, Any]) -> int | None:
@@ -78,6 +118,9 @@ async def send_appointment_reminder_enhanced(
             )
 
         # Получаем данные пациента
+        _ensure_doctor_can_send_appointment_reminder(
+            db, appointment, current_user
+        )
         patient = crud_patient.get_patient(db, appointment.patient_id)
         if not patient:
             raise HTTPException(

--- a/backend/app/api/v1/endpoints/telegram_notifications.py
+++ b/backend/app/api/v1/endpoints/telegram_notifications.py
@@ -97,7 +97,7 @@ def _safe_payment_template_data(payment_data: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _doctor_allowed_patient_ids(db: Session, current_user: User) -> set[int]:
+def _doctor_allowed_doctor_ids(db: Session, current_user: User) -> set[int]:
     doctor = (
         db.query(Doctor)
         .filter(Doctor.user_id == current_user.id, Doctor.active.is_(True))
@@ -115,7 +115,11 @@ def _doctor_allowed_patient_ids(db: Session, current_user: User) -> set[int]:
     # when the value does not target another real Doctor row.
     if not assigned_doctor:
         allowed_doctor_ids.add(current_user.id)
+    return allowed_doctor_ids
 
+
+def _doctor_allowed_patient_ids(db: Session, current_user: User) -> set[int]:
+    allowed_doctor_ids = _doctor_allowed_doctor_ids(db, current_user)
     rows = (
         db.query(Visit.patient_id)
         .filter(
@@ -125,6 +129,24 @@ def _doctor_allowed_patient_ids(db: Session, current_user: User) -> set[int]:
         .all()
     )
     return {row[0] for row in rows if row[0] is not None}
+
+
+def _ensure_doctor_can_send_appointment_reminder(
+    db: Session,
+    appointment: Any,
+    current_user: User,
+) -> None:
+    if current_user.role != "Doctor":
+        return
+    if current_user.is_superuser:
+        return
+    if getattr(appointment, "doctor_id", None) not in _doctor_allowed_doctor_ids(
+        db, current_user
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
 
 
 def _ensure_doctor_can_send_patient_lab_results(
@@ -232,6 +254,9 @@ async def send_appointment_reminder(
             )
 
         # Получаем данные пациента
+        _ensure_doctor_can_send_appointment_reminder(
+            db, appointment, current_user
+        )
         patient = crud_patient.get_patient(db, appointment.patient_id)
         if not patient:
             raise HTTPException(

--- a/backend/tests/unit/test_email_sms_enhanced_payment_owner.py
+++ b/backend/tests/unit/test_email_sms_enhanced_payment_owner.py
@@ -10,6 +10,56 @@ from app.api.v1.endpoints import email_sms_enhanced
 
 
 @pytest.mark.asyncio
+async def test_doctor_cannot_send_appointment_reminder_enhanced_for_other_doctor(
+    monkeypatch,
+):
+    appointment = SimpleNamespace(
+        id=456,
+        patient_id=123,
+        doctor_id=99,
+    )
+    get_patient = Mock()
+    get_service = Mock()
+
+    monkeypatch.setattr(
+        email_sms_enhanced.crud_appointment,
+        "get_appointment",
+        lambda _db, _appointment_id: appointment,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        email_sms_enhanced,
+        "_doctor_allowed_doctor_ids",
+        lambda _db, _current_user: {42},
+    )
+    monkeypatch.setattr(
+        email_sms_enhanced.crud_patient,
+        "get_patient",
+        get_patient,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        email_sms_enhanced,
+        "get_email_sms_enhanced_service",
+        get_service,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await email_sms_enhanced.send_appointment_reminder_enhanced(
+            appointment_id=456,
+            channels=["email"],
+            template_data=None,
+            background_tasks=BackgroundTasks(),
+            db=object(),
+            current_user=SimpleNamespace(role="Doctor", is_superuser=False),
+        )
+
+    assert exc_info.value.status_code == 403
+    get_patient.assert_not_called()
+    get_service.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_send_payment_confirmation_enhanced_preserves_no_id_payload(
     monkeypatch,
 ):

--- a/backend/tests/unit/test_telegram_notifications_privacy.py
+++ b/backend/tests/unit/test_telegram_notifications_privacy.py
@@ -131,6 +131,48 @@ async def test_send_appointment_reminder_response_hides_patient_contact_metadata
 
 
 @pytest.mark.asyncio
+async def test_doctor_cannot_send_appointment_reminder_for_other_doctor(
+    monkeypatch,
+):
+    appointment = SimpleNamespace(
+        id=457,
+        patient_id=123,
+        doctor_id=99,
+    )
+
+    monkeypatch.setattr(
+        telegram_notifications.crud_appointment,
+        "get_appointment",
+        lambda _db, _appointment_id: appointment,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_notifications,
+        "_doctor_allowed_doctor_ids",
+        lambda _db, _current_user: {42},
+    )
+    get_patient = Mock()
+    monkeypatch.setattr(
+        telegram_notifications.crud_patient,
+        "get_patient",
+        get_patient,
+        raising=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await telegram_notifications.send_appointment_reminder(
+            appointment_id=457,
+            reminder_type="24h",
+            background_tasks=BackgroundTasks(),
+            db=object(),
+            current_user=SimpleNamespace(role="Doctor", is_superuser=False),
+        )
+
+    assert exc_info.value.status_code == 403
+    get_patient.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_send_appointment_reminder_unregistered_response_hides_patient_phone(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- Restrict Doctor-triggered appointment reminders to appointments owned by the caller's linked active `Doctor.id`.
- Apply the guard to both Telegram appointment reminders and enhanced email/SMS appointment reminders.
- Preserve Admin, Registrar, and superuser behavior.

## Cyclic Execution Evidence
- Fresh main sync: worktree created from `origin/main` at `5ee3ac31` after PR #1598 was merged.
- Clean workspace: pass 39 started in a dedicated worktree and only the allowed notification/test files are changed.
- Branch: `codex/contract-scan-audit-39`.
- Scope gate: local gate run twice with known root cause files. Telegram gate returned narrow override with `gate_misroute=yes`, `override_used=yes`, `known_root_cause_file=backend/app/api/v1/endpoints/telegram_notifications.py`. Email/SMS sibling gate returned narrow override with `gate_misroute=no`, `override_used=yes`, `known_root_cause_file=backend/app/api/v1/endpoints/email_sms_enhanced.py`.
- Red-check handling: if CI or review gates fail, this PR will be fixed in place before any next PR cycle.

## Contract Impact
- Canonical surface: mounted runtime appointment reminder endpoints under `backend/app/api/v1/endpoints/telegram_notifications.py` and `backend/app/api/v1/endpoints/email_sms_enhanced.py`.
- Request shape: unchanged; both endpoints still accept the existing `appointment_id` query parameter.
- Response shape: unchanged for authorized callers.
- Status codes: Doctor callers now receive `403` before patient lookup or notification side effects when the appointment belongs to another Doctor. Existing `404` missing appointment behavior remains unchanged.
- Frontend consumer: existing consumers can keep the same request and response handling; forbidden Doctor misuse now gets an explicit authorization failure.
- Compatibility path or alias: no aliases, redirects, BFF-lite routes, or `/api/v1/ui/*` routes were added or changed.
- Contract proof: unit tests assert the new Doctor denial happens before `crud_patient.get_patient` and before enhanced notification service calls.

## RBAC / Permissions
- Roles allowed: Admin, Registrar, and superuser retain broad reminder access; Doctor is allowed only for appointments owned by their linked active `Doctor.id`.
- Roles denied: Doctor users are denied for appointments whose `doctor_id` is outside their allowed linked Doctor ids.
- Positive auth proof: existing unit coverage for authorized Telegram reminder behavior remains in the targeted test file.
- Negative auth proof: new Telegram and enhanced email/SMS tests assert `403` for a Doctor sending a reminder for another Doctor's appointment.

## Notification / Realtime
- Event type or websocket channel: patient-facing Telegram and enhanced email/SMS appointment reminder sends.
- Payload version / ack behavior: unchanged for authorized sends.
- Read/unread or delivery semantics: unchanged; unauthorized Doctor requests are blocked before any reminder delivery side effect.
- Reconnect/resync proof: no websocket or realtime resync surface is changed by this PR.

## Frontend Resilience
- Empty data proof: no frontend data rendering path changed; missing appointments still use the existing backend `404`.
- Partial data proof: patient lookup is not attempted when Doctor authorization fails, preventing partial downstream notification execution.
- Forbidden secondary path behavior: Doctor cross-owner access now returns a backend `403` for both Telegram and enhanced email/SMS reminder paths.
- Missing draft/resource behavior: no draft/resource lifecycle is changed; missing appointment behavior remains the existing `404`.
- Stale route/deep-link behavior: stale callers using a valid but cross-owner `appointment_id` now receive `403` instead of causing a patient-facing reminder.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/telegram_notifications.py`, `backend/app/api/v1/endpoints/email_sms_enhanced.py`, `backend/tests/unit/test_telegram_notifications_privacy.py`, `backend/tests/unit/test_email_sms_enhanced_payment_owner.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite/read-model endpoints, migrations, broad notification catalog/settings/webhook/admin Telegram changes.
- Migration/docs/test impact: no migration or docs changes; targeted unit tests only.
- Rollback note: revert this PR to restore previous broad Doctor reminder behavior.

## Validation
- Targeted tests or smoke run: Python compile for both changed endpoints and both changed test files; `pytest backend\tests\unit\test_telegram_notifications_privacy.py`; `pytest backend\tests\unit\test_telegram_notifications_privacy.py backend\tests\unit\test_email_sms_enhanced_payment_owner.py`; `git diff --check`.
- Result: Telegram unit file passed `16 passed`; combined unit files passed `19 passed`; `git diff --check` exited 0 with CRLF warnings only.
- Not checked: full backend suite, frontend build, browser smoke, and production notification delivery.
