### PR TITLE
🎨 Palette: Add aria-busy and roles to Loading components for screen readers

### DIFF
--- a/frontend/src/components/common/Loading.jsx
+++ b/frontend/src/components/common/Loading.jsx
@@ -121,7 +121,7 @@ export function Loading({
   };
 
   return (
-    <div style={containerStyle}>
+    <div style={containerStyle} aria-busy={true} aria-live="polite" role="status">
       {renderLoader()}
       {text && <div style={textStyle}>{text}</div>}
     </div>);
@@ -154,7 +154,7 @@ export function ButtonLoading({ loading, children, style = {}, disabled = false,
   };
 
   return (
-    <button {...props} style={buttonStyle} disabled={loading || disabled}>
+    <button {...props} style={buttonStyle} disabled={loading || disabled} aria-busy={loading}>
       {loading && <div style={spinnerStyle} />}
       {children}
     </button>);
@@ -194,7 +194,7 @@ export function TableLoadingOld({ columns = 3, rows = 5 }) {
   };
 
   return (
-    <table style={tableStyle}>
+    <table style={tableStyle} aria-busy={true}>
       <thead>
         <tr>
           {Array.from({ length: columns }).map((_, i) =>
@@ -265,7 +265,7 @@ export function CardLoadingOld({ count = 3 }) {
   };
 
   return (
-    <div style={containerStyle}>
+    <div style={containerStyle} aria-busy={true}>
       {Array.from({ length: count }).map((_, i) =>
       <div key={i} style={cardStyle}>
           <div style={{ ...skeletonStyle, height: '24px', marginBottom: getSpacing('md') }} />
@@ -323,7 +323,7 @@ export function ListLoading({ count = 5 }) {
   };
 
   return (
-    <div style={containerStyle}>
+    <div style={containerStyle} aria-busy={true}>
       {Array.from({ length: count }).map((_, i) =>
       <div key={i} style={itemStyle}>
           <div style={avatarStyle} />


### PR DESCRIPTION
## 💡 What
Added `aria-busy`, `aria-live`, and `role="status"` accessibility attributes to the shared `Loading`, `ButtonLoading`, `TableLoadingOld`, `CardLoadingOld`, and `ListLoading` components.

## 🎯 Why
When components enter a loading state (such as fetching data or processing a form submission), visual users can see the spinners or skeleton loaders. However, without proper ARIA attributes, screen readers are unaware of this processing state. Adding these attributes ensures assistive technologies announce the state changes to visually impaired users, improving the overall accessibility and user experience of the application.

## ♿ Accessibility
*   Added `aria-busy={true}`, `aria-live="polite"`, and `role="status"` to the main container of the `Loading` component.
*   Added `aria-busy={loading}` to the `<button>` element in the `ButtonLoading` component.
*   Added `aria-busy={true}` to the container elements of `TableLoadingOld`, `CardLoadingOld`, and `ListLoading` skeleton components.

---
*PR created automatically by Jules for task [6069354891345162320](https://jules.google.com/task/6069354891345162320) started by @drsapaev*