### PR TITLE
fix(ci): accept optional db param in NotificationSenderService.__init__

### DIFF
--- a/backend/app/services/notifications_pkg/__init__.py
+++ b/backend/app/services/notifications_pkg/__init__.py
@@ -47,7 +47,8 @@ class NotificationSenderService(
     Composed of focused mixin modules under notifications_pkg/.
     """
 
-    def __init__(self):
+    def __init__(self, db=None):
+        self._db = db
         self._email_settings = None
         self._sms_settings = None
 


### PR DESCRIPTION
Fixes 5+ e2e_visit_flow 500 errors caused by NotificationService(db) call.