### PR TITLE
fix(frontend): anchor layout sidebar admin links

### DIFF
--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -10,6 +10,26 @@ const dentistryHomeRoute = getCanonicalRouteById('doctor-dentistry')?.path || ge
 const labHomeRoute = getRoleHomeRoute('lab');
 const registrarHomeRoute = getRoleHomeRoute('registrar');
 
+const ADMIN_NAV_ITEM_SOURCES = [
+  { routeId: 'admin-dashboard', label: 'Админ: Дашборд' },
+  { routeId: 'admin-users', label: 'Админ: Пользователи' },
+  { routeId: 'admin-analytics', label: 'Админ: Аналитика' },
+  { routeId: 'admin-settings', label: 'Админ: Настройки' },
+  { routeId: 'admin-security', label: 'Админ: Безопасность' },
+];
+
+const adminNavItems = ADMIN_NAV_ITEM_SOURCES
+  .map(({ routeId, label }) => {
+    const route = getCanonicalRouteById(routeId);
+
+    if (!route) {
+      return null;
+    }
+
+    return { to: route.path, label };
+  })
+  .filter(Boolean);
+
 export default function Sidebar() {
   const { getColor, getSpacing } = useTheme();
   const st = auth.getState();
@@ -78,13 +98,7 @@ export default function Sidebar() {
   } else {
     // Обычная логика для других страниц
     if (role === 'admin') {
-      byRole.push(
-        { to: '/admin', label: 'Админ: Дашборд' },
-        { to: '/admin/users', label: 'Админ: Пользователи' },
-        { to: '/admin/analytics', label: 'Админ: Аналитика' },
-        { to: '/admin/settings', label: 'Админ: Настройки' },
-        { to: '/admin/security', label: 'Админ: Безопасность' }
-      );
+      byRole.push(...adminNavItems);
     }
     if (role === 'registrar') {
       byRole.push(


### PR DESCRIPTION
## Summary

- Anchor legacy layout sidebar admin link targets to canonical route ids.
- Preserve the existing five admin sidebar labels and ordering.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` after PR #1610 merge.
- Clean workspace: inspected before edits; worktree had unrelated pre-existing dirty files, and only `frontend/src/components/layout/Sidebar.jsx` was staged/committed.
- Branch: `fix/layout-sidebar-route-registry`.
- Scope gate: allowed `frontend/src/components/layout/Sidebar.jsx` and existing routing selectors/registry; denied unrelated admin panels, backend, migrations, generated output, RBAC, and redirect changes.
- Red-check handling: fix failed targeted tests or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: frontend route registry entries `admin-dashboard`, `admin-users`, `admin-analytics`, `admin-settings`, and `admin-security`.
- Request shape: not applicable - no API request or backend endpoint changed.
- Response shape: not applicable - no backend response or DTO changed.
- Status codes: not applicable - no HTTP behavior changed.
- Frontend consumer: legacy `components/layout/Sidebar.jsx` admin menu now resolves `to` from `getCanonicalRouteById`.
- Compatibility path or alias: not applicable - no route alias, redirect, or legacy compatibility path changed.
- Contract proof: route contract test and production build passed.

## RBAC / Permissions

not applicable - no route access policy, role helper, guard, permission check, or authenticated endpoint changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, queue realtime, or event delivery behavior changed.

## Frontend Resilience

- Empty data proof: missing registry route is filtered out instead of creating an invalid NavLink.
- Partial data proof: labels stay local presentation strings, so registry label drift does not break this legacy menu rendering.
- Forbidden secondary path behavior: not applicable - the sidebar does not call a secondary API path.
- Missing draft/resource behavior: not applicable - the sidebar does not create or reopen drafts/resources.
- Stale route/deep-link behavior: not applicable - this patch changes only link targets, not route matching or deep-link parsing.

## Scope Gate

- Allowed paths: `frontend/src/components/layout/Sidebar.jsx`; routing selectors/registry were reference/allowed anchors but not changed.
- Denied paths: unrelated admin panels, backend runtime, migrations, generated output, RBAC guards, and route redirect contracts.
- Migration/docs/test impact: no migration; no docs update; no test file change because existing route contract covers canonical registry entries.
- Rollback note: revert commit `2b7d172d` to restore the prior hardcoded admin sidebar paths.

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js`; `npm.cmd run build`; `git diff --check`.
- Result: passed locally; `git diff --check` exited 0 with existing CRLF warnings only.
- Not checked: browser visual smoke, because this patch preserves labels/order and changes only route target source-of-truth.