### PR TITLE
refactor: replace 5 window.confirm() with useConfirm hook in registrar area

### DIFF
--- a/frontend/src/components/queue/ModernQueueManager.jsx
+++ b/frontend/src/components/queue/ModernQueueManager.jsx
@@ -3,6 +3,8 @@ import { QRCodeSVG } from 'qrcode.react';
 import ModernDialog from '../dialogs/ModernDialog';
 import { toast } from 'react-toastify';
 import PropTypes from 'prop-types';
+// UX Audit Registrar #2: useConfirm hook для замены window.confirm().
+import { useConfirm } from '../common/ConfirmDialog';
 // UX Audit Stage 3 (Queue issue 7.3):
 // Заменены SF Symbols (Icon) на lucide-react — единая библиотека иконок.
 // Раньше Queue был единственным экраном, использующим SF Symbols.
@@ -51,6 +53,10 @@ const ModernQueueManager = ({
   const effectiveDate = selectedDate !== undefined && selectedDate !== '' ? selectedDate : internalDate;
   const [showQrDialog, setShowQrDialog] = useState(false);
   const [autoRefresh, setAutoRefresh] = useState(true);
+
+  // UX Audit Registrar #2: useConfirm hook для замены window.confirm().
+  // Возвращает [confirm, dialog]; dialog должен быть отрендерен в JSX.
+  const [confirm, confirmDialog] = useConfirm();
 
   // Переводы
   const t = {
@@ -214,13 +220,18 @@ const ModernQueueManager = ({
     }
 
     // Confirmation: открытие приёма закрывает онлайн-запись для новых пациентов.
+    // UX Audit Registrar #2: window.confirm() → useConfirm hook.
     const doctorName = doctors.find((d) => String(d.id) === String(effectiveDoctor))?.full_name || 'выбранного врача';
-    const confirmed = window.confirm(
-      `Открыть приём для "${doctorName}"?\n\n` +
-      'После открытия приёма онлайн-запись через QR будет закрыта — ' +
-      'новые пациенты не смогут записаться онлайн.\n\n' +
-      'Нажмите «ОК» чтобы продолжить, или «Отмена» чтобы вернуться.'
-    );
+    const confirmed = await confirm({
+      title: 'Открыть приём',
+      message: `Открыть приём для «${doctorName}»?`,
+      description:
+        'После открытия приёма онлайн-запись через QR будет закрыта — ' +
+        'новые пациенты не смогут записаться онлайн.',
+      confirmLabel: 'Открыть приём',
+      cancelLabel: 'Отмена',
+      intent: 'warning',
+    });
     if (!confirmed) {
       return;
     }
@@ -254,11 +265,16 @@ const ModernQueueManager = ({
       return;
     }
 
-    const confirmed = window.confirm(
-      'Закрыть приём?\n\n' +
-      'Онлайн-запись через QR будет открыта — новые пациенты смогут записаться онлайн.\n\n' +
-      'Нажмите «ОК» чтобы продолжить, или «Отмена» чтобы вернуться.'
-    );
+    // UX Audit Registrar #2: window.confirm() → useConfirm hook.
+    const confirmed = await confirm({
+      title: 'Закрыть приём',
+      message: 'Закрыть приём?',
+      description:
+        'Онлайн-запись через QR будет открыта — новые пациенты смогут записаться онлайн.',
+      confirmLabel: 'Закрыть приём',
+      cancelLabel: 'Отмена',
+      intent: 'primary',
+    });
     if (!confirmed) {
       return;
     }
@@ -737,6 +753,9 @@ const ModernQueueManager = ({
           </div>
         </div>
       </ModernDialog>
+
+      {/* UX Audit Registrar #2: ConfirmDialog (useConfirm hook). */}
+      {confirmDialog}
     </div>);
 
 };

--- a/frontend/src/components/wizard/AppointmentWizardV2.jsx
+++ b/frontend/src/components/wizard/AppointmentWizardV2.jsx
@@ -56,6 +56,8 @@ import {
 } from '../../api/patients';
 import logger from '../../utils/logger';
 import tokenManager from '../../utils/tokenManager';
+// UX Audit Registrar #2: useConfirm hook для замены window.confirm().
+import { useConfirm } from '../common/ConfirmDialog';
 // ⭐ SSOT: Unified service extraction
 import { normalizeServicesFromInitialData } from '../../utils/serviceCodeResolver';
 import './AppointmentWizardV2.css';
@@ -118,6 +120,10 @@ const AppointmentWizardV2 = ({
   // Проверка прав доступа
   const { hasRole } = useRoleAccess();
   const hasRegistrarAccess = hasRole(['Admin', 'Registrar', 'Receptionist']);
+
+  // UX Audit Registrar #2: useConfirm hook для замены window.confirm().
+  // Возвращает [confirm, dialog]; dialog должен быть отрендерен в JSX.
+  const [confirm, confirmDialog] = useConfirm();
 
   // Состояние мастера
   const [currentStep, setCurrentStep] = useState(STEP_PATIENT);
@@ -1341,9 +1347,17 @@ const AppointmentWizardV2 = ({
       totalAmount > 0 ? `Сумма: ${new Intl.NumberFormat('ru-RU').format(totalAmount)} сум` : 'Бесплатно',
     ].filter(Boolean);
 
-    const confirmed = window.confirm(
-      'Создать запись?\n\n' + summaryLines.join('\n')
-    );
+    // UX Audit Registrar #2: window.confirm() → useConfirm hook.
+    // Раньше: window.confirm('Создать запись?\n\n' + summaryLines.join('\n'))
+    // Теперь: macOS-style ConfirmDialog через useConfirm.
+    const confirmed = await confirm({
+      title: 'Создать запись',
+      message: 'Создать запись с указанными данными?',
+      description: summaryLines.join('\n'),
+      confirmLabel: 'Создать',
+      cancelLabel: 'Отмена',
+      intent: 'primary',
+    });
     if (!confirmed) {
       return;
     }
@@ -2904,6 +2918,9 @@ const AppointmentWizardV2 = ({
           </div>
         </div>
       </ModernDialog>
+
+      {/* UX Audit Registrar #2: ConfirmDialog (useConfirm hook). */}
+      {confirmDialog}
 
       {/* Диалоги онлайн оплаты удалены из UI */}
     </>);

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -1603,7 +1603,7 @@ const RegistrarPanel = () => {
                 logger.info('Открыть детали записи:', row);
                 // Здесь можно открыть модальное окно с деталями записи
               }}
-              onActionClick={(action, row, event) => {
+              onActionClick={async (action, row, event) => {
                 switch (action) {
                   case 'view':
                     logger.info('Просмотр записи:', row);
@@ -1617,26 +1617,42 @@ const RegistrarPanel = () => {
                     logger.info('Открытие модального окна оплаты для записи:', row);
                     setPaymentDialog({ open: true, row, paid: false, source: 'table' });
                     break;
-                  case 'in_cabinet':
-                    // UX Audit Registrar #15: confirmation перед отправкой в кабинет.
-                    if (!window.confirm(`Отправить пациента "${row.patient_fio || row.patient_name || ''}" в кабинет?`)) {
-                      break;
-                    }
+                  case 'in_cabinet': {
+                    // UX Audit Registrar #2: window.confirm() → useConfirm hook.
+                    // Раньше: if (!window.confirm(`Отправить пациента "..." в кабинет?`)) break;
+                    // Теперь: macOS-style ConfirmDialog через useConfirm.
+                    const inCabinetName = row.patient_fio || row.patient_name || '';
+                    const inCabinetOk = await confirm({
+                      title: 'Отправить в кабинет',
+                      message: `Отправить пациента «${inCabinetName}» в кабинет?`,
+                      confirmLabel: 'Отправить',
+                      cancelLabel: 'Отмена',
+                      intent: 'primary',
+                    });
+                    if (!inCabinetOk) break;
                     logger.info('Отправка пациента в кабинет:', row);
                     updateAppointmentStatus(row.id, 'in_cabinet', '', row);
                     break;
+                  }
                   case 'call':
                     logger.info('Вызов пациента:', row);
                     handleStartVisit(row);
                     break;
-                  case 'complete':
-                    // UX Audit Registrar #15: confirmation перед завершением приёма.
-                    if (!window.confirm(`Завершить приём пациента "${row.patient_fio || row.patient_name || ''}"?`)) {
-                      break;
-                    }
+                  case 'complete': {
+                    // UX Audit Registrar #2: window.confirm() → useConfirm hook.
+                    const completeName = row.patient_fio || row.patient_name || '';
+                    const completeOk = await confirm({
+                      title: 'Завершение приёма',
+                      message: `Завершить приём пациента «${completeName}»?`,
+                      confirmLabel: 'Завершить',
+                      cancelLabel: 'Отмена',
+                      intent: 'primary',
+                    });
+                    if (!completeOk) break;
                     logger.info('Завершение приёма:', row);
                     updateAppointmentStatus(row.id, 'done', '', row);
                     break;
+                  }
                   case 'print':
                     logger.info('Печать талона:', row);
                     setPrintDialog({ open: true, type: 'ticket', data: row });


### PR DESCRIPTION
## Summary

- UX Audit Registrar #2. Replaced 5 native `window.confirm()` calls with macOS-style `ConfirmDialog` via `useConfirm()` hook.
- Files: `pages/RegistrarPanel.jsx` (2 calls), `components/wizard/AppointmentWizardV2.jsx` (1 call), `components/queue/ModernQueueManager.jsx` (2 calls).
- No behavior change — same confirmation flow, but with proper macOS visual language, intent-based icons, action-specific button labels, and async/await pattern.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` (commit `db43bdaf` — includes merged PR #1902).
- Clean workspace: 3 files touched (+77/-25).
- Branch: `refactor/registrar-confirm-dialog`
- Scope gate: allowed `frontend/src/{pages,components/wizard,components/queue}/*.jsx`; denied backend, routing, CSS files.
- Red-check handling: fix any failed targeted check in this same PR before merge.

## Contract Impact

not applicable - frontend-only UI dialog migration. No API contract, request shape, response shape, or status code change. Same user-intent semantics (OK/Cancel → confirm/cancel).

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. The confirmation dialogs gate the same actions as before; only the dialog UI changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: `confirm()` returns `false` if the dialog is dismissed (Esc, backdrop click, or new confirm supersedes) — same as `window.confirm()` returning `false`.
- Partial data proof: patient name fallback to `''` preserved (`row.patient_fio || row.patient_name || ''`).
- Forbidden secondary path behavior: n/a — confirm dialog has no auth path.
- Missing draft/resource behavior: `useConfirm` cleanup on unmount resolves pending promise as `false` (no dangling state).
- Stale route/deep-link behavior: n/a — confirm is local UI state, not URL-driven.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`, `frontend/src/components/wizard/AppointmentWizardV2.jsx`, `frontend/src/components/queue/ModernQueueManager.jsx`.
- Denied paths: backend, routing, CSS files, other components.
- Migration/docs/test impact: no migration; no test files changed.
- Rollback note: revert this commit. `window.confirm()` calls return (and ESLint `no-restricted-syntax` warnings return).

## Validation

- Targeted tests or smoke run: `vite build` (full production bundle) + `vitest run` (full suite) + `eslint` (full src).
- Result: passed — `vite build` exit 0 (~35s); `vitest run` 515/515 tests pass, 105/105 test files pass; `eslint` 0 errors, 257 warnings (was 262 — 5 fewer, all `no-restricted-syntax` warnings for `window.confirm` removed).
- Not checked: full browser panel smoke (left to CI e2e). The changes are 1:1 confirm-dialog equivalents — no behavior change.