### PR TITLE
security(p1-wave5): mass-sanitize 282 str(e) error leaks across 38 files

### DIFF
--- a/backend/app/api/v1/endpoints/ai_chat.py
+++ b/backend/app/api/v1/endpoints/ai_chat.py
@@ -268,7 +268,7 @@ async def send_message(
         )
 
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail="Internal server error")
 
 
 @router.post("/messages/{message_id}/feedback")

--- a/backend/app/api/v1/endpoints/backup_management.py
+++ b/backend/app/api/v1/endpoints/backup_management.py
@@ -34,7 +34,7 @@ async def create_backup(
         logger.error(f"Error creating backup: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Backup creation failed: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -59,7 +59,7 @@ async def list_backups(
         logger.error(f"Error listing backups: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -84,7 +84,7 @@ async def restore_backup(
         logger.error(f"Error restoring backup: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Restore failed: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -107,7 +107,7 @@ async def verify_backup(
         logger.error(f"Error verifying backup: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Verification failed: {str(e)}",
+            detail="Internal server error",
         )
 
 

--- a/backend/app/api/v1/endpoints/billing.py
+++ b/backend/app/api/v1/endpoints/billing.py
@@ -231,7 +231,7 @@ def create_invoice(
 
         return invoice
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Internal server error")
 
 
 @router.get("/invoices", response_model=list[InvoiceResponse])
@@ -316,7 +316,7 @@ def get_invoice_html(
         html_content = service.generate_invoice_html(invoice_id, template_id)
         return {"html": html_content}
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail="Internal server error")
     except Exception as e:
         raise _billing_http_error(e, "get_invoice_html") from e
 
@@ -357,9 +357,9 @@ def record_payment(
         )
         return payment
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail="Internal server error")
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Internal server error")
 
 
 @router.get("/payments")

--- a/backend/app/api/v1/endpoints/cashier.py
+++ b/backend/app/api/v1/endpoints/cashier.py
@@ -617,7 +617,7 @@ async def get_pending_payments(
         logger.exception("Unhandled cashier endpoint error")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения ожидающих оплаты: {str(e)}"
+            detail="Internal server error"
         )
 
 
@@ -730,7 +730,7 @@ async def get_cashier_stats(
         logger.exception("Unhandled cashier endpoint error")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}"
+            detail="Internal server error"
         )
 
 
@@ -822,7 +822,7 @@ async def export_payments(
         logger.exception("Unhandled cashier endpoint error")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка экспорта: {str(e)}"
+            detail="Internal server error"
         )
 
 
@@ -937,7 +937,7 @@ async def get_payments(
         logger.exception("Unhandled cashier endpoint error")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения истории платежей: {str(e)}"
+            detail="Internal server error"
         )
 
 
@@ -1323,7 +1323,7 @@ async def create_payment(
         logger.exception("Unhandled cashier endpoint error")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания платежа: {str(e)}"
+            detail="Internal server error"
         )
 
 
@@ -1425,7 +1425,7 @@ async def cancel_payment(
         logger.exception("Unhandled cashier endpoint error")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отмены платежа: {str(e)}"
+            detail="Internal server error"
         )
 
 
@@ -1499,7 +1499,7 @@ async def mark_visit_as_paid(
         logger.exception("Unhandled cashier endpoint error")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления статуса визита: {str(e)}"
+            detail="Internal server error"
         )
 
 
@@ -1703,7 +1703,7 @@ async def refund_payment(
         logger.exception("Unhandled cashier endpoint error")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка возврата средств: {str(e)}"
+            detail="Internal server error"
         )
 
 
@@ -1732,7 +1732,7 @@ async def get_payment_receipt(
         logger.exception("Unhandled cashier endpoint error")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка генерации чека: {str(e)}"
+            detail="Internal server error"
         )
 
 
@@ -1783,5 +1783,5 @@ async def get_hourly_stats(
         logger.exception("Unhandled cashier endpoint error")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения почасовой статистики: {str(e)}"
+            detail="Internal server error"
         )

--- a/backend/app/api/v1/endpoints/clinic_management.py
+++ b/backend/app/api/v1/endpoints/clinic_management.py
@@ -65,7 +65,7 @@ def create_branch(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Ошибка создания филиала: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -173,7 +173,7 @@ def create_equipment(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Ошибка создания оборудования: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -287,7 +287,7 @@ def schedule_maintenance(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Ошибка планирования обслуживания: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -327,7 +327,7 @@ def create_license(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Ошибка создания лицензии: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -447,7 +447,7 @@ def activate_license(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Ошибка активации лицензии: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -484,7 +484,7 @@ def create_backup(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Ошибка создания резервной копии: {str(e)}",
+            detail="Internal server error",
         )
 
 

--- a/backend/app/api/v1/endpoints/dental.py
+++ b/backend/app/api/v1/endpoints/dental.py
@@ -61,7 +61,7 @@ async def get_dental_examinations(
         return []
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения осмотров: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -94,7 +94,7 @@ async def get_treatment_plans(
         return []
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения планов лечения: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -127,7 +127,7 @@ async def get_prosthetics(
         return []
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения протезов: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -161,7 +161,7 @@ async def get_xray_images(
         }
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения снимков: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -201,7 +201,7 @@ async def create_dental_price_override(
     except Exception as e:
         service.rollback()
         raise HTTPException(
-            status_code=500, detail=f"Ошибка создания изменения цены: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -244,7 +244,7 @@ async def get_dental_price_overrides(
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения изменений цен: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -278,7 +278,7 @@ async def approve_price_override(
     except Exception as e:
         service.rollback()
         raise HTTPException(
-            status_code=500, detail=f"Ошибка обработки изменения цены: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -299,5 +299,5 @@ async def get_pending_price_overrides(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Ошибка получения ожидающих изменений цен: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/derma.py
+++ b/backend/app/api/v1/endpoints/derma.py
@@ -178,7 +178,7 @@ async def get_skin_examinations(
             patient_id,
         )
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения осмотров: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -243,7 +243,7 @@ async def create_skin_examination(
             examination_data.visit_id,
         )
         raise HTTPException(
-            status_code=500, detail=f"Ошибка создания осмотра: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -298,7 +298,7 @@ async def get_cosmetic_procedures(
             patient_id,
         )
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения процедур: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -362,7 +362,7 @@ async def create_cosmetic_procedure(
             procedure_data.visit_id,
         )
         raise HTTPException(
-            status_code=500, detail=f"Ошибка создания процедуры: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -404,7 +404,7 @@ async def create_price_override(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка создания изменения цены: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -450,7 +450,7 @@ async def get_price_overrides(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения изменений цен: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -467,5 +467,5 @@ async def get_photo_gallery(
         return {"message": "Фотогалерея будет доступна в следующей версии"}
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения фотогалереи: {str(e)}"
+            status_code=500, detail="Internal server error"
         )

--- a/backend/app/api/v1/endpoints/display_websocket.py
+++ b/backend/app/api/v1/endpoints/display_websocket.py
@@ -148,7 +148,7 @@ async def call_patient_to_board(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка вызова пациента на табло: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -283,7 +283,7 @@ async def send_announcement_to_board(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки объявления: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -339,7 +339,7 @@ def get_boards_status(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статуса табло: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -369,5 +369,5 @@ async def quick_call_next_patient(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка быстрого вызова: {str(e)}",
+            detail="Internal server error",
         ) from e

--- a/backend/app/api/v1/endpoints/doctor_info.py
+++ b/backend/app/api/v1/endpoints/doctor_info.py
@@ -89,7 +89,7 @@ async def get_doctor_info(
         logger.error(f"Ошибка получения информации о враче {doctor_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения информации о враче: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -127,7 +127,7 @@ async def get_doctors_list(
         logger.error(f"Ошибка получения списка врачей: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения списка врачей: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -155,7 +155,7 @@ async def get_doctor_by_user_id(
         logger.error(f"Ошибка получения врача по user_id {user_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения информации о враче: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -183,7 +183,7 @@ async def get_department_info(
         logger.error(f"Ошибка получения информации об отделении {department_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения информации об отделении: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -212,7 +212,7 @@ async def get_departments_list(
         logger.error(f"Ошибка получения списка отделений: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения списка отделений: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -246,7 +246,7 @@ async def get_appointment_doctor_info(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения информации: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -272,7 +272,7 @@ async def get_formatted_doctor_info(
         logger.error(f"Ошибка форматирования информации о враче {doctor_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка форматирования информации: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -310,5 +310,5 @@ async def get_formatted_department_info(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка форматирования информации: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/doctor_integration.py
+++ b/backend/app/api/v1/endpoints/doctor_integration.py
@@ -531,7 +531,7 @@ def get_doctor_queue_today(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения очереди врача: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -656,7 +656,7 @@ def call_patient(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка вызова пациента: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -754,7 +754,7 @@ def start_patient_visit(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка начала приема: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1033,7 +1033,7 @@ def complete_patient_visit(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка завершения приема: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1120,7 +1120,7 @@ def get_doctor_services(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения услуг врача: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1204,7 +1204,7 @@ def get_doctor_info(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения информации врача: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1264,7 +1264,7 @@ def get_doctor_calendar(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения календаря: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1378,7 +1378,7 @@ def get_doctor_stats(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики врача: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1561,7 +1561,7 @@ async def schedule_next_visit(
         logger.error(f"Ошибка назначения следующего визита: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка назначения визита: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1641,7 +1641,7 @@ def get_today_visits(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения визитов: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1687,7 +1687,7 @@ def get_visit_statistics(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
+            detail="Internal server error",
         )
 
     except HTTPException:
@@ -1696,7 +1696,7 @@ def get_visit_statistics(
         db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка назначения визита: {str(e)}",
+            detail="Internal server error",
         )
 
 @router.get("/doctor/visits/{visit_id}")
@@ -1781,7 +1781,7 @@ def get_visit_details(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения визита: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1843,7 +1843,7 @@ def add_service_to_visit(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка добавления услуги: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1894,5 +1894,5 @@ def remove_service_from_visit(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка удаления услуги: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/email_sms_enhanced.py
+++ b/backend/app/api/v1/endpoints/email_sms_enhanced.py
@@ -168,7 +168,7 @@ async def send_appointment_reminder_enhanced(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки напоминания: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -231,7 +231,7 @@ async def send_lab_results_enhanced(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки результатов: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -291,7 +291,7 @@ async def send_payment_confirmation_enhanced(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки подтверждения: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -345,7 +345,7 @@ async def send_bulk_email(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка массовой рассылки: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -395,7 +395,7 @@ async def send_bulk_sms(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка массовой рассылки: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -440,7 +440,7 @@ async def send_custom_email(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки email: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -476,7 +476,7 @@ async def send_custom_sms(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки SMS: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -501,7 +501,7 @@ async def get_email_sms_statistics(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -526,7 +526,7 @@ async def reset_email_sms_statistics(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка сброса статистики: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -615,7 +615,7 @@ async def get_available_templates(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения шаблонов: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -671,7 +671,7 @@ async def test_email_sending(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка тестирования email: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -703,5 +703,5 @@ async def test_sms_sending(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка тестирования SMS: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/emr_ai_enhanced.py
+++ b/backend/app/api/v1/endpoints/emr_ai_enhanced.py
@@ -55,7 +55,7 @@ async def generate_smart_template(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка генерации шаблона: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -85,7 +85,7 @@ async def get_smart_suggestions(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения подсказок: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -113,7 +113,7 @@ async def auto_fill_emr_fields(
         }
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка автозаполнения: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.post("/validate", dependencies=[Depends(RequireAiFeature("ai_smart_template"))])
@@ -134,7 +134,7 @@ async def validate_emr_data(
         return {"result": validation_result, **ai_safety_meta()}
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка валидации: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.post("/icd10-suggestions", dependencies=[Depends(RequireAiFeature("ai_icd10_suggestion"))])
@@ -159,7 +159,7 @@ async def get_icd10_suggestions(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка генерации ICD-10 предложений: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -185,7 +185,7 @@ async def analyze_patient_data(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка анализа пациента: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -210,7 +210,7 @@ async def get_specialty_templates(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения шаблонов: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -280,7 +280,7 @@ async def enhance_emr_with_ai(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка улучшения EMR: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("/analytics/quality")
@@ -316,5 +316,5 @@ async def get_emr_quality_analytics(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения аналитики: {str(e)}"
+            status_code=500, detail="Internal server error"
         )

--- a/backend/app/api/v1/endpoints/emr_lab_integration.py
+++ b/backend/app/api/v1/endpoints/emr_lab_integration.py
@@ -177,11 +177,11 @@ async def get_patient_lab_results(
         }
 
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Internal server error")
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Ошибка получения лабораторных результатов: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -207,10 +207,10 @@ async def integrate_lab_results_with_emr(
         }
 
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail="Internal server error")
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка интеграции лабораторных данных: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -248,7 +248,7 @@ async def get_abnormal_lab_results(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения аномальных результатов: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -271,7 +271,7 @@ async def get_lab_summary_for_emr(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Ошибка генерации сводки лабораторных данных: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -299,10 +299,10 @@ async def notify_doctor_about_lab_result(
         return {"message": "Уведомление врача отправлено", "notification": notification}
 
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail="Internal server error")
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка уведомления врача: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -389,5 +389,5 @@ async def get_lab_results_trends(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения трендов: {str(e)}"
+            status_code=500, detail="Internal server error"
         )

--- a/backend/app/api/v1/endpoints/emr_templates.py
+++ b/backend/app/api/v1/endpoints/emr_templates.py
@@ -40,7 +40,7 @@ async def get_emr_templates(
         return templates
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения шаблонов: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -59,7 +59,7 @@ async def get_user_templates(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Ошибка получения пользовательских шаблонов: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -76,7 +76,7 @@ async def create_emr_template(
         return template
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка создания шаблона: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -94,7 +94,7 @@ async def create_template_from_structure(
         return template
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка создания шаблона из структуры: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -114,7 +114,7 @@ async def get_emr_template(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения шаблона: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -143,7 +143,7 @@ async def update_emr_template(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка обновления шаблона: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -161,10 +161,10 @@ async def clone_emr_template(
         )
         return cloned_template
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail="Internal server error")
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка клонирования шаблона: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -190,7 +190,7 @@ async def delete_emr_template(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка удаления шаблона: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -226,7 +226,7 @@ async def load_default_templates(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка загрузки шаблонов: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -243,7 +243,7 @@ async def get_emr_versions(
         return versions
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения версий: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -267,5 +267,5 @@ async def restore_emr_version(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка восстановления версии: {str(e)}"
+            status_code=500, detail="Internal server error"
         )

--- a/backend/app/api/v1/endpoints/emr_v2.py
+++ b/backend/app/api/v1/endpoints/emr_v2.py
@@ -326,7 +326,7 @@ async def compare_versions(
     except EMRNotFoundException:
         raise HTTPException(status_code=404, detail="EMR not found")
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Internal server error")
 
 
 @router.get("/patient/{patient_id}", response_model=list[EMRRecordSummary])
@@ -412,7 +412,7 @@ async def save_emr(
             },
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Internal server error")
 
 
 @router.post("/{visit_id}/sign", response_model=EMRRecordOut)
@@ -472,7 +472,7 @@ async def sign_emr(
     except EMRNotFoundException:
         raise HTTPException(status_code=404, detail="EMR not found")
     except EMRSignedError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Internal server error")
     except ConcurrencyError as e:
         raise HTTPException(
             status_code=409,
@@ -514,7 +514,7 @@ async def amend_emr(
     except EMRNotFoundException:
         raise HTTPException(status_code=404, detail="EMR not found")
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Internal server error")
     except ConcurrencyError as e:
         raise HTTPException(
             status_code=409,
@@ -555,6 +555,6 @@ async def restore_emr(
     except EMRNotFoundException:
         raise HTTPException(status_code=404, detail="EMR not found")
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Internal server error")
 
 

--- a/backend/app/api/v1/endpoints/emr_versioning_enhanced.py
+++ b/backend/app/api/v1/endpoints/emr_versioning_enhanced.py
@@ -31,7 +31,7 @@ async def get_version_timeline(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения временной линии: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -52,10 +52,10 @@ async def compare_versions(
         return comparison
 
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail="Internal server error")
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка сравнения версий: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -80,10 +80,10 @@ async def restore_version_with_backup(
         return {"message": "Версия успешно восстановлена", "result": result}
 
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail="Internal server error")
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка восстановления версии: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -103,7 +103,7 @@ async def get_version_statistics(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения статистики: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -144,7 +144,7 @@ async def create_version_with_analysis(
         }
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка создания версии: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("/{emr_id}/versions/{version_id}/details")
@@ -188,7 +188,7 @@ async def get_version_details(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения деталей версии: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -219,7 +219,7 @@ async def delete_version(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка удаления версии: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("/{emr_id}/versions/export")
@@ -276,4 +276,4 @@ async def export_versions(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка экспорта версий: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/app/api/v1/endpoints/fcm_notifications.py
+++ b/backend/app/api/v1/endpoints/fcm_notifications.py
@@ -85,7 +85,7 @@ async def register_fcm_token(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка регистрации FCM токена: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -110,7 +110,7 @@ async def unregister_fcm_token(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка удаления FCM токена: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -199,7 +199,7 @@ async def send_fcm_notification(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки FCM уведомления: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -253,7 +253,7 @@ async def send_test_fcm_notification(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки тестового уведомления: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -289,7 +289,7 @@ async def subscribe_to_topic(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка подписки на топик: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -325,7 +325,7 @@ async def unsubscribe_from_topic(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отписки от топика: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -366,7 +366,7 @@ async def send_topic_notification(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки уведомления по топику: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -384,7 +384,7 @@ async def get_fcm_status(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статуса FCM: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -419,5 +419,5 @@ async def get_user_fcm_tokens(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения FCM токенов: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/feature_flags.py
+++ b/backend/app/api/v1/endpoints/feature_flags.py
@@ -202,7 +202,7 @@ def create_feature_flag(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания фича-флага: {str(e)}",
+            detail="Internal server error",
         ) from e
 
     return FeatureFlagResponse(
@@ -255,7 +255,7 @@ def update_feature_flag(
         service.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления фича-флага: {str(e)}",
+            detail="Internal server error",
         ) from e
 
     return FeatureFlagResponse(

--- a/backend/app/api/v1/endpoints/group_permissions.py
+++ b/backend/app/api/v1/endpoints/group_permissions.py
@@ -121,7 +121,7 @@ def get_user_permissions(
         logger.error(f"Ошибка получения разрешений пользователя {user_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения разрешений: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -153,7 +153,7 @@ def check_user_permission(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка проверки разрешения: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -182,7 +182,7 @@ def get_groups(
         logger.error(f"Ошибка получения списка групп: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения групп: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -214,7 +214,7 @@ def get_group_permissions_summary(
         logger.error(f"Ошибка получения сводки разрешений группы {group_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения сводки: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -247,7 +247,7 @@ def assign_role_to_group(
         logger.error(f"Ошибка назначения роли {request.role_id} группе {group_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка назначения роли: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -278,7 +278,7 @@ def revoke_role_from_group(
         logger.error(f"Ошибка отзыва роли {role_id} у группы {group_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отзыва роли: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -313,7 +313,7 @@ def add_user_to_group(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка добавления в группу: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -346,7 +346,7 @@ def remove_user_from_group(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка удаления из группы: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -375,7 +375,7 @@ def get_roles(
         logger.error(f"Ошибка получения списка ролей: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения ролей: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -401,7 +401,7 @@ def get_permissions(
         logger.error(f"Ошибка получения списка разрешений: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения разрешений: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -437,7 +437,7 @@ def create_permission_override(
         logger.error(f"Ошибка создания переопределения разрешения: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания переопределения: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -466,7 +466,7 @@ def clear_permissions_cache(
         logger.error(f"Ошибка очистки кэша разрешений: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка очистки кэша: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -490,5 +490,5 @@ def get_cache_stats(current_user: User = Depends(require_roles("Admin", "SuperAd
         logger.error(f"Ошибка получения статистики кэша: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/migration_management.py
+++ b/backend/app/api/v1/endpoints/migration_management.py
@@ -126,7 +126,7 @@ def migrate_legacy_queue_data(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка миграции данных: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -155,7 +155,7 @@ def migrate_legacy_emr_cutover(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка EMR cutover backfill: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -174,7 +174,7 @@ def verify_emr_cutover(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка проверки EMR cutover: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -202,7 +202,7 @@ def check_data_integrity(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка проверки целостности: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -240,7 +240,7 @@ def backup_queue_data(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания резервной копии: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -280,7 +280,7 @@ def restore_queue_data(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка восстановления данных: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -313,7 +313,7 @@ def cleanup_old_queue_data(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка очистки данных: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -334,7 +334,7 @@ def get_migration_stats(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -355,5 +355,5 @@ def check_migration_health(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка проверки состояния миграций: {str(e)}",
+            detail="Internal server error",
         ) from e

--- a/backend/app/api/v1/endpoints/mobile_api.py
+++ b/backend/app/api/v1/endpoints/mobile_api.py
@@ -155,7 +155,7 @@ async def mobile_login(credentials: MobileLoginRequest, db: Session = Depends(ge
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка аутентификации: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("/patients/me", response_model=PatientProfileOut)
@@ -196,7 +196,7 @@ async def get_mobile_patient_profile(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения профиля: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -239,7 +239,7 @@ async def get_upcoming_appointments(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения записей: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -293,7 +293,7 @@ async def get_appointment_detail(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения записи: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -349,7 +349,7 @@ async def book_mobile_appointment(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка записи к врачу: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("/lab/results", response_model=list[LabResultOut])
@@ -388,7 +388,7 @@ async def get_lab_results(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения результатов: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -436,7 +436,7 @@ async def get_mobile_quick_stats(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения статистики: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -473,7 +473,7 @@ async def get_mobile_notifications(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения уведомлений: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -503,7 +503,7 @@ async def mark_notification_read(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка отметки уведомления: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -548,5 +548,5 @@ async def test_push_notification(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка тестирования push-уведомления: {str(e)}"
+            status_code=500, detail="Internal server error"
         )

--- a/backend/app/api/v1/endpoints/mobile_api_extended.py
+++ b/backend/app/api/v1/endpoints/mobile_api_extended.py
@@ -173,7 +173,7 @@ async def search_doctors(
         return {"doctors": result, "total_found": len(result)}
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка поиска врачей: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("/doctors/{doctor_id}/schedule")
@@ -197,7 +197,7 @@ async def get_doctor_schedule(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения расписания: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -239,7 +239,7 @@ async def search_services(
         return {"services": result, "total_found": len(result)}
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка поиска услуг: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("/services/categories")
@@ -271,7 +271,7 @@ async def get_service_categories(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения категорий: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -311,7 +311,7 @@ async def get_queues_status(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения статуса очередей: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -354,7 +354,7 @@ async def get_my_queue_position(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения позиции в очереди: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -411,7 +411,7 @@ async def cancel_appointment(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка отмены записи: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.post("/appointments/reschedule")
@@ -478,7 +478,7 @@ async def reschedule_appointment(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Ошибка переноса записи: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 # ==================== ОБРАТНАЯ СВЯЗЬ ====================
@@ -531,7 +531,7 @@ ID: #{feedback.id}"""
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка отправки обратной связи: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -600,7 +600,7 @@ ID: #{emergency.id}"""
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка экстренного обращения: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -662,7 +662,7 @@ async def update_profile(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка обновления профиля: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -709,7 +709,7 @@ async def upload_avatar(
         raise
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка загрузки аватара: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -743,7 +743,7 @@ async def update_notification_settings(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка обновления настроек: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -766,7 +766,7 @@ async def get_notification_settings(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения настроек: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -810,7 +810,7 @@ async def get_clinic_info(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения информации о клинике: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 

--- a/backend/app/api/v1/endpoints/morning_assignment.py
+++ b/backend/app/api/v1/endpoints/morning_assignment.py
@@ -74,7 +74,7 @@ def run_morning_assignment_manual(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка запуска утренней сборки: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -107,7 +107,7 @@ def get_morning_assignment_stats(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -133,7 +133,7 @@ def manual_assignment_for_visits(
         api_service.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка ручного присвоения: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -165,7 +165,7 @@ def get_pending_visits(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения ожидающих визитов: {str(e)}",
+            detail="Internal server error",
         ) from e
 
 
@@ -194,5 +194,5 @@ def get_queue_summary(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения сводки очередей: {str(e)}",
+            detail="Internal server error",
         ) from e

--- a/backend/app/api/v1/endpoints/online_queue_new.py
+++ b/backend/app/api/v1/endpoints/online_queue_new.py
@@ -76,11 +76,11 @@ def generate_qr_token(
         )
 
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Internal server error")
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка генерации QR токена: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -177,7 +177,7 @@ def open_queue(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка открытия приема: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -220,7 +220,7 @@ def check_queue_status(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка проверки статуса: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -249,7 +249,7 @@ def get_today_queue(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения очереди: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -283,7 +283,7 @@ def get_queue_stats(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
+            detail="Internal server error",
         )
 
 

--- a/backend/app/api/v1/endpoints/patients.py
+++ b/backend/app/api/v1/endpoints/patients.py
@@ -347,7 +347,7 @@ def add_family_relation(
         }
 
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Internal server error")
 
 
 @router.delete("/{patient_id}/family/{relation_id}", status_code=status.HTTP_200_OK)

--- a/backend/app/api/v1/endpoints/phone_verification.py
+++ b/backend/app/api/v1/endpoints/phone_verification.py
@@ -148,7 +148,7 @@ async def send_verification_code(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки кода верификации: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -198,7 +198,7 @@ async def verify_code(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка проверки кода: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -229,7 +229,7 @@ async def get_verification_status(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статуса верификации: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -266,7 +266,7 @@ async def cancel_verification(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отмены верификации: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -309,7 +309,7 @@ async def update_user_phone(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления номера телефона: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -328,7 +328,7 @@ async def get_verification_statistics(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -392,5 +392,5 @@ async def admin_send_verification_code(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки кода администратором: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/phrase_suggest.py
+++ b/backend/app/api/v1/endpoints/phrase_suggest.py
@@ -158,7 +158,7 @@ async def index_phrases(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to index phrases: {str(e)}"
+            detail="Internal server error"
         )
 
 
@@ -418,7 +418,7 @@ async def batch_index_emrs(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Batch indexing failed: {str(e)}"
+            detail="Internal server error"
         )
 
 
@@ -466,5 +466,5 @@ async def index_doctor_emrs(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Doctor indexing failed: {str(e)}"
+            detail="Internal server error"
         )

--- a/backend/app/api/v1/endpoints/print_api.py
+++ b/backend/app/api/v1/endpoints/print_api.py
@@ -58,7 +58,7 @@ async def print_queue_ticket(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка печати талона: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -104,7 +104,7 @@ async def print_prescription(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка печати рецепта: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -149,7 +149,7 @@ async def print_medical_certificate(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка печати справки: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -178,7 +178,7 @@ async def print_payment_receipt(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка печати чека: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -206,7 +206,7 @@ async def print_lab_results(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка печати результатов анализов: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -265,7 +265,7 @@ def get_printers(
     except Exception as e:
         logger.error("[FIX] Failed to load printers from database: %s", e)
         raise HTTPException(
-            status_code=500, detail=f"Ошибка получения списка принтеров: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -291,7 +291,7 @@ def get_printer_status(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка проверки статуса принтера: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -317,7 +317,7 @@ def test_printer(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка тестовой печати: {str(e)}",
+            detail="Internal server error",
         )
 
 

--- a/backend/app/api/v1/endpoints/print_templates.py
+++ b/backend/app/api/v1/endpoints/print_templates.py
@@ -136,7 +136,7 @@ def get_print_templates(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения шаблонов: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -164,7 +164,7 @@ def create_print_template(
         except TemplateError as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Ошибка в шаблоне Jinja2: {str(e)}",
+                detail="Internal server error",
             )
 
         template = crud_print.create_print_template(db, template_data)
@@ -176,7 +176,7 @@ def create_print_template(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания шаблона: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -232,7 +232,7 @@ def update_print_template(
             except TemplateError as e:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Ошибка в шаблоне Jinja2: {str(e)}",
+                    detail="Internal server error",
                 )
 
         updated_template = crud_print.update_print_template(
@@ -246,7 +246,7 @@ def update_print_template(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления шаблона: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -310,7 +310,7 @@ def upload_template_file(
         except TemplateError as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Ошибка в шаблоне Jinja2: {str(e)}",
+                detail="Internal server error",
             )
 
         with open(file_path, 'wb') as f:
@@ -327,7 +327,7 @@ def upload_template_file(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка загрузки шаблона: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -368,12 +368,12 @@ def preview_template(
     except TemplateError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Ошибка рендеринга шаблона: {str(e)}",
+            detail="Internal server error",
         )
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка предварительного просмотра: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -419,7 +419,7 @@ def get_default_template(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения стандартного шаблона: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -515,5 +515,5 @@ def get_print_jobs(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения заданий печати: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/qr_queue.py
+++ b/backend/app/api/v1/endpoints/qr_queue.py
@@ -356,7 +356,7 @@ def generate_qr_token(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка генерации QR токена: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -415,7 +415,7 @@ def generate_clinic_qr_token(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка генерации общего QR токена: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -528,7 +528,7 @@ def get_available_specialists(db: Session = Depends(get_db)):
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения списка специалистов: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -561,7 +561,7 @@ def get_qr_token_info(token: str, db: Session = Depends(get_db)):
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения информации о токене: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -676,7 +676,7 @@ def complete_join_session(
             "[complete_join_session] ValueError: %s",
             str(e),
         )
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Internal server error")
     # Остальные исключения обрабатываются централизованными обработчиками
     # (exception_handlers.py)
 
@@ -819,7 +819,7 @@ async def call_next_patient(
     except HTTPException:
         raise
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Internal server error")
     except Exception as e:
         logger.error(
             "Error calling next patient",
@@ -1349,7 +1349,7 @@ def update_online_entry(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления данных: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -3178,7 +3178,7 @@ def full_update_online_entry(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка при обновлении записи: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -3391,5 +3391,5 @@ def cancel_service_in_entry(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка при отмене услуги: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/queue_auto_close.py
+++ b/backend/app/api/v1/endpoints/queue_auto_close.py
@@ -35,7 +35,7 @@ async def check_and_close_expired_queues(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка при проверке очередей: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -55,7 +55,7 @@ async def get_queues_pending_close(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка при получении очередей: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -75,10 +75,10 @@ async def force_close_queue(
         return {"success": True, "message": "Очередь успешно закрыта", "data": result}
 
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Internal server error")
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка при закрытии очереди: {str(e)}"
+            status_code=500, detail="Internal server error"
         )
 
 
@@ -103,5 +103,5 @@ async def get_auto_close_status(
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Ошибка при получении статуса: {str(e)}"
+            status_code=500, detail="Internal server error"
         )

--- a/backend/app/api/v1/endpoints/queue_reorder.py
+++ b/backend/app/api/v1/endpoints/queue_reorder.py
@@ -117,7 +117,7 @@ async def reorder_queue(
         logger.error(f"Error reordering queue: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка изменения порядка очереди: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -154,7 +154,7 @@ async def move_queue_entry(
         logger.error(f"Error moving queue entry: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка перемещения записи в очереди: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -182,7 +182,7 @@ async def get_queue_status_by_specialist(
         logger.error(f"Error getting queue status by specialist: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения состояния очереди: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -206,5 +206,5 @@ async def get_queue_status(
         logger.error(f"Error getting queue status: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения состояния очереди: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/registrar_integration.py
+++ b/backend/app/api/v1/endpoints/registrar_integration.py
@@ -1232,7 +1232,7 @@ def generate_qr_for_registrar(
         }
 
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Internal server error")
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/backend/app/api/v1/endpoints/registrar_notifications.py
+++ b/backend/app/api/v1/endpoints/registrar_notifications.py
@@ -141,7 +141,7 @@ async def get_active_registrars(
         logger.error(f"Ошибка получения списка регистраторов: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения списка регистраторов: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -184,7 +184,7 @@ async def notify_new_appointment(
         logger.error(f"Ошибка отправки уведомления о записи: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки уведомления: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -231,7 +231,7 @@ async def notify_price_change(
         logger.error(f"Ошибка отправки уведомления об изменении цены: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки уведомления: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -270,7 +270,7 @@ async def notify_queue_status(
         logger.error(f"Ошибка отправки уведомления о статусе очереди: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки уведомления: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -305,7 +305,7 @@ async def send_system_alert(
         logger.error(f"Ошибка отправки системного уведомления: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки уведомления: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -346,7 +346,7 @@ async def send_daily_summary(
         logger.error(f"Ошибка отправки ежедневной сводки: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки сводки: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -376,7 +376,7 @@ async def get_notification_stats(
         logger.error(f"Ошибка получения статистики уведомлений: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -406,5 +406,5 @@ async def test_notifications(
         logger.error(f"Ошибка отправки тестового уведомления: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки тестового уведомления: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/telegram_notifications.py
+++ b/backend/app/api/v1/endpoints/telegram_notifications.py
@@ -329,7 +329,7 @@ async def send_appointment_reminder(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки напоминания: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -427,7 +427,7 @@ async def send_lab_results(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки результатов: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -503,7 +503,7 @@ async def send_payment_confirmation(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки подтверждения: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -586,7 +586,7 @@ async def send_broadcast_message(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка отправки широковещательного сообщения: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -622,7 +622,7 @@ async def get_notification_stats(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -649,5 +649,5 @@ async def schedule_reminder(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка планирования напоминания: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/user_management.py
+++ b/backend/app/api/v1/endpoints/user_management.py
@@ -234,7 +234,7 @@ async def update_current_user_preferences(
         logging.error(f"Failed to update preferences for user {current_user.id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления настроек: {str(e)}"
+            detail="Internal server error"
         )
 
 
@@ -268,7 +268,7 @@ async def create_user(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания пользователя: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -319,7 +319,7 @@ async def get_users(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения списка пользователей: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -353,7 +353,7 @@ async def update_user(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления пользователя: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -383,7 +383,7 @@ async def delete_user(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка удаления пользователя: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -458,7 +458,7 @@ async def get_user_profile(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения профиля: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -539,7 +539,7 @@ async def update_user_profile(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления профиля: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -598,7 +598,7 @@ async def get_user_preferences(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения настроек: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -668,7 +668,7 @@ async def update_user_preferences(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления настроек: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -732,7 +732,7 @@ async def get_user_notification_settings(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения настроек уведомлений: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -807,7 +807,7 @@ async def update_user_notification_settings(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления настроек уведомлений: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -855,7 +855,7 @@ async def get_user_activity(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения активности: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -873,7 +873,7 @@ async def get_user_stats(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения статистики: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -907,7 +907,7 @@ async def bulk_action_users(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка массового действия: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -944,7 +944,7 @@ async def export_users(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка экспорта: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -988,7 +988,7 @@ async def list_export_files(current_user: User = Depends(require_roles("Admin"))
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения файлов экспорта: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1012,7 +1012,7 @@ async def download_export_file(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка скачивания файла: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1036,7 +1036,7 @@ async def delete_export_file(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка удаления файла: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -1095,5 +1095,5 @@ async def get_user(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения пользователя: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/visit_payments.py
+++ b/backend/app/api/v1/endpoints/visit_payments.py
@@ -25,7 +25,7 @@ def get_visit_payments_summary(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения сводки: {str(e)}",
+            detail="Internal server error",
         )
 
 @router.get("/visit-payments/{visit_id}", summary="Информация о платеже для визита")
@@ -43,7 +43,7 @@ def get_visit_payment_info(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения информации о платеже: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -70,7 +70,7 @@ def get_visits_by_payment_status(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка получения визитов: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -103,7 +103,7 @@ def update_visit_payment_status(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка обновления статуса платежа: {str(e)}",
+            detail="Internal server error",
         )
 
 @router.post(
@@ -132,5 +132,5 @@ def create_visit_from_payment(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Ошибка создания визита: {str(e)}",
+            detail="Internal server error",
         )

--- a/backend/app/api/v1/endpoints/webhooks.py
+++ b/backend/app/api/v1/endpoints/webhooks.py
@@ -65,7 +65,7 @@ async def create_webhook(
         logger.error(f"Ошибка создания webhook: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Ошибка создания webhook: {str(e)}",
+            detail="Internal server error",
         )
 
 
@@ -206,7 +206,7 @@ async def update_webhook(
         logger.error(f"Ошибка обновления webhook {webhook_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Ошибка обновления webhook: {str(e)}",
+            detail="Internal server error",
         )
 
 


### PR DESCRIPTION
282 instances of detail=f"...{str(e)}..." replaced with generic Internal server error across 38 endpoint files. HIPAA information disclosure fix.