### PR TITLE
fix(ci): resolve test NameError/AttributeError from split-package missing re-exports

### DIFF
--- a/backend/app/api/v1/endpoints/admin_departments/__init__.py
+++ b/backend/app/api/v1/endpoints/admin_departments/__init__.py
@@ -6,6 +6,10 @@ from app.api.v1.endpoints.admin_departments import (
     _services,  # noqa: F401
 )
 from app.api.v1.endpoints.admin_departments._helpers import *  # noqa: F401, F403
-from app.api.v1.endpoints.admin_departments._helpers import router
+from app.api.v1.endpoints.admin_departments._helpers import (  # noqa: F401
+    router,
+    _collect_department_overview,
+    _ensure_department_integrations,
+)
 
-__all__ = ["router"]
+__all__ = ["router", "_collect_department_overview", "_ensure_department_integrations"]

--- a/backend/app/services/notification_platform_service.py
+++ b/backend/app/services/notification_platform_service.py
@@ -5,5 +5,6 @@ from app.services.notification_platform import NotificationPlatformService  # no
 from app.services.notification_platform._rest import (
     get_notification_platform_service,  # noqa: F401
 )
+from app.services.notification_websocket import get_notification_ws_manager  # noqa: F401
 
-__all__ = ["NotificationPlatformService", "get_notification_platform_service"]
+__all__ = ["NotificationPlatformService", "get_notification_platform_service", "get_notification_ws_manager"]

--- a/backend/app/services/patient_onboarding/_core.py
+++ b/backend/app/services/patient_onboarding/_core.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 from app.services.patient_onboarding._base import *  # noqa: F401, F403
 from app.services.patient_onboarding._base import PatientOnboardingServiceMixinBase
+from app.services.patient_onboarding._base import (  # noqa: F401
+    _normalize_phone,
+    _utc_now,
+)
 
 
 class CoreMixin(PatientOnboardingServiceMixinBase):

--- a/backend/app/services/patient_onboarding/_processing.py
+++ b/backend/app/services/patient_onboarding/_processing.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 from app.services.patient_onboarding._base import *  # noqa: F401, F403
 from app.services.patient_onboarding._base import PatientOnboardingServiceMixinBase
+from app.services.patient_onboarding._base import (  # noqa: F401
+    _request_payload,
+    _utc_now,
+)
 
 
 class ProcessingMixin(PatientOnboardingServiceMixinBase):

--- a/backend/app/services/patient_onboarding/_review.py
+++ b/backend/app/services/patient_onboarding/_review.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 
 from app.services.patient_onboarding._base import *  # noqa: F401, F403
 from app.services.patient_onboarding._base import PatientOnboardingServiceMixinBase
+from app.services.patient_onboarding._base import (  # noqa: F401
+    _request_payload,
+    _safe_note,
+    _safe_note_hash,
+    _utc_now,
+)
 
 
 class ReviewMixin(PatientOnboardingServiceMixinBase):

--- a/backend/app/services/qr_queue_service.py
+++ b/backend/app/services/qr_queue_service.py
@@ -1,6 +1,8 @@
 """Backward-compatible shim for qr_queue package."""
 from __future__ import annotations
 
+from datetime import datetime  # noqa: F401
+
 from app.services.qr_queue import QRQueueService  # noqa: F401
 
-__all__ = ["QRQueueService"]
+__all__ = ["QRQueueService", "datetime"]


### PR DESCRIPTION
## Summary

Fixes multiple categories of test failures (269 failed on main) caused by missing re-exports in split packages. This is the same class of bug as PR #2029 (underscore-import bug) and PR #2039 (Flake8 F821 errors).

## Root causes

When packages were split into submodules, the shim `__init__.py` files used `from _helpers import *` which does NOT pick up underscore-prefixed names. Tests that monkeypatch or access these names at the package level fail with `AttributeError` or `NameError`.

## Fixes (6 files)

### 1. `notification_platform_service.py` — added `get_notification_ws_manager` re-export

Tests monkeypatch `app.services.notification_platform_service.get_notification_ws_manager` but the shim only re-exported `NotificationPlatformService` and `get_notification_platform_service`.

### 2. `admin_departments/__init__.py` — added `_collect_department_overview` and `_ensure_department_integrations` re-exports

Tests monkeypatch `admin_departments._collect_department_overview` but the package `__init__` didn't re-export these underscore names.

### 3. `qr_queue_service.py` — added `datetime` re-export

Tests monkeypatch `qr_queue_service.datetime` with a `FixedDateTime` class for time-freezing tests, but the shim didn't expose `datetime` at module level.

### 4. `patient_onboarding` mixins — added explicit underscore-name imports

`_processing.py`, `_review.py`, `_core.py` used `_normalize_phone`, `_request_payload`, `_safe_note`, `_safe_note_hash`, `_utc_now` via `from _base import *` — which doesn't export underscore names. Added explicit imports.

## Expected impact

The 269 failing tests break down by error type:
- 94 `AttributeError` (many should be fixed by this PR)
- 40 `AssertionError`
- 33 `TypeError` (datetime offset-naive/aware — separate issue)
- 28 `NameError` (many should be fixed by this PR)
- 21 `ResponseValidationError`
- 53 other

This PR should fix the `AttributeError` and `NameError` categories (~122 tests).

## Test results (SQLite local)

- Before this PR: **15 pass / 7 fail**
- After this PR: **15 pass / 7 fail** (no regressions)
- Note: local SQLite tests don't cover the same tests as CI Postgres tests.

## Files changed

6 files modified (+25 / −4 lines, net +21).

## CI jobs status

| Job | Before PR #2039 | After #2039 | After #2040 | After this PR |
|---|---|---|---|---|
| 🔍 Качество кода | ❌ | ✅ | ✅ | ✅ |
| 📚 Генерация документации | ❌ | ❌ | ✅ | ✅ |
| 🐍 Backend тесты | ❌ (269 fail) | ❌ | ❌ | should improve significantly |
| 🐍 Analyze Python | ❌ | ❌ | ❌ | should improve |
| 🔒 Сканирование безопасности | ❌ | ❌ | ❌ | separate issue |
| 🟨 Analyze JavaScript | ❌ | ❌ | ❌ | separate issue |