### PR TITLE
fix(frontend): anchor theme public route guard

### DIFF
--- a/frontend/src/contexts/ThemeContext.jsx
+++ b/frontend/src/contexts/ThemeContext.jsx
@@ -13,12 +13,12 @@ import {
 import apiClient from '../api/client.js';
 import { mixColors, toRgbaString } from '../theme/colorUtils.js';
 import logger from '../utils/logger';
+import { isPublicRoutePath } from '../routing/routeSelectors.js';
 
 const ThemeContext = createContext();
 const THEME_PREFERENCE_SAVE_DEBOUNCE_MS = 400;
 const THEME_PREFERENCE_CACHE_MS = 30_000;
 const AUTH_TOKEN_STORAGE_KEY = 'auth_token';
-const PUBLIC_PATH_PREFIXES = ['/login', '/health', '/setup', '/forbidden', '/unauthorized', '/not-found'];
 const themePreferenceCache = new Map();
 const themePreferenceRequestPromiseByToken = new Map();
 
@@ -32,11 +32,6 @@ function getAuthTokenSnapshot() {
   } catch {
     return null;
   }
-}
-
-function isPublicPath(pathname) {
-  const normalizedPath = String(pathname || '/').toLowerCase();
-  return normalizedPath === '/' || PUBLIC_PATH_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix));
 }
 
 function ThemeRouteSync({ onPathnameChange }) {
@@ -319,7 +314,7 @@ export const ThemeProvider = ({ children }) => {
     let cancelled = false;
     const currentPath = pathname;
 
-    if (!authToken || isPublicPath(currentPath)) {
+    if (!authToken || isPublicRoutePath(currentPath)) {
       hydratedTokenRef.current = null;
       lastSavedPreferenceRef.current = null;
       setPreferencesReady(true);
@@ -461,7 +456,7 @@ export const ThemeProvider = ({ children }) => {
       saveTimeoutRef.current = null;
     }
 
-    if (!authToken || !preferencesReady || isPublicPath(pathname)) {
+    if (!authToken || !preferencesReady || isPublicRoutePath(pathname)) {
       return undefined;
     }
 


### PR DESCRIPTION
## Summary

- Replace `ThemeContext` hardcoded public path prefixes with the route-registry-backed `isPublicRoutePath` selector.
- Keep theme preference loading/saving behavior tied to canonical route `auth` metadata.

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` after PR #1612 merge.
- Clean workspace: inspected before edits; worktree had unrelated pre-existing dirty files, and only `frontend/src/contexts/ThemeContext.jsx` was staged/committed.
- Branch: `fix/theme-public-route-registry`.
- Scope gate: allowed `ThemeContext` and existing route selectors; denied unrelated contexts, admin panels, backend, migrations, generated output, RBAC, and redirect changes.
- Red-check handling: fix failed targeted tests or CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: `ROUTE_REGISTRY` route `auth` metadata consumed through `isPublicRoutePath`.
- Request shape: not applicable - no API request or backend endpoint changed.
- Response shape: not applicable - no backend response or DTO changed.
- Status codes: not applicable - no HTTP behavior changed.
- Frontend consumer: `ThemeContext` now suppresses remote theme preference load/save on registry-public routes.
- Compatibility path or alias: legacy aliases still resolve through `getEffectiveRouteByPath`; no redirect behavior changed.
- Contract proof: route contract test, ThemeContext test, and production build passed.

## RBAC / Permissions

not applicable - no route access policy, role helper, guard, permission check, or authenticated endpoint changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, queue realtime, event delivery, unread, ack, reconnect, or resync behavior changed.

## Frontend Resilience

- Empty data proof: `isPublicRoutePath` treats unknown paths as public, avoiding preference calls from non-canonical paths.
- Partial data proof: legacy aliases resolve through `getEffectiveRouteByPath` before auth metadata is read.
- Forbidden secondary path behavior: not applicable - no secondary API path is called by this change.
- Missing draft/resource behavior: not applicable - theme preferences do not create or reopen drafts/resources.
- Stale route/deep-link behavior: stale or unknown paths suppress remote preference side effects instead of saving from non-canonical paths.

## Scope Gate

- Allowed paths: `frontend/src/contexts/ThemeContext.jsx`; existing route selector was reference/allowed anchor but not changed in this PR.
- Denied paths: unrelated contexts, Notification UI, admin panels, backend runtime, migrations, generated output, RBAC guards, and route redirect contracts.
- Migration/docs/test impact: no migration; no docs update; no test file change because existing route and ThemeContext tests cover the behavior.
- Rollback note: revert commit `384f3ee0` to restore the prior ThemeContext-local public path list.

## Validation

- Targeted tests or smoke run: `npm.cmd run test:run -- src/routing/__tests__/routeContract.test.js src/contexts/__tests__/ThemeContext.test.jsx`; `npm.cmd run build`; `git diff --check`.
- Result: passed locally; targeted tests 44/44; `git diff --check` exited 0 with existing CRLF warnings only.
- Not checked: browser theme preference smoke, because this patch changes route guard source-of-truth and not theme UI rendering.