### PR TITLE
fix(setup): Checkbox onChange signature + migrate api/setup.js to api/client

### DIFF
--- a/frontend/src/api/setup.js
+++ b/frontend/src/api/setup.js
@@ -1,27 +1,18 @@
 import logger from '../utils/logger';
-import { buildApiUrl } from './runtime';
+// UX Audit Setup bugfix: миграция с raw fetch() на api/client.js.
+// Раньше здесь было 2 raw fetch() вызова к /setup/status и /setup/initialize
+// с ручным JSON-parsing и error-handling.
+// Теперь auth/CSRF/refresh-token обрабатываются централизованно через
+// axios-interceptor в api/client.js. Это особенно важно для /setup/initialize,
+// потому что это pre-auth endpoint, но всё равно нужен unified error handling
+// (network errors, 500s, timeout).
+import { api } from './client';
 
 const SETUP_STATUS_CACHE_MS = 30_000;
 
 let setupStatusCache = null;
 let setupStatusCacheAt = 0;
 let setupStatusRequestPromise = null;
-
-async function parseJsonResponse(response) {
-  let payload = null;
-  try {
-    payload = await response.json();
-  } catch {
-    payload = null;
-  }
-
-  if (!response.ok) {
-    const detail = payload?.detail || payload?.message || 'Setup request failed';
-    throw new Error(detail);
-  }
-
-  return payload;
-}
 
 export function clearSetupStatusCache() {
   setupStatusCache = null;
@@ -44,8 +35,10 @@ export async function fetchSetupStatus() {
 
   setupStatusRequestPromise = (async () => {
     try {
-      const response = await fetch(buildApiUrl('/setup/status'));
-      const payload = await parseJsonResponse(response);
+      // UX Audit Setup bugfix: raw fetch() → api.get().
+      // Axios сам парсит JSON и бросает Error с detail при не-2xx.
+      const response = await api.get('/setup/status');
+      const payload = response.data;
       setupStatusCache = payload;
       setupStatusCacheAt = Date.now();
       return payload;
@@ -56,7 +49,9 @@ export async function fetchSetupStatus() {
         });
         return setupStatusCache;
       }
-      throw error;
+      // Нормализуем error message из axios response.
+      const detail = error?.response?.data?.detail || error?.message || 'Setup status request failed';
+      throw new Error(detail);
     } finally {
       setupStatusRequestPromise = null;
     }
@@ -66,15 +61,15 @@ export async function fetchSetupStatus() {
 }
 
 export async function initializeSetup(payload) {
-  const response = await fetch(buildApiUrl('/setup/initialize'), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify(payload)
-  });
-
-  const result = await parseJsonResponse(response);
-  clearSetupStatusCache();
-  return result;
+  // UX Audit Setup bugfix: raw fetch() POST → api.post().
+  // Axios автоматически ставит Content-Type: application/json и парсит ответ.
+  try {
+    const response = await api.post('/setup/initialize', payload);
+    clearSetupStatusCache();
+    return response.data;
+  } catch (error) {
+    // Нормализуем error message из axios response.
+    const detail = error?.response?.data?.detail || error?.message || 'Setup request failed';
+    throw new Error(detail);
+  }
 }

--- a/frontend/src/pages/Setup.jsx
+++ b/frontend/src/pages/Setup.jsx
@@ -307,8 +307,11 @@ export default function Setup() {
   // UX Audit Stage 2 (Setup issue 2.2): toggle «Филиал = клиника».
   // При включении — копируем текущие значения клиники в филиал.
   // При выключении — оставляем скопированные значения как есть (не очищаем).
-  const handleBranchSameAsClinicChange = (event) => {
-    const checked = event.target.checked;
+  //
+  // UX Audit Setup bugfix: macos Checkbox вызывает onChange(boolean) напрямую,
+  // а не onChange(event). Раньше здесь было `event.target.checked` —
+  // это undefined, и чекбокс вообще не работал.
+  const handleBranchSameAsClinicChange = (checked) => {
     setBranchSameAsClinic(checked);
     if (checked) {
       setForm((prev) => ({


### PR DESCRIPTION
## Summary

- UX Audit Setup. Fixed 2 bugs: critical Checkbox onChange signature mismatch (checkbox «Филиал = клиника» was completely broken) + migrated api/setup.js from raw fetch() to api/client.js.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` (commit `e6441252`).
- Clean workspace: 2 files touched (+31/-33).
- Branch: `fix/setup-bugs`
- Scope gate: allowed `frontend/src/pages/Setup.jsx`, `frontend/src/api/setup.js`; denied backend, routing, other components.
- Red-check handling: fix any failed targeted check in this same PR before merge.

## Contract Impact

- Canonical surface: `frontend/src/api/setup.js` `fetchSetupStatus()` + `initializeSetup()`.
- Request shape: unchanged. API still receives same payload to `/setup/status` and `/setup/initialize`.
- Response shape: unchanged. Axios `response.data` is equivalent to `await response.json()`.
- Status codes: unchanged.
- Frontend consumer: `pages/Setup.jsx` (initializeSetup) + `hooks/useSetupStatus.js` (fetchSetupStatus).
- Compatibility path or alias: function signatures unchanged — same input/output contract, just fixed implementation.
- Contract proof: `initializeSetup(payload)` still returns the same data shape. Error messages normalized via `error?.response?.data?.detail || error?.message`.

## RBAC / Permissions

not applicable - Setup is a pre-auth screen. No auth tokens involved. The /setup/* endpoints are public (first-run initialization).

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: `fetchSetupStatus` cache fallback preserved — if request fails and cache exists, returns cached value.
- Partial data proof: error normalization handles both axios errors (with response.data.detail) and network errors (with just message).
- Forbidden secondary path behavior: n/a — Setup is pre-auth.
- Missing draft/resource behavior: `initializeSetup` clears cache on success (was already doing this).
- Stale route/deep-link behavior: n/a — Setup is routeless.

## Scope Gate

- Allowed paths: `frontend/src/pages/Setup.jsx`, `frontend/src/api/setup.js`.
- Denied paths: backend, routing, other components, CSS files.
- Migration/docs/test impact: no migration; no test files changed.
- Rollback note: revert this commit. Checkbox breaks again + raw fetch returns.

## Validation

- Targeted tests or smoke run: `vite build` (full production bundle) + `vitest run` (full suite) + `eslint`.
- Result: passed — `vite build` exit 0 (~28s); `vitest run` 557/560 tests pass (3 pre-existing failures unrelated to this PR — DentistPanel, DisplayBoardUnified, VisitDetails contracts, all from PR #1910/1912/1913, also fail on main); `eslint` 0 errors, 0 warnings in changed files.
- Not checked: full browser smoke of the Checkbox toggle (left to manual QA). The bug is logic-level: `onChange(boolean)` vs `onChange(event)` — fixed via 1-line signature change.