### PR TITLE
fix(derma): add missing closing </div> for tab content wrapper

### DIFF
--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -1949,6 +1949,9 @@ const DermatologistPanelUnified = () => {
               getSpacing={getSpacing}
             />
           }
+
+        </div>{/* End of tab content wrapper */}
+
         {/* Модальное окно Schedule Next */}
         {scheduleNextModal.open &&
         <ScheduleNextModal


### PR DESCRIPTION
## Summary

- Fix: DermaHistoryTab extraction removed a wrapping </div> for the tab content container. Added it back.
- div balance: 55/55 (was 55/54).

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main.
- Clean workspace: DermatologistPanelUnified.jsx only.
- Branch: fix/derma-missing-div
- Scope gate: allowed dermatologist panel only.
- Red-check handling: fix failed CI in this PR.

## Contract Impact

- Canonical surface: DermatologistPanelUnified (frontend-only).
- Request shape: no API change.
- Response shape: identical — just a closing HTML tag.
- Status codes: not applicable - React component, no HTTP.
- Frontend consumer: DermatologistPanelUnified.
- Compatibility path or alias: no prop changes.
- Contract proof: frontend build validates JSX is valid.

## RBAC / Permissions

not applicable - no role gating changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no new events.
- Payload version / ack behavior: not applicable - no payloads.
- Read/unread or delivery semantics: not applicable - no message queue.
- Reconnect/resync proof: not applicable - no realtime.

## Frontend Resilience

- Empty data proof: not applicable - structural fix, no data dependency.
- Partial data proof: not applicable.
- Forbidden secondary path behavior: not applicable.
- Missing draft/resource behavior: not applicable.
- Stale route/deep-link behavior: not applicable.

## Scope Gate

- Allowed paths: DermatologistPanelUnified.jsx.
- Denied paths: all other files.
- Migration/docs/test impact: none.
- Rollback note: revert single commit.

## Validation

- Targeted tests or smoke run: awaiting CI - frontend lint, unit tests, build.
- Result: pending.
- Not checked: visual regression.

Generated with Claude Code