### PR TITLE
refactor(registrar): unify design system to macOS tokens (Strategic Direction 2)

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -485,10 +485,11 @@ const RegistrarPanel = () => {
   const statusFilterLabel = statusFilter ? t(REGISTRAR_STATUS_LABEL_KEYS[statusFilter] || statusFilter) : null;
   const { theme, isDark, getSpacing, getFontSize, getColor } = useTheme();
   // Адаптивные цвета из централизованной системы темизации
-  const cardBg = isDark ? 'var(--color-background-primary)' : 'var(--color-background-secondary)';
-  const textColor = isDark ? 'var(--color-text-primary)' : 'var(--color-text-primary)';
-  const borderColor = isDark ? 'var(--color-border-medium)' : 'var(--color-border-light)';
-  const accentColor = 'var(--color-primary-500)';
+  // DS-2 fix: replaced --color-* variables with --mac-* canonical tokens
+  const cardBg = isDark ? 'var(--mac-bg-secondary)' : 'var(--mac-bg-primary)';
+  const textColor = 'var(--mac-text-primary)';
+  const borderColor = isDark ? 'var(--mac-border)' : 'var(--mac-border-secondary)';
+  const accentColor = 'var(--mac-accent-blue)';
 
   // Используем централизованную типографику и отступы
   // Используем CSS переменные вместо getSpacing и getColor
@@ -1554,7 +1555,7 @@ const RegistrarPanel = () => {
     if (dataSource === 'error') {
       return (
         <div style={{
-          background: 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)',
+          background: 'var(--mac-error)',
           color: 'white',
           padding: '8px 12px',
           borderRadius: '6px',
@@ -1590,7 +1591,7 @@ const RegistrarPanel = () => {
     if (dataSource === 'api') {
       return (
         <div style={{
-          background: 'linear-gradient(135deg, #10b981 0%, #059669 100%)',
+          background: 'var(--mac-success)',
           color: 'white',
           padding: '8px 12px',
           borderRadius: '6px',
@@ -1614,7 +1615,7 @@ const RegistrarPanel = () => {
     if (dataSource === 'loading') {
       return (
         <div style={{
-          background: 'linear-gradient(135deg, #3b82f6 0%, #2563eb 100%)',
+          background: 'var(--mac-accent-blue)',
           color: 'white',
           padding: '8px 12px',
           borderRadius: '6px',
@@ -1761,7 +1762,7 @@ const RegistrarPanel = () => {
           top: '0',
           zIndex: 9999,
           padding: '8px 16px',
-          background: 'var(--color-primary-600)',
+          background: 'var(--mac-accent-blue-hover)',
           color: 'white',
           textDecoration: 'none',
           borderRadius: '0 0 4px 4px'
@@ -2109,7 +2110,7 @@ const RegistrarPanel = () => {
                                 padding: '8px 12px',
                                 borderRadius: '6px',
                                 fontSize: '13px',
-                                background: theme === 'light' ? '#f3f4f6' : '#4b5563',
+                                background: theme === 'light' ? 'var(--mac-bg-secondary)' : 'var(--mac-bg-quaternary)',
                                 color: textColor,
                                 border: 'none',
                                 cursor: 'pointer',
@@ -2129,7 +2130,7 @@ const RegistrarPanel = () => {
                                 padding: '8px 12px',
                                 borderRadius: '6px',
                                 fontSize: '13px',
-                                background: theme === 'light' ? '#f3f4f6' : '#4b5563',
+                                background: theme === 'light' ? 'var(--mac-bg-secondary)' : 'var(--mac-bg-quaternary)',
                                 color: textColor,
                                 border: 'none',
                                 cursor: 'pointer',
@@ -2151,7 +2152,7 @@ const RegistrarPanel = () => {
                                 padding: '8px 12px',
                                 borderRadius: '6px',
                                 fontSize: '13px',
-                                background: theme === 'light' ? '#f3f4f6' : '#4b5563',
+                                background: theme === 'light' ? 'var(--mac-bg-secondary)' : 'var(--mac-bg-quaternary)',
                                 color: textColor,
                                 border: 'none',
                                 cursor: 'pointer',
@@ -2287,7 +2288,7 @@ const RegistrarPanel = () => {
                         }}
                         style={{
                           padding: '12px 24px',
-                          background: 'var(--mac-accent-blue, #3b82f6)',
+                          background: 'var(--mac-accent-blue)',
                           color: 'white',
                           border: 'none',
                           borderRadius: '8px',
@@ -2296,8 +2297,8 @@ const RegistrarPanel = () => {
                           cursor: 'pointer',
                           transition: 'all 0.2s'
                         }}
-                        onMouseOver={(e) => e.target.style.background = 'var(--mac-accent-blue, #2563eb)'}
-                        onMouseOut={(e) => e.target.style.background = 'var(--mac-accent-blue, #3b82f6)'}>
+                        onMouseOver={(e) => e.target.style.background = 'var(--mac-accent-blue-hover)'}
+                        onMouseOut={(e) => e.target.style.background = 'var(--mac-accent-blue)'}>
 
                                 <Icon name="key" size="small" style={{ marginRight: '6px' }} />Войти снова
                               </button>
@@ -2309,7 +2310,7 @@ const RegistrarPanel = () => {
                         }}
                         style={{
                           padding: '12px 24px',
-                          background: '#10b981',
+                          background: 'var(--mac-accent-green)',
                           color: 'white',
                           border: 'none',
                           borderRadius: '8px',
@@ -2318,8 +2319,8 @@ const RegistrarPanel = () => {
                           cursor: 'pointer',
                           transition: 'all 0.2s'
                         }}
-                        onMouseOver={(e) => e.target.style.background = '#059669'}
-                        onMouseOut={(e) => e.target.style.background = '#10b981'}>
+                        onMouseOver={(e) => e.target.style.background = 'var(--mac-accent-green-hover)'}
+                        onMouseOut={(e) => e.target.style.background = 'var(--mac-accent-green)'}>
 
                                 <Icon name="arrow.up.arrow.down" size="small" style={{ marginRight: '6px' }} />Обновить данные
                               </button>
@@ -2331,7 +2332,7 @@ const RegistrarPanel = () => {
                         }}
                         style={{
                           padding: '12px 24px',
-                          background: '#6b7280',
+                          background: 'var(--mac-text-tertiary)',
                           color: 'white',
                           border: 'none',
                           borderRadius: '8px',
@@ -2340,8 +2341,8 @@ const RegistrarPanel = () => {
                           cursor: 'pointer',
                           transition: 'all 0.2s'
                         }}
-                        onMouseOver={(e) => e.target.style.background = '#4b5563'}
-                        onMouseOut={(e) => e.target.style.background = '#6b7280'}>
+                        onMouseOver={(e) => e.target.style.background = 'var(--mac-text-secondary)'}
+                        onMouseOut={(e) => e.target.style.background = 'var(--mac-text-tertiary)'}>
 
                                 <Icon name="arrow.up.arrow.down" size="small" style={{ marginRight: '6px' }} />Перезапустить приложение
                               </button>
@@ -2663,7 +2664,7 @@ const RegistrarPanel = () => {
               display: 'flex',
               justifyContent: 'center',
               padding: '16px',
-              borderTop: `1px solid ${theme === 'light' ? '#e5e7eb' : '#374151'}`
+              borderTop: `1px solid ${theme === 'light' ? 'var(--mac-border-secondary)' : 'var(--mac-bg-quaternary)'}`
             }}>
                   <button
                 onClick={loadMoreAppointments}
@@ -2674,8 +2675,8 @@ const RegistrarPanel = () => {
                   borderRadius: '8px',
                   border: 'none',
                   background: paginationInfo.loadingMore ?
-                  '#9ca3af' :
-                  'linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%)',
+                  'var(--mac-text-tertiary)' :
+                  'var(--mac-accent-blue)',
                   color: 'white',
                   fontSize: '14px',
                   fontWeight: '500',
@@ -3058,7 +3059,7 @@ const RegistrarPanel = () => {
                 alignItems: 'center',
                 justifyContent: 'center',
                 backgroundColor: theme === 'dark' ? 'rgba(59, 130, 246, 0.2)' : 'rgba(59, 130, 246, 0.14)',
-                color: 'var(--mac-accent-blue, #3b82f6)',
+                color: 'var(--mac-accent-blue)',
                 flexShrink: 0
               }}>
                 📅
@@ -3112,7 +3113,7 @@ const RegistrarPanel = () => {
                 padding: '10px 12px',
                 borderRadius: '10px',
                 border: `1px solid ${theme === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)'}`,
-                backgroundColor: theme === 'dark' ? 'rgba(255,255,255,0.05)' : '#ffffff',
+                backgroundColor: theme === 'dark' ? 'rgba(255,255,255,0.05)' : 'var(--mac-bg-primary)',
                 color: getColor('textPrimary'),
                 fontSize: '14px',
                 fontFamily: 'inherit',

--- a/frontend/src/pages/registrar/DESIGN_SYSTEM.md
+++ b/frontend/src/pages/registrar/DESIGN_SYSTEM.md
@@ -1,0 +1,158 @@
+# Registrar Panel — Canonical Design System
+
+> **Status**: macOS Design System is the single canonical system for the Registrar Panel.
+> All other design systems (unified, TS tokens, Tailwind, legacy CSS) are deprecated.
+
+## Audit Context
+
+The UX audit (§5.6 Consistency, score 3/10) identified **six competing design systems** in the codebase:
+1. macOS Design System (`--mac-*` tokens, `components/ui/macos/*`)
+2. Unified Design System v2.0 (`--color-*` tokens, `theme/unifiedTheme.js`)
+3. TS Tokens (`theme/tokens/colors.ts` — aspirational, never adopted)
+4. Tailwind utility classes (scattered in a few components)
+5. Legacy CSS classes (`clinic-button`, `hover-lift`, etc.)
+6. Inline `style={{}}` blocks with hardcoded hex colors
+
+**Strategic Direction 2** (audit §8) calls for choosing ONE design system. The macOS Design System was selected because:
+- 38 components already written in `components/ui/macos/`
+- `macos-tokens.css` (677 lines) is the most complete token file
+- `styles/macos.css` (870 lines) provides comprehensive utility classes
+- The `Unified` theme was an incomplete migration attempt
+
+## Canonical Tokens (macOS)
+
+### Primary Colors
+| Token | Value | Use |
+|---|---|---|
+| `--mac-accent-blue` | `#007aff` | Primary actions, links, focus rings |
+| `--mac-accent-blue-hover` | `#0051d5` | Hover state for primary actions |
+| `--mac-accent-blue-active` | `#004bb5` | Active/pressed state |
+
+### Semantic Colors
+| Token | Value | Use |
+|---|---|---|
+| `--mac-success` | `#30d158` | Success states, "loaded from server" |
+| `--mac-warning` | `#ff9f0a` | Warnings, "showing fallback data" |
+| `--mac-error` / `--mac-danger` | `#ff453a` | Errors, "failed to load" |
+
+### Text Colors
+| Token | Value | Use |
+|---|---|---|
+| `--mac-text-primary` | `#000000` | Primary body text |
+| `--mac-text-secondary` | `#455568` | Secondary text, captions |
+| `--mac-text-tertiary` | `#5d6f84` | Muted text, placeholders |
+
+### Background Colors
+| Token | Value | Use |
+|---|---|---|
+| `--mac-bg-primary` | `#eef3fa` | Card backgrounds, primary surfaces |
+| `--mac-bg-secondary` | `#e3ebf5` | Secondary surfaces, stripes |
+| `--mac-bg-tertiary` | `#d7e1ee` | Tertiary surfaces |
+| `--mac-bg-quaternary` | `#ccd8e7` | Quaternary surfaces, dark mode fallbacks |
+
+### Border Colors
+| Token | Value | Use |
+|---|---|---|
+| `--mac-border` | `#b8c8da` | Primary borders |
+| `--mac-border-secondary` | `#cad8e7` | Lighter borders, dividers |
+| `--mac-separator` | (defined in macos.css) | Separators between sections |
+
+## Migration Status (Registrar Panel)
+
+| Artifact | Before Audit | After DS-2 (this PR) |
+|---|---|---|
+| Hardcoded hex colors | 16 | **0** |
+| `--color-*` variable usages | 8 | **0** |
+| `--mac-*` variable usages | 100 | **127** |
+| Legacy CSS classes (`clinic-button`, etc.) | 6 | **0** (removed in QW-01) |
+| Inline `style={{}}` blocks | 96 | 97 (DS-2 only changed values, not structure) |
+
+## What Changed in DS-2
+
+### Hardcoded hex → macOS tokens
+
+| Hex | macOS Token | Context |
+|---|---|---|
+| `#f3f4f6` | `var(--mac-bg-secondary)` | Light mode background |
+| `#4b5563` | `var(--mac-bg-quaternary)` | Dark mode background |
+| `#10b981` | `var(--mac-accent-green)` | Success button background |
+| `#059669` | `var(--mac-accent-green-hover)` | Success button hover |
+| `#6b7280` | `var(--mac-text-tertiary)` | Gray button background |
+| `#4b5563` | `var(--mac-text-secondary)` | Gray button hover |
+| `#e5e7eb` | `var(--mac-border-secondary)` | Light mode border |
+| `#374151` | `var(--mac-bg-quaternary)` | Dark mode border |
+| `#9ca3af` | `var(--mac-text-tertiary)` | Muted text |
+| `#ffffff` | `var(--mac-bg-primary)` | White background |
+| `#ef4444` / `#dc2626` gradient | `var(--mac-error)` | Error state gradient |
+| `#3b82f6` / `#2563eb` gradient | `var(--mac-accent-blue)` | Loading state gradient |
+| `#3b82f6` / `#1d4ed8` gradient | `var(--mac-accent-blue)` | "Load more" button gradient |
+
+### `--color-*` → `--mac-*` variables
+
+| Old (unified) | New (macOS) | Variable |
+|---|---|---|
+| `var(--color-background-primary)` | `var(--mac-bg-primary)` | `cardBg` |
+| `var(--color-background-secondary)` | `var(--mac-bg-secondary)` | `cardBg` |
+| `var(--color-text-primary)` | `var(--mac-text-primary)` | `textColor` |
+| `var(--color-border-medium)` | `var(--mac-border)` | `borderColor` |
+| `var(--color-border-light)` | `var(--mac-border-secondary)` | `borderColor` |
+| `var(--color-primary-500)` | `var(--mac-accent-blue)` | `accentColor` |
+| `var(--color-primary-600)` | `var(--mac-accent-blue-hover)` | Tooltip background |
+
+## What's NOT Changed (Deferred)
+
+### Inline `style={{}}` blocks (97 remaining)
+
+The 97 inline style blocks remain. They are now using macOS tokens (no hardcoded hex), but the structure is still inline. Full migration to CSS classes would require:
+1. Creating a `registrar.css` with named classes for each style pattern
+2. Replacing `style={{...}}` with `className="registrar-..."` 
+3. Adding ESLint rule `react-native/no-inline-styles` to prevent regression
+
+This is a larger effort (estimated 2-3 days) and is deferred to a follow-up PR.
+
+### Other panels (AdminPanel, CashierPanel, etc.)
+
+This PR only addresses the Registrar Panel. Other panels still have:
+- AdminPanel.jsx: 260 inline style blocks
+- DentistPanelUnified.jsx: 265 inline style blocks
+- DermatologistPanelUnified.jsx: 171 inline style blocks
+
+These will be migrated one panel at a time in follow-up PRs.
+
+## ESLint Enforcement (Future)
+
+To prevent regression, the following ESLint rule should be added to `.eslintrc`:
+
+```json
+{
+  "rules": {
+    "no-restricted-syntax": [
+      "warn",
+      {
+        "selector": "Literal[value=/^#[0-9a-fA-F]{3,8}$/]",
+        "message": "Use macOS design tokens (var(--mac-*)) instead of hardcoded hex colors"
+      }
+    ]
+  }
+}
+```
+
+This is deferred because it would currently trigger warnings in other panels that haven't been migrated yet.
+
+## Verification
+
+Run this command to verify the Registrar Panel uses only macOS tokens:
+
+```bash
+python3 -c "
+import re
+with open('frontend/src/pages/RegistrarPanel.jsx') as f:
+    content = f.read()
+hex = re.findall(r'#[0-9a-fA-F]{3,8}', content)
+color_vars = re.findall(r'var\(--color-', content)
+mac_vars = re.findall(r'var\(--mac-', content)
+print(f'Hardcoded hex: {len(hex)} (expected: 0)')
+print(f'--color-* vars: {len(color_vars)} (expected: 0)')
+print(f'--mac-* vars: {len(mac_vars)} (expected: >100)')
+"
+```


### PR DESCRIPTION
## Summary

Strategic Direction 2 — Design System Unification (audit §8). Consolidates the Registrar Panel to use ONLY macOS design system tokens. Eliminates all hardcoded hex colors and `--color-*` (unified) variable usages.

The audit (§5.6 Consistency, score 3/10) identified six competing design systems. This PR makes macOS the single canonical system for the Registrar Panel.

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main at commit e18ddcd (PR #1684 merge — Decomp 6a)
- Clean workspace: only RegistrarPanel.jsx and new DESIGN_SYSTEM.md touched
- Branch: refactor/design-system-unification
- Scope gate: allowed registrar panel + design system docs; denied other panels, backend, migrations
- Red-check handling: full vitest suite run after commit (467/467 passing); will fix any failing CI checks in this same PR before merge

## Contract Impact

- Canonical surface: not applicable - no backend contract changes (frontend-only style changes)
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: RegistrarPanel.jsx (style values only - no structural/behavioral change)
- Compatibility path or alias: not applicable - no API contract touched in this PR
- Contract proof: RegistrarPanel contract test suite passes 13/13; full suite 467/467

## RBAC / Permissions

- Roles allowed: admin, registrar (unchanged)
- Roles denied: doctor, patient, cashier, lab, cardio, derma, dentist (unchanged)
- Positive auth proof: routeRegistry.js unchanged; routeGuards.jsx unchanged
- Negative auth proof: not applicable - no changes to route role arrays or guard logic

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed in this PR. All changes are CSS variable substitutions.

## Frontend Resilience

- Empty data proof: not applicable - style changes do not affect data handling
- Partial data proof: not applicable - style changes do not affect data fetching
- Forbidden secondary path behavior: not applicable - no new code paths introduced
- Missing draft/resource behavior: not applicable - style changes only
- Stale route/deep-link behavior: not applicable - URL contract unchanged; only CSS variable values changed

## Scope Gate

- Allowed paths: frontend/src/pages/RegistrarPanel.jsx, frontend/src/pages/registrar/DESIGN_SYSTEM.md (new)
- Denied paths: other frontend panels (AdminPanel, CashierPanel, etc.), backend Python files, database migrations, ESLint config
- Migration/docs/test impact: no migration; new DESIGN_SYSTEM.md docs; no test changes needed
- Rollback note: revert 1 commit on this branch; no database state to revert; no feature flags to disable

## Validation

- Targeted tests or smoke run: full vitest suite (105 test files, 467 tests) passes locally; RegistrarPanel contract tests pass 13/13
- Result: passed (467/467, 0 regressions vs main baseline)
- Not checked: visual regression (CI does not have visual diff tooling); manual visual QA recommended

---

## What's in this PR

### DS-2: Replace hardcoded hex + `--color-*` with macOS tokens

**16 hardcoded hex colors → 0**:
- `#f3f4f6`/`#4b5563` → `var(--mac-bg-secondary/quaternary)` (backgrounds)
- `#10b981`/`#059669` → `var(--mac-accent-green/hover)` (success buttons)
- `#6b7280`/`#4b5563` → `var(--mac-text-tertiary/secondary)` (gray buttons)
- `#e5e7eb`/`#374151` → `var(--mac-border-secondary/quaternary)` (borders)
- `#9ca3af` → `var(--mac-text-tertiary)` (muted text)
- `#ffffff` → `var(--mac-bg-primary)` (white background)
- Gradients (`#ef4444→#dc2626`, `#3b82f6→#2563eb`, `#3b82f6→#1d4ed8`) → solid `var(--mac-error/success/accent-blue)`

**8 `--color-*` variable usages → 0**:
- `var(--color-background-primary/secondary)` → `var(--mac-bg-primary/secondary)`
- `var(--color-text-primary)` → `var(--mac-text-primary)`
- `var(--color-border-medium/light)` → `var(--mac-border/border-secondary)`
- `var(--color-primary-500/600)` → `var(--mac-accent-blue/hover)`

**Removed fallback values** from `var()` calls (e.g. `var(--mac-accent-blue, #3b82f6)` → `var(--mac-accent-blue)`) — fallbacks are unnecessary since tokens are always defined in `macos-tokens.css`.

### DESIGN_SYSTEM.md

New documentation file at `frontend/src/pages/registrar/DESIGN_SYSTEM.md` with:
- Canonical token reference (primary, semantic, text, bg, border)
- Migration status table (before/after)
- Hex → token mapping table
- What's deferred (inline styles, other panels, ESLint rule)
- Verification command

## Migration Status

| Artifact | Before Audit | After DS-2 |
|---|---|---|
| Hardcoded hex colors | 16 | **0** |
| `--color-*` variable usages | 8 | **0** |
| `--mac-*` variable usages | 100 | **127** |
| Legacy CSS classes | 6 | **0** (removed in QW-01) |
| Inline `style={{}}` blocks | 96 | 97 (values changed, not structure) |

## Files Changed

| File | Change | Lines |
|---|---|---|
| `frontend/src/pages/RegistrarPanel.jsx` | Modified | +26/-25 |
| `frontend/src/pages/registrar/DESIGN_SYSTEM.md` | **New** | +158 |

## What's NOT Changed (Deferred)

### Inline `style={{}}` blocks (97 remaining)

The 97 inline style blocks now use macOS tokens (no hardcoded hex), but the structure is still inline. Full migration to CSS classes requires:
1. Creating `registrar.css` with named classes
2. Replacing `style={{...}}` with `className="registrar-..."`
3. Adding ESLint rule `react-native/no-inline-styles`

Estimated 2-3 days. Deferred to follow-up PR.

### Other panels

AdminPanel (260 inline styles), DentistPanelUnified (265), DermatologistPanelUnified (171) still have design system drift. Will be migrated one panel at a time.

### ESLint enforcement

A `no-restricted-syntax` rule to forbid hardcoded hex would prevent regression, but is deferred until all panels are migrated.

## Audit Score Impact

| Section | Before | After | Notes |
|---|---|---|---|
| §5.6 Consistency | 3/10 | **6/10** (projected) | Was 3 competing systems, now 1 canonical with 97 inline styles |
| §5.12 Scalability | 3/10 | 3/10 (unchanged) | Inline styles still block ESLint enforcement |

Full score 8/10 requires migrating inline styles to CSS classes.

## Test Results

| Suite | Before | After | Status |
|---|---|---|---|
| Full vitest suite | 467/467 | 467/467 | no regression |
| RegistrarPanel contract | 13/13 | 13/13 | no regression |
| ESLint errors | 0 | 0 | no new errors |
| Vite production build | ok | ok | builds clean |
