### PR TITLE
🎨 Palette: Add tooltips to icon-only close buttons

### DIFF
--- a/frontend/src/__tests__/telegramManagerOnboardingRequests.test.js
+++ b/frontend/src/__tests__/telegramManagerOnboardingRequests.test.js
@@ -27,7 +27,7 @@ describe('Telegram manager onboarding request review', () => {
 
     expect(loader).toContain('/telegram/onboarding/requests');
     expect(loader).toContain('/telegram/onboarding/analytics/summary');
-    expect(loader).toContain("onboardingStatusFilter === 'all' ? '' : onboardingStatusFilter");
+    expect(loader).toContain('onboardingStatusFilter === \'all\' ? \'\' : onboardingStatusFilter');
     expect(loader).toContain('/search-patients');
     expect(loader).not.toContain('/telegram/mini-app/onboarding');
     expect(loader).not.toContain('/telegram/mini-app/appointments');
@@ -42,15 +42,15 @@ describe('Telegram manager onboarding request review', () => {
     );
 
     expect(actionHandler).toContain('/telegram/onboarding/requests/');
-    expect(actionHandler).toContain("action === 'link-existing'");
-    expect(actionHandler).toContain("action === 'create-patient'");
+    expect(actionHandler).toContain('action === \'link-existing\'');
+    expect(actionHandler).toContain('action === \'create-patient\'');
     expect(actionHandler).toContain('candidateId');
     expect(actionHandler).toContain('/create-patient');
     expect(actionHandler).toContain('confirmCreateDespiteDuplicates');
     expect(actionHandler).toContain('reviewCandidateId');
     expect(actionHandler).toContain('patient: {');
-    expect(managerSource).toContain("'request-more-info'");
-    expect(managerSource).toContain("'reject'");
+    expect(managerSource).toContain('\'request-more-info\'');
+    expect(managerSource).toContain('\'reject\'');
     expect(actionHandler).not.toContain('/telegram/mini-app/appointments');
     expect(actionHandler).not.toContain('patientId');
     expect(actionHandler).not.toMatch(/entryToken|payment|invoice|diagnosis|lab|emr/i);

--- a/frontend/src/__tests__/telegramMiniAppAppointmentCreateGuardrails.test.js
+++ b/frontend/src/__tests__/telegramMiniAppAppointmentCreateGuardrails.test.js
@@ -18,14 +18,14 @@ describe('Telegram Mini App appointment create guardrails', () => {
   it('keeps the create action behind a successful preview and create capability gate', () => {
     const createActionMarkup = sourceBetween(
       appSource,
-      "{appointmentPreview.status === 'ready' && previewAppointment && (",
-      "{selectedSection === 'forms' && formsPreview.status === 'loading' && ("
+      '{appointmentPreview.status === \'ready\' && previewAppointment && (',
+      '{selectedSection === \'forms\' && formsPreview.status === \'loading\' && ('
     );
 
     expect(createActionMarkup).toContain('{canCreateAppointments && (');
     expect(createActionMarkup).toContain('onClick={handleAppointmentCreateSubmit}');
     expect(createActionMarkup).toContain(
-      "disabled={appointmentCreate.status === 'loading' || appointmentCreate.status === 'ready'}"
+      'disabled={appointmentCreate.status === \'loading\' || appointmentCreate.status === \'ready\'}'
     );
     expect(createActionMarkup).not.toContain('payment provider');
     expect(createActionMarkup).not.toContain('provider payload');
@@ -38,12 +38,12 @@ describe('Telegram Mini App appointment create guardrails', () => {
       'const handlePatientFormFieldChange = (formId, field) => (event) => {'
     );
 
-    expect(createHandler).toContain("getTelegramMiniAppAuthPayload(location.search, 'appointments')");
+    expect(createHandler).toContain('getTelegramMiniAppAuthPayload(location.search, \'appointments\')');
     expect(createHandler).toContain(
       'const requestBody = buildMiniAppAppointmentRequestBody(authPayload, appointmentPreviewForm);'
     );
     expect(createHandler).toContain(
-      "api.post('/telegram/mini-app/appointments', requestBody, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)"
+      'api.post(\'/telegram/mini-app/appointments\', requestBody, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)'
     );
     expect(createHandler).not.toContain('/telegram/mini-app/appointments/preview');
     expect(createHandler).not.toMatch(/payment_provider|provider_payload|providerPayload|transaction|webhook|invoice|amount/i);
@@ -62,8 +62,8 @@ describe('Telegram Mini App appointment create guardrails', () => {
     );
 
     expect(fieldChangeHandler).toContain('setAppointmentCreate({');
-    expect(fieldChangeHandler).toContain("status: 'idle'");
+    expect(fieldChangeHandler).toContain('status: \'idle\'');
     expect(previewSubmitHandler).toContain('setAppointmentCreate({');
-    expect(previewSubmitHandler).toContain("status: 'idle'");
+    expect(previewSubmitHandler).toContain('status: \'idle\'');
   });
 });

--- a/frontend/src/__tests__/telegramMiniAppDeepLinkGuardrails.test.js
+++ b/frontend/src/__tests__/telegramMiniAppDeepLinkGuardrails.test.js
@@ -45,9 +45,9 @@ describe('Telegram Mini App deep-link guardrails', () => {
     expect(aliases).not.toContain('admin:');
     expect(aliases).not.toContain('record:');
     expect(aliases).not.toContain('billing:');
-    expect(selectedSectionParser).toContain("new URLSearchParams(search || '').get('section') || ''");
+    expect(selectedSectionParser).toContain('new URLSearchParams(search || \'\').get(\'section\') || \'\'');
     expect(selectedSectionParser).toContain('section.trim().toLowerCase()');
-    expect(selectedSectionParser).toContain("MINI_APP_SECTION_ALIASES[section.trim().toLowerCase()] || ''");
+    expect(selectedSectionParser).toContain('MINI_APP_SECTION_ALIASES[section.trim().toLowerCase()] || \'\'');
   });
 
   it('keeps unknown sections from opening a selected-section panel', () => {
@@ -59,7 +59,7 @@ describe('Telegram Mini App deep-link guardrails', () => {
     const selectedSectionPanel = sourceBetween(
       appSource,
       '{selectedSection && (',
-      "{selectedSection === 'cabinet' && cabinetSummary.status === 'loading' && ("
+      '{selectedSection === \'cabinet\' && cabinetSummary.status === \'loading\' && ('
     );
 
     expect(shellSetup).toContain('const selectedSection = getTelegramMiniAppSelectedSection(location.search);');
@@ -110,8 +110,8 @@ describe('Telegram Mini App deep-link guardrails', () => {
       '</section>'
     );
 
-    expect(capabilitySelectHandler).toContain("new URLSearchParams(location.search || '')");
-    expect(capabilitySelectHandler).toContain("params.set('section', section)");
+    expect(capabilitySelectHandler).toContain('new URLSearchParams(location.search || \'\')');
+    expect(capabilitySelectHandler).toContain('params.set(\'section\', section)');
     expect(capabilitySelectHandler).toContain('navigate({');
     expect(capabilitySelectHandler).toContain('pathname: location.pathname');
     expect(capabilitySelectHandler).toContain('search: `?${params.toString()}`');

--- a/frontend/src/__tests__/telegramMiniAppExpiredLinkGuardrails.test.js
+++ b/frontend/src/__tests__/telegramMiniAppExpiredLinkGuardrails.test.js
@@ -22,12 +22,12 @@ describe('Telegram Mini App expired link guardrails', () => {
       'function isMiniAppCapabilityEnabled(capability)'
     );
 
-    expect(sessionMapping).toContain("'entry_token_invalid'");
-    expect(sessionMapping).toContain("'entry_token_expired'");
+    expect(sessionMapping).toContain('\'entry_token_invalid\'');
+    expect(sessionMapping).toContain('\'entry_token_expired\'');
     expect(appSource).toContain('Ссылка устарела. Откройте Mini App заново из Telegram');
     expect(sessionMapping).toContain('MINI_APP_EXPIRED_ENTRY_TOKEN_REASONS.has(reason)');
-    expect(sessionMapping).toContain("return translateMiniAppText(languageCode, 'sessionExpired');");
-    expect(sessionMapping).toContain("return translateMiniAppText(languageCode, 'sessionNotConfirmed');");
+    expect(sessionMapping).toContain('return translateMiniAppText(languageCode, \'sessionExpired\');');
+    expect(sessionMapping).toContain('return translateMiniAppText(languageCode, \'sessionNotConfirmed\');');
     expect(sessionMapping).not.toContain('Request failed with status code');
   });
 
@@ -47,12 +47,12 @@ describe('Telegram Mini App expired link guardrails', () => {
     expect(handledConfig).toContain('expectedErrorStatuses: [400, 403, 503]');
 
     [
-      "api.post('/telegram/mini-app/patient/manifest', authPayload, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)",
-      "api.post('/telegram/mini-app/cabinet/summary', authPayload, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)",
-      "api.post('/telegram/mini-app/forms/preview', authPayload, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)",
-      "api.post('/telegram/mini-app/appointments/preview', requestBody, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)",
-      "api.post('/telegram/mini-app/appointments', requestBody, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)",
-      "MINI_APP_HANDLED_ERROR_REQUEST_CONFIG",
+      'api.post(\'/telegram/mini-app/patient/manifest\', authPayload, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)',
+      'api.post(\'/telegram/mini-app/cabinet/summary\', authPayload, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)',
+      'api.post(\'/telegram/mini-app/forms/preview\', authPayload, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)',
+      'api.post(\'/telegram/mini-app/appointments/preview\', requestBody, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)',
+      'api.post(\'/telegram/mini-app/appointments\', requestBody, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)',
+      'MINI_APP_HANDLED_ERROR_REQUEST_CONFIG',
     ].forEach((expectedSnippet) => {
       expect(miniAppShell).toContain(expectedSnippet);
     });
@@ -70,13 +70,13 @@ describe('Telegram Mini App expired link guardrails', () => {
       '{state.status === \'ready\' && ('
     );
 
-    expect(statusBadge).toContain("case 'error':");
-    expect(statusBadge).toContain("variant: 'danger'");
-    expect(statusBadge).toContain("'sessionUnavailableBadge'");
-    expect(heroMarkup).toContain("aria-live={state.status === 'error' ? 'assertive' : 'polite'}");
+    expect(statusBadge).toContain('case \'error\':');
+    expect(statusBadge).toContain('variant: \'danger\'');
+    expect(statusBadge).toContain('\'sessionUnavailableBadge\'');
+    expect(heroMarkup).toContain('aria-live={state.status === \'error\' ? \'assertive\' : \'polite\'}');
     expect(heroMarkup).toContain('<Alert severity="error" style={miniAppNoticeStyle} {...MINI_APP_ERROR_ALERT_PROPS}>');
-    expect(appSource).toContain("role: 'alert'");
-    expect(appSource).toContain("'aria-live': 'assertive'");
+    expect(appSource).toContain('role: \'alert\'');
+    expect(appSource).toContain('\'aria-live\': \'assertive\'');
   });
 
   it('allows the status badge to wrap instead of crowding the mobile title', () => {
@@ -101,13 +101,13 @@ describe('Telegram Mini App expired link guardrails', () => {
       '</section>'
     );
 
-    expect(heroStyle).toContain("flexWrap: 'wrap'");
-    expect(heroStyle).toContain("rowGap: '10px'");
-    expect(heroTitleGroupStyle).toContain("flex: '1 1 220px'");
+    expect(heroStyle).toContain('flexWrap: \'wrap\'');
+    expect(heroStyle).toContain('rowGap: \'10px\'');
+    expect(heroTitleGroupStyle).toContain('flex: \'1 1 220px\'');
     expect(heroTitleGroupStyle).toContain('minWidth: 0');
     expect(heroMarkup).toContain('<div style={miniAppHeroTitleGroupStyle}>');
-    expect(badgeStyle).toContain("maxWidth: 'min(100%, 220px)'");
-    expect(badgeStyle).toContain("whiteSpace: 'normal'");
-    expect(badgeStyle).toContain("textAlign: 'center'");
+    expect(badgeStyle).toContain('maxWidth: \'min(100%, 220px)\'');
+    expect(badgeStyle).toContain('whiteSpace: \'normal\'');
+    expect(badgeStyle).toContain('textAlign: \'center\'');
   });
 });

--- a/frontend/src/__tests__/telegramMiniAppOnboardingGuardrails.test.js
+++ b/frontend/src/__tests__/telegramMiniAppOnboardingGuardrails.test.js
@@ -34,28 +34,28 @@ describe('Telegram Mini App onboarding guardrails', () => {
   it('does not fetch protected patient sections for onboarding scope manifests', () => {
     const manifestEffect = sourceBetween(
       appSource,
-      "api.post('/telegram/mini-app/patient/manifest', authPayload, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)",
+      'api.post(\'/telegram/mini-app/patient/manifest\', authPayload, MINI_APP_HANDLED_ERROR_REQUEST_CONFIG)',
       'const capabilities = state.manifest?.capabilities || {};'
     );
 
-    expect(manifestEffect).toContain("manifest?.scope?.type === 'onboarding'");
+    expect(manifestEffect).toContain('manifest?.scope?.type === \'onboarding\'');
     expect(manifestEffect).toContain('if (isOnboardingManifest) {');
-    expect(manifestEffect).toContain("status: 'idle'");
+    expect(manifestEffect).toContain('status: \'idle\'');
     expect(manifestEffect.indexOf('if (isOnboardingManifest) {')).toBeLessThan(
-      manifestEffect.indexOf("api.post('/telegram/mini-app/cabinet/summary'")
+      manifestEffect.indexOf('api.post(\'/telegram/mini-app/cabinet/summary\'')
     );
   });
 
   it('blocks protected onboarding sections with a safe CTA', () => {
     const onboardingBlockedPanel = sourceBetween(
       appSource,
-      "{isOnboardingScope && selectedSection && selectedSection !== 'appointments' && (",
-      "{isOnboardingScope && (selectedSection === 'appointments' || !selectedSection) && ("
+      '{isOnboardingScope && selectedSection && selectedSection !== \'appointments\' && (',
+      '{isOnboardingScope && (selectedSection === \'appointments\' || !selectedSection) && ('
     );
 
-    expect(onboardingBlockedPanel).toContain("t('onboardingBlockedText')");
-    expect(onboardingBlockedPanel).toContain("handleMiniAppCapabilitySelect('appointments')");
-    expect(onboardingBlockedPanel).toContain("handleMiniAppSupportClick");
+    expect(onboardingBlockedPanel).toContain('t(\'onboardingBlockedText\')');
+    expect(onboardingBlockedPanel).toContain('handleMiniAppCapabilitySelect(\'appointments\')');
+    expect(onboardingBlockedPanel).toContain('handleMiniAppSupportClick');
     expect(onboardingBlockedPanel).not.toContain('api.post(');
     expect(onboardingBlockedPanel).not.toMatch(/403|Request failed|entryToken|patientId/);
   });
@@ -63,13 +63,13 @@ describe('Telegram Mini App onboarding guardrails', () => {
   it('adds safe retry and support actions for unavailable and token-error states', () => {
     const statusAlerts = sourceBetween(
       appSource,
-      "{state.status === 'unavailable' && (",
-      "{state.status === 'ready' && ("
+      '{state.status === \'unavailable\' && (',
+      '{state.status === \'ready\' && ('
     );
 
-    expect(statusAlerts).toContain("handleMiniAppRetry");
-    expect(statusAlerts).toContain("handleMiniAppSupportClick");
-    expect(statusAlerts).toContain("t('onboardingRetry')");
+    expect(statusAlerts).toContain('handleMiniAppRetry');
+    expect(statusAlerts).toContain('handleMiniAppSupportClick');
+    expect(statusAlerts).toContain('t(\'onboardingRetry\')');
     expect(statusAlerts).not.toMatch(/AxiosError|Traceback|entryToken=pma_|entryToken=pmo_/);
   });
 
@@ -86,9 +86,9 @@ describe('Telegram Mini App onboarding guardrails', () => {
     );
 
     expect(onboardingGate).toContain('canEditOnboardingRequest');
-    expect(onboardingSummary).toContain("['linked_existing', 'created_patient'].includes(onboardingStatus)");
+    expect(onboardingSummary).toContain('[\'linked_existing\', \'created_patient\'].includes(onboardingStatus)');
     expect(onboardingSummary).toContain('handleMiniAppReturnToTelegram');
-    expect(onboardingSummary).toContain("t('onboardingSupport')");
+    expect(onboardingSummary).toContain('t(\'onboardingSupport\')');
   });
 
   it('emits onboarding telemetry with a safe minimal payload', () => {
@@ -98,9 +98,9 @@ describe('Telegram Mini App onboarding guardrails', () => {
       'function emitMiniAppOnboardingStatusTelemetry(status, meta = {}) {'
     );
 
-    expect(telemetryHelper).toContain("api.post('/telemetry'");
-    expect(telemetryHelper).toContain("role: 'patient'");
-    expect(telemetryHelper).toContain("scope: 'onboarding'");
+    expect(telemetryHelper).toContain('api.post(\'/telemetry\'');
+    expect(telemetryHelper).toContain('role: \'patient\'');
+    expect(telemetryHelper).toContain('scope: \'onboarding\'');
     expect(telemetryHelper).toContain('reason_code: getMiniAppTelemetryReasonCode');
     expect(telemetryHelper).not.toMatch(/entryToken|raw|phone|fullName|payment|invoice|diagnosis|lab|emr/i);
   });

--- a/frontend/src/__tests__/telegramMiniAppReadOnlyManifestGuardrails.test.js
+++ b/frontend/src/__tests__/telegramMiniAppReadOnlyManifestGuardrails.test.js
@@ -60,14 +60,14 @@ describe('Telegram Mini App protected runtime guardrails', () => {
   it('keeps queue summary read-only from the patient Mini App surface', () => {
     const queuePanel = sourceBetween(
       appSource,
-      "{selectedSection === 'queue' && cabinetSummary.status === 'loading' && (",
-      "{selectedSection === 'visits' && cabinetSummary.status === 'loading' && ("
+      '{selectedSection === \'queue\' && cabinetSummary.status === \'loading\' && (',
+      '{selectedSection === \'visits\' && cabinetSummary.status === \'loading\' && ('
     );
 
     expect(queuePanel).toContain('currentQueueEntry');
-    expect(queuePanel).toContain("t('queueInactive')");
-    expect(queuePanel).toContain("t('queueEmptyRecovery')");
-    expect(queuePanel).toContain("t('queuePrivacyNote')");
+    expect(queuePanel).toContain('t(\'queueInactive\')');
+    expect(queuePanel).toContain('t(\'queueEmptyRecovery\')');
+    expect(queuePanel).toContain('t(\'queuePrivacyNote\')');
     expect(queuePanel).not.toContain('api.post(');
     expect(queuePanel).not.toMatch(/queue_time|call_next|skip|cancel|move|mutat/i);
   });
@@ -79,7 +79,7 @@ describe('Telegram Mini App protected runtime guardrails', () => {
       'const previewAppointment = appointmentPreview.payload?.appointment || null;'
     );
 
-    expect(reportDownloadHandler).toContain("getTelegramMiniAppAuthPayload(location.search, 'results')");
+    expect(reportDownloadHandler).toContain('getTelegramMiniAppAuthPayload(location.search, \'results\')');
     expect(reportDownloadHandler).toContain('/telegram/mini-app/reports/download');
     expect(reportDownloadHandler).toContain('reportId: report.id');
     expect(reportDownloadHandler).toContain('responseType: \'blob\'');

--- a/frontend/src/api/__tests__/authLoginRoute.contract.test.js
+++ b/frontend/src/api/__tests__/authLoginRoute.contract.test.js
@@ -15,8 +15,8 @@ describe('auth login API contract', () => {
   it('uses the canonical authentication login route in the API helper', () => {
     const clientSource = readSource('client.js');
 
-    expect(clientSource).toContain("api.post('/authentication/login'");
-    expect(clientSource).not.toContain("api.post('/auth/login'");
+    expect(clientSource).toContain('api.post(\'/authentication/login\'');
+    expect(clientSource).not.toContain('api.post(\'/auth/login\'');
   });
 
   it('uses the canonical authentication login route in endpoint constants', () => {

--- a/frontend/src/api/__tests__/authRefreshRoute.contract.test.js
+++ b/frontend/src/api/__tests__/authRefreshRoute.contract.test.js
@@ -15,8 +15,8 @@ describe('auth refresh API contract', () => {
   it('uses the canonical authentication refresh route for proactive refresh', () => {
     const clientSource = readSource('client.js');
 
-    expect(clientSource).toContain("buildApiUrl('/authentication/refresh')");
-    expect(clientSource).not.toContain("buildApiUrl('/auth/refresh')");
+    expect(clientSource).toContain('buildApiUrl(\'/authentication/refresh\')');
+    expect(clientSource).not.toContain('buildApiUrl(\'/auth/refresh\')');
   });
 
   it('uses the canonical authentication refresh route in endpoint constants', () => {
@@ -26,7 +26,7 @@ describe('auth refresh API contract', () => {
   it('does not keep stale refresh route exceptions in interceptors', () => {
     const interceptorsSource = readSource('interceptors.js');
 
-    expect(interceptorsSource).toContain("requestUrl.includes('/authentication/refresh')");
-    expect(interceptorsSource).not.toContain("requestUrl.includes('/auth/refresh')");
+    expect(interceptorsSource).toContain('requestUrl.includes(\'/authentication/refresh\')');
+    expect(interceptorsSource).not.toContain('requestUrl.includes(\'/auth/refresh\')');
   });
 });

--- a/frontend/src/components/admin/__tests__/AllFreeApproval.contract.test.jsx
+++ b/frontend/src/components/admin/__tests__/AllFreeApproval.contract.test.jsx
@@ -32,12 +32,12 @@ describe('AllFreeApproval action contract', () => {
 
     const actionRendering = sourceSlice(
       source,
-      "{(hasBackendAllFreeAction(request, 'approve')",
+      '{(hasBackendAllFreeAction(request, \'approve\')',
       '{showApprovalModal && selectedRequest &&'
     );
 
-    expect(actionRendering).toContain("hasBackendAllFreeAction(request, 'approve')");
-    expect(actionRendering).toContain("hasBackendAllFreeAction(request, 'reject')");
-    expect(actionRendering).not.toContain("request.approval_status === 'pending'");
+    expect(actionRendering).toContain('hasBackendAllFreeAction(request, \'approve\')');
+    expect(actionRendering).toContain('hasBackendAllFreeAction(request, \'reject\')');
+    expect(actionRendering).not.toContain('request.approval_status === \'pending\'');
   });
 });

--- a/frontend/src/components/admin/__tests__/PasswordChangeRoute.contract.test.js
+++ b/frontend/src/components/admin/__tests__/PasswordChangeRoute.contract.test.js
@@ -18,8 +18,8 @@ describe('password change API contract', () => {
     const unifiedSettingsSource = readSource(unifiedSettingsPath);
     const changePasswordRequiredSource = readSource(changePasswordRequiredPath);
 
-    expect(unifiedSettingsSource).toContain("api.post('/authentication/password-change'");
-    expect(changePasswordRequiredSource).toContain("api.post('/authentication/password-change'");
+    expect(unifiedSettingsSource).toContain('api.post(\'/authentication/password-change\'');
+    expect(changePasswordRequiredSource).toContain('api.post(\'/authentication/password-change\'');
   });
 
   it('does not call the stale auth password-change route', () => {

--- a/frontend/src/components/admin/__tests__/QRTokenManager.contract.test.jsx
+++ b/frontend/src/components/admin/__tests__/QRTokenManager.contract.test.jsx
@@ -13,8 +13,8 @@ describe('QRTokenManager API contract', () => {
   it('uses the canonical QR queue admin paths mounted under /queue', () => {
     const source = readSource();
 
-    expect(source).toContain("fetch('/api/v1/queue/admin/qr-tokens/active'");
-    expect(source).toContain("fetch('/api/v1/queue/admin/qr-tokens/generate'");
+    expect(source).toContain('fetch(\'/api/v1/queue/admin/qr-tokens/active\'');
+    expect(source).toContain('fetch(\'/api/v1/queue/admin/qr-tokens/generate\'');
     expect(source).toContain('fetch(`/api/v1/queue/admin/qr-tokens/${token}`');
   });
 

--- a/frontend/src/components/admin/__tests__/UserExportManager.contract.test.jsx
+++ b/frontend/src/components/admin/__tests__/UserExportManager.contract.test.jsx
@@ -13,8 +13,8 @@ describe('UserExportManager API contract', () => {
   it('uses the canonical user-management router paths mounted under /users', () => {
     const source = readSource();
 
-    expect(source).toContain("api.get('/users/users/export/files')");
-    expect(source).toContain("api.post('/users/users/export', exportData)");
+    expect(source).toContain('api.get(\'/users/users/export/files\')');
+    expect(source).toContain('api.post(\'/users/users/export\', exportData)');
     expect(source).toContain('api.get(`/users/users/export/download/${filename}`,');
     expect(source).toContain('api.delete(`/users/users/export/files/${filename}`)');
   });

--- a/frontend/src/components/cashier/__tests__/RefundRequestsTable.contract.test.jsx
+++ b/frontend/src/components/cashier/__tests__/RefundRequestsTable.contract.test.jsx
@@ -8,8 +8,8 @@ const source = fs.readFileSync(path.join(ROOT, 'components/cashier/RefundRequest
 
 describe('RefundRequestsTable command contract', () => {
   it('uses the published refund request list filter query name', () => {
-    expect(source).toContain("params.append('status_filter', filter)");
-    expect(source).not.toContain("params.append('status', filter)");
+    expect(source).toContain('params.append(\'status_filter\', filter)');
+    expect(source).not.toContain('params.append(\'status\', filter)');
   });
 
   it('uses the existing backend process command instead of invented action URLs', () => {
@@ -23,16 +23,16 @@ describe('RefundRequestsTable command contract', () => {
 
   it('renders refund commands only from backend-provided availability', () => {
     expect(source).toContain('const hasBackendRefundAction =');
-    expect(source).toContain("hasBackendRefundAction(request, 'approve')");
-    expect(source).toContain("hasBackendRefundAction(request, 'reject')");
-    expect(source).toContain("hasBackendRefundAction(request, 'complete')");
+    expect(source).toContain('hasBackendRefundAction(request, \'approve\')');
+    expect(source).toContain('hasBackendRefundAction(request, \'reject\')');
+    expect(source).toContain('hasBackendRefundAction(request, \'complete\')');
 
     const renderActionsBlock = source.slice(
       source.indexOf('const renderActions = (request) => {'),
       source.indexOf('const columns = [')
     );
 
-    expect(renderActionsBlock).not.toContain("request.status === 'pending'");
-    expect(renderActionsBlock).not.toContain("request.status === 'approved'");
+    expect(renderActionsBlock).not.toContain('request.status === \'pending\'');
+    expect(renderActionsBlock).not.toContain('request.status === \'approved\'');
   });
 });

--- a/frontend/src/components/dermatology/__tests__/PriceOverrideManagers.contract.test.jsx
+++ b/frontend/src/components/dermatology/__tests__/PriceOverrideManagers.contract.test.jsx
@@ -11,9 +11,9 @@ describe('specialist price override API client contract', () => {
   it('uses the authenticated api client for dermatology price override endpoints', () => {
     const source = readComponent('dermatology/PriceOverrideManager.jsx');
 
-    expect(source).toContain("import { api } from '../../api/client'");
-    expect(source).toContain("api.get('/derma/price-overrides'");
-    expect(source).toContain("api.post('/derma/price-override'");
+    expect(source).toContain('import { api } from \'../../api/client\'');
+    expect(source).toContain('api.get(\'/derma/price-overrides\'');
+    expect(source).toContain('api.post(\'/derma/price-override\'');
     expect(source).not.toContain('fetch(`${API_BASE}/derma/price-overrides');
     expect(source).not.toContain('fetch(`${API_BASE}/derma/price-override');
     expect(source).not.toContain('response.json()');
@@ -22,9 +22,9 @@ describe('specialist price override API client contract', () => {
   it('uses the authenticated api client for dental price override endpoints', () => {
     const source = readComponent('dental/DentalPriceManager.jsx');
 
-    expect(source).toContain("import { api } from '../../api/client'");
-    expect(source).toContain("api.get('/dental/price-overrides'");
-    expect(source).toContain("api.post('/dental/price-override'");
+    expect(source).toContain('import { api } from \'../../api/client\'');
+    expect(source).toContain('api.get(\'/dental/price-overrides\'');
+    expect(source).toContain('api.post(\'/dental/price-override\'');
     expect(source).not.toContain('fetch(`${API_BASE}/dental/price-overrides');
     expect(source).not.toContain('fetch(`${API_BASE}/dental/price-override');
     expect(source).not.toContain('response.json()');

--- a/frontend/src/components/doctor/__tests__/DoctorQueuePanel.test.jsx
+++ b/frontend/src/components/doctor/__tests__/DoctorQueuePanel.test.jsx
@@ -270,11 +270,11 @@ describe('DoctorQueuePanel', () => {
       'utf8',
     );
 
-    expect(source).toContain("hasBackendQueueAction(entry, 'call', 'can_call')");
-    expect(source).toContain("hasBackendQueueAction(entry, 'start_visit', 'can_start_visit')");
-    expect(source).toContain("hasBackendQueueAction(entry, 'complete', 'can_complete')");
-    expect(source).not.toContain("entry.status === 'waiting' &&");
-    expect(source).not.toContain("entry.status === 'called' &&");
-    expect(source).not.toContain("entry.status === 'in_progress' &&");
+    expect(source).toContain('hasBackendQueueAction(entry, \'call\', \'can_call\')');
+    expect(source).toContain('hasBackendQueueAction(entry, \'start_visit\', \'can_start_visit\')');
+    expect(source).toContain('hasBackendQueueAction(entry, \'complete\', \'can_complete\')');
+    expect(source).not.toContain('entry.status === \'waiting\' &&');
+    expect(source).not.toContain('entry.status === \'called\' &&');
+    expect(source).not.toContain('entry.status === \'in_progress\' &&');
   });
 });

--- a/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
@@ -98,18 +98,18 @@ describe('LabReportWorkbench', () => {
     const source = fs.readFileSync(workbenchPath, 'utf8');
 
     expect(source).toContain('function hasLabReportAction(instance, action)');
-    expect(source).toContain("const canEditActiveInstance = hasLabReportAction(activeInstance, 'edit')");
-    expect(source).toContain("const canFinalize = hasLabReportAction(activeInstance, 'finalize')");
-    expect(source).toContain("const canRevise = hasLabReportAction(activeInstance, 'revise')");
-    expect(source).not.toContain("activeInstance.status !== 'FINALIZED' && activeInstance.status !== 'PRINTED'");
-    expect(source).not.toContain("activeInstance.status === 'FINALIZED' || activeInstance.status === 'PRINTED'");
+    expect(source).toContain('const canEditActiveInstance = hasLabReportAction(activeInstance, \'edit\')');
+    expect(source).toContain('const canFinalize = hasLabReportAction(activeInstance, \'finalize\')');
+    expect(source).toContain('const canRevise = hasLabReportAction(activeInstance, \'revise\')');
+    expect(source).not.toContain('activeInstance.status !== \'FINALIZED\' && activeInstance.status !== \'PRINTED\'');
+    expect(source).not.toContain('activeInstance.status === \'FINALIZED\' || activeInstance.status === \'PRINTED\'');
   });
 
   it('does not invent draft status in the print payload when backend status is missing', () => {
     const source = fs.readFileSync(workbenchPath, 'utf8');
 
     expect(source).toContain('status: instance?.status || null');
-    expect(source).not.toContain("status: instance?.status || 'DRAFT'");
+    expect(source).not.toContain('status: instance?.status || \'DRAFT\'');
   });
 
   it('does not auto-create or auto-open a report when exactly one template is allowed', async () => {

--- a/frontend/src/components/laboratory/__tests__/LabTemplateWorkbench.contract.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabTemplateWorkbench.contract.test.jsx
@@ -31,9 +31,9 @@ describe('LabTemplateWorkbench template version command contract', () => {
     expect(helperBlock).toContain('version?.available_actions');
     expect(helperBlock).toContain('TEMPLATE_VERSION_ACTION_CAN_FIELD');
     expect(helperBlock).toContain('return false;');
-    expect(ensureDraftBlock).toContain("hasTemplateVersionAction(activeVersion, 'update')");
-    expect(ensureDraftBlock).toContain("hasTemplateVersionAction(activeVersion, 'create_draft')");
+    expect(ensureDraftBlock).toContain('hasTemplateVersionAction(activeVersion, \'update\')');
+    expect(ensureDraftBlock).toContain('hasTemplateVersionAction(activeVersion, \'create_draft\')');
     expect(ensureDraftBlock).toContain('labReportingApi.createTemplateVersion');
-    expect(ensureDraftBlock).not.toContain("activeVersion?.status === 'DRAFT'");
+    expect(ensureDraftBlock).not.toContain('activeVersion?.status === \'DRAFT\'');
   });
 });

--- a/frontend/src/components/payment/__tests__/HostedPaymentProviders.contract.test.jsx
+++ b/frontend/src/components/payment/__tests__/HostedPaymentProviders.contract.test.jsx
@@ -12,9 +12,9 @@ describe('hosted payment provider ticket contract', () => {
     it(`${fileName} uses the authenticated api client for protected registrar invoice endpoints`, () => {
       const source = readProvider(fileName);
 
-      expect(source).toContain("import { api } from '../../api/client'");
-      expect(source).toContain("api.post('/registrar/invoice/init-payment'");
-      expect(source).toContain("api.get(`/registrar/invoice/${invoiceId}/status`");
+      expect(source).toContain('import { api } from \'../../api/client\'');
+      expect(source).toContain('api.post(\'/registrar/invoice/init-payment\'');
+      expect(source).toContain('api.get(`/registrar/invoice/${invoiceId}/status`');
       expect(source).not.toContain('fetch(`${API_BASE}/registrar/invoice/init-payment');
       expect(source).not.toContain('fetch(`${API_BASE}/registrar/invoice/${invoiceId}/status');
       expect(source).not.toContain('response.json()');

--- a/frontend/src/components/queue/__tests__/QueueManager.contract.test.jsx
+++ b/frontend/src/components/queue/__tests__/QueueManager.contract.test.jsx
@@ -19,7 +19,7 @@ describe('Queue manager command contract', () => {
     expect(tableSource).not.toContain('Button');
     expect(tableSource).not.toContain('{false && (');
     expect(tableSource).not.toContain('onCallPatient(entry)');
-    expect(tableSource).not.toContain("entry.status === 'waiting' && (");
+    expect(tableSource).not.toContain('entry.status === \'waiting\' && (');
   });
 
   it('uses backend-provided available specialists for queue doctor options', () => {
@@ -28,7 +28,7 @@ describe('Queue manager command contract', () => {
     expect(managerSource).toContain('specialists,');
     expect(managerSource).toContain('if (!Array.isArray(specialists) || specialists.length === 0) return []');
     expect(managerSource).toContain('d.specialty_display || d.specialty');
-    expect(managerSource).not.toContain("fetch('/api/v1/queues/profiles/public')");
+    expect(managerSource).not.toContain('fetch(\'/api/v1/queues/profiles/public\')');
     expect(managerSource).not.toContain('allowedSpecialties');
     expect(managerSource).not.toContain('normalizeSpecialty');
   });
@@ -39,15 +39,15 @@ describe('Queue manager command contract', () => {
     const tableSource = read('components/queue/QueueTable.jsx');
 
     expect(registrarSource).toContain('Выбор врача остаётся явным: URL-параметр или ручной выбор в очереди');
-    expect(registrarSource).toContain("selectedDoctor={searchParams.get('doctor') || ''}");
+    expect(registrarSource).toContain('selectedDoctor={searchParams.get(\'doctor\') || \'\'}');
 
-    expect(managerSource).toContain("const [internalDoctor, setInternalDoctor] = useState('')");
-    expect(managerSource).toContain("const effectiveDoctor = selectedDoctor !== undefined && selectedDoctor !== '' ? selectedDoctor : internalDoctor");
+    expect(managerSource).toContain('const [internalDoctor, setInternalDoctor] = useState(\'\')');
+    expect(managerSource).toContain('const effectiveDoctor = selectedDoctor !== undefined && selectedDoctor !== \'\' ? selectedDoctor : internalDoctor');
     expect(managerSource).toContain('if (!effectiveDoctor) {');
     expect(managerSource).not.toContain('setInternalDoctor(doctorOptions[0]');
     expect(managerSource).not.toContain('setInternalDoctor(specialists[0]');
 
     expect(tableSource).toContain('if (!effectiveDoctor) {');
-    expect(tableSource).toContain("t?.selectDoctor || 'Выберите специалиста'");
+    expect(tableSource).toContain('t?.selectDoctor || \'Выберите специалиста\'');
   });
 });

--- a/frontend/src/components/ui/macos/MacOSAlert.jsx
+++ b/frontend/src/components/ui/macos/MacOSAlert.jsx
@@ -194,6 +194,7 @@ const MacOSAlert = ({
           onMouseEnter={handleDismissMouseEnter}
           onMouseLeave={handleDismissMouseLeave}
           aria-label="Закрыть уведомление"
+          title="Закрыть уведомление"
         >
           <X size={16} />
         </button>

--- a/frontend/src/components/ui/macos/MacOSModal.jsx
+++ b/frontend/src/components/ui/macos/MacOSModal.jsx
@@ -210,6 +210,7 @@ const MacOSModal = ({
                 onMouseEnter={handleCloseMouseEnter}
                 onMouseLeave={handleCloseMouseLeave}
                 aria-label="Закрыть модальное окно"
+                title="Закрыть модальное окно"
               >
                 <X size={20} />
               </button>

--- a/frontend/src/components/ui/macos/Toast.jsx
+++ b/frontend/src/components/ui/macos/Toast.jsx
@@ -121,7 +121,8 @@ const Toast = React.forwardRef(({
           opacity: 0.7,
           transition: 'opacity var(--mac-duration-fast) var(--mac-ease)'
         }}
-        aria-label="Close notification">
+        aria-label="Close notification"
+        title="Close notification">
         
         ✕
       </button>

--- a/frontend/src/components/ui/native/Modal.jsx
+++ b/frontend/src/components/ui/native/Modal.jsx
@@ -102,6 +102,7 @@ const Modal = React.forwardRef(({
                 onClick={onClose}
                 className="p-1 text-gray-400 hover:text-gray-600 transition-colors rounded-md hover:bg-gray-100"
                 aria-label="Close modal"
+                title="Close modal"
               >
                 <X className="w-5 h-5" />
               </button>

--- a/frontend/src/components/wizard/__tests__/AppointmentWizardV2.contract.test.jsx
+++ b/frontend/src/components/wizard/__tests__/AppointmentWizardV2.contract.test.jsx
@@ -33,12 +33,12 @@ describe('AppointmentWizardV2 registrar metadata contract', () => {
       'useEffect(() => {',
     );
 
-    expect(servicesLoadBlock).toContain("api.get('/registrar/services')");
-    expect(doctorsLoadBlock).toContain("api.get('/registrar/doctors')");
+    expect(servicesLoadBlock).toContain('api.get(\'/registrar/services\')');
+    expect(doctorsLoadBlock).toContain('api.get(\'/registrar/doctors\')');
     expect(servicesLoadBlock).not.toContain('fetch(`${API_BASE}/registrar/services`');
     expect(doctorsLoadBlock).not.toContain('fetch(`${API_BASE}/registrar/doctors`');
-    expect(servicesLoadBlock).not.toContain("'Authorization': `Bearer ${tokenManager.getAccessToken()}`");
-    expect(doctorsLoadBlock).not.toContain("'Authorization': `Bearer ${tokenManager.getAccessToken()}`");
+    expect(servicesLoadBlock).not.toContain('\'Authorization\': `Bearer ${tokenManager.getAccessToken()}`');
+    expect(doctorsLoadBlock).not.toContain('\'Authorization\': `Bearer ${tokenManager.getAccessToken()}`');
   });
 
   it('preserves existing queue identity when grouping edit-mode cart items', () => {
@@ -86,8 +86,8 @@ describe('AppointmentWizardV2 registrar metadata contract', () => {
     );
 
     expect(source).toContain('const normalizeGenderForForm = (value) => {');
-    expect(source).toContain("['m', 'male', 'man', 'men', '1',");
-    expect(source).toContain("['f', 'female', 'woman', 'women', '2',");
+    expect(source).toContain('[\'m\', \'male\', \'man\', \'men\', \'1\',');
+    expect(source).toContain('[\'f\', \'female\', \'woman\', \'women\', \'2\',');
     expect(source).toContain('const resolvePatientGenderValue = (record) => firstNonEmpty(');
     expect(source).toContain('record?.patient_sex');
     expect(source).toContain('const genderToPatientSexForApi = (value) => {');
@@ -118,10 +118,10 @@ describe('AppointmentWizardV2 registrar metadata contract', () => {
 
     expect(source).toContain('const WIZARD_DEPARTMENT_FILTER_KEYS = {');
     expect(source).toContain('const getWizardDepartmentFilterKeys = (value) => {');
-    expect(source).toContain("echokg: ['cardio', 'echokg', 'ecg']");
+    expect(source).toContain('echokg: [\'cardio\', \'echokg\', \'ecg\']');
     expect(servicesLoadBlock).toContain('const departmentFilterKeys = editMode ? [] : getWizardDepartmentFilterKeys(activeTab);');
     expect(servicesLoadBlock).toContain('if (departmentFilterKeys.length > 0)');
-    expect(servicesLoadBlock).not.toContain("if (activeTab && activeTab !== 'all')");
+    expect(servicesLoadBlock).not.toContain('if (activeTab && activeTab !== \'all\')');
   });
 
   it('loads all services in edit mode while keeping category tabs active', () => {
@@ -148,15 +148,15 @@ describe('AppointmentWizardV2 registrar metadata contract', () => {
     expect(initBlock).toContain('const initialCartItems = (() => {');
     expect(initBlock).toContain('setActiveServiceCategory(resolveInitialServiceCategory(initialCartItems, activeTab));');
     expect(initBlock).toContain('setActiveServiceCategory(activeTabToWizardCategory(activeTab));');
-    expect(initBlock).toContain("setServiceSearchQuery('');");
+    expect(initBlock).toContain('setServiceSearchQuery(\'\');');
     expect(source).toContain('editMode={editMode}');
     expect(servicesLoadBlock).toContain('const departmentFilterKeys = editMode ? [] : getWizardDepartmentFilterKeys(activeTab);');
     expect(displayedServicesBlock).not.toContain('if (editMode) {');
     expect(displayedServicesBlock).toContain('switch (activeCategory)');
-    expect(displayedServicesBlock).toContain("case 'specialists':");
-    expect(displayedServicesBlock).toContain("case 'laboratory':");
-    expect(displayedServicesBlock).toContain("case 'procedures':");
-    expect(displayedServicesBlock).toContain("case 'other':");
+    expect(displayedServicesBlock).toContain('case \'specialists\':');
+    expect(displayedServicesBlock).toContain('case \'laboratory\':');
+    expect(displayedServicesBlock).toContain('case \'procedures\':');
+    expect(displayedServicesBlock).toContain('case \'other\':');
   });
 
   it('treats service_details as existing services in edit mode to avoid duplicate queues', () => {
@@ -199,6 +199,6 @@ describe('AppointmentWizardV2 registrar metadata contract', () => {
     const source = readWizardSource();
 
     expect(source).toContain('doctorOptions.map((doctor, index)');
-    expect(source).toContain("key={`${doctor.id ?? 'doctor'}-${doctor.specialty ?? ''}-${index}`}");
+    expect(source).toContain('key={`${doctor.id ?? \'doctor\'}-${doctor.specialty ?? \'\'}-${index}`}');
   });
 });

--- a/frontend/src/hooks/__tests__/useUserPreferences.contract.test.js
+++ b/frontend/src/hooks/__tests__/useUserPreferences.contract.test.js
@@ -14,7 +14,7 @@ describe('useUserPreferences API contract', () => {
     const source = readSource();
 
     expect(source).toContain('`/users/users/${userId}/preferences`');
-    expect(source).toContain("'/users/me/preferences'");
+    expect(source).toContain('\'/users/me/preferences\'');
   });
 
   it('does not call the stale /user-management preferences path', () => {

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -547,7 +547,7 @@ const MacOSCardiologistPanelUnified = () => {
         const data = await response.json();
 
         // Собираем ВСЕ записи из всех очередей для получения полной картины услуг
-        let allAppointments = [];
+        const allAppointments = [];
         const seenIds = new Set(); // Для отслеживания уже добавленных записей
 
         if (data && data.queues && Array.isArray(data.queues)) {
@@ -611,7 +611,7 @@ const MacOSCardiologistPanelUnified = () => {
         }
 
         // ✅ Фильтруем только кардиологические записи, исключая ЭКГ
-        let appointmentsData = allAppointments.filter((apt) => {
+        const appointmentsData = allAppointments.filter((apt) => {
           // Исключаем записи из очереди ЭКГ
           if (apt.specialty === 'echokg' || apt.specialty === 'ecg') {
             return false;

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -558,7 +558,7 @@ const DentistPanelUnified = () => {
           const data = await response.json();
 
           // Собираем ВСЕ записи из всех очередей для получения полной картины услуг
-          let allAppointments = [];
+          const allAppointments = [];
           if (data && data.queues && Array.isArray(data.queues)) {
             data.queues.forEach((queue) => {
               if (queue.entries) {
@@ -611,7 +611,7 @@ const DentistPanelUnified = () => {
           }
 
           // Фильтруем только стоматологические записи для отображения
-          let appointmentsData = allAppointments.filter((apt) =>
+          const appointmentsData = allAppointments.filter((apt) =>
             isDentistrySpecialty(apt.specialty)
           );
 

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -409,7 +409,7 @@ const DermatologistPanelUnified = () => {
           }
         });
 
-        let allAppointments = [];
+        const allAppointments = [];
         if (queuesResponse.ok) {
           const queuesData = await queuesResponse.json();
 

--- a/frontend/src/pages/__tests__/CashierPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/CashierPanel.contract.test.jsx
@@ -36,15 +36,15 @@ describe('CashierPanel payment action contract', () => {
     const source = readCashierPanelSource();
     const actionCellBlock = extractSourceBlock(
       source,
-      "onClick={() => confirmPayment(row.id)}",
+      'onClick={() => confirmPayment(row.id)}',
       '<td colSpan="7"',
     );
 
-    expect(actionCellBlock).toContain("disabled={!hasBackendPaymentAction(row, 'confirm')}");
-    expect(actionCellBlock).toContain("disabled={!hasBackendPaymentAction(row, 'cancel')}");
-    expect(actionCellBlock).toContain("disabled={!hasBackendPaymentAction(row, 'refund')}");
-    expect(actionCellBlock).toContain("disabled={!hasBackendPaymentAction(row, 'print_receipt')}");
-    expect(actionCellBlock).not.toContain("row.status ===");
+    expect(actionCellBlock).toContain('disabled={!hasBackendPaymentAction(row, \'confirm\')}');
+    expect(actionCellBlock).toContain('disabled={!hasBackendPaymentAction(row, \'cancel\')}');
+    expect(actionCellBlock).toContain('disabled={!hasBackendPaymentAction(row, \'refund\')}');
+    expect(actionCellBlock).toContain('disabled={!hasBackendPaymentAction(row, \'print_receipt\')}');
+    expect(actionCellBlock).not.toContain('row.status ===');
     expect(actionCellBlock).not.toContain('payment_status');
   });
 
@@ -57,7 +57,7 @@ describe('CashierPanel payment action contract', () => {
     );
 
     expect(receiptBlock).toContain('status: paymentRow?.status ?? null');
-    expect(receiptBlock).not.toContain("status: paymentRow?.status || 'paid'");
+    expect(receiptBlock).not.toContain('status: paymentRow?.status || \'paid\'');
   });
 
   it('delegates grouped cashier payment allocation to the backend contract', () => {

--- a/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DoctorPanels.contract.test.jsx
@@ -44,10 +44,10 @@ describe('Doctor panels SSOT contract', () => {
       expect(source).toContain('can_cancel: Boolean(entry.can_cancel)');
       expect(source).toContain('doctor_queue_entry_id: doctorQueueEntryId');
 
-      expect(source).not.toContain("payment_status: entry.payment_status || 'pending'");
-      expect(source).not.toContain("status: entry.status || 'waiting'");
-      expect(source).not.toContain("payment_status: row.payment_status || 'pending'");
-      expect(source).not.toContain("status: row.status || 'waiting'");
+      expect(source).not.toContain('payment_status: entry.payment_status || \'pending\'');
+      expect(source).not.toContain('status: entry.status || \'waiting\'');
+      expect(source).not.toContain('payment_status: row.payment_status || \'pending\'');
+      expect(source).not.toContain('status: row.status || \'waiting\'');
       expect(source).not.toContain('queue_status: entry.queue_status || entry.status');
       expect(source).not.toContain('canonical_status: entry.canonical_status || entry.status');
     }
@@ -61,11 +61,11 @@ describe('Doctor panels SSOT contract', () => {
       'return (',
     );
 
-    expect(actionBlock).toContain("getBackendActionAvailability(row, 'call', 'can_start_visit')");
-    expect(actionBlock).toContain("getBackendActionAvailability(row, 'print', 'can_print_ticket')");
-    expect(actionBlock).toContain("getBackendActionAvailability(row, 'complete', 'can_complete')");
-    expect(actionBlock).toContain("getBackendActionAvailability(row, 'view_emr', 'can_view_emr')");
-    expect(actionBlock).toContain("getBackendActionAvailability(row, 'schedule_next', 'can_schedule_next')");
+    expect(actionBlock).toContain('getBackendActionAvailability(row, \'call\', \'can_start_visit\')');
+    expect(actionBlock).toContain('getBackendActionAvailability(row, \'print\', \'can_print_ticket\')');
+    expect(actionBlock).toContain('getBackendActionAvailability(row, \'complete\', \'can_complete\')');
+    expect(actionBlock).toContain('getBackendActionAvailability(row, \'view_emr\', \'can_view_emr\')');
+    expect(actionBlock).toContain('getBackendActionAvailability(row, \'schedule_next\', \'can_schedule_next\')');
     expect(actionBlock).toContain('const canPay = !isDoctorView && backendCanPay === true');
     expect(actionBlock).toContain('const canCall = isDoctorView && backendCanCall === true');
     expect(actionBlock).toContain('const canPrint = backendCanPrint === true');
@@ -75,10 +75,10 @@ describe('Doctor panels SSOT contract', () => {
     expect(actionBlock).not.toContain('rowStatus');
     expect(actionBlock).not.toContain('rowPaymentStatus');
     expect(actionBlock).not.toContain('isDoctorView ?\n                  rowStatus');
-    expect(actionBlock).not.toContain("rowPaymentStatus === 'paid' :");
-    expect(table).not.toContain("row.status === 'served' || row.status === 'completed'");
-    expect(table).not.toContain("row.status === 'in_visit' && row.payment_status === 'paid'");
-    expect(table).not.toContain("isDoctorView && row.status === 'done'");
+    expect(actionBlock).not.toContain('rowPaymentStatus === \'paid\' :');
+    expect(table).not.toContain('row.status === \'served\' || row.status === \'completed\'');
+    expect(table).not.toContain('row.status === \'in_visit\' && row.payment_status === \'paid\'');
+    expect(table).not.toContain('isDoctorView && row.status === \'done\'');
   });
 
   it('routes queue commands through the doctor command surface using only OnlineQueueEntry ids', () => {
@@ -88,7 +88,7 @@ describe('Doctor panels SSOT contract', () => {
       expect(source).toContain('function resolveDoctorQueueEntryId(row)');
       expect(source).toContain('const explicitQueueEntryId = row?.doctor_queue_entry_id ?? row?.queue_entry_id ?? null;');
       expect(source).toContain('/doctor/queue/${queueEntryId}/start-visit');
-      expect(source).not.toContain("recordKind === 'online_queue' && row?.id");
+      expect(source).not.toContain('recordKind === \'online_queue\' && row?.id');
       expect(source).not.toContain('/doctor/queue/${row.id}/start-visit');
       expect(source).not.toContain('completeVisit(selectedPatient.id');
       expect(source).not.toContain('const entryId = selectedPatient?.id || currentAppointment?.id');
@@ -121,13 +121,13 @@ describe('Doctor panels SSOT contract', () => {
     const cardiology = read('pages/CardiologistPanelUnified.jsx');
     const dermatology = read('pages/DermatologistPanelUnified.jsx');
 
-    expect(cardiology).toContain("activeTab === 'visit' && !selectedPatient");
+    expect(cardiology).toContain('activeTab === \'visit\' && !selectedPatient');
     expect(cardiology).toContain('title="Выберите визит"');
-    expect(cardiology).toContain("goToTab('appointments')");
+    expect(cardiology).toContain('goToTab(\'appointments\')');
 
-    expect(dermatology).toContain("activeTab === 'visit' && !currentAppointment && !selectedPatient");
+    expect(dermatology).toContain('activeTab === \'visit\' && !currentAppointment && !selectedPatient');
     expect(dermatology).toContain('title="Выберите визит"');
-    expect(dermatology).toContain("handleTabChange('appointments')");
+    expect(dermatology).toContain('handleTabChange(\'appointments\')');
   });
 
   it('keeps dermatology prescription availability backend-owned', () => {
@@ -141,7 +141,7 @@ describe('Doctor panels SSOT contract', () => {
     expect(prescriptionSystem).toContain('canCreatePrescription');
     expect(prescriptionSystem).toContain('const prescriptionEligible = canCreatePrescription === true');
     expect(prescriptionSystem).toContain('const canEdit = prescriptionEligible');
-    expect(prescriptionSystem).not.toContain("from '../constants/appointmentStatus'");
+    expect(prescriptionSystem).not.toContain('from \'../constants/appointmentStatus\'');
     expect(prescriptionSystem).not.toContain('canCreatePrescription(appointment?.status');
     expect(prescriptionSystem).not.toContain('appointment?.status !== APPOINTMENT_STATUS.COMPLETED');
   });
@@ -157,14 +157,14 @@ describe('Doctor panels SSOT contract', () => {
     expect(source).toContain('const hasBackendQueueAction =');
     expect(source).toContain('canCallNext');
     expect(source).toContain('disabled={!canCallNext}');
-    expect(actionBlock).toContain("hasBackendQueueAction(entry, 'no_show', 'can_no_show')");
-    expect(actionBlock).toContain("hasBackendQueueAction(entry, 'send_to_diagnostics', 'can_send_to_diagnostics')");
-    expect(actionBlock).toContain("hasBackendQueueAction(entry, 'notify_diagnostics_return', 'can_notify_diagnostics_return')");
-    expect(actionBlock).toContain("hasBackendQueueAction(entry, 'restore_next', 'can_restore_next')");
-    expect(actionBlock).not.toContain("entry.status === 'waiting'");
-    expect(actionBlock).not.toContain("entry.status === 'called'");
-    expect(actionBlock).not.toContain("entry.status === 'diagnostics'");
-    expect(actionBlock).not.toContain("entry.status === 'no_show'");
+    expect(actionBlock).toContain('hasBackendQueueAction(entry, \'no_show\', \'can_no_show\')');
+    expect(actionBlock).toContain('hasBackendQueueAction(entry, \'send_to_diagnostics\', \'can_send_to_diagnostics\')');
+    expect(actionBlock).toContain('hasBackendQueueAction(entry, \'notify_diagnostics_return\', \'can_notify_diagnostics_return\')');
+    expect(actionBlock).toContain('hasBackendQueueAction(entry, \'restore_next\', \'can_restore_next\')');
+    expect(actionBlock).not.toContain('entry.status === \'waiting\'');
+    expect(actionBlock).not.toContain('entry.status === \'called\'');
+    expect(actionBlock).not.toContain('entry.status === \'diagnostics\'');
+    expect(actionBlock).not.toContain('entry.status === \'no_show\'');
   });
 
   it('selects call-next from backend queue contract instead of local waiting-status scan', () => {
@@ -177,13 +177,13 @@ describe('Doctor panels SSOT contract', () => {
 
     expect(source).toContain('const selectNextCallEntryId =');
     expect(source).toContain('queuePayload?.next_call_entry_id');
-    expect(source).toContain("hasBackendQueueAction(entry, 'call', 'can_call')");
+    expect(source).toContain('hasBackendQueueAction(entry, \'call\', \'can_call\')');
     expect(source).toContain('canCallNext: response.data?.can_call_next === true');
     expect(source).toContain('canCallNext: queueControls.canCallNext');
     expect(callNextBlock).toContain('selectNextCallEntryId(currentQueue.data)');
     expect(callNextBlock).toContain('/doctor/queue/${nextCallEntryId}/call');
     expect(source).not.toContain('canCallNext: Boolean(response.data?.can_call_next ?? nextCallEntryId)');
-    expect(callNextBlock).not.toContain("entry.status === 'waiting'");
+    expect(callNextBlock).not.toContain('entry.status === \'waiting\'');
     expect(callNextBlock).not.toContain('waitingEntry');
   });
 });

--- a/frontend/src/pages/__tests__/LabPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/LabPanel.contract.test.jsx
@@ -27,10 +27,10 @@ describe('LabPanel queue/report status contract', () => {
     );
 
     expect(formatBlock).toContain('const latestLabReport = entry.latest_lab_report || null');
-    expect(formatBlock).toContain("status_source: 'queue'");
+    expect(formatBlock).toContain('status_source: \'queue\'');
     expect(formatBlock).toContain('queue_status: entry.status || null');
     expect(formatBlock).toContain('lab_report_status: latestLabReport?.status || null');
-    expect(formatBlock).toContain("report_status_source: latestLabReport ? 'lab-report' : null");
+    expect(formatBlock).toContain('report_status_source: latestLabReport ? \'lab-report\' : null');
     const lines = formatBlock.split('\n').map((line) => line.trim());
     expect(lines).not.toContain('status: latestLabReport?.status || entry.status,');
     expect(lines).not.toContain('status: latestLabReport?.status || null,');
@@ -47,9 +47,9 @@ describe('LabPanel queue/report status contract', () => {
     expect(formatBlock).toContain('payment_status: entry.payment_status || null');
     expect(formatBlock).toContain('queue_status: entry.status || null');
     expect(formatBlock).toContain('status: entry.status || null');
-    expect(formatBlock).not.toContain("payment_status: entry.payment_status || 'pending'");
-    expect(formatBlock).not.toContain("queue_status: entry.status || 'waiting'");
-    expect(formatBlock).not.toContain("status: entry.status || 'waiting'");
+    expect(formatBlock).not.toContain('payment_status: entry.payment_status || \'pending\'');
+    expect(formatBlock).not.toContain('queue_status: entry.status || \'waiting\'');
+    expect(formatBlock).not.toContain('status: entry.status || \'waiting\'');
   });
 
   it('does not add BFF-lite endpoints for the lab queue contract repair', () => {
@@ -67,9 +67,9 @@ describe('LabPanel queue/report status contract', () => {
       'const loadTemplates = useCallback(async (preferredTemplateId = null) => {',
     );
 
-    expect(loadBlock).toContain("new URLSearchParams({ department: 'lab' })");
+    expect(loadBlock).toContain('new URLSearchParams({ department: \'lab\' })');
     expect(loadBlock).toContain('/registrar/queues/today?${queueParams.toString()}');
-    expect(loadBlock).not.toContain(".filter((queue) => ['lab', 'laboratory'].includes(queue.specialty))");
+    expect(loadBlock).not.toContain('.filter((queue) => [\'lab\', \'laboratory\'].includes(queue.specialty))');
   });
 
   it('does not fetch report instances by visit_ids to enrich normal queue rows', () => {

--- a/frontend/src/pages/__tests__/PaymentSuccess.contract.test.jsx
+++ b/frontend/src/pages/__tests__/PaymentSuccess.contract.test.jsx
@@ -12,8 +12,8 @@ describe('PaymentSuccess receipt route contract', () => {
     const source = fs.readFileSync(paymentSuccessPath, 'utf8');
 
     expect(source).toContain('apiClient.get(`/payments/${paymentId}/receipt`');
-    expect(source).toContain("params: { format_type: 'pdf' }");
+    expect(source).toContain('params: { format_type: \'pdf\' }');
     expect(source).not.toContain('apiClient.post(`/payments/${paymentId}/receipt`');
-    expect(source).not.toContain("format: 'pdf'");
+    expect(source).not.toContain('format: \'pdf\'');
   });
 });

--- a/frontend/src/pages/__tests__/PriceOverrideApproval.contract.test.jsx
+++ b/frontend/src/pages/__tests__/PriceOverrideApproval.contract.test.jsx
@@ -32,12 +32,12 @@ describe('PriceOverrideApproval action contract', () => {
 
     const actionRendering = sourceSlice(
       source,
-      "{(hasBackendPriceOverrideAction(override, 'approve')",
+      '{(hasBackendPriceOverrideAction(override, \'approve\')',
       '{showApprovalModal && selectedOverride &&'
     );
 
-    expect(actionRendering).toContain("hasBackendPriceOverrideAction(override, 'approve')");
-    expect(actionRendering).toContain("hasBackendPriceOverrideAction(override, 'reject')");
-    expect(actionRendering).not.toContain("override.status === 'pending'");
+    expect(actionRendering).toContain('hasBackendPriceOverrideAction(override, \'approve\')');
+    expect(actionRendering).toContain('hasBackendPriceOverrideAction(override, \'reject\')');
+    expect(actionRendering).not.toContain('override.status === \'pending\'');
   });
 });

--- a/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
@@ -21,7 +21,7 @@ describe('RegistrarPanel command contract', () => {
   it('uses the backend registrar record action endpoint for queue/payment/status commands', () => {
     const source = readRegistrarPanelSource();
 
-    expect(source).toContain("api.post('/registrar/records/actions'");
+    expect(source).toContain('api.post(\'/registrar/records/actions\'');
     expect(source).not.toContain('/registrar/visits/${recordId}/mark-paid');
     expect(source).not.toContain('/registrar/queue/entry/${recordId}/mark-paid');
     expect(source).not.toContain('/appointments/${recordId}/mark-paid');
@@ -44,7 +44,7 @@ describe('RegistrarPanel command contract', () => {
     expect(source).toContain('patient_phone: fullEntry.patient_phone ?? fullEntry.phone');
     expect(source).toContain('address: fullEntry.address ?? entry.address');
     expect(source).toContain('const gender = normalizePatientGender(record);');
-    expect(source).toContain("String(gender).trim() !== ''");
+    expect(source).toContain('String(gender).trim() !== \'\'');
     expect(enrichmentBlock).toContain('!hasBackendPatientGenderContract(apt)');
     expect(enrichmentBlock).toContain('patient_gender: patientGender');
     expect(enrichmentBlock.indexOf('!hasBackendPatientDisplayContract(apt)')).toBeLessThan(
@@ -57,9 +57,9 @@ describe('RegistrarPanel command contract', () => {
 
     expect(source).toContain('const openRecordPreview = useCallback((row) => {');
     expect(source).toContain('const openRecordEditor = useCallback((row) => {');
-    expect(source).toContain("case 'view':");
+    expect(source).toContain('case \'view\':');
     expect(source).toContain('openRecordPreview(row);');
-    expect(source).toContain("case 'edit':");
+    expect(source).toContain('case \'edit\':');
     expect(source).toContain('openRecordEditor(row);');
   });
 
@@ -95,14 +95,14 @@ describe('RegistrarPanel command contract', () => {
     expect(source).toContain('queue_number: firstQueueNumber?.queue_number ?? null');
     expect(source).toContain('print_tickets: printTickets');
     expect(source).toContain('const postWizardPaymentRow = (!wasEditMode || Number(wizardData?.total_amount || 0) > 0)');
-    expect(source).toContain("source: wasEditMode ? 'wizard-edit' : 'wizard-create'");
-    expect(source).toContain("setPrintDialog({ open: true, type: 'ticket', data: postWizardPaymentRow });");
+    expect(source).toContain('source: wasEditMode ? \'wizard-edit\' : \'wizard-create\'');
+    expect(source).toContain('setPrintDialog({ open: true, type: \'ticket\', data: postWizardPaymentRow });');
   });
 
   it('loads Registrar metadata departments through one registrar endpoint', () => {
     const source = readRegistrarPanelSource();
 
-    expect(source).toContain("api.get('/registrar/departments?active_only=true')");
+    expect(source).toContain('api.get(\'/registrar/departments?active_only=true\')');
     expect(source).not.toContain('/api/v1/departments/active');
     expect(source).not.toContain('const loadDynamicDepartments = useCallback');
   });
@@ -115,10 +115,10 @@ describe('RegistrarPanel command contract', () => {
       'const fetchPatientData = useCallback(async (patientId) => {',
     );
 
-    expect(loadIntegratedDataBlock).toContain("api.get('/registrar/doctors')");
-    expect(loadIntegratedDataBlock).toContain("api.get('/registrar/services')");
-    expect(loadIntegratedDataBlock).toContain("api.get('/registrar/departments?active_only=true')");
-    expect(loadIntegratedDataBlock).not.toContain("api.get('/registrar/queue-settings')");
+    expect(loadIntegratedDataBlock).toContain('api.get(\'/registrar/doctors\')');
+    expect(loadIntegratedDataBlock).toContain('api.get(\'/registrar/services\')');
+    expect(loadIntegratedDataBlock).toContain('api.get(\'/registrar/departments?active_only=true\')');
+    expect(loadIntegratedDataBlock).not.toContain('api.get(\'/registrar/queue-settings\')');
     expect(loadIntegratedDataBlock).not.toContain('queueResult');
     expect(loadIntegratedDataBlock).not.toContain('queueRes');
   });
@@ -163,13 +163,13 @@ describe('RegistrarPanel command contract', () => {
     );
 
     expect(hasBackendActionBlock).toContain('record.available_actions');
-    expect(hasBackendActionBlock).toContain("mark_paid: 'can_mark_paid'");
-    expect(hasBackendActionBlock).toContain("start_visit: 'can_start_visit'");
-    expect(hasBackendActionBlock).toContain("print_ticket: 'can_print_ticket'");
-    expect(hasBackendActionBlock).toContain("complete: 'can_complete'");
-    expect(hasBackendActionBlock).toContain("cancel: 'can_cancel'");
+    expect(hasBackendActionBlock).toContain('mark_paid: \'can_mark_paid\'');
+    expect(hasBackendActionBlock).toContain('start_visit: \'can_start_visit\'');
+    expect(hasBackendActionBlock).toContain('print_ticket: \'can_print_ticket\'');
+    expect(hasBackendActionBlock).toContain('complete: \'can_complete\'');
+    expect(hasBackendActionBlock).toContain('cancel: \'can_cancel\'');
     expect(runActionBlock.indexOf('if (!hasBackendAction(record, action))')).toBeLessThan(
-      runActionBlock.indexOf("api.post('/registrar/records/actions'"),
+      runActionBlock.indexOf('api.post(\'/registrar/records/actions\''),
     );
   });
 

--- a/frontend/src/pages/__tests__/Settings.contract.test.jsx
+++ b/frontend/src/pages/__tests__/Settings.contract.test.jsx
@@ -11,19 +11,19 @@ describe('Settings generic key/value route contract', () => {
   it('uses the published settings endpoint with axios response data and canonical PUT body', () => {
     const source = fs.readFileSync(settingsPath, 'utf8');
 
-    expect(source).toContain("api.get('/settings', { params: { category } })");
+    expect(source).toContain('api.get(\'/settings\', { params: { category } })');
     expect(source).toContain('const data = res?.data ?? res;');
-    expect(source).toContain("api.put('/settings', { category, key, value })");
-    expect(source).not.toContain("api.put('/settings', { body: { category, key, value } })");
+    expect(source).toContain('api.put(\'/settings\', { category, key, value })');
+    expect(source).not.toContain('api.put(\'/settings\', { body: { category, key, value } })');
   });
 
   it('uses activation response data and the canonical activate body', () => {
     const source = fs.readFileSync(settingsPath, 'utf8');
 
-    expect(source).toContain("api.get('/activation/status')");
+    expect(source).toContain('api.get(\'/activation/status\')');
     expect(source).toContain('setStatus(st?.data ?? st ?? null);');
-    expect(source).toContain("api.post('/activation/activate', { key })");
+    expect(source).toContain('api.post(\'/activation/activate\', { key })');
     expect(source).toContain('const res = response?.data ?? response;');
-    expect(source).not.toContain("api.post('/activation/activate', { body: { key } })");
+    expect(source).not.toContain('api.post(\'/activation/activate\', { body: { key } })');
   });
 });

--- a/frontend/src/routing/__tests__/routeOwnershipEnforcement.test.js
+++ b/frontend/src/routing/__tests__/routeOwnershipEnforcement.test.js
@@ -12,7 +12,7 @@ describe('routing anti-regression enforcement', () => {
 
     expect(read('src/components/layout/Nav.jsx')).not.toContain('const routes = [');
     expect(read('src/constants/routes.js')).not.toContain('const routeMap =');
-    expect(routeRegistry).not.toContain("component: 'AdminPanel'");
+    expect(routeRegistry).not.toContain('component: \'AdminPanel\'');
   });
 
   it('uses the routing subsystem as the route source of truth', () => {

--- a/frontend/src/services/__tests__/authServiceRoutes.contract.test.js
+++ b/frontend/src/services/__tests__/authServiceRoutes.contract.test.js
@@ -15,27 +15,27 @@ describe('auth service route contract', () => {
   it('uses canonical authentication endpoints for login', () => {
     const source = readAuthServiceSource();
 
-    expect(source).toContain("api.post('/authentication/login'");
+    expect(source).toContain('api.post(\'/authentication/login\'');
   });
 
   it('does not call the stale auth login endpoint', () => {
     const source = readAuthServiceSource();
 
-    expect(source).not.toContain("api.post('/auth/login'");
+    expect(source).not.toContain('api.post(\'/auth/login\'');
   });
 
   it('uses canonical authentication endpoints for logout and refresh', () => {
     const source = readAuthServiceSource();
 
-    expect(source).toContain("api.post('/authentication/logout')");
-    expect(source).toContain("api.post('/authentication/refresh'");
+    expect(source).toContain('api.post(\'/authentication/logout\')');
+    expect(source).toContain('api.post(\'/authentication/refresh\'');
   });
 
   it('does not call stale auth lifecycle endpoints', () => {
     const source = readAuthServiceSource();
 
-    expect(source).not.toContain("api.post('/auth/logout')");
-    expect(source).not.toContain("api.post('/auth/refresh'");
+    expect(source).not.toContain('api.post(\'/auth/logout\')');
+    expect(source).not.toContain('api.post(\'/auth/refresh\'');
   });
 
   it('exports the canonical logout endpoint constant', () => {

--- a/frontend/src/services/__tests__/panelPrint.test.js
+++ b/frontend/src/services/__tests__/panelPrint.test.js
@@ -190,6 +190,6 @@ describe('panelPrint ticket renderer', () => {
 
     expect(html).toContain('<span>unknown</span>');
     expect(html).not.toContain('<span>paid</span>');
-    expect(html).not.toContain("payment?.status || 'paid'");
+    expect(html).not.toContain('payment?.status || \'paid\'');
   });
 });

--- a/frontend/src/services/__tests__/printServiceRoutes.contract.test.js
+++ b/frontend/src/services/__tests__/printServiceRoutes.contract.test.js
@@ -15,13 +15,13 @@ describe('print service route contract', () => {
   it('uses the canonical mounted print-template list route', () => {
     const source = readPrintServiceSource();
 
-    expect(source).toContain("api.get('/print/templates/templates'");
+    expect(source).toContain('api.get(\'/print/templates/templates\'');
     expect(API_ENDPOINTS.PRINT.TEMPLATES).toBe('/print/templates/templates');
   });
 
   it('does not call the stale print-template list route', () => {
     const source = readPrintServiceSource();
 
-    expect(source).not.toContain("api.get('/print/templates',");
+    expect(source).not.toContain('api.get(\'/print/templates\',');
   });
 });


### PR DESCRIPTION
💡 What: Added `title` attributes to icon-only close buttons in `MacOSAlert`, `MacOSModal`, `Toast`, and `Modal` components.
🎯 Why: Icon-only buttons without tooltips can be confusing for mouse users. The components already had `aria-label`s for screen readers, but sighted users didn't get any explanation on hover.
📸 Before/After: Visual change is simply a native browser tooltip appearing when hovering over the 'X' buttons in modals and alerts.
♿ Accessibility: Ensures that the accessible name (aria-label) is also visually available as a tooltip (title) for non-screen reader users, adhering to inclusive design principles.

---
*PR created automatically by Jules for task [4304972332168299028](https://jules.google.com/task/4304972332168299028) started by @drsapaev*