### PR TITLE
fix(doctor): PR-12 — add Время column to DoctorPanel queue table + fix QueueTable

### DIFF
--- a/frontend/src/components/queue/QueueTable.jsx
+++ b/frontend/src/components/queue/QueueTable.jsx
@@ -130,7 +130,7 @@ const QueueTable = ({
                                     {entry.patient_phone || entry.phone || '—'}
                                 </td>
                                 <td className="qt-table-cell-secondary">
-                                    {formatTime(entry.created_at || entry.timestamp)}
+                                    {formatTime(entry.queue_time || entry.created_at || entry.timestamp)}
                                 </td>
                                 <td className="qt-table-cell-status">
                                     {getStatusBadge(entry.status)}

--- a/frontend/src/pages/DoctorPanel.jsx
+++ b/frontend/src/pages/DoctorPanel.jsx
@@ -51,6 +51,7 @@ import RoleNotificationCenter from '../components/notifications/RoleNotification
 
 import logger from '../utils/logger';
 import tokenManager from '../utils/tokenManager';
+import { getRegistrarTimestampDisplay } from '../utils/dateUtils';
 
 const hasBackendQueueAction = (entry, action, flagName) => {
   if (!entry) return false;
@@ -1201,6 +1202,7 @@ const DoctorPanel = () => {
                         <th style={thStyle}>№</th>
                         <th style={thStyle}>Пациент</th>
                         <th style={thStyle}>Телефон</th>
+                        <th style={thStyle}>Время</th>
                         <th style={thStyle}>Услуги</th>
                         <th style={thStyle}>Статус</th>
                         <th style={thStyle}>Действия</th>
@@ -1242,6 +1244,31 @@ const DoctorPanel = () => {
                             </div>
                           </td>
                           <td style={tdStyle}>{entry.phone || '—'}</td>
+                          <td style={tdStyle}>
+                            {/* PR-12: show queue_time / created_at + "Изменено" */}
+                            {(() => {
+                              const timeDisplay = getRegistrarTimestampDisplay(entry);
+                              if (!timeDisplay.primaryDate && !timeDisplay.primaryTime) {
+                                return '—';
+                              }
+                              return (
+                                <div style={{ fontSize: 'var(--mac-font-size-xs)', color: 'var(--mac-text-secondary)' }}>
+                                  <div style={{ fontWeight: 'var(--mac-font-weight-semibold)', marginBottom: '2px' }}>
+                                    {timeDisplay.primaryLabel}
+                                  </div>
+                                  <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                                    <Clock size={10} />
+                                    {timeDisplay.primaryTime}
+                                  </div>
+                                  {timeDisplay.showChanged &&
+                                    <div style={{ marginTop: '2px', color: 'var(--mac-text-tertiary)' }}>
+                                      {timeDisplay.changedLabel}: {timeDisplay.changedTime}
+                                    </div>
+                                  }
+                                </div>
+                              );
+                            })()}
+                          </td>
                           <td style={tdStyle}>
                             {entry.service_details?.length > 0 ?
                       entry.service_details.slice(0, 2).map((svc, i) =>


### PR DESCRIPTION
## Summary

PR-12 of the time-display audit remediation. Audit found:
1. **DoctorPanel.jsx** queue table had NO time column — doctor couldn't see when patient joined queue or when visit was last modified. Backend already returns `queue_time`/`created_at`/`updated_at` in doctor queue API (`doctor_integration/_queue_ops.py:196-204`).
2. **QueueTable.jsx** used `entry.created_at` instead of `entry.queue_time`, inconsistent with `EnhancedAppointmentsTable` which prefers `queue_time`.

- `DoctorPanel.jsx`: added "Время" column between Телефон and Услуги, renders `getRegistrarTimestampDisplay(entry)` showing "Очередь" label + queue_time (or "Создано" + created_at fallback) + "Изменено: HH:MM:SS" when updated_at differs from primary by >60s
- `DoctorPanel.jsx`: imported `getRegistrarTimestampDisplay` from dateUtils
- `QueueTable.jsx`: changed `formatTime(entry.created_at)` to `formatTime(entry.queue_time || entry.created_at || entry.timestamp)` to prefer queue_time (consistent with EnhancedAppointmentsTable)

## Cyclic Execution Evidence

- Fresh main sync: yes, branched from 945dbcd2 (PR-11 head on main)
- Clean workspace: yes
- Branch: fix/pr-12-doctor-panel-time-column
- Scope gate: frontend-only, 2 files (DoctorPanel.jsx + QueueTable.jsx)
- Red-check handling: no new tests needed — existing 560 tests verify no regressions; the new column is purely additive UI

## Contract Impact

- Canonical surface: DoctorPanel queue tab (UI only), QueueTable component (UI only)
- Request shape: unchanged — no API changes
- Response shape: unchanged — backend already returns queue_time/created_at/updated_at in doctor queue API
- Status codes: unchanged
- Frontend consumer: Doctor now sees "Время" column with queue_time + "Изменено" indicator. QueueTable (used in QueueView) now shows queue_time instead of created_at.
- Compatibility path or alias: none — same data, just displayed now
- Contract proof: 560 frontend tests pass, ESLint 0 errors

## RBAC / Permissions

- Roles allowed: unchanged — DoctorPanel is for Doctor role
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only changes frontend table rendering — no WS changes, no notification event types introduced
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: not applicable because this PR does not touch any notification or inbox state
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: when entry has no time fields, getRegistrarTimestampDisplay returns empty strings → cell shows '—'
- Partial data proof: getRegistrarTimestampDisplay falls back queue_time → created_at, so partial data still renders
- Forbidden secondary path behavior: not applicable because this PR only adds a display column — no auth path changes
- Missing draft/resource behavior: when entry.queue_time and entry.created_at are both null, cell shows '—'
- Stale route/deep-link behavior: not applicable because this PR does not change any URL paths or route definitions

## Scope Gate

- Allowed paths: src/pages/DoctorPanel.jsx, src/components/queue/QueueTable.jsx
- Denied paths: no backend changes, no other frontend files
- Migration/docs/test impact: no new tests, no schema migration, no docs
- Rollback note: reverting removes the "Время" column from DoctorPanel and restores QueueTable to use created_at; doctor loses visibility into queue time and "Изменено" indicator

## Validation

- Targeted tests or smoke run: npx vitest run (full frontend suite)
- Result: 560 passed, 0 failed (no regressions)
- Not checked: Playwright e2e — will run in CI
