### PR TITLE
fix(frontend): anchor admin route switcher in registry

### DIFF
--- a/frontend/src/components/admin/AdminRouteSwitcher.jsx
+++ b/frontend/src/components/admin/AdminRouteSwitcher.jsx
@@ -1,22 +1,38 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ArrowLeftRight, LayoutDashboard, LineChart } from 'lucide-react';
+import { getCanonicalRouteById, getEffectiveRouteByPath } from '../../routing/routeSelectors.js';
 
-const ROUTES = [
-  {
-    id: 'dashboard',
-    path: '/admin',
-    label: 'Обзор',
+const SWITCHER_ROUTE_IDS = ['admin-dashboard', 'admin-analytics'];
+
+const ROUTE_PRESENTATION_BY_ID = {
+  'admin-dashboard': {
     description: 'Сводка по клинике и операционные карточки',
     icon: LayoutDashboard,
   },
-  {
-    id: 'analytics',
-    path: '/admin/analytics',
-    label: 'Аналитика',
+  'admin-analytics': {
     description: 'Подробные разрезы, KPI и прогнозы',
     icon: LineChart,
   },
-];
+};
+
+const switcherRoutes = SWITCHER_ROUTE_IDS
+  .map((routeId) => {
+    const route = getCanonicalRouteById(routeId);
+    const presentation = ROUTE_PRESENTATION_BY_ID[routeId];
+
+    if (!route || !presentation) {
+      return null;
+    }
+
+    return {
+      id: route.id,
+      path: route.path,
+      label: route.nav?.label || route.title,
+      description: presentation.description,
+      icon: presentation.icon,
+    };
+  })
+  .filter(Boolean);
 
 const switcherStyle = {
   display: 'grid',
@@ -87,11 +103,12 @@ const getRouteIconStyle = (isActive) => ({
   flex: '0 0 auto',
 });
 
-export default function AdminRouteSwitcher({ current }) {
+export default function AdminRouteSwitcher() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const activeId = current || (location.pathname.startsWith('/admin/analytics') ? 'analytics' : 'dashboard');
+  const currentRoute = getEffectiveRouteByPath(location.pathname);
+  const activeId = SWITCHER_ROUTE_IDS.includes(currentRoute?.id) ? currentRoute.id : 'admin-dashboard';
 
   return (
     <section
@@ -103,7 +120,7 @@ export default function AdminRouteSwitcher({ current }) {
         Быстрый переход между экранами
       </div>
       <div style={routeGridStyle}>
-        {ROUTES.map((route) => {
+        {switcherRoutes.map((route) => {
           const Icon = route.icon;
           const isActive = activeId === route.id;
 


### PR DESCRIPTION
## Summary

- Anchor `AdminRouteSwitcher` route facts to `routeSelectors` / `routeRegistry`.
- Keep only presentation descriptions and icons local to the component.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` after PR #1609 merge.
- Clean workspace: inspected before edits; worktree had unrelated pre-existing dirty files, and only `frontend/src/components/admin/AdminRouteSwitcher.jsx` was staged/committed.
- Branch: `fix/admin-route-switcher-registry`.
- Scope gate: allowed `AdminRouteSwitcher` and existing routing selectors/registry; denied unrelated admin panels, backend, migrations, generated output, RBAC, and redirect changes.
- Red-check handling: failed PR Review Quality Gate is being fixed in this same PR by updating PR metadata.

## Contract Impact

- Canonical surface: frontend route registry entries `admin-dashboard` and `admin-analytics`.
- Request shape: not applicable - no API request or backend endpoint changed.
- Response shape: not applicable - no backend response or DTO changed.
- Status codes: not applicable - no HTTP behavior changed.
- Frontend consumer: `AdminRouteSwitcher` now reads canonical path/label from route selectors instead of local route literals.
- Compatibility path or alias: not applicable - no route alias, redirect, or legacy compatibility path changed.
- Contract proof: route contract test and production build passed.

## RBAC / Permissions

not applicable - no route access policy, role helper, guard, permission check, or authenticated endpoint changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, queue realtime, or event delivery behavior changed.

## Frontend Resilience

- Empty data proof: missing registry route is filtered out instead of creating an invalid button.
- Partial data proof: route label falls back from `route.nav.label` to `route.title`.
- Forbidden secondary path behavior: not applicable - the switcher does not call a secondary API path.
- Missing draft/resource behavior: not applicable - the switcher does not create or reopen drafts/resources.
- Stale route/deep-link behavior: active state resolves through `getEffectiveRouteByPath`; non-switcher admin paths fall back to dashboard highlight.

## Scope Gate

- Allowed paths: `frontend/src/components/admin/AdminRouteSwitcher.jsx`; routing selectors/registry were reference/allowed anchors but not changed.
- Denied paths: unrelated admin panels, backend runtime, migrations, generated output, RBAC guards, and route redirect contracts.
- Migration/docs/test impact: no migration; no docs update; no test file change because existing route contract covers canonical registry entries.
- Rollback note: revert commit `c7c8f360` to restore the prior local switcher route literals.

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js`; `npm.cmd run build`; `git diff --check`.
- Result: passed locally; `git diff --check` exited 0 with existing CRLF warnings only.
- Not checked: browser visual smoke, because this patch changes navigation source-of-truth only and preserves the rendered labels/descriptions/icons.