### PR TITLE
fix(registrar): Episode 5 — data loss fix, auto-refresh pause, breadcrumb

### DIFF
--- a/backend/app/services/registrar_edit_delta_service.py
+++ b/backend/app/services/registrar_edit_delta_service.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, attributes
 
 from app.crud.patient import normalize_patient_name
 from app.models.clinic import Doctor
@@ -261,7 +261,12 @@ class RegistrarEditDeltaService:
                     )
                 )
             entry.services = services
+            # R-41 fix: flag_modified для JSON column — без этого SQLAlchemy
+            # не обнаруживает изменение mutable JSON field, update не persist'ится.
+            # Silent data loss: пользователь меняет услуги, но БД не обновляется.
+            attributes.flag_modified(entry, 'services')
             entry.service_codes = self._merged_service_codes(entry.service_codes, service)
+            attributes.flag_modified(entry, 'service_codes')
             entry.total_amount = int(Decimal(str(entry.total_amount or 0)) + delta_amount)
             entry.updated_at = changed_at
 

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -1065,12 +1065,18 @@ const RegistrarPanel = () => {
     // meant a registrar with a payment dialog open for 2+ minutes would not
     // see new online-queue patients arrive in the worklist behind the dialog.
     //
-    // Now we only pause for `showWizard` — the wizard form holds unsaved
-    // patient data that silent refresh could overwrite if the table state
-    // gets re-derived. Payment / print / cancel dialogs operate on a single
-    // row snapshot and do not interact with the worklist rendering, so
-    // background refresh is safe and keeps the worklist live.
-    if (showWizard) return;
+    // R-26 fix: pause auto-refresh when ANY dialog is open.
+    // Раньше только showWizard — но payment/cancel/reschedule dialogs
+    // тоже могут пострадать от фонового refresh (row positions change).
+    const anyDialogOpen = showWizard
+      || paymentDialog.open
+      || cancelDialog.open
+      || printDialog.open
+      || recordPreviewDialog.open
+      || contextMenu.open
+      || forceMajeureModal.open
+      || showSlotsModal;
+    if (anyDialogOpen) return;
     if (!autoRefresh) return;
     if (Date.now() < autoRefreshCooldownUntilRef.current) return;
 
@@ -1777,6 +1783,50 @@ const RegistrarPanel = () => {
 
         Перейти к основному содержимому
       </a>
+
+      {/* R-03 fix: breadcrumb навигация для wayfinding.
+          Показывает текущую view, выбранное отделение, поисковый запрос. */}
+      <nav aria-label="Навигация" className="registrar-breadcrumb" style={{
+        padding: '4px 0',
+        fontSize: '13px',
+        color: 'var(--mac-text-secondary)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        flexWrap: 'wrap',
+      }}>
+        <button
+          type="button"
+          onClick={() => {
+            const p = new URLSearchParams(searchParams);
+            p.set('view', 'welcome');
+            p.delete('q');
+            p.delete('status');
+            setSearchParams(p, { replace: true });
+          }}
+          style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--mac-accent)', font: 'inherit', padding: 0 }}
+        >
+          Регистратура
+        </button>
+        {activeTab && (
+          <>
+            <span>›</span>
+            <span>{queueProfiles.find(p => p.key === activeTab)?.title || activeTab}</span>
+          </>
+        )}
+        {searchQuery && (
+          <>
+            <span>›</span>
+            <span>Поиск: «{searchQuery}»</span>
+          </>
+        )}
+        {showWizard && (
+          <>
+            <span>›</span>
+            <span>{wizardEditMode ? 'Редактирование' : 'Новая запись'}</span>
+          </>
+        )}
+      </nav>
 
       {/* Современные вкладки */}
       {(!currentView || currentView !== 'welcome' && currentView !== 'queue') &&


### PR DESCRIPTION
## Summary

Episode 5: data loss fix + auto-refresh pause + breadcrumb.

- R-41 (High): flag_modified for SQLAlchemy JSON columns — silent data loss fix
- R-26 (Medium): Auto-refresh pause for ALL dialogs (not just wizard)
- R-03 (Medium): Breadcrumb navigation

2 files, +62/-7 lines.

## Cyclic Execution Evidence

- Fresh main sync: branch from main (commit 657c61c)
- Clean workspace: git status empty
- Branch: fix/registrar-workflow-round5 to main
- Scope gate: 2 files. Backend + frontend. Migrations, configs not touched.
- Red-check handling: Python AST OK for backend. Frontend CI will verify.

## Contract Impact

not applicable - backend fix (flag_modified) does not change API contract. Frontend changes are UI-only.

## RBAC / Permissions

not applicable - does not affect RBAC.

## Notification / Realtime

not applicable - does not affect websocket or notifications.

## Frontend Resilience

- Empty data proof: breadcrumb conditional render — if activeTab null, no department shown. anyDialogOpen — if all false, auto-refresh works normally.
- Partial data proof: flag_modified — if services were modified before fix, changes were not persisted. After fix, new changes persist. Breadcrumb — queueProfiles may be empty, fallback to activeTab raw key.
- Forbidden secondary path behavior: not applicable - flag_modified, auto-refresh pause, breadcrumb не добавляют новых путей
- Missing draft/resource behavior: not applicable - breadcrumb conditional render, anyDialogOpen fallback to false
- Stale route/deep-link behavior: breadcrumb click resets q/status but preserves dept (R-02 URL sync).

## Scope Gate

- Allowed paths: backend/app/services/registrar_edit_delta_service.py, frontend/src/pages/RegistrarPanel.jsx
- Denied paths: backend endpoints, frontend/src/api/, migrations, configs, CI, docs
- Migration/docs/test impact: no migrations. Existing tests not affected.
- Rollback note: git revert. All changes are additive.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: Python AST OK for backend. grep: flag_modified for services and service_codes. anyDialogOpen checks 8 dialog states. Breadcrumb conditional render with queueProfiles title. CI will verify frontend.
- Result: passed for static analysis.
- Not checked: runtime — after merge: edit services in a record, verify DB updated (R-41). Open payment dialog, verify auto-refresh paused (R-26). Breadcrumb shows path (R-03).

---

Registrar Episode 5: data loss fix, auto-refresh pause, breadcrumb · 2026-07-02