### PR TITLE
fix(dental): render confirmDialog + sessionWarning in JSX

### DIFF
--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -3331,6 +3331,43 @@ const DentistPanelUnified = () => {
         position="bottom-right" />
 
       <RoleNotificationCenter userRole="dentist" />
+
+      {/* C-1 (UX audit): portal-mounted ConfirmDialog */}
+      {confirmDialog}
+
+      {/* C-2 (UX audit): session timeout warning dialog */}
+      {sessionWarning && (
+        <div
+          role="alertdialog"
+          aria-label="Предупреждение об истечении сессии"
+          style={{
+            position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+            background: 'rgba(0,0,0,0.5)', display: 'flex',
+            alignItems: 'center', justifyContent: 'center', zIndex: 10000,
+          }}
+        >
+          <div style={{
+            background: 'var(--mac-surface, white)', border: '1px solid var(--mac-border, #d8dde8)',
+            borderRadius: '12px', padding: '24px', maxWidth: '420px', width: '90%',
+          }}>
+            <h3 style={{ margin: '0 0 12px 0', fontSize: '18px', color: 'var(--mac-text-primary, #1a1d29)' }}>
+              Сессия скоро истечёт
+            </h3>
+            <p style={{ margin: '0 0 16px 0', fontSize: '14px', color: 'var(--mac-text-secondary, #6b7280)', lineHeight: 1.5 }}>
+              Ваша сессия истекает. Несохранённые данные могут быть потеряны.
+              Сохраните текущий приём или продлите сессию.
+            </p>
+            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+              <button onClick={() => setSessionWarning(null)} style={{ padding: '8px 16px', border: '1px solid var(--mac-border, #d8dde8)', borderRadius: '6px', background: 'transparent', cursor: 'pointer', fontSize: '14px' }}>
+                Позже
+              </button>
+              <button onClick={() => { setSessionWarning(null); notify.info('Продлеваем сессию...'); }} style={{ padding: '8px 16px', border: 'none', borderRadius: '6px', background: 'var(--mac-accent, #dc2626)', color: 'white', cursor: 'pointer', fontSize: '14px' }}>
+                Продлить сессию
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>);
 
 };


### PR DESCRIPTION
## Summary

- Fix: previous commit (PR #1824) added useConfirm and useSessionTimeoutWarning hooks but forgot to render their dialog portals in JSX. Without this, confirm dialog before completeVisit would never appear.
- Added {confirmDialog} and session timeout warning modal to the main component JSX.

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main.
- Clean workspace: DentistPanelUnified.jsx only.
- Branch: feature/dental-r15-extraction
- Scope gate: allowed dental panel only.
- Red-check handling: fix failed CI in this PR.

## Contract Impact

- Canonical surface: DentistPanelUnified (frontend-only).
- Request shape: no API change.
- Response shape: confirm dialog and session warning now render visually.
- Status codes: not applicable - React component, no HTTP.
- Frontend consumer: DentistPanelUnified.
- Compatibility path or alias: uses shared useConfirm hook (same as cardio).
- Contract proof: frontend build validates JSX is valid.

## RBAC / Permissions

not applicable - no role gating changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - no new events.
- Payload version / ack behavior: not applicable - no payloads.
- Read/unread or delivery semantics: not applicable - no message queue.
- Reconnect/resync proof: not applicable - no realtime.

## Frontend Resilience

- Empty data proof: not applicable - dialogs are triggered by user actions or timer.
- Partial data proof: not applicable.
- Forbidden secondary path behavior: not applicable.
- Missing draft/resource behavior: not applicable.
- Stale route/deep-link behavior: not applicable.

## Scope Gate

- Allowed paths: DentistPanelUnified.jsx.
- Denied paths: all other files.
- Migration/docs/test impact: none.
- Rollback note: revert single commit.

## Validation

- Targeted tests or smoke run: awaiting CI - frontend lint, unit tests, build.
- Result: pending.
- Not checked: manual confirm dialog test.

Generated with Claude Code