### PR TITLE
refactor(registrar): R-22 — extract 3 helpers from get_today_queues (phase 1)

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -1371,6 +1371,81 @@ def start_queue_visit(
         )
 
 
+
+# ===================== HELPERS ДЛЯ get_today_queues (R-22 decomposition) =====================
+
+
+def _parse_queue_target_date(target_date: str | None) -> "date":
+    """R-22: Парсинг даты для очереди. Возвращает today если невалидно."""
+    from datetime import datetime
+    if target_date:
+        import re
+        if re.match(r'^\d{4}-\d{2}-\d{2}$', target_date):
+            try:
+                return datetime.strptime(target_date, '%Y-%m-%d').date()
+            except (ValueError, TypeError):
+                pass
+    return date.today()
+
+
+def _normalize_department_filter(department: str | None) -> set[str] | None:
+    """R-22: Нормализация department фильтра для очереди."""
+    if not department:
+        return None
+    normalized = str(department).strip().lower()
+    aliases = {
+        "lab": {"lab", "laboratory"},
+        "laboratory": {"lab", "laboratory"},
+    }
+    return aliases.get(normalized, {normalized})
+
+
+def _load_queue_data_for_date(db: Session, target_day: "date") -> tuple:
+    """R-22: Загрузка visits, appointments и online entries для даты.
+
+    Returns:
+        tuple of (visits, appointments, online_entries)
+    """
+    from app.models.appointment import Appointment
+    from app.models.online_queue import DailyQueue, OnlineQueueEntry
+    from app.models.visit import Visit
+
+    visits = (
+        db.query(Visit)
+        .filter(
+            Visit.visit_date == target_day,
+            ~func.lower(func.coalesce(Visit.status, "")).in_(
+                REGISTRAR_HIDDEN_QUEUE_STATUSES
+            ),
+        )
+        .all()
+    )
+
+    appointments = (
+        db.query(Appointment)
+        .filter(
+            Appointment.appointment_date == target_day,
+            ~func.lower(func.coalesce(Appointment.status, "")).in_(
+                REGISTRAR_HIDDEN_QUEUE_STATUSES
+            ),
+        )
+        .all()
+    )
+
+    online_entries = (
+        db.query(OnlineQueueEntry)
+        .join(DailyQueue, OnlineQueueEntry.queue_id == DailyQueue.id)
+        .filter(
+            DailyQueue.day == target_day,
+            OnlineQueueEntry.status.in_(["waiting", "called", "paid"]),
+        )
+        .order_by(OnlineQueueEntry.queue_time.asc(), OnlineQueueEntry.id.asc())
+        .all()
+    )
+
+    return visits, appointments, online_entries
+
+
 # ===================== ТЕКУЩИЕ ОЧЕРЕДИ =====================
 
 
@@ -1440,76 +1515,12 @@ def get_today_queues(
                 visit.patient_id,
             )
 
-        # [OK] УПРОЩЕНО: Валидация формата даты перед парсингом (Single Source of Truth)
-        # Если дата не указана, используем сегодня
-        if target_date:
-            # Проверяем формат даты перед парсингом (YYYY-MM-DD)
-            import re
+        # R-22: date parsing + department filter extracted to helpers
+        today = _parse_queue_target_date(target_date)
+        department_filter = _normalize_department_filter(department)
 
-            date_pattern = r'^\d{4}-\d{2}-\d{2}$'
-            if re.match(date_pattern, target_date):
-                try:
-                    today = datetime.strptime(target_date, '%Y-%m-%d').date()
-                except (ValueError, TypeError):
-                    # Если парсинг не удался (некорректная дата), используем сегодня
-                    today = date.today()
-            else:
-                # Неправильный формат - используем сегодня
-                today = date.today()
-        else:
-            today = date.today()
-
-        department_filter: set[str] | None = None
-        if department:
-            normalized_department = str(department).strip().lower()
-            department_aliases = {
-                "lab": {"lab", "laboratory"},
-                "laboratory": {"lab", "laboratory"},
-            }
-            department_filter = department_aliases.get(
-                normalized_department,
-                {normalized_department},
-            )
-
-        # Получаем все визиты на сегодня (новая система)
-        visits = (
-            db.query(Visit)
-            .filter(
-                Visit.visit_date == today,
-                ~func.lower(func.coalesce(Visit.status, "")).in_(
-                    REGISTRAR_HIDDEN_QUEUE_STATUSES
-                ),
-            )
-            .all()
-        )
-
-        # Получаем все appointments на сегодня (старая система)
-        appointments = (
-            db.query(Appointment)
-            .filter(
-                Appointment.appointment_date == today,
-                ~func.lower(func.coalesce(Appointment.status, "")).in_(
-                    REGISTRAR_HIDDEN_QUEUE_STATUSES
-                ),
-            )
-            .all()
-        )
-
-        # [OK] ДОБАВЛЕНО: Получаем записи из онлайн-очереди (OnlineQueueEntry)
-        from app.models.online_queue import DailyQueue, OnlineQueueEntry
-
-        online_entries = (
-            db.query(OnlineQueueEntry)
-            .join(DailyQueue, OnlineQueueEntry.queue_id == DailyQueue.id)
-            .filter(
-                DailyQueue.day == today,
-                # [OK] ИСПРАВЛЕНО: Добавлен статус "paid" чтобы оплаченные записи
-                # отображались в списке регистратора (UI может фильтровать по статусу)
-                OnlineQueueEntry.status.in_(["waiting", "called", "paid"]),
-            )
-            .order_by(OnlineQueueEntry.queue_time.asc(), OnlineQueueEntry.id.asc())  # ✅ EXPLICIT SORT: Oldest first
-            .all()
-        )
+        # R-22: data loading extracted to helper
+        visits, appointments, online_entries = _load_queue_data_for_date(db, today)
 
         # Группируем записи по специальности
         queues_by_specialty = {}


### PR DESCRIPTION
## Summary

R-22 Phase 1: extract 3 self-contained helpers from the 1745-line `get_today_queues` monolith. Pure extraction — zero behavior change.

- **`_parse_queue_target_date(target_date)`** — date parsing with YYYY-MM-DD validation + fallback to today (was 30 lines inline)
- **`_normalize_department_filter(department)`** — department alias normalization (lab/laboratory) (was 12 lines inline)
- **`_load_queue_data_for_date(db, target_day)`** — loads Visit, Appointment, OnlineQueueEntry with REGISTRAR_HIDDEN_QUEUE_STATUSES filter (was 40 lines inline)

**Impact:** get_today_queues 1745→1682 lines (-63). 3 new testable functions. Zero behavior change.

## Cyclic Execution Evidence

- Fresh main sync: branch от main (commit 988558d)
- Clean workspace: git status пустой
- Branch: refactor/registrar-decompose-get-today-queues → main
- Scope gate: 1 backend файл — registrar_integration.py. Frontend, migrations, configs не затронуты.
- Red-check handling: Python AST parse ✓. Helper functions return same values as inline code — pure extraction.

## Contract Impact

not applicable - helpers are private functions (underscore prefix), not endpoints. Endpoint signature unchanged. Response shape unchanged. No API contract change.

## RBAC / Permissions

not applicable - RBAC not changed. @require_roles on endpoint unchanged. Helpers are internal.

## Notification / Realtime

not applicable - does not affect websocket or notifications.

## Frontend Resilience

not applicable - backend-only refactoring. Frontend not affected.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/registrar_integration.py
- Denied paths: frontend, backend models, migrations, configs, CI, docs
- Migration/docs/test impact: no migrations. Existing tests not affected — helpers return same values as inline code.
- Rollback note: git revert. Pure extraction — inline code can be restored.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: Python AST parse ✓. grep: _parse_queue_target_date, _normalize_department_filter, _load_queue_data_for_date defined and called. Inline date parsing and data loading replaced. get_today_queries reduced from 1745 to 1682 lines.
- Result: passed for static analysis. Backend tests will verify in CI.
- Not checked: runtime — but pure extraction, same logic.

---

R-22 Phase 1: extract 3 helpers from get_today_queues monolith · 2026-07-02