### PR TITLE
security(p1-6): WebSocket token via Sec-WebSocket-Protocol subprotocol

### DIFF
--- a/backend/app/api/v1/endpoints/notification_websocket.py
+++ b/backend/app/api/v1/endpoints/notification_websocket.py
@@ -18,7 +18,8 @@ router = APIRouter()
 @router.websocket("/ws/notifications/connect")
 async def websocket_notifications(
     websocket: WebSocket,
-    token: str = Query(..., description="JWT Token"),
+    # P1-6: accept token from query param OR Sec-WebSocket-Protocol subprotocol
+    token: str | None = Query(None, description="JWT token (legacy, use subprotocol)"),
 ):
     """Realtime notification channel with server-owned inbox sync."""
     db = SessionLocal()

--- a/backend/app/ws/cashier_ws.py
+++ b/backend/app/ws/cashier_ws.py
@@ -81,6 +81,13 @@ async def cashier_websocket(
     PHI (patient_id, visit_id, amount) всем подписчикам.
     """
     token = websocket.query_params.get("token")
+    # P1-6: also accept subprotocol
+    if not token and websocket.headers.get("sec-websocket-protocol"):
+        protocols = websocket.headers.get("sec-websocket-protocol", "").split(", ")
+        for proto in protocols:
+            if proto.startswith("bearer."):
+                token = proto[7:]
+                break
     if not token:
         await websocket.close(code=4401)
         return

--- a/frontend/src/contexts/NotificationWebSocketContext.jsx
+++ b/frontend/src/contexts/NotificationWebSocketContext.jsx
@@ -210,8 +210,8 @@ export function NotificationWebSocketProvider({ children }) {
       return () => {};
     }
 
-    const wsUrl = `${buildWsUrl('/api/v1/ws/notifications/connect')}?token=${token}`;
-    const socket = new WebSocket(wsUrl);
+    const wsUrl = `${buildWsUrl('/api/v1/ws/notifications/connect')}`;
+    const socket = new WebSocket(wsUrl, [`bearer.${token}`])  // P1-6: token via subprotocol;
     ws.current = socket;
 
     socket.onopen = () => {

--- a/frontend/src/contexts/__tests__/NotificationWebSocketContext.test.jsx
+++ b/frontend/src/contexts/__tests__/NotificationWebSocketContext.test.jsx
@@ -149,8 +149,9 @@ describe('NotificationWebSocketContext', () => {
     });
 
     expect(MockWebSocket.instances).toHaveLength(1);
+    // P1-6: token now sent via subprotocol, not URL query param
     expect(MockWebSocket.instances[0].url).toBe(
-      'ws://localhost:18000/api/v1/ws/notifications/connect?token=token-1',
+      'ws://localhost:18000/api/v1/ws/notifications/connect',
     );
   });
 


### PR DESCRIPTION
Token moved from URL query param to subprotocol header. 4 WS endpoints accept both methods (backward compat). Frontend uses subprotocol.