### PR TITLE
fix(wizard): PR-14 — wire expectedEntryUpdatedAt for optimistic locking

### DIFF
--- a/frontend/src/components/wizard/AppointmentWizardV2.jsx
+++ b/frontend/src/components/wizard/AppointmentWizardV2.jsx
@@ -1637,6 +1637,10 @@ const AppointmentWizardV2 = ({
 
       const originalServiceIds = new Set();
       const originalQueueIds = new Set(); // ✅ Moved here for availability in handleComplete
+      // PR-14: collect updated_at per queue entry for optimistic locking.
+      // Map<entryId, isoString> — passed to applyRegistrarEditDelta as
+      // expectedEntryUpdatedAt so backend can detect concurrent edits.
+      const entryUpdatedAtMap = {};
 
       if (hasQueueEntries) {
         // ✅ Устанавливаем source по умолчанию для записей типа visit
@@ -1739,6 +1743,11 @@ const AppointmentWizardV2 = ({
 
             if (serviceId) originalServiceIds.add(serviceId);
             if (queueId) originalQueueIds.add(queueId);
+            // PR-14: collect updated_at for optimistic locking
+            if (queueId) {
+              const ts = serviceDetail.updated_at || serviceDetail.last_changed_at || initialData.updated_at || initialData.last_changed_at;
+              if (ts) entryUpdatedAtMap[queueId] = ts;
+            }
             if (serviceCode) originalServiceCodes.add(String(serviceCode).toUpperCase().trim());
             if (serviceName) originalServiceNames.add(String(serviceName).toLowerCase().trim());
           });
@@ -1838,6 +1847,11 @@ const AppointmentWizardV2 = ({
               originalServiceIds.add(q.service_id);
               const queueId = resolveExplicitQueueEntryId(q);
               if (queueId) originalQueueIds.add(queueId); // ✅ Сохраняем ID записи очереди
+              // PR-14: collect updated_at for optimistic locking
+              if (queueId) {
+                const ts = q.updated_at || q.last_changed_at || initialData.updated_at || initialData.last_changed_at;
+                if (ts) entryUpdatedAtMap[queueId] = ts;
+              }
               // Находим service_code и name по service_id
               const service = servicesData.find((s) => s.id === q.service_id);
               if (service) {
@@ -2031,7 +2045,10 @@ const AppointmentWizardV2 = ({
               discountMode: wizardData.cart.discount_mode,
               allFree: wizardData.cart.all_free,
               services: editDeltaServices,
-              existingQueueEntryIds: Array.from(originalQueueIds)
+              existingQueueEntryIds: Array.from(originalQueueIds),
+              // PR-14: pass optimistic-locking map so backend can detect
+              // concurrent edits (last-write-wins → 409 Conflict).
+              expectedEntryUpdatedAt: Object.keys(entryUpdatedAtMap).length > 0 ? entryUpdatedAtMap : null,
             });
 
             if (!editDeltaResult?.success) {


### PR DESCRIPTION
## Summary

PR-14 of the time-display audit remediation (final PR). Audit found that `AppointmentWizardV2` never sends `expected_entry_updated_at` to `/registrar/cart/edit-delta`, silently bypassing the backend optimistic-locking contract (`registrar_edit_delta_service.py:49-60`). Two concurrent edits can both succeed (last-write-wins, possible lost services).

The API function (`api/queue.js:applyRegistrarEditDelta`) already accepts `expectedEntryUpdatedAt` param — it just was never passed by the wizard.

- `AppointmentWizardV2.jsx`: collect `entryUpdatedAtMap` (Map<entryId, isoString>) from `service_details` loop and `queue_numbers` loop, with fallback to `initialData.updated_at || initialData.last_changed_at` when per-entry timestamp is missing
- Pass `entryUpdatedAtMap` as `expectedEntryUpdatedAt` to `applyRegistrarEditDelta` when non-empty. Backend will detect concurrent edits and return 409.

## Cyclic Execution Evidence

- Fresh main sync: yes, branched from 3a6b0398 (PR-13 head on main)
- Clean workspace: yes
- Branch: fix/pr-14-wizard-optimistic-locking
- Scope gate: frontend-only, 1 file (AppointmentWizardV2.jsx)
- Red-check handling: no new tests needed — existing 560 tests verify no regressions; the optimistic-locking path is backend-validated

## Contract Impact

- Canonical surface: POST /api/v1/registrar/cart/edit-delta (now receives expected_entry_updated_at)
- Request shape: unchanged — expected_entry_updated_at is an optional field, backend already supports it
- Response shape: unchanged — backend may now return 409 Conflict when concurrent edit detected (was: silently overwriting)
- Status codes: NEW — 409 Conflict possible when another registrar edited the same visit concurrently. Wizard should handle this gracefully (show error, reload data).
- Frontend consumer: registrar wizard now passes optimistic-locking map; two concurrent edits will be detected
- Compatibility path or alias: when expectedEntryUpdatedAt is null/empty (no timestamps collected), backend skips the check (backward compatible)
- Contract proof: 560 frontend tests pass, backend already has tests for optimistic locking in registrar_edit_delta_service

## RBAC / Permissions

- Roles allowed: unchanged — Registrar/Admin role can still call edit-delta
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only changes wizard API call — no WS changes, no notification event types introduced
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: not applicable because this PR does not touch any notification or inbox state
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: when no queue entries have updated_at, entryUpdatedAtMap is empty → expectedEntryUpdatedAt is null → backend skips check (backward compatible)
- Partial data proof: falls back to initialData.updated_at when per-entry timestamp missing, so partial data still enables locking
- Forbidden secondary path behavior: not applicable because this PR only adds optimistic-locking data — no auth path changes
- Missing draft/resource behavior: when initialData has no time fields, map is empty, backend skips check
- Stale route/deep-link behavior: not applicable because this PR does not change any URL paths or route definitions

## Scope Gate

- Allowed paths: src/components/wizard/AppointmentWizardV2.jsx
- Denied paths: no backend changes, no other frontend files
- Migration/docs/test impact: no new tests, no schema migration, no docs
- Rollback note: reverting restores the silent bypass; two concurrent edits can both succeed again

## Validation

- Targeted tests or smoke run: npx vitest run (full frontend suite)
- Result: 560 passed, 0 failed (no regressions)
- Not checked: Playwright e2e — will run in CI
