### PR TITLE
chore(dependabot): reduce noise — group pip updates, lower limits, ignore major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,15 @@
 version: 2
 updates:
-  # Обновление Python зависимостей
+  # Python зависимости (backend)
+  # P-009 cleanup: groups minor/patch into one PR, limits to 5 open PRs,
+  # ignores major versions for critical packages that need manual testing.
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "drsapaev"
     assignees:
@@ -18,7 +20,30 @@ updates:
     labels:
       - "dependencies"
       - "python"
-      
+    groups:
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+        excludes:
+          - "fastapi"
+          - "pydantic"
+          - "SQLAlchemy"
+          - "alembic"
+          - "psycopg"
+    ignore:
+      # Major versions: manual review required (breaking changes likely)
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+      # protobuf 5→7 is a breaking migration; skip until explicitly planned
+      - dependency-name: "protobuf"
+        update-types: ["version-update:semver-major"]
+      # redis 5→9 is a major rewrite; skip until explicitly planned
+      - dependency-name: "redis"
+        update-types: ["version-update:semver-major"]
+
   # Root npm dependencies
   - package-ecosystem: "npm"
     directory: "/"
@@ -26,7 +51,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "12:00"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 2
     reviewers:
       - "drsapaev"
     assignees:
@@ -56,7 +81,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "13:00"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 2
     reviewers:
       - "drsapaev"
     assignees:
@@ -75,18 +100,24 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        excludes:
+          # Keep these as standalone PRs (security-sensitive or breaking-prone)
+          - "react"
+          - "react-dom"
+          - "react-router"
+          - "react-router-dom"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
-  # Обновление GitHub Actions
+  # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "10:00"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     reviewers:
       - "drsapaev"
     assignees:
@@ -97,15 +128,17 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-      
-  # Обновление Docker образов
+
+  # Docker images (ops/)
+  # P-009 cleanup: kept but limit lowered to 1 — Docker base image bumps
+  # should be manual (require rebuild + integration testing)
   - package-ecosystem: "docker"
     directory: "/ops"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "11:00"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
     reviewers:
       - "drsapaev"
     assignees:
@@ -116,11 +149,8 @@ updates:
     labels:
       - "dependencies"
       - "docker"
-    # Игнорировать определенные обновления для стабильности
     ignore:
-      # Игнорировать обновления Python до стабильной версии (3.14.0 нестабильна)
       - dependency-name: "python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Игнорировать обновления Node.js до стабильной версии  
       - dependency-name: "node"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

- Reduce Dependabot PR noise: 22 open PRs → expected ~5-8 with new config.
- Group Python pip minor/patch updates into one PR instead of separate PRs per package.
- Lower open-pull-requests-limits across all ecosystems.
- Ignore major version bumps for protobuf (5→7 breaking) and redis (5→9 breaking).
- Closed 7 stale/risky/duplicate PRs via API.

## Cyclic Execution Evidence

- Fresh main sync: branch `chore/dependabot-cleanup` created from `origin/main` (sha 6058de4a)
- Clean workspace: only `.github/dependabot.yml` changed
- Branch: `chore/dependabot-cleanup`
- Scope gate: allowed `.github/dependabot.yml` only; denied all application code
- Red-check handling: fix any failed CI check in this same PR before merge

## Contract Impact

not applicable - configuration file only, no API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no data fetching involved
- Partial data proof: not applicable, configuration file only
- Forbidden secondary path behavior: not applicable, no secondary path introduced
- Missing draft/resource behavior: not applicable, no draft or resource lifecycle affected
- Stale route/deep-link behavior: not applicable, no routing changes

## Scope Gate

- Allowed paths: `.github/dependabot.yml`
- Denied paths: all application code, backend, frontend, migrations, ops
- Migration/docs/test impact: no migration; no test changes; no docs regen
- Rollback note: revert this single commit to restore old config

## Validation

- Targeted tests or smoke run: YAML syntax validated by GitHub Actions on push
- Result: pending CI
- Not checked: Dependabot will pick up new config on next scheduled run (Monday)

## Closed PRs (context)

| PR | Reason |
|---|---|
| #1276 | stale (>4 weeks), will regenerate as grouped |
| #1277 | protobuf 5→7 major, breaking — now ignored in config |
| #1279 | stale (>4 weeks), will regenerate as grouped |
| #1280 | stale (>4 weeks), will regenerate as grouped |
| #1607 | redis 5→9 major, breaking — now ignored in config |
| #1626 | superseded by #1645 (vite group) |
| #1632 | duplicate of #1633 |

🤖 Generated with Z.ai UX Audit Team