### PR TITLE
refactor: decompose get_today_queues (600→95 LOC) into 4 focused helpers

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration/_today_queues.py
+++ b/backend/app/api/v1/endpoints/registrar_integration/_today_queues.py
@@ -12,6 +12,616 @@ from app.api.v1.endpoints.registrar_integration._helpers import (
 )  # noqa: F401
 
 
+def _resolve_entry_department(
+    db: Session,
+    entry_type: str,
+    entry_data,
+    record_id,
+    visit_department,
+):
+    """Resolve department_key and department for a queue entry.
+
+    For visit entries: uses visit_department + VisitService → Service.department_key.
+    For appointment entries: uses appointment.services → Service.department_key.
+    Returns (entry_department_key, entry_department).
+    """
+    from app.models.service import Service
+    from app.models.visit import VisitService
+
+    # [OK] ДОБАВЛЯЕМ department_key и department для фронтенда
+    entry_department_key = None
+    entry_department = None
+    if entry_type == "visit":
+        # Для Visit используем department, который был сохранен выше
+        entry_department = visit_department
+
+        # Для Visit получаем department_key из услуг
+        from app.models.visit import VisitService
+
+        visit_services_for_dept = (
+            db.query(VisitService)
+            .filter(VisitService.visit_id == record_id)
+            .all()
+        )
+        for vs in visit_services_for_dept:
+            if vs.service_id:
+                svc = (
+                    db.query(Service)
+                    .filter(Service.id == vs.service_id)
+                    .first()
+                )
+                if svc and svc.department_key:
+                    entry_department_key = svc.department_key
+                    break
+    elif entry_type == "appointment":
+        if entry_data is None:
+            logger.warning("get_today_queues: appointment entry with None data, skipping")
+            return None, None
+        # Для Appointment получаем из услуг или напрямую
+        appointment_obj = entry_data
+        if (
+            hasattr(appointment_obj, 'services')
+            and appointment_obj.services
+        ):
+            for service_item in appointment_obj.services:
+                svc = None
+                if isinstance(service_item, dict):
+                    service_id = service_item.get('id')
+                    if service_id:
+                        svc = (
+                            db.query(Service)
+                            .filter(Service.id == service_id)
+                            .first()
+                        )
+                elif isinstance(service_item, int):
+                    svc = (
+                        db.query(Service)
+                        .filter(Service.id == service_item)
+                        .first()
+                    )
+                elif isinstance(service_item, str):
+                    # [OK] ДОБАВЛЕНО: Поиск услуги по названию (Appointment.services - это JSON строк)
+                    svc = (
+                        db.query(Service)
+                        .filter(Service.name == service_item)
+                        .first()
+                    )
+
+                if svc and svc.department_key:
+                    entry_department_key = svc.department_key
+                    break
+
+    return entry_department_key, entry_department
+
+
+def _process_visits_for_queues(
+    db: Session,
+    visits: list,
+    today,
+    queues_by_specialty: dict,
+    seen_visit_ids: set,
+):
+    """Process Visit records and append them to queues_by_specialty.
+
+    Handles ECG service detection and split logic:
+    - Visits with both ECG and non-ECG services are split into echokg + cardiology.
+    - Visits with only ECG go to echokg.
+    - Other visits go to specialty from service.department_key or visit.department.
+    """
+    from app.models.service import Service
+    from app.models.visit import VisitService
+
+    for visit in visits:
+        # Пропускаем если уже обработан
+        if visit.id in seen_visit_ids:
+            continue
+        # ⚠️ НЕ добавляем в seen_visit_ids здесь - сначала проверяем OQE
+
+        # ⭐ PHASE 1.1: Пропускаем Visit если есть связанный OnlineQueueEntry
+        # Очередь должна читаться ТОЛЬКО из OnlineQueueEntry (SSOT)
+        has_queue_entry = _same_patient_queue_entry_for_visit(db, visit)
+        if has_queue_entry:
+            # ⚠️ НЕ добавляем в seen_visit_ids - пусть OQE обрабатывается
+            logger.debug(
+                "get_today_queues: PHASE 1.1 - Visit %d пропущен, есть OnlineQueueEntry",
+                visit.id,
+            )
+            continue
+
+        # ✅ Только Visit БЕЗ OQE добавляем в seen_visit_ids
+        seen_visit_ids.add(visit.id)
+
+        # [OK] Определяем specialty на основе услуг визита, а не только department
+        # Проверяем услуги визита для правильного определения очереди
+        from app.models.service import Service
+        from app.models.visit import VisitService
+
+        visit_services = (
+            db.query(VisitService).filter(VisitService.visit_id == visit.id).all()
+        )
+        service_ids = [vs.service_id for vs in visit_services]
+        services = (
+            db.query(Service).filter(Service.id.in_(service_ids)).all()
+            if service_ids
+            else []
+        )
+
+        # R-22: ECG detection extracted to helper
+        has_ecg, ecg_services_count, non_ecg_services_count = _detect_ecg_services(services)
+
+        # Только ЭКГ: если есть ЭКГ услуги и нет не-ЭКГ услуг
+        has_only_ecg = has_ecg and non_ecg_services_count == 0
+        logger.debug(
+            "get_today_queues: Итог для Visit %d: has_ecg=%s, has_only_ecg=%s, ЭКГ услуг=%d, не-ЭКГ услуг=%d",
+            visit.id,
+            has_ecg,
+            has_only_ecg,
+            ecg_services_count,
+            non_ecg_services_count,
+        )
+
+        # [OK] Определяем specialty: если есть ЭКГ, разделяем на отдельные очереди
+        visit_date = visit.visit_date or today  # noqa: F841  # manual-review: variable intentionally kept for debugging/future use
+        patient_id = visit.patient_id
+
+        if has_ecg and not has_only_ecg:
+            # Визит содержит и ЭКГ и другие услуги - разделяем:
+            # 1. Создаем запись для ЭКГ в очередь echokg (только ЭКГ услуги)
+            specialty_ecg = "echokg"
+            # R-22: ensure ECG queue exists
+            _ensure_specialty_queue(queues_by_specialty, specialty_ecg, visit.doctor_id)
+
+            # R-22: created_at extraction moved to helper
+            visit_created_at = _get_visit_created_at(visit)
+
+            # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
+            # R-22: queue_time extraction moved to helper
+            visit_queue_time = _get_visit_queue_time(db, visit)
+
+            queues_by_specialty[specialty_ecg]["entries"].append(
+                {
+                    "type": "visit",
+                    "data": visit,
+                    "created_at": visit_created_at,
+                    "queue_time": visit_queue_time,  # ✅ ИСПРАВЛЕНО: Добавляем queue_time для правильной сортировки
+                    "filter_services": True,  # Флаг для фильтрации услуг при обработке
+                    "ecg_only": True,  # Только ЭКГ услуги для этой записи
+                }
+            )
+
+            # 2. Создаем запись для кардиолога в очередь cardiology (без ЭКГ услуг)
+            specialty = "cardiology"
+            # R-22: ensure queue exists
+            _ensure_specialty_queue(queues_by_specialty, specialty, visit.doctor_id)
+            # R-22: created_at extraction moved to helper
+            visit_created_at = _get_visit_created_at(visit)
+
+            # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
+            # R-22: queue_time extraction moved to helper
+            visit_queue_time = _get_visit_queue_time(db, visit)
+
+            queues_by_specialty[specialty]["entries"].append(
+                {
+                    "type": "visit",
+                    "data": visit,
+                    "created_at": visit_created_at,
+                    "queue_time": visit_queue_time,  # ✅ ИСПРАВЛЕНО: Добавляем queue_time для правильной сортировки
+                    "filter_services": True,  # Флаг для фильтрации услуг при обработке
+                    "ecg_only": False,  # Исключаем ЭКГ услуги
+                }
+            )
+            continue  # Переходим к следующему визиту
+        elif has_ecg and has_only_ecg:
+            # Только ЭКГ - идёт в echokg
+            specialty = "echokg"
+
+            # R-22: ensure queue exists
+            _ensure_specialty_queue(queues_by_specialty, specialty, visit.doctor_id)
+
+            # R-22: created_at extraction moved to helper
+            visit_created_at = _get_visit_created_at(visit)
+
+            # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
+            # R-22: queue_time extraction moved to helper
+            visit_queue_time = _get_visit_queue_time(db, visit)
+
+            queues_by_specialty[specialty]["entries"].append(
+                {
+                    "type": "visit",
+                    "data": visit,
+                    "created_at": visit_created_at,
+                    "queue_time": visit_queue_time,  # ✅ ИСПРАВЛЕНО: Добавляем queue_time для правильной сортировки
+                    "filter_services": True,  # [OK] ИСПРАВЛЕНО: Включаем фильтрацию услуг
+                    "ecg_only": True,  # [OK] ИСПРАВЛЕНО: Показываем только ЭКГ услуги
+                }
+            )
+            continue  # Переходим к следующему визиту
+        else:
+            # [OK] ОБНОВЛЕНО: Определяем specialty по department_key из услуг визита
+            # Приоритет: service.department_key > visit.department > "general"
+            specialty = None
+
+            # Проверяем department_key из услуг
+            for service in services:
+                if service.department_key:
+                    specialty = service.department_key
+                    break
+
+            # Fallback на visit.department
+            if not specialty:
+                specialty = visit.department or "general"
+
+        if specialty not in queues_by_specialty:
+            queues_by_specialty[specialty] = {
+                "entries": [],
+                "doctor": None,
+                "doctor_id": visit.doctor_id,
+            }
+
+        # Безопасно получаем дату создания
+        # [OK] УПРОЩЕНО: Используем getattr вместо try/except (Single Source of Truth)
+        visit_created_at = getattr(visit, 'confirmed_at', None) or getattr(
+            visit, 'created_at', None
+        )
+
+        # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
+        visit_queue_time = None
+        try:
+            queue_entry_row = _same_patient_queue_entry_for_visit(db, visit)
+            if queue_entry_row and queue_entry_row.queue_time:
+                visit_queue_time = queue_entry_row.queue_time
+        except Exception:
+            pass  # Тихая ошибка - используем created_at как fallback
+
+        # ⭐ PHASE 1.2: Visit без OQE всегда type='visit'
+        # Visit с source='online' уже пропущен выше (имеет OnlineQueueEntry)
+
+        queues_by_specialty[specialty]["entries"].append(
+            {
+                "type": "visit",  # ✅ PHASE 1.2: Всегда 'visit' для Visit без OQE
+                "data": visit,
+                "created_at": visit_created_at,
+                "queue_time": visit_queue_time,
+            }
+        )
+
+        # [OK] УПРОЩЕНО: Используем getattr вместо try/except (Single Source of Truth)
+        # ✅ ИСПРАВЛЕНО: Для visit записей обновляем doctor_id только если doctor ещё не установлен
+        # Это предотвращает перезапись doctor_id, установленного online_queue записями
+        if not queues_by_specialty[specialty]["doctor"]:
+            visit_doctor = getattr(visit, 'doctor', None)
+            if visit_doctor:
+                queues_by_specialty[specialty]["doctor"] = visit_doctor
+                # ✅ ИСПРАВЛЕНО: Обновляем doctor_id, если doctor найден
+                queues_by_specialty[specialty]["doctor_id"] = visit_doctor.id
+        # ✅ ИСПРАВЛЕНО: Убрана логика обновления doctor_id для visit записей, если specialty уже существует
+        # Это предотвращает перезапись doctor_id, установленного online_queue записями (которые обрабатываются позже)
+
+
+
+def _collect_lab_report_summaries(
+    db: Session,
+    queues_by_specialty: dict,
+    department_filter,
+):
+    """Collect lab report summaries for visible entries.
+
+    Returns (latest_lab_reports_by_visit: dict, include_lab_report_summary: bool).
+    """
+    include_lab_report_summary = bool(
+        department_filter and department_filter.intersection({"lab", "laboratory"})
+    )
+    visible_entry_wrappers = []
+    if include_lab_report_summary:
+        for specialty, data in queues_by_specialty.items():
+            specialty_key = str(specialty or "").strip().lower()
+            if department_filter and specialty_key not in department_filter:
+                continue
+            visible_entry_wrappers.extend(data["entries"])
+
+    visible_visit_ids: set[int] = set()
+    for entry_wrapper in visible_entry_wrappers:
+        entry_type = entry_wrapper.get("type")
+        entry_data = entry_wrapper.get("data")
+        entry_visit_id = (
+            entry_wrapper.get("visit_id")
+            or getattr(entry_data, "visit_id", None)
+            or (
+                getattr(entry_data, "id", None)
+                if entry_type == "visit"
+                else None
+            )
+        )
+        if entry_visit_id:
+            visible_visit_ids.add(entry_visit_id)
+
+    latest_lab_reports_by_visit = _latest_lab_report_summaries_by_visit(
+        db,
+        visible_visit_ids,
+    )
+    return latest_lab_reports_by_visit, include_lab_report_summary
+
+
+def _build_queue_result(
+    db: Session,
+    current_user,
+    queues_by_specialty: dict,
+    department_filter,
+    today,
+):
+    """Build the final result list from queues_by_specialty.
+
+    Processes each specialty queue: sorts entries, serializes each entry
+    (visit/appointment/online_queue), resolves department/payment/status,
+    and constructs the queue payload.
+
+    Returns the result list.
+    """
+    from datetime import datetime
+
+    result = []
+    queue_number = 1
+    seen_entry_keys = set()
+    latest_lab_reports_by_visit, include_lab_report_summary = (
+        _collect_lab_report_summaries(
+            db=db,
+            queues_by_specialty=queues_by_specialty,
+            department_filter=department_filter,
+        )
+    )
+
+
+    for specialty, queue_data in queues_by_specialty.items():
+        specialty_key = str(specialty or "").strip().lower()
+        if department_filter and specialty_key not in department_filter:
+            continue
+
+        entries_list = queue_data.get("entries", [])
+        if not entries_list:
+            continue
+
+        # Сортируем записи по queue_time, затем по created_at
+        entries_list.sort(
+            key=lambda e: (
+                e.get("queue_time") or e.get("created_at") or datetime.max,
+                e.get("data").id if hasattr(e.get("data"), "id") else 0,
+            )
+        )
+
+        # R-22 fix: separate output list to avoid in-place mutation during iteration
+        entries = []
+        for idx, entry in enumerate(entries_list):
+            entry_type = entry.get("type")
+            entry_data = entry.get("data")
+            entry_id_val = getattr(entry_data, "id", "")
+            entry_key = f"{entry_type}_{entry_id_val}"
+            # R-22 fix: entry_wrapper is alias for entry (used in result serialization)
+            entry_wrapper = entry
+            # Пропускаем дубликаты
+            if entry_key in seen_entry_keys:
+                logger.debug(
+                    "get_today_queues: Пропущен дубликат: %s (тип: %s)",
+                    entry_key,
+                    entry_type,
+                )
+                continue
+
+            seen_entry_keys.add(entry_key)
+
+            # Инициализируем общие переменные
+            patient_id = None
+            patient_name = "Неизвестный пациент"
+            phone = "Не указан"
+            patient_birth_year = None
+            address = None
+            services = []
+            service_codes = []
+            service_details = []  # ✅ НОВОЕ: Полные данные услуг для редактирования
+            total_cost = 0
+            source = "desk"
+            entry_status = "waiting"
+            visit_time = None
+            discount_mode = "none"
+            record_id = None
+            visit_department = (
+                None  # ✅ ДОБАВЛЕНО: для хранения department из Visit
+            )
+            appointment_date = None  # R-22 fix: для queue_entry lookup
+            doctor_id = None  # R-22 fix: для queue_entry lookup
+
+            if entry_type == "visit":
+                # R-22 Phase 8: visit processing extracted to helper
+                _vis = _process_visit_entry(
+                    db=db,
+                    entry_data=entry_data,
+                    entry_wrapper=entry_wrapper,
+                    specialty=specialty,
+                )
+                if _vis is None:
+                    continue
+                record_id = _vis["record_id"]
+                patient_id = _vis["patient_id"]
+                visit_time = _vis["visit_time"]
+                patient_name = _vis["patient_name"]
+                phone = _vis["phone"]
+                patient_birth_year = _vis["patient_birth_year"]
+                address = _vis["address"]
+                services = _vis["services"]
+                service_codes = _vis["service_codes"]
+                service_details = _vis["service_details"]
+                total_cost = _vis["total_cost"]
+                entry_status = _vis["entry_status"]
+                discount_mode = _vis["discount_mode"]
+                source = _vis["source"]
+                visit_department = _vis["visit_department"]
+
+            elif entry_type == "appointment":
+                # R-22 Phase 6: appointment processing extracted to helper
+                _appt = _process_appointment_entry(
+                    db=db,
+                    entry_data=entry_data,
+                    entry_wrapper=entry_wrapper,
+                    today=today,
+                )
+                if _appt is None:
+                    continue
+                record_id = _appt["record_id"]
+                patient_id = _appt["patient_id"]
+                appointment_date = _appt["appointment_date"]
+                doctor_id = _appt["doctor_id"]
+                visit_time = _appt["visit_time"]
+                patient_name = _appt["patient_name"]
+                phone = _appt["phone"]
+                patient_birth_year = _appt["patient_birth_year"]
+                address = _appt["address"]
+                services = _appt["services"]
+                service_codes = _appt["service_codes"]
+                total_cost = _appt["total_cost"]
+                entry_status = _appt["entry_status"]
+                discount_mode = _appt["discount_mode"]
+                source = _appt["source"]
+
+            elif entry_type == "online_queue":
+                # R-22 Phase 7: online_queue processing extracted to helper
+                _oqe = _process_online_queue_entry(
+                    db=db,
+                    entry_data=entry_data,
+                    entry_wrapper=entry_wrapper,
+                    specialty=specialty,
+                )
+                if _oqe is None:
+                    continue
+                record_id = _oqe["record_id"]
+                patient_id = _oqe["patient_id"]
+                patient_name = _oqe["patient_name"]
+                phone = _oqe["phone"]
+                patient_birth_year = _oqe["patient_birth_year"]
+                address = _oqe["address"]
+                entry_status = _oqe["entry_status"]
+                source = _oqe["source"]
+                discount_mode = _oqe["discount_mode"]
+                visit_time = _oqe["visit_time"]
+                services = _oqe["services"]
+                service_codes = _oqe["service_codes"]
+                service_details = _oqe["service_details"]
+                total_cost = _oqe["total_cost"]
+
+            # appointment_id must mean a real Appointment.id for this row.
+            # Visit rows do not have an explicit Appointment FK, so a fuzzy
+            # patient/date/doctor match can expose an unrelated appointment.
+            appointment_id_value = record_id if entry_type == "appointment" else None
+
+            # R-22 Phase 5: queue entry metadata lookup extracted to helper
+            queue_entry_number, queue_entry_time, queue_entry_updated_at = _resolve_queue_entry_metadata(
+                db=db,
+                entry_type=entry_type,
+                entry_data=entry_data,
+                entry_wrapper=entry_wrapper,
+                record_id=record_id,
+                patient_id=patient_id,
+                appointment_date=appointment_date,
+                doctor_id=doctor_id,
+                idx=idx,
+            )
+
+            # [OK] ДОБАВЛЯЕМ department_key и department для фронтенда
+            entry_department_key, entry_department = _resolve_entry_department(
+                db=db,
+                entry_type=entry_type,
+                entry_data=entry_data,
+                record_id=record_id,
+                visit_department=visit_department,
+            )
+
+            # ✅ ИСПРАВЛЕНО: Определяем queue_time для ответа (приоритет: из queue_entries > из entry_wrapper > created_at)
+            entry_queue_time = queue_entry_time
+            if not entry_queue_time and entry_wrapper.get("queue_time"):
+                entry_queue_time = entry_wrapper["queue_time"]
+            if not entry_queue_time:
+                entry_queue_time = entry_wrapper.get("created_at")
+            entry_updated_at = (
+                queue_entry_updated_at
+                or entry_wrapper.get("oqe_updated_at")
+                or getattr(entry_data, "updated_at", None)
+                or entry_wrapper.get("created_at")
+            )
+            entry_display_time_kind = (
+                "queue_time" if queue_entry_time or entry_wrapper.get("queue_time") else "created_at"
+            )
+
+            entry_visit_id = (
+                entry_wrapper.get("visit_id")
+                or getattr(entry_data, "visit_id", None)
+                or (record_id if entry_type == "visit" else None)
+            )
+            latest_lab_report = (
+                latest_lab_reports_by_visit.get(entry_visit_id)
+                if entry_visit_id
+                else None
+            )
+            payment_status, payment_type = _resolve_payment_truth(
+                db,
+                visit_id=entry_visit_id,
+                legacy_paid_at=getattr(entry_data, "payment_processed_at", None),
+            )
+            canonical_status = _normalize_queue_status_for_registrar(entry_status)
+            available_actions = _registrar_available_actions(
+                user=current_user,
+                payment_status=payment_status,
+                queue_status=canonical_status,
+                visit_id=entry_visit_id,
+                patient_id=patient_id,
+            )
+            # R-22 Phase 4: entry serialization extracted to helper
+            # (can_* flags are computed inside _serialize_queue_entry)
+            entries.append(
+                _serialize_queue_entry(
+                    entry_type=entry_type,
+                    record_id=record_id,
+                    source=source,
+                    appointment_id_value=appointment_id_value,
+                    entry_visit_id=entry_visit_id,
+                    queue_entry_number=queue_entry_number,
+                    patient_id=patient_id,
+                    patient_name=patient_name,
+                    patient_birth_year=patient_birth_year,
+                    phone=phone,
+                    address=address,
+                    services=services,
+                    service_codes=service_codes,
+                    service_details=service_details,
+                    entry_wrapper=entry_wrapper,
+                    total_cost=total_cost,
+                    payment_status=payment_status,
+                    payment_type=payment_type,
+                    available_actions=available_actions,
+                    canonical_status=canonical_status,
+                    entry_queue_time=entry_queue_time,
+                    entry_updated_at=entry_updated_at,
+                    entry_display_time_kind=entry_display_time_kind,
+                    visit_time=visit_time,
+                    discount_mode=discount_mode,
+                    entry_data=entry_data,
+                    latest_lab_report=latest_lab_report,
+                    entry_department_key=entry_department_key,
+                    entry_department=entry_department,
+                )
+            )
+
+        # R-22 Phase 4: queue payload construction extracted to helper
+        queue_data = _build_queue_payload(
+            queue_data=queue_data,
+            specialty=specialty,
+            queue_number=queue_number,
+            entries=entries,
+        )
+
+        result.append(queue_data)
+        queue_number += 1
+
+    return result
+
+
 @router.get("/registrar/queues/today", response_model=dict[str, Any])
 def get_today_queues(
     target_date: str | None = Query(
@@ -64,191 +674,14 @@ def get_today_queues(
         seen_visit_ids = set()  # Для отслеживания уже обработанных Visit
         seen_appointment_ids = set()  # Для отслеживания уже обработанных Appointment
         # Обрабатываем Visit (новая система)
-        for visit in visits:
-            # Пропускаем если уже обработан
-            if visit.id in seen_visit_ids:
-                continue
-            # ⚠️ НЕ добавляем в seen_visit_ids здесь - сначала проверяем OQE
-
-            # ⭐ PHASE 1.1: Пропускаем Visit если есть связанный OnlineQueueEntry
-            # Очередь должна читаться ТОЛЬКО из OnlineQueueEntry (SSOT)
-            has_queue_entry = _same_patient_queue_entry_for_visit(db, visit)
-            if has_queue_entry:
-                # ⚠️ НЕ добавляем в seen_visit_ids - пусть OQE обрабатывается
-                logger.debug(
-                    "get_today_queues: PHASE 1.1 - Visit %d пропущен, есть OnlineQueueEntry",
-                    visit.id,
-                )
-                continue
-
-            # ✅ Только Visit БЕЗ OQE добавляем в seen_visit_ids
-            seen_visit_ids.add(visit.id)
-
-            # [OK] Определяем specialty на основе услуг визита, а не только department
-            # Проверяем услуги визита для правильного определения очереди
-            from app.models.service import Service
-            from app.models.visit import VisitService
-
-            visit_services = (
-                db.query(VisitService).filter(VisitService.visit_id == visit.id).all()
-            )
-            service_ids = [vs.service_id for vs in visit_services]
-            services = (
-                db.query(Service).filter(Service.id.in_(service_ids)).all()
-                if service_ids
-                else []
-            )
-
-            # R-22: ECG detection extracted to helper
-            has_ecg, ecg_services_count, non_ecg_services_count = _detect_ecg_services(services)
-
-            # Только ЭКГ: если есть ЭКГ услуги и нет не-ЭКГ услуг
-            has_only_ecg = has_ecg and non_ecg_services_count == 0
-            logger.debug(
-                "get_today_queues: Итог для Visit %d: has_ecg=%s, has_only_ecg=%s, ЭКГ услуг=%d, не-ЭКГ услуг=%d",
-                visit.id,
-                has_ecg,
-                has_only_ecg,
-                ecg_services_count,
-                non_ecg_services_count,
-            )
-
-            # [OK] Определяем specialty: если есть ЭКГ, разделяем на отдельные очереди
-            visit_date = visit.visit_date or today  # noqa: F841  # manual-review: variable intentionally kept for debugging/future use
-            patient_id = visit.patient_id
-
-            if has_ecg and not has_only_ecg:
-                # Визит содержит и ЭКГ и другие услуги - разделяем:
-                # 1. Создаем запись для ЭКГ в очередь echokg (только ЭКГ услуги)
-                specialty_ecg = "echokg"
-                # R-22: ensure ECG queue exists
-                _ensure_specialty_queue(queues_by_specialty, specialty_ecg, visit.doctor_id)
-
-                # R-22: created_at extraction moved to helper
-                visit_created_at = _get_visit_created_at(visit)
-
-                # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
-                # R-22: queue_time extraction moved to helper
-                visit_queue_time = _get_visit_queue_time(db, visit)
-
-                queues_by_specialty[specialty_ecg]["entries"].append(
-                    {
-                        "type": "visit",
-                        "data": visit,
-                        "created_at": visit_created_at,
-                        "queue_time": visit_queue_time,  # ✅ ИСПРАВЛЕНО: Добавляем queue_time для правильной сортировки
-                        "filter_services": True,  # Флаг для фильтрации услуг при обработке
-                        "ecg_only": True,  # Только ЭКГ услуги для этой записи
-                    }
-                )
-
-                # 2. Создаем запись для кардиолога в очередь cardiology (без ЭКГ услуг)
-                specialty = "cardiology"
-                # R-22: ensure queue exists
-                _ensure_specialty_queue(queues_by_specialty, specialty, visit.doctor_id)
-                # R-22: created_at extraction moved to helper
-                visit_created_at = _get_visit_created_at(visit)
-
-                # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
-                # R-22: queue_time extraction moved to helper
-                visit_queue_time = _get_visit_queue_time(db, visit)
-
-                queues_by_specialty[specialty]["entries"].append(
-                    {
-                        "type": "visit",
-                        "data": visit,
-                        "created_at": visit_created_at,
-                        "queue_time": visit_queue_time,  # ✅ ИСПРАВЛЕНО: Добавляем queue_time для правильной сортировки
-                        "filter_services": True,  # Флаг для фильтрации услуг при обработке
-                        "ecg_only": False,  # Исключаем ЭКГ услуги
-                    }
-                )
-                continue  # Переходим к следующему визиту
-            elif has_ecg and has_only_ecg:
-                # Только ЭКГ - идёт в echokg
-                specialty = "echokg"
-
-                # R-22: ensure queue exists
-                _ensure_specialty_queue(queues_by_specialty, specialty, visit.doctor_id)
-
-                # R-22: created_at extraction moved to helper
-                visit_created_at = _get_visit_created_at(visit)
-
-                # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
-                # R-22: queue_time extraction moved to helper
-                visit_queue_time = _get_visit_queue_time(db, visit)
-
-                queues_by_specialty[specialty]["entries"].append(
-                    {
-                        "type": "visit",
-                        "data": visit,
-                        "created_at": visit_created_at,
-                        "queue_time": visit_queue_time,  # ✅ ИСПРАВЛЕНО: Добавляем queue_time для правильной сортировки
-                        "filter_services": True,  # [OK] ИСПРАВЛЕНО: Включаем фильтрацию услуг
-                        "ecg_only": True,  # [OK] ИСПРАВЛЕНО: Показываем только ЭКГ услуги
-                    }
-                )
-                continue  # Переходим к следующему визиту
-            else:
-                # [OK] ОБНОВЛЕНО: Определяем specialty по department_key из услуг визита
-                # Приоритет: service.department_key > visit.department > "general"
-                specialty = None
-
-                # Проверяем department_key из услуг
-                for service in services:
-                    if service.department_key:
-                        specialty = service.department_key
-                        break
-
-                # Fallback на visit.department
-                if not specialty:
-                    specialty = visit.department or "general"
-
-            if specialty not in queues_by_specialty:
-                queues_by_specialty[specialty] = {
-                    "entries": [],
-                    "doctor": None,
-                    "doctor_id": visit.doctor_id,
-                }
-
-            # Безопасно получаем дату создания
-            # [OK] УПРОЩЕНО: Используем getattr вместо try/except (Single Source of Truth)
-            visit_created_at = getattr(visit, 'confirmed_at', None) or getattr(
-                visit, 'created_at', None
-            )
-
-            # ✅ ИСПРАВЛЕНО: Получаем queue_time из связанной записи в queue_entries
-            visit_queue_time = None
-            try:
-                queue_entry_row = _same_patient_queue_entry_for_visit(db, visit)
-                if queue_entry_row and queue_entry_row.queue_time:
-                    visit_queue_time = queue_entry_row.queue_time
-            except Exception:
-                pass  # Тихая ошибка - используем created_at как fallback
-
-            # ⭐ PHASE 1.2: Visit без OQE всегда type='visit'
-            # Visit с source='online' уже пропущен выше (имеет OnlineQueueEntry)
-
-            queues_by_specialty[specialty]["entries"].append(
-                {
-                    "type": "visit",  # ✅ PHASE 1.2: Всегда 'visit' для Visit без OQE
-                    "data": visit,
-                    "created_at": visit_created_at,
-                    "queue_time": visit_queue_time,
-                }
-            )
-
-            # [OK] УПРОЩЕНО: Используем getattr вместо try/except (Single Source of Truth)
-            # ✅ ИСПРАВЛЕНО: Для visit записей обновляем doctor_id только если doctor ещё не установлен
-            # Это предотвращает перезапись doctor_id, установленного online_queue записями
-            if not queues_by_specialty[specialty]["doctor"]:
-                visit_doctor = getattr(visit, 'doctor', None)
-                if visit_doctor:
-                    queues_by_specialty[specialty]["doctor"] = visit_doctor
-                    # ✅ ИСПРАВЛЕНО: Обновляем doctor_id, если doctor найден
-                    queues_by_specialty[specialty]["doctor_id"] = visit_doctor.id
-            # ✅ ИСПРАВЛЕНО: Убрана логика обновления doctor_id для visit записей, если specialty уже существует
-            # Это предотвращает перезапись doctor_id, установленного online_queue записями (которые обрабатываются позже)
+        # Process Visit records into queues_by_specialty
+        _process_visits_for_queues(
+            db=db,
+            visits=visits,
+            today=today,
+            queues_by_specialty=queues_by_specialty,
+            seen_visit_ids=seen_visit_ids,
+        )
 
         # R-22 Phase 3: online entries processing extracted to helper
         _process_online_queue_entries(db, online_entries, visits, queues_by_specialty, seen_visit_ids)
@@ -257,342 +690,14 @@ def get_today_queues(
         _process_legacy_appointments(db, appointments, queues_by_specialty, seen_appointment_ids, today)
 
         # Формируем результат
-        result = []
-        queue_number = 1
-        seen_entry_keys = set()
-        include_lab_report_summary = bool(
-            department_filter and department_filter.intersection({"lab", "laboratory"})
+        # Build the final result from queues_by_specialty
+        result = _build_queue_result(
+            db=db,
+            current_user=current_user,
+            queues_by_specialty=queues_by_specialty,
+            department_filter=department_filter,
+            today=today,
         )
-        visible_entry_wrappers = []
-        if include_lab_report_summary:
-            for specialty, data in queues_by_specialty.items():
-                specialty_key = str(specialty or "").strip().lower()
-                if department_filter and specialty_key not in department_filter:
-                    continue
-                visible_entry_wrappers.extend(data["entries"])
-
-        visible_visit_ids: set[int] = set()
-        for entry_wrapper in visible_entry_wrappers:
-            entry_type = entry_wrapper.get("type")
-            entry_data = entry_wrapper.get("data")
-            entry_visit_id = (
-                entry_wrapper.get("visit_id")
-                or getattr(entry_data, "visit_id", None)
-                or (
-                    getattr(entry_data, "id", None)
-                    if entry_type == "visit"
-                    else None
-                )
-            )
-            if entry_visit_id:
-                visible_visit_ids.add(entry_visit_id)
-
-        latest_lab_reports_by_visit = _latest_lab_report_summaries_by_visit(
-            db,
-            visible_visit_ids,
-        )
-
-        for specialty, queue_data in queues_by_specialty.items():
-            specialty_key = str(specialty or "").strip().lower()
-            if department_filter and specialty_key not in department_filter:
-                continue
-
-            entries_list = queue_data.get("entries", [])
-            if not entries_list:
-                continue
-
-            # Сортируем записи по queue_time, затем по created_at
-            entries_list.sort(
-                key=lambda e: (
-                    e.get("queue_time") or e.get("created_at") or datetime.max,
-                    e.get("data").id if hasattr(e.get("data"), "id") else 0,
-                )
-            )
-
-            # R-22 fix: separate output list to avoid in-place mutation during iteration
-            entries = []
-            for idx, entry in enumerate(entries_list):
-                entry_type = entry.get("type")
-                entry_data = entry.get("data")
-                entry_id_val = getattr(entry_data, "id", "")
-                entry_key = f"{entry_type}_{entry_id_val}"
-                # R-22 fix: entry_wrapper is alias for entry (used in result serialization)
-                entry_wrapper = entry
-                # Пропускаем дубликаты
-                if entry_key in seen_entry_keys:
-                    logger.debug(
-                        "get_today_queues: Пропущен дубликат: %s (тип: %s)",
-                        entry_key,
-                        entry_type,
-                    )
-                    continue
-
-                seen_entry_keys.add(entry_key)
-
-                # Инициализируем общие переменные
-                patient_id = None
-                patient_name = "Неизвестный пациент"
-                phone = "Не указан"
-                patient_birth_year = None
-                address = None
-                services = []
-                service_codes = []
-                service_details = []  # ✅ НОВОЕ: Полные данные услуг для редактирования
-                total_cost = 0
-                source = "desk"
-                entry_status = "waiting"
-                visit_time = None
-                discount_mode = "none"
-                record_id = None
-                visit_department = (
-                    None  # ✅ ДОБАВЛЕНО: для хранения department из Visit
-                )
-                appointment_date = None  # R-22 fix: для queue_entry lookup
-                doctor_id = None  # R-22 fix: для queue_entry lookup
-
-                if entry_type == "visit":
-                    # R-22 Phase 8: visit processing extracted to helper
-                    _vis = _process_visit_entry(
-                        db=db,
-                        entry_data=entry_data,
-                        entry_wrapper=entry_wrapper,
-                        specialty=specialty,
-                    )
-                    if _vis is None:
-                        continue
-                    record_id = _vis["record_id"]
-                    patient_id = _vis["patient_id"]
-                    visit_time = _vis["visit_time"]
-                    patient_name = _vis["patient_name"]
-                    phone = _vis["phone"]
-                    patient_birth_year = _vis["patient_birth_year"]
-                    address = _vis["address"]
-                    services = _vis["services"]
-                    service_codes = _vis["service_codes"]
-                    service_details = _vis["service_details"]
-                    total_cost = _vis["total_cost"]
-                    entry_status = _vis["entry_status"]
-                    discount_mode = _vis["discount_mode"]
-                    source = _vis["source"]
-                    visit_department = _vis["visit_department"]
-
-                elif entry_type == "appointment":
-                    # R-22 Phase 6: appointment processing extracted to helper
-                    _appt = _process_appointment_entry(
-                        db=db,
-                        entry_data=entry_data,
-                        entry_wrapper=entry_wrapper,
-                        today=today,
-                    )
-                    if _appt is None:
-                        continue
-                    record_id = _appt["record_id"]
-                    patient_id = _appt["patient_id"]
-                    appointment_date = _appt["appointment_date"]
-                    doctor_id = _appt["doctor_id"]
-                    visit_time = _appt["visit_time"]
-                    patient_name = _appt["patient_name"]
-                    phone = _appt["phone"]
-                    patient_birth_year = _appt["patient_birth_year"]
-                    address = _appt["address"]
-                    services = _appt["services"]
-                    service_codes = _appt["service_codes"]
-                    total_cost = _appt["total_cost"]
-                    entry_status = _appt["entry_status"]
-                    discount_mode = _appt["discount_mode"]
-                    source = _appt["source"]
-
-                elif entry_type == "online_queue":
-                    # R-22 Phase 7: online_queue processing extracted to helper
-                    _oqe = _process_online_queue_entry(
-                        db=db,
-                        entry_data=entry_data,
-                        entry_wrapper=entry_wrapper,
-                        specialty=specialty,
-                    )
-                    if _oqe is None:
-                        continue
-                    record_id = _oqe["record_id"]
-                    patient_id = _oqe["patient_id"]
-                    patient_name = _oqe["patient_name"]
-                    phone = _oqe["phone"]
-                    patient_birth_year = _oqe["patient_birth_year"]
-                    address = _oqe["address"]
-                    entry_status = _oqe["entry_status"]
-                    source = _oqe["source"]
-                    discount_mode = _oqe["discount_mode"]
-                    visit_time = _oqe["visit_time"]
-                    services = _oqe["services"]
-                    service_codes = _oqe["service_codes"]
-                    service_details = _oqe["service_details"]
-                    total_cost = _oqe["total_cost"]
-
-                # appointment_id must mean a real Appointment.id for this row.
-                # Visit rows do not have an explicit Appointment FK, so a fuzzy
-                # patient/date/doctor match can expose an unrelated appointment.
-                appointment_id_value = record_id if entry_type == "appointment" else None
-
-                # R-22 Phase 5: queue entry metadata lookup extracted to helper
-                queue_entry_number, queue_entry_time, queue_entry_updated_at = _resolve_queue_entry_metadata(
-                    db=db,
-                    entry_type=entry_type,
-                    entry_data=entry_data,
-                    entry_wrapper=entry_wrapper,
-                    record_id=record_id,
-                    patient_id=patient_id,
-                    appointment_date=appointment_date,
-                    doctor_id=doctor_id,
-                    idx=idx,
-                )
-
-                # [OK] ДОБАВЛЯЕМ department_key и department для фронтенда
-                entry_department_key = None
-                entry_department = None
-                if entry_type == "visit":
-                    # Для Visit используем department, который был сохранен выше
-                    entry_department = visit_department
-
-                    # Для Visit получаем department_key из услуг
-                    from app.models.visit import VisitService
-
-                    visit_services_for_dept = (
-                        db.query(VisitService)
-                        .filter(VisitService.visit_id == record_id)
-                        .all()
-                    )
-                    for vs in visit_services_for_dept:
-                        if vs.service_id:
-                            svc = (
-                                db.query(Service)
-                                .filter(Service.id == vs.service_id)
-                                .first()
-                            )
-                            if svc and svc.department_key:
-                                entry_department_key = svc.department_key
-                                break
-                elif entry_type == "appointment":
-                    if entry_data is None:
-                        logger.warning("get_today_queues: appointment entry with None data, skipping")
-                        continue
-                    # Для Appointment получаем из услуг или напрямую
-                    appointment_obj = entry_data
-                    if (
-                        hasattr(appointment_obj, 'services')
-                        and appointment_obj.services
-                    ):
-                        for service_item in appointment_obj.services:
-                            svc = None
-                            if isinstance(service_item, dict):
-                                service_id = service_item.get('id')
-                                if service_id:
-                                    svc = (
-                                        db.query(Service)
-                                        .filter(Service.id == service_id)
-                                        .first()
-                                    )
-                            elif isinstance(service_item, int):
-                                svc = (
-                                    db.query(Service)
-                                    .filter(Service.id == service_item)
-                                    .first()
-                                )
-                            elif isinstance(service_item, str):
-                                # [OK] ДОБАВЛЕНО: Поиск услуги по названию (Appointment.services - это JSON строк)
-                                svc = (
-                                    db.query(Service)
-                                    .filter(Service.name == service_item)
-                                    .first()
-                                )
-
-                            if svc and svc.department_key:
-                                entry_department_key = svc.department_key
-                                break
-
-                # ✅ ИСПРАВЛЕНО: Определяем queue_time для ответа (приоритет: из queue_entries > из entry_wrapper > created_at)
-                entry_queue_time = queue_entry_time
-                if not entry_queue_time and entry_wrapper.get("queue_time"):
-                    entry_queue_time = entry_wrapper["queue_time"]
-                if not entry_queue_time:
-                    entry_queue_time = entry_wrapper.get("created_at")
-                entry_updated_at = (
-                    queue_entry_updated_at
-                    or entry_wrapper.get("oqe_updated_at")
-                    or getattr(entry_data, "updated_at", None)
-                    or entry_wrapper.get("created_at")
-                )
-                entry_display_time_kind = (
-                    "queue_time" if queue_entry_time or entry_wrapper.get("queue_time") else "created_at"
-                )
-
-                entry_visit_id = (
-                    entry_wrapper.get("visit_id")
-                    or getattr(entry_data, "visit_id", None)
-                    or (record_id if entry_type == "visit" else None)
-                )
-                latest_lab_report = (
-                    latest_lab_reports_by_visit.get(entry_visit_id)
-                    if entry_visit_id
-                    else None
-                )
-                payment_status, payment_type = _resolve_payment_truth(
-                    db,
-                    visit_id=entry_visit_id,
-                    legacy_paid_at=getattr(entry_data, "payment_processed_at", None),
-                )
-                canonical_status = _normalize_queue_status_for_registrar(entry_status)
-                available_actions = _registrar_available_actions(
-                    user=current_user,
-                    payment_status=payment_status,
-                    queue_status=canonical_status,
-                    visit_id=entry_visit_id,
-                    patient_id=patient_id,
-                )
-                # R-22 Phase 4: entry serialization extracted to helper
-                # (can_* flags are computed inside _serialize_queue_entry)
-                entries.append(
-                    _serialize_queue_entry(
-                        entry_type=entry_type,
-                        record_id=record_id,
-                        source=source,
-                        appointment_id_value=appointment_id_value,
-                        entry_visit_id=entry_visit_id,
-                        queue_entry_number=queue_entry_number,
-                        patient_id=patient_id,
-                        patient_name=patient_name,
-                        patient_birth_year=patient_birth_year,
-                        phone=phone,
-                        address=address,
-                        services=services,
-                        service_codes=service_codes,
-                        service_details=service_details,
-                        entry_wrapper=entry_wrapper,
-                        total_cost=total_cost,
-                        payment_status=payment_status,
-                        payment_type=payment_type,
-                        available_actions=available_actions,
-                        canonical_status=canonical_status,
-                        entry_queue_time=entry_queue_time,
-                        entry_updated_at=entry_updated_at,
-                        entry_display_time_kind=entry_display_time_kind,
-                        visit_time=visit_time,
-                        discount_mode=discount_mode,
-                        entry_data=entry_data,
-                        latest_lab_report=latest_lab_report,
-                        entry_department_key=entry_department_key,
-                        entry_department=entry_department,
-                    )
-                )
-
-            # R-22 Phase 4: queue payload construction extracted to helper
-            queue_data = _build_queue_payload(
-                queue_data=queue_data,
-                specialty=specialty,
-                queue_number=queue_number,
-                entries=entries,
-            )
-
-            result.append(queue_data)
-            queue_number += 1
 
         return {
             "queues": result,


### PR DESCRIPTION
## Summary

`get_today_queues` was the **largest endpoint function** in the codebase at 600 LOC. Decomposed into a 95-LOC orchestrator + 4 focused helpers.

## Extracted 4 helpers

### 1. `_resolve_entry_department` (80 LOC)
Resolve `department_key` and `department` for a queue entry.
- Visit entries: `visit_department` + `VisitService → Service.department_key`
- Appointment entries: `appointment.services → Service.department_key`

### 2. `_process_visits_for_queues` (200 LOC)
Process Visit records and append to `queues_by_specialty`. Handles ECG service detection and split logic:
- Visits with both ECG + non-ECG → split into `echokg` + `cardiology`
- ECG-only visits → `echokg`
- Other visits → specialty from `service.department_key` or `visit.department`

### 3. `_collect_lab_report_summaries` (56 LOC)
Collect lab report summaries for visible entries when department filter includes `lab`/`laboratory`.

### 4. `_build_queue_result` (278 LOC)
Build the final result list from `queues_by_specialty`. Sorts entries, serializes each entry (visit/appointment/online_queue), resolves department/payment/status, constructs queue payload.

## Orchestrator (95 LOC)

```python
get_today_queues():
  1. Parse date + normalize department filter
  2. Load queue data (visits, appointments, online_entries)
  3. _process_visits_for_queues(...)
  4. _process_online_queue_entries(...)  # existing helper
  5. _process_legacy_appointments(...)   # existing helper
  6. _build_queue_result(...)
  7. Return response
```

## Bug fix

`continue` in `_resolve_entry_department` appointment branch was valid inside the main loop but needed to be `return None, None` in the extracted helper (can't `continue` outside a loop).

## Test results (SQLite local)

- Before this PR (on main): **14 pass / 8 fail**
- After this PR: **14 pass / 8 fail** (no regressions)
- Remaining 8 failures are pre-existing environmental (SQLite vs Postgres).

## Function sizes after this PR

```
get_today_queues:                  95 lines  (was 600, this PR)
_resolve_entry_department:          80 lines  (new)
_process_visits_for_queues:        200 lines  (new)
_collect_lab_report_summaries:      56 lines  (new)
_build_queue_result:               278 lines  (new)
```

All functions in this file are now ≤278 LOC.

## Files changed

1 file modified: `app/api/v1/endpoints/registrar_integration/_today_queues.py` (+625 / −520 lines, net +105).

## Next steps after merge

1. Decompose `get_detailed_endpoints_documentation` (544 LOC) — next largest function.
2. Decompose `_handle_clinic_bot_update` (392 LOC).
3. Decompose `get_all_appointments` (390 LOC).
4. Address 11 missing `response_model` endpoints (P3).
5. Address 7 list-endpoints missing pagination (P3).