### PR TITLE
refactor(registrar): R-22 phase 5 — extract queue entry lookup helper + promote nested functions

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -1865,6 +1865,139 @@ def _build_queue_payload(
     }
 
 
+
+# ===================== R-22 Phase 5: Queue entry lookup =====================
+
+
+def _same_patient_queue_entry_for_visit_id(
+    db: Session,
+    visit_id: int | None,
+    patient_id: int | None,
+):
+    """R-22 Phase 5: Find the OnlineQueueEntry linked to a visit by visit_id + patient_id.
+
+    Returns None if either id is None or no entry is found.
+    """
+    from app.models.online_queue import OnlineQueueEntry
+    if visit_id is None or patient_id is None:
+        return None
+    return (
+        db.query(OnlineQueueEntry)
+        .filter(
+            OnlineQueueEntry.visit_id == visit_id,
+            OnlineQueueEntry.patient_id == patient_id,
+        )
+        .order_by(OnlineQueueEntry.id.asc())
+        .first()
+    )
+
+
+def _same_patient_queue_entry_for_visit(db: Session, visit):
+    """R-22 Phase 5: Convenience wrapper around _same_patient_queue_entry_for_visit_id."""
+    return _same_patient_queue_entry_for_visit_id(
+        db,
+        visit.id,
+        visit.patient_id,
+    )
+
+
+def _resolve_queue_entry_metadata(
+    *,
+    db: Session,
+    entry_type: str,
+    entry_data: Any,
+    entry_wrapper: dict,
+    record_id: int | None,
+    patient_id: int | None,
+    appointment_date: Any,
+    doctor_id: int | None,
+    idx: int,
+) -> tuple[int, Any, Any]:
+    """R-22 Phase 5: Resolve (queue_entry_number, queue_entry_time, queue_entry_updated_at).
+
+    Lookup priority depends on entry_type:
+    - online_queue: read directly from OnlineQueueEntry (or entry_wrapper for QR-visits)
+    - visit: lookup via _same_patient_queue_entry_for_visit_id
+    - appointment: SQL query against queue_entries table (same patient + day + doctor)
+    Falls back to (idx, None, None) on any error.
+    """
+    queue_entry_number = idx
+    queue_entry_time = None
+    queue_entry_updated_at = None
+
+    if not record_id:
+        return queue_entry_number, queue_entry_time, queue_entry_updated_at
+
+    try:
+        if entry_type == "online_queue":
+            # entry_data may be Visit (for QR-visits) or OnlineQueueEntry
+            is_visit_object = hasattr(entry_data, 'visit_date') and not hasattr(entry_data, 'queue_id')
+
+            if is_visit_object:
+                queue_entry_number = entry_wrapper.get("oqe_number") or idx
+                queue_entry_time = entry_wrapper.get("oqe_queue_time")
+                queue_entry_updated_at = entry_wrapper.get("oqe_updated_at")
+            else:
+                queue_entry_number = (
+                    entry_data.number
+                    if hasattr(entry_data, 'number') and entry_data.number is not None
+                    else idx
+                )
+                queue_entry_time = (
+                    entry_data.queue_time
+                    if hasattr(entry_data, 'queue_time') and entry_data.queue_time
+                    else None
+                )
+                queue_entry_updated_at = getattr(entry_data, 'updated_at', None)
+        elif entry_type == "visit":
+            queue_entry_row = _same_patient_queue_entry_for_visit_id(
+                db,
+                record_id,
+                patient_id,
+            )
+            if queue_entry_row:
+                queue_entry_number = queue_entry_row.number
+                queue_entry_time = queue_entry_row.queue_time
+                queue_entry_updated_at = queue_entry_row.updated_at
+        elif (
+            entry_type == "appointment"
+            and patient_id
+            and appointment_date
+            and doctor_id is not None
+        ):
+            queue_entry_row = db.execute(
+                text(
+                    """
+                    SELECT qe.number, qe.queue_time, qe.updated_at
+                    FROM queue_entries qe
+                    JOIN daily_queues dq ON qe.queue_id = dq.id
+                    WHERE qe.patient_id = :patient_id
+                      AND qe.visit_id IS NULL
+                      AND dq.day = :appointment_date
+                      AND dq.specialist_id = :doctor_id
+                    ORDER BY qe.created_at DESC
+                    LIMIT 1
+                    """
+                ),
+                {
+                    "patient_id": patient_id,
+                    "appointment_date": appointment_date,
+                    "doctor_id": doctor_id,
+                },
+            ).first()
+            if queue_entry_row:
+                queue_entry_number = queue_entry_row.number
+                queue_entry_time = queue_entry_row.queue_time
+                queue_entry_updated_at = queue_entry_row.updated_at
+    except Exception as e:
+        logger.debug(
+            "get_today_queues: Ошибка получения queue_time: %s", str(e)
+        )
+
+    return queue_entry_number, queue_entry_time, queue_entry_updated_at
+
+
+
 # ===================== ТЕКУЩИЕ ОЧЕРЕДИ =====================
 
 
@@ -1910,29 +2043,8 @@ def get_today_queues(
         from app.models.patient import Patient
         from app.models.visit import Visit
 
-        def _same_patient_queue_entry_for_visit_id(
-            visit_id: int | None,
-            patient_id: int | None,
-        ) -> OnlineQueueEntry | None:
-            if visit_id is None or patient_id is None:
-                return None
-            return (
-                db.query(OnlineQueueEntry)
-                .filter(
-                    OnlineQueueEntry.visit_id == visit_id,
-                    OnlineQueueEntry.patient_id == patient_id,
-                )
-                .order_by(OnlineQueueEntry.id.asc())
-                .first()
-            )
-
-        def _same_patient_queue_entry_for_visit(
-            visit: Visit,
-        ) -> OnlineQueueEntry | None:
-            return _same_patient_queue_entry_for_visit_id(
-                visit.id,
-                visit.patient_id,
-            )
+        # R-22 Phase 5: _same_patient_queue_entry_for_visit_id and _same_patient_queue_entry_for_visit
+        # promoted to module-level helpers (take db as first parameter).
 
         # R-22: date parsing + department filter extracted to helpers
         today = _parse_queue_target_date(target_date)
@@ -1954,7 +2066,7 @@ def get_today_queues(
 
             # ⭐ PHASE 1.1: Пропускаем Visit если есть связанный OnlineQueueEntry
             # Очередь должна читаться ТОЛЬКО из OnlineQueueEntry (SSOT)
-            has_queue_entry = _same_patient_queue_entry_for_visit(visit)
+            has_queue_entry = _same_patient_queue_entry_for_visit(db, visit)
             if has_queue_entry:
                 # ⚠️ НЕ добавляем в seen_visit_ids - пусть OQE обрабатывается
                 logger.debug(
@@ -2102,7 +2214,7 @@ def get_today_queues(
             # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
             visit_queue_time = None
             try:
-                queue_entry_row = _same_patient_queue_entry_for_visit(visit)
+                queue_entry_row = _same_patient_queue_entry_for_visit(db, visit)
                 if queue_entry_row and queue_entry_row.queue_time:
                     visit_queue_time = queue_entry_row.queue_time
             except Exception:
@@ -2507,7 +2619,7 @@ def get_today_queues(
                         visit = entry_data
                         # ✅ SSOT FIX: Для QR-визитов нужно получить данные из OnlineQueueEntry
                         # Frontend использует этот ID для вызова full-update endpoint
-                        queue_entry_for_visit = _same_patient_queue_entry_for_visit(visit)
+                        queue_entry_for_visit = _same_patient_queue_entry_for_visit(db, visit)
                         if queue_entry_for_visit:
                             record_id = queue_entry_for_visit.id
                             # ⭐ PHASE 1 FIX: Сохраняем данные из OQE для использования позже
@@ -2699,106 +2811,18 @@ def get_today_queues(
                 # patient/date/doctor match can expose an unrelated appointment.
                 appointment_id_value = record_id if entry_type == "appointment" else None
 
-                # ✅ ИСПРАВЛЕНО: Получаем РЕАЛЬНЫЙ номер и queue_time из queue_entries
-                # Используем Table reflection вместо ORM модели для избежания конфликта DailyQueue
-                queue_entry_number = idx  # По умолчанию используем idx
-                queue_entry_time = None  # По умолчанию нет queue_time
-
-                # Пробуем получить номер и queue_time из таблицы queue_entries через Table reflection
-                queue_entry_updated_at = None
-
-                if record_id:
-                    try:
-                        # Используем прямой SQL запрос через Table reflection (без импорта модели)
-                        # text/select уже импортированы на уровне модуля (R-22 cleanup)
-
-                        # Используем прямой SQL для избежания конфликта с моделями
-                        if entry_type == "online_queue":
-                            # ✅ SSOT FIX: entry_data может быть Visit (для QR-записей) или OnlineQueueEntry
-                            # Проверяем тип объекта
-                            is_visit_object = hasattr(entry_data, 'visit_date') and not hasattr(entry_data, 'queue_id')
-                            
-                            if is_visit_object:
-                                # ⭐ PHASE 1 FIX: Используем уже полученные данные из entry_wrapper
-                                queue_entry_number = entry_wrapper.get("oqe_number") or idx
-                                queue_entry_time = entry_wrapper.get("oqe_queue_time")
-                                queue_entry_updated_at = entry_wrapper.get("oqe_updated_at")
-                            else:
-                                # ⭐ PHASE 1 FIX: Для OnlineQueueEntry номер и queue_time из entry_data
-                                queue_entry_number = (
-                                    entry_data.number
-                                    if hasattr(entry_data, 'number') and entry_data.number is not None
-                                    else idx
-                                )
-                                logger.debug(
-                                    "PHASE1 DEBUG: entry_data.id=%s, entry_data.number=%s, queue_entry_number=%s, idx=%s",
-                                    getattr(entry_data, 'id', 'N/A'),
-                                    getattr(entry_data, 'number', 'N/A'),
-                                    queue_entry_number,
-                                    idx
-                                )
-                                queue_entry_time = (
-                                    entry_data.queue_time
-                                    if hasattr(entry_data, 'queue_time')
-                                    and entry_data.queue_time
-                                    else None
-                                )
-                                queue_entry_updated_at = getattr(entry_data, 'updated_at', None)
-                            logger.debug(
-                                "get_today_queues: OnlineQueue номер: ID=%d, number=%d, queue_time=%s, patient=%s",
-                                record_id,
-                                queue_entry_number,
-                                queue_entry_time,
-                                patient_name,
-                            )
-                        elif entry_type == "visit":
-                            # Ищем запись по visit_id
-                            queue_entry_row = _same_patient_queue_entry_for_visit_id(
-                                record_id,
-                                patient_id,
-                            )
-                            if queue_entry_row:
-                                queue_entry_number = queue_entry_row.number
-                                queue_entry_time = queue_entry_row.queue_time
-                                queue_entry_updated_at = queue_entry_row.updated_at
-                        elif (
-                            entry_type == "appointment"
-                            and patient_id
-                            and appointment_date
-                            and doctor_id is not None
-                        ):
-                            # Для Appointment используем только queue entry того же пациента, дня и врача.
-                            queue_entry_row = db.execute(
-                                text(
-                                    """
-                                    SELECT qe.number, qe.queue_time, qe.updated_at
-                                    FROM queue_entries qe
-                                    JOIN daily_queues dq ON qe.queue_id = dq.id
-                                    WHERE qe.patient_id = :patient_id
-                                      AND qe.visit_id IS NULL
-                                      AND dq.day = :appointment_date
-                                      AND dq.specialist_id = :doctor_id
-                                    ORDER BY qe.created_at DESC
-                                    LIMIT 1
-                                    """
-                                ),
-                                {
-                                    "patient_id": patient_id,
-                                    "appointment_date": appointment_date,
-                                    "doctor_id": doctor_id,
-                                },
-                            ).first()
-                            if queue_entry_row:
-                                queue_entry_number = queue_entry_row.number
-                                queue_entry_time = queue_entry_row.queue_time
-                                queue_entry_updated_at = queue_entry_row.updated_at
-                    except Exception as e:
-                        # Логируем ошибку, но продолжаем работу с дефолтным номером
-                        # Это не критично - порядковые номера работают как fallback
-                        logger.debug(
-                            "get_today_queues: Ошибка получения queue_time: %s", str(e)
-                        )
-                        pass  # Тихая ошибка - порядковые номера достаточно
+                # R-22 Phase 5: queue entry metadata lookup extracted to helper
+                queue_entry_number, queue_entry_time, queue_entry_updated_at = _resolve_queue_entry_metadata(
+                    db=db,
+                    entry_type=entry_type,
+                    entry_data=entry_data,
+                    entry_wrapper=entry_wrapper,
+                    record_id=record_id,
+                    patient_id=patient_id,
+                    appointment_date=appointment_date,
+                    doctor_id=doctor_id,
+                    idx=idx,
+                )
 
                 # [OK] ДОБАВЛЯЕМ department_key и department для фронтенда
                 entry_department_key = None


### PR DESCRIPTION
## Summary

- R-22 Phase 5: продолжение декомпозиции `get_today_queues` (был 1099 строк после Phase 4 → 990 строк, −10%).
- Из основной функции вынесены:
  - `_resolve_queue_entry_metadata` (90 строк) — resolves `(queue_entry_number, queue_entry_time, queue_entry_updated_at)` для online_queue/visit/appointment. Lookup priority: OQE direct → visit_id lookup → SQL query for appointment.
  - `_same_patient_queue_entry_for_visit_id` и `_same_patient_queue_entry_for_visit` — **повышены с nested-функций до module-level** (теперь принимают `db` первым параметром). Это устраняет F821 (undefined name) в новом helper'е и открывает путь к дальнейшей декомпозиции.

## Cyclic Execution Evidence

- Fresh main sync: ветка создана от origin/main после merge PR #1715 (R-22 Phase 4).
- Clean workspace: только один файл изменён (`backend/app/api/v1/endpoints/registrar_integration.py`).
- Branch: refactor/registrar-r22-phase5
- Scope gate: allowed только `registrar_integration.py`; denied миграции, schema-changes, новые endpoints, изменения OpenAPI.
- Red-check handling: первый прогон ruff выявил F821 (undefined name `_same_patient_queue_entry_for_visit_id` в новом helper'е) — исправлено повышением nested-функций до module-level в том же коммите.

## Contract Impact

- Canonical surface: GET /api/v1/registrar/queues/today
- Request shape: authenticated request, query params `target_date` (YYYY-MM-DD) и `department` (опционально), без body
- Response shape: `{queues: [...], total_queues: int, date: str, timezone: str}` без изменений; поля `queue_entry_number`, `queue_time`, `updated_at` сохранены идентично
- Status codes: 200 для разрешённых ролей, 401 unauthenticated, 403 forbidden role
- Frontend consumer: registrar panel (`RegistrarPanel.jsx`), lab queue (`LabQueueWorkbench.jsx` через façade)
- Compatibility path or alias: не применимо - поля ответа идентичны main, ломающих изменений нет
- Contract proof: 12 integration-тестов из `test_registrar_all_appointments.py` + 4 role guard + 11 visit confirmation + 7 online queue scenarios проходят без изменений fixtures

## RBAC / Permissions

- Roles allowed: Admin, Registrar, Cashier, Doctor, Lab, cardio, cardiology, derma, dentist
- Roles denied: все остальные роли
- Positive auth proof: `test_legacy_queue_today_role_guard.py` (4 теста) проверяет разрешённые роли → 200
- Negative auth proof: тот же файл проверяет неразрешённые роли → 403

## Notification / Realtime

not applicable - рефакторинг сериализации очереди, websocket/FCM/Telegram каналы не затронуты.

## Frontend Resilience

- Empty data proof: очередь без записей возвращает `entries: []` корректно (проверено в существующих тестах).
- Partial data proof: пропущенные записи (`appointment entry with None data`) логируются и skip-аются без падения endpoint-а.
- Forbidden secondary path behavior: не применимо, нет вторичных путей.
- Missing draft/resource behavior: не применимо.
- Stale route/deep-link behavior: не применимо.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/registrar_integration.py
- Denied paths: любые другие файлы, миграции, schema, frontend, тесты
- Migration/docs/test impact: нет миграций; docs не затронуты; тесты не модифицировались
- Rollback note: revert одного файла `registrar_integration.py` к main-версии возвращает прежнее поведение без побочных эффектов

## DevBrain Memory Impact

not applicable - mechanical refactoring без новых бизнес-правил или state-машин.

## Validation

- Targeted tests or smoke run: `pytest tests/integration/test_registrar_*.py tests/integration/test_legacy_queue_today_role_guard.py tests/integration/test_visit_confirmation_api.py tests/integration/test_online_queue_scenarios.py tests/integration/test_legacy_queues_api.py tests/integration/test_qr_queue_join.py tests/characterization/test_registrar_*.py tests/unit/test_registrar_*.py`
- Result: 94/94 passed
- Not checked: full CI/CD pipeline (Backend/Frontend unit+e2e, Integration, Security scan, Context Boundary, Parity) — будет запущен на PR
