### PR TITLE
refactor(registrar): CSS migration batch 11 — breadcrumb + history + worklist headers (−65% total)

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -1603,7 +1603,7 @@ const RegistrarPanel = () => {
         <div className="registrar-ds-indicator registrar-ds-success">
           <Icon name="checkmark.circle" size="small" className="registrar-text-white" />
           <span>Данные загружены с сервера</span>
-          <span style={{ marginLeft: 'auto', fontSize: '12px', opacity: 0.9 }}>
+          <span className="registrar-ds-count">
             {count} из {paginationInfo.total} записей
           </span>
         </div>);
@@ -1793,7 +1793,7 @@ const RegistrarPanel = () => {
             p.delete('status');
             setSearchParams(p, { replace: true });
           }}
-          style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--mac-accent)', font: 'inherit', padding: 0 }}
+          className="registrar-breadcrumb-link"
         >
           Регистратура
         </button>
@@ -2093,27 +2093,12 @@ const RegistrarPanel = () => {
                 {/* История записей */}
                 <div>
                   <div className="registrar-flex-between" style={{ marginBottom: 'var(--mac-spacing-4)' }}>
-                    <h3 style={{
-                    fontSize: 'var(--mac-font-size-xl)',
-                    margin: 0,
-                    color: 'var(--mac-text-primary)',
-                    fontWeight: 'var(--mac-font-weight-semibold)',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 'var(--mac-spacing-2)'
-                  }}>
+                    <h3 className="registrar-history-heading">
                       <Icon name="eye" size="default" className="registrar-text-accent" />
                       История записей
                     </h3>
                     {showCalendar &&
-                  <Badge variant="secondary" style={{
-                    fontSize: 'var(--mac-font-size-sm)',
-                    fontWeight: 'var(--mac-font-weight-medium)',
-                    padding: 'var(--mac-spacing-2) var(--mac-spacing-3)',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 'var(--mac-spacing-2)'
-                  }}>
+                  <Badge variant="secondary" className="registrar-badge-date">
                         <Icon name="magnifyingglass" size="small" />
                         {new Date(historyDate).toLocaleDateString('ru-RU', { day: 'numeric', month: 'long', year: 'numeric' })}
                       </Badge>
@@ -2338,15 +2323,8 @@ const RegistrarPanel = () => {
               <div
                 style={registrarWorkflowHeaderStyle}
                 aria-label="Сводка рабочего списка регистратуры">
-                <div style={{ minWidth: 0, flex: '1 1 280px' }}>
-                  <div style={{
-                    color: 'var(--mac-text-secondary)',
-                    fontSize: 'var(--mac-font-size-xs)',
-                    fontWeight: 'var(--mac-font-weight-semibold)',
-                    letterSpacing: '0.04em',
-                    textTransform: 'uppercase',
-                    marginBottom: 'var(--mac-spacing-1)'
-                  }}>
+                <div className="registrar-worklist-container">
+                  <div className="registrar-worklist-meta">
                     Регистратура
                   </div>
                   <h2 style={registrarWorkflowTitleStyle}>
@@ -2871,11 +2849,7 @@ const RegistrarPanel = () => {
               border: `1px solid ${theme === 'dark' ? 'rgba(59, 130, 246, 0.22)' : 'rgba(59, 130, 246, 0.14)'}`,
               backgroundColor: theme === 'dark' ? 'rgba(59, 130, 246, 0.08)' : 'rgba(59, 130, 246, 0.06)'
             }}>
-            <div style={{
-              display: 'flex',
-              alignItems: 'flex-start',
-              gap: '12px'
-            }}>
+            <div className="registrar-flex-start">
               <div className="registrar-reschedule-icon registrar-text-accent"
                 style={{
                   backgroundColor: theme === 'dark' ? 'rgba(59, 130, 246, 0.2)' : 'rgba(59, 130, 246, 0.14)'

--- a/frontend/src/pages/registrar/registrar.css
+++ b/frontend/src/pages/registrar/registrar.css
@@ -543,3 +543,64 @@
   margin: 0;
   marginBottom: 12px;
 }
+
+/* Breadcrumb link button (reset to inline text) */
+.registrar-breadcrumb-link {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--mac-accent);
+  font: inherit;
+  padding: 0;
+}
+
+/* Data source indicator count text */
+.registrar-ds-count {
+  margin-left: auto;
+  font-size: 12px;
+  opacity: 0.9;
+}
+
+/* History section heading (reuse section-heading but with margin: 0 override) */
+.registrar-history-heading {
+  font-size: var(--mac-font-size-xl);
+  margin: 0;
+  color: var(--mac-text-primary);
+  font-weight: var(--mac-font-weight-semibold);
+  display: flex;
+  align-items: center;
+  gap: var(--mac-spacing-2);
+}
+
+/* Badge with icon (history date display) */
+.registrar-badge-date {
+  font-size: var(--mac-font-size-sm);
+  font-weight: var(--mac-font-weight-medium);
+  padding: var(--mac-spacing-2) var(--mac-spacing-3);
+  display: flex;
+  align-items: center;
+  gap: var(--mac-spacing-2);
+}
+
+/* Worklist meta label (uppercase, small) */
+.registrar-worklist-meta {
+  color: var(--mac-text-secondary);
+  font-size: var(--mac-font-size-xs);
+  font-weight: var(--mac-font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: var(--mac-spacing-1);
+}
+
+/* Worklist container (flex: 1 1 280px) */
+.registrar-worklist-container {
+  min-width: 0;
+  flex: 1 1 280px;
+}
+
+/* Flex start (alignItems: flex-start) */
+.registrar-flex-start {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}


### PR DESCRIPTION
## Summary

Continuing Strategic Direction 2 (DS-3): migrating inline `style={{}}` blocks to CSS classes. This batch replaces 7 blocks (all fully removed), bringing the total from 97 → 34 (−63, −64.9%).

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main at commit 988558d (PR #1702 merge)
- Clean workspace: only RegistrarPanel.jsx and registrar.css touched
- Branch: refactor/registrar-css-batch11
- Scope gate: allowed registrar panel + CSS; denied other panels, backend, migrations
- Red-check handling: full vitest suite run after commit (467/467 passing); will fix any failing CI checks in this same PR before merge

## Contract Impact

- Canonical surface: not applicable - no backend contract changes (CSS class changes only)
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: RegistrarPanel.jsx (style attribute to className, no behavioral change)
- Compatibility path or alias: not applicable - no API contract touched in this PR
- Contract proof: RegistrarPanel contract test suite passes 13/13; full suite 467/467

## RBAC / Permissions

- Roles allowed: admin, registrar (unchanged)
- Roles denied: doctor, patient, cashier, lab, cardio, derma, dentist (unchanged)
- Positive auth proof: routeRegistry.js unchanged; routeGuards.jsx unchanged
- Negative auth proof: not applicable - no changes to route role arrays or guard logic

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed in this PR.

## Frontend Resilience

- Empty data proof: not applicable - CSS class changes do not affect data handling
- Partial data proof: not applicable - CSS class changes do not affect data fetching
- Forbidden secondary path behavior: not applicable - no new code paths introduced
- Missing draft/resource behavior: not applicable - CSS class substitutions only
- Stale route/deep-link behavior: not applicable - URL contract unchanged; only style attributes changed

## Scope Gate

- Allowed paths: frontend/src/pages/RegistrarPanel.jsx, frontend/src/pages/registrar/registrar.css
- Denied paths: backend Python files, database migrations, other frontend panels, ESLint config
- Migration/docs/test impact: no migration; no docs changes; no test changes needed
- Rollback note: revert 1 commit on this branch; no database state to revert; no feature flags to disable

## Validation

- Targeted tests or smoke run: full vitest suite (105 test files, 467 tests) passes locally; RegistrarPanel contract tests pass 13/13
- Result: passed (467/467, 0 regressions vs main baseline)
- Not checked: visual regression (manual visual QA recommended for CSS class changes)

---

## What's in this PR

### 7 inline style blocks replaced (all fully removed)

| Block | Props before | After |
|---|---|---|
| Breadcrumb link button | 6 | `className='registrar-breadcrumb-link'` |
| DataSource count text | 3 | `className='registrar-ds-count'` |
| History section heading | 7 | `className='registrar-history-heading'` |
| Badge with date display | 6 | `className='registrar-badge-date'` |
| Worklist meta label | 6 | `className='registrar-worklist-meta'` |
| Worklist container | 2 | `className='registrar-worklist-container'` |
| Flex start container | 3 | `className='registrar-flex-start'` |

### CSS additions

7 new utility classes:
- `.registrar-breadcrumb-link`, `.registrar-ds-count`
- `.registrar-history-heading`, `.registrar-badge-date`
- `.registrar-worklist-meta`, `.registrar-worklist-container`
- `.registrar-flex-start`

## Inline style progression

| Stage | Inline style blocks | Delta |
|---|---|---|
| Original (audit baseline) | 97 | — |
| After DS-3 batches 1-10 (PRs #1687-1702) | 41 | -56 |
| After DS-3 batch 11 (this PR) | **34** | -7 (total -63, **-64.9%**) |

## Files Changed

| File | Change | Lines |
|---|---|---|
| `frontend/src/pages/RegistrarPanel.jsx` | Modified | +6/-30 |
| `frontend/src/pages/registrar/registrar.css` | Modified | +47/-0 |

## Test Results

| Suite | Before | After | Status |
|---|---|---|---|
| Full vitest suite | 467/467 | 467/467 | no regression |
| ESLint errors | 0 | 0 | no new errors |
| Vite production build | ok | ok | builds clean |
