### PR TITLE
fix(ci): add missing 'requests' import in admin_telegram/_settings.py

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram/_settings.py
+++ b/backend/app/api/v1/endpoints/admin_telegram/_settings.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import requests  # noqa: F401
+
 from app.api.v1.endpoints.admin_telegram._helpers import *  # noqa
 
 from app.api.v1.endpoints.admin_telegram._helpers import (


### PR DESCRIPTION
Fixes NameError for 'requests' in admin_telegram settings endpoints.