### PR TITLE
refactor(dentist): CSS migration - 174 to 0 inline styles (-100%)

### DIFF
--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -1679,12 +1679,7 @@ const DentistPanelUnified = () => {
       boxShadow: 'var(--mac-shadow-sm)',
       border: '1px solid var(--mac-border)'
     }}>
-        <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        marginBottom: '24px'
-      }}>
+        <div class="dental-flex-between-16">
           <h3 className="dental-text-lg-semi dental-text-primary">Быстрые действия</h3>
         </div>
         <div style={{
@@ -1771,12 +1766,7 @@ const DentistPanelUnified = () => {
       boxShadow: 'var(--mac-shadow-sm)',
       border: '1px solid var(--mac-border)'
     }}>
-        <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        marginBottom: '24px'
-      }}>
+        <div class="dental-flex-between-16">
           <h3 className="dental-text-lg-semi dental-text-primary">Последние записи</h3>
         </div>
         <div className="dental-flex-col dental-gap-16">
@@ -1921,10 +1911,10 @@ const DentistPanelUnified = () => {
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '16px' }}>
               <p className="dental-text-desc dental-text-desc dental-text-secondary">
-                <strong style={{ fontWeight: 'var(--mac-font-weight-semibold)' }}>Возраст:</strong> {patient.age} лет
+                <strong class="dental-fw-700">Возраст:</strong> {patient.age} лет
               </p>
               <p className="dental-text-desc dental-text-desc dental-text-secondary">
-                <strong style={{ fontWeight: 'var(--mac-font-weight-semibold)' }}>Последний визит:</strong> {patient.lastVisit || 'Не было'}
+                <strong class="dental-fw-700">Последний визит:</strong> {patient.lastVisit || 'Не было'}
               </p>
             </div>
 
@@ -2162,7 +2152,7 @@ const DentistPanelUnified = () => {
       return (
         <div className="dental-flex-col dental-gap-24">
           <Card padding="lg">
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '20px' }}>
+            <div class="dental-flex-between-16">
               <h3 className="dental-text-primary">
                 <Stethoscope size={20} />
                 Прием пациента: {selectedPatient.patient_name || selectedPatient.name || `№${selectedPatient.number}`}
@@ -2290,12 +2280,7 @@ const DentistPanelUnified = () => {
   const renderTemplates = () =>
   <div className="dental-flex-col dental-gap-24">
       <Card padding="lg">
-        <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        marginBottom: '16px'
-      }}>
+        <div class="dental-flex-between-16">
           <div>
             <h3 className="dental-text-primary">Шаблоны протоколов</h3>
             <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-secondary">
@@ -2331,8 +2316,8 @@ const DentistPanelUnified = () => {
             gap: '12px',
             marginBottom: '12px'
           }}>
-              <div className="dental-icon-bg" style={{ background: 'var(--mac-accent-blue-bg)', borderRadius: 'var(--mac-radius-lg)' }}>
-                <Scissors className="dental-icon-20" style={{ color: 'var(--mac-accent-blue)' }} />
+              <div className="dental-icon-bg" class="dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
+                <Scissors className="dental-icon-20" class="dental-text-blue" />
               </div>
               <div>
                 <h4 className="dental-text-primary">Лечение кариеса</h4>
@@ -2342,7 +2327,7 @@ const DentistPanelUnified = () => {
             <p className="dental-text-value dental-text-primary">
               Стандартный протокол лечения кариеса с анестезией и пломбированием
             </p>
-            <div style={{ display: 'flex', gap: '8px' }}>
+            <div class="dental-flex dental-gap-8">
               <Button size="sm" style={{ flex: 1 }} onClick={handleProtocolTemplates} type="button">
                 Использовать
               </Button>
@@ -2383,7 +2368,7 @@ const DentistPanelUnified = () => {
             <p className="dental-text-value dental-text-primary">
               Протокол лечения корневых каналов с инструментальной обработкой
             </p>
-            <div style={{ display: 'flex', gap: '8px' }}>
+            <div class="dental-flex dental-gap-8">
               <Button size="sm" style={{ flex: 1 }} onClick={handleProtocolTemplates} type="button">
                 Использовать
               </Button>
@@ -2413,7 +2398,7 @@ const DentistPanelUnified = () => {
             gap: '12px',
             marginBottom: '12px'
           }}>
-              <div className="dental-icon-bg" style={{ background: 'var(--mac-success-bg)', borderRadius: 'var(--mac-radius-lg)' }}>
+              <div className="dental-icon-bg" class="dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
                 <Scissors className="dental-icon-20" style={{ color: 'var(--mac-success)'  }} />
               </div>
               <div>
@@ -2424,7 +2409,7 @@ const DentistPanelUnified = () => {
             <p className="dental-text-value dental-text-primary">
               Протокол профессиональной гигиены полости рта
             </p>
-            <div style={{ display: 'flex', gap: '8px' }}>
+            <div class="dental-flex dental-gap-8">
               <Button size="sm" style={{ flex: 1 }} onClick={handleProtocolTemplates} type="button">
                 Использовать
               </Button>
@@ -2448,12 +2433,7 @@ const DentistPanelUnified = () => {
   <div className="dental-flex-col dental-gap-24">
       {savedVisitProtocols.length > 0 &&
       <Card padding="lg">
-          <div style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          marginBottom: '16px'
-        }}>
+          <div class="dental-flex-between-16">
             <div>
               <h3 className="dental-text-primary">Сохранённые протоколы визитов</h3>
               <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-secondary">
@@ -2501,12 +2481,7 @@ const DentistPanelUnified = () => {
       }
 
       <Card padding="lg">
-        <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        marginBottom: '16px'
-      }}>
+        <div class="dental-flex-between-16">
           <div>
             <h3 className="dental-text-primary">Отчеты и аналитика</h3>
             <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-secondary">
@@ -2546,7 +2521,7 @@ const DentistPanelUnified = () => {
             gap: '12px',
             marginBottom: '12px'
           }}>
-              <div className="dental-icon-bg" style={{ background: 'var(--mac-accent-blue-bg)', borderRadius: 'var(--mac-radius-lg)' }}>
+              <div className="dental-icon-bg" class="dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
                 <BarChart3 className="dental-icon-20" style={{ color: 'var(--mac-accent-blue)'  }} />
               </div>
               <div>
@@ -2578,7 +2553,7 @@ const DentistPanelUnified = () => {
             gap: '12px',
             marginBottom: '12px'
           }}>
-              <div className="dental-icon-bg" style={{ background: 'var(--mac-success-bg)', borderRadius: 'var(--mac-radius-lg)' }}>
+              <div className="dental-icon-bg" class="dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
                 <Users className="dental-icon-20" style={{ color: 'var(--mac-success)'  }} />
               </div>
               <div>
@@ -2996,16 +2971,7 @@ const DentistPanelUnified = () => {
       }
 
       {showDentalChart && selectedPatient &&
-      <div style={{
-        position: 'fixed',
-        inset: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        backdropFilter: 'blur(4px)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 50
-      }}>
+      <div class="dental-modal-overlay">
           <div style={{
           background: 'var(--mac-bg-primary)',
           borderRadius: 'var(--mac-radius-xl)',
@@ -3018,12 +2984,7 @@ const DentistPanelUnified = () => {
           boxShadow: 'var(--mac-shadow-xl)',
           border: '1px solid var(--mac-border)'
         }}>
-            <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            marginBottom: '16px'
-          }}>
+            <div class="dental-flex-between-16">
               <h2 className="dental-heading-xl dental-text-primary">
                 Схема зубов: {selectedPatientDisplayName}
               </h2>
@@ -3040,7 +3001,7 @@ const DentistPanelUnified = () => {
                 e.target.style.backgroundColor = 'transparent';
               }}>
 
-                <XCircle style={{ height: '24px', width: '24px' }} />
+                <XCircle class="dental-icon-20" />
               </button>
             </div>
             <TeethChart
@@ -3058,16 +3019,7 @@ const DentistPanelUnified = () => {
       }
 
       {showTreatmentPlanner && selectedPatient &&
-      <div style={{
-        position: 'fixed',
-        inset: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        backdropFilter: 'blur(4px)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 50
-      }}>
+      <div class="dental-modal-overlay">
           <div style={{
           background: 'var(--mac-bg-primary)',
           borderRadius: 'var(--mac-radius-xl)',
@@ -3080,12 +3032,7 @@ const DentistPanelUnified = () => {
           boxShadow: 'var(--mac-shadow-xl)',
           border: '1px solid var(--mac-border)'
         }}>
-            <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            marginBottom: '16px'
-          }}>
+            <div class="dental-flex-between-16">
               <h2 className="dental-heading-xl dental-text-primary">
                 План лечения: {selectedPatientDisplayName}
               </h2>
@@ -3102,7 +3049,7 @@ const DentistPanelUnified = () => {
                 e.target.style.backgroundColor = 'transparent';
               }}>
 
-                <XCircle style={{ height: '24px', width: '24px' }} />
+                <XCircle class="dental-icon-20" />
               </button>
             </div>
             <TreatmentPlanner

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -2034,7 +2034,7 @@ const DentistPanelUnified = () => {
               }}>
 
                 <div className="dental-flex dental-gap-12">
-                  <div className="dental-icon-bg" style={{ background: 'var(--mac-accent-purple)', borderRadius: 'var(--mac-radius-full)' }}>
+                  <div className="dental-icon-bg dental-icon-bg-purple dental-icon-bg-full">
                     <span className="dental-text-value dental-text-white">
                       {patient.name?.charAt(0)}
                     </span>
@@ -2116,19 +2116,8 @@ const DentistPanelUnified = () => {
           </Button>
         </div>
 
-        <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
-        gap: '16px'
-      }}>
-          <div
-          style={{
-            padding: '16px',
-            border: '1px solid var(--mac-border)',
-            borderRadius: 'var(--mac-radius-lg)',
-            cursor: 'default',
-            transition: 'all var(--mac-duration-normal) var(--mac-ease)'
-          }}>
+        <div className="dental-grid-auto-fill-280">
+          <div className="dental-template-card">
 
             <div class="dental-flex-center-12">
               <div className="dental-icon-bg" class="dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
@@ -2157,18 +2146,11 @@ const DentistPanelUnified = () => {
             </div>
           </div>
 
-          <div
-          style={{
-            padding: '16px',
-            border: '1px solid var(--mac-border)',
-            borderRadius: 'var(--mac-radius-lg)',
-            cursor: 'default',
-            transition: 'all var(--mac-duration-normal) var(--mac-ease)'
-          }}>
+          <div className="dental-template-card">
 
             <div class="dental-flex-center-12">
-              <div className="dental-icon-bg" style={{ background: 'var(--mac-danger-bg)', borderRadius: 'var(--mac-radius-lg)' }}>
-                <Scissors className="dental-icon-20" style={{ color: 'var(--mac-danger)' }} />
+              <div className="dental-icon-bg dental-icon-bg-danger-bg dental-icon-radius-lg">
+                <Scissors className="dental-icon-20 dental-text-danger" />
               </div>
               <div>
                 <h4 className="dental-text-primary">Эндодонтическое лечение</h4>
@@ -2193,18 +2175,11 @@ const DentistPanelUnified = () => {
             </div>
           </div>
 
-          <div
-          style={{
-            padding: '16px',
-            border: '1px solid var(--mac-border)',
-            borderRadius: 'var(--mac-radius-lg)',
-            cursor: 'default',
-            transition: 'all var(--mac-duration-normal) var(--mac-ease)'
-          }}>
+          <div className="dental-template-card">
 
             <div class="dental-flex-center-12">
               <div className="dental-icon-bg" class="dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
-                <Scissors className="dental-icon-20" style={{ color: 'var(--mac-success)'  }} />
+                <Scissors className="dental-icon-20 dental-text-success" />
               </div>
               <div>
                 <h4 className="dental-text-primary">Профессиональная гигиена</h4>
@@ -2247,22 +2222,11 @@ const DentistPanelUnified = () => {
             </div>
           </div>
 
-          <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
-          gap: '16px'
-        }}>
+          <div className="dental-grid-auto-fill-280">
             {savedVisitProtocols.map((protocol) =>
           <div
             key={protocol.visit_id}
-            style={{
-              padding: '16px',
-              border: '1px solid var(--mac-border)',
-              borderRadius: 'var(--mac-radius-lg)',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '12px'
-            }}>
+            className="dental-protocol-card-flex">
                 <div>
                   <div className="dental-text-primary">{protocol.patient_name}</div>
                   <div className="dental-text-desc dental-text-desc dental-text-secondary">
@@ -2274,9 +2238,7 @@ const DentistPanelUnified = () => {
                 </div>
                 <Button
                 onClick={() => reopenVisitProtocol(protocol)}
-                style={{
-                  alignSelf: 'flex-start'
-                }}>
+                className="dental-align-self-start">
                   Открыть протокол
                 </Button>
               </div>
@@ -2302,11 +2264,7 @@ const DentistPanelUnified = () => {
           </Button>
         </div>
 
-        <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
-        gap: '16px'
-      }}>
+        <div className="dental-grid-auto-fill-240-16">
           <div
           role="button"
           tabIndex={0}
@@ -2322,7 +2280,7 @@ const DentistPanelUnified = () => {
 
             <div class="dental-flex-center-12">
               <div className="dental-icon-bg" class="dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
-                <BarChart3 className="dental-icon-20" style={{ color: 'var(--mac-accent-blue)'  }} />
+                <BarChart3 className="dental-icon-20 dental-text-blue" />
               </div>
               <div>
                 <h4 className="dental-text-primary">Общий обзор</h4>
@@ -2349,7 +2307,7 @@ const DentistPanelUnified = () => {
 
             <div class="dental-flex-center-12">
               <div className="dental-icon-bg" class="dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
-                <Users className="dental-icon-20" style={{ color: 'var(--mac-success)'  }} />
+                <Users className="dental-icon-20 dental-text-success" />
               </div>
               <div>
                 <h4 className="dental-text-primary">По пациентам</h4>
@@ -2516,18 +2474,10 @@ const DentistPanelUnified = () => {
           {prosthetics.map((prosthetic) =>
         <div
           key={prosthetic.id}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: '16px',
-            background: 'var(--mac-bg-secondary)',
-            borderRadius: 'var(--mac-radius-lg)',
-            transition: 'all var(--mac-duration-normal) var(--mac-ease)'
-          }}>
+          className="dental-prosthetic-row">
 
               <div className="dental-flex dental-gap-16">
-                <div className="dental-icon-bg-40" style={{ background: 'var(--mac-warning)'  }}>
+                <div className="dental-icon-bg-40 dental-icon-bg-warning">
                   <Smile className="dental-icon-20 dental-text-white" />
                 </div>
                 <div>
@@ -2615,25 +2565,10 @@ const DentistPanelUnified = () => {
     return (
       <div className="dental-p-8">
         <div className="dental-flex-col dental-gap-24">
-          <div style={{
-            height: '32px',
-            background: 'var(--mac-bg-secondary)',
-            borderRadius: 'var(--mac-radius-md)',
-            width: '25%',
-            animation: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite'
-          }}></div>
-          <div style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
-            gap: '24px'
-          }}>
+          <div className="dental-skeleton-bar"></div>
+          <div className="dental-skeleton-grid">
             {[...Array(4)].map((_, i) =>
-            <div key={i} style={{
-              height: '96px',
-              background: 'var(--mac-bg-secondary)',
-              borderRadius: 'var(--mac-radius-md)',
-              animation: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite'
-            }}></div>
+            <div key={i} className="dental-skeleton-card"></div>
             )}
           </div>
         </div>
@@ -2749,18 +2684,7 @@ const DentistPanelUnified = () => {
 
       {showDentalChart && selectedPatient &&
       <div class="dental-modal-overlay">
-          <div style={{
-          background: 'var(--mac-bg-primary)',
-          borderRadius: 'var(--mac-radius-xl)',
-          padding: '24px',
-          width: '100%',
-          maxWidth: '1152px',
-          height: '100%',
-          maxHeight: '90vh',
-          overflow: 'auto',
-          boxShadow: 'var(--mac-shadow-xl)',
-          border: '1px solid var(--mac-border)'
-        }}>
+          <div className="dental-modal-card-xl">
             <div class="dental-flex-between-16">
               <h2 className="dental-heading-xl dental-text-primary">
                 Схема зубов: {selectedPatientDisplayName}
@@ -2797,18 +2721,7 @@ const DentistPanelUnified = () => {
 
       {showTreatmentPlanner && selectedPatient &&
       <div class="dental-modal-overlay">
-          <div style={{
-          background: 'var(--mac-bg-primary)',
-          borderRadius: 'var(--mac-radius-xl)',
-          padding: '24px',
-          width: '100%',
-          maxWidth: '1152px',
-          height: '100%',
-          maxHeight: '90vh',
-          overflow: 'auto',
-          boxShadow: 'var(--mac-shadow-xl)',
-          border: '1px solid var(--mac-border)'
-        }}>
+          <div className="dental-modal-card-xl">
             <div class="dental-flex-between-16">
               <h2 className="dental-heading-xl dental-text-primary">
                 План лечения: {selectedPatientDisplayName}

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -81,29 +81,6 @@ const API_V1_BASE = getApiBaseUrl();
 const DENTISTRY_WAITING_STATUSES = ['waiting', 'confirmed', 'pending'];
 const DENTISTRY_CALLED_STATUSES = ['called', 'in_progress'];
 const DENTISTRY_COMPLETED_STATUSES = ['completed', 'done'];
-const DENTISTRY_LAZY_FALLBACK_STYLE = {
-  margin: 'var(--mac-spacing-4)',
-  padding: 'var(--mac-spacing-4)',
-  color: 'var(--mac-text-secondary)',
-  textAlign: 'center'
-};
-const dentistryAppointmentsHeaderStyle = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'flex-start',
-  gap: 'var(--mac-spacing-4)',
-  marginBottom: 'var(--mac-spacing-4)',
-  flexWrap: 'wrap'
-};
-const dentistryAppointmentsTitleStyle = {
-  fontSize: 'var(--mac-font-size-lg)',
-  fontWeight: 'var(--mac-font-weight-medium)',
-  display: 'flex',
-  alignItems: 'center',
-  color: 'var(--mac-text-primary)',
-  margin: 0,
-  minWidth: 'min(100%, 260px)'
-};
 let dentistAppointmentsCache = null;
 let dentistAppointmentsLoadPromise = null;
 let dentistServicesCache = null;
@@ -1706,15 +1683,7 @@ const DentistPanelUnified = () => {
         <div class="dental-flex-row-wrap">
           <div class="dental-flex-1 dental-min-w-200">
             <div class="dental-search-wrap">
-              <Search style={{
-              position: 'absolute',
-              left: '12px',
-              top: '50%',
-              transform: 'translateY(-50%)',
-              height: '16px',
-              width: '16px',
-              color: 'var(--mac-text-tertiary)'
-            }} />
+              <Search className="dental-search-icon dental-icon-16" />
               <input
               type="text"
               placeholder="Поиск пациентов..."
@@ -1813,7 +1782,7 @@ const DentistPanelUnified = () => {
             aria-label={`Open examination for ${patient.name || patient.id}`}
             onClick={() => handleExamination(patient)}
             title="Осмотр"
-            style={{ padding: '8px' }}>
+            className="dental-p-8px">
 
                 <Eye aria-hidden="true" className="dental-icon-16" />
               </Button>
@@ -1824,7 +1793,7 @@ const DentistPanelUnified = () => {
             aria-label={`Open diagnoses for ${patient.name || patient.id}`}
             onClick={() => handleDiagnosis(patient)}
             title="Диагнозы"
-            style={{ padding: '8px' }}>
+            className="dental-p-8px">
 
                 <Stethoscope aria-hidden="true" className="dental-icon-16" />
               </Button>
@@ -1835,7 +1804,7 @@ const DentistPanelUnified = () => {
             aria-label={`Open visit protocol for ${patient.name || patient.id}`}
             onClick={() => handleVisitProtocol(patient)}
             title="Протокол визита"
-            style={{ padding: '8px' }}>
+            className="dental-p-8px">
 
                 <FileText aria-hidden="true" className="dental-icon-16" />
               </Button>
@@ -1846,7 +1815,7 @@ const DentistPanelUnified = () => {
             aria-label={`Open dental chart for ${patient.name || patient.id}`}
             onClick={() => handleDentalChart(patient)}
             title="Схема зубов"
-            style={{ padding: '8px' }}>
+            className="dental-p-8px">
 
                 <Tooth aria-hidden="true" className="dental-icon-16" />
               </Button>
@@ -1857,7 +1826,7 @@ const DentistPanelUnified = () => {
             aria-label={`Open treatment for ${patient.name || patient.id}`}
             onClick={() => handleTreatment(patient)}
             title="Лечение"
-            style={{ padding: '8px' }}>
+            className="dental-p-8px">
 
                 <Scissors aria-hidden="true" className="dental-icon-16" />
               </Button>
@@ -1868,7 +1837,7 @@ const DentistPanelUnified = () => {
             aria-label={`Open prosthetics for ${patient.name || patient.id}`}
             onClick={() => handleProsthetic(patient)}
             title="Протезирование"
-            style={{ padding: '8px' }}>
+            className="dental-p-8px">
 
                 <Smile aria-hidden="true" className="dental-icon-16" />
               </Button>
@@ -1881,23 +1850,11 @@ const DentistPanelUnified = () => {
 
   // Рендер записей
   const renderAppointments = () =>
-  <div style={{
-    width: '100%',
-    maxWidth: 'none',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '24px'
-  }}>
-      <Card padding="lg" style={{
-      width: '100%',
-      maxWidth: '100%',
-      minWidth: 0,
-      boxSizing: 'border-box',
-      overflow: 'hidden'
-    }}>
-        <div style={dentistryAppointmentsHeaderStyle}>
-          <h3 style={dentistryAppointmentsTitleStyle}>
-            <Calendar size={20} style={{ marginRight: '8px', color: 'var(--mac-success)' }} />
+  <div className="dental-appointments-root">
+      <Card padding="lg" className="dental-appointments-card">
+        <div className="dental-appointments-header">
+          <h3 className="dental-appointments-title">
+            <Calendar className="dental-icon-20 dental-text-success dental-mr-8" />
             Записи к стоматологу
           </h3>
           <AppointmentSummaryBar
@@ -2772,7 +2729,7 @@ const DentistPanelUnified = () => {
       {showReports &&
       <Suspense
         fallback={
-          <Card role="status" aria-live="polite" style={DENTISTRY_LAZY_FALLBACK_STYLE}>
+          <Card role="status" aria-live="polite" className="dental-lazy-fallback">
             Загрузка отчетов...
           </Card>
         }>

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -1682,11 +1682,7 @@ const DentistPanelUnified = () => {
         <div class="dental-flex-between-16">
           <h3 className="dental-text-lg-semi dental-text-primary">Быстрые действия</h3>
         </div>
-        <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-        gap: '24px'
-      }}>
+        <div class="dental-grid-auto">
           <Button
           onClick={() => handleTabChange('patients')}
           variant="primary"
@@ -1817,9 +1813,9 @@ const DentistPanelUnified = () => {
   <div className="dental-flex-col dental-gap-24">
       {/* Поиск и фильтры */}
       <Card padding="lg">
-        <div style={{ display: 'flex', flexDirection: 'row', gap: '16px', flexWrap: 'wrap' }}>
-          <div style={{ flex: 1, minWidth: '200px' }}>
-            <div style={{ position: 'relative' }}>
+        <div class="dental-flex-row-wrap">
+          <div class="dental-flex-1 dental-min-w-200">
+            <div class="dental-search-wrap">
               <Search style={{
               position: 'absolute',
               left: '12px',
@@ -1870,19 +1866,12 @@ const DentistPanelUnified = () => {
       </Card>
 
       {/* Список пациентов */}
-      <div style={{
-      display: 'grid',
-      gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
-      gap: '24px'
-    }}>
+      <div class="dental-grid-auto-fill-250">
         {filteredPatients.map((patient) =>
       <Card
         key={patient.id}
         padding="lg"
-        style={{
-          transition: 'all var(--mac-duration-normal) var(--mac-ease)',
-          cursor: 'pointer'
-        }}
+        class="dental-card-btn"
         onMouseEnter={(e) => {
           e.currentTarget.style.boxShadow = 'var(--mac-shadow-lg)';
           e.currentTarget.style.transform = 'translateY(-2px)';
@@ -1892,9 +1881,9 @@ const DentistPanelUnified = () => {
           e.currentTarget.style.transform = 'translateY(0)';
         }}>
 
-            <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: '16px' }}>
+            <div class="dental-flex-between-16">
               <div className="dental-flex dental-gap-12">
-                <div className="dental-avatar" style={{ background: 'var(--mac-accent-blue)' }}>
+                <div className="dental-avatar" class="dental-icon-bg dental-icon-bg-blue">
                   <span className="dental-text-value dental-heading dental-text-white">
                     {patient.name?.charAt(0)}
                   </span>
@@ -1909,7 +1898,7 @@ const DentistPanelUnified = () => {
               </Badge>
             </div>
 
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '16px' }}>
+            <div class="dental-flex-col dental-gap-8">
               <p className="dental-text-desc dental-text-desc dental-text-secondary">
                 <strong class="dental-fw-700">Возраст:</strong> {patient.age} лет
               </p>
@@ -1918,13 +1907,13 @@ const DentistPanelUnified = () => {
               </p>
             </div>
 
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '8px' }}>
+            <div class="dental-grid-2col dental-gap-8">
               <Button
             size="sm"
             onClick={() => handlePatientSelect(patient)}
-            style={{ gridColumn: 'span 2', marginBottom: '8px' }}>
+            class="dental-grid-span-2">
 
-                <Edit className="dental-icon-16" style={{ marginRight: '4px' }} />
+                <Edit className="dental-icon-16" class="dental-mr-4" />
                 Карточка пациента
               </Button>
               <Button
@@ -2058,11 +2047,7 @@ const DentistPanelUnified = () => {
           Выберите пациента для проведения или просмотра объективного осмотра
         </p>
 
-        <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
-        gap: '16px'
-      }}>
+        <div class="dental-grid-auto-fill-250">
           {patients.map((patient) =>
         <div
           key={patient.id}
@@ -2106,11 +2091,7 @@ const DentistPanelUnified = () => {
           Выберите пациента для постановки диагнозов и назначений
         </p>
 
-        <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
-        gap: '16px'
-      }}>
+        <div class="dental-grid-auto-fill-250">
           {patients.map((patient) =>
         <div
           key={patient.id}
@@ -2188,11 +2169,7 @@ const DentistPanelUnified = () => {
             Выберите пациента из очереди или выберите из списка для создания протокола визита
           </p>
 
-          <div style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
-            gap: '16px'
-          }}>
+          <div class="dental-grid-auto-fill-250">
             {patients.map((patient) =>
             <div
               key={patient.id}
@@ -2237,11 +2214,7 @@ const DentistPanelUnified = () => {
           Выберите пациента для просмотра и управления фото и рентгеновскими снимками
         </p>
 
-        <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
-        gap: '16px'
-      }}>
+        <div class="dental-grid-auto-fill-250">
           {patients.map((patient) =>
         <div
           key={patient.id}
@@ -2310,12 +2283,7 @@ const DentistPanelUnified = () => {
             transition: 'all var(--mac-duration-normal) var(--mac-ease)'
           }}>
 
-            <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '12px',
-            marginBottom: '12px'
-          }}>
+            <div class="dental-flex-center-12">
               <div className="dental-icon-bg" class="dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
                 <Scissors className="dental-icon-20" class="dental-text-blue" />
               </div>
@@ -2328,7 +2296,7 @@ const DentistPanelUnified = () => {
               Стандартный протокол лечения кариеса с анестезией и пломбированием
             </p>
             <div class="dental-flex dental-gap-8">
-              <Button size="sm" style={{ flex: 1 }} onClick={handleProtocolTemplates} type="button">
+              <Button size="sm" class="dental-flex-1" onClick={handleProtocolTemplates} type="button">
                 Использовать
               </Button>
               <Button
@@ -2351,12 +2319,7 @@ const DentistPanelUnified = () => {
             transition: 'all var(--mac-duration-normal) var(--mac-ease)'
           }}>
 
-            <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '12px',
-            marginBottom: '12px'
-          }}>
+            <div class="dental-flex-center-12">
               <div className="dental-icon-bg" style={{ background: 'var(--mac-danger-bg)', borderRadius: 'var(--mac-radius-lg)' }}>
                 <Scissors className="dental-icon-20" style={{ color: 'var(--mac-danger)' }} />
               </div>
@@ -2369,7 +2332,7 @@ const DentistPanelUnified = () => {
               Протокол лечения корневых каналов с инструментальной обработкой
             </p>
             <div class="dental-flex dental-gap-8">
-              <Button size="sm" style={{ flex: 1 }} onClick={handleProtocolTemplates} type="button">
+              <Button size="sm" class="dental-flex-1" onClick={handleProtocolTemplates} type="button">
                 Использовать
               </Button>
               <Button
@@ -2392,12 +2355,7 @@ const DentistPanelUnified = () => {
             transition: 'all var(--mac-duration-normal) var(--mac-ease)'
           }}>
 
-            <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '12px',
-            marginBottom: '12px'
-          }}>
+            <div class="dental-flex-center-12">
               <div className="dental-icon-bg" class="dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
                 <Scissors className="dental-icon-20" style={{ color: 'var(--mac-success)'  }} />
               </div>
@@ -2410,7 +2368,7 @@ const DentistPanelUnified = () => {
               Протокол профессиональной гигиены полости рта
             </p>
             <div class="dental-flex dental-gap-8">
-              <Button size="sm" style={{ flex: 1 }} onClick={handleProtocolTemplates} type="button">
+              <Button size="sm" class="dental-flex-1" onClick={handleProtocolTemplates} type="button">
                 Использовать
               </Button>
               <Button
@@ -2515,12 +2473,7 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-            <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '12px',
-            marginBottom: '12px'
-          }}>
+            <div class="dental-flex-center-12">
               <div className="dental-icon-bg" class="dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
                 <BarChart3 className="dental-icon-20" style={{ color: 'var(--mac-accent-blue)'  }} />
               </div>
@@ -2547,12 +2500,7 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-            <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '12px',
-            marginBottom: '12px'
-          }}>
+            <div class="dental-flex-center-12">
               <div className="dental-icon-bg" class="dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
                 <Users className="dental-icon-20" style={{ color: 'var(--mac-success)'  }} />
               </div>
@@ -2579,12 +2527,7 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-            <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '12px',
-            marginBottom: '12px'
-          }}>
+            <div class="dental-flex-center-12">
               <div className="dental-icon-bg dental-icon-bg-purple-bg dental-icon-bg-lg-shadow">
                 <Stethoscope className="dental-icon-20 dental-text-purple" />
               </div>
@@ -2611,12 +2554,7 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-            <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '12px',
-            marginBottom: '12px'
-          }}>
+            <div class="dental-flex-center-12">
               <div className="dental-icon-bg dental-icon-bg-warning-bg dental-icon-bg-lg-shadow">
                 <Building className="dental-icon-20 dental-text-warning" />
               </div>
@@ -2643,11 +2581,7 @@ const DentistPanelUnified = () => {
           Выберите пациента для просмотра и редактирования схемы зубов
         </p>
 
-        <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
-        gap: '16px'
-      }}>
+        <div class="dental-grid-auto-fill-250">
           {patients.map((patient) =>
         <div
           key={patient.id}
@@ -2691,11 +2625,7 @@ const DentistPanelUnified = () => {
           Выберите пациента для создания или редактирования плана лечения
         </p>
 
-        <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
-        gap: '16px'
-      }}>
+        <div class="dental-grid-auto-fill-250">
           {patients.map((patient) =>
         <div
           key={patient.id}

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -1586,10 +1586,10 @@ const DentistPanelUnified = () => {
 
       {/* Быстрые действия */}
       <div className="dental-section-card">
-        <div class="dental-flex-between-16">
+        <div className="dental-flex-between-16">
           <h3 className="dental-text-lg-semi dental-text-primary">Быстрые действия</h3>
         </div>
-        <div class="dental-grid-auto">
+        <div className="dental-grid-auto">
           <Button
           onClick={() => handleTabChange('patients')}
           variant="primary"
@@ -1643,7 +1643,7 @@ const DentistPanelUnified = () => {
 
       {/* Последние записи */}
       <div className="dental-section-card">
-        <div class="dental-flex-between-16">
+        <div className="dental-flex-between-16">
           <h3 className="dental-text-lg-semi dental-text-primary">Последние записи</h3>
         </div>
         <div className="dental-flex-col dental-gap-16">
@@ -1680,9 +1680,9 @@ const DentistPanelUnified = () => {
   <div className="dental-flex-col dental-gap-24">
       {/* Поиск и фильтры */}
       <Card padding="lg">
-        <div class="dental-flex-row-wrap">
-          <div class="dental-flex-1 dental-min-w-200">
-            <div class="dental-search-wrap">
+        <div className="dental-flex-row-wrap">
+          <div className="dental-flex-1 dental-min-w-200">
+            <div className="dental-search-wrap">
               <Search className="dental-search-icon dental-icon-16" />
               <input
               type="text"
@@ -1725,12 +1725,12 @@ const DentistPanelUnified = () => {
       </Card>
 
       {/* Список пациентов */}
-      <div class="dental-grid-auto-fill-250">
+      <div className="dental-grid-auto-fill-250">
         {filteredPatients.map((patient) =>
       <Card
         key={patient.id}
         padding="lg"
-        class="dental-card-btn"
+        className="dental-card-btn"
         onMouseEnter={(e) => {
           e.currentTarget.style.boxShadow = 'var(--mac-shadow-lg)';
           e.currentTarget.style.transform = 'translateY(-2px)';
@@ -1740,9 +1740,9 @@ const DentistPanelUnified = () => {
           e.currentTarget.style.transform = 'translateY(0)';
         }}>
 
-            <div class="dental-flex-between-16">
+            <div className="dental-flex-between-16">
               <div className="dental-flex dental-gap-12">
-                <div className="dental-avatar" class="dental-icon-bg dental-icon-bg-blue">
+                <div className="dental-avatar" className="dental-icon-bg dental-icon-bg-blue">
                   <span className="dental-text-value dental-heading dental-text-white">
                     {patient.name?.charAt(0)}
                   </span>
@@ -1757,22 +1757,22 @@ const DentistPanelUnified = () => {
               </Badge>
             </div>
 
-            <div class="dental-flex-col dental-gap-8">
+            <div className="dental-flex-col dental-gap-8">
               <p className="dental-text-desc dental-text-desc dental-text-secondary">
-                <strong class="dental-fw-700">Возраст:</strong> {patient.age} лет
+                <strong className="dental-fw-700">Возраст:</strong> {patient.age} лет
               </p>
               <p className="dental-text-desc dental-text-desc dental-text-secondary">
-                <strong class="dental-fw-700">Последний визит:</strong> {patient.lastVisit || 'Не было'}
+                <strong className="dental-fw-700">Последний визит:</strong> {patient.lastVisit || 'Не было'}
               </p>
             </div>
 
-            <div class="dental-grid-2col dental-gap-8">
+            <div className="dental-grid-2col dental-gap-8">
               <Button
             size="sm"
             onClick={() => handlePatientSelect(patient)}
-            class="dental-grid-span-2">
+            className="dental-grid-span-2">
 
-                <Edit className="dental-icon-16" class="dental-mr-4" />
+                <Edit className="dental-icon-16" className="dental-mr-4" />
                 Карточка пациента
               </Button>
               <Button
@@ -1894,7 +1894,7 @@ const DentistPanelUnified = () => {
           Выберите пациента для проведения или просмотра объективного осмотра
         </p>
 
-        <div class="dental-grid-auto-fill-250">
+        <div className="dental-grid-auto-fill-250">
           {patients.map((patient) =>
         <div
           key={patient.id}
@@ -1938,7 +1938,7 @@ const DentistPanelUnified = () => {
           Выберите пациента для постановки диагнозов и назначений
         </p>
 
-        <div class="dental-grid-auto-fill-250">
+        <div className="dental-grid-auto-fill-250">
           {patients.map((patient) =>
         <div
           key={patient.id}
@@ -1980,7 +1980,7 @@ const DentistPanelUnified = () => {
       return (
         <div className="dental-flex-col dental-gap-24">
           <Card padding="lg">
-            <div class="dental-flex-between-16">
+            <div className="dental-flex-between-16">
               <h3 className="dental-text-primary">
                 <Stethoscope size={20} />
                 Прием пациента: {selectedPatient.patient_name || selectedPatient.name || `№${selectedPatient.number}`}
@@ -2016,7 +2016,7 @@ const DentistPanelUnified = () => {
             Выберите пациента из очереди или выберите из списка для создания протокола визита
           </p>
 
-          <div class="dental-grid-auto-fill-250">
+          <div className="dental-grid-auto-fill-250">
             {patients.map((patient) =>
             <div
               key={patient.id}
@@ -2061,7 +2061,7 @@ const DentistPanelUnified = () => {
           Выберите пациента для просмотра и управления фото и рентгеновскими снимками
         </p>
 
-        <div class="dental-grid-auto-fill-250">
+        <div className="dental-grid-auto-fill-250">
           {patients.map((patient) =>
         <div
           key={patient.id}
@@ -2100,7 +2100,7 @@ const DentistPanelUnified = () => {
   const renderTemplates = () =>
   <div className="dental-flex-col dental-gap-24">
       <Card padding="lg">
-        <div class="dental-flex-between-16">
+        <div className="dental-flex-between-16">
           <div>
             <h3 className="dental-text-primary">Шаблоны протоколов</h3>
             <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-secondary">
@@ -2119,9 +2119,9 @@ const DentistPanelUnified = () => {
         <div className="dental-grid-auto-fill-280">
           <div className="dental-template-card">
 
-            <div class="dental-flex-center-12">
-              <div className="dental-icon-bg" class="dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
-                <Scissors className="dental-icon-20" class="dental-text-blue" />
+            <div className="dental-flex-center-12">
+              <div className="dental-icon-bg" className="dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
+                <Scissors className="dental-icon-20" className="dental-text-blue" />
               </div>
               <div>
                 <h4 className="dental-text-primary">Лечение кариеса</h4>
@@ -2131,8 +2131,8 @@ const DentistPanelUnified = () => {
             <p className="dental-text-value dental-text-primary">
               Стандартный протокол лечения кариеса с анестезией и пломбированием
             </p>
-            <div class="dental-flex dental-gap-8">
-              <Button size="sm" class="dental-flex-1" onClick={handleProtocolTemplates} type="button">
+            <div className="dental-flex dental-gap-8">
+              <Button size="sm" className="dental-flex-1" onClick={handleProtocolTemplates} type="button">
                 Использовать
               </Button>
               <Button
@@ -2148,7 +2148,7 @@ const DentistPanelUnified = () => {
 
           <div className="dental-template-card">
 
-            <div class="dental-flex-center-12">
+            <div className="dental-flex-center-12">
               <div className="dental-icon-bg dental-icon-bg-danger-bg dental-icon-radius-lg">
                 <Scissors className="dental-icon-20 dental-text-danger" />
               </div>
@@ -2160,8 +2160,8 @@ const DentistPanelUnified = () => {
             <p className="dental-text-value dental-text-primary">
               Протокол лечения корневых каналов с инструментальной обработкой
             </p>
-            <div class="dental-flex dental-gap-8">
-              <Button size="sm" class="dental-flex-1" onClick={handleProtocolTemplates} type="button">
+            <div className="dental-flex dental-gap-8">
+              <Button size="sm" className="dental-flex-1" onClick={handleProtocolTemplates} type="button">
                 Использовать
               </Button>
               <Button
@@ -2177,8 +2177,8 @@ const DentistPanelUnified = () => {
 
           <div className="dental-template-card">
 
-            <div class="dental-flex-center-12">
-              <div className="dental-icon-bg" class="dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
+            <div className="dental-flex-center-12">
+              <div className="dental-icon-bg" className="dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
                 <Scissors className="dental-icon-20 dental-text-success" />
               </div>
               <div>
@@ -2189,8 +2189,8 @@ const DentistPanelUnified = () => {
             <p className="dental-text-value dental-text-primary">
               Протокол профессиональной гигиены полости рта
             </p>
-            <div class="dental-flex dental-gap-8">
-              <Button size="sm" class="dental-flex-1" onClick={handleProtocolTemplates} type="button">
+            <div className="dental-flex dental-gap-8">
+              <Button size="sm" className="dental-flex-1" onClick={handleProtocolTemplates} type="button">
                 Использовать
               </Button>
               <Button
@@ -2213,7 +2213,7 @@ const DentistPanelUnified = () => {
   <div className="dental-flex-col dental-gap-24">
       {savedVisitProtocols.length > 0 &&
       <Card padding="lg">
-          <div class="dental-flex-between-16">
+          <div className="dental-flex-between-16">
             <div>
               <h3 className="dental-text-primary">Сохранённые протоколы визитов</h3>
               <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-secondary">
@@ -2248,7 +2248,7 @@ const DentistPanelUnified = () => {
       }
 
       <Card padding="lg">
-        <div class="dental-flex-between-16">
+        <div className="dental-flex-between-16">
           <div>
             <h3 className="dental-text-primary">Отчеты и аналитика</h3>
             <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-secondary">
@@ -2278,8 +2278,8 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-            <div class="dental-flex-center-12">
-              <div className="dental-icon-bg" class="dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
+            <div className="dental-flex-center-12">
+              <div className="dental-icon-bg" className="dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
                 <BarChart3 className="dental-icon-20 dental-text-blue" />
               </div>
               <div>
@@ -2305,8 +2305,8 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-            <div class="dental-flex-center-12">
-              <div className="dental-icon-bg" class="dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
+            <div className="dental-flex-center-12">
+              <div className="dental-icon-bg" className="dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
                 <Users className="dental-icon-20 dental-text-success" />
               </div>
               <div>
@@ -2332,7 +2332,7 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-            <div class="dental-flex-center-12">
+            <div className="dental-flex-center-12">
               <div className="dental-icon-bg dental-icon-bg-purple-bg dental-icon-bg-lg-shadow">
                 <Stethoscope className="dental-icon-20 dental-text-purple" />
               </div>
@@ -2359,7 +2359,7 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-            <div class="dental-flex-center-12">
+            <div className="dental-flex-center-12">
               <div className="dental-icon-bg dental-icon-bg-warning-bg dental-icon-bg-lg-shadow">
                 <Building className="dental-icon-20 dental-text-warning" />
               </div>
@@ -2386,7 +2386,7 @@ const DentistPanelUnified = () => {
           Выберите пациента для просмотра и редактирования схемы зубов
         </p>
 
-        <div class="dental-grid-auto-fill-250">
+        <div className="dental-grid-auto-fill-250">
           {patients.map((patient) =>
         <div
           key={patient.id}
@@ -2430,7 +2430,7 @@ const DentistPanelUnified = () => {
           Выберите пациента для создания или редактирования плана лечения
         </p>
 
-        <div class="dental-grid-auto-fill-250">
+        <div className="dental-grid-auto-fill-250">
           {patients.map((patient) =>
         <div
           key={patient.id}
@@ -2683,9 +2683,9 @@ const DentistPanelUnified = () => {
       }
 
       {showDentalChart && selectedPatient &&
-      <div class="dental-modal-overlay">
+      <div className="dental-modal-overlay">
           <div className="dental-modal-card-xl">
-            <div class="dental-flex-between-16">
+            <div className="dental-flex-between-16">
               <h2 className="dental-heading-xl dental-text-primary">
                 Схема зубов: {selectedPatientDisplayName}
               </h2>
@@ -2702,7 +2702,7 @@ const DentistPanelUnified = () => {
                 e.target.style.backgroundColor = 'transparent';
               }}>
 
-                <XCircle class="dental-icon-20" />
+                <XCircle className="dental-icon-20" />
               </button>
             </div>
             <TeethChart
@@ -2720,9 +2720,9 @@ const DentistPanelUnified = () => {
       }
 
       {showTreatmentPlanner && selectedPatient &&
-      <div class="dental-modal-overlay">
+      <div className="dental-modal-overlay">
           <div className="dental-modal-card-xl">
-            <div class="dental-flex-between-16">
+            <div className="dental-flex-between-16">
               <h2 className="dental-heading-xl dental-text-primary">
                 План лечения: {selectedPatientDisplayName}
               </h2>
@@ -2739,7 +2739,7 @@ const DentistPanelUnified = () => {
                 e.target.style.backgroundColor = 'transparent';
               }}>
 
-                <XCircle class="dental-icon-20" />
+                <XCircle className="dental-icon-20" />
               </button>
             </div>
             <TreatmentPlanner

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -1561,109 +1561,45 @@ const DentistPanelUnified = () => {
   const renderDashboard = () =>
   <div className="dental-flex-col dental-gap-32">
       {/* Статистические карточки */}
-      <div style={{
-      display: 'grid',
-      gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
-      gap: '24px'
-    }}>
-        <div style={{
-        background: 'var(--mac-bg-primary)',
-        borderRadius: 'var(--mac-radius-xl)',
-        padding: '24px',
-        boxShadow: 'var(--mac-shadow-sm)',
-        border: '1px solid var(--mac-border)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        transition: 'all var(--mac-duration-normal) var(--mac-ease)',
-        cursor: 'default'
-      }}>
+      <div className="dental-grid-stat-cards">
+        <div className="dental-stat-card-default">
           <div>
             <p className="dental-text-desc dental-text-secondary">Всего пациентов</p>
             <p className="dental-stat-number dental-text-primary">{stats.totalPatients}</p>
-            <p style={{
-            fontSize: 'var(--mac-font-size-xs)',
-            color: 'var(--mac-success)',
-            marginTop: '4px'
-          }}>+12% за месяц</p>
+            <p className="dental-stat-delta dental-text-success">+12% за месяц</p>
           </div>
           <div className="dental-icon-bg dental-icon-bg-blue dental-icon-bg-xl-shadow">
             <Users className="dental-icon-28 dental-text-white" />
           </div>
         </div>
 
-        <div style={{
-        background: 'var(--mac-bg-primary)',
-        borderRadius: 'var(--mac-radius-xl)',
-        padding: '24px',
-        boxShadow: 'var(--mac-shadow-sm)',
-        border: '1px solid var(--mac-border)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        transition: 'all var(--mac-duration-normal) var(--mac-ease)',
-        cursor: 'default'
-      }}>
+        <div className="dental-stat-card-default">
           <div>
             <p className="dental-text-desc dental-text-secondary">Записей сегодня</p>
             <p className="dental-stat-number dental-text-primary">{stats.todayAppointments}</p>
-            <p style={{
-            fontSize: 'var(--mac-font-size-xs)',
-            color: 'var(--mac-accent-blue)',
-            marginTop: '4px'
-          }}>8 из 12 слотов</p>
+            <p className="dental-stat-delta dental-text-blue">8 из 12 слотов</p>
           </div>
           <div className="dental-icon-bg dental-icon-bg-success dental-icon-bg-xl-shadow">
             <Calendar className="dental-icon-28 dental-text-white" />
           </div>
         </div>
 
-        <div style={{
-        background: 'var(--mac-bg-primary)',
-        borderRadius: 'var(--mac-radius-xl)',
-        padding: '24px',
-        boxShadow: 'var(--mac-shadow-sm)',
-        border: '1px solid var(--mac-border)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        transition: 'all var(--mac-duration-normal) var(--mac-ease)',
-        cursor: 'default'
-      }}>
+        <div className="dental-stat-card-default">
           <div>
             <p className="dental-text-desc dental-text-secondary">Активные планы</p>
             <p className="dental-stat-number dental-text-primary">{stats.activeTreatmentPlans}</p>
-            <p style={{
-            fontSize: 'var(--mac-font-size-xs)',
-            color: 'var(--mac-accent-purple)',
-            marginTop: '4px'
-          }}>+8% к прошлому месяцу</p>
+            <p className="dental-stat-delta dental-text-purple">+8% к прошлому месяцу</p>
           </div>
           <div className="dental-icon-bg dental-icon-bg-purple dental-icon-bg-xl-shadow">
             <FileText className="dental-icon-28 dental-text-white" />
           </div>
         </div>
 
-        <div style={{
-        background: 'var(--mac-bg-primary)',
-        borderRadius: 'var(--mac-radius-xl)',
-        padding: '24px',
-        boxShadow: 'var(--mac-shadow-sm)',
-        border: '1px solid var(--mac-border)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        transition: 'all var(--mac-duration-normal) var(--mac-ease)',
-        cursor: 'default'
-      }}>
+        <div className="dental-stat-card-default">
           <div>
             <p className="dental-text-desc dental-text-secondary">Протезы</p>
             <p className="dental-stat-number dental-text-primary">{stats.completedProsthetics}</p>
-            <p style={{
-            fontSize: 'var(--mac-font-size-xs)',
-            color: 'var(--mac-warning)',
-            marginTop: '4px'
-          }}>+15% к прошлому месяцу</p>
+            <p className="dental-stat-delta dental-text-warning">+15% к прошлому месяцу</p>
           </div>
           <div className="dental-icon-bg dental-icon-bg-warning dental-icon-bg-xl-shadow">
             <Smile className="dental-icon-28 dental-text-white" />
@@ -1672,13 +1608,7 @@ const DentistPanelUnified = () => {
       </div>
 
       {/* Быстрые действия */}
-      <div style={{
-      background: 'var(--mac-bg-primary)',
-      borderRadius: 'var(--mac-radius-xl)',
-      padding: '24px',
-      boxShadow: 'var(--mac-shadow-sm)',
-      border: '1px solid var(--mac-border)'
-    }}>
+      <div className="dental-section-card">
         <div class="dental-flex-between-16">
           <h3 className="dental-text-lg-semi dental-text-primary">Быстрые действия</h3>
         </div>
@@ -1702,17 +1632,7 @@ const DentistPanelUnified = () => {
           <Button
           onClick={() => handleTabChange('appointments')}
           variant="outline"
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '12px',
-            padding: '16px 24px',
-            borderRadius: 'var(--mac-radius-lg)',
-            boxShadow: 'var(--mac-shadow-sm)',
-            transition: 'all var(--mac-duration-normal) var(--mac-ease)',
-            border: '1px solid var(--mac-border)',
-            fontWeight: 'var(--mac-font-weight-medium)'
-          }}
+          className="dental-quick-action-btn"
           onMouseEnter={(e) => {
             e.currentTarget.style.boxShadow = 'var(--mac-shadow-md)';
             e.currentTarget.style.transform = 'translateY(-2px)';
@@ -1728,17 +1648,7 @@ const DentistPanelUnified = () => {
           <Button
           onClick={() => handleTabChange('dental-chart')}
           variant="outline"
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '12px',
-            padding: '16px 24px',
-            borderRadius: 'var(--mac-radius-lg)',
-            boxShadow: 'var(--mac-shadow-sm)',
-            transition: 'all var(--mac-duration-normal) var(--mac-ease)',
-            border: '1px solid var(--mac-border)',
-            fontWeight: 'var(--mac-font-weight-medium)'
-          }}
+          className="dental-quick-action-btn"
           onMouseEnter={(e) => {
             e.currentTarget.style.boxShadow = 'var(--mac-shadow-md)';
             e.currentTarget.style.transform = 'translateY(-2px)';
@@ -1755,13 +1665,7 @@ const DentistPanelUnified = () => {
       </div>
 
       {/* Последние записи */}
-      <div style={{
-      background: 'var(--mac-bg-primary)',
-      borderRadius: 'var(--mac-radius-xl)',
-      padding: '24px',
-      boxShadow: 'var(--mac-shadow-sm)',
-      border: '1px solid var(--mac-border)'
-    }}>
+      <div className="dental-section-card">
         <div class="dental-flex-between-16">
           <h3 className="dental-text-lg-semi dental-text-primary">Последние записи</h3>
         </div>
@@ -1769,16 +1673,7 @@ const DentistPanelUnified = () => {
           {appointmentsTableData.slice(0, 5).map((appointment) =>
         <div
           key={appointment.id}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: '24px',
-            background: 'var(--mac-bg-secondary)',
-            borderRadius: 'var(--mac-radius-lg)',
-            transition: 'all var(--mac-duration-normal) var(--mac-ease)',
-            cursor: 'default'
-          }}>
+          className="dental-appointment-row">
 
               <div className="dental-flex dental-gap-16">
                 <div className="dental-icon-bg dental-icon-bg-blue dental-icon-bg-lg-shadow">
@@ -1791,14 +1686,9 @@ const DentistPanelUnified = () => {
                   <p className="dental-text-desc dental-text-desc dental-text-secondary">{appointment.date} {appointment.time}</p>
                 </div>
               </div>
-              <div style={{
-            padding: '4px 12px',
-            borderRadius: 'var(--mac-radius-full)',
-            fontSize: 'var(--mac-font-size-xs)',
-            fontWeight: 'var(--mac-font-weight-medium)',
-            background: appointment.status === 'confirmed' ? 'var(--mac-success-bg)' : 'var(--mac-warning-bg)',
-            color: appointment.status === 'confirmed' ? 'var(--mac-success)' : 'var(--mac-warning)'
-          }}>
+              <div
+            className="dental-status-badge"
+            data-status={appointment.status === 'confirmed' ? 'confirmed' : 'pending'}>
                 {appointment.status}
               </div>
             </div>

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -1742,7 +1742,7 @@ const DentistPanelUnified = () => {
 
             <div className="dental-flex-between-16">
               <div className="dental-flex dental-gap-12">
-                <div className="dental-avatar" className="dental-icon-bg dental-icon-bg-blue">
+                <div className="dental-avatar dental-icon-bg dental-icon-bg-blue">
                   <span className="dental-text-value dental-heading dental-text-white">
                     {patient.name?.charAt(0)}
                   </span>
@@ -1772,7 +1772,7 @@ const DentistPanelUnified = () => {
             onClick={() => handlePatientSelect(patient)}
             className="dental-grid-span-2">
 
-                <Edit className="dental-icon-16" className="dental-mr-4" />
+                <Edit className="dental-icon-16 dental-mr-4" />
                 Карточка пациента
               </Button>
               <Button
@@ -2120,8 +2120,8 @@ const DentistPanelUnified = () => {
           <div className="dental-template-card">
 
             <div className="dental-flex-center-12">
-              <div className="dental-icon-bg" className="dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
-                <Scissors className="dental-icon-20" className="dental-text-blue" />
+              <div className="dental-icon-bg dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
+                <Scissors className="dental-icon-20 dental-text-blue" />
               </div>
               <div>
                 <h4 className="dental-text-primary">Лечение кариеса</h4>
@@ -2178,7 +2178,7 @@ const DentistPanelUnified = () => {
           <div className="dental-template-card">
 
             <div className="dental-flex-center-12">
-              <div className="dental-icon-bg" className="dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
+              <div className="dental-icon-bg dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
                 <Scissors className="dental-icon-20 dental-text-success" />
               </div>
               <div>
@@ -2279,7 +2279,7 @@ const DentistPanelUnified = () => {
           }}>
 
             <div className="dental-flex-center-12">
-              <div className="dental-icon-bg" className="dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
+              <div className="dental-icon-bg dental-icon-bg-blue-light dental-icon-bg-lg-shadow">
                 <BarChart3 className="dental-icon-20 dental-text-blue" />
               </div>
               <div>
@@ -2306,7 +2306,7 @@ const DentistPanelUnified = () => {
           }}>
 
             <div className="dental-flex-center-12">
-              <div className="dental-icon-bg" className="dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
+              <div className="dental-icon-bg dental-icon-bg-success-bg dental-icon-bg-lg-shadow">
                 <Users className="dental-icon-20 dental-text-success" />
               </div>
               <div>

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -1559,7 +1559,7 @@ const DentistPanelUnified = () => {
   // Вкладки
   // Рендер дашборда
   const renderDashboard = () =>
-  <div className="dental-flex-col" style={{ gap: '32px' }}>
+  <div className="dental-flex-col dental-gap-32">
       {/* Статистические карточки */}
       <div style={{
       display: 'grid',
@@ -1579,7 +1579,7 @@ const DentistPanelUnified = () => {
         cursor: 'default'
       }}>
           <div>
-            <p className="dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Всего пациентов</p>
+            <p className="dental-text-desc dental-text-secondary">Всего пациентов</p>
             <p className="dental-stat-number dental-text-primary">{stats.totalPatients}</p>
             <p style={{
             fontSize: 'var(--mac-font-size-xs)',
@@ -1587,7 +1587,7 @@ const DentistPanelUnified = () => {
             marginTop: '4px'
           }}>+12% за месяц</p>
           </div>
-          <div className="dental-icon-bg" style={{ background: 'var(--mac-accent-blue)', borderRadius: 'var(--mac-radius-xl)', boxShadow: 'var(--mac-shadow-lg)' }}>
+          <div className="dental-icon-bg dental-icon-bg-blue dental-icon-bg-xl-shadow">
             <Users className="dental-icon-28 dental-text-white" />
           </div>
         </div>
@@ -1605,7 +1605,7 @@ const DentistPanelUnified = () => {
         cursor: 'default'
       }}>
           <div>
-            <p className="dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Записей сегодня</p>
+            <p className="dental-text-desc dental-text-secondary">Записей сегодня</p>
             <p className="dental-stat-number dental-text-primary">{stats.todayAppointments}</p>
             <p style={{
             fontSize: 'var(--mac-font-size-xs)',
@@ -1613,7 +1613,7 @@ const DentistPanelUnified = () => {
             marginTop: '4px'
           }}>8 из 12 слотов</p>
           </div>
-          <div className="dental-icon-bg" style={{ background: 'var(--mac-success)', borderRadius: 'var(--mac-radius-xl)', boxShadow: 'var(--mac-shadow-lg)' }}>
+          <div className="dental-icon-bg dental-icon-bg-success dental-icon-bg-xl-shadow">
             <Calendar className="dental-icon-28 dental-text-white" />
           </div>
         </div>
@@ -1631,7 +1631,7 @@ const DentistPanelUnified = () => {
         cursor: 'default'
       }}>
           <div>
-            <p className="dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Активные планы</p>
+            <p className="dental-text-desc dental-text-secondary">Активные планы</p>
             <p className="dental-stat-number dental-text-primary">{stats.activeTreatmentPlans}</p>
             <p style={{
             fontSize: 'var(--mac-font-size-xs)',
@@ -1639,7 +1639,7 @@ const DentistPanelUnified = () => {
             marginTop: '4px'
           }}>+8% к прошлому месяцу</p>
           </div>
-          <div className="dental-icon-bg" style={{ background: 'var(--mac-accent-purple)', borderRadius: 'var(--mac-radius-xl)', boxShadow: 'var(--mac-shadow-lg)' }}>
+          <div className="dental-icon-bg dental-icon-bg-purple dental-icon-bg-xl-shadow">
             <FileText className="dental-icon-28 dental-text-white" />
           </div>
         </div>
@@ -1657,7 +1657,7 @@ const DentistPanelUnified = () => {
         cursor: 'default'
       }}>
           <div>
-            <p className="dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Протезы</p>
+            <p className="dental-text-desc dental-text-secondary">Протезы</p>
             <p className="dental-stat-number dental-text-primary">{stats.completedProsthetics}</p>
             <p style={{
             fontSize: 'var(--mac-font-size-xs)',
@@ -1665,7 +1665,7 @@ const DentistPanelUnified = () => {
             marginTop: '4px'
           }}>+15% к прошлому месяцу</p>
           </div>
-          <div className="dental-icon-bg" style={{ background: 'var(--mac-warning)', borderRadius: 'var(--mac-radius-xl)', boxShadow: 'var(--mac-shadow-lg)' }}>
+          <div className="dental-icon-bg dental-icon-bg-warning dental-icon-bg-xl-shadow">
             <Smile className="dental-icon-28 dental-text-white" />
           </div>
         </div>
@@ -1706,7 +1706,7 @@ const DentistPanelUnified = () => {
           }}>
 
             <Plus className="dental-icon-20" />
-            <span style={{ fontWeight: 'var(--mac-font-weight-medium)' }}>Новый пациент</span>
+            <span className="dental-fw-medium">Новый пациент</span>
           </Button>
           <Button
           onClick={() => handleTabChange('appointments')}
@@ -1732,7 +1732,7 @@ const DentistPanelUnified = () => {
           }}>
 
             <Calendar className="dental-icon-20" />
-            <span style={{ fontWeight: 'var(--mac-font-weight-medium)' }}>Записать на прием</span>
+            <span className="dental-fw-medium">Записать на прием</span>
           </Button>
           <Button
           onClick={() => handleTabChange('dental-chart')}
@@ -1758,7 +1758,7 @@ const DentistPanelUnified = () => {
           }}>
 
             <Tooth className="dental-icon-20" />
-            <span style={{ fontWeight: 'var(--mac-font-weight-medium)' }}>Схема зубов</span>
+            <span className="dental-fw-medium">Схема зубов</span>
           </Button>
         </div>
       </div>
@@ -1779,7 +1779,7 @@ const DentistPanelUnified = () => {
       }}>
           <h3 className="dental-text-lg-semi dental-text-primary">Последние записи</h3>
         </div>
-        <div className="dental-flex-col" style={{ gap: '16px' }}>
+        <div className="dental-flex-col dental-gap-16">
           {appointmentsTableData.slice(0, 5).map((appointment) =>
         <div
           key={appointment.id}
@@ -1794,15 +1794,15 @@ const DentistPanelUnified = () => {
             cursor: 'default'
           }}>
 
-              <div className="dental-flex" style={{ gap: '16px' }}>
-                <div className="dental-icon-bg" style={{ background: 'var(--mac-accent-blue)', borderRadius: 'var(--mac-radius-lg)', boxShadow: 'var(--mac-shadow-sm)' }}>
+              <div className="dental-flex dental-gap-16">
+                <div className="dental-icon-bg dental-icon-bg-blue dental-icon-bg-lg-shadow">
                   <span className="dental-text-value dental-fw-700 dental-text-white">
                     {appointment.patientName?.charAt(0)}
                   </span>
                 </div>
                 <div>
                   <p className="dental-text-primary">{appointment.patientName}</p>
-                  <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>{appointment.date} {appointment.time}</p>
+                  <p className="dental-text-desc dental-text-desc dental-text-secondary">{appointment.date} {appointment.time}</p>
                 </div>
               </div>
               <div style={{
@@ -1824,7 +1824,7 @@ const DentistPanelUnified = () => {
 
   // Рендер пациентов
   const renderPatients = () =>
-  <div className="dental-flex-col" style={{ gap: '24px' }}>
+  <div className="dental-flex-col dental-gap-24">
       {/* Поиск и фильтры */}
       <Card padding="lg">
         <div style={{ display: 'flex', flexDirection: 'row', gap: '16px', flexWrap: 'wrap' }}>
@@ -1903,7 +1903,7 @@ const DentistPanelUnified = () => {
         }}>
 
             <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: '16px' }}>
-              <div className="dental-flex" style={{ gap: '12px' }}>
+              <div className="dental-flex dental-gap-12">
                 <div className="dental-avatar" style={{ background: 'var(--mac-accent-blue)' }}>
                   <span className="dental-text-value dental-heading dental-text-white">
                     {patient.name?.charAt(0)}
@@ -1911,7 +1911,7 @@ const DentistPanelUnified = () => {
                 </div>
                 <div>
                   <h3 className="dental-text-primary">{patient.name}</h3>
-                  <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>{patient.phone}</p>
+                  <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-secondary">{patient.phone}</p>
                 </div>
               </div>
               <Badge variant={patient.status === 'active' ? 'success' : 'warning'}>
@@ -1920,10 +1920,10 @@ const DentistPanelUnified = () => {
             </div>
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '16px' }}>
-              <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>
+              <p className="dental-text-desc dental-text-desc dental-text-secondary">
                 <strong style={{ fontWeight: 'var(--mac-font-weight-semibold)' }}>Возраст:</strong> {patient.age} лет
               </p>
-              <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>
+              <p className="dental-text-desc dental-text-desc dental-text-secondary">
                 <strong style={{ fontWeight: 'var(--mac-font-weight-semibold)' }}>Последний визит:</strong> {patient.lastVisit || 'Не было'}
               </p>
             </div>
@@ -2061,10 +2061,10 @@ const DentistPanelUnified = () => {
 
   // Рендер осмотров
   const renderExaminations = () =>
-  <div className="dental-flex-col" style={{ gap: '24px' }}>
+  <div className="dental-flex-col dental-gap-24">
       <Card padding="lg">
         <h3 className="dental-text-primary">Объективные осмотры</h3>
-        <p className="dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>
+        <p className="dental-text-desc dental-text-secondary">
           Выберите пациента для проведения или просмотра объективного осмотра
         </p>
 
@@ -2089,15 +2089,15 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-              <div className="dental-flex" style={{ gap: '12px' }}>
-                <div className="dental-icon-bg" style={{ background: 'var(--mac-success)', borderRadius: 'var(--mac-radius-full)' }}>
+              <div className="dental-flex dental-gap-12">
+                <div className="dental-icon-bg dental-icon-bg-success dental-icon-bg-full">
                   <span className="dental-text-value dental-text-white">
                     {patient.name?.charAt(0)}
                   </span>
                 </div>
                 <div>
                   <p className="dental-text-primary">{patient.name}</p>
-                  <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Провести осмотр</p>
+                  <p className="dental-text-desc dental-text-desc dental-text-secondary">Провести осмотр</p>
                 </div>
               </div>
             </div>
@@ -2109,10 +2109,10 @@ const DentistPanelUnified = () => {
 
   // Рендер диагнозов
   const renderDiagnoses = () =>
-  <div className="dental-flex-col" style={{ gap: '24px' }}>
+  <div className="dental-flex-col dental-gap-24">
       <Card padding="lg">
         <h3 className="dental-text-primary">Диагнозы и назначения</h3>
-        <p className="dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>
+        <p className="dental-text-desc dental-text-secondary">
           Выберите пациента для постановки диагнозов и назначений
         </p>
 
@@ -2137,15 +2137,15 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-              <div className="dental-flex" style={{ gap: '12px' }}>
-                <div className="dental-icon-bg" style={{ background: 'var(--mac-accent-blue)', borderRadius: 'var(--mac-radius-full)' }}>
+              <div className="dental-flex dental-gap-12">
+                <div className="dental-icon-bg dental-icon-bg-blue dental-icon-bg-full">
                   <span className="dental-text-value dental-text-white">
                     {patient.name?.charAt(0)}
                   </span>
                 </div>
                 <div>
                   <p className="dental-text-primary">{patient.name}</p>
-                  <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Поставить диагноз</p>
+                  <p className="dental-text-desc dental-text-desc dental-text-secondary">Поставить диагноз</p>
                 </div>
               </div>
             </div>
@@ -2160,7 +2160,7 @@ const DentistPanelUnified = () => {
     // Если выбран пациент из очереди - показываем EMR
     if (selectedPatient) {
       return (
-        <div className="dental-flex-col" style={{ gap: '24px' }}>
+        <div className="dental-flex-col dental-gap-24">
           <Card padding="lg">
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '20px' }}>
               <h3 className="dental-text-primary">
@@ -2191,10 +2191,10 @@ const DentistPanelUnified = () => {
 
     // Иначе показываем список пациентов для выбора протокола
     return (
-      <div className="dental-flex-col" style={{ gap: '24px' }}>
+      <div className="dental-flex-col dental-gap-24">
         <Card padding="lg">
           <h3 className="dental-text-primary">Протоколы визитов</h3>
-          <p className="dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>
+          <p className="dental-text-desc dental-text-secondary">
             Выберите пациента из очереди или выберите из списка для создания протокола визита
           </p>
 
@@ -2219,7 +2219,7 @@ const DentistPanelUnified = () => {
                 e.currentTarget.style.background = 'transparent';
               }}>
 
-                <div className="dental-flex" style={{ gap: '12px' }}>
+                <div className="dental-flex dental-gap-12">
                   <div className="dental-icon-bg" style={{ background: 'var(--mac-accent-purple)', borderRadius: 'var(--mac-radius-full)' }}>
                     <span className="dental-text-value dental-text-white">
                       {patient.name?.charAt(0)}
@@ -2227,7 +2227,7 @@ const DentistPanelUnified = () => {
                   </div>
                   <div>
                     <p className="dental-text-primary">{patient.name}</p>
-                    <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Создать протокол</p>
+                    <p className="dental-text-desc dental-text-desc dental-text-secondary">Создать протокол</p>
                   </div>
                 </div>
               </div>
@@ -2240,10 +2240,10 @@ const DentistPanelUnified = () => {
 
   // Рендер фото архива
   const renderPhotos = () =>
-  <div className="dental-flex-col" style={{ gap: '24px' }}>
+  <div className="dental-flex-col dental-gap-24">
       <Card padding="lg">
         <h3 className="dental-text-primary">Фото и рентген архив</h3>
-        <p className="dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>
+        <p className="dental-text-desc dental-text-secondary">
           Выберите пациента для просмотра и управления фото и рентгеновскими снимками
         </p>
 
@@ -2268,15 +2268,15 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-              <div className="dental-flex" style={{ gap: '12px' }}>
-                <div className="dental-icon-bg" style={{ background: 'var(--mac-warning)', borderRadius: 'var(--mac-radius-full)' }}>
+              <div className="dental-flex dental-gap-12">
+                <div className="dental-icon-bg dental-icon-bg-warning dental-icon-bg-full">
                   <span className="dental-text-value dental-text-white">
                     {patient.name?.charAt(0)}
                   </span>
                 </div>
                 <div>
                   <p className="dental-text-primary">{patient.name}</p>
-                  <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Открыть архив</p>
+                  <p className="dental-text-desc dental-text-desc dental-text-secondary">Открыть архив</p>
                 </div>
               </div>
             </div>
@@ -2288,7 +2288,7 @@ const DentistPanelUnified = () => {
 
   // Рендер шаблонов
   const renderTemplates = () =>
-  <div className="dental-flex-col" style={{ gap: '24px' }}>
+  <div className="dental-flex-col dental-gap-24">
       <Card padding="lg">
         <div style={{
         display: 'flex',
@@ -2298,13 +2298,13 @@ const DentistPanelUnified = () => {
       }}>
           <div>
             <h3 className="dental-text-primary">Шаблоны протоколов</h3>
-            <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>
+            <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-secondary">
               Стандартные протоколы для быстрого создания протоколов визитов
             </p>
           </div>
           <Button
           onClick={handleProtocolTemplates}
-          className="dental-flex" style={{ gap: '8px' }}>
+          className="dental-flex dental-gap-8">
 
             <FileText className="dental-icon-16" />
             Управление шаблонами
@@ -2336,7 +2336,7 @@ const DentistPanelUnified = () => {
               </div>
               <div>
                 <h4 className="dental-text-primary">Лечение кариеса</h4>
-                <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>60 мин</p>
+                <p className="dental-text-desc dental-text-desc dental-text-secondary">60 мин</p>
               </div>
             </div>
             <p className="dental-text-value dental-text-primary">
@@ -2377,7 +2377,7 @@ const DentistPanelUnified = () => {
               </div>
               <div>
                 <h4 className="dental-text-primary">Эндодонтическое лечение</h4>
-                <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>120 мин</p>
+                <p className="dental-text-desc dental-text-desc dental-text-secondary">120 мин</p>
               </div>
             </div>
             <p className="dental-text-value dental-text-primary">
@@ -2418,7 +2418,7 @@ const DentistPanelUnified = () => {
               </div>
               <div>
                 <h4 className="dental-text-primary">Профессиональная гигиена</h4>
-                <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>75 мин</p>
+                <p className="dental-text-desc dental-text-desc dental-text-secondary">75 мин</p>
               </div>
             </div>
             <p className="dental-text-value dental-text-primary">
@@ -2445,7 +2445,7 @@ const DentistPanelUnified = () => {
 
   // Рендер отчетов
   const renderReports = () =>
-  <div className="dental-flex-col" style={{ gap: '24px' }}>
+  <div className="dental-flex-col dental-gap-24">
       {savedVisitProtocols.length > 0 &&
       <Card padding="lg">
           <div style={{
@@ -2456,7 +2456,7 @@ const DentistPanelUnified = () => {
         }}>
             <div>
               <h3 className="dental-text-primary">Сохранённые протоколы визитов</h3>
-              <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>
+              <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-secondary">
                 Последние протоколы доступны для повторного открытия без ручной пересборки
               </p>
             </div>
@@ -2480,7 +2480,7 @@ const DentistPanelUnified = () => {
             }}>
                 <div>
                   <div className="dental-text-primary">{protocol.patient_name}</div>
-                  <div className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>
+                  <div className="dental-text-desc dental-text-desc dental-text-secondary">
                     Визит #{protocol.visit_id} • {new Date(protocol.saved_at).toLocaleString('ru-RU')}
                   </div>
                 </div>
@@ -2509,13 +2509,13 @@ const DentistPanelUnified = () => {
       }}>
           <div>
             <h3 className="dental-text-primary">Отчеты и аналитика</h3>
-            <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>
+            <p className="dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-desc dental-text-secondary">
               Статистика по пациентам, врачам, процедурам и клинике
             </p>
           </div>
           <Button
           onClick={handleReports}
-          className="dental-flex" style={{ gap: '8px' }}>
+          className="dental-flex dental-gap-8">
 
             <BarChart3 className="dental-icon-16" />
             Открыть отчеты
@@ -2551,7 +2551,7 @@ const DentistPanelUnified = () => {
               </div>
               <div>
                 <h4 className="dental-text-primary">Общий обзор</h4>
-                <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Основные показатели</p>
+                <p className="dental-text-desc dental-text-desc dental-text-secondary">Основные показатели</p>
               </div>
             </div>
             <p className="dental-text-value dental-text-primary">
@@ -2583,7 +2583,7 @@ const DentistPanelUnified = () => {
               </div>
               <div>
                 <h4 className="dental-text-primary">По пациентам</h4>
-                <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Демография и активность</p>
+                <p className="dental-text-desc dental-text-desc dental-text-secondary">Демография и активность</p>
               </div>
             </div>
             <p className="dental-text-value dental-text-primary">
@@ -2610,12 +2610,12 @@ const DentistPanelUnified = () => {
             gap: '12px',
             marginBottom: '12px'
           }}>
-              <div className="dental-icon-bg" style={{ background: 'var(--mac-accent-purple-bg)', borderRadius: 'var(--mac-radius-lg)' }}>
-                <Stethoscope className="dental-icon-20" style={{ color: 'var(--mac-accent-purple)'  }} />
+              <div className="dental-icon-bg dental-icon-bg-purple-bg dental-icon-bg-lg-shadow">
+                <Stethoscope className="dental-icon-20 dental-text-purple" />
               </div>
               <div>
                 <h4 className="dental-text-primary">По врачам</h4>
-                <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Производительность</p>
+                <p className="dental-text-desc dental-text-desc dental-text-secondary">Производительность</p>
               </div>
             </div>
             <p className="dental-text-value dental-text-primary">
@@ -2642,12 +2642,12 @@ const DentistPanelUnified = () => {
             gap: '12px',
             marginBottom: '12px'
           }}>
-              <div className="dental-icon-bg" style={{ background: 'var(--mac-warning-bg)', borderRadius: 'var(--mac-radius-lg)' }}>
-                <Building className="dental-icon-20" style={{ color: 'var(--mac-warning)'  }} />
+              <div className="dental-icon-bg dental-icon-bg-warning-bg dental-icon-bg-lg-shadow">
+                <Building className="dental-icon-20 dental-text-warning" />
               </div>
               <div>
                 <h4 className="dental-text-primary">По клинике</h4>
-                <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Оборудование и загруженность</p>
+                <p className="dental-text-desc dental-text-desc dental-text-secondary">Оборудование и загруженность</p>
               </div>
             </div>
             <p className="dental-text-value dental-text-primary">
@@ -2661,10 +2661,10 @@ const DentistPanelUnified = () => {
 
   // Рендер схем зубов
   const renderDentalChart = () =>
-  <div className="dental-flex-col" style={{ gap: '24px' }}>
+  <div className="dental-flex-col dental-gap-24">
       <Card padding="lg">
         <h3 className="dental-text-primary">Схемы зубов</h3>
-        <p className="dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>
+        <p className="dental-text-desc dental-text-secondary">
           Выберите пациента для просмотра и редактирования схемы зубов
         </p>
 
@@ -2689,15 +2689,15 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-              <div className="dental-flex" style={{ gap: '12px' }}>
-                <div className="dental-icon-bg" style={{ background: 'var(--mac-accent-blue)', borderRadius: 'var(--mac-radius-full)' }}>
+              <div className="dental-flex dental-gap-12">
+                <div className="dental-icon-bg dental-icon-bg-blue dental-icon-bg-full">
                   <span className="dental-text-value dental-text-white">
                     {patient.name?.charAt(0)}
                   </span>
                 </div>
                 <div>
                   <p className="dental-text-primary">{patient.name}</p>
-                  <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Открыть схему</p>
+                  <p className="dental-text-desc dental-text-desc dental-text-secondary">Открыть схему</p>
                 </div>
               </div>
             </div>
@@ -2709,10 +2709,10 @@ const DentistPanelUnified = () => {
 
   // Рендер планов лечения
   const renderTreatmentPlans = () =>
-  <div className="dental-flex-col" style={{ gap: '24px' }}>
+  <div className="dental-flex-col dental-gap-24">
       <Card padding="lg">
         <h3 className="dental-text-primary">Планы лечения</h3>
-        <p className="dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>
+        <p className="dental-text-desc dental-text-secondary">
           Выберите пациента для создания или редактирования плана лечения
         </p>
 
@@ -2737,15 +2737,15 @@ const DentistPanelUnified = () => {
             e.currentTarget.style.background = 'transparent';
           }}>
 
-              <div className="dental-flex" style={{ gap: '12px' }}>
-                <div className="dental-icon-bg" style={{ background: 'var(--mac-success)', borderRadius: 'var(--mac-radius-full)' }}>
+              <div className="dental-flex dental-gap-12">
+                <div className="dental-icon-bg dental-icon-bg-success dental-icon-bg-full">
                   <span className="dental-text-value dental-text-white">
                     {patient.name?.charAt(0)}
                   </span>
                 </div>
                 <div>
                   <p className="dental-text-primary">{patient.name}</p>
-                  <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>Открыть план</p>
+                  <p className="dental-text-desc dental-text-desc dental-text-secondary">Открыть план</p>
                 </div>
               </div>
             </div>
@@ -2757,10 +2757,10 @@ const DentistPanelUnified = () => {
 
   // Рендер протезирования
   const renderProsthetics = () =>
-  <div className="dental-flex-col" style={{ gap: '24px' }}>
+  <div className="dental-flex-col dental-gap-24">
       <Card padding="lg">
         <h3 className="dental-text-primary">Протезирование</h3>
-        <div className="dental-flex-col" style={{ gap: '12px' }}>
+        <div className="dental-flex-col dental-gap-12">
           {prosthetics.map((prosthetic) =>
         <div
           key={prosthetic.id}
@@ -2774,13 +2774,13 @@ const DentistPanelUnified = () => {
             transition: 'all var(--mac-duration-normal) var(--mac-ease)'
           }}>
 
-              <div className="dental-flex" style={{ gap: '16px' }}>
+              <div className="dental-flex dental-gap-16">
                 <div className="dental-icon-bg-40" style={{ background: 'var(--mac-warning)'  }}>
                   <Smile className="dental-icon-20 dental-text-white" />
                 </div>
                 <div>
                   <p className="dental-text-primary">{prosthetic.patientName}</p>
-                  <p className="dental-text-desc dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}>{prosthetic.type}</p>
+                  <p className="dental-text-desc dental-text-desc dental-text-secondary">{prosthetic.type}</p>
                 </div>
               </div>
               <Badge variant={prosthetic.status === 'completed' ? 'success' : 'warning'}>
@@ -2795,7 +2795,7 @@ const DentistPanelUnified = () => {
 
   // Рендер AI помощника
   const renderAIAssistant = () =>
-  <div className="dental-flex-col" style={{ gap: '24px' }}>
+  <div className="dental-flex-col dental-gap-24">
       <Card padding="lg">
         <h3 className="dental-text-primary">AI Помощник</h3>
         <AIAssistant
@@ -2862,7 +2862,7 @@ const DentistPanelUnified = () => {
   if (loading) {
     return (
       <div className="dental-p-8">
-        <div className="dental-flex-col" style={{ gap: '24px' }}>
+        <div className="dental-flex-col dental-gap-24">
           <div style={{
             height: '32px',
             background: 'var(--mac-bg-secondary)',
@@ -3030,7 +3030,7 @@ const DentistPanelUnified = () => {
               <button
               onClick={() => setShowDentalChart(false)}
               aria-label={`Закрыть схему зубов пациента ${selectedPatientDisplayName}`}
-              className="dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}
+              className="dental-text-desc dental-text-secondary"
               onMouseEnter={(e) => {
                 e.target.style.color = 'var(--mac-text-primary)';
                 e.target.style.backgroundColor = 'var(--mac-bg-secondary)';
@@ -3092,7 +3092,7 @@ const DentistPanelUnified = () => {
               <button
               onClick={() => setShowTreatmentPlanner(false)}
               aria-label={`Закрыть план лечения пациента ${selectedPatientDisplayName}`}
-              className="dental-text-desc" style={{ color: 'var(--mac-text-secondary)' }}
+              className="dental-text-desc dental-text-secondary"
               onMouseEnter={(e) => {
                 e.target.style.color = 'var(--mac-text-primary)';
                 e.target.style.backgroundColor = 'var(--mac-bg-secondary)';

--- a/frontend/src/pages/dentistry.css
+++ b/frontend/src/pages/dentistry.css
@@ -448,3 +448,8 @@
   padding: 48px;
   text-align: center;
 }
+
+/* ─── Batch 11: Additional utilities ─── */
+.dental-grid-span-2 { grid-column: span 2; margin-bottom: 8px; }
+.dental-mr-4 { margin-right: 4px; }
+.dental-mb { margin-bottom: var(--mac-spacing-4); }

--- a/frontend/src/pages/dentistry.css
+++ b/frontend/src/pages/dentistry.css
@@ -453,3 +453,209 @@
 .dental-grid-span-2 { grid-column: span 2; margin-bottom: 8px; }
 .dental-mr-4 { margin-right: 4px; }
 .dental-mb { margin-bottom: var(--mac-spacing-4); }
+
+/* ─── Batch 12: Dashboard stat cards ─── */
+.dental-grid-stat-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+/* Full stat card with flex space-between layout (dashboard cards) */
+.dental-stat-card-default {
+  background: var(--mac-bg-primary);
+  border-radius: var(--mac-radius-xl);
+  padding: 24px;
+  box-shadow: var(--mac-shadow-sm);
+  border: 1px solid var(--mac-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  transition: all var(--mac-duration-normal) var(--mac-ease);
+  cursor: default;
+}
+
+/* Stat delta text (xs + small top margin; pair with .dental-text-<color>) */
+.dental-stat-delta {
+  font-size: var(--mac-font-size-xs);
+  margin-top: 4px;
+}
+
+/* ─── Batch 13: Section card + quick action button + appointment row + status badge ─── */
+.dental-section-card {
+  background: var(--mac-bg-primary);
+  border-radius: var(--mac-radius-xl);
+  padding: 24px;
+  box-shadow: var(--mac-shadow-sm);
+  border: 1px solid var(--mac-border);
+}
+
+/* Outline quick-action button (pairs with variant="outline" Button) */
+.dental-quick-action-btn {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 24px;
+  border-radius: var(--mac-radius-lg);
+  box-shadow: var(--mac-shadow-sm);
+  transition: all var(--mac-duration-normal) var(--mac-ease);
+  border: 1px solid var(--mac-border);
+  font-weight: var(--mac-font-weight-medium);
+}
+
+/* Appointment row in "Recent appointments" list */
+.dental-appointment-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px;
+  background: var(--mac-bg-secondary);
+  border-radius: var(--mac-radius-lg);
+  transition: all var(--mac-duration-normal) var(--mac-ease);
+  cursor: default;
+}
+
+/* Status badge — pair with data-status attribute */
+.dental-status-badge {
+  padding: 4px 12px;
+  border-radius: var(--mac-radius-full);
+  font-size: var(--mac-font-size-xs);
+  font-weight: var(--mac-font-weight-medium);
+}
+.dental-status-badge[data-status="confirmed"] {
+  background: var(--mac-success-bg);
+  color: var(--mac-success);
+}
+.dental-status-badge[data-status="pending"] {
+  background: var(--mac-warning-bg);
+  color: var(--mac-warning);
+}
+
+/* ─── Batch 14: Appointments root + table card + appointments header/title + lazy fallback ─── */
+.dental-appointments-root {
+  width: 100%;
+  max-width: none;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+.dental-appointments-card {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+.dental-appointments-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--mac-spacing-4);
+  margin-bottom: var(--mac-spacing-4);
+  flex-wrap: wrap;
+}
+.dental-appointments-title {
+  font-size: var(--mac-font-size-lg);
+  font-weight: var(--mac-font-weight-medium);
+  display: flex;
+  align-items: center;
+  color: var(--mac-text-primary);
+  margin: 0;
+  min-width: min(100%, 260px);
+}
+.dental-lazy-fallback {
+  margin: var(--mac-spacing-4);
+  padding: var(--mac-spacing-4);
+  color: var(--mac-text-secondary);
+  text-align: center;
+}
+
+/* Margin-right 8px (used by inline calendar icon next to title) */
+.dental-mr-8 { margin-right: 8px; }
+
+/* ─── Batch 15: Template cards + protocol cards + reports grid + prosthetic items ─── */
+.dental-grid-auto-fill-280 {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+.dental-grid-auto-fill-240-16 {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+/* Template card (cursor: default, hover transition) */
+.dental-template-card {
+  padding: 16px;
+  border: 1px solid var(--mac-border);
+  border-radius: var(--mac-radius-lg);
+  cursor: default;
+  transition: all var(--mac-duration-normal) var(--mac-ease);
+}
+
+/* Saved protocol card (flex column with gap) */
+.dental-protocol-card-flex {
+  padding: 16px;
+  border: 1px solid var(--mac-border);
+  border-radius: var(--mac-radius-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dental-align-self-start { align-self: flex-start; }
+
+/* Prosthetic row (flex space-between, bg secondary) */
+.dental-prosthetic-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  background: var(--mac-bg-secondary);
+  border-radius: var(--mac-radius-lg);
+  transition: all var(--mac-duration-normal) var(--mac-ease);
+}
+
+/* Icon background with danger-bg fill + large radius */
+.dental-icon-bg-danger-bg { background: var(--mac-danger-bg); }
+.dental-icon-radius-lg { border-radius: var(--mac-radius-lg); }
+
+/* ─── Batch 16: Loading skeleton + modal cards ─── */
+@keyframes dental-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.dental-skeleton-bar {
+  height: 32px;
+  background: var(--mac-bg-secondary);
+  border-radius: var(--mac-radius-md);
+  width: 25%;
+  animation: dental-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+.dental-skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+.dental-skeleton-card {
+  height: 96px;
+  background: var(--mac-bg-secondary);
+  border-radius: var(--mac-radius-md);
+  animation: dental-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+/* Large modal card for dental chart / treatment planner (1152px max width) */
+.dental-modal-card-xl {
+  background: var(--mac-bg-primary);
+  border-radius: var(--mac-radius-xl);
+  padding: 24px;
+  width: 100%;
+  max-width: 1152px;
+  height: 100%;
+  max-height: 90vh;
+  overflow: auto;
+  box-shadow: var(--mac-shadow-xl);
+  border: 1px solid var(--mac-border);
+}

--- a/frontend/src/pages/dentistry.css
+++ b/frontend/src/pages/dentistry.css
@@ -275,3 +275,176 @@
   grid-template-columns: repeat(3, 1fr);
   gap: var(--mac-spacing-3);
 }
+
+/* ─── Batch 9: Text color helpers ─── */
+.dental-text-secondary { color: var(--mac-text-secondary); }
+.dental-text-tertiary  { color: var(--mac-text-tertiary); }
+.dental-text-accent    { color: var(--mac-accent); }
+.dental-text-success   { color: var(--mac-success); }
+.dental-text-warning   { color: var(--mac-warning); }
+.dental-text-danger    { color: var(--mac-danger); }
+.dental-text-blue      { color: var(--mac-accent-blue); }
+.dental-text-purple    { color: var(--mac-accent-purple); }
+.dental-text-orange    { color: var(--mac-accent-orange); }
+.dental-text-on-accent { color: var(--mac-text-on-accent); }
+
+/* ─── Batch 9: Gap utilities ─── */
+.dental-gap-4  { gap: var(--mac-spacing-1); }  /* 4px */
+.dental-gap-8  { gap: var(--mac-spacing-2); }  /* 8px */
+.dental-gap-12 { gap: 12px; }
+.dental-gap-16 { gap: var(--mac-spacing-4); }  /* 16px */
+.dental-gap-24 { gap: 24px; }
+.dental-gap-32 { gap: 32px; }
+
+/* ─── Batch 9: Flex helpers (with explicit gap) ─── */
+.dental-flex-center-12 { display: flex; align-items: center; gap: 12px; }
+.dental-flex-center-16 { display: flex; align-items: center; gap: var(--mac-spacing-4); }
+.dental-flex-between-12 { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.dental-flex-between-16 { display: flex; align-items: center; justify-content: space-between; gap: var(--mac-spacing-4); }
+.dental-flex-wrap { display: flex; flex-wrap: wrap; align-items: center; gap: var(--mac-spacing-2); }
+.dental-flex-row-wrap { display: flex; flex-direction: row; gap: 16px; flex-wrap: wrap; }
+.dental-flex-1 { flex: 1; }
+.dental-min-w-200 { min-width: 200px; }
+
+/* ─── Batch 9: Icon background color variants ─── */
+.dental-icon-bg-blue    { background: var(--mac-accent-blue); }
+.dental-icon-bg-success { background: var(--mac-success); }
+.dental-icon-bg-purple  { background: var(--mac-accent-purple); }
+.dental-icon-bg-warning { background: var(--mac-warning); }
+.dental-icon-bg-danger  { background: var(--mac-danger); }
+.dental-icon-bg-accent  { background: var(--mac-accent); }
+.dental-icon-bg-blue-light { background: var(--mac-accent-blue-bg, rgba(0, 122, 255, 0.12)); }
+.dental-icon-bg-purple-bg { background: var(--mac-accent-purple-bg, rgba(88, 86, 214, 0.12)); }
+.dental-icon-bg-warning-bg { background: var(--mac-warning-bg, rgba(255, 149, 0, 0.12)); }
+.dental-icon-bg-success-bg { background: var(--mac-success-bg, rgba(52, 199, 89, 0.12)); }
+
+/* Icon background with radius + shadow (stat card icons) */
+.dental-icon-bg-xl-shadow {
+  border-radius: var(--mac-radius-xl);
+  box-shadow: var(--mac-shadow-lg);
+}
+.dental-icon-bg-lg-shadow {
+  border-radius: var(--mac-radius-lg);
+  box-shadow: var(--mac-shadow-sm);
+}
+.dental-icon-bg-full { border-radius: var(--mac-radius-full); }
+
+/* ─── Batch 9: Grid utilities ─── */
+.dental-grid-auto-fill-250 {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: var(--mac-spacing-4);
+}
+.dental-grid-auto-fill-200 {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--mac-spacing-3);
+}
+
+/* ─── Batch 9: Padding helpers ─── */
+.dental-p-8px  { padding: 8px; }
+.dental-p-16px { padding: 16px; }
+
+/* ─── Batch 9: Font weight medium ─── */
+.dental-fw-medium { font-weight: var(--mac-font-weight-medium); }
+
+/* ─── Batch 9: Stat card layout ─── */
+.dental-stat-card-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.dental-stat-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* ─── Batch 9: Quick action button (with icon + label) ─── */
+.dental-quick-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--mac-border);
+  border-radius: var(--mac-radius-lg);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+/* ─── Batch 9: Appointment item ─── */
+.dental-appointment-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px;
+  border: 1px solid var(--mac-border);
+  border-radius: var(--mac-radius-lg);
+}
+
+/* ─── Batch 9: Search wrapper ─── */
+.dental-search-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 200px;
+}
+.dental-search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--mac-text-tertiary);
+  pointer-events: none;
+}
+
+/* ─── Batch 9: Modal / overlay ─── */
+.dental-modal-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background-color: color-mix(in srgb, var(--mac-bg-primary), black 42%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+.dental-modal-card {
+  background-color: var(--mac-card-bg);
+  border: 1px solid var(--mac-card-border);
+  border-radius: 12px;
+  padding: 24px;
+  width: 100%;
+  max-width: 500px;
+  margin: 16px;
+  box-shadow: var(--mac-shadow-xl);
+}
+
+/* ─── Batch 9: Section description paragraph ─── */
+.dental-section-desc {
+  color: var(--mac-text-secondary);
+  margin: 0;
+}
+
+/* ─── Batch 9: List item with icon ─── */
+.dental-list-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border: 1px solid var(--mac-border);
+  border-radius: var(--mac-radius-md);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.dental-list-item:hover {
+  background: var(--mac-fill-quaternary);
+}
+
+/* ─── Batch 9: Error/empty state ─── */
+.dental-error-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 48px;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary

Completes the CSS migration for **DentistPanelUnified.jsx**: 174 → **0** inline `style={{}}` blocks (−100%). This is the 4th panel to be fully migrated, following RegistrarPanel, CashierPanel, and DoctorPanel.

## Changes

### DentistPanelUnified.jsx — 174 → 0 inline blocks (−100%)

6 batches (9-14) across 6 commits:

| Batch | Commit | What was done | Δ |
|---|---|---|---|
| 9 | `413934b` | Text colors + gaps + icon bg + flex | −78 |
| 10 | `ab6c2e8` | Flex+grid+modal patterns | −22 |
| 11 | `6bf6342` | Remaining flex/grid/position patterns | −28 |
| 12 | `0f3435c` | Dashboard stat cards + quick actions + appointment list | −15 |
| 13 | `a7605f6` | Search icon + action buttons + appointments header + 3 style constants removed | −12 |
| 14 | `cc56cd1` | Templates + protocols + reports + prosthetics + skeleton + modals | −18 |

### dentistry.css — 277 → 661 lines (+384)

~80 utility classes total (was ~30), all using `var(--mac-*)` tokens. New classes organized in 6 batch sections:
- Text color helpers (secondary, tertiary, accent, success, warning, danger, blue, purple, orange, on-accent)
- Gap utilities (4, 8, 12, 16, 24, 32px)
- Flex helpers (center-12, center-16, between-12, between-16, wrap, row-wrap, flex-1, min-w-200)
- Icon background color variants (blue, success, purple, warning, danger, accent, *-bg, *-light) + radius/shadow variants
- Grid utilities (auto-fill-250, auto-fill-200, auto-fit, 2col, 3col, span-2)
- Stat card, procedure card, quick action, appointment item, search wrapper, modal overlay/card, list item, error state
- `@keyframes dental-pulse` (the original inline `animation: 'pulse ...'` referenced a keyframes not defined in any globally-imported CSS)

### Other changes

- Removed 3 module-scope style constants: `DENTISTRY_LAZY_FALLBACK_STYLE`, `dentistryAppointmentsHeaderStyle`, `dentistryAppointmentsTitleStyle`
- Used CSS attribute selectors (`[data-status="confirmed"]` / `[data-status="pending"]`) for dynamic status badge colors (matches the doctor-panel Phase 3 pattern)
- DentistPanelUnified.jsx: 3686 → 3323 lines (−363, −10%)

## Cyclic Execution Evidence
- Fresh main sync: branch `refactor/dentist-css-final` created from `origin/main` at commit `c02631e3`
- Clean workspace: only `DentistPanelUnified.jsx` and `dentistry.css` touched
- Branch: `refactor/dentist-css-final`
- Scope gate: allowed dentist panel + its CSS file; denied backend, migrations, other panels
- Red-check handling: full vitest suite run (517/517 passing) after each batch; will fix any failing CI checks in this same PR before merge

## Contract Impact
- Canonical surface: not applicable - no backend contract changes (CSS class substitutions only)
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: DentistPanelUnified.jsx (style attribute to className, no behavioral change); 3 style constants removed (replaced by CSS classes)
- Compatibility path or alias: not applicable - no API contract touched in this PR
- Contract proof: full suite 517/517 passing

## RBAC / Permissions
- Roles allowed: dentist (unchanged)
- Roles denied: all others (unchanged)
- Positive auth proof: routeRegistry.js unchanged; routeGuards.jsx unchanged
- Negative auth proof: not applicable - no changes to route role arrays or guard logic

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed. All changes are CSS class substitutions and style constant removals.

## Frontend Resilience
- Empty data proof: not applicable - CSS class changes do not affect data handling
- Partial data proof: not applicable - CSS class changes do not affect data fetching
- Forbidden secondary path behavior: not applicable - no new code paths introduced
- Missing draft/resource behavior: not applicable - CSS class substitutions only
- Stale route/deep-link behavior: not applicable - URL contract unchanged; only style attributes changed

## Scope Gate
- Allowed paths: `frontend/src/pages/DentistPanelUnified.jsx`, `frontend/src/pages/dentistry.css`
- Denied paths: backend Python files, database migrations, other frontend panels, ESLint config, routing files
- Migration/docs/test impact: no migration; CSS file updated; no test changes needed
- Rollback note: revert 6 commits on this branch; no database state to revert; no feature flags to disable

## Validation
- Targeted tests or smoke run: full vitest suite (106 test files, 517 tests) passes locally
- Result: passed (517/517, 0 regressions vs main baseline)
- Not checked: visual regression (manual visual QA recommended for CSS class changes - dentist dashboard, appointments, tooth chart, procedures, prosthetics, templates, reports)
- Manual checks performed locally:
  - `grep -c 'style={{' frontend/src/pages/DentistPanelUnified.jsx` -> **0**
  - `wc -l frontend/src/pages/DentistPanelUnified.jsx` -> 3323 (was 3686)
  - `wc -l frontend/src/pages/dentistry.css` -> 661 (was 277)
  - `grep -rn '#[0-9a-fA-F]\{3,8\}' frontend/src/pages/dentistry.css` -> 0 hardcoded hex colors
  - `grep -rn 'var(--color-' frontend/src/pages/dentistry.css` -> 0 legacy color vars

## Related

- Audit PDF: `download/UX_UI_Audit_Registrar_Panel_MediClinic_Pro.pdf` (original 5.2/10)
- Prior panel migrations: #1792 (CashierPanel + DoctorPanel), #1803 (RegistrarPanel Phase 2+3)
- Follow-up: DermatologistPanelUnified (151 inline styles), DisplayBoardUnified (55), CardiologistPanelUnified (15), LabPanel (11), PatientPanel (7)
