### PR TITLE
test(frontend): align finance modal status select assertion

### DIFF
--- a/frontend/src/components/admin/__tests__/FinanceModal.test.jsx
+++ b/frontend/src/components/admin/__tests__/FinanceModal.test.jsx
@@ -60,9 +60,9 @@ describe('FinanceModal', () => {
       },
     });
 
-    const statusSelect = screen.getByDisplayValue('Статус не передан');
+    const statusSelect = screen.getByRole('button', { name: 'Статус не передан' });
 
-    expect(statusSelect).toHaveValue('');
-    expect(statusSelect).not.toHaveValue('completed');
+    expect(statusSelect).toHaveTextContent('Статус не передан');
+    expect(statusSelect).not.toHaveTextContent('Завершена');
   });
 });


### PR DESCRIPTION
## Summary
- Update `FinanceModal.test.jsx` to assert the current macOS `Select` trigger instead of a removed native select display value.
- Preserve the regression check that a transaction with missing status does not appear as completed.

## Cyclic Execution Evidence
- Fresh main sync: branch created from `origin/main` at merge commit `8e6ffbc5` in a clean secondary worktree.
- Clean workspace: clean worktree used at `C:\final-worktrees\finance-modal-ci-fix`; only `frontend/src/components/admin/__tests__/FinanceModal.test.jsx` changed.
- Branch: `fix/finance-modal-macselect-test`.
- Scope gate: allowed the failing FinanceModal unit test only; denied component behavior, admin UI refactors, routing, backend, and tmp artifacts.
- Red-check handling: this PR exists to fix the red `Frontend unit tests` check caused by `FinanceModal.test.jsx`; any new red check will be fixed in this same PR.

## Contract Impact
- Canonical surface: not applicable because this is a frontend test assertion update only.
- Request shape: not applicable because no API request changed.
- Response shape: not applicable because no API response changed.
- Status codes: not applicable because no backend status behavior changed.
- Frontend consumer: `FinanceModal` test now targets the rendered `MacSelect` button consumer surface.
- Compatibility path or alias: not applicable because no route, alias, or compatibility path changed.
- Contract proof: full frontend Vitest run passed locally after the assertion update.

## RBAC / Permissions
- Roles allowed: unchanged because no authorization or route policy changed.
- Roles denied: unchanged because no denied-role behavior changed.
- Positive auth proof: not applicable because the test does not exercise auth.
- Negative auth proof: not applicable because the test does not exercise denied auth.

## Notification / Realtime
- Event type or websocket channel: not applicable because no notification or websocket channel changed.
- Payload version / ack behavior: not applicable because no realtime payload behavior changed.
- Read/unread or delivery semantics: not applicable because no notification delivery behavior changed.
- Reconnect/resync proof: not applicable because no reconnect or resync behavior changed.

## Frontend Resilience
- Empty data proof: not applicable because this test renders a modal with explicit transaction data.
- Partial data proof: missing `transaction.status` is covered by the updated assertion showing `Статус не передан`.
- Forbidden secondary path behavior: not applicable because this modal test does not navigate secondary paths.
- Missing draft/resource behavior: not applicable because this modal does not create or reopen drafts/resources in this test.
- Stale route/deep-link behavior: not applicable because this modal test does not use routes or deep links.

## Scope Gate
- Allowed paths: `frontend/src/components/admin/__tests__/FinanceModal.test.jsx`.
- Denied paths: `FinanceModal.jsx`, shared `Select`, routing, backend, CI config, generated output, and tmp screenshots.
- Migration/docs/test impact: no migration or docs; one existing unit test updated to match the current component shape.
- Rollback note: revert commit `4de5ed58` to restore the previous native-select assertion.

## Validation
- Targeted tests or smoke run: `npm.cmd run test:run -- src/components/admin/__tests__/FinanceModal.test.jsx`; `npm.cmd run test:run`; `git diff --check`.
- Result: targeted test passed 2/2; full frontend Vitest passed 108 files and 504 tests; diff check exited 0 with a CRLF warning on the edited test file.
- Not checked: frontend build and browser smoke were not rerun because this PR changes only a test assertion and the previous build check was already green.