### PR TITLE
fix(lab): round 7 — search в шаблонах + keyboard shortcuts

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -239,6 +239,24 @@ export default function LabReportWorkbench({
     };
   }, [activeInstance]);
 
+  // WF-22 fix: keyboard shortcuts для efficiency.
+  // Ctrl+S (Cmd+S на Mac) → save draft (preventDefault — браузер не показывает Save Dialog)
+  // Доступно только когда canSaveDraft (editable state).
+  const handleSaveDraftRef = useRef(null);
+  useEffect(() => {
+    if (!canSaveDraft) return;
+    const handler = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        if (!saving && handleSaveDraftRef.current) {
+          handleSaveDraftRef.current();
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [canSaveDraft, saving]);
+
   useEffect(() => {
     if (activeInstance || !selectedAppointment) {
       return;
@@ -312,9 +330,6 @@ export default function LabReportWorkbench({
       return;
     }
     // WF-07 fix: запоминаем статус до save, чтобы обнаружить auto-transition.
-    // Backend bulk_upsert_values автоматически меняет DRAFT → IN_PROGRESS
-    // при первом сохранении. Раньше пользователь не знал об этом — surprise
-    // transition. Теперь показываем явное сообщение если статус изменился.
     const previousStatus = activeInstance.status;
     setSaving(true);
     setBusyAction('save');
@@ -326,7 +341,6 @@ export default function LabReportWorkbench({
         values: { ...draftValues },
         signer: { ...signerSnapshot },
       };
-      // WF-07: проверяем, изменился ли статус автоматически
       const newStatus = latest?.status || previousStatus;
       if (previousStatus === 'DRAFT' && newStatus === 'IN_PROGRESS') {
         notify('info', 'Черновик сохранён. Статус изменён на «Заполняется» — отчёт теперь в работе.');
@@ -340,6 +354,8 @@ export default function LabReportWorkbench({
       setBusyAction('');
     }
   }
+  // WF-22 fix: обновляем ref для keyboard shortcut.
+  handleSaveDraftRef.current = handleSaveDraft;
 
   // WF-round5: handleMarkReady убран — Mark Ready был функционально пустой
   // операцией (backend разрешал одинаковые действия для DRAFT/IN_PROGRESS/READY).

--- a/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
@@ -217,6 +217,8 @@ export default function LabTemplateWorkbench({
   onTemplatesChanged,
   notify
 }) {
+  // WF-21 fix: search в списке шаблонов для консистентности с LabQueueWorkbench.
+  const [templateSearch, setTemplateSearch] = useState('');
   const [draftVersion, setDraftVersion] = useState(hydrateVersion(null));
   const [newTemplate, setNewTemplate] = useState({
     code: '',
@@ -492,8 +494,50 @@ export default function LabTemplateWorkbench({
             </Button>
           </div>
 
+          {/* WF-21 fix: search для консистентности с LabQueueWorkbench */}
+          <div style={{ position: 'relative', marginBottom: '8px' }}>
+            <input
+              type="search"
+              value={templateSearch}
+              onChange={(e) => setTemplateSearch(e.target.value)}
+              placeholder="Поиск по названию, коду, семейству…"
+              aria-label="Поиск шаблонов"
+              style={{
+                width: '100%',
+                padding: '8px 12px',
+                borderRadius: '10px',
+                border: '1px solid var(--mac-border)',
+                background: 'var(--mac-bg-primary)',
+                color: 'var(--mac-text-primary)',
+                fontSize: '14px',
+                outline: 'none',
+              }}
+            />
+            {templateSearch && (
+              <button
+                type="button"
+                onClick={() => setTemplateSearch('')}
+                aria-label="Очистить поиск"
+                style={{
+                  position: 'absolute', right: '8px', top: '50%',
+                  transform: 'translateY(-50%)', background: 'none',
+                  border: 'none', cursor: 'pointer',
+                  color: 'var(--mac-text-muted)', fontSize: '16px',
+                }}
+              >
+                ×
+              </button>
+            )}
+          </div>
+
           <div style={{ display: 'grid', gap: '8px' }}>
-            {templates.map((template) => (
+            {templates
+              .filter((t) => {
+                if (!templateSearch.trim()) return true;
+                const q = templateSearch.trim().toLowerCase();
+                return [t.name, t.code, t.family].some((f) => (f || '').toLowerCase().includes(q));
+              })
+              .map((template) => (
               <button
                 key={template.id}
                 type="button"


### PR DESCRIPTION
## Summary

Последние 2 фикса из workflow-аудита — финальный polish:

- **WF-21 (Low):** Search в LabTemplateWorkbench — консистентность с LabQueueWorkbench. Поиск по name, code, family.
- **WF-22 (Low):** Keyboard shortcut Ctrl+S / Cmd+S → save draft. Доступно только в editable state.

2 файла, +65/-5 строк. Backend не затронут.

## Cyclic Execution Evidence

- Fresh main sync: branch от main (commit 1fb2525)
- Clean workspace: git status пустой
- Branch: fix/workflow-lab-panel-round7 → main
- Scope gate: 2 frontend файла. Backend не затронут.
- Red-check handling: JSX bracket balance ✓ для обоих файлов.

## Contract Impact

not applicable - UI-only: search input + keyboard handler. API client не изменён. Backend не затронут.

## RBAC / Permissions

not applicable - не затрагивает RBAC.

## Notification / Realtime

not applicable - не затрагивает websocket или notifications.

## Frontend Resilience

- Empty data proof: search при пустом templateSearch показывает все шаблоны. Ctrl+S при !canSaveDraft — handler не регистрируется (useEffect return early).
- Partial data proof: handleSaveDraftRef pattern — ref обновляется каждый render, avoids stale closure. Ctrl+S при saving=true — игнорируется.
- Forbidden secondary path behavior: not applicable - search filter и keyboard handler не добавляют новых путей.
- Missing draft/resource behavior: search фильтр возвращает [] если ничего не найдено — список пустой, не падает.
- Stale route/deep-link behavior: not applicable - search и shortcuts client-side only, не влияют на routing.

## Scope Gate

- Allowed paths: frontend/src/components/laboratory/LabTemplateWorkbench.jsx, frontend/src/components/laboratory/LabReportWorkbench.jsx
- Denied paths: backend, frontend/src/api/, migrations, configs, CI, docs
- Migration/docs/test impact: нет. Существующие тесты не затронуты.
- Rollback note: git revert. Additive changes.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: JSX bracket balance ✓ для обоих файлов. grep: templateSearch state + filter + input. handleSaveDraftRef + useEffect keydown handler с preventDefault. Ctrl+S/Cmd+S + canSaveDraft guard + saving guard.
- Result: passed.
- Not checked: runtime — после merge: ввести поиск в шаблонах, нажать Ctrl+S в редакторе отчёта.

### Чек-лист

- [ ] Таб «Шаблоны» → поиск работает по name/code/family (WF-21)
- [ ] Кнопка × очищает поиск (WF-21)
- [ ] Редактор отчёта → Ctrl+S → save draft (WF-22)
- [ ] Cmd+S на Mac → save draft (WF-22)
- [ ] Ctrl+S на FINALIZED → ничего не происходит (WF-22)

---

Workflow round 7: search + keyboard shortcuts — final polish · 2026-07-02