### PR TITLE
chore(dependabot): ignore storybook/vite/vitest major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,6 +73,21 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Storybook 8→10 is a major migration requiring all @storybook/* packages
+      # to be updated together. Dependabot bumped @storybook/react-vite to v10
+      # while @storybook/addon-essentials stayed at v8, breaking npm ci.
+      - dependency-name: "@storybook/react-vite"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "storybook"
+        update-types: ["version-update:semver-major"]
+      # Vite 6→8 major requires plugin-react 6+ and can break build config
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      # Vitest 3→4 major changes test runner API
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitest/coverage-v8"
+        update-types: ["version-update:semver-major"]
 
   # Frontend npm dependencies
   - package-ecosystem: "npm"
@@ -108,6 +123,21 @@ updates:
           - "react-router-dom"
     ignore:
       - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+      # Storybook 8→10 is a major migration requiring all @storybook/* packages
+      # to be updated together. Dependabot bumped @storybook/react-vite to v10
+      # while @storybook/addon-essentials stayed at v8, breaking npm ci.
+      - dependency-name: "@storybook/react-vite"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "storybook"
+        update-types: ["version-update:semver-major"]
+      # Vite 6→8 major requires plugin-react 6+ and can break build config
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      # Vitest 3→4 major changes test runner API
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitest/coverage-v8"
         update-types: ["version-update:semver-major"]
 
   # GitHub Actions


### PR DESCRIPTION
## Summary

- Adds explicit ignore rules for storybook, vite, vitest major versions in dependabot.yml.
- Prevents recurrence of PR #1645 which broke npm ci with peer dependency conflicts.
- Companion to revert PR #1650.

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main
- Clean workspace: only `.github/dependabot.yml` changed
- Branch: `chore/dependabot-ignore-storybook-major`
- Scope gate: allowed `.github/dependabot.yml` only
- Red-check handling: prevents future recurrence of the #1645 breakage

## Contract Impact

not applicable - configuration file only, no API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, configuration file only, no data fetching involved
- Partial data proof: not applicable, YAML config has no partial state
- Forbidden secondary path behavior: not applicable, no secondary path introduced
- Missing draft/resource behavior: not applicable, no draft or resource lifecycle affected
- Stale route/deep-link behavior: not applicable, no routing changes

## Scope Gate

- Allowed paths: `.github/dependabot.yml`
- Denied paths: all application code
- Migration/docs/test impact: none
- Rollback note: revert this commit to allow major version bumps again

## Validation

- Targeted tests or smoke run: YAML syntax validated by CI
- Result: pending
- Not checked: Dependabot will pick up config on next scheduled run