### PR TITLE
fix(frontend): anchor chat public route guard

### DIFF
--- a/frontend/src/contexts/ChatContext.jsx
+++ b/frontend/src/contexts/ChatContext.jsx
@@ -12,14 +12,9 @@ import {
   MESSAGING_CONTRACT_VERSION,
   isSupportedMessagingContractVersion,
 } from '../constants/messagingContract';
+import { isPublicRoutePath } from '../routing/routeSelectors';
 
 const ChatContext = createContext(null);
-const PUBLIC_PATH_PREFIXES = ['/login', '/health', '/setup', '/forbidden', '/unauthorized', '/not-found'];
-
-function isPublicPath(pathname) {
-  const normalizedPath = String(pathname || '/').toLowerCase();
-  return normalizedPath === '/' || PUBLIC_PATH_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix));
-}
 
 export const ChatProvider = ({ children }) => {
   const location = useLocation();
@@ -27,7 +22,7 @@ export const ChatProvider = ({ children }) => {
   const user = authState.profile;
   const token = authState.token;
   const isBoardRoute = location.pathname.startsWith('/queue-board') || location.pathname.startsWith('/display-board');
-  const isPublicRoute = isPublicPath(location.pathname);
+  const isPublicRoute = isPublicRoutePath(location.pathname);
 
   const [conversations, setConversations] = useState([]);
   const [messages, setMessages] = useState([]);

--- a/frontend/src/routing/routeSelectors.js
+++ b/frontend/src/routing/routeSelectors.js
@@ -98,6 +98,11 @@ export function getEffectiveRouteByPath(pathname) {
   return legacyRedirect?.route || null;
 }
 
+export function isPublicRoutePath(pathname) {
+  const route = getEffectiveRouteByPath(pathname);
+  return !route || route.auth === 'public';
+}
+
 export function isRouteAccessibleToProfile(route, profile, options = {}) {
   if (!route) return false;
   if (route.group === 'internal-demo' && !options.internalDemoEnabled) {


### PR DESCRIPTION
## Summary

- Add `isPublicRoutePath` in route selectors as the canonical public-route side-effect guard.
- Replace `ChatContext` hardcoded public path prefixes with the route-registry-backed selector.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` after PR #1611 merge.
- Clean workspace: inspected before edits; worktree had unrelated pre-existing dirty files, and only `frontend/src/contexts/ChatContext.jsx` plus `frontend/src/routing/routeSelectors.js` were staged/committed.
- Branch: `fix/chat-public-route-registry`.
- Scope gate: allowed `ChatContext` and route selectors; denied `ThemeContext`, Notification UI, backend, migrations, generated output, RBAC, and redirect changes.
- Red-check handling: fix failed targeted tests or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: `ROUTE_REGISTRY` route `auth` metadata consumed through `isPublicRoutePath`.
- Request shape: not applicable - no API request or backend endpoint changed.
- Response shape: not applicable - no backend response or DTO changed.
- Status codes: not applicable - no HTTP behavior changed.
- Frontend consumer: `ChatContext` now decides whether to suppress chat loading/WS side effects from route registry auth metadata.
- Compatibility path or alias: legacy aliases still resolve through `getEffectiveRouteByPath`; no redirect behavior changed.
- Contract proof: route contract test, ChatContext test, and production build passed.

## RBAC / Permissions

not applicable - no route access policy, role helper, guard, permission check, or authenticated endpoint changed.

## Notification / Realtime

- Event type or websocket channel: chat websocket `/ws/chat` side-effect guard only; no payload event types changed.
- Payload version / ack behavior: no `MESSAGING_CONTRACT_VERSION`, ack, read receipt, or payload parsing behavior changed.
- Read/unread or delivery semantics: existing read/unread handling is preserved; public-route suppression now follows route registry auth metadata.
- Reconnect/resync proof: ChatContext targeted test still passes for protected `/admin` hydration and public `/` suppression.

## Frontend Resilience

- Empty data proof: unknown paths are treated as public by `isPublicRoutePath`, matching the existing NotificationWebSocket fail-closed shape.
- Partial data proof: legacy aliases resolve through `getEffectiveRouteByPath` before auth metadata is read.
- Forbidden secondary path behavior: not applicable - no secondary API path is called by this selector.
- Missing draft/resource behavior: not applicable - chat does not create or reopen drafts/resources.
- Stale route/deep-link behavior: stale or unknown paths suppress chat side effects instead of opening chat requests from non-canonical paths.

## Scope Gate

- Allowed paths: `frontend/src/contexts/ChatContext.jsx`, `frontend/src/routing/routeSelectors.js`.
- Denied paths: `ThemeContext`, Notification UI, unrelated admin panels, backend runtime, migrations, generated output, RBAC guards, and route redirect contracts.
- Migration/docs/test impact: no migration; no docs update; no test file change because existing route and ChatContext tests cover the behavior.
- Rollback note: revert commit `ed7d059b` to restore the prior ChatContext-local public path list.

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js src/contexts/__tests__/ChatContext.test.jsx`; `npm.cmd run build`; `git diff --check`.
- Result: passed locally; targeted tests 45/45; `git diff --check` exited 0 with existing CRLF warnings only.
- Not checked: browser chat smoke, because this patch changes route guard source-of-truth and not chat UI rendering.