### PR TITLE
fix(ruff): PEP 604 annotations — Optional[X] → X | None (1164 sites, UP045)

### DIFF
--- a/backend/app/api/v1/endpoints/activation.py
+++ b/backend/app/api/v1/endpoints/activation.py
@@ -87,11 +87,11 @@ async def activation_status(
     "/list", response_model=ActivationListOut, summary="Список выданных ключей (Admin)"
 )
 async def activation_list(
-    status: Optional[str] = Query(
+    status: str | None = Query(
         None, description="issued|trial|active|expired|revoked"
     ),
-    key_like: Optional[str] = Query(None, description="подстрока ключа"),
-    machine_hash: Optional[str] = Query(None),
+    key_like: str | None = Query(None, description="подстрока ключа"),
+    machine_hash: str | None = Query(None),
     limit: int = Query(100, ge=1, le=1000),
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),

--- a/backend/app/api/v1/endpoints/admin_ai.py
+++ b/backend/app/api/v1/endpoints/admin_ai.py
@@ -288,8 +288,8 @@ def update_ai_settings(
 @router.get("/ai/stats", response_model=AIStatsResponse)
 def get_ai_stats(
     days_back: int = 30,
-    provider_id: Optional[int] = None,
-    specialty: Optional[str] = None,
+    provider_id: int | None = None,
+    specialty: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -307,9 +307,9 @@ def get_ai_stats(
 def get_ai_usage_logs(
     skip: int = 0,
     limit: int = 100,
-    provider_id: Optional[int] = None,
-    task_type: Optional[str] = None,
-    success_only: Optional[bool] = None,
+    provider_id: int | None = None,
+    task_type: str | None = None,
+    success_only: bool | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):

--- a/backend/app/api/v1/endpoints/admin_appointments.py
+++ b/backend/app/api/v1/endpoints/admin_appointments.py
@@ -106,11 +106,11 @@ def _resolve_effective_cabinet(
 def list_admin_appointments(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=500),
-    patient_id: Optional[int] = Query(None),
-    doctor_id: Optional[int] = Query(None),
-    status_filter: Optional[str] = Query(None, alias="status"),
-    date_from: Optional[str] = Query(None),
-    date_to: Optional[str] = Query(None),
+    patient_id: int | None = Query(None),
+    doctor_id: int | None = Query(None),
+    status_filter: str | None = Query(None, alias="status"),
+    date_from: str | None = Query(None),
+    date_to: str | None = Query(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):

--- a/backend/app/api/v1/endpoints/admin_clinic.py
+++ b/backend/app/api/v1/endpoints/admin_clinic.py
@@ -352,7 +352,7 @@ def get_system_info(current_user: User = Depends(require_roles("Admin"))):
 
 @router.get("/service-categories", response_model=list[ServiceCategoryOut])
 def get_service_categories(
-    specialty: Optional[str] = None,
+    specialty: str | None = None,
     active_only: bool = True,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),

--- a/backend/app/api/v1/endpoints/admin_departments.py
+++ b/backend/app/api/v1/endpoints/admin_departments.py
@@ -42,16 +42,16 @@ ADMIN_DEPARTMENTS_PUBLIC_ERROR = "Internal server error"
 class DepartmentIntegrationOptions(BaseModel):
     """Настройки автоматической интеграции отделения в очередь/услуги."""
 
-    queue_prefix: Optional[str] = Field(None, max_length=10)
-    queue_type: Optional[str] = Field(None, pattern="^(live|online|mixed)$")
-    auto_close_time: Optional[str] = Field(None, max_length=5)
-    start_number: Optional[int] = Field(None, ge=1, le=999)
-    max_daily_queue: Optional[int] = Field(None, ge=1, le=9999)
-    service_name: Optional[str] = Field(None, max_length=256)
-    service_code: Optional[str] = Field(None, max_length=32)
-    service_price: Optional[Decimal] = None
-    service_currency: Optional[str] = Field("UZS", max_length=8)
-    service_category_code: Optional[str] = Field(None, max_length=2)
+    queue_prefix: str | None = Field(None, max_length=10)
+    queue_type: str | None = Field(None, pattern="^(live|online|mixed)$")
+    auto_close_time: str | None = Field(None, max_length=5)
+    start_number: int | None = Field(None, ge=1, le=999)
+    max_daily_queue: int | None = Field(None, ge=1, le=9999)
+    service_name: str | None = Field(None, max_length=256)
+    service_code: str | None = Field(None, max_length=32)
+    service_price: Decimal | None = None
+    service_currency: str | None = Field("UZS", max_length=8)
+    service_category_code: str | None = Field(None, max_length=2)
 
 
 class DepartmentCreate(BaseModel):
@@ -59,27 +59,27 @@ class DepartmentCreate(BaseModel):
 
     key: str
     name_ru: str
-    name_uz: Optional[str] = None
-    icon: Optional[str] = "folder"
-    color: Optional[str] = None
-    gradient: Optional[str] = None
-    display_order: Optional[int] = 999
-    active: Optional[bool] = True
-    description: Optional[str] = None
-    integration: Optional[DepartmentIntegrationOptions] = None
+    name_uz: str | None = None
+    icon: str | None = "folder"
+    color: str | None = None
+    gradient: str | None = None
+    display_order: int | None = 999
+    active: bool | None = True
+    description: str | None = None
+    integration: DepartmentIntegrationOptions | None = None
 
 
 class DepartmentUpdate(BaseModel):
     """Схема для обновления отделения"""
 
-    name_ru: Optional[str] = None
-    name_uz: Optional[str] = None
-    icon: Optional[str] = None
-    color: Optional[str] = None
-    gradient: Optional[str] = None
-    display_order: Optional[int] = None
-    active: Optional[bool] = None
-    description: Optional[str] = None
+    name_ru: str | None = None
+    name_uz: str | None = None
+    icon: str | None = None
+    color: str | None = None
+    gradient: str | None = None
+    display_order: int | None = None
+    active: bool | None = None
+    description: str | None = None
 
 
 class DepartmentResponse(BaseModel):
@@ -88,13 +88,13 @@ class DepartmentResponse(BaseModel):
     id: int
     key: str
     name_ru: str
-    name_uz: Optional[str]
+    name_uz: str | None
     icon: str
-    color: Optional[str]
-    gradient: Optional[str]
+    color: str | None
+    gradient: str | None
     display_order: int
     active: bool
-    description: Optional[str]
+    description: str | None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -102,7 +102,7 @@ class DepartmentResponse(BaseModel):
 class DepartmentResponseWithSettings(DepartmentResponse):
     """Схема ответа отделения с настройками"""
 
-    queue_prefix: Optional[str] = None
+    queue_prefix: str | None = None
 
 
 def _default_stats() -> dict[str, int]:
@@ -137,7 +137,7 @@ def _ensure_clinic_setting(
 def _ensure_department_integrations(
     db: Session,
     department: Department,
-    options: Optional[DepartmentIntegrationOptions] = None,
+    options: DepartmentIntegrationOptions | None = None,
 ) -> dict[str, Any]:
     """Гарантирует, что отделение подключено к очередям, услугам и мастеру регистрации."""
     opts = options.dict(exclude_unset=True) if options else {}
@@ -573,7 +573,7 @@ def update_department(
 @router.post("/{department_id}/initialize", response_model=dict, include_in_schema=False)
 def initialize_department(
     department_id: int,
-    integration: Optional[DepartmentIntegrationOptions] = None,
+    integration: DepartmentIntegrationOptions | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -955,7 +955,7 @@ def _legacy_departments_overview_payload(
 @router.post("/{department_id}/initialize", response_model=dict)
 def initialize_department(
     department_id: int,
-    payload: Optional[dict[str, Any]] = None,
+    payload: dict[str, Any] | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):

--- a/backend/app/api/v1/endpoints/admin_doctors.py
+++ b/backend/app/api/v1/endpoints/admin_doctors.py
@@ -110,7 +110,7 @@ def get_doctors(
     skip: int = 0,
     limit: int = 100,
     active_only: bool = False,
-    specialty: Optional[str] = None,
+    specialty: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -128,7 +128,7 @@ def get_doctors(
 
 @router.get("/doctors/available-users", response_model=list[DoctorUserOption])
 def get_available_doctor_users(
-    doctor_id: Optional[int] = Query(
+    doctor_id: int | None = Query(
         None,
         description="ID редактируемого врача, чтобы вернуть уже привязанного пользователя",
     ),

--- a/backend/app/api/v1/endpoints/admin_stats.py
+++ b/backend/app/api/v1/endpoints/admin_stats.py
@@ -482,8 +482,8 @@ def get_analytics_overview(
     period: str = Query(
         "week", description="Период: today, week, month, quarter, year"
     ),
-    department: Optional[str] = Query(None, description="Отделение (опционально)"),
-    doctor_id: Optional[int] = Query(None, description="ID врача (опционально)"),
+    department: str | None = Query(None, description="Отделение (опционально)"),
+    doctor_id: int | None = Query(None, description="ID врача (опционально)"),
     db: Session = Depends(get_db),
     _: User = Depends(require_roles("Admin")),
 ) -> dict[str, Any]:
@@ -647,7 +647,7 @@ def get_analytics_charts(
     chart_type: str = Query(
         "appointments", description="Тип графика: appointments, revenue"
     ),
-    department: Optional[str] = Query(None, description="Отделение (опционально)"),
+    department: str | None = Query(None, description="Отделение (опционально)"),
     db: Session = Depends(get_db),
     _: User = Depends(require_roles("Admin")),
 ) -> dict[str, Any]:

--- a/backend/app/api/v1/endpoints/admin_telegram.py
+++ b/backend/app/api/v1/endpoints/admin_telegram.py
@@ -2293,7 +2293,7 @@ def _sanitize_telegram_webhook_info(webhook_info: dict[str, Any]) -> dict[str, A
 
 
 class TelegramWebhookRequest(BaseModel):
-    webhook_url: Optional[str] = None
+    webhook_url: str | None = None
 
 
 def _has_secret_value(value: Any) -> bool:
@@ -2745,8 +2745,8 @@ async def register_staff_bot_commands(
 
 @router.post("/telegram/set-webhook")
 def set_telegram_webhook(
-    payload: Optional[TelegramWebhookRequest] = Body(default=None),
-    webhook_url: Optional[str] = Query(default=None),
+    payload: TelegramWebhookRequest | None = Body(default=None),
+    webhook_url: str | None = Query(default=None),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -3089,7 +3089,7 @@ def get_telegram_integration_status(
 @router.get("/telegram/templates")
 def get_telegram_templates(
     language: str = "ru",
-    template_type: Optional[str] = None,
+    template_type: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):

--- a/backend/app/api/v1/endpoints/advanced_analytics.py
+++ b/backend/app/api/v1/endpoints/advanced_analytics.py
@@ -23,7 +23,7 @@ FINANCIAL_ADVANCED_ANALYTICS_ROLES = ["admin", "manager"]
 async def get_kpi_metrics(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ADVANCED_ANALYTICS_ROLES)),
 ):
@@ -48,7 +48,7 @@ async def get_kpi_metrics(
 async def get_doctor_performance(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ADVANCED_ANALYTICS_ROLES)),
 ):
@@ -95,7 +95,7 @@ async def get_advanced_patient_analytics(
 async def get_advanced_revenue_analytics(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ADVANCED_ANALYTICS_ROLES)),
 ):
@@ -132,7 +132,7 @@ async def get_predictive_analytics(
 async def get_advanced_comprehensive_report(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     include_predictive: bool = Query(
         True, description="Включить предиктивную аналитику"
     ),

--- a/backend/app/api/v1/endpoints/ai.py
+++ b/backend/app/api/v1/endpoints/ai.py
@@ -66,9 +66,9 @@ class ComplaintAnalysisRequest(BaseModel):
     """Запрос на анализ жалоб"""
 
     complaint: str
-    patient_age: Optional[int] = None
-    patient_gender: Optional[str] = None
-    provider: Optional[AIProviderType] = None
+    patient_age: int | None = None
+    patient_gender: str | None = None
+    provider: AIProviderType | None = None
     use_mcp: bool = True  # Использовать MCP по умолчанию
 
 
@@ -76,27 +76,27 @@ class ICD10SuggestRequest(BaseModel):
     """Запрос на подсказки МКБ-10"""
 
     symptoms: list[str]
-    diagnosis: Optional[str] = None
-    provider: Optional[AIProviderType] = None
+    diagnosis: str | None = None
+    provider: AIProviderType | None = None
 
 
 class LabInterpretRequest(BaseModel):
     """Запрос на интерпретацию анализов"""
 
     results: list[dict[str, Any]]
-    patient_age: Optional[int] = None
-    patient_gender: Optional[str] = None
-    provider: Optional[AIProviderType] = None
+    patient_age: int | None = None
+    patient_gender: str | None = None
+    provider: AIProviderType | None = None
 
 
 class ECGInterpretRequest(BaseModel):
     """Запрос на интерпретацию ЭКГ"""
 
     parameters: dict[str, Any]
-    auto_interpretation: Optional[str] = None
-    patient_age: Optional[int] = None
-    patient_gender: Optional[str] = None
-    provider: Optional[AIProviderType] = None
+    auto_interpretation: str | None = None
+    patient_age: int | None = None
+    patient_gender: str | None = None
+    provider: AIProviderType | None = None
 
 
 @router.get("/providers")
@@ -227,8 +227,8 @@ async def interpret_lab_results(
 @router.post("/skin-analyze")
 async def analyze_skin(
     image: UploadFile = File(...),
-    metadata: Optional[str] = Form(None),
-    provider: Optional[AIProviderType] = Form(None),
+    metadata: str | None = Form(None),
+    provider: AIProviderType | None = Form(None),
     current_user: User = Depends(get_current_user),
 ) -> dict[str, Any]:
     """Анализ состояния кожи по фото"""
@@ -301,23 +301,23 @@ class DifferentialDiagnosisRequest(BaseModel):
     """Запрос на дифференциальную диагностику"""
 
     symptoms: list[str]
-    patient_info: Optional[dict[str, Any]] = None
-    provider: Optional[AIProviderType] = None
+    patient_info: dict[str, Any] | None = None
+    provider: AIProviderType | None = None
 
 
 class SymptomAnalysisRequest(BaseModel):
     """Запрос на анализ симптомов"""
 
     symptoms: list[str]
-    severity: Optional[list[int]] = None
-    provider: Optional[AIProviderType] = None
+    severity: list[int] | None = None
+    provider: AIProviderType | None = None
 
 
 class ClinicalDecisionRequest(BaseModel):
     """Запрос на поддержку клинических решений"""
 
     case_data: dict[str, Any]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 @router.post("/differential-diagnosis")
@@ -374,15 +374,15 @@ class MedicalImageAnalysisRequest(BaseModel):
     """Запрос на анализ медицинского изображения"""
 
     image_type: str  # xray, ultrasound, dermatoscopy, generic
-    metadata: Optional[dict[str, Any]] = None
-    provider: Optional[AIProviderType] = None
+    metadata: dict[str, Any] | None = None
+    provider: AIProviderType | None = None
 
 
 @router.post("/analyze-xray")
 async def analyze_xray_image(
     image: UploadFile = File(...),
-    metadata: Optional[str] = Form(None),
-    provider: Optional[AIProviderType] = Form(None),
+    metadata: str | None = Form(None),
+    provider: AIProviderType | None = Form(None),
     current_user: User = Depends(get_current_user),
 ):
     """Анализ рентгеновского снимка"""
@@ -415,8 +415,8 @@ async def analyze_xray_image(
 @router.post("/analyze-ultrasound")
 async def analyze_ultrasound_image(
     image: UploadFile = File(...),
-    metadata: Optional[str] = Form(None),
-    provider: Optional[AIProviderType] = Form(None),
+    metadata: str | None = Form(None),
+    provider: AIProviderType | None = Form(None),
     current_user: User = Depends(get_current_user),
 ):
     """Анализ УЗИ изображения"""
@@ -449,8 +449,8 @@ async def analyze_ultrasound_image(
 @router.post("/analyze-dermatoscopy")
 async def analyze_dermatoscopy_image(
     image: UploadFile = File(...),
-    metadata: Optional[str] = Form(None),
-    provider: Optional[AIProviderType] = Form(None),
+    metadata: str | None = Form(None),
+    provider: AIProviderType | None = Form(None),
     current_user: User = Depends(get_current_user),
 ):
     """Анализ дерматоскопического изображения"""
@@ -484,8 +484,8 @@ async def analyze_dermatoscopy_image(
 async def analyze_medical_image_generic(
     image: UploadFile = File(...),
     image_type: str = Form(...),
-    metadata: Optional[str] = Form(None),
-    provider: Optional[AIProviderType] = Form(None),
+    metadata: str | None = Form(None),
+    provider: AIProviderType | None = Form(None),
     current_user: User = Depends(get_current_user),
 ):
     """Универсальный анализ медицинского изображения"""
@@ -523,8 +523,8 @@ class TreatmentPlanRequest(BaseModel):
 
     patient_data: dict[str, Any]
     diagnosis: str
-    medical_history: Optional[list[dict[str, Any]]] = None
-    provider: Optional[AIProviderType] = None
+    medical_history: list[dict[str, Any]] | None = None
+    provider: AIProviderType | None = None
 
 
 class MedicationOptimizationRequest(BaseModel):
@@ -533,7 +533,7 @@ class MedicationOptimizationRequest(BaseModel):
     current_medications: list[dict[str, Any]]
     patient_profile: dict[str, Any]
     condition: str
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class TreatmentEffectivenessRequest(BaseModel):
@@ -541,7 +541,7 @@ class TreatmentEffectivenessRequest(BaseModel):
 
     treatment_history: list[dict[str, Any]]
     patient_response: dict[str, Any]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class LifestyleModificationsRequest(BaseModel):
@@ -549,7 +549,7 @@ class LifestyleModificationsRequest(BaseModel):
 
     patient_profile: dict[str, Any]
     conditions: list[str]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 @router.post("/generate-treatment-plan")
@@ -629,8 +629,8 @@ class DrugInteractionRequest(BaseModel):
     """Запрос на проверку лекарственных взаимодействий"""
 
     medications: list[dict[str, Any]]
-    patient_profile: Optional[dict[str, Any]] = None
-    provider: Optional[AIProviderType] = None
+    patient_profile: dict[str, Any] | None = None
+    provider: AIProviderType | None = None
 
 
 class DrugSafetyRequest(BaseModel):
@@ -639,7 +639,7 @@ class DrugSafetyRequest(BaseModel):
     medication: dict[str, Any]
     patient_profile: dict[str, Any]
     conditions: list[str]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class DrugAlternativesRequest(BaseModel):
@@ -648,7 +648,7 @@ class DrugAlternativesRequest(BaseModel):
     medication: str
     reason: str
     patient_profile: dict[str, Any]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class DrugDosageRequest(BaseModel):
@@ -657,7 +657,7 @@ class DrugDosageRequest(BaseModel):
     medication: str
     patient_profile: dict[str, Any]
     indication: str
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 @router.post("/check-drug-interactions")
@@ -737,7 +737,7 @@ class RiskAssessmentRequest(BaseModel):
     patient_data: dict[str, Any]
     risk_factors: list[str]
     condition: str
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class ComplicationPredictionRequest(BaseModel):
@@ -746,7 +746,7 @@ class ComplicationPredictionRequest(BaseModel):
     patient_profile: dict[str, Any]
     procedure_or_condition: str
     timeline: str
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class MortalityRiskRequest(BaseModel):
@@ -754,8 +754,8 @@ class MortalityRiskRequest(BaseModel):
 
     patient_data: dict[str, Any]
     condition: str
-    scoring_system: Optional[str] = None
-    provider: Optional[AIProviderType] = None
+    scoring_system: str | None = None
+    provider: AIProviderType | None = None
 
 
 class SurgicalRiskRequest(BaseModel):
@@ -764,7 +764,7 @@ class SurgicalRiskRequest(BaseModel):
     patient_profile: dict[str, Any]
     surgery_type: str
     anesthesia_type: str
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class ReadmissionRiskRequest(BaseModel):
@@ -773,7 +773,7 @@ class ReadmissionRiskRequest(BaseModel):
     patient_data: dict[str, Any]
     discharge_condition: str
     social_factors: dict[str, Any]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 @router.post("/assess-patient-risk")
@@ -872,7 +872,7 @@ class AudioTranscriptionRequest(BaseModel):
 
     language: str = "ru"
     medical_context: bool = True
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class TextStructuringRequest(BaseModel):
@@ -880,29 +880,29 @@ class TextStructuringRequest(BaseModel):
 
     text: str
     document_type: str  # consultation, prescription, discharge, examination
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class EntityExtractionRequest(BaseModel):
     """Запрос на извлечение медицинских сущностей"""
 
     text: str
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class MedicalSummaryRequest(BaseModel):
     """Запрос на генерацию медицинского резюме"""
 
     consultation_text: str
-    patient_history: Optional[str] = None
-    provider: Optional[AIProviderType] = None
+    patient_history: str | None = None
+    provider: AIProviderType | None = None
 
 
 class RecordValidationRequest(BaseModel):
     """Запрос на валидацию медицинской записи"""
 
     record_data: dict[str, Any]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 @router.post("/transcribe-audio")
@@ -1007,7 +1007,7 @@ class ScheduleOptimizationRequest(BaseModel):
 
     schedule_data: dict[str, Any]
     constraints: dict[str, Any]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class AppointmentDurationRequest(BaseModel):
@@ -1015,7 +1015,7 @@ class AppointmentDurationRequest(BaseModel):
 
     appointment_data: dict[str, Any]
     historical_data: list[dict[str, Any]]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class OptimalSlotsRequest(BaseModel):
@@ -1024,7 +1024,7 @@ class OptimalSlotsRequest(BaseModel):
     doctor_profile: dict[str, Any]
     patient_requirements: dict[str, Any]
     available_slots: list[dict[str, Any]]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class WorkloadAnalysisRequest(BaseModel):
@@ -1032,7 +1032,7 @@ class WorkloadAnalysisRequest(BaseModel):
 
     doctors_data: list[dict[str, Any]]
     time_period: str
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class ShiftRecommendationsRequest(BaseModel):
@@ -1040,7 +1040,7 @@ class ShiftRecommendationsRequest(BaseModel):
 
     department_data: dict[str, Any]
     staffing_requirements: dict[str, Any]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 @router.post("/optimize-doctor-schedule")
@@ -1134,7 +1134,7 @@ class DocumentationQualityRequest(BaseModel):
 
     medical_records: list[dict[str, Any]]
     quality_standards: dict[str, Any]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class DocumentationGapsRequest(BaseModel):
@@ -1142,7 +1142,7 @@ class DocumentationGapsRequest(BaseModel):
 
     patient_record: dict[str, Any]
     required_fields: list[str]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class DocumentationImprovementsRequest(BaseModel):
@@ -1150,7 +1150,7 @@ class DocumentationImprovementsRequest(BaseModel):
 
     record_analysis: dict[str, Any]
     best_practices: dict[str, Any]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class ClinicalConsistencyRequest(BaseModel):
@@ -1159,7 +1159,7 @@ class ClinicalConsistencyRequest(BaseModel):
     diagnosis: str
     symptoms: list[str]
     treatment: dict[str, Any]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class PrescriptionSafetyRequest(BaseModel):
@@ -1167,7 +1167,7 @@ class PrescriptionSafetyRequest(BaseModel):
 
     prescriptions: list[dict[str, Any]]
     patient_profile: dict[str, Any]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 @router.post("/analyze-documentation-quality")
@@ -1263,7 +1263,7 @@ class MedicalTrendsRequest(BaseModel):
     medical_data: list[dict[str, Any]]
     time_period: str
     analysis_type: str
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class AnomalyDetectionRequest(BaseModel):
@@ -1271,7 +1271,7 @@ class AnomalyDetectionRequest(BaseModel):
 
     dataset: list[dict[str, Any]]
     baseline_data: dict[str, Any]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class OutcomePredictionRequest(BaseModel):
@@ -1279,7 +1279,7 @@ class OutcomePredictionRequest(BaseModel):
 
     patient_data: dict[str, Any]
     historical_outcomes: list[dict[str, Any]]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class InsightsReportRequest(BaseModel):
@@ -1287,7 +1287,7 @@ class InsightsReportRequest(BaseModel):
 
     analytics_data: dict[str, Any]
     report_type: str
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 class RiskPatternsRequest(BaseModel):
@@ -1295,7 +1295,7 @@ class RiskPatternsRequest(BaseModel):
 
     population_data: list[dict[str, Any]]
     risk_factors: list[str]
-    provider: Optional[AIProviderType] = None
+    provider: AIProviderType | None = None
 
 
 @router.post("/analyze-medical-trends")

--- a/backend/app/api/v1/endpoints/ai_analytics.py
+++ b/backend/app/api/v1/endpoints/ai_analytics.py
@@ -44,7 +44,7 @@ class AIUsageTrackingRequest(BaseModel):
     output_data: dict = Field(..., description="Выходные данные")
     execution_time: float = Field(..., description="Время выполнения в секундах")
     success: bool = Field(True, description="Успешность выполнения")
-    error_message: Optional[str] = Field(None, description="Сообщение об ошибке")
+    error_message: str | None = Field(None, description="Сообщение об ошибке")
 
 
 class AIUsageAnalyticsResponse(BaseModel):
@@ -141,8 +141,8 @@ async def track_ai_usage(
 async def get_ai_usage_analytics(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    user_id: Optional[int] = Query(None, description="Фильтр по пользователю"),
-    ai_function: Optional[str] = Query(None, description="Фильтр по AI функции"),
+    user_id: int | None = Query(None, description="Фильтр по пользователю"),
+    ai_function: str | None = Query(None, description="Фильтр по AI функции"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles(["Admin"])),
 ):
@@ -547,7 +547,7 @@ async def compare_ai_models(
 # ===================== ВСПОМОГАТЕЛЬНЫЕ ФУНКЦИИ =====================
 
 
-def _get_most_used_function(function_breakdown: dict) -> Optional[str]:
+def _get_most_used_function(function_breakdown: dict) -> str | None:
     """Находит наиболее используемую AI функцию"""
     if not function_breakdown:
         return None

--- a/backend/app/api/v1/endpoints/ai_chat.py
+++ b/backend/app/api/v1/endpoints/ai_chat.py
@@ -51,17 +51,17 @@ def _build_ai_ws_payload(event_type: str, session_id: int | None = None, **data:
 
 class ChatSessionCreate(BaseModel):
     """Создание новой сессии"""
-    context_type: Optional[str] = Field(None, description="emr, lab, general, triage")
-    context_id: Optional[int] = Field(None, description="ID связанной сущности")
-    specialty: Optional[str] = Field(None, description="Специализация для персонализации")
+    context_type: str | None = Field(None, description="emr, lab, general, triage")
+    context_id: int | None = Field(None, description="ID связанной сущности")
+    specialty: str | None = Field(None, description="Специализация для персонализации")
 
 
 class ChatSessionResponse(BaseModel):
     """Ответ с информацией о сессии"""
     id: int
-    title: Optional[str]
-    context_type: Optional[str]
-    specialty: Optional[str]
+    title: str | None
+    context_type: str | None
+    specialty: str | None
     is_active: bool
     message_count: int
     created_at: str
@@ -81,10 +81,10 @@ class ChatMessageResponse(BaseModel):
     id: int
     role: str
     content: str
-    provider: Optional[str]
-    model: Optional[str]
-    tokens_used: Optional[int]
-    latency_ms: Optional[int]
+    provider: str | None
+    model: str | None
+    tokens_used: int | None
+    latency_ms: int | None
     is_error: bool
     was_cached: bool
     created_at: str
@@ -95,8 +95,8 @@ class ChatMessageResponse(BaseModel):
 class ChatFeedbackCreate(BaseModel):
     """Feedback на сообщение AI"""
     feedback_type: str = Field(..., description="helpful, not_helpful, incorrect, inappropriate")
-    comment: Optional[str] = Field(None, max_length=1000)
-    correction: Optional[str] = Field(None, max_length=5000)
+    comment: str | None = Field(None, max_length=1000)
+    correction: str | None = Field(None, max_length=5000)
 
 
 # =============================================================================
@@ -210,7 +210,7 @@ async def delete_session(
 async def get_messages(
     session_id: int,
     limit: int = Query(50, ge=1, le=200),
-    before_id: Optional[int] = Query(None, description="Pagination: get messages before this ID"),
+    before_id: int | None = Query(None, description="Pagination: get messages before this ID"),
     current_user: User = Depends(require_ai_permission(AIPermission.CHAT)),
     db: Session = Depends(get_db)
 ):
@@ -297,7 +297,7 @@ async def add_feedback(
 # WebSocket Endpoint for Streaming
 # =============================================================================
 
-async def authenticate_websocket(token: str, db: Session) -> Optional[User]:
+async def authenticate_websocket(token: str, db: Session) -> User | None:
     """
     Аутентификация WebSocket по JWT token.
     """
@@ -360,7 +360,7 @@ async def chat_websocket(
     logger.info(f"WebSocket chat connected: user={user.id}")
 
     service = get_chat_service(db)
-    current_session_id: Optional[int] = None
+    current_session_id: int | None = None
 
     try:
         async for message in websocket.iter_json():

--- a/backend/app/api/v1/endpoints/ai_tracking.py
+++ b/backend/app/api/v1/endpoints/ai_tracking.py
@@ -35,8 +35,8 @@ def _ai_tracking_http_error(exc: Exception, operation: str) -> HTTPException:
 @router.get("/models/stats", response_model=list[AIModelStats])
 async def get_ai_model_stats(
     days_back: int = Query(30, ge=1, le=365, description="Количество дней назад"),
-    provider_id: Optional[int] = Query(None, description="ID провайдера"),
-    specialty: Optional[str] = Query(None, description="Специализация"),
+    provider_id: int | None = Query(None, description="ID провайдера"),
+    specialty: str | None = Query(None, description="Специализация"),
     db: Session = Depends(get_db),
 ):
     """

--- a/backend/app/api/v1/endpoints/analytics_export.py
+++ b/backend/app/api/v1/endpoints/analytics_export.py
@@ -54,7 +54,7 @@ async def export_kpi_report(
     format: str,
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ANALYTICS_EXPORT_ROLES)),
 ):
@@ -101,7 +101,7 @@ async def export_comprehensive_report(
     format: str,
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     include_predictive: bool = Query(
         True, description="Включить предиктивную аналитику"
     ),
@@ -175,7 +175,7 @@ async def export_doctor_performance_report(
     format: str,
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(CLINICAL_ANALYTICS_EXPORT_ROLES)),
 ):
@@ -223,7 +223,7 @@ async def export_revenue_report(
     format: str,
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ANALYTICS_EXPORT_ROLES)),
 ):

--- a/backend/app/api/v1/endpoints/analytics_kpi.py
+++ b/backend/app/api/v1/endpoints/analytics_kpi.py
@@ -40,7 +40,7 @@ def _percentage_change(current: float, previous: float) -> float:
 
 
 def _build_kpi_snapshot(
-    db: Session, start: datetime, end: datetime, department: Optional[str]
+    db: Session, start: datetime, end: datetime, department: str | None
 ) -> dict:
     analytics_service = get_advanced_analytics_service()
     comprehensive = AnalyticsService.calculate_statistics(db, start, end, department)
@@ -133,7 +133,7 @@ def _build_kpi_snapshot(
 
 
 def _build_kpi_trend_rows(
-    current: dict, previous: dict, metric: Optional[str] = None
+    current: dict, previous: dict, metric: str | None = None
 ) -> list[dict]:
     keys = [
         "revenue",
@@ -171,7 +171,7 @@ def _build_kpi_trend_rows(
 async def get_kpi_metrics(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
@@ -245,8 +245,8 @@ async def get_kpi_metrics(
 async def get_kpi_trends(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
-    metric: Optional[str] = Query(None, description="Конкретная метрика"),
+    department: str | None = Query(None, description="Отделение"),
+    metric: str | None = Query(None, description="Конкретная метрика"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
@@ -274,7 +274,7 @@ async def get_kpi_trends(
 async def get_kpi_comparison(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     comparison_period: str = Query("previous", description="Период сравнения"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),

--- a/backend/app/api/v1/endpoints/analytics_predictive.py
+++ b/backend/app/api/v1/endpoints/analytics_predictive.py
@@ -50,7 +50,7 @@ def _build_context(
     db: Session,
     start: datetime,
     end: datetime,
-    department: Optional[str],
+    department: str | None,
 ) -> dict:
     analytics_service = get_advanced_analytics_service()
     period_days = max((end - start).days + 1, 1)
@@ -378,7 +378,7 @@ def _build_trends(context: dict) -> list[dict]:
 async def get_predictive_analytics(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     forecast_days: int = Query(30, description="Дни прогноза"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
@@ -428,7 +428,7 @@ async def get_predictive_analytics(
 async def get_prediction_accuracy(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
@@ -459,7 +459,7 @@ async def get_prediction_accuracy(
 async def get_scenario_analysis(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     scenario: str = Query(
         "optimistic", description="Сценарий: optimistic, realistic, pessimistic"
     ),
@@ -509,7 +509,7 @@ async def get_scenario_analysis(
 async def get_predictive_insights(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     insight_type: str = Query(
         "all", description="Тип инсайтов: all, revenue, patients, efficiency"
     ),

--- a/backend/app/api/v1/endpoints/analytics_visualization.py
+++ b/backend/app/api/v1/endpoints/analytics_visualization.py
@@ -27,7 +27,7 @@ FINANCIAL_ANALYTICS_ROLES = ["admin", "manager"]
 async def get_dashboard_visualization(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
@@ -89,7 +89,7 @@ async def get_dashboard_visualization(
 async def get_kpi_visualization(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
@@ -139,7 +139,7 @@ async def get_kpi_visualization(
 async def get_doctor_performance_visualization(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(["admin", "doctor", "nurse"])),
 ):
@@ -236,7 +236,7 @@ async def get_patient_analytics_visualization(
 async def get_revenue_analytics_visualization(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(FINANCIAL_ANALYTICS_ROLES)),
 ):
@@ -286,7 +286,7 @@ async def get_revenue_analytics_visualization(
 async def get_comprehensive_visualization(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Отделение"),
+    department: str | None = Query(None, description="Отделение"),
     include_predictive: bool = Query(
         True, description="Включить предиктивную аналитику"
     ),

--- a/backend/app/api/v1/endpoints/api_documentation.py
+++ b/backend/app/api/v1/endpoints/api_documentation.py
@@ -14,7 +14,7 @@ router = APIRouter()
 
 @router.get("/documentation/endpoints")
 async def get_detailed_endpoints_documentation(
-    category: Optional[str] = Query(None, description="Категория эндпоинтов"),
+    category: str | None = Query(None, description="Категория эндпоинтов"),
     current_user: User = Depends(get_current_user),
 ):
     """Получить детальную документацию по эндпоинтам"""
@@ -561,7 +561,7 @@ async def get_detailed_endpoints_documentation(
 
 @router.get("/documentation/examples")
 async def get_api_examples(
-    endpoint: Optional[str] = Query(None, description="Конкретный эндпоинт"),
+    endpoint: str | None = Query(None, description="Конкретный эндпоинт"),
     current_user: User = Depends(get_current_user),
 ):
     """Получить примеры использования API"""

--- a/backend/app/api/v1/endpoints/appointments.py
+++ b/backend/app/api/v1/endpoints/appointments.py
@@ -231,27 +231,27 @@ def _ensure_appointment_update_fields_allowed(
 # Схема для ответа pending-payments
 class PendingPaymentResponse(BaseModel):
     id: int
-    patient_id: Optional[int]
-    patient_name: Optional[str]
-    patient_last_name: Optional[str]
-    patient_first_name: Optional[str]
-    doctor_id: Optional[int]
-    department: Optional[str]
-    appointment_date: Optional[str]
-    appointment_time: Optional[str]
+    patient_id: int | None
+    patient_name: str | None
+    patient_last_name: str | None
+    patient_first_name: str | None
+    doctor_id: int | None
+    department: str | None
+    appointment_date: str | None
+    appointment_time: str | None
     status: str
     services: list[str]
     services_names: list[str]
-    payment_amount: Optional[float]
-    created_at: Optional[str]
+    payment_amount: float | None
+    created_at: str | None
     record_type: str
-    visit_ids: Optional[list[int]] = None
+    visit_ids: list[int] | None = None
 
 
 # --- helpers ---------------------------------------------------------------
 
 
-def _pick_date(date_str: Optional[str], date: Optional[str], d: Optional[str]) -> str:
+def _pick_date(date_str: str | None, date: str | None, d: str | None) -> str:
     """Берём дату из любого из 3х синонимов; если ничего нет — 422."""
     v = date_str or date or d
     if not v:
@@ -290,11 +290,11 @@ def list_appointments(
     db: Session = Depends(deps.get_db),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = Query(None, description="Фильтр по ID пациента"),
-    doctor_id: Optional[int] = Query(None, description="Фильтр по ID врача"),
-    department: Optional[str] = Query(None, description="Фильтр по отделению"),
-    date_from: Optional[str] = Query(None, description="Дата начала (YYYY-MM-DD)"),
-    date_to: Optional[str] = Query(None, description="Дата окончания (YYYY-MM-DD)"),
+    patient_id: int | None = Query(None, description="Фильтр по ID пациента"),
+    doctor_id: int | None = Query(None, description="Фильтр по ID врача"),
+    department: str | None = Query(None, description="Фильтр по отделению"),
+    date_from: str | None = Query(None, description="Дата начала (YYYY-MM-DD)"),
+    date_to: str | None = Query(None, description="Дата окончания (YYYY-MM-DD)"),
     current_user: User = Depends(deps.get_current_user),
 ):
     """
@@ -423,8 +423,8 @@ async def get_pending_payments(
     db: Session = Depends(deps.get_db),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    date_from: Optional[str] = Query(default=None),
-    date_to: Optional[str] = Query(default=None),
+    date_from: str | None = Query(default=None),
+    date_to: str | None = Query(default=None),
     current_user: User = Depends(deps.get_current_user),
 ):
     """
@@ -820,9 +820,9 @@ def open_day(
 def stats(
     department: str = Query(...),
     # принимаем все варианты имени даты; внутри нормализуем к одной строке
-    date_str: Optional[str] = Query(None),
-    date: Optional[str] = Query(None),
-    d: Optional[str] = Query(None),
+    date_str: str | None = Query(None),
+    date: str | None = Query(None),
+    d: str | None = Query(None),
     db: Session = Depends(deps.get_db),
     current_user=Depends(deps.get_current_user),
 ):
@@ -873,9 +873,9 @@ def close_day(
 @router.get("/qrcode", name="qrcode_png")
 def qrcode_png(
     department: str = Query(...),
-    date_str: Optional[str] = Query(None),
-    date: Optional[str] = Query(None),
-    d: Optional[str] = Query(None),
+    date_str: str | None = Query(None),
+    date: str | None = Query(None),
+    d: str | None = Query(None),
     current_user=Depends(deps.get_current_user),
 ):
     """
@@ -892,8 +892,8 @@ async def get_pending_payments(
     db: Session = Depends(deps.get_db),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    date_from: Optional[str] = Query(default=None),
-    date_to: Optional[str] = Query(default=None),
+    date_from: str | None = Query(default=None),
+    date_to: str | None = Query(default=None),
     current_user: User = Depends(deps.get_current_user),
 ):
     """

--- a/backend/app/api/v1/endpoints/audit.py
+++ b/backend/app/api/v1/endpoints/audit.py
@@ -15,10 +15,10 @@ router = APIRouter(prefix="/audit", tags=["audit"])
 class AuditOut(BaseModel):
     id: int
     action: str
-    entity_type: Optional[str] = None
-    entity_id: Optional[int] = None
-    actor_user_id: Optional[int] = None
-    payload: Optional[dict[str, Any]] = None
+    entity_type: str | None = None
+    entity_id: int | None = None
+    actor_user_id: int | None = None
+    payload: dict[str, Any] | None = None
     created_at: str
 
 
@@ -42,10 +42,10 @@ def _row_to_out(r) -> AuditOut:
 async def list_audit(
     db: Session = Depends(get_db),
     user=Depends(require_roles("Admin", "Registrar", "Doctor", "Lab", "Cashier")),
-    action: Optional[str] = Query(default=None, max_length=64),
-    entity_type: Optional[str] = Query(default=None, max_length=64),
-    entity_id: Optional[int] = Query(default=None, ge=1),
-    actor_user_id: Optional[int] = Query(default=None, ge=1),
+    action: str | None = Query(default=None, max_length=64),
+    entity_type: str | None = Query(default=None, max_length=64),
+    entity_id: int | None = Query(default=None, ge=1),
+    actor_user_id: int | None = Query(default=None, ge=1),
     limit: int = Query(default=100, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
 ):

--- a/backend/app/api/v1/endpoints/billing.py
+++ b/backend/app/api/v1/endpoints/billing.py
@@ -39,56 +39,56 @@ def _billing_http_error(exc: Exception, operation: str) -> HTTPException:
 
 
 class InvoiceItemCreate(BaseModel):
-    service_id: Optional[int] = None
+    service_id: int | None = None
     description: str = Field(..., min_length=1, max_length=500)
     quantity: float = Field(..., gt=0)
     unit_price: float = Field(..., ge=0)
     discount_rate: float = Field(0, ge=0, le=100)
-    notes: Optional[str] = None
+    notes: str | None = None
 
 
 class InvoiceCreate(BaseModel):
     patient_id: int
-    visit_id: Optional[int] = None
-    appointment_id: Optional[int] = None
+    visit_id: int | None = None
+    appointment_id: int | None = None
     invoice_type: InvoiceType = InvoiceType.STANDARD
     items: list[InvoiceItemCreate] = Field(..., min_length=1)
-    description: Optional[str] = None
-    notes: Optional[str] = None
-    payment_terms: Optional[str] = None
+    description: str | None = None
+    notes: str | None = None
+    payment_terms: str | None = None
     due_days: int = Field(30, ge=1, le=365)
     auto_send: bool = False
     send_reminders: bool = True
     # Периодические счета
     is_recurring: bool = False
-    recurrence_type: Optional[RecurrenceType] = None
+    recurrence_type: RecurrenceType | None = None
     recurrence_interval: int = Field(1, ge=1)
 
 
 class InvoiceUpdate(BaseModel):
-    description: Optional[str] = None
-    notes: Optional[str] = None
-    payment_terms: Optional[str] = None
-    due_date: Optional[datetime] = None
-    auto_send: Optional[bool] = None
-    send_reminders: Optional[bool] = None
-    status: Optional[InvoiceStatus] = None
+    description: str | None = None
+    notes: str | None = None
+    payment_terms: str | None = None
+    due_date: datetime | None = None
+    auto_send: bool | None = None
+    send_reminders: bool | None = None
+    status: InvoiceStatus | None = None
 
 
 class PaymentCreate(BaseModel):
     invoice_id: int
     amount: float = Field(..., gt=0)
     payment_method: PaymentMethod
-    reference_number: Optional[str] = Field(None, max_length=100)
-    description: Optional[str] = None
-    notes: Optional[str] = None
+    reference_number: str | None = Field(None, max_length=100)
+    description: str | None = None
+    notes: str | None = None
 
 
 class InvoiceTemplateCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
-    description: Optional[str] = None
+    description: str | None = None
     template_content: str = Field(..., min_length=1)
-    css_styles: Optional[str] = None
+    css_styles: str | None = None
     is_default: bool = False
     auto_generate_for_visits: bool = False
     auto_generate_for_appointments: bool = False
@@ -98,48 +98,48 @@ class InvoiceTemplateCreate(BaseModel):
 
 class BillingRuleCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
-    description: Optional[str] = None
+    description: str | None = None
     trigger_event: str = Field(
         ..., pattern=r'^(visit_completed|appointment_created|service_added)$'
     )
-    service_types: Optional[str] = None  # JSON строка
-    patient_categories: Optional[str] = None  # JSON строка
-    amount_threshold_min: Optional[float] = Field(None, ge=0)
-    amount_threshold_max: Optional[float] = Field(None, ge=0)
+    service_types: str | None = None  # JSON строка
+    patient_categories: str | None = None  # JSON строка
+    amount_threshold_min: float | None = Field(None, ge=0)
+    amount_threshold_max: float | None = Field(None, ge=0)
     invoice_type: InvoiceType = InvoiceType.STANDARD
     payment_terms_days: int = Field(30, ge=1, le=365)
     auto_send: bool = False
     send_reminders: bool = True
-    template_id: Optional[int] = None
+    template_id: int | None = None
     priority: int = Field(0, ge=0)
 
 
 class BillingSettingsUpdate(BaseModel):
-    invoice_number_prefix: Optional[str] = Field(None, max_length=10)
-    default_tax_rate: Optional[float] = Field(None, ge=0, le=100)
-    tax_included_in_price: Optional[bool] = None
-    default_payment_terms_days: Optional[int] = Field(None, ge=1, le=365)
-    overdue_threshold_days: Optional[int] = Field(None, ge=1, le=365)
-    auto_generate_invoices: Optional[bool] = None
-    auto_send_invoices: Optional[bool] = None
-    auto_send_reminders: Optional[bool] = None
-    reminder_days_before: Optional[str] = None
-    reminder_days_after: Optional[str] = None
-    currency_code: Optional[str] = Field(None, max_length=3)
-    currency_symbol: Optional[str] = Field(None, max_length=5)
-    company_name: Optional[str] = Field(None, max_length=255)
-    company_address: Optional[str] = None
-    company_phone: Optional[str] = Field(None, max_length=50)
-    company_email: Optional[str] = Field(None, max_length=100)
-    company_website: Optional[str] = Field(None, max_length=100)
+    invoice_number_prefix: str | None = Field(None, max_length=10)
+    default_tax_rate: float | None = Field(None, ge=0, le=100)
+    tax_included_in_price: bool | None = None
+    default_payment_terms_days: int | None = Field(None, ge=1, le=365)
+    overdue_threshold_days: int | None = Field(None, ge=1, le=365)
+    auto_generate_invoices: bool | None = None
+    auto_send_invoices: bool | None = None
+    auto_send_reminders: bool | None = None
+    reminder_days_before: str | None = None
+    reminder_days_after: str | None = None
+    currency_code: str | None = Field(None, max_length=3)
+    currency_symbol: str | None = Field(None, max_length=5)
+    company_name: str | None = Field(None, max_length=255)
+    company_address: str | None = None
+    company_phone: str | None = Field(None, max_length=50)
+    company_email: str | None = Field(None, max_length=100)
+    company_website: str | None = Field(None, max_length=100)
 
 
 class InvoiceResponse(BaseModel):
     id: int
     invoice_number: str
     patient_id: int
-    visit_id: Optional[int]
-    appointment_id: Optional[int]
+    visit_id: int | None
+    appointment_id: int | None
     invoice_type: str
     status: str
     subtotal: float
@@ -150,10 +150,10 @@ class InvoiceResponse(BaseModel):
     paid_amount: float
     balance: float
     issue_date: datetime
-    due_date: Optional[datetime]
-    paid_date: Optional[datetime]
-    description: Optional[str]
-    notes: Optional[str]
+    due_date: datetime | None
+    paid_date: datetime | None
+    description: str | None
+    notes: str | None
     is_auto_generated: bool
     is_recurring: bool
     created_at: datetime
@@ -169,10 +169,10 @@ class PaymentResponse(BaseModel):
     amount: float
     payment_method: str
     payment_date: datetime
-    reference_number: Optional[str]
-    description: Optional[str]
+    reference_number: str | None
+    description: str | None
     is_confirmed: bool
-    confirmed_at: Optional[datetime]
+    confirmed_at: datetime | None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
@@ -239,11 +239,11 @@ def create_invoice(
 def get_invoices(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = None,
-    status: Optional[InvoiceStatus] = None,
-    invoice_type: Optional[InvoiceType] = None,
-    date_from: Optional[date] = None,
-    date_to: Optional[date] = None,
+    patient_id: int | None = None,
+    status: InvoiceStatus | None = None,
+    invoice_type: InvoiceType | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(require_roles(*BILLING_VIEW_ROLES)),
 ):
@@ -306,7 +306,7 @@ def delete_invoice(
 @router.get("/invoices/{invoice_id}/html")
 def get_invoice_html(
     invoice_id: int,
-    template_id: Optional[int] = None,
+    template_id: int | None = None,
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(require_roles(*BILLING_VIEW_ROLES)),
 ):
@@ -367,8 +367,8 @@ def record_payment(
 def get_payments(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    date_from: Optional[date] = None,
-    date_to: Optional[date] = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(require_roles(*BILLING_VIEW_ROLES)),
 ):
@@ -503,8 +503,8 @@ def update_billing_settings(
 
 @router.get("/analytics")
 def get_billing_analytics(
-    date_from: Optional[date] = None,
-    date_to: Optional[date] = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(require_roles(*BILLING_VIEW_ROLES)),
 ):

--- a/backend/app/api/v1/endpoints/cardio.py
+++ b/backend/app/api/v1/endpoints/cardio.py
@@ -98,7 +98,7 @@ async def get_ecg_results(
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles(*CARDIO_ROLES)),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = None,
+    patient_id: int | None = None,
 ) -> list[CardioECGRecordOut]:
     """
     Получить список ЭКГ исследований для пациента.
@@ -236,7 +236,7 @@ async def get_blood_tests(
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles(*CARDIO_ROLES)),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = None,
+    patient_id: int | None = None,
 ) -> list[CardioBloodTestOut]:
     """
     Получить список анализов крови
@@ -345,7 +345,7 @@ async def create_blood_test(
 async def get_risk_assessment(
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles(*CARDIO_ROLES)),
-    patient_id: Optional[int] = None,
+    patient_id: int | None = None,
 ) -> dict[str, Any]:
     """
     Получить оценку кардиологических рисков

--- a/backend/app/api/v1/endpoints/cashier.py
+++ b/backend/app/api/v1/endpoints/cashier.py
@@ -87,20 +87,20 @@ class PendingPaymentItem(BaseModel):
     id: int
     patient_id: int
     patient_name: str
-    patient_iin: Optional[str] = None
-    visit_id: Optional[int] = None  # Первый visit_id (для совместимости)
+    patient_iin: str | None = None
+    visit_id: int | None = None  # Первый visit_id (для совместимости)
     visit_ids: list[int] = []  # Все visit_id этого пациента
-    appointment_id: Optional[int] = None
+    appointment_id: int | None = None
     services: list[dict[str, Any]] = []
     total_amount: Decimal
     paid_amount: Decimal = Decimal("0")
     remaining_amount: Decimal
     status: str
     created_at: datetime
-    queue_number: Optional[str] = None
-    department: Optional[str] = None
+    queue_number: str | None = None
+    department: str | None = None
     payment_contract: str = "single_visit"
-    payment_visit_id: Optional[int] = None
+    payment_visit_id: int | None = None
     payment_visit_ids: list[int] = Field(default_factory=list)
     can_create_direct_payment: bool = True
     can_create_grouped_payment: bool = False
@@ -113,14 +113,14 @@ class PaymentHistoryItem(BaseModel):
     id: int
     patient_id: int
     patient_name: str
-    visit_id: Optional[int] = None
+    visit_id: int | None = None
     amount: Decimal
     method: str
     status: str
     created_at: datetime
-    paid_at: Optional[datetime] = None
-    note: Optional[str] = None
-    cashier_name: Optional[str] = None
+    paid_at: datetime | None = None
+    note: str | None = None
+    cashier_name: str | None = None
     available_actions: list[str] = Field(default_factory=list)
     can_confirm: bool = False
     can_cancel: bool = False
@@ -142,25 +142,25 @@ class PaginatedResponse(BaseModel, Generic[T]):
 
 class CreatePaymentRequest(BaseModel):
     """Запрос на создание платежа"""
-    visit_id: Optional[int] = Field(None, description="ID визита")
-    appointment_id: Optional[int] = Field(None, description="ID записи")
-    patient_id: Optional[int] = Field(None, description="ID пациента")
+    visit_id: int | None = Field(None, description="ID визита")
+    appointment_id: int | None = Field(None, description="ID записи")
+    patient_id: int | None = Field(None, description="ID пациента")
     amount: Decimal = Field(..., gt=0, description="Сумма платежа")
     method: str = Field(default="cash", description="Метод оплаты (cash, card)")
-    note: Optional[str] = Field(None, description="Примечание")
+    note: str | None = Field(None, description="Примечание")
 
 
 class PaymentResponse(BaseModel):
     """Ответ при создании/получении платежа"""
     id: int
-    visit_id: Optional[int] = None
-    patient_id: Optional[int] = None
+    visit_id: int | None = None
+    patient_id: int | None = None
     amount: Decimal
     method: str
     status: str
     created_at: datetime
-    paid_at: Optional[datetime] = None
-    note: Optional[str] = None
+    paid_at: datetime | None = None
+    note: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -168,10 +168,10 @@ class PaymentResponse(BaseModel):
 class CreateGroupedPaymentRequest(BaseModel):
     """Backend-owned allocation request for grouped cashier payment rows."""
     visit_ids: list[int] = Field(..., min_length=1, description="Visit ids from a cashier grouped pending-payment row")
-    patient_id: Optional[int] = Field(None, description="Expected patient id for all grouped visits")
+    patient_id: int | None = Field(None, description="Expected patient id for all grouped visits")
     amount: Decimal = Field(..., gt=0, description="Total payment amount to allocate")
     method: str = Field(default="cash", description="Payment method (cash, card)")
-    note: Optional[str] = Field(None, description="Payment note")
+    note: str | None = Field(None, description="Payment note")
 
 
 class GroupedPaymentAllocationItem(BaseModel):
@@ -196,7 +196,7 @@ class GroupedPaymentResponse(BaseModel):
 
 class CancelPaymentRequest(BaseModel):
     """Запрос на отмену платежа"""
-    reason: Optional[str] = None
+    reason: str | None = None
 
 
 class RefundRequest(BaseModel):
@@ -218,7 +218,7 @@ class RefundResponse(BaseModel):
 
 # ===================== ВСПОМОГАТЕЛЬНЫЕ ФУНКЦИИ =====================
 
-def get_patient_name(patient: Optional[Patient], patient_id: int) -> str:
+def get_patient_name(patient: Patient | None, patient_id: int) -> str:
     """Получить имя пациента"""
     if patient:
         if hasattr(patient, 'short_name') and callable(patient.short_name):
@@ -239,7 +239,7 @@ def get_patient_name(patient: Optional[Patient], patient_id: int) -> str:
     return f"Пациент #{patient_id}"
 
 
-def _decimal_to_float(value: Any) -> Optional[float]:
+def _decimal_to_float(value: Any) -> float | None:
     if value is None:
         return None
     try:
@@ -293,10 +293,10 @@ async def _emit_payment_notification(
     payment: Payment,
     current_user: Any,
     change_type: str,
-    patient_id: Optional[int] = None,
-    visit: Optional[Visit] = None,
-    reason: Optional[str] = None,
-    extra_metadata: Optional[dict[str, Any]] = None,
+    patient_id: int | None = None,
+    visit: Visit | None = None,
+    reason: str | None = None,
+    extra_metadata: dict[str, Any] | None = None,
 ) -> None:
     """Emit canonical payment_notification for patient inbox without breaking cashier flow."""
     try:
@@ -391,9 +391,9 @@ async def _emit_payment_notification(
 async def get_pending_payments(
     db: Session = Depends(deps.get_db),
     current_user = Depends(deps.require_roles("Admin", "Cashier")),
-    date_from: Optional[date] = Query(None, description="Дата начала"),
-    date_to: Optional[date] = Query(None, description="Дата окончания"),
-    search: Optional[str] = Query(None, description="Поиск по ФИО пациента"),
+    date_from: date | None = Query(None, description="Дата начала"),
+    date_to: date | None = Query(None, description="Дата окончания"),
+    search: str | None = Query(None, description="Поиск по ФИО пациента"),
     page: int = Query(1, ge=1, description="Номер страницы"),
     size: int = Query(20, ge=1, le=100, description="Размер страницы"),
 ):
@@ -638,8 +638,8 @@ class CashierStatsResponse(BaseModel):
 async def get_cashier_stats(
     db: Session = Depends(deps.get_db),
     current_user = Depends(deps.require_roles("Admin", "Cashier")),
-    date_from: Optional[date] = Query(None, description="Дата начала"),
-    date_to: Optional[date] = Query(None, description="Дата окончания"),
+    date_from: date | None = Query(None, description="Дата начала"),
+    date_to: date | None = Query(None, description="Дата окончания"),
 ):
     """
     Получить агрегированную статистику платежей за период.
@@ -740,8 +740,8 @@ async def get_cashier_stats(
 async def export_payments(
     db: Session = Depends(deps.get_db),
     current_user = Depends(deps.require_roles("Admin", "Cashier")),
-    date_from: Optional[date] = Query(None, description="Дата начала"),
-    date_to: Optional[date] = Query(None, description="Дата окончания"),
+    date_from: date | None = Query(None, description="Дата начала"),
+    date_to: date | None = Query(None, description="Дата окончания"),
 ):
     """
     Экспорт всех платежей за период в CSV.
@@ -833,11 +833,11 @@ async def export_payments(
 async def get_payments(
     db: Session = Depends(deps.get_db),
     current_user = Depends(deps.require_roles("Admin", "Cashier")),
-    date_from: Optional[date] = Query(None, description="Дата начала"),
-    date_to: Optional[date] = Query(None, description="Дата окончания"), 
-    search: Optional[str] = Query(None, description="Поиск по пациенту"),
-    status_filter: Optional[str] = Query(None, alias="status", description="Фильтр по статусу (paid/pending/cancelled)"),
-    method: Optional[str] = Query(None, description="Фильтр по методу оплаты (cash/card)"),
+    date_from: date | None = Query(None, description="Дата начала"),
+    date_to: date | None = Query(None, description="Дата окончания"), 
+    search: str | None = Query(None, description="Поиск по пациенту"),
+    status_filter: str | None = Query(None, alias="status", description="Фильтр по статусу (paid/pending/cancelled)"),
+    method: str | None = Query(None, description="Фильтр по методу оплаты (cash/card)"),
     page: int = Query(1, ge=1, description="Номер страницы"),
     size: int = Query(20, ge=1, le=100, description="Размер страницы"),
 ):
@@ -1668,7 +1668,7 @@ class HourlyStatItem(BaseModel):
 async def get_hourly_stats(
     db: Session = Depends(deps.get_db),
     current_user = Depends(deps.require_roles("Admin", "Cashier")),
-    target_date: Optional[date] = Query(None, description="Дата для статистики (по умолчанию сегодня)"),
+    target_date: date | None = Query(None, description="Дата для статистики (по умолчанию сегодня)"),
 ):
     """
     Получить почасовую статистику платежей за день.

--- a/backend/app/api/v1/endpoints/clinic_management.py
+++ b/backend/app/api/v1/endpoints/clinic_management.py
@@ -75,8 +75,8 @@ def get_branches(
     db: Session = Depends(get_db),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    status: Optional[str] = Query(None, description="Фильтр по статусу"),
-    search: Optional[str] = Query(
+    status: str | None = Query(None, description="Фильтр по статусу"),
+    search: str | None = Query(
         None, description="Поиск по названию, адресу или коду"
     ),
     current_user: User = Depends(require_admin),
@@ -183,10 +183,10 @@ def get_equipment(
     db: Session = Depends(get_db),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    branch_id: Optional[int] = Query(None, description="Фильтр по филиалу"),
-    equipment_type: Optional[str] = Query(None, description="Фильтр по типу"),
-    status: Optional[str] = Query(None, description="Фильтр по статусу"),
-    search: Optional[str] = Query(
+    branch_id: int | None = Query(None, description="Фильтр по филиалу"),
+    equipment_type: str | None = Query(None, description="Фильтр по типу"),
+    status: str | None = Query(None, description="Фильтр по статусу"),
+    search: str | None = Query(
         None, description="Поиск по названию, модели или серийному номеру"
     ),
     current_user: User = Depends(require_admin),
@@ -337,9 +337,9 @@ def get_licenses(
     db: Session = Depends(get_db),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    license_type: Optional[str] = Query(None, description="Фильтр по типу лицензии"),
-    status: Optional[str] = Query(None, description="Фильтр по статусу"),
-    search: Optional[str] = Query(
+    license_type: str | None = Query(None, description="Фильтр по типу лицензии"),
+    status: str | None = Query(None, description="Фильтр по статусу"),
+    search: str | None = Query(
         None, description="Поиск по названию, ключу или издателю"
     ),
     current_user: User = Depends(require_admin),
@@ -494,8 +494,8 @@ def get_backups(
     db: Session = Depends(get_db),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    status: Optional[str] = Query(None, description="Фильтр по статусу"),
-    backup_type: Optional[str] = Query(None, description="Фильтр по типу"),
+    status: str | None = Query(None, description="Фильтр по статусу"),
+    backup_type: str | None = Query(None, description="Фильтр по типу"),
     current_user: User = Depends(require_admin),
 ):
     """Получить список резервных копий"""
@@ -617,7 +617,7 @@ def set_system_info(
     db: Session = Depends(get_db),
     key: str,
     value: dict[str, Any],
-    description: Optional[str] = None,
+    description: str | None = None,
     current_user: User = Depends(require_admin),
 ):
     """Установить системную информацию"""

--- a/backend/app/api/v1/endpoints/cloud_printing.py
+++ b/backend/app/api/v1/endpoints/cloud_printing.py
@@ -72,16 +72,16 @@ class MedicalDocumentRequest(BaseModel):
     printer_id: str = Field(..., description="ID принтера")
     document_type: str = Field(..., pattern="^(prescription|receipt|ticket|report)$")
     patient_data: dict[str, Any] = Field(..., description="Данные пациента")
-    template_data: Optional[dict[str, Any]] = Field(None, description="Данные шаблона")
+    template_data: dict[str, Any] | None = Field(None, description="Данные шаблона")
 
 
 class PrintJobResponse(BaseModel):
     """Ответ с информацией о задании печати"""
 
     success: bool
-    job_id: Optional[str] = None
+    job_id: str | None = None
     message: str
-    error: Optional[str] = None
+    error: str | None = None
 
 
 class JobStatusResponse(BaseModel):

--- a/backend/app/api/v1/endpoints/dental.py
+++ b/backend/app/api/v1/endpoints/dental.py
@@ -28,7 +28,7 @@ class DentalPriceOverrideRequest(BaseModel):
     service_id: int
     new_price: Decimal
     reason: str
-    details: Optional[str] = None
+    details: str | None = None
     treatment_completed: bool = True
 
 
@@ -39,7 +39,7 @@ class DentalPriceOverrideResponse(BaseModel):
     original_price: Decimal
     new_price: Decimal
     reason: str
-    details: Optional[str]
+    details: str | None
     status: str
     treatment_completed: bool
     created_at: datetime
@@ -50,7 +50,7 @@ async def get_dental_examinations(
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles(*DENTAL_CLINICIAN_ROLES)),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = None,
+    patient_id: int | None = None,
 ) -> list[dict[str, Any]]:
     """
     Получить список стоматологических осмотров
@@ -83,7 +83,7 @@ async def get_treatment_plans(
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles(*DENTAL_CLINICIAN_ROLES)),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = None,
+    patient_id: int | None = None,
 ) -> list[dict[str, Any]]:
     """
     Получить список планов лечения
@@ -116,7 +116,7 @@ async def get_prosthetics(
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles(*DENTAL_CLINICIAN_ROLES)),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = None,
+    patient_id: int | None = None,
 ) -> list[dict[str, Any]]:
     """
     Получить список протезов
@@ -148,7 +148,7 @@ async def create_prosthetic(
 async def get_xray_images(
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles(*DENTAL_CLINICIAN_ROLES)),
-    patient_id: Optional[int] = None,
+    patient_id: int | None = None,
 ) -> dict[str, Any]:
     """
     Получить рентгеновские снимки пациента
@@ -207,8 +207,8 @@ async def create_dental_price_override(
 async def get_dental_price_overrides(
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles(*DENTAL_CLINICIAN_ROLES)),
-    visit_id: Optional[int] = Query(None, description="ID визита"),
-    status: Optional[str] = Query(
+    visit_id: int | None = Query(None, description="ID визита"),
+    status: str | None = Query(
         None, description="Статус (pending, approved, rejected)"
     ),
     limit: int = Query(50, ge=1, le=100),
@@ -248,7 +248,7 @@ async def get_dental_price_overrides(
 
 class PriceOverrideApprovalRequest(BaseModel):
     action: str
-    rejection_reason: Optional[str] = None
+    rejection_reason: str | None = None
 
 
 @router.put(

--- a/backend/app/api/v1/endpoints/derma.py
+++ b/backend/app/api/v1/endpoints/derma.py
@@ -35,7 +35,7 @@ class PriceOverrideRequest(BaseModel):
     service_id: int
     new_price: Decimal
     reason: str
-    details: Optional[str] = None
+    details: str | None = None
 
 
 class PriceOverrideResponse(BaseModel):
@@ -45,7 +45,7 @@ class PriceOverrideResponse(BaseModel):
     original_price: Decimal
     new_price: Decimal
     reason: str
-    details: Optional[str]
+    details: str | None
     status: str
     created_at: datetime
 
@@ -134,7 +134,7 @@ async def get_skin_examinations(
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles(*DERMA_ROLES)),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = None,
+    patient_id: int | None = None,
 ) -> list[DermaExaminationOut]:
     """
     Получить список осмотров кожи
@@ -254,7 +254,7 @@ async def get_cosmetic_procedures(
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles(*DERMA_ROLES)),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = None,
+    patient_id: int | None = None,
 ) -> list[DermaProcedureOut]:
     """
     Получить список косметических процедур
@@ -410,8 +410,8 @@ async def create_price_override(
 async def get_price_overrides(
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles(*DERMA_ROLES)),
-    visit_id: Optional[int] = Query(None, description="ID визита"),
-    status: Optional[str] = Query(
+    visit_id: int | None = Query(None, description="ID визита"),
+    status: str | None = Query(
         None, description="Статус (pending, approved, rejected)"
     ),
     limit: int = Query(50, ge=1, le=100),
@@ -456,7 +456,7 @@ async def get_price_overrides(
 async def get_photo_gallery(
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles(*DERMA_ROLES)),
-    patient_id: Optional[int] = None,
+    patient_id: int | None = None,
 ) -> dict[str, Any]:
     """
     Получить фотогалерею пациента

--- a/backend/app/api/v1/endpoints/dermatology_photos.py
+++ b/backend/app/api/v1/endpoints/dermatology_photos.py
@@ -142,7 +142,7 @@ async def upload_photos(
 @router.get("/")
 def get_patient_photos(
     patient_id: int,
-    category: Optional[str] = None,
+    category: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Doctor", "derma")),
 ):

--- a/backend/app/api/v1/endpoints/discount_benefits.py
+++ b/backend/app/api/v1/endpoints/discount_benefits.py
@@ -26,14 +26,14 @@ router = APIRouter()
 
 class DiscountCreate(BaseModel):
     name: str = Field(..., max_length=200)
-    description: Optional[str] = None
+    description: str | None = None
     discount_type: DiscountType
     value: float = Field(..., gt=0)
     min_amount: float = Field(default=0, ge=0)
-    max_discount: Optional[float] = Field(None, gt=0)
-    start_date: Optional[datetime] = None
-    end_date: Optional[datetime] = None
-    usage_limit: Optional[int] = Field(None, gt=0)
+    max_discount: float | None = Field(None, gt=0)
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    usage_limit: int | None = Field(None, gt=0)
     applies_to_services: bool = True
     applies_to_appointments: bool = True
     applies_to_packages: bool = True
@@ -42,72 +42,72 @@ class DiscountCreate(BaseModel):
 
 
 class DiscountUpdate(BaseModel):
-    name: Optional[str] = Field(None, max_length=200)
-    description: Optional[str] = None
-    value: Optional[float] = Field(None, gt=0)
-    min_amount: Optional[float] = Field(None, ge=0)
-    max_discount: Optional[float] = Field(None, gt=0)
-    is_active: Optional[bool] = None
-    start_date: Optional[datetime] = None
-    end_date: Optional[datetime] = None
-    usage_limit: Optional[int] = Field(None, gt=0)
-    applies_to_services: Optional[bool] = None
-    applies_to_appointments: Optional[bool] = None
-    applies_to_packages: Optional[bool] = None
-    can_combine_with_others: Optional[bool] = None
-    priority: Optional[int] = Field(None, ge=0)
+    name: str | None = Field(None, max_length=200)
+    description: str | None = None
+    value: float | None = Field(None, gt=0)
+    min_amount: float | None = Field(None, ge=0)
+    max_discount: float | None = Field(None, gt=0)
+    is_active: bool | None = None
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    usage_limit: int | None = Field(None, gt=0)
+    applies_to_services: bool | None = None
+    applies_to_appointments: bool | None = None
+    applies_to_packages: bool | None = None
+    can_combine_with_others: bool | None = None
+    priority: int | None = Field(None, ge=0)
 
 
 class BenefitCreate(BaseModel):
     name: str = Field(..., max_length=200)
-    description: Optional[str] = None
+    description: str | None = None
     benefit_type: BenefitType
     discount_percentage: float = Field(..., gt=0, le=100)
-    max_discount_amount: Optional[float] = Field(None, gt=0)
+    max_discount_amount: float | None = Field(None, gt=0)
     requires_document: bool = True
-    document_types: Optional[str] = None
-    age_min: Optional[int] = Field(None, ge=0)
-    age_max: Optional[int] = Field(None, ge=0)
+    document_types: str | None = None
+    age_min: int | None = Field(None, ge=0)
+    age_max: int | None = Field(None, ge=0)
     applies_to_services: bool = True
     applies_to_appointments: bool = True
-    monthly_limit: Optional[float] = Field(None, gt=0)
-    yearly_limit: Optional[float] = Field(None, gt=0)
+    monthly_limit: float | None = Field(None, gt=0)
+    yearly_limit: float | None = Field(None, gt=0)
 
 
 class BenefitUpdate(BaseModel):
-    name: Optional[str] = Field(None, max_length=200)
-    description: Optional[str] = None
-    discount_percentage: Optional[float] = Field(None, gt=0, le=100)
-    max_discount_amount: Optional[float] = Field(None, gt=0)
-    is_active: Optional[bool] = None
-    requires_document: Optional[bool] = None
-    document_types: Optional[str] = None
-    age_min: Optional[int] = Field(None, ge=0)
-    age_max: Optional[int] = Field(None, ge=0)
-    applies_to_services: Optional[bool] = None
-    applies_to_appointments: Optional[bool] = None
-    monthly_limit: Optional[float] = Field(None, gt=0)
-    yearly_limit: Optional[float] = Field(None, gt=0)
+    name: str | None = Field(None, max_length=200)
+    description: str | None = None
+    discount_percentage: float | None = Field(None, gt=0, le=100)
+    max_discount_amount: float | None = Field(None, gt=0)
+    is_active: bool | None = None
+    requires_document: bool | None = None
+    document_types: str | None = None
+    age_min: int | None = Field(None, ge=0)
+    age_max: int | None = Field(None, ge=0)
+    applies_to_services: bool | None = None
+    applies_to_appointments: bool | None = None
+    monthly_limit: float | None = Field(None, gt=0)
+    yearly_limit: float | None = Field(None, gt=0)
 
 
 class PatientBenefitCreate(BaseModel):
     patient_id: int
     benefit_id: int
-    document_number: Optional[str] = None
-    document_issued_date: Optional[datetime] = None
-    document_expiry_date: Optional[datetime] = None
+    document_number: str | None = None
+    document_issued_date: datetime | None = None
+    document_expiry_date: datetime | None = None
 
 
 class LoyaltyProgramCreate(BaseModel):
     name: str = Field(..., max_length=200)
-    description: Optional[str] = None
+    description: str | None = None
     points_per_ruble: float = Field(default=1.0, gt=0)
     min_purchase_for_points: float = Field(default=0, ge=0)
     ruble_per_point: float = Field(default=1.0, gt=0)
     min_points_to_redeem: int = Field(default=100, gt=0)
-    max_points_per_purchase: Optional[int] = Field(None, gt=0)
-    start_date: Optional[datetime] = None
-    end_date: Optional[datetime] = None
+    max_points_per_purchase: int | None = Field(None, gt=0)
+    start_date: datetime | None = None
+    end_date: datetime | None = None
 
 
 class DiscountCalculationRequest(BaseModel):
@@ -119,35 +119,35 @@ class DiscountCalculationRequest(BaseModel):
 class ApplyDiscountRequest(BaseModel):
     discount_id: int
     amount: float = Field(..., gt=0)
-    appointment_id: Optional[int] = None
-    visit_id: Optional[int] = None
-    invoice_id: Optional[int] = None
+    appointment_id: int | None = None
+    visit_id: int | None = None
+    invoice_id: int | None = None
 
 
 class ApplyBenefitRequest(BaseModel):
     patient_benefit_id: int
     amount: float = Field(..., gt=0)
-    appointment_id: Optional[int] = None
-    visit_id: Optional[int] = None
-    invoice_id: Optional[int] = None
+    appointment_id: int | None = None
+    visit_id: int | None = None
+    invoice_id: int | None = None
 
 
 class EarnPointsRequest(BaseModel):
     patient_id: int
     program_id: int
     amount: float = Field(..., gt=0)
-    appointment_id: Optional[int] = None
-    visit_id: Optional[int] = None
-    invoice_id: Optional[int] = None
+    appointment_id: int | None = None
+    visit_id: int | None = None
+    invoice_id: int | None = None
 
 
 class RedeemPointsRequest(BaseModel):
     patient_id: int
     program_id: int
     points: int = Field(..., gt=0)
-    appointment_id: Optional[int] = None
-    visit_id: Optional[int] = None
-    invoice_id: Optional[int] = None
+    appointment_id: int | None = None
+    visit_id: int | None = None
+    invoice_id: int | None = None
 
 
 # === СКИДКИ ===
@@ -177,7 +177,7 @@ async def create_discount(
 @router.get("/discounts")
 async def get_discounts(
     active_only: bool = Query(True),
-    service_ids: Optional[list[int]] = Query(None),
+    service_ids: list[int] | None = Query(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -363,7 +363,7 @@ async def assign_benefit_to_patient(
 @router.post("/benefits/verify/{patient_benefit_id}")
 async def verify_patient_benefit(
     patient_benefit_id: int,
-    notes: Optional[str] = None,
+    notes: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -618,8 +618,8 @@ async def calculate_total_discount(
 
 @router.get("/analytics/discounts")
 async def get_discount_analytics(
-    start_date: Optional[datetime] = Query(None),
-    end_date: Optional[datetime] = Query(None),
+    start_date: datetime | None = Query(None),
+    end_date: datetime | None = Query(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -632,8 +632,8 @@ async def get_discount_analytics(
 
 @router.get("/analytics/benefits")
 async def get_benefit_analytics(
-    start_date: Optional[datetime] = Query(None),
-    end_date: Optional[datetime] = Query(None),
+    start_date: datetime | None = Query(None),
+    end_date: datetime | None = Query(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -646,7 +646,7 @@ async def get_benefit_analytics(
 
 @router.get("/analytics/loyalty")
 async def get_loyalty_analytics(
-    program_id: Optional[int] = Query(None),
+    program_id: int | None = Query(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):

--- a/backend/app/api/v1/endpoints/display_websocket.py
+++ b/backend/app/api/v1/endpoints/display_websocket.py
@@ -39,8 +39,8 @@ router = APIRouter()
 
 
 async def authenticate_websocket_token(
-    token: Optional[str], db: Session
-) -> Optional[User]:
+    token: str | None, db: Session
+) -> User | None:
     """
     Аутентификация WebSocket соединения по JWT токену
     """
@@ -62,7 +62,7 @@ async def authenticate_websocket_token(
 
 @router.websocket("/ws/board/{board_id}")
 async def websocket_display_board(
-    websocket: WebSocket, board_id: str, token: Optional[str] = None
+    websocket: WebSocket, board_id: str, token: str | None = None
 ):
     """
     WebSocket подключение для табло очереди с аутентификацией
@@ -152,7 +152,7 @@ async def call_patient_to_board(
 
 @router.websocket("/ws/queue/{department}")
 async def websocket_queue_department(
-    websocket: WebSocket, department: str, token: Optional[str] = None
+    websocket: WebSocket, department: str, token: str | None = None
 ):
     """
     WebSocket подключение для очереди по отделению
@@ -344,7 +344,7 @@ def get_boards_status(
 @router.post("/quick/call-next")
 async def quick_call_next_patient(
     specialty: str,
-    board_id: Optional[str] = None,
+    board_id: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Doctor", "Registrar")),
 ):

--- a/backend/app/api/v1/endpoints/doctor_info.py
+++ b/backend/app/api/v1/endpoints/doctor_info.py
@@ -27,13 +27,13 @@ class DoctorInfoResponse(BaseModel):
     full_name: str
     specialization: str
     department: str
-    department_id: Optional[int] = None
-    cabinet: Optional[dict[str, Any]] = None
-    phone: Optional[str] = None
-    email: Optional[str] = None
+    department_id: int | None = None
+    cabinet: dict[str, Any] | None = None
+    phone: str | None = None
+    email: str | None = None
     is_active: bool
-    schedule: Optional[str] = None
-    experience_years: Optional[int] = None
+    schedule: str | None = None
+    experience_years: int | None = None
 
 
 class DepartmentInfoResponse(BaseModel):
@@ -41,10 +41,10 @@ class DepartmentInfoResponse(BaseModel):
 
     id: int
     name: str
-    description: Optional[str] = None
-    head_doctor: Optional[str] = None
-    phone: Optional[str] = None
-    location: Optional[str] = None
+    description: str | None = None
+    head_doctor: str | None = None
+    phone: str | None = None
+    location: str | None = None
     is_active: bool
 
 
@@ -95,8 +95,8 @@ async def get_doctor_info(
 
 @router.get("/doctors", response_model=DoctorListResponse)
 async def get_doctors_list(
-    specialization: Optional[str] = Query(None, description="Фильтр по специализации"),
-    department_name: Optional[str] = Query(None, description="Фильтр по отделению"),
+    specialization: str | None = Query(None, description="Фильтр по специализации"),
+    department_name: str | None = Query(None, description="Фильтр по отделению"),
     active_only: bool = Query(True, description="Только активные врачи"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles(["Admin", "Registrar", "Doctor"])),

--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -83,7 +83,7 @@ def _resolve_queue_allowed_tags(specialty: str) -> list[str]:
     return DOCTOR_QUEUE_ALLOWED_TAGS.get(normalized, [normalized])
 
 
-def _serialize_queue_doctor(doctor: Optional[Doctor], current_user: User, specialty: str):
+def _serialize_queue_doctor(doctor: Doctor | None, current_user: User, specialty: str):
     normalized = _normalize_queue_specialty(specialty)
     if doctor:
         return {
@@ -252,20 +252,20 @@ def _ensure_schedule_next_patient_access(
 class ScheduleNextVisitService(BaseModel):
     service_id: int
     quantity: int = 1
-    custom_price: Optional[float] = None
+    custom_price: float | None = None
 
 
 class ScheduleNextVisitRequest(BaseModel):
     patient_id: int
     services: list[ScheduleNextVisitService] = Field(default_factory=list)
-    service_ids: Optional[list[int]] = None
+    service_ids: list[int] | None = None
     visit_date: date
-    visit_time: Optional[str] = None
+    visit_time: str | None = None
     discount_mode: str = Field(
         default="none", pattern="^(none|repeat|benefit|all_free)$"
     )
     all_free: bool = False
-    notes: Optional[str] = None
+    notes: str | None = None
     confirmation_channel: str = Field(
         default="phone", pattern="^(phone|telegram|pwa|auto)$"
     )
@@ -740,7 +740,7 @@ def start_patient_visit(
 @router.post("/doctor/queue/{entry_id}/complete")
 def complete_patient_visit(
     entry_id: int,
-    visit_data: Optional[dict[str, Any]] = None,
+    visit_data: dict[str, Any] | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(
         require_roles(
@@ -1626,10 +1626,10 @@ def get_today_visits(
 
 @router.get("/doctor/visits/statistics")
 def get_visit_statistics(
-    date_from: Optional[str] = Query(
+    date_from: str | None = Query(
         None, description="Дата начала в формате YYYY-MM-DD"
     ),
-    date_to: Optional[str] = Query(
+    date_to: str | None = Query(
         None, description="Дата окончания в формате YYYY-MM-DD"
     ),
     db: Session = Depends(get_db),
@@ -1769,7 +1769,7 @@ def add_service_to_visit(
     visit_id: int,
     service_id: int,
     quantity: int = 1,
-    custom_price: Optional[float] = None,
+    custom_price: float | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(
         require_roles("Admin", "Doctor", "cardio", "cardiology", "derma", "dentist")

--- a/backend/app/api/v1/endpoints/email_sms_enhanced.py
+++ b/backend/app/api/v1/endpoints/email_sms_enhanced.py
@@ -104,7 +104,7 @@ def _ensure_payment_confirmation_belongs_to_patient(
 async def send_appointment_reminder_enhanced(
     appointment_id: int,
     channels: list[str] = Query(["email", "sms"], description="Каналы отправки"),
-    template_data: Optional[dict[str, Any]] = None,
+    template_data: dict[str, Any] | None = None,
     background_tasks: BackgroundTasks = BackgroundTasks(),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar", "Doctor")),
@@ -177,7 +177,7 @@ async def send_lab_results_enhanced(
     patient_id: int,
     lab_results_id: int,
     channels: list[str] = Query(["email", "sms"], description="Каналы отправки"),
-    template_data: Optional[dict[str, Any]] = None,
+    template_data: dict[str, Any] | None = None,
     background_tasks: BackgroundTasks = BackgroundTasks(),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Lab", "Doctor")),
@@ -240,7 +240,7 @@ async def send_payment_confirmation_enhanced(
     patient_id: int,
     payment_data: dict[str, Any],
     channels: list[str] = Query(["email", "sms"], description="Каналы отправки"),
-    template_data: Optional[dict[str, Any]] = None,
+    template_data: dict[str, Any] | None = None,
     background_tasks: BackgroundTasks = BackgroundTasks(),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Cashier")),
@@ -299,10 +299,10 @@ async def send_payment_confirmation_enhanced(
 async def send_bulk_email(
     recipients: list[dict[str, Any]],
     subject: str,
-    template_name: Optional[str] = None,
-    template_data: Optional[dict[str, Any]] = None,
-    html_content: Optional[str] = None,
-    text_content: Optional[str] = None,
+    template_name: str | None = None,
+    template_data: dict[str, Any] | None = None,
+    html_content: str | None = None,
+    text_content: str | None = None,
     batch_size: int = Query(50, description="Размер батча"),
     delay_between_batches: float = Query(
         1.0, description="Задержка между батчами (сек)"
@@ -352,9 +352,9 @@ async def send_bulk_email(
 @router.post("/send-bulk-sms")
 async def send_bulk_sms(
     recipients: list[dict[str, Any]],
-    message: Optional[str] = None,
-    template_name: Optional[str] = None,
-    template_data: Optional[dict[str, Any]] = None,
+    message: str | None = None,
+    template_name: str | None = None,
+    template_data: dict[str, Any] | None = None,
     batch_size: int = Query(100, description="Размер батча"),
     delay_between_batches: float = Query(
         0.5, description="Задержка между батчами (сек)"
@@ -403,11 +403,11 @@ async def send_bulk_sms(
 async def send_custom_email(
     to_email: str,
     subject: str,
-    template_name: Optional[str] = None,
-    template_data: Optional[dict[str, Any]] = None,
-    html_content: Optional[str] = None,
-    text_content: Optional[str] = None,
-    attachments: Optional[list[dict[str, Any]]] = None,
+    template_name: str | None = None,
+    template_data: dict[str, Any] | None = None,
+    html_content: str | None = None,
+    text_content: str | None = None,
+    attachments: list[dict[str, Any]] | None = None,
     priority: str = Query("normal", description="Приоритет: normal, high"),
     background_tasks: BackgroundTasks = BackgroundTasks(),
     db: Session = Depends(get_db),
@@ -447,10 +447,10 @@ async def send_custom_email(
 @router.post("/send-custom-sms")
 async def send_custom_sms(
     phone: str,
-    message: Optional[str] = None,
-    template_name: Optional[str] = None,
-    template_data: Optional[dict[str, Any]] = None,
-    sender: Optional[str] = None,
+    message: str | None = None,
+    template_name: str | None = None,
+    template_data: dict[str, Any] | None = None,
+    sender: str | None = None,
     priority: str = Query("normal", description="Приоритет: normal, high"),
     background_tasks: BackgroundTasks = BackgroundTasks(),
     db: Session = Depends(get_db),

--- a/backend/app/api/v1/endpoints/emr_ai.py
+++ b/backend/app/api/v1/endpoints/emr_ai.py
@@ -214,25 +214,25 @@ class AISuggestionV2(BaseModel):
     content: str
     confidence: float
     source: str = "AI"
-    explanation: Optional[str] = None
+    explanation: str | None = None
     model: str = "mock"
     requiresDoctorConfirmation: bool = True
 
 
 class DoctorContextEntry(BaseModel):
     """Single entry from doctor history"""
-    content: Optional[str] = None
-    diagnosis: Optional[str] = None
-    created_at: Optional[str] = None
+    content: str | None = None
+    diagnosis: str | None = None
+    created_at: str | None = None
 
 
 class DoctorContext(BaseModel):
     """Doctor history context for better suggestions"""
-    doctor_id: Optional[int] = None
-    specialty: Optional[str] = None
-    field_name: Optional[str] = None
-    previous_entries: Optional[list[DoctorContextEntry]] = None
-    unique_phrases: Optional[list[str]] = None
+    doctor_id: int | None = None
+    specialty: str | None = None
+    field_name: str | None = None
+    previous_entries: list[DoctorContextEntry] | None = None
+    unique_phrases: list[str] | None = None
 
 
 class SuggestRequestV2(BaseModel):
@@ -240,7 +240,7 @@ class SuggestRequestV2(BaseModel):
     emr_snapshot: dict[str, Any]
     specialty: str = "general"
     language: str = "ru"
-    doctor_context: Optional[DoctorContext] = None
+    doctor_context: DoctorContext | None = None
 
 
 class SuggestResponseV2(BaseModel):
@@ -256,7 +256,7 @@ class SuggestResponseV2(BaseModel):
 def generate_v2_suggestions(
     emr_data: dict[str, Any], 
     specialty: str,
-    doctor_context: Optional[DoctorContext] = None,
+    doctor_context: DoctorContext | None = None,
 ) -> list[AISuggestionV2]:
     """Generate mock suggestions in EMR v2 format"""
     suggestions = []

--- a/backend/app/api/v1/endpoints/emr_ai_enhanced.py
+++ b/backend/app/api/v1/endpoints/emr_ai_enhanced.py
@@ -30,7 +30,7 @@ def ai_safety_meta() -> dict[str, Any]:
 async def generate_smart_template(
     specialty: str = Query(..., description="Специализация врача"),
     patient_data: dict[str, Any] = None,
-    doctor_preferences: Optional[dict[str, Any]] = None,
+    doctor_preferences: dict[str, Any] | None = None,
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.require_roles("Admin", "Doctor")),
 ) -> Any:
@@ -284,9 +284,9 @@ async def enhance_emr_with_ai(
 
 @router.get("/analytics/quality")
 async def get_emr_quality_analytics(
-    specialty: Optional[str] = Query(None, description="Фильтр по специализации"),
-    date_from: Optional[str] = Query(None, description="Дата начала"),
-    date_to: Optional[str] = Query(None, description="Дата окончания"),
+    specialty: str | None = Query(None, description="Фильтр по специализации"),
+    date_from: str | None = Query(None, description="Дата начала"),
+    date_to: str | None = Query(None, description="Дата окончания"),
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.require_roles("Admin", "Doctor")),
 ) -> Any:

--- a/backend/app/api/v1/endpoints/emr_export.py
+++ b/backend/app/api/v1/endpoints/emr_export.py
@@ -112,7 +112,7 @@ async def export_emr_to_xml(
 @router.post("/export/csv")
 async def export_emr_to_csv(
     emr_data: dict,
-    fields: Optional[list[str]] = Query(None, description="Поля для экспорта"),
+    fields: list[str] | None = Query(None, description="Поля для экспорта"),
     current_user: User = Depends(get_current_user),
 ):
     """Экспорт EMR в CSV формат"""

--- a/backend/app/api/v1/endpoints/emr_lab_integration.py
+++ b/backend/app/api/v1/endpoints/emr_lab_integration.py
@@ -138,9 +138,9 @@ def _ensure_lab_result_notification_scope(
 @router.get("/patients/{patient_id}/lab-results")
 async def get_patient_lab_results(
     patient_id: int,
-    date_from: Optional[str] = Query(None, description="Дата начала (YYYY-MM-DD)"),
-    date_to: Optional[str] = Query(None, description="Дата окончания (YYYY-MM-DD)"),
-    test_types: Optional[str] = Query(None, description="Типы тестов через запятую"),
+    date_from: str | None = Query(None, description="Дата начала (YYYY-MM-DD)"),
+    date_to: str | None = Query(None, description="Дата окончания (YYYY-MM-DD)"),
+    test_types: str | None = Query(None, description="Типы тестов через запятую"),
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.require_roles("Admin", "Doctor")),
 ) -> Any:
@@ -308,9 +308,9 @@ async def notify_doctor_about_lab_result(
 
 @router.get("/lab-results/statistics")
 async def get_lab_results_statistics(
-    date_from: Optional[str] = Query(None, description="Дата начала (YYYY-MM-DD)"),
-    date_to: Optional[str] = Query(None, description="Дата окончания (YYYY-MM-DD)"),
-    test_type: Optional[str] = Query(None, description="Тип теста"),
+    date_from: str | None = Query(None, description="Дата начала (YYYY-MM-DD)"),
+    date_to: str | None = Query(None, description="Дата окончания (YYYY-MM-DD)"),
+    test_type: str | None = Query(None, description="Тип теста"),
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.require_roles("Admin", "Doctor")),
 ) -> Any:

--- a/backend/app/api/v1/endpoints/emr_templates.py
+++ b/backend/app/api/v1/endpoints/emr_templates.py
@@ -24,8 +24,8 @@ router = APIRouter()
 
 @router.get("/templates", response_model=list[EMRTemplateOut])
 async def get_emr_templates(
-    specialty: Optional[str] = Query(None, description="Фильтр по специализации"),
-    is_public: Optional[bool] = Query(None, description="Только публичные шаблоны"),
+    specialty: str | None = Query(None, description="Фильтр по специализации"),
+    is_public: bool | None = Query(None, description="Только публичные шаблоны"),
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
@@ -47,7 +47,7 @@ async def get_emr_templates(
 
 @router.get("/templates/user", response_model=list[EMRTemplateOut])
 async def get_user_templates(
-    specialty: Optional[str] = Query(None, description="Фильтр по специализации"),
+    specialty: str | None = Query(None, description="Фильтр по специализации"),
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):

--- a/backend/app/api/v1/endpoints/emr_v2.py
+++ b/backend/app/api/v1/endpoints/emr_v2.py
@@ -155,7 +155,7 @@ def filter_patient_emrs_for_access(
 class DoctorHistoryEntry(BaseModel):
     """Single history entry"""
     content: str
-    diagnosis: Optional[str] = None
+    diagnosis: str | None = None
     created_at: str
 
 
@@ -171,7 +171,7 @@ async def get_doctor_history(
     doctor_id: int = Query(..., description="Doctor ID"),
     field_name: str = Query(..., description="Field name (complaints, diagnosis, etc.)"),
     specialty: str = Query("general", description="Doctor specialty"),
-    search_text: Optional[str] = Query(None, description="Search text for similarity"),
+    search_text: str | None = Query(None, description="Search text for similarity"),
     limit: int = Query(10, ge=1, le=50, description="Max entries"),
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.require_roles(*EMR_V2_ALLOWED_ROLES)),

--- a/backend/app/api/v1/endpoints/emr_versioning_enhanced.py
+++ b/backend/app/api/v1/endpoints/emr_versioning_enhanced.py
@@ -63,7 +63,7 @@ async def compare_versions(
 async def restore_version_with_backup(
     emr_id: int,
     version_id: int,
-    reason: Optional[str] = Query(None, description="Причина восстановления"),
+    reason: str | None = Query(None, description="Причина восстановления"),
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.require_roles("Admin", "Doctor")),
 ) -> Any:
@@ -112,7 +112,7 @@ async def create_version_with_analysis(
     emr_id: int,
     version_data: dict[str, Any],
     change_type: str = Query(..., description="Тип изменения"),
-    change_description: Optional[str] = Query(None, description="Описание изменения"),
+    change_description: str | None = Query(None, description="Описание изменения"),
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.require_roles("Admin", "Doctor")),
 ) -> Any:

--- a/backend/app/api/v1/endpoints/fcm_notifications.py
+++ b/backend/app/api/v1/endpoints/fcm_notifications.py
@@ -23,7 +23,7 @@ class FCMTokenRequest(BaseModel):
 
     device_token: str
     device_type: str = "web"  # web, android, ios
-    device_info: Optional[dict[str, str]] = None
+    device_info: dict[str, str] | None = None
 
 
 class FCMNotificationRequest(BaseModel):
@@ -31,13 +31,13 @@ class FCMNotificationRequest(BaseModel):
 
     title: str
     body: str
-    user_ids: Optional[list[int]] = None
-    device_tokens: Optional[list[str]] = None
-    data: Optional[dict[str, Any]] = None
-    image: Optional[str] = None
-    click_action: Optional[str] = None
+    user_ids: list[int] | None = None
+    device_tokens: list[str] | None = None
+    data: dict[str, Any] | None = None
+    image: str | None = None
+    click_action: str | None = None
     sound: str = "default"
-    badge: Optional[int] = None
+    badge: int | None = None
 
 
 class FCMTopicRequest(BaseModel):
@@ -53,9 +53,9 @@ class FCMTopicNotificationRequest(BaseModel):
     topic: str
     title: str
     body: str
-    data: Optional[dict[str, Any]] = None
-    image: Optional[str] = None
-    condition: Optional[str] = None
+    data: dict[str, Any] | None = None
+    image: str | None = None
+    condition: str | None = None
 
 
 @router.post("/register-token")

--- a/backend/app/api/v1/endpoints/feature_flags.py
+++ b/backend/app/api/v1/endpoints/feature_flags.py
@@ -27,15 +27,15 @@ class FeatureFlagResponse(BaseModel):
     id: int
     key: str
     name: str
-    description: Optional[str] = None
+    description: str | None = None
     enabled: bool
     config: dict[str, Any]
     category: str
     environment: str
     created_at: str
-    updated_at: Optional[str] = None
-    created_by: Optional[str] = None
-    updated_by: Optional[str] = None
+    updated_at: str | None = None
+    created_by: str | None = None
+    updated_by: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -45,7 +45,7 @@ class FeatureFlagCreateRequest(BaseModel):
 
     key: str = Field(..., min_length=1, max_length=100, pattern="^[a-z0-9_]+$")
     name: str = Field(..., min_length=1, max_length=200)
-    description: Optional[str] = Field(None, max_length=1000)
+    description: str | None = Field(None, max_length=1000)
     enabled: bool = False
     config: dict[str, Any] = Field(default_factory=dict)
     category: str = Field(default="general", max_length=50)
@@ -57,22 +57,22 @@ class FeatureFlagCreateRequest(BaseModel):
 class FeatureFlagUpdateRequest(BaseModel):
     """Запрос на обновление фича-флага"""
 
-    name: Optional[str] = Field(None, min_length=1, max_length=200)
-    description: Optional[str] = Field(None, max_length=1000)
-    enabled: Optional[bool] = None
-    config: Optional[dict[str, Any]] = None
-    category: Optional[str] = Field(None, max_length=50)
-    environment: Optional[str] = Field(
+    name: str | None = Field(None, min_length=1, max_length=200)
+    description: str | None = Field(None, max_length=1000)
+    enabled: bool | None = None
+    config: dict[str, Any] | None = None
+    category: str | None = Field(None, max_length=50)
+    environment: str | None = Field(
         None, pattern="^(production|staging|development|all)$"
     )
-    reason: Optional[str] = Field(None, max_length=500)
+    reason: str | None = Field(None, max_length=500)
 
 
 class FeatureFlagToggleRequest(BaseModel):
     """Запрос на переключение состояния флага"""
 
     enabled: bool
-    reason: Optional[str] = Field(None, max_length=500)
+    reason: str | None = Field(None, max_length=500)
 
 
 class FeatureFlagHistoryResponse(BaseModel):
@@ -81,13 +81,13 @@ class FeatureFlagHistoryResponse(BaseModel):
     id: int
     flag_key: str
     action: str
-    old_value: Optional[dict[str, Any]] = None
-    new_value: Optional[dict[str, Any]] = None
-    changed_by: Optional[str] = None
+    old_value: dict[str, Any] | None = None
+    new_value: dict[str, Any] | None = None
+    changed_by: str | None = None
     changed_at: str
-    ip_address: Optional[str] = None
-    user_agent: Optional[str] = None
-    reason: Optional[str] = None
+    ip_address: str | None = None
+    user_agent: str | None = None
+    reason: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -105,7 +105,7 @@ class BulkToggleRequest(BaseModel):
 
     flag_keys: list[str]
     enabled: bool
-    reason: Optional[str] = Field(None, max_length=500)
+    reason: str | None = Field(None, max_length=500)
 
 
 # ===================== ЭНДПОИНТЫ =====================
@@ -113,7 +113,7 @@ class BulkToggleRequest(BaseModel):
 
 @router.get("/admin/feature-flags", response_model=list[FeatureFlagResponse])
 def get_all_feature_flags(
-    category: Optional[str] = None,
+    category: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -355,7 +355,7 @@ def bulk_toggle_feature_flags(
 @router.delete("/admin/feature-flags/{flag_key}")
 def delete_feature_flag(
     flag_key: str,
-    reason: Optional[str] = None,
+    reason: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):

--- a/backend/app/api/v1/endpoints/file_system.py
+++ b/backend/app/api/v1/endpoints/file_system.py
@@ -94,17 +94,17 @@ async def _read_limited_import_archive(file: UploadFile, max_bytes: int) -> byte
 async def upload_file(
     request: Request,
     file: UploadFile = File(...),
-    title: Optional[str] = Form(None),
-    description: Optional[str] = Form(None),
+    title: str | None = Form(None),
+    description: str | None = Form(None),
     file_type: str = Form(...),
     permission: str = Form("private"),
-    patient_id: Optional[int] = Form(None),
-    appointment_id: Optional[int] = Form(None),
-    visit_id: Optional[int] = Form(None),
-    emr_id: Optional[int] = Form(None),
-    folder_id: Optional[int] = Form(None),
-    tags: Optional[str] = Form(None),
-    expires_at: Optional[datetime] = Form(None),
+    patient_id: int | None = Form(None),
+    appointment_id: int | None = Form(None),
+    visit_id: int | None = Form(None),
+    emr_id: int | None = Form(None),
+    folder_id: int | None = Form(None),
+    tags: str | None = Form(None),
+    expires_at: datetime | None = Form(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(
         require_roles("Admin", "Doctor", "Nurse", "Receptionist")
@@ -306,12 +306,12 @@ async def search_files(
 
 @router.get("/", response_model=FileList)
 async def get_files(
-    file_type: Optional[str] = Query(None, description="Тип файла"),
-    patient_id: Optional[int] = Query(None, description="ID пациента"),
-    appointment_id: Optional[int] = Query(None, description="ID записи"),
-    visit_id: Optional[int] = Query(None, description="ID визита"),
-    emr_id: Optional[int] = Query(None, description="ID медкарты"),
-    folder_id: Optional[int] = Query(None, description="ID папки"),
+    file_type: str | None = Query(None, description="Тип файла"),
+    patient_id: int | None = Query(None, description="ID пациента"),
+    appointment_id: int | None = Query(None, description="ID записи"),
+    visit_id: int | None = Query(None, description="ID визита"),
+    emr_id: int | None = Query(None, description="ID медкарты"),
+    folder_id: int | None = Query(None, description="ID папки"),
     page: int = Query(1, ge=1, description="Номер страницы"),
     size: int = Query(20, ge=1, le=100, description="Размер страницы"),
     db: Session = Depends(get_db),
@@ -370,11 +370,11 @@ async def get_files(
 async def update_file(
     request: Request,
     file_id: int,
-    title: Optional[str] = Form(None),
-    description: Optional[str] = Form(None),
-    permission: Optional[str] = Form(None),
-    tags: Optional[str] = Form(None),
-    expires_at: Optional[datetime] = Form(None),
+    title: str | None = Form(None),
+    description: str | None = Form(None),
+    permission: str | None = Form(None),
+    tags: str | None = Form(None),
+    expires_at: datetime | None = Form(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(
         require_roles("Admin", "Doctor", "Nurse", "Receptionist")
@@ -442,7 +442,7 @@ async def replace_file_content(
     request: Request,
     file_id: int,
     file: UploadFile = File(...),
-    change_description: Optional[str] = Form(None),
+    change_description: str | None = Form(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(
         require_roles("Admin", "Doctor", "Nurse", "Receptionist")
@@ -622,7 +622,7 @@ async def export_files(
 @router.post("/import", response_model=FileImportResponse)
 async def import_files(
     file: UploadFile = File(...),
-    target_folder_id: Optional[int] = Form(None),
+    target_folder_id: int | None = Form(None),
     overwrite_existing: bool = Form(False),
     db: Session = Depends(get_db),
     current_user: User = Depends(

--- a/backend/app/api/v1/endpoints/file_upload_simple.py
+++ b/backend/app/api/v1/endpoints/file_upload_simple.py
@@ -117,7 +117,7 @@ def _build_target_path(safe_filename: str, file_hash: str) -> tuple[Path, str]:
 @router.post("/upload-simple")
 async def upload_file_simple(
     file: UploadFile = File(...),
-    title: Optional[str] = Form(None),
+    title: str | None = Form(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):

--- a/backend/app/api/v1/endpoints/force_majeure.py
+++ b/backend/app/api/v1/endpoints/force_majeure.py
@@ -34,9 +34,9 @@ class ForceMajeureTransferRequest(BaseModel):
     """Запрос на массовый перенос очереди"""
 
     specialist_id: int = Field(..., description="ID специалиста")
-    target_date: Optional[date] = Field(None, description="Дата очереди (по умолчанию сегодня)")
+    target_date: date | None = Field(None, description="Дата очереди (по умолчанию сегодня)")
     reason: str = Field(..., min_length=5, description="Причина переноса")
-    entry_ids: Optional[list[int]] = Field(None, description="ID конкретных записей (все если не указано)")
+    entry_ids: list[int] | None = Field(None, description="ID конкретных записей (все если не указано)")
     send_notifications: bool = Field(True, description="Отправить уведомления пациентам")
 
 
@@ -44,10 +44,10 @@ class ForceMajeureCancelRequest(BaseModel):
     """Запрос на массовую отмену с возвратом"""
 
     specialist_id: int = Field(..., description="ID специалиста")
-    target_date: Optional[date] = Field(None, description="Дата очереди (по умолчанию сегодня)")
+    target_date: date | None = Field(None, description="Дата очереди (по умолчанию сегодня)")
     reason: str = Field(..., min_length=5, description="Причина отмены")
     refund_type: str = Field("deposit", description="Тип возврата: deposit или bank_transfer")
-    entry_ids: Optional[list[int]] = Field(None, description="ID конкретных записей (все если не указано)")
+    entry_ids: list[int] | None = Field(None, description="ID конкретных записей (все если не указано)")
     send_notifications: bool = Field(True, description="Отправить уведомления пациентам")
 
 
@@ -56,19 +56,19 @@ class RefundRequestResponse(BaseModel):
 
     id: int
     patient_id: int
-    patient_name: Optional[str] = None
+    patient_name: str | None = None
     payment_id: int
     original_amount: float
     refund_amount: float
     commission_amount: float
     refund_type: str
     status: str
-    reason: Optional[str] = None
+    reason: str | None = None
     is_automatic: bool
-    bank_card_number: Optional[str] = None
+    bank_card_number: str | None = None
     created_at: datetime
-    processed_at: Optional[datetime] = None
-    processed_by_name: Optional[str] = None
+    processed_at: datetime | None = None
+    processed_by_name: str | None = None
     available_actions: list[str] = Field(default_factory=list)
     can_approve: bool = False
     can_reject: bool = False
@@ -81,9 +81,9 @@ class ProcessRefundRequest(BaseModel):
     """Запрос на обработку заявки на возврат"""
 
     action: str = Field(..., description="Действие: approve, reject, complete")
-    rejection_reason: Optional[str] = Field(None, description="Причина отклонения")
-    bank_card_number: Optional[str] = Field(None, description="Номер карты для возврата")
-    manager_notes: Optional[str] = Field(None, description="Примечания менеджера")
+    rejection_reason: str | None = Field(None, description="Причина отклонения")
+    bank_card_number: str | None = Field(None, description="Номер карты для возврата")
+    manager_notes: str | None = Field(None, description="Примечания менеджера")
 
 
 class DepositResponse(BaseModel):
@@ -91,7 +91,7 @@ class DepositResponse(BaseModel):
 
     id: int
     patient_id: int
-    patient_name: Optional[str] = None
+    patient_name: str | None = None
     balance: float
     currency: str
     is_active: bool
@@ -108,7 +108,7 @@ class DepositTransactionResponse(BaseModel):
     transaction_type: str
     amount: float
     balance_after: float
-    description: Optional[str] = None
+    description: str | None = None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
@@ -119,7 +119,7 @@ class AddDepositRequest(BaseModel):
 
     patient_id: int
     amount: float = Field(..., gt=0)
-    description: Optional[str] = None
+    description: str | None = None
 
 
 class UseDepositRequest(BaseModel):
@@ -127,8 +127,8 @@ class UseDepositRequest(BaseModel):
 
     patient_id: int
     amount: float = Field(..., gt=0)
-    visit_id: Optional[int] = None
-    description: Optional[str] = None
+    visit_id: int | None = None
+    description: str | None = None
 
 
 # ========================= ФОРС-МАЖОР =========================
@@ -183,7 +183,7 @@ async def cancel_queue_with_refund(
 @router.get("/pending-entries", response_model=list[dict[str, Any]])
 async def get_pending_entries_for_force_majeure(
     specialist_id: int = Query(..., description="ID специалиста"),
-    target_date: Optional[date] = Query(None, description="Дата очереди"),
+    target_date: date | None = Query(None, description="Дата очереди"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar")),
 ):
@@ -205,8 +205,8 @@ async def get_pending_entries_for_force_majeure(
 
 @router.get("/refund-requests", response_model=list[RefundRequestResponse])
 async def get_refund_requests(
-    status_filter: Optional[str] = Query(None, description="Фильтр по статусу"),
-    patient_id: Optional[int] = Query(None, description="Фильтр по пациенту"),
+    status_filter: str | None = Query(None, description="Фильтр по статусу"),
+    patient_id: int | None = Query(None, description="Фильтр по пациенту"),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
@@ -282,7 +282,7 @@ async def process_refund_request(
 @router.get("/deposits", response_model=list[DepositResponse])
 async def get_deposits(
     active_only: bool = Query(True, description="Только активные"),
-    min_balance: Optional[float] = Query(None, description="Минимальный баланс"),
+    min_balance: float | None = Query(None, description="Минимальный баланс"),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),

--- a/backend/app/api/v1/endpoints/global_search.py
+++ b/backend/app/api/v1/endpoints/global_search.py
@@ -38,11 +38,11 @@ GLOBAL_SEARCH_ROLES = (
 
 class PatientSearchResult(BaseModel):
     id: int
-    first_name: Optional[str] = None
-    last_name: Optional[str] = None
-    middle_name: Optional[str] = None
-    phone: Optional[str] = None
-    birth_date: Optional[date] = None
+    first_name: str | None = None
+    last_name: str | None = None
+    middle_name: str | None = None
+    phone: str | None = None
+    birth_date: date | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -50,22 +50,22 @@ class PatientSearchResult(BaseModel):
 class VisitSearchResult(BaseModel):
     id: int
     patient_id: int
-    patient_name: Optional[str] = None
-    status: Optional[str] = None
-    visit_date: Optional[date] = None
-    visit_time: Optional[str] = None
-    specialist_name: Optional[str] = None
+    patient_name: str | None = None
+    status: str | None = None
+    visit_date: date | None = None
+    visit_time: str | None = None
+    specialist_name: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
 
 class LabResultSearchResult(BaseModel):
     id: int
-    patient_id: Optional[int] = None
-    patient_name: Optional[str] = None
+    patient_id: int | None = None
+    patient_name: str | None = None
     status: str
-    test_type: Optional[str] = None
-    created_at: Optional[datetime] = None
+    test_type: str | None = None
+    created_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/api/v1/endpoints/group_permissions.py
+++ b/backend/app/api/v1/endpoints/group_permissions.py
@@ -29,8 +29,8 @@ class PermissionResponse(BaseModel):
     id: int
     name: str
     codename: str
-    description: Optional[str]
-    category: Optional[str]
+    description: str | None
+    category: str | None
     is_active: bool
 
 
@@ -38,7 +38,7 @@ class RoleResponse(BaseModel):
     id: int
     name: str
     display_name: str
-    description: Optional[str]
+    description: str | None
     level: int
     is_active: bool
     is_system: bool
@@ -49,7 +49,7 @@ class GroupResponse(BaseModel):
     id: int
     name: str
     display_name: str
-    description: Optional[str]
+    description: str | None
     group_type: str
     is_active: bool
     users_count: int
@@ -89,8 +89,8 @@ class PermissionOverrideRequest(BaseModel):
     user_id: int
     permission_id: int
     override_type: str = Field(..., pattern="^(grant|deny)$")
-    reason: Optional[str] = None
-    expires_hours: Optional[int] = None
+    reason: str | None = None
+    expires_hours: int | None = None
 
 
 # ===================== ПОЛУЧЕНИЕ РАЗРЕШЕНИЙ =====================
@@ -163,7 +163,7 @@ def check_user_permission(
 @router.get("/groups", response_model=list[GroupResponse])
 def get_groups(
     active_only: bool = Query(True, description="Только активные группы"),
-    group_type: Optional[str] = Query(None, description="Тип группы"),
+    group_type: str | None = Query(None, description="Тип группы"),
     limit: int = Query(50, ge=1, le=100, description="Количество групп"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "SuperAdmin")),
@@ -382,7 +382,7 @@ def get_roles(
 @router.get("/permissions", response_model=list[PermissionResponse])
 def get_permissions(
     active_only: bool = Query(True, description="Только активные разрешения"),
-    category: Optional[str] = Query(None, description="Категория разрешений"),
+    category: str | None = Query(None, description="Категория разрешений"),
     limit: int = Query(100, ge=1, le=200, description="Количество разрешений"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "SuperAdmin")),

--- a/backend/app/api/v1/endpoints/medical_equipment.py
+++ b/backend/app/api/v1/endpoints/medical_equipment.py
@@ -49,17 +49,17 @@ class DeviceInfoResponse(BaseModel):
     connection_type: str
     status: str
     location: str
-    last_seen: Optional[datetime] = None
-    last_measurement: Optional[datetime] = None
-    calibration_date: Optional[datetime] = None
-    maintenance_date: Optional[datetime] = None
+    last_seen: datetime | None = None
+    last_measurement: datetime | None = None
+    calibration_date: datetime | None = None
+    maintenance_date: datetime | None = None
 
 
 class MeasurementRequest(BaseModel):
     """Запрос на измерение"""
 
     device_id: str = Field(..., description="ID устройства")
-    patient_id: Optional[str] = Field(None, description="ID пациента")
+    patient_id: str | None = Field(None, description="ID пациента")
 
 
 class MeasurementResponse(BaseModel):
@@ -68,20 +68,20 @@ class MeasurementResponse(BaseModel):
     device_id: str
     device_type: str
     timestamp: datetime
-    patient_id: Optional[str] = None
+    patient_id: str | None = None
     measurements: dict[str, Any]
-    raw_data: Optional[str] = None
-    quality_score: Optional[float] = None
-    notes: Optional[str] = None
+    raw_data: str | None = None
+    quality_score: float | None = None
+    notes: str | None = None
 
 
 class DeviceConfigRequest(BaseModel):
     """Запрос на обновление конфигурации устройства"""
 
-    name: Optional[str] = None
-    location: Optional[str] = None
-    connection_params: Optional[dict[str, Any]] = None
-    maintenance_date: Optional[datetime] = None
+    name: str | None = None
+    location: str | None = None
+    connection_params: dict[str, Any] | None = None
+    maintenance_date: datetime | None = None
 
 
 class DiagnosticsResponse(BaseModel):
@@ -91,14 +91,14 @@ class DiagnosticsResponse(BaseModel):
     timestamp: datetime
     success: bool
     tests: dict[str, Any]
-    error: Optional[str] = None
+    error: str | None = None
 
 
 class StatisticsResponse(BaseModel):
     """Ответ со статистикой устройства"""
 
     total_measurements: int
-    last_measurement: Optional[datetime] = None
+    last_measurement: datetime | None = None
     average_quality: float
     measurements_today: int
     measurements_this_week: int
@@ -376,11 +376,11 @@ async def take_measurement(
 
 @router.get("/measurements")
 async def get_measurements(
-    device_id: Optional[str] = Query(None, description="ID устройства"),
-    patient_id: Optional[str] = Query(None, description="ID пациента"),
-    device_type: Optional[str] = Query(None, description="Тип устройства"),
-    start_date: Optional[date] = Query(None, description="Начальная дата"),
-    end_date: Optional[date] = Query(None, description="Конечная дата"),
+    device_id: str | None = Query(None, description="ID устройства"),
+    patient_id: str | None = Query(None, description="ID пациента"),
+    device_type: str | None = Query(None, description="Тип устройства"),
+    start_date: date | None = Query(None, description="Начальная дата"),
+    end_date: date | None = Query(None, description="Конечная дата"),
     limit: int = Query(100, ge=1, le=1000, description="Количество записей"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
@@ -641,9 +641,9 @@ async def get_equipment_overview(
 @router.get("/measurements/export")
 async def export_measurements(
     format: str = Query("json", pattern="^(json|csv)$", description="Формат экспорта"),
-    device_id: Optional[str] = Query(None, description="ID устройства"),
-    start_date: Optional[date] = Query(None, description="Начальная дата"),
-    end_date: Optional[date] = Query(None, description="Конечная дата"),
+    device_id: str | None = Query(None, description="ID устройства"),
+    start_date: date | None = Query(None, description="Начальная дата"),
+    end_date: date | None = Query(None, description="Конечная дата"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
     _: None = Depends(require_roles([Roles.ADMIN, Roles.DOCTOR])),
@@ -699,7 +699,7 @@ async def export_measurements(
 @router.post("/quick-measurement/{device_type}")
 async def quick_measurement(
     device_type: str,
-    patient_id: Optional[str] = Query(None, description="ID пациента"),
+    patient_id: str | None = Query(None, description="ID пациента"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
     _: None = Depends(require_roles([Roles.ADMIN, Roles.DOCTOR, Roles.REGISTRAR])),

--- a/backend/app/api/v1/endpoints/migration_management.py
+++ b/backend/app/api/v1/endpoints/migration_management.py
@@ -31,29 +31,29 @@ class BackupResult(BaseModel):
     """Результат создания резервной копии"""
 
     success: bool
-    backup_file: Optional[str] = None
-    queues_count: Optional[int] = None
-    total_entries: Optional[int] = None
-    error: Optional[str] = None
+    backup_file: str | None = None
+    queues_count: int | None = None
+    total_entries: int | None = None
+    error: str | None = None
 
 
 class RestoreResult(BaseModel):
     """Результат восстановления"""
 
     success: bool
-    restored_queues: Optional[int] = None
-    restored_entries: Optional[int] = None
-    error: Optional[str] = None
+    restored_queues: int | None = None
+    restored_entries: int | None = None
+    error: str | None = None
 
 
 class CleanupResult(BaseModel):
     """Результат очистки"""
 
     success: bool
-    deleted_queues: Optional[int] = None
-    deleted_entries: Optional[int] = None
-    cutoff_date: Optional[str] = None
-    error: Optional[str] = None
+    deleted_queues: int | None = None
+    deleted_entries: int | None = None
+    cutoff_date: str | None = None
+    error: str | None = None
 
 
 class IntegrityCheckResult(BaseModel):
@@ -62,7 +62,7 @@ class IntegrityCheckResult(BaseModel):
     passed: bool
     checks: dict[str, Any]
     checked_at: str
-    error: Optional[str] = None
+    error: str | None = None
 
 
 class EMRCutoverBackfillResult(BaseModel):
@@ -78,7 +78,7 @@ class EMRCutoverBackfillResult(BaseModel):
     rebound_files: int
     errors: list[dict[str, Any]]
     generated_at: str
-    verification: Optional[dict[str, Any]] = None
+    verification: dict[str, Any] | None = None
 
 
 class EMRCutoverVerificationResult(BaseModel):
@@ -123,7 +123,7 @@ def migrate_legacy_queue_data(
 )
 def migrate_legacy_emr_cutover(
     dry_run: bool = Query(False, description="Только проверить, без записи изменений"),
-    limit: Optional[int] = Query(None, ge=1, le=10000, description="Лимит legacy EMR для одного прогона"),
+    limit: int | None = Query(None, ge=1, le=10000, description="Лимит legacy EMR для одного прогона"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -198,7 +198,7 @@ def check_data_integrity(
 
 @router.post("/admin/migration/backup-queue-data", response_model=BackupResult)
 def backup_queue_data(
-    target_date: Optional[str] = Query(None, description="Дата в формате YYYY-MM-DD"),
+    target_date: str | None = Query(None, description="Дата в формате YYYY-MM-DD"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):

--- a/backend/app/api/v1/endpoints/mobile_api_extended.py
+++ b/backend/app/api/v1/endpoints/mobile_api_extended.py
@@ -41,19 +41,19 @@ router = APIRouter()
 class DoctorSearchRequest(BaseModel):
     """Запрос поиска врачей"""
 
-    specialty: Optional[str] = None
-    name: Optional[str] = None
-    available_date: Optional[str] = None
+    specialty: str | None = None
+    name: str | None = None
+    available_date: str | None = None
     limit: int = 10
 
 
 class ServiceSearchRequest(BaseModel):
     """Запрос поиска услуг"""
 
-    category: Optional[str] = None
-    name: Optional[str] = None
-    price_min: Optional[float] = None
-    price_max: Optional[float] = None
+    category: str | None = None
+    name: str | None = None
+    price_min: float | None = None
+    price_max: float | None = None
     limit: int = 20
 
 
@@ -73,7 +73,7 @@ class AppointmentCancelRequest(BaseModel):
     """Запрос отмены записи"""
 
     appointment_id: int
-    reason: Optional[str] = None
+    reason: str | None = None
 
 
 class AppointmentRescheduleRequest(BaseModel):
@@ -81,36 +81,36 @@ class AppointmentRescheduleRequest(BaseModel):
 
     appointment_id: int
     new_date: str
-    new_time: Optional[str] = None
-    reason: Optional[str] = None
+    new_time: str | None = None
+    reason: str | None = None
 
 
 class FeedbackRequest(BaseModel):
     """Запрос обратной связи"""
 
     type: str  # review, complaint, suggestion, question
-    rating: Optional[int] = None  # 1-5
+    rating: int | None = None  # 1-5
     message: str
-    appointment_id: Optional[int] = None
+    appointment_id: int | None = None
 
 
 class EmergencyContactRequest(BaseModel):
     """Запрос экстренной связи"""
 
     type: str  # ambulance, emergency_doctor, clinic
-    message: Optional[str] = None
-    location: Optional[dict[str, float]] = None  # {"lat": 41.0, "lng": 69.0}
+    message: str | None = None
+    location: dict[str, float] | None = None  # {"lat": 41.0, "lng": 69.0}
 
 
 class ProfileUpdateRequest(BaseModel):
     """Обновление профиля"""
 
-    full_name: Optional[str] = None
-    birth_date: Optional[str] = None
-    address: Optional[str] = None
-    emergency_contact: Optional[str] = None
-    allergies: Optional[str] = None
-    chronic_conditions: Optional[str] = None
+    full_name: str | None = None
+    birth_date: str | None = None
+    address: str | None = None
+    emergency_contact: str | None = None
+    allergies: str | None = None
+    chronic_conditions: str | None = None
 
 
 class NotificationSettingsRequest(BaseModel):

--- a/backend/app/api/v1/endpoints/morning_assignment.py
+++ b/backend/app/api/v1/endpoints/morning_assignment.py
@@ -48,7 +48,7 @@ class ManualAssignmentRequest(BaseModel):
 
 @router.post("/admin/morning-assignment/run", response_model=MorningAssignmentResponse)
 def run_morning_assignment_manual(
-    target_date: Optional[str] = Query(
+    target_date: str | None = Query(
         None, description="Дата в формате YYYY-MM-DD, по умолчанию сегодня"
     ),
     db: Session = Depends(get_db),
@@ -81,7 +81,7 @@ def run_morning_assignment_manual(
 
 @router.get("/admin/morning-assignment/stats", response_model=AssignmentStatsResponse)
 def get_morning_assignment_stats(
-    target_date: Optional[str] = Query(
+    target_date: str | None = Query(
         None, description="Дата в формате YYYY-MM-DD, по умолчанию сегодня"
     ),
     db: Session = Depends(get_db),
@@ -143,7 +143,7 @@ def manual_assignment_for_visits(
 
 @router.get("/admin/morning-assignment/pending-visits")
 def get_pending_visits(
-    target_date: Optional[str] = Query(
+    target_date: str | None = Query(
         None, description="Дата в формате YYYY-MM-DD, по умолчанию сегодня"
     ),
     db: Session = Depends(get_db),
@@ -172,7 +172,7 @@ def get_pending_visits(
 
 @router.get("/admin/morning-assignment/queue-summary")
 def get_queue_summary(
-    target_date: Optional[str] = Query(
+    target_date: str | None = Query(
         None, description="Дата в формате YYYY-MM-DD, по умолчанию сегодня"
     ),
     db: Session = Depends(get_db),

--- a/backend/app/api/v1/endpoints/notifications.py
+++ b/backend/app/api/v1/endpoints/notifications.py
@@ -65,8 +65,8 @@ def _validate_recipient_scope(
     *,
     platform_service,
     current_user: User,
-    recipient_id: Optional[int],
-    recipient_type: Optional[str],
+    recipient_id: int | None,
+    recipient_type: str | None,
 ) -> None:
     expected_recipient_id = current_user.id
 
@@ -301,7 +301,7 @@ async def send_appointment_reminder(
 async def send_visit_confirmation(
     background_tasks: BackgroundTasks,
     visit_id: int,
-    queue_number: Optional[int] = None,
+    queue_number: int | None = None,
     current_user: User = Depends(require_roles(["admin", "doctor", "nurse"])),
     db: Session = Depends(get_db),
 ):
@@ -409,7 +409,7 @@ async def send_system_alert(
     background_tasks: BackgroundTasks,
     alert_type: str,
     message: str,
-    details: Optional[dict[str, Any]] = None,
+    details: dict[str, Any] | None = None,
     current_user: User = Depends(require_roles(["admin"])),
     db: Session = Depends(get_db),
 ):
@@ -574,16 +574,16 @@ async def delete_notification_template(
 @router.get("/inbox", response_model=NotificationInboxResponse)
 @router.get("/history", response_model=NotificationInboxResponse)
 async def get_notification_history(
-    role: Optional[str] = Query(None),
+    role: str | None = Query(None),
     status: str = Query("all"),
-    event_type: Optional[str] = Query(None),
-    severity: Optional[str] = Query(None),
-    department_key: Optional[str] = Query(None),
-    search: Optional[str] = Query(None),
-    cursor: Optional[int] = Query(None),
+    event_type: str | None = Query(None),
+    severity: str | None = Query(None),
+    department_key: str | None = Query(None),
+    search: str | None = Query(None),
+    cursor: int | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
-    recipient_id: Optional[int] = Query(None),
-    recipient_type: Optional[str] = Query(None),
+    recipient_id: int | None = Query(None),
+    recipient_type: str | None = Query(None),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -611,16 +611,16 @@ async def get_notification_history(
 
 @router.get("/sync", response_model=NotificationInboxResponse)
 async def sync_notifications(
-    role: Optional[str] = Query(None),
+    role: str | None = Query(None),
     status: str = Query("all"),
-    event_type: Optional[str] = Query(None),
-    severity: Optional[str] = Query(None),
-    department_key: Optional[str] = Query(None),
-    search: Optional[str] = Query(None),
-    cursor: Optional[int] = Query(None),
+    event_type: str | None = Query(None),
+    severity: str | None = Query(None),
+    department_key: str | None = Query(None),
+    search: str | None = Query(None),
+    cursor: int | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
-    recipient_id: Optional[int] = Query(None),
-    recipient_type: Optional[str] = Query(None),
+    recipient_id: int | None = Query(None),
+    recipient_type: str | None = Query(None),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -647,10 +647,10 @@ async def sync_notifications(
 
 @router.get("/unread-count", response_model=NotificationUnreadCountResponse)
 async def get_unread_notification_count(
-    role: Optional[str] = Query(None),
-    department_key: Optional[str] = Query(None),
-    recipient_id: Optional[int] = Query(None),
-    recipient_type: Optional[str] = Query(None),
+    role: str | None = Query(None),
+    department_key: str | None = Query(None),
+    recipient_id: int | None = Query(None),
+    recipient_type: str | None = Query(None),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -743,10 +743,10 @@ async def archive_notification(
 
 @router.post("/mark-all-read", response_model=NotificationMutationResponse)
 async def mark_all_notifications_read(
-    role: Optional[str] = Query(None),
-    department_key: Optional[str] = Query(None),
-    recipient_id: Optional[int] = Query(None),
-    recipient_type: Optional[str] = Query(None),
+    role: str | None = Query(None),
+    department_key: str | None = Query(None),
+    recipient_id: int | None = Query(None),
+    recipient_type: str | None = Query(None),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):

--- a/backend/app/api/v1/endpoints/online_queue.py
+++ b/backend/app/api/v1/endpoints/online_queue.py
@@ -44,9 +44,9 @@ def open_day_alias(
 @router.get("/stats", name="online_queue_stats")
 def stats_alias(
     department: str = Query(...),
-    date_str: Optional[str] = Query(None),
-    date: Optional[str] = Query(None),
-    d: Optional[str] = Query(None),
+    date_str: str | None = Query(None),
+    date: str | None = Query(None),
+    d: str | None = Query(None),
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
@@ -64,9 +64,9 @@ def stats_alias(
 @router.get("/qrcode", name="online_queue_qrcode")
 def qrcode_alias(
     department: str = Query(...),
-    date_str: Optional[str] = Query(None),
-    date: Optional[str] = Query(None),
-    d: Optional[str] = Query(None),
+    date_str: str | None = Query(None),
+    date: str | None = Query(None),
+    d: str | None = Query(None),
     current_user=Depends(get_current_user),
 ):
     return impl.qrcode_png(
@@ -83,9 +83,9 @@ def qrcode_alias(
 )
 def close_alias(
     department: str = Query(...),
-    date_str: Optional[str] = Query(None),
-    date: Optional[str] = Query(None),
-    d: Optional[str] = Query(None),
+    date_str: str | None = Query(None),
+    date: str | None = Query(None),
+    d: str | None = Query(None),
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):

--- a/backend/app/api/v1/endpoints/online_queue_legacy.py
+++ b/backend/app/api/v1/endpoints/online_queue_legacy.py
@@ -21,7 +21,7 @@ router = APIRouter()
 async def generate_qr_code_legacy(
     day: str = Query(..., description="Дата в формате YYYY-MM-DD"),
     specialist_id: int = Query(..., description="ID специалиста"),
-    department: Optional[str] = Query("general", description="Отделение"),
+    department: str | None = Query("general", description="Отделение"),
     expires_hours: int = Query(24, description="Срок действия в часах"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -112,8 +112,8 @@ async def get_queue_status_legacy(
 @router.post("/join")
 async def join_queue_legacy(
     token: str,
-    phone: Optional[str] = None,
-    telegram_id: Optional[str] = None,
+    phone: str | None = None,
+    telegram_id: str | None = None,
     db: Session = Depends(get_db),
 ):
     """

--- a/backend/app/api/v1/endpoints/online_queue_new.py
+++ b/backend/app/api/v1/endpoints/online_queue_new.py
@@ -230,7 +230,7 @@ def check_queue_status(
 
 @router.get("/online-queue/today")
 def get_today_queue(
-    specialist_id: Optional[int] = Query(None, description="ID специалиста"),
+    specialist_id: int | None = Query(None, description="ID специалиста"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):

--- a/backend/app/api/v1/endpoints/patient_appointments.py
+++ b/backend/app/api/v1/endpoints/patient_appointments.py
@@ -29,17 +29,17 @@ class PatientAppointmentResponse(BaseModel):
     """Ответ с информацией о записи для пациента"""
     id: int
     appointment_date: str
-    appointment_time: Optional[str] = None
-    doctor_name: Optional[str] = None
-    doctor_id: Optional[int] = None
-    department: Optional[str] = None
-    department_name: Optional[str] = None
-    cabinet: Optional[str] = None
+    appointment_time: str | None = None
+    doctor_name: str | None = None
+    doctor_id: int | None = None
+    department: str | None = None
+    department_name: str | None = None
+    cabinet: str | None = None
     status: str
     services: list[str] = []
     can_cancel: bool = False
     can_reschedule: bool = False
-    hours_until_appointment: Optional[float] = None
+    hours_until_appointment: float | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -50,7 +50,7 @@ class PatientResultResponse(BaseModel):
     title: str
     date: str
     status: str
-    file_url: Optional[str] = None
+    file_url: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -101,7 +101,7 @@ def can_modify_appointment(appointment: Appointment, min_hours: int = 24) -> tup
         return False, 0
 
 
-def get_department_display_name(department: Optional[str]) -> str:
+def get_department_display_name(department: str | None) -> str:
     """Получить читаемое название отделения."""
     names = {
         'cardiology': 'Кардиология',
@@ -114,7 +114,7 @@ def get_department_display_name(department: Optional[str]) -> str:
     return names.get(department.lower(), department) if department else 'Не указано'
 
 
-def extract_department_value(appointment: Appointment) -> Optional[str]:
+def extract_department_value(appointment: Appointment) -> str | None:
     """Достать строковое представление отделения из записи."""
     department = getattr(appointment, "department", None)
     if isinstance(department, str):
@@ -132,7 +132,7 @@ def extract_department_value(appointment: Appointment) -> Optional[str]:
 async def get_my_appointments(
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.get_current_user),
-    status_filter: Optional[str] = Query(None, description="Фильтр по статусу"),
+    status_filter: str | None = Query(None, description="Фильтр по статусу"),
     include_past: bool = Query(False, description="Включить прошедшие записи"),
 ):
     """
@@ -361,7 +361,7 @@ async def reschedule_my_appointment(
 async def get_available_slots(
     appointment_id: int,
     date_from: str = Query(..., description="Начальная дата YYYY-MM-DD"),
-    date_to: Optional[str] = Query(None, description="Конечная дата YYYY-MM-DD"),
+    date_to: str | None = Query(None, description="Конечная дата YYYY-MM-DD"),
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.get_current_user),
 ):

--- a/backend/app/api/v1/endpoints/patients.py
+++ b/backend/app/api/v1/endpoints/patients.py
@@ -82,8 +82,8 @@ def list_patients(
     db: Session = Depends(deps.get_db),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    q: Optional[str] = Query(None, description="Поиск по ФИО, телефону или документу"),
-    phone: Optional[str] = Query(None, description="Точный поиск по номеру телефона"),
+    q: str | None = Query(None, description="Поиск по ФИО, телефону или документу"),
+    phone: str | None = Query(None, description="Точный поиск по номеру телефона"),
     current_user: User = Depends(deps.require_roles("Admin", "Registrar", "Doctor", "Lab", "Cashier", "Nurse")),
 ):
     """
@@ -311,7 +311,7 @@ def add_family_relation(
     patient_id: int,
     related_patient_id: int = Query(..., description="ID родственника"),
     relation_type: str = Query("other", description="Тип связи: parent, child, guardian, spouse, sibling, other"),
-    description: Optional[str] = Query(None, description="Описание связи"),
+    description: str | None = Query(None, description="Описание связи"),
     is_primary_contact: bool = Query(False, description="Основное контактное лицо"),
     current_user: User = Depends(deps.require_roles("Admin", "Registrar")),
 ):

--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -117,8 +117,8 @@ class PaymentInvoiceCreateRequest(BaseModel):
     provider: str = Field(
         ..., pattern="^(click|payme)$", description="Платежный провайдер"
     )
-    description: Optional[str] = Field(None, description="Описание платежа")
-    patient_info: Optional[dict[str, Any]] = Field(
+    description: str | None = Field(None, description="Описание платежа")
+    patient_info: dict[str, Any] | None = Field(
         None, description="Информация о пациенте"
     )
 
@@ -129,7 +129,7 @@ class PaymentInvoiceResponse(BaseModel):
     currency: str
     provider: str
     status: str
-    description: Optional[str]
+    description: str | None
     created_at: datetime
 
 
@@ -145,20 +145,20 @@ class PaymentInitRequest(BaseModel):
     provider: str = Field(..., description="Провайдер платежа (click, payme, kaspi)")
     amount: float = Field(..., gt=0, description="Сумма платежа")
     currency: str = Field(default="UZS", description="Валюта платежа")
-    description: Optional[str] = Field(None, description="Описание платежа")
-    return_url: Optional[str] = Field(None, description="URL возврата при успехе")
-    cancel_url: Optional[str] = Field(None, description="URL возврата при отмене")
+    description: str | None = Field(None, description="Описание платежа")
+    return_url: str | None = Field(None, description="URL возврата при успехе")
+    cancel_url: str | None = Field(None, description="URL возврата при отмене")
 
 
 class PaymentInitResponse(BaseModel):
     """Ответ на инициализацию платежа"""
 
     success: bool
-    payment_id: Optional[int] = None
-    provider_payment_id: Optional[str] = None
-    payment_url: Optional[str] = None
-    status: Optional[str] = None
-    error_message: Optional[str] = None
+    payment_id: int | None = None
+    provider_payment_id: str | None = None
+    payment_url: str | None = None
+    status: str | None = None
+    error_message: str | None = None
 
 
 class PaymentStatusResponse(BaseModel):
@@ -168,11 +168,11 @@ class PaymentStatusResponse(BaseModel):
     status: str
     amount: float
     currency: str
-    provider: Optional[str] = None
-    provider_payment_id: Optional[str] = None
+    provider: str | None = None
+    provider_payment_id: str | None = None
     created_at: datetime
-    paid_at: Optional[datetime] = None
-    provider_data: Optional[dict[str, Any]] = None
+    paid_at: datetime | None = None
+    provider_data: dict[str, Any] | None = None
 
 
 class PaymentListResponse(BaseModel):
@@ -242,12 +242,12 @@ def init_payment(
 class PaymentCreateRequest(BaseModel):
     """Запрос на создание платежа"""
 
-    visit_id: Optional[int] = Field(None, description="ID визита")
-    appointment_id: Optional[int] = Field(None, description="ID записи (appointment)")
+    visit_id: int | None = Field(None, description="ID визита")
+    appointment_id: int | None = Field(None, description="ID записи (appointment)")
     amount: float = Field(..., gt=0, description="Сумма платежа")
     currency: str = Field(default="UZS", description="Валюта платежа")
     method: str = Field(default="cash", description="Метод оплаты (cash, card)")
-    note: Optional[str] = Field(None, description="Примечание")
+    note: str | None = Field(None, description="Примечание")
 
 
 @router.post("/", response_model=dict[str, Any])
@@ -280,9 +280,9 @@ def create_payment(
 @router.get("/", response_model=PaymentListResponse)
 def list_payments(
     db: Session = Depends(get_db),
-    visit_id: Optional[int] = Query(None, description="Фильтр по ID визита"),
-    date_from: Optional[str] = Query(None, description="Дата начала (YYYY-MM-DD)"),
-    date_to: Optional[str] = Query(None, description="Дата окончания (YYYY-MM-DD)"),
+    visit_id: int | None = Query(None, description="Фильтр по ID визита"),
+    date_from: str | None = Query(None, description="Дата начала (YYYY-MM-DD)"),
+    date_to: str | None = Query(None, description="Дата окончания (YYYY-MM-DD)"),
     limit: int = Query(50, ge=1, le=1000),
     offset: int = Query(0, ge=0),
     current_user=Depends(deps.require_roles("Admin", "Cashier", "Registrar", "Doctor")),

--- a/backend/app/api/v1/endpoints/phone_verification.py
+++ b/backend/app/api/v1/endpoints/phone_verification.py
@@ -24,8 +24,8 @@ class SendVerificationCodeRequest(BaseModel):
 
     phone: str
     purpose: str = "verification"
-    provider: Optional[str] = None
-    custom_message: Optional[str] = None
+    provider: str | None = None
+    custom_message: str | None = None
 
     @field_validator('phone')
     @classmethod
@@ -337,8 +337,8 @@ async def get_verification_statistics(
 async def admin_send_verification_code(
     phone: str = Query(..., description="Номер телефона в формате +998XXXXXXXXX"),
     purpose: str = Query("verification", description="Цель верификации"),
-    provider: Optional[str] = Query(None, description="SMS провайдер"),
-    message: Optional[str] = Query(None, description="Кастомное сообщение с {code}"),
+    provider: str | None = Query(None, description="SMS провайдер"),
+    message: str | None = Query(None, description="Кастомное сообщение с {code}"),
     current_user: User = Depends(require_roles(["Admin", "SuperAdmin"])),
 ):
     """Отправка кода верификации администратором"""

--- a/backend/app/api/v1/endpoints/phrase_suggest.py
+++ b/backend/app/api/v1/endpoints/phrase_suggest.py
@@ -32,7 +32,7 @@ class PhraseSuggestRequest(BaseModel):
     currentText: str = Field("", description="Текущий текст в поле")
     cursorPosition: int = Field(0, ge=0, description="Позиция курсора")
     doctorId: int = Field(..., description="ID врача")
-    specialty: Optional[str] = Field(None, description="Специальность врача")
+    specialty: str | None = Field(None, description="Специальность врача")
     maxSuggestions: int = Field(5, ge=1, le=10, description="Максимум подсказок")
 
 
@@ -41,7 +41,7 @@ class PhraseSuggestion(BaseModel):
     text: str = Field(..., description="Текст продолжения (хвост)")
     source: str = Field("history", description="Источник: history")
     usageCount: int = Field(0, description="Частота использования")
-    lastUsed: Optional[str] = Field(None, description="Дата последнего использования")
+    lastUsed: str | None = Field(None, description="Дата последнего использования")
 
 
 class PhraseSuggestResponse(BaseModel):
@@ -54,7 +54,7 @@ class PhraseSuggestResponse(BaseModel):
 class IndexPhraseRequest(BaseModel):
     """Запрос на индексацию фраз из EMR"""
     doctorId: int
-    specialty: Optional[str] = None
+    specialty: str | None = None
     emrData: dict[str, Any]
 
 
@@ -199,8 +199,8 @@ class TelemetryRequest(BaseModel):
     doctorId: int
     field: str
     event: str = Field(..., pattern="^(shown|accepted|dismissed)$")
-    phraseId: Optional[int] = None
-    timeMs: Optional[int] = None
+    phraseId: int | None = None
+    timeMs: int | None = None
 
 
 class TelemetryResponse(BaseModel):
@@ -243,7 +243,7 @@ class TelemetryStatsResponse(BaseModel):
     totalShown: int
     totalAccepted: int
     acceptanceRate: float
-    avgTimeToAcceptMs: Optional[int]
+    avgTimeToAcceptMs: int | None
     topAcceptedPhrases: list[dict[str, Any]]
 
 
@@ -340,7 +340,7 @@ async def update_field_preferences(
 
 class BatchIndexRequest(BaseModel):
     """Запрос на batch-индексацию"""
-    limit: Optional[int] = Field(None, description="Максимум врачей")
+    limit: int | None = Field(None, description="Максимум врачей")
     offset: int = Field(0, ge=0, description="Смещение")
 
 
@@ -396,7 +396,7 @@ async def batch_index_emrs(
 class DoctorIndexRequest(BaseModel):
     """Запрос на индексацию одного врача"""
     doctorId: int
-    specialty: Optional[str] = None
+    specialty: str | None = None
 
 
 class DoctorIndexResponse(BaseModel):

--- a/backend/app/api/v1/endpoints/print_templates.py
+++ b/backend/app/api/v1/endpoints/print_templates.py
@@ -117,8 +117,8 @@ def _template_path(filename: str) -> Path:
 
 @router.get("/templates", response_model=list[PrintTemplateOut])
 def get_print_templates(
-    template_type: Optional[str] = None,
-    language: Optional[str] = None,
+    template_type: str | None = None,
+    language: str | None = None,
     active_only: bool = True,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar", "Doctor")),
@@ -496,8 +496,8 @@ def _print_template_types_payload():
 
 @router.get("/jobs", response_model=list[PrintJobOut])
 def get_print_jobs(
-    status_filter: Optional[str] = None,
-    document_type: Optional[str] = None,
+    status_filter: str | None = None,
+    document_type: str | None = None,
     limit: int = 50,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar")),

--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -128,7 +128,7 @@ class QRTokenGenerateRequest(BaseModel):
     expires_hours: int = Field(
         default=24, ge=1, le=168, description="Время жизни токена в часах"
     )
-    target_date: Optional[str] = Field(
+    target_date: str | None = Field(
         None, description="Целевая дата для очереди (YYYY-MM-DD)"
     )
     visit_type: str = Field(
@@ -139,7 +139,7 @@ class QRTokenGenerateRequest(BaseModel):
 class ClinicQRTokenGenerateRequest(BaseModel):
     """Запрос на генерацию общего QR токена клиники"""
 
-    target_date: Optional[str] = Field(
+    target_date: str | None = Field(
         None, description="Целевая дата для очереди (YYYY-MM-DD)"
     )
     expires_hours: int = Field(
@@ -163,19 +163,19 @@ class QRTokenInfoResponse(BaseModel):
     """Информация о QR токене"""
 
     token: str
-    specialist_id: Optional[int] = None  # None для общего QR клиники
+    specialist_id: int | None = None  # None для общего QR клиники
     specialist_name: str
     department: str
     department_name: str
     queue_length: int
     queue_active: bool
-    expires_at: Optional[str] = None
-    is_clinic_wide: Optional[bool] = False  # Флаг общего QR
-    target_date: Optional[str] = None  # Дата очереди
-    selectable_specialists: Optional[list[dict[str, Any]]] = None
-    allowed: Optional[bool] = None
-    status: Optional[str] = None
-    message: Optional[str] = None
+    expires_at: str | None = None
+    is_clinic_wide: bool | None = False  # Флаг общего QR
+    target_date: str | None = None  # Дата очереди
+    selectable_specialists: list[dict[str, Any]] | None = None
+    allowed: bool | None = None
+    status: str | None = None
+    message: str | None = None
 
 
 class JoinSessionStartRequest(BaseModel):
@@ -200,8 +200,8 @@ class JoinSessionCompleteRequest(BaseModel):
         ..., min_length=2, max_length=200, description="ФИО пациента"
     )
     phone: str = Field(..., min_length=5, max_length=20, description="Номер телефона")
-    telegram_id: Optional[int] = Field(None, description="Telegram ID")
-    specialist_ids: Optional[list[int]] = Field(
+    telegram_id: int | None = Field(None, description="Telegram ID")
+    specialist_ids: list[int] | None = Field(
         None, description="Список ID специалистов (для общего QR)"
     )
 
@@ -212,7 +212,7 @@ class JoinSessionCompleteMultipleResponse(BaseModel):
     success: bool
     queue_time: str
     entries: list[dict[str, Any]]
-    errors: Optional[list[dict[str, Any]]] = None
+    errors: list[dict[str, Any]] | None = None
     message: str
 
 
@@ -232,7 +232,7 @@ class QueueStatusResponse(BaseModel):
 
     active: bool
     queue_length: int
-    current_number: Optional[int]
+    current_number: int | None
     entries: list[dict[str, Any]]
 
 
@@ -240,9 +240,9 @@ class CallNextPatientResponse(BaseModel):
     """Ответ на вызов следующего пациента"""
 
     success: bool
-    message: Optional[str] = None
-    patient: Optional[dict[str, Any]] = None
-    queue_length: Optional[int] = None
+    message: str | None = None
+    patient: dict[str, Any] | None = None
+    queue_length: int | None = None
 
 
 class ActiveQRTokenResponse(BaseModel):
@@ -677,7 +677,7 @@ def complete_join_session(
 @router.get("/status/{specialist_id}", response_model=QueueStatusResponse)
 def get_queue_status(
     specialist_id: int,
-    target_date: Optional[str] = None,
+    target_date: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Doctor", "Registrar")),
 ):
@@ -706,7 +706,7 @@ def get_queue_status(
 @router.post("/{specialist_id}/call-next", response_model=CallNextPatientResponse)
 async def call_next_patient(
     specialist_id: int,
-    target_date: Optional[str] = Query(
+    target_date: str | None = Query(
         None, description="Дата очереди (YYYY-MM-DD), по умолчанию сегодня"
     ),
     db: Session = Depends(get_db),
@@ -852,7 +852,7 @@ def deactivate_qr_token(
 
 class RestoreToNextRequest(BaseModel):
     """Запрос на восстановление пациента следующим в очереди"""
-    reason: Optional[str] = Field(None, description="Причина восстановления")
+    reason: str | None = Field(None, description="Причина восстановления")
 
 
 class SetIncompleteRequest(BaseModel):
@@ -1085,8 +1085,8 @@ def mark_entry_incomplete(
 @router.get("/admin/queue-analytics/{specialist_id}")
 def get_queue_analytics(
     specialist_id: int,
-    start_date: Optional[str] = None,
-    end_date: Optional[str] = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -1193,10 +1193,10 @@ def get_queue_analytics(
 class UpdateOnlineEntryRequest(BaseModel):
     """Запрос на обновление данных онлайн записи"""
 
-    patient_name: Optional[str] = None
-    phone: Optional[str] = None
-    birth_year: Optional[int] = None
-    address: Optional[str] = None
+    patient_name: str | None = None
+    phone: str | None = None
+    birth_year: int | None = None
+    address: str | None = None
 
 
 @router.put("/online-entry/{entry_id}/update")
@@ -1311,7 +1311,7 @@ class FullUpdateOnlineEntryRequest(BaseModel):
     discount_mode: str  # none/repeat/benefit
     services: list[dict]  # [{service_id, quantity}]
     all_free: bool = False
-    aggregated_ids: Optional[list[int]] = None  # ⭐ FIX: IDs of all merged entries for dedup check
+    aggregated_ids: list[int] | None = None  # ⭐ FIX: IDs of all merged entries for dedup check
 
 
 @router.put("/online-entry/{entry_id}/full-update")

--- a/backend/app/api/v1/endpoints/queue.py
+++ b/backend/app/api/v1/endpoints/queue.py
@@ -90,27 +90,27 @@ class QueueTokenResponse(BaseModel):
 
 class QueueJoinRequest(BaseModel):
     token: str
-    phone: Optional[str] = None
-    telegram_id: Optional[str] = None
-    patient_name: Optional[str] = None
+    phone: str | None = None
+    telegram_id: str | None = None
+    patient_name: str | None = None
 
 
 class QueueJoinResponse(BaseModel):
     success: bool
-    number: Optional[int] = None
+    number: int | None = None
     message: str
     duplicate: bool = False
-    queue_info: Optional[dict] = None
+    queue_info: dict | None = None
 
 
 class QueueEntryResponse(BaseModel):
     id: int
     number: int
-    patient_name: Optional[str]
-    phone: Optional[str]
+    patient_name: str | None
+    phone: str | None
     status: str
     created_at: datetime
-    called_at: Optional[datetime]
+    called_at: datetime | None
 
 
 class QueueStatusResponse(BaseModel):
@@ -118,7 +118,7 @@ class QueueStatusResponse(BaseModel):
     day: date
     specialist_name: str
     is_open: bool
-    opened_at: Optional[datetime]
+    opened_at: datetime | None
     total_entries: int
     waiting_entries: int
     entries: list[QueueEntryResponse]

--- a/backend/app/api/v1/endpoints/queue_position.py
+++ b/backend/app/api/v1/endpoints/queue_position.py
@@ -75,7 +75,7 @@ class QueuePositionResponse(BaseModel):
     status: str
     people_ahead: int
     priority: int
-    queue_time: Optional[str] = None
+    queue_time: str | None = None
     queue_info: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -83,9 +83,9 @@ class NotificationResult(BaseModel):
     """Результат отправки уведомления"""
     success: bool
     sent: bool
-    message_id: Optional[str] = None
-    reason: Optional[str] = None
-    error: Optional[str] = None
+    message_id: str | None = None
+    reason: str | None = None
+    error: str | None = None
 
 
 class BatchNotificationResult(BaseModel):
@@ -103,7 +103,7 @@ class SendPositionNotificationRequest(BaseModel):
 class SendCallNotificationRequest(BaseModel):
     """Запрос на отправку уведомления о вызове"""
     entry_id: int = Field(..., description="ID записи в очереди")
-    cabinet_number: Optional[str] = Field(None, description="Номер кабинета")
+    cabinet_number: str | None = Field(None, description="Номер кабинета")
 
 
 # ========================= ЭНДПОИНТЫ =========================

--- a/backend/app/api/v1/endpoints/queues.py
+++ b/backend/app/api/v1/endpoints/queues.py
@@ -14,8 +14,8 @@ router = APIRouter(tags=["queues"])
 @router.get("/stats")
 def stats(
     department: str,
-    d: Optional[str] = Query(None),
-    date: Optional[str] = Query(None),
+    d: str | None = Query(None),
+    date: str | None = Query(None),
     db: Session = Depends(get_db),
 ):
     date_str = d or date
@@ -30,8 +30,8 @@ def stats(
 @router.post("/next-ticket")
 def next_ticket(
     department: str,
-    d: Optional[str] = Query(None),
-    date: Optional[str] = Query(None),
+    d: str | None = Query(None),
+    date: str | None = Query(None),
     db: Session = Depends(get_db),
     _current_user=Depends(require_roles("Admin", "Registrar")),
 ):

--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -643,27 +643,27 @@ class QueueProfileCreate(BaseModel):
     """Schema for creating a new QueueProfile"""
     key: str = Field(..., min_length=1, max_length=50, description="Unique key (e.g., 'cardiology')")
     title: str = Field(..., min_length=1, max_length=100, description="English title")
-    title_ru: Optional[str] = Field(None, max_length=100, description="Russian title")
+    title_ru: str | None = Field(None, max_length=100, description="Russian title")
     queue_tags: list[str] = Field(default=[], description="List of queue_tag values for this profile")
-    department_key: Optional[str] = Field(None, max_length=50)
+    department_key: str | None = Field(None, max_length=50)
     display_order: int = Field(default=0, ge=0)
     is_active: bool = Field(default=True)
     show_on_qr_page: bool = Field(default=True, description="Show this profile on QR join page")
-    icon: Optional[str] = Field(None, max_length=50, description="Lucide icon name (e.g., 'Heart')")
-    color: Optional[str] = Field(None, max_length=20, description="Hex color (e.g., '#E53E3E')")
+    icon: str | None = Field(None, max_length=50, description="Lucide icon name (e.g., 'Heart')")
+    color: str | None = Field(None, max_length=20, description="Hex color (e.g., '#E53E3E')")
 
 
 class QueueProfileUpdate(BaseModel):
     """Schema for updating an existing QueueProfile"""
-    title: Optional[str] = Field(None, max_length=100)
-    title_ru: Optional[str] = Field(None, max_length=100)
-    queue_tags: Optional[list[str]] = None
-    department_key: Optional[str] = Field(None, max_length=50)
-    display_order: Optional[int] = Field(None, ge=0)
-    is_active: Optional[bool] = None
-    show_on_qr_page: Optional[bool] = Field(None, description="Show this profile on QR join page")
-    icon: Optional[str] = Field(None, max_length=50)
-    color: Optional[str] = Field(None, max_length=20)
+    title: str | None = Field(None, max_length=100)
+    title_ru: str | None = Field(None, max_length=100)
+    queue_tags: list[str] | None = None
+    department_key: str | None = Field(None, max_length=50)
+    display_order: int | None = Field(None, ge=0)
+    is_active: bool | None = None
+    show_on_qr_page: bool | None = Field(None, description="Show this profile on QR join page")
+    icon: str | None = Field(None, max_length=50)
+    color: str | None = Field(None, max_length=20)
 
 
 @router.post("/queues/profiles")
@@ -861,7 +861,7 @@ def reorder_queue_profiles(
 
 @router.get("/registrar/services")
 def get_registrar_services(
-    specialty: Optional[str] = Query(None, description="Фильтр по специальности"),
+    specialty: str | None = Query(None, description="Фильтр по специальности"),
     active_only: bool = Query(True, description="Только активные услуги"),
     db: Session = Depends(get_db),
     # Разрешаем доступ также профильным ролям врачей
@@ -1019,7 +1019,7 @@ def get_registrar_services(
 
 @router.get("/registrar/doctors")
 def get_registrar_doctors(
-    specialty: Optional[str] = Query(None, description="Фильтр по специальности"),
+    specialty: str | None = Query(None, description="Фильтр по специальности"),
     with_schedule: bool = Query(True, description="Включить расписание"),
     db: Session = Depends(get_db),
     # Разрешаем доступ также профильным ролям врачей
@@ -2525,10 +2525,10 @@ def _process_visit_entry(
 
 @router.get("/registrar/queues/today")
 def get_today_queues(
-    target_date: Optional[str] = Query(
+    target_date: str | None = Query(
         None, description="Дата (YYYY-MM-DD), по умолчанию сегодня"
     ),
-    department: Optional[str] = Query(None, description="Фильтр по отделению"),
+    department: str | None = Query(None, description="Фильтр по отделению"),
     db: Session = Depends(get_db),
     # [OK] ИСПРАВЛЕНО: Добавлена роль Cashier для доступа к очереди
     current_user: User = Depends(
@@ -3133,7 +3133,7 @@ def get_today_queues(
 def get_registrar_calendar(
     start_date: date = Query(..., description="Начальная дата"),
     end_date: date = Query(..., description="Конечная дата"),
-    doctor_id: Optional[int] = Query(None, description="Фильтр по врачу"),
+    doctor_id: int | None = Query(None, description="Фильтр по врачу"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar")),
 ):

--- a/backend/app/api/v1/endpoints/registrar_notifications.py
+++ b/backend/app/api/v1/endpoints/registrar_notifications.py
@@ -34,7 +34,7 @@ class NotificationRequest(BaseModel):
     priority: str = Field(
         default="normal", description="Приоритет: normal, high, urgent, critical"
     )
-    department: Optional[str] = Field(None, description="Отделение (опционально)")
+    department: str | None = Field(None, description="Отделение (опционально)")
 
 
 class AppointmentNotificationRequest(BaseModel):
@@ -56,7 +56,7 @@ class QueueStatusNotificationRequest(BaseModel):
 
     queue_entry_id: int = Field(..., description="ID записи в очереди")
     status_change: str = Field(..., description="Изменение статуса")
-    additional_info: Optional[str] = Field(
+    additional_info: str | None = Field(
         None, description="Дополнительная информация"
     )
 
@@ -67,7 +67,7 @@ class SystemAlertRequest(BaseModel):
     alert_type: str = Field(..., description="Тип уведомления")
     message: str = Field(..., description="Текст уведомления")
     priority: str = Field(default="normal", description="Приоритет")
-    department: Optional[str] = Field(None, description="Отделение")
+    department: str | None = Field(None, description="Отделение")
 
 
 class NotificationResponse(BaseModel):
@@ -75,8 +75,8 @@ class NotificationResponse(BaseModel):
 
     success: bool
     message: str
-    sent_count: Optional[int] = None
-    results: Optional[list[dict[str, Any]]] = None
+    sent_count: int | None = None
+    results: list[dict[str, Any]] | None = None
 
 
 class RegistrarListResponse(BaseModel):
@@ -101,7 +101,7 @@ class NotificationStatsResponse(BaseModel):
 
 @router.get("/registrars", response_model=RegistrarListResponse)
 async def get_active_registrars(
-    department: Optional[str] = None,
+    department: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles(["Admin", "Registrar"])),
 ):
@@ -311,7 +311,7 @@ async def send_system_alert(
 
 @router.post("/daily-summary", response_model=NotificationResponse)
 async def send_daily_summary(
-    target_date: Optional[str] = None,
+    target_date: str | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles(["Admin", "Registrar"])),
 ):

--- a/backend/app/api/v1/endpoints/registrar_wizard.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard.py
@@ -79,16 +79,16 @@ def _ensure_visit_doctor_access(db: Session, visit: Visit, current_user: User) -
 class ServiceItemRequest(BaseModel):
     service_id: int
     quantity: int = Field(default=1, ge=1)
-    custom_price: Optional[Decimal] = None  # Для врачебного переопределения цены
+    custom_price: Decimal | None = None  # Для врачебного переопределения цены
 
 
 class VisitRequest(BaseModel):
-    doctor_id: Optional[int] = None  # Может быть None для лабораторных услуг
+    doctor_id: int | None = None  # Может быть None для лабораторных услуг
     services: list[ServiceItemRequest]
     visit_date: date
-    visit_time: Optional[str] = None  # HH:MM
-    department: Optional[str] = None
-    notes: Optional[str] = None
+    visit_time: str | None = None  # HH:MM
+    department: str | None = None
+    notes: str | None = None
 
 
 class CartRequest(BaseModel):
@@ -97,7 +97,7 @@ class CartRequest(BaseModel):
     discount_mode: str = Field(default="none")  # none|repeat|benefit|all_free
     payment_method: str = Field(default="cash")  # cash|card|online|click|payme
     all_free: bool = Field(default=False)  # Чекбокс "All Free"
-    notes: Optional[str] = None
+    notes: str | None = None
 
 
 class CartResponse(BaseModel):
@@ -110,23 +110,23 @@ class CartResponse(BaseModel):
         int, list[dict]
     ]  # visit_id -> [{"queue_tag": str, "number": int, "queue_id": int}]
     print_tickets: list[dict[str, Any]]
-    created_visits: Optional[list[dict[str, Any]]] = (
+    created_visits: list[dict[str, Any]] | None = (
         None  # Информация о созданных визитах
     )
 
 
 class EditDeltaPatientData(BaseModel):
-    full_name: Optional[str] = None
-    phone: Optional[str] = None
-    birth_date: Optional[date] = None
-    sex: Optional[str] = None
-    address: Optional[str] = None
+    full_name: str | None = None
+    phone: str | None = None
+    birth_date: date | None = None
+    sex: str | None = None
+    address: str | None = None
 
 
 class EditDeltaServiceItem(BaseModel):
     service_id: int
     quantity: int = Field(default=1, ge=1)
-    specialist_id: Optional[int] = None
+    specialist_id: int | None = None
 
 
 class EditDeltaRequest(BaseModel):
@@ -135,7 +135,7 @@ class EditDeltaRequest(BaseModel):
     payment_method: str = Field(default="cash")
     discount_mode: str = Field(default="none")
     all_free: bool = Field(default=False)
-    patient_data: Optional[EditDeltaPatientData] = None
+    patient_data: EditDeltaPatientData | None = None
     services: list[EditDeltaServiceItem] = Field(default_factory=list)
     existing_queue_entry_ids: list[int] = Field(default_factory=list)
     # R-08 fix: optimistic locking — map of entry_id → ISO updated_at string.
@@ -147,7 +147,7 @@ class EditDeltaRequest(BaseModel):
 class EditDeltaResponse(BaseModel):
     success: bool
     message: str
-    invoice_id: Optional[int] = None
+    invoice_id: int | None = None
     visit_ids: list[int] = Field(default_factory=list)
     total_amount: Decimal = Decimal("0")
     queue_numbers: dict[int, list[dict[str, Any]]] = Field(default_factory=dict)
@@ -157,8 +157,8 @@ class EditDeltaResponse(BaseModel):
 
 
 class MarkPaidRequest(BaseModel):
-    amount: Optional[Decimal] = None
-    method: Optional[str] = Field(default="cash")
+    amount: Decimal | None = None
+    method: str | None = Field(default="cash")
 
 
 class RegistrarRecordRef(BaseModel):
@@ -168,12 +168,12 @@ class RegistrarRecordRef(BaseModel):
 
 class RegistrarRecordActionRequest(BaseModel):
     action: str
-    record_kind: Optional[str] = None
-    record_id: Optional[int] = None
-    records: Optional[list[RegistrarRecordRef]] = None
-    reason: Optional[str] = None
-    amount: Optional[Decimal] = None
-    method: Optional[str] = Field(default="cash")
+    record_kind: str | None = None
+    record_id: int | None = None
+    records: list[RegistrarRecordRef] | None = None
+    reason: str | None = None
+    amount: Decimal | None = None
+    method: str | None = Field(default="cash")
 
 
 class RegistrarRecordActionItemResponse(BaseModel):
@@ -181,10 +181,10 @@ class RegistrarRecordActionItemResponse(BaseModel):
     record_id: int
     success: bool
     skipped: bool = False
-    status: Optional[str] = None
-    payment_status: Optional[str] = None
-    error: Optional[str] = None
-    result: Optional[dict[str, Any]] = None
+    status: str | None = None
+    payment_status: str | None = None
+    error: str | None = None
+    result: dict[str, Any] | None = None
 
 
 class RegistrarRecordActionResponse(BaseModel):
@@ -198,9 +198,9 @@ class RegistrarRecordActionResponse(BaseModel):
 
 class RepeatEligibilityCandidate(BaseModel):
     service_id: int
-    doctor_id: Optional[int] = None
+    doctor_id: int | None = None
     visit_date: date
-    candidate_key: Optional[str] = None
+    candidate_key: str | None = None
 
 
 class RepeatEligibilityPreviewRequest(BaseModel):
@@ -209,9 +209,9 @@ class RepeatEligibilityPreviewRequest(BaseModel):
 
 
 class RepeatEligibilityPreviewItem(BaseModel):
-    candidate_key: Optional[str] = None
+    candidate_key: str | None = None
     service_id: int
-    doctor_id: Optional[int] = None
+    doctor_id: int | None = None
     visit_date: date
     eligible: bool
     reason: str
@@ -607,15 +607,15 @@ def _create_queue_entries(
 class InvoicePaymentRequest(BaseModel):
     invoice_id: int
     provider: str = Field(default="click")  # click|payme
-    return_url: Optional[str] = None
-    cancel_url: Optional[str] = None
+    return_url: str | None = None
+    cancel_url: str | None = None
 
 
 class InvoicePaymentResponse(BaseModel):
     success: bool
-    payment_url: Optional[str] = None
-    provider_payment_id: Optional[str] = None
-    error_message: Optional[str] = None
+    payment_url: str | None = None
+    provider_payment_id: str | None = None
+    error_message: str | None = None
 
 
 SUPPORTED_INVOICE_PAYMENT_PROVIDERS = {"click", "payme"}
@@ -1217,7 +1217,7 @@ def apply_registrar_cart_edit_delta(
 class PriceOverrideApprovalRequest(BaseModel):
     override_id: int
     action: str = Field(..., pattern="^(approve|reject)$")  # approve или reject
-    rejection_reason: Optional[str] = None
+    rejection_reason: str | None = None
 
 
 class PriceOverrideListResponse(BaseModel):
@@ -1227,11 +1227,11 @@ class PriceOverrideListResponse(BaseModel):
     service_name: str
     doctor_name: str
     doctor_specialty: str
-    patient_name: Optional[str]
+    patient_name: str | None
     original_price: Decimal
     new_price: Decimal
     reason: str
-    details: Optional[str]
+    details: str | None
     status: str
     available_actions: list[str]
     can_approve: bool
@@ -1251,7 +1251,7 @@ def _price_override_available_actions(override_status: str) -> list[str]:
 def get_pending_price_overrides(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar")),
-    status_filter: Optional[str] = Query(
+    status_filter: str | None = Query(
         default="pending", pattern="^(pending|approved|rejected|all)$"
     ),
     limit: int = Query(default=50, ge=1, le=100),
@@ -1397,21 +1397,21 @@ def approve_price_override(
 class AllFreeApprovalRequest(BaseModel):
     visit_id: int
     action: str = Field(..., pattern="^(approve|reject)$")  # approve или reject
-    rejection_reason: Optional[str] = None
+    rejection_reason: str | None = None
 
 
 class AllFreeVisitResponse(BaseModel):
     id: int
     patient_id: int
-    patient_name: Optional[str]
-    patient_phone: Optional[str]
+    patient_name: str | None
+    patient_phone: str | None
     services: list[str]
     total_original_amount: Decimal
-    doctor_name: Optional[str]
-    doctor_specialty: Optional[str]
-    visit_date: Optional[date]
-    visit_time: Optional[str]
-    notes: Optional[str]
+    doctor_name: str | None
+    doctor_specialty: str | None
+    visit_date: date | None
+    visit_time: str | None
+    notes: str | None
     created_at: datetime
     approval_status: str
     available_actions: list[str]
@@ -1431,7 +1431,7 @@ def _all_free_available_actions(approval_status: str) -> list[str]:
 def get_all_free_requests(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
-    status_filter: Optional[str] = Query(
+    status_filter: str | None = Query(
         default="pending", pattern="^(pending|approved|rejected|all)$"
     ),
     limit: int = Query(default=50, ge=1, le=100),
@@ -1936,19 +1936,19 @@ def update_wizard_settings(
 class VisitResponse(BaseModel):
     id: int
     patient_id: int
-    patient_fio: Optional[str] = None
-    patient_phone: Optional[str] = None
-    doctor_id: Optional[int] = None
-    doctor_name: Optional[str] = None
-    doctor_specialty: Optional[str] = None
-    department: Optional[str] = None
-    visit_date: Optional[date] = None
-    visit_time: Optional[str] = None
+    patient_fio: str | None = None
+    patient_phone: str | None = None
+    doctor_id: int | None = None
+    doctor_name: str | None = None
+    doctor_specialty: str | None = None
+    department: str | None = None
+    visit_date: date | None = None
+    visit_time: str | None = None
     status: str
     discount_mode: str
     approval_status: str
-    services: Optional[list[str]] = None
-    notes: Optional[str] = None
+    services: list[str] | None = None
+    notes: str | None = None
     created_at: datetime
 
 
@@ -1958,11 +1958,11 @@ def get_visits(
     current_user: User = Depends(require_roles("Admin", "Registrar", "Doctor", "cardio", "derma", "dentist", "Cashier", "Lab")),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = Query(None, description="Фильтр по ID пациента"),
-    doctor_id: Optional[int] = Query(None, description="Фильтр по ID врача"),
-    department: Optional[str] = Query(None, description="Фильтр по отделению"),
-    date_from: Optional[str] = Query(None, description="Дата начала (YYYY-MM-DD)"),
-    date_to: Optional[str] = Query(None, description="Дата окончания (YYYY-MM-DD)"),
+    patient_id: int | None = Query(None, description="Фильтр по ID пациента"),
+    doctor_id: int | None = Query(None, description="Фильтр по ID врача"),
+    department: str | None = Query(None, description="Фильтр по отделению"),
+    date_from: str | None = Query(None, description="Дата начала (YYYY-MM-DD)"),
+    date_to: str | None = Query(None, description="Дата окончания (YYYY-MM-DD)"),
 ):
     """Получить объединенный список записей из таблиц visits (новый мастер) и appointments (старый мастер)"""
     try:
@@ -2174,9 +2174,9 @@ def get_all_appointments(
     ),
     limit: int = Query(200, ge=1, le=1000),
     offset: int = Query(0, ge=0),
-    date_from: Optional[str] = Query(None, description="Дата начала (YYYY-MM-DD)"),
-    date_to: Optional[str] = Query(None, description="Дата окончания (YYYY-MM-DD)"),
-    search: Optional[str] = Query(
+    date_from: str | None = Query(None, description="Дата начала (YYYY-MM-DD)"),
+    date_to: str | None = Query(None, description="Дата окончания (YYYY-MM-DD)"),
+    search: str | None = Query(
         None, description="Поиск по ФИО, телефону или услугам"
     ),
 ):
@@ -2897,7 +2897,7 @@ def _run_single_registrar_record_action(
 @router.post("/registrar/visits/{visit_id}/mark-paid")
 def mark_visit_as_paid(
     visit_id: int,
-    payment_req: Optional[MarkPaidRequest] = Body(default=None),
+    payment_req: MarkPaidRequest | None = Body(default=None),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar", "Cashier")),
 ):
@@ -3053,7 +3053,7 @@ def mark_visit_as_paid(
 @router.post("/registrar/queue/entry/{entry_id}/mark-paid")
 def mark_queue_entry_as_paid(
     entry_id: int,
-    payment_req: Optional[MarkPaidRequest] = Body(default=None),
+    payment_req: MarkPaidRequest | None = Body(default=None),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "Registrar", "Cashier")),
 ):
@@ -3422,8 +3422,8 @@ def run_registrar_record_action(
 
 class ConfirmVisitRequest(BaseModel):
     confirmation_method: str = Field(default="phone", pattern="^(phone|manual)$")
-    confirmed_by: Optional[str] = None  # Номер телефона или ID сотрудника
-    notes: Optional[str] = None
+    confirmed_by: str | None = None  # Номер телефона или ID сотрудника
+    notes: str | None = None
 
 
 class ConfirmVisitResponse(BaseModel):
@@ -3431,8 +3431,8 @@ class ConfirmVisitResponse(BaseModel):
     message: str
     visit_id: int
     status: str
-    queue_numbers: Optional[dict[str, Any]] = None
-    print_tickets: Optional[list[dict[str, Any]]] = None
+    queue_numbers: dict[str, Any] | None = None
+    print_tickets: list[dict[str, Any]] | None = None
 
 
 @router.post(

--- a/backend/app/api/v1/endpoints/reports.py
+++ b/backend/app/api/v1/endpoints/reports.py
@@ -43,41 +43,41 @@ def log_report_service_error(report_type: str) -> None:
 class ReportRequest(BaseModel):
     """Базовая модель запроса отчета"""
 
-    start_date: Optional[date] = None
-    end_date: Optional[date] = None
+    start_date: date | None = None
+    end_date: date | None = None
     format: str = Field(default="json", pattern="^(json|csv|excel|pdf)$")
-    filters: Optional[dict[str, Any]] = None
+    filters: dict[str, Any] | None = None
 
 
 class PatientReportRequest(ReportRequest):
     """Запрос отчета по пациентам"""
 
-    department: Optional[str] = None
+    department: str | None = None
 
 
 class AppointmentReportRequest(ReportRequest):
     """Запрос отчета по записям"""
 
-    doctor_id: Optional[int] = None
-    department: Optional[str] = None
+    doctor_id: int | None = None
+    department: str | None = None
 
 
 class FinancialReportRequest(ReportRequest):
     """Запрос финансового отчета"""
 
-    department: Optional[str] = None
+    department: str | None = None
 
 
 class QueueReportRequest(ReportRequest):
     """Запрос отчета по очередям"""
 
-    doctor_id: Optional[int] = None
+    doctor_id: int | None = None
 
 
 class DoctorPerformanceReportRequest(ReportRequest):
     """Запрос отчета по производительности врачей"""
 
-    doctor_id: Optional[int] = None
+    doctor_id: int | None = None
 
 
 class ScheduleReportRequest(BaseModel):
@@ -90,7 +90,7 @@ class ScheduleReportRequest(BaseModel):
     schedule: str = Field(..., pattern="^(daily|weekly|monthly)$")
     recipients: list[str] = Field(..., min_length=1)
     format: str = Field(default="excel", pattern="^(json|csv|excel|pdf)$")
-    filters: Optional[dict[str, Any]] = None
+    filters: dict[str, Any] | None = None
 
 
 class ReportResponse(BaseModel):
@@ -100,11 +100,11 @@ class ReportResponse(BaseModel):
     report_type: str
     generated_at: str
     format: str
-    data: Optional[dict[str, Any]] = None
-    filename: Optional[str] = None
-    filepath: Optional[str] = None
-    size: Optional[int] = None
-    error: Optional[str] = None
+    data: dict[str, Any] | None = None
+    filename: str | None = None
+    filepath: str | None = None
+    size: int | None = None
+    error: str | None = None
 
 
 # ===================== ОСНОВНЫЕ ОТЧЕТЫ =====================
@@ -340,7 +340,7 @@ async def generate_doctor_performance_report(
 
 @router.get("/daily-summary")
 async def get_daily_summary(
-    target_date: Optional[date] = Query(
+    target_date: date | None = Query(
         None, description="Дата для сводки (по умолчанию сегодня)"
     ),
     db: Session = Depends(get_db),

--- a/backend/app/api/v1/endpoints/roles.py
+++ b/backend/app/api/v1/endpoints/roles.py
@@ -39,8 +39,8 @@ def _raise_roles_internal_error(operation: str, exc: Exception) -> NoReturn:
 
 @router.get("/", response_model=RoleListResponse)
 async def get_roles(
-    is_active: Optional[bool] = Query(None, description="Filter by active status"),
-    is_system: Optional[bool] = Query(None, description="Filter by system roles"),
+    is_active: bool | None = Query(None, description="Filter by active status"),
+    is_system: bool | None = Query(None, description="Filter by system roles"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):

--- a/backend/app/api/v1/endpoints/salary.py
+++ b/backend/app/api/v1/endpoints/salary.py
@@ -39,7 +39,7 @@ class SalaryChangeCreate(BaseModel):
     user_id: int
     new_salary: Decimal
     change_type: str = "adjustment"
-    reason: Optional[str] = None
+    reason: str | None = None
     effective_date: datetime
     currency: str = "UZS"
 
@@ -53,7 +53,7 @@ class SalaryPaymentCreate(BaseModel):
     deductions: Decimal = Decimal("0")
     taxes: Decimal = Decimal("0")
     currency: str = "UZS"
-    notes: Optional[str] = None
+    notes: str | None = None
 
 
 def _model_to_dict(model: BaseModel) -> dict:
@@ -128,7 +128,7 @@ async def get_salary_payments(
     user_id: int,
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles("Admin", "HR")),
-    year: Optional[int] = None,
+    year: int | None = None,
     limit: int = Query(24, ge=1, le=100),
 ) -> list[dict[str, Any]]:
     """
@@ -165,8 +165,8 @@ async def create_salary_payment(
 async def update_payment_status(
     payment_id: int,
     status: str,
-    payment_date: Optional[datetime] = None,
-    payment_method: Optional[str] = None,
+    payment_date: datetime | None = None,
+    payment_method: str | None = None,
     db: Session = Depends(deps.get_db),
     user: User = Depends(deps.require_roles("Admin")),
 ) -> dict[str, Any]:

--- a/backend/app/api/v1/endpoints/schedule.py
+++ b/backend/app/api/v1/endpoints/schedule.py
@@ -31,10 +31,10 @@ def _to_out(r) -> ScheduleRowOut:
 async def list_templates(
     db: Session = Depends(deps.get_db),
     user=Depends(deps.require_roles("Admin", "Registrar", "Doctor")),
-    department: Optional[str] = Query(default=None, max_length=64),
-    doctor_id: Optional[int] = Query(default=None, ge=1),
-    weekday: Optional[int] = Query(default=None, ge=0, le=6),
-    active: Optional[bool] = Query(default=None),
+    department: str | None = Query(default=None, max_length=64),
+    doctor_id: int | None = Query(default=None, ge=1),
+    weekday: int | None = Query(default=None, ge=0, le=6),
+    active: bool | None = Query(default=None),
     limit: int = Query(default=200, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
 ):
@@ -89,9 +89,9 @@ async def delete_template(
 async def get_weekly_schedule(
     db: Session = Depends(deps.get_db),
     user=Depends(deps.require_roles("Admin", "Registrar", "Doctor")),
-    department: Optional[str] = Query(default=None, description="Отделение"),
-    doctor_id: Optional[int] = Query(default=None, description="ID врача"),
-    week_start: Optional[str] = Query(
+    department: str | None = Query(default=None, description="Отделение"),
+    doctor_id: int | None = Query(default=None, description="ID врача"),
+    week_start: str | None = Query(
         default=None, description="Начало недели (YYYY-MM-DD)"
     ),
 ):
@@ -121,8 +121,8 @@ async def get_daily_schedule(
     db: Session = Depends(deps.get_db),
     user=Depends(deps.require_roles("Admin", "Registrar", "Doctor")),
     date_str: str = Query(..., description="Дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(default=None, description="Отделение"),
-    doctor_id: Optional[int] = Query(default=None, description="ID врача"),
+    department: str | None = Query(default=None, description="Отделение"),
+    doctor_id: int | None = Query(default=None, description="ID врача"),
 ):
     """
     Получить расписание на конкретный день
@@ -146,7 +146,7 @@ async def get_available_slots(
     user=Depends(deps.require_roles("Admin", "Registrar", "Doctor")),
     date_str: str = Query(..., description="Дата (YYYY-MM-DD)"),
     department: str = Query(..., description="Отделение"),
-    doctor_id: Optional[int] = Query(default=None, description="ID врача"),
+    doctor_id: int | None = Query(default=None, description="ID врача"),
 ):
     """
     Получить доступные слоты времени для записи на конкретную дату
@@ -168,7 +168,7 @@ async def get_available_slots(
 async def get_doctors_by_department(
     db: Session = Depends(deps.get_db),
     user=Depends(deps.require_roles("Admin", "Registrar", "Doctor")),
-    department: Optional[str] = Query(default=None, description="Отделение"),
+    department: str | None = Query(default=None, description="Отделение"),
 ):
     """
     Получить список врачей, сгруппированных по отделениям

--- a/backend/app/api/v1/endpoints/section_templates.py
+++ b/backend/app/api/v1/endpoints/section_templates.py
@@ -46,7 +46,7 @@ class MessageResponse(BaseModel):
 )
 async def get_section_templates(
     section_type: str,
-    icd10_code: Optional[str] = Query(None, description="ICD-10 code for filtering"),
+    icd10_code: str | None = Query(None, description="ICD-10 code for filtering"),
     limit: int = Query(10, ge=1, le=50),
     current_user: User = Depends(deps.get_current_user),
     db: AsyncSession = Depends(deps.get_db),

--- a/backend/app/api/v1/endpoints/security_management.py
+++ b/backend/app/api/v1/endpoints/security_management.py
@@ -200,7 +200,7 @@ def reset_rate_limits(
     target_type: str = Query(
         ..., pattern="^(ip|patient|all)$", description="Тип цели для сброса"
     ),
-    target_id: Optional[str] = Query(None, description="ID цели (IP или patient_id)"),
+    target_id: str | None = Query(None, description="ID цели (IP или patient_id)"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):

--- a/backend/app/api/v1/endpoints/services.py
+++ b/backend/app/api/v1/endpoints/services.py
@@ -30,10 +30,10 @@ logger = logging.getLogger(__name__)
 class ServiceCategoryOut(BaseModel):
     id: int
     code: str
-    name_ru: Optional[str] = None
-    name_uz: Optional[str] = None
-    name_en: Optional[str] = None
-    specialty: Optional[str] = None
+    name_ru: str | None = None
+    name_uz: str | None = None
+    name_en: str | None = None
+    specialty: str | None = None
     active: bool = True
 
     model_config = ConfigDict(from_attributes=True)
@@ -41,88 +41,88 @@ class ServiceCategoryOut(BaseModel):
 
 class ServiceCategoryCreate(BaseModel):
     code: str = Field(..., max_length=50)
-    name_ru: Optional[str] = Field(None, max_length=100)
-    name_uz: Optional[str] = Field(None, max_length=100)
-    name_en: Optional[str] = Field(None, max_length=100)
-    specialty: Optional[str] = Field(None, max_length=100)
+    name_ru: str | None = Field(None, max_length=100)
+    name_uz: str | None = Field(None, max_length=100)
+    name_en: str | None = Field(None, max_length=100)
+    specialty: str | None = Field(None, max_length=100)
     active: bool = True
 
 
 class ServiceCategoryUpdate(BaseModel):
-    code: Optional[str] = Field(None, max_length=50)
-    name_ru: Optional[str] = Field(None, max_length=100)
-    name_uz: Optional[str] = Field(None, max_length=100)
-    name_en: Optional[str] = Field(None, max_length=100)
-    specialty: Optional[str] = Field(None, max_length=100)
-    active: Optional[bool] = None
+    code: str | None = Field(None, max_length=50)
+    name_ru: str | None = Field(None, max_length=100)
+    name_uz: str | None = Field(None, max_length=100)
+    name_en: str | None = Field(None, max_length=100)
+    specialty: str | None = Field(None, max_length=100)
+    active: bool | None = None
 
 
 class ServiceOut(BaseModel):
     id: int
-    code: Optional[str] = None
+    code: str | None = None
     name: str
-    department: Optional[str] = None
-    unit: Optional[str] = None
-    price: Optional[float] = None
-    currency: Optional[str] = None
+    department: str | None = None
+    unit: str | None = None
+    price: float | None = None
+    currency: str | None = None
     active: bool = True
-    category_id: Optional[int] = None
-    duration_minutes: Optional[int] = None
-    doctor_id: Optional[int] = None
+    category_id: int | None = None
+    duration_minutes: int | None = None
+    doctor_id: int | None = None
     # ✅ НОВЫЕ ПОЛЯ ДЛЯ МАСТЕРА РЕГИСТРАЦИИ
-    category_code: Optional[str] = None  # K, D, C, L, S, O
-    service_code: Optional[str] = None  # K01, D02, C03, etc.
-    requires_doctor: Optional[bool] = None
-    queue_tag: Optional[str] = None
-    is_consultation: Optional[bool] = None
-    allow_doctor_price_override: Optional[bool] = None
-    department_key: Optional[str] = None  # ✅ ДОБАВЛЕНО: связь с отделением
+    category_code: str | None = None  # K, D, C, L, S, O
+    service_code: str | None = None  # K01, D02, C03, etc.
+    requires_doctor: bool | None = None
+    queue_tag: str | None = None
+    is_consultation: bool | None = None
+    allow_doctor_price_override: bool | None = None
+    department_key: str | None = None  # ✅ ДОБАВЛЕНО: связь с отделением
 
     model_config = ConfigDict(from_attributes=True)
 
 
 class ServiceCreate(BaseModel):
-    code: Optional[str] = Field(None, max_length=32)
+    code: str | None = Field(None, max_length=32)
     name: str = Field(..., max_length=256)
-    department: Optional[str] = Field(None, max_length=64)
-    unit: Optional[str] = Field(None, max_length=32)
-    price: Optional[Decimal] = None
-    currency: Optional[str] = Field("UZS", max_length=8)
+    department: str | None = Field(None, max_length=64)
+    unit: str | None = Field(None, max_length=32)
+    price: Decimal | None = None
+    currency: str | None = Field("UZS", max_length=8)
     active: bool = True
-    category_id: Optional[int] = None
-    duration_minutes: Optional[int] = Field(30, ge=1, le=480)
-    doctor_id: Optional[int] = None
+    category_id: int | None = None
+    duration_minutes: int | None = Field(30, ge=1, le=480)
+    doctor_id: int | None = None
     # ✅ НОВЫЕ ПОЛЯ ДЛЯ МАСТЕРА РЕГИСТРАЦИИ
-    category_code: Optional[str] = Field(None, max_length=2, pattern="^[KDCLSOP]$")
-    service_code: Optional[str] = Field(None, max_length=16)
+    category_code: str | None = Field(None, max_length=2, pattern="^[KDCLSOP]$")
+    service_code: str | None = Field(None, max_length=16)
     requires_doctor: bool = False
-    queue_tag: Optional[str] = Field(None, max_length=32)
+    queue_tag: str | None = Field(None, max_length=32)
     is_consultation: bool = False
     allow_doctor_price_override: bool = False
-    department_key: Optional[str] = Field(
+    department_key: str | None = Field(
         None, max_length=50
     )  # ✅ ДОБАВЛЕНО: связь с отделением
 
 
 class ServiceUpdate(BaseModel):
-    code: Optional[str] = Field(None, max_length=32)
-    name: Optional[str] = Field(None, max_length=256)
-    department: Optional[str] = Field(None, max_length=64)
-    unit: Optional[str] = Field(None, max_length=32)
-    price: Optional[Decimal] = None
-    currency: Optional[str] = Field(None, max_length=8)
-    active: Optional[bool] = None
-    category_id: Optional[int] = None
-    duration_minutes: Optional[int] = Field(None, ge=1, le=480)
-    doctor_id: Optional[int] = None
+    code: str | None = Field(None, max_length=32)
+    name: str | None = Field(None, max_length=256)
+    department: str | None = Field(None, max_length=64)
+    unit: str | None = Field(None, max_length=32)
+    price: Decimal | None = None
+    currency: str | None = Field(None, max_length=8)
+    active: bool | None = None
+    category_id: int | None = None
+    duration_minutes: int | None = Field(None, ge=1, le=480)
+    doctor_id: int | None = None
     # ✅ НОВЫЕ ПОЛЯ ДЛЯ МАСТЕРА РЕГИСТРАЦИИ
-    category_code: Optional[str] = Field(None, max_length=2, pattern="^[KDCLSOP]$")
-    service_code: Optional[str] = Field(None, max_length=16)
-    requires_doctor: Optional[bool] = None
-    queue_tag: Optional[str] = Field(None, max_length=32)
-    is_consultation: Optional[bool] = None
-    allow_doctor_price_override: Optional[bool] = None
-    department_key: Optional[str] = Field(
+    category_code: str | None = Field(None, max_length=2, pattern="^[KDCLSOP]$")
+    service_code: str | None = Field(None, max_length=16)
+    requires_doctor: bool | None = None
+    queue_tag: str | None = Field(None, max_length=32)
+    is_consultation: bool | None = None
+    allow_doctor_price_override: bool | None = None
+    department_key: str | None = Field(
         None, max_length=50
     )  # ✅ ДОБАВЛЕНО: связь с отделением
 
@@ -321,7 +321,7 @@ def _row_to_out(r) -> ServiceOut:
 async def list_service_categories(
     db: Session = Depends(get_db),
     # user=Depends(require_roles("Admin", "Registrar", "Doctor")),
-    active: Optional[bool] = Query(default=None),
+    active: bool | None = Query(default=None),
 ):
     """Delegate category listing to the service layer."""
     return ServicesApiService(db).list_service_categories(active=active)
@@ -393,10 +393,10 @@ async def list_services(
     # user=Depends(
     #     require_roles("Admin", "Registrar", "Doctor", "Lab", "Cashier", "User")
     # ),
-    q: Optional[str] = Query(default=None, max_length=120),
-    active: Optional[bool] = Query(default=None),
-    category_id: Optional[int] = Query(default=None),
-    department: Optional[str] = Query(default=None),
+    q: str | None = Query(default=None, max_length=120),
+    active: bool | None = Query(default=None),
+    category_id: int | None = Query(default=None),
+    department: str | None = Query(default=None),
     limit: int = Query(default=200, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
 ):
@@ -424,7 +424,7 @@ async def list_services(
 class QueueGroupInfo(BaseModel):
     """Schema for a single queue group"""
     display_name: str
-    display_name_uz: Optional[str] = None
+    display_name_uz: str | None = None
     service_codes: list[str] = []
     service_prefixes: list[str] = []
     exclude_codes: list[str] = []
@@ -476,10 +476,10 @@ async def get_queue_groups(
 
 class ServiceCodeRepairItem(BaseModel):
     id: int
-    before_code: Optional[str] = None
-    before_service_code: Optional[str] = None
-    after_code: Optional[str] = None
-    after_service_code: Optional[str] = None
+    before_code: str | None = None
+    before_service_code: str | None = None
+    after_code: str | None = None
+    after_service_code: str | None = None
     changed: bool = False
 
 
@@ -668,7 +668,7 @@ async def delete_service(
 class DoctorOut(BaseModel):
     id: int
     specialty: str
-    cabinet: Optional[str] = None
+    cabinet: str | None = None
     active: bool = True
 
     model_config = ConfigDict(from_attributes=True)
@@ -694,17 +694,17 @@ class ServiceAuditLogOut(BaseModel):
 
     id: int
     service_id: int
-    user_id: Optional[int] = None
+    user_id: int | None = None
     action: str
-    changes: Optional[dict] = None
-    old_values: Optional[dict] = None
-    new_values: Optional[dict] = None
-    comment: Optional[str] = None
+    changes: dict | None = None
+    old_values: dict | None = None
+    new_values: dict | None = None
+    comment: str | None = None
     created_at: datetime
 
     # Enriched fields
-    user_name: Optional[str] = None
-    service_name: Optional[str] = None
+    user_name: str | None = None
+    service_name: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -807,13 +807,13 @@ async def get_recent_service_changes(
 class ServiceResolveResponse(BaseModel):
     """Response schema для resolve_service endpoint"""
 
-    service_id: Optional[int] = None
-    service_code: Optional[str] = None
-    normalized_code: Optional[str] = None
-    category: Optional[str] = None
-    subcategory: Optional[str] = None
+    service_id: int | None = None
+    service_code: str | None = None
+    normalized_code: str | None = None
+    category: str | None = None
+    subcategory: str | None = None
     departments: list[str] = []
-    ui_type: Optional[str] = None
+    ui_type: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -822,8 +822,8 @@ class ServiceResolveResponse(BaseModel):
     "/resolve", response_model=ServiceResolveResponse, summary="Разрешить услугу (SSOT)"
 )
 async def resolve_service_endpoint(
-    service_id: Optional[int] = Query(None, description="ID услуги"),
-    code: Optional[str] = Query(None, description="Код услуги"),
+    service_id: int | None = Query(None, description="ID услуги"),
+    code: str | None = Query(None, description="Код услуги"),
     db: Session = Depends(get_db),
     # user=Depends(require_roles("Admin", "Registrar", "Doctor", "Lab", "Cashier")),
 ):
@@ -858,7 +858,7 @@ class ServiceBatchUpdateRequest(BaseModel):
 
     service_ids: list[int] = Field(..., min_items=1, max_items=100)
     updates: dict[str, Any] = Field(..., min_items=1)
-    comment: Optional[str] = None
+    comment: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/api/v1/endpoints/sms_providers.py
+++ b/backend/app/api/v1/endpoints/sms_providers.py
@@ -36,7 +36,7 @@ class SMSTestRequest(BaseModel):
 
     phone: str
     message: str
-    provider: Optional[str] = None
+    provider: str | None = None
 
 
 class SMSProviderInfo(BaseModel):
@@ -44,9 +44,9 @@ class SMSProviderInfo(BaseModel):
 
     name: str
     available: bool
-    balance: Optional[float] = None
-    currency: Optional[str] = None
-    error: Optional[str] = None
+    balance: float | None = None
+    currency: str | None = None
+    error: str | None = None
 
 
 def _unavailable_provider_info(provider_name: str, exc: Exception) -> SMSProviderInfo:
@@ -68,7 +68,7 @@ def _sanitize_sms_provider_result(result: dict) -> dict:
     return result
 
 
-def _sanitize_sms_response_error(success: bool, error: Optional[str]) -> Optional[str]:
+def _sanitize_sms_response_error(success: bool, error: str | None) -> str | None:
     if not success and error:
         return SMS_PROVIDER_UNAVAILABLE_ERROR
     return error
@@ -189,7 +189,7 @@ async def test_sms_sending(
 async def send_2fa_code(
     phone: str,
     code: str,
-    provider: Optional[str] = None,
+    provider: str | None = None,
     current_user: User = Depends(require_roles(["Admin", "Registrar"])),
 ):
     """Отправить код 2FA (для администраторов и регистраторов)"""

--- a/backend/app/api/v1/endpoints/specialized_panels.py
+++ b/backend/app/api/v1/endpoints/specialized_panels.py
@@ -24,7 +24,7 @@ FINANCIAL_SPECIALIZED_PANEL_ROLES = ("Admin", "Manager")
 async def get_cardiology_patients(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    search: Optional[str] = Query(None),
+    search: str | None = Query(None),
     current_user: User = Depends(require_roles("Admin", "Doctor")),
     db: Session = Depends(get_db),
 ):
@@ -40,10 +40,10 @@ async def get_cardiology_patients(
 async def get_cardiology_visits(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = Query(None),
-    status: Optional[str] = Query(None),
-    start_date: Optional[date] = Query(None),
-    end_date: Optional[date] = Query(None),
+    patient_id: int | None = Query(None),
+    status: str | None = Query(None),
+    start_date: date | None = Query(None),
+    end_date: date | None = Query(None),
     current_user: User = Depends(require_roles("Admin", "Doctor")),
     db: Session = Depends(get_db),
 ):
@@ -60,8 +60,8 @@ async def get_cardiology_visits(
 
 @router.get("/cardiology/analytics")
 async def get_cardiology_analytics(
-    start_date: Optional[date] = Query(None),
-    end_date: Optional[date] = Query(None),
+    start_date: date | None = Query(None),
+    end_date: date | None = Query(None),
     current_user: User = Depends(require_roles(*FINANCIAL_SPECIALIZED_PANEL_ROLES)),
     db: Session = Depends(get_db),
 ):
@@ -76,7 +76,7 @@ async def get_cardiology_analytics(
 async def get_dentistry_patients(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    search: Optional[str] = Query(None),
+    search: str | None = Query(None),
     current_user: User = Depends(require_roles("Admin", "Doctor")),
     db: Session = Depends(get_db),
 ):
@@ -92,10 +92,10 @@ async def get_dentistry_patients(
 async def get_dentistry_visits(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = Query(None),
-    status: Optional[str] = Query(None),
-    start_date: Optional[date] = Query(None),
-    end_date: Optional[date] = Query(None),
+    patient_id: int | None = Query(None),
+    status: str | None = Query(None),
+    start_date: date | None = Query(None),
+    end_date: date | None = Query(None),
     current_user: User = Depends(require_roles("Admin", "Doctor")),
     db: Session = Depends(get_db),
 ):
@@ -112,8 +112,8 @@ async def get_dentistry_visits(
 
 @router.get("/dentistry/analytics")
 async def get_dentistry_analytics(
-    start_date: Optional[date] = Query(None),
-    end_date: Optional[date] = Query(None),
+    start_date: date | None = Query(None),
+    end_date: date | None = Query(None),
     current_user: User = Depends(require_roles(*FINANCIAL_SPECIALIZED_PANEL_ROLES)),
     db: Session = Depends(get_db),
 ):
@@ -126,7 +126,7 @@ async def get_dentistry_analytics(
 
 @router.get("/specialized/services")
 async def get_specialized_services(
-    department: Optional[str] = Query(
+    department: str | None = Query(
         None, description="Отделение: cardiology, dentistry"
     ),
     current_user: User = Depends(require_roles("Admin", "Doctor")),
@@ -139,7 +139,7 @@ async def get_specialized_services(
 @router.get("/specialized/patient-history/{patient_id}")
 async def get_specialized_patient_history(
     patient_id: int,
-    department: Optional[str] = Query(
+    department: str | None = Query(
         None, description="Отделение: cardiology, dentistry"
     ),
     current_user: User = Depends(require_roles("Admin", "Doctor")),
@@ -157,8 +157,8 @@ async def get_specialized_patient_history(
 
 @router.get("/specialized/statistics")
 async def get_specialized_statistics(
-    start_date: Optional[date] = Query(None),
-    end_date: Optional[date] = Query(None),
+    start_date: date | None = Query(None),
+    end_date: date | None = Query(None),
     current_user: User = Depends(require_roles(*FINANCIAL_SPECIALIZED_PANEL_ROLES)),
     db: Session = Depends(get_db),
 ):

--- a/backend/app/api/v1/endpoints/system_management.py
+++ b/backend/app/api/v1/endpoints/system_management.py
@@ -43,7 +43,7 @@ class BackupRequest(BaseModel):
 
     backup_type: str = Field(..., pattern="^(full|database|configuration)$")
     include_files: bool = True
-    description: Optional[str] = None
+    description: str | None = None
 
 
 class RestoreRequest(BaseModel):
@@ -58,22 +58,22 @@ class BackupResponse(BaseModel):
     """Ответ с информацией о бэкапе"""
 
     success: bool
-    backup_name: Optional[str] = None
-    status: Optional[str] = None
-    size: Optional[int] = None
-    created_at: Optional[str] = None
-    error: Optional[str] = None
+    backup_name: str | None = None
+    status: str | None = None
+    size: int | None = None
+    created_at: str | None = None
+    error: str | None = None
 
 
 class MonitoringThresholds(BaseModel):
     """Пороговые значения для мониторинга"""
 
-    cpu_usage: Optional[float] = Field(None, ge=0, le=100)
-    memory_usage: Optional[float] = Field(None, ge=0, le=100)
-    disk_usage: Optional[float] = Field(None, ge=0, le=100)
-    response_time: Optional[float] = Field(None, ge=0)
-    error_rate: Optional[float] = Field(None, ge=0, le=100)
-    database_connections: Optional[int] = Field(None, ge=0)
+    cpu_usage: float | None = Field(None, ge=0, le=100)
+    memory_usage: float | None = Field(None, ge=0, le=100)
+    disk_usage: float | None = Field(None, ge=0, le=100)
+    response_time: float | None = Field(None, ge=0)
+    error_rate: float | None = Field(None, ge=0, le=100)
+    database_connections: int | None = Field(None, ge=0)
 
 
 # ===================== БЭКАПЫ =====================
@@ -316,7 +316,7 @@ async def get_metrics_summary(
 
 @router.get("/monitoring/alerts")
 async def get_alerts(
-    severity: Optional[str] = Query(None, pattern="^(critical|warning|info)$"),
+    severity: str | None = Query(None, pattern="^(critical|warning|info)$"),
     limit: int = Query(100, ge=1, le=1000),
     current_user: User = Depends(get_current_user),
     _: None = Depends(require_roles([Roles.ADMIN, Roles.MANAGER])),

--- a/backend/app/api/v1/endpoints/telemetry.py
+++ b/backend/app/api/v1/endpoints/telemetry.py
@@ -97,9 +97,9 @@ class TelemetryEvent(BaseModel):
     """Single telemetry event"""
     event: str = Field(..., max_length=50)
     entity: str = Field(default="emr", max_length=20)
-    timestamp: Optional[int] = None
-    session_id: Optional[str] = Field(None, max_length=50)
-    meta: Optional[dict[str, Any]] = None
+    timestamp: int | None = None
+    session_id: str | None = Field(None, max_length=50)
+    meta: dict[str, Any] | None = None
 
 
 class TelemetryBatch(BaseModel):

--- a/backend/app/api/v1/endpoints/two_factor_devices.py
+++ b/backend/app/api/v1/endpoints/two_factor_devices.py
@@ -35,11 +35,11 @@ def raise_two_factor_device_internal_error(
 
 class DeviceInfo(BaseModel):
     id: str
-    name: Optional[str] = None
+    name: str | None = None
     device_type: str
-    browser: Optional[str] = None
-    os: Optional[str] = None
-    location: Optional[str] = None
+    browser: str | None = None
+    os: str | None = None
+    location: str | None = None
     ip_address: str
     user_agent: str
     created_at: datetime
@@ -48,7 +48,7 @@ class DeviceInfo(BaseModel):
 
 
 class DeviceCreateRequest(BaseModel):
-    name: Optional[str] = None
+    name: str | None = None
     device_fingerprint: str
     user_agent: str
     ip_address: str

--- a/backend/app/api/v1/endpoints/two_factor_sms_email.py
+++ b/backend/app/api/v1/endpoints/two_factor_sms_email.py
@@ -43,9 +43,9 @@ def raise_two_factor_sms_internal_error(
 @router.post("/send-code")
 async def send_verification_code(
     method: str = Query(..., description="Метод отправки: sms или email"),
-    phone_number: Optional[str] = Query(None, description="Номер телефона для SMS"),
-    email_address: Optional[str] = Query(None, description="Email адрес"),
-    provider: Optional[str] = Query(
+    phone_number: str | None = Query(None, description="Номер телефона для SMS"),
+    email_address: str | None = Query(None, description="Email адрес"),
+    provider: str | None = Query(
         None, description="SMS провайдер: eskiz, playmobile, mock"
     ),
     db: Session = Depends(get_db),
@@ -110,8 +110,8 @@ async def send_verification_code(
 async def verify_verification_code(
     method: str = Query(..., description="Метод верификации: sms или email"),
     code: str = Query(..., description="Код подтверждения"),
-    phone_number: Optional[str] = Query(None, description="Номер телефона для SMS"),
-    email_address: Optional[str] = Query(None, description="Email адрес"),
+    phone_number: str | None = Query(None, description="Номер телефона для SMS"),
+    email_address: str | None = Query(None, description="Email адрес"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -173,8 +173,8 @@ async def get_verification_status(
 @router.post("/resend-code")
 async def resend_verification_code(
     method: str = Query(..., description="Метод отправки: sms или email"),
-    phone_number: Optional[str] = Query(None, description="Номер телефона для SMS"),
-    email_address: Optional[str] = Query(None, description="Email адрес"),
+    phone_number: str | None = Query(None, description="Номер телефона для SMS"),
+    email_address: str | None = Query(None, description="Email адрес"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):

--- a/backend/app/api/v1/endpoints/user_data_transfer.py
+++ b/backend/app/api/v1/endpoints/user_data_transfer.py
@@ -24,10 +24,10 @@ router = APIRouter()
 class UserDataSummaryResponse(BaseModel):
     user_id: int
     username: str
-    full_name: Optional[str]
-    email: Optional[str]
-    phone: Optional[str]
-    patient_id: Optional[int]
+    full_name: str | None
+    email: str | None
+    phone: str | None
+    patient_id: int | None
     data_counts: dict[str, int]
     transferable_data: list[dict[str, Any]]
 
@@ -278,7 +278,7 @@ def confirm_data_transfer(
 
 @router.get("/transfer/history")
 def get_transfer_history(
-    user_id: Optional[int] = Query(None, description="ID пользователя для фильтрации"),
+    user_id: int | None = Query(None, description="ID пользователя для фильтрации"),
     limit: int = Query(50, ge=1, le=100, description="Количество записей"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin", "SuperAdmin")),

--- a/backend/app/api/v1/endpoints/user_management.py
+++ b/backend/app/api/v1/endpoints/user_management.py
@@ -277,15 +277,15 @@ async def create_user(
 async def get_users(
     page: int = Query(1, ge=1),
     per_page: int = Query(20, ge=1, le=100),
-    role: Optional[str] = Query(
+    role: str | None = Query(
         None, pattern="^(Admin|Doctor|Nurse|Receptionist|Cashier|Lab|Patient)$"
         # TODO(DB_ROLES): Replace regex with DB-driven validation in Phase 0.5
     ),
-    status_filter: Optional[str] = Query(
+    status_filter: str | None = Query(
         None, pattern="^(active|inactive|suspended|pending|locked)$", alias="status"
     ),
-    is_active: Optional[bool] = Query(None),
-    search: Optional[str] = Query(None, min_length=1, max_length=100),
+    is_active: bool | None = Query(None),
+    search: str | None = Query(None, min_length=1, max_length=100),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles("Admin")),
 ):
@@ -361,7 +361,7 @@ async def update_user(
 @router.delete("/users/{user_id}")
 async def delete_user(
     user_id: int,
-    transfer_to: Optional[int] = Query(
+    transfer_to: int | None = Query(
         None, description="ID пользователя для передачи данных"
     ),
     db: Session = Depends(get_db),

--- a/backend/app/api/v1/endpoints/visit_confirmation.py
+++ b/backend/app/api/v1/endpoints/visit_confirmation.py
@@ -20,15 +20,15 @@ router = APIRouter()
 
 class TelegramConfirmRequest(BaseModel):
     token: str = Field(..., min_length=10)
-    telegram_user_id: Optional[str] = None
-    telegram_username: Optional[str] = None
+    telegram_user_id: str | None = None
+    telegram_username: str | None = None
 
 
 class PWAConfirmRequest(BaseModel):
     token: str = Field(..., min_length=10)
-    patient_phone: Optional[str] = None
-    user_agent: Optional[str] = None
-    ip_address: Optional[str] = None
+    patient_phone: str | None = None
+    user_agent: str | None = None
+    ip_address: str | None = None
 
 
 class ConfirmationResponse(BaseModel):
@@ -38,9 +38,9 @@ class ConfirmationResponse(BaseModel):
     status: str
     patient_name: str
     visit_date: str
-    visit_time: Optional[str]
-    queue_numbers: Optional[list[dict[str, Any]]] = None
-    print_tickets: Optional[list[dict[str, Any]]] = None
+    visit_time: str | None
+    queue_numbers: list[dict[str, Any]] | None = None
+    print_tickets: list[dict[str, Any]] | None = None
 
 
 def _raise_http_error(exc: VisitConfirmationDomainError) -> None:

--- a/backend/app/api/v1/endpoints/visit_payments.py
+++ b/backend/app/api/v1/endpoints/visit_payments.py
@@ -106,9 +106,9 @@ def update_visit_payment_status(
 )
 def create_visit_from_payment(
     visit_id: int,
-    patient_id: Optional[int] = Query(None, description="ID пациента"),
-    doctor_id: Optional[int] = Query(None, description="ID врача"),
-    notes: Optional[str] = Query(None, description="Заметки к визиту"),
+    patient_id: int | None = Query(None, description="ID пациента"),
+    doctor_id: int | None = Query(None, description="ID врача"),
+    notes: str | None = Query(None, description="Заметки к визиту"),
     db: Session = Depends(get_db),
     _: dict = Depends(require_roles("Admin", "Registrar")),
 ):

--- a/backend/app/api/v1/endpoints/visits.py
+++ b/backend/app/api/v1/endpoints/visits.py
@@ -22,39 +22,39 @@ VISIT_READ_ROLES = ("Admin", "Registrar", "Doctor", "Cashier", "Lab", "Nurse")
 
 # Pydantic fallbacks (если полноценные схемы уже есть в app.schemas, в следующих шагах заменим)
 class VisitCreate(BaseModel):
-    patient_id: Optional[int] = None
-    doctor_id: Optional[int] = None
-    notes: Optional[str] = None
-    planned_date: Optional[date] = None  # <-- новая поддержка
-    department: Optional[str] = None
-    source: Optional[str] = Field(default="desk", max_length=20)
+    patient_id: int | None = None
+    doctor_id: int | None = None
+    notes: str | None = None
+    planned_date: date | None = None  # <-- новая поддержка
+    department: str | None = None
+    source: str | None = Field(default="desk", max_length=20)
 
 
 class VisitOut(BaseModel):
     id: int
-    patient_id: Optional[int] = None
-    doctor_id: Optional[int] = None
+    patient_id: int | None = None
+    doctor_id: int | None = None
     status: str
-    created_at: Optional[datetime] = None
-    started_at: Optional[datetime] = None
-    finished_at: Optional[datetime] = None
-    notes: Optional[str] = None
-    planned_date: Optional[date] = None  # <-- новая поддержка
-    source: Optional[str] = None
-    patient_name: Optional[str] = None
-    patient_fio: Optional[str] = None
-    patient_phone: Optional[str] = None
-    patient_birth_year: Optional[int] = None
-    birth_year: Optional[int] = None
-    address: Optional[str] = None
-    patient: Optional[dict[str, Any]] = None
-    doctor_name: Optional[str] = None
-    room: Optional[str] = None
-    doctor: Optional[dict[str, Any]] = None
+    created_at: datetime | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    notes: str | None = None
+    planned_date: date | None = None  # <-- новая поддержка
+    source: str | None = None
+    patient_name: str | None = None
+    patient_fio: str | None = None
+    patient_phone: str | None = None
+    patient_birth_year: int | None = None
+    birth_year: int | None = None
+    address: str | None = None
+    patient: dict[str, Any] | None = None
+    doctor_name: str | None = None
+    room: str | None = None
+    doctor: dict[str, Any] | None = None
 
 
 class VisitServiceIn(BaseModel):
-    code: Optional[str] = Field(default=None, max_length=32)
+    code: str | None = Field(default=None, max_length=32)
     name: str = Field(max_length=255)
     price: float = 0.0
     qty: int = 1
@@ -185,10 +185,10 @@ def _ensure_doctor_can_create_visit_for_payload(
 
 @router.get("/visits", response_model=list[VisitOut], summary="Список визитов")
 def list_visits(
-    patient_id: Optional[int] = Query(default=None),
-    doctor_id: Optional[int] = Query(default=None),
-    status_q: Optional[str] = Query(default=None),
-    planned: Optional[date] = Query(default=None, alias="planned_date"),
+    patient_id: int | None = Query(default=None),
+    doctor_id: int | None = Query(default=None),
+    status_q: str | None = Query(default=None),
+    planned: date | None = Query(default=None, alias="planned_date"),
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     db: Session = Depends(get_db),
@@ -339,7 +339,7 @@ def set_status(
 def reschedule_visit(
     visit_id: int,
     new_date: date = Query(..., alias="new_date"),
-    new_time: Optional[str] = Query(None, alias="new_time", description="Опциональное новое время в формате HH:MM"),
+    new_time: str | None = Query(None, alias="new_time", description="Опциональное новое время в формате HH:MM"),
     db: Session = Depends(get_db),
 ):
     """

--- a/backend/app/api/v1/endpoints/wait_time_analytics.py
+++ b/backend/app/api/v1/endpoints/wait_time_analytics.py
@@ -84,8 +84,8 @@ class ServiceWaitAnalyticsResponse(BaseModel):
 async def get_wait_time_analytics(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Фильтр по отделению"),
-    doctor_id: Optional[int] = Query(None, description="Фильтр по врачу"),
+    department: str | None = Query(None, description="Фильтр по отделению"),
+    doctor_id: int | None = Query(None, description="Фильтр по врачу"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles(["Admin", "Registrar", "Doctor"])),
 ):
@@ -129,7 +129,7 @@ async def get_wait_time_analytics(
 
 @router.get("/real-time-wait-estimates", response_model=RealTimeWaitEstimateResponse)
 async def get_real_time_wait_estimates(
-    department: Optional[str] = Query(None, description="Фильтр по отделению"),
+    department: str | None = Query(None, description="Фильтр по отделению"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles(["Admin", "Registrar", "Doctor"])),
 ):
@@ -148,7 +148,7 @@ async def get_real_time_wait_estimates(
 async def get_service_wait_analytics(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    service_codes: Optional[str] = Query(None, description="Коды услуг через запятую"),
+    service_codes: str | None = Query(None, description="Коды услуг через запятую"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles(["Admin", "Registrar", "Doctor"])),
 ):
@@ -191,7 +191,7 @@ async def get_service_wait_analytics(
 @router.get("/wait-time-summary")
 async def get_wait_time_summary(
     days: int = Query(7, ge=1, le=30, description="Количество дней для анализа"),
-    department: Optional[str] = Query(None, description="Фильтр по отделению"),
+    department: str | None = Query(None, description="Фильтр по отделению"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles(["Admin", "Registrar", "Doctor"])),
 ):
@@ -238,7 +238,7 @@ async def get_wait_time_comparison(
     compare_with_previous: bool = Query(
         True, description="Сравнить с предыдущим периодом"
     ),
-    department: Optional[str] = Query(None, description="Фильтр по отделению"),
+    department: str | None = Query(None, description="Фильтр по отделению"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles(["Admin", "Registrar", "Doctor"])),
 ):
@@ -323,7 +323,7 @@ async def get_wait_time_comparison(
 async def get_wait_time_heatmap(
     start_date: str = Query(..., description="Начальная дата (YYYY-MM-DD)"),
     end_date: str = Query(..., description="Конечная дата (YYYY-MM-DD)"),
-    department: Optional[str] = Query(None, description="Фильтр по отделению"),
+    department: str | None = Query(None, description="Фильтр по отделению"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_roles(["Admin", "Registrar", "Doctor"])),
 ):

--- a/backend/app/api/v1/endpoints/webhooks.py
+++ b/backend/app/api/v1/endpoints/webhooks.py
@@ -76,8 +76,8 @@ async def get_webhooks(
     db: Session = Depends(get_db),
     skip: int = 0,
     limit: int = 100,
-    status_filter: Optional[WebhookStatus] = None,
-    event_type: Optional[str] = None,
+    status_filter: WebhookStatus | None = None,
+    event_type: str | None = None,
     current_user: User = Depends(
         require_roles([Roles.ADMIN, Roles.MANAGER, Roles.REGISTRAR])
     ),
@@ -390,7 +390,7 @@ async def get_webhook_calls(
     webhook_id: int,
     skip: int = 0,
     limit: int = 100,
-    status_filter: Optional[WebhookCallStatus] = None,
+    status_filter: WebhookCallStatus | None = None,
     current_user: User = Depends(
         require_roles([Roles.ADMIN, Roles.MANAGER, Roles.REGISTRAR])
     ),

--- a/backend/app/api/v1/endpoints/websocket_auth.py
+++ b/backend/app/api/v1/endpoints/websocket_auth.py
@@ -52,8 +52,8 @@ def _resolve_websocket_user(payload: dict, db: Session) -> User | None:
 
 
 async def authenticate_websocket_token(
-    token: Optional[str], db: Session
-) -> Optional[User]:
+    token: str | None, db: Session
+) -> User | None:
     """
     Аутентификация WebSocket соединения по JWT токену
     """
@@ -216,7 +216,7 @@ async def ws_queue_authenticated(
 
 @router.websocket("/ws/queue/optional-auth")
 async def ws_queue_optional_auth(
-    websocket: WebSocket, department: str, date: str, token: Optional[str] = None
+    websocket: WebSocket, department: str, date: str, token: str | None = None
 ):
     """
     ⚠️ DEPRECATED: WebSocket соединение с опциональной аутентификацией
@@ -371,7 +371,7 @@ async def _handle_authenticated_message(
 async def _handle_message_with_auth_level(
     websocket: WebSocket,
     message: dict,
-    user: Optional[User],
+    user: User | None,
     department: str,
     date: str,
     db: Session,

--- a/backend/app/services/appointments_api_service.py
+++ b/backend/app/services/appointments_api_service.py
@@ -360,24 +360,24 @@ router = APIRouter(prefix="/appointments", tags=["appointments"])
 
 class PendingPaymentResponse(BaseModel):
     id: int
-    patient_id: Optional[int]
-    patient_name: Optional[str]
-    patient_last_name: Optional[str]
-    patient_first_name: Optional[str]
-    doctor_id: Optional[int]
-    department: Optional[str]
-    appointment_date: Optional[str]
-    appointment_time: Optional[str]
+    patient_id: int | None
+    patient_name: str | None
+    patient_last_name: str | None
+    patient_first_name: str | None
+    doctor_id: int | None
+    department: str | None
+    appointment_date: str | None
+    appointment_time: str | None
     status: str
     services: list[str]
     services_names: list[str]
-    payment_amount: Optional[float]
-    created_at: Optional[str]
+    payment_amount: float | None
+    created_at: str | None
     record_type: str
-    visit_ids: Optional[list[int]] = None
+    visit_ids: list[int] | None = None
 
 
-def _pick_date(date_str: Optional[str], date: Optional[str], d: Optional[str]) -> str:
+def _pick_date(date_str: str | None, date: str | None, d: str | None) -> str:
     value = date_str or date or d
     if not value:
         raise HTTPException(
@@ -396,11 +396,11 @@ def list_appointments(
     db: Session = Depends(deps.get_db),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    patient_id: Optional[int] = Query(None, description="Patient id filter"),
-    doctor_id: Optional[int] = Query(None, description="Doctor id filter"),
-    department: Optional[str] = Query(None, description="Department filter"),
-    date_from: Optional[str] = Query(None, description="From date (YYYY-MM-DD)"),
-    date_to: Optional[str] = Query(None, description="To date (YYYY-MM-DD)"),
+    patient_id: int | None = Query(None, description="Patient id filter"),
+    doctor_id: int | None = Query(None, description="Doctor id filter"),
+    department: str | None = Query(None, description="Department filter"),
+    date_from: str | None = Query(None, description="From date (YYYY-MM-DD)"),
+    date_to: str | None = Query(None, description="To date (YYYY-MM-DD)"),
     current_user: User = Depends(deps.get_current_user),
 ):
     del current_user
@@ -441,8 +441,8 @@ async def get_pending_payments(
     db: Session = Depends(deps.get_db),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    date_from: Optional[str] = Query(default=None),
-    date_to: Optional[str] = Query(default=None),
+    date_from: str | None = Query(default=None),
+    date_to: str | None = Query(default=None),
     current_user: User = Depends(deps.get_current_user),
 ):
     del current_user
@@ -591,9 +591,9 @@ def open_day(
 @router.get("/stats", name="stats")
 def stats(
     department: str = Query(...),
-    date_str: Optional[str] = Query(None),
-    date: Optional[str] = Query(None),
-    d: Optional[str] = Query(None),
+    date_str: str | None = Query(None),
+    date: str | None = Query(None),
+    d: str | None = Query(None),
     db: Session = Depends(deps.get_db),
     current_user: User = Depends(deps.get_current_user),
 ):
@@ -643,9 +643,9 @@ def close_day(
 @router.get("/qrcode", name="qrcode_png")
 def qrcode_png(
     department: str = Query(...),
-    date_str: Optional[str] = Query(None),
-    date: Optional[str] = Query(None),
-    d: Optional[str] = Query(None),
+    date_str: str | None = Query(None),
+    date: str | None = Query(None),
+    d: str | None = Query(None),
     current_user: User = Depends(deps.get_current_user),
 ):
     del current_user

--- a/backend/app/services/visits_api_service.py
+++ b/backend/app/services/visits_api_service.py
@@ -402,28 +402,28 @@ router = APIRouter()
 
 
 class VisitCreate(BaseModel):
-    patient_id: Optional[int] = None
-    doctor_id: Optional[int] = None
-    notes: Optional[str] = None
-    planned_date: Optional[date] = None
-    source: Optional[str] = Field(default="desk", max_length=20)
+    patient_id: int | None = None
+    doctor_id: int | None = None
+    notes: str | None = None
+    planned_date: date | None = None
+    source: str | None = Field(default="desk", max_length=20)
 
 
 class VisitOut(BaseModel):
     id: int
-    patient_id: Optional[int] = None
-    doctor_id: Optional[int] = None
+    patient_id: int | None = None
+    doctor_id: int | None = None
     status: str
-    created_at: Optional[datetime] = None
-    started_at: Optional[datetime] = None
-    finished_at: Optional[datetime] = None
-    notes: Optional[str] = None
-    planned_date: Optional[date] = None
-    source: Optional[str] = None
+    created_at: datetime | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    notes: str | None = None
+    planned_date: date | None = None
+    source: str | None = None
 
 
 class VisitServiceIn(BaseModel):
-    code: Optional[str] = Field(default=None, max_length=32)
+    code: str | None = Field(default=None, max_length=32)
     name: str = Field(max_length=255)
     price: float = 0.0
     qty: int = 1
@@ -436,10 +436,10 @@ class VisitWithServices(BaseModel):
 
 @router.get("/visits", response_model=list[VisitOut], summary="Список визитов")
 def list_visits(
-    patient_id: Optional[int] = Query(default=None),
-    doctor_id: Optional[int] = Query(default=None),
-    status_q: Optional[str] = Query(default=None),
-    planned: Optional[date] = Query(default=None, alias="planned_date"),
+    patient_id: int | None = Query(default=None),
+    doctor_id: int | None = Query(default=None),
+    status_q: str | None = Query(default=None),
+    planned: date | None = Query(default=None, alias="planned_date"),
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     db: Session = Depends(get_db),


### PR DESCRIPTION
## Summary

- Automated cleanup: 1164 UP045 (PEP 604) fixes across 91 files.
- Converts `Optional[X]` → `X | None` (PEP 604 syntax, Python 3.10+).
- 2 remaining require manual review (complex type expressions).

## Cyclic Execution Evidence

- Fresh main sync: ветка от main после merge PR #1768 (W293 whitespace).
- Clean workspace: 91 файлов, 1164 type annotation fixes.
- Branch: fix/ruff-up045-pep604
- Scope gate: allowed только UP045 unsafe fix; denied любые другие changes.
- Red-check handling: py_compile verified all files, app import verified OK.

## Contract Impact

- Canonical surface: backend API endpoints and services
- Request shape: не применимо - изменены только type annotations
- Response shape: не применимо - API response не изменён
- Status codes: не применимо - endpoints не затронуты
- Frontend consumer: не применимо - backend-only cleanup
- Compatibility path or alias: не применимо - PEP 604 is backward compatible (Python 3.10+)
- Contract proof: py_compile OK, app import OK

## RBAC / Permissions

not applicable - annotation cleanup, не затрагивает role guards.

## Notification / Realtime

not applicable - annotation cleanup, event type / websocket channel / payload version / delivery semantics / reconnect не затронуты.

## Frontend Resilience

- Empty data proof: не применимо.
- Partial data proof: не применимо.
- Forbidden secondary path behavior: не применимо.
- Missing draft/resource behavior: не применимо.
- Stale route/deep-link behavior: не применимо.

## Scope Gate

- Allowed paths: 91 backend files (UP045 fix only)
- Denied paths: frontend, тесты, миграции, новые endpoints
- Migration/docs/test impact: нет
- Rollback note: revert восстанавливает Optional[X] syntax

## DevBrain Memory Impact

not applicable - annotation cleanup.

## Validation

- Targeted tests or smoke run: py_compile + `from app.main import app`
- Result: All files compile OK, Import OK
- Not checked: full CI/CD pipeline — будет запущен на PR
