### PR TITLE
fix(ci): add missing _normalize_staff_button_text + _send_patient_bot_reply imports

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook/_staff_commands.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook/_staff_commands.py
@@ -41,6 +41,10 @@ from app.api.v1.endpoints.telegram_webhook._helpers import (
     _telegram_onboarding_entry_markup,
     _telegram_settings_message,
 )  # noqa: F401
+from app.api.v1.endpoints.telegram_webhook._patient_commands import (  # noqa: F401
+    _normalize_staff_button_text,
+    _send_patient_bot_reply,
+)
 
 
 async def _handle_staff_read_only_menu(


### PR DESCRIPTION
Fixes 50 NameError failures for _normalize_staff_button_text in test_telegram_webhook_security.