### PR TITLE
fix(security): bump aiohttp to 3.14.1 and python-multipart to 0.0.31 (14 CVEs)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,10 +15,10 @@ pydantic[email]
 pyotp>=2.9,<2.10
 requests>=2.34.2,<3.0
 httpx>=0.25,<0.29
-python-multipart>=0.0.29,<0.0.30
+python-multipart>=0.0.31,<0.0.32
 jinja2>=3.1,<3.2
 pyserial>=3.5,<4.0
-aiohttp>=3.13.5,<3.14
+aiohttp>=3.14.1,<3.15
 aiofiles>=24.1,<25.0
 beautifulsoup4>=4.14.3,<5.0
 weasyprint>=68.1,<69.0


### PR DESCRIPTION
## Summary

- Bump `aiohttp` from `>=3.13.5,<3.14` to `>=3.14.1,<3.15` — fixes 11 CVEs.
- Bump `python-multipart` from `>=0.0.29,<0.0.30` to `>=0.0.31,<0.0.32` — fixes 3 CVEs.
- Resolves 🔒 Security сканирование CI failure on main (run 28439021300).

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/security-deps-aiohttp-multipart` created from current `origin/main` (sha 8ca2dc8e)
- Clean workspace: only `backend/requirements.txt` changed, 2 lines
- Branch: `fix/security-deps-aiohttp-multipart`
- Scope gate: allowed backend/requirements.txt only; denied frontend, migrations, application code, ops scripts
- Red-check handling: this PR is itself a red-check fix for the failing security job on main

## Contract Impact

not applicable - no API, websocket, event, or frontend consumer contract changed. Both packages are backend dependencies; aiohttp is used as async HTTP client/server, python-multipart is used by FastAPI for form parsing. Patch/minor version bumps within existing upper-bound discipline; no public API surface changes for application code that consumes these libraries.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. Dependency version bump only.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed. Although aiohttp is used for some async networking, no application code that uses it is modified in this PR; the version bump fixes library-level security defects without changing observable runtime behavior.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed. Backend-only dependency update.

## Scope Gate

- Allowed paths: `backend/requirements.txt` (2 lines changed)
- Denied paths: `backend/app/**`, `frontend/**`, migrations, ops scripts, generated docs
- Migration/docs/test impact: no migration; no test changes; no docs regen required
- Rollback note: revert this single commit to restore the old (vulnerable) pinned versions

## Validation

- Targeted tests or smoke run: backend dependency install via `pip install -r requirements.txt` (CI will run on this PR); pip-audit will re-scan and confirm 0 vulnerabilities from these 2 packages
- Result: pending CI — expected to pass once pip-audit confirms the new versions are not flagged
- Not checked: full backend test suite runtime behavior under aiohttp 3.14.x (CI's `🐍 Backend тесты` job will cover this)

## Out of scope

- Other dependency updates not required by security advisories
- Frontend npm dependency updates (separate audit cycle)