### PR TITLE
fix(frontend): enforce route registry setup entrypoint

### DIFF
--- a/frontend/e2e/setup-login.spec.js
+++ b/frontend/e2e/setup-login.spec.js
@@ -1,0 +1,54 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+const SETUP_CTA_NAME = '\u0421\u043e\u0437\u0434\u0430\u0442\u044c \u043a\u043b\u0438\u043d\u0438\u043a\u0443';
+const LEGACY_REGISTER_NAME = '\u0420\u0435\u0433\u0438\u0441\u0442\u0440\u0430\u0446\u0438\u044f';
+
+async function openLoginWithSetupStatus(page, initialized) {
+  const setupStatusRequests = [];
+
+  await page.addInitScript(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  await page.route('**/api/v1/setup/status', async (route) => {
+    setupStatusRequests.push(route.request().url());
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ initialized }),
+    });
+  });
+
+  await page.goto('/login', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('input[name="username"]')).toBeVisible();
+  await expect.poll(() => setupStatusRequests.length).toBeGreaterThan(0);
+
+  return setupStatusRequests;
+}
+
+test.describe('Login setup entrypoint', () => {
+  test('shows setup CTA only before clinic initialization', async ({ page }) => {
+    await openLoginWithSetupStatus(page, false);
+
+    await expect(page.getByRole('button', { name: SETUP_CTA_NAME })).toBeVisible();
+    await expect(page.getByRole('button', { name: LEGACY_REGISTER_NAME })).toHaveCount(0);
+  });
+
+  test('navigates setup CTA to canonical setup route', async ({ page }) => {
+    await openLoginWithSetupStatus(page, false);
+
+    await page.getByRole('button', { name: SETUP_CTA_NAME }).click();
+
+    await expect(page).toHaveURL(/\/setup$/);
+  });
+
+  test('hides setup CTA after clinic initialization', async ({ page }) => {
+    await openLoginWithSetupStatus(page, true);
+
+    await expect(page.getByRole('button', { name: SETUP_CTA_NAME })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: LEGACY_REGISTER_NAME })).toHaveCount(0);
+    await expect(page).toHaveURL(/\/login$/);
+  });
+});

--- a/frontend/src/components/auth/LoginFormStyled.jsx
+++ b/frontend/src/components/auth/LoginFormStyled.jsx
@@ -6,13 +6,19 @@ import { api, buildApiUrl, setToken } from '../../api/client';
 import { setProfile } from '../../stores/auth';
 import auth from '../../stores/auth.js';
 import { getRouteForProfile } from '../../constants/routes';
-import { getEffectiveRouteByPath } from '../../routing/routeSelectors.js';
+import { getCanonicalRouteById, getEffectiveRouteByPath } from '../../routing/routeSelectors.js';
+import { useSetupStatus } from '../../hooks/useSetupStatus.js';
 import { colors } from '../../theme/tokens';
 import TwoFactorVerify from '../TwoFactorVerify.jsx';
 import ForgotPassword from './ForgotPassword';
 import { formatLoginErrorMessage, LOGIN_ERROR_MESSAGES } from './loginErrorUtils';
 import { Button, Card, CardHeader, CardTitle, CardContent, Input, Select, Checkbox, Alert } from '../ui/macos';
 import logger from '../../utils/logger';
+
+const landingRoute = getCanonicalRouteById('landing')?.path || '/';
+const loginRoute = getCanonicalRouteById('login')?.path || '/login';
+const changePasswordRequiredRoute = getCanonicalRouteById('change-password-required')?.path || '/change-password-required';
+const setupRoute = getCanonicalRouteById('setup')?.path || '/setup';
 
 // macOS-стиль анимации для декоративных элементов
 const floatingAnimation = `
@@ -33,7 +39,9 @@ const LoginFormStyled = () => {void
   useTheme();
   const navigate = useNavigate();
   const location = useLocation();
-  const from = location.state?.from?.pathname || '/';
+  const setupStatus = useSetupStatus();
+  const from = location.state?.from?.pathname || landingRoute;
+  const showSetupCta = setupStatus.initialized === false;
   const authControlStyles = {
     backgroundColor: 'rgba(255, 255, 255, 0.98)',
     color: '#0f172a',
@@ -161,7 +169,7 @@ const LoginFormStyled = () => {void
         if (data.must_change_password) {
           setToken(accessToken);
           localStorage.setItem('auth_token', accessToken);
-          navigate('/change-password-required', {
+          navigate(changePasswordRequiredRoute, {
             state: { currentPassword: formData.password },
             replace: true
           });
@@ -181,11 +189,11 @@ const LoginFormStyled = () => {void
           const state = auth.getState ? auth.getState() : { profile: null };
           const profile = state?.profile || null;
           const computedRoute = getRouteForProfile(profile);
-          const fromClean = from || '/';
+          const fromClean = from || landingRoute;
 
           // Если from ведёт на другой защищённый раздел панели — игнорируем его
           let target = computedRoute;
-          if (fromClean && fromClean !== '/' && fromClean !== '/login') {
+          if (fromClean && fromClean !== landingRoute && fromClean !== loginRoute) {
             if (isProtectedPanelPath(fromClean)) {
               if (fromClean === computedRoute) target = fromClean;
             } else {
@@ -206,7 +214,7 @@ const LoginFormStyled = () => {void
           navigate(target, { replace: true });
         } catch (profileError) {
           logger.warn('Не удалось получить профиль:', profileError);
-          navigate('/', { replace: true });
+          navigate(landingRoute, { replace: true });
         }
       } else {
         throw new Error('Не получен токен доступа');
@@ -260,7 +268,7 @@ const LoginFormStyled = () => {void
         const state = auth.getState ? auth.getState() : { profile: null };
         const profile = state?.profile || null;
         const computedRoute = getRouteForProfile(profile);
-        const target = computedRoute || from || '/';
+        const target = computedRoute || from || landingRoute;
 
         navigate(target, { replace: true });
       }
@@ -570,13 +578,15 @@ const LoginFormStyled = () => {void
           </form>
 
           <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
-            <Button type="button" variant="outline" fullWidth size="small" onClick={() => navigate('/register')} style={{ ...authSecondaryButtonStyles, ...authButtonBaseStyles }}>
+            {showSetupCta && (
+            <Button type="button" variant="outline" fullWidth size="small" onClick={() => navigate(setupRoute)} style={{ ...authSecondaryButtonStyles, ...authButtonBaseStyles }}>
               <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
                 <UserPlus size={16} />
-                Регистрация
+                Создать клинику
               </span>
             </Button>
-            <Button type="button" variant="outline" fullWidth size="small" onClick={() => navigate('/')} style={{ ...authSecondaryButtonStyles, ...authButtonBaseStyles }}>
+            )}
+            <Button type="button" variant="outline" fullWidth size="small" onClick={() => navigate(landingRoute)} style={{ ...authSecondaryButtonStyles, ...authButtonBaseStyles }}>
               <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
                 <UserRound size={16} />
                 Гость

--- a/frontend/src/components/auth/__tests__/LoginFormStyled.setupCta.test.jsx
+++ b/frontend/src/components/auth/__tests__/LoginFormStyled.setupCta.test.jsx
@@ -1,0 +1,60 @@
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import LoginFormStyled from '../LoginFormStyled.jsx';
+
+const { useSetupStatusMock } = vi.hoisted(() => ({
+  useSetupStatusMock: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useSetupStatus.js', () => ({
+  useSetupStatus: useSetupStatusMock,
+}));
+
+vi.mock('../../../contexts/ThemeContext', () => ({
+  useTheme: () => ({}),
+}));
+
+const setupCtaName = /\u0421\u043e\u0437\u0434\u0430\u0442\u044c \u043a\u043b\u0438\u043d\u0438\u043a\u0443/i;
+const registrationName = /\u0420\u0435\u0433\u0438\u0441\u0442\u0440\u0430\u0446\u0438\u044f/i;
+
+const renderLoginForm = () => {
+  render(
+    <MemoryRouter>
+      <LoginFormStyled />
+    </MemoryRouter>
+  );
+};
+
+describe('LoginFormStyled setup CTA', () => {
+  beforeEach(() => {
+    useSetupStatusMock.mockReset();
+  });
+
+  it('shows primary setup CTA when the system is not initialized', () => {
+    useSetupStatusMock.mockReturnValue({
+      initialized: false,
+      isLoading: false,
+      error: null,
+    });
+
+    renderLoginForm();
+
+    expect(screen.getByRole('button', { name: setupCtaName })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: registrationName })).not.toBeInTheDocument();
+  });
+
+  it('hides primary setup CTA after initialization', () => {
+    useSetupStatusMock.mockReturnValue({
+      initialized: true,
+      isLoading: false,
+      error: null,
+    });
+
+    renderLoginForm();
+
+    expect(screen.queryByRole('button', { name: setupCtaName })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: registrationName })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import auth, { setProfile } from '../../stores/auth.js';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useTheme } from '../../contexts/ThemeContext.jsx';
+import { getCanonicalRouteById, getRoleHomeRoute } from '../../routing/routeSelectors.js';
 import '../../styles/cursor-effects.css';
 import '../../styles/animations.css';
 import '../ui/animations.css';
@@ -38,6 +39,11 @@ export default function Header() {
   // Normalize receptionist to registrar for UI consistency
   const roleNormalized = roleLower === 'receptionist' ? 'registrar' : roleLower;
   const view = new URLSearchParams(location.search).get('view');
+  const cashierHomeRoute = getRoleHomeRoute('cashier');
+  const cardiologyHomeRoute = getCanonicalRouteById('doctor-cardiology')?.path || getRoleHomeRoute('cardio');
+  const dermatologyHomeRoute = getCanonicalRouteById('doctor-dermatology')?.path || getRoleHomeRoute('derma');
+  const dentistryHomeRoute = getCanonicalRouteById('doctor-dentistry')?.path || getRoleHomeRoute('dentist');
+  const registrarHomeRoute = getRoleHomeRoute('registrar');
 
   // Используем централизованную систему дизайна вместо дублированных токенов
   const {
@@ -55,14 +61,14 @@ export default function Header() {
   const navItems = [];
   // Для администратора навигационные пункты скрыты
   if (roleNormalized !== 'admin') {
-    if (roleNormalized === 'registrar') navItems.push({ to: '/cashier-panel', label: 'Кассир', icon: <CreditCard size={16} /> });
-    if (roleNormalized === 'cashier') navItems.push({ to: '/cashier-panel', label: 'Касса', icon: <CreditCard size={16} /> });
+    if (roleNormalized === 'registrar') navItems.push({ to: cashierHomeRoute, label: 'Кассир', icon: <CreditCard size={16} /> });
+    if (roleNormalized === 'cashier') navItems.push({ to: cashierHomeRoute, label: 'Касса', icon: <CreditCard size={16} /> });
   }
 
   // Специализированные роли
-  if (roleLower === 'cardio') navItems.push({ to: '/cardiologist', label: 'Кардиолог', icon: '❤️' });
-  if (roleLower === 'derma') navItems.push({ to: '/dermatologist', label: 'Дерматолог', icon: '✨' });
-  if (roleLower === 'dentist') navItems.push({ to: '/dentist', label: 'Стоматолог', icon: '🦷' });
+  if (roleLower === 'cardio') navItems.push({ to: cardiologyHomeRoute, label: 'Кардиолог', icon: '❤️' });
+  if (roleLower === 'derma') navItems.push({ to: dermatologyHomeRoute, label: 'Дерматолог', icon: '✨' });
+  if (roleLower === 'dentist') navItems.push({ to: dentistryHomeRoute, label: 'Стоматолог', icon: '🦷' });
 
   // Стили в стиле RegistrarPanel - на весь экран
   void {
@@ -339,7 +345,7 @@ export default function Header() {
           })}
 
           {/* Быстрые ссылки для регистратора внутри панели */}
-          {roleNormalized === 'registrar' && location.pathname === '/registrar-panel' &&
+          {roleNormalized === 'registrar' && location.pathname === registrarHomeRoute &&
           <>
               <button
               className="interactive-element hover-lift ripple-effect focus-ring"
@@ -367,7 +373,7 @@ export default function Header() {
                   boxShadow: 'none'
                 })
               }}
-              onClick={() => navigate('/registrar-panel?view=welcome')}
+              onClick={() => navigate(`${registrarHomeRoute}?view=welcome`)}
               title="Главная">
               
                 <Home size={16} />
@@ -399,7 +405,7 @@ export default function Header() {
                   boxShadow: 'none'
                 })
               }}
-              onClick={() => navigate('/registrar-panel?view=queue')}
+              onClick={() => navigate(`${registrarHomeRoute}?view=queue`)}
               title="Онлайн‑записи">
               
                 <span>📱</span>
@@ -429,7 +435,7 @@ export default function Header() {
                   const val = e.currentTarget.value;
                   if (val) params.set('date', val);else params.delete('date');
                   params.set('view', 'welcome');
-                  navigate(`/registrar-panel?${params.toString()}`, { replace: true });
+                  navigate(`${registrarHomeRoute}?${params.toString()}`, { replace: true });
                 }} />
               
                   <div style={{ position: 'relative' }}>
@@ -468,7 +474,7 @@ export default function Header() {
                       const val = e.currentTarget.value.trim();
                       if (val) params.set('q', val);else params.delete('q');
                       params.set('view', 'welcome');
-                      navigate(`/registrar-panel?${params.toString()}`, { replace: true });
+                      navigate(`${registrarHomeRoute}?${params.toString()}`, { replace: true });
                     }
                   }} />
                 
@@ -537,7 +543,7 @@ export default function Header() {
           {user ?
           <>
               <button
-              onClick={() => navigate('/registrar-panel')}
+              onClick={() => navigate(registrarHomeRoute)}
               className="interactive-element hover-lift ripple-effect focus-ring user-profile-button"
               style={{
                 height: '40px',

--- a/frontend/src/components/layout/HeaderNew.jsx
+++ b/frontend/src/components/layout/HeaderNew.jsx
@@ -9,9 +9,14 @@ import { Button, Icon } from '../ui/macos';
 import GlobalSearchBar from '../search/GlobalSearchBar';
 import ChatButton from '../chat/ChatButton';
 import { COLOR_SCHEMES } from '../../theme/colorScheme.js';
-import { getEffectiveRouteByPath, getRoleHomeRoute } from '../../routing/routeSelectors.js';
+import { getCanonicalRouteById, getEffectiveRouteByPath, getRoleHomeRoute } from '../../routing/routeSelectors.js';
 
 import logger from '../../utils/logger';
+
+const landingRoute = getCanonicalRouteById('landing')?.path || '/';
+const loginRoute = getCanonicalRouteById('login')?.path || '/login';
+const profileRoute = getCanonicalRouteById('clinical-profile')?.path || '/clinical/profile';
+const registrarHomeRoute = getRoleHomeRoute('registrar');
 
 export function isThemeMenuInteraction(event, themeMenuRoot) {
   const path = event.composedPath ? event.composedPath() : [];
@@ -162,7 +167,7 @@ export default function HeaderNew() {
   <Button
     variant="ghost"
     size="sm"
-    onClick={() => navigate('/')}
+    onClick={() => navigate(landingRoute)}
     title="На главную"
     style={{
       color: 'var(--mac-text-primary)',
@@ -213,7 +218,7 @@ export default function HeaderNew() {
         variant="outline"
         size="small"
         title="Главная"
-        onClick={() => navigate('/registrar?tab=welcome')}
+        onClick={() => navigate(`${registrarHomeRoute}?tab=welcome`)}
         className="hdr-hide-md"
         style={{ display: 'flex', alignItems: 'center', gap: '6px', flexShrink: 0, color: theme === 'dark' ? 'rgba(255,255,255,0.9)' : undefined }}>
 
@@ -224,7 +229,7 @@ export default function HeaderNew() {
         variant="outline"
         size="small"
         title="Онлайн‑записи"
-        onClick={() => navigate('/registrar?tab=queue')}
+        onClick={() => navigate(`${registrarHomeRoute}?tab=queue`)}
         className="hdr-hide-xs"
         style={{ display: 'flex', alignItems: 'center', gap: '6px', flexShrink: 0, color: theme === 'dark' ? 'rgba(255,255,255,0.9)' : undefined }}>
 
@@ -407,7 +412,7 @@ export default function HeaderNew() {
           <Button
         variant="outline"
         size="small"
-        onClick={() => navigate('/clinical/profile')}
+        onClick={() => navigate(profileRoute)}
         title="Профиль пользователя"
         className="hdr-hide-sm"
         style={{
@@ -428,7 +433,7 @@ export default function HeaderNew() {
         id="logout-header-btn"
         variant="danger"
         size="small"
-        onClick={() => {auth.clearToken();setProfile(null);navigate('/login');}}
+        onClick={() => {auth.clearToken();setProfile(null);navigate(loginRoute);}}
         title="Выйти"
         className="hdr-hide-sm"
         style={{
@@ -446,7 +451,7 @@ export default function HeaderNew() {
     <Button
       variant="primary"
       size="small"
-      onClick={() => navigate('/login')}
+      onClick={() => navigate(loginRoute)}
       className="hdr-hide-sm"
       style={{
         display: 'flex',

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,6 +1,14 @@
 import { NavLink, useLocation } from 'react-router-dom';
 import auth from '../../stores/auth.js';
 import { useTheme } from '../../contexts/ThemeContext.jsx';
+import { getCanonicalRouteById, getRoleHomeRoute } from '../../routing/routeSelectors.js';
+
+const cashierHomeRoute = getRoleHomeRoute('cashier');
+const cardiologyHomeRoute = getCanonicalRouteById('doctor-cardiology')?.path || getRoleHomeRoute('cardio');
+const dermatologyHomeRoute = getCanonicalRouteById('doctor-dermatology')?.path || getRoleHomeRoute('derma');
+const dentistryHomeRoute = getCanonicalRouteById('doctor-dentistry')?.path || getRoleHomeRoute('dentist');
+const labHomeRoute = getRoleHomeRoute('lab');
+const registrarHomeRoute = getRoleHomeRoute('registrar');
 
 export default function Sidebar() {
   const { getColor, getSpacing } = useTheme();
@@ -8,10 +16,10 @@ export default function Sidebar() {
   const profile = st.profile || st.user || {};
   const role = String(profile?.role || profile?.role_name || '').toLowerCase();
   const location = useLocation();
-  const isCardioRoute = location.pathname.startsWith('/cardiologist');
-  const isDermaRoute = location.pathname.startsWith('/dermatologist');
-  const isDentistRoute = location.pathname.startsWith('/dentist');
-  const isLabRoute = location.pathname.startsWith('/lab-panel');
+  const isCardioRoute = location.pathname.startsWith(cardiologyHomeRoute);
+  const isDermaRoute = location.pathname.startsWith(dermatologyHomeRoute);
+  const isDentistRoute = location.pathname.startsWith(dentistryHomeRoute);
+  const isLabRoute = location.pathname.startsWith(labHomeRoute);
 
   const common = [];
 
@@ -20,52 +28,52 @@ export default function Sidebar() {
   // Если мы на специализированной странице, показываем ТОЛЬКО кнопки этой специальности
   if (isCardioRoute) {
     byRole.push(
-      { to: '/cardiologist?tab=queue', label: 'Очередь' },
-      { to: '/cardiologist?tab=appointments', label: 'Записи' },
-      { to: '/cardiologist?tab=visit', label: 'Прием' },
-      { to: '/cardiologist?tab=ecg', label: 'ЭКГ' },
-      { to: '/cardiologist?tab=blood', label: 'Анализы' },
-      { to: '/cardiologist?tab=ai', label: 'AI Помощник' },
-      { to: '/cardiologist?tab=services', label: 'Услуги' },
-      { to: '/cardiologist?tab=history', label: 'История' }
+      { to: `${cardiologyHomeRoute}?tab=queue`, label: 'Очередь' },
+      { to: `${cardiologyHomeRoute}?tab=appointments`, label: 'Записи' },
+      { to: `${cardiologyHomeRoute}?tab=visit`, label: 'Прием' },
+      { to: `${cardiologyHomeRoute}?tab=ecg`, label: 'ЭКГ' },
+      { to: `${cardiologyHomeRoute}?tab=blood`, label: 'Анализы' },
+      { to: `${cardiologyHomeRoute}?tab=ai`, label: 'AI Помощник' },
+      { to: `${cardiologyHomeRoute}?tab=services`, label: 'Услуги' },
+      { to: `${cardiologyHomeRoute}?tab=history`, label: 'История' }
     );
   } else if (isDermaRoute) {
     byRole.push(
-      { to: '/dermatologist?tab=queue', label: 'Очередь' },
-      { to: '/dermatologist?tab=appointments', label: 'Записи' },
-      { to: '/dermatologist?tab=visit', label: 'Прием' },
-      { to: '/dermatologist?tab=patients', label: 'Пациенты' },
-      { to: '/dermatologist?tab=photos', label: 'Фото' },
-      { to: '/dermatologist?tab=skin', label: 'Осмотр кожи' },
-      { to: '/dermatologist?tab=cosmetic', label: 'Косметология' },
-      { to: '/dermatologist?tab=ai', label: 'AI Помощник' },
-      { to: '/dermatologist?tab=services', label: 'Услуги' },
-      { to: '/dermatologist?tab=history', label: 'История' }
+      { to: `${dermatologyHomeRoute}?tab=queue`, label: 'Очередь' },
+      { to: `${dermatologyHomeRoute}?tab=appointments`, label: 'Записи' },
+      { to: `${dermatologyHomeRoute}?tab=visit`, label: 'Прием' },
+      { to: `${dermatologyHomeRoute}?tab=patients`, label: 'Пациенты' },
+      { to: `${dermatologyHomeRoute}?tab=photos`, label: 'Фото' },
+      { to: `${dermatologyHomeRoute}?tab=skin`, label: 'Осмотр кожи' },
+      { to: `${dermatologyHomeRoute}?tab=cosmetic`, label: 'Косметология' },
+      { to: `${dermatologyHomeRoute}?tab=ai`, label: 'AI Помощник' },
+      { to: `${dermatologyHomeRoute}?tab=services`, label: 'Услуги' },
+      { to: `${dermatologyHomeRoute}?tab=history`, label: 'История' }
     );
   } else if (isDentistRoute) {
     byRole.push(
-      { to: '/dentist?tab=dashboard', label: 'Дашборд' },
-      { to: '/dentist?tab=patients', label: 'Пациенты' },
-      { to: '/dentist?tab=appointments', label: 'Записи' },
-      { to: '/dentist?tab=examinations', label: 'Осмотры' },
-      { to: '/dentist?tab=diagnoses', label: 'Диагнозы' },
-      { to: '/dentist?tab=visits', label: 'Протоколы' },
-      { to: '/dentist?tab=photos', label: 'Архив' },
-      { to: '/dentist?tab=templates', label: 'Шаблоны' },
-      { to: '/dentist?tab=reports', label: 'Отчеты' },
-      { to: '/dentist?tab=dental-chart', label: 'Схемы зубов' },
-      { to: '/dentist?tab=treatment-plans', label: 'Планы лечения' },
-      { to: '/dentist?tab=prosthetics', label: 'Протезирование' },
-      { to: '/dentist?tab=ai-assistant', label: 'AI Помощник' }
+      { to: `${dentistryHomeRoute}?tab=dashboard`, label: 'Дашборд' },
+      { to: `${dentistryHomeRoute}?tab=patients`, label: 'Пациенты' },
+      { to: `${dentistryHomeRoute}?tab=appointments`, label: 'Записи' },
+      { to: `${dentistryHomeRoute}?tab=examinations`, label: 'Осмотры' },
+      { to: `${dentistryHomeRoute}?tab=diagnoses`, label: 'Диагнозы' },
+      { to: `${dentistryHomeRoute}?tab=visits`, label: 'Протоколы' },
+      { to: `${dentistryHomeRoute}?tab=photos`, label: 'Архив' },
+      { to: `${dentistryHomeRoute}?tab=templates`, label: 'Шаблоны' },
+      { to: `${dentistryHomeRoute}?tab=reports`, label: 'Отчеты' },
+      { to: `${dentistryHomeRoute}?tab=dental-chart`, label: 'Схемы зубов' },
+      { to: `${dentistryHomeRoute}?tab=treatment-plans`, label: 'Планы лечения' },
+      { to: `${dentistryHomeRoute}?tab=prosthetics`, label: 'Протезирование' },
+      { to: `${dentistryHomeRoute}?tab=ai-assistant`, label: 'AI Помощник' }
     );
   } else if (isLabRoute) {
     byRole.push(
-      { to: '/lab-panel?tab=tests', label: 'Анализы' },
-      { to: '/lab-panel?tab=appointments', label: 'Записи' },
-      { to: '/lab-panel?tab=results', label: 'Результаты' },
-      { to: '/lab-panel?tab=patients', label: 'Пациенты' },
-      { to: '/lab-panel?tab=reports', label: 'Отчеты' },
-      { to: '/lab-panel?tab=ai', label: 'AI Анализ' }
+      { to: `${labHomeRoute}?tab=tests`, label: 'Анализы' },
+      { to: `${labHomeRoute}?tab=appointments`, label: 'Записи' },
+      { to: `${labHomeRoute}?tab=results`, label: 'Результаты' },
+      { to: `${labHomeRoute}?tab=patients`, label: 'Пациенты' },
+      { to: `${labHomeRoute}?tab=reports`, label: 'Отчеты' },
+      { to: `${labHomeRoute}?tab=ai`, label: 'AI Анализ' }
     );
   } else {
     // Обычная логика для других страниц
@@ -80,8 +88,8 @@ export default function Sidebar() {
     }
     if (role === 'registrar') {
       byRole.push(
-        { to: '/registrar-panel', label: 'Панель регистратора' },
-        { to: '/cashier-panel', label: 'Касса' }
+        { to: registrarHomeRoute, label: 'Панель регистратора' },
+        { to: cashierHomeRoute, label: 'Касса' }
       );
     }
     if (role === 'doctor') {
@@ -89,12 +97,12 @@ export default function Sidebar() {
     }
     if (role === 'lab') {
       byRole.push(
-        { to: '/lab-panel', label: 'Лаборатория' }
+        { to: labHomeRoute, label: 'Лаборатория' }
       );
     }
     if (role === 'cashier') {
       byRole.push(
-        { to: '/cashier-panel', label: 'Касса' }
+        { to: cashierHomeRoute, label: 'Касса' }
       );
     }
     if (role === 'nurse') {

--- a/frontend/src/components/payment/PaymentWidget.jsx
+++ b/frontend/src/components/payment/PaymentWidget.jsx
@@ -217,9 +217,10 @@ const PaymentWidget = ({
             };
 
             setPaymentData(confirmedPaymentData);
-            setPaymentStatus('completed');
+            const confirmedStatus = String(confirmResponse.data?.status || '');
+            setPaymentStatus(confirmedStatus || 'initialized');
 
-            if (onSuccess) {
+            if (confirmedStatus === 'paid' && onSuccess) {
               onSuccess(confirmedPaymentData);
             }
 
@@ -259,10 +260,11 @@ const PaymentWidget = ({
       const response = await apiClient.get(`/payments/${paymentData.payment_id}`);
 
       if (response.data?.status) {
-        const nextStatus = normalizePaymentStatus(response.data.status);
+        // Keep exact backend payment status; frontend must not collapse provider/status aliases.
+        const nextStatus = String(response.data.status);
         setPaymentStatus(nextStatus);
 
-        if (nextStatus === 'completed' && onSuccess) {
+        if (nextStatus === 'paid' && onSuccess) {
           onSuccess({
             ...paymentData,
             ...response.data,
@@ -300,28 +302,6 @@ const PaymentWidget = ({
     }).format(amountValue);
   };
 
-  const normalizePaymentStatus = (status) => {
-    const normalized = String(status || '').toLowerCase();
-
-    if (normalized === 'paid' || normalized === 'completed' || normalized === 'success') {
-      return 'completed';
-    }
-
-    if (normalized === 'processing') {
-      return 'redirected';
-    }
-
-    if (normalized === 'cancelled' || normalized === 'canceled' || normalized === 'failed') {
-      return 'failed';
-    }
-
-    if (normalized === 'initialized' || normalized === 'redirected' || normalized === 'pending') {
-      return normalized;
-    }
-
-    return normalized || 'pending';
-  };
-
   // Рендер статуса платежа
   const renderPaymentStatus = () => {
     switch (paymentStatus) {
@@ -338,6 +318,7 @@ const PaymentWidget = ({
           </Alert>);
 
       case 'redirected':
+      case 'processing':
         return (
           <Alert severity="info" icon={<InfoIcon />}>
             Перенаправление на страницу оплаты...
@@ -350,20 +331,32 @@ const PaymentWidget = ({
             </Button>
           </Alert>);
 
-      case 'completed':
+      case 'paid':
         return (
           <Alert severity="success" icon={<CheckIcon />}>
             Платеж успешно завершен!
           </Alert>);
 
       case 'failed':
+      case 'cancelled':
+      case 'canceled':
         return (
           <Alert severity="error" icon={<ErrorIcon />}>
             Платеж не удался. Попробуйте еще раз.
           </Alert>);
 
+      case 'refunded':
+      case 'void':
+        return (
+          <Alert severity="warning" icon={<ErrorIcon />}>
+            Status: {paymentStatus}
+          </Alert>);
+
       default:
-        return null;
+        return paymentStatus ? (
+          <Alert severity="info" icon={<InfoIcon />}>
+            Status: {paymentStatus}
+          </Alert>) : null;
     }
   };
 
@@ -479,7 +472,7 @@ const PaymentWidget = ({
             size="large"
             fullWidth
             onClick={confirmPayment}
-            disabled={loading || !selectedProvider || paymentStatus === 'completed'}>
+            disabled={loading || !selectedProvider || paymentStatus === 'paid'}>
             
             {loading ?
             <>

--- a/frontend/src/components/search/GlobalSearchBar.jsx
+++ b/frontend/src/components/search/GlobalSearchBar.jsx
@@ -4,11 +4,34 @@
  */
 import { useState, useEffect, useRef, useCallback } from 'react';
 import ReactDOM from 'react-dom';
-import { useNavigate } from 'react-router-dom';
+import { generatePath, useNavigate } from 'react-router-dom';
 import { api } from '../../api';
 import auth from '../../stores/auth';
 import logger from '../../utils/logger';
 import PropTypes from 'prop-types';
+import { getCanonicalRouteById, getRoleHomeRoute } from '../../routing/routeSelectors.js';
+
+const patientSearchRouteByRole = {
+  registrar: getRoleHomeRoute('registrar'),
+  receptionist: getRoleHomeRoute('registrar'),
+  cardio: getRoleHomeRoute('cardio'),
+  derma: getRoleHomeRoute('derma'),
+  dentist: getRoleHomeRoute('dentist'),
+  doctor: getRoleHomeRoute('doctor'),
+  lab: getRoleHomeRoute('lab'),
+  cashier: getRoleHomeRoute('cashier'),
+  admin: getRoleHomeRoute('admin'),
+};
+const clinicalPickupPath = getCanonicalRouteById('clinical-pickup')?.path || '/clinical/pickup/:patientId';
+
+function routeWithQuery(path, params) {
+  const searchParams = new URLSearchParams(params);
+  return `${path}?${searchParams.toString()}`;
+}
+
+function patientPickupRoute(patientId) {
+  return generatePath(clinicalPickupPath, { patientId });
+}
 
 // Debounce hook
 function useDebounce(value, delay) {
@@ -178,44 +201,22 @@ export default function GlobalSearchBar({ className = '' }) {
       case 'patient':
         // Role-based navigation for patients
         // All panels now support ?patientId parameter
-        if (role === 'registrar' || role === 'receptionist') {
-          // Registrar, Receptionist -> Registrar panel with patient search
-          navigate(`/registrar?patientId=${item.id}`);
-        } else if (role === 'cardio') {
-          // Cardiologist -> Cardiology panel with patient context
-          navigate(`/doctor/cardiology?patientId=${item.id}`);
-        } else if (role === 'derma') {
-          // Dermatologist -> Dermatology panel with patient context
-          navigate(`/doctor/dermatology?patientId=${item.id}`);
-        } else if (role === 'dentist') {
-          // Dentist -> Dentist panel with patient context
-          navigate(`/doctor/dentistry?patientId=${item.id}`);
-        } else if (role === 'doctor') {
-          // General doctor -> Doctor panel with patient context
-          navigate(`/doctor?patientId=${item.id}`);
-        } else if (role === 'lab') {
-          // Lab -> Lab panel with patient context
-          navigate(`/lab?patientId=${item.id}`);
-        } else if (role === 'cashier') {
-          // Cashier -> Cashier panel with patient context
-          navigate(`/cashier?patientId=${item.id}`);
-        } else if (role === 'admin') {
-          // Admin -> Admin panel with patient search
-          navigate(`/admin?patientId=${item.id}`);
+        if (patientSearchRouteByRole[role]) {
+          navigate(routeWithQuery(patientSearchRouteByRole[role], { patientId: item.id }));
         } else {
           // Fallback for any other role
-          navigate(`/clinical/pickup/${item.id}`);
+          navigate(patientPickupRoute(item.id));
         }
         break;
       case 'visit':
         if (role === 'doctor') {
-          navigate(`/doctor?visitId=${item.id}`);
+          navigate(routeWithQuery(patientSearchRouteByRole.doctor, { visitId: item.id }));
         } else {
-          navigate(`/registrar?visitId=${item.id}&patientId=${item.patient_id}`);
+          navigate(routeWithQuery(patientSearchRouteByRole.registrar, { visitId: item.id, patientId: item.patient_id }));
         }
         break;
       case 'lab':
-        navigate(`/clinical/pickup/${item.patient_id}?tab=lab&orderId=${item.id}`);
+        navigate(routeWithQuery(patientPickupRoute(item.patient_id), { tab: 'lab', orderId: item.id }));
         break;
     }
   };

--- a/frontend/src/pages/PaymentSuccess.jsx
+++ b/frontend/src/pages/PaymentSuccess.jsx
@@ -138,7 +138,7 @@ const PaymentSuccess = () => {
         setPaymentData(response.data);
 
         // Если платеж успешен, генерируем квитанцию
-        if (response.data.status === 'completed') {
+        if (response.data.status === 'paid') {
           generateReceipt();
         }
       } else {
@@ -261,40 +261,30 @@ const PaymentSuccess = () => {
     return names[provider] || provider;
   };
 
-  const normalizePaymentStatus = (status) => {
-    const normalized = String(status || '').toLowerCase();
-
-    if (normalized === 'paid' || normalized === 'completed' || normalized === 'success') {
-      return 'completed';
-    }
-
-    return normalized;
-  };
-
   const getStatusText = (status) => {
     const texts = {
       pending: 'Ожидает',
       processing: 'Обработка',
-      completed: 'Завершен',
       paid: 'Оплачен',
       failed: 'Неудачно',
-      cancelled: 'Отменен'
+      cancelled: 'Отменен',
+      refunded: 'Возвращен',
+      void: 'Аннулирован'
     };
-    const normalized = String(status || '').toLowerCase();
-    return texts[normalized] || status;
+    return texts[status] || status;
   };
 
   const getStatusColor = (status) => {
     const colors = {
       pending: 'warning',
       processing: 'info',
-      completed: 'success',
       paid: 'success',
       failed: 'danger',
-      cancelled: 'default'
+      cancelled: 'default',
+      refunded: 'warning',
+      void: 'default'
     };
-    const normalized = String(status || '').toLowerCase();
-    return colors[normalized] || 'default';
+    return colors[status] || 'default';
   };
 
   if (loading) {
@@ -350,7 +340,7 @@ const PaymentSuccess = () => {
     );
   }
 
-  const isSuccess = normalizePaymentStatus(paymentData?.status) === 'completed';
+  const isSuccess = paymentData?.status === 'paid';
 
   return (
     <main style={pageStyle}>

--- a/frontend/src/pages/Search.jsx
+++ b/frontend/src/pages/Search.jsx
@@ -3,6 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import { api } from '../api';
 import { getVisit } from '../api/visits';
 import { AppEmpty, AppError, Button } from '../components/ui/macos';
+import { getRoleHomeRoute } from '../routing/routeSelectors.js';
+
+const registrarHomeRoute = getRoleHomeRoute('registrar');
 
 // Modern Search Page with Full Functionality
 export default function Search() {
@@ -106,12 +109,12 @@ export default function Search() {
   const goToPatient = (patient) => {
     // Open registrar panel with the patient pre-selected for new appointment
     const patientName = `${patient.last_name || ''} ${patient.first_name || ''} ${patient.middle_name || ''}`.trim();
-    navigate(`/registrar?action=new&patientId=${patient.id}&patientName=${encodeURIComponent(patientName)}`);
+    navigate(`${registrarHomeRoute}?action=new&patientId=${patient.id}&patientName=${encodeURIComponent(patientName)}`);
   };
 
   // Navigate to visit details in registrar panel
   const goToVisit = (visit) => {
-    navigate(`/registrar?visitId=${visit.id}&patientId=${visit.patient_id}`);
+    navigate(`${registrarHomeRoute}?visitId=${visit.id}&patientId=${visit.patient_id}`);
   };
   const handleActivationKeyDown = (event, onActivate) => {
     if (event.key === 'Enter' || event.key === ' ') {

--- a/frontend/src/pages/VisitDetails.jsx
+++ b/frontend/src/pages/VisitDetails.jsx
@@ -6,6 +6,9 @@ import RescheduleDialog from '../components/RescheduleDialog';
 
 import { getErrorMessage } from '../utils/errorHandler';
 import logger from '../utils/logger';
+import { getCanonicalRouteById } from '../routing/routeSelectors.js';
+
+const clinicalAppointmentsPath = getCanonicalRouteById('clinical-appointments')?.path || '/clinical/appointments';
 
 function normalizeVisitDetailPayload(data) {
   if (!data) return null;
@@ -42,7 +45,7 @@ function resolveVisitSchedule(visit) {
  * - Allows opening RescheduleDialog
  * - Quick actions: reschedule to tomorrow (one-click)
  *
- * Route: /visits/:id
+ * Route: clinical-visit-details in routeRegistry
  */
 function VisitDetails() {
   const { id } = useParams();
@@ -172,7 +175,7 @@ function VisitDetails() {
           
           Назад
         </button>
-        <Link to="/visits" className="px-3 py-2 border rounded bg-white hover:bg-gray-50">Список приёмов</Link>
+        <Link to={clinicalAppointmentsPath} className="px-3 py-2 border rounded bg-white hover:bg-gray-50">Список приёмов</Link>
       </div>
 
       <RescheduleDialog

--- a/frontend/src/pages/__tests__/Login.accessibility.test.jsx
+++ b/frontend/src/pages/__tests__/Login.accessibility.test.jsx
@@ -15,6 +15,14 @@ vi.mock('../../api/client', () => ({
   setToken: vi.fn(),
 }));
 
+vi.mock('../../hooks/useSetupStatus.js', () => ({
+  useSetupStatus: () => ({
+    initialized: true,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
 function renderLogin() {
   return render(
     <MemoryRouter>

--- a/frontend/src/routing/routeRegistry.js
+++ b/frontend/src/routing/routeRegistry.js
@@ -385,7 +385,7 @@ export const ROUTE_REGISTRY = [
     title: 'Clinic Setup',
     owner: 'platform.setup',
     component: 'Setup',
-    legacyRedirectFrom: [],
+    legacyRedirectFrom: ['/register'],
     layout: layout({ hideHeader: true, hideSidebar: true, pageTitle: 'Clinic Setup' }),
   },
   {


### PR DESCRIPTION
## Summary

- Keep `/setup` as the canonical clinic setup route and `/register` as a legacy redirect only.
- Show the login setup CTA only when backend-owned setup status reports the system is uninitialized.
- Route shared frontend navigation through route registry selectors and preserve backend-owned payment status values.

## Cyclic Execution Evidence

- Fresh main sync: branch created from local `main` matching `origin/main` at `b61c87c1`.
- Clean workspace: workspace inspected before staging; unrelated dirty files were present and left unstaged.
- Branch: `fix/setup-login-entrypoint`.
- Scope gate: allowed route registry, login setup CTA, shared navigation/payment consumers, and targeted tests; denied unrelated admin/UI/theme/files changes, backend, migrations, and generated output.
- Red-check handling: PR Review Quality Gate failed on missing template sections; this PR body update fixes that red check in the same PR before merge.

## Contract Impact

- Canonical surface: frontend route registry canonical `/setup`; `/register` is compatibility-only `legacyRedirectFrom`.
- Request shape: existing setup status request `GET /api/v1/setup/status`; no new request body.
- Response shape: setup CTA reads backend-owned `initialized`; payment consumers keep backend `status` values exact.
- Status codes: unchanged; no backend endpoint or status-code behavior changed.
- Frontend consumer: `LoginFormStyled`, shared route selectors/navigation, payment widget/success surfaces.
- Compatibility path or alias: `/register` remains legacy redirect to `/setup`, not a canonical public registration route.
- Contract proof: route contract tests, setup routing tests, login CTA Vitest, and Playwright setup login smoke.

## RBAC / Permissions

not applicable - no backend RBAC, permission policy, role helper, token handling, or protected-route authorization behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, queue realtime, or subscription behavior changed.

## Frontend Resilience

- Empty data proof: setup status hook keeps setup CTA hidden on missing/failed setup status by defaulting to initialized.
- Partial data proof: setup CTA depends only on backend `initialized`; tests cover true/false branches.
- Forbidden secondary path behavior: `/register` is legacy-only and `/setup` remains guarded after initialization.
- Missing draft/resource behavior: not applicable, no draft or resource lifecycle is created or reopened.
- Stale route/deep-link behavior: setup routing and route contract tests cover `/setup` and legacy route behavior.

## Scope Gate

- Allowed paths: `frontend/src/routing/routeRegistry.js`, login/auth setup CTA, shared frontend navigation consumers, payment display consumers, and targeted Vitest/Playwright tests.
- Denied paths: unrelated admin panels, macOS UI library/theme changes, backend runtime, migrations, generated output, secrets, and production deploy settings.
- Migration/docs/test impact: no migration or docs change; targeted unit/contract/browser tests added or run.
- Rollback note: revert commit `f2bcf1a2` or PR #1609 to restore the prior frontend behavior.

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/components/auth/__tests__/LoginFormStyled.setupCta.test.jsx src/routing/__tests__/routeContract.test.js src/routing/__tests__/routeOwnershipEnforcement.test.js src/utils/__tests__/setupRouting.test.js`; `npx.cmd playwright test e2e/setup-login.spec.js --project=chromium --reporter=list`; `npm.cmd run build`; `git diff --cached --check`.
- Result: passed locally; Playwright browser smoke also confirmed `initialized=false` navigates to `/setup` and `initialized=true` hides setup CTA.
- Not checked: full all-browser Playwright matrix and live backend clinic initialization mutation flow.