### PR TITLE
UX Audit Stage 2: Landing — CTA unification, language dropdown, video fix

### DIFF
--- a/frontend/src/pages/Landing.css
+++ b/frontend/src/pages/Landing.css
@@ -201,6 +201,94 @@ body.landing-body {
   font-size: 16px;
 }
 
+/* ===========================================================================
+   UX Audit Stage 2 (Landing issue 1.2): Language dropdown
+   Заменил cycle-переключатель на полноценный dropdown с 4 языками.
+   =========================================================================== */
+.landing-language-wrap {
+  position: relative;
+}
+
+.landing-language-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 50;
+  min-width: 200px;
+  list-style: none;
+  margin: 0;
+  padding: 6px;
+  display: grid;
+  gap: 2px;
+  border-radius: 16px;
+  background: var(--landing-surface, rgba(255, 255, 255, 0.95));
+  border: 1px solid var(--landing-border, rgba(148, 163, 184, 0.2));
+  box-shadow: var(--landing-shadow, 0 24px 80px rgba(15, 23, 42, 0.12));
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+.landing-shell--dark .landing-language-dropdown {
+  background: rgba(15, 23, 42, 0.96);
+  border-color: rgba(148, 163, 184, 0.24);
+}
+
+.landing-language-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--mac-text-primary, inherit);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 10px;
+  transition: background-color 150ms ease;
+}
+
+.landing-language-option:hover,
+.landing-language-option:focus-visible {
+  background: rgba(14, 165, 233, 0.1);
+  outline: none;
+}
+
+.landing-language-option--active {
+  background: rgba(14, 165, 233, 0.14);
+  color: var(--mac-accent-blue, #0ea5e9);
+}
+
+.landing-language-option .landing-language-code {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--mac-text-secondary, #64748b);
+  text-transform: uppercase;
+}
+
+.landing-language-option--active .landing-language-code {
+  color: var(--mac-accent-blue, #0ea5e9);
+}
+
+.landing-language-option svg {
+  color: var(--mac-accent-blue, #0ea5e9);
+  flex: 0 0 auto;
+}
+
+/* Dropdown: на мобиле — на всю ширину toolbar */
+@media (max-width: 520px) {
+  .landing-language-dropdown {
+    right: auto;
+    left: 0;
+    min-width: 180px;
+  }
+}
+
 .landing-hero {
   display: grid;
   grid-template-columns: minmax(0, 1.12fr) minmax(320px, 0.88fr);

--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -1,4 +1,4 @@
-import React, { startTransition, useEffect, useMemo } from 'react';
+import React, { startTransition, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTheme } from '../contexts/ThemeContext';
 import { useTranslation } from '../hooks/useTranslation';
@@ -51,8 +51,7 @@ function SurfaceLabel({ children }) {
 
 
 SurfaceLabel.propTypes = {
-  ...(SurfaceLabel.propTypes || {}),
-  children: PropTypes.any,
+  children: PropTypes.node,
 };
 
 function SectionHeading({ eyebrow, title, description, align = 'left' }) {
@@ -67,11 +66,10 @@ function SectionHeading({ eyebrow, title, description, align = 'left' }) {
 
 
 SectionHeading.propTypes = {
-  ...(SectionHeading.propTypes || {}),
-  align: PropTypes.any,
-  description: PropTypes.any,
-  eyebrow: PropTypes.any,
-  title: PropTypes.any,
+  align: PropTypes.oneOf(['left', 'center']),
+  description: PropTypes.string,
+  eyebrow: PropTypes.string,
+  title: PropTypes.string,
 };
 
 function MetricCard({ value, label, detail, style }) {
@@ -86,11 +84,10 @@ function MetricCard({ value, label, detail, style }) {
 
 
 MetricCard.propTypes = {
-  ...(MetricCard.propTypes || {}),
-  detail: PropTypes.any,
-  label: PropTypes.any,
-  style: PropTypes.any,
-  value: PropTypes.any,
+  detail: PropTypes.string,
+  label: PropTypes.string,
+  style: PropTypes.object,
+  value: PropTypes.node,
 };
 
 function FeatureCard({ accent, icon: Icon, badge, title, description }) {
@@ -108,12 +105,11 @@ function FeatureCard({ accent, icon: Icon, badge, title, description }) {
 
 
 FeatureCard.propTypes = {
-  ...(FeatureCard.propTypes || {}),
-  accent: PropTypes.any,
-  badge: PropTypes.any,
-  description: PropTypes.any,
-  icon: PropTypes.any,
-  title: PropTypes.any,
+  accent: PropTypes.string,
+  badge: PropTypes.string,
+  description: PropTypes.string,
+  icon: PropTypes.elementType,
+  title: PropTypes.string,
 };
 
 function ShowcaseCard({ icon: Icon, label, title, description, style }) {
@@ -138,12 +134,11 @@ function ShowcaseCard({ icon: Icon, label, title, description, style }) {
 
 
 ShowcaseCard.propTypes = {
-  ...(ShowcaseCard.propTypes || {}),
-  description: PropTypes.any,
-  icon: PropTypes.any,
-  label: PropTypes.any,
-  style: PropTypes.any,
-  title: PropTypes.any,
+  description: PropTypes.string,
+  icon: PropTypes.elementType,
+  label: PropTypes.string,
+  style: PropTypes.object,
+  title: PropTypes.string,
 };
 
 function WorkflowStep({ title, description }) {
@@ -160,9 +155,8 @@ function WorkflowStep({ title, description }) {
 
 
 WorkflowStep.propTypes = {
-  ...(WorkflowStep.propTypes || {}),
-  description: PropTypes.any,
-  title: PropTypes.any,
+  description: PropTypes.string,
+  title: PropTypes.string,
 };
 
 function ContactRow({ icon: Icon, label, value, href }) {
@@ -189,13 +183,14 @@ function ContactRow({ icon: Icon, label, value, href }) {
 }
 
 
+// UX Audit Stage 2 (Landing issue 1.5): почищены propTypes-артефакты.
+// Удалён `...(ContactRow.propTypes || {})` (бессмысленный spread из codemod)
+// и удалён несуществующий prop `startsWith: PropTypes.any`.
 ContactRow.propTypes = {
-  ...(ContactRow.propTypes || {}),
-  href: PropTypes.any,
-  icon: PropTypes.any,
-  label: PropTypes.any,
-  startsWith: PropTypes.any,
-  value: PropTypes.any,
+  href: PropTypes.string,
+  icon: PropTypes.elementType,
+  label: PropTypes.string,
+  value: PropTypes.string,
 };
 
 function toTelegramUrl(handle) {
@@ -219,8 +214,13 @@ export default function Landing() {
 
   const currentLanguageIndex = availableLanguages.findIndex((item) => item.code === language);
   const currentLanguage = availableLanguages[currentLanguageIndex] || availableLanguages[0];
-  const nextLanguage =
-    availableLanguages[(currentLanguageIndex + 1) % availableLanguages.length] || availableLanguages[0];
+  // UX Audit Stage 2: nextLanguage удалён — был нужен только для cycle-переключателя,
+  // сейчас используется dropdown и прямое handleLanguageSelect(code).
+
+  // UX Audit Stage 2 (Landing issue 1.2): свитчер языков → dropdown вместо cycle.
+  // Раньше было 4 языка (RU→UZ→EN→KZ→RU) и чтобы попасть в EN из RU нужно 2 клика.
+  // Теперь dropdown открывается одним кликом и сразу показывает все варианты.
+  const [showLangDropdown, setShowLangDropdown] = useState(false);
 
   useEffect(() => {
     const root = document.getElementById('root');
@@ -237,21 +237,82 @@ export default function Landing() {
     };
   }, []);
 
-  const handleLanguageCycle = () => {
-    if (!nextLanguage?.code) {
+  // UX Audit Stage 2 (Landing issue 1.2): заменили cycle на dropdown select.
+  // handleLanguageCycle удалён, вместо него — handleLanguageSelect(code).
+  const handleLanguageSelect = (code) => {
+    if (!code) {
       return;
     }
 
     startTransition(() => {
-      setLanguage(nextLanguage.code);
+      setLanguage(code);
     });
+    setShowLangDropdown(false);
   };
+
+  // UX Audit Stage 2 (Landing issue 1.2): close dropdown on outside click / Escape.
+  useEffect(() => {
+    if (!showLangDropdown) {
+      return undefined;
+    }
+
+    const handleClickOutside = (event) => {
+      const trigger = document.getElementById('landing-lang-trigger');
+      const dropdown = document.getElementById('landing-lang-dropdown');
+      if (
+        trigger && !trigger.contains(event.target) &&
+        dropdown && !dropdown.contains(event.target)
+      ) {
+        setShowLangDropdown(false);
+      }
+    };
+
+    const handleEscape = (event) => {
+      if (event.key === 'Escape') {
+        setShowLangDropdown(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [showLangDropdown]);
 
   const scrollToSection = (sectionId) => {
     document.getElementById(sectionId)?.scrollIntoView({
       behavior: 'smooth',
       block: 'start'
     });
+  };
+
+  // UX Audit Stage 2 (Landing issue 1.2): smooth-scroll для футер-якорей.
+  // Раньше клик на якорь в футере (#product, #workflow и т.д.) делал резкий
+  // browser-jump, потому что это были <a href="#..."> без обработчика.
+  // Теперь перехватываем клик и используем тот же scrollToSection.
+  const handleFooterLinkClick = (event, href) => {
+    if (!href || !href.startsWith('#')) {
+      return;
+    }
+    event.preventDefault();
+    const sectionId = href.slice(1);
+    scrollToSection(sectionId);
+  };
+
+  // UX Audit Stage 2 (Landing issue 1.1): унификация CTA.
+  // Раньше 7 кнопок с 5 разными текстами вели на /login.
+  // Теперь 2 цели: «Войти в систему» (→ /login) и «Связаться с продажами» (→ telegram).
+  // Кнопка «Связаться с продажами» открывает Telegram-чат с поддержкой.
+  const handleSalesContact = () => {
+    const telegramUrl = toTelegramUrl(t('telegram'));
+    if (telegramUrl) {
+      window.open(telegramUrl, '_blank', 'noopener,noreferrer');
+    } else {
+      // Fallback: скроллим к секции контактов
+      scrollToSection('contact');
+    }
   };
 
   return (
@@ -293,17 +354,61 @@ export default function Landing() {
               {isDark ? <Sun size={16} /> : <Moon size={16} />}
             </Button>
 
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleLanguageCycle}
-              className="landing-toolbar-button landing-language-button"
-              aria-label={`${copy.languageSwitchLabel}: ${currentLanguage?.name || language} -> ${nextLanguage?.name || language}`}
-              title={`${copy.languageSwitchLabel}: ${nextLanguage?.name || language}`}
-            >
-              <span className="landing-language-flag">{currentLanguage?.flag || '🌐'}</span>
-              <span>{language.toUpperCase()}</span>
-            </Button>
+            {/* UX Audit Stage 2 (Landing issue 1.2):
+                Свитчер языков теперь dropdown вместо cycle.
+                Раньше было 4 клика чтобы вернуться к исходному языку, теперь — 1 клик. */}
+            <div className="landing-language-wrap">
+              <Button
+                id="landing-lang-trigger"
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowLangDropdown((v) => !v)}
+                className="landing-toolbar-button landing-language-button"
+                aria-label={copy.languageSwitchLabel}
+                title={copy.languageSwitchLabel}
+                aria-expanded={showLangDropdown}
+                aria-haspopup="listbox"
+              >
+                <span className="landing-language-flag">{currentLanguage?.flag || '🌐'}</span>
+                <span>{language.toUpperCase()}</span>
+                <ChevronRight
+                  size={12}
+                  aria-hidden="true"
+                  style={{
+                    transform: showLangDropdown ? 'rotate(90deg)' : 'rotate(0deg)',
+                    transition: 'transform 150ms ease',
+                    marginLeft: 2,
+                  }}
+                />
+              </Button>
+
+              {showLangDropdown && (
+                <ul
+                  id="landing-lang-dropdown"
+                  role="listbox"
+                  aria-label={copy.languageSwitchLabel}
+                  className="landing-language-dropdown"
+                >
+                  {availableLanguages.map((lang) => {
+                    const isActive = lang.code === language;
+                    return (
+                      <li key={lang.code} role="option" aria-selected={isActive}>
+                        <button
+                          type="button"
+                          className={`landing-language-option ${isActive ? 'landing-language-option--active' : ''}`}
+                          onClick={() => handleLanguageSelect(lang.code)}
+                        >
+                          <span className="landing-language-flag" aria-hidden="true">{lang.flag || '🌐'}</span>
+                          <span>{lang.name}</span>
+                          <span className="landing-language-code">{lang.code.toUpperCase()}</span>
+                          {isActive && <CheckCircle size={14} aria-hidden="true" />}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
 
             <Button variant="primary" size="sm" onClick={() => navigate('/login')} className="landing-header-login">
               <User size={16} />
@@ -324,9 +429,16 @@ export default function Landing() {
             <p className="landing-hero-description">{copy.hero.description}</p>
 
             <div className="landing-cta-row">
+              {/* UX Audit Stage 2 (Landing issue 1.1):
+                  Унификация CTA. Раньше 7 кнопок с 5 текстами вели на /login.
+                  Теперь 2 цели:
+                    - «Войти в систему» (primary) → /login
+                    - «Связаться с продажами» (outline) → Telegram-чат
+                  Hero secondary («Смотреть 2-минутный обзор») оставлен как scroll-to-section,
+                  но переименован в «Посмотреть интерфейс» в landingContent.js. */}
               <Button variant="primary" size="lg" onClick={() => navigate('/login')} className="landing-primary-cta">
                 <User size={18} />
-                {copy.hero.primaryCta}
+                {copy.headerLogin}
               </Button>
 
               <Button variant="outline" size="lg" onClick={() => scrollToSection('screens')} className="landing-secondary-cta">
@@ -574,11 +686,19 @@ export default function Landing() {
                   ))}
                 </ul>
 
+                {/* UX Audit Stage 2 (Landing issue 1.1):
+                    Pricing 3 кнопки раньше все вели на /login с разными текстами
+                    («Запросить демо», «Выбрать Professional», «Обсудить Enterprise»).
+                    Теперь: featured plan → /login (trial start),
+                    остальные 2 → sales contact (Telegram) для персональной консультации. */}
                 <Button
                   variant={plan.featured ? 'primary' : 'outline'}
                   size="lg"
-                  onClick={() => navigate('/login')}
+                  onClick={plan.featured ? () => navigate('/login') : handleSalesContact}
                   className="landing-plan-button"
+                  title={plan.featured
+                    ? 'Открыть демо-режим системы'
+                    : 'Связаться с продажами для персонального предложения'}
                 >
                   {plan.cta}
                 </Button>
@@ -623,11 +743,15 @@ export default function Landing() {
             </div>
 
             <div className="landing-final-actions">
+              {/* UX Audit Stage 2 (Landing issue 1.1):
+                  Final CTA 2 кнопки раньше обе вели на /login.
+                  Теперь: primary «Запросить демо» → /login (trial),
+                  secondary «Активировать лицензию» → sales contact (Telegram). */}
               <Button variant="primary" size="lg" onClick={() => navigate('/login')}>
                 <User size={18} />
                 {copy.finalCta.primaryCta}
               </Button>
-              <Button variant="outline" size="lg" onClick={() => navigate('/login')}>
+              <Button variant="outline" size="lg" onClick={handleSalesContact}>
                 <Key size={18} />
                 {copy.finalCta.secondaryCta}
               </Button>
@@ -664,7 +788,15 @@ export default function Landing() {
                 <strong>{group.title}</strong>
                 <div className="landing-footer-links">
                   {group.links.map((link) => (
-                    <a key={link.label} href={link.href} className="landing-footer-link">
+                    // UX Audit Stage 2 (Landing issue 1.2):
+                    // Smooth-scroll для футер-якорей через handleFooterLinkClick.
+                    // Раньше это был резкий browser-jump.
+                    <a
+                      key={link.label}
+                      href={link.href}
+                      className="landing-footer-link"
+                      onClick={(e) => handleFooterLinkClick(e, link.href)}
+                    >
                       {link.label}
                     </a>
                   ))}

--- a/frontend/src/pages/__tests__/Landing.test.jsx
+++ b/frontend/src/pages/__tests__/Landing.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -45,8 +45,10 @@ describe('Landing', () => {
         name: /Единая система управления клиникой, которая держит EMR, очередь и платежи в одном ритме/i
       })
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Открыть демо/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Смотреть 2-минутный обзор/i })).toBeInTheDocument();
+    // UX Audit Stage 2: Hero primary CTA changed from "Открыть демо" to "Войти"
+    // (uses copy.headerLogin now). There are 2 "Войти" buttons (header + hero).
+    expect(screen.getAllByRole('button', { name: /^Войти$/i }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole('button', { name: /Посмотреть интерфейс/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Модули/i })).toBeInTheDocument();
     expect(
       screen.getByRole('heading', {
@@ -61,12 +63,20 @@ describe('Landing', () => {
     expect(screen.getByText(/\+998 \(95\) 104-34-34/i)).toBeInTheDocument();
   });
 
-  it('cycles localized hero copy when the language button is pressed', async () => {
+  // UX Audit Stage 2: language cycle replaced with dropdown.
+  // Test now: open dropdown → click UZ option → verify heading changed.
+  it('switches to Uzbek when UZ option is selected in language dropdown', async () => {
     const user = userEvent.setup();
 
     renderLanding();
 
+    // Click trigger button to open dropdown
     await user.click(screen.getByRole('button', { name: /Сменить язык/i }));
+
+    // Find the UZ option in the dropdown listbox
+    const listbox = screen.getByRole('listbox');
+    const uzOption = within(listbox).getByText("O'zbek");
+    await user.click(uzOption);
 
     expect(
       screen.getByRole('heading', {

--- a/frontend/src/pages/landingContent.js
+++ b/frontend/src/pages/landingContent.js
@@ -16,7 +16,7 @@ const BASE_COPY = {
     description:
       'MediClinic Pro собирает регистратуру, врача, QR-очередь, платежи, Telegram и отчеты в один workflow без ручных разрывов между командами.',
     primaryCta: 'Открыть демо',
-    secondaryCta: 'Смотреть 2-минутный обзор',
+    secondaryCta: 'Посмотреть интерфейс',
     proofChips: ['EMR врача', 'QR-очередь', 'Telegram-уведомления', 'Платежи и отчеты'],
     quickStats: [
       { value: '4', label: 'ключевые роли', detail: 'регистратура, врач, касса, руководитель' },
@@ -357,7 +357,7 @@ const EN_OVERRIDES = {
     description:
       'MediClinic Pro brings reception, doctors, QR queue, payments, Telegram and reporting into one workflow with no manual gaps between teams.',
     primaryCta: 'Open demo',
-    secondaryCta: 'Watch the 2-minute walkthrough',
+    secondaryCta: 'View interface',
     proofChips: ['Doctor EMR', 'QR queue', 'Telegram alerts', 'Payments and reports'],
     quickStats: [
       { value: '4', label: 'core roles', detail: 'reception, doctor, cashier, leadership' },
@@ -678,7 +678,7 @@ const UZ_OVERRIDES = {
     description:
       'MediClinic Pro registratura, shifokor, QR-navbat, tolovlar, Telegram va hisobotlarni bitta workflow ichida birlashtiradi, jamoalar orasida qol mehnatisiz.',
     primaryCta: 'Demo ochish',
-    secondaryCta: '2 daqiqalik korib chiqishni korish',
+    secondaryCta: "Interfeysni ko'rish",
     proofChips: ['Shifokor EMR', 'QR-navbat', 'Telegram signal', 'Tolovlar va hisobotlar'],
     quickStats: [
       { value: '4', label: 'asosiy rol', detail: 'registratura, shifokor, kassa, rahbar' },
@@ -999,7 +999,7 @@ const KK_OVERRIDES = {
     description:
       'MediClinic Pro тіркеуді, дәрігерді, QR-кезекті, төлемдерді, Telegram және есептерді бір workflow ішінде біріктіреді, командалар арасындағы қол еңбегін азайтады.',
     primaryCta: 'Демоны ашу',
-    secondaryCta: '2 минуттық шолуды көру',
+    secondaryCta: 'Интерфейсті қарау',
     proofChips: ['Дәрігер EMR', 'QR-кезек', 'Telegram сигналдары', 'Төлемдер мен есептер'],
     quickStats: [
       { value: '4', label: 'негізгі рөл', detail: 'тіркеу, дәрігер, касса, басшылық' },


### PR DESCRIPTION
## UX Audit Stage 2 — Landing.jsx

### Changes
- 7 CTA unified to 2 goals: Login (→/login) + Sales contact (→Telegram)
- Language switcher: cycle → dropdown with role=listbox
- Renamed «2-минутный обзор» → «Посмотреть интерфейс» on 4 languages
- Smooth-scroll for footer anchor links
- PropTypes cleanup: 7 codemod artifacts removed

### Test fixes
- Updated Landing.test.jsx: «Открыть демо» → «Войти» (CTA renamed)
- Updated language test: cycle → dropdown interaction

### Validation
- ✅ 515 tests pass (105 files)