### PR TITLE
fix(registrar): R-27 reschedule visit with optional new_time slot

### DIFF
--- a/backend/app/api/v1/endpoints/visits.py
+++ b/backend/app/api/v1/endpoints/visits.py
@@ -78,6 +78,18 @@ def _vservices(db: Session) -> Table:
     return Table("visit_services", md, autoload_with=db.get_bind())
 
 
+def _isValid_time_str(value: str) -> bool:
+    """R-27 fix: validate HH:MM time string (24-hour, leading zeros required)."""
+    if not value or len(value) != 5 or value[2] != ":":
+        return False
+    try:
+        hours = int(value[:2])
+        minutes = int(value[3:])
+    except (ValueError, TypeError):
+        return False
+    return 0 <= hours <= 23 and 0 <= minutes <= 59
+
+
 def _update_queue_entries_for_visit_owner(
     db: Session,
     *,
@@ -327,11 +339,12 @@ def set_status(
 def reschedule_visit(
     visit_id: int,
     new_date: date = Query(..., alias="new_date"),
+    new_time: Optional[str] = Query(None, alias="new_time", description="Опциональное новое время в формате HH:MM"),
     db: Session = Depends(get_db),
 ):
     """
-    Перенос визита на указанную дату (записывается в planned_date).
-    Требует, чтобы в таблице visits была колонка planned_date.
+    Перенос визита на указанную дату (записывается в visit_date).
+    Опционально обновляет visit_time, если передан new_time (формат HH:MM).
     """
     t = _visits(db)
     # Проверка наличия колонки visit_date
@@ -355,8 +368,20 @@ def reschedule_visit(
             status_code=409, detail="Cannot reschedule a visit that has been started"
         )
 
+    # R-27 fix: обновляем и дату, и опционально время
+    update_values: dict = {"visit_date": new_date}
+    if new_time is not None:
+        # Валидация формата HH:MM
+        new_time_str = new_time.strip()
+        if not _isValid_time_str(new_time_str):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="new_time must be in HH:MM format (e.g. 09:30)",
+            )
+        update_values["visit_time"] = new_time_str
+
     upd = (
-        t.update().where(t.c.id == visit_id).values(visit_date=new_date).returning(t)
+        t.update().where(t.c.id == visit_id).values(**update_values).returning(t)
     )
     row = db.execute(upd).mappings().first()
     if not row:

--- a/backend/tests/integration/test_visits_reschedule_aliases.py
+++ b/backend/tests/integration/test_visits_reschedule_aliases.py
@@ -109,3 +109,95 @@ class TestVisitsRescheduleAliases:
         )
         assert blocked_response.status_code == 409, blocked_response.text
         assert "canceled" in blocked_response.json()["detail"].lower()
+
+    def test_reschedule_with_new_time_updates_visit_time(
+        self,
+        client,
+        db_session,
+        auth_headers,
+        test_patient,
+        test_doctor,
+    ):
+        """R-27 fix: reschedule with new_time should update visit_time."""
+        visit = Visit(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=date.today(),
+            visit_time="10:00",
+            status="open",
+            source="desk",
+        )
+        db_session.add(visit)
+        db_session.commit()
+        db_session.refresh(visit)
+
+        response = client.post(
+            f"/api/v1/visits/visits/{visit.id}/reschedule",
+            headers=auth_headers,
+            params={
+                "new_date": (date.today() + timedelta(days=2)).isoformat(),
+                "new_time": "14:30",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        db_session.refresh(visit)
+        assert visit.visit_date == date.today() + timedelta(days=2)
+        assert visit.visit_time == "14:30"
+
+    def test_reschedule_without_new_time_preserves_visit_time(
+        self,
+        client,
+        db_session,
+        auth_headers,
+        test_patient,
+        test_doctor,
+    ):
+        """R-27 fix: reschedule without new_time should preserve existing visit_time."""
+        visit = Visit(
+            patient_id=test_patient.id,
+            doctor_id=test_doctor.id,
+            visit_date=date.today(),
+            visit_time="09:15",
+            status="open",
+            source="desk",
+        )
+        db_session.add(visit)
+        db_session.commit()
+        db_session.refresh(visit)
+
+        response = client.post(
+            f"/api/v1/visits/visits/{visit.id}/reschedule",
+            headers=auth_headers,
+            params={
+                "new_date": (date.today() + timedelta(days=2)).isoformat(),
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        db_session.refresh(visit)
+        assert visit.visit_date == date.today() + timedelta(days=2)
+        assert visit.visit_time == "09:15"  # preserved
+
+    def test_reschedule_with_invalid_time_format_returns_422(
+        self,
+        client,
+        db_session,
+        auth_headers,
+        test_patient,
+        test_doctor,
+    ):
+        """R-27 fix: invalid new_time format should return 422."""
+        visit = self._make_visit(db_session, test_patient, test_doctor)
+
+        response = client.post(
+            f"/api/v1/visits/visits/{visit.id}/reschedule",
+            headers=auth_headers,
+            params={
+                "new_date": (date.today() + timedelta(days=2)).isoformat(),
+                "new_time": "25:99",  # invalid
+            },
+        )
+
+        assert response.status_code == 422, response.text
+        assert "HH:MM" in response.json()["detail"]

--- a/frontend/src/api/visits.js
+++ b/frontend/src/api/visits.js
@@ -12,11 +12,14 @@ export async function getVisit(visitId) {
 /**
  * Перенести визит на произвольную дату/время.
  * POST /api/v1/visits/visits/{visit_id}/reschedule
- * Тело запроса — то, что передаёшь в payload (например { date_str: "YYYY-MM-DD", time_str: "HH:MM" }).
+ * @param {number} visitId
+ * @param {string} newDate — YYYY-MM-DD
+ * @param {string} [newTime] — HH:MM (optional, R-27 fix)
  */
-export async function rescheduleVisit(visitId, newDate) {
+export async function rescheduleVisit(visitId, newDate, newTime) {
   const params = new URLSearchParams();
   if (newDate) params.set('new_date', newDate);
+  if (newTime) params.set('new_time', newTime);
   const { data } = await api.post(
     `/visits/visits/${encodeURIComponent(visitId)}/reschedule?${params.toString()}`
   );

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -492,6 +492,8 @@ const RegistrarPanel = () => {
   // reschedule slots dialog. Replaces the previous window.prompt() call that was
   // jarring, blocking, and lacked a date picker.
   const [customRescheduleDate, setCustomRescheduleDate] = useState('');
+  // R-27 fix: optional time picker for reschedule (HH:MM)
+  const [customRescheduleTime, setCustomRescheduleTime] = useState('');
   const autoRefresh = true; // Новые состояния для интеграции с админ панелью
   // Decomp 3: reschedule helpers extracted to useRegistrarReschedule hook
   const {
@@ -2758,6 +2760,8 @@ const RegistrarPanel = () => {
                 notify.success('Визит успешно перенесён на завтра');
                 removeRescheduledAppointmentFromView(rescheduleData, targetVisitId);
                 setRescheduleData(null);
+                setCustomRescheduleDate('');
+                setCustomRescheduleTime('');
                 loadAppointments({ source: 'reschedule_tomorrow' });
               } catch (e) {
                 logger.error('Ошибка переноса на завтра:', e);
@@ -2778,6 +2782,7 @@ const RegistrarPanel = () => {
               if (!rescheduleData) return;
 
               const dateStr = customRescheduleDate || '';
+              const timeStr = (customRescheduleTime || '').trim();
 
               if (!dateStr) {
                 notify.error('Выберите дату переноса');
@@ -2786,6 +2791,12 @@ const RegistrarPanel = () => {
 
               if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
                 notify.error('Неверный формат даты. Используйте YYYY-MM-DD');
+                return;
+              }
+
+              // R-27 fix: validate optional time (HH:MM)
+              if (timeStr && !/^\d{2}:\d{2}$/.test(timeStr)) {
+                notify.error('Неверный формат времени. Используйте HH:MM');
                 return;
               }
 
@@ -2799,7 +2810,9 @@ const RegistrarPanel = () => {
               // R-43 fix: confirmation dialog для destructive action.
               const ok = await confirm({
                 title: 'Перенос на другую дату',
-                message: `Перенести запись пациента на ${dateStr}?`,
+                message: timeStr
+                  ? `Перенести запись пациента на ${dateStr} в ${timeStr}?`
+                  : `Перенести запись пациента на ${dateStr}?`,
                 confirmLabel: 'Перенести',
                 cancelLabel: 'Отмена',
                 intent: 'primary',
@@ -2813,12 +2826,13 @@ const RegistrarPanel = () => {
                   notify.error('Не удалось определить визит для переноса');
                   return;
                 }
-                logger.info(`Перенос визита ${targetVisitId} на ${dateStr}`);
-                await rescheduleVisit(targetVisitId, dateStr);
-                notify.success(`Визит перенесён на ${dateStr}`);
+                logger.info(`Перенос визита ${targetVisitId} на ${dateStr}${timeStr ? ' ' + timeStr : ''}`);
+                await rescheduleVisit(targetVisitId, dateStr, timeStr || undefined);
+                notify.success(`Визит перенесён на ${dateStr}${timeStr ? ' ' + timeStr : ''}`);
                 removeRescheduledAppointmentFromView(rescheduleData, targetVisitId);
                 setRescheduleData(null);
                 setCustomRescheduleDate('');
+                setCustomRescheduleTime('');
                 loadAppointments({ source: 'reschedule_date' });
               } catch (e) {
                 logger.error('Ошибка переноса на дату:', e);
@@ -2875,8 +2889,25 @@ const RegistrarPanel = () => {
                   color: getColor('textPrimary')
                 }}
             />
+            {/* R-27 fix: optional time picker (HH:MM) */}
+            <label htmlFor="reschedule-custom-time" className="registrar-reschedule-label" style={{ color: getColor('textPrimary'), marginTop: '12px' }}>
+              Время переноса (необязательно)
+            </label>
+            <input
+              id="reschedule-custom-time"
+              type="time"
+              value={customRescheduleTime}
+              aria-label="Время переноса записи"
+              onChange={(e) => setCustomRescheduleTime(e.target.value)}
+              className="registrar-reschedule-input"
+              style={{
+                border: `1px solid ${theme === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)'}`,
+                backgroundColor: theme === 'dark' ? 'rgba(255,255,255,0.05)' : 'var(--mac-bg-primary)',
+                color: getColor('textPrimary')
+              }}
+            />
             <div className="registrar-reschedule-hint" style={{ color: getColor('textSecondary') }}>
-              Выберите дату и нажмите «{t('select_date')}».
+              Выберите дату и нажмите «{t('select_date')}». Время необязательно — если не указано, сохранится текущее.
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **R-27 fix**: reschedule visit endpoint now supports optional `new_time` (HH:MM) parameter.
- **Before**: `POST /api/v1/visits/{visit_id}/reschedule?new_date=YYYY-MM-DD` — обновлял только `visit_date`, время оставалось старым или терялось.
- **After**: `POST /api/v1/visits/{visit_id}/reschedule?new_date=YYYY-MM-DD&new_time=HH:MM` — обновляет и дату, и опционально время. Если `new_time` не передан — существующее `visit_time` сохраняется (backward compatible).
- Frontend: в диалог переноса записи добавлен `<input type="time">` picker (необязательное поле). Confirmation message показывает время, если указано.

## Cyclic Execution Evidence

- Fresh main sync: ветка создана от origin/main после merge PR #1727.
- Clean workspace: 4 файла изменены (backend endpoint, backend test, frontend API client, frontend panel).
- Branch: fix/registrar-r27-reschedule-time-slot
- Scope gate: allowed только visits endpoint, visits API client, RegistrarPanel, reschedule test; denied миграции, schema-changes, новые endpoints.
- Red-check handling: первый прогон тестов выявил все 9 pass (4 original + 2 parametrized×2 + 3 new).

## Contract Impact

- Canonical surface: POST /api/v1/visits/visits/{visit_id}/reschedule и legacy alias POST /api/v1/visits/{visit_id}/reschedule
- Request shape: query params `new_date` (YYYY-MM-DD, обязательно) + `new_time` (HH:MM, опционально, R-27 fix)
- Response shape: VisitOut без изменений
- Status codes: 200 success, 404 visit not found, 409 cannot reschedule closed/canceled/started, 422 invalid time format (R-27 fix)
- Frontend consumer: registrar panel (`RegistrarPanel.jsx`) reschedule dialog
- Compatibility path or alias: `new_time` опциональный — существующие вызовы без `new_time` работают как раньше (visit_time сохраняется)
- Contract proof: 3 новых integration-теста + 6 существующих проходят

## RBAC / Permissions

- Roles allowed: Admin, Registrar
- Roles denied: все остальные
- Positive auth proof: `test_visits_reschedule_aliases.py` (9 тестов) используют auth_headers с admin token → 200/422
- Negative auth proof: endpoint защищён `Depends(require_roles("Admin", "Registrar"))`, неразрешённые роли → 403

## Notification / Realtime

not applicable - reschedule не триггерит websocket/FCM/Telegram уведомления в текущей реализации.

## Frontend Resilience

- Empty data proof: если customRescheduleTime пустой — передаётся undefined, backend сохраняет существующее visit_time.
- Partial data proof: валидация формата HH:MM на frontend (regex) и backend (_isValid_time_str).
- Forbidden secondary path behavior: не применимо.
- Missing draft/resource behavior: не применимо.
- Stale route/deep-link behavior: не применимо.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/visits.py, backend/tests/integration/test_visits_reschedule_aliases.py, frontend/src/api/visits.js, frontend/src/pages/RegistrarPanel.jsx
- Denied paths: любые другие файлы, миграции, schema-changes
- Migration/docs/test impact: нет миграций; docs не затронуты; добавлены 3 новых тест-кейса
- Rollback note: revert 4 файлов возвращает прежнее поведение (только new_date)

## DevBrain Memory Impact

not applicable - bug fix без новых бизнес-правил или state-машин.

## Validation

- Targeted tests or smoke run: `pytest tests/integration/test_visits_reschedule_aliases.py tests/integration/test_visit_status_owner_guard.py tests/integration/test_visit_confirmation_api.py tests/integration/test_e2e_visit_flow.py tests/integration/test_e2e_doctor_visit.py tests/integration/test_doctor_integration_visit_routes.py`
- Result: 57/57 passed (9 + 8 + 11 + 10 + 12 + 7)
- Not checked: full CI/CD pipeline (Backend/Frontend unit+e2e, Integration, Security scan, Context Boundary, Parity) — будет запущен на PR
