### PR TITLE
refactor(registrar): CSS migration batch 2 — 5 more inline styles → classes

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -2193,13 +2193,7 @@ const RegistrarPanel = () => {
 
                     return isEmptyQueue;
                   })() &&
-                  <div style={{
-                    padding: '60px 20px',
-                    textAlign: 'center',
-                    background: cardBg,
-                    borderRadius: '12px',
-                    border: `1px solid ${borderColor}`
-                  }}>
+                  <div className="registrar-empty-state">
                           {/* QW-04: empty state 1 of 3 (session-expired / empty-queue). */}
                     {/* Full unification deferred — requires EmptyState.jsx migration */}
                     {/* from Tailwind/native to macOS design system first. */}
@@ -2245,17 +2239,7 @@ const RegistrarPanel = () => {
                           // Перенаправляем на страницу входа
                           window.location.href = '/login';
                         }}
-                        style={{
-                          padding: '12px 24px',
-                          background: 'var(--mac-accent-blue)',
-                          color: 'white',
-                          border: 'none',
-                          borderRadius: '8px',
-                          fontSize: '14px',
-                          fontWeight: '500',
-                          cursor: 'pointer',
-                          transition: 'all 0.2s'
-                        }}
+                        className="registrar-btn-lg registrar-btn-accent"
                         onMouseOver={(e) => e.target.style.background = 'var(--mac-accent-blue-hover)'}
                         onMouseOut={(e) => e.target.style.background = 'var(--mac-accent-blue)'}>
 
@@ -2267,17 +2251,7 @@ const RegistrarPanel = () => {
                           // Обновляем данные
                           loadAppointments({ source: 'manual_refresh_button' });
                         }}
-                        style={{
-                          padding: '12px 24px',
-                          background: 'var(--mac-accent-green)',
-                          color: 'white',
-                          border: 'none',
-                          borderRadius: '8px',
-                          fontSize: '14px',
-                          fontWeight: '500',
-                          cursor: 'pointer',
-                          transition: 'all 0.2s'
-                        }}
+                        className="registrar-btn-lg registrar-btn-success"
                         onMouseOver={(e) => e.target.style.background = 'var(--mac-accent-green-hover)'}
                         onMouseOut={(e) => e.target.style.background = 'var(--mac-accent-green)'}>
 
@@ -2289,17 +2263,7 @@ const RegistrarPanel = () => {
                           // Перезапускаем приложение
                           window.location.reload();
                         }}
-                        style={{
-                          padding: '12px 24px',
-                          background: 'var(--mac-text-tertiary)',
-                          color: 'white',
-                          border: 'none',
-                          borderRadius: '8px',
-                          fontSize: '14px',
-                          fontWeight: '500',
-                          cursor: 'pointer',
-                          transition: 'all 0.2s'
-                        }}
+                        className="registrar-btn-lg registrar-btn-neutral"
                         onMouseOver={(e) => e.target.style.background = 'var(--mac-text-secondary)'}
                         onMouseOut={(e) => e.target.style.background = 'var(--mac-text-tertiary)'}>
 
@@ -2506,13 +2470,7 @@ const RegistrarPanel = () => {
               {appointmentsLoading ?
             <AnimatedLoader.TableSkeleton rows={8} columns={10} /> :
             filteredAppointments.length === 0 && dataSource === 'api' ?
-            <div style={{
-              padding: '60px 20px',
-              textAlign: 'center',
-              background: cardBg,
-              borderRadius: '12px',
-              border: `1px solid ${borderColor}`
-            }}>
+            <div className="registrar-empty-state">
                   <div style={{
                 fontSize: '48px',
                 marginBottom: '16px',
@@ -2689,7 +2647,7 @@ const RegistrarPanel = () => {
           }
         ]}>
         {recordPreviewDialog.row && (
-          <div style={{ display: 'grid', gap: '12px', color: 'var(--mac-text-primary)' }}>
+          <div className="registrar-text-primary" style={{ display: 'grid', gap: '12px' }}>
             {[
               ['Пациент', recordPreviewDialog.row.patient_fio || recordPreviewDialog.row.patient_name],
               ['Телефон', recordPreviewDialog.row.patient_phone || recordPreviewDialog.row.phone],
@@ -2704,17 +2662,16 @@ const RegistrarPanel = () => {
             ].filter(([, value]) => value !== null && value !== undefined && value !== '').map(([label, value]) => (
               <div
                 key={label}
+                className="registrar-surface"
                 style={{
                   display: 'grid',
                   gridTemplateColumns: 'minmax(120px, 0.36fr) minmax(0, 1fr)',
                   gap: '12px',
                   alignItems: 'start',
                   padding: '10px 12px',
-                  border: '1px solid var(--mac-separator)',
-                  borderRadius: 'var(--mac-radius-md)',
-                  background: 'var(--mac-bg-secondary)'
+                  borderRadius: 'var(--mac-radius-md)'
                 }}>
-                <span style={{ color: 'var(--mac-text-secondary)', fontSize: '13px' }}>{label}</span>
+                <span className="registrar-text-secondary" style={{ fontSize: '13px' }}>{label}</span>
                 <span style={{ minWidth: 0, overflowWrap: 'anywhere', fontWeight: 500 }}>
                   {String(value)}
                 </span>

--- a/frontend/src/pages/registrar/registrar.css
+++ b/frontend/src/pages/registrar/registrar.css
@@ -127,6 +127,18 @@
   color: white;
 }
 
+/* Larger button variant for empty-state CTAs */
+.registrar-btn-lg {
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: none;
+  color: white;
+}
+
 .registrar-btn-accent {
   background: var(--mac-accent-blue);
 }


### PR DESCRIPTION
## Summary

Continuing Strategic Direction 2 (DS-3): migrating inline `style={{}}` blocks to CSS classes from `registrar.css`. This batch replaces 5 more blocks, bringing the total from 97 → 86 (−11 since DS-3 started).

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main at commit e2bd9f2 (PR #1687 merge)
- Clean workspace: only RegistrarPanel.jsx and registrar.css touched
- Branch: refactor/registrar-css-migration-batch2
- Scope gate: allowed registrar panel + CSS; denied other panels, backend, migrations
- Red-check handling: full vitest suite run after commit (467/467 passing); will fix any failing CI checks in this same PR before merge

## Contract Impact

- Canonical surface: not applicable - no backend contract changes (CSS class changes only)
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: RegistrarPanel.jsx (style attribute → className, no behavioral change)
- Compatibility path or alias: not applicable - no API contract touched in this PR
- Contract proof: RegistrarPanel contract test suite passes 13/13; full suite 467/467

## RBAC / Permissions

- Roles allowed: admin, registrar (unchanged)
- Roles denied: doctor, patient, cashier, lab, cardio, derma, dentist (unchanged)
- Positive auth proof: routeRegistry.js unchanged; routeGuards.jsx unchanged
- Negative auth proof: not applicable - no changes to route role arrays or guard logic

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed in this PR. All changes are CSS class substitutions.

## Frontend Resilience

- Empty data proof: not applicable - CSS class changes do not affect data handling
- Partial data proof: not applicable - CSS class changes do not affect data fetching
- Forbidden secondary path behavior: not applicable - no new code paths introduced
- Missing draft/resource behavior: not applicable - CSS class substitutions only
- Stale route/deep-link behavior: not applicable - URL contract unchanged; only style attributes changed

## Scope Gate

- Allowed paths: frontend/src/pages/RegistrarPanel.jsx, frontend/src/pages/registrar/registrar.css
- Denied paths: backend Python files, database migrations, other frontend panels, ESLint config
- Migration/docs/test impact: no migration; no docs changes; no test changes needed
- Rollback note: revert 1 commit on this branch; no database state to revert; no feature flags to disable

## Validation

- Targeted tests or smoke run: full vitest suite (105 test files, 467 tests) passes locally; RegistrarPanel contract tests pass 13/13
- Result: passed (467/467, 0 regressions vs main baseline)
- Not checked: visual regression (manual visual QA recommended for CSS class changes)

---

## What's in this PR

### 5 inline style blocks → CSS classes

| Block | Before | After |
|---|---|---|
| Session-expired 'Login again' button | 10-property inline style | `className='registrar-btn-lg registrar-btn-accent'` |
| Session-expired 'Refresh data' button | 10-property inline style | `className='registrar-btn-lg registrar-btn-success'` |
| Session-expired 'Restart app' button | 10-property inline style | `className='registrar-btn-lg registrar-btn-neutral'` |
| Empty-state container 1 (session-expired) | 5-property inline style | `className='registrar-empty-state'` |
| Empty-state container 2 (worklist empty) | 5-property inline style | `className='registrar-empty-state'` |

### CSS additions

Added `.registrar-btn-lg` class to `registrar.css` — larger button variant (padding: 12px 24px) for empty-state CTAs.

### Partial replacements (color → className)

- Record preview dialog container: `color: 'var(--mac-text-primary)'` → `className='registrar-text-primary'`
- Record preview row: `border + background` inline → `className='registrar-surface'`
- Record preview label: `color: 'var(--mac-text-secondary)'` → `className='registrar-text-secondary'`

## Inline style progression

| Stage | Inline style blocks | Δ |
|---|---|---|
| Original (audit baseline) | 97 | — |
| After DS-3 batch 1 (PR #1687) | 91 | −6 |
| After DS-3 batch 2 (this PR) | **86** | −5 (total −11, −11.3%) |

## Files Changed

| File | Change | Lines |
|---|---|---|
| `frontend/src/pages/RegistrarPanel.jsx` | Modified | +8/-45 |
| `frontend/src/pages/registrar/registrar.css` | Modified | +12/-0 |

## Test Results

| Suite | Before | After | Status |
|---|---|---|---|
| Full vitest suite | 467/467 | 467/467 | no regression |
| ESLint errors | 0 | 0 | no new errors |
| Vite production build | ok | ok | builds clean |
