### PR TITLE
fix(timezone): PR-13 — replace UTC/browser-local date calls with Asia/Tashkent helpers

### DIFF
--- a/frontend/src/components/cardiology/HistoryTab.jsx
+++ b/frontend/src/components/cardiology/HistoryTab.jsx
@@ -14,6 +14,7 @@
 import PropTypes from 'prop-types';
 import { Calendar, Eye, Download, FileText } from 'lucide-react';
 import { Button, Badge, MacOSCard, MacOSEmptyState } from '../ui/macos';
+import { formatRegistrarDate } from '../../utils/dateUtils';
 
 /**
  * @param {Object} props
@@ -185,9 +186,7 @@ export function HistoryTab({
 
                 {/* Timestamp */}
                 <div style={{ flexShrink: 0, fontSize: getFontSize('xs'), color: getColor('textSecondary') }}>
-                  {entry.timestamp ? new Date(entry.timestamp).toLocaleDateString('ru-RU', {
-                    day: '2-digit', month: '2-digit', year: 'numeric',
-                  }) : '—'}
+                  {entry.timestamp ? formatRegistrarDate(entry.timestamp, 'ru-RU') : '—'}
                 </div>
               </div>
             ))}

--- a/frontend/src/components/cardiology/VisitTab.jsx
+++ b/frontend/src/components/cardiology/VisitTab.jsx
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import { User, FileText, RefreshCw, Save, Calendar, Phone } from 'lucide-react';
 import { Button, MacOSCard, MacOSEmptyState } from '../ui/macos';
 import { EMRContainerV2 } from '../emr-v2/EMRContainerV2';
+import { formatRegistrarDate, formatRegistrarDateTime } from '../../utils/dateUtils';
 
 export function VisitTab({
   selectedPatient,
@@ -95,12 +96,12 @@ export function VisitTab({
             {emr.version != null && <span title="Версия EMR">v{emr.version}</span>}
             {emr.updated_at && (
               <span title="Последнее изменение">
-                изм. {new Date(emr.updated_at).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                изм. {formatRegistrarDateTime(emr.updated_at, 'ru-RU')}
               </span>
             )}
             {emr.signed_at && (
               <span title="Подписана">
-                подписана {new Date(emr.signed_at).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: 'numeric' })}
+                подписана {formatRegistrarDate(emr.signed_at, 'ru-RU')}
               </span>
             )}
             {emr.signed_by != null && emr.signed_by > 0 && <span title="Кем подписана">врач #{emr.signed_by}</span>}

--- a/frontend/src/components/dental/DentalPriceManager.jsx
+++ b/frontend/src/components/dental/DentalPriceManager.jsx
@@ -17,6 +17,7 @@ import { api } from '../../api/client';
 import logger from '../../utils/logger';
 import PropTypes from 'prop-types';
 import { Input } from '../ui/macos';
+import { formatRegistrarDate } from '../../utils/dateUtils';
 
 /**
  * Компонент для указания цены стоматологом после лечения
@@ -298,7 +299,7 @@ const DentalPriceManager = ({
                         </span>
                       </div>
                       <span className="text-sm text-gray-500 dark:text-gray-400">
-                        {new Date(override.created_at).toLocaleDateString('ru-RU')}
+                        {formatRegistrarDate(override.created_at, 'ru-RU')}
                       </span>
                     </div>
                     

--- a/frontend/src/components/dermatology/PriceOverrideManager.jsx
+++ b/frontend/src/components/dermatology/PriceOverrideManager.jsx
@@ -16,6 +16,7 @@ import { api } from '../../api/client';
 import logger from '../../utils/logger';
 import PropTypes from 'prop-types';
 import { Input } from '../ui/macos';
+import { formatRegistrarDate } from '../../utils/dateUtils';
 
 /**
  * Компонент для управления изменениями цен дерматологом
@@ -519,7 +520,7 @@ const PriceOverrideManager = ({
                     fontSize: 'var(--mac-font-size-sm)',
                     color: 'var(--mac-text-tertiary)'
                   }}>
-                        {new Date(override.created_at).toLocaleDateString('ru-RU')}
+                        {formatRegistrarDate(override.created_at, 'ru-RU')}
                       </span>
                     </div>
                     

--- a/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
+++ b/frontend/src/components/tables/EnhancedAppointmentsTable.jsx
@@ -40,6 +40,7 @@ import {
   getRegistrarTimestampDisplay,
   formatRegistrarDate,
   formatRegistrarTime,
+  getLocalDateString,
 } from '../../utils/dateUtils';
 
 // ⭐ SSOT: Centralized service code resolver
@@ -973,8 +974,21 @@ const EnhancedAppointmentsTable = ({
         if (row.payment_type) return t[row.payment_type] || row.payment_type;
         return paymentStatus === 'paid' ? t.unknownPayment : t.pendingPayment;
       })(),
-      row.created_at ? formatRegistrarDate(row.created_at) : row.appointment_date || '',
-      row.created_at ? formatRegistrarTime(row.created_at, 'ru-RU', { includeSeconds: true }) : row.appointment_time || '',
+      (() => {
+        // PR-13: use getRegistrarTimestampDisplay for CSV consistency with UI
+        const td = getRegistrarTimestampDisplay(row);
+        return td.primaryDate || formatRegistrarDate(row.created_at) || row.appointment_date || '';
+      })(),
+      (() => {
+        const td = getRegistrarTimestampDisplay(row);
+        return td.primaryTime || formatRegistrarTime(row.created_at, 'ru-RU', { includeSeconds: true }) || row.appointment_time || '';
+      })(),
+      (() => {
+        // PR-13: add "Изменено" column to CSV when present
+        const td = getRegistrarTimestampDisplay(row);
+        if (!td.showChanged) return '';
+        return `${td.changedDate} ${td.changedTime}`;
+      })(),
       t[row.status] || row.status || '',
       (() => {
         if (row.cost_display === 'free') return t.paymentFree;
@@ -987,7 +1001,7 @@ const EnhancedAppointmentsTable = ({
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
     const link = document.createElement('a');
     link.href = URL.createObjectURL(blob);
-    link.download = `appointments_${new Date().toISOString().split('T')[0]}.csv`;
+    link.download = `appointments_${getLocalDateString()}.csv`;
     link.click();
   }, [filteredData, t, formatPhoneNumber, getDisplayAmount, isDoctorView]);
 
@@ -996,7 +1010,7 @@ const EnhancedAppointmentsTable = ({
   // Функция для отображения номеров очередей
   const renderQueueNumbers = useCallback((row) => {
     // Получаем текущую дату
-    const today = new Date().toISOString().split('T')[0];
+    const today = getLocalDateString();
 
     // Helper для форматирования времени
 

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -5,6 +5,7 @@ import { useLocation } from 'react-router-dom';
 import { useDoctorPanelState } from '../hooks/useDoctorPanelState';
 import { useTheme } from '../contexts/ThemeContext';
 import { adaptTimeFields } from '../utils/registrarAggregation';
+import { getLocalDateString, parseRegistrarTimestamp } from '../utils/dateUtils';
 import {
   Button, Badge, Card,
   Input } from '../components/ui/macos';
@@ -1490,12 +1491,22 @@ const DentistPanelUnified = () => {
 
   // Статистика
   const stats = useMemo(() => {
-    const todayString = new Date().toDateString();
+    // PR-13: use getLocalDateString() instead of new Date().toDateString()
+    // to avoid browser-local timezone issues (off-by-one for early-morning Tashkent)
+    const todayString = getLocalDateString();
     const todayAppointmentsCount = appointmentsTableData.filter((apt) => {
-      if (!apt.appointment_date) {
+      if (!apt.appointment_date && !apt.queue_time && !apt.created_at) {
         return false;
       }
-      return new Date(apt.appointment_date).toDateString() === todayString;
+      // Try to get the date from queue_time/created_at (timezone-aware) first,
+      // then fall back to appointment_date
+      const ts = apt.queue_time || apt.created_at;
+      if (ts) {
+        const aptDate = getLocalDateString(parseRegistrarTimestamp(ts));
+        return aptDate === todayString;
+      }
+      // Fall back to appointment_date (may be YYYY-MM-DD already)
+      return apt.appointment_date === todayString;
     }).length;
 
     const activeTreatmentPlansCount = appointmentsTableData.filter((apt) => apt.status === 'in_progress' || apt.status === 'waiting').length;

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -71,7 +71,7 @@ import PaymentManager from '../components/payment/PaymentManager';
 // import EditPatientModal from '../components/common/EditPatientModal';
 
 // Утилиты для работы с датами
-import { getLocalDateString } from '../utils/dateUtils';
+import { getLocalDateString, formatRegistrarDate } from '../utils/dateUtils';
 import { rescheduleTomorrow, rescheduleVisit } from '../api/visits';
 // Note: formatNetworkErrorMessage + isNetworkFetchError moved to useRegistrarData.js (Decomp 4)
 import { getErrorMessage } from '../utils/errorHandler';
@@ -1530,7 +1530,9 @@ const RegistrarPanel = () => {
                   </h2>
                   <p className="registrar-workflow-meta">
                     {showCalendar ?
-                    new Date(historyDate).toLocaleDateString(language === 'ru' ? 'ru-RU' : 'uz-UZ', { day: 'numeric', month: 'long', year: 'numeric' }) :
+                    // PR-13: use formatRegistrarDate to avoid browser-local timezone issues
+                    // historyDate is YYYY-MM-DD (Tashkent), parse as Tashkent midnight
+                    formatRegistrarDate(`${historyDate}T00:00:00+05:00`, language === 'ru' ? 'ru-RU' : 'uz-UZ') :
                     t('today')} · {filteredAppointments.length} {t('tabs_appointments')}
                   </p>
                 </div>


### PR DESCRIPTION
## Summary

PR-13 of the time-display audit remediation. Audit found multiple places using `new Date().toISOString().split('T')[0]` (UTC date) or `toLocaleDateString` without `timeZone` option (browser-local). Both cause off-by-one date errors for early-morning (00:00–05:00 Asia/Tashkent) visits where UTC date lags Tashkent date by one day.

All replacements use `formatRegistrarDate`/`formatRegistrarDateTime`/`getLocalDateString` from `utils/dateUtils.js` which enforce Asia/Tashkent timezone regardless of browser locale.

- `EnhancedAppointmentsTable.jsx`: CSV filename + renderQueueNumbers today → `getLocalDateString()`; CSV export now uses `getRegistrarTimestampDisplay(row)` + adds "Изменено" column
- `DentistPanelUnified.jsx`: `todayAppointmentsCount` → `getLocalDateString()` + timezone-aware date comparison
- `RegistrarPanel.jsx`: calendar header → `formatRegistrarDate` with explicit `+05:00` offset
- `cardiology/VisitTab.jsx`: "изм." + "подписана" → `formatRegistrarDateTime`/`formatRegistrarDate`
- `cardiology/HistoryTab.jsx`: entry timestamp → `formatRegistrarDate`
- `dermatology/PriceOverrideManager.jsx`: `override.created_at` → `formatRegistrarDate`
- `dental/DentalPriceManager.jsx`: `override.created_at` → `formatRegistrarDate`

## Cyclic Execution Evidence

- Fresh main sync: yes, branched from 21940a9b (PR-12 head on main)
- Clean workspace: yes
- Branch: fix/pr-13-timezone-fixes
- Scope gate: frontend-only, 7 files (1 table + 2 panels + 4 sub-components)
- Red-check handling: no new tests needed — existing 560 tests verify no regressions; all replacements use already-tested helpers from dateUtils.js

## Contract Impact

- Canonical surface: frontend date rendering only — no API changes
- Request shape: unchanged
- Response shape: unchanged — same dates, just formatted in Asia/Tashkent now
- Status codes: unchanged
- Frontend consumer: dates now display correctly for early-morning Tashkent visits; CSV export now includes "Изменено" column and uses queue_time (consistent with UI)
- Compatibility path or alias: none — same data, just timezone-correct rendering
- Contract proof: 560 frontend tests pass, ESLint 0 errors

## RBAC / Permissions

- Roles allowed: unchanged — no auth changes
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only changes frontend date formatting — no WS changes, no notification event types introduced
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: not applicable because this PR does not touch any notification or inbox state
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: when timestamp is null/undefined, formatRegistrarDate returns '' — UI shows '—'
- Partial data proof: formatRegistrarDate handles both ISO 8601 with offset and naive timestamps (treats naive as Asia/Tashkent)
- Forbidden secondary path behavior: not applicable because this PR only changes date formatting — no auth path changes
- Missing draft/resource behavior: when timestamp missing, helpers return empty string
- Stale route/deep-link behavior: not applicable because this PR does not change any URL paths or route definitions

## Scope Gate

- Allowed paths: src/components/tables/EnhancedAppointmentsTable.jsx, src/pages/DentistPanelUnified.jsx, src/pages/RegistrarPanel.jsx, src/components/cardiology/VisitTab.jsx, src/components/cardiology/HistoryTab.jsx, src/components/dermatology/PriceOverrideManager.jsx, src/components/dental/DentalPriceManager.jsx
- Denied paths: no backend changes, no other frontend files
- Migration/docs/test impact: no new tests, no schema migration, no docs
- Rollback note: reverting restores UTC/browser-local date formatting; early-morning visits will show wrong date again

## Validation

- Targeted tests or smoke run: npx vitest run (full frontend suite)
- Result: 560 passed, 0 failed (no regressions)
- Not checked: Playwright e2e — will run in CI
