### PR TITLE
fix(ci): comprehensive cross-module imports for telegram_webhook package

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook/_clinic_bot.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook/_clinic_bot.py
@@ -27,11 +27,34 @@ logger = logging.getLogger(__name__)
 from app.api.v1.endpoints.telegram_webhook._helpers import *  # noqa: F401, F403
 
 from app.api.v1.endpoints.telegram_webhook._staff_commands import (  # noqa: F401
-    _handle_staff_link_start,
-    _handle_ticket_qr_start,
+    _billing_totals,
+    _build_lab_report_pdf,
+    _clinic_payments_message,
+    _clinic_queue_message,
+    _clinic_status_message,
+    _clinic_visits_message,
+    _format_money,
     _handle_contact_link,
+    _handle_staff_link_start,
     _handle_staff_read_only_menu,
+    _handle_ticket_qr_start,
+    _latest_ready_lab_report_instances,
+    _message_chat_id,
     _message_from_update,
+    _message_text,
+    _patient_display_name,
+    _patient_for_telegram_chat,
+    _patient_recent_visits,
+    _patient_today_queue_entries,
+    _send_clinic_lab_results,
+    _send_language_choice,
+    _set_notification_consent,
+)
+from app.api.v1.endpoints.telegram_webhook._patient_commands import (  # noqa: F401
+    _is_patient_settings_context_template,
+    _latest_patient_bot_template_key,
+    _send_patient_bot_reply,
+    _upsert_ticket_qr_telegram_user,
 )
 
 from app.api.v1.endpoints.telegram_webhook._helpers import (

--- a/backend/app/api/v1/endpoints/telegram_webhook/_patient_commands.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook/_patient_commands.py
@@ -42,6 +42,10 @@ from app.api.v1.endpoints.telegram_webhook._helpers import *  # noqa: F401, F403
 from app.api.v1.endpoints.telegram_webhook._helpers import (
     _normalize_patient_language,
 )  # noqa: F401
+from app.api.v1.endpoints.telegram_webhook._staff_commands import (  # noqa: F401
+    _queue_entry_name,
+    _queue_entry_position,
+)
 
 
 async def _send_patient_bot_reply(

--- a/backend/app/api/v1/endpoints/telegram_webhook/_routes.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook/_routes.py
@@ -9,8 +9,16 @@ from typing import Any
 
 from app.api.v1.endpoints.telegram_webhook._clinic_bot import *  # noqa: F401, F403
 from app.api.v1.endpoints.telegram_webhook._clinic_bot import (
+    _build_mini_app_appointment_booking_preview_from_request,
+    _build_mini_app_patient_cabinet_summary_from_request,
+    _build_mini_app_patient_forms_preview_from_request,
+    _build_mini_app_patient_manifest_from_request,
+    _build_mini_app_patient_report_download_response,
     _handle_clinic_bot_update,
     _raise_telegram_webhook_internal_error,
+    _save_mini_app_patient_form_submission_from_request,
+    _telegram_bot_info_failure,
+    _telegram_user_from_onboarding_request_auth,
     _validate_webhook_secret,
 )
 

--- a/backend/app/api/v1/endpoints/telegram_webhook/_staff_commands.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook/_staff_commands.py
@@ -42,14 +42,26 @@ from app.api.v1.endpoints.telegram_webhook._helpers import (
     _telegram_settings_message,
 )  # noqa: F401
 from app.api.v1.endpoints.telegram_webhook._patient_commands import (  # noqa: F401
+    _create_staff_action_confirmation_request,
+    _is_patient_settings_context_template,
+    _latest_patient_bot_template_key,
     _linked_staff_for_chat,
     _normalize_staff_button_text,
+    _record_staff_action_denied_audit,
     _record_staff_command_audit,
+    _record_staff_link_audit,
     _send_patient_bot_reply,
+    _staff_menu_for_role,
+    _staff_menu_item_for_command,
+    _staff_menu_item_for_text,
     _staff_menu_keyboard,
+    _staff_menu_message,
     _staff_read_only_commands,
+    _staff_read_only_domain_data_message,
     _staff_read_only_item_labels,
     _staff_state_change_operation_for_command,
+    _upsert_staff_link_telegram_user,
+    _upsert_ticket_qr_telegram_user,
 )
 
 


### PR DESCRIPTION
Fixes all remaining NameError failures (50+) by adding explicit cross-module imports.