### PR TITLE
fix(ci): resolve TypeError datetime offset-naive/aware failures (36 tests)

### DIFF
--- a/backend/app/services/file_system_service.py
+++ b/backend/app/services/file_system_service.py
@@ -149,9 +149,11 @@ class FileSystemService:
         expires_at = getattr(share, "expires_at", None)
         if expires_at is None:
             return True
-        now = (
-            datetime.now(expires_at.tzinfo) if expires_at.tzinfo else datetime.now(UTC)
-        )
+        # Normalize naive datetimes to UTC so we can compare with datetime.now(UTC).
+        # Legacy callers/tests may store naive expires_at (e.g. datetime.utcnow()).
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        now = datetime.now(UTC)
         return expires_at > now
 
     @staticmethod

--- a/backend/app/services/queue_svc/_base.py
+++ b/backend/app/services/queue_svc/_base.py
@@ -30,6 +30,20 @@ from app.services.queue_session import (  # noqa: F401
 logger = logging.getLogger(__name__)
 
 
+def _now(tz=None) -> datetime:
+    """Return the current datetime, honoring test monkeypatches.
+
+    Tests freeze time by patching ``app.services.queue_service.datetime`` with
+    a ``FixedDateTime`` subclass. The split modules under ``queue_svc`` import
+    ``datetime`` directly from the stdlib, so a plain ``datetime.now()`` would
+    bypass the patch. Look the class up via the public shim module at call
+    time so the patched class (if any) is used.
+    """
+    from app.services import queue_service
+
+    return queue_service.datetime.now(tz)
+
+
 class QueueError(Exception):
     """Базовое исключение для сервиса очереди."""
 

--- a/backend/app/services/queue_svc/_core.py
+++ b/backend/app/services/queue_svc/_core.py
@@ -5,7 +5,7 @@ Split from queue_service.py.
 from __future__ import annotations
 
 from app.services.queue_svc._base import *  # noqa: F401, F403
-from app.services.queue_svc._base import QueueBusinessServiceMixinBase
+from app.services.queue_svc._base import QueueBusinessServiceMixinBase, _now
 
 
 class CoreMixin(QueueBusinessServiceMixinBase):
@@ -117,7 +117,7 @@ class CoreMixin(QueueBusinessServiceMixinBase):
         except Exception:
             logger.warning("Unknown timezone '%s', falling back to Asia/Tashkent", tz)
             zone = ZoneInfo("Asia/Tashkent")
-        return datetime.now(zone)
+        return _now(zone)
 
 
     def normalize_queue_payload(self, payload: dict[str, Any]) -> dict[str, Any]:

--- a/backend/app/services/queue_svc/_operations.py
+++ b/backend/app/services/queue_svc/_operations.py
@@ -5,12 +5,13 @@ Split from queue_service.py.
 from __future__ import annotations
 
 from app.services.queue_svc._base import *  # noqa: F401, F403
-from app.services.queue_svc._base import QueueBusinessServiceMixinBase
+from app.services.queue_svc._base import QueueBusinessServiceMixinBase, _now
 
 
 class OperationsMixin(QueueBusinessServiceMixinBase):
     """Operations methods."""
 
+    @classmethod
     def check_queue_time_window(
         cls, target_date: date, queue_opened_at: datetime | None = None
     ) -> tuple[bool, str]:
@@ -20,7 +21,7 @@ class OperationsMixin(QueueBusinessServiceMixinBase):
         Returns:
             (is_allowed, message)
         """
-        now = datetime.now()
+        now = _now()
         today = now.date()
         current_time = now.time()
 
@@ -390,7 +391,7 @@ class OperationsMixin(QueueBusinessServiceMixinBase):
         """
         queue_settings = self._load_queue_settings(db)
         timezone = ZoneInfo(queue_settings.get("timezone", "Asia/Tashkent"))
-        now_local = datetime.now(timezone)
+        now_local = _now(timezone)
 
         day = target_date
         if day is None:
@@ -516,7 +517,7 @@ class OperationsMixin(QueueBusinessServiceMixinBase):
 
         queue_settings = self._load_queue_settings(db)
         timezone = ZoneInfo(queue_settings.get("timezone", "Asia/Tashkent"))
-        now_local = datetime.now(timezone)
+        now_local = _now(timezone)
 
         expires_cmp = queue_token.expires_at
         if expires_cmp:

--- a/backend/app/services/wait_time_predictor.py
+++ b/backend/app/services/wait_time_predictor.py
@@ -42,10 +42,22 @@ _CACHE_TS: datetime | None = None
 _CACHE_TTL = timedelta(minutes=5)
 
 
+def _to_aware_utc(dt: datetime) -> datetime:
+    """Normalize a datetime to timezone-aware UTC.
+
+    Tests and legacy callers may store naive datetimes (e.g. ``datetime.utcnow()``)
+    into ``_CACHE_TS``. Comparing aware ``datetime.now(UTC)`` against a naive
+    cache timestamp raises ``TypeError``. Treat naive timestamps as UTC.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
 def _ensure_cache_fresh(db: Session) -> None:
     """Refresh cache if older than TTL."""
     global _CACHE, _CACHE_TS
-    if _CACHE_TS is not None and datetime.now(UTC) - _CACHE_TS < _CACHE_TTL:
+    if _CACHE_TS is not None and datetime.now(UTC) - _to_aware_utc(_CACHE_TS) < _CACHE_TTL:
         return
 
     logger.info("wait_time_predictor: refreshing cache...")


### PR DESCRIPTION
Fixes 36 TypeError datetime failures in test_wait_time_predictor.py, test_queue_time_window.py, test_codex_security_fixes.py.