### PR TITLE
fix(cardio+emr): UX audit Quick Wins — visibility, edit-patient, ghost-mode, payment, complete-visit

### DIFF
--- a/frontend/src/components/common/EditPatientModal.jsx
+++ b/frontend/src/components/common/EditPatientModal.jsx
@@ -1,43 +1,86 @@
-// Stub component for EditPatientModal
-// This component has been replaced by AppointmentWizardV2
-// Keeping this stub to prevent build errors in legacy panel files
+// QW-02 (UX audit): EditPatientModal — functional wrapper around AppointmentWizardV2.
+//
+// Background (P-002 Critical): this component was previously a stub that
+// rendered "This legacy modal has been replaced by AppointmentWizardV2"
+// and a Close button. The cardiologist/dermatologist/dentist panels still
+// call `setEditPatientModal({ open: true, ... })` from their action
+// handlers, so doctors ended up in a functional dead-end: clicking
+// "Edit patient" opened a stub modal instead of an actual edit form.
+//
+// Fix: render AppointmentWizardV2 in editMode with the row data passed
+// through `patient`. The wizard already supports editMode + initialData
+// (used by RegistrarPanel), enforces RBAC via useRoleAccess, and emits
+// onComplete when the edit succeeds. We delegate to that path instead
+// of duplicating the form.
 import PropTypes from 'prop-types';
+import AppointmentWizardV2 from '../wizard/AppointmentWizardV2';
+import logger from '../../utils/logger';
 
-const EditPatientModal = ({ isOpen, onClose }) => {
-    if (!isOpen) return null;
+const EditPatientModal = ({ isOpen, onClose, patient, onSave, loading = false }) => {
+  if (!isOpen) {
+    return null;
+  }
 
-    return (
-        <div style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            background: 'rgba(0,0,0,0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 9999
-        }}>
-            <div style={{
-                background: 'var(--mac-card-bg, white)',
-                padding: '20px',
-                borderRadius: '8px',
-                maxWidth: '400px',
-                border: '1px solid var(--mac-card-border, #d8dde8)'
-            }}>
-                <h3 style={{ marginTop: 0 }}>Edit Patient Modal</h3>
-                <p>This legacy modal has been replaced by AppointmentWizardV2.</p>
-                <button onClick={onClose}>Close</button>
-            </div>
-        </div>
-    );
+  // Translate the legacy `patient` shape (partial row from the appointments
+  // table) into the initialData contract expected by AppointmentWizardV2
+  // in edit mode. The wizard is tolerant of missing fields — it normalizes
+  // internally — but we at least make sure the queue entry id and patient
+  // identity are passed through when available.
+  const initialData = patient
+    ? {
+        id: patient?.id ?? patient?.appointment_id ?? patient?.queue_entry_id ?? null,
+        queue_entry_id:
+          patient?.queue_entry_id ?? patient?.queueEntryId ?? patient?.id ?? null,
+        patient: {
+          id: patient?.patient_id ?? patient?.id ?? null,
+          fio: patient?.patient_fio ?? patient?.fio ?? patient?.fullName ?? '',
+          birth_date: patient?.birth_date ?? patient?.birthday ?? '',
+          phone: patient?.phone ?? '',
+          address: patient?.address ?? '',
+          gender: patient?.gender ?? ''
+        },
+        // Carry over the original row so the wizard can read services /
+        // doctor / discount if present.
+        __raw: patient
+      }
+    : null;
+
+  const handleComplete = (wizardData) => {
+    logger.info('[EditPatientModal] AppointmentWizardV2 completed (edit mode)', wizardData);
+    if (typeof onSave === 'function') {
+      // Fire-and-forget: parent decides whether to await.
+      Promise.resolve(onSave(wizardData)).catch((err) => {
+        logger.warn('[EditPatientModal] onSave rejected', err);
+      });
+    }
+    if (typeof onClose === 'function') {
+      onClose();
+    }
+  };
+
+  return (
+    <AppointmentWizardV2
+      isOpen={isOpen}
+      editMode={true}
+      initialData={initialData}
+      isProcessing={loading}
+      setIsProcessing={() => { /* no-op: parent does not track processing state */ }}
+      onClose={onClose}
+      onComplete={handleComplete}
+    />
+  );
 };
 
 EditPatientModal.propTypes = {
   ...(EditPatientModal.propTypes || {}),
   isOpen: PropTypes.any,
   onClose: PropTypes.any,
+  patient: PropTypes.any,
+  onSave: PropTypes.any,
+  loading: PropTypes.any,
+  // Theme is accepted for backwards compat with cardio/derma/dentist callers
+  // but is no longer used — AppointmentWizardV2 has its own theming.
+  theme: PropTypes.any
 };
 
 export default EditPatientModal;

--- a/frontend/src/components/emr-v2/EMRContainerV2.jsx
+++ b/frontend/src/components/emr-v2/EMRContainerV2.jsx
@@ -53,6 +53,8 @@ import {
 import './EMRContainerV2.css';
 // P-013 fix: shared ConfirmDialog hook replacing window.confirm() calls.
 import { useConfirm } from '../common/ConfirmDialog';
+// QW-03 (UX audit): replace native alert() in Ghost Mode with notify.warning.
+import notify from '../../services/notify';
 
 /**
  * EMRContainerV2 Component
@@ -381,7 +383,10 @@ export function EMRContainerV2({ visitId, patientId, specialty, ICD10Component }
     // Toggle Ghost Mode with validation
     const toggleGhostMode = () => {
         if (isSigned || isAmended) {
-            alert('Ghost Mode недоступен в подписанной карте.');
+            // QW-03 (UX audit): replaced native alert() with notify.warning to keep
+            // the visual style consistent with the rest of the app and to avoid
+            // blocking the main thread.
+            notify.warning('Ghost Mode недоступен в подписанной карте.');
             return;
         }
         const newValue = !experimentalGhostMode;

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -111,7 +111,9 @@ const MacOSCardiologistPanelUnified = () => {
     notes: ''
   });
   const [loading, setLoading] = useState(false);
-  const [, setMessage] = useState({ type: '', text: '' });
+  // QW-01 (UX audit): removed swallowed setMessage — all calls now route through `notify`
+  // (react-toastify) so users actually see error/success/warning feedback.
+  // `message` destructure was dropped, which silently discarded every notification.
   const [scheduleNextModal, setScheduleNextModal] = useState({ open: false, patient: null });
   const [editPatientModal, setEditPatientModal] = useState({ open: false, patient: null, loading: false });
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -180,7 +182,7 @@ const MacOSCardiologistPanelUnified = () => {
   const openBloodTestForm = () => {
     const { patientId } = getSelectedPatientContext();
     if (!patientId) {
-      setMessage({ type: 'error', text: 'Сначала выберите пациента или визит кардиолога' });
+      notify.error('Сначала выберите пациента или визит кардиолога');
       return;
     }
 
@@ -260,12 +262,9 @@ const MacOSCardiologistPanelUnified = () => {
 
       setPatientFiles(Array.from(mergedFiles.values()));
     } catch (error) {
-      setMessage({
-        type: 'error',
-        text: getErrorMessage(error, 'Не удалось обновить данные пациента. Проверьте соединение и попробуйте снова.')
-      });
+      notify.error(getErrorMessage(error, 'Не удалось обновить данные пациента. Проверьте соединение и попробуйте снова.'));
     }
-  }, [getSelectedPatientContext, setMessage]);
+  }, [getSelectedPatientContext]);
 
   // ✅ Очистка EMR и visitData при смене пациента
   useEffect(() => {
@@ -337,10 +336,7 @@ const MacOSCardiologistPanelUnified = () => {
           setServices(servicesData);
         }
       } catch (error) {
-      setMessage({
-        type: 'error',
-        text: getErrorMessage(error, 'Не удалось загрузить список услуг. Проверьте соединение и попробуйте снова.')
-      });
+      notify.error(getErrorMessage(error, 'Не удалось загрузить список услуг. Проверьте соединение и попробуйте снова.'));
       }
     };
 
@@ -387,12 +383,9 @@ const MacOSCardiologistPanelUnified = () => {
         specialty: prev?.specialty || 'cardiology'
       }));
       setActiveTab('appointments');
-      setMessage({ type: 'info', text: `Загружен пациент: ${patientName}. Выберите визит с каноническим visit_id.` });
+      notify.info(`Загружен пациент: ${patientName}. Выберите визит с каноническим visit_id.`);
     } catch (error) {
-      setMessage({
-        type: 'error',
-        text: getErrorMessage(error, 'Не удалось загрузить пациента. Проверьте соединение и попробуйте снова.')
-      });
+      notify.error(getErrorMessage(error, 'Не удалось загрузить пациента. Проверьте соединение и попробуйте снова.'));
     }
   }, [patientIdFromUrl, visitIdFromUrl, selectedPatient]);
 
@@ -629,14 +622,11 @@ const MacOSCardiologistPanelUnified = () => {
         setAppointments(enrichedAppointmentsData);
       }
     } catch (error) {
-      setMessage({
-        type: 'error',
-        text: getErrorMessage(error, 'Не удалось загрузить записи кардиолога. Проверьте соединение и попробуйте снова.')
-      });
+      notify.error(getErrorMessage(error, 'Не удалось загрузить записи кардиолога. Проверьте соединение и попробуйте снова.'));
     } finally {
       setAppointmentsLoading(false);
     }
-  }, [getAllPatientServices, setMessage]);
+  }, [getAllPatientServices]);
 
   // Загружаем записи при переключении на вкладку
   useEffect(() => {
@@ -689,13 +679,10 @@ const MacOSCardiologistPanelUnified = () => {
         return await response.json();
       }
     } catch (error) {
-      setMessage({
-        type: 'error',
-        text: getErrorMessage(error, 'Не удалось загрузить данные пациента. Проверьте соединение и попробуйте снова.')
-      });
+      notify.error(getErrorMessage(error, 'Не удалось загрузить данные пациента. Проверьте соединение и попробуйте снова.'));
     }
     return null;
-  }, [setMessage]);
+  }, []);
 
   // Функция для преобразования данных пациента из формата API в формат PatientModal
   const transformPatientData = useCallback((apiPatient) => {
@@ -758,7 +745,7 @@ const MacOSCardiologistPanelUnified = () => {
         // Если не удалось загрузить, используем данные из row (частичные)
         const partialPatient = createPartialPatientFromRow(row);
         setEditPatientModal({ open: true, patient: partialPatient, loading: false });
-        setMessage({ type: 'warning', text: 'Не удалось загрузить карточку пациента, показаны данные из очереди' });
+        notify.warning('Не удалось загрузить карточку пациента, показаны данные из очереди');
         return;
       }
 
@@ -769,10 +756,7 @@ const MacOSCardiologistPanelUnified = () => {
     } catch (error) {
       const partialPatient = createPartialPatientFromRow(row);
       setEditPatientModal({ open: true, patient: partialPatient, loading: false });
-      setMessage({
-        type: 'error',
-        text: getErrorMessage(error, 'Не удалось загрузить карточку пациента. Проверьте соединение и попробуйте снова.')
-      });
+      notify.error(getErrorMessage(error, 'Не удалось загрузить карточку пациента. Проверьте соединение и попробуйте снова.'));
     }
   }, [fetchPatientData, transformPatientData, createPartialPatientFromRow]);
 
@@ -783,7 +767,7 @@ const MacOSCardiologistPanelUnified = () => {
       const appointmentId = row.appointment_id || null;
       const visitId = await ensureCanonicalVisitId(row);
       if (!visitId) {
-        setMessage({ type: 'error', text: 'Не удалось определить канонический visit_id для пациента' });
+        notify.error('Не удалось определить канонический visit_id для пациента');
         return;
       }
 
@@ -829,7 +813,7 @@ const MacOSCardiologistPanelUnified = () => {
           const appointmentId = row.appointment_id || null;
           const visitId = await ensureCanonicalVisitId(row);
           if (!visitId) {
-            setMessage({ type: 'error', text: 'Не удалось открыть EMR без канонического visit_id' });
+            notify.error('Не удалось открыть EMR без канонического visit_id');
             break;
           }
 
@@ -865,7 +849,7 @@ const MacOSCardiologistPanelUnified = () => {
           const queueEntryId = resolveDoctorQueueEntryId(row);
           if (queueEntryId === null) {
             logger.warn('[Cardiology] Cannot start visit without OnlineQueueEntry id', row);
-            setMessage({ type: 'error', text: 'Cannot start visit without a queue entry id' });
+            notify.error('Cannot start visit without a queue entry id');
             break;
           }
           const token = tokenManager.getAccessToken();
@@ -879,13 +863,10 @@ const MacOSCardiologistPanelUnified = () => {
 
           if (response.ok) {
             await loadMacOSCardiologyAppointments();
-            setMessage({ type: 'success', text: `Пациент ${row.patient_fio} вызван` });
+            notify.success(`Пациент ${row.patient_fio} вызван`);
           }
         } catch (error) {
-          setMessage({
-            type: 'error',
-            text: getErrorMessage(error, 'Не удалось вызвать пациента. Проверьте соединение и попробуйте снова.')
-          });
+          notify.error(getErrorMessage(error, 'Не удалось вызвать пациента. Проверьте соединение и попробуйте снова.'));
         }
         break;
       case 'payment':
@@ -908,7 +889,7 @@ const MacOSCardiologistPanelUnified = () => {
           try {
             const visitId = await ensureCanonicalVisitId(row);
             if (!visitId) {
-              setMessage({ type: 'error', text: 'Не удалось завершить приём без канонического visit_id' });
+              notify.error('Не удалось завершить приём без канонического visit_id');
               break;
             }
             // Переходим на вкладку визита для завершения
@@ -936,10 +917,7 @@ const MacOSCardiologistPanelUnified = () => {
             // Переходим на вкладку visit для завершения
             goToTab('visit');
           } catch (error) {
-            setMessage({
-              type: 'error',
-              text: getErrorMessage(error, 'Не удалось завершить приём. Проверьте соединение и попробуйте снова.')
-            });
+            notify.error(getErrorMessage(error, 'Не удалось завершить приём. Проверьте соединение и попробуйте снова.'));
           }
           break;
         }
@@ -971,10 +949,10 @@ const MacOSCardiologistPanelUnified = () => {
   const handleAISuggestion = (type, suggestion) => {
     if (type === 'icd10') {
       setVisitData({ ...visitData, icd10: suggestion });
-      setMessage({ type: 'success', text: 'Код МКБ-10 добавлен из AI предложения' });
+      notify.success('Код МКБ-10 добавлен из AI предложения');
     } else if (type === 'diagnosis') {
       setVisitData({ ...visitData, diagnosis: suggestion });
-      setMessage({ type: 'success', text: 'Диагноз добавлен из AI предложения' });
+      notify.success('Диагноз добавлен из AI предложения');
     }
   };
 
@@ -986,7 +964,7 @@ const MacOSCardiologistPanelUnified = () => {
       setLoading(true);
       const queueEntryId = resolveDoctorQueueEntryId(selectedPatient);
       if (queueEntryId === null) {
-        setMessage({ type: 'error', text: 'Cannot complete visit without a queue entry id' });
+        notify.error('Cannot complete visit without a queue entry id');
         return;
       }
 
@@ -999,7 +977,7 @@ const MacOSCardiologistPanelUnified = () => {
         notes: visitData.notes
       };
       await queueService.completeVisit(queueEntryId, visitPayload);
-      setMessage({ type: 'success', text: 'Прием завершен успешно' });
+      notify.success('Прием завершен успешно');
 
       // Очищаем форму и возвращаемся в очередь
       setSelectedPatient(null);
@@ -1011,20 +989,17 @@ const MacOSCardiologistPanelUnified = () => {
       try {
         const next = await queueService.callNextWaiting('cardiology');
         if (next?.success) {
-          setMessage({ type: 'success', text: `Вызван следующий пациент №${next.entry.number}` });
+          notify.success(`Вызван следующий пациент №${next.entry.number}`);
         }
       } catch (err) {
-        setMessage({
-          type: 'warning',
-          text: getErrorMessage(
-            err,
-            'Следующий пациент не вызван автоматически. Проверьте соединение и попробуйте снова.'
-          )
-        });
+        notify.warning(getErrorMessage(
+          err,
+          'Следующий пациент не вызван автоматически. Проверьте соединение и попробуйте снова.'
+        ));
       }
 
     } catch (error) {
-      setMessage({ type: 'error', text: getErrorMessage(error, 'Не удалось завершить действие. Проверьте соединение и попробуйте снова.') });
+      notify.error(getErrorMessage(error, 'Не удалось завершить действие. Проверьте соединение и попробуйте снова.'));
     } finally {
       setLoading(false);
     }
@@ -1035,7 +1010,7 @@ const MacOSCardiologistPanelUnified = () => {
     try {
       const token = tokenManager.getAccessToken();
       if (!visitId) {
-        setMessage({ type: 'error', text: 'Не указан visit_id для EMR v2' });
+        notify.error('Не указан visit_id для EMR v2');
         return null;
       }
 
@@ -1057,14 +1032,11 @@ const MacOSCardiologistPanelUnified = () => {
         return null;
       } else {
         const error = await response.json().catch(() => ({ detail: 'Ошибка при загрузке EMR' }));
-      setMessage({
-        type: 'error',
-        text: getErrorMessage(error, 'Не удалось загрузить EMR. Проверьте соединение и попробуйте снова.')
-      });
+      notify.error(getErrorMessage(error, 'Не удалось загрузить EMR. Проверьте соединение и попробуйте снова.'));
         return null;
       }
     } catch (error) {
-      setMessage({ type: 'error', text: getErrorMessage(error, 'Не удалось загрузить EMR. Проверьте соединение и попробуйте снова.') });
+      notify.error(getErrorMessage(error, 'Не удалось загрузить EMR. Проверьте соединение и попробуйте снова.'));
       return null;
     }
   };
@@ -1172,10 +1144,7 @@ const MacOSCardiologistPanelUnified = () => {
     try {
       await handleSaveVisit();
     } catch (error) {
-      setMessage({
-        type: 'error',
-        text: getErrorMessage(error, 'Не удалось завершить приём через EMR. Проверьте соединение и попробуйте снова.')
-      });
+      notify.error(getErrorMessage(error, 'Не удалось завершить приём через EMR. Проверьте соединение и попробуйте снова.'));
     }
   };
 
@@ -1185,7 +1154,7 @@ const MacOSCardiologistPanelUnified = () => {
     const { patientId, visitId } = getSelectedPatientContext();
 
     if (!patientId) {
-      setMessage({ type: 'error', text: 'Нельзя сохранить анализ без выбранного пациента' });
+      notify.error('Нельзя сохранить анализ без выбранного пациента');
       return;
     }
 
@@ -1217,20 +1186,14 @@ const MacOSCardiologistPanelUnified = () => {
         setShowForm({ open: false, type: 'blood' });
         setBloodTestForm(getEmptyBloodTestForm());
         await loadPatientData();
-        setMessage({ type: 'success', text: 'Анализ крови сохранен успешно' });
+        notify.success('Анализ крови сохранен успешно');
         return;
       }
 
       const errorData = await response.json().catch(() => ({}));
-      setMessage({
-        type: 'error',
-        text: getErrorMessage(errorData?.detail || errorData?.message || '', 'Не удалось сохранить анализ. Проверьте соединение и попробуйте снова.')
-      });
+      notify.error(getErrorMessage(errorData?.detail || errorData?.message || '', 'Не удалось сохранить анализ. Проверьте соединение и попробуйте снова.'));
     } catch (error) {
-      setMessage({
-        type: 'error',
-        text: getErrorMessage(error, 'Не удалось сохранить анализ. Проверьте соединение и попробуйте снова.')
-      });
+      notify.error(getErrorMessage(error, 'Не удалось сохранить анализ. Проверьте соединение и попробуйте снова.'));
     }
   };
 
@@ -1312,10 +1275,7 @@ const MacOSCardiologistPanelUnified = () => {
       document.body.removeChild(link);
       window.URL.revokeObjectURL(url);
     } catch (error) {
-      setMessage({
-        type: 'error',
-        text: getErrorMessage(error, 'Не удалось скачать файл. Проверьте соединение и попробуйте снова.')
-      });
+      notify.error(getErrorMessage(error, 'Не удалось скачать файл. Проверьте соединение и попробуйте снова.'));
     }
   };
 
@@ -1342,10 +1302,7 @@ const MacOSCardiologistPanelUnified = () => {
         throw new Error('Браузер заблокировал окно предпросмотра');
       }
     } catch (error) {
-      setMessage({
-        type: 'error',
-        text: getErrorMessage(error, 'Не удалось открыть файл. Проверьте соединение и попробуйте снова.')
-      });
+      notify.error(getErrorMessage(error, 'Не удалось открыть файл. Проверьте соединение и попробуйте снова.'));
     }
   };
 

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -42,6 +42,8 @@ import { resolveCanonicalVisitId } from '../utils/canonicalVisit';
 import { getErrorMessage } from '../utils/errorHandler';
 import logger from '../utils/logger';
 import notify from '../services/notify';
+// QW-10 (UX audit): shared ConfirmDialog hook used before completing a visit.
+import { useConfirm } from '../components/common/ConfirmDialog';
 import RoleNotificationCenter from '../components/notifications/RoleNotificationCenter';
 import tokenManager from '../utils/tokenManager';
 
@@ -114,6 +116,9 @@ const MacOSCardiologistPanelUnified = () => {
   // QW-01 (UX audit): removed swallowed setMessage — all calls now route through `notify`
   // (react-toastify) so users actually see error/success/warning feedback.
   // `message` destructure was dropped, which silently discarded every notification.
+  // QW-10 (UX audit): confirm hook used before completing a visit (prevents
+  // accidental completion with empty diagnosis/treatment).
+  const [confirm, confirmDialog] = useConfirm();
   const [scheduleNextModal, setScheduleNextModal] = useState({ open: false, patient: null });
   const [editPatientModal, setEditPatientModal] = useState({ open: false, patient: null, loading: false });
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -963,6 +968,47 @@ const MacOSCardiologistPanelUnified = () => {
   // Обработка сохранения визита
   const handleSaveVisit = async () => {
     if (!selectedPatient) return;
+
+    // QW-10 (UX audit): confirm before completing the visit. completeVisit is
+    // an irreversible action that closes the encounter and auto-calls the next
+    // patient. Without a confirm, a doctor could accidentally complete a visit
+    // with an empty diagnosis or treatment, leaving the EMR incomplete. We
+    // surface a stronger warning (intent='warning') when critical fields are
+    // empty, and a normal confirmation otherwise.
+    const hasDiagnosis = Boolean(visitData?.diagnosis?.trim());
+    const hasComplaint = Boolean(visitData?.complaint?.trim());
+    const missingCritical = !hasDiagnosis || !hasComplaint;
+
+    const confirmOptions = missingCritical
+      ? {
+          title: 'Завершить приём без диагноза?',
+          message: hasDiagnosis
+            ? 'Не заполнена жалоба пациента.'
+            : hasComplaint
+              ? 'Не заполнен диагноз. Рекомендуется указать диагноз перед завершением приёма.'
+              : 'Не заполнены жалоба и диагноз. Рекомендуется заполнить их перед завершением.',
+          description:
+            'После завершения приёма EMR будет сохранена в текущем состоянии. ' +
+            'Дополнить карту можно будет через поправку (amend).',
+          confirmLabel: 'Завершить всё равно',
+          cancelLabel: 'Вернуться к заполнению',
+          intent: 'warning',
+        }
+      : {
+          title: 'Завершить приём?',
+          message: 'Приём будет сохранён, и система автоматически вызовет следующего пациента.',
+          description:
+            'Перед завершением убедитесь, что диагноз, лечение и рекомендации заполнены корректно. ' +
+            'После подписания EMR изменения возможны только через поправку.',
+          confirmLabel: 'Завершить приём',
+          cancelLabel: 'Отмена',
+          intent: 'primary',
+        };
+
+    const ok = await confirm(confirmOptions);
+    if (!ok) {
+      return;
+    }
 
     try {
       setLoading(true);
@@ -2348,6 +2394,9 @@ const MacOSCardiologistPanelUnified = () => {
           theme={{ isDark, getColor, getSpacing, getFontSize }} />
 
         }
+
+        {/* QW-10 (UX audit): portal-mounted ConfirmDialog used before completing a visit */}
+        {confirmDialog}
 
         {/* Настройки кардиолога: плавающая кнопка и панель */}
         <button

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -870,9 +870,13 @@ const MacOSCardiologistPanelUnified = () => {
         }
         break;
       case 'payment':
-        // Открыть окно оплаты
-        // Здесь можно добавить модальное окно оплаты
-        notify.info(`Оплата для пациента: ${row.patient_fio}. Функция будет реализована позже.`);
+        // QW-05 (UX audit): removed dead "functionality will be added later" stub.
+        // The `payment` action is disabled for doctor view at the table level
+        // (canPay = !isDoctorView && backendCanPay), so we should never arrive
+        // here in production. If we do, log the event for debugging rather than
+        // surfacing a "feature not implemented" toast to the doctor — that
+        // breaks Nielsen heuristic #2 (match between system and real world).
+        logger.info('[Cardiology] payment action invoked (disabled for doctor view)', row);
         break;
       case 'print':
         try {

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -114,8 +114,9 @@ const MacOSCardiologistPanelUnified = () => {
   });
   const [loading, setLoading] = useState(false);
   // QW-01 (UX audit): removed swallowed setMessage — all calls now route through `notify`
-  // (react-toastify) so users actually see error/success/warning feedback.
-  // `message` destructure was dropped, which silently discarded every notification.
+  // (the shared adapter in services/notify.js) so users actually see error/success/warning
+  // feedback. The `message` destructure was dropped, which silently discarded every
+  // notification before this fix.
   // QW-10 (UX audit): confirm hook used before completing a visit (prevents
   // accidental completion with empty diagnosis/treatment).
   const [confirm, confirmDialog] = useConfirm();


### PR DESCRIPTION
## Summary

- Implements the Quick Wins phase (1–2 sprints, ~15 SP) of the UX/UI audit for the cardiologist panel, addressing 1 Critical, 2 High, and 2 Medium findings.
- Five scoped changes touching 3 files in the cardiologist path: restore user-visible error feedback (QW-01), replace the EditPatientModal stub with a real edit form (QW-02), replace native alert in Ghost Mode with a styled toast (QW-03), remove a dead payment-action stub (QW-05), and add a confirm dialog before completing a visit (QW-10).
- No schema, API contract, RBAC, or routing changes — this is the smallest reversible slice of the 3-phase roadmap (Quick Wins → Mid-term → Strategic).

## Cyclic Execution Evidence

- Fresh main sync: branch `feature/ux-audit-quick-wins` created from current `origin/main` (HEAD `3bff857e`).
- Clean workspace: inspected before edits; only `frontend/src/pages/CardiologistPanelUnified.jsx`, `frontend/src/components/common/EditPatientModal.jsx`, and `frontend/src/components/emr-v2/EMRContainerV2.jsx` changed.
- Branch: `feature/ux-audit-quick-wins`
- Scope gate: allowed cardiologist panel, shared EditPatientModal, EMR container; denied backend endpoints, routes, RBAC, registrar panel, dermatologist/dentist panels (other than the EditPatientModal wrapper that they share).
- Red-check handling: if frontend lint/unit/build/e2e fail on this PR, fix in this same PR before merge.

## Contract Impact

not applicable - no backend endpoint, request shape, response shape, or status code changed. All five Quick Wins are frontend-only. The only API touch points (`queueService.completeVisit`, `POST /cardio/blood-tests`, `GET /v2/emr/:visitId`) are called exactly as before; QW-01 only changes how local errors are surfaced after the call, and QW-10 only adds a confirm step before the call.

## RBAC / Permissions

not applicable - no role gating, route guard, or permission check changed. QW-02 delegates to `AppointmentWizardV2`, which already enforces RBAC internally via `useRoleAccess(['Admin', 'Registrar', 'Receptionist'])`. Doctors in the cardiologist panel were never expected to edit patients directly (that is a registrar responsibility); the EditPatientModal wrapper preserves the existing call sites without expanding or contracting any role's permissions.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed. QW-01 routes existing error messages through `notify` (react-toastify), which is already mounted app-wide; no new notification channels, no new websocket subscriptions, no new event types. QW-03 replaces a synchronous `alert()` with the same `notify.warning()` channel.

## Frontend Resilience

- Empty data proof: QW-01 — when an API call fails with no error body, `getErrorMessage(error, fallback)` still surfaces the fallback string via `notify.error(...)`; the previous `setMessage` path silently discarded this.
- Partial data proof: QW-02 — when the row passed to EditPatientModal is missing fields (e.g. no `patient_id`), `initialData` is built defensively with `?? null` fallbacks; AppointmentWizardV2 already tolerates partial initialData.
- Forbidden secondary path behavior: not applicable, no secondary paths introduced.
- Missing draft/resource behavior: QW-10 — if `selectedPatient` is null, `handleSaveVisit` returns early before reaching the confirm dialog; if the confirm dialog is dismissed, the visit is not completed.
- Stale route/deep-link behavior: not applicable, no route or deep-link handling changed.

## Scope Gate

- Allowed paths: `frontend/src/pages/CardiologistPanelUnified.jsx`, `frontend/src/components/common/EditPatientModal.jsx`, `frontend/src/components/emr-v2/EMRContainerV2.jsx`.
- Denied paths: backend (any), routes/registry, RBAC, registrar/derma/dentist panels (except the shared EditPatientModal wrapper), CSS migration (separate effort, see commit `3bff857e`).
- Migration/docs/test impact: no migration; no docs; `cardio-fix-live.spec.js` (Playwright E2E) is expected to still pass — it exercises the blood-test → history flow that QW-01 touches only through error handling.
- Rollback note: revert all 5 commits on this branch; no data migration to undo.

## Validation

- Targeted tests or smoke run: awaiting CI — frontend lint, frontend unit tests (including `DoctorPanels.contract.test.jsx`), frontend build, frontend e2e (`cardio-fix-live.spec.js`).
- Result: pending — will update this section once CI completes.
- Not checked: full manual smoke of cardiologist panel (planned for after CI green); derma/dentist panel smoke (EditPatientModal wrapper is shared, but only cardio calls it from a doctor view today).

## Change list (for traceability)

| QW | Finding | Priority | File | Commit |
|----|---------|----------|------|--------|
| QW-01 | P-001 | Critical | `CardiologistPanelUnified.jsx` | `fbe36a34` |
| QW-02 | P-002 | Critical | `EditPatientModal.jsx` | `a20947d0` |
| QW-03 | P-014 | Medium | `EMRContainerV2.jsx` | `b5a4d118` |
| QW-05 | P-018 | Medium | `CardiologistPanelUnified.jsx` | `07b5e061` |
| QW-10 | P-010 | High | `CardiologistPanelUnified.jsx` | `c31561e1` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)