### PR TITLE
fix(visits): scope doctor visit creation

### DIFF
--- a/backend/app/api/v1/endpoints/visits.py
+++ b/backend/app/api/v1/endpoints/visits.py
@@ -152,6 +152,25 @@ def _doctor_allowed_visit_doctor_ids(db: Session, current_user) -> set[int]:
     return allowed_ids
 
 
+def _ensure_doctor_can_create_visit_for_payload(
+    db: Session,
+    payload: VisitCreate,
+    current_user,
+) -> None:
+    if getattr(current_user, "role", None) == "Admin" or getattr(
+        current_user, "is_superuser", False
+    ):
+        return
+    if getattr(current_user, "role", None) != "Doctor":
+        return
+
+    doctor_id = getattr(payload, "doctor_id", None)
+    if doctor_id is None or doctor_id not in _doctor_allowed_visit_doctor_ids(
+        db, current_user
+    ):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+
 @router.get("/visits", response_model=List[VisitOut], summary="Список визитов")
 def list_visits(
     patient_id: Optional[int] = Query(default=None),
@@ -193,6 +212,7 @@ def create_visit(
     db: Session = Depends(get_db),
     current_user = Depends(require_roles("Admin", "Registrar", "Doctor")),
 ):
+    _ensure_doctor_can_create_visit_for_payload(db, payload, current_user)
     result = VisitsApiService(db).create_visit(
         request=request,
         payload=payload,

--- a/backend/tests/integration/test_visit_status_owner_guard.py
+++ b/backend/tests/integration/test_visit_status_owner_guard.py
@@ -158,6 +158,60 @@ def test_doctor_visit_list_is_limited_to_own_doctor_id(client, db_session) -> No
     assert unscoped_response.status_code == 403
 
 
+def test_doctor_cannot_create_visit_for_other_doctor(client, db_session) -> None:
+    own_user, _own_doctor = _create_doctor_user(db_session, label="create_own")
+    _other_user, other_doctor = _create_doctor_user(
+        db_session, label="create_other"
+    )
+    other_patient = _create_patient(db_session)
+
+    response = client.post(
+        "/api/v1/visits/visits",
+        json={
+            "patient_id": other_patient.id,
+            "doctor_id": other_doctor.id,
+            "notes": "wrong owner create",
+            "planned_date": str(date.today()),
+            "source": "desk",
+        },
+        headers=_doctor_headers(client, own_user),
+    )
+
+    assert response.status_code == 403
+    assert (
+        db_session.query(Visit)
+        .filter(
+            Visit.patient_id == other_patient.id,
+            Visit.doctor_id == other_doctor.id,
+            Visit.notes == "wrong owner create",
+        )
+        .count()
+        == 0
+    )
+
+
+def test_doctor_can_create_visit_for_own_doctor_id(client, db_session) -> None:
+    own_user, own_doctor = _create_doctor_user(db_session, label="create_allowed")
+    patient = _create_patient(db_session)
+
+    response = client.post(
+        "/api/v1/visits/visits",
+        json={
+            "patient_id": patient.id,
+            "doctor_id": own_doctor.id,
+            "notes": "own doctor create",
+            "planned_date": str(date.today()),
+            "source": "desk",
+        },
+        headers=_doctor_headers(client, own_user),
+    )
+
+    assert response.status_code == 201, response.text
+    payload = response.json()
+    assert payload["patient_id"] == patient.id
+    assert payload["doctor_id"] == own_doctor.id
+
+
 def test_doctor_cannot_add_service_to_other_doctor_visit(client, db_session) -> None:
     own_user, _own_doctor = _create_doctor_user(db_session, label="svc_own")
     _other_user, other_doctor = _create_doctor_user(db_session, label="svc_other")


### PR DESCRIPTION
## Summary
- Restrict Doctor-created visits to the caller's linked active `Doctor.id`.
- Preserve Admin and Registrar create behavior.
- Add regression coverage for both denied cross-doctor creation and allowed own-doctor creation.

## Cyclic Execution Evidence
- Fresh main sync: worktree created from `origin/main` at `f22aae0a` after PR #1599 was merged.
- Clean workspace: pass 40 started in a dedicated worktree and only the allowed visit endpoint/test files are changed.
- Branch: `codex/contract-scan-audit-40`.
- Scope gate: local gate run with known root cause `backend/app/api/v1/endpoints/visits.py`; result was narrow override, `gate_misroute=no`, `override_used=yes`.
- Red-check handling: if CI or review gates fail, this PR will be fixed in place before any next PR cycle.

## Contract Impact
- Canonical surface: mounted runtime `POST /api/v1/visits/visits` visit creation endpoint.
- Request shape: unchanged; the endpoint still accepts the existing `VisitCreate` payload.
- Response shape: unchanged for authorized callers.
- Status codes: Doctor callers now receive `403` when creating a visit with missing or foreign `doctor_id`. Admin and Registrar behavior is unchanged.
- Frontend consumer: existing Admin/Registrar create flows keep the same contract; Doctor callers must send their own linked `Doctor.id`.
- Compatibility path or alias: no aliases, redirects, BFF-lite routes, or `/api/v1/ui/*` routes were added or changed.
- Contract proof: integration tests assert Doctor cross-owner create is rejected without inserting a `Visit`, and own-doctor create still returns `201`.

## RBAC / Permissions
- Roles allowed: Admin and Registrar retain broad create access; Doctor can create only for their linked active `Doctor.id` plus the existing legacy-safe id allowance.
- Roles denied: Doctor users are denied when `doctor_id` is missing or points to another Doctor.
- Positive auth proof: new integration test verifies Doctor can create a visit for their own linked Doctor id.
- Negative auth proof: new integration test verifies Doctor cannot create a visit for another Doctor id and no wrong-owner row is inserted.

## Notification / Realtime
- Event type or websocket channel: no notification or websocket channel is changed by this PR.
- Payload version / ack behavior: no realtime payload or ack behavior is changed.
- Read/unread or delivery semantics: no notification delivery/read state is changed.
- Reconnect/resync proof: no websocket or realtime resync surface is changed.

## Frontend Resilience
- Empty data proof: no frontend empty-state rendering path changed.
- Partial data proof: failed Doctor authorization happens before `VisitsApiService.create_visit`, so no partial wrong-owner visit row is created.
- Forbidden secondary path behavior: Doctor cross-owner create now returns a backend `403`.
- Missing draft/resource behavior: no draft/resource lifecycle is changed; invalid/missing payload validation remains the existing FastAPI/Pydantic behavior.
- Stale route/deep-link behavior: existing route remains mounted; stale Doctor callers using foreign ids now fail with `403` instead of creating a wrong-owner visit.

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/visits.py`, `backend/tests/integration/test_visit_status_owner_guard.py`.
- Denied paths: frontend, `/api/v1/ui/*`, BFF-lite/read-model endpoints, migrations, queue allocator internals, registrar batch endpoints, broad visits service refactors.
- Migration/docs/test impact: no migration or docs changes; targeted integration/unit tests only.
- Rollback note: revert this PR to restore previous broad Doctor create behavior.

## Validation
- Targeted tests or smoke run: Python compile for `visits.py` and `test_visit_status_owner_guard.py`; `pytest backend\tests\integration\test_visit_status_owner_guard.py`; `pytest backend\tests\integration\test_visit_status_owner_guard.py backend\tests\unit\test_visits_router_service_wiring.py`; `git diff --check`.
- Result: owner-guard integration file passed `7 passed`; combined visits owner/wiring run passed `16 passed`; `git diff --check` exited 0 with CRLF warnings only.
- Not checked: full backend suite, frontend build, browser smoke, and production database migration path.
