### PR TITLE
security(payment): P0 fixes — atomic refund, signature verification, Jinja2 autoescape

### DIFF
--- a/backend/app/api/v1/endpoints/cashier.py
+++ b/backend/app/api/v1/endpoints/cashier.py
@@ -1578,22 +1578,43 @@ async def refund_payment(
                 detail=f"Невозможно выполнить возврат для платежа со статусом '{payment.status}'"
             )
 
-        # Проверяем, что сумма возврата не превышает доступную
-        already_refunded = payment.refunded_amount or Decimal("0")
-        available_for_refund = payment.amount - already_refunded
+        # Atomic refund: use SQL UPDATE with WHERE guard to prevent race condition.
+        # Two concurrent requests could both read refunded_amount=0 and both pass
+        # the available_for_refund check. This atomic UPDATE ensures only one wins.
+        from sqlalchemy import text as sql_text
 
-        if refund_data.amount > available_for_refund:
+        refund_amount_decimal = Decimal(str(refund_data.amount))
+        atomic_update = sql_text("""
+            UPDATE payments
+            SET refunded_amount = COALESCE(refunded_amount, 0) + :refund_amount,
+                refund_reason = :reason,
+                refunded_at = :now,
+                refunded_by = :user_id
+            WHERE id = :payment_id
+              AND COALESCE(refunded_amount, 0) + :refund_amount <= amount
+        """)
+        result = db.execute(atomic_update, {
+            "refund_amount": refund_amount_decimal,
+            "reason": refund_data.reason,
+            "now": datetime.utcnow(),
+            "user_id": current_user.id if hasattr(current_user, 'id') else None,
+            "payment_id": payment_id,
+        })
+
+        if result.rowcount == 0:
+            # Either payment doesn't exist or refund would exceed amount (race lost)
+            db.rollback()
+            already_refunded = payment.refunded_amount or Decimal("0")
+            available = payment.amount - already_refunded
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Сумма возврата ({refund_data.amount}) превышает доступную ({available_for_refund})"
+                detail=f"Сумма возврата ({refund_data.amount}) превышает доступную ({available}). Возможно, возврат уже был выполнен."
             )
 
-        # Обновляем платеж
-        new_refunded_amount = already_refunded + refund_data.amount
-        payment.refunded_amount = new_refunded_amount
-        payment.refund_reason = refund_data.reason
-        payment.refunded_at = datetime.utcnow()
-        payment.refunded_by = current_user.id if hasattr(current_user, 'id') else None
+        db.commit()
+        db.refresh(payment)
+
+        new_refunded_amount = payment.refunded_amount or Decimal("0")
 
         # Если возвращена вся сумма — статус "refunded"
         if new_refunded_amount >= payment.amount:
@@ -1605,12 +1626,8 @@ async def refund_payment(
                 if visit and visit.status == 'paid':
                     visit.status = _preserve_cashier_visit_status(visit.status)
                     db.add(visit)
-        else:
-            # Частичный возврат — оставляем "paid" но с пометкой
-            pass
-
-        db.commit()
-        db.refresh(payment)
+            db.commit()
+            db.refresh(payment)
 
         refund_change_type = "full_refund" if payment.status == "refunded" else "partial_refund"
         refund_visit = db.query(Visit).filter(Visit.id == payment.visit_id).first() if payment.visit_id else None

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any
 
-from jinja2 import Template
+from jinja2 import Environment, select_autoescape
 from sqlalchemy.orm import Session
 
 from app.models.appointment import Appointment
@@ -1028,8 +1028,9 @@ class BillingService:
             'total_in_words': self._amount_to_words(invoice.total_amount),
         }
 
-        # Рендерим шаблон
-        jinja_template = Template(template_content)
+        # Рендерим шаблон (autoescape=True prevents SSTI/XSS from patient data)
+        env = Environment(autoescape=select_autoescape(["html", "xml"]))
+        jinja_template = env.from_string(template_content)
         html_content = jinja_template.render(**template_data)
 
         return html_content

--- a/backend/app/services/payment_providers/base.py
+++ b/backend/app/services/payment_providers/base.py
@@ -139,7 +139,7 @@ class BasePaymentProvider(ABC):
         self, webhook_data: dict[str, Any], signature: str = None, auth_header: str = None
     ) -> bool:
         """
-        Валидация подписи webhook (опционально)
+        Валидация подписи webhook — MUST be overridden by each provider.
 
         Args:
             webhook_data: Данные webhook
@@ -148,9 +148,15 @@ class BasePaymentProvider(ABC):
 
         Returns:
             bool: True если подпись валидна
+
+        Raises:
+            NotImplementedError: If the provider subclass forgets to override.
         """
-        logger.warning(f"Валидация подписи не реализована для {self.provider_name}")
-        return True
+        raise NotImplementedError(
+            f"Provider {self.provider_name} must implement validate_webhook_signature. "
+            "Returning True by default is a security vulnerability — all webhooks "
+            "would be accepted without signature verification."
+        )
 
     def format_amount(self, amount: Decimal, currency: str) -> int:
         """

--- a/backend/app/services/payment_providers/click.py
+++ b/backend/app/services/payment_providers/click.py
@@ -2,6 +2,7 @@
 Интеграция с Click платежной системой (Узбекистан)
 """
 
+import hmac
 import hashlib
 from decimal import Decimal
 from typing import Any
@@ -254,7 +255,7 @@ class ClickProvider(BasePaymentProvider):
             return False
 
         expected_signature = self._generate_webhook_signature(webhook_data)
-        is_valid = signature == expected_signature
+        is_valid = hmac.compare_digest(signature, expected_signature)
 
         if not is_valid:
             self.log_error("validate_webhook_signature", "Signature mismatch", {

--- a/backend/app/services/payment_providers/kaspi.py
+++ b/backend/app/services/payment_providers/kaspi.py
@@ -322,4 +322,4 @@ class KaspiProvider(BasePaymentProvider):
         # Генерируем ожидаемую подпись
         expected_signature = self._generate_signature(data_copy)
 
-        return signature == expected_signature
+        return hmac.compare_digest(signature, expected_signature)

--- a/backend/app/services/payment_providers/payme.py
+++ b/backend/app/services/payment_providers/payme.py
@@ -2,6 +2,7 @@
 Интеграция с PayMe платежной системой (Узбекистан)
 """
 
+import hmac
 import base64
 from datetime import datetime
 from decimal import Decimal
@@ -328,7 +329,7 @@ class PayMeProvider(BasePaymentProvider):
             received_secret = decoded[7:]  # Убираем "Paycom:"
 
             # Сравниваем с нашим secret_key
-            if received_secret != self.secret_key:
+            if not hmac.compare_digest(received_secret, self.secret_key or ""):
                 self.log_error("validate_webhook_signature", "Secret key mismatch", {})
                 return False
 

--- a/backend/app/services/payment_webhook.py
+++ b/backend/app/services/payment_webhook.py
@@ -147,7 +147,7 @@ class PaymentWebhookService:
                 secret_key.encode("utf-8"), sign_string.encode("utf-8"), hashlib.sha256
             ).hexdigest()
 
-            return signature.lower() == expected_signature.lower()
+            return hmac.compare_digest(signature.lower(), expected_signature.lower())
         except Exception:
             return False
 
@@ -172,7 +172,7 @@ class PaymentWebhookService:
             # Создаём подпись
             expected_signature = hashlib.md5(sign_string.encode("utf-8"), usedforsecurity=False).hexdigest()
 
-            return data["sign_string"] == expected_signature
+            return hmac.compare_digest(data["sign_string"], expected_signature)
         except Exception:
             return False
 


### PR DESCRIPTION
## Summary

Fixes 5 critical security findings from the payment/billing audit: refund race condition, default-true signature validation, timing-unsafe comparisons, Jinja2 SSTI/XSS.

## Changes

### 1. Refund race condition (C1) — `cashier.py`

**Problem**: The refund endpoint used a non-atomic read-modify-write pattern. Two concurrent cashier requests could both read `refunded_amount=0`, both pass the `available_for_refund` check, and both write — allowing `refunded_amount > payment.amount` (double-refund).

**Fix**: Replaced with atomic SQL UPDATE:
```sql
UPDATE payments SET refunded_amount = COALESCE(refunded_amount, 0) + :amount
WHERE id = :id AND COALESCE(refunded_amount, 0) + :amount <= amount
```
If `rowcount == 0`, the refund is rejected (race lost or amount exceeded). Atomic at the DB level — only one concurrent request wins.

### 2. Default-true webhook signature validation (C3) — `base.py`

**Problem**: `BasePaymentProvider.validate_webhook_signature()` returned `True` with only a warning log. Any new provider that forgot to override would accept all webhooks without verification.

**Fix**: Changed to `raise NotImplementedError`. All 3 active providers (Click, Payme, Kaspi) already override this method.

### 3. Timing-unsafe signature comparisons (C5) — 5 sites, 4 files

**Problem**: All signature comparisons used `==`/`!=`, vulnerable to timing attacks.

**Fix**: Replaced with `hmac.compare_digest()`:
- `click.py:257`: `==` → `hmac.compare_digest()`
- `payme.py:331`: `!=` → `not hmac.compare_digest()`
- `kaspi.py:325`: `==` → `hmac.compare_digest()`
- `payment_webhook.py:150`: `.lower() == .lower()` → `compare_digest()`
- `payment_webhook.py:175`: `==` → `compare_digest()`

### 4. Jinja2 SSTI/XSS in invoice rendering (C4) — `billing_service.py`

**Problem**: `Template(template_content).render()` used `autoescape=False` by default. Patient-controlled fields (name, item description) could contain `<script>` tags.

**Fix**: Replaced with `Environment(autoescape=select_autoescape(['html', 'xml'])).from_string()`. All patient data is now HTML-escaped.

## Cyclic Execution Evidence
- Fresh main sync: branch `fix/payment-p0-critical-fixes` created from `origin/main` at commit `5d756704`
- Clean workspace: 7 backend files modified
- Branch: `fix/payment-p0-critical-fixes`
- Scope gate: allowed cashier.py, base.py, click.py, payme.py, kaspi.py, payment_webhook.py, billing_service.py; denied all other files
- Red-check handling: Python syntax verified (valid AST for all 7 files), frontend tests verified (554/554), build verified (passes)

## Contract Impact
- Canonical surface: `POST /cashier/payments/{id}/refund` — now atomic (no behavior change for single requests, but concurrent requests can no longer double-refund). Response shape unchanged.
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged (400 for amount exceeded, same as before — now also triggers on race-lost)
- Frontend consumer: none (backend-only change)
- Compatibility path or alias: not applicable - refund endpoint behavior is the same for legitimate single requests; only concurrent race attempts are now rejected
- Contract proof: Python syntax valid, 554/554 frontend tests pass

## RBAC / Permissions
- Roles allowed: Admin, Cashier (unchanged)
- Roles denied: all others (unchanged)
- Positive auth proof: routeRegistry.js unchanged; routeGuards.jsx unchanged
- Negative auth proof: not applicable - no changes to route role arrays or guard logic

## Notification / Realtime
not applicable - no notification events, websocket channels, or delivery semantics changed. Payment refund notifications are unchanged.

## Frontend Resilience
- Empty data proof: not applicable - backend-only change, no frontend data handling affected
- Partial data proof: not applicable - backend-only change, no frontend data fetching affected
- Forbidden secondary path behavior: not applicable - no new frontend code paths introduced
- Missing draft/resource behavior: not applicable - backend-only change, no frontend draft/resource handling affected
- Stale route/deep-link behavior: not applicable - URL contract unchanged, no frontend routing affected

## Scope Gate
- Allowed paths: `backend/app/api/v1/endpoints/cashier.py`, `backend/app/services/payment_providers/base.py`, `backend/app/services/payment_providers/click.py`, `backend/app/services/payment_providers/payme.py`, `backend/app/services/payment_providers/kaspi.py`, `backend/app/services/payment_webhook.py`, `backend/app/services/billing_service.py`
- Denied paths: all frontend files, all other backend files
- Migration/docs/test impact: no migration; no test changes needed; refund behavior is backward compatible for single requests
- Rollback note: revert 1 commit; no database state; refund race condition restored (less secure but functional)

## Validation
- Targeted tests or smoke run: frontend vitest suite (111 test files, 554 tests) passes
- Result: passed (554/554, 0 regressions)
- Not checked: backend test suite (requires Python deps not available locally — CI will verify); actual refund flow (requires running backend + DB); actual webhook signature verification (requires running backend + provider config)
- Manual checks:
  - `grep -n 'hmac.compare_digest' backend/app/services/payment_providers/*.py` → 3 files
  - `grep -n 'hmac.compare_digest' backend/app/services/payment_webhook.py` → 2 comparisons
  - `grep -n 'NotImplementedError' backend/app/services/payment_providers/base.py` → found in validate_webhook_signature
  - `grep -n 'autoescape' backend/app/services/billing_service.py` → found
  - `grep -n 'COALESCE(refunded_amount' backend/app/api/v1/endpoints/cashier.py` → found (atomic refund)
  - Python syntax: valid for all 7 files
  - Build: passes (2712 modules)
