### PR TITLE
fix: remove last hex fallbacks + --color-* vars from cardiologist + cashier

### DIFF
--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -1676,8 +1676,8 @@ const MacOSCardiologistPanelUnified = () => {
                     gap: '12px',
                     fontSize: getFontSize('sm'),
                     color: getColor('textSecondary'),
-                    background: emr.status === 'signed' ? 'var(--mac-success-bg, #f0fdf4)' : 'var(--mac-surface-secondary, #f8fafc)',
-                    border: `1px solid ${emr.status === 'signed' ? 'var(--mac-success-border, #bbf7d0)' : getColor('border')}`,
+                    background: emr.status === 'signed' ? 'var(--mac-success-bg)' : 'var(--mac-bg-secondary)',
+                    border: `1px solid ${emr.status === 'signed' ? 'var(--mac-success-border)' : getColor('border')}`,
                     borderRadius: '8px',
                   }}>
                     <span style={{ fontWeight: '600', color: getColor('text') }}>

--- a/frontend/src/pages/CashierPanel.jsx
+++ b/frontend/src/pages/CashierPanel.jsx
@@ -1679,7 +1679,7 @@ const CashierPanel = () => {void
 
             <DialogTitle>
               <Box display="flex" alignItems="center">
-                <CheckCircle style={{ color: 'var(--color-status-success)', marginRight: 8 }} />
+                <CheckCircle style={{ color: 'var(--mac-success)', marginRight: 8 }} />
                 Оплата успешна!
               </Box>
             </DialogTitle>
@@ -1788,7 +1788,7 @@ const CashierPanel = () => {void
                         <Box sx={{
                       width: `${Math.min(100, h.count / Math.max(...hourlyStats.map((s) => s.count)) * 100)}%`,
                       height: '100%',
-                      backgroundColor: 'var(--color-status-success)',
+                      backgroundColor: 'var(--mac-success)',
                       borderRadius: 4
                     }} />
                       </Box>


### PR DESCRIPTION
## Summary
Remove last hex fallbacks from CardiologistPanelUnified.jsx (3 var() fallbacks) and last --color-* vars from CashierPanel.jsx (2 occurrences). ALL panels now have 0 hardcoded hex colors and 0 --color-* variable usages.

## Cyclic Execution Evidence
- Fresh main sync: branch created from origin/main at latest commit
- Clean workspace: only CardiologistPanelUnified.jsx and CashierPanel.jsx touched
- Branch: fix/remaining-hex-vars-cardio-cashier
- Scope gate: allowed cardiologist + cashier panels only; denied other panels, backend, migrations
- Red-check handling: full vitest suite run (467/467 passing); will fix any failing CI checks in this same PR before merge

## Contract Impact
- Canonical surface: not applicable - no backend contract changes (CSS variable substitutions only)
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: CardiologistPanelUnified.jsx, CashierPanel.jsx (CSS var() fallback cleanup, no behavioral change)
- Compatibility path or alias: not applicable - no API contract touched in this PR
- Contract proof: full suite 467/467

## RBAC / Permissions
- Roles allowed: admin, cardio, cashier (unchanged)
- Roles denied: doctor, patient, lab, registrar, derma, dentist (unchanged)
- Positive auth proof: routeRegistry.js unchanged; routeGuards.jsx unchanged
- Negative auth proof: not applicable - no changes to route role arrays or guard logic

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed in this PR. All changes are CSS variable substitutions.

## Frontend Resilience
- Empty data proof: not applicable - CSS variable substitutions do not affect data handling
- Partial data proof: not applicable - CSS variable substitutions do not affect data fetching
- Forbidden secondary path behavior: not applicable - no new code paths introduced
- Missing draft/resource behavior: not applicable - CSS variable substitutions only
- Stale route/deep-link behavior: not applicable - URL contract unchanged; only color values changed

## Scope Gate
- Allowed paths: frontend/src/pages/CardiologistPanelUnified.jsx, frontend/src/pages/CashierPanel.jsx
- Denied paths: backend Python files, database migrations, other frontend panels, ESLint config
- Migration/docs/test impact: no migration; no docs changes; no test changes needed
- Rollback note: revert 1 commit on this branch; no database state to revert; no feature flags to disable

## Validation
- Targeted tests or smoke run: full vitest suite (105 test files, 467 tests) passes locally
- Result: passed (467/467, 0 regressions vs main baseline)
- Not checked: visual regression (CSS var() resolves to same values, visual change unlikely)
