### PR TITLE
refactor: migrate 11 components from utils/api.js to api/client.js

### DIFF
--- a/frontend/src/components/ai/AnalyticsInsights.jsx
+++ b/frontend/src/components/ai/AnalyticsInsights.jsx
@@ -29,7 +29,7 @@ import {
 
 'lucide-react';
 import { toast } from 'react-toastify';
-import { api } from '../../utils/api';
+import { api } from '../../api/client';
 
 import logger from '../../utils/logger';
 

--- a/frontend/src/components/ai/DrugInteractionChecker.jsx
+++ b/frontend/src/components/ai/DrugInteractionChecker.jsx
@@ -27,7 +27,7 @@ import {
   Badge,
 } from '../ui/macos';
 import { toast } from 'react-toastify';
-import { api } from '../../utils/api';
+import { api } from '../../api/client';
 
 import logger from '../../utils/logger';
 const DrugInteractionChecker = () => {

--- a/frontend/src/components/ai/MedicalImageAnalyzer.jsx
+++ b/frontend/src/components/ai/MedicalImageAnalyzer.jsx
@@ -14,7 +14,7 @@ import {
   Heart } from
 'lucide-react';
 import { toast } from 'react-toastify';
-import { api } from '../../utils/api';
+import { api } from '../../api/client';
 import logger from '../../utils/logger';
 import {
   MacOSCard,

--- a/frontend/src/components/ai/QualityControl.jsx
+++ b/frontend/src/components/ai/QualityControl.jsx
@@ -27,7 +27,7 @@ import {
   Zap } from
 'lucide-react';
 import { toast } from 'react-toastify';
-import { api } from '../../utils/api';
+import { api } from '../../api/client';
 
 import logger from '../../utils/logger';
 

--- a/frontend/src/components/ai/RiskAssessment.jsx
+++ b/frontend/src/components/ai/RiskAssessment.jsx
@@ -28,7 +28,7 @@ import {
   Select,
 } from '../ui/macos';
 import { toast } from 'react-toastify';
-import { api } from '../../utils/api';
+import { api } from '../../api/client';
 
 import logger from '../../utils/logger';
 const RiskAssessment = () => {

--- a/frontend/src/components/ai/SmartScheduling.jsx
+++ b/frontend/src/components/ai/SmartScheduling.jsx
@@ -30,7 +30,7 @@ import {
 
 'lucide-react';
 import { toast } from 'react-toastify';
-import { api } from '../../utils/api';
+import { api } from '../../api/client';
 
 import logger from '../../utils/logger';
 

--- a/frontend/src/components/ai/TreatmentRecommendations.jsx
+++ b/frontend/src/components/ai/TreatmentRecommendations.jsx
@@ -25,7 +25,7 @@ import {
   Textarea,
 } from '../ui/macos';
 import { toast } from 'react-toastify';
-import { api } from '../../utils/api';
+import { api } from '../../api/client';
 
 import logger from '../../utils/logger';
 const TreatmentRecommendations = () => {

--- a/frontend/src/components/ai/VoiceToText.jsx
+++ b/frontend/src/components/ai/VoiceToText.jsx
@@ -30,7 +30,7 @@ import {
   Checkbox,
 } from '../ui/macos';
 import { toast } from 'react-toastify';
-import { api } from '../../utils/api';
+import { api } from '../../api/client';
 
 import logger from '../../utils/logger';
 const VoiceToText = () => {

--- a/frontend/src/components/analytics/AIAnalytics.jsx
+++ b/frontend/src/components/analytics/AIAnalytics.jsx
@@ -31,7 +31,7 @@ import {
 
 'lucide-react';
 import { toast } from 'react-toastify';
-import { api } from '../../utils/api';
+import { api } from '../../api/client';
 
 import logger from '../../utils/logger';
 const AIAnalytics = () => {

--- a/frontend/src/components/analytics/WaitTimeAnalytics.jsx
+++ b/frontend/src/components/analytics/WaitTimeAnalytics.jsx
@@ -26,7 +26,7 @@ import {
   Zap } from
 'lucide-react';
 import { toast } from 'react-toastify';
-import { api } from '../../utils/api';
+import { api } from '../../api/client';
 
 import logger from '../../utils/logger';
 const WaitTimeAnalytics = () => {

--- a/frontend/src/components/auth/PhoneVerification.jsx
+++ b/frontend/src/components/auth/PhoneVerification.jsx
@@ -9,7 +9,7 @@ import {
   RefreshCw,
   Send
 } from 'lucide-react';
-import { api } from '../../utils/api';
+import { api } from '../../api/client';
 import { toast } from 'react-toastify';
 
 import logger from '../../utils/logger';


### PR DESCRIPTION
## Eliminate 4th axios instance

All 11 remaining components migrated from `utils/api.js` to `api/client.js`.

### Migrated (11 files)
- 8 AI components (AnalyticsInsights, DrugInteractionChecker, MedicalImageAnalyzer, QualityControl, RiskAssessment, SmartScheduling, TreatmentRecommendations, VoiceToText)
- 2 analytics components (AIAnalytics, WaitTimeAnalytics)
- 1 auth component (PhoneVerification)

### Result
- `utils/api.js` has **ZERO consumers** now
- All API calls go through centralized `api/client.js` with auth/CSRF/refresh/rate-limit
- File can be safely deleted in follow-up

### Validation
- ✅ 515 tests pass
- ✅ 0 lint errors
- ✅ Build OK