### PR TITLE
refactor(admin): Sprint 7a batch 1 — Card→MacOSCard naming homogenization

### DIFF
--- a/frontend/src/components/admin/AISettings.jsx
+++ b/frontend/src/components/admin/AISettings.jsx
@@ -22,7 +22,7 @@ import {
 
 'lucide-react';
 import {
-  Card, Button, Badge, Input, Checkbox,
+  MacOSCard, Button, Badge, Input, Checkbox,
 } from '../ui/macos';
 import { api } from '../../api/client';
 
@@ -163,12 +163,12 @@ const AISettings = () => {
 
   if (loading) {
     return (
-      <Card className="admin-p-32">
+      <MacOSCard className="admin-p-32">
         <div className="admin-flex-center-justify">
           <RefreshCw className="admin-icon-20-spin-mr-8" />
           <span className="admin-text-primary">Загрузка AI настроек...</span>
         </div>
-      </Card>);
+      </MacOSCard>);
 
   }
 
@@ -216,38 +216,38 @@ const AISettings = () => {
       {/* Статистика */}
       {stats.total_requests !== undefined &&
       <div className="admin-grid-auto-200">
-          <Card className="admin-loading-p-24-center">
+          <MacOSCard className="admin-loading-p-24-center">
             <div className="admin-stat-number admin-text-blue admin-mb-8">
               {stats.total_requests}
             </div>
             <div className="admin-text-sm-secondary">
               Всего запросов
             </div>
-          </Card>
-          <Card className="admin-loading-p-24-center">
+          </MacOSCard>
+          <MacOSCard className="admin-loading-p-24-center">
             <div className="admin-stat-number admin-text-success admin-mb-8">
               {stats.successful_requests}
             </div>
             <div className="admin-text-sm-secondary">
               Успешных
             </div>
-          </Card>
-          <Card className="admin-loading-p-24-center">
+          </MacOSCard>
+          <MacOSCard className="admin-loading-p-24-center">
             <div className="admin-stat-number admin-text-warning admin-mb-8">
               {Math.round(stats.cache_hit_rate)}%
             </div>
             <div className="admin-text-sm-secondary">
               Кэш
             </div>
-          </Card>
-          <Card className="admin-loading-p-24-center">
+          </MacOSCard>
+          <MacOSCard className="admin-loading-p-24-center">
             <div className="admin-stat-number admin-text-purple admin-mb-8">
               {stats.total_tokens_used}
             </div>
             <div className="admin-text-sm-secondary">
               Токенов
             </div>
-          </Card>
+          </MacOSCard>
         </div>
       }
 
@@ -258,7 +258,7 @@ const AISettings = () => {
           const testResult = testResults[provider.id];
 
           return (
-            <Card key={provider.id} className="admin-p-24">
+            <MacOSCard key={provider.id} className="admin-p-24">
               <div className="admin-flex-between-mb-16">
                 <div className="admin-flex-center">
                   <div className="admin-status-dot-12" style={{ '--admin-dot-bg': provider.active ? 'var(--mac-success)' : 'var(--mac-text-tertiary)' }} />
@@ -394,12 +394,12 @@ const AISettings = () => {
                   <TestTube aria-hidden="true" className="admin-icon-14" />
                 </Button>
               </div>
-            </Card>);
+            </MacOSCard>);
 
         })}
 
         {/* Карточка добавления нового провайдера */}
-        <Card className="admin-p-24 admin-text-center admin-card-dashed">
+        <MacOSCard className="admin-p-24 admin-text-center admin-card-dashed">
           <Brain className="admin-icon-48-mx-auto-mb-16-tertiary" />
           <h3 className="admin-heading-lg admin-text-med admin-text-primary admin-m-0 admin-mb-8">
             Добавить AI провайдера
@@ -411,11 +411,11 @@ const AISettings = () => {
             <Plus className="admin-icon-16-mr-8" />
             Добавить
           </Button>
-        </Card>
+        </MacOSCard>
       </div>
 
       {/* Системные настройки */}
-      <Card className="admin-p-24">
+      <MacOSCard className="admin-p-24">
         <h3 className="admin-heading-lg admin-text-med admin-text-primary admin-m-0 admin-mb-16 admin-flex-center">
           <Settings className="admin-icon-20-mr-8-blue" />
           Системные настройки AI
@@ -428,7 +428,7 @@ const AISettings = () => {
             logger.log('Сохранение системных настроек:', settings);
           }} />
         
-      </Card>
+      </MacOSCard>
 
       {/* Форма провайдера */}
       {(showAddForm || editingProvider) &&
@@ -486,7 +486,7 @@ const ProviderForm = ({ provider, providerConfigs, onSave, onCancel }) => {
   };
 
   return (
-    <Card className="admin-p-24">
+    <MacOSCard className="admin-p-24">
       <h3 className="admin-heading-lg admin-text-med admin-text-primary admin-m-0 admin-mb-16">
         {provider ? 'Редактирование провайдера' : 'Добавление AI провайдера'}
       </h3>
@@ -630,7 +630,7 @@ const ProviderForm = ({ provider, providerConfigs, onSave, onCancel }) => {
           </Button>
         </div>
       </form>
-    </Card>);
+    </MacOSCard>);
 
 };
 

--- a/frontend/src/components/admin/ActivationSystem.jsx
+++ b/frontend/src/components/admin/ActivationSystem.jsx
@@ -22,7 +22,7 @@ import {
 
 'lucide-react';
 import {
-  AppError, AppLoading, Card, Button, Badge, Input, Table, Checkbox, Select,
+  AppError, AppLoading, MacOSCard, Button, Badge, Input, Table, Checkbox, Select,
 } from '../ui/macos';
 
 import logger from '../../utils/logger';
@@ -181,19 +181,19 @@ const ActivationSystem = () => {
 
   if (loading) {
     return (
-      <Card className="admin-card-p-32">
+      <MacOSCard className="admin-card-p-32">
         <AppLoading
           title="Загрузка системы активации"
           description="Получаем список ключей и статус сервера."
           size="sm"
         />
-      </Card>);
+      </MacOSCard>);
 
   }
 
   if (showInitialLoadError) {
     return (
-      <Card className="admin-card-p-32">
+      <MacOSCard className="admin-card-p-32">
         <AppError
           title="Не удалось загрузить систему активации"
           description={loadError}
@@ -203,7 +203,7 @@ const ActivationSystem = () => {
             </Button>
           }
         />
-      </Card>);
+      </MacOSCard>);
 
   }
 
@@ -267,42 +267,42 @@ const ActivationSystem = () => {
 
       {/* Статистика */}
       <div className="admin-grid-auto-200">
-        <Card className="admin-card-p-24-center">
+        <MacOSCard className="admin-card-p-24-center">
           <div className="admin-stat-num-2xl-bold-dynamic-mb-8" style={{ '--admin-stat-color': 'var(--mac-accent-blue)' }}>
             {stats.total_activations || 0}
           </div>
           <div className="admin-stat-label-sm-secondary-block-activation">
             Всего активаций
           </div>
-        </Card>
-        <Card className="admin-card-p-24-center">
+        </MacOSCard>
+        <MacOSCard className="admin-card-p-24-center">
           <div className="admin-stat-num-2xl-bold-dynamic-mb-8" style={{ '--admin-stat-color': 'var(--mac-success)' }}>
             {stats.active_activations || 0}
           </div>
           <div className="admin-stat-label-sm-secondary-block-activation">
             Активных
           </div>
-        </Card>
-        <Card className="admin-card-p-24-center">
+        </MacOSCard>
+        <MacOSCard className="admin-card-p-24-center">
           <div className="admin-stat-num-2xl-bold-dynamic-mb-8" style={{ '--admin-stat-color': 'var(--mac-warning)' }}>
             {stats.trial_activations || 0}
           </div>
           <div className="admin-stat-label-sm-secondary-block-activation">
             Пробных
           </div>
-        </Card>
-        <Card className="admin-card-p-24-center">
+        </MacOSCard>
+        <MacOSCard className="admin-card-p-24-center">
           <div className="admin-stat-num-2xl-bold-dynamic-mb-8" style={{ '--admin-stat-color': 'var(--mac-error)' }}>
             {stats.expired_activations || 0}
           </div>
           <div className="admin-stat-label-sm-secondary-block-activation">
             Истекших
           </div>
-        </Card>
+        </MacOSCard>
       </div>
 
       {/* Фильтры */}
-      <Card className="admin-p-24">
+      <MacOSCard className="admin-p-24">
         <div className="admin-grid-auto-300">
           <div>
             <label className="admin-label-block-sm-med-primary-mb-8">
@@ -337,10 +337,10 @@ const ActivationSystem = () => {
               className="admin-w-full" />
           </div>
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Таблица активаций */}
-      <Card className="admin-card-p-0-overflow-hidden">
+      <MacOSCard className="admin-card-p-0-overflow-hidden">
         <div className="admin-p-16">
           <Table
             columns={[
@@ -469,7 +469,7 @@ const ActivationSystem = () => {
             } />
           
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Форма создания ключа */}
       {showCreateForm &&
@@ -480,7 +480,7 @@ const ActivationSystem = () => {
       }
 
       {/* Информация */}
-      <Card className="admin-card-info-bg">
+      <MacOSCard className="admin-card-info-bg">
         <h3 className="admin-shield-h3-info">
           <Shield className="admin-icon-20-mr-8" />
           Как работает система активации
@@ -492,7 +492,7 @@ const ActivationSystem = () => {
           <p className="admin-p-list-item-m0">• Система работает офлайн после успешной активации</p>
           <p className="admin-p-list-item-m0">• Все активации логируются для аудита</p>
         </div>
-      </Card>
+      </MacOSCard>
       {/* P-013 fix: portal-mounted ConfirmDialog rendered once per panel */}
       {confirmDialog}
     </div>);
@@ -531,7 +531,7 @@ const ActivationKeyForm = ({ onSave, onCancel }) => {
   };
 
   return (
-    <Card className="admin-p-24">
+    <MacOSCard className="admin-p-24">
       <h3 className="admin-h3-lg-med-primary-mb-16">
         Создание ключа активации
       </h3>
@@ -643,7 +643,7 @@ const ActivationKeyForm = ({ onSave, onCancel }) => {
           </Button>
         </div>
       </form>
-    </Card>);
+    </MacOSCard>);
 
 };
 

--- a/frontend/src/components/admin/AllFreeApproval.jsx
+++ b/frontend/src/components/admin/AllFreeApproval.jsx
@@ -16,7 +16,7 @@ import {
   Bell } from
 'lucide-react';
 import {
-  Card, Badge, Button, Select,
+  MacOSCard, Badge, Button, Select,
 } from '../ui/macos';
 import { useTheme } from '../../contexts/ThemeContext';
 import { toast } from 'react-toastify';
@@ -174,7 +174,7 @@ const AllFreeApproval = () => {void
   reduce((sum, req) => sum + Number(req.total_original_amount || 0), 0);
 
   return (
-    <Card
+    <MacOSCard
       variant="default"
       padding="default">
       
@@ -228,7 +228,7 @@ const AllFreeApproval = () => {void
 
         {/* Статистика */}
         <div className="admin-d-grid-gtc-repeat-auto-fit-minm-gap-16">
-          <Card
+          <MacOSCard
             variant="default"
             padding="default">
             
@@ -245,9 +245,9 @@ const AllFreeApproval = () => {void
                 </p>
               </div>
             </div>
-          </Card>
+          </MacOSCard>
           
-          <Card
+          <MacOSCard
             variant="default"
             padding="default">
             
@@ -264,9 +264,9 @@ const AllFreeApproval = () => {void
                 </p>
               </div>
             </div>
-          </Card>
+          </MacOSCard>
           
-          <Card
+          <MacOSCard
             variant="default"
             padding="default">
             
@@ -283,9 +283,9 @@ const AllFreeApproval = () => {void
                 </p>
               </div>
             </div>
-          </Card>
+          </MacOSCard>
           
-          <Card
+          <MacOSCard
             variant="default"
             padding="default">
             
@@ -302,7 +302,7 @@ const AllFreeApproval = () => {void
                 </p>
               </div>
             </div>
-          </Card>
+          </MacOSCard>
         </div>
 
         {/* Список заявок */}
@@ -319,7 +319,7 @@ const AllFreeApproval = () => {void
 
         <div className="grid gap-4">
             {allFreeRequests.map((request) =>
-          <Card
+          <MacOSCard
             key={request.id}
             className="p-6 border border-gray-200 dark:border-gray-700 hover:shadow-md transition-shadow">
             
@@ -457,7 +457,7 @@ const AllFreeApproval = () => {void
               }
                   </div>
             }
-              </Card>
+              </MacOSCard>
           )}
           </div>
         }
@@ -527,7 +527,7 @@ const AllFreeApproval = () => {void
           </div>
         }
       </div>
-    </Card>);
+    </MacOSCard>);
 
 };
 

--- a/frontend/src/components/admin/DisplayBoardSettings.jsx
+++ b/frontend/src/components/admin/DisplayBoardSettings.jsx
@@ -24,7 +24,7 @@ import {
   Edit } from
 'lucide-react';
 import {
-  Card, Button, Select,
+  MacOSCard, Button, Select,
 } from '../ui/macos';
 import { api } from '../../api/client';
 
@@ -172,18 +172,18 @@ const DisplayBoardSettings = () => {
 
   if (loading) {
     return (
-      <Card className="p-8">
+      <MacOSCard className="p-8">
         <div className="flex items-center justify-center">
           <RefreshCw className="animate-spin mr-2" size={20} />
           <span>Загрузка настроек табло...</span>
         </div>
-      </Card>);
+      </MacOSCard>);
 
   }
 
   if (!selectedBoard) {
     return (
-      <Card className="p-8">
+      <MacOSCard className="p-8">
         <div className="text-center">
           <Monitor size={48} className="mx-auto text-gray-400 mb-4" />
           <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
@@ -191,7 +191,7 @@ const DisplayBoardSettings = () => {
           </h3>
           <p className="text-gray-500">Создайте первое табло для отображения очереди</p>
         </div>
-      </Card>);
+      </MacOSCard>);
 
   }
 
@@ -241,27 +241,27 @@ const DisplayBoardSettings = () => {
 
       {/* Статистика */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <Card className="p-4 text-center">
+        <MacOSCard className="p-4 text-center">
           <div className="text-2xl font-bold text-blue-600">{stats.total_boards || 0}</div>
           <div className="text-sm text-gray-600">Всего табло</div>
-        </Card>
-        <Card className="p-4 text-center">
+        </MacOSCard>
+        <MacOSCard className="p-4 text-center">
           <div className="text-2xl font-bold text-green-600">{stats.total_calls_today || 0}</div>
           <div className="text-sm text-gray-600">Вызовов сегодня</div>
-        </Card>
-        <Card className="p-4 text-center">
+        </MacOSCard>
+        <MacOSCard className="p-4 text-center">
           <div className="text-2xl font-bold text-orange-600">{stats.total_announcements || 0}</div>
           <div className="text-sm text-gray-600">Объявлений</div>
-        </Card>
-        <Card className="p-4 text-center">
+        </MacOSCard>
+        <MacOSCard className="p-4 text-center">
           <div className="text-2xl font-bold text-purple-600">{Math.round(stats.uptime_percentage || 0)}%</div>
           <div className="text-sm text-gray-600">Время работы</div>
-        </Card>
+        </MacOSCard>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Основные настройки */}
-        <Card className="p-6">
+        <MacOSCard className="p-6">
           <h3 className="text-lg font-medium mb-4 flex items-center">
             <Monitor size={20} className="mr-2 text-blue-600" />
             {selectedBoard.display_name}
@@ -382,10 +382,10 @@ const DisplayBoardSettings = () => {
               </label>
             </div>
           </div>
-        </Card>
+        </MacOSCard>
 
         {/* Настройки звука */}
-        <Card className="p-6">
+        <MacOSCard className="p-6">
           <h3 className="text-lg font-medium mb-4 flex items-center">
             <Volume2 size={20} className="mr-2 text-green-600" />
             Звуковые настройки
@@ -465,11 +465,11 @@ const DisplayBoardSettings = () => {
               </>
             }
           </div>
-        </Card>
+        </MacOSCard>
       </div>
 
       {/* Тестирование */}
-      <Card className="p-6">
+      <MacOSCard className="p-6">
         <h3 className="text-lg font-medium mb-4 flex items-center">
           <TestTube size={20} className="mr-2 text-purple-600" />
           Тестирование табло
@@ -531,12 +531,12 @@ const DisplayBoardSettings = () => {
             </div>
           </div>
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Управление контентом */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Баннеры */}
-        <Card className="p-6">
+        <MacOSCard className="p-6">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-medium flex items-center">
               <Image size={20} className="mr-2 text-orange-600" />
@@ -592,10 +592,10 @@ const DisplayBoardSettings = () => {
             )
             }
           </div>
-        </Card>
+        </MacOSCard>
 
         {/* Объявления */}
-        <Card className="p-6">
+        <MacOSCard className="p-6">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-medium flex items-center">
               <MessageCircle size={20} className="mr-2 text-green-600" />
@@ -613,11 +613,11 @@ const DisplayBoardSettings = () => {
               <p>Объявления не добавлены</p>
             </div>
           </div>
-        </Card>
+        </MacOSCard>
       </div>
 
       {/* Информация */}
-      <Card className="p-6 bg-blue-50 border-blue-200 dark:bg-blue-900/20 dark:border-blue-700">
+      <MacOSCard className="p-6 bg-blue-50 border-blue-200 dark:bg-blue-900/20 dark:border-blue-700">
         <h3 className="text-lg font-medium mb-2 flex items-center text-blue-800 dark:text-blue-400">
           <Monitor size={20} className="mr-2" />
           Информация о табло
@@ -629,7 +629,7 @@ const DisplayBoardSettings = () => {
           <p>• Настройки конфиденциальности защищают персональные данные</p>
           <p>• Голосовые объявления поддерживают несколько языков</p>
         </div>
-      </Card>
+      </MacOSCard>
     </div>);
 
 };

--- a/frontend/src/components/admin/FinanceModal.jsx
+++ b/frontend/src/components/admin/FinanceModal.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { X, Save, DollarSign, Calendar, AlertCircle, Receipt } from 'lucide-react';
-import { Card, Button } from '../ui/macos';
+import { MacOSCard, Button } from '../ui/macos';
 import {
   Select,
 } from '../ui/macos';
@@ -228,7 +228,7 @@ const FinanceModal = ({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <Card className="w-full max-w-3xl max-h-[90vh] overflow-y-auto">
+      <MacOSCard className="w-full max-w-3xl max-h-[90vh] overflow-y-auto">
         <div className="p-6">
           {/* Заголовок */}
           <div className="flex items-center justify-between mb-6">
@@ -584,7 +584,7 @@ const FinanceModal = ({
             </div>
           </form>
         </div>
-      </Card>
+      </MacOSCard>
     </div>
   );
 };

--- a/frontend/src/components/admin/GroupPermissionsManager.jsx
+++ b/frontend/src/components/admin/GroupPermissionsManager.jsx
@@ -21,7 +21,7 @@ import {
   User } from
 'lucide-react';
 import {
-  Card, Button, Badge, Input, Select, SegmentedControl, Skeleton,
+  MacOSCard, Button, Badge, Input, Select, SegmentedControl, Skeleton,
 } from '../ui/macos';
 import { toast } from 'react-toastify';
 import { api } from '../../api/client';
@@ -297,7 +297,7 @@ const GroupPermissionsManager = () => {
   const renderUsersTab = () =>
   <div className="admin-flex admin-gap-24">
       {/* Левая панель - список пользователей */}
-      <Card className="admin-card-sidebar-300">
+      <MacOSCard className="admin-card-sidebar-300">
         <h3 className="admin-list-h3">
           <Users className="admin-icon-20" />
           Пользователи
@@ -348,10 +348,10 @@ const GroupPermissionsManager = () => {
             </div>
         }
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Правая панель - разрешения пользователя */}
-      <Card className="admin-card-main-flex-1">
+      <MacOSCard className="admin-card-main-flex-1">
         {selectedUser ?
       <>
             <div className="admin-flex-between-mb-16">
@@ -466,14 +466,14 @@ const GroupPermissionsManager = () => {
             <p className="admin-m-0">Выберите пользователя из списка слева</p>
           </div>
       }
-      </Card>
+      </MacOSCard>
     </div>;
 
 
   const renderGroupsTab = () =>
   <div className="admin-flex admin-gap-24">
       {/* Левая панель - список групп */}
-      <Card className="admin-card-sidebar-300">
+      <MacOSCard className="admin-card-sidebar-300">
         <h3 className="admin-list-h3">
           <Users className="admin-icon-20" />
           Группы
@@ -521,10 +521,10 @@ const GroupPermissionsManager = () => {
             </div>
         )}
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Правая панель - сводка группы */}
-      <Card className="admin-card-main-flex-1">
+      <MacOSCard className="admin-card-main-flex-1">
         {selectedGroup ?
       <>
             <div className="admin-flex-between-mb-16">
@@ -649,12 +649,12 @@ const GroupPermissionsManager = () => {
             <p className="admin-m-0">Выберите группу из списка слева</p>
           </div>
       }
-      </Card>
+      </MacOSCard>
     </div>;
 
 
   const renderCacheTab = () =>
-  <Card className="admin-p-24">
+  <MacOSCard className="admin-p-24">
       <div className="admin-flex-between-mb-24">
         <h3 className="admin-header-h3-m0">
           <Settings className="admin-icon-20" />
@@ -668,7 +668,7 @@ const GroupPermissionsManager = () => {
 
       {cacheStats &&
     <div className="admin-grid-auto-200">
-          <Card className="admin-stat-banner-info">
+          <MacOSCard className="admin-stat-banner-info">
             <div className="admin-flex-center-12">
               <Clock className="admin-icon-24-info" />
               <div>
@@ -680,9 +680,9 @@ const GroupPermissionsManager = () => {
                 </div>
               </div>
             </div>
-          </Card>
+          </MacOSCard>
 
-          <Card className="admin-stat-banner-success">
+          <MacOSCard className="admin-stat-banner-success">
             <div className="admin-flex-center-12">
               <Users className="admin-icon-24-success" />
               <div>
@@ -694,9 +694,9 @@ const GroupPermissionsManager = () => {
                 </div>
               </div>
             </div>
-          </Card>
+          </MacOSCard>
 
-          <Card className="admin-stat-banner-warning">
+          <MacOSCard className="admin-stat-banner-warning">
             <div className="admin-flex-center-12">
               <Key className="admin-icon-24-warning" />
               <div>
@@ -708,7 +708,7 @@ const GroupPermissionsManager = () => {
                 </div>
               </div>
             </div>
-          </Card>
+          </MacOSCard>
         </div>
     }
 
@@ -724,7 +724,7 @@ const GroupPermissionsManager = () => {
         )}
         </div>
       </div>
-    </Card>;
+    </MacOSCard>;
 
 
   return (

--- a/frontend/src/components/admin/RegistrarNotificationManager.jsx
+++ b/frontend/src/components/admin/RegistrarNotificationManager.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import {
-  Card, Button, Badge, Input, Select, Textarea,
+  MacOSCard, Button, Badge, Input, Select, Textarea,
 } from '../ui/macos';
 import {
   Bell,
@@ -145,7 +145,7 @@ const RegistrarNotificationManager = () => {
   const renderSendTab = () =>
   <div className="admin-flex-col-24">
       {/* Форма отправки уведомления */}
-      <Card className="admin-p-24">
+      <MacOSCard className="admin-p-24">
         <h3 className="admin-m-0016px0-primary-flex-ai-center-gap-8-lg-med">
           <Send className="admin-icon-20" />
           Отправить уведомление
@@ -223,10 +223,10 @@ const RegistrarNotificationManager = () => {
           {loading ? <RefreshCw className="admin-w-16-h-16-anim-spin1slinearinfinite" /> : <Send className="admin-icon-16" />}
           Отправить уведомление
         </Button>
-      </Card>
+      </MacOSCard>
 
       {/* Быстрые действия */}
-      <Card className="admin-p-24">
+      <MacOSCard className="admin-p-24">
         <h3 className="admin-m-0016px0-primary-flex-ai-center-gap-8-lg-med">
           <Activity className="admin-icon-20" />
           Быстрые действия
@@ -259,12 +259,12 @@ const RegistrarNotificationManager = () => {
             </Button>
           </div>
         </div>
-      </Card>
+      </MacOSCard>
     </div>;
 
 
   const renderRegistrarsTab = () =>
-  <Card className="admin-p-24">
+  <MacOSCard className="admin-p-24">
       <div className="admin-flex-jc-between-ai-center-mb-24">
         <h3 className="admin-m-0-primary-flex-ai-center-gap-8-lg-med">
           <Users className="admin-icon-20" />
@@ -325,11 +325,11 @@ const RegistrarNotificationManager = () => {
           Нет активных регистраторов
         </div>
     }
-    </Card>;
+    </MacOSCard>;
 
 
   const renderStatsTab = () =>
-  <Card className="admin-p-24">
+  <MacOSCard className="admin-p-24">
       <div className="admin-flex-jc-between-ai-center-mb-24">
         <h3 className="admin-m-0-primary-flex-ai-center-gap-8-lg-med">
           <BarChart3 className="admin-icon-20" />
@@ -402,7 +402,7 @@ const RegistrarNotificationManager = () => {
           </div>
         </div>
     }
-    </Card>;
+    </MacOSCard>;
 
 
   const tabs = [

--- a/frontend/src/components/admin/ReportsManager.jsx
+++ b/frontend/src/components/admin/ReportsManager.jsx
@@ -19,7 +19,7 @@ import {
   FileX,
   Loader2 } from
 'lucide-react';
-import { Card, Button, Badge } from '../ui/macos';
+import { MacOSCard, Button, Badge } from '../ui/macos';
 import {
   MacOSStatCard,
   Table,
@@ -219,7 +219,7 @@ const ReportsManager = () => {
   const renderGenerateTab = () =>
   <div className="admin-flex-col-24">
       {/* Форма генерации отчета */}
-      <Card className="admin-card-p-24-bg-card-12">
+      <MacOSCard className="admin-card-p-24-bg-card-12">
         <h3 className="admin-h3-18-600-primary-mb-20">
           <BarChart3 className="admin-icon-20-mr-10-blue" />
           Генерация отчета
@@ -297,10 +297,10 @@ const ReportsManager = () => {
           }
           </Button>
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Быстрые отчеты */}
-      <Card className="admin-card-p-24-bg-card-12">
+      <MacOSCard className="admin-card-p-24-bg-card-12">
         <h3 className="admin-h3-18-600-primary-mb-20">
           <Clock className="admin-icon-20-mr-10-blue" />
           Быстрые отчеты (сегодня)
@@ -318,11 +318,11 @@ const ReportsManager = () => {
           loading={!quickReports.daily} />
 
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Последние отчеты */}
       {reports.length > 0 &&
-    <Card className="admin-p-24">
+    <MacOSCard className="admin-p-24">
           <h3 className="admin-h4-lg-semi-primary-mb-16">Последние отчеты</h3>
           <Table
         columns={[
@@ -365,14 +365,14 @@ const ReportsManager = () => {
         hoverable={true}
         striped={true} />
 
-        </Card>
+        </MacOSCard>
     }
     </div>;
 
 
   const renderFilesTab = () =>
   <div className="admin-flex-col-24">
-      <Card className="admin-card-p-24-bg-card-12-min-h-400">
+      <MacOSCard className="admin-card-p-24-bg-card-12-min-h-400">
         <div className="admin-flex-between-mb-24">
           <h3 className="admin-h3-18-600-primary-m0-flex">
             <FileSpreadsheet className="admin-icon-22-mr-10-blue" />
@@ -464,14 +464,14 @@ const ReportsManager = () => {
         striped={true} />
 
       }
-      </Card>
+      </MacOSCard>
     </div>;
 
 
   const renderSettingsTab = () =>
   <div className="admin-flex-col-24">
       {/* Автоматические отчеты */}
-      <Card className="admin-card-p-24-bg-card-12">
+      <MacOSCard className="admin-card-p-24-bg-card-12">
         <div className="admin-flex-start-16-mb-24">
           <div className="admin-icon-box-56-gradient-blue">
             <Clock className="admin-icon-32-white" />
@@ -504,10 +504,10 @@ const ReportsManager = () => {
             Настроить уведомления
           </Button>
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Хранение и очистка */}
-      <Card className="admin-card-p-24-bg-card-12">
+      <MacOSCard className="admin-card-p-24-bg-card-12">
         <div className="admin-flex-start-16-mb-24">
           <div className="admin-icon-box-56-gradient-green">
             <FileSpreadsheet className="admin-icon-32-white" />
@@ -540,10 +540,10 @@ const ReportsManager = () => {
             Экспорт в облако
           </Button>
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Статистика хранения */}
-      <Card className="admin-card-p-24-bg-card-12">
+      <MacOSCard className="admin-card-p-24-bg-card-12">
         <h3 className="admin-h3-18-600-primary-mb-20">Статистика хранения</h3>
 
         <div className="admin-grid-3col-24">
@@ -574,14 +574,14 @@ const ReportsManager = () => {
             </div>
           </div>
         </div>
-      </Card>
+      </MacOSCard>
     </div>;
 
 
   return (
     <div className="admin-flex-col-24">
       {error ?
-      <Card className="admin-card-p-48-flex-justify-center">
+      <MacOSCard className="admin-card-p-48-flex-justify-center">
           <MacOSEmptyState
           icon={AlertCircle}
           title="Ошибка загрузки данных"
@@ -592,7 +592,7 @@ const ReportsManager = () => {
               Повторить попытку
             </Button>
           </MacOSEmptyState>
-        </Card> :
+        </MacOSCard> :
 
       <>
           <div className="admin-flex-between">

--- a/frontend/src/components/admin/TelegramSettings.jsx
+++ b/frontend/src/components/admin/TelegramSettings.jsx
@@ -19,7 +19,7 @@ import {
 
 'lucide-react';
 import {
-  Card, Button, Input, Select, Checkbox,
+  MacOSCard, Button, Input, Select, Checkbox,
 } from '../ui/macos';
 
 import { api } from '../../api/client';
@@ -153,12 +153,12 @@ const TelegramSettings = () => {
 
   if (loading) {
     return (
-      <Card className="admin-p-32">
+      <MacOSCard className="admin-p-32">
         <div className="admin-flex-ai-center-jc-center">
           <RefreshCw className="admin-w-20-h-20-mr-8-anim-spin1slinearinfinite" />
           <span className="admin-text-primary">Загрузка Telegram настроек...</span>
         </div>
-      </Card>);
+      </MacOSCard>);
 
   }
 
@@ -211,43 +211,43 @@ const TelegramSettings = () => {
 
       {/* Статистика */}
       <div className="admin-grid-gtc-rauto-fitcminmax200pxc1fr-gap-16">
-        <Card className="admin-p-24-ta-center">
+        <MacOSCard className="admin-p-24-ta-center">
           <div className="admin-2xl-bold-blue-mb-8">
             {stats.total_users || 0}
           </div>
           <div className="admin-text-sm admin-text-secondary">
             Всего пользователей
           </div>
-        </Card>
-        <Card className="admin-p-24-ta-center">
+        </MacOSCard>
+        <MacOSCard className="admin-p-24-ta-center">
           <div className="admin-2xl-bold-success-mb-8">
             {stats.messages_sent || 0}
           </div>
           <div className="admin-text-sm admin-text-secondary">
             Сообщений отправлено
           </div>
-        </Card>
-        <Card className="admin-p-24-ta-center">
+        </MacOSCard>
+        <MacOSCard className="admin-p-24-ta-center">
           <div className="admin-2xl-bold-warning-mb-8">
             {stats.messages_delivered || 0}
           </div>
           <div className="admin-text-sm admin-text-secondary">
             Доставлено
           </div>
-        </Card>
-        <Card className="admin-p-24-ta-center">
+        </MacOSCard>
+        <MacOSCard className="admin-p-24-ta-center">
           <div className="admin-2xl-bold-error-mb-8">
             {stats.messages_failed || 0}
           </div>
           <div className="admin-text-sm admin-text-secondary">
             Ошибок
           </div>
-        </Card>
+        </MacOSCard>
       </div>
 
       <div className="admin-grid-gtc-rauto-fitcminmax400pxc1fr-gap-24">
         {/* Основные настройки */}
-        <Card className="admin-p-24">
+        <MacOSCard className="admin-p-24">
           <h3 className="admin-lg-med-mb-16-flex-ai-center-primary-m-0">
             <Bot className="admin-w-20-h-20-mr-8-blue" />
             Настройки бота
@@ -324,10 +324,10 @@ const TelegramSettings = () => {
               </Button>
             </div>
           </div>
-        </Card>
+        </MacOSCard>
 
         {/* Настройки уведомлений */}
-        <Card className="admin-p-24">
+        <MacOSCard className="admin-p-24">
           <h3 className="admin-lg-med-mb-16-flex-ai-center-primary-m-0">
             <Bell className="admin-w-20-h-20-mr-8-success" />
             Уведомления
@@ -408,11 +408,11 @@ const TelegramSettings = () => {
               </div>
             }
           </div>
-        </Card>
+        </MacOSCard>
       </div>
 
       {/* Тестирование */}
-      <Card className="admin-p-24">
+      <MacOSCard className="admin-p-24">
         <h3 className="admin-lg-med-mb-16-flex-ai-center-primary-m-0">
           <Send className="admin-w-20-h-20-mr-8-purple" />
           Тестирование отправки сообщений
@@ -457,10 +457,10 @@ const TelegramSettings = () => {
             Отправить тест
           </Button>
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Инструкция */}
-      <Card className="admin-p-24-bg-info-bg-bd-1solidvar-mac-info-border">
+      <MacOSCard className="admin-p-24-bg-info-bg-bd-1solidvar-mac-info-border">
         <h3 className="admin-lg-med-mb-8-flex-ai-center-info-m-0">
           <MessageSquare className="admin-w-20-h-20-mr-8" />
           Настройка Telegram бота
@@ -472,7 +472,7 @@ const TelegramSettings = () => {
           <p className="admin-m-0">4. Установите webhook для получения сообщений</p>
           <p className="admin-m-0">5. Добавьте ID чатов администраторов для служебных уведомлений</p>
         </div>
-      </Card>
+      </MacOSCard>
     </div>);
 
 };

--- a/frontend/src/components/admin/UserDataTransferManager.jsx
+++ b/frontend/src/components/admin/UserDataTransferManager.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import {
-  Card, Button, Input, Checkbox, SegmentedControl,
+  MacOSCard, Button, Input, Checkbox, SegmentedControl,
 } from '../ui/macos';
 import { Users, ArrowRight, Search, CheckCircle, XCircle, History, BarChart3 } from 'lucide-react';
 import { toast } from 'react-toastify';
@@ -237,7 +237,7 @@ const UserDataTransferManager = () => {
   const renderTransferTab = () =>
   <div className="admin-flex-col-24">
       {/* Поиск пользователей */}
-      <Card className="admin-p-24">
+      <MacOSCard className="admin-p-24">
         <h3 className="admin-lg-med-primary-m-0016px0-flex-ai-center-gap-8">
           <Search className="admin-icon-20" />
           Поиск пользователей
@@ -296,11 +296,11 @@ const UserDataTransferManager = () => {
             </div>
         }
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Выбранные пользователи */}
       <div className="admin-grid-gtc-rauto-fitcminmax300pxc1fr-gap-24">
-        <Card className="admin-p-24">
+        <MacOSCard className="admin-p-24">
           <h3 className="admin-lg-med-primary-m-0016px0">
             Пользователь-источник
           </h3>
@@ -332,9 +332,9 @@ const UserDataTransferManager = () => {
               Выберите пользователя-источника из результатов поиска
             </div>
         }
-        </Card>
+        </MacOSCard>
 
-        <Card className="admin-p-24">
+        <MacOSCard className="admin-p-24">
           <h3 className="admin-lg-med-primary-m-0016px0">
             Пользователь-получатель
           </h3>
@@ -363,12 +363,12 @@ const UserDataTransferManager = () => {
               Выберите пользователя-получателя из результатов поиска
             </div>
         }
-        </Card>
+        </MacOSCard>
       </div>
 
       {/* Сводка данных источника */}
       {userDataSummary &&
-    <Card className="admin-p-24">
+    <MacOSCard className="admin-p-24">
           <h3 className="admin-lg-med-primary-m-0016px0">
             Данные для передачи
           </h3>
@@ -398,11 +398,11 @@ const UserDataTransferManager = () => {
               </div>
             </div>
           </div>
-        </Card>
+        </MacOSCard>
     }
 
       {/* Выбор типов данных */}
-      <Card className="admin-p-24">
+      <MacOSCard className="admin-p-24">
         <h3 className="admin-lg-med-primary-m-0016px0">
           Типы данных для передачи
         </h3>
@@ -433,7 +433,7 @@ const UserDataTransferManager = () => {
             </label>
         )}
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Кнопка передачи */}
       <div className="admin-flex-jc-center">
@@ -461,7 +461,7 @@ const UserDataTransferManager = () => {
 
 
   const renderHistoryTab = () =>
-  <Card className="admin-p-24">
+  <MacOSCard className="admin-p-24">
       <div className="admin-flex-jc-between-ai-center-mb-16">
         <h3 className="admin-lg-med-primary-m-0">
           История передач
@@ -502,11 +502,11 @@ const UserDataTransferManager = () => {
       )}
         </div>
     }
-    </Card>;
+    </MacOSCard>;
 
 
   const renderStatisticsTab = () =>
-  <Card className="admin-p-24">
+  <MacOSCard className="admin-p-24">
       <div className="admin-flex-jc-between-ai-center-mb-16">
         <h3 className="admin-lg-med-primary-m-0">
           Статистика передач
@@ -549,7 +549,7 @@ const UserDataTransferManager = () => {
           Нажмите «Обновить» для загрузки статистики
         </div>
     }
-    </Card>;
+    </MacOSCard>;
 
 
   return (

--- a/frontend/src/components/admin/UserExportManager.jsx
+++ b/frontend/src/components/admin/UserExportManager.jsx
@@ -17,7 +17,7 @@ import {
   File } from
 'lucide-react';
 import {
-  Card, Button, Input, Select, Checkbox, SegmentedControl, Skeleton,
+  MacOSCard, Button, Input, Select, Checkbox, SegmentedControl, Skeleton,
 } from '../ui/macos';
 import { toast } from 'react-toastify';
 import { api } from '../../api/client';
@@ -232,7 +232,7 @@ const UserExportManager = () => {
   const renderExportTab = () =>
   <div className="admin-d-grid-gtc-1fr-1fr-gap-24">
       {/* Левая панель - настройки экспорта */}
-      <Card className="admin-p-24">
+      <MacOSCard className="admin-p-24">
         <h3 className="admin-m-0-0-24px-0-d-flex-ai-center-gap-8-fs-lg-fw-med-primary">
           <Settings className="admin-icon-20" />
           Настройки экспорта
@@ -314,10 +314,10 @@ const UserExportManager = () => {
             </label>
           </div>
         </div>
-      </Card>
+      </MacOSCard>
 
       {/* Правая панель - фильтры */}
-      <Card className="admin-p-24">
+      <MacOSCard className="admin-p-24">
         <h3 className="admin-m-0-0-24px-0-d-flex-ai-center-gap-8-fs-lg-fw-med-primary">
           <Filter className="admin-icon-20" />
           Фильтры
@@ -446,12 +446,12 @@ const UserExportManager = () => {
           }
           </Button>
         </div>
-      </Card>
+      </MacOSCard>
     </div>;
 
 
   const renderFilesTab = () =>
-  <Card className="admin-p-24">
+  <MacOSCard className="admin-p-24">
       <div className="admin-d-flex-jc-between-ai-center-mb-24">
         <h3 className="admin-m-0-d-flex-ai-center-gap-8-fs-lg-fw-med-primary">
           <FileText className="admin-icon-20" />
@@ -516,7 +516,7 @@ const UserExportManager = () => {
       )}
         </div>
     }
-    </Card>;
+    </MacOSCard>;
 
 
   return (


### PR DESCRIPTION
## Summary

- Sprint 7a of 9-sprint admin redesign roadmap. Batch 1: 11 admin files migrated from plain `Card` to `MacOSCard` for naming consistency.
- No functional changes — `Card` and `MacOSCard` are the same component (`MacOSCard` is an alias export from `ui/macos/Card.jsx`). 11 files used `Card` while 34 used `MacOSCard` — now all 45 use `MacOSCard` consistently.
- Pure naming consistency for maintainability.

### Files migrated (11)
- AISettings.jsx, ActivationSystem.jsx, AllFreeApproval.jsx, DisplayBoardSettings.jsx, FinanceModal.jsx, GroupPermissionsManager.jsx, RegistrarNotificationManager.jsx, ReportsManager.jsx, TelegramSettings.jsx, UserDataTransferManager.jsx, UserExportManager.jsx

## Cyclic Execution Evidence

- Fresh main sync: branch created from current `origin/main` (`d89d6ee3` — includes merged Sprint 6 PR #1855).
- Clean workspace: 11 files touched (import + JSX usage renamed).
- Branch: `refactor/admin-sprint7a-card-homogenization-batch1`
- Scope gate: allowed 11 admin `.jsx` files (Card→MacOSCard rename only); denied backend, routing, any other component.
- Red-check handling: fix any failed targeted check in this same PR before merge.

## Contract Impact

not applicable - admin frontend naming refactor only, no API, websocket, event, or frontend consumer contract changed. Card and MacOSCard are the same component (alias export). No behavior change.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed. Card and MacOSCard are identical components (alias export from `ui/macos/Card.jsx`). The rename is purely cosmetic for code consistency.

## Scope Gate

- Allowed paths: 11 admin `.jsx` files (Card→MacOSCard rename).
- Denied paths: backend, routing, any other component, Card.jsx itself.
- Migration/docs/test impact: no migration; no test files changed.
- Rollback note: revert this commit. `Card` naming returns to 11 files.

## Validation

- Targeted tests or smoke run: `vite build` + `eslint` on sample files + `vitest run`.
- Result: passed — `vite build` exit 0 (~24s); `eslint` 0 errors; `vitest run` 515/515 pass.
- Not checked: full browser panel smoke (left to CI e2e). The rename is purely cosmetic — same component, same behavior.

Roadmap (9-sprint admin redesign):
- Sprint 5 (#1853, merged) — internal tabs cleanup.
- Sprint 6 (#1855, merged) — shared MacOSTab.
- Sprint 7a batch 1 (this PR) — Card→MacOSCard naming: 11 files, +165/-165.
- Sprint 7a batch 2 — remaining visual: Tables, Forms, gradual admin.css migration.
- Sprint 8 — sidebar redesign (macOS native).
- Sprint 9 — polish: loading/empty/error states, micro-interactions, dark mode.
