### PR TITLE
security(payment): disable legacy webhook router, env-gate test-init, validate payment_status

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -85,7 +85,7 @@ from app.api.v1.endpoints import (
     patients,
     payment_reconciliation,
     payment_settings,
-    payment_webhook,
+    # payment_webhook,  # DEPRECATED — legacy webhook router
     payments,
     phone_verification,
     phrase_suggest,
@@ -241,7 +241,8 @@ api_router.include_router(
     system_management.router, prefix="/system", tags=["system-management"]
 )
 # Эндпоинты системы webhook'ов
-api_router.include_router(payment_webhook.router, tags=["webhooks"])
+# DEPRECATED: legacy webhook router — use /payments/webhook/* instead.
+# api_router.include_router(payment_webhook.router, tags=["webhooks"])
 api_router.include_router(webhooks.router, prefix="/webhooks", tags=["webhooks"])
 api_router.include_router(queues.router, prefix="/queues", tags=["queues"])
 api_router.include_router(appointments.router, tags=["appointments"])

--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -351,8 +351,16 @@ def test_init_payment(
     db: Session = Depends(get_db),
     current_user=Depends(deps.require_roles("Admin", "Registrar", "Cashier")),
 ) -> PaymentInitResponse:
-    """Test payment initialization for authorized payment staff."""
-    # Runtime write path: keep this aligned with /payments/init RBAC.
+    """Test payment initialization — DISABLED unless ENABLE_TEST_PAYMENT_INIT=true.
+
+    This endpoint bypasses audit logging and failure notifications.
+    Enable only in dev/staging via ENABLE_TEST_PAYMENT_INIT env var.
+    """
+    if not getattr(settings, "ENABLE_TEST_PAYMENT_INIT", False):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Test payment init is disabled. Set ENABLE_TEST_PAYMENT_INIT=true to enable.",
+        )
     service = PaymentTestInitService(db, get_payment_manager())
     try:
         result = service.init_test_payment(

--- a/backend/app/api/v1/endpoints/visit_payments.py
+++ b/backend/app/api/v1/endpoints/visit_payments.py
@@ -84,11 +84,19 @@ def update_visit_payment_status(
     _: dict = Depends(require_roles("Admin", "Registrar")),
 ):
     """Обновление статуса платежа для визита"""
+    # Validate payment_status against allowed values
+    allowed_statuses = {"unpaid", "pending", "paid", "partial", "refunded", "cancelled"}
+    normalized = payment_status.lower().strip()
+    if normalized not in allowed_statuses:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid payment_status '{payment_status}'. Allowed: {', '.join(sorted(allowed_statuses))}",
+        )
     service = VisitPaymentApiService(db)
     try:
         return service.update_visit_payment_status(
             visit_id=visit_id,
-            payment_status=payment_status,
+            payment_status=normalized,
         )
     except VisitPaymentApiDomainError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -73,6 +73,10 @@ class Settings(BaseSettings):
         default=False,
         description="Enable legacy/fallback auth login endpoints. Keep false outside explicit break-glass/dev use.",
     )
+    ENABLE_TEST_PAYMENT_INIT: bool = Field(
+        default=False,
+        description="Enable /payments/test-init endpoint (bypasses audit logging). Keep false in production.",
+    )
 
     # --- CORS (при необходимости) ---
     BACKEND_CORS_ORIGINS: list[str] = Field(
@@ -555,6 +559,13 @@ def get_settings() -> Settings:
             errors.append(
                 "DISABLE_2FA_REQUIREMENT must not be set in production. "
                 "This env var disables 2FA enforcement for Admin/Cashier roles."
+            )
+
+        # 8. ENABLE_TEST_PAYMENT_INIT must be False in production
+        if s.ENABLE_TEST_PAYMENT_INIT:
+            errors.append(
+                "ENABLE_TEST_PAYMENT_INIT must be False in production. "
+                "The /payments/test-init endpoint bypasses audit logging."
             )
 
         # === OUTPUT WARNINGS ===


### PR DESCRIPTION
## Summary

Fixes 3 findings from the payment/billing audit: disable legacy webhook router, env-gate test-init endpoint, validate payment_status enum.

## Changes

### 1. Disable legacy webhook router (C2) — `api.py`

**Problem**: Two live webhook ingress paths existed:
- `/payments/webhook/{click,payme,kaspi}` (newer, transactional, uses `ProviderWebhookService`)
- `/webhooks/payment/{payme,click}` (legacy, non-transactional, uses `PaymentWebhookService`, can auto-create visits/appointments)

Both accepted the same provider webhooks with different signature schemes and different side-effects. The legacy path had no transaction wrapping and could auto-create visits from webhook payloads.

**Fix**: Commented out the legacy router registration in `api.py`. The newer `/payments/webhook/*` path handles all 3 providers with proper transactional integrity.

### 2. Env-gate `/payments/test-init` (H5) — `payments.py` + `config.py`

**Problem**: The test-init endpoint bypassed audit logging and failure notifications. Frontend chose this path via a literal token string comparison (`'demo_token_for_ui_testing'`) — not env-gated.

**Fix**: 
- Added `ENABLE_TEST_PAYMENT_INIT` setting (default `False`) to `config.py`
- The endpoint now returns 403 unless the flag is `True`
- Added production validator that hard-fails if `ENABLE_TEST_PAYMENT_INIT=True` in prod

### 3. Validate `payment_status` enum (M-10) — `visit_payments.py`

**Problem**: The `update-status` endpoint accepted any arbitrary string as `payment_status` — no enum check. Could set payment_status to anything.

**Fix**: Added enum validation: only allows `{unpaid, pending, paid, partial, refunded, cancelled}`. Returns 400 for invalid values. Normalizes to lowercase before passing to service.

## Cyclic Execution Evidence
- Fresh main sync: branch `fix/payment-legacy-webhook-test-init` created from `origin/main` at commit `f597efb9`
- Clean workspace: 4 backend files modified
- Branch: `fix/payment-legacy-webhook-test-init`
- Scope gate: allowed api.py, config.py, payments.py, visit_payments.py; denied all other files
- Red-check handling: Python syntax verified (valid AST for all 4 files), frontend tests verified (554/554), build verified (passes)

## Contract Impact
- Canonical surface: `/webhooks/payment/{payme,click}` endpoints now return 404 (router disabled). `/payments/test-init` now returns 403 unless `ENABLE_TEST_PAYMENT_INIT=true`. `/visit-payments/{id}/update-status` now returns 400 for invalid payment_status values.
- Request shape: unchanged
- Response shape: unchanged for valid requests
- Status codes: 404 for legacy webhooks, 403 for test-init (when disabled), 400 for invalid payment_status
- Frontend consumer: none — frontend uses `/payments/webhook/*` (newer path) and `/payments/init` (canonical). Frontend test-init calls will receive 403 (expected behavior — test-init is dev-only).
- Compatibility path or alias: not applicable - legacy webhook endpoints were duplicates of the canonical /payments/webhook/* path. Payment providers should be configured to use /payments/webhook/* exclusively.
- Contract proof: Python syntax valid, 554/554 frontend tests pass

## RBAC / Permissions
- Roles allowed: Admin, Cashier, Registrar (unchanged — test-init still requires Admin/Registrar/Cashier, just additionally requires env flag)
- Roles denied: all others (unchanged)
- Positive auth proof: routeRegistry.js unchanged; routeGuards.jsx unchanged
- Negative auth proof: not applicable - no changes to route role arrays or guard logic

## Notification / Realtime
not applicable - no notification events, websocket channels, or delivery semantics changed. Legacy webhook router disabled was a payment webhook ingress path, not a notification channel.

## Frontend Resilience
- Empty data proof: not applicable - backend-only change, no frontend data handling affected
- Partial data proof: not applicable - backend-only change, no frontend data fetching affected
- Forbidden secondary path behavior: not applicable - no new frontend code paths introduced
- Missing draft/resource behavior: not applicable - backend-only change, no frontend draft/resource handling affected
- Stale route/deep-link behavior: not applicable - URL contract unchanged for canonical endpoints. Legacy /webhooks/payment/* endpoints now return 404 (expected — they were duplicates).

## Scope Gate
- Allowed paths: `backend/app/api/v1/api.py`, `backend/app/core/config.py`, `backend/app/api/v1/endpoints/payments.py`, `backend/app/api/v1/endpoints/visit_payments.py`
- Denied paths: all frontend files, all other backend files
- Migration/docs/test impact: no migration; no test changes needed; payment providers should be configured to use /payments/webhook/* (not /webhooks/payment/*)
- Rollback note: revert 1 commit; no database state; legacy webhook router restored (less secure but functional)

## Validation
- Targeted tests or smoke run: frontend vitest suite (111 test files, 554 tests) passes
- Result: passed (554/554, 0 regressions)
- Not checked: backend test suite (requires Python deps not available locally — CI will verify); actual webhook flow (requires running backend + provider config)
- Manual checks:
  - `grep -n 'payment_webhook.router' backend/app/api/v1/api.py` → commented out
  - `grep -n 'ENABLE_TEST_PAYMENT_INIT' backend/app/core/config.py` → found (setting + prod validator)
  - `grep -n 'ENABLE_TEST_PAYMENT_INIT' backend/app/api/v1/endpoints/payments.py` → found (403 gate)
  - `grep -n 'allowed_statuses' backend/app/api/v1/endpoints/visit_payments.py` → found (enum validation)
  - Python syntax: valid for all 4 files
  - Build: passes (2712 modules)
