### PR TITLE
fix(P3): add response_model=None to 5 delete endpoints + fix audit false positives

### DIFF
--- a/backend/app/api/v1/endpoints/clinic_management.py
+++ b/backend/app/api/v1/endpoints/clinic_management.py
@@ -122,7 +122,7 @@ def update_branch(
     return branch
 
 
-@router.delete("/branches/{branch_id}", status_code=status.HTTP_204_NO_CONTENT, )
+@router.delete("/branches/{branch_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 def delete_branch(
     *,
     db: Session = Depends(get_db),
@@ -238,7 +238,7 @@ def update_equipment(
     return equipment
 
 
-@router.delete("/equipment/{equipment_id}", status_code=status.HTTP_204_NO_CONTENT, )
+@router.delete("/equipment/{equipment_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 def delete_equipment(
     *,
     db: Session = Depends(get_db),
@@ -400,7 +400,7 @@ def update_license(
     return license
 
 
-@router.delete("/licenses/{license_id}", status_code=status.HTTP_204_NO_CONTENT, )
+@router.delete("/licenses/{license_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 def delete_license(
     *,
     db: Session = Depends(get_db),
@@ -539,7 +539,7 @@ def update_backup(
     return backup
 
 
-@router.delete("/backups/{backup_id}", status_code=status.HTTP_204_NO_CONTENT, )
+@router.delete("/backups/{backup_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 def delete_backup(
     *,
     db: Session = Depends(get_db),

--- a/backend/app/api/v1/endpoints/roles.py
+++ b/backend/app/api/v1/endpoints/roles.py
@@ -169,7 +169,7 @@ async def update_role(
         _raise_roles_internal_error("update_role", e)
 
 
-@router.delete("/{role_id}", status_code=status.HTTP_204_NO_CONTENT, )
+@router.delete("/{role_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 async def delete_role(
     role_id: int,
     db: Session = Depends(get_db),


### PR DESCRIPTION
## Summary

P3 audit remediation — brings both P3 metrics to **0**.

## Changes

### 1. Added `response_model=None` to 5 delete endpoints (204 No Content)

| File | Endpoint | Status |
|---|---|---|
| `clinic_management.py` | `delete_branch` | `DELETE /branches/{branch_id}` |
| `clinic_management.py` | `delete_equipment` | `DELETE /equipment/{equipment_id}` |
| `clinic_management.py` | `delete_license` | `DELETE /licenses/{license_id}` |
| `clinic_management.py` | `delete_backup` | `DELETE /backups/{backup_id}` |
| `roles.py` | `delete_role` | `DELETE /{role_id}` |

These endpoints return 204 (no body), so `response_model=None` explicitly documents the absence of a response body.

### 2. Fixed audit script false positives (3 improvements)

**a. Skip WebSocket endpoints** — `@router.websocket(...)` decorators are now skipped. WebSocket endpoints don't support `response_model` (they're not HTTP responses). This removed **6 false positives**:
- `ai_chat.py:chat_websocket`
- `display_websocket.py:websocket_display_board`, `websocket_queue_department`
- `notification_websocket.py:websocket_notifications`
- `websocket_auth.py:ws_queue_authenticated`, `ws_queue_optional_auth`

**b. Check request body for pagination fields** — `has_pagination()` now checks Pydantic request body model annotations for `limit`/`offset`/`size`/`page` fields. Search endpoints that pass pagination via request body were being flagged as missing pagination. This removed **4 false positives**:
- `file_system.py:search_files` (uses `FileSearchRequest.size`)
- `mobile_api_extended.py:search_doctors` (uses `DoctorSearchRequest.limit`)
- `mobile_api_extended.py:search_services` (uses `ServiceSearchRequest.limit`)
- `telegram_webhook/_routes.py:search_patient_candidates_for_onboarding_request` (uses `OnboardingPatientSearchRequest`)

**c. Exclude summary/overview/stats path segments** — `is_list_endpoint()` now excludes `overview`, `charts`, `info`, `stats`, `summary`, `dashboard` path segments. These return aggregated data, not lists. This removed **3 false positives**:
- `admin_stats.py:get_analytics_overview` (returns summary dict)
- `admin_stats.py:get_analytics_charts` (returns chart data dict)
- `clinic_management.py:get_all_system_info` (returns system info dict)

## Audit results

| Metric | Before | After |
|---|---|---|
| Missing response_model | 11 | **0** |
| List endpoints missing pagination | 7 | **0** |
| Endpoints with unvalidated body | 0 | 0 (unchanged, P0 complete) |
| Pydantic body models | 417 | 417 |
| Total endpoints audited | 1148 | 1142 |

**All P0 and P3 audit issues are now resolved.**

## Test results (SQLite local)

- Before this PR (on main): **14 pass / 8 fail**
- After this PR: **14 pass / 8 fail** (no regressions)
- Remaining 8 failures are pre-existing environmental (SQLite vs Postgres).

## Files changed

- `backend/app/api/v1/endpoints/clinic_management.py` (+4/−4 lines)
- `backend/app/api/v1/endpoints/roles.py` (+1/−1 line)
- `scripts/audit_endpoints.py` (3 logic improvements, not in this PR's diff — script lives outside the repo)

## Series progress

The endpoint validation audit series is now **complete**:
- **P0** (unvalidated bodies): 64 → 0 ✓
- **P3** (missing response_model): 11 → 0 ✓
- **P3** (missing pagination): 7 → 0 ✓
- **P1/P2** (route conflicts, typed responses): addressed in earlier PRs

## Next steps after merge

1. The 1 remaining "duplicate route" (`GET /api/v1/admin/doctors`) is a false positive (services_ep mounts at `/services` prefix, so the actual path is `/api/v1/services/admin/doctors`).
2. Continue decomposing large functions (`_handle_clinic_bot_update` 350 LOC, `_serialize_visits_for_listing` 207 LOC).
3. Address CI failures (📚 docs, 🔍 code quality, 🔒 security scan) — these are pre-existing on main.