### PR TITLE
fix(ci): comprehensive re-exports for telegram_webhook + admin_telegram packages

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram/__init__.py
+++ b/backend/app/api/v1/endpoints/admin_telegram/__init__.py
@@ -20,6 +20,7 @@ from app.api.v1.endpoints.admin_telegram import (
     _settings,  # noqa: F401
     _staff_actions,  # noqa: F401
 )
+import requests  # noqa: F401
 from app.api.v1.endpoints.admin_telegram._helpers import *  # noqa: F401, F403
 
 # Re-export underscore-prefixed symbols that other modules (notably
@@ -45,9 +46,16 @@ from app.api.v1.endpoints.admin_telegram._staff_actions import (  # noqa: F401
     _get_staff_bot_token_runtime_status,
     confirm_staff_action,
 )
+from app.api.v1.endpoints.admin_telegram._helpers import (  # noqa: F401
+    issue_staff_link_start_token,
+)
+from app.api.v1.endpoints.admin_telegram._settings import (  # noqa: F401
+    get_telegram_webhook_info,
+)
 
 __all__ = [
     "router",
+    "requests",
     "PATIENT_BOOKING_ENTRY_ROUTE",
     "PATIENT_MINI_APP_ENTRY_ROUTE",
     "PATIENT_PAYMENT_ENTRY_ROUTE",
@@ -64,4 +72,6 @@ __all__ = [
     "_staff_runtime_reference_hash",
     "validate_staff_link_start_token",
     "confirm_staff_action",
+    "issue_staff_link_start_token",
+    "get_telegram_webhook_info",
 ]

--- a/backend/app/api/v1/endpoints/telegram_webhook/__init__.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook/__init__.py
@@ -1,9 +1,102 @@
 """
 Telegram webhook package.
 
-Re-exports router for backward compatibility with api.py:
-    from app.api.v1.endpoints.telegram_webhook import router
-"""
-from app.api.v1.endpoints.telegram_webhook._routes import router
+Re-exports router and shared symbols for backward compatibility with
+tests and other modules that import from the package root.
 
-__all__ = ["router"]
+Before the split into a package, telegram_webhook.py was a single file
+with all these names at module level. Tests access them via
+`telegram_webhook._some_function` — which requires explicit re-exports
+because `from ... import *` does not pick up underscore-prefixed names.
+"""
+# Import endpoint modules to register routes on the shared router.
+from app.api.v1.endpoints.telegram_webhook import (  # noqa: F401
+    _clinic_bot,
+    _patient_commands,
+    _routes,
+    _staff_commands,
+)
+from app.api.v1.endpoints.telegram_webhook._helpers import *  # noqa: F401, F403
+from app.api.v1.endpoints.telegram_webhook._helpers import router  # noqa: F401
+
+# Re-export underscore-prefixed symbols and constants that tests and
+# other modules access via `telegram_webhook.<name>`.
+from app.api.v1.endpoints.telegram_webhook._helpers import (  # noqa: F401
+    PATIENT_BOOKING_ENTRY_ROUTE,
+    PATIENT_MINI_APP_ENTRY_ROUTE,
+    PATIENT_PAYMENT_ENTRY_ROUTE,
+    TELEGRAM_CONTACT_REJECTED_MESSAGE,
+    TELEGRAM_LANGUAGE_MENU,
+    TELEGRAM_LOCALIZED_TEXTS,
+    TELEGRAM_STAFF_LINKED_MESSAGE,
+    TELEGRAM_STAFF_LINK_REJECTED_MESSAGE,
+    TELEGRAM_STAFF_LINK_REPLY_MARKUP,
+    TELEGRAM_TICKET_QR_PREFIX,
+    _localized_main_menu,
+    _localized_notification_consent_menu,
+    _localized_services_menu,
+    _localized_settings_menu,
+    _localized_text,
+    _normalize_patient_language,
+    _parse_patient_mini_app_entry_token,
+    _parse_patient_onboarding_entry_token,
+    _telegram_settings_message,
+)
+from app.api.v1.endpoints.telegram_webhook._clinic_bot import (  # noqa: F401
+    _handle_clinic_bot_update,
+)
+from app.api.v1.endpoints.telegram_webhook._patient_commands import (  # noqa: F401
+    _send_patient_bot_reply,
+)
+from app.api.v1.endpoints.telegram_webhook._routes import (  # noqa: F401
+    send_message_to_user,
+)
+from app.api.v1.endpoints.telegram_webhook._staff_commands import (  # noqa: F401
+    _clinic_payments_message,
+    _clinic_queue_message,
+    _clinic_visits_message,
+    _handle_contact_link,
+    _handle_ticket_qr_start,
+    _latest_ready_lab_report_instances,
+    _queue_entry_position,
+    _send_clinic_lab_results,
+)
+
+__all__ = [
+    "router",
+    "send_message_to_user",
+    # Constants
+    "PATIENT_BOOKING_ENTRY_ROUTE",
+    "PATIENT_MINI_APP_ENTRY_ROUTE",
+    "PATIENT_PAYMENT_ENTRY_ROUTE",
+    "TELEGRAM_CONTACT_REJECTED_MESSAGE",
+    "TELEGRAM_LANGUAGE_MENU",
+    "TELEGRAM_LOCALIZED_TEXTS",
+    "TELEGRAM_STAFF_LINKED_MESSAGE",
+    "TELEGRAM_STAFF_LINK_REJECTED_MESSAGE",
+    "TELEGRAM_STAFF_LINK_REPLY_MARKUP",
+    "TELEGRAM_TICKET_QR_PREFIX",
+    # Functions from _helpers
+    "_localized_main_menu",
+    "_localized_notification_consent_menu",
+    "_localized_services_menu",
+    "_localized_settings_menu",
+    "_localized_text",
+    "_normalize_patient_language",
+    "_parse_patient_mini_app_entry_token",
+    "_parse_patient_onboarding_entry_token",
+    "_telegram_settings_message",
+    # Functions from _clinic_bot
+    "_handle_clinic_bot_update",
+    # Functions from _patient_commands
+    "_send_patient_bot_reply",
+    # Functions from _staff_commands
+    "_clinic_payments_message",
+    "_clinic_queue_message",
+    "_clinic_visits_message",
+    "_handle_contact_link",
+    "_handle_ticket_qr_start",
+    "_latest_ready_lab_report_instances",
+    "_queue_entry_position",
+    "_send_clinic_lab_results",
+]


### PR DESCRIPTION
## Summary

Fixes the largest category of backend test failures (134+ tests in `test_telegram_webhook_security` + 44 in `test_telegram_staff_read_only_menu_runtime`) by adding comprehensive re-exports to the split package `__init__.py` files.

## Root cause

After splitting `telegram_webhook.py` and `admin_telegram.py` into packages, the tests that access functions/constants at the package root (e.g. `telegram_webhook._handle_clinic_bot_update`, `telegram_webhook.TELEGRAM_LANGUAGE_MENU`) failed with `AttributeError` because the split `__init__.py` only re-exported `router`.

## Fixes

### `telegram_webhook/__init__.py` — added 30 re-exports

**Constants (11):**
`TELEGRAM_CONTACT_REJECTED_MESSAGE`, `TELEGRAM_LANGUAGE_MENU`, `TELEGRAM_LOCALIZED_TEXTS`, `TELEGRAM_STAFF_LINKED_MESSAGE`, `TELEGRAM_STAFF_LINK_REJECTED_MESSAGE`, `TELEGRAM_STAFF_LINK_REPLY_MARKUP`, `TELEGRAM_TICKET_QR_PREFIX`, `PATIENT_BOOKING_ENTRY_ROUTE`, `PATIENT_MINI_APP_ENTRY_ROUTE`, `PATIENT_PAYMENT_ENTRY_ROUTE`

**Functions from `_helpers` (10):**
`_localized_main_menu`, `_localized_services_menu`, `_localized_settings_menu`, `_localized_notification_consent_menu`, `_localized_text`, `_normalize_patient_language`, `_parse_patient_mini_app_entry_token`, `_parse_patient_onboarding_entry_token`, `_telegram_settings_message`

**Functions from other submodules (11):**
`_handle_clinic_bot_update` (from `_clinic_bot`), `_send_patient_bot_reply` (from `_patient_commands`), `send_message_to_user` (from `_routes`), `_clinic_payments_message`, `_clinic_queue_message`, `_clinic_visits_message`, `_handle_contact_link`, `_handle_ticket_qr_start`, `_latest_ready_lab_report_instances`, `_queue_entry_position`, `_send_clinic_lab_results` (from `_staff_commands`)

### `admin_telegram/__init__.py` — added 3 re-exports

- `requests` module (tests monkeypatch `admin_telegram.requests`)
- `issue_staff_link_start_token` (from `_helpers`)
- `get_telegram_webhook_info` (from `_settings`)

## Expected impact

| Test suite | Failures before | Expected after |
|---|---|---|
| `test_telegram_webhook_security` | 134 | ~0 |
| `test_telegram_staff_read_only_menu_runtime` | 44 | ~0 |
| Other telegram/admin tests | ~20 | ~0 |
| **Total** | **~198** | **~0** |

This should reduce the 268 failing tests to ~70 (the remaining TypeError/AssertionError/ResponseValidationError categories that are separate issues).

## Test results (SQLite local)

- Before: **15 pass / 7 fail**
- After: **15 pass / 7 fail** (no regressions)
- Note: local SQLite tests don't cover the telegram_webhook_security tests.

## Files changed

2 files modified (+107 / −4 lines, net +103).

## CI progress

| Job | PR #2039 | #2040 | #2041 | This PR |
|---|---|---|---|---|
| 🔍 Качество кода | ✅ | ✅ | ✅ | ✅ |
| 📚 Генерация документации | ❌ | ✅ | ✅ | ✅ |
| 🐍 Backend тесты | 269 fail | 269 fail | 268 fail | **should drop to ~70** |
| 🐍 Analyze Python | ❌ | ❌ | ❌ | should improve |
| 🔒 Сканирование безопасности | ❌ | ❌ | ❌ | separate issue |
| 🟨 Analyze JavaScript | ❌ | ❌ | ❌ | separate issue |