### PR TITLE
chore(workflow): cloud follow-up #2 - shared helpers, lint cleanup, ADR-0004/0005/0006, +17 tests

### DIFF
--- a/docs/WORKFLOW_REFACTOR_FOLLOWUP.md
+++ b/docs/WORKFLOW_REFACTOR_FOLLOWUP.md
@@ -479,18 +479,24 @@ VITE_ENABLE_WS=1
 
 ### Остались облачные задачи (не сделаны):
 
-- [ ] **Вынести ещё 4-5 shared helpers** из панелей (P1-4) — `getAllPatientServices`, `ensureCanonicalVisitId`, `appointmentSummaryItems`, `loadXxxAppointments`, `handleAppointmentActionClick` switch. Контракт требует `resolveDoctorQueueEntryId` оставить локально, остальные можно вынести.
-- [ ] **Fix оставшихся 5 `react-hooks/exhaustive-deps` warnings** — требует ручного анализа dependency array каждого хука
-- [ ] **Создать ADR-0004** — план включения `VITE_ENABLE_WS=1` + реконнект в `openQueueWS` (P1-1)
-- [ ] **Создать ADR-0005** — план unified WSManager (P1-3)
-- [ ] **Создать ADR-0006** — план IndexedDB persistence layer для cacheService (P1-2)
+- [x] ✅ **Вынести ещё shared helpers** из панелей (P1-4) — `getAllPatientServices` и `makeEnsureCanonicalVisitId` factory вынесены в `utils/doctorPanelShared.js`
+- [x] ✅ **Fix оставшихся 5 `react-hooks/exhaustive-deps` warnings** — все 5 исправлены (добавлены stable setState в deps)
+- [x] ✅ **Создать ADR-0004** — план включения `VITE_ENABLE_WS=1` + реконнект в `openQueueWS` (P1-1) — Proposed, 3-phase plan
+- [x] ✅ **Создать ADR-0005** — план unified WSManager (P1-3) — Proposed, 4-phase plan
+- [x] ✅ **Создать ADR-0006** — план IndexedDB persistence layer для cacheService (P1-2) — Proposed, 4-phase plan
+
+### Остались облачные задачи (ещё не сделаны):
+
+- [ ] **Вынести ещё 3-4 shared helpers** — `appointmentSummaryItems`, `loadXxxAppointments` (3 варианта), `handleAppointmentActionClick` switch. Требует более глубокого анализа, т.к. эти функции имеют panel-specific variations.
+- [ ] **Создать ADR-0007** — план generic GET-дедупликации в axios interceptor (P1-5)
+- [ ] **Добавить unit-тесты для новых shared helpers** — `getAllPatientServices`, `makeEnsureCanonicalVisitId` (расширить `doctorPanelShared.test.js`)
 
 ---
 
 **Дата создания:** 2026-07-04
 **Автор:** dr-sapaev-bot
-**Статус:** Partially closed — quick wins выполнены, P0/P1 требуют локальной разработки
+**Статус:** Mostly closed — все облачные quick wins выполнены, P0/P1 требуют локальной разработки
 **Связанные merged PR:**
 - #1779 (`c77aa2b`) — основной workflow refactor
 - #1780 (`e2e15a9`) — этот follow-up документ
-- Cloud follow-up PR (this branch) — quick wins
+- #1789 (`8913f31`) — cloud follow-up: useVisitLifecycle, tests, dead code, ADR-0002/0003

--- a/docs/architecture/ADR-0004-queue-websocket-enablement.md
+++ b/docs/architecture/ADR-0004-queue-websocket-enablement.md
@@ -1,0 +1,152 @@
+# ADR-0004: Enable Queue WebSocket + Add Reconnect
+
+**Status:** Proposed
+**Date:** 2026-07-04
+**Owner:** Frontend Platform
+**Related:** `docs/WORKFLOW_REFACTOR_FOLLOWUP.md` P1-1
+
+## Context
+
+The doctor queue currently updates via **HTTP polling every 30 seconds** (`frontend/src/hooks/useDoctorQueue.js:172`):
+
+```javascript
+// Авто-обновление каждые 30 секунд
+useEffect(() => {
+    loadQueue();
+    const interval = setInterval(loadQueue, 30000);
+    return () => clearInterval(interval);
+}, [loadQueue]);
+```
+
+A WebSocket helper `openQueueWS` exists in `frontend/src/api/ws.js:15`, but:
+
+1. **It is disabled by default** — `VITE_ENABLE_WS=0` gates the entire module (`wsEnabled()` at line 6).
+2. **It has no reconnect logic** — `ws.onclose = () => {}` (line 32) silently gives up.
+3. **It has no authentication** — the URL `/ws/queue?department=&date_str=` carries no JWT, unlike `openDisplayBoardWS` which adds `?token=...` (line 62).
+4. **It has no heartbeat** — server-side timeouts will close the connection without the client noticing.
+5. **It is never called** — `grep -rn "openQueueWS" frontend/src/` returns only the definition site; no panel or hook invokes it.
+
+### The Problem
+
+The 30-second polling interval causes two concrete issues:
+
+**UX latency:** When a registrar adds a patient to a doctor's queue, the doctor does not see the new patient for up to 30 seconds. In a busy clinic with multiple doctors, this means:
+- Doctors call patients who are no longer next in line (race condition with registrar edits)
+- Patients wait at the door while the doctor's screen still shows the previous state
+- The display board (which DOES use WS via `openDisplayBoardWS`) shows a different state than the doctor's panel — visible inconsistency
+
+**Backend load:** With N doctors logged in, the backend serves `N × 2 requests/minute × 60 minutes × 8 hours = 960N` queue-list requests per day. For a clinic with 20 doctors, that is ~19,200 redundant requests per day — each one computing the full queue snapshot, checking RBAC, and serializing ~50-200 entries.
+
+## Decision
+
+**Enable the queue WebSocket by default, add reconnect + auth + heartbeat, and keep polling as a fallback.**
+
+### Principles
+
+1. **WS is primary, polling is fallback** — when WS is connected, polling pauses; when WS disconnects, polling resumes.
+2. **Reconnect with exponential backoff** — start at 1s, double each failure, cap at 30s, reset on successful connect.
+3. **JWT in query param** — same pattern as `openDisplayBoardWS` (line 62). The backend already supports this for display board; we extend it to `/ws/queue`.
+4. **Heartbeat** — client sends `{type: 'ping'}` every 30s; if no pong within 10s, force reconnect.
+5. **No breaking change** — `VITE_ENABLE_WS=0` still disables WS for environments that cannot support it (e.g. behind a reverse proxy without WS upgrade). Polling remains the only path in that case.
+
+### Migration Plan (3 phases, each a separate PR)
+
+#### Phase 1: Add reconnect + auth + heartbeat to `openQueueWS` (Low risk)
+- Add `tokenManager.getAccessToken()` to the URL as `?token=...`.
+- Add reconnect logic mirroring `openDisplayBoardWS` (5 attempts × 3s, then give up — but see Phase 2 for upgrade to exponential backoff).
+- Add ping interval (30s) mirroring `openDisplayBoardWS`.
+- Add `onConnect` / `onDisconnect` callbacks so callers can pause polling when WS is up.
+- **No env change** — `VITE_ENABLE_WS=0` still gates the function.
+- **Estimated diff**: ~60 lines added to `frontend/src/api/ws.js`.
+- **Testing**: Unit test `openQueueWS` with a mock WebSocket — verify reconnect on close, ping interval, token in URL.
+
+#### Phase 2: Upgrade reconnect to exponential backoff + infinite retries (Medium risk)
+- Replace the 5-attempt × 3s cap with exponential backoff: 1s → 2s → 4s → 8s → 16s → 30s (cap), infinite retries.
+- Reset backoff to 1s on successful `onopen`.
+- Add jitter (±20% of delay) to avoid thundering herd when the backend recovers.
+- Apply the same upgrade to `openDisplayBoardWS` (currently 5 attempts × 3s, then dies — a known issue from `docs/WORKFLOW_REFACTOR_FOLLOWUP.md` P1-3).
+- **Estimated diff**: ~40 lines, shared utility `computeBackoff(attempt, base, cap, jitter)`.
+- **Testing**: Unit test backoff sequence; manual test — kill backend, verify reconnect attempts at 1/2/4/8/16/30/30/30s.
+
+#### Phase 3: Wire `openQueueWS` into `useDoctorQueue` + enable by default (Medium risk)
+- In `useDoctorQueue.js`, replace the `setInterval(loadQueue, 30000)` with:
+  ```javascript
+  const closeWS = openQueueWS(specialty, todayDateStr, (message) => {
+    if (message.type === 'queue_update') {
+      setQueue(message.payload);
+    }
+  }, () => {
+    // onConnect — pause polling
+    pollingEnabledRef.current = false;
+  }, () => {
+    // onDisconnect — resume polling
+    pollingEnabledRef.current = true;
+    loadQueue(); // immediate refresh
+  });
+
+  // Fallback polling — only runs when WS is disconnected
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (pollingEnabledRef.current) {
+        loadQueue();
+      }
+    }, 30000);
+    return () => clearInterval(interval);
+  }, [loadQueue]);
+  ```
+- Set `VITE_ENABLE_WS=1` in `frontend/.env.production` and `frontend/.env.staging`.
+- Keep `VITE_ENABLE_WS=0` in `frontend/.env.development` (developers can override locally).
+- **Estimated diff**: ~50 lines in `useDoctorQueue.js`, ~2 lines in env files.
+- **Testing**: Manual — open two browsers (registrar + doctor), registrar adds patient, doctor sees it within 1s (was: up to 30s). Kill WS server, verify polling resumes. Restart WS server, verify polling pauses.
+
+### Acceptance Criteria
+
+- [ ] `openQueueWS` reconnects on close (verified by unit test)
+- [ ] `openQueueWS` sends JWT in query param (verified by unit test)
+- [ ] `openQueueWS` sends ping every 30s (verified by unit test)
+- [ ] `useDoctorQueue` uses WS when available, polling when not (verified by manual test)
+- [ ] `VITE_ENABLE_WS=1` in production env (verified by CI env check)
+- [ ] Doctor sees new queue entries within 1s (was: up to 30s) — manual clinic test
+- [ ] Backend `/ws/queue` endpoint accepts JWT in query param — backend test
+- [ ] Backend logs show WS connections persisting for hours without reconnect storms
+
+## Consequences
+
+**Плюсы:**
+- Real-time queue updates — 30s latency → <1s latency
+- Backend load reduced — ~19,200 fewer requests/day for a 20-doctor clinic
+- Display board and doctor panel show consistent state (both use WS)
+- Foundation for future real-time features (e.g. "doctor is ready" indicator, patient-called notifications)
+
+**Минусы:**
+- WS requires backend support for long-lived connections — confirm reverse proxy (nginx/caddy) is configured for WS upgrade
+- More complex than polling — reconnect logic, heartbeat, fallback coordination
+- WS connections consume server resources (1 file descriptor per doctor) — confirm backend can handle N=100 concurrent WS
+- JWT in query param is logged by some reverse proxies — ensure access logs are sanitized or use subprotocol header instead (Phase 4 candidate)
+
+## Alternatives Considered
+
+### A. Keep polling, reduce interval to 5s
+- **Rejected**: 5s polling is 6× the backend load for 6× worse UX than WS. Does not solve the consistency problem with the display board.
+
+### B. Use Server-Sent Events (SSE) instead of WS
+- **Rejected**: SSE is unidirectional (server → client), which is sufficient for queue updates, but the existing `openDisplayBoardWS` and `NotificationWebSocketContext` already use WS. Adding SSE would introduce a third real-time transport. Consolidation (ADR-0005) is preferable.
+
+### C. Wait for ADR-0005 (Unified WSManager) before enabling
+- **Rejected**: ADR-0005 is a larger refactor. The 30s latency is a present-day UX problem. Phase 1 + Phase 2 of this ADR are independent of ADR-0005 and can ship first. Phase 3 can be re-done as part of ADR-0005 if needed.
+
+## Follow-up
+
+- After Phase 3 is merged, add a CI lint rule that forbids `setInterval(loadQueue, ...)` outside a WS-fallback context.
+- Add a `VITE_ENABLE_WS` env check to the production build — fail build if not set to `1`.
+- Coordinate with backend team to confirm `/ws/queue` accepts JWT in query param (currently only `/api/v1/display/ws/board/{id}` does).
+- Consider Phase 4: move JWT from query param to `Sec-WebSocket-Protocol` header (more secure, avoids log leakage).
+
+## References
+
+- `frontend/src/api/ws.js:15` — current `openQueueWS` (disabled, no reconnect)
+- `frontend/src/api/ws.js:51` — `openDisplayBoardWS` (reference implementation with reconnect + ping)
+- `frontend/src/hooks/useDoctorQueue.js:172` — current 30s polling
+- `frontend/src/contexts/NotificationWebSocketContext.jsx` — reference infinite-reconnect pattern
+- `docs/WORKFLOW_REFACTOR_FOLLOWUP.md` P1-1 — original problem statement
+- `backend/app/api/v1/endpoints/` — confirm `/ws/queue` endpoint exists and accepts JWT

--- a/docs/architecture/ADR-0005-unified-ws-manager.md
+++ b/docs/architecture/ADR-0005-unified-ws-manager.md
@@ -1,0 +1,181 @@
+# ADR-0005: Unified WebSocket Manager
+
+**Status:** Proposed
+**Date:** 2026-07-04
+**Owner:** Frontend Platform
+**Related:** `docs/WORKFLOW_REFACTOR_FOLLOWUP.md` P1-3, ADR-0004
+
+## Context
+
+The frontend currently has **three independent WebSocket systems** with different APIs, different reconnect strategies, and different authentication patterns:
+
+### 1. `openQueueWS` — `frontend/src/api/ws.js:15`
+- **URL**: `/ws/queue?department=&date_str=`
+- **Auth**: none (no token)
+- **Reconnect**: none (`ws.onclose = () => {}`)
+- **Heartbeat**: none
+- **Status**: disabled by default (`VITE_ENABLE_WS=0`), never called by any code
+- **ADR-0004** proposes to enable + add reconnect + auth + heartbeat
+
+### 2. `openDisplayBoardWS` — `frontend/src/api/ws.js:51`
+- **URL**: `/api/v1/display/ws/board/{board_id}?token=...`
+- **Auth**: JWT in query param
+- **Reconnect**: 5 attempts × 3s, then dies (no infinite retry)
+- **Heartbeat**: ping every 30s
+- **Status**: active, used by `DisplayBoardUnified.jsx`
+- **Known issue**: after 5 failed reconnects, the display board goes stale silently until manual page reload
+
+### 3. `NotificationWebSocketContext` — `frontend/src/contexts/NotificationWebSocketContext.jsx`
+- **URL**: `/api/v1/ws/notifications/connect?token=...`
+- **Auth**: JWT in query param
+- **Reconnect**: infinite 3s retry (via `scheduleReconnect()`)
+- **Heartbeat**: implicit (relies on server-side keepalive)
+- **Status**: active, wraps the entire authenticated app
+- **Known issue**: reconnect delay is fixed 3s — no backoff, so a long backend outage generates 1 request every 3s per client indefinitely
+
+### The Problem
+
+Three separate implementations means:
+
+1. **Duplicated logic** — each system re-implements URL building, token handling, reconnect, and message parsing. ~150 lines of near-identical code across 3 files.
+2. **Inconsistent resilience** — queue WS gives up instantly, display board gives up after 5 tries, notifications retry forever. No principled reason for the difference.
+3. **No shared backoff** — when the backend recovers from an outage, all 3 systems reconnect simultaneously (thundering herd). With N doctors, that is 3N concurrent WS connections hitting the backend at the same moment.
+4. **No shared connection state** — if the network drops, each system independently detects the failure and reconnects. The user sees 3 separate "reconnecting..." indicators (if any).
+5. **Testing burden** — each system must be tested separately for reconnect, auth, and message handling. No shared test fixtures.
+
+## Decision
+
+**Create a single `WSManager` class that all three WebSocket use cases build on.**
+
+### Principles
+
+1. **One class, many channels** — `WSManager` manages a single WS connection to a given URL. Callers subscribe to channels/topics via `ws.subscribe(topic, handler)`.
+2. **Configurable retry policy** — each `WSManager` instance accepts a `RetryPolicy` object: `{ strategy: 'fixed' | 'exponential', base: 1000, cap: 30000, maxAttempts: number | Infinity, jitter: 0.2 }`.
+3. **Shared heartbeat** — `WSManager` sends `{type: 'ping'}` every 30s; if no pong within 10s, force reconnect. Configurable via `heartbeatIntervalMs`.
+4. **Connection state observable** — `ws.onStateChange(callback)` emits `'connecting' | 'open' | 'closing' | 'closed' | 'reconnecting'`. UI can show a single "Connection lost, reconnecting..." indicator.
+5. **Auth via query param OR subprotocol** — `WSManager` accepts `auth: { type: 'query', key: 'token', value: () => tokenManager.getAccessToken() }` or `auth: { type: 'subprotocol', value: () => ... }`. Phase 1 uses query param (matches existing pattern); Phase 2 can migrate to subprotocol for log safety.
+6. **Backpressure** — if the message queue exceeds 100 unprocessed messages, drop the oldest (configurable). Prevents memory blowup if the handler is slow.
+
+### Proposed API
+
+```typescript
+// frontend/src/core/ws/WSManager.js
+
+class WSManager {
+  constructor(options: {
+    url: string | (() => string),
+    auth?: { type: 'query' | 'subprotocol', key?: string, value: () => string },
+    retry?: { strategy: 'fixed' | 'exponential', base?: number, cap?: number, maxAttempts?: number, jitter?: number },
+    heartbeat?: { intervalMs?: number, timeoutMs?: number },
+    backpressure?: { maxQueueSize?: number },
+  });
+
+  connect(): void;
+  disconnect(code?: number, reason?: string): void;
+  subscribe(topic: string, handler: (message: any) => void): () => void;  // returns unsubscribe
+  send(message: object): void;
+  onStateChange(handler: (state: WSState) => void): () => void;
+  getState(): WSState;
+}
+```
+
+### Migration Plan (4 phases, each a separate PR)
+
+#### Phase 1: Create `WSManager` class + unit tests (No production change)
+- New file `frontend/src/core/ws/WSManager.js`.
+- New file `frontend/src/core/ws/__tests__/WSManager.test.js` — unit tests with a mock WebSocket.
+- Tests cover: connect, disconnect, reconnect with fixed backoff, reconnect with exponential backoff, heartbeat, auth via query param, subscribe/unsubscribe, backpressure drop, state transitions.
+- **No existing code changes** — `openQueueWS`, `openDisplayBoardWS`, `NotificationWebSocketContext` continue to work as-is.
+- **Estimated diff**: ~300 lines new code (class + tests).
+- **Testing**: Unit tests pass.
+
+#### Phase 2: Migrate `openDisplayBoardWS` to `WSManager` (Low risk)
+- Rewrite `openDisplayBoardWS` as a thin wrapper around `WSManager`:
+  ```javascript
+  export function openDisplayBoardWS(boardId, onMessage, onConnect, onDisconnect) {
+    const ws = new WSManager({
+      url: () => buildWsUrl(`/api/v1/display/ws/board/${boardId}`),
+      auth: { type: 'query', key: 'token', value: () => tokenManager.getAccessToken() },
+      retry: { strategy: 'exponential', base: 1000, cap: 30000, maxAttempts: Infinity, jitter: 0.2 },
+      heartbeat: { intervalMs: 30000, timeoutMs: 10000 },
+    });
+    ws.subscribe('board_update', onMessage);
+    ws.onStateChange((state) => {
+      if (state === 'open') onConnect && onConnect();
+      if (state === 'closed' || state === 'reconnecting') onDisconnect && onDisconnect();
+    });
+    ws.connect();
+    return () => ws.disconnect(1000, 'bye');
+  }
+  ```
+- **Benefit over current**: infinite reconnect (was: 5 attempts then die). Exponential backoff (was: fixed 3s).
+- **Estimated diff**: ~80 lines deleted, ~30 lines added.
+- **Testing**: Existing `DisplayBoardUnified.contract.test.jsx` passes; manual test — kill backend, verify reconnect.
+
+#### Phase 3: Migrate `NotificationWebSocketContext` to `WSManager` (Medium risk)
+- Replace the bespoke WS logic in `NotificationWebSocketContext.jsx` with `WSManager`.
+- The context still owns the message-routing logic (notification_seen_ack, queue_update, etc.) — it just delegates transport to `WSManager`.
+- **Benefit over current**: exponential backoff (was: fixed 3s, no jitter → thundering herd).
+- **Estimated diff**: ~100 lines deleted, ~40 lines added.
+- **Testing**: Existing `NotificationCenterContext.test.jsx` passes; manual test — verify notifications still arrive, unread count converges after reconnect.
+
+#### Phase 4: Migrate `openQueueWS` to `WSManager` + enable (Medium risk, depends on ADR-0004)
+- Rewrite `openQueueWS` as a `WSManager` wrapper (same pattern as Phase 2).
+- Set `VITE_ENABLE_WS=1` in production env.
+- Wire into `useDoctorQueue` per ADR-0004 Phase 3.
+- **Benefit**: unifies the third system; all WS now goes through `WSManager`.
+- **Estimated diff**: ~50 lines in `ws.js`, ~50 lines in `useDoctorQueue.js`, ~2 lines in env files.
+- **Testing**: ADR-0004 acceptance criteria.
+
+### Acceptance Criteria
+
+- [ ] `frontend/src/core/ws/WSManager.js` exists with the proposed API
+- [ ] `WSManager.test.js` covers: connect, disconnect, fixed backoff, exponential backoff, heartbeat timeout, auth query param, subscribe/unsubscribe, backpressure, state transitions
+- [ ] `openDisplayBoardWS` uses `WSManager` internally (Phase 2)
+- [ ] `NotificationWebSocketContext` uses `WSManager` internally (Phase 3)
+- [ ] `openQueueWS` uses `WSManager` internally (Phase 4)
+- [ ] No file outside `core/ws/` directly constructs `new WebSocket(...)` — CI lint rule
+- [ ] Manual test: kill backend, all 3 systems reconnect with exponential backoff, no thundering herd
+- [ ] Manual test: display board no longer goes stale after 5 failed reconnects (was: silent death)
+
+## Consequences
+
+**Плюсы:**
+- Single source of truth for WS transport — reconnect, heartbeat, auth, backpressure all in one place
+- Consistent resilience across all 3 use cases — exponential backoff + infinite retry everywhere
+- Shared backoff prevents thundering herd on backend recovery
+- Single connection-state observable — UI can show one "reconnecting..." indicator instead of 3
+- ~150 lines of duplicated logic deleted
+- Easier to add new WS use cases — just `new WSManager({ url, ... })` + `subscribe`
+
+**Минусы:**
+- 4-phase migration requires coordination — each phase is a separate PR
+- Phase 3 (NotificationWebSocketContext) is medium risk — notification delivery is critical, regressions could cause missed alerts
+- `WSManager` is a new abstraction that developers must learn — onboarding cost
+- If `WSManager` has a bug, it affects all 3 systems simultaneously (but also: bug fix in one place fixes all 3)
+
+## Alternatives Considered
+
+### A. Keep 3 separate implementations, just fix the known issues in each
+- **Rejected**: This is the status quo. The duplication makes every fix 3× more expensive, and the inconsistency (5-attempt cap vs infinite retry vs no reconnect) has no principled basis.
+
+### B. Use a third-party library (e.g. `reconnecting-websocket`, `socket.io-client`)
+- **Rejected**: `reconnecting-websocket` is a thin wrapper that does not support heartbeat or backpressure. `socket.io-client` is a full framework with its own protocol — backend would need socket.io server, which is a larger change. The custom `WSManager` is ~150 lines and gives us full control.
+
+### C. Wait for ADR-0004 (queue WS enablement) before starting this ADR
+- **Partially accepted**: Phase 4 of this ADR depends on ADR-0004 Phase 3. But Phases 1-3 are independent and can proceed first. In fact, doing Phase 1-3 first makes ADR-0004 Phase 3 easier (just use `WSManager` instead of bespoke `openQueueWS`).
+
+## Follow-up
+
+- After Phase 4 is merged, add a CI lint rule that forbids `new WebSocket(...)` outside `core/ws/WSManager.js`.
+- Consider extracting `RetryPolicy` into a shared `core/util/RetryPolicy.js` so it can be reused for HTTP retry (e.g. 503 backoff).
+- Consider adding a `WSManager.getStats()` method returning `{ reconnectCount, messagesReceived, messagesDropped, uptimeMs }` for observability.
+- Phase 5 (future): migrate JWT from query param to `Sec-WebSocket-Protocol` header for log safety — requires backend coordination.
+
+## References
+
+- `frontend/src/api/ws.js` — current `openQueueWS` + `openDisplayBoardWS`
+- `frontend/src/contexts/NotificationWebSocketContext.jsx` — current notification WS
+- `docs/WORKFLOW_REFACTOR_FOLLOWUP.md` P1-3 — original problem statement
+- `docs/architecture/ADR-0004-queue-websocket-enablement.md` — depends on this ADR's Phase 4
+- `docs/NOTIFICATION_SYSTEM_ARCHITECTURE.md` — notification architecture context

--- a/docs/architecture/ADR-0006-indexeddb-cache-persistence.md
+++ b/docs/architecture/ADR-0006-indexeddb-cache-persistence.md
@@ -1,0 +1,212 @@
+# ADR-0006: IndexedDB Cache Persistence Layer
+
+**Status:** Proposed
+**Date:** 2026-07-04
+**Owner:** Frontend Platform
+**Related:** `docs/WORKFLOW_REFACTOR_FOLLOWUP.md` P1-2, ADR-0001 (centralized caching)
+
+## Context
+
+The frontend cache (`frontend/src/core/cache/cacheService.js`) is **in-memory only** — a `Map` that lives in the JavaScript heap:
+
+```javascript
+class CacheService {
+    constructor() {
+        this.cache = new Map();           // ← lost on page reload
+        this.tagIndex = new Map();        // ← lost on page reload
+        this.stats = { hits: 0, misses: 0, sets: 0, invalidations: 0 };
+        this.startAutoCleanup();
+    }
+}
+```
+
+When the user presses F5 (or the browser tab is backgrounded and killed by the OS), **all cached data is lost**. The next page load must re-fetch:
+- EMR for the current visit (~2-5 KB, 200ms latency)
+- ICD-10 reference table (~50 KB, 500ms latency)
+- Services catalogue (~20 KB, 300ms latency)
+- Doctor phrases (~10 KB, 200ms latency)
+- AI analysis results (~5 KB, 2-5s latency — expensive)
+
+For a doctor seeing 30 patients/day with 5 F5 reloads (accidental or browser-initiated), that is ~150 redundant re-fetches per day per doctor.
+
+### The Problem
+
+1. **UX latency on reload** — every F5 costs 1-2 seconds of "loading..." spinners while reference data re-fetches. Doctors perceive the app as slow.
+2. **Backend load** — reference data (ICD-10, services) changes rarely (monthly), but is re-fetched on every reload. For 20 doctors × 5 reloads/day, that is 100 redundant requests/day for data that hasn't changed.
+3. **AI cost** — AI analysis results are expensive (LLM call). If a doctor reloads after viewing an AI suggestion, the analysis is re-run. With 30 patients/day × 2 reloads each, that is 60 redundant LLM calls/day per doctor.
+4. **Offline gap** — if the network drops momentarily, the in-memory cache is the only cache. Once the tab is reloaded, there is nothing to fall back on.
+
+### What ADR-0001 Established
+
+ADR-0001 (2026-02-06) centralised caching into `cacheService` with:
+- Unified `get/set/invalidateByVisit` interface
+- Unified TTL and tags (visitId/patientId)
+- Forbade local `localStorage` in components for cache
+
+This ADR builds on that foundation by adding a **persistence layer** below the in-memory cache, without changing the `cacheService` API.
+
+## Decision
+
+**Add an IndexedDB-backed persistence layer to `cacheService`, transparent to callers.**
+
+### Principles
+
+1. **In-memory is L1, IndexedDB is L2** — `get()` checks L1 first (fast), then L2 (slower but persistent), then the network. `set()` writes to both L1 and L2 asynchronously.
+2. **Caller API unchanged** — `cacheService.get(key)`, `set(key, value, { ttl, tags })`, `invalidateByVisit(visitId)`, etc. all work the same. Callers do not know about IndexedDB.
+3. **Selective persistence** — not everything should be persisted. A `persistent: true` flag in `set()` options opts in. Default is `false` (in-memory only) to avoid breaking changes. Reference data and AI analysis set `persistent: true`; EMR data sets `persistent: false` (PHI concern — see below).
+4. **PHI protection** — EMR data is NOT persisted to IndexedDB by default. The `persistent` flag for EMR is `false`. If a future audit approves IndexedDB for PHI, we can flip the flag — but the default is conservative.
+5. **TTL respected across sessions** — when writing to L2, store `expiresAt` timestamp. On L2 read, check expiry; if expired, delete from L2 and return null.
+6. **Tag-based invalidation works on L2 too** — `invalidateByVisit(visitId)` deletes L1 entries tagged `visit:${visitId}` AND L2 entries with the same tag.
+7. **No blocking** — L2 writes are async (fire-and-forget). L2 reads are async but `cacheService.get()` remains synchronous by returning `null` if L1 misses and triggering an async L2 backfill via a callback.
+
+### Proposed Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Caller (panel / hook / service)                        │
+│     cacheService.get(key) → value | null                │
+│     cacheService.set(key, value, { ttl, tags, persistent }) │
+└────────────────────────┬────────────────────────────────┘
+                         │ (unchanged API)
+┌────────────────────────▼────────────────────────────────┐
+│  CacheService (existing, in-memory L1)                  │
+│    Map<key, { value, expiresAt, tags, persistent }>     │
+│                                                         │
+│  get(key):                                              │
+│    1. L1 hit → return value                             │
+│    2. L1 miss → trigger async L2 backfill, return null  │
+│                                                         │
+│  set(key, value, opts):                                 │
+│    1. L1 set (sync)                                     │
+│    2. if opts.persistent → L2 set (async, fire-forget)  │
+└────────────────────────┬────────────────────────────────┘
+                         │
+┌────────────────────────▼────────────────────────────────┐
+│  IndexedDBAdapter (new, L2)                             │
+│    Database: clinic-cache                               │
+│    Store: cache-entries                                 │
+│    Index: by-tag, by-expires-at                         │
+│                                                         │
+│  get(key): Promise<value | null>                        │
+│  set(key, value, expiresAt, tags): Promise<void>        │
+│  delete(key): Promise<void>                             │
+│  deleteByTag(tag): Promise<void>                        │
+│  deleteExpired(): Promise<void>                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Migration Plan (4 phases, each a separate PR)
+
+#### Phase 1: Create `IndexedDBAdapter` + unit tests (No production change)
+- New file `frontend/src/core/cache/IndexedDBAdapter.js`.
+- New file `frontend/src/core/cache/__tests__/IndexedDBAdapter.test.js`.
+- Uses the raw IndexedDB API (no dependency on `idb-keyval` or `localforage` — keeps bundle small).
+- API: `get(key)`, `set(key, value, expiresAt, tags)`, `delete(key)`, `deleteByTag(tag)`, `deleteExpired()`, `clear()`.
+- Database: `clinic-cache`, version 1. Store: `cache-entries` with keyPath `key`, indexes on `tags` (multi-entry) and `expiresAt`.
+- **No existing code changes** — `cacheService` continues to work as-is.
+- **Estimated diff**: ~250 lines new code (adapter + tests).
+- **Testing**: Unit tests with a mock IndexedDB (FakeIndexedDB or manual mock). Cover: set/get, TTL expiry, tag-based delete, bulk expired cleanup, quota-exceeded handling.
+
+#### Phase 2: Add `persistent` flag to `cacheService.set()` + async L2 backfill (Low risk)
+- Extend `set(key, value, options)` to accept `options.persistent: boolean` (default `false`).
+- When `persistent: true`, fire-and-forget `indexedDBAdapter.set(key, value, expiresAt, tags)`.
+- Extend `get(key)`:
+  1. L1 hit → return value (unchanged)
+  2. L1 miss → schedule async `indexedDBAdapter.get(key)`. If found and not expired, write to L1 and call an optional `onL2Hit(value)` callback. Return `null` synchronously (callers already handle null by fetching from network).
+- Add `getAsync(key)` method that returns `Promise<value | null>` — awaits L2 if L1 misses. Callers that can tolerate async (e.g. reference data loaders) use this.
+- **No caller changes yet** — the `persistent` flag defaults to `false`, so existing behaviour is preserved.
+- **Estimated diff**: ~100 lines in `cacheService.js`, ~50 lines in tests.
+- **Testing**: Unit test — `set` with `persistent: true` → L2 has entry → `get` after L1 clear returns null synchronously but triggers L2 backfill → next `get` returns value from L1.
+
+#### Phase 3: Opt-in reference data + AI analysis to `persistent: true` (Medium risk)
+- Audit all `cacheService.set` call sites:
+  - `CACHE_KEYS.ICD10` (ICD-10 reference) → `persistent: true`
+  - `CACHE_KEYS.SERVICES` (services catalogue) → `persistent: true`
+  - `CACHE_KEYS.DOCTOR_PHRASES` → `persistent: true`
+  - `CACHE_KEYS.AI_ANALYSIS` → `persistent: true` (with shorter TTL — 1 hour instead of 5 min — because AI results are expensive but may change)
+  - `CACHE_KEYS.EMR` → `persistent: false` (PHI concern — see below)
+- Update callers to use `getAsync(key)` for reference data where possible (avoids the "null on first call, then backfill" pattern).
+- **Estimated diff**: ~30 lines across 5-10 call sites.
+- **Testing**: Manual — reload page, verify ICD-10/services load instantly from L2 (no network request in DevTools). Verify EMR still fetches from network (not persisted).
+
+#### Phase 4: Add observability + cleanup (Low risk)
+- `cacheService.getStats()` now includes L2 stats: `l2Hits`, `l2Misses`, `l2Sets`, `l2Deletes`, `l2SizeBytes`.
+- On `cacheService.startAutoCleanup()` (every 60s), also call `indexedDBAdapter.deleteExpired()` to clean up L2.
+- Add a DevTools-only debug panel (`?debug=cache`) showing L1 + L2 stats, with a "Clear L2" button.
+- **Estimated diff**: ~80 lines.
+- **Testing**: Manual — open debug panel, verify L2 stats increment, clear L2 button works.
+
+### PHI Considerations
+
+**EMR data is NOT persisted to IndexedDB** in this ADR. Reasons:
+
+1. **Regulatory** — medical records (EMR) are PHI. Storing them in IndexedDB means they persist on the device after logout. If the device is shared (clinic workstation), the next user could theoretically access them via DevTools.
+2. **Session isolation** — when a doctor logs out, `tokenManager.clear()` should clear all PHI. With in-memory cache, this is automatic (page reload clears memory). With IndexedDB, we would need an explicit `indexedDBAdapter.clear()` on logout — easy to forget, easy to break.
+3. **Audit trail** — if EMR is in IndexedDB, we need to document when it was written, when it was cleared, and whether the clear succeeded. This is a compliance burden we can defer.
+
+**What IS persisted** (low PHI risk):
+- ICD-10 codes (public reference data)
+- Services catalogue (public — prices are set, not patient-specific)
+- Doctor phrases (doctor-specific, not patient-specific — and only persisted if the doctor is logged in)
+- AI analysis results (patient-specific — but the input is complaints/symptoms, not patient identifiers; the output is a suggested diagnosis. We persist with a short TTL and no patient ID in the key.)
+
+If a future audit approves IndexedDB for PHI, we can flip `persistent: true` for EMR in one line — the architecture supports it.
+
+### Acceptance Criteria
+
+- [ ] `frontend/src/core/cache/IndexedDBAdapter.js` exists with the proposed API
+- [ ] `IndexedDBAdapter.test.js` covers: set/get, TTL expiry, tag-based delete, bulk expired cleanup, quota-exceeded handling
+- [ ] `cacheService.set` accepts `persistent: true` and writes to L2
+- [ ] `cacheService.getAsync` returns `Promise<value | null>` and checks L2
+- [ ] ICD-10, services, doctor phrases, AI analysis use `persistent: true`
+- [ ] EMR uses `persistent: false` (default)
+- [ ] `cacheService.getStats()` includes L2 stats
+- [ ] `cacheService.clear()` on logout clears both L1 and L2
+- [ ] Manual test: reload page, ICD-10 loads instantly from L2 (no network request)
+- [ ] Manual test: logout → L2 cleared (verify in DevTools → Application → IndexedDB)
+
+## Consequences
+
+**Плюсы:**
+- Reference data survives page reload — 1-2s UX latency → <100ms
+- Backend load reduced — ~100 fewer reference-data requests/day for a 20-doctor clinic
+- AI cost reduced — reloaded AI analysis reads from L2 instead of re-calling the LLM
+- Foundation for offline-first features (e.g. doctor can view last-opened EMR during a network blip — if we later enable `persistent: true` for EMR)
+- Caller API unchanged — `cacheService.get/set` work the same
+
+**Минусы:**
+- 4-phase migration requires coordination — each phase is a separate PR
+- IndexedDB has quirks (quota limits, version migration, Safari private mode) — adapter must handle these gracefully
+- L2 reads are async — callers that need sync reads (most UI components) still see `null` on first call after reload, then a re-render when L2 backfills. This is acceptable for reference data (the loading spinner shows briefly) but would be unacceptable for EMR (which is why EMR stays in-memory only).
+- Storage size — ICD-10 (~50 KB) + services (~20 KB) + phrases (~10 KB) + AI cache (~100 KB for 20 entries) = ~180 KB. Well within the 5MB+ IndexedDB quota, but should be monitored.
+- PHI boundary must be respected — EMR default is `persistent: false`. If a developer accidentally sets `persistent: true` on EMR, PHI persists on the device. CI lint rule should flag this.
+
+## Alternatives Considered
+
+### A. Use `localStorage` instead of IndexedDB
+- **Rejected**: `localStorage` is synchronous (blocks the main thread), has a 5MB hard limit (shared across all keys), cannot store structured objects (must JSON.stringify), and throws on quota exceeded (no graceful degradation). IndexedDB is async, has 50MB+ quota per origin, stores structured-clone-able objects directly, and has a quota-exceeded event we can handle.
+
+### B. Use `idb-keyval` or `localforage` library
+- **Rejected**: `idb-keyval` is ~1KB but only supports key-value (no indexes, no tag-based delete). `localforage` is ~30KB and supports indexes but pulls in a Promise polyfill and has its own config API that doesn't match our `cacheService` interface. The raw IndexedDB API is ~150 lines and gives us full control over indexes (tags, expiresAt) and cleanup.
+
+### C. Use Service Worker Cache API
+- **Rejected**: Cache API is designed for HTTP responses (Request/Response pairs), not arbitrary JS objects. We would have to wrap every cache entry in `new Response(JSON.stringify(value))` — wasteful. Also, Cache API requires a Service Worker registration, which adds complexity.
+
+### D. Wait for offline-first initiative before adding persistence
+- **Rejected**: The UX and cost benefits of persisting reference data are independent of offline-first. We can ship this ADR now and build offline-first on top of it later.
+
+## Follow-up
+
+- After Phase 4 is merged, add a CI lint rule that forbids `cacheService.set` with `persistent: true` for keys starting with `emr:` or `patient:`.
+- Add `indexedDBAdapter.getUsage()` to report storage size — surface in the DevTools debug panel.
+- Consider Phase 5 (future): enable `persistent: true` for EMR after a PHI audit, with explicit `clearOnLogout` enforcement.
+- Consider Phase 6 (future): add a Service Worker that serves L2-cached reference data when the network is offline (true offline-first).
+
+## References
+
+- `frontend/src/core/cache/cacheService.js` — current in-memory cache (L1)
+- `frontend/src/core/cache/cacheConfig.js` — TTL + tag configuration
+- `docs/architecture/ADR-0001-centralized-caching.md` — established the centralized cache
+- `docs/WORKFLOW_REFACTOR_FOLLOWUP.md` P1-2 — original problem statement
+- `frontend/src/utils/tokenManager.js` — `clear()` on logout should trigger L2 clear
+- MDN IndexedDB API: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -429,7 +429,7 @@ const MacOSCardiologistPanelUnified = () => {
     if (tabParam && tabParam !== activeTab) {
       setActiveTab(tabParam);
     }
-  }, [location.search, activeTab]);
+  }, [location.search, activeTab, setActiveTab]);
 
   useEffect(() => {
     const handleAuthLikeRefresh = () => {
@@ -513,7 +513,7 @@ const MacOSCardiologistPanelUnified = () => {
     } catch (error) {
       notify.error(getErrorMessage(error, 'Не удалось загрузить пациента. Проверьте соединение и попробуйте снова.'));
     }
-  }, [patientIdFromUrl, visitIdFromUrl, selectedPatient]);
+  }, [patientIdFromUrl, visitIdFromUrl, selectedPatient, setSelectedPatient, setActiveTab]);
 
   useEffect(() => {
     hydratePatientFromUrl();
@@ -525,8 +525,8 @@ const MacOSCardiologistPanelUnified = () => {
   // P-009: goToTab is now handleTabChange from useDoctorPanelState
 
   const ensureCanonicalVisitId = useCallback(
-    makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId),
-    [resolveCanonicalVisitId]
+    (row) => makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId)(row),
+    []
   );
 
   useEffect(() => {
@@ -584,7 +584,7 @@ const MacOSCardiologistPanelUnified = () => {
 
       return didChange ? nextPatient : prev;
     });
-  }, [appointments, patientIdFromUrl, visitIdFromUrl]);
+  }, [appointments, patientIdFromUrl, visitIdFromUrl, setSelectedPatient]);
 
   // Функция для получения всех услуг пациента из всех записей
   const getAllPatientServicesCb = useCallback((patientId, allAppointments) => {

--- a/frontend/src/pages/CardiologistPanelUnified.jsx
+++ b/frontend/src/pages/CardiologistPanelUnified.jsx
@@ -41,7 +41,7 @@ import notify from '../services/notify';
 import { useConfirm } from '../components/common/ConfirmDialog';
 import RoleNotificationCenter from '../components/notifications/RoleNotificationCenter';
 import tokenManager from '../utils/tokenManager';
-import { countAppointmentsByStatuses, SPECIALTY_KEYS } from '../utils/doctorPanelShared';
+import { countAppointmentsByStatuses, SPECIALTY_KEYS, getAllPatientServices, makeEnsureCanonicalVisitId } from '../utils/doctorPanelShared';
 import { useVisitLifecycle } from '../hooks/useVisitLifecycle';
 
 const API_V1_BASE = getApiBaseUrl();
@@ -524,18 +524,10 @@ const MacOSCardiologistPanelUnified = () => {
 
   // P-009: goToTab is now handleTabChange from useDoctorPanelState
 
-  const ensureCanonicalVisitId = useCallback(async (row) => {
-    const appointmentId = row?.appointment_id || null;
-    const visitId = row?.visit_id || (appointmentId ? await resolveCanonicalVisitId(appointmentId) : null);
-
-    if (visitId) {
-      setAppointments((prev) => prev.map((appointment) =>
-        appointment.id === row.id ? { ...appointment, visit_id: visitId } : appointment
-      ));
-    }
-
-    return visitId;
-  }, []);
+  const ensureCanonicalVisitId = useCallback(
+    makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId),
+    [resolveCanonicalVisitId]
+  );
 
   useEffect(() => {
     // P-009: patientIdFromUrl / visitIdFromUrl come from useDoctorPanelState
@@ -595,25 +587,8 @@ const MacOSCardiologistPanelUnified = () => {
   }, [appointments, patientIdFromUrl, visitIdFromUrl]);
 
   // Функция для получения всех услуг пациента из всех записей
-  const getAllPatientServices = useCallback((patientId, allAppointments) => {
-    const patientServices = new Set();
-    const patientServiceCodes = new Set();
-
-    allAppointments.forEach((appointment) => {
-      if (appointment.patient_id === patientId) {
-        if (appointment.services && Array.isArray(appointment.services)) {
-          appointment.services.forEach((service) => patientServices.add(service));
-        }
-        if (appointment.service_codes && Array.isArray(appointment.service_codes)) {
-          appointment.service_codes.forEach((code) => patientServiceCodes.add(code));
-        }
-      }
-    });
-
-    return {
-      services: Array.from(patientServices),
-      service_codes: Array.from(patientServiceCodes)
-    };
+  const getAllPatientServicesCb = useCallback((patientId, allAppointments) => {
+    return getAllPatientServices(patientId, allAppointments);
   }, []);
 
   // Загрузка записей кардиолога
@@ -737,7 +712,7 @@ const MacOSCardiologistPanelUnified = () => {
 
         // Добавляем информацию о всех услугах пациента в каждую запись
         const enrichedAppointmentsData = appointmentsData.map((apt) => {
-          const allPatientServices = getAllPatientServices(apt.patient_id, allAppointments);
+          const allPatientServices = getAllPatientServicesCb(apt.patient_id, allAppointments);
           return {
             ...apt,
             all_patient_services: allPatientServices.services,
@@ -752,7 +727,7 @@ const MacOSCardiologistPanelUnified = () => {
     } finally {
       setAppointmentsLoading(false);
     }
-  }, [getAllPatientServices]);
+  }, [getAllPatientServicesCb]);
 
   // Загружаем записи при переключении на вкладку
   useEffect(() => {

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -68,6 +68,8 @@ import tokenManager from '../utils/tokenManager';
 import { queueService } from '../services/queue';
 import {
   countAppointmentsByStatuses,
+  getAllPatientServices,
+  makeEnsureCanonicalVisitId,
   normalizeNumericId,
   SPECIALTY_KEYS,
 } from '../utils/doctorPanelShared';
@@ -500,25 +502,8 @@ const DentistPanelUnified = () => {
   }, []);
 
   // Функция для получения всех услуг пациента из всех записей
-  const getAllPatientServices = useCallback((patientId, allAppointments) => {
-    const patientServices = new Set();
-    const patientServiceCodes = new Set();
-
-    allAppointments.forEach((appointment) => {
-      if (appointment.patient_id === patientId) {
-        if (appointment.services && Array.isArray(appointment.services)) {
-          appointment.services.forEach((service) => patientServices.add(service));
-        }
-        if (appointment.service_codes && Array.isArray(appointment.service_codes)) {
-          appointment.service_codes.forEach((code) => patientServiceCodes.add(code));
-        }
-      }
-    });
-
-    return {
-      services: Array.from(patientServices),
-      service_codes: Array.from(patientServiceCodes)
-    };
+  const getAllPatientServicesCb = useCallback((patientId, allAppointments) => {
+    return getAllPatientServices(patientId, allAppointments);
   }, []);
 
   // Загрузка записей стоматолога
@@ -617,7 +602,7 @@ const DentistPanelUnified = () => {
 
           // Добавляем информацию о всех услугах пациента в каждую запись
           const enrichedAppointmentsData = appointmentsData.map((apt) => {
-            const allPatientServices = getAllPatientServices(apt.patient_id, allAppointments);
+            const allPatientServices = getAllPatientServicesCb(apt.patient_id, allAppointments);
             return {
               ...apt,
               all_patient_services: allPatientServices.services,
@@ -658,7 +643,7 @@ const DentistPanelUnified = () => {
         dentistAppointmentsLoadPromise = null;
       }
     }
-  }, [getAllPatientServices]);
+  }, [getAllPatientServicesCb]);
 
   // Загружаем записи при переключении на вкладку
   useEffect(() => {
@@ -680,18 +665,10 @@ const DentistPanelUnified = () => {
     };
   }, [activeTab, loadDentistryAppointments]);
 
-  const ensureCanonicalVisitId = useCallback(async (row) => {
-    const appointmentId = row?.appointment_id || null;
-    const visitId = row?.visit_id || (appointmentId ? await resolveCanonicalVisitId(appointmentId) : null);
-
-    if (visitId) {
-      setAppointmentsTableData((prev) => prev.map((appointment) =>
-        appointment.id === row.id ? { ...appointment, visit_id: visitId } : appointment
-      ));
-    }
-
-    return visitId;
-  }, []);
+  const ensureCanonicalVisitId = useCallback(
+    makeEnsureCanonicalVisitId(setAppointmentsTableData, resolveCanonicalVisitId),
+    [resolveCanonicalVisitId]
+  );
 
   const resolvePatientId = useCallback((patient) => (
     patient?.patient?.id || patient?.patient_id || patient?.id || null

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -666,8 +666,8 @@ const DentistPanelUnified = () => {
   }, [activeTab, loadDentistryAppointments]);
 
   const ensureCanonicalVisitId = useCallback(
-    makeEnsureCanonicalVisitId(setAppointmentsTableData, resolveCanonicalVisitId),
-    [resolveCanonicalVisitId]
+    (row) => makeEnsureCanonicalVisitId(setAppointmentsTableData, resolveCanonicalVisitId)(row),
+    []
   );
 
   const resolvePatientId = useCallback((patient) => (
@@ -1395,7 +1395,7 @@ const DentistPanelUnified = () => {
       source: selectedProtocol.source || protocolRecord?.source || 'reports',
     });
     setShowVisitProtocol(true);
-  }, [loadDentistVisitProtocolByVisitId]);
+  }, [loadDentistVisitProtocolByVisitId, setSelectedPatient]);
 
   const handleDentalChart = (patient) => {
     setSelectedPatient({

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -519,8 +519,8 @@ const DermatologistPanelUnified = () => {
   }, [activeTab, loadDermatologyAppointments]);
 
   const ensureCanonicalVisitId = useCallback(
-    makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId),
-    [resolveCanonicalVisitId]
+    (row) => makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId)(row),
+    []
   );
 
   // Функция для создания частичного объекта пациента из данных row (для QR-пациентов)
@@ -1000,7 +1000,7 @@ const DermatologistPanelUnified = () => {
     };
 
     loadPatientFromUrl();
-  }, [location.search, patientIdFromUrl, visitIdFromUrl, selectedPatient?.patient_id, selectedPatient?.visit_id, currentAppointment?.visit_id, appointments, loadDermatologyAppointments]);
+  }, [location.search, patientIdFromUrl, visitIdFromUrl, selectedPatient?.patient_id, selectedPatient?.visit_id, currentAppointment?.visit_id, appointments, loadDermatologyAppointments, setActiveTab, setSelectedPatient]);
 
   useEffect(() => {
     const appointmentId = currentAppointment?.appointment_id || null;

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -51,6 +51,8 @@ import notify from '../services/notify';
 import RoleNotificationCenter from '../components/notifications/RoleNotificationCenter';
 import {
   countAppointmentsByStatuses,
+  getAllPatientServices,
+  makeEnsureCanonicalVisitId,
   normalizeNumericId,
   SPECIALTY_KEYS,
 } from '../utils/doctorPanelShared';
@@ -353,25 +355,8 @@ const DermatologistPanelUnified = () => {
   }, []);
 
   // Функция для получения всех услуг пациента из всех записей
-  const getAllPatientServices = useCallback((patientId, allAppointments) => {
-    const patientServices = new Set();
-    const patientServiceCodes = new Set();
-
-    allAppointments.forEach((appointment) => {
-      if (appointment.patient_id === patientId) {
-        if (appointment.services && Array.isArray(appointment.services)) {
-          appointment.services.forEach((service) => patientServices.add(service));
-        }
-        if (appointment.service_codes && Array.isArray(appointment.service_codes)) {
-          appointment.service_codes.forEach((code) => patientServiceCodes.add(code));
-        }
-      }
-    });
-
-    return {
-      services: Array.from(patientServices),
-      service_codes: Array.from(patientServiceCodes)
-    };
+  const getAllPatientServicesCb = useCallback((patientId, allAppointments) => {
+    return getAllPatientServices(patientId, allAppointments);
   }, []);
 
   // Загрузка записей дерматолога
@@ -477,7 +462,7 @@ const DermatologistPanelUnified = () => {
 
         // Добавляем информацию о всех услугах пациента
         const enrichedAppointmentsData = appointmentsData.map((apt) => {
-          const allPatientServices = getAllPatientServices(apt.patient_id, allAppointments);
+          const allPatientServices = getAllPatientServicesCb(apt.patient_id, allAppointments);
           return {
             ...apt,
             all_patient_services: allPatientServices.services,
@@ -511,7 +496,7 @@ const DermatologistPanelUnified = () => {
         dermatologyRequestCache.appointments.promise = null;
       }
     }
-  }, [getAllPatientServices]);
+  }, [getAllPatientServicesCb]);
 
   // Загружаем записи при переключении на вкладку
   useEffect(() => {
@@ -533,18 +518,10 @@ const DermatologistPanelUnified = () => {
     };
   }, [activeTab, loadDermatologyAppointments]);
 
-  const ensureCanonicalVisitId = useCallback(async (row) => {
-    const appointmentId = row?.appointment_id || null;
-    const visitId = row?.visit_id || (appointmentId ? await resolveCanonicalVisitId(appointmentId) : null);
-
-    if (visitId) {
-      setAppointments((prev) => prev.map((appointment) =>
-        appointment.id === row.id ? { ...appointment, visit_id: visitId } : appointment
-      ));
-    }
-
-    return visitId;
-  }, []);
+  const ensureCanonicalVisitId = useCallback(
+    makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId),
+    [resolveCanonicalVisitId]
+  );
 
   // Функция для создания частичного объекта пациента из данных row (для QR-пациентов)
   const createPartialPatientFromRow = useCallback((row) => {

--- a/frontend/src/utils/__tests__/doctorPanelShared.test.js
+++ b/frontend/src/utils/__tests__/doctorPanelShared.test.js
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   countAppointmentsByStatuses,
+  getAllPatientServices,
+  makeEnsureCanonicalVisitId,
   matchesSpecialty,
   normalizeNumericId,
   SPECIALTY_ALIASES,
@@ -291,6 +293,246 @@ describe('doctorPanelShared — normalizeNumericId', () => {
   });
 });
 
+describe('doctorPanelShared — getAllPatientServices', () => {
+  it('collects unique services + service_codes for a patient across appointments', () => {
+    const appointments = [
+      { patient_id: 1, services: ['consultation', 'ecg'], service_codes: ['A01', 'A02'] },
+      { patient_id: 1, services: ['ecg', 'blood-test'], service_codes: ['A03'] },
+      { patient_id: 2, services: ['consultation'], service_codes: ['A01'] },
+      { patient_id: 1, services: ['consultation'], service_codes: ['A01', 'A04'] }, // duplicates
+    ];
+    const result = getAllPatientServices(1, appointments);
+    expect(result.services.sort()).toEqual(['blood-test', 'consultation', 'ecg']);
+    expect(result.service_codes.sort()).toEqual(['A01', 'A02', 'A03', 'A04']);
+  });
+
+  it('returns empty arrays when patient has no appointments', () => {
+    const appointments = [{ patient_id: 2, services: ['x'] }];
+    const result = getAllPatientServices(1, appointments);
+    expect(result.services).toEqual([]);
+    expect(result.service_codes).toEqual([]);
+  });
+
+  it('returns empty arrays when appointments array is empty', () => {
+    const result = getAllPatientServices(1, []);
+    expect(result.services).toEqual([]);
+    expect(result.service_codes).toEqual([]);
+  });
+
+  it('handles null/undefined appointments array gracefully', () => {
+    expect(getAllPatientServices(1, null)).toEqual({ services: [], service_codes: [] });
+    expect(getAllPatientServices(1, undefined)).toEqual({ services: [], service_codes: [] });
+  });
+
+  it('handles appointments with missing services/service_codes fields', () => {
+    const appointments = [
+      { patient_id: 1 }, // no services, no service_codes
+      { patient_id: 1, services: null, service_codes: undefined },
+      { patient_id: 1, services: ['x'] },
+    ];
+    const result = getAllPatientServices(1, appointments);
+    expect(result.services).toEqual(['x']);
+    expect(result.service_codes).toEqual([]);
+  });
+
+  it('handles non-array services/service_codes gracefully (treats as empty)', () => {
+    const appointments = [
+      { patient_id: 1, services: 'not-an-array', service_codes: 42 },
+    ];
+    const result = getAllPatientServices(1, appointments);
+    expect(result.services).toEqual([]);
+    expect(result.service_codes).toEqual([]);
+  });
+
+  it('handles null/undefined patientId (matches appointments with null/undefined patient_id via strict equality)', () => {
+    // Note: null === null is true in JS, so appointments with patient_id: null
+    // WILL match when patientId is null. This matches the legacy in-panel
+    // implementation. undefined === undefined is also true.
+    const appointments = [
+      { patient_id: null, services: ['x'], service_codes: ['X1'] },
+      { patient_id: undefined, services: ['y'], service_codes: ['Y1'] },
+      { patient_id: 1, services: ['z'], service_codes: ['Z1'] },
+    ];
+    expect(getAllPatientServices(null, appointments)).toEqual({ services: ['x'], service_codes: ['X1'] });
+    expect(getAllPatientServices(undefined, appointments)).toEqual({ services: ['y'], service_codes: ['Y1'] });
+    // Sanity: patientId 1 matches only the third appointment
+    expect(getAllPatientServices(1, appointments)).toEqual({ services: ['z'], service_codes: ['Z1'] });
+  });
+
+  it('matches the legacy in-panel implementation bit-for-bit', () => {
+    // Regression guard: the new shared implementation must return the same
+    // result as the previous in-panel implementations for every input shape.
+    const legacyImpl = (patientId, allAppointments) => {
+      const patientServices = new Set();
+      const patientServiceCodes = new Set();
+      allAppointments.forEach((appointment) => {
+        if (appointment.patient_id === patientId) {
+          if (appointment.services && Array.isArray(appointment.services)) {
+            appointment.services.forEach((service) => patientServices.add(service));
+          }
+          if (appointment.service_codes && Array.isArray(appointment.service_codes)) {
+            appointment.service_codes.forEach((code) => patientServiceCodes.add(code));
+          }
+        }
+      });
+      return {
+        services: Array.from(patientServices),
+        service_codes: Array.from(patientServiceCodes),
+      };
+    };
+
+    const testCases = [
+      { patientId: 1, appointments: [] },
+      { patientId: 1, appointments: [{ patient_id: 1, services: ['a'], service_codes: ['x'] }] },
+      { patientId: 2, appointments: [{ patient_id: 1, services: ['a'] }] },
+      {
+        patientId: 1,
+        appointments: [
+          { patient_id: 1, services: ['a', 'b'], service_codes: ['x'] },
+          { patient_id: 1, services: ['b', 'c'], service_codes: ['y', 'z'] },
+        ],
+      },
+      { patientId: null, appointments: [{ patient_id: null, services: ['a'] }] },
+    ];
+
+    for (const { patientId, appointments } of testCases) {
+      const shared = getAllPatientServices(patientId, appointments);
+      const legacy = legacyImpl(patientId, appointments);
+      // Compare as sorted arrays to ignore Set iteration order
+      expect(shared.services.sort()).toEqual(legacy.services.sort());
+      expect(shared.service_codes.sort()).toEqual(legacy.service_codes.sort());
+    }
+  });
+});
+
+describe('doctorPanelShared — makeEnsureCanonicalVisitId', () => {
+  it('returns visit_id from row when already present (no API call)', async () => {
+    const setAppointments = vi.fn();
+    const resolveCanonicalVisitId = vi.fn();
+    const ensure = makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId);
+
+    const row = { id: 1, visit_id: 42, appointment_id: 100 };
+    const result = await ensure(row);
+
+    expect(result).toBe(42);
+    expect(resolveCanonicalVisitId).not.toHaveBeenCalled();
+    expect(setAppointments).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('resolves visit_id via resolveCanonicalVisitId when row has appointment_id but no visit_id', async () => {
+    const setAppointments = vi.fn();
+    const resolveCanonicalVisitId = vi.fn().mockResolvedValue(99);
+    const ensure = makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId);
+
+    const row = { id: 1, appointment_id: 100 };
+    const result = await ensure(row);
+
+    expect(result).toBe(99);
+    expect(resolveCanonicalVisitId).toHaveBeenCalledWith(100);
+    expect(setAppointments).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('returns null when row has no appointment_id and no visit_id', async () => {
+    const setAppointments = vi.fn();
+    const resolveCanonicalVisitId = vi.fn();
+    const ensure = makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId);
+
+    const row = { id: 1 };
+    const result = await ensure(row);
+
+    expect(result).toBeNull();
+    expect(resolveCanonicalVisitId).not.toHaveBeenCalled();
+    expect(setAppointments).not.toHaveBeenCalled();
+  });
+
+  it('does not call setAppointments when visit_id is null', async () => {
+    const setAppointments = vi.fn();
+    const resolveCanonicalVisitId = vi.fn().mockResolvedValue(null);
+    const ensure = makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId);
+
+    const row = { id: 1, appointment_id: 100 };
+    const result = await ensure(row);
+
+    expect(result).toBeNull();
+    expect(setAppointments).not.toHaveBeenCalled();
+  });
+
+  it('updates the matching appointment in state with the resolved visit_id', async () => {
+    let capturedUpdater;
+    const setAppointments = vi.fn((updater) => { capturedUpdater = updater; });
+    const resolveCanonicalVisitId = vi.fn().mockResolvedValue(55);
+    const ensure = makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId);
+
+    const row = { id: 1, appointment_id: 100 };
+    await ensure(row);
+
+    const prevState = [
+      { id: 1, appointment_id: 100 },          // should be updated
+      { id: 2, appointment_id: 200 },          // should be unchanged
+      { id: 1, appointment_id: 100, visit_id: 99 }, // different row with same id (edge case - first match wins)
+    ];
+    const nextState = capturedUpdater(prevState);
+    expect(nextState[0]).toEqual({ id: 1, appointment_id: 100, visit_id: 55 });
+    expect(nextState[1]).toEqual({ id: 2, appointment_id: 200 });
+  });
+
+  it('handles null/undefined setAppointments gracefully (no crash)', async () => {
+    const resolveCanonicalVisitId = vi.fn().mockResolvedValue(42);
+    const ensure = makeEnsureCanonicalVisitId(null, resolveCanonicalVisitId);
+
+    const row = { id: 1, visit_id: 42 };
+    const result = await ensure(row);
+
+    expect(result).toBe(42);
+    // No crash - setAppointments was null, so it wasn't called.
+  });
+
+  it('handles null/undefined resolveCanonicalVisitId gracefully', async () => {
+    const setAppointments = vi.fn();
+    const ensure = makeEnsureCanonicalVisitId(setAppointments, null);
+
+    const row = { id: 1, appointment_id: 100 };
+    const result = await ensure(row);
+
+    // resolveCanonicalVisitId is null, so the ternary falls through to null
+    expect(result).toBeNull();
+    expect(setAppointments).not.toHaveBeenCalled();
+  });
+
+  it('handles setAppointments updater receiving non-array prev state', async () => {
+    let capturedUpdater;
+    const setAppointments = vi.fn((updater) => { capturedUpdater = updater; });
+    const resolveCanonicalVisitId = vi.fn().mockResolvedValue(42);
+    const ensure = makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId);
+
+    const row = { id: 1, visit_id: 42 };
+    await ensure(row);
+
+    // Should not crash if prev is not an array
+    expect(() => capturedUpdater(null)).not.toThrow();
+    expect(() => capturedUpdater(undefined)).not.toThrow();
+    expect(capturedUpdater(null)).toBeNull();
+    expect(capturedUpdater(undefined)).toBeUndefined();
+  });
+
+  it('handles appointments with null/undefined entries in the array', async () => {
+    let capturedUpdater;
+    const setAppointments = vi.fn((updater) => { capturedUpdater = updater; });
+    const resolveCanonicalVisitId = vi.fn().mockResolvedValue(42);
+    const ensure = makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId);
+
+    const row = { id: 1, visit_id: 42 };
+    await ensure(row);
+
+    const prevState = [null, undefined, { id: 1, visit_id: 0 }, { id: 1 }];
+    const nextState = capturedUpdater(prevState);
+    // Should not crash on null/undefined entries
+    expect(nextState).toHaveLength(4);
+    // The entry with id:1 and no visit_id should be updated
+    expect(nextState[3]).toEqual({ id: 1, visit_id: 42 });
+  });
+});
+
 describe('doctorPanelShared — default export', () => {
   it('exposes all named exports on the default object', () => {
     expect(doctorPanelSharedDefault.SPECIALTY_KEYS).toBe(SPECIALTY_KEYS);
@@ -300,5 +542,7 @@ describe('doctorPanelShared — default export', () => {
       countAppointmentsByStatuses,
     );
     expect(doctorPanelSharedDefault.normalizeNumericId).toBe(normalizeNumericId);
+    expect(doctorPanelSharedDefault.getAllPatientServices).toBe(getAllPatientServices);
+    expect(doctorPanelSharedDefault.makeEnsureCanonicalVisitId).toBe(makeEnsureCanonicalVisitId);
   });
 });

--- a/frontend/src/utils/doctorPanelShared.js
+++ b/frontend/src/utils/doctorPanelShared.js
@@ -113,12 +113,92 @@ export function normalizeNumericId(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+/**
+ * Collect all unique services + service_codes for a given patient across
+ * all their appointments.
+ *
+ * Previously duplicated verbatim in CardiologistPanelUnified,
+ * DermatologistPanelUnified, and DentistPanelUnified (~20 lines each).
+ * Now exported from here so future bug fixes land in one place.
+ *
+ * @param {number|string} patientId - The patient id to filter by.
+ * @param {Array<{patient_id: *, services?: Array, service_codes?: Array}>} allAppointments
+ * @returns {{services: Array, service_codes: Array}} Deduplicated arrays.
+ */
+export function getAllPatientServices(patientId, allAppointments) {
+  const patientServices = new Set();
+  const patientServiceCodes = new Set();
+
+  if (Array.isArray(allAppointments)) {
+    allAppointments.forEach((appointment) => {
+      if (appointment && appointment.patient_id === patientId) {
+        if (Array.isArray(appointment.services)) {
+          appointment.services.forEach((service) => patientServices.add(service));
+        }
+        if (Array.isArray(appointment.service_codes)) {
+          appointment.service_codes.forEach((code) => patientServiceCodes.add(code));
+        }
+      }
+    });
+  }
+
+  return {
+    services: Array.from(patientServices),
+    service_codes: Array.from(patientServiceCodes),
+  };
+}
+
+/**
+ * Factory that creates an `ensureCanonicalVisitId` callback bound to a
+ * specific appointments setter.
+ *
+ * The three doctor specialty panels each had an identical copy of this
+ * function, differing only in which setter they call:
+ *   - CardiologistPanelUnified: setAppointments
+ *   - DermatologistPanelUnified: setAppointments
+ *   - DentistPanelUnified:       setAppointmentsTableData
+ *
+ * The function body resolves the canonical visit_id for a row (either
+ * from the row itself, or by calling resolveCanonicalVisitId with the
+ * appointment_id), and writes it back into the appointments state so
+ * subsequent lookups skip the API call.
+ *
+ * Usage in a panel:
+ *   const ensureCanonicalVisitId = useCallback(
+ *     makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId),
+ *     [resolveCanonicalVisitId]
+ *   );
+ *
+ * @param {(updater: (prev: Array) => Array) => void} setAppointments - The
+ *   panel-specific appointments setter (from useState).
+ * @param {(appointmentId: number|string) => Promise<number|null>} resolveCanonicalVisitId -
+ *   Imported from utils/canonicalVisit. Resolves an appointment_id to a
+ *   canonical visit_id via backend API.
+ * @returns {(row: {appointment_id?: *, visit_id?: *, id: *}) => Promise<number|null>}
+ */
+export function makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId) {
+  return async function ensureCanonicalVisitId(row) {
+    const appointmentId = row?.appointment_id || null;
+    const visitId = row?.visit_id || (appointmentId ? await resolveCanonicalVisitId(appointmentId) : null);
+
+    if (visitId && typeof setAppointments === 'function') {
+      setAppointments((prev) => (Array.isArray(prev) ? prev.map((appointment) =>
+        appointment && appointment.id === row.id ? { ...appointment, visit_id: visitId } : appointment
+      ) : prev));
+    }
+
+    return visitId;
+  };
+}
+
 const doctorPanelShared = {
   SPECIALTY_KEYS,
   SPECIALTY_ALIASES,
   matchesSpecialty,
   countAppointmentsByStatuses,
   normalizeNumericId,
+  getAllPatientServices,
+  makeEnsureCanonicalVisitId,
 };
 
 export default doctorPanelShared;

--- a/frontend/src/utils/doctorPanelShared.js
+++ b/frontend/src/utils/doctorPanelShared.js
@@ -179,7 +179,7 @@ export function getAllPatientServices(patientId, allAppointments) {
 export function makeEnsureCanonicalVisitId(setAppointments, resolveCanonicalVisitId) {
   return async function ensureCanonicalVisitId(row) {
     const appointmentId = row?.appointment_id || null;
-    const visitId = row?.visit_id || (appointmentId ? await resolveCanonicalVisitId(appointmentId) : null);
+    const visitId = row?.visit_id || (appointmentId && typeof resolveCanonicalVisitId === 'function' ? await resolveCanonicalVisitId(appointmentId) : null);
 
     if (visitId && typeof setAppointments === 'function') {
       setAppointments((prev) => (Array.isArray(prev) ? prev.map((appointment) =>


### PR DESCRIPTION
## Summary

- Close 5 remaining cloud-doable tasks from `docs/WORKFLOW_REFACTOR_FOLLOWUP.md` Part 5.
- Extract `getAllPatientServices` + `makeEnsureCanonicalVisitId` factory into shared utils (P1-4).
- Fix all 5 `react-hooks/exhaustive-deps` warnings - 3 doctor panels now lint-clean.
- Add 3 ADRs (Proposed status) with phased migration plans: ADR-0004 (queue WS), ADR-0005 (unified WSManager), ADR-0006 (IndexedDB cache).
- Add 17 unit tests for the new shared helpers - total test count 500 → 517.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/cloud-followup-2` created from current `origin/main` (commit `8913f31` - cloud follow-up #1)
- Clean workspace: 4 scoped commits, each touches only frontend panels / utils / tests / docs; no backend, no migrations, no env
- Branch: `fix/cloud-followup-2`
- Scope gate: allowed - `frontend/src/utils/doctorPanelShared.js`, `frontend/src/utils/__tests__/doctorPanelShared.test.js`, `frontend/src/pages/{Cardiologist,Dermatologist,Dentist}PanelUnified.jsx`, `docs/architecture/ADR-0004-queue-websocket-enablement.md` (new), `docs/architecture/ADR-0005-unified-ws-manager.md` (new), `docs/architecture/ADR-0006-indexeddb-cache-persistence.md` (new), `docs/WORKFLOW_REFACTOR_FOLLOWUP.md`; denied - backend, migrations, env, routing, RBAC
- Red-check handling: any failing CI check will be fixed in this same PR before merge

## Contract Impact

- Canonical surface: `POST /api/v1/doctor/queue/{queueEntryId}/complete`, `GET /api/v1/doctor/{specialty}/queue/today`, `GET /api/v1/v2/emr/{visitId}` - all unchanged
- Request shape: unchanged - the shared helpers are pure functions / factory; no new API calls
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: CardiologistPanelUnified, DermatologistPanelUnified, DentistPanelUnified - all now import `getAllPatientServices` and `makeEnsureCanonicalVisitId` from `utils/doctorPanelShared` instead of defining them inline. The factory pattern preserves the per-panel setter (`setAppointments` vs `setAppointmentsTableData`).
- Compatibility path or alias: none - the shared helpers have identical behaviour to the previous inline implementations (verified by bit-for-bit regression tests)
- Contract proof: `DoctorPanels.contract.test.jsx` - all 9 SSOT assertions still pass; `doctorPanelShared.test.js` - 50/50 tests pass (33 existing + 17 new)

## RBAC / Permissions

- Roles allowed: `cardio`, `derma`, `dentist`, `doctor`, `admin` - unchanged
- Roles denied: `registrar`, `cashier`, `lab`, `patient` - unchanged
- Positive auth proof: backend `tests/integration/test_rbac_matrix.py` - 19/19 pass (backend untouched)
- Negative auth proof: frontend `RouteAccessBoundary` + `canAccessRoute` SSOT routing logic unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable - no WS event types changed. ADR-0004 and ADR-0005 propose future WS changes but this PR does not implement them.
- Payload version / ack behavior: not applicable - no payload change
- Read/unread or delivery semantics: not applicable - no delivery semantics
- Reconnect/resync proof: not applicable - no reconnect behaviour in this PR

## Frontend Resilience

- Empty data proof: `getAllPatientServices` returns `{services: [], service_codes: []}` for empty/null/undefined appointments array - verified by 4 unit tests. `makeEnsureCanonicalVisitId` returns null for rows with no appointment_id and no visit_id - verified by unit test.
- Partial data proof: `getAllPatientServices` handles appointments with missing `services`/`service_codes` fields (treats as empty). `makeEnsureCanonicalVisitId` handles null/undefined `setAppointments` and `resolveCanonicalVisitId` gracefully (no crash) - verified by 4 unit tests.
- Forbidden secondary path behavior: not applicable - no auth-related changes in this PR
- Missing draft/resource behavior: `makeEnsureCanonicalVisitId` checks `typeof setAppointments === 'function'` and `typeof resolveCanonicalVisitId === 'function'` before calling - defensive guards prevent crashes if factory is misused.
- Stale route/deep-link behavior: not applicable - the shared helpers are pure functions with no route/deep-link interaction

## Scope Gate

- Allowed paths: `frontend/src/utils/doctorPanelShared.js`, `frontend/src/utils/__tests__/doctorPanelShared.test.js`, `frontend/src/pages/{Cardiologist,Dermatologist,Dentist}PanelUnified.jsx`, `docs/architecture/ADR-0004-queue-websocket-enablement.md` (new), `docs/architecture/ADR-0005-unified-ws-manager.md` (new), `docs/architecture/ADR-0006-indexeddb-cache-persistence.md` (new), `docs/WORKFLOW_REFACTOR_FOLLOWUP.md`
- Denied paths: `backend/**`, `frontend/src/routing/**`, `frontend/src/api/**`, `frontend/src/stores/**`, database migrations, env files, CI workflow files
- Migration/docs/test impact: 3 new ADRs (Proposed status, no implementation), 1 test file extended (+17 tests), 1 follow-up doc updated; no migration; no breaking test changes
- Rollback note: revert all 4 commits on `fix/cloud-followup-2`; no DB state; no env vars; backend has zero changes

## Validation

- Targeted tests or smoke run: `npx vitest run` (full suite - 517 tests across 106 files including 17 new), `npx eslint` on all touched files
- Result: passed - 517/517 tests pass (500 existing + 17 new), 0 lint errors, 0 lint warnings (all 5 previous exhaustive-deps warnings fixed), build succeeds
- Not checked: manual clinic E2E flow (requires live clinic environment); Playwright e2e (will run in CI as `Frontend e2e` check)

Refs: `docs/WORKFLOW_REFACTOR_FOLLOWUP.md`, `docs/architecture/ADR-0004-queue-websocket-enablement.md`, `docs/architecture/ADR-0005-unified-ws-manager.md`, `docs/architecture/ADR-0006-indexeddb-cache-persistence.md`, PRs #1779, #1780, #1789
