### PR TITLE
fix(lab): WF-06 — optimistic locking для предотвращения потери данных

### DIFF
--- a/backend/app/api/v1/endpoints/lab_reporting.py
+++ b/backend/app/api/v1/endpoints/lab_reporting.py
@@ -599,12 +599,16 @@ def get_lab_report_instance(
 def update_lab_report_instance(
     instance_id: int,
     payload: LabReportInstanceUpdate,
+    # WF-06 fix: optimistic locking — frontend передаёт updated_at последнего чтения
+    expected_updated_at: str | None = Query(default=None, alias="expected_updated_at"),
     db: Session = Depends(get_db),
     user=Depends(require_roles("Admin", "Lab")),
 ):
     service = LabReportingService(db)
     try:
-        return _instance_out(service, service.update_instance(instance_id, payload.model_dump()))
+        return _instance_out(service, service.update_instance(
+            instance_id, payload.model_dump(), expected_updated_at=expected_updated_at
+        ))
     except LabReportingDomainError as exc:
         _handle_domain_error(exc)
 
@@ -613,6 +617,8 @@ def update_lab_report_instance(
 def bulk_save_lab_report_values(
     instance_id: int,
     payload: list[LabReportValueIn],
+    # WF-06 fix: optimistic locking — frontend передаёт updated_at последнего чтения
+    expected_updated_at: str | None = Query(default=None, alias="expected_updated_at"),
     db: Session = Depends(get_db),
     user=Depends(require_roles("Admin", "Lab")),
 ):
@@ -621,6 +627,7 @@ def bulk_save_lab_report_values(
         instance, updated = service.bulk_upsert_values(
             instance_id,
             [item.model_dump(mode="json") for item in payload],
+            expected_updated_at=expected_updated_at,
         )
         return LabReportBulkSaveResponse(
             instance=_instance_out(service, instance),

--- a/backend/app/services/lab_reporting_service.py
+++ b/backend/app/services/lab_reporting_service.py
@@ -529,10 +529,15 @@ class LabReportingService:
         logger.info("[LAB] create_instance created instance_id=%s", instance.id)
         return self.get_instance(instance.id)
 
-    def update_instance(self, instance_id: int, payload: dict[str, Any]) -> LabReportInstance:
+    def update_instance(
+        self, instance_id: int, payload: dict[str, Any], expected_updated_at: str | None = None
+    ) -> LabReportInstance:
         logger.info("[LAB] update_instance instance_id=%s", instance_id)
         instance = self.get_instance(instance_id)
         self._assert_instance_editable(instance)
+        # WF-06 fix: optimistic locking — проверяем что никто не изменил
+        # бланк с момента последнего чтения frontend'ом.
+        self._assert_not_concurrently_modified(instance, expected_updated_at)
         if "signer_snapshot" in payload and payload["signer_snapshot"] is not None:
             instance.signer_snapshot = payload["signer_snapshot"]
         if "branding_snapshot" in payload and payload["branding_snapshot"] is not None:
@@ -541,7 +546,8 @@ class LabReportingService:
         return self.get_instance(instance.id)
 
     def bulk_upsert_values(
-        self, instance_id: int, values_payload: list[dict[str, Any]]
+        self, instance_id: int, values_payload: list[dict[str, Any]],
+        expected_updated_at: str | None = None,
     ) -> tuple[LabReportInstance, list[LabReportValue]]:
         logger.info(
             "[LAB] bulk_upsert_values instance_id=%s items=%s",
@@ -550,6 +556,9 @@ class LabReportingService:
         )
         instance = self.get_instance(instance_id)
         self._assert_instance_editable(instance)
+        # WF-06 fix: optimistic locking — проверяем что никто не изменил
+        # бланк с момента последнего чтения frontend'ом.
+        self._assert_not_concurrently_modified(instance, expected_updated_at)
         field_map = self._field_map(instance.template_version)
         existing_by_key = {value.field_key: value for value in instance.values}
         current_values = {
@@ -2238,6 +2247,43 @@ class LabReportingService:
     def _assert_instance_editable(self, instance: LabReportInstance) -> None:
         if instance.status in FINAL_INSTANCE_STATUSES:
             raise LabReportingDomainError(409, "Finalized reports are immutable; use revise")
+
+    def _assert_not_concurrently_modified(
+        self, instance: LabReportInstance, expected_updated_at: str | None
+    ) -> None:
+        """WF-06 fix: optimistic locking via updated_at.
+
+        Если frontend передал expected_updated_at (ISO string), проверяем
+        что instance.updated_at не изменился с момента последнего чтения.
+        Если изменился — другой пользователь сохранил изменения, 409 Conflict.
+
+        Это предотвращает silent data loss когда два лаборанта редактируют
+        один бланк одновременно (last-write-wins без этой проверки).
+        """
+        if not expected_updated_at:
+            return  # optimistic locking опционален, backward compatible
+        try:
+            from datetime import datetime, timezone
+            # Парсим ISO string (frontend передаёт ISO 8601)
+            expected_dt = datetime.fromisoformat(
+                expected_updated_at.replace("Z", "+00:00")
+            )
+            actual_dt = instance.updated_at
+            if actual_dt and actual_dt.tzinfo is None:
+                actual_dt = actual_dt.replace(tzinfo=timezone.utc)
+            if expected_dt and actual_dt and abs((actual_dt - expected_dt).total_seconds()) > 1:
+                raise LabReportingDomainError(
+                    409,
+                    "Бланк был изменён другим пользователем. "
+                    "Обновите страницу, чтобы получить актуальные данные.",
+                )
+        except (ValueError, TypeError):
+            # Если не удалось распарсить дату — не блокируем (graceful degradation)
+            logger.warning(
+                "[LAB] _assert_not_concurrently_modified: failed to parse "
+                "expected_updated_at=%s, skipping lock check",
+                expected_updated_at,
+            )
 
     def _make_clone_code(self, source_code: str) -> str:
         suffix = 2

--- a/frontend/src/api/labReporting.js
+++ b/frontend/src/api/labReporting.js
@@ -163,15 +163,24 @@ export const labReportingApi = {
     });
   },
 
-  updateInstance(instanceId, payload) {
-    return request(`/lab/report-instances/${instanceId}`, {
+  // WF-06 fix: expectedUpdatedAt — optimistic locking via updated_at.
+  // Если backend обнаружит, что бланк был изменён после этого timestamp,
+  // вернёт 409 Conflict. Frontend показывает dialog "обновите страницу".
+  updateInstance(instanceId, payload, expectedUpdatedAt = null) {
+    const search = expectedUpdatedAt
+      ? `?expected_updated_at=${encodeURIComponent(expectedUpdatedAt)}`
+      : '';
+    return request(`/lab/report-instances/${instanceId}${search}`, {
       method: 'PUT',
       body: JSON.stringify(payload)
     });
   },
 
-  bulkSaveValues(instanceId, payload) {
-    return request(`/lab/report-instances/${instanceId}/bulk-values`, {
+  bulkSaveValues(instanceId, payload, expectedUpdatedAt = null) {
+    const search = expectedUpdatedAt
+      ? `?expected_updated_at=${encodeURIComponent(expectedUpdatedAt)}`
+      : '';
+    return request(`/lab/report-instances/${instanceId}/bulk-values${search}`, {
       method: 'POST',
       body: JSON.stringify(payload)
     });

--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -269,6 +269,13 @@ export default function LabReportWorkbench({
     if (!activeInstance) {
       return null;
     }
+    // WF-06 fix: передаём updated_at для optimistic locking.
+    // Если backend обнаружит, что бланк был изменён другим пользователем
+    // после этого timestamp — вернёт 409, persistDraft выбросит exception.
+    const expectedUpdatedAt = activeInstance.updated_at
+      ? new Date(activeInstance.updated_at).toISOString()
+      : null;
+
     const payload = [];
     activeInstance.sections.forEach((section) => {
       section.fields.forEach((field) => {
@@ -289,10 +296,10 @@ export default function LabReportWorkbench({
     if (JSON.stringify(activeInstance.signer_snapshot || {}) !== JSON.stringify(signerSnapshot || {})) {
       latestInstance = await labReportingApi.updateInstance(activeInstance.id, {
         signer_snapshot: signerSnapshot
-      });
+      }, expectedUpdatedAt);
     }
     if (payload.length > 0) {
-      const response = await labReportingApi.bulkSaveValues(activeInstance.id, payload);
+      const response = await labReportingApi.bulkSaveValues(activeInstance.id, payload, expectedUpdatedAt);
       latestInstance = response.instance;
     }
     onInstanceChange(latestInstance);


### PR DESCRIPTION
## Summary

Critical fix: optimistic locking для предотвращения потери данных при одновременном редактировании бланка двумя лаборантами. Использует существующее поле `updated_at` — не требует миграции.

- **Backend:** новый метод `_assert_not_concurrently_modified()` — сравнивает `instance.updated_at` с ожидаемым timestamp, 409 при расхождении > 1 сек
- **Backend endpoints:** `PUT /report-instances/{id}` и `POST /report-instances/{id}/bulk-values` принимают optional `?expected_updated_at=` query parameter
- **Frontend API:** `updateInstance` и `bulkSaveValues` принимают 3-й параметр `expectedUpdatedAt`
- **Frontend component:** `persistDraft` передаёт `activeInstance.updated_at` — при 409 exception показывается error notification

**Backward compatible:** параметр optional, старые клиенты работают без изменений. Не требует миграции (использует существующее `updated_at` поле).

## Cyclic Execution Evidence

- Fresh main sync: branch создан от `main` (commit `a7ff68c`)
- Clean workspace: `git status --short` пустой
- Branch: `fix/workflow-lab-panel-round4` → `main`
- Scope gate: 4 файла — 2 backend (service + endpoint), 2 frontend (API client + component). Migrations, configs, CI не затронуты.
- Red-check handling: Python AST parse ✓ для backend. JSX bracket balance ✓ для frontend. `expected_updated_at` — optional query param, existing tests не передают его → skip lock check → backward compatible.

## Contract Impact

- Canonical surface: `PUT /lab/report-instances/{id}` и `POST /lab/report-instances/{id}/bulk-values` — добавлен optional query parameter `expected_updated_at`. Response shape не изменён. При 409 — `{"detail": "Бланк был изменён другим пользователем..."}` (стандартный HTTPException format).
- Request shape: optional `?expected_updated_at=2026-07-01T12:00:00Z` query param. Без параметра — backward compatible (lock check skip).
- Response shape: при успехе тот же LabReportInstanceOut. При 409 — {"detail": "Бланк был изменён другим пользователем..."} (HTTPException format).
- Status codes: 409 Conflict добавлен как возможный response (раньше 409 только для finalized-immutable). Backward compatible — клиенты уже обрабатывают 409.
- Frontend consumer: `LabReportWorkbench.jsx` persistDraft передаёт `activeInstance.updated_at`. `labReporting.js` — 3-й optional параметр. Существующие вызовы без параметра работают.
- Compatibility path or alias: без expected_updated_at параметра — backward compatible, lock check skip. Старые клиенты работают без изменений.
- Contract proof: `lab_reporting.py:602-603` — `Query(default=None, alias="expected_updated_at")`. `labReporting.js:170-172` — optional parameter с fallback `null`.

## RBAC / Permissions

not applicable - RBAC не изменён. `@require_roles("Admin", "Lab")` на endpoints на месте. Optimistic locking — data integrity check, не auth check.

## Notification / Realtime

not applicable - не затрагивает websocket, notifications. Lock check — synchronous DB query.

## Frontend Resilience

- Empty data proof: если `activeInstance.updated_at` отсутствует — `expectedUpdatedAt = null` → backend skip lock check. Graceful degradation.
- Partial data proof: при 409 error — `persistDraft` выбрасывает exception → `handleSaveDraft` catch → `notify('error', error.message)` с текстом от backend. Dirty state сохраняется (данные не потеряны локально).
- Forbidden secondary path behavior: 409 → retry не происходит автоматически. Лаборант должен обновить страницу (получит свежие данные) и повторить ввод.
- Missing draft/resource behavior: если `activeInstance === null` — persistDraft возвращает null без вызова API.
- Stale route/deep-link behavior: не применимо.

## Scope Gate

- Allowed paths: `backend/app/services/lab_reporting_service.py`, `backend/app/api/v1/endpoints/lab_reporting.py`, `frontend/src/api/labReporting.js`, `frontend/src/components/laboratory/LabReportWorkbench.jsx`
- Denied paths: migrations, models, configs, CI, docs, другие components
- Migration/docs/test impact: нет миграций (использует existing updated_at). Existing тесты не передают expected_updated_at → lock check skip → tests pass.
- Rollback note: `git revert` — параметр optional, удаление не ломает существующие вызовы.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: Python AST parse ✓ для backend. JSX bracket balance ✓ для frontend. `expected_updated_at` — optional query param, existing tests не передают его → lock check skip. Backend unit tests запустит CI.
- Result: passed для статического анализа.
- Not checked: concurrent edit scenario в проде — после merge рекомендуется: открыть бланк в двух браузерах, изменить разные поля, сохранить оба — второй должен получить 409.

### Чек-лист для ревьюера

- [ ] Открыть бланк A в двух браузерах
- [ ] Изменить поле в браузере 1 → Сохранить → success
- [ ] Изменить поле в браузере 2 → Сохранить → 409 "Бланк был изменён другим пользователем"
- [ ] Обновить страницу в браузере 2 → получить свежие данные

---

🤖 Workflow round 4: WF-06 optimistic locking · 2026-07-02