### PR TITLE
fix(ci): add missing imports exposed by router fix — 13 NameErrors

### DIFF
--- a/backend/app/api/v1/endpoints/admin_telegram/_settings.py
+++ b/backend/app/api/v1/endpoints/admin_telegram/_settings.py
@@ -12,6 +12,7 @@ from app.api.v1.endpoints.admin_telegram._helpers import (
 )  # noqa: F401
 from app.api.v1.endpoints.admin_telegram._staff_actions import (  # noqa: F401
     TelegramWebhookRequest,
+    webhook_info_error_response,
 )
 from app.schemas.notifications import UpdateTelegramSettingsRequest
 

--- a/backend/app/services/patient_onboarding/_core.py
+++ b/backend/app/services/patient_onboarding/_core.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 from app.services.patient_onboarding._base import *  # noqa: F401, F403
 from app.services.patient_onboarding._base import PatientOnboardingServiceMixinBase
 from app.services.patient_onboarding._base import (  # noqa: F401
+    _as_aware_utc,
+    _clean_text,
+    _mask_name,
     _normalize_phone,
+    _phone_matches,
     _utc_now,
 )
 

--- a/backend/app/services/patient_onboarding/_processing.py
+++ b/backend/app/services/patient_onboarding/_processing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from app.services.patient_onboarding._base import *  # noqa: F401, F403
 from app.services.patient_onboarding._base import PatientOnboardingServiceMixinBase
 from app.services.patient_onboarding._base import (  # noqa: F401
+    _clean_text,
     _request_payload,
     _utc_now,
 )

--- a/backend/app/services/patient_onboarding/_review.py
+++ b/backend/app/services/patient_onboarding/_review.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 from app.services.patient_onboarding._base import *  # noqa: F401, F403
 from app.services.patient_onboarding._base import PatientOnboardingServiceMixinBase
 from app.services.patient_onboarding._base import (  # noqa: F401
+    _as_aware_utc,
+    _clean_text,
+    _mask_name,
     _request_payload,
     _safe_note,
     _safe_note_hash,


### PR DESCRIPTION
The router fix (PR #2053) exposed new code paths that have missing imports. Fixes 13 NameError failures.