### PR TITLE
fix(emr): R-13 remove duplicate ECGViewer + EchoForm from CardiologySection

### DIFF
--- a/frontend/src/components/emr-v2/sections/specialty/CardiologySection.css
+++ b/frontend/src/components/emr-v2/sections/specialty/CardiologySection.css
@@ -270,3 +270,55 @@
     background: #fecaca;
     color: #991b1b;
 }
+/* R-13 / P-005 (UX audit): info panel replacing the duplicate ECGViewer / EchoForm */
+.cardiology-info-panel {
+    display: flex;
+    gap: 12px;
+    padding: 16px;
+    background: #f0f9ff;
+    border: 1px solid #bae6fd;
+    border-radius: 8px;
+    margin-bottom: 16px;
+}
+
+.cardiology-info-panel .cardiology-info-icon {
+    font-size: 24px;
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.cardiology-info-panel .cardiology-info-text h4 {
+    margin: 0 0 6px 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: #0c4a6e;
+}
+
+.cardiology-info-panel .cardiology-info-text p {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: #075985;
+}
+
+.cardiology-ecg-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 8px;
+    margin: 8px 0;
+    font-size: 13px;
+    color: #334155;
+}
+
+.cardiology-ecg-summary div {
+    padding: 4px 8px;
+    background: #f8fafc;
+    border-radius: 4px;
+}
+
+.cardiology-ecg-interpretation {
+    margin: 8px 0 0 0;
+    font-size: 13px;
+    color: #475569;
+    line-height: 1.5;
+}

--- a/frontend/src/components/emr-v2/sections/specialty/CardiologySection.jsx
+++ b/frontend/src/components/emr-v2/sections/specialty/CardiologySection.jsx
@@ -1,19 +1,25 @@
 /**
  * CardiologySection - Специализированная секция для кардиологии
- * 
- * Интегрирует:
- * - ECGViewer для просмотра и анализа ЭКГ
- * - Поля для ЭхоКГ результатов
- * - Кардиологические маркеры (тропонин, CRP, холестерин)
- * - Калькуляторы рисков
+ *
+ * R-13 / P-005 (UX audit): the ECGViewer and EchoForm were previously
+ * rendered inside this EMR specialty section AND on the dedicated
+ * 'ecg' tab of CardiologistPanelUnified - two independent instances of
+ * the same component sharing the same visitId/patientId but with
+ * independent local state. Edits in one place were not visible in the
+ * other without a reload, which violated DRY and created cognitive load
+ * (the doctor had to remember "where did I enter this?").
+ *
+ * Fix: this section now shows a read-only summary of the latest ECG and
+ * Echo data stored in specialty_data.ecg / specialty_data.echo, plus a
+ * pointer to the dedicated 'ecg' tab where the full ECGViewer / EchoForm
+ * live. Labs and the SCORE2 risk calculator stay here (they are unique
+ * to the EMR context and not duplicated elsewhere).
  */
 
 import PropTypes from 'prop-types';
 import { useState, useCallback } from 'react';
 import EMRSection from '../EMRSection';
 import EMRTextField from '../EMRTextField';
-import ECGViewer from '../../../cardiology/ECGViewer';
-import EchoForm from '../../../cardiology/EchoForm';
 import { useAppData } from '../../../../contexts/AppDataContext';
 import './CardiologySection.css';
 
@@ -35,21 +41,17 @@ export function CardiologySection({
   labResults = {},
   onChange,
   disabled = false,
-  visitId,
-  patientId
+  // R-13: visitId and patientId are no longer used inside this section
+  // (ECGViewer was removed). They are still accepted in propTypes for
+  // backwards compatibility with EMRContainerV2, which passes them
+  // unconditionally.
+  visitId: _visitId,
+  patientId: _patientId
 }) {void
   useAppData();
   const [activeTab, setActiveTab] = useState('ecg'); // 'ecg' | 'echo' | 'labs' | 'risk'
 
   // Handlers
-  const handleECGDataUpdate = useCallback((updatedData) => {
-    onChange?.('ecg', updatedData);
-  }, [onChange]);
-
-  const handleEchoDataUpdate = useCallback((updatedData) => {
-    onChange?.('echo', updatedData);
-  }, [onChange]);
-
   const handleLabResultChange = useCallback((field, value) => {
     onChange?.('cardio_labs', {
       ...labResults,
@@ -96,31 +98,102 @@ export function CardiologySection({
                 </button>
             </div>
 
-            {/* ECG Tab */}
+            {/* ECG Tab - R-13: read-only summary instead of duplicate ECGViewer */}
             {activeTab === 'ecg' &&
       <div className="cardiology-tab-content">
-                    <ECGViewer
-          visitId={visitId}
-          patientId={patientId}
-          onDataUpdate={handleECGDataUpdate} />
-        
-                    {ecgData?.interpretation &&
+                    <div className="cardiology-info-panel" role="status">
+                            <div className="cardiology-info-icon">📋</div>
+                            <div className="cardiology-info-text">
+                                <h4>ЭКГ доступна на отдельной вкладке</h4>
+                                <p>
+                                    Полный просмотрщик ЭКГ (загрузка файлов, парсинг параметров,
+                                    AI-анализ) находится на вкладке <strong>«ЭКГ»</strong> в боковой
+                                    панели кардиолога. Это устраняет дублирование данных и
+                                    гарантирует, что изменения отображаются в одном месте.
+                                </p>
+                            </div>
+                        </div>
+
+                    {/* Summary of the latest ECG data stored in specialty_data.ecg */}
+                    {(ecgData?.heart_rate || ecgData?.rhythm || ecgData?.interpretation) &&
         <div className="cardiology-interpretation">
-                            <h4>Интерпретация ЭКГ:</h4>
-                            <p>{ecgData.interpretation}</p>
+                            <h4>Последняя запись ЭКГ:</h4>
+                            <div className="cardiology-ecg-summary">
+                                {ecgData?.heart_rate &&
+                                    <div><strong>ЧСС:</strong> {ecgData.heart_rate} уд/мин</div>
+                                }
+                                {ecgData?.rhythm &&
+                                    <div><strong>Ритм:</strong> {ecgData.rhythm}</div>
+                                }
+                                {ecgData?.pr_interval &&
+                                    <div><strong>PR:</strong> {ecgData.pr_interval} мс</div>
+                                }
+                                {ecgData?.qrs_duration &&
+                                    <div><strong>QRS:</strong> {ecgData.qrs_duration} мс</div>
+                                }
+                                {ecgData?.qt_interval &&
+                                    <div><strong>QT:</strong> {ecgData.qt_interval} мс</div>
+                                }
+                                {ecgData?.st_segment &&
+                                    <div><strong>ST:</strong> {ecgData.st_segment}</div>
+                                }
+                                {ecgData?.t_wave &&
+                                    <div><strong>T:</strong> {ecgData.t_wave}</div>
+                                }
+                            </div>
+                            {ecgData?.interpretation &&
+                                <p className="cardiology-ecg-interpretation">
+                                    <em>Интерпретация:</em> {ecgData.interpretation}
+                                </p>
+                            }
                         </div>
         }
                 </div>
       }
 
-            {/* Echo Tab */}
+            {/* Echo Tab - R-13: read-only summary instead of duplicate EchoForm */}
             {activeTab === 'echo' &&
       <div className="cardiology-tab-content">
-                    <EchoForm
-          initialData={echoData}
-          onSave={handleEchoDataUpdate}
-          disabled={disabled} />
-        
+                    <div className="cardiology-info-panel" role="status">
+                            <div className="cardiology-info-icon">📋</div>
+                            <div className="cardiology-info-text">
+                                <h4>ЭхоКГ доступна на отдельной вкладке</h4>
+                                <p>
+                                    Полная форма ЭхоКГ (левый желудочек, предсердия, клапаны,
+                                    заключение) находится на вкладке <strong>«ЭКГ»</strong> в боковой
+                                    панели кардиолога (в разделе ЭхоКГ под загрузчиком ЭКГ).
+                                </p>
+                            </div>
+                        </div>
+
+                    {/* Summary of the latest Echo data stored in specialty_data.echo */}
+                    {(echoData?.ef || echoData?.edd || echoData?.la || echoData?.conclusion) &&
+        <div className="cardiology-interpretation">
+                            <h4>Последние данные ЭхоКГ:</h4>
+                            <div className="cardiology-ecg-summary">
+                                {echoData?.edd &&
+                                    <div><strong>КДО ЛЖ:</strong> {echoData.edd} мм</div>
+                                }
+                                {echoData?.esd &&
+                                    <div><strong>КСО ЛЖ:</strong> {echoData.esd} мм</div>
+                                }
+                                {echoData?.ef &&
+                                    <div><strong>ФВ:</strong> {echoData.ef}%</div>
+                                }
+                                {echoData?.la &&
+                                    <div><strong>ЛП:</strong> {echoData.la} мм</div>
+                                }
+                                {echoData?.aortic?.peak_velocity &&
+                                    <div><strong>Vmax аорт. клапана:</strong> {echoData.aortic.peak_velocity} м/с</div>
+                                }
+                            </div>
+                            {echoData?.conclusion &&
+                                <p className="cardiology-ecg-interpretation">
+                                    <em>Заключение:</em> {echoData.conclusion}
+                                </p>
+                            }
+                        </div>
+        }
                 </div>
       }
 


### PR DESCRIPTION
## Summary

- Closes UX audit findings P-005 + P-006 (High): ECGViewer was rendered in two places — on the dedicated "ecg" tab of CardiologistPanelUnified AND inside CardiologySection.ecg in the EMR container. EchoForm had the same duplication. Both instances shared the same visitId/patientId but had independent local state, so edits in one place were not visible in the other without a reload. The doctor had to remember "where did I enter this?" — cognitive load + risk of inconsistent data.
- Now that R-11 / PR #1718 (merged) made ECGViewer persist parsed parameters to the backend, the duplicate inside CardiologySection adds no value — the same records are visible from the dedicated "ecg" tab anyway.
- Replaces the two duplicate component instances inside CardiologySection with read-only info-panels that (a) point the doctor to the dedicated "ecg" tab and (b) surface a summary of the latest ECG / Echo data stored in specialty_data. Labs and the SCORE2 risk calculator stay in CardiologySection unchanged (they are unique to the EMR context).

## Cyclic Execution Evidence

- Fresh main sync: branch `feature/remove-ecg-viewer-duplicate` created from `origin/main` HEAD `cd922c05` (the squash-merge commit of PR #1718).
- Clean workspace: inspected before edits; only `frontend/src/components/emr-v2/sections/specialty/CardiologySection.jsx` and `frontend/src/components/emr-v2/sections/specialty/CardiologySection.css` changed.
- Branch: `feature/remove-ecg-viewer-duplicate`
- Scope gate: allowed CardiologySection + its CSS; denied the dedicated ECGViewer/EchoForm components (untouched), CardiologistPanelUnified.jsx (untouched — the "ecg" tab keeps the canonical instance), registrar/derma/dentist panels.
- Red-check handling: if frontend lint/unit/build/e2e fail on this PR, fix in this same PR before merge.

## Contract Impact

- Canonical surface: CardiologySection React component (frontend-only, no API).
- Request shape: props `ecgData`, `echoData`, `labResults`, `onChange`, `disabled`, `visitId`, `patientId` — unchanged. EMRContainerV2.jsx calls `<CardiologySection ecgData={data.specialty_data?.ecg} echoData={data.specialty_data?.echo} labResults={data.specialty_data?.cardio_labs} onChange={...} disabled={...} visitId={...} patientId={...} />` — same call site, no breaking change.
- Response shape: the component still renders an EMRSection with four tabs (ecg / echo / labs / risk). The ecg and echo tabs now render info-panels + read-only summaries instead of the full ECGViewer / EchoForm. Labs and risk tabs are unchanged.
- Status codes: not applicable, React component — no HTTP status codes involved. The component renders synchronously and does not perform any network requests of its own (the canonical ECGViewer on the dedicated "ecg" tab still owns all /files and /cardio/ecg network calls).
- Frontend consumer: `EMRContainerV2.jsx` (only call site).
- Compatibility path or alias: `visitId` and `patientId` props are still accepted (kept in propTypes for backwards compat) but no longer used inside the component — they are renamed to `_visitId` / `_patientId` in the destructure to signal intentional non-use.
- Contract proof: no existing tests directly assert CardiologySection internals; the `DoctorPanels.contract.test.jsx` suite asserts SSOT contracts at the panel level (route, role, payment_status, available_actions) and does not touch CardiologySection. Frontend unit tests + e2e will validate that the component still mounts and the EMR container still renders.

## RBAC / Permissions

not applicable - no role gating, route guard, or permission check changed. CardiologySection is rendered inside EMRContainerV2, which is itself gated by the cardiologist panel's RBAC. The component does not perform any auth checks of its own.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed. The removed ECGViewer instance previously called `notify.success` / `notify.error` after persisting parsed parameters to /cardio/ecg (added in PR #1718) — that notify path is unchanged because the canonical ECGViewer instance on the dedicated "ecg" tab still exists and still calls notify. The info-panel replacement in CardiologySection does not emit any notifications.

## Frontend Resilience

- Empty data proof: when `ecgData` is `{}` (no ECG stored in specialty_data), the ECG tab shows only the info-panel pointing to the dedicated tab — the summary block is hidden via `{(ecgData?.heart_rate || ecgData?.rhythm || ecgData?.interpretation) && ...}`. Same for `echoData`.
- Partial data proof: each summary field is individually gated (`{ecgData?.heart_rate && <div>...</div>}`), so a partially-populated ecgData (e.g. only heart_rate set) renders only the populated fields without crashing.
- Forbidden secondary path behavior: not applicable, no secondary paths introduced. The info-panel is a static pointer; the canonical ECGViewer on the "ecg" tab is the only path to upload/parse/persist ECGs.
- Missing draft/resource behavior: if `ecgData` or `echoData` is null (not just empty), the optional chaining `ecgData?.heart_rate` returns undefined and the summary block is hidden — no crash.
- Stale route/deep-link behavior: not applicable, no route or deep-link handling changed.

## Scope Gate

- Allowed paths: `frontend/src/components/emr-v2/sections/specialty/CardiologySection.jsx`, `frontend/src/components/emr-v2/sections/specialty/CardiologySection.css`.
- Denied paths: ECGViewer.jsx (untouched), EchoForm.jsx (untouched), CardiologistPanelUnified.jsx (untouched — the "ecg" tab keeps the canonical ECGViewer + EchoForm), backend (any), routes/registry, RBAC, registrar/derma/dentist panels.
- Migration/docs/test impact: no migration; no docs; no new tests (CardiologySection has no direct unit tests; the contract test suite covers panel-level concerns only).
- Rollback note: revert the single commit on this branch; no data migration to undo. The canonical ECGViewer on the "ecg" tab is unchanged, so no ECG data is lost.

## Validation

- Targeted tests or smoke run: awaiting CI — frontend lint, frontend unit tests (including `DoctorPanels.contract.test.jsx` and `notificationGuardrails.test.js`), frontend build, frontend e2e.
- Result: pending — will update this section once CI completes.
- Not checked: full manual smoke of the EMR CardiologySection tabs (planned for after CI green); derma/dentist specialty sections (no changes there).

## Change list (for traceability)

- R-13: P-005 + P-006 High — 2 files (CardiologySection.jsx + .css) — commit `fc18e2f5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
