### PR TITLE
fix(lint): remove 3 genuinely unused imports (React, RefreshCw, formatSeverityLabel)

### DIFF
--- a/frontend/src/components/cardiology/HistoryTab.jsx
+++ b/frontend/src/components/cardiology/HistoryTab.jsx
@@ -12,7 +12,7 @@
  */
 
 import PropTypes from 'prop-types';
-import { Calendar, RefreshCw, Eye, Download, FileText } from 'lucide-react';
+import { Calendar, Eye, Download, FileText } from 'lucide-react';
 import { Button, Badge, MacOSCard, MacOSEmptyState } from '../ui/macos';
 
 /**

--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -8,7 +8,6 @@ import { printService } from '../../services/print';
 import logger from '../../utils/logger';
 import {
   formatLabStatus,
-  formatSeverityLabel,
   getLabStatusVariant,
   signerFieldLabels
 } from './labUiLabels';

--- a/frontend/src/components/ui/macos/MacOSMetricCard.jsx
+++ b/frontend/src/components/ui/macos/MacOSMetricCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Minus, ArrowUpRight, ArrowDownRight } from 'lucide-react';
 import PropTypes from 'prop-types';
 

--- a/frontend/src/components/ui/macos/MacOSStatCard.jsx
+++ b/frontend/src/components/ui/macos/MacOSStatCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import PropTypes from 'prop-types';
 


### PR DESCRIPTION
## Summary

- Removed 3 genuinely unused imports across 4 files.
- MacOSMetricCard.jsx, MacOSStatCard.jsx: removed unused `React` import (React 18+ doesn't need it in scope).
- HistoryTab.jsx: removed unused `RefreshCw` from lucide-react import.
- LabReportWorkbench.jsx: removed unused `formatSeverityLabel` import.
- 97 warnings → 94 warnings (3 fixed, 0 errors).

## Cyclic Execution Evidence

- Fresh main sync: ветка от main после merge PR #1798 (eslint config).
- Clean workspace: 4 frontend files.
- Branch: fix/eslint-genuine-unused-vars
- Scope gate: allowed только unused import removal; denied любые другие changes.
- Red-check handling: 13 contract tests pass, eslint 0 errors.

## Contract Impact

- Canonical surface: frontend components
- Request shape: не применимо - unused import removal
- Response shape: не применимо
- Status codes: не применимо
- Frontend consumer: не применимо - no functional change
- Compatibility path or alias: не применимо
- Contract proof: 13 contract tests pass, 0 eslint errors

## RBAC / Permissions

- Roles allowed: не применимо - unused import removal
- Roles denied: не применимо
- Positive auth proof: не применимо
- Negative auth proof: не применимо

## Notification / Realtime

not applicable - unused import removal, event type / websocket channel / payload version / delivery semantics / reconnect не затронуты.

## Frontend Resilience

- Empty data proof: не применимо.
- Partial data proof: не применимо.
- Forbidden secondary path behavior: не применимо.
- Missing draft/resource behavior: не применимо.
- Stale route/deep-link behavior: не применимо.

## Scope Gate

- Allowed paths: 4 frontend files (unused import removal only)
- Denied paths: backend, тесты, миграции
- Migration/docs/test impact: нет
- Rollback note: revert восстанавливает unused imports

## DevBrain Memory Impact

not applicable - unused import removal.

## Validation

- Targeted tests or smoke run: `npx vitest --run src/pages/__tests__/RegistrarPanel.contract.test.jsx` + `npx eslint src/`
- Result: 13/13 tests passed, 0 errors, 94 warnings (down from 97)
- Not checked: full CI/CD pipeline — будет запущен на PR
