### PR TITLE
fix(vercel): add --legacy-peer-deps to npm ci (fixes Vercel deploy)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "npm --prefix frontend run build",
-  "installCommand": "npm --prefix frontend ci",
+  "installCommand": "npm --prefix frontend ci --legacy-peer-deps",
   "framework": "vite",
   "outputDirectory": "frontend/dist",
   "git": {


### PR DESCRIPTION
## Summary

Vercel deployment fails with `npm ci can only install packages when your package.json and package-lock.json are in sync`. Root cause: `vercel.json` uses `npm ci` (without `--legacy-peer-deps`), but the CI workflow already uses `npm ci --legacy-peer-deps` (added in PR #1803).

## Root cause

There is a pre-existing peer dependency conflict in the project:
- `recharts@3.9.1` → `react-redux@9` wants `redux@^5.0.0`
- `react-beautiful-dnd@13.1.1` → `react-redux@7` wants `redux@^4.0.0`

npm 10 (used by Vercel's Node 20) cannot resolve this conflict with plain `npm ci`. The `--legacy-peer-deps` flag tells npm to use the older (npm 6) peer dep resolution behavior, which tolerates the conflict.

## Fix

Changed `vercel.json`:
```diff
- "installCommand": "npm --prefix frontend ci",
+ "installCommand": "npm --prefix frontend ci --legacy-peer-deps",
```

This makes Vercel use the same install command as CI.

## Cyclic Execution Evidence
- Fresh main sync: branch `fix/vercel-npm-ci` created from `origin/main` at commit `34564cb8`
- Clean workspace: only `vercel.json` touched
- Branch: `fix/vercel-npm-ci`
- Scope gate: allowed `vercel.json`; denied all other files
- Red-check handling: Vercel deployment will be the CI check for this PR

## Contract Impact
- Canonical surface: not applicable - no backend contract changes
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: none (build config change only)
- Compatibility path or alias: not applicable
- Contract proof: no code changes, only build config

## RBAC / Permissions
- Roles allowed: all (unchanged)
- Roles denied: none (unchanged)
- Positive auth proof: routeRegistry.js unchanged; routeGuards.jsx unchanged
- Negative auth proof: not applicable - no changes to route role arrays or guard logic

## Notification / Realtime
not applicable - no notification, websocket, chat, or realtime behavior changed. Build config change only.

## Frontend Resilience
- Empty data proof: not applicable - build config change
- Partial data proof: not applicable - build config change
- Forbidden secondary path behavior: not applicable - no new code paths introduced
- Missing draft/resource behavior: not applicable - build config change
- Stale route/deep-link behavior: not applicable - URL contract unchanged

## Scope Gate
- Allowed paths: `vercel.json`
- Denied paths: all other files
- Migration/docs/test impact: no migration; no test changes needed
- Rollback note: revert 1 commit; no database state to revert; no feature flags to disable

## Validation
- Targeted tests or smoke run: not applicable (build config change only)
- Result: Vercel deployment should succeed after merge
- Not checked: actual Vercel deployment (will be verified by Vercel's preview deployment on this PR)
- Manual checks performed locally:
  - `npm ci --legacy-peer-deps` succeeds locally
  - `npm run build` succeeds locally
