### PR TITLE
🎨 Palette: Add aria-label to chat message reaction emojis

### DIFF
--- a/frontend/src/components/chat/ChatWindow.jsx
+++ b/frontend/src/components/chat/ChatWindow.jsx
@@ -879,7 +879,7 @@ const ChatWindow = ({ isOpen, onClose }) => {
                                                     </div>
                                                 </div>
                                                 <div className="conv-action">
-                                                    <Plus size={16} color='var(--mac-accent-blue)' />
+                                                    <Plus size={16} color="var(--mac-accent-blue)" />
                                                 </div>
                                             </div>
               )
@@ -1083,6 +1083,7 @@ const ChatWindow = ({ isOpen, onClose }) => {
                                                                         {['👍', '❤️', '😂', '😮', '😢', '🔥'].map((emoji) =>
                             <button
                               key={emoji}
+                              aria-label={`React with ${emoji}`}
                               onClick={(e) => {
                                 e.stopPropagation();
                                 toggleReaction(item.id, emoji);


### PR DESCRIPTION
💡 What: Added aria-label to reaction menu buttons in ChatWindow.
🎯 Why: Screen readers would previously just read out the emoji symbol name, which could lack contextual meaning ("smiling face with heart-eyes"). Adding explicit descriptive text makes it clear this button will *add* this specific reaction to the message.
📸 Before/After: Before, buttons only contained the emoji text. After, they contain an `aria-label` like "React with 👍".
♿ Accessibility: Improved screen reader navigation for message reactions.

---
*PR created automatically by Jules for task [15839854979621710122](https://jules.google.com/task/15839854979621710122) started by @drsapaev*