### PR TITLE
refactor: normalize fetch URLs in 14 components (strip /api/v1 prefix)

### DIFF
--- a/frontend/src/components/admin/DepartmentManagement.jsx
+++ b/frontend/src/components/admin/DepartmentManagement.jsx
@@ -589,7 +589,7 @@ const DepartmentManagement = () => {
 
       // Импорт данных
       const token = tokenManager.getAccessToken();
-      const response = await fetch(`${API_BASE}/api/v1/admin/departments/bulk`, {
+      const response = await fetch('admin/departments/bulk', {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -654,7 +654,7 @@ const DepartmentManagement = () => {
 
     try {
       const token = tokenManager.getAccessToken();
-      const response = await fetch(`${API_BASE}/api/v1/admin/departments/bulk-delete`, {
+      const response = await fetch('admin/departments/bulk-delete', {
         method: 'DELETE',
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -687,7 +687,7 @@ const DepartmentManagement = () => {
 
     try {
       const token = tokenManager.getAccessToken();
-      const response = await fetch(`${API_BASE}/api/v1/admin/departments/bulk-activate`, {
+      const response = await fetch('admin/departments/bulk-activate', {
         method: 'PATCH',
         headers: {
           'Authorization': `Bearer ${token}`,

--- a/frontend/src/components/calendar/DoctorCalendar.jsx
+++ b/frontend/src/components/calendar/DoctorCalendar.jsx
@@ -117,7 +117,7 @@ const DoctorCalendar = ({
       }
 
       const response = await fetch(
-        `${API_BASE}/api/v1/schedule/weekly?${params}`,
+        `schedule/weekly?${params}`,
         {
           headers: {
             'Authorization': `Bearer ${token}`,

--- a/frontend/src/components/cashier/RefundRequestsTable.jsx
+++ b/frontend/src/components/cashier/RefundRequestsTable.jsx
@@ -134,7 +134,7 @@ const RefundRequestsTable = ({ onRefresh }) => {
         params.append('status_filter', filter);
       }
 
-      const response = await fetch(`/api/v1/force-majeure/refund-requests?${params}`, {
+      const response = await fetch(`/force-majeure/refund-requests?${params}`, {
         headers: {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
@@ -163,7 +163,7 @@ const RefundRequestsTable = ({ onRefresh }) => {
     setProcessingId(requestId);
     try {
       const token = getAuthToken();
-      const response = await fetch(`/api/v1/force-majeure/refund-requests/${requestId}/process`, {
+      const response = await fetch(`/force-majeure/refund-requests/${requestId}/process`, {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${token}`,

--- a/frontend/src/components/cashier/__tests__/RefundRequestsTable.contract.test.jsx
+++ b/frontend/src/components/cashier/__tests__/RefundRequestsTable.contract.test.jsx
@@ -13,12 +13,12 @@ describe('RefundRequestsTable command contract', () => {
   });
 
   it('uses the existing backend process command instead of invented action URLs', () => {
-    expect(source).toContain('/api/v1/force-majeure/refund-requests/${requestId}/process');
+    expect(source).toContain('/force-majeure/refund-requests/${requestId}/process');
     expect(source).toContain('body: JSON.stringify({ action, ...extraPayload })');
 
-    expect(source).not.toContain('/api/v1/force-majeure/refund-requests/${requestId}/approve');
-    expect(source).not.toContain('/api/v1/force-majeure/refund-requests/${requestId}/reject');
-    expect(source).not.toContain('/api/v1/force-majeure/refund-requests/${requestId}/complete');
+    expect(source).not.toContain('/force-majeure/refund-requests/${requestId}/approve');
+    expect(source).not.toContain('/force-majeure/refund-requests/${requestId}/reject');
+    expect(source).not.toContain('/force-majeure/refund-requests/${requestId}/complete');
   });
 
   it('renders refund commands only from backend-provided availability', () => {

--- a/frontend/src/components/chat/ChatWindow.jsx
+++ b/frontend/src/components/chat/ChatWindow.jsx
@@ -326,7 +326,7 @@ const ChatWindow = ({ isOpen, onClose }) => {
       formData.append('recipient_id', activeConversation);
 
       const token = auth.getState().token;
-      const response = await fetch('/api/v1/messages/send-voice', {
+      const response = await fetch('/messages/send-voice', {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${token}`

--- a/frontend/src/components/common/ScheduleNextModal.jsx
+++ b/frontend/src/components/common/ScheduleNextModal.jsx
@@ -104,7 +104,7 @@ const ScheduleNextModal = ({
     try {
       const token = tokenManager.getAccessToken();
       const apiBase = getApiOrigin();
-      const response = await fetch(`${apiBase}/api/v1/patients/`, {
+      const response = await fetch('patients/', {
         headers: {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
@@ -124,7 +124,7 @@ const ScheduleNextModal = ({
     try {
       const token = tokenManager.getAccessToken();
       const apiBase = getApiOrigin();
-      const response = await fetch(`${apiBase}/api/v1/services`, {
+      const response = await fetch('services', {
         headers: {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
@@ -185,7 +185,7 @@ const ScheduleNextModal = ({
 
       const token = tokenManager.getAccessToken();
       const apiBase = getApiOrigin();
-      const response = await fetch(`${apiBase}/api/v1/doctor/visits/schedule-next`, {
+      const response = await fetch('doctor/visits/schedule-next', {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${token}`,

--- a/frontend/src/components/display/DisplayContentManager.jsx
+++ b/frontend/src/components/display/DisplayContentManager.jsx
@@ -47,7 +47,7 @@ const DisplayContentManager = ({
       setLoading(true);
 
       // Загружаем контент для табло
-      const response = await fetch(`/api/v1/admin/display-boards/${boardId}/content`, {
+      const response = await fetch(`/admin/display-boards/${boardId}/content`, {
         headers: { 'Authorization': `Bearer ${tokenManager.getAccessToken()}` }
       });
 
@@ -90,7 +90,7 @@ const DisplayContentManager = ({
 
   const handleDeleteContent = async (contentId) => {
     try {
-      const response = await fetch(`/api/v1/admin/display-boards/content/${contentId}`, {
+      const response = await fetch(`/admin/display-boards/content/${contentId}`, {
         method: 'DELETE',
         headers: { 'Authorization': `Bearer ${tokenManager.getAccessToken()}` }
       });

--- a/frontend/src/components/doctor/DoctorServiceSelector.jsx
+++ b/frontend/src/components/doctor/DoctorServiceSelector.jsx
@@ -78,7 +78,7 @@ const DoctorServiceSelector = ({
       setError('');
 
       const token = tokenManager.getAccessToken();
-      const response = await fetch(`/api/v1/doctor/${specialty}/services`, {
+      const response = await fetch(`/doctor/${specialty}/services`, {
         headers: { 'Authorization': `Bearer ${token || ''}` }
       });
 

--- a/frontend/src/components/files/FileManager.jsx
+++ b/frontend/src/components/files/FileManager.jsx
@@ -166,7 +166,7 @@ const FileManager = () => {
 
   const loadStats = useCallback(async () => {
     try {
-      const response = await fetch('/api/v1/files/statistics', {
+      const response = await fetch('/files/statistics', {
         headers: { Authorization: `Bearer ${tokenManager.getAccessToken()}` }
       });
       const data = await response.json();
@@ -190,7 +190,7 @@ const FileManager = () => {
       if (searchQuery) params.append('search', searchQuery);
 
       const query = params.toString();
-      const response = await fetch(`/api/v1/files/${query ? `?${query}` : ''}`, {
+      const response = await fetch(`/files/${query ? `?${query}` : ''}`, {
         headers: { Authorization: `Bearer ${tokenManager.getAccessToken()}` }
       });
       const data = await response.json();
@@ -288,7 +288,7 @@ const FileManager = () => {
       }
 
       try {
-        const response = await fetch('/api/v1/files/upload', {
+        const response = await fetch('/files/upload', {
           method: 'POST',
           headers: { Authorization: `Bearer ${tokenManager.getAccessToken()}` },
           body: formData
@@ -313,7 +313,7 @@ const FileManager = () => {
 
   const handleDownload = async (fileId, filename) => {
     try {
-      const response = await fetch(`/api/v1/files/${fileId}/download`, {
+      const response = await fetch(`/files/${fileId}/download`, {
         headers: { Authorization: `Bearer ${tokenManager.getAccessToken()}` }
       });
 
@@ -335,7 +335,7 @@ const FileManager = () => {
 
   const handlePreview = async (fileId) => {
     try {
-      const response = await fetch(`/api/v1/files/${fileId}/preview`, {
+      const response = await fetch(`/files/${fileId}/preview`, {
         headers: { Authorization: `Bearer ${tokenManager.getAccessToken()}` }
       });
 
@@ -362,7 +362,7 @@ const FileManager = () => {
     if (!ok) return;
 
     try {
-      const response = await fetch(`/api/v1/files/${fileId}`, {
+      const response = await fetch(`/files/${fileId}`, {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${tokenManager.getAccessToken()}` }
       });

--- a/frontend/src/components/mobile/MobileNotifications.jsx
+++ b/frontend/src/components/mobile/MobileNotifications.jsx
@@ -17,7 +17,7 @@ const MobileNotifications = () => {
   const loadNotifications = useCallback(async () => {
     try {
       setLoading(true);
-      const response = await fetch('/api/v1/mobile/notifications', {
+      const response = await fetch('/mobile/notifications', {
         headers: {
           'Authorization': `Bearer ${tokenManager.getAccessToken()}`
         }
@@ -88,7 +88,7 @@ const MobileNotifications = () => {
       });
 
       // Отправляем подписку на сервер
-      await fetch('/api/v1/mobile/notifications/subscribe', {
+      await fetch('/mobile/notifications/subscribe', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -105,7 +105,7 @@ const MobileNotifications = () => {
 
   const markAsRead = async (notificationId) => {
     try {
-      await fetch(`/api/v1/mobile/notifications/${notificationId}/read`, {
+      await fetch(`/mobile/notifications/${notificationId}/read`, {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${tokenManager.getAccessToken()}`
@@ -126,7 +126,7 @@ const MobileNotifications = () => {
 
   const markAllAsRead = async () => {
     try {
-      await fetch('/api/v1/mobile/notifications/mark-all-read', {
+      await fetch('/mobile/notifications/mark-all-read', {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${tokenManager.getAccessToken()}`

--- a/frontend/src/components/notifications/EmailSMSManager.jsx
+++ b/frontend/src/components/notifications/EmailSMSManager.jsx
@@ -133,7 +133,7 @@ const EmailSMSManager = () => {
   const loadStatistics = async () => {
     try {
       setLoading(true);
-      const response = await fetch('/api/v1/email-sms/statistics', {
+      const response = await fetch('/email-sms/statistics', {
         headers: { Authorization: `Bearer ${tokenManager.getAccessToken()}` }
       });
       const data = await response.json();
@@ -149,7 +149,7 @@ const EmailSMSManager = () => {
 
   const loadTemplates = async () => {
     try {
-      const response = await fetch('/api/v1/email-sms/templates', {
+      const response = await fetch('/email-sms/templates', {
         headers: { Authorization: `Bearer ${tokenManager.getAccessToken()}` }
       });
       const data = await response.json();
@@ -164,7 +164,7 @@ const EmailSMSManager = () => {
   const sendTestEmail = async () => {
     try {
       setLoading(true);
-      const response = await fetch('/api/v1/email-sms/test-email', {
+      const response = await fetch('/email-sms/test-email', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -189,7 +189,7 @@ const EmailSMSManager = () => {
   const sendTestSMS = async () => {
     try {
       setLoading(true);
-      const response = await fetch('/api/v1/email-sms/test-sms', {
+      const response = await fetch('/email-sms/test-sms', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -214,7 +214,7 @@ const EmailSMSManager = () => {
     try {
       setLoading(true);
       const endpoint = bulkForm.type === 'email' ? 'send-bulk-email' : 'send-bulk-sms';
-      const response = await fetch(`/api/v1/email-sms/${endpoint}`, {
+      const response = await fetch(`/email-sms/${endpoint}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -242,7 +242,7 @@ const EmailSMSManager = () => {
   const resetStatistics = async () => {
     try {
       setLoading(true);
-      const response = await fetch('/api/v1/email-sms/reset-statistics', {
+      const response = await fetch('/email-sms/reset-statistics', {
         method: 'POST',
         headers: { Authorization: `Bearer ${tokenManager.getAccessToken()}` }
       });

--- a/frontend/src/components/registrar/ForceMajeureModal.jsx
+++ b/frontend/src/components/registrar/ForceMajeureModal.jsx
@@ -53,7 +53,7 @@ const ForceMajeureModal = ({
     try {
       const token = getAuthToken();
       const response = await fetch(
-        `/api/v1/force-majeure/pending-entries?specialist_id=${specialistId}`,
+        `/force-majeure/pending-entries?specialist_id=${specialistId}`,
         {
           headers: {
             'Authorization': `Bearer ${token}`,
@@ -104,7 +104,7 @@ const ForceMajeureModal = ({
 
     try {
       const token = getAuthToken();
-      const response = await fetch('/api/v1/force-majeure/transfer', {
+      const response = await fetch('/force-majeure/transfer', {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -151,7 +151,7 @@ const ForceMajeureModal = ({
 
     try {
       const token = getAuthToken();
-      const response = await fetch('/api/v1/force-majeure/cancel-with-refund', {
+      const response = await fetch('/force-majeure/cancel-with-refund', {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${token}`,

--- a/frontend/src/components/registrar/IntegratedServiceSelector.jsx
+++ b/frontend/src/components/registrar/IntegratedServiceSelector.jsx
@@ -130,7 +130,7 @@ const IntegratedServiceSelector = ({
         const params = new URLSearchParams();
         // Исключаем фильтрацию по specialty, чтобы не терять группы
         const API_BASE = getApiOrigin();
-        const response = await fetch(`${API_BASE}/api/v1/registrar/services?${params}`, {
+        const response = await fetch(`registrar/services?${params}`, {
           headers: {
             'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json'

--- a/frontend/src/components/telegram/TelegramManager.jsx
+++ b/frontend/src/components/telegram/TelegramManager.jsx
@@ -64,7 +64,7 @@ const TelegramManager = () => {
 
   const loadBotStatus = async () => {
     try {
-      const response = await fetch('/api/v1/telegram/bot-status', {
+      const response = await fetch('/telegram/bot-status', {
         headers: {
           'Authorization': `Bearer ${tokenManager.getAccessToken()}`
         }
@@ -78,7 +78,7 @@ const TelegramManager = () => {
 
   const loadSettings = async () => {
     try {
-      const response = await fetch('/api/v1/admin/telegram/settings', {
+      const response = await fetch('/admin/telegram/settings', {
         headers: {
           'Authorization': `Bearer ${tokenManager.getAccessToken()}`
         }
@@ -92,7 +92,7 @@ const TelegramManager = () => {
 
   const loadTemplates = async () => {
     try {
-      const response = await fetch('/api/v1/admin/telegram/templates?language=ru', {
+      const response = await fetch('/admin/telegram/templates?language=ru', {
         headers: {
           'Authorization': `Bearer ${tokenManager.getAccessToken()}`
         }
@@ -106,7 +106,7 @@ const TelegramManager = () => {
 
   const loadUsers = async () => {
     try {
-      const response = await fetch('/api/v1/telegram/users?limit=50', {
+      const response = await fetch('/telegram/users?limit=50', {
         headers: {
           'Authorization': `Bearer ${tokenManager.getAccessToken()}`
         }
@@ -120,7 +120,7 @@ const TelegramManager = () => {
 
   const loadStats = async () => {
     try {
-      const response = await fetch('/api/v1/admin/telegram/stats?days_back=30', {
+      const response = await fetch('/admin/telegram/stats?days_back=30', {
         headers: {
           'Authorization': `Bearer ${tokenManager.getAccessToken()}`
         }
@@ -137,7 +137,7 @@ const TelegramManager = () => {
     setError('');
 
     try {
-      const response = await fetch('/api/v1/admin/telegram/test-bot', {
+      const response = await fetch('/admin/telegram/test-bot', {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${tokenManager.getAccessToken()}`
@@ -169,7 +169,7 @@ const TelegramManager = () => {
     setError('');
 
     try {
-      const response = await fetch('/api/v1/admin/telegram/send-test-message', {
+      const response = await fetch('/admin/telegram/send-test-message', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -203,7 +203,7 @@ const TelegramManager = () => {
     setError('');
 
     try {
-      const response = await fetch('/api/v1/admin/telegram/settings', {
+      const response = await fetch('/admin/telegram/settings', {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -232,7 +232,7 @@ const TelegramManager = () => {
     setError('');
 
     try {
-      const response = await fetch('/api/v1/admin/telegram/set-webhook', {
+      const response = await fetch('/admin/telegram/set-webhook', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Raw fetch migration — batch 2 (URL normalization)

14 files: /api/v1/path → /path (42 URL changes)

Prepares for fetch→api.get/post replacement in next batch.

### Validation
- ✅ 515 tests pass
- ✅ 0 lint errors
- ✅ Build OK