### PR TITLE
fix: V4 syntax errors + Sentry release CI + health endpoint

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -1,0 +1,93 @@
+name: 📦 Sentry Release + Source Maps
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/src/**'
+      - 'frontend/package.json'
+      - 'frontend/package-lock.json'
+      - 'frontend/vite.config.js'
+      - '.github/workflows/sentry-release.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sentry-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sentry-release:
+    name: 📦 Build + upload source maps to Sentry
+    runs-on: ubuntu-latest
+    # Only run if SENTRY_AUTH_TOKEN secret is set (skip otherwise — no-op)
+    if: ${{ vars.ENABLE_SENTRY_RELEASE == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps
+        run: |
+          cd frontend
+          npm ci
+
+      - name: Install @sentry/vite-plugin (if not in package.json)
+        run: |
+          cd frontend
+          if ! npm ls @sentry/vite-plugin >/dev/null 2>&1; then
+            echo "Installing @sentry/vite-plugin (dev dependency)..."
+            npm install --save-dev @sentry/vite-plugin@^5.3.0
+          else
+            echo "@sentry/vite-plugin already installed."
+          fi
+
+      - name: Build with Sentry source map upload
+        env:
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_SENTRY_ENV: production
+          VITE_APP_VERSION: ${{ github.sha }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          cd frontend
+          npm run build
+
+      - name: Create Sentry release
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          # Install sentry CLI
+          curl -sL https://sentry.io/get-cli/ | bash
+
+          # Create a new release
+          VERSION="clinic-frontend@${GITHUB_SHA::7}"
+          sentry-cli releases new "$VERSION" --project "$SENTRY_PROJECT"
+
+          # Finalize the release
+          sentry-cli releases finalize "$VERSION"
+
+          # Set commits for the release (links git commits to Sentry issues)
+          sentry-cli releases set-commits "$VERSION" --auto
+
+          echo "✅ Sentry release $VERSION created and finalized."
+
+      - name: Notify on failure
+        if: failure()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            console.log('Sentry release failed. Check if SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT secrets are set.');
+            console.log('To enable: Settings → Secrets and variables → Actions → add the 3 secrets.');
+            console.log('Then set repository variable ENABLE_SENTRY_RELEASE=true to activate this workflow.');

--- a/backend/alembic/versions/0021_printing_tables.py
+++ b/backend/alembic/versions/0021_printing_tables.py
@@ -330,7 +330,6 @@ def upgrade() -> None:
     if bind.dialect.name == "postgresql":
         for table_name in ("printer_configs", "print_templates", "print_jobs"):
             op.execute(
-                sa.text(
                 sa.text(  # nosec B608 — Alembic migration DDL, table name hardcoded in migration script
                     f"""
                     SELECT setval(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -301,6 +301,92 @@ def root():
 
 
 # -----------------------------------------------------------------------------
+# Comprehensive health check — for uptime monitoring + load balancer probes
+# -----------------------------------------------------------------------------
+@app.get(f"{API_V1_STR}/health/detailed", tags=["health"])
+def detailed_health():
+    """Comprehensive health check for uptime monitoring (e.g. UptimeRobot, BetterStack).
+
+    Returns status of all subsystems. If any critical subsystem is down,
+    returns HTTP 503 (suitable for load balancer health checks).
+
+    Light check — does NOT hit external services (Sentry, Telegram API).
+    Only checks local DB + Redis connectivity.
+
+    Public endpoint (no auth) — safe to expose to uptime monitors.
+    """
+    import time
+    from datetime import datetime
+
+    checks = {}
+    overall_ok = True
+
+    # 1. Database
+    try:
+        from sqlalchemy import text as sql_text
+        from app.db.session import SessionLocal
+        db = SessionLocal()
+        try:
+            db.execute(sql_text("SELECT 1"))
+            checks["database"] = {"status": "ok"}
+        finally:
+            db.close()
+    except Exception as e:
+        checks["database"] = {"status": "down", "error": str(e)[:100]}
+        overall_ok = False
+
+    # 2. Redis (optional — may not be configured in dev)
+    try:
+        import redis
+        from app.core.config import settings
+        redis_url = getattr(settings, "ARQ_REDIS_URL", "redis://localhost:6379/0")
+        r = redis.from_url(redis_url, socket_connect_timeout=2, socket_timeout=2)
+        r.ping()
+        checks["redis"] = {"status": "ok"}
+    except Exception as e:
+        # Redis is optional in dev — don't fail health check
+        checks["redis"] = {"status": "skipped", "reason": "not configured or unreachable"}
+
+    # 3. Sentry SDK (check if initialized, don't send event)
+    try:
+        import sentry_sdk
+        client = sentry_sdk.Hub.current.client
+        checks["sentry"] = {"status": "ok" if client else "disabled"}
+    except Exception:
+        checks["sentry"] = {"status": "disabled"}
+
+    # 4. App version + environment
+    checks["app"] = {
+        "version": os.getenv("APP_VERSION", "0.9.0"),
+        "env": os.getenv("ENV", "dev"),
+        "python": sys.version.split()[0] if 'sys' in dir() else "?",
+    }
+
+    # 5. Uptime (approximate — process start time)
+    checks["uptime_seconds"] = int(time.time() - _app_start_time) if _app_start_time else 0
+
+    response = {
+        "status": "ok" if overall_ok else "degraded",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "checks": checks,
+    }
+
+    from fastapi import Response
+    if not overall_ok:
+        return Response(
+            content=json.dumps(response),
+            status_code=503,
+            media_type="application/json",
+        )
+    return response
+
+
+# Track app start time for uptime calculation
+import time as _time
+_app_start_time = _time.time()
+
+
+# -----------------------------------------------------------------------------
 # Диагностика подключённых маршрутов (called from lifespan)
 # -----------------------------------------------------------------------------
 async def _startup_tasks() -> None:

--- a/backend/app/scripts/audit_data.py
+++ b/backend/app/scripts/audit_data.py
@@ -63,7 +63,6 @@ def count_orphans(conn, child_t, child_c, parent_t, parent_c="id"):
     insp = sa.inspect(conn)
     if not table_has(insp, child_t, child_c) or not table_has(insp, parent_t, parent_c):
         return None
-    q = sa.text(
     q = sa.text(  # nosec B608 — audit script with hardcoded table names, no user input
         f"""
         SELECT COUNT(*) AS cnt

--- a/backend/app/scripts/audit_foreign_keys.py
+++ b/backend/app/scripts/audit_foreign_keys.py
@@ -83,7 +83,6 @@ def check_orphaned_records(
 ) -> int:
     """Return the orphaned-row count for one FK relationship."""
     try:
-        query = text(
         query = text(  # nosec B608 — FK audit script with hardcoded table names, no user input
             f"""
             SELECT COUNT(*) as count

--- a/backend/app/scripts/migrate_sqlite_to_postgres.py
+++ b/backend/app/scripts/migrate_sqlite_to_postgres.py
@@ -611,7 +611,6 @@ def migrate_sqlite_to_postgres(
 
                 if not dry_run and plan.primary_keys == ("id",):
                     target_connection.execute(
-                        text(
                         text(  # nosec B608 — one-shot SQLite→PG migration script, hardcoded queries
                             f"""
                             SELECT setval(


### PR DESCRIPTION
## Summary

Three related fixes in one PR:
1. **CRITICAL**: Fix syntax errors in V4 bandit nosec placements (broke Backend CI on main)
2. Sentry release + source map upload CI workflow
3. Comprehensive health endpoint for uptime monitoring

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/v6-syntax-errors-sentry-release-health` based on `main @ b260bd04`
- Clean workspace: 2 commits, 6 files (4 modified + 1 new + 1 new workflow)
- Branch: fix/v6-syntax-errors-sentry-release-health → main
- Scope gate: allowed backend/alembic/versions/0021_printing_tables.py, backend/app/scripts/{audit_data,audit_foreign_keys,migrate_sqlite_to_postgres}.py, backend/app/main.py, .github/workflows/sentry-release.yml; denied touching frontend source
- Red-check handling: will fix any CI failures before merge

## Contract Impact

- Canonical surface: GET /api/v1/health/detailed (NEW endpoint, no breaking change to existing / or /api/v1/health)
- Request shape: not applicable - GET, no params, no body
- Response shape: not applicable - new endpoint, no existing consumers to break
- Status codes: not applicable - new endpoint, 200/503 only
- Frontend consumer: not applicable - endpoint for uptime monitors, not frontend
- Compatibility path or alias: not applicable - new endpoint, no existing consumers
- Contract proof: endpoint is public (no auth), returns JSON, follows existing /api/v1/health pattern

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. New health endpoint is public (same as existing / and /api/v1/health).

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed. Only backend syntax fixes + new backend endpoint + new CI workflow.

## Scope Gate

- Allowed paths: backend/alembic/versions/0021_printing_tables.py, backend/app/scripts/{audit_data,audit_foreign_keys,migrate_sqlite_to_postgres}.py, backend/app/main.py, .github/workflows/sentry-release.yml
- Denied paths: frontend/src/, backend/app/api/v1/endpoints/ (except main.py), backend/app/models/, backend/app/services/
- Migration/docs/test impact: no migrations; no docs; no test changes (syntax fix only + new endpoint)
- Rollback note: single commit revert via `git revert 6e5db844`

## Validation

- Targeted tests or smoke run: verified all 4 syntax-fixed files pass `python3 -c "import ast; ast.parse(open(f).read())"`; verified main.py syntax OK
- Result: pending CI on this PR
- Not checked: actual endpoint response (requires running backend with DB)

## What's in this PR

### 1. Fix syntax errors in V4 bandit nosec placements (CRITICAL)

V4 (PR #1788) added `nosec B608` comments to 4 files. The placement script inserted duplicate `sa.text(` / `text(` lines:

- `backend/alembic/versions/0021_printing_tables.py:332` — double `sa.text(`
- `backend/app/scripts/audit_data.py:67` — double `sa.text(`
- `backend/app/scripts/audit_foreign_keys.py:87` — double `text(`
- `backend/app/scripts/migrate_sqlite_to_postgres.py:614` — double `text(`

This caused `SyntaxError: '(' was never closed` → `alembic upgrade head` failed → Backend тесты CI failed on every push to main since V4.

Fix: removed the duplicate `text(` / `sa.text(` line, kept the nosec comment on the correct line.

### 2. Sentry release + source map upload CI workflow

New `.github/workflows/sentry-release.yml`:
- Triggers on push to main when `frontend/src/**` changes
- Builds frontend with `@sentry/vite-plugin` (auto-installs if missing from package.json)
- Creates Sentry release tagged with git SHA
- Uploads source maps → Sentry can de-minify stack traces
- Sets commits → Sentry links issues to git commits

**Gated by repository variable `ENABLE_SENTRY_RELEASE=true`** (default: off). Safe to merge without activation.

### 3. Comprehensive health endpoint

New `GET /api/v1/health/detailed` endpoint in `backend/app/main.py`:
- Checks DB connectivity (`SELECT 1`)
- Checks Redis (optional — `skipped` if not configured)
- Checks Sentry SDK init status
- Returns app version + environment + uptime
- HTTP 200 if all critical checks pass, HTTP 503 if DB is down
- Public (no auth) — safe for uptime monitors

## Test plan

- [ ] CI passes — especially 🐍 Backend тесты (was failing with SyntaxError)
- [ ] After merge: `curl /api/v1/health/detailed` returns 200 with subsystem status
- [ ] After merge + secrets set: Sentry release workflow creates release on next frontend push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
