### PR TITLE
fix(lab): UX-стабилизация панели лаборатории (11 фиксов из аудита)

### DIFF
--- a/frontend/src/components/laboratory/LabQueueWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabQueueWorkbench.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 import {
   Badge, Button, Card, CardContent, CardHeader, CardTitle, Icon, Alert,
 } from '../ui/macos';
@@ -9,6 +10,62 @@ import {
   formatSpecialtyLabel,
   getLabStatusVariant
 } from './labUiLabels';
+
+// P-05 fix: маскирование PII (номера телефона) в карточках очереди.
+// Лабораторное помещение — публичное пространство, экран видят другие
+// пациенты и сотрудники. Раскрытие — по клику, с обратной маской.
+// Маска сохраняет последние 2 цифры (для опознания пациента) и страну.
+function maskPhone(phone) {
+  if (!phone || typeof phone !== 'string') return '';
+  const trimmed = phone.trim();
+  if (!trimmed) return '';
+  // Сохраняем +country code (до первого пробела) и последние 2 цифры
+  const digits = trimmed.replace(/\D/g, '');
+  if (digits.length < 4) return '***';
+  const lastTwo = digits.slice(-2);
+  // Если есть +country — сохраняем её
+  const countryMatch = trimmed.match(/^\+\d{1,3}/);
+  const country = countryMatch ? countryMatch[0] : '+';
+  return `${country} ***-**-${lastTwo}`;
+}
+
+// P-05 fix: компонент-обёртка для переключения маска/открыто.
+// Раскрытие может быть ограничено ролью через prop canReveal.
+function MaskedPhone({ phone, canReveal = true }) {
+  const [revealed, setRevealed] = useState(false);
+  if (!phone) return <span style={{ color: 'var(--mac-text-secondary)' }}>не указан</span>;
+  if (!canReveal) {
+    return <span>{maskPhone(phone)}</span>;
+  }
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        setRevealed((v) => !v);
+      }}
+      title={revealed ? 'Скрыть номер' : 'Показать номер (доступ ограничен)'}
+      aria-label={revealed ? 'Скрыть номер телефона' : 'Показать номер телефона'}
+      style={{
+        background: 'none',
+        border: 'none',
+        padding: 0,
+        cursor: 'pointer',
+        color: 'inherit',
+        font: 'inherit',
+        textDecoration: 'underline dotted',
+        textUnderlineOffset: '2px',
+      }}
+    >
+      {revealed ? phone : maskPhone(phone)}
+    </button>
+  );
+}
+
+MaskedPhone.propTypes = {
+  phone: PropTypes.string,
+  canReveal: PropTypes.bool,
+};
 
 const cardGridStyle = {
   display: 'grid',
@@ -77,6 +134,35 @@ export default function LabQueueWorkbench({
   selectedAppointment = null,
   reportHistory = []
 }) {
+  // QW-8 fix: локальный state поиска и фильтра статусов.
+  // Раньше при 30+ записях в очереди лаборант вынужден был скроллить
+  // и визуально искать нужного пациента. Теперь — мгновенный поиск
+  // по ФИО + фильтр по статусу (waiting/in_progress/completed).
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+
+  const normalizedSearch = searchQuery.trim().toLowerCase();
+  const filteredAppointments = appointments.filter((appointment) => {
+    // Фильтр по статусу
+    if (statusFilter === 'active' && !activeQueueStatuses.has(appointment.status)) {
+      return false;
+    }
+    if (statusFilter === 'completed' && !['completed', 'done'].includes(appointment.status)) {
+      return false;
+    }
+    // Фильтр по поиску (ФИО, телефон, ID)
+    if (normalizedSearch) {
+      const haystack = [
+        appointment.patient_fio,
+        appointment.patient_phone,
+        String(appointment.patient_id || ''),
+        String(appointment.visit_id || ''),
+      ].filter(Boolean).join(' ').toLowerCase();
+      if (!haystack.includes(normalizedSearch)) return false;
+    }
+    return true;
+  });
+
   return (
     <div style={{ display: 'grid', gap: '16px' }}>
       <Card variant="filled" padding="none">
@@ -108,17 +194,204 @@ export default function LabQueueWorkbench({
               Обновить
             </Button>
           </div>
+          {/* QW-8 fix: панель поиска и фильтра статусов. */}
+          <div
+            style={{
+              display: 'flex',
+              gap: '12px',
+              flexWrap: 'wrap',
+              marginTop: '12px',
+              alignItems: 'center',
+            }}
+          >
+            <div
+              style={{
+                position: 'relative',
+                flex: '1 1 240px',
+                minWidth: '200px',
+              }}
+            >
+              <Icon
+                name="magnifyingglass"
+                size={14}
+                styleAttr={{
+                  position: 'absolute',
+                  left: '10px',
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  color: 'var(--mac-text-muted)',
+                  pointerEvents: 'none',
+                }}
+              />
+              <input
+                type="search"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Поиск по ФИО, телефону, ID…"
+                aria-label="Поиск по очереди лаборатории"
+                style={{
+                  width: '100%',
+                  padding: '8px 12px 8px 32px',
+                  borderRadius: '10px',
+                  border: '1px solid var(--mac-border)',
+                  background: 'var(--mac-bg-primary)',
+                  color: 'var(--mac-text-primary)',
+                  fontSize: '14px',
+                  outline: 'none',
+                }}
+              />
+              {searchQuery && (
+                <button
+                  type="button"
+                  onClick={() => setSearchQuery('')}
+                  aria-label="Очистить поиск"
+                  style={{
+                    position: 'absolute',
+                    right: '8px',
+                    top: '50%',
+                    transform: 'translateY(-50%)',
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: 'var(--mac-text-muted)',
+                    padding: '4px',
+                    fontSize: '16px',
+                    lineHeight: 1,
+                  }}
+                >
+                  ×
+                </button>
+              )}
+            </div>
+            <div
+              role="group"
+              aria-label="Фильтр по статусу"
+              style={{ display: 'flex', gap: '4px' }}
+            >
+              {[
+                { key: 'all',        label: 'Все' },
+                { key: 'active',     label: 'В работе' },
+                { key: 'completed',  label: 'Завершены' },
+              ].map((opt) => (
+                <button
+                  key={opt.key}
+                  type="button"
+                  onClick={() => setStatusFilter(opt.key)}
+                  aria-pressed={statusFilter === opt.key}
+                  style={{
+                    padding: '6px 12px',
+                    borderRadius: '8px',
+                    border: `1px solid ${statusFilter === opt.key ? 'var(--mac-accent)' : 'var(--mac-border)'}`,
+                    background: statusFilter === opt.key ? 'var(--mac-accent)' : 'var(--mac-bg-primary)',
+                    color: statusFilter === opt.key ? 'white' : 'var(--mac-text-primary)',
+                    cursor: 'pointer',
+                    fontSize: '13px',
+                    fontWeight: statusFilter === opt.key ? 600 : 400,
+                  }}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          {/* QW-8 fix: индикатор количества отфильтрованных записей. */}
+          {(searchQuery || statusFilter !== 'all') && (
+            <div
+              style={{
+                marginTop: '8px',
+                fontSize: '12px',
+                color: 'var(--mac-text-muted)',
+              }}
+            >
+              Показано: {filteredAppointments.length} из {appointments.length}
+              {searchQuery && ` · поиск: «${searchQuery}»`}
+              {statusFilter !== 'all' && ` · фильтр: ${
+                { active: 'в работе', completed: 'завершены' }[statusFilter]
+              }`}
+            </div>
+          )}
         </CardHeader>
         <CardContent style={{ padding: '16px', background: 'var(--mac-bg-secondary)' }}>
           {loading ? (
-            <div style={{ padding: '24px', textAlign: 'center', color: 'var(--mac-text-secondary)' }}>
-              Загрузка лабораторной очереди...
+            // QW-3 fix: skeleton-загрузка вместо текста «Загрузка…».
+            // Skeleton показывает структуру будущих карточек и снижает
+            // ощущение медлительности. 3 карточки-заглушки с shimmer-анимацией.
+            <div style={cardGridStyle} aria-busy="true" aria-live="polite">
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={i}
+                  style={{
+                    ...queueCardStyle,
+                    background: 'var(--mac-bg-tertiary)',
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px' }}>
+                    <div style={{ display: 'grid', gap: '8px', flex: 1 }}>
+                      <div
+                        style={{
+                          height: '18px',
+                          width: '60%',
+                          borderRadius: '4px',
+                          background: 'linear-gradient(90deg, var(--mac-border) 25%, var(--mac-bg-secondary) 50%, var(--mac-border) 75%)',
+                          backgroundSize: '200% 100%',
+                          animation: 'lab-skeleton-shimmer 1.5s infinite',
+                        }}
+                      />
+                      <div
+                        style={{
+                          height: '14px',
+                          width: '80%',
+                          borderRadius: '4px',
+                          background: 'linear-gradient(90deg, var(--mac-border) 25%, var(--mac-bg-secondary) 50%, var(--mac-border) 75%)',
+                          backgroundSize: '200% 100%',
+                          animation: 'lab-skeleton-shimmer 1.5s infinite',
+                        }}
+                      />
+                      <div
+                        style={{
+                          height: '14px',
+                          width: '50%',
+                          borderRadius: '4px',
+                          background: 'linear-gradient(90deg, var(--mac-border) 25%, var(--mac-bg-secondary) 50%, var(--mac-border) 75%)',
+                          backgroundSize: '200% 100%',
+                          animation: 'lab-skeleton-shimmer 1.5s infinite',
+                        }}
+                      />
+                    </div>
+                    <div
+                      style={{
+                        height: '22px',
+                        width: '80px',
+                        borderRadius: '11px',
+                        background: 'linear-gradient(90deg, var(--mac-border) 25%, var(--mac-bg-secondary) 50%, var(--mac-border) 75%)',
+                        backgroundSize: '200% 100%',
+                        animation: 'lab-skeleton-shimmer 1.5s infinite',
+                      }}
+                    />
+                  </div>
+                </div>
+              ))}
+              <style>{`
+                @keyframes lab-skeleton-shimmer {
+                  0% { background-position: 200% 0; }
+                  100% { background-position: -200% 0; }
+                }
+                @media (prefers-reduced-motion: reduce) {
+                  [style*="lab-skeleton-shimmer"] {
+                    animation: none !important;
+                  }
+                }
+              `}</style>
             </div>
-          ) : appointments.length === 0 ? (
-            <Alert severity="info">На сегодня не найдено лабораторных записей.</Alert>
+          ) : filteredAppointments.length === 0 ? (
+            <Alert severity="info">
+              {appointments.length === 0
+                ? 'На сегодня не найдено лабораторных записей.'
+                : 'Ничего не найдено. Измените поисковый запрос или фильтр.'}
+            </Alert>
           ) : (
             <div style={cardGridStyle}>
-              {appointments.map((appointment) => {
+              {filteredAppointments.map((appointment) => {
                 const isSelected = selectedAppointment?.id === appointment.id;
                 return (
                   <div
@@ -135,7 +408,10 @@ export default function LabQueueWorkbench({
                           {appointment.patient_fio || 'Пациент без имени'}
                         </div>
                       <div style={{ color: 'var(--mac-text-secondary)', fontSize: '14px' }}>
-                        Визит: {appointment.visit_id || 'не привязан'} | Телефон: {appointment.patient_phone || 'не указан'}
+                        Визит: {appointment.visit_id || 'не привязан'} | Телефон:{' '}
+                        {/* P-05 fix: маскирование номера телефона в публичном
+                            пространстве лаборатории. Раскрытие — по клику. */}
+                        <MaskedPhone phone={appointment.patient_phone} />
                       </div>
                     </div>
                       <Badge variant={getLabStatusVariant(appointment.status)}>
@@ -156,7 +432,25 @@ export default function LabQueueWorkbench({
 
                     <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', alignItems: 'center' }}>
                       <div style={{ color: 'var(--mac-text-secondary)', fontSize: '13px' }}>
-                        Пациент ID: {appointment.patient_id}
+                        {/* P-05 fix: patient_id — внутренний идентификатор, не нужен
+                            лаборанту для работы. Скрываем по умолчанию, раскрытие —
+                            по клику. Снижает риск утечки PII через скриншоты. */}
+                        <details style={{ display: 'inline' }}>
+                          <summary
+                            style={{
+                              display: 'inline-block',
+                              cursor: 'pointer',
+                              color: 'var(--mac-text-muted)',
+                              listStyle: 'none',
+                            }}
+                            aria-label="Показать внутренний ID пациента"
+                          >
+                            ID пациента ▸
+                          </summary>
+                          <span style={{ marginLeft: 6, fontFamily: 'monospace' }}>
+                            {appointment.patient_id}
+                          </span>
+                        </details>
                       </div>
                       <Button variant="primary" onClick={() => onOpenAppointment(appointment)}>
                         <Icon name="doc.text" size={16} />

--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -246,6 +246,130 @@ function buildLabPrintPayload(instance, appointment) {
   };
 }
 
+// P-20 fix: визуальный stepper жизненного цикла лабораторного бланка.
+// State machine: DRAFT → IN_PROGRESS → READY → FINALIZED → PRINTED
+// (с возможностью revise() — возвратом на DRAFT из FINALIZED).
+// Раньше статус отображался одним Badge без контекста «куда двигаться дальше».
+// Stepper показывает пройденные шаги, текущий и будущие.
+const LAB_REPORT_STEPS = [
+  { key: 'DRAFT',       label: 'Черновик' },
+  { key: 'IN_PROGRESS', label: 'Заполняется' },
+  { key: 'READY',       label: 'Готов' },
+  { key: 'FINALIZED',   label: 'Финализирован' },
+  { key: 'PRINTED',     label: 'Напечатан' },
+];
+
+function getLabReportStepIndex(status) {
+  if (!status) return -1;
+  const idx = LAB_REPORT_STEPS.findIndex((s) => s.key === status);
+  return idx;
+}
+
+function LabStatusStepper({ status }) {
+  const currentIndex = getLabReportStepIndex(status);
+  if (currentIndex < 0) {
+    // Неизвестный статус — fallback на Badge
+    return null;
+  }
+
+  return (
+    <div
+      role="navigation"
+      aria-label="Прогресс бланка"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        flexWrap: 'wrap',
+        marginTop: '8px',
+      }}
+    >
+      {LAB_REPORT_STEPS.map((step, index) => {
+        const isCompleted = index < currentIndex;
+        const isCurrent = index === currentIndex;
+        const isFuture = index > currentIndex;
+        const isLast = index === LAB_REPORT_STEPS.length - 1;
+
+        return (
+          <div
+            key={step.key}
+            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '6px',
+                padding: '4px 10px',
+                borderRadius: '12px',
+                fontSize: '12px',
+                fontWeight: isCurrent ? 600 : 400,
+                background: isCurrent
+                  ? 'var(--mac-accent)'
+                  : isCompleted
+                    ? 'color-mix(in oklab, var(--mac-accent) 15%, var(--mac-bg-primary))'
+                    : 'var(--mac-bg-tertiary)',
+                color: isCurrent
+                  ? 'white'
+                  : isCompleted
+                    ? 'var(--mac-accent)'
+                    : 'var(--mac-text-muted)',
+                border: `1px solid ${
+                  isCurrent
+                    ? 'var(--mac-accent)'
+                    : isCompleted
+                      ? 'color-mix(in oklab, var(--mac-accent) 30%, transparent)'
+                      : 'var(--mac-border)'
+                }`,
+              }}
+              aria-current={isCurrent ? 'step' : undefined}
+              title={
+                isCompleted
+                  ? `${step.label} — пройден`
+                  : isCurrent
+                    ? `${step.label} — текущий шаг`
+                    : `${step.label} — предстоит`
+              }
+            >
+              {isCompleted && (
+                <Icon name="checkmark.circle.fill" size={12} />
+              )}
+              {isCurrent && (
+                <span
+                  style={{
+                    width: '6px',
+                    height: '6px',
+                    borderRadius: '50%',
+                    background: 'white',
+                    display: 'inline-block',
+                  }}
+                  aria-hidden="true"
+                />
+              )}
+              {step.label}
+            </div>
+            {!isLast && (
+              <div
+                style={{
+                  width: '12px',
+                  height: '1px',
+                  background: isFuture ? 'var(--mac-border)' : 'var(--mac-accent)',
+                  opacity: isFuture ? 0.5 : 0.8,
+                }}
+                aria-hidden="true"
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+LabStatusStepper.propTypes = {
+  status: PropTypes.string,
+};
+
 export default function LabReportWorkbench({
   selectedAppointment = null,
   templates,
@@ -688,6 +812,9 @@ export default function LabReportWorkbench({
                   <div style={{ color: 'var(--mac-text-secondary)', fontSize: '14px' }}>
                     Визит: {activeInstance.visit_id || 'без визита'} | Бланк #{activeInstance.id}
                   </div>
+                  {/* P-20 fix: визуальный stepper жизненного цикла бланка.
+                      Показывает текущую фазу и будущие шаги. */}
+                  <LabStatusStepper status={activeInstance.status} />
                 </div>
 
                 <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>

--- a/frontend/src/components/laboratory/LabResultsManager.jsx
+++ b/frontend/src/components/laboratory/LabResultsManager.jsx
@@ -59,6 +59,31 @@ const LAB_CATEGORIES = {
   other: { name: 'Другие', icon: <TestTube /> }
 };
 
+// P-02 fix: вычисление возраста из birth_date для проброса в AI.
+// Если birth_date невалидна или пациент не указал — возвращаем null
+// и AI-кнопка блокируется (см. handleOpenAIAnalysis).
+function calculateAgeFromBirthDate(birthDate) {
+  if (!birthDate) return null;
+  const birth = new Date(birthDate);
+  if (Number.isNaN(birth.getTime())) return null;
+  const now = new Date();
+  let age = now.getFullYear() - birth.getFullYear();
+  const monthDiff = now.getMonth() - birth.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < birth.getDate())) {
+    age -= 1;
+  }
+  return age >= 0 && age < 130 ? age : null;
+}
+
+// Нормализация пола: backend хранит M|F|X, AI ожидает male|female|other
+function normalizeSexForAI(sex) {
+  if (!sex) return null;
+  const s = String(sex).trim().toUpperCase();
+  if (s === 'M' || s === 'MALE') return 'male';
+  if (s === 'F' || s === 'FEMALE') return 'female';
+  return 'other';
+}
+
 // Статусы результатов
 const RESULT_STATUS = {
   pending: { label: 'Ожидается', color: 'warning' },
@@ -69,7 +94,50 @@ const RESULT_STATUS = {
 
 const tabButtonClassName = (isActive) => `theme-tab-button${isActive ? ' theme-tab-button--active' : ''}`;
 
-const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
+// QW-6 fix: inline-валидация числовых полей формы результата.
+// Раньше value, reference_min, reference_max принимали любой текст —
+// пользователь мог ввести "выше нормы" в числовое поле и сохранить.
+// Теперь валидация происходит при вводе, и кнопка «Сохранить» блокируется
+// при ошибке. Также проверяется, что min < max.
+function isNumericString(value) {
+  if (value === '' || value == null) return true; // пустое — допустимо (необязательное поле)
+  const num = Number(value);
+  return !Number.isNaN(num) && Number.isFinite(num);
+}
+
+function validateResultForm(form) {
+  const errors = {};
+
+  // value — должно быть числом, если указано
+  if (form.value && !isNumericString(form.value)) {
+    errors.value = 'Значение должно быть числом';
+  }
+
+  // reference_min — должно быть числом, если указано
+  if (form.reference_min && !isNumericString(form.reference_min)) {
+    errors.reference_min = 'Минимум должен быть числом';
+  }
+
+  // reference_max — должно быть числом, если указано
+  if (form.reference_max && !isNumericString(form.reference_max)) {
+    errors.reference_max = 'Максимум должен быть числом';
+  }
+
+  // Если указаны оба — min должен быть < max
+  if (
+    form.reference_min
+    && form.reference_max
+    && isNumericString(form.reference_min)
+    && isNumericString(form.reference_max)
+    && Number(form.reference_min) >= Number(form.reference_max)
+  ) {
+    errors.reference_max = 'Максимум должен быть больше минимума';
+  }
+
+  return errors;
+}
+
+const LabResultsManager = ({ patientId, visitId, onUpdate, patientAge = null, patientGender = null }) => {
   // P-013 fix: shared ConfirmDialog hook (replaces 1 window.confirm() call).
   const [confirm, confirmDialog] = useConfirm();
   const [activeTab, setActiveTab] = useState('all');
@@ -80,6 +148,16 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
   const [loading, setLoading] = useState(false);
   const [showAIAnalysis, setShowAIAnalysis] = useState(false);
   const [, setAiAnalysisResults] = useState(null);
+  // P-08 fix: выбор конкретных результатов для отправки пациенту.
+  // Раньше sendToPatient отправлял ВСЕ результаты визита — включая
+  // незавершённые. Теперь пользователь явно выбирает чекбоксами.
+  const [selectedResultIds, setSelectedResultIds] = useState(new Set());
+  // P-02 fix: данные пациента, загружаемые по patientId, если возраст/пол
+  // не переданы через props. Без них AI-анализ блокируется, чтобы не
+  // интерпретировать результаты с захардкоженными значениями.
+  const [patientProfile, setPatientProfile] = useState(null);
+  const [patientProfileLoading, setPatientProfileLoading] = useState(false);
+  const [aiBlockedReason, setAiBlockedReason] = useState('');
 
   // Форма результата
   const [resultForm, setResultForm] = useState({
@@ -107,6 +185,81 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
     }
   }, [visitId]);
 
+  // P-02 fix: загрузка профиля пациента, чтобы получить birth_date и sex
+  // для AI-интерпретации. Используется только если возраст/пол не переданы
+  // через props (prop patientAge/patientGender имеют приоритет — позволяют
+  // родительскому компоненту передать уже известные данные без доп. запроса).
+  useEffect(() => {
+    if (!patientId) {
+      setPatientProfile(null);
+      return;
+    }
+    // Если возраст/пол уже переданы через props — запрос не нужен
+    if (patientAge != null && patientGender) {
+      setPatientProfile(null);
+      return;
+    }
+    let cancelled = false;
+    setPatientProfileLoading(true);
+    api.get(`/patients/${patientId}`)
+      .then((response) => {
+        if (cancelled) return;
+        setPatientProfile(response?.data || response || null);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        logger.error('Не удалось загрузить профиль пациента для AI-анализа:', error);
+        setPatientProfile(null);
+      })
+      .finally(() => {
+        if (!cancelled) setPatientProfileLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [patientId, patientAge, patientGender]);
+
+  // P-02 fix: вычисляем финальные возраст/пол с приоритетом props над загруженным профилем.
+  const resolvedPatientAge = patientAge ??
+    (patientProfile?.birth_date ? calculateAgeFromBirthDate(patientProfile.birth_date) : null);
+  const resolvedPatientGender = patientGender ??
+    normalizeSexForAI(patientProfile?.sex);
+
+  // P-02 fix: AI-анализ блокируется, если нет возраста или пола.
+  // Референсные интервалы многих анализов (гемоглобин, креатинин, гормоны)
+  // зависят от этих параметров — интерпретация с заглушкой опасна.
+  useEffect(() => {
+    if (patientProfileLoading) {
+      setAiBlockedReason('Загрузка данных пациента…');
+      return;
+    }
+    if (resolvedPatientAge == null) {
+      setAiBlockedReason(
+        'AI-анализ недоступен: не указана дата рождения пациента. ' +
+        'Заполните профиль пациента и повторите попытку.'
+      );
+      return;
+    }
+    if (!resolvedPatientGender) {
+      setAiBlockedReason(
+        'AI-анализ недоступен: не указан пол пациента. ' +
+        'Референсные интервалы зависят от пола — интерпретация невозможна.'
+      );
+      return;
+    }
+    setAiBlockedReason('');
+  }, [patientProfileLoading, resolvedPatientAge, resolvedPatientGender]);
+
+  // P-02 fix: открытие AI-диалога с явной блокировкой при отсутствии данных.
+  // Раньше кнопка была активна и передавала patientId ? 35 : null —
+  // то есть AI получал захардкоженный возраст для любого пациента.
+  const handleOpenAIAnalysis = () => {
+    if (results.length === 0) return;
+    if (resolvedPatientAge == null || !resolvedPatientGender) {
+      notify.error?.(aiBlockedReason || 'AI-анализ недоступен: проверьте данные пациента');
+      return;
+    }
+    setShowAIAnalysis(true);
+  };
+
   // Загрузка результатов
   useEffect(() => {
     if (visitId) {
@@ -118,6 +271,11 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
   const filteredResults = activeTab === 'all' ?
   results :
   results.filter((r) => r.category === activeTab);
+
+  // QW-6 fix: производное состояние ошибок валидации формы.
+  // Пересчитывается при каждом изменении resultForm.
+  const formErrors = validateResultForm(resultForm);
+  const hasFormErrors = Object.keys(formErrors).length > 0;
 
   // Подсчет по категориям
   const getCategoryCount = (category) => {
@@ -143,6 +301,11 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
 
   // Сохранение результата
   const handleSaveResult = async () => {
+    // QW-6 fix: блокируем сохранение при ошибках валидации.
+    if (hasFormErrors) {
+      notify.error?.('Проверьте корректность числовых полей');
+      return;
+    }
     try {
       const status = determineStatus(
         resultForm.value,
@@ -227,35 +390,101 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
 
   // Экспорт в PDF
   const exportToPDF = async () => {
+    let url = null;
     try {
       const response = await api.get(`/visits/${visitId}/lab-results/pdf`, {
         responseType: 'blob'
       });
 
-      const url = window.URL.createObjectURL(new Blob([response.data]));
+      url = window.URL.createObjectURL(new Blob([response.data]));
       const link = document.createElement('a');
       link.href = url;
       link.setAttribute('download', `lab_results_${visitId}.pdf`);
       document.body.appendChild(link);
       link.click();
       link.remove();
-
     } catch (error) {
       logger.error('Ошибка экспорта PDF:', error);
+    } finally {
+      // P-07 fix: явно освобождаем object URL, чтобы избежать memory leak
+      // при каждом экспорте. Раньше URL.createObjectURL вызывался, но
+      // revokeObjectURL — никогда. При повторных экспортах в длинной
+      // сессии память утекала по ~размеру PDF на каждый клик.
+      if (url) {
+        window.URL.revokeObjectURL(url);
+      }
     }
   };
 
-  // Отправка пациенту
+  // P-08 fix: отправка пациенту только выбранных результатов.
+  // Раньше отправлялись ВСЕ результаты визита без возможности выбора,
+  // что могло привести к отправке незавершённых или неподтверждённых данных.
+  // Теперь: если ничего не выбрано — спрашиваем подтверждение «Отправить все?»;
+  // если выбраны — отправляем только их и показываем явный список в подтверждении.
+  const toggleResultSelection = (resultId) => {
+    setSelectedResultIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(resultId)) {
+        next.delete(resultId);
+      } else {
+        next.add(resultId);
+      }
+      return next;
+    });
+  };
+
   const sendToPatient = async () => {
+    const selectedIds = Array.from(selectedResultIds);
+    const sendingAll = selectedIds.length === 0;
+    const selectedResults = sendingAll
+      ? results
+      : results.filter((r) => selectedResultIds.has(r.id));
+
+    if (selectedResults.length === 0) {
+      notify.error('Нет результатов для отправки');
+      return;
+    }
+
+    // P-08 fix: явное подтверждение с количеством и составом.
+    const listPreview = selectedResults
+      .slice(0, 5)
+      .map((r) => `• ${r.test_name}: ${r.value} ${r.unit || ''}`)
+      .join('\n');
+    const moreNote = selectedResults.length > 5
+      ? `\n…и ещё ${selectedResults.length - 5}`
+      : '';
+
+    const ok = await confirm({
+      title: 'Отправка результатов пациенту',
+      message: `Будет отправлено в Telegram: ${selectedResults.length} ${selectedResults.length === 1 ? 'результат' : 'результатов'}.`,
+      description: `${listPreview}${moreNote}\n\nКанал: Telegram\nОтменить отправку после доставки невозможно.`,
+      confirmLabel: 'Отправить',
+      cancelLabel: 'Отмена',
+      intent: 'primary',
+    });
+    if (!ok) return;
+
     try {
       await api.post(`/patients/${patientId}/send-lab-results`, {
         visit_id: visitId,
-        method: 'telegram'
+        method: 'telegram',
+        // P-08 fix: явно передаём выбранные ID. Если ничего не выбрано —
+        // backend получит пустой массив и (по контракту useLabResults)
+        // отправит все результаты визита. Это поведение сохранено для
+        // обратной совместимости, но теперь это осознанный выбор пользователя.
+        result_ids: selectedIds,
       });
 
-      notify.success('Результаты отправлены пациенту');
+      notify.success(
+        `Отправлено в Telegram: ${selectedResults.length} ${selectedResults.length === 1 ? 'результат' : 'результатов'}`
+      );
+      // Сбрасываем выбор после успешной отправки
+      setSelectedResultIds(new Set());
     } catch (error) {
       logger.error('Ошибка отправки результатов:', error);
+      notify.error(
+        error?.response?.data?.detail || error?.message || 'Не удалось отправить результаты'
+      );
     }
   };
 
@@ -322,20 +551,29 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
                 <Download style={{ width: 16, height: 16, marginRight: 8 }} />
                 Экспорт PDF
               </Button>
-              <Button size="small" onClick={sendToPatient}>
+              <Button
+                size="small"
+                onClick={sendToPatient}
+                title="Отправить выбранные результаты в Telegram пациенту"
+                aria-label="Отправить выбранные результаты в Telegram пациенту"
+              >
                 <Send style={{ width: 16, height: 16, marginRight: 8 }} />
-                Отправить
+                Отправить в Telegram
+                {/* P-08 fix: badge с количеством выбранных результатов. */}
+                {selectedResultIds.size > 0 && (
+                  <Badge variant="primary" style={{ marginLeft: 8 }}>
+                    {selectedResultIds.size}
+                  </Badge>
+                )}
               </Button>
               <AIButton
                 text="AI Анализ"
                 size="small"
-                onClick={() => {
-                  if (results.length > 0) {
-                    setShowAIAnalysis(true);
-                  }
-                }}
-                disabled={results.length === 0}
-                tooltip="AI интерпретация результатов" />
+                onClick={handleOpenAIAnalysis}
+                disabled={results.length === 0 || patientProfileLoading || Boolean(aiBlockedReason)}
+                tooltip={aiBlockedReason || (results.length === 0
+                  ? 'Нет результатов для анализа'
+                  : 'AI интерпретация результатов с учётом возраста и пола пациента')} />
               
             </Box>
           </Box>
@@ -370,6 +608,34 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
               <table className="clinic-ops-table">
                 <thead>
                   <tr>
+                    {/* P-08 fix: колонка выбора для отправки пациенту. */}
+                    <th style={{ textAlign: 'center', width: '40px' }}>
+                      <input
+                        type="checkbox"
+                        aria-label="Выбрать все результаты для отправки"
+                        title="Выбрать все видимые результаты"
+                        checked={
+                          filteredResults.length > 0 &&
+                          filteredResults.every((r) => selectedResultIds.has(r.id))
+                        }
+                        ref={(el) => {
+                          if (el) el.indeterminate =
+                            selectedResultIds.size > 0 &&
+                            !filteredResults.every((r) => selectedResultIds.has(r.id));
+                        }}
+                        onChange={(e) => {
+                          setSelectedResultIds((prev) => {
+                            const next = new Set(prev);
+                            if (e.target.checked) {
+                              filteredResults.forEach((r) => next.add(r.id));
+                            } else {
+                              filteredResults.forEach((r) => next.delete(r.id));
+                            }
+                            return next;
+                          });
+                        }}
+                      />
+                    </th>
                     <th style={{ textAlign: 'left' }}>Исследование</th>
                     <th style={{ textAlign: 'left' }}>Результат</th>
                     <th style={{ textAlign: 'left' }}>Норма</th>
@@ -381,6 +647,15 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
                 <tbody>
                   {filteredResults.map((result) =>
                 <tr key={result.id}>
+                      <td style={{ textAlign: 'center' }}>
+                        {/* P-08 fix: индивидуальный выбор для отправки. */}
+                        <input
+                          type="checkbox"
+                          aria-label={`Выбрать ${result.test_name} для отправки`}
+                          checked={selectedResultIds.has(result.id)}
+                          onChange={() => toggleResultSelection(result.id)}
+                        />
+                      </td>
                       <td>
                         <Typography variant="body2" style={{ fontWeight: 500 }}>
                           {result.test_name}
@@ -502,34 +777,62 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
             <Box style={{ display: 'flex', gap: '16px' }}>
               <Box style={{ flex: 2 }}>
                 <Input
+                  type="number"
+                  inputMode="decimal"
+                  step="any"
                   label="Результат"
                   value={resultForm.value}
-                  onChange={(e) => setResultForm({ ...resultForm, value: e.target.value })} />
-                
+                  onChange={(e) => setResultForm({ ...resultForm, value: e.target.value })}
+                  error={Boolean(formErrors.value)}
+                />
+                {/* QW-6 fix: inline-сообщение об ошибке под полем. */}
+                {formErrors.value && (
+                  <Typography variant="caption" color="error" style={{ display: 'block', marginTop: '4px' }}>
+                    {formErrors.value}
+                  </Typography>
+                )}
               </Box>
-              
+
               <Box style={{ flex: 1 }}>
                 <Input
                   label="Ед."
                   value={resultForm.unit}
                   onChange={(e) => setResultForm({ ...resultForm, unit: e.target.value })} />
-                
+
               </Box>
-              
+
               <Box style={{ flex: 1 }}>
                 <Input
+                  type="number"
+                  inputMode="decimal"
+                  step="any"
                   label="Мин. норма"
                   value={resultForm.reference_min}
-                  onChange={(e) => setResultForm({ ...resultForm, reference_min: e.target.value })} />
-                
+                  onChange={(e) => setResultForm({ ...resultForm, reference_min: e.target.value })}
+                  error={Boolean(formErrors.reference_min)}
+                />
+                {formErrors.reference_min && (
+                  <Typography variant="caption" color="error" style={{ display: 'block', marginTop: '4px' }}>
+                    {formErrors.reference_min}
+                  </Typography>
+                )}
               </Box>
-              
+
               <Box style={{ flex: 1 }}>
                 <Input
+                  type="number"
+                  inputMode="decimal"
+                  step="any"
                   label="Макс. норма"
                   value={resultForm.reference_max}
-                  onChange={(e) => setResultForm({ ...resultForm, reference_max: e.target.value })} />
-                
+                  onChange={(e) => setResultForm({ ...resultForm, reference_max: e.target.value })}
+                  error={Boolean(formErrors.reference_max)}
+                />
+                {formErrors.reference_max && (
+                  <Typography variant="caption" color="error" style={{ display: 'block', marginTop: '4px' }}>
+                    {formErrors.reference_max}
+                  </Typography>
+                )}
               </Box>
             </Box>
             
@@ -563,7 +866,7 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
           }}>
             Отмена
           </Button>
-          <Button variant="contained" onClick={handleSaveResult} disabled={!resultForm.test_name}>
+          <Button variant="contained" onClick={handleSaveResult} disabled={!resultForm.test_name || hasFormErrors}>
             {selectedResult ? 'Сохранить' : 'Добавить'}
           </Button>
         </DialogActions>
@@ -632,6 +935,18 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
           </DialogTitle>
           
           <DialogContent>
+            {/* P-02 fix: явное отображение данных пациента, на основе которых
+                строится AI-интерпретация. Пользователь видит реальные значения
+                вместо молчаливого хардкода. */}
+            <Alert severity="info" sx={{ mb: 2 }}>
+              <Typography variant="caption" component="div">
+                <strong>Пациент:</strong> {resolvedPatientAge != null ? `${resolvedPatientAge} лет` : 'возраст неизвестен'}
+                {', '}
+                <strong>Пол:</strong> {resolvedPatientGender
+                  ? ({ male: 'мужской', female: 'женский', other: 'другой' }[resolvedPatientGender] || resolvedPatientGender)
+                  : 'не указан'}
+              </Typography>
+            </Alert>
             <AIAssistant
             analysisType="lab"
             data={{
@@ -641,8 +956,10 @@ const LabResultsManager = ({ patientId, visitId, onUpdate }) => {
                 unit: r.unit,
                 reference: `${r.reference_min}-${r.reference_max}`
               })),
-              patient_age: patientId ? 35 : null, // Здесь нужно получить реальный возраст
-              patient_gender: null
+              // P-02 fix: ранее было `patientId ? 35 : null` — хардкод возраста.
+              // Теперь передаются реальные значения, проверенные выше.
+              patient_age: resolvedPatientAge,
+              patient_gender: resolvedPatientGender
             }}
             onResult={(result) => {
               setAiAnalysisResults(result);
@@ -669,6 +986,11 @@ LabResultsManager.propTypes = {
   onUpdate: PropTypes.any,
   patientId: PropTypes.any,
   visitId: PropTypes.any,
+  // P-02 fix: опциональные props, позволяющие родителю передать уже известные
+  // возраст/пол и избежать лишнего запроса GET /patients/{id}. Если не переданы —
+  // компонент загрузит профиль сам. AI блокируется до получения данных.
+  patientAge: PropTypes.number,
+  patientGender: PropTypes.oneOf(['male', 'female', 'other']),
 };
 
 export default LabResultsManager;

--- a/frontend/src/pages/LabPanel.jsx
+++ b/frontend/src/pages/LabPanel.jsx
@@ -122,10 +122,27 @@ export default function LabPanel() {
   const [activeInstance, setActiveInstance] = useState(null);
   const [templateResolution, setTemplateResolution] = useState(null);
   const [templateResolutionLoading, setTemplateResolutionLoading] = useState(false);
-  const [message, setMessage] = useState({ type: '', text: '' });
+  // QW-4 fix: message теперь содержит опциональный retryAction — функцию,
+  // которая вызывается при клике «Повторить» в Alert. Раньше ошибки
+  // показывались на 5 секунд без возможности восстановиться — пользователь
+  // переключал таб и не видел сообщения. Теперь:
+  //   - errors показываются 12 секунд (вместо 5)
+  //   - info/success — 5 секунд (как раньше)
+  //   - error с retryAction показывает кнопку «Повторить»
+  //   - любой клик по Alert закрывает его
+  const [message, setMessage] = useState({ type: '', text: '', retryAction: null, retryLabel: '' });
 
-  const notify = useCallback((type, text) => {
-    setMessage({ type, text });
+  const notify = useCallback((type, text, options = {}) => {
+    setMessage({
+      type,
+      text,
+      retryAction: typeof options.retryAction === 'function' ? options.retryAction : null,
+      retryLabel: options.retryLabel || 'Повторить',
+    });
+  }, []);
+
+  const dismissMessage = useCallback(() => {
+    setMessage({ type: '', text: '', retryAction: null, retryLabel: '' });
   }, []);
 
   const mergeResolvedVisitIntoState = useCallback((appointmentId, visitId) => {
@@ -234,7 +251,9 @@ export default function LabPanel() {
       logger.error('[LabPanel] loadLabAppointments failed', error);
       notify(
         'error',
-        getErrorMessage(error, 'Не удалось загрузить лабораторную очередь. Проверьте соединение и попробуйте снова.')
+        getErrorMessage(error, 'Не удалось загрузить лабораторную очередь. Проверьте соединение и попробуйте снова.'),
+        // QW-4 fix: кнопка «Повторить» в Alert.
+        { retryAction: () => loadLabAppointments(), retryLabel: 'Загрузить снова' }
       );
     } finally {
       setAppointmentsLoading(false);
@@ -261,7 +280,9 @@ export default function LabPanel() {
       logger.error('[LabPanel] loadTemplates failed', error);
       notify(
         'error',
-        getErrorMessage(error, 'Не удалось загрузить шаблоны лаборатории. Проверьте соединение и попробуйте снова.')
+        getErrorMessage(error, 'Не удалось загрузить шаблоны лаборатории. Проверьте соединение и попробуйте снова.'),
+        // QW-4 fix: кнопка «Повторить» в Alert.
+        { retryAction: () => loadTemplates(), retryLabel: 'Загрузить снова' }
       );
     }
   }, [notify, selectedTemplate?.id]);
@@ -278,7 +299,9 @@ export default function LabPanel() {
       logger.error('[LabPanel] loadReportHistory failed', error);
       notify(
         'error',
-        getErrorMessage(error, 'Не удалось загрузить историю лабораторных бланков. Проверьте соединение и попробуйте снова.')
+        getErrorMessage(error, 'Не удалось загрузить историю лабораторных бланков. Проверьте соединение и попробуйте снова.'),
+        // QW-4 fix: кнопка «Повторить» в Alert.
+        { retryAction: () => loadReportHistory(patientId), retryLabel: 'Загрузить снова' }
       );
     }
   }, [notify]);
@@ -291,7 +314,9 @@ export default function LabPanel() {
       logger.error('[LabPanel] loadRecentReports failed', error);
       notify(
         'error',
-        getErrorMessage(error, 'Не удалось загрузить список лабораторных бланков. Проверьте соединение и попробуйте снова.')
+        getErrorMessage(error, 'Не удалось загрузить список лабораторных бланков. Проверьте соединение и попробуйте снова.'),
+        // QW-4 fix: кнопка «Повторить» в Alert.
+        { retryAction: () => loadRecentReports(), retryLabel: 'Загрузить снова' }
       );
     }
   }, [notify]);
@@ -369,7 +394,17 @@ export default function LabPanel() {
     if (!message.text) {
       return undefined;
     }
-    const timer = window.setTimeout(() => setMessage({ type: '', text: '' }), 5000);
+    // QW-4 fix: errors показываются дольше (12 сек), т.к. требуют внимания;
+    // info/success — 5 сек. Если есть retryAction, не скрываем автоматически
+    // (пользователь должен либо нажать «Повторить», либо закрыть вручную).
+    if (message.retryAction) {
+      return undefined;
+    }
+    const delay = message.type === 'error' ? 12000 : 5000;
+    const timer = window.setTimeout(
+      () => setMessage({ type: '', text: '', retryAction: null, retryLabel: '' }),
+      delay
+    );
     return () => window.clearTimeout(timer);
   }, [message]);
 
@@ -394,6 +429,50 @@ export default function LabPanel() {
         minHeight: '100%'
       }}
     >
+      {/* P-13 fix: skip-to-content link для keyboard-пользователей.
+          Скрыт визуально, появляется при фокусе. Позволяет перескочить
+          tablist и попасть прямо к содержимому активного таба. */}
+      <a
+        href={`#${LAB_PANEL_TABLIST_ID}`}
+        style={{
+          position: 'absolute',
+          left: -9999,
+          top: 'auto',
+          width: 1,
+          height: 1,
+          overflow: 'hidden',
+          padding: 0,
+          margin: 0,
+          clip: 'rect(0 0 0 0)',
+          whiteSpace: 'nowrap',
+          border: 0,
+        }}
+        onFocus={(e) => {
+          e.target.style.cssText = [
+            'position:fixed',
+            'top:8px',
+            'left:8px',
+            'width:auto',
+            'height:auto',
+            'overflow:visible',
+            'padding:8px 16px',
+            'margin:0',
+            'clip:auto',
+            'white-space:nowrap',
+            'background:var(--mac-accent)',
+            'color:white',
+            'border-radius:8px',
+            'z-index:9999',
+            'font-weight:600',
+            'box-shadow:0 4px 12px rgba(0,0,0,0.2)',
+          ].join(';');
+        }}
+        onBlur={(e) => {
+          e.target.style.cssText = '';
+        }}
+      >
+        Перейти к навигации по табам
+      </a>
       <Card variant="filled" padding="none">
         <CardHeader
           style={{
@@ -458,7 +537,41 @@ export default function LabPanel() {
             aria-live={message.type === 'error' ? 'assertive' : 'polite'}
             style={{ padding: '16px', background: 'var(--mac-bg-secondary)' }}
           >
-            <Alert severity={message.type === 'error' ? 'error' : 'info'}>{message.text}</Alert>
+            {/* QW-4 fix: Alert с кнопками «Повторить» (если есть retryAction)
+                и «Закрыть». Раньше Alert только показывал текст — теперь
+                пользователь может восстановиться после ошибки одним кликом. */}
+            <Alert
+              severity={message.type === 'error' ? 'error' : 'info'}
+              action={(
+                <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                  {message.retryAction && (
+                    <Button
+                      size="small"
+                      variant="primary"
+                      onClick={() => {
+                        const action = message.retryAction;
+                        dismissMessage();
+                        // Небольшая задержка, чтобы UI успел обновиться
+                        setTimeout(() => action(), 0);
+                      }}
+                    >
+                      <Icon name="arrow.clockwise" size={14} />
+                      {message.retryLabel || 'Повторить'}
+                    </Button>
+                  )}
+                  <Button
+                    size="small"
+                    variant="outline"
+                    onClick={dismissMessage}
+                    aria-label="Закрыть уведомление"
+                  >
+                    <Icon name="xmark" size={14} />
+                  </Button>
+                </div>
+              )}
+            >
+              {message.text}
+            </Alert>
           </CardContent>
         )}
       </Card>


### PR DESCRIPTION
## Summary

Реализована первая фаза стабилизации панели лаборатории по результатам экспертного UX/UI-аудита. 11 фиксов (1 Critical + 3 High + 5 Medium + 2 Low) в 4 файлах, +900/-44 строк.

- **P-02 (Critical):** убран хардкод `patient_age=35` в AI-анализе — теперь берутся реальные `birth_date`/`sex` пациента; AI блокируется до получения данных
- **P-05 (High):** маскирование PII (телефон, patient_id) в карточках очереди с раскрытием по клику
- **P-08 (High):** `sendToPatient` с явным выбором результатов через checkbox и подтверждением
- **P-20 (Medium):** визуальный stepper жизненного цикла бланка `DRAFT → IN_PROGRESS → READY → FINALIZED → PRINTED`
- **QW-3, QW-4, QW-6, QW-8:** skeleton-загрузка, retry-кнопка в Alert, inline-валидация числовых полей, search-фильтр в очереди
- **P-07, P-13, P-14:** memory leak fix, skip-to-content link, tooltip для кнопки Send

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/ux-audit-lab-panel` создан от текущего `origin/main` (commit `9b53832`), `mergeable: true` по данным GitHub API
- Clean workspace: `git status --short` пустой после всех 4 коммитов
- Branch: `fix/ux-audit-lab-panel` → `main`
- Scope gate: только 4 frontend-файла в `frontend/src/components/laboratory/` и `frontend/src/pages/LabPanel.jsx`; backend, migrations, configs, CI не затронуты
- Red-check handling: CI checks пропущены (path-filter не сработал на backend-изменения); ручная верификация синтаксиса через Python-парсер балансировки скобок пройдена для всех 4 файлов

## Contract Impact

- Canonical surface: `POST /patients/{patient_id}/send-lab-results` — добавлена передача опционального `result_ids: number[]` в payload (P-08 fix). Ранее поле уже поддерживалось backend (см. `useLabResults.js:144`), но компонент `LabResultsManager` его не передавал. Никаких новых endpoints или схем.
- Request shape: `POST /patients/{id}/send-lab-results` теперь получает `{ visit_id: number, method: 'telegram', result_ids: number[] }` вместо `{ visit_id, method }`. Поле `result_ids` опциональное — пустой массив сохраняет старое поведение «отправить все».
- Response shape: не изменена — backend возвращает те же 200/4xx/5xx с теми же payload-схемами
- Status codes: не изменены — те же HTTP-коды, что и раньше (200 OK при успехе, 401/403/404/500 при ошибках)
- Frontend consumer: `LabResultsManager.jsx` — единственный потребитель этого endpoint, изменён в этом PR. Hook `useLabResults.js` уже передавал `result_ids` ранее — его поведение не изменено.
- Compatibility path or alias: не требуется — поле `result_ids` опциональное; существующие вызовы без него продолжат работать (backend интерпретирует пустой/отсутствующий массив как «все результаты визита»)
- Contract proof: backend `telegram_notifications.py:331-355` уже принимает `result_ids` (см. endpoint signature). frontend `useLabResults.js:140-155` уже использовал этот параметр. Изменение в `LabResultsManager.jsx:415-423` только добавляет явную передачу.

## RBAC / Permissions

- Roles allowed: изменения не затрагивают RBAC — те же роли (Admin, Lab, Doctor, Registrar, Receptionist, Cashier) имеют тот же доступ к тем же endpoints. Backend-декораторы `@require_roles(...)` на всех lab-endpoints (`lab_reporting.py:234, 243, 253, 267, 276, 286, 317, 330, 345, 359, 376, 390, 403, 416, 432, 463, 479, 496, 510, 530, 543, 555, 568, 582`) не изменены.
- Roles denied: не изменено — политики отказа на backend (`_ensure_doctor_can_read_lab_instance`, `_doctor_allowed_visit_ids`) не затронуты. Frontend не добавляет новых auth-проверок.
- Positive auth proof: токен `Authorization: Bearer` передаётся через `labReporting.js` и `tokenManager` без изменений. Все существующие endpoints продолжат работать с теми же ролями. P-02 fix добавляет запрос `GET /patients/{id}` — этот endpoint уже защищён `require_roles` на backend.
- Negative auth proof: не изменено — backend не получил новых guard'ов. Если у пользователя не было роли для `/patients/{id}`, он и не получит к ней доступ через новый вызов в `LabResultsManager`. AI-блокировка (P-02) — это UI-функция, не RBAC-проверка: она не даёт и не отнимает права, только предотвращает некорректный вызов AI.

## Notification / Realtime

- Event type or websocket channel: не затронуты. `RoleNotificationCenter` в `LabPanel.jsx` остался без изменений. WebSocket-каналы не добавлены/удалены.
- Payload version / ack behavior: не изменён. Telegram-уведомления отправляются через тот же endpoint `POST /patients/{id}/send-lab-results` с тем же каналом `telegram`. Единственное изменение — `result_ids` в payload (см. Contract Impact), но это содержимое данных, не формат события.
- Read/unread or delivery semantics: не изменены. Backend `telegram_notifications.py:331` продолжает отправлять те же уведомления; P-08 fix только фильтрует, какие результаты попадут в отправку (явный список вместо «все»).
- Reconnect/resync proof: не применимо — realtime-логика не изменена. Retry-кнопка (QW-4) повторяет обычный REST-запрос, не websocket-reconnect.

## Frontend Resilience

- Empty data proof: `LabQueueWorkbench` — при `appointments.length === 0` показывается Alert «На сегодня не найдено лабораторных записей»; при пустом результате поиска/фильтра — отдельный Alert «Ничего не найдено. Измените поисковый запрос или фильтр.»
- Partial data proof: `LabResultsManager` — если `patientProfile` не загрузился (ошибка сети), AI-кнопка блокируется с понятным сообщением вместо молчаливого хардкода. `LabReportWorkbench` — при частичном `patient_snapshot` fallback на `Пациент #{id}`
- Forbidden secondary path behavior: retry-кнопка в Alert вызывает ту же функцию загрузки через `retryAction`; при повторной ошибке Alert обновляется, не накапливается. При наличии retryAction Alert persistent (не исчезает по таймеру)
- Missing draft/resource behavior: `LabReportWorkbench` — при `activeInstance === null` stepper не рендерится (защита `currentIndex < 0 → return null`). При неизвестном статусе — fallback на Badge
- Stale route/deep-link behavior: `LabPanel.jsx` сохраняет синхронизацию таба с `?tab=...` через `useSearchParams` и `navigate(..., { replace: true })`. При прямом URL на «Бланки» без выбранного appointment отображается пустой редактор (не падает)

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/LabResultsManager.jsx`, `frontend/src/components/laboratory/LabQueueWorkbench.jsx`, `frontend/src/components/laboratory/LabReportWorkbench.jsx`, `frontend/src/pages/LabPanel.jsx`
- Denied paths: backend (`backend/**`), API-клиент (`frontend/src/api/**`), migrations (`backend/alembic_versions/**`), CI (`.github/workflows/**`), configs (`.env*`, `docker-compose*.yml`), docs (`docs/**`)
- Migration/docs/test impact: отсутствует. Существующие тесты в `frontend/src/components/laboratory/__tests__/` не затронуты. Новых тестов не добавлено (см. Validation — окружение агента без `node_modules`)
- Rollback note: все правки обратно совместимы (новые props опциональны, retry opt-in, новые state-поля изолированы). Откат — `git revert` 4 коммитов в обратном порядке: `37d0278` → `bdd1a53` → `8785875` → `7e14d32`

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: Синтаксис JSX проверен через Python-парсер балансировки скобок для всех 4 файлов — passed. grep-верификация всех 11 маркеров фиксов (P-02, P-05, P-07, P-08, P-13, P-14, P-20, QW-3, QW-4, QW-6, QW-8) — all present. Хардкод `patientId ? 35 : null` убран из активного кода (остался только в комментариях-описаниях фиксов). `git diff --stat main..HEAD` подтверждает ровно 4 файла, +900/-44 строк.
- Result: passed для статического анализа. 4 файла изменены, 4 логических коммита, working tree clean.
- Not checked: unit-тесты `vitest` (требуется `cd frontend && npm test` локально), E2E `playwright` (требуется `npx playwright test` локально), визуальный smoke в dev-сервере по чек-листу ниже, CI checks пропущены path-filter'ом — ревьюер должен запустить CI вручную.

### Чек-лист для ревьюера (visual smoke)

- [ ] AI-анализ с заполненным профилем → видны реальные возраст/пол
- [ ] AI-анализ с незаполненным `birth_date` → кнопка заблокирована, есть сообщение
- [ ] Маскирование телефона в очереди → раскрытие по клику
- [ ] Поиск по ФИО в очереди → мгновенная фильтрация
- [ ] Skeleton при загрузке очереди (throttle network в DevTools)
- [ ] Retry-кнопка при ошибке сети (offline mode в DevTools)
- [ ] Checkbox выбора результатов → Send с подтверждением
- [ ] Inline-валидация: ввести «выше нормы» в числовое поле → красное сообщение, Save disabled
- [ ] Stepper бланка: открыть бланк в разных статусах → подсветка текущего шага

---

🤖 Сгенерировано как часть UX-аудита панели лаборатории · 2026-07-01
