### PR TITLE
security(auth): P0 fixes — unify token expiry, add jti + blacklist check, prod validators

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import uuid
 from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import Any
@@ -67,10 +68,10 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None) -> s
     to_encode = data.copy()
     if expires_delta is None:
         expires_delta = timedelta(
-            minutes=getattr(settings, "ACCESS_TOKEN_EXPIRE_MINUTES", 60 * 24)
+            minutes=getattr(settings, "ACCESS_TOKEN_EXPIRE_MINUTES", 30)
         )
     expire = datetime.utcnow() + expires_delta
-    to_encode.update({"exp": expire})
+    to_encode.update({"exp": expire, "jti": str(uuid.uuid4())})
     encoded_jwt = jwt.encode(
         to_encode,
         settings.SECRET_KEY,
@@ -281,6 +282,35 @@ async def get_current_user(
             detail="User not found",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+    # Check token blacklist (jti-based revocation)
+    try:
+        payload = jwt.decode(
+            token,
+            settings.SECRET_KEY,
+            algorithms=[getattr(settings, "ALGORITHM", "HS256")],
+        )
+        jti = payload.get("jti")
+        if jti:
+            from app.services.token_blacklist_service import TokenBlacklistService
+            if TokenBlacklistService.is_token_blacklisted(db, jti):
+                logger.warning(
+                    "[deps.get_current_user] token jti=%s is blacklisted (revoked)",
+                    jti,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Token has been revoked",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+    except HTTPException:
+        raise
+    except Exception as blacklist_err:
+        logger.warning(
+            "[deps.get_current_user] blacklist check failed (non-blocking): %s",
+            blacklist_err,
+        )
+
     logger.debug(
         "[deps.get_current_user] authenticated user resolved role=%s active=%s",
         getattr(user, "role", None),

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -68,7 +68,7 @@ class Settings(BaseSettings):
         description="Legacy JWT helper secret. Defaults to SECRET_KEY when unset.",
     )
     AUTH_ALGORITHM: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7  # 7 дней
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30  # 30 minutes — use refresh tokens for longer sessions
     ENABLE_FALLBACK_AUTH: bool = Field(
         default=False,
         description="Enable legacy/fallback auth login endpoints. Keep false outside explicit break-glass/dev use.",
@@ -541,6 +541,21 @@ def get_settings() -> Settings:
                 warnings_list.append(
                     f"CORS origin '{origin}' should use HTTPS in production."
                 )
+
+        # 6. ENABLE_FALLBACK_AUTH must be False in production (2FA bypass risk)
+        if s.ENABLE_FALLBACK_AUTH:
+            errors.append(
+                "ENABLE_FALLBACK_AUTH must be False in production. "
+                "Legacy/fallback login endpoints bypass 2FA, account lockout, "
+                "and login-attempt logging. Set ENABLE_FALLBACK_AUTH=false."
+            )
+
+        # 7. DISABLE_2FA_REQUIREMENT must not be set in production
+        if os.getenv("DISABLE_2FA_REQUIREMENT", "").lower() in ("1", "true", "yes"):
+            errors.append(
+                "DISABLE_2FA_REQUIREMENT must not be set in production. "
+                "This env var disables 2FA enforcement for Admin/Cashier roles."
+            )
 
         # === OUTPUT WARNINGS ===
         for warning in warnings_list:

--- a/backend/app/services/authentication_service.py
+++ b/backend/app/services/authentication_service.py
@@ -35,7 +35,7 @@ class AuthenticationService:
 
     def __init__(self):
         self.algorithm = "HS256"
-        self.access_token_expire_minutes = 30
+        self.access_token_expire_minutes = settings.ACCESS_TOKEN_EXPIRE_MINUTES
         self.refresh_token_expire_days = 30
         self.password_reset_expire_hours = 1
         self.email_verification_expire_hours = 24
@@ -55,7 +55,7 @@ class AuthenticationService:
                 minutes=self.access_token_expire_minutes
             )
 
-        to_encode.update({"exp": expire, "type": "access"})
+        to_encode.update({"exp": expire, "type": "access", "jti": str(uuid.uuid4())})
         encoded_jwt = jwt.encode(
             to_encode, settings.SECRET_KEY, algorithm=self.algorithm
         )


### PR DESCRIPTION
## Summary

Fixes 4 critical security findings from the authentication audit: token expiry unification, jti + blacklist enforcement, production validators for auth bypass flags.

## Changes

### 1. Token expiry unified (C3) — `config.py`, `authentication_service.py`, `deps.py`

**Problem**: 3 different access token expiry values existed:
- `config.py`: 7 days (10080 min) — catastrophic for stolen tokens
- `authentication_service.py`: 30 min (hardcoded) — ignored config
- `deps.py create_access_token`: 1 day (fallback) — different again

**Fix**: 
- `config.py` default changed from 7 days to **30 min**
- `authentication_service.py` now uses `settings.ACCESS_TOKEN_EXPIRE_MINUTES` (was hardcoded 30)
- `deps.py` fallback changed from 1 day to 30 min
- Single source of truth: `settings.ACCESS_TOKEN_EXPIRE_MINUTES`

### 2. Token blacklist now functional (C2) — `deps.py`, `authentication_service.py`

**Problem**: Access tokens had no `jti` claim. The token blacklist (which checks by `jti`) was completely non-functional. `get_current_user` never consulted the blacklist. Stolen access tokens were valid until natural expiry (up to 7 days).

**Fix**:
- Added `jti = str(uuid.uuid4())` to access tokens in both `deps.py create_access_token` and `authentication_service.py create_access_token`
- Added blacklist check to `get_current_user`: after user resolution, decodes token, extracts `jti`, checks `TokenBlacklistService.is_token_blacklisted()`. If blacklisted → 401 "Token has been revoked"
- Non-blocking on blacklist check errors (logs warning, continues — avoids breaking if DB is down)
- **Impact**: logout and "revoke all sessions" now actually invalidate access tokens

### 3. Production validators for auth bypass flags (C1, H6) — `config.py`

**Problem**: 
- `ENABLE_FALLBACK_AUTH=True` in production would enable 4 legacy login endpoints that bypass 2FA, account lockout, and login-attempt logging
- `DISABLE_2FA_REQUIREMENT` env var bypasses 2FA for Admin/Cashier roles — no production check existed

**Fix**: Added 2 production validators in `config.py` `_validate_production_config()`:
- Hard-fail if `ENABLE_FALLBACK_AUTH=True` and `ENV=prod`
- Hard-fail if `DISABLE_2FA_REQUIREMENT` env var is set and `ENV=prod`

## Cyclic Execution Evidence
- Fresh main sync: branch `fix/auth-p0-critical-fixes` created from `origin/main` at commit `4f660f16`
- Clean workspace: 3 backend files modified (config.py, deps.py, authentication_service.py)
- Branch: `fix/auth-p0-critical-fixes`
- Scope gate: allowed config.py, deps.py, authentication_service.py; denied all other files
- Red-check handling: Python syntax verified (valid AST for all 3 files), frontend tests verified (559/559), build verified (passes)

## Contract Impact
- Canonical surface: all authenticated endpoints — access tokens now carry `jti` claim and are checked against blacklist. Token expiry changed from 7 days to 30 min (configurable). Existing tokens without `jti` still work (blacklist check skips if jti missing — backward compatible).
- Request shape: unchanged
- Response shape: unchanged (jti is internal to JWT, not exposed in API responses)
- Status codes: 401 for revoked tokens (new behavior — previously revoked tokens stayed valid)
- Frontend consumer: none (backend-only change). Frontend token refresh logic (5 min before expiry) continues to work — refresh tokens are unchanged.
- Compatibility path or alias: not applicable - existing tokens without jti are still accepted (blacklist check is skipped when jti is absent, maintaining backward compatibility). No API contract changed.
- Contract proof: Python syntax valid, 559/559 frontend tests pass

## RBAC / Permissions
- Roles allowed: all (unchanged)
- Roles denied: none (unchanged)
- Positive auth proof: routeRegistry.js unchanged; routeGuards.jsx unchanged
- Negative auth proof: not applicable - no changes to route role arrays or guard logic. The blacklist check applies equally to all roles.

## Notification / Realtime
not applicable - no notification events, websocket channels, or delivery semantics changed. Auth token changes are internal to JWT processing.

## Frontend Resilience
- Empty data proof: not applicable - backend-only change, no frontend data handling affected
- Partial data proof: not applicable - backend-only change, no frontend data fetching affected
- Forbidden secondary path behavior: not applicable - no new frontend code paths introduced
- Missing draft/resource behavior: not applicable - backend-only change, no frontend draft/resource handling affected
- Stale route/deep-link behavior: not applicable - URL contract unchanged, no frontend routing affected. Token refresh logic continues to work (refresh tokens unchanged, only access token expiry shortened).

## Scope Gate
- Allowed paths: `backend/app/core/config.py`, `backend/app/api/deps.py`, `backend/app/services/authentication_service.py`
- Denied paths: all frontend files, all other backend files
- Migration/docs/test impact: no migration; no test changes needed; config default changed (7 days → 30 min)
- Rollback note: revert 1 commit; no database state; access tokens revert to 7-day expiry without jti (less secure but functional)

## Validation
- Targeted tests or smoke run: frontend vitest suite (112 test files, 559 tests) passes
- Result: passed (559/559, 0 regressions)
- Not checked: backend test suite (requires Python deps not available locally — CI will verify); actual token revocation flow (requires running backend + DB)
- Manual checks:
  - `grep -n 'jti' backend/app/api/deps.py` → found in create_access_token + get_current_user blacklist check
  - `grep -n 'jti' backend/app/services/authentication_service.py` → found in create_access_token
  - `grep -n 'ACCESS_TOKEN_EXPIRE_MINUTES' backend/app/core/config.py` → `30` (was `60 * 24 * 7`)
  - `grep -n 'ENABLE_FALLBACK_AUTH' backend/app/core/config.py` → production validator added
  - `grep -n 'DISABLE_2FA_REQUIREMENT' backend/app/core/config.py` → production validator added
  - Python syntax: valid for all 3 files
  - Build: passes (2712 modules)
