### PR TITLE
refactor(registrar): Decomposition steps 4-5 — extract data + actions hooks (−304 lines)

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -27,6 +27,8 @@ import { getRegistrarTranslator } from './registrarTranslations';
 import { useRegistrarHotkeys } from './registrar/useRegistrarHotkeys';
 // Decomp 3: reschedule helpers extracted to useRegistrarReschedule hook
 import { useRegistrarReschedule } from './registrar/useRegistrarReschedule';
+// Decomp 4: data-loading functions extracted to useRegistrarData hook
+import { useRegistrarData } from './registrar/useRegistrarData';
 
 // Decomp step 1: helpers extracted to ./registrar/registrarHelpers.js
 import {
@@ -41,9 +43,7 @@ import {
   findRegistrarRecordBySelectionKey,
   hasBackendAction,
   getRegistrarActionForStatus,
-  hasBackendPatientDisplayContract,
   normalizePatientGender,
-  hasBackendPatientGenderContract,
   formatPreviewList,
   buildPostWizardPaymentRow,
   isMultiRecordAggregateRow,
@@ -75,7 +75,7 @@ import ModernStatistics from '../components/statistics/ModernStatistics';
 // Утилиты для работы с датами
 import { getLocalDateString, getYesterdayDateString } from '../utils/dateUtils';
 import { rescheduleTomorrow, rescheduleVisit } from '../api/visits';
-import { formatNetworkErrorMessage, isNetworkFetchError } from '../utils/networkErrorMessages';
+// Note: formatNetworkErrorMessage + isNetworkFetchError moved to useRegistrarData.js (Decomp 4)
 import { getErrorMessage } from '../utils/errorHandler';
 import {
   aggregatePatientsForAllDepartments as aggregateRegistrarPatients,
@@ -538,232 +538,20 @@ const RegistrarPanel = () => {
   // system canonical Button component). See audit §5.5, §5.6.
 
 
-  // Загрузка данных из админ панели
-  const loadIntegratedData = useCallback(async () => {
-    logger.info('🔧 loadIntegratedData called at:', new Date().toISOString());
-    try {
-      // Сбрасываем устаревшие значения перед загрузкой truth из API.
-      // Если backend недоступен, лучше показать пустое состояние, чем локальные моки.
-      setDoctors([]);
-      setServices({});
-      setDynamicDepartments([]);
+  // Decomp 4: data-loading functions extracted to useRegistrarData hook.
+  // loadAppointments and loadMoreAppointments remain inline due to complex
+  // ref dependencies (loadAppointmentsInFlightRef, autoRefreshCooldownUntilRef,
+  // autoRefreshCooldownLoggedRef, filteredAppointmentsRef).
+  const {
+    loadIntegratedData,
+    enrichAppointmentsWithPatientData,
+  } = useRegistrarData({
+    setDoctors,
+    setServices,
+    setDynamicDepartments,
+    appointmentOverridesRef,
+  });
 
-      // Загружаем врачей, услуги и настройки очередей из админ панели
-      try {
-        const token = tokenManager.getAccessToken();
-        logger.info('🔍 RegistrarPanel: token present:', Boolean(token));
-
-        // ✅ ОПТИМИЗАЦИЯ: Загружаем все данные параллельно с Promise.allSettled
-        logger.info('🚀 Загружаем данные параллельно...');
-        const [doctorsResult, servicesResult, departmentsResult] = await Promise.allSettled([
-        api.get('/registrar/doctors'),
-        api.get('/registrar/services'),
-        api.get('/registrar/departments?active_only=true')]
-        );
-
-        // Обрабатываем результаты
-        const doctorsRes = doctorsResult.status === 'fulfilled' ? doctorsResult.value : { ok: false };
-        const servicesRes = servicesResult.status === 'fulfilled' ? servicesResult.value : { ok: false };
-        const departmentsRes = departmentsResult.status === 'fulfilled' ? departmentsResult.value : { success: false };
-
-        // Логируем результаты
-        if (doctorsResult.status === 'fulfilled') {
-          logger.info('📊 Ответ врачей: OK');
-        } else {
-          logger.error('❌ Ошибка загрузки врачей:', doctorsResult.reason?.message);
-        }
-        if (servicesResult.status === 'fulfilled') {
-          logger.info('📊 Ответ услуг: OK');
-        } else {
-          logger.error('❌ Ошибка загрузки услуг:', servicesResult.reason?.message);
-        }
-        if (departmentsResult.status === 'fulfilled') {
-          logger.info('📊 Ответ отделений: OK', departmentsRes.data);
-        } else {
-          logger.error('❌ Ошибка загрузки отделений:', departmentsResult.reason);
-        }
-
-        logger.info('🔄 Обрабатываем ответы API...');
-
-        // Проверяем, что все ответы успешны
-        const allSuccess = doctorsRes && doctorsRes.data && servicesRes && servicesRes.data;
-        logger.info('📊 Статус ответов:', {
-          doctors: doctorsRes && doctorsRes.data ? 'OK' : 'ERROR',
-          services: servicesRes && servicesRes.data ? 'OK' : 'ERROR',
-          allSuccess
-        });
-
-        if (!allSuccess) {
-          logger.warn('⚠️ Некоторые API недоступны, но продолжаем работу');
-        }
-
-        if (doctorsRes && doctorsRes.data) {
-          try {
-            const doctorsData = doctorsRes.data;
-            const apiDoctors = doctorsData.doctors || [];
-            logger.info('✅ Данные врачей получены:', apiDoctors.length, 'врачей');
-            // Если API вернул данные — используем их
-            if (apiDoctors.length > 0) {
-              setDoctors(apiDoctors);
-              logger.info('✅ Врачи обновлены из API');
-            }
-          } catch (error) {
-            logger.warn('Ошибка обработки данных врачей:', error.message);
-          }
-        } else {
-          logger.warn('❌ API врачей недоступен, оставляем пустое состояние');
-        }
-
-        // Обработка отделений
-        if (departmentsRes && departmentsRes.data) {
-          const depts = departmentsRes.data.data || [];
-          if (Array.isArray(depts) && depts.length > 0) {
-            setDynamicDepartments(depts);
-            logger.info('✅ Отделения обновлены из API:', depts.length);
-          }
-        }
-
-        if (servicesRes && servicesRes.data) {
-          try {
-            const servicesData = servicesRes.data;
-            const apiServices = servicesData.services_by_group || {};
-            logger.info('✅ Данные услуг получены:', Object.keys(apiServices));
-            // Если API вернул данные — используем их
-            if (Object.keys(apiServices).length > 0) {
-              setServices(apiServices);
-              logger.info('✅ Услуги обновлены из API');
-            }
-          } catch (error) {
-            logger.warn('Ошибка обработки данных услуг:', error.message);
-          }
-        } else {
-          logger.warn('❌ API услуг недоступен, оставляем пустое состояние');
-        }
-
-
-        logger.info('🎯 Загрузка интегрированных данных завершена');
-      } catch (fetchError) {
-        // Backend недоступен - оставляем пустое состояние без локальных моков.
-        logger.warn('Backend недоступен для загрузки интегрированных данных, оставляем пустое состояние:', fetchError.message);
-      }
-
-    } catch (error) {
-      logger.error('Ошибка загрузки интегрированных данных:', error);
-      notify.error('Ошибка загрузки данных из админ панели');
-    } finally {
-
-
-
-
-
-
-
-
-      // УБИРАЕМ setAppointmentsLoading(false) - это не должно влиять на загрузку записей
-      // setAppointmentsLoading(false);
-    }}, []); // Функция для получения данных пациента по ID
-  const fetchPatientData = useCallback(async (patientId) => {// Проверяем, является ли это демо-пациентом (ID >= 1000)
-      if (patientId >= 1000) {// Возвращаем null для демо-пациентов, так как их данные уже есть в записи
-        return null;}const token = tokenManager.getAccessToken();
-      if (!token) return null;
-
-      try {
-        const response = await fetch(`${API_BASE}/api/v1/patients/${patientId}`, {
-          headers: { 'Authorization': `Bearer ${token}` }
-        });
-
-        if (response.ok) {
-          return await response.json();
-        }
-      } catch (error) {
-        // Подавляем ошибки для демо-режима
-        const rawMessage = error?.message || '';
-        if (isNetworkFetchError(rawMessage)) {
-          logger.warn('[Registrar] Не удалось загрузить пациента из URL: backend недоступен', {
-            patientId,
-            rawMessage,
-          });
-          return null;
-        }
-
-        logger.error(`Error fetching patient ${patientId}:`, {
-          error: formatNetworkErrorMessage({
-            rawMessage,
-            fallbackMessage: 'Не удалось загрузить пациента из URL',
-          }),
-          rawMessage,
-        });
-      }
-      return null;
-    }, []);
-
-  // Функция для обогащения записей данными пациентов и недостающими полями
-  const enrichAppointmentsWithPatientData = useCallback(async (appointments) => {
-    const enrichedAppointments = await Promise.all(appointments.map(async (apt) => {
-      let enrichedApt = { ...apt };
-
-      // Обогащаем данными пациента
-      if (apt.patient_id && (!hasBackendPatientDisplayContract(apt) || !hasBackendPatientGenderContract(apt))) {
-        const patient = await fetchPatientData(apt.patient_id);
-        if (patient) {
-          // ✅ ИСПРАВЛЕНО: Формируем patient_fio безопасно, используя все доступные поля
-          // Если поля пустые, используем fallback
-          let patient_fio = '';
-          if (patient.last_name && patient.first_name) {
-            patient_fio = `${patient.last_name} ${patient.first_name}`;
-            if (patient.middle_name) {
-              patient_fio += ` ${patient.middle_name}`;
-            }
-          } else if (patient.last_name) {
-            patient_fio = patient.last_name;
-          } else if (patient.first_name) {
-            patient_fio = patient.first_name;
-          } else {
-            // Fallback, если все поля пустые (не должно произойти благодаря валидации)
-            patient_fio = `Пациент ID=${patient.id}`;
-          }
-
-          const patientGender = normalizePatientGender(patient);
-          enrichedApt = {
-            ...enrichedApt,
-            patient_fio: patient_fio.trim() || `Пациент ID=${patient.id}`,
-            patient_phone: patient.phone,
-            patient_birth_year: patient.birth_date ? new Date(patient.birth_date).getFullYear() : null,
-            patient_gender: patientGender,
-            gender: patientGender,
-            sex: patientGender,
-            address: patient.address || 'Не указан' // Добавляем адрес из данных пациента
-          };
-        }
-      }
-
-      // Применяем локальные оверрайды (например, после оплаты), чтобы не было отката
-      const overrideKey = String(enrichedApt.id);
-      const ov = appointmentOverridesRef.current[overrideKey];
-      if (ov && (!ov.expiresAt || ov.expiresAt > Date.now())) {
-        // ✅ ИСПРАВЛЕНО: Применяем только определенные поля из оверрайда, сохраняя queue_numbers
-        enrichedApt = {
-          ...enrichedApt,
-          status: ov.status !== undefined ? ov.status : enrichedApt.status,
-          payment_status: ov.payment_status !== undefined ? ov.payment_status : enrichedApt.payment_status
-          // queue_numbers остается из enrichedApt (из API)
-        };
-      } else if (ov) {
-        delete appointmentOverridesRef.current[overrideKey];
-      }
-      enrichedApt = {
-        ...enrichedApt,
-        visit_type: enrichedApt.visit_type ?? null,
-        payment_type: enrichedApt.payment_type ?? null,
-        payment_status: enrichedApt.payment_status ?? null,
-        services: enrichedApt.services || [],
-        cost: Number(enrichedApt.cost ?? 0)
-      };
-
-      return enrichedApt;
-    }));
-    return enrichedAppointments;
-  }, [fetchPatientData]);
 
   // Улучшенная загрузка записей с поддержкой тихого режима
   const loadAppointments = useCallback(async (options = {}) => {

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -29,6 +29,8 @@ import { useRegistrarHotkeys } from './registrar/useRegistrarHotkeys';
 import { useRegistrarReschedule } from './registrar/useRegistrarReschedule';
 // Decomp 4: data-loading functions extracted to useRegistrarData hook
 import { useRegistrarData } from './registrar/useRegistrarData';
+// Decomp 5: record action handlers extracted to useRegistrarActions hook
+import { useRegistrarActions } from './registrar/useRegistrarActions';
 
 // Decomp step 1: helpers extracted to ./registrar/registrarHelpers.js
 import {
@@ -39,10 +41,6 @@ import {
   registrarWorkflowTitleStyle,
   registrarWorkflowMetaStyle,
   registrarWorkflowActionsStyle,
-  getRegistrarRecordRefs,
-  findRegistrarRecordBySelectionKey,
-  hasBackendAction,
-  getRegistrarActionForStatus,
   normalizePatientGender,
   formatPreviewList,
   buildPostWizardPaymentRow,
@@ -1061,106 +1059,16 @@ const RegistrarPanel = () => {
   }, [autoRefresh, showWizard, loadAppointments]);
 
   // Функции для жесткого потока
-  const runRegistrarRecordAction = useCallback(async (record, action, payload = {}) => {
-    const records = getRegistrarRecordRefs(record);
-    if (records.length === 0) {
-      logger.warn('RegistrarPanel: action requires backend record refs', { action, record });
-      notify.error('Missing backend record data for action');
-      return null;
-    }
-    if (!hasBackendAction(record, action)) {
-      logger.warn('RegistrarPanel: backend did not expose requested action', { action, record });
-      notify.error('Action is not available for this record');
-      return null;
-    }
+  // Decomp 5: record action handlers extracted to useRegistrarActions hook.
+  // openRecordPreview, openRecordEditor, handleContextMenuAction remain
+  // inline because they are simple state setters (1-3 lines each).
+  const {
+    runRegistrarRecordAction,
+    handleStartVisit,
+    handlePayment,
+    updateAppointmentStatus,
+  } = useRegistrarActions({ appointments, loadAppointments });
 
-    const response = await api.post('/registrar/records/actions', {
-      ...payload,
-      action,
-      records
-    });
-    return response.data;
-  }, []);
-
-  const handleStartVisit = useCallback(async (appointment) => {
-    try {
-      const result = await runRegistrarRecordAction(appointment, 'start_visit');
-      if (!result) return null;
-      if (!result.success) {
-        throw new Error(result.results?.find((item) => !item.success)?.error || 'start_visit_failed');
-      }
-
-      logger.info('RegistrarPanel: start_visit completed through backend command contract', result);
-      notify.success('Patient called successfully');
-      await loadAppointments({ source: 'start_visit_success' });
-      return result;
-    } catch (error) {
-      logger.error('RegistrarPanel: Start visit API error:', error);
-      notify.error(getErrorMessage(error, 'Could not start visit. Check connection and try again.'));
-      return null;
-    }
-  }, [loadAppointments, runRegistrarRecordAction]);
-
-  const handlePayment = async (appointment, paymentData = null) => {
-    try {
-      const result = await runRegistrarRecordAction(appointment, 'mark_paid', {
-        amount: paymentData?.amount ?? null,
-        method: paymentData?.method ?? null
-      });
-      if (!result) return null;
-
-      const successCount = Number(result.success_count || 0);
-      const skippedCount = Number(result.skipped_count || 0);
-      const failedCount = Number(result.failed_count || 0);
-
-      if (successCount > 0 || skippedCount > 0) {
-        const message = skippedCount > 0
-          ? 'Payment completed: ' + successCount + ', already paid: ' + skippedCount
-          : 'Payment completed: ' + successCount;
-        notify.success(failedCount > 0 ? message + '. Failed: ' + failedCount : message);
-        setTimeout(() => loadAppointments({ silent: true, source: 'payment_success' }), 800);
-        return result.results || [];
-      }
-
-      notify.error(result.results?.find((item) => !item.success)?.error || 'Payment failed');
-      return result.results || [];
-    } catch (error) {
-      logger.error('RegistrarPanel: Payment error:', error);
-      notify.error(getErrorMessage(error, 'Payment failed'));
-      return null;
-    }
-  };
-
-  const updateAppointmentStatus = useCallback(async (recordSelectionKey, status, reason = '', sourceRecord = null) => {
-    try {
-      const record = sourceRecord || findRegistrarRecordBySelectionKey(appointments, recordSelectionKey);
-      const requiredBackendAction = getRegistrarActionForStatus(status);
-      if (!requiredBackendAction) {
-        logger.warn('RegistrarPanel: unsupported status command', { recordSelectionKey, status, record });
-        notify.error('Action is not available for this record');
-        return null;
-      }
-      if (!record) {
-        logger.warn('RegistrarPanel: selected record is missing for status command', { recordSelectionKey, status });
-        notify.error('Action is not available for this record');
-        return null;
-      }
-
-      const result = await runRegistrarRecordAction(record, requiredBackendAction, { reason });
-      if (!result) return null;
-      if (!result.success) {
-        throw new Error(result.results?.find((item) => !item.success)?.error || 'status_update_failed');
-      }
-
-      await loadAppointments({ source: 'status_update' });
-      notify.success('Status updated');
-      return result;
-    } catch (error) {
-      logger.error('RegistrarPanel: Update status error:', error);
-      notify.error(getErrorMessage(error, 'Could not update status. Check connection and try again.'));
-      return null;
-    }
-  }, [appointments, loadAppointments, runRegistrarRecordAction]);
 
   // QW-01 fix: handleBulkAction removed along with bulk-action UI.
 

--- a/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
@@ -10,6 +10,7 @@ const registrarPanelPath = path.resolve(__dirname, '../RegistrarPanel.jsx');
 // Decomp step 2: hotkeys extracted to ./registrar/useRegistrarHotkeys.js.
 // Decomp step 3: reschedule helpers extracted to ./registrar/useRegistrarReschedule.js.
 // Decomp step 4: data-loading functions extracted to ./registrar/useRegistrarData.js.
+// Decomp step 5: record action handlers extracted to ./registrar/useRegistrarActions.js.
 // Contract tests must read all files because they verify that certain
 // functions exist in the registrar panel source tree (not necessarily
 // in the orchestrator file itself).
@@ -17,6 +18,7 @@ const registrarHelpersPath = path.resolve(__dirname, '../registrar/registrarHelp
 const useRegistrarHotkeysPath = path.resolve(__dirname, '../registrar/useRegistrarHotkeys.js');
 const useRegistrarReschedulePath = path.resolve(__dirname, '../registrar/useRegistrarReschedule.js');
 const useRegistrarDataPath = path.resolve(__dirname, '../registrar/useRegistrarData.js');
+const useRegistrarActionsPath = path.resolve(__dirname, '../registrar/useRegistrarActions.js');
 
 const readRegistrarPanelSource = () => fs.readFileSync(registrarPanelPath, 'utf8');
 const readRegistrarHelpersSource = () => fs.readFileSync(registrarHelpersPath, 'utf8');
@@ -30,6 +32,8 @@ const readRegistrarSourceTree = () => [
   fs.readFileSync(useRegistrarReschedulePath, 'utf8'),
   '// ─── useRegistrarData.js ───',
   fs.readFileSync(useRegistrarDataPath, 'utf8'),
+  '// ─── useRegistrarActions.js ───',
+  fs.readFileSync(useRegistrarActionsPath, 'utf8'),
 ].join('\n\n');
 
 const extractSourceBlock = (source, startMarker, endMarker) => {

--- a/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
@@ -9,12 +9,14 @@ const registrarPanelPath = path.resolve(__dirname, '../RegistrarPanel.jsx');
 // Decomp step 1: helpers extracted to ./registrar/registrarHelpers.js.
 // Decomp step 2: hotkeys extracted to ./registrar/useRegistrarHotkeys.js.
 // Decomp step 3: reschedule helpers extracted to ./registrar/useRegistrarReschedule.js.
+// Decomp step 4: data-loading functions extracted to ./registrar/useRegistrarData.js.
 // Contract tests must read all files because they verify that certain
 // functions exist in the registrar panel source tree (not necessarily
 // in the orchestrator file itself).
 const registrarHelpersPath = path.resolve(__dirname, '../registrar/registrarHelpers.js');
 const useRegistrarHotkeysPath = path.resolve(__dirname, '../registrar/useRegistrarHotkeys.js');
 const useRegistrarReschedulePath = path.resolve(__dirname, '../registrar/useRegistrarReschedule.js');
+const useRegistrarDataPath = path.resolve(__dirname, '../registrar/useRegistrarData.js');
 
 const readRegistrarPanelSource = () => fs.readFileSync(registrarPanelPath, 'utf8');
 const readRegistrarHelpersSource = () => fs.readFileSync(registrarHelpersPath, 'utf8');
@@ -26,6 +28,8 @@ const readRegistrarSourceTree = () => [
   fs.readFileSync(useRegistrarHotkeysPath, 'utf8'),
   '// ─── useRegistrarReschedule.js ───',
   fs.readFileSync(useRegistrarReschedulePath, 'utf8'),
+  '// ─── useRegistrarData.js ───',
+  fs.readFileSync(useRegistrarDataPath, 'utf8'),
 ].join('\n\n');
 
 const extractSourceBlock = (source, startMarker, endMarker) => {
@@ -51,10 +55,13 @@ describe('RegistrarPanel command contract', () => {
 
   it('passes through registrar queue patient display fields before legacy patient fetch fallback', () => {
     const source = readRegistrarSourceTree();
+    // Decomp 4: enrichAppointmentsWithPatientData moved to useRegistrarData.js.
+    // End marker changed from 'const loadAppointments' (now in different file)
+    // to 'return enrichedAppointments;' (last line of the function in the hook).
     const enrichmentBlock = extractSourceBlock(
       source,
       'const enrichAppointmentsWithPatientData = useCallback(async (appointments) => {',
-      'const loadAppointments = useCallback(async (options = {}) => {',
+      'return enrichedAppointments;',
     );
 
     expect(source).toContain('if (apt.patient_id && (!hasBackendPatientDisplayContract(apt) || !hasBackendPatientGenderContract(apt)))');

--- a/frontend/src/pages/registrar/useRegistrarActions.js
+++ b/frontend/src/pages/registrar/useRegistrarActions.js
@@ -1,0 +1,149 @@
+/**
+ * Registrar Panel — record action handlers hook.
+ *
+ * Decomposition step 5: extracted from RegistrarPanel.jsx.
+ *
+ * Extracted functions:
+ * - runRegistrarRecordAction: posts to /registrar/records/actions batch
+ *   endpoint. Validates record refs and backend action availability
+ *   before calling API.
+ * - handleStartVisit: wraps runRegistrarRecordAction for 'start_visit'.
+ *   Shows success/error toast, reloads appointments.
+ * - handlePayment: wraps runRegistrarRecordAction for 'mark_paid'.
+ *   Handles partial success (some records already paid), shows toast,
+ *   silent reload after 800ms.
+ * - updateAppointmentStatus: maps status string to backend action,
+ *   calls runRegistrarRecordAction, reloads appointments.
+ *
+ * NOT extracted (remain in RegistrarPanel — simple state setters):
+ * - openRecordPreview: just calls setRecordPreviewDialog({open: true, row})
+ * - openRecordEditor: just calls setWizardEditMode/InitialData/ShowWizard
+ * - handleContextMenuAction: switch statement calling the above + setters
+ *
+ * @param {Object} deps
+ * @param {Array} deps.appointments - current appointments array
+ * @param {Function} deps.loadAppointments - reload function
+ */
+import { useCallback } from 'react';
+import { api } from '../../api/client';
+import logger from '../../utils/logger';
+import notify from '../../services/notify';
+import { getErrorMessage } from '../../utils/errorHandler';
+import {
+  getRegistrarRecordRefs,
+  findRegistrarRecordBySelectionKey,
+  hasBackendAction,
+  getRegistrarActionForStatus,
+} from './registrarHelpers';
+
+export const useRegistrarActions = ({ appointments, loadAppointments }) => {
+  const runRegistrarRecordAction = useCallback(async (record, action, payload = {}) => {
+    const records = getRegistrarRecordRefs(record);
+    if (records.length === 0) {
+      logger.warn('RegistrarPanel: action requires backend record refs', { action, record });
+      notify.error('Missing backend record data for action');
+      return null;
+    }
+    if (!hasBackendAction(record, action)) {
+      logger.warn('RegistrarPanel: backend did not expose requested action', { action, record });
+      notify.error('Action is not available for this record');
+      return null;
+    }
+
+    const response = await api.post('/registrar/records/actions', {
+      ...payload,
+      action,
+      records,
+    });
+    return response.data;
+  }, []);
+
+  const handleStartVisit = useCallback(async (appointment) => {
+    try {
+      const result = await runRegistrarRecordAction(appointment, 'start_visit');
+      if (!result) return null;
+      if (!result.success) {
+        throw new Error(result.results?.find((item) => !item.success)?.error || 'start_visit_failed');
+      }
+
+      logger.info('RegistrarPanel: start_visit completed through backend command contract', result);
+      notify.success('Patient called successfully');
+      await loadAppointments({ source: 'start_visit_success' });
+      return result;
+    } catch (error) {
+      logger.error('RegistrarPanel: Start visit API error:', error);
+      notify.error(getErrorMessage(error, 'Could not start visit. Check connection and try again.'));
+      return null;
+    }
+  }, [loadAppointments, runRegistrarRecordAction]);
+
+  const handlePayment = useCallback(async (appointment, paymentData = null) => {
+    try {
+      const result = await runRegistrarRecordAction(appointment, 'mark_paid', {
+        amount: paymentData?.amount ?? null,
+        method: paymentData?.method ?? null,
+      });
+      if (!result) return null;
+
+      const successCount = Number(result.success_count || 0);
+      const skippedCount = Number(result.skipped_count || 0);
+      const failedCount = Number(result.failed_count || 0);
+
+      if (successCount > 0 || skippedCount > 0) {
+        const message = skippedCount > 0
+          ? 'Payment completed: ' + successCount + ', already paid: ' + skippedCount
+          : 'Payment completed: ' + successCount;
+        notify.success(failedCount > 0 ? message + '. Failed: ' + failedCount : message);
+        setTimeout(() => loadAppointments({ silent: true, source: 'payment_success' }), 800);
+        return result.results || [];
+      }
+
+      notify.error(result.results?.find((item) => !item.success)?.error || 'Payment failed');
+      return result.results || [];
+    } catch (error) {
+      logger.error('RegistrarPanel: Payment error:', error);
+      notify.error(getErrorMessage(error, 'Payment failed'));
+      return null;
+    }
+  }, [loadAppointments, runRegistrarRecordAction]);
+
+  const updateAppointmentStatus = useCallback(async (recordSelectionKey, status, reason = '', sourceRecord = null) => {
+    try {
+      const record = sourceRecord || findRegistrarRecordBySelectionKey(appointments, recordSelectionKey);
+      const requiredBackendAction = getRegistrarActionForStatus(status);
+      if (!requiredBackendAction) {
+        logger.warn('RegistrarPanel: unsupported status command', { recordSelectionKey, status, record });
+        notify.error('Action is not available for this record');
+        return null;
+      }
+      if (!record) {
+        logger.warn('RegistrarPanel: selected record is missing for status command', { recordSelectionKey, status });
+        notify.error('Action is not available for this record');
+        return null;
+      }
+
+      const result = await runRegistrarRecordAction(record, requiredBackendAction, { reason });
+      if (!result) return null;
+      if (!result.success) {
+        throw new Error(result.results?.find((item) => !item.success)?.error || 'status_update_failed');
+      }
+
+      await loadAppointments({ source: 'status_update' });
+      notify.success('Status updated');
+      return result;
+    } catch (error) {
+      logger.error('RegistrarPanel: Update status error:', error);
+      notify.error(getErrorMessage(error, 'Could not update status. Check connection and try again.'));
+      return null;
+    }
+  }, [appointments, loadAppointments, runRegistrarRecordAction]);
+
+  return {
+    runRegistrarRecordAction,
+    handleStartVisit,
+    handlePayment,
+    updateAppointmentStatus,
+  };
+};
+
+export default useRegistrarActions;

--- a/frontend/src/pages/registrar/useRegistrarData.js
+++ b/frontend/src/pages/registrar/useRegistrarData.js
@@ -1,0 +1,266 @@
+/**
+ * Registrar Panel — data loading hook (partial extraction).
+ *
+ * Decomposition step 4: extracted from RegistrarPanel.jsx.
+ *
+ * Extracted functions:
+ * - loadIntegratedData: loads doctors, services, departments in parallel
+ *   from /registrar/* endpoints. Sets state via provided setters.
+ * - fetchPatientData: fetches single patient by ID from /api/v1/patients/:id.
+ *   Returns null for demo patients (ID >= 1000) or on error.
+ * - enrichAppointmentsWithPatientData: enriches appointment records with
+ *   patient display fields (FIO, phone, birth year, gender, address) if
+ *   missing from backend response. Also applies local overrides.
+ *
+ * NOT extracted (remain in RegistrarPanel due to complex ref dependencies):
+ * - loadAppointments: depends on loadAppointmentsInFlightRef,
+ *   autoRefreshCooldownUntilRef, autoRefreshCooldownLoggedRef,
+ *   filteredAppointmentsRef, and calls enrichAppointmentsWithPatientData.
+ * - loadMoreAppointments: depends on paginationInfo state and loadAppointments.
+ *
+ * @param {Object} deps
+ * @param {Function} deps.setDoctors - state setter for doctors array
+ * @param {Function} deps.setServices - state setter for services object
+ * @param {Function} deps.setDynamicDepartments - state setter for departments
+ * @param {Object} deps.appointmentOverridesRef - ref to overrides object
+ */
+import { useCallback } from 'react';
+import { api } from '../../api/client';
+import logger from '../../utils/logger';
+import tokenManager from '../../utils/tokenManager';
+import notify from '../../services/notify';
+import { formatNetworkErrorMessage, isNetworkFetchError } from '../../utils/networkErrorMessages';
+import {
+  API_BASE,
+  hasBackendPatientDisplayContract,
+  hasBackendPatientGenderContract,
+  normalizePatientGender,
+} from './registrarHelpers';
+
+export const useRegistrarData = ({
+  setDoctors,
+  setServices,
+  setDynamicDepartments,
+  appointmentOverridesRef,
+}) => {
+  // ───────────────────────────────────────────────────────────
+  // loadIntegratedData: parallel fetch of doctors + services + departments
+  // ───────────────────────────────────────────────────────────
+  const loadIntegratedData = useCallback(async () => {
+    logger.info('🔧 loadIntegratedData called at:', new Date().toISOString());
+    try {
+      // Сбрасываем устаревшие значения перед загрузкой truth из API.
+      setDoctors([]);
+      setServices({});
+      setDynamicDepartments([]);
+
+      try {
+        const token = tokenManager.getAccessToken();
+        logger.info('🔍 RegistrarPanel: token present:', Boolean(token));
+
+        // ✅ ОПТИМИЗАЦИЯ: Загружаем все данные параллельно с Promise.allSettled
+        logger.info('🚀 Загружаем данные параллельно...');
+        const [doctorsResult, servicesResult, departmentsResult] = await Promise.allSettled([
+          api.get('/registrar/doctors'),
+          api.get('/registrar/services'),
+          api.get('/registrar/departments?active_only=true'),
+        ]);
+
+        const doctorsRes = doctorsResult.status === 'fulfilled' ? doctorsResult.value : { ok: false };
+        const servicesRes = servicesResult.status === 'fulfilled' ? servicesResult.value : { ok: false };
+        const departmentsRes = departmentsResult.status === 'fulfilled' ? departmentsResult.value : { success: false };
+
+        if (doctorsResult.status === 'fulfilled') {
+          logger.info('📊 Ответ врачей: OK');
+        } else {
+          logger.error('❌ Ошибка загрузки врачей:', doctorsResult.reason?.message);
+        }
+        if (servicesResult.status === 'fulfilled') {
+          logger.info('📊 Ответ услуг: OK');
+        } else {
+          logger.error('❌ Ошибка загрузки услуг:', servicesResult.reason?.message);
+        }
+        if (departmentsResult.status === 'fulfilled') {
+          logger.info('📊 Ответ отделений: OK', departmentsRes.data);
+        } else {
+          logger.error('❌ Ошибка загрузки отделений:', departmentsResult.reason);
+        }
+
+        logger.info('🔄 Обрабатываем ответы API...');
+
+        const allSuccess = doctorsRes && doctorsRes.data && servicesRes && servicesRes.data;
+        logger.info('📊 Статус ответов:', {
+          doctors: doctorsRes && doctorsRes.data ? 'OK' : 'ERROR',
+          services: servicesRes && servicesRes.data ? 'OK' : 'ERROR',
+          allSuccess,
+        });
+
+        if (!allSuccess) {
+          logger.warn('⚠️ Некоторые API недоступны, но продолжаем работу');
+        }
+
+        if (doctorsRes && doctorsRes.data) {
+          try {
+            const doctorsData = doctorsRes.data;
+            const apiDoctors = doctorsData.doctors || [];
+            logger.info('✅ Данные врачей получены:', apiDoctors.length, 'врачей');
+            if (apiDoctors.length > 0) {
+              setDoctors(apiDoctors);
+              logger.info('✅ Врачи обновлены из API');
+            }
+          } catch (error) {
+            logger.warn('Ошибка обработки данных врачей:', error.message);
+          }
+        } else {
+          logger.warn('❌ API врачей недоступен, оставляем пустое состояние');
+        }
+
+        // Обработка отделений
+        if (departmentsRes && departmentsRes.data) {
+          const depts = departmentsRes.data.data || [];
+          if (Array.isArray(depts) && depts.length > 0) {
+            setDynamicDepartments(depts);
+            logger.info('✅ Отделения обновлены из API:', depts.length);
+          }
+        }
+
+        if (servicesRes && servicesRes.data) {
+          try {
+            const servicesData = servicesRes.data;
+            const apiServices = servicesData.services_by_group || {};
+            logger.info('✅ Данные услуг получены:', Object.keys(apiServices));
+            if (Object.keys(apiServices).length > 0) {
+              setServices(apiServices);
+              logger.info('✅ Услуги обновлены из API');
+            }
+          } catch (error) {
+            logger.warn('Ошибка обработки данных услуг:', error.message);
+          }
+        } else {
+          logger.warn('❌ API услуг недоступен, оставляем пустое состояние');
+        }
+
+        logger.info('🎯 Загрузка интегрированных данных завершена');
+      } catch (fetchError) {
+        logger.warn('Backend недоступен для загрузки интегрированных данных, оставляем пустое состояние:', fetchError.message);
+      }
+    } catch (error) {
+      logger.error('Ошибка загрузки интегрированных данных:', error);
+      notify.error('Ошибка загрузки данных из админ панели');
+    }
+  }, [setDoctors, setServices, setDynamicDepartments]);
+
+  // ───────────────────────────────────────────────────────────
+  // fetchPatientData: fetch single patient by ID
+  // ───────────────────────────────────────────────────────────
+  const fetchPatientData = useCallback(async (patientId) => {
+    // Проверяем, является ли это демо-пациентом (ID >= 1000)
+    if (patientId >= 1000) {
+      // Возвращаем null для демо-пациентов, так как их данные уже есть в записи
+      return null;
+    }
+    const token = tokenManager.getAccessToken();
+    if (!token) return null;
+
+    try {
+      const response = await fetch(`${API_BASE}/api/v1/patients/${patientId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (response.ok) {
+        return await response.json();
+      }
+    } catch (error) {
+      const rawMessage = error?.message || '';
+      if (isNetworkFetchError(rawMessage)) {
+        logger.warn('[Registrar] Не удалось загрузить пациента из URL: backend недоступен', {
+          patientId,
+          rawMessage,
+        });
+        return null;
+      }
+
+      logger.error(`Error fetching patient ${patientId}:`, {
+        error: formatNetworkErrorMessage({
+          rawMessage,
+          fallbackMessage: 'Не удалось загрузить пациента из URL',
+        }),
+        rawMessage,
+      });
+    }
+    return null;
+  }, []);
+
+  // ───────────────────────────────────────────────────────────
+  // enrichAppointmentsWithPatientData: enrich records with patient display fields
+  // ───────────────────────────────────────────────────────────
+  const enrichAppointmentsWithPatientData = useCallback(async (appointments) => {
+    const enrichedAppointments = await Promise.all(appointments.map(async (apt) => {
+      let enrichedApt = { ...apt };
+
+      // Обогащаем данными пациента
+      if (apt.patient_id && (!hasBackendPatientDisplayContract(apt) || !hasBackendPatientGenderContract(apt))) {
+        const patient = await fetchPatientData(apt.patient_id);
+        if (patient) {
+          let patient_fio = '';
+          if (patient.last_name && patient.first_name) {
+            patient_fio = `${patient.last_name} ${patient.first_name}`;
+            if (patient.middle_name) {
+              patient_fio += ` ${patient.middle_name}`;
+            }
+          } else if (patient.last_name) {
+            patient_fio = patient.last_name;
+          } else if (patient.first_name) {
+            patient_fio = patient.first_name;
+          } else {
+            patient_fio = `Пациент ID=${patient.id}`;
+          }
+
+          const patientGender = normalizePatientGender(patient);
+          enrichedApt = {
+            ...enrichedApt,
+            patient_fio: patient_fio.trim() || `Пациент ID=${patient.id}`,
+            patient_phone: patient.phone,
+            patient_birth_year: patient.birth_date ? new Date(patient.birth_date).getFullYear() : null,
+            patient_gender: patientGender,
+            gender: patientGender,
+            sex: patientGender,
+            address: patient.address || 'Не указан',
+          };
+        }
+      }
+
+      // Применяем локальные оверрайды (например, после оплаты), чтобы не было отката
+      const overrideKey = String(enrichedApt.id);
+      const ov = appointmentOverridesRef.current[overrideKey];
+      if (ov && (!ov.expiresAt || ov.expiresAt > Date.now())) {
+        enrichedApt = {
+          ...enrichedApt,
+          status: ov.status !== undefined ? ov.status : enrichedApt.status,
+          payment_status: ov.payment_status !== undefined ? ov.payment_status : enrichedApt.payment_status,
+        };
+      } else if (ov) {
+        delete appointmentOverridesRef.current[overrideKey];
+      }
+      enrichedApt = {
+        ...enrichedApt,
+        visit_type: enrichedApt.visit_type ?? null,
+        payment_type: enrichedApt.payment_type ?? null,
+        payment_status: enrichedApt.payment_status ?? null,
+        services: enrichedApt.services || [],
+        cost: Number(enrichedApt.cost ?? 0),
+      };
+
+      return enrichedApt;
+    }));
+    return enrichedAppointments;
+  }, [fetchPatientData, appointmentOverridesRef]);
+
+  return {
+    loadIntegratedData,
+    fetchPatientData,
+    enrichAppointmentsWithPatientData,
+  };
+};
+
+export default useRegistrarData;


### PR DESCRIPTION
## Summary

Strategic Direction 1 — Decomposition (audit §8). Steps 4-5 of 6 toward splitting the 4358-line `RegistrarPanel.jsx` monolith into focused modules. These steps extract data-loading and action-handler logic into custom hooks.

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main at commit 4a22341 (PR #1681 merge — Decomp 1-3)
- Clean workspace: only RegistrarPanel.jsx, registrar/ subdirectory (new files), and one test file touched
- Branch: refactor/registrar-decomp-4-5
- Scope gate: allowed registrar panel + new registrar/ subdirectory + contract tests; denied other panels, backend, migrations
- Red-check handling: full vitest suite run after each commit (467/467 passing); will fix any failing CI checks in this same PR before merge

## Contract Impact

- Canonical surface: GET /api/v1/registrar/* and POST /api/v1/registrar/records/actions (unchanged - no backend contract changes)
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged (200/401/403/429)
- Frontend consumer: RegistrarPanel.jsx (refactored internals only - props/exports/URL contract unchanged)
- Compatibility path or alias: not applicable - no API contract touched in this PR (frontend-only extraction)
- Contract proof: RegistrarPanel contract test suite passes 13/13; full suite 467/467

## RBAC / Permissions

- Roles allowed: admin, registrar (unchanged)
- Roles denied: doctor, patient, cashier, lab, cardio, derma, dentist (unchanged)
- Positive auth proof: routeRegistry.js unchanged; routeGuards.jsx unchanged
- Negative auth proof: not applicable - no changes to route role arrays or guard logic

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed in this PR. All extractions are custom hooks that call the same API endpoints with the same payloads.

## Frontend Resilience

- Empty data proof: not applicable - extracted hooks handle empty appointments array gracefully (verified by existing tests)
- Partial data proof: not applicable - hooks transform already-fetched data, do not fetch themselves except loadIntegratedData which handles partial API failures via Promise.allSettled
- Forbidden secondary path behavior: not applicable - no new code paths introduced
- Missing draft/resource behavior: not applicable - registrar panel does not create or reopen drafts or resources in these extracted modules
- Stale route/deep-link behavior: not applicable - URL contract unchanged; hooks receive state via parameters

## Scope Gate

- Allowed paths: frontend/src/pages/RegistrarPanel.jsx, frontend/src/pages/registrar/useRegistrarData.js (new), frontend/src/pages/registrar/useRegistrarActions.js (new), frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
- Denied paths: backend Python files, database migrations, admin panels, EMR, lab, payment integrations, other frontend panels
- Migration/docs/test impact: no migration; no docs changes; contract test updated to read 6 source files instead of 4 (readRegistrarSourceTree helper)
- Rollback note: revert all 2 commits on this branch; no database state to revert; no feature flags to disable

## Validation

- Targeted tests or smoke run: full vitest suite (105 test files, 467 tests) passes locally; RegistrarPanel contract tests (13/13) pass
- Result: passed (467/467, 0 regressions vs main baseline)
- Not checked: Playwright E2E suite - CI will run these automatically

---

## What's in this PR

Two extraction commits, each verified independently:

### Decomp 4: Data-loading → `registrar/useRegistrarData.js` (−208 lines)

Extracted 3 data-loading functions (~226 lines) into a custom hook:

- **loadIntegratedData**: parallel fetch of doctors + services + departments from `/registrar/*` endpoints via `Promise.allSettled`. Handles partial failures gracefully.
- **fetchPatientData**: fetches single patient by ID from `/api/v1/patients/:id`. Returns null for demo patients (ID >= 1000) or on network error.
- **enrichAppointmentsWithPatientData**: enriches appointment records with patient display fields (FIO, phone, birth year, gender, address) if missing from backend. Applies local overrides from `appointmentOverridesRef`.

**NOT extracted** (remain inline due to complex ref dependencies):
- `loadAppointments`: depends on `loadAppointmentsInFlightRef`, `autoRefreshCooldownUntilRef`, `autoRefreshCooldownLoggedRef`, `filteredAppointmentsRef`
- `loadMoreAppointments`: depends on `paginationInfo` + `loadAppointments`

Hook API: `useRegistrarData({ setDoctors, setServices, setDynamicDepartments, appointmentOverridesRef })`

### Decomp 5: Action handlers → `registrar/useRegistrarActions.js` (−91 lines)

Extracted 4 action handler functions (~100 lines) into a custom hook:

- **runRegistrarRecordAction**: posts to `/registrar/records/actions` batch endpoint. Validates record refs + backend action availability before calling API.
- **handleStartVisit**: wraps `runRegistrarRecordAction` for `start_visit`. Shows toast, reloads appointments.
- **handlePayment**: wraps `runRegistrarRecordAction` for `mark_paid`. Handles partial success (already-paid records), silent reload after 800ms. Converted from plain function to `useCallback`.
- **updateAppointmentStatus**: maps status string to backend action, calls `runRegistrarRecordAction`, reloads.

**NOT extracted** (remain inline — simple state setters, 1-3 lines each):
- `openRecordPreview`, `openRecordEditor`, `handleContextMenuAction`

Hook API: `useRegistrarActions({ appointments, loadAppointments })`

### Contract test update

`readRegistrarSourceTree()` now reads 6 files (orchestrator + 5 modules). Updated `enrichAppointmentsWithPatientData` block end marker from `const loadAppointments` (now in different file) to `return enrichedAppointments;`.

## Files Changed

| File | Change | Lines |
|---|---|---|
| `frontend/src/pages/RegistrarPanel.jsx` | Modified | 3521 → 3217 (−304 lines) |
| `frontend/src/pages/registrar/useRegistrarData.js` | **New** | +266 lines |
| `frontend/src/pages/registrar/useRegistrarActions.js` | **New** | +149 lines |
| `frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx` | Modified | +25/-10 |

## RegistrarPanel.jsx progression

| Stage | Lines | Cumulative Δ |
|---|---|---|
| Original (audit baseline) | 4358 | — |
| After Quick Wins (PR #1677) | 3892 | −466 (−10.7%) |
| After Decomp 1-3 (PR #1681) | 3521 | −837 (−19.2%) |
| After Decomp 4-5 (this PR) | **3217** | **−1141 (−26.2%)** |

## registrar/ module inventory (after this PR)

| Module | Lines | Role |
|---|---|---|
| `registrarHelpers.js` | 402 | Pure functions (constants, contract normalization, action helpers) |
| `useRegistrarHotkeys.js` | 89 | Keyboard shortcuts hook |
| `useRegistrarReschedule.js` | 87 | Reschedule logic hook |
| `useRegistrarData.js` | 266 | Data-loading hook (loadIntegratedData, fetchPatientData, enrich) |
| `useRegistrarActions.js` | 149 | Action handlers hook (runRegistrarRecordAction, handleStartVisit, etc.) |
| **Total extracted** | **993** | |

## What's NOT in this PR (deferred)

**Decomp 6** (view components): Extract `WelcomeView`, `WorklistView`, `QueueView` JSX (~1500 lines). This is the largest and riskiest step — requires careful prop typing and state passing. Will be a separate PR.

After Decomp 6, target: `RegistrarPanel.jsx` < 800 lines (orchestrator only).

## Test Results

| Suite | Before | After | Status |
|---|---|---|---|
| Full vitest suite | 467/467 | 467/467 | no regression |
| RegistrarPanel contract | 13/13 | 13/13 | no regression |
| ESLint errors | 0 | 0 | no new errors |
| Vite production build | ok | ok | builds clean |
