### PR TITLE
fix(qr_queue): visit_id is None → is_(None) for SQL filter (backend test fix)

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -1472,7 +1472,7 @@ def full_update_online_entry(
             # entries as already having the requested services.
             session_filters = [
                 DailyQueue.day == queue_day,
-                OnlineQueueEntry.visit_id is None,
+                OnlineQueueEntry.visit_id.is_(None),
                 OnlineQueueEntry.status.in_(["waiting", "called", "in_service"]),
             ]
             session_label = None


### PR DESCRIPTION
## Summary

- Fixed failing backend CI/CD test: `test_full_update_without_visit_id_matches_same_session_phone_digits`.
- **Root cause**: `OnlineQueueEntry.visit_id is None` is a Python expression that always evaluates to `False`, not a SQL `IS NULL` filter. This meant the session aggregation query never matched any entries, so existing service `queue_time` was not preserved during full-update.
- **Fix**: changed to `OnlineQueueEntry.visit_id.is_(None)` — proper SQLAlchemy IS NULL filter.

## Cyclic Execution Evidence

- Fresh main sync: ветка от main после merge PR #1802 (gitleaks allowlist).
- Clean workspace: 1 файл (qr_queue.py, 1 line changed).
- Branch: fix/qr-queue-visit-id-is-none-sql
- Scope gate: allowed только 1-line SQL filter fix; denied любые другие.
- Red-check handling: all 22 qr_queue tests pass (test_qr_queue_full_update + test_qr_queue_join + test_online_queue_scenarios).

## Contract Impact

- Canonical surface: PUT /api/v1/queue/online-entry/{id}/full-update
- Request shape: не применимо - bug fix in internal query
- Response shape: queue_time now correctly preserved from existing entries (was being overwritten with current time)
- Status codes: не применимо
- Frontend consumer: registrar panel, QR queue management
- Compatibility path or alias: не применимо - bug fix
- Contract proof: 22 qr_queue tests pass

## RBAC / Permissions

- Roles allowed: не применимо - internal query fix
- Roles denied: не применимо
- Positive auth proof: не применимо
- Negative auth proof: не применимо

## Notification / Realtime

not applicable - internal query fix, event type / websocket channel / payload version / delivery semantics / reconnect не затронуты.

## Frontend Resilience

- Empty data proof: не применимо.
- Partial data proof: не применимо.
- Forbidden secondary path behavior: не применимо.
- Missing draft/resource behavior: не применимо.
- Stale route/deep-link behavior: не применимо.

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/qr_queue.py
- Denied paths: любые другие файлы
- Migration/docs/test impact: нет
- Rollback note: revert восстанавливает broken SQL filter

## DevBrain Memory Impact

not applicable - bug fix.

## Validation

- Targeted tests or smoke run: `pytest tests/integration/test_qr_queue_full_update.py tests/integration/test_qr_queue_join.py tests/integration/test_online_queue_scenarios.py`
- Result: 22/22 passed
- Not checked: full CI/CD pipeline — будет запущен на PR
