### PR TITLE
feat(cardio): P-019 surface EMR audit info in cardiologist panel

### DIFF
--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -1243,13 +1243,8 @@ const MacOSCardiologistPanelUnified = () => {
     }
   }, [selectedPatient, authRefreshTick]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Проверяем демо-режим после всех хуков
-  const isDemoMode = window.location.pathname.includes('/medilab-demo');
-
-  // В демо-режиме не рендерим компонент
-  if (isDemoMode) {
-    return null;
-  }
+  // isDemoMode and early return are already declared above (before the
+  // P-019 useEffect was inserted). The duplicate declaration was removed.
 
 
 

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -1234,12 +1234,22 @@ const MacOSCardiologistPanelUnified = () => {
   // specific action (call/complete/view_emr), not on initial patient
   // selection — so the doctor had no visibility into who last touched
   // the record.
+  // MUST be above the isDemoMode early return to satisfy the
+  // rules-of-hooks lint rule.
   useEffect(() => {
     const { visitId } = getSelectedPatientContext();
     if (visitId && selectedPatient) {
       loadEMR(visitId);
     }
   }, [selectedPatient, authRefreshTick]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Проверяем демо-режим после всех хуков
+  const isDemoMode = window.location.pathname.includes('/medilab-demo');
+
+  // В демо-режиме не рендерим компонент
+  if (isDemoMode) {
+    return null;
+  }
 
 
 

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -1046,6 +1046,21 @@ const MacOSCardiologistPanelUnified = () => {
     }
   };
 
+  // P-019 (UX audit): load EMR when a patient is selected so the audit
+  // badge on the visit tab can show status, version, last-modified, and
+  // signed-by. Previously EMR was only loaded when the doctor clicked a
+  // specific action (call/complete/view_emr), not on initial patient
+  // selection — so the doctor had no visibility into who last touched
+  // the record.
+  // MUST be above the isDemoMode early return to satisfy the
+  // rules-of-hooks lint rule (no conditional hook calls).
+  useEffect(() => {
+    const { visitId } = getSelectedPatientContext();
+    if (visitId && selectedPatient) {
+      loadEMR(visitId);
+    }
+  }, [selectedPatient, authRefreshTick]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Проверяем демо-режим после всех хуков
   const isDemoMode = window.location.pathname.includes('/medilab-demo');
 
@@ -1227,24 +1242,8 @@ const MacOSCardiologistPanelUnified = () => {
   };
 
   // Сохранение EMR
-
-  // P-019 (UX audit): load EMR when a patient is selected so the audit
-  // badge on the visit tab can show status, version, last-modified, and
-  // signed-by. Previously EMR was only loaded when the doctor clicked a
-  // specific action (call/complete/view_emr), not on initial patient
-  // selection — so the doctor had no visibility into who last touched
-  // the record.
-  // MUST be above the isDemoMode early return to satisfy the
-  // rules-of-hooks lint rule.
-  useEffect(() => {
-    const { visitId } = getSelectedPatientContext();
-    if (visitId && selectedPatient) {
-      loadEMR(visitId);
-    }
-  }, [selectedPatient, authRefreshTick]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // isDemoMode and early return are already declared above (before the
-  // P-019 useEffect was inserted). The duplicate declaration was removed.
+  // (P-019 useEffect was moved above the isDemoMode early return
+  //  to satisfy the rules-of-hooks lint rule. See line ~1049.)
 
 
 

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -118,7 +118,7 @@ const MacOSCardiologistPanelUnified = () => {
     ldlThreshold: 100,
     showEcgEchoTogether: true,
   });
-  const [, setEmr] = useState(null);
+  const [emr, setEmr] = useState(null);
 
   // Ref для отслеживания предыдущего пациента для очистки EMR
   const prevSelectedPatientRef = useRef(null);
@@ -1228,6 +1228,19 @@ const MacOSCardiologistPanelUnified = () => {
 
   // Сохранение EMR
 
+  // P-019 (UX audit): load EMR when a patient is selected so the audit
+  // badge on the visit tab can show status, version, last-modified, and
+  // signed-by. Previously EMR was only loaded when the doctor clicked a
+  // specific action (call/complete/view_emr), not on initial patient
+  // selection — so the doctor had no visibility into who last touched
+  // the record.
+  useEffect(() => {
+    const { visitId } = getSelectedPatientContext();
+    if (visitId && selectedPatient) {
+      loadEMR(visitId);
+    }
+  }, [selectedPatient, authRefreshTick]); // eslint-disable-line react-hooks/exhaustive-deps
+
 
 
 
@@ -1679,6 +1692,66 @@ const MacOSCardiologistPanelUnified = () => {
                     </div>
                 }
                 </div>
+
+                {/* P-019 (UX audit): EMR audit badge — show status, version,
+                    last-modified date, and who signed/amended the record.
+                    Previously this info was hidden inside the EMR container's
+                    toggle-only history panel; now the cardiologist sees it at
+                    a glance on the visit tab. */}
+                {emr && (
+                  <div className="cardio-emr-audit-badge" style={{
+                    marginTop: '12px',
+                    padding: '8px 12px',
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    alignItems: 'center',
+                    gap: '12px',
+                    fontSize: getFontSize('sm'),
+                    color: getColor('textSecondary'),
+                    background: emr.status === 'signed' ? 'var(--mac-success-bg, #f0fdf4)' : 'var(--mac-surface-secondary, #f8fafc)',
+                    border: `1px solid ${emr.status === 'signed' ? 'var(--mac-success-border, #bbf7d0)' : getColor('border')}`,
+                    borderRadius: '8px',
+                  }}>
+                    <span style={{ fontWeight: '600', color: getColor('text') }}>
+                      EMR #{emr.id ?? '—'}
+                    </span>
+                    <span style={{
+                      padding: '2px 8px',
+                      borderRadius: '4px',
+                      fontWeight: '600',
+                      fontSize: '11px',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.5px',
+                      background: emr.status === 'signed' ? '#16a34a' : emr.status === 'amended' ? '#ca8a04' : '#6b7280',
+                      color: '#ffffff',
+                    }}>
+                      {emr.status || 'draft'}
+                    </span>
+                    {emr.version != null && (
+                      <span title="Версия EMR">v{emr.version}</span>
+                    )}
+                    {emr.updated_at && (
+                      <span title="Последнее изменение">
+                        изм. {new Date(emr.updated_at).toLocaleDateString('ru-RU', {
+                          day: '2-digit', month: '2-digit', year: 'numeric',
+                          hour: '2-digit', minute: '2-digit',
+                        })}
+                      </span>
+                    )}
+                    {emr.signed_at && (
+                      <span title="Подписана">
+                        подписана {new Date(emr.signed_at).toLocaleDateString('ru-RU', {
+                          day: '2-digit', month: '2-digit', year: 'numeric',
+                        })}
+                      </span>
+                    )}
+                    {emr.signed_by != null && emr.signed_by > 0 && (
+                      <span title="Кем подписана">
+                        врач #{emr.signed_by}
+                      </span>
+                    )}
+                  </div>
+                )}
               </MacOSCard>
 
 


### PR DESCRIPTION
## Summary

- P-019 (Medium): the cardiologist had no visibility into who last modified a patient's EMR, when it was signed, or what its current status was. The EMRHistoryPanel existed inside EMRContainerV2 but was only accessible via a toggle button. Added an EMR audit badge to the patient card on the visit tab showing status, version, last-modified, and signed-by at a glance.
- Also fixed the `emr` useState destructuring (was `const [, setEmr]` — value ignored) and added a useEffect to load EMR on patient selection.

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main HEAD f6dc4847 (PR #1740 merge).
- Clean workspace: only frontend/src/pages/CardiologistPanelUnified.jsx changed.
- Branch: feature/audit-logs-clinical-ui
- Scope gate: allowed CardiologistPanelUnified.jsx; denied all other files.
- Red-check handling: fix failed CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: CardiologistPanelUnified React component (frontend-only, no API).
- Request shape: no API change. The new useEffect calls the existing GET /v2/emr/:visitId endpoint (same as loadEMR, which was already called from action handlers).
- Response shape: the patient card now renders an additional audit badge below the name/phone grid when emr data is loaded. No existing elements removed.
- Status codes: not applicable, React component - the audit badge reads from already-loaded emr state; no additional HTTP request beyond the existing loadEMR call.
- Frontend consumer: CardiologistPanelUnified.jsx (only consumer).
- Compatibility path or alias: the audit badge uses var(--mac-*) design tokens with hardcoded fallbacks. The emr object shape (id, version, status, updated_at, signed_at, signed_by) matches the existing GET /v2/emr/:visitId response.
- Contract proof: frontend unit tests (including DoctorPanels.contract.test.jsx) will validate that the component still mounts.

## RBAC / Permissions

not applicable - no role gating or permission check changed. The audit badge reads from EMR data that was already authorized by the existing loadEMR call. The GET /v2/emr/:visitId endpoint enforces RBAC server-side.

## Notification / Realtime

- Event type or websocket channel: not applicable - no new events or websocket channels. The audit badge is a passive display of already-loaded data.
- Payload version / ack behavior: not applicable - no payloads sent to server.
- Read/unread or delivery semantics: not applicable - the badge is a static display element.
- Reconnect/resync proof: not applicable - no realtime connection involved.

## Frontend Resilience

- Empty data proof: when emr is null (no EMR for this visit, or EMR not yet loaded), the audit badge is not rendered (the {emr && ...} guard). The patient card shows name/phone as before.
- Partial data proof: each field in the badge is individually guarded ({emr.version != null && ...}, {emr.updated_at && ...}, {emr.signed_at && ...}, {emr.signed_by != null && emr.signed_by > 0 && ...}). A partially-populated emr object renders only the available fields.
- Forbidden secondary path behavior: not applicable - the audit badge is read-only display; no user interaction.
- Missing draft/resource behavior: if emr is null (not just empty), the {emr && ...} guard short-circuits and the badge is not rendered. No crash.
- Stale route/deep-link behavior: not applicable - the useEffect that loads EMR fires on selectedPatient change, which covers deep-link scenarios.

## Scope Gate

- Allowed paths: frontend/src/pages/CardiologistPanelUnified.jsx.
- Denied paths: all other files.
- Migration/docs/test impact: no migration; no docs; no new tests.
- Rollback note: revert the single commit; no data migration.

## Validation

- Targeted tests or smoke run: awaiting CI - frontend lint, unit tests, build, e2e.
- Result: pending.
- Not checked: manual smoke of audit badge with signed/amended/draft EMR.

## Change list

- P-019: Medium - EMR audit badge in patient card - commit a3b8f53a.

Generated with Claude Code