### PR TITLE
🎨 Palette: Add keyboard accessibility to mobile notifications

### DIFF
--- a/frontend/src/components/mobile/MobileNotifications.jsx
+++ b/frontend/src/components/mobile/MobileNotifications.jsx
@@ -181,7 +181,7 @@ const MobileNotifications = () => {
           onClick={() => window.open('chrome://settings/content/notifications')}
           variant="outline"
           size="sm">
-          
+
           <Settings className="w-4 h-4 mr-2" />
           Открыть настройки
         </Button>
@@ -209,7 +209,7 @@ const MobileNotifications = () => {
             onClick={requestNotificationPermission}
             size="sm"
             variant="outline">
-            
+
               Включить
             </Button>
           }
@@ -219,7 +219,7 @@ const MobileNotifications = () => {
             onClick={markAllAsRead}
             size="sm"
             variant="ghost">
-            
+
               <Check className="w-4 h-4 mr-1" />
               Все прочитано
             </Button>
@@ -246,8 +246,16 @@ const MobileNotifications = () => {
           'bg-gray-50' :
           'bg-blue-50 border-blue-200'}`
           }
-          onClick={() => markAsRead(notification.id)}>
-          
+          role="button"
+          tabIndex={0}
+          onClick={() => markAsRead(notification.id)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              markAsRead(notification.id);
+            }
+          }}>
+
               <div className="flex items-start space-x-3">
                 <div className="text-lg">
                   {getNotificationIcon(notification.type)}


### PR DESCRIPTION
💡 What: Added `role="button"`, `tabIndex={0}`, and `onKeyDown` attributes to the notification `Card` component mapping in `MobileNotifications.jsx`.
🎯 Why: Previously, notification cards were only clickable via mouse (`onClick` and `cursor-pointer`), making them inaccessible to users who rely on keyboard navigation or screen readers to dismiss/read notifications.
♿ Accessibility: Improved keyboard accessibility by ensuring interactive elements can receive focus and be activated using `Enter` or `Space` keys. This aligns with standard web accessibility guidelines for interactive elements mimicking button behavior.

---
*PR created automatically by Jules for task [3754733037596357751](https://jules.google.com/task/3754733037596357751) started by @drsapaev*