### PR TITLE
feat(header): P-027 surface Cmd+K shortcut in Header for CommandPalette discovery

### DIFF
--- a/frontend/src/components/layout/HeaderNew.jsx
+++ b/frontend/src/components/layout/HeaderNew.jsx
@@ -538,6 +538,47 @@ export default function HeaderNew() {
       </div>
       <div className="hdr-center" style={{ minWidth: 0, display: 'flex', alignItems: 'center', gap: '16px' }}>
         <GlobalSearchBar />
+        {/* P-027 (UX audit): surface the Cmd+K shortcut so power-users
+            discover the CommandPalette without reading docs. */}
+        <kbd
+          title="Открыть командную палитру (Cmd+K / Ctrl+K)"
+          onClick={() => {
+            // Dispatch a keyboard event to trigger the CommandPalette's
+            // global listener. This is simpler than importing the component.
+            const isMac = navigator.platform.toUpperCase().includes('MAC');
+            const event = new KeyboardEvent('keydown', {
+              key: 'k',
+              metaKey: isMac,
+              ctrlKey: !isMac,
+              bubbles: true,
+            });
+            document.dispatchEvent(event);
+          }}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            padding: '2px 8px',
+            fontSize: '11px',
+            fontWeight: '500',
+            color: 'var(--mac-text-secondary, #6b7280)',
+            background: 'var(--mac-surface-secondary, #f3f4f6)',
+            border: '1px solid var(--mac-border, #d1d5db)',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+            lineHeight: '1.4',
+            userSelect: 'none',
+            transition: 'background 0.15s ease',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = 'var(--mac-surface-hover, #e5e7eb)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = 'var(--mac-surface-secondary, #f3f4f6)';
+          }}
+        >
+          ⌘K
+        </kbd>
         {roleNav}
       </div>
       <div className="hdr-right" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>{controls}</div>

--- a/frontend/src/components/layout/HeaderNew.jsx
+++ b/frontend/src/components/layout/HeaderNew.jsx
@@ -541,7 +541,10 @@ export default function HeaderNew() {
         {/* P-027 (UX audit): surface the Cmd+K shortcut so power-users
             discover the CommandPalette without reading docs. */}
         <kbd
+          role="button"
+          tabIndex={0}
           title="Открыть командную палитру (Cmd+K / Ctrl+K)"
+          aria-label="Открыть командную палитру (Cmd+K или Ctrl+K)"
           onClick={() => {
             // Dispatch a keyboard event to trigger the CommandPalette's
             // global listener. This is simpler than importing the component.
@@ -553,6 +556,19 @@ export default function HeaderNew() {
               bubbles: true,
             });
             document.dispatchEvent(event);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              const isMac = navigator.platform.toUpperCase().includes('MAC');
+              const event = new KeyboardEvent('keydown', {
+                key: 'k',
+                metaKey: isMac,
+                ctrlKey: !isMac,
+                bubbles: true,
+              });
+              document.dispatchEvent(event);
+            }
           }}
           style={{
             display: 'inline-flex',


### PR DESCRIPTION
## Summary

- P-027 (Low): the CommandPalette (Cmd+K / Ctrl+K) is a powerful feature for admin navigation, but it was completely hidden — no visible UI element hinted at its existence. Added a compact <kbd>⌘K</kbd> badge next to the GlobalSearchBar in HeaderNew.
- Also evaluated P-024, P-025, P-028, P-029 — all skipped with documented rationale (see commit message).

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main HEAD 7649a83e (PR #1735 merge).
- Clean workspace: only frontend/src/components/layout/HeaderNew.jsx changed.
- Branch: feature/low-priority-cleanup-batch
- Scope gate: allowed HeaderNew.jsx; denied all other files.
- Red-check handling: fix failed CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: HeaderNew React component (frontend-only, no API).
- Request shape: no API change. The kbd badge dispatches a synthetic KeyboardEvent to trigger the CommandPalette.
- Response shape: HeaderNew renders an additional <kbd> element next to GlobalSearchBar. No existing elements removed or reordered.
- Status codes: not applicable, React component - no HTTP status codes involved. The kbd badge is a static UI element that dispatches a client-side KeyboardEvent; no network request is made.
- Frontend consumer: App.jsx (renders HeaderNew in the layout).
- Compatibility path or alias: the kbd badge uses var(--mac-*) design tokens with hardcoded fallbacks, so it works in both light and dark themes.
- Contract proof: frontend unit tests (including HeaderNew.test.jsx) will validate that the component still mounts.

## RBAC / Permissions

not applicable - no role gating or permission check changed. The kbd badge is visible to all authenticated users; the CommandPalette itself enforces RBAC internally.

## Notification / Realtime

- Event type or websocket channel: not applicable - no new events or websocket channels. The kbd click dispatches a local KeyboardEvent on document, which the CommandPalette's global listener picks up. No server-side event is emitted.
- Payload version / ack behavior: not applicable - no payloads sent to server.
- Read/unread or delivery semantics: not applicable - the kbd badge is a static UI element with no message queue.
- Reconnect/resync proof: not applicable - no realtime connection involved.

## Frontend Resilience

- Empty data proof: the kbd badge is static text ('⌘K') — no data dependency. Renders identically regardless of app state.
- Partial data proof: not applicable - the kbd badge has no data input. It is a static element with a hardcoded label and a click handler. There is no partial or missing data scenario.
- Forbidden secondary path behavior: not applicable - the click handler dispatches a synthetic event; if the CommandPalette is not mounted, the event is simply ignored by the document.
- Missing draft/resource behavior: not applicable - the kbd badge does not read or write drafts, resources, or any persistent state. It is a stateless trigger. If the CommandPalette component is unmounted (e.g. user not authenticated), the dispatched event has no listener and is harmlessly discarded.
- Stale route/deep-link behavior: not applicable - no route or deep-link handling changed.

## Scope Gate

- Allowed paths: frontend/src/components/layout/HeaderNew.jsx.
- Denied paths: all other files.
- Migration/docs/test impact: no migration; no docs; no new tests.
- Rollback note: revert the single commit; no data migration.

## Validation

- Targeted tests or smoke run: awaiting CI — frontend lint, unit tests (including HeaderNew.test.jsx), build, e2e.
- Result: pending.
- Not checked: manual click of the kbd badge to verify CommandPalette opens.

## Change list

- P-027: Low — Cmd+K shortcut badge in Header — commit 6cbc8490.
- P-024, P-025, P-028, P-029: skipped with documented rationale (see commit message).

Generated with Claude Code
