### PR TITLE
refactor(admin): Sprint 7bc — table wrapper + macOS table styling

### DIFF
--- a/frontend/src/components/admin/AdminAppointments.jsx
+++ b/frontend/src/components/admin/AdminAppointments.jsx
@@ -364,6 +364,7 @@ const AdminAppointments = () => {
               }
             />
           ) : (
+            <div className="admin-table-wrapper">
             <table className="admin-w-100pct-bc-collapse" aria-label="Таблица записей">
               <thead>
                 <tr
@@ -514,6 +515,7 @@ const AdminAppointments = () => {
                 })}
               </tbody>
             </table>
+          </div>
           )}
         </div>
       </MacOSCard>

--- a/frontend/src/components/admin/AdminDoctors.jsx
+++ b/frontend/src/components/admin/AdminDoctors.jsx
@@ -222,6 +222,7 @@ const AdminDoctors = () => {
               }
             />
           ) : (
+            <div className="admin-table-wrapper">
             <table className="admin-w-100pct-bc-collapse" aria-label="Таблица врачей">
               <thead>
                 <tr
@@ -328,6 +329,7 @@ const AdminDoctors = () => {
                 ))}
               </tbody>
             </table>
+          </div>
           )}
         </div>
       </MacOSCard>

--- a/frontend/src/components/admin/AdminFinanceOverview.jsx
+++ b/frontend/src/components/admin/AdminFinanceOverview.jsx
@@ -321,6 +321,7 @@ const AdminFinanceOverview = () => {
               )}
             />
           ) : (
+            <div className="admin-table-wrapper">
             <table className="admin-w-full" aria-label="Таблица транзакций">
               <thead>
                 <tr className="admin-bd-b-1px-solid-var-mac-se">
@@ -428,6 +429,7 @@ const AdminFinanceOverview = () => {
                 ))}
               </tbody>
             </table>
+          </div>
           )}
         </div>
       </MacOSCard>

--- a/frontend/src/components/admin/AdminPatients.jsx
+++ b/frontend/src/components/admin/AdminPatients.jsx
@@ -253,6 +253,7 @@ const AdminPatients = () => {
               }
             />
           ) : (
+            <div className="admin-table-wrapper">
             <table className="admin-w-100pct-bc-collapse" aria-label="Таблица пациентов">
               <thead>
                 <tr
@@ -351,6 +352,7 @@ const AdminPatients = () => {
                 ))}
               </tbody>
             </table>
+          </div>
           )}
         </div>
       </MacOSCard>

--- a/frontend/src/components/admin/DepartmentManagement.jsx
+++ b/frontend/src/components/admin/DepartmentManagement.jsx
@@ -1091,7 +1091,8 @@ const DepartmentManagement = () => {
 
                     {/* ✅ ТАБЛИЧНЫЙ ВИД ОТДЕЛЕНИЙ */}
                     <div className="admin-table-container">
-                        <table className="admin-table-full">
+                        <div className="admin-table-wrapper">
+            <table className="admin-table-full">
                             <thead>
                                 <tr className="admin-table-head">
                                     <th className="admin-th-w-40">
@@ -1202,6 +1203,7 @@ const DepartmentManagement = () => {
                 })}
                             </tbody>
                         </table>
+          </div>
                     </div>
 
                     {departments.length === 0 &&

--- a/frontend/src/components/admin/QueueProfilesManager.jsx
+++ b/frontend/src/components/admin/QueueProfilesManager.jsx
@@ -562,7 +562,8 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                 )}
 
                 {/* Profiles table */}
-                <table className="admin-qp-table">
+                <div className="admin-table-wrapper">
+            <table className="admin-qp-table">
                     <thead>
                         <tr>
                             <th className="admin-ta-left-p-12px-8px-bd-b-2px-solid-var-mac-bo-fs-12-fw-600-secondary-tt-uppercase-w-40">
@@ -690,6 +691,7 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                         ))}
                     </tbody>
                 </table>
+          </div>
 
                 {filteredProfiles.length === 0 && (
                     <div className="admin-ta-center-p-40-secondary">

--- a/frontend/src/components/admin/admin.css
+++ b/frontend/src/components/admin/admin.css
@@ -12470,3 +12470,44 @@
   color: var(--mac-success);
   margin-bottom: 8px;
 }
+
+/* ============================================
+   Sprint 7b: Shared table wrapper — macOS native appearance
+   Rounded corners, clipped overflow, subtle shadow.
+   Usage: <div className="admin-table-wrapper"><table>...</table></div>
+   ============================================ */
+.admin-table-wrapper {
+  border-radius: var(--mac-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--mac-border);
+  background: var(--mac-bg-primary);
+  box-shadow: var(--mac-shadow-sm);
+}
+
+.admin-table-wrapper table {
+  margin: 0;
+}
+
+.admin-table-wrapper thead {
+  background: var(--mac-bg-secondary);
+}
+
+.admin-table-wrapper th {
+  font-size: var(--mac-font-size-xs);
+  font-weight: var(--mac-font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--mac-text-secondary);
+}
+
+.admin-table-wrapper tbody tr {
+  transition: background-color var(--mac-duration-fast) var(--mac-ease);
+}
+
+.admin-table-wrapper tbody tr:hover {
+  background: var(--mac-bg-secondary);
+}
+
+.admin-table-wrapper tbody tr:last-child td {
+  border-bottom: none;
+}


### PR DESCRIPTION
## Summary

- Sprint 7b of 9-sprint admin redesign roadmap. Added shared table wrapper for macOS-native table appearance (rounded corners, clipped overflow, shadow, uppercase headers, hover states).
- 6 admin files updated: native `<table>` wrapped with `<div className='admin-table-wrapper'>`.
- Sprint 7c (Form elements): 9 files have native `<input>` — deferred to next batch (37+ inputs, too large for one PR).

### Changes
- `admin.css`: added `.admin-table-wrapper` class with macOS tokens (rounded corners, clipped overflow, subtle shadow, uppercase headers, hover states)
- 6 files wrapped: AdminAppointments, AdminDoctors, AdminFinanceOverview, AdminPatients, DepartmentManagement, QueueProfilesManager

### Finding
Table CSS already used macos tokens (verified — 0 hardcoded colors in table-related classes after CSS migration PR #1828). This PR adds the missing visual container: rounded corners + overflow clip + shadow — the macOS-native table appearance.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` (`5e15b86d` — includes Sprint 7a).
- Clean workspace: 7 files touched (1 CSS + 6 JSX).
- Branch: `refactor/admin-sprint7bc-tables-forms`
- Scope gate: allowed admin.css + 6 admin JSX files (table wrapper only).
- Red-check handling: fix any failed targeted check in this same PR before merge.

## Contract Impact

not applicable - admin frontend visual styling only, no API, websocket, event, or frontend consumer contract changed. No route paths, no data flow. The table wrapper is a CSS-only visual container around existing tables.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed. The table wrapper is a CSS-only visual container — same table structure, same data, same behavior. Only visual appearance changes (rounded corners, shadow, uppercase headers).

## Scope Gate

- Allowed paths: `frontend/src/components/admin/admin.css`, 6 admin `.jsx` files (table wrapper div).
- Denied paths: backend, routing, any other component.
- Migration/docs/test impact: no migration; no test files changed.
- Rollback note: revert this commit. Table wrapper divs disappear. Tables render without rounded corners/shadow.

## Validation

- Targeted tests or smoke run: `vite build` + `vitest run`.
- Result: passed — `vite build` exit 0 (~25s); `vitest run` 515/515 pass.
- Not checked: full browser panel smoke (left to CI e2e). The wrapper is CSS-only — no behavior change.

Roadmap (9-sprint admin redesign):
- Sprint 5 (#1853, merged) — internal tabs cleanup.
- Sprint 6 (#1855, merged) — shared MacOSTab.
- Sprint 7a (#1857, merged) — Card→MacOSCard naming.
- Sprint 7b (this PR) — table wrapper: 7 files, +55/-2.
- Sprint 7c — form elements (deferred to batch 2: 9 files, 37+ inputs).
- Sprint 8 — sidebar redesign (macOS native).
- Sprint 9 — polish: loading/empty/error states, micro-interactions, dark mode.
