### PR TITLE
feat(SW-05): global command palette (Cmd+K) for admin navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,8 @@ import { MacOSThemeProvider } from './theme/macosTheme.jsx';
 import { bootstrapStoredColorScheme } from './theme/colorScheme.js';
 import { Sidebar } from './components/ui/macos';
 import HeaderNew from './components/layout/HeaderNew.jsx';
+// SW-05 fix: global command palette (Cmd+K)
+import { CommandPalette } from './components/common/CommandPalette';
 import Health from './pages/Health.jsx';
 import Landing from './pages/Landing.jsx';
 import LoginFormStyled from './components/auth/LoginFormStyled.jsx';
@@ -323,6 +325,8 @@ function AppShell({ children }) {
           {children}
         </main>
       </div>
+      {/* SW-05 fix: global command palette — Cmd+K / Ctrl+K to open */}
+      <CommandPalette profile={authState.profile} navigate={navigate} />
     </div>
   );
 }

--- a/frontend/src/components/common/CommandPalette.jsx
+++ b/frontend/src/components/common/CommandPalette.jsx
@@ -1,0 +1,442 @@
+/**
+ * CommandPalette — global Cmd+K / Ctrl+K command palette for admin navigation.
+ *
+ * SW-05 fix: admin sidebar has 38 routes. Finding a function requires scanning
+ * the sidebar manually. This palette lets the admin press Cmd+K, type 2-3 letters,
+ * and jump to any route instantly. Also supports quick actions (create appointment,
+ * new patient, etc.).
+ *
+ * Features:
+ *   - Fuzzy search on route label, id, path, and section
+ *   - Keyboard navigation (ArrowUp/Down, Enter, Escape)
+ *   - Quick actions (not just navigation)
+ *   - Recent items (last 5 visited via palette)
+ *   - Role-aware: only shows routes the current user can access
+ *
+ * Usage in App.jsx:
+ *   <CommandPalette profile={authState.profile} navigate={navigate} />
+ *   // The palette listens for Cmd+K globally and renders itself via portal.
+ */
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { Search, ArrowRight, Clock } from 'lucide-react';
+import { getCanonicalRoutes, isRouteAccessibleToProfile } from '../../routing/routeSelectors';
+
+const MAX_RESULTS = 8;
+const MAX_RECENT = 5;
+const RECENT_KEY = 'cmd_palette_recent';
+
+// Quick actions available in the palette (not routes, but shortcuts)
+const QUICK_ACTIONS = [
+  {
+    id: 'action-new-appointment',
+    label: 'Новая запись',
+    description: 'Открыть мастер создания записи',
+    icon: 'plus',
+    keywords: ['запись', 'новая', 'создать', 'appointment', 'new'],
+    action: 'navigate',
+    target: '/registrar?action=new',
+    section: 'Действия',
+  },
+  {
+    id: 'action-search-patient',
+    label: 'Поиск пациента',
+    description: 'Открыть форму поиска пациента',
+    icon: 'search',
+    keywords: ['пациент', 'поиск', 'find', 'patient', 'search'],
+    action: 'navigate',
+    target: '/clinical/search',
+    section: 'Действия',
+  },
+  {
+    id: 'action-back',
+    label: 'Назад',
+    description: 'Вернуться на предыдущую страницу',
+    icon: 'arrow.left',
+    keywords: ['назад', 'back', 'previous'],
+    action: 'back',
+    section: 'Действия',
+  },
+];
+
+function loadRecent() {
+  try {
+    const raw = localStorage.getItem(RECENT_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveRecent(items) {
+  try {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(items.slice(0, MAX_RECENT)));
+  } catch {
+    // ignore
+  }
+}
+
+function fuzzyMatch(query, text) {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  const t = (text || '').toLowerCase();
+  if (t.includes(q)) return true;
+  // Simple fuzzy: check if all chars of query appear in order
+  let qi = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) qi++;
+  }
+  return qi === q.length;
+}
+
+function scoreResult(query, item) {
+  if (!query) return 0;
+  const q = query.toLowerCase();
+  const label = (item.label || '').toLowerCase();
+  const id = (item.id || '').toLowerCase();
+  const path = (item.path || '').toLowerCase();
+  const keywords = (item.keywords || []).map(k => k.toLowerCase());
+
+  // Exact match = highest score
+  if (label === q) return 100;
+  if (id === q) return 95;
+
+  // Starts with
+  if (label.startsWith(q)) return 80;
+  if (id.startsWith(q)) return 75;
+
+  // Contains
+  if (label.includes(q)) return 60;
+  if (path.includes(q)) return 50;
+  if (id.includes(q)) return 45;
+
+  // Keywords
+  for (const kw of keywords) {
+    if (kw === q) return 70;
+    if (kw.startsWith(q)) return 55;
+    if (kw.includes(q)) return 40;
+  }
+
+  // Fuzzy match
+  if (fuzzyMatch(q, label)) return 20;
+  if (fuzzyMatch(q, id)) return 15;
+
+  return 0;
+}
+
+export function CommandPalette({ profile, navigate }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [recent, setRecent] = useState(loadRecent);
+  const inputRef = useRef(null);
+  const listRef = useRef(null);
+
+  // Build items from routes + quick actions
+  const allItems = useMemo(() => {
+    const routes = getCanonicalRoutes();
+    const accessibleRoutes = routes.filter(route =>
+      route.nav !== false &&
+      route.group !== 'internal-demo' &&
+      route.group !== 'public' &&
+      isRouteAccessibleToProfile(route, profile)
+    );
+
+    const routeItems = accessibleRoutes.map(route => ({
+      id: route.id,
+      label: route.nav?.label || route.title || route.id,
+      description: route.nav?.section || route.group || '',
+      path: route.path,
+      icon: route.nav?.icon,
+      section: route.nav?.section || 'Маршруты',
+      keywords: [route.id, route.path, route.title],
+      action: 'navigate',
+      target: route.path,
+    }));
+
+    // Filter quick actions by role
+    const roleNorm = (profile?.role || '').toLowerCase();
+    const actionItems = QUICK_ACTIONS.filter(action => {
+      if (action.id === 'action-new-appointment') {
+        return roleNorm === 'admin' || roleNorm === 'registrar';
+      }
+      if (action.id === 'action-search-patient') {
+        return true; // all clinical roles can search
+      }
+      return true;
+    });
+
+    return [...actionItems, ...routeItems];
+  }, [profile]);
+
+  // Filter + sort
+  const results = useMemo(() => {
+    if (!query.trim()) {
+      // Show recent first, then first N items
+      const recentItems = recent
+        .map(id => allItems.find(item => item.id === id))
+        .filter(Boolean);
+      const nonRecent = allItems.filter(item => !recent.includes(item.id));
+      return [...recentItems, ...nonRecent].slice(0, MAX_RESULTS);
+    }
+
+    return allItems
+      .map(item => ({ item, score: scoreResult(query, item) }))
+      .filter(({ score }) => score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, MAX_RESULTS)
+      .map(({ item }) => item);
+  }, [query, allItems, recent]);
+
+  // Global Cmd+K / Ctrl+K listener
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setIsOpen(prev => !prev);
+      }
+      if (e.key === 'Escape' && isOpen) {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen]);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('');
+      setSelectedIndex(0);
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [isOpen]);
+
+  // Reset selection when results change
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  // Keyboard navigation
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex(prev => Math.min(prev + 1, results.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex(prev => Math.max(prev - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const item = results[selectedIndex];
+      if (item) handleSelect(item);
+    }
+  }, [results, selectedIndex]);
+
+  const handleSelect = useCallback((item) => {
+    // Save to recent
+    const newRecent = [item.id, ...recent.filter(id => id !== item.id)].slice(0, MAX_RECENT);
+    setRecent(newRecent);
+    saveRecent(newRecent);
+
+    // Execute action
+    if (item.action === 'navigate' && item.target) {
+      navigate(item.target);
+    } else if (item.action === 'back') {
+      window.history.back();
+    }
+
+    setIsOpen(false);
+  }, [navigate, recent]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (listRef.current) {
+      const selected = listRef.current.children[selectedIndex];
+      if (selected) {
+        selected.scrollIntoView({ block: 'nearest' });
+      }
+    }
+  }, [selectedIndex]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 9999,
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        paddingTop: '15vh',
+        backgroundColor: 'rgba(0, 0, 0, 0.4)',
+        backdropFilter: 'blur(4px)',
+      }}
+      onClick={() => setIsOpen(false)}
+      role="button"
+      tabIndex={-1}
+      onKeyDown={(e) => { if (e.key === 'Escape') setIsOpen(false); }}
+      aria-label="Закрыть панель команд"
+    >
+      <div
+        role="dialog"
+        aria-label="Command palette"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => { if (e.key === 'Escape') setIsOpen(false); }}
+        style={{
+          width: '90%',
+          maxWidth: '560px',
+          maxHeight: '60vh',
+          display: 'flex',
+          flexDirection: 'column',
+          backgroundColor: 'var(--mac-bg-primary, #ffffff)',
+          borderRadius: '14px',
+          boxShadow: '0 20px 60px rgba(0, 0, 0, 0.3)',
+          border: '1px solid var(--mac-border, rgba(0,0,0,0.1))',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Search input */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px',
+          padding: '14px 16px',
+          borderBottom: '1px solid var(--mac-border, rgba(0,0,0,0.08))',
+        }}>
+          <Search size={18} style={{ color: 'var(--mac-text-secondary, #6b7280)', flexShrink: 0 }} />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Поиск маршрута или действия..."
+            aria-label="Search commands"
+            style={{
+              flex: 1,
+              border: 'none',
+              outline: 'none',
+              backgroundColor: 'transparent',
+              color: 'var(--mac-text-primary, #1a1a1a)',
+              fontSize: '15px',
+              fontFamily: 'inherit',
+            }}
+          />
+          <kbd style={{
+            padding: '2px 6px',
+            borderRadius: '4px',
+            backgroundColor: 'var(--mac-bg-secondary, rgba(0,0,0,0.05))',
+            color: 'var(--mac-text-secondary, #6b7280)',
+            fontSize: '11px',
+            fontFamily: 'ui-monospace, monospace',
+          }}>ESC</kbd>
+        </div>
+
+        {/* Results */}
+        <div
+          ref={listRef}
+          role="listbox"
+          style={{
+            overflowY: 'auto',
+            flex: 1,
+            padding: '6px',
+          }}
+        >
+          {results.length === 0 && (
+            <div style={{
+              padding: '24px 16px',
+              textAlign: 'center',
+              color: 'var(--mac-text-secondary, #6b7280)',
+              fontSize: '14px',
+            }}>
+              Ничего не найдено для «{query}»
+            </div>
+          )}
+          {results.map((item, index) => {
+            const isSelected = index === selectedIndex;
+            const isRecent = !query && recent.includes(item.id);
+            return (
+              <div
+                key={item.id}
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => handleSelect(item)}
+                tabIndex={isSelected ? 0 : -1}
+                onKeyDown={(e) => { if (e.key === 'Enter') handleSelect(item); }}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '10px',
+                  padding: '10px 12px',
+                  borderRadius: '8px',
+                  cursor: 'pointer',
+                  backgroundColor: isSelected
+                    ? 'var(--mac-accent-blue, #007aff)'
+                    : 'transparent',
+                  color: isSelected
+                    ? '#ffffff'
+                    : 'var(--mac-text-primary, #1a1a1a)',
+                  transition: 'background-color 0.1s ease',
+                }}
+              >
+                {isRecent && (
+                  <Clock size={14} style={{
+                    color: isSelected ? 'rgba(255,255,255,0.7)' : 'var(--mac-text-secondary, #6b7280)',
+                    flexShrink: 0,
+                  }} />
+                )}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{
+                    fontSize: '14px',
+                    fontWeight: 500,
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}>
+                    {item.label}
+                  </div>
+                  {item.description && (
+                    <div style={{
+                      fontSize: '12px',
+                      color: isSelected ? 'rgba(255,255,255,0.7)' : 'var(--mac-text-secondary, #6b7280)',
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}>
+                      {item.description}
+                    </div>
+                  )}
+                </div>
+                {isSelected && (
+                  <ArrowRight size={14} style={{ color: 'rgba(255,255,255,0.7)', flexShrink: 0 }} />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '12px',
+          padding: '8px 16px',
+          borderTop: '1px solid var(--mac-border, rgba(0,0,0,0.08))',
+          fontSize: '11px',
+          color: 'var(--mac-text-secondary, #6b7280)',
+        }}>
+          <span>↑↓ навигация</span>
+          <span>↵ выбрать</span>
+          <span>esc закрыть</span>
+          <span style={{ marginLeft: 'auto' }}>{results.length} результатов</span>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export default CommandPalette;


### PR DESCRIPTION
## Summary

- New CommandPalette component: press Cmd+K / Ctrl+K to search and jump to any route.
- SW-05 from UX audit: admin sidebar has 38 routes, finding a function required manual scanning.
- Features: fuzzy search, keyboard navigation, quick actions, recent items, role-aware filtering.

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main (sha fb7732fe)
- Clean workspace: 1 new file (CommandPalette.jsx) + 1 modified (App.jsx)
- Branch: ux-audit-sw05-command-palette
- Scope gate: allowed src/components/common/ and src/App.jsx; denied backend, routing, migrations
- Red-check handling: fix any failed CI check in this PR

## Contract Impact

not applicable - no API, websocket, event, or frontend consumer contract changed. New UI component only, no existing routes modified.

## RBAC / Permissions

not applicable - the palette uses existing isRouteAccessibleToProfile to filter routes by role. No new permissions granted or revoked.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: palette shows all accessible routes when query is empty, with recent items first
- Partial data proof: if no results match, shows explicit empty state message
- Forbidden secondary path behavior: not applicable, no secondary path introduced
- Missing draft/resource behavior: not applicable, palette does not create or reopen drafts
- Stale route/deep-link behavior: not applicable, palette navigates to canonical routes only

## Scope Gate

- Allowed paths: src/components/common/CommandPalette.jsx (new), src/App.jsx (import + render)
- Denied paths: backend, routing, migrations, ops, other components
- Migration/docs/test impact: none
- Rollback note: revert this commit to remove the palette

## Validation

- Targeted tests or smoke run: ESLint, vite build, vitest (routing + doctor panel)
- Result: passed — 0 errors, 51/51 tests, build ~15s
- Not checked: manual browser smoke of Cmd+K interaction