### PR TITLE
fix(admin): Sprint 1 P0 — silent regressions & data-integrity fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 2026-07-04 — Admin Sprint 1: P0 silent regressions & data-integrity fixes (fix/admin-sprint1-p0-silent-regressions)
+
+### Void codemod damage — phantom `useState` / `useTheme` (3 files)
+Auto-codemod `const X = useState(...)` → `void useState(...)` left syntax artifacts in 3 live admin files. Removed the phantom lines (the deleted state vars were genuinely unused — codemod was right to remove the binding, wrong to leave the call dangling).
+
+- **`BillingManager.jsx:99–100`** — removed `void\nuseState(null);` (was `selectedInvoice`, unused — `paymentForm.invoice_id` already tracks the target invoice).
+- **`DiscountBenefitsManager.jsx:57–58`** — removed `void\nuseState(null);` (was `editingItem`, unused — create-form is the only flow).
+- **`UnifiedFinance.jsx:44–45`** — removed `void\nuseTheme();` (same fix as `UnifiedNotifications` in Step 3 PR #1830).
+
+Note: 3 other files (`WebhookManager.jsx:55–56`, `DynamicPricingManager.jsx:178–179`, `DisplayBoardSettings.jsx:35,40`) have `const [, setX] = useState(...)` — valid JS, setters are called but UI was never implemented. Not P0 (never-implemented feature, not a codemod break). Deferred to P2 cleanup.
+
+### Raw `fetch()` → axios migration (2 files, P0 security)
+`TelegramSettings.jsx` (7 call sites) and `GraphQLExplorer.jsx` (2 call sites) used raw `fetch()` with manual `Bearer ${tokenManager.getAccessToken()}` headers, bypassing the axios instance's auth-refresh interceptor. On access-token rotation this would silently send a stale token → 401 → silent failure.
+
+- **`TelegramSettings.jsx`** — migrated `loadData` (3 GETs via `Promise.allSettled`), `saveSettings` (PUT), `testBot` (POST), `setWebhook` (POST), `sendTestMessage` (POST) to `api.get/put/post`. Removed `tokenManager` import, added `import { api } from '../../api/client'`.
+- **`GraphQLExplorer.jsx`** — migrated `loadSchema` (POST introspection) and `executeQuery` (POST query) to `api.post('/graphql', ...)`. Removed `tokenManager` import.
+
+### Fake-data fallback removal (2 files, P0 data integrity)
+On API failure, 2 admin components showed fabricated numbers — admin saw a "healthy" dashboard when the backend was down.
+
+- **`ClinicManagement.jsx:75–84, 100–109`** — removed hardcoded fallback `{ total_branches: 3, active_licenses: 7, total_backups: 12, ... }`. On API error now sets `stats = null` / `systemHealth = null`, which triggers the existing `<MacOSEmptyState title="Статистика недоступна" />` and the `systemHealth ?` guard.
+- **`MedicalEquipmentManager.jsx:67–90, 100–112, 124–146`** — removed 3 mock-fallback blocks (devices: "Тонометр Omron M3" / "Термометр Braun"; overview: 2 devices / 15 measurements; measurements: fabricated BP/thermometer readings). On API error now sets empty arrays / zero-defaults overview. Admin no longer risks acting on fabricated equipment data.
+
+Verification:
+- `vite build` → ✓ built in ~25s, exit 0, all chunks emitted.
+- `vitest run` → ✓ 515/515 tests pass across 105 test files.
+- `eslint` on 7 modified files → 0 errors (1 pre-existing warning unchanged).
+- `grep` for `fetch(` / `tokenManager` in TelegramSettings + GraphQLExplorer → 0 matches.
+
 ## 2026-07-04 — Admin panel dead-code cleanup — Step 3 (chore/admin-step3-wire-and-delete)
 - **Wire-in: `UnifiedNotifications` → `/admin/push-notifications`** (new route). Restores 2 admin functions that had live backend endpoints but dead frontend UI:
   - **FCM push notifications** (`FCMManager.jsx`, 521 lines) — `/fcm/status`, `/fcm/user-tokens`, `/fcm/send-test-notification`, `/fcm/send-notification` endpoints.

--- a/frontend/src/components/admin/BillingManager.jsx
+++ b/frontend/src/components/admin/BillingManager.jsx
@@ -96,8 +96,7 @@ const BillingManager = () => {
   const [, setSettings] = useState(null);
   const [loading, setLoading] = useState(false);
   const [showCreateInvoice, setShowCreateInvoice] = useState(false);
-  const [showRecordPayment, setShowRecordPayment] = useState(false);void
-  useState(null);
+  const [showRecordPayment, setShowRecordPayment] = useState(false);
 
   // Форма для создания счета
   const [invoiceForm, setInvoiceForm] = useState({

--- a/frontend/src/components/admin/ClinicManagement.jsx
+++ b/frontend/src/components/admin/ClinicManagement.jsx
@@ -70,50 +70,27 @@ const ClinicManagement = () => {
       api.get('/clinic/health').catch((err) => Promise.reject(err))]
       );
 
+      // P0 fix: removed hardcoded fake-stats fallback. On API failure, set null
+      // so the existing <MacOSEmptyState title="Статистика недоступна" /> renders
+      // instead of fabricated numbers (admin was seeing "3 branches, 8 licenses,
+      // 12 backups" even when the backend was down).
       if (statsResponse.status === 'fulfilled') {
         setStats(statsResponse.value.data);
       } else {
         logger.error('Ошибка загрузки статистики:', statsResponse.reason);
-        // Fallback данные для статистики
-        setStats({
-          total_branches: 3,
-          active_branches: 3,
-          total_equipment: 15,
-          active_equipment: 14,
-          total_licenses: 8,
-          active_licenses: 7,
-          total_backups: 12,
-          recent_backups: 3
-        });
+        setStats(null);
       }
 
       if (healthResponse.status === 'fulfilled') {
         setSystemHealth(healthResponse.value.data);
       } else {
         logger.error('Ошибка загрузки состояния системы:', healthResponse.reason);
-        // Fallback данные для состояния системы
-        setSystemHealth({
-          status: 'healthy',
-          warnings: []
-        });
+        setSystemHealth(null);
       }
     } catch (error) {
       logger.error('Ошибка загрузки данных системы:', error);
-      // Fallback данные при ошибке
-      setStats({
-        total_branches: 3,
-        active_branches: 3,
-        total_equipment: 15,
-        active_equipment: 14,
-        total_licenses: 8,
-        active_licenses: 7,
-        total_backups: 12,
-        recent_backups: 3
-      });
-      setSystemHealth({
-        status: 'healthy',
-        warnings: []
-      });
+      setStats(null);
+      setSystemHealth(null);
       setMessage({ type: 'error', text: 'Ошибка загрузки данных системы' });
     } finally {
       setLoading(false);

--- a/frontend/src/components/admin/DiscountBenefitsManager.jsx
+++ b/frontend/src/components/admin/DiscountBenefitsManager.jsx
@@ -54,8 +54,7 @@ const DiscountBenefitsManager = () => {
   const [benefits, setBenefits] = useState([]);
   const [loyaltyPrograms, setLoyaltyPrograms] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [showCreateForm, setShowCreateForm] = useState(false);void
-  useState(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
   const [analytics, setAnalytics] = useState(null);
 
   // Формы для создания/редактирования

--- a/frontend/src/components/admin/GraphQLExplorer.jsx
+++ b/frontend/src/components/admin/GraphQLExplorer.jsx
@@ -21,8 +21,8 @@ import {
 'lucide-react';
 import { toast } from 'react-toastify';
 
+import { api } from '../../api/client';
 import logger from '../../utils/logger';
-import tokenManager from '../../utils/tokenManager';
 
 const GraphQLExplorer = () => {
   const [activeTab, setActiveTab] = useState('explorer');
@@ -278,36 +278,26 @@ const GraphQLExplorer = () => {
 
   const loadSchema = async () => {
     try {
-      const accessToken = tokenManager.getAccessToken();
-      const response = await fetch('/api/graphql', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {})
-        },
-        body: JSON.stringify({
-          query: `
-            query IntrospectionQuery {
-              __schema {
-                types {
+      const { data } = await api.post('/graphql', {
+        query: `
+          query IntrospectionQuery {
+            __schema {
+              types {
+                name
+                description
+                fields {
                   name
                   description
-                  fields {
+                  type {
                     name
-                    description
-                    type {
-                      name
-                    }
                   }
                 }
               }
             }
-          `
-        })
+          }
+        `
       });
-
-      if (response.ok) {
-        const data = await response.json();
+      if (data?.data?.__schema) {
         setSchema(data.data.__schema);
       }
     } catch (error) {
@@ -335,19 +325,10 @@ const GraphQLExplorer = () => {
         }
       }
 
-      const response = await fetch('/api/graphql', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${tokenManager.getAccessToken()}`
-        },
-        body: JSON.stringify({
-          query: query,
-          variables: parsedVariables
-        })
+      const { data } = await api.post('/graphql', {
+        query,
+        variables: parsedVariables
       });
-
-      const data = await response.json();
       setResult(data);
 
       if (data.errors) {

--- a/frontend/src/components/admin/MedicalEquipmentManager.jsx
+++ b/frontend/src/components/admin/MedicalEquipmentManager.jsx
@@ -64,30 +64,12 @@ const MedicalEquipmentManager = () => {
       const response = await api.get('/medical-equipment/devices');
       setDevices(response.data.devices || []);
     } catch (error) {
+      // P0 fix: removed mock-device fallback. Was showing fabricated "Тонометр
+      // Omron M3" / "Термометр Braun" devices on API failure — admin could act
+      // on non-existent equipment. Now shows empty list (existing MacOSEmptyState
+      // renders "Нет устройств").
       logger.error('Ошибка загрузки устройств:', error);
-      // Fallback данные для демонстрации
-      setDevices([
-      {
-        id: 1,
-        name: 'Тонометр Omron M3',
-        device_type: 'blood_pressure',
-        manufacturer: 'Omron',
-        model: 'M3',
-        serial_number: 'OMR001',
-        status: 'online',
-        location: 'Кабинет 1'
-      },
-      {
-        id: 2,
-        name: 'Термометр Braun',
-        device_type: 'thermometer',
-        manufacturer: 'Braun',
-        model: 'ThermoScan 7',
-        serial_number: 'BRN002',
-        status: 'offline',
-        location: 'Кабинет 2'
-      }]
-      );
+      setDevices([]);
     } finally {
       setLoading(false);
     }
@@ -98,17 +80,16 @@ const MedicalEquipmentManager = () => {
       const response = await api.get('/medical-equipment/statistics/overview');
       setOverview(response.data.overview);
     } catch (error) {
+      // P0 fix: removed mock-overview fallback. Was showing fabricated stats
+      // (2 devices, 15 measurements) on API failure. Now zeroes — render uses
+      // overview.* directly so null would crash; zero-defaults are safe.
       logger.error('Ошибка загрузки обзора:', error);
-      // Fallback данные при ошибке сети
       setOverview({
-        total_devices: 2,
-        online_devices: 1,
-        offline_devices: 1,
-        total_measurements: 15,
-        device_types: {
-          blood_pressure: 1,
-          thermometer: 1
-        }
+        total_devices: 0,
+        online_devices: 0,
+        offline_devices: 0,
+        total_measurements: 0,
+        device_types: {}
       });
     }
   };
@@ -122,28 +103,10 @@ const MedicalEquipmentManager = () => {
       const response = await api.get('/medical-equipment/measurements', { params });
       setMeasurements(response.data.measurements || []);
     } catch (error) {
+      // P0 fix: removed mock-measurements fallback. Was showing fabricated
+      // blood-pressure/thermometer readings on API failure.
       logger.error('Ошибка загрузки измерений:', error);
-      // Fallback данные при ошибке сети
-      setMeasurements([
-      {
-        id: 1,
-        device_type: 'blood_pressure',
-        patient_id: 'P001',
-        systolic: 120,
-        diastolic: 80,
-        pulse: 72,
-        timestamp: new Date().toISOString(),
-        device_name: 'Тонометр Omron M3'
-      },
-      {
-        id: 2,
-        device_type: 'thermometer',
-        patient_id: 'P002',
-        temperature: 36.6,
-        timestamp: new Date(Date.now() - 3600000).toISOString(),
-        device_name: 'Термометр Braun'
-      }]
-      );
+      setMeasurements([]);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/admin/TelegramSettings.jsx
+++ b/frontend/src/components/admin/TelegramSettings.jsx
@@ -22,8 +22,8 @@ import {
   Card, Button, Input, Select, Checkbox,
 } from '../ui/macos';
 
+import { api } from '../../api/client';
 import logger from '../../utils/logger';
-import tokenManager from '../../utils/tokenManager';
 
 const DEFAULT_LANGUAGE_OPTIONS = [
   { value: 'ru', label: '\u0420\u0443\u0441\u0441\u043a\u0438\u0439' },
@@ -62,31 +62,22 @@ const TelegramSettings = () => {
       setLoading(true);
 
       // Загружаем настройки, информацию о боте и статистику
-      const [settingsRes, webhookRes, statsRes] = await Promise.all([
-      fetch('/api/v1/admin/telegram/settings', {
-        headers: { 'Authorization': `Bearer ${tokenManager.getAccessToken()}` }
-      }),
-      fetch('/api/v1/admin/telegram/webhook-info', {
-        headers: { 'Authorization': `Bearer ${tokenManager.getAccessToken()}` }
-      }),
-      fetch('/api/v1/admin/telegram/stats?days_back=7', {
-        headers: { 'Authorization': `Bearer ${tokenManager.getAccessToken()}` }
-      })]
-      );
+      const [settingsRes, webhookRes, statsRes] = await Promise.allSettled([
+        api.get('/admin/telegram/settings'),
+        api.get('/admin/telegram/webhook-info'),
+        api.get('/admin/telegram/stats', { params: { days_back: 7 } }),
+      ]);
 
-      if (settingsRes.ok) {
-        const settingsData = await settingsRes.json();
-        setSettings(settingsData);
+      if (settingsRes.status === 'fulfilled') {
+        setSettings(settingsRes.value.data);
       }
 
-      if (webhookRes.ok) {
-        const webhookData = await webhookRes.json();
-        setWebhookInfo(webhookData);
+      if (webhookRes.status === 'fulfilled') {
+        setWebhookInfo(webhookRes.value.data);
       }
 
-      if (statsRes.ok) {
-        const statsData = await statsRes.json();
-        setStats(statsData);
+      if (statsRes.status === 'fulfilled') {
+        setStats(statsRes.value.data);
       }
 
     } catch (error) {
@@ -106,21 +97,8 @@ const TelegramSettings = () => {
       setSaving(true);
       setMessage({ type: '', text: '' });
 
-      const response = await fetch('/api/v1/admin/telegram/settings', {
-        method: 'PUT',
-        headers: {
-          'Authorization': `Bearer ${tokenManager.getAccessToken()}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(settings)
-      });
-
-      if (response.ok) {
-        const result = await response.json();
-        setMessage({ type: 'success', text: result.message });
-      } else {
-        throw new Error('Ошибка сохранения настроек');
-      }
+      const { data: result } = await api.put('/admin/telegram/settings', settings);
+      setMessage({ type: 'success', text: result.message || 'Настройки сохранены' });
     } catch (error) {
       logger.error('Ошибка сохранения:', error);
       setMessage({ type: 'error', text: 'Ошибка сохранения настроек Telegram' });
@@ -133,21 +111,9 @@ const TelegramSettings = () => {
     try {
       setMessage({ type: '', text: '' });
 
-      const response = await fetch('/api/v1/admin/telegram/test-bot', {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${tokenManager.getAccessToken()}`
-        }
-      });
-
-      if (response.ok) {
-        const result = await response.json();
-        setBotInfo(result.bot_info);
-        setMessage({ type: 'success', text: result.message });
-      } else {
-        const error = await response.json();
-        throw new Error(error.detail);
-      }
+      const { data: result } = await api.post('/admin/telegram/test-bot');
+      setBotInfo(result.bot_info);
+      setMessage({ type: 'success', text: result.message });
     } catch (error) {
       logger.error('Ошибка тестирования бота:', error);
       setMessage({ type: 'error', text: error.message });
@@ -158,23 +124,9 @@ const TelegramSettings = () => {
     try {
       const webhookUrl = `${window.location.origin}/api/v1/telegram/webhook`;
 
-      const response = await fetch('/api/v1/admin/telegram/set-webhook', {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${tokenManager.getAccessToken()}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ webhook_url: webhookUrl })
-      });
-
-      if (response.ok) {
-        const result = await response.json();
-        setMessage({ type: 'success', text: result.message });
-        await loadData(); // Перезагружаем данные
-      } else {
-        const error = await response.json();
-        throw new Error(error.detail);
-      }
+      const { data: result } = await api.post('/admin/telegram/set-webhook', { webhook_url: webhookUrl });
+      setMessage({ type: 'success', text: result.message });
+      await loadData(); // Перезагружаем данные
     } catch (error) {
       logger.error('Ошибка установки webhook:', error);
       setMessage({ type: 'error', text: error.message });
@@ -188,25 +140,11 @@ const TelegramSettings = () => {
     }
 
     try {
-      const response = await fetch('/api/v1/admin/telegram/send-test-message', {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${tokenManager.getAccessToken()}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          chat_id: parseInt(testChatId),
-          message: testMessage
-        })
+      const { data: result } = await api.post('/admin/telegram/send-test-message', {
+        chat_id: parseInt(testChatId),
+        message: testMessage
       });
-
-      if (response.ok) {
-        const result = await response.json();
-        setMessage({ type: 'success', text: result.message });
-      } else {
-        const error = await response.json();
-        throw new Error(error.detail);
-      }
+      setMessage({ type: 'success', text: result.message });
     } catch (error) {
       logger.error('Ошибка отправки:', error);
       setMessage({ type: 'error', text: error.message });

--- a/frontend/src/components/admin/UnifiedFinance.jsx
+++ b/frontend/src/components/admin/UnifiedFinance.jsx
@@ -41,8 +41,7 @@ AdminTabs.propTypes = {
 
 const UnifiedFinance = ({ renderFinance }) => {
   const [searchParams] = useSearchParams();
-  const section = searchParams.get('section') || 'finance';void
-  useTheme();
+  const section = searchParams.get('section') || 'finance';
 
   const getActiveTab = (section) => {
     switch (section) {


### PR DESCRIPTION
## Summary

- Sprint 1 of 4-sprint admin cleanup roadmap. Fixes 3 categories of P0 issues found in the A-Z audit: void codemod damage (3 files), raw fetch() bypassing auth interceptor (2 files), fake-data fallback masking backend failures (2 files).
- No new features, no API contract changes. All fixes restore broken/unsafe behavior in live admin components.
- Full audit: `analysis/ADMIN_PANEL_A_Z_ANALYSIS.md` · Remaining issues: `analysis/REMAINING_ISSUES_AFTER_CLEANUP.md`

### P0-1: Void codemod damage — phantom `useState` / `useTheme` (3 files)
Auto-codemod `const X = useState(...)` → `void useState(...)` left syntax artifacts. Removed the phantom lines (the deleted state vars were genuinely unused — codemod was right to remove the binding, wrong to leave the call dangling).
- `BillingManager.jsx:99–100` — removed phantom `void useState(null)` (was `selectedInvoice`, unused; `paymentForm.invoice_id` already tracks the target invoice).
- `DiscountBenefitsManager.jsx:57–58` — removed phantom `void useState(null)` (was `editingItem`, unused; create-form is the only flow).
- `UnifiedFinance.jsx:44–45` — removed `void useTheme()` (same fix as `UnifiedNotifications` in Step 3 PR #1830).
- Note: 3 other files (`WebhookManager:55–56`, `DynamicPricingManager:178–179`, `DisplayBoardSettings:35,40`) have `const [, setX] = useState(...)` — valid JS, setters are called but UI was never implemented. Not P0 (never-implemented feature, not a codemod break). Deferred to P2 cleanup.

### P0-2: Raw `fetch()` → axios migration (2 files, security)
`TelegramSettings.jsx` (7 sites) and `GraphQLExplorer.jsx` (2 sites) used raw `fetch()` with manual `Bearer ${tokenManager.getAccessToken()}` headers, bypassing the axios instance's auth-refresh interceptor. On access-token rotation this would silently send a stale token → 401 → silent failure.
- `TelegramSettings.jsx` — migrated `loadData` (3 GETs via `Promise.allSettled`), `saveSettings` (PUT), `testBot` (POST), `setWebhook` (POST), `sendTestMessage` (POST) to `api.get/put/post`. Removed `tokenManager` import, added `import { api } from '../../api/client'`.
- `GraphQLExplorer.jsx` — migrated `loadSchema` (POST introspection) and `executeQuery` (POST query) to `api.post('/graphql', ...)`. Removed `tokenManager` import.

### P0-3: Fake-data fallback removal (2 files, data integrity)
On API failure, 2 admin components showed fabricated numbers — admin saw a "healthy" dashboard when the backend was down.
- `ClinicManagement.jsx:75–84, 100–109` — removed hardcoded fallback `{ total_branches: 3, active_licenses: 7, total_backups: 12, ... }`. On API error now sets `stats = null` / `systemHealth = null`, which triggers the existing `<MacOSEmptyState title="Статистика недоступна" />` and the `systemHealth ?` guard.
- `MedicalEquipmentManager.jsx:67–90, 100–112, 124–146` — removed 3 mock-fallback blocks (devices: "Тонометр Omron M3" / "Термометр Braun"; overview: 2 devices / 15 measurements; measurements: fabricated BP/thermometer readings). On API error now sets empty arrays / zero-defaults overview. Admin no longer risks acting on fabricated equipment data.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/admin-sprint1-p0-silent-regressions` created from current `origin/main` (`0cf40850` — includes merged Step 1 + Step 2 + Step 3 + CSS migration).
- Clean workspace: inspected before edits; only the 7 modified files + `CHANGELOG.md` touched.
- Branch: `fix/admin-sprint1-p0-silent-regressions`
- Scope gate: allowed `frontend/src/components/admin/{BillingManager,DiscountBenefitsManager,UnifiedFinance,TelegramSettings,GraphQLExplorer,ClinicManagement,MedicalEquipmentManager}.jsx` (fixes only), `CHANGELOG.md`; denied backend runtime, migrations, generated output, routing files, any other admin component.
- Red-check handling: fix any failed targeted check (eslint, vite build, vitest) in this same PR before merge.

## Contract Impact

not applicable - admin frontend bug fixes only, no API, websocket, event, or frontend consumer contract changed. The axios migration changes the HTTP client used by `TelegramSettings` and `GraphQLExplorer` from raw `fetch()` to the shared axios instance, but the request URLs, methods, bodies, and response handling are equivalent. No backend route, schema, or response shape changed. `routeRegistry.js`, `routeGuards.jsx`, `routeSelectors.js` untouched.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. The axios instance (`api/client`) uses the same `tokenManager.getAccessToken()` internally but applies the auth-refresh interceptor on 401, which the raw `fetch()` calls bypassed. All 35 admin routes still resolve to live components with the same `roles: ['Admin']` enforcement.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed. `TelegramSettings` manages Telegram bot configuration (bot token, webhook URL, test messages); the axios migration does not change what endpoints are called or what data is sent, only the HTTP client and auth-header handling.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed for existing patient/doctor/registrar flows. The 7 modified files are all admin-only components. The `ClinicManagement` and `MedicalEquipmentManager` fixes improve resilience: on API failure they now show `MacOSEmptyState` / empty lists instead of fabricated data, so the admin cannot act on non-existent records. The `BillingManager` / `DiscountBenefitsManager` / `UnifiedFinance` void-codemod fixes remove syntax artifacts that had no runtime effect (the deleted state vars were unused). The `TelegramSettings` / `GraphQLExplorer` axios migration makes auth-refresh work correctly on 401.

## Scope Gate

- Allowed paths: `frontend/src/components/admin/{BillingManager,DiscountBenefitsManager,UnifiedFinance,TelegramSettings,GraphQLExplorer,ClinicManagement,MedicalEquipmentManager}.jsx`, `CHANGELOG.md`.
- Denied paths: backend runtime, migrations, generated output, `routeRegistry.js`, `routeGuards.jsx`, `routeSelectors.js`, `App.jsx`, any other admin component.
- Migration/docs/test impact: no migration; `CHANGELOG.md` entry added; no test files changed (the 7 modified files have no contract tests — verified via `rg "import.*{(BillingManager|DiscountBenefitsManager|UnifiedFinance|TelegramSettings|GraphQLExplorer|ClinicManagement|MedicalEquipmentManager)}" frontend/src --glob "*.test.*"` → 0 matches).
- Rollback note: revert this commit. All 7 files return to their pre-fix state. The void codemod artifacts return (no runtime effect — vars were unused). The raw `fetch()` calls return (security risk re-emerges). The fake-data fallbacks return (data-integrity risk re-emerges).

## Validation

- Targeted tests or smoke run: `vite build` (full production bundle) + `eslint` on 7 modified files + `vitest run` (full suite).
- Result: passed — `vite build` exit 0 (~25s, all chunks emitted); `eslint` 0 errors (1 pre-existing warning unchanged); `vitest run` 515/515 pass across 105 test files.
- Not checked: full browser panel smoke (left to CI e2e). The axios migration preserves request/response shapes; the fake-data removal triggers existing `MacOSEmptyState` fallbacks that were already in the render tree.

Roadmap (4 sprints):
- Sprint 1 (this PR) — P0: void codemod (3 files) + raw fetch migration (2 files) + fake-data removal (2 files). 8 files, +97/-212.
- Sprint 2 — P1 functional: ReportsManager weekly/monthly spinner, AdminDoctors duplicate, AdminAppointments label inconsistency, CRUD modals error swallowing, window.location.reload removal.
- Sprint 3 — P1 architectural: delete admin-advanced-users route + stub, consolidate Telegram routes, migrate admin/ErrorBoundary to common/ErrorBoundary, sidebar section overflow.
- Sprint 4 — P2 polish: helper duplication (IconButton x3, formatCurrency x3), RU/EN standardization, useEffect audit, WebhookManager/DynamicPricingManager/DisplayBoardSettings `const [, setX]` cleanup.
