### PR TITLE
refactor(cardio): R-15 extract EcgTab from CardiologistPanelUnified

### DIFF
--- a/frontend/src/components/cardiology/EcgTab.jsx
+++ b/frontend/src/components/cardiology/EcgTab.jsx
@@ -1,0 +1,70 @@
+/**
+ * EcgTab — R-15 (UX audit): extracted from CardiologistPanelUnified.
+ *
+ * Renders the "ЭКГ" tab content:
+ *   1. "Добавить ЭКГ" button
+ *   2. ECGViewer (file upload, parsing, AI analysis)
+ *   3. EchoForm (echocardiography results)
+ *
+ * All state stays in the parent. This is a presentational wrapper.
+ */
+
+import PropTypes from 'prop-types';
+import { Plus } from 'lucide-react';
+import { Button } from '../ui/macos';
+import ECGViewer from './ECGViewer';
+import EchoForm from './EchoForm';
+
+/**
+ * @param {Object} props
+ * @param {Object} props.selectedPatient - Currently selected patient
+ * @param {Function} props.onAddEcg - Open the ECG add flow
+ * @param {Function} props.onDataUpdate - Reload patient data after ECG/Echo changes
+ * @param {Function} props.getSpacing - Theme spacing getter
+ */
+export function EcgTab({
+  selectedPatient,
+  onAddEcg,
+  onDataUpdate,
+  getSpacing,
+}) {
+  if (!selectedPatient) {
+    return null;
+  }
+
+  return (
+    <div style={{
+      width: '100%',
+      maxWidth: 'none',
+      overflow: 'visible',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: getSpacing('xl'),
+    }}>
+      <div className="flex justify-end">
+        <Button onClick={onAddEcg}>
+          <Plus size={16} className="cardio-icon-mr" /> Добавить ЭКГ
+        </Button>
+      </div>
+      <ECGViewer
+        visitId={selectedPatient?.visit_id}
+        patientId={selectedPatient?.patient_id || selectedPatient?.patient?.id}
+        onDataUpdate={onDataUpdate}
+      />
+      <EchoForm
+        visitId={selectedPatient?.visit_id}
+        patientId={selectedPatient?.patient_id || selectedPatient?.patient?.id}
+        onDataUpdate={onDataUpdate}
+      />
+    </div>
+  );
+}
+
+EcgTab.propTypes = {
+  selectedPatient: PropTypes.object,
+  onAddEcg: PropTypes.func.isRequired,
+  onDataUpdate: PropTypes.func.isRequired,
+  getSpacing: PropTypes.func.isRequired,
+};
+
+export default EcgTab;

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -33,9 +33,8 @@ import './cardiology.css';
 import AppointmentSummaryBar from '../components/doctor/AppointmentSummaryBar';
 import DoctorServiceSelector from '../components/doctor/DoctorServiceSelector';
 import AIAssistant from '../components/ai/AIAssistant';
-import ECGViewer from '../components/cardiology/ECGViewer';
 import BloodTestsTab from '../components/cardiology/BloodTestsTab';
-import EchoForm from '../components/cardiology/EchoForm';
+import EcgTab from '../components/cardiology/EcgTab';
 import ScheduleNextModal from '../components/common/ScheduleNextModal';
 import EditPatientModal from '../components/common/EditPatientModal';
 import { queueService } from '../services/queue';
@@ -1816,37 +1815,14 @@ const MacOSCardiologistPanelUnified = () => {
             </MacOSCard>
           }
 
+          {/* ЭКГ — R-15: extracted to EcgTab component */}
           {activeTab === 'ecg' &&
-          <div style={{
-            width: '100%',
-            maxWidth: 'none',
-            overflow: 'visible',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: getSpacing('xl')
-          }}>
-              <div className="flex justify-end">
-                <Button onClick={() => setShowForm({ open: true, type: 'ecg' })}>
-                  <Plus size={16} className="cardio-icon-mr" /> Добавить ЭКГ
-                </Button>
-              </div>
-              {/* Используем новые компоненты ЭКГ и ЭхоКГ */}
-              <ECGViewer
-              visitId={selectedPatient?.visit_id}
-              patientId={selectedPatient?.patient_id || selectedPatient?.patient?.id}
-              onDataUpdate={() => {
-                loadPatientData();
-              }} />
-
-
-              <EchoForm
-              visitId={selectedPatient?.visit_id}
-              patientId={selectedPatient?.patient_id || selectedPatient?.patient?.id}
-              onDataUpdate={() => {
-                loadPatientData();
-              }} />
-
-            </div>
+            <EcgTab
+              selectedPatient={selectedPatient}
+              onAddEcg={() => setShowForm({ open: true, type: 'ecg' })}
+              onDataUpdate={loadPatientData}
+              getSpacing={getSpacing}
+            />
           }
 
           {/* Анализы крови — R-15: extracted to BloodTestsTab component */}


### PR DESCRIPTION
## Summary

- R-15 (High): second incremental extraction. Extracted the 'ecg' tab (ECGViewer + EchoForm + add button) into EcgTab.jsx. Also removed now-unused ECGViewer/EchoForm imports from the parent.
- CardiologistPanelUnified.jsx: 2311 → 2287 lines (total from original: 2698 → 2287, −411 lines, −15%).

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main HEAD 1257e64f (PR #1746 merge).
- Clean workspace: only EcgTab.jsx (new) and CardiologistPanelUnified.jsx (updated) changed.
- Branch: feature/r15-extract-ecg-tab
- Scope gate: allowed cardiologist panel + new EcgTab component; denied all other files.
- Red-check handling: fix failed CI checks in this same PR before merge.

## Contract Impact

- Canonical surface: CardiologistPanelUnified + EcgTab (frontend-only, no API).
- Request shape: no API change. EcgTab is a presentational wrapper around ECGViewer and EchoForm.
- Response shape: the ecg tab renders identically — same ECGViewer, same EchoForm, same add button.
- Status codes: not applicable, React components - no HTTP status codes involved.
- Frontend consumer: CardiologistPanelUnified.jsx (only consumer of EcgTab).
- Compatibility path or alias: EcgTab receives selectedPatient, onAddEcg, onDataUpdate, getSpacing via props. ECGViewer and EchoForm are imported directly by EcgTab (removed from parent imports).
- Contract proof: frontend unit tests + build validate that the panel still mounts.

## RBAC / Permissions

not applicable - no role gating or permission check changed. EcgTab is rendered inside CardiologistPanelUnified, which is already gated by RBAC.

## Notification / Realtime

- Event type or websocket channel: not applicable - no new events or websocket channels.
- Payload version / ack behavior: not applicable - no payloads sent to server.
- Read/unread or delivery semantics: not applicable - the component is a passive wrapper.
- Reconnect/resync proof: not applicable - no realtime connection involved.

## Frontend Resilience

- Empty data proof: when selectedPatient is null, EcgTab returns null (the parent's activeTab === 'ecg' guard also prevents rendering when no patient is selected).
- Partial data proof: EcgTab passes selectedPatient?.visit_id and selectedPatient?.patient_id with optional chaining — handles partial patient objects.
- Forbidden secondary path behavior: not applicable - EcgTab is the only rendering path for the ecg tab.
- Missing draft/resource behavior: if selectedPatient is null, EcgTab returns null — no crash.
- Stale route/deep-link behavior: not applicable - no route handling changed.

## Scope Gate

- Allowed paths: frontend/src/components/cardiology/EcgTab.jsx (new), frontend/src/pages/CardiologistPanelUnified.jsx (updated).
- Denied paths: all other files.
- Migration/docs/test impact: no migration; no docs; no new tests.
- Rollback note: revert the single commit. EcgTab.jsx is self-contained.

## Validation

- Targeted tests or smoke run: awaiting CI - frontend lint, unit tests, build, e2e.
- Result: pending.
- Not checked: visual regression (should be identical — same components, same props).

## Change list

- R-15 (incremental 2): High - extract EcgTab - commit ecb71a59.
  - CardiologistPanelUnified.jsx: 2311 → 2287 lines (−24)
  - EcgTab.jsx: new, 70 lines
  - Total from original: 2698 → 2287 (−411, −15%)

Generated with Claude Code