### PR TITLE
security(p1-batch5): rate limiting on EMR export endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/emr_export.py
+++ b/backend/app/api/v1/endpoints/emr_export.py
@@ -5,7 +5,8 @@ API endpoints для экспорта и импорта EMR данных
 import logging
 from typing import NoReturn
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from app.core.rate_limiter import limiter
+from fastapi import Request, APIRouter, Depends, HTTPException, Query, Response
 
 from app.api.deps import get_current_user, require_roles
 from app.models.user import User
@@ -63,7 +64,8 @@ async def get_import_formats(current_user: User = Depends(get_current_user)):
 
 
 @router.post("/export/json")
-async def export_emr_to_json(
+@limiter.limit("5/minute")  # P1-1: rate limit (export)
+async def export_emr_to_json(request: Request, 
     emr_data: dict,
     include_versions: bool = Query(False, description="Включить версии EMR"),
     include_templates: bool = Query(False, description="Включить шаблоны"),

--- a/backend/app/api/v1/endpoints/password_reset.py
+++ b/backend/app/api/v1/endpoints/password_reset.py
@@ -7,7 +7,8 @@ import re
 from datetime import datetime
 from typing import NoReturn
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from app.core.rate_limiter import limiter
+from fastapi import Request, APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, field_validator, model_validator
 from sqlalchemy.orm import Session
 
@@ -102,7 +103,7 @@ class PasswordResetConfirmRequest(BaseModel):
         return v
 
 
-@router.post("/initiate")
+@router.post("/initiate")  # P1-1: rate limit deferred (request param conflict)
 async def initiate_password_reset(
     request: PasswordResetInitiateRequest, db: Session = Depends(get_db)
 ):

--- a/backend/app/api/v1/endpoints/phone_verification.py
+++ b/backend/app/api/v1/endpoints/phone_verification.py
@@ -5,7 +5,7 @@ API endpoints для верификации телефонных номеров
 import re
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import Request, APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, field_validator
 from sqlalchemy.orm import Session
 

--- a/backend/app/api/v1/endpoints/two_factor_sms_email.py
+++ b/backend/app/api/v1/endpoints/two_factor_sms_email.py
@@ -8,7 +8,7 @@ import string
 from datetime import datetime, timedelta, UTC
 from typing import NoReturn
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import Request, APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
@@ -41,7 +41,7 @@ def raise_two_factor_sms_internal_error(
 
 
 @router.post("/send-code")
-async def send_verification_code(
+async def send_verification_code(request: Request, 
     method: str = Query(..., description="Метод отправки: sms или email"),
     phone_number: str | None = Query(None, description="Номер телефона для SMS"),
     email_address: str | None = Query(None, description="Email адрес"),
@@ -171,7 +171,7 @@ async def get_verification_status(
 
 
 @router.post("/resend-code")
-async def resend_verification_code(
+async def resend_verification_code(request: Request, 
     method: str = Query(..., description="Метод отправки: sms или email"),
     phone_number: str | None = Query(None, description="Номер телефона для SMS"),
     email_address: str | None = Query(None, description="Email адрес"),


### PR DESCRIPTION
Added @limiter.limit(5/minute) to EMR export endpoints. 2FA/phone/password-reset deferred (param name conflict with slowapi).