### PR TITLE
fix(visit): PR-10 — bump visit.updated_at when services added/removed

### DIFF
--- a/backend/app/crud/visit.py
+++ b/backend/app/crud/visit.py
@@ -2,7 +2,7 @@
 CRUD операции для работы с визитами
 """
 
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
 from sqlalchemy import and_, desc
@@ -279,7 +279,11 @@ def add_visit_service(
     quantity: int = 1,
     custom_price: float | None = None,
 ) -> VisitService:
-    """Добавить услугу к визиту"""
+    """Добавить услугу к визиту.
+
+    PR-10: bumps visit.updated_at so the "Изменено" timestamp in
+    registrar/doctor tables reflects doctor-side service additions.
+    """
     # Получаем цену услуги
     service = db.query(Service).filter(Service.id == service_id).first()
     price = (
@@ -298,19 +302,28 @@ def add_visit_service(
         service_id=service_id,
         quantity=quantity,
         price=price,
-        custom_price=custom_price,
         code=service_code,
         name=service.name if service else "",
     )
 
     db.add(visit_service)
+
+    # PR-10: bump visit.updated_at so frontend "Изменено" indicator fires.
+    visit = db.query(Visit).filter(Visit.id == visit_id).first()
+    if visit is not None:
+        visit.updated_at = datetime.now(UTC)
+
     db.commit()
     db.refresh(visit_service)
     return visit_service
 
 
 def remove_visit_service(db: Session, visit_service_id: int) -> bool:
-    """Удалить услугу из визита"""
+    """Удалить услугу из визита.
+
+    PR-10: bumps visit.updated_at so the "Изменено" timestamp in
+    registrar/doctor tables reflects doctor-side service removals.
+    """
     visit_service = (
         db.query(VisitService).filter(VisitService.id == visit_service_id).first()
     )
@@ -318,7 +331,14 @@ def remove_visit_service(db: Session, visit_service_id: int) -> bool:
     if not visit_service:
         return False
 
+    visit_id = visit_service.visit_id
     db.delete(visit_service)
+
+    # PR-10: bump visit.updated_at so frontend "Изменено" indicator fires.
+    visit = db.query(Visit).filter(Visit.id == visit_id).first()
+    if visit is not None:
+        visit.updated_at = datetime.now(UTC)
+
     db.commit()
     return True
 

--- a/backend/tests/unit/test_visit_service_bumps_updated_at.py
+++ b/backend/tests/unit/test_visit_service_bumps_updated_at.py
@@ -1,0 +1,185 @@
+"""Unit tests for visit.updated_at bumping on service add/remove (PR-10).
+
+Audit found that `crud/visit.py:add_visit_service` does NOT bump
+`visit.updated_at` when a service is added. This means the "Изменено"
+timestamp in registrar/doctor tables can never reflect doctor-side
+service additions.
+
+These tests verify that add_visit_service and remove_visit_service
+both bump visit.updated_at.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.core.security import get_password_hash
+from app.crud.visit import add_visit_service, remove_visit_service
+from app.models.clinic import Doctor
+from app.models.patient import Patient
+from app.models.service import Service
+from app.models.user import User
+from app.models.visit import Visit, VisitService
+
+
+def _make_visit(db_session, *, patient=None, doctor=None) -> Visit:
+    """Create a minimal Visit row for testing."""
+    if patient is None:
+        patient = _make_patient(db_session)
+    if doctor is None:
+        doctor = _make_doctor(db_session)
+
+    visit = Visit(
+        patient_id=patient.id,
+        doctor_id=doctor.id,
+        visit_date=__import__("datetime").date.today(),
+        status="scheduled",
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+    return visit
+
+
+def _make_patient(db_session) -> Patient:
+    suffix = uuid4().hex[:10]
+    user = User(
+        username=f"vs_pt_{suffix}",
+        email=f"vs-pt-{suffix}@test.local",
+        full_name=f"VS Patient {suffix}",
+        hashed_password=get_password_hash("pass123"),
+        role="Patient",
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    patient = Patient(
+        user_id=user.id,
+        first_name="Patient",
+        last_name=f"Test{suffix}",
+        phone=f"+99890{suffix[:7]}",
+    )
+    db_session.add(patient)
+    db_session.commit()
+    db_session.refresh(patient)
+    return patient
+
+
+def _make_doctor(db_session) -> Doctor:
+    suffix = uuid4().hex[:10]
+    user = User(
+        username=f"vs_doc_{suffix}",
+        email=f"vs-doc-{suffix}@test.local",
+        full_name=f"Dr. {suffix}",
+        hashed_password=get_password_hash("pass123"),
+        role="Doctor",
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    doctor = Doctor(
+        user_id=user.id,
+        specialty="cardiology",
+        active=True,
+    )
+    db_session.add(doctor)
+    db_session.commit()
+    db_session.refresh(doctor)
+    return doctor
+
+
+def _make_service(db_session, *, name: str = "Test Service") -> Service:
+    service = Service(
+        name=name,
+        price=50000,
+        duration_minutes=30,
+    )
+    db_session.add(service)
+    db_session.commit()
+    db_session.refresh(service)
+    return service
+
+
+class TestAddVisitServiceBumpsUpdatedAt:
+    """PR-10: add_visit_service must bump visit.updated_at."""
+
+    def test_add_visit_service_sets_updated_at_when_previously_null(self, db_session):
+        """When visit.updated_at is None, add_visit_service should set it."""
+        visit = _make_visit(db_session)
+        service = _make_service(db_session)
+
+        # Sanity: updated_at should be None initially (default only fires on insert,
+        # but we explicitly check it's not set to a real value yet)
+        assert visit.updated_at is None or visit.updated_at <= visit.created_at + timedelta(seconds=1)
+
+        add_visit_service(db_session, visit_id=visit.id, service_id=service.id)
+
+        db_session.expire_all()
+        refreshed = db_session.query(Visit).filter(Visit.id == visit.id).first()
+        assert refreshed.updated_at is not None
+        # updated_at should be recent (within last 10 seconds)
+        now = datetime.now(timezone.utc)
+        assert (now - refreshed.updated_at.replace(tzinfo=timezone.utc)).total_seconds() < 10
+
+    def test_add_visit_service_bumps_updated_at_when_already_set(self, db_session):
+        """When visit.updated_at is already set, add_visit_service should bump it."""
+        visit = _make_visit(db_session)
+        service = _make_service(db_session)
+
+        # Set an old updated_at
+        old_updated_at = visit.created_at - timedelta(hours=1)
+        visit.updated_at = old_updated_at
+        db_session.commit()
+
+        add_visit_service(db_session, visit_id=visit.id, service_id=service.id)
+
+        db_session.expire_all()
+        refreshed = db_session.query(Visit).filter(Visit.id == visit.id).first()
+        assert refreshed.updated_at is not None
+        # updated_at should be newer than the old value
+        assert refreshed.updated_at.replace(tzinfo=timezone.utc) > old_updated_at.replace(tzinfo=timezone.utc)
+
+    def test_add_visit_service_creates_visit_service_row(self, db_session):
+        """Sanity: add_visit_service still creates the VisitService row."""
+        visit = _make_visit(db_session)
+        service = _make_service(db_session)
+
+        result = add_visit_service(db_session, visit_id=visit.id, service_id=service.id)
+
+        assert result is not None
+        assert result.visit_id == visit.id
+        assert result.service_id == service.id
+
+
+class TestRemoveVisitServiceBumpsUpdatedAt:
+    """PR-10: remove_visit_service must also bump visit.updated_at."""
+
+    def test_remove_visit_service_bumps_updated_at(self, db_session):
+        """Removing a service should bump visit.updated_at."""
+        visit = _make_visit(db_session)
+        service = _make_service(db_session)
+        visit_service = add_visit_service(db_session, visit_id=visit.id, service_id=service.id)
+
+        # Capture updated_at after add (which now bumps)
+        db_session.expire_all()
+        visit_after_add = db_session.query(Visit).filter(Visit.id == visit.id).first()
+        updated_at_after_add = visit_after_add.updated_at
+
+        # Wait a moment to ensure timestamp differs
+        import time
+        time.sleep(0.1)
+
+        result = remove_visit_service(db_session, visit_service_id=visit_service.id)
+        assert result is True
+
+        db_session.expire_all()
+        refreshed = db_session.query(Visit).filter(Visit.id == visit.id).first()
+        assert refreshed.updated_at is not None
+        # updated_at should be newer than after-add value
+        assert refreshed.updated_at.replace(tzinfo=timezone.utc) >= updated_at_after_add.replace(tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

PR-10 of the time-display audit remediation. Audit found that `crud/visit.py:add_visit_service` does NOT bump `visit.updated_at` when a service is added. This means the "Изменено" timestamp in registrar/doctor tables could never reflect doctor-side service additions through `PUT /doctor/visits/{visit_id}/add-service`.

The registrar-side `edit-delta` endpoint already correctly bumps `visit.updated_at` — this PR fixes the doctor-side path to match.

- `add_visit_service`: now sets `visit.updated_at = datetime.now(UTC)` before commit
- `remove_visit_service`: now also bumps `visit.updated_at` (same pattern, for consistency)
- Added `UTC` import to `app/crud/visit.py`
- **Bonus**: removed invalid `custom_price` kwarg from `VisitService` constructor (was passing `custom_price` which is not a VisitService column — existing bug found during testing)

## Cyclic Execution Evidence

- Fresh main sync: yes, branched from f43b8d1e (PR-9 head on main)
- Clean workspace: yes
- Branch: fix/pr-10-add-visit-service-bump-updated-at
- Scope gate: backend-only, 2 files (crud/visit.py + new test file)
- Red-check handling: wrote 4 unit tests first, all 4 RED (TypeError on custom_price, then updated_at not bumped), implemented fix, all 4 GREEN

## Contract Impact

- Canonical surface: PUT /doctor/visits/{visit_id}/add-service, DELETE visit_service
- Request shape: unchanged
- Response shape: unchanged — visit.updated_at now reflects the edit, but the API response shape is the same
- Status codes: unchanged
- Frontend consumer: registrar/doctor tables that show "Изменено" timestamp will now correctly reflect doctor-side service additions. No client change needed.
- Compatibility path or alias: none — visit.updated_at was already a field, just wasn't being bumped
- Contract proof: tests/unit/test_visit_service_bumps_updated_at.py asserts updated_at is set/bumped

## RBAC / Permissions

- Roles allowed: unchanged — add_visit_service is called from doctor endpoints (Doctor/Admin role)
- Roles denied: unchanged
- Positive auth proof: existing doctor integration tests pass
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only changes a CRUD function's timestamp behavior — no WS changes, no notification event types introduced
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: not applicable because this PR does not touch any notification or inbox state
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: N/A — backend CRUD change
- Partial data proof: not applicable because this PR only changes timestamp bumping — no partial data scenario to handle
- Forbidden secondary path behavior: not applicable because this PR only changes timestamp bumping — no auth path changes
- Missing draft/resource behavior: if visit not found, updated_at is simply not bumped (defensive `if visit is not None` guard)
- Stale route/deep-link behavior: not applicable because this PR does not change any URL paths or route definitions

## Scope Gate

- Allowed paths: app/crud/visit.py, tests/unit/test_visit_service_bumps_updated_at.py
- Denied paths: no changes outside crud/visit.py + test file
- Migration/docs/test impact: 1 new test file (4 tests), no schema migration (updated_at column already exists), no docs
- Rollback note: reverting restores the old behavior where visit.updated_at is not bumped on service add/remove; frontend "Изменено" indicator will not fire for doctor-side service changes

## Validation

- Targeted tests or smoke run: pytest tests/architecture/ tests/unit/ tests/integration/test_visit_confirmation_api.py tests/integration/test_e2e_visit_flow.py tests/integration/test_e2e_doctor_visit.py tests/integration/test_visit_payments_router_order.py
- Result: 998 passed, 9 skipped, 2 xfailed, 0 failed
- Not checked: full integration suite — will run in CI
