### PR TITLE
🎨 Palette: [UX improvement] Add keyboard focus and React state hover to list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-12 - Missing aria-busy on Complex Loading States
 **Learning:** While buttons effectively communicated their loading states via `aria-busy`, larger container components in the design system (Tables, Lists, Stat Cards) with custom loading skeletons or empty states completely lacked this attribute. This creates a confusing experience for screen reader users who aren't notified when these regions are processing or waiting for data.
 **Action:** Always add `aria-busy="true"` (or `aria-busy={loading}`) to the root container of complex UI components that handle asynchronous data loading, especially when rendering custom loading skeletons or empty states instead of standard UI elements.
+## 2024-05-13 - Focus Styles on Interactive List Items
+**Learning:** Some custom UI components (like MacOSList) managed pseudo-class hover effects directly via DOM mutation (`e.currentTarget.style.backgroundColor`) in JS, completely omitting keyboard focus (`onFocus` / `onBlur`) states. This hides interactivity from keyboard-only users.
+**Action:** When implementing custom interactive lists or options, use React state (e.g., `focusedIndex`) and apply focus outline styles dynamically (`outline: 2px solid var(--mac-accent-blue)`) while attaching `onFocus`/`onBlur` handlers to ensure keyboard accessibility matches mouse hover behavior.

--- a/frontend/src/components/ui/macos/MacOSList.jsx
+++ b/frontend/src/components/ui/macos/MacOSList.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 
 const MacOSList = ({
@@ -16,6 +17,9 @@ const MacOSList = ({
   className,
   style
 }) => {
+  const [hoveredIndex, setHoveredIndex] = useState(-1);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+
   const sizeStyles = {
     sm: {
       padding: '8px 0',
@@ -66,17 +70,19 @@ const MacOSList = ({
     ...style
   };
 
-  const itemStyle = (index, isSelected = false) => ({
+  const itemStyle = (index, isSelected = false, isHovered = false, isFocused = false) => ({
     padding: currentSize.itemPadding,
     fontSize: currentSize.fontSize,
     color: 'var(--mac-text-primary)',
     cursor: hoverable || selectable ? 'pointer' : 'default',
-    background: isSelected ? 'var(--mac-bg-blue)' : 'transparent',
+    background: isSelected ? 'var(--mac-bg-blue)' : (isHovered && hoverable ? 'var(--mac-bg-secondary)' : 'transparent'),
     borderBottom: dividers && index < items.length - 1 ? '1px solid var(--mac-separator)' : 'none',
     transition: 'all var(--mac-duration-normal) var(--mac-ease)',
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'space-between'
+    justifyContent: 'space-between',
+    outline: isFocused ? '2px solid var(--mac-accent-blue)' : 'none',
+    outlineOffset: '-2px'
   });
 
   const handleItemClick = (item, index) => {
@@ -88,16 +94,24 @@ const MacOSList = ({
     }
   };
 
-  const handleMouseEnter = (e, isSelected) => {
+  const handleMouseEnter = (index) => {
     if (hoverable) {
-      e.currentTarget.style.backgroundColor = isSelected ? 'var(--mac-bg-blue)' : 'var(--mac-bg-secondary)';
+      setHoveredIndex(index);
     }
   };
 
-  const handleMouseLeave = (e, isSelected) => {
+  const handleMouseLeave = () => {
     if (hoverable) {
-      e.currentTarget.style.backgroundColor = isSelected ? 'var(--mac-bg-blue)' : 'transparent';
+      setHoveredIndex(-1);
     }
+  };
+
+  const handleFocus = (index) => {
+    setFocusedIndex(index);
+  };
+
+  const handleBlur = () => {
+    setFocusedIndex(-1);
   };
 
   const handleKeyDown = (e, item, index) => {
@@ -188,14 +202,19 @@ const MacOSList = ({
         const isSelected = selectedIndex === index;
         const isInteractive = selectable || Boolean(onItemClick);
 
+        const isHovered = hoveredIndex === index;
+        const isFocused = focusedIndex === index;
+
         if (isInteractive) {
           return (
             <div
               key={index}
-              style={itemStyle(index, isSelected)}
+              style={itemStyle(index, isSelected, isHovered, isFocused)}
               onClick={() => handleItemClick(item, index)}
-              onPointerEnter={(e) => handleMouseEnter(e, isSelected)}
-              onPointerLeave={(e) => handleMouseLeave(e, isSelected)}
+              onPointerEnter={() => handleMouseEnter(index)}
+              onPointerLeave={handleMouseLeave}
+              onFocus={() => handleFocus(index)}
+              onBlur={handleBlur}
               onKeyDown={(e) => handleKeyDown(e, item, index)}
               tabIndex={0}
               role="button"
@@ -208,9 +227,9 @@ const MacOSList = ({
         return (
           <div
             key={index}
-            style={itemStyle(index, isSelected)}
-            onPointerEnter={(e) => handleMouseEnter(e, isSelected)}
-            onPointerLeave={(e) => handleMouseLeave(e, isSelected)}
+            style={itemStyle(index, isSelected, isHovered, isFocused)}
+            onPointerEnter={() => handleMouseEnter(index)}
+            onPointerLeave={handleMouseLeave}
             role="listitem">
             
             {renderItem ? renderItem(item, index) : renderDefaultItem(item, index)}


### PR DESCRIPTION
💡 What: Refactored `MacOSList` to use React state for hover and focus management, replacing direct DOM mutation, and added a visible focus ring for keyboard navigation.
🎯 Why: Previously, `MacOSList` managed hover states via `e.currentTarget.style.backgroundColor` directly, and entirely lacked `onFocus`/`onBlur` tracking, making it impossible for keyboard-only users to see which item was currently focused.
📸 Before/After: See generated Playwright videos.
♿ Accessibility: Interactive list items are now visibly distinguishable when focused via keyboard navigation (`tabIndex={0}`), ensuring parity with mouse hover feedback.

---
*PR created automatically by Jules for task [14514184125630159191](https://jules.google.com/task/14514184125630159191) started by @drsapaev*