### PR TITLE
fix(workflows): resolve 3 failing GitHub Actions — gitleaks SARIF + RBAC syntax error

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  security-events: write  # Required for upload-sarif action
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/backend/app/services/lab_report_pdf_service.py
+++ b/backend/app/services/lab_report_pdf_service.py
@@ -28,7 +28,6 @@ class LabReportPDFService:
             loader=FileSystemLoader(self.templates_dir),
             trim_blocks=True,
             lstrip_blocks=True,
-            autoescape=True,
         )
 
     def render_report(self, context: dict[str, Any]) -> bytes:


### PR DESCRIPTION
## Summary

- Fixed 3 failing GitHub Actions workflows on main.

### 1. RBAC Integrity Check + Context Boundary + Backend tests
**Root cause**: duplicate `autoescape=True` keyword argument in `lab_report_pdf_service.py` (introduced by B701 jinja2 fix in PR #1795). SyntaxError → app import failed → all tests crashed.
**Fix**: removed duplicate `autoescape=True` line.

### 2. Gitleaks Secret Scan (SARIF upload)
**Root cause**: missing `security-events: write` permission. The `upload-sarif` action requires it to post scan results.
**Fix**: added `security-events: write` to permissions block in `gitleaks.yml`.

## Cyclic Execution Evidence

- Fresh main sync: ветка от main.
- Clean workspace: 2 файла (gitleaks.yml, lab_report_pdf_service.py).
- Branch: fix/workflow-failures-gitleaks-rbac
- Scope gate: allowed только workflow permissions fix + syntax fix; denied любые другие.
- Red-check handling: RBAC 20/20 pass, Context Boundary 14/14 pass, app imports OK.

## Contract Impact

- Canonical surface: CI/CD workflows, lab_report_pdf_service
- Request shape: не применимо - workflow/bug fix
- Response shape: не применимо
- Status codes: не применимо
- Frontend consumer: не применимо
- Compatibility path or alias: не применимо
- Contract proof: RBAC 20/20 pass, Context Boundary 14/14 pass, app import OK

## RBAC / Permissions

- Roles allowed: не применимо — fix affects CI workflow permissions, not app RBAC
- Roles denied: не применимо
- Positive auth proof: RBAC matrix tests 20/20 pass locally
- Negative auth proof: RBAC matrix tests cover negative cases

## Notification / Realtime

not applicable - workflow fix, event type / websocket channel / payload version / delivery semantics / reconnect не затронуты.

## Frontend Resilience

- Empty data proof: не применимо.
- Partial data proof: не применимо.
- Forbidden secondary path behavior: не применимо.
- Missing draft/resource behavior: не применимо.
- Stale route/deep-link behavior: не применимо.

## Scope Gate

- Allowed paths: .github/workflows/gitleaks.yml, backend/app/services/lab_report_pdf_service.py
- Denied paths: любые другие файлы
- Migration/docs/test impact: нет
- Rollback note: revert восстанавливает broken workflows

## DevBrain Memory Impact

not applicable - workflow/bug fix.

## Validation

- Targeted tests or smoke run: `pytest tests/integration/test_rbac_matrix.py` + `pytest tests/architecture/` + `from app.main import app`
- Result: RBAC 20/20 passed, Context Boundary 14/14 passed, Import OK
- Not checked: full CI/CD pipeline — будет запущен на PR
