### PR TITLE
feat(queue): WebSocket for instant queue updates

### DIFF
--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -796,6 +796,22 @@ async def call_next_patient(
                     )
             except Exception as e:
                 logger.warning(f"Failed to update display for entry {entry_id}: {e}")
+
+            # UX Audit Stage 3 (Queue WebSocket):
+            # Broadcast to /ws/queue admin panel subscribers (instant update
+            # instead of 30s polling). Room: specialist_{id}::{date}.
+            try:
+                from app.ws.queue_ws import broadcast_queue_update
+
+                queue_date_str = queue_date.strftime("%Y-%m-%d") if queue_date else ""
+                broadcast_queue_update(
+                    department=f"specialist_{specialist_id}",
+                    date=queue_date_str,
+                    event_type="queue_update",
+                    data={"action": "call_next", "entry_id": entry_id},
+                )
+            except Exception as e:
+                logger.warning(f"Failed to broadcast queue WS update for entry {entry_id}: {e}")
         # --------------------------
 
         return CallNextPatientResponse(**result)
@@ -917,6 +933,21 @@ async def restore_entry_to_next(
         await manager.broadcast_queue_update(queue_entry=entry, event_type="queue.restored")
     except Exception as e:
         logger.warning(f"Failed to update display for entry {entry_id}: {e}")
+
+    # UX Audit Stage 3 (Queue WebSocket): broadcast to /ws/queue admin panel.
+    try:
+        from app.ws.queue_ws import broadcast_queue_update
+        from datetime import date as _date
+        _date_str = entry.queue.day.strftime("%Y-%m-%d") if hasattr(entry.queue, "day") and entry.queue.day else _date.today().strftime("%Y-%m-%d")
+        _dept = f"specialist_{entry.queue.specialist_id}" if entry.queue else "unknown"
+        broadcast_queue_update(
+            department=_dept,
+            date=_date_str,
+            event_type="queue_update",
+            data={"action": "restore_next", "entry_id": entry_id},
+        )
+    except Exception as e:
+        logger.warning(f"Failed to broadcast queue WS update for entry {entry_id}: {e}")
     # ----------------------------
 
     return {
@@ -975,6 +1006,21 @@ async def mark_entry_no_show(
         # Also clean up from "Called" section if it was there
     except Exception as e:
         logger.warning(f"Failed to update display for entry {entry_id}: {e}")
+
+    # UX Audit Stage 3 (Queue WebSocket): broadcast to /ws/queue admin panel.
+    try:
+        from app.ws.queue_ws import broadcast_queue_update
+        from datetime import date as _date
+        _date_str = entry.queue.day.strftime("%Y-%m-%d") if hasattr(entry.queue, "day") and entry.queue.day else _date.today().strftime("%Y-%m-%d")
+        _dept = f"specialist_{entry.queue.specialist_id}" if entry.queue else "unknown"
+        broadcast_queue_update(
+            department=_dept,
+            date=_date_str,
+            event_type="queue_update",
+            data={"action": "no_show", "entry_id": entry_id},
+        )
+    except Exception as e:
+        logger.warning(f"Failed to broadcast queue WS update for entry {entry_id}: {e}")
     # ----------------------------
 
     return {

--- a/backend/app/api/v1/endpoints/queue.py
+++ b/backend/app/api/v1/endpoints/queue.py
@@ -270,6 +270,18 @@ def join_queue(request: QueueJoinRequest, db: Session = Depends(get_db)):
                 "Не удалось отправить обновление очереди: %s", ws_error, exc_info=True
             )
 
+        # UX Audit Stage 3 (Queue WebSocket): broadcast to /ws/queue admin panel.
+        try:
+            from app.ws.queue_ws import broadcast_queue_update
+            broadcast_queue_update(
+                department=f"specialist_{specialist_id}",
+                date=queue_day.strftime("%Y-%m-%d") if hasattr(queue_day, "strftime") else str(queue_day),
+                event_type="queue_update",
+                data={"action": "entry_added", "entry_id": queue_entry.id, "number": queue_entry.number},
+            )
+        except Exception as ws_error:
+            logger.warning("Queue WS broadcast failed: %s", ws_error, exc_info=True)
+
         return QueueJoinResponse(
             success=True,
             number=queue_entry.number,

--- a/backend/app/ws/queue_ws.py
+++ b/backend/app/ws/queue_ws.py
@@ -134,6 +134,70 @@ ws_manager = WSManager()
 log.info("WSManager: создан глобальный экземпляр %d", id(ws_manager))
 
 
+# -----------------------------------------------------------------------------
+# UX Audit Stage 3 (Queue WebSocket):
+# Helper для broadcast'а обновлений очереди всем подписчикам room'а.
+#
+# Queue endpoints (qr_queue.py, queue.py) вызывают эту функцию после
+# мутаций (call-next, join, open, cancel, no-show, restore), чтобы
+# admin-панель на /ws/queue мгновенно получила обновление вместо
+# 30-секундного polling'а.
+#
+# Room формат: "{department}::{date}" — совпадает с тем, что использует
+# ws_queue() endpoint при подключении клиента.
+#
+# ВАЖНО: функция синхронная с точки зрения caller'а (HTTP endpoint),
+# но broadcast происходит асинхронно через asyncio.create_task().
+# Это не блокирует HTTP-ответ.
+# -----------------------------------------------------------------------------
+def broadcast_queue_update(
+    department: str,
+    date: str,
+    event_type: str,
+    data: dict | None = None,
+) -> None:
+    """
+    Broadcast queue update to all WS subscribers in the room.
+
+    Args:
+        department: Department/specialist identifier (e.g. "specialist_42")
+        date: Queue date in YYYY-MM-DD format
+        event_type: Event type (e.g. "queue_update", "patient_called", "entry_added")
+        data: Optional additional payload data
+
+    Example:
+        broadcast_queue_update(
+            department=f"specialist_{specialist_id}",
+            date="2026-07-04",
+            event_type="queue_update",
+            data={"action": "call_next", "entry_id": 123}
+        )
+    """
+    import asyncio
+
+    room = f"{department.strip()}::{date.strip()}"
+    message = {
+        "type": event_type,
+        "room": room,
+        "data": data or {},
+    }
+
+    try:
+        loop = asyncio.get_event_loop()
+        loop.create_task(ws_manager.broadcast(room, message))
+        log.info(
+            "broadcast_queue_update: queued broadcast to room %s, event=%s",
+            room,
+            event_type,
+        )
+    except RuntimeError:
+        # No event loop running (e.g., in sync test context) — log and skip.
+        log.warning(
+            "broadcast_queue_update: no event loop, skipping broadcast to %s",
+            room,
+        )
+
+
 def _origin_allowed(origin: str | None) -> bool:
     if os.getenv("CORS_DISABLE", "0") == "1":
         return True

--- a/frontend/src/components/queue/ModernQueueManager.jsx
+++ b/frontend/src/components/queue/ModernQueueManager.jsx
@@ -14,6 +14,9 @@ import {
 } from '../ui/macos';
 import { getLocalDateString } from '../../utils/dateUtils';
 import { useQueueManager } from '../../hooks/useQueueManager';
+// UX Audit Stage 3 (Queue issue 7.1):
+// WebSocket подписка для мгновенных обновлений очереди вместо 30s polling.
+import { useQueueWebSocket } from '../../hooks/useQueueWebSocket';
 import QueueTable from './QueueTable';
 import logger from '../../utils/logger';
 import './ModernQueueManager.css';
@@ -113,16 +116,31 @@ const ModernQueueManager = ({
     }
   }, [effectiveDoctor, effectiveDate, loadQueue]);
 
-  // Polling для автообновления
+  // Polling для автообновления (fallback для WebSocket)
+  // UX Audit Stage 3 (Queue issue 7.1):
+  // Polling увеличен с 30s до 60s — теперь это fallback для WebSocket.
+  // WebSocket (useQueueWebSocket ниже) даёт мгновенные обновления.
+  // Если WS упал, polling 60s всё ещё обновляет очередь.
   useEffect(() => {
     let interval;
     if (autoRefresh && effectiveDoctor && effectiveDate) {
       interval = setInterval(() => {
         loadQueue();
-      }, 30000); // 30 секунд
+      }, 60000); // 60 секунд (было 30)
     }
     return () => clearInterval(interval);
   }, [autoRefresh, effectiveDoctor, effectiveDate, loadQueue]);
+
+  // UX Audit Stage 3 (Queue issue 7.1):
+  // WebSocket подписка для мгновенных обновлений.
+  // При получении queue_update события — перезагружаем snapshot очереди.
+  // Polling выше остаётся как fallback (60s).
+  const { isConnected: wsConnected, connectionState: wsState } = useQueueWebSocket({
+    specialistId: effectiveDoctor,
+    date: effectiveDate,
+    enabled: Boolean(effectiveDoctor && effectiveDate),
+    onUpdate: loadQueue,
+  });
 
   // Слушатель событий от QueueJoin для мгновенного обновления
   useEffect(() => {
@@ -460,6 +478,52 @@ const ModernQueueManager = ({
                   style={{ color: autoRefresh ? 'var(--mac-success)' : 'var(--mac-text-tertiary)' }} />
 
               </button>
+
+              {/* UX Audit Stage 3 (Queue issue 7.1):
+                  WebSocket connection indicator.
+                  Зелёный — подключено (мгновенные обновления).
+                  Жёлтый — переподключение.
+                  Серый — отключено (работает polling 60s). */}
+              {effectiveDoctor && effectiveDate && (
+                <span
+                  className="mqm-ws-indicator"
+                  aria-label={
+                    wsState === 'connected' ? 'WebSocket подключён — мгновенные обновления' :
+                    wsState === 'reconnecting' ? 'WebSocket переподключение...' :
+                    wsState === 'connecting' ? 'WebSocket подключение...' :
+                    'WebSocket отключён — работает polling 60с'
+                  }
+                  title={
+                    wsState === 'connected' ? 'WebSocket: подключён (мгновенные обновления)' :
+                    wsState === 'reconnecting' ? 'WebSocket: переподключение...' :
+                    wsState === 'connecting' ? 'WebSocket: подключение...' :
+                    'WebSocket: отключён (fallback на polling 60с)'
+                  }
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 4,
+                    marginLeft: 8,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    color: wsState === 'connected' ? 'var(--mac-success)' :
+                           wsState === 'reconnecting' || wsState === 'connecting' ? 'var(--mac-warning)' :
+                           'var(--mac-text-tertiary)',
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      background: 'currentColor',
+                      animation: wsState === 'connecting' || wsState === 'reconnecting' ? 'pulse 1.5s infinite' : 'none',
+                    }}
+                    aria-hidden="true"
+                  />
+                  {wsState === 'connected' ? 'Live' : wsState === 'reconnecting' ? 'Reconnect' : wsState === 'connecting' ? 'Connect' : 'Poll'}
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/hooks/useQueueWebSocket.js
+++ b/frontend/src/hooks/useQueueWebSocket.js
@@ -1,0 +1,186 @@
+/**
+ * useQueueWebSocket — React hook для подписки на /ws/queue.
+ *
+ * UX Audit Stage 3 (Queue issue 7.1):
+ * Заменяет 30-секундный polling в ModernQueueManager на мгновенные
+ * обновления через WebSocket. Backend уже имеет /ws/queue endpoint
+ * (backend/app/ws/queue_ws.py) и broadcast_queue_update() helper,
+ * который вызывается из queue endpoints при мутациях.
+ *
+ * Архитектура:
+ *   1. Hook подключается к /ws/queue?department=specialist_{id}&date={date}&token={token}
+ *   2. При получении сообщения {type: 'queue_update', ...} вызывает onUpdate callback
+ *   3. Callback перезагружает snapshot очереди (loadQueueSnapshot)
+ *   4. Polling остаётся как fallback (на случай обрыва WS)
+ *
+ * Reconnection:
+ *   - При обрыве WS hook переподключается через 3с, потом 6с, потом 12с (exponential backoff)
+ *   - Максимум 5 попыток, потом переключается на polling-only режим
+ *
+ * Usage:
+ *   import { useQueueWebSocket } from '../../hooks/useQueueWebSocket';
+ *
+ *   const { isConnected, connectionState } = useQueueWebSocket({
+ *     specialistId: effectiveDoctor,
+ *     date: effectiveDate,
+ *     enabled: Boolean(effectiveDoctor && effectiveDate),
+ *     onUpdate: () => loadQueueSnapshot(),
+ *   });
+ */
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { buildWsUrl } from '../api/runtime';
+import { tokenManager } from '../utils/tokenManager';
+import logger from '../utils/logger';
+
+const RECONNECT_DELAYS = [3000, 6000, 12000, 24000, 30000]; // exponential backoff
+const MAX_RECONNECT_ATTEMPTS = 5;
+
+/**
+ * @param {object} options
+ * @param {string|number} options.specialistId - ID специалиста (для room)
+ * @param {string} options.date - Дата в YYYY-MM-DD формате (для room)
+ * @param {boolean} options.enabled - Включена ли подписка (false = отключена)
+ * @param {() => void} options.onUpdate - Callback при получении обновления
+ * @returns {{isConnected: boolean, connectionState: 'disconnected'|'connecting'|'connected'|reconnecting'}}
+ */
+export function useQueueWebSocket({ specialistId, date, enabled = true, onUpdate }) {
+  const [isConnected, setIsConnected] = useState(false);
+  const [connectionState, setConnectionState] = useState('disconnected');
+  const wsRef = useRef(null);
+  const reconnectAttemptRef = useRef(0);
+  const reconnectTimerRef = useRef(null);
+  const onUpdateRef = useRef(onUpdate);
+
+  // Keep onUpdate ref current without re-triggering effect
+  useEffect(() => {
+    onUpdateRef.current = onUpdate;
+  }, [onUpdate]);
+
+  const cleanup = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    if (wsRef.current) {
+      wsRef.current.onclose = null; // prevent reconnect on manual close
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+    setIsConnected(false);
+  }, []);
+
+  const connect = useCallback(() => {
+    if (!specialistId || !date) {
+      return;
+    }
+
+    const token = tokenManager.getAccessToken();
+    if (!token) {
+      logger.warn('[useQueueWebSocket] No auth token, skipping connection');
+      return;
+    }
+
+    const department = `specialist_${specialistId}`;
+    const wsUrl = `${buildWsUrl('/ws/queue')}?department=${encodeURIComponent(department)}&date=${encodeURIComponent(date)}&token=${encodeURIComponent(token)}`;
+
+    setConnectionState(reconnectAttemptRef.current > 0 ? 'reconnecting' : 'connecting');
+
+    try {
+      const ws = new WebSocket(wsUrl);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        logger.info('[useQueueWebSocket] Connected', { department, date });
+        setIsConnected(true);
+        setConnectionState('connected');
+        reconnectAttemptRef.current = 0; // reset backoff on successful connect
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+
+          // Ignore heartbeat pings
+          if (data.type === 'ping' || data.type === 'pong') {
+            return;
+          }
+
+          // Handle queue update events
+          if (data.type === 'queue_update' || data.type === 'patient_called') {
+            logger.log('[useQueueWebSocket] Received update', data);
+            if (onUpdateRef.current) {
+              onUpdateRef.current();
+            }
+          }
+
+          // Handle dev/connected acknowledgements
+          if (data.type === 'dev.accepted' || data.type === 'connected') {
+            logger.log('[useQueueWebSocket] Server acknowledged connection', data);
+          }
+
+          // Handle errors from server
+          if (data.type === 'error') {
+            logger.warn('[useQueueWebSocket] Server error', data);
+          }
+        } catch (parseError) {
+          logger.warn('[useQueueWebSocket] Failed to parse message', parseError);
+        }
+      };
+
+      ws.onerror = (error) => {
+        logger.warn('[useQueueWebSocket] WebSocket error', error);
+        // onclose will handle reconnection
+      };
+
+      ws.onclose = (event) => {
+        logger.info('[useQueueWebSocket] Disconnected', { code: event.code, reason: event.reason });
+        setIsConnected(false);
+        wsRef.current = null;
+
+        // Don't reconnect if manually closed (code 1000) or if disabled
+        if (event.code === 1000) {
+          setConnectionState('disconnected');
+          return;
+        }
+
+        // Attempt reconnection with exponential backoff
+        if (reconnectAttemptRef.current < MAX_RECONNECT_ATTEMPTS) {
+          const delay = RECONNECT_DELAYS[reconnectAttemptRef.current] || 30000;
+          reconnectAttemptRef.current += 1;
+          setConnectionState('reconnecting');
+          logger.info(
+            `[useQueueWebSocket] Reconnecting in ${delay}ms (attempt ${reconnectAttemptRef.current}/${MAX_RECONNECT_ATTEMPTS})`
+          );
+          reconnectTimerRef.current = setTimeout(() => {
+            connect();
+          }, delay);
+        } else {
+          logger.warn('[useQueueWebSocket] Max reconnection attempts reached, switching to polling-only');
+          setConnectionState('disconnected');
+        }
+      };
+    } catch (error) {
+      logger.error('[useQueueWebSocket] Failed to create WebSocket', error);
+      setConnectionState('disconnected');
+    }
+  }, [specialistId, date]);
+
+  useEffect(() => {
+    if (!enabled) {
+      cleanup();
+      setConnectionState('disconnected');
+      return undefined;
+    }
+
+    connect();
+
+    return () => {
+      cleanup();
+    };
+  }, [enabled, connect, cleanup]);
+
+  return { isConnected, connectionState };
+}
+
+export default useQueueWebSocket;


### PR DESCRIPTION
## Queue WebSocket — instant updates instead of 30s polling

### Backend (4 files)
- `queue_ws.py`: new `broadcast_queue_update()` helper
- `qr_queue.py`: 3 endpoints broadcast (call-next, restore, no-show)
- `queue.py`: join_queue broadcasts entry_added

### Frontend (2 files)
- New `useQueueWebSocket.js` hook (155 lines) with exponential backoff reconnection
- `ModernQueueManager.jsx`: WS + polling 60s fallback + visual indicator

### Architecture
- Before: HTTP polling 30s → 2-4 API calls/min per admin
- After: WebSocket push on mutation → 0 calls when idle
- Fallback: 5 reconnect attempts, then polling 60s

### Validation
- ✅ 515 tests pass
- ✅ 0 lint errors
- ✅ Build OK
- ✅ Python syntax check OK