### PR TITLE
fix(registrar): hide canceled records from active queue

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
-from sqlalchemy import and_
+from sqlalchemy import and_, func
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_roles
@@ -62,6 +62,7 @@ REGISTRAR_START_STATUSES = {"waiting", "queued"}
 REGISTRAR_PRINT_STATUSES = {"waiting", "queued"}
 REGISTRAR_COMPLETE_STATUSES = {"called", "in_cabinet", "in_progress"}
 REGISTRAR_CANCEL_BLOCKED_STATUSES = {"canceled", "cancelled", "completed", "done", "served"}
+REGISTRAR_HIDDEN_QUEUE_STATUSES = {"canceled", "cancelled", "no_show"}
 REGISTRAR_VIEW_EMR_STATUSES = {"completed", "done", "served"}
 REGISTRAR_SCHEDULE_NEXT_STATUSES = {"completed", "done", "served"}
 
@@ -1582,11 +1583,27 @@ def get_today_queues(
             )
 
         # Получаем все визиты на сегодня (новая система)
-        visits = db.query(Visit).filter(Visit.visit_date == today).all()
+        visits = (
+            db.query(Visit)
+            .filter(
+                Visit.visit_date == today,
+                ~func.lower(func.coalesce(Visit.status, "")).in_(
+                    REGISTRAR_HIDDEN_QUEUE_STATUSES
+                ),
+            )
+            .all()
+        )
 
         # Получаем все appointments на сегодня (старая система)
         appointments = (
-            db.query(Appointment).filter(Appointment.appointment_date == today).all()
+            db.query(Appointment)
+            .filter(
+                Appointment.appointment_date == today,
+                ~func.lower(func.coalesce(Appointment.status, "")).in_(
+                    REGISTRAR_HIDDEN_QUEUE_STATUSES
+                ),
+            )
+            .all()
         )
 
         # [OK] ДОБАВЛЕНО: Получаем записи из онлайн-очереди (OnlineQueueEntry)
@@ -2575,6 +2592,8 @@ def get_today_queues(
                         "in_progress": "called",
                         "completed": "served",
                         "cancelled": "no_show",
+                        "canceled": "no_show",
+                        "no_show": "no_show",
                     }
                     entry_status = status_mapping.get(visit.status, "waiting")
 
@@ -2661,6 +2680,8 @@ def get_today_queues(
                         "in_visit": "called",
                         "completed": "served",
                         "cancelled": "no_show",
+                        "canceled": "no_show",
+                        "no_show": "no_show",
                     }
                     entry_status = status_mapping.get(appointment.status, "waiting")
 

--- a/backend/tests/integration/test_registrar_all_appointments.py
+++ b/backend/tests/integration/test_registrar_all_appointments.py
@@ -353,6 +353,76 @@ class TestRegistrarAllAppointments:
         assert found_visit["visit_id"] == visit.id
         assert found_visit["appointment_id"] is None
 
+    def test_today_queues_hides_canceled_visit_and_appointment_rows(
+        self,
+        client,
+        db_session,
+        auth_headers,
+        test_patient,
+        test_doctor,
+        test_service,
+    ):
+        canceled_visit = Visit(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=date.today(),
+            visit_time="10:00",
+            status="canceled",
+            discount_mode="none",
+            department="cardiology",
+            source="desk",
+        )
+        canceled_appointment = Appointment(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            appointment_date=date.today(),
+            appointment_time="11:00",
+            status="cancelled",
+            visit_type="paid",
+            payment_type="cash",
+            services=[],
+        )
+        db_session.add_all([canceled_visit, canceled_appointment])
+        db_session.flush()
+        db_session.add(
+            VisitService(
+                visit_id=canceled_visit.id,
+                service_id=test_service.id,
+                code=test_service.code,
+                name=test_service.name,
+                qty=1,
+                price=test_service.price,
+                currency="UZS",
+            )
+        )
+        db_session.commit()
+
+        response = client.get(
+            f"/api/v1/registrar/queues/today?target_date={date.today().isoformat()}",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        entries = [
+            entry for queue_payload in payload["queues"] for entry in queue_payload["entries"]
+        ]
+
+        assert all(
+            not (
+                entry.get("record_kind") == "visit"
+                and entry.get("visit_id") == canceled_visit.id
+            )
+            for entry in entries
+        )
+        assert all(
+            not (
+                entry.get("record_kind") == "appointment"
+                and entry.get("appointment_id") == canceled_appointment.id
+            )
+            for entry in entries
+        )
+
     def test_today_queues_visit_ignores_other_patient_queue_entry_with_same_visit_id(
         self,
         client,


### PR DESCRIPTION
﻿## Summary

- Hide canceled/no-show Visit and Appointment records from the active registrar `/registrar/queues/today` read model.
- Normalize `canceled` as terminal in the registrar status mapping so it cannot fall back to `waiting`.
- Add regression coverage for canceled Visit and Appointment rows.

## Cyclic Execution Evidence

- Fresh main sync: started from `main...origin/main` with clean git status before the fix branch.
- Clean workspace: initial workspace was clean; branch `fix/registrar-cancel-hides-active-row` contains only the intended backend read-model/test patch.
- Branch: `fix/registrar-cancel-hides-active-row`.
- Scope gate: queue/status strict mode via `agent_gate`; first frontend suspicion was replaced by confirmed backend root cause after API evidence.
- Red-check handling: if checks fail, fixes stay in this PR; PR Review Quality Gate body failure is fixed by this body update.

## Contract Impact

- Canonical surface: `GET /api/v1/registrar/queues/today` active registrar queue read model.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: unchanged.
- Frontend consumer: `RegistrarPanel` consumes the same response shape; canceled terminal records are no longer returned as active rows.
- Compatibility path or alias: `canceled`, `cancelled`, and `no_show` are treated as terminal hidden statuses for this active queue read model.
- Contract proof: targeted integration test verifies canceled Visit and cancelled Appointment rows are absent from today queues.

## RBAC / Permissions

not applicable - no route, endpoint guard, role helper, or permission policy changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: browser QA on `http://localhost:5173/registrar` after cancel rendered the empty-state text `Очередь пуста` and `0 Все записи`.
- Partial data proof: not checked - patch only removes terminal canceled rows from backend active queue read-model.
- Forbidden secondary path behavior: not checked - no RBAC/forbidden path changed.
- Missing draft/resource behavior: not checked - no draft/resource path changed.
- Stale route/deep-link behavior: not checked - route/deep-link behavior unchanged.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/registrar_integration.py`; `backend/tests/integration/test_registrar_all_appointments.py`.
- Denied paths: frontend runtime/UI files, DB migrations/schema, payment/queue number assignment logic, deploy/secrets.
- Migration/docs/test impact: no migration or docs changes; one targeted backend integration regression test added.
- Rollback note: revert commit `8859ce76` to restore previous active queue read-model behavior.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `C:\final\.venv\Scripts\python.exe -m py_compile backend/app/api/v1/endpoints/registrar_integration.py`; `scripts\run_backend_pytest.ps1 tests/integration/test_registrar_all_appointments.py::TestRegistrarAllAppointments::test_today_queues_hides_canceled_visit_and_appointment_rows tests/integration/test_registrar_record_actions.py::test_registrar_record_action_can_cancel_online_queue_entry -q`; `git diff --check`; dev API query; browser QA.
- Result: local compile passed; backend targeted tests passed `2 passed`; `git diff --check` passed; dev API after cancel returned `entry_count=0`; browser rendered empty state with console warn/error count 0.
- Not checked: full frontend test suite, because no frontend files changed; DB migration tests, because no schema changed.
