### PR TITLE
perf: add eager loading to lab_reporting endpoints (N+1 fix)

### DIFF
--- a/backend/app/api/v1/endpoints/lab_reporting.py
+++ b/backend/app/api/v1/endpoints/lab_reporting.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, UTC
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload, selectinload
 
 from app.api.deps import get_db, require_roles
 from app.models.clinic import Doctor


### PR DESCRIPTION
Added joinedload(LabReportInstance.patient) to lab report list queries — eliminates N+1 SELECT per instance.