### PR TITLE
fix(ci): use shared router instance in telegram_webhook/_routes.py — fixes 50+ 404 errors

### DIFF
--- a/backend/app/api/v1/endpoints/telegram_webhook/_routes.py
+++ b/backend/app/api/v1/endpoints/telegram_webhook/_routes.py
@@ -43,7 +43,9 @@ from app.schemas.notifications import (
     TelegramWebhookUpdateRequest,
 )
 
-router = APIRouter()
+# Use the shared router from _helpers (not a new instance) so that routes
+# registered here are visible when api.py imports telegram_webhook.router.
+from app.api.v1.endpoints.telegram_webhook._helpers import router  # noqa: F401
 
 
 def _is_duplicate_update(db, update_id: int | None) -> bool:


### PR DESCRIPTION
Critical fix: _routes.py was creating its own APIRouter() instead of using the shared router from _helpers.py. Routes were registered on the wrong instance, causing 404 in all telegram webhook tests.