### PR TITLE
🎨 Palette: Add accessible loading state to StateWrapper

### DIFF
--- a/frontend/src/components/common/StateWrapper.jsx
+++ b/frontend/src/components/common/StateWrapper.jsx
@@ -60,7 +60,13 @@ export function StateWrapper({
   // First load: show skeleton
   if (isLoading && !hasHadDataRef.current) {
     return (
-      <div style={{ padding: '16px 8px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
+      <div
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+        aria-label="Загрузка данных"
+        style={{ padding: '16px 8px', display: 'flex', flexDirection: 'column', gap: '12px' }}
+      >
         {Array.from({ length: skeletonRows }).map((_, i) => (
           <Skeleton
             key={i}

--- a/frontend/src/components/ui/macos/Skeleton.jsx
+++ b/frontend/src/components/ui/macos/Skeleton.jsx
@@ -42,11 +42,11 @@ const Skeleton = ({
 
   const renderTextSkeleton = () => {
     if (lines === 1) {
-      return <div className={className} style={textStyle} />;
+      return <div className={className} style={textStyle} aria-hidden="true" />;
     }
 
     return (
-      <div className={className} style={containerStyle}>
+      <div className={className} style={containerStyle} aria-hidden="true">
         {Array.from({ length: lines }, (_, index) => (
           <div
             key={index}
@@ -61,15 +61,15 @@ const Skeleton = ({
   };
 
   const renderCircleSkeleton = () => (
-    <div className={className} style={circleStyle} />
+    <div className={className} style={circleStyle} aria-hidden="true" />
   );
 
   const renderRectSkeleton = () => (
-    <div className={className} style={rectStyle} />
+    <div className={className} style={rectStyle} aria-hidden="true" />
   );
 
   const renderCardSkeleton = () => (
-    <div className={className} style={containerStyle}>
+    <div className={className} style={containerStyle} aria-hidden="true">
       <div style={{ ...rectStyle, height: '16px', width: '60%' }} />
       <div style={{ ...rectStyle, height: '24px', width: '80%' }} />
       <div style={{ ...rectStyle, height: '14px', width: '40%' }} />
@@ -77,7 +77,7 @@ const Skeleton = ({
   );
 
   const renderTableSkeleton = () => (
-    <div className={className} style={containerStyle}>
+    <div className={className} style={containerStyle} aria-hidden="true">
       {/* Header */}
       <div style={{ display: 'flex', gap: spacing }}>
         {Array.from({ length: 4 }, (_, index) => (
@@ -102,7 +102,7 @@ const Skeleton = ({
   );
 
   const renderListSkeleton = () => (
-    <div className={className} style={containerStyle}>
+    <div className={className} style={containerStyle} aria-hidden="true">
       {Array.from({ length: lines }, (_, index) => (
         <div
           key={index}


### PR DESCRIPTION
💡 **What**: Added `role="status"`, `aria-live="polite"`, `aria-busy="true"`, and `aria-label="Загрузка данных"` to the main loading container in `StateWrapper.jsx`, and `aria-hidden="true"` to the inner `Skeleton.jsx` blocks.
🎯 **Why**: When complex UI panels fetch data and show skeletons, screen readers were previously silent or read out structural elements (like "group"). By adding ARIA loading properties to the wrapper, assistive technology correctly announces "Загрузка данных". Adding `aria-hidden` to skeletons prevents redundant noise.
📸 **Before/After**: Visually identical; completely improves the non-visual experience.
♿ **Accessibility**: Significant improvement for screen reader users when panels enter asynchronous loading states.

---
*PR created automatically by Jules for task [4784227944802564212](https://jules.google.com/task/4784227944802564212) started by @drsapaev*