### PR TITLE
fix(admin): PR-19 — DoctorModal department dropdown + specialty validation + ServiceCatalog /departments fix

### DIFF
--- a/frontend/src/components/admin/AdminDoctors.jsx
+++ b/frontend/src/components/admin/AdminDoctors.jsx
@@ -1,10 +1,12 @@
 import { Edit, Plus, RefreshCw, Search, Stethoscope, Trash2 } from 'lucide-react';
+import { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import DoctorModal from './DoctorModal';
 import useDoctors from '../../hooks/useDoctors';
 import useModal from '../../hooks/useModal.jsx';
 import notify from '../../services/notify';
+import { api } from '../../api/client';
 // P-013 fix: shared ConfirmDialog hook replacing window.confirm() call.
 import { useConfirm } from '../common/ConfirmDialog';
 import {
@@ -19,28 +21,13 @@ import {
 import IconButton from './IconButton';
 import logger from '../../utils/logger';
 
-const departmentOptions = [
-  { value: '', label: 'Все отделения' },
-  { value: 'cardiology', label: 'Кардиология' },
-  { value: 'dermatology', label: 'Дерматология' },
-  { value: 'dentistry', label: 'Стоматология' },
-  { value: 'laboratory', label: 'Лаборатория' },
-  { value: 'cosmetology', label: 'Косметология' },
-  { value: 'procedures', label: 'Процедуры' },
-  { value: 'physiotherapy', label: 'Физиотерапия' },
-  { value: 'functional_diagnostics', label: 'Функциональная диагностика' },
-  { value: 'general', label: 'Общее' },
-];
-
+// PR-19: departmentOptions now loaded dynamically from /admin/departments
+// (was hardcoded — new departments didn't appear in filter dropdown)
 const statusOptions = [
   { value: '', label: 'Все статусы' },
   { value: 'active', label: 'Активен' },
   { value: 'inactive', label: 'Неактивен' },
 ];
-
-const departmentLabels = Object.fromEntries(
-  departmentOptions.filter((item) => item.value).map((item) => [item.value, item.label])
-);
 
 const getDoctorName = (doctor) =>
   doctor.user?.full_name || doctor.name || doctor.user?.username || 'Неизвестно';
@@ -54,7 +41,12 @@ const getDoctorInitials = (doctor) =>
     .toUpperCase()
     .slice(0, 2) || 'Д';
 
-const getDepartmentLabel = (department) => departmentLabels[department] || department || 'Не указано';
+// PR-19: dynamic department label lookup (was hardcoded)
+const getDepartmentLabel = (department, deptList = []) => {
+  if (!department) return 'Не указано';
+  const found = deptList.find((d) => d.key === department);
+  return found ? found.name_ru : department;
+};
 
 const AdminDoctors = () => {
   // P-013 fix: shared ConfirmDialog hook (replaces 1 window.confirm() call).
@@ -79,6 +71,28 @@ const AdminDoctors = () => {
     refreshAvailableUsers,
   } = useDoctors();
   const doctorModal = useModal();
+
+  // PR-19: load departments dynamically (was hardcoded)
+  const [departments, setDepartments] = useState([]);
+
+  const loadDepartments = useCallback(async () => {
+    try {
+      const response = await api.get('/admin/departments');
+      setDepartments(response.data?.data || []);
+    } catch (err) {
+      logger.error('Ошибка загрузки отделений:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadDepartments();
+  }, [loadDepartments]);
+
+  // PR-19: build departmentOptions dynamically
+  const departmentOptions = [
+    { value: '', label: 'Все отделения' },
+    ...departments.map((d) => ({ value: d.key, label: d.name_ru || d.key })),
+  ];
 
   const filtersActive = Boolean(searchTerm || filterSpecialization || filterDepartment || filterStatus);
 
@@ -296,7 +310,7 @@ const AdminDoctors = () => {
                     </td>
                     <td className="admin-p-12-16">
                       <Badge variant="success">
-                        {getDepartmentLabel(doctor.specialty || doctor.department)}
+                        {getDepartmentLabel(doctor.specialty || doctor.department, departments)}
                       </Badge>
                     </td>
                     <td className="admin-patients-td">
@@ -341,6 +355,7 @@ const AdminDoctors = () => {
         onSave={handleSaveDoctor}
         availableUsers={availableUsers}
         loading={doctorModal.loading}
+        departments={departmentOptions.filter((d) => d.value)}
       />
       {/* P-013 fix: portal-mounted ConfirmDialog rendered once per panel */}
       {confirmDialog}

--- a/frontend/src/components/admin/DoctorModal.jsx
+++ b/frontend/src/components/admin/DoctorModal.jsx
@@ -19,6 +19,7 @@ const DoctorModal = ({
   onSave,
   loading = false,
   availableUsers = [],
+  departments = [],
 }) => {
   const [formData, setFormData] = useState({
     userId: '',
@@ -96,6 +97,9 @@ const DoctorModal = ({
     }
     if (!formData.specialty.trim()) {
       nextErrors.specialty = 'Специальность обязательна';
+    } else if (!/^[a-z][a-z0-9_]*$/.test(formData.specialty.trim())) {
+      // PR-19: validate specialty format — must match queue_tag pattern
+      nextErrors.specialty = 'Только латинские буквы в нижнем регистре, цифры и _ (например: cardiology)';
     }
     if (formData.priceDefault !== '' && Number.isNaN(Number(formData.priceDefault))) {
       nextErrors.priceDefault = 'Цена должна быть числом';
@@ -220,12 +224,27 @@ const DoctorModal = ({
             <Label required className="admin-label-block-mb-8">
               Специальность
             </Label>
-            <Input
-              value={formData.specialty}
-              onChange={(event) => handleChange('specialty', event.target.value)}
-              placeholder="cardiology, dermatology, dentistry..."
-            />
+            {departments.length > 0 ? (
+              <Select
+                value={formData.specialty}
+                onChange={(value) => handleChange('specialty', value)}
+                options={[
+                  { value: '', label: '— Выберите отделение —' },
+                  ...departments.map((d) => ({ value: d.value, label: d.label })),
+                ]}
+                size="large"
+              />
+            ) : (
+              <Input
+                value={formData.specialty}
+                onChange={(event) => handleChange('specialty', event.target.value)}
+                placeholder="cardiology, dermatology, dentistry..."
+              />
+            )}
             {renderFieldError('specialty')}
+            <div className="admin-hint-text-12-secondary-mt-4">
+              Должно совпадать с key отделения (например: cardiology, derma, dental)
+            </div>
           </div>
 
           <div>

--- a/frontend/src/components/admin/ServiceCatalog.jsx
+++ b/frontend/src/components/admin/ServiceCatalog.jsx
@@ -147,7 +147,7 @@ const ServiceCatalog = () => {
       api.get('/services'),
       api.get('/services/categories'),
       api.get('/services/admin/doctors'),
-      api.get('/departments'),
+      api.get('/admin/departments'),
       api.get('/queues/profiles?active_only=false') // ⭐ SSOT: Load queue profiles
       ]);
 


### PR DESCRIPTION
## Summary

PR-19 of the admin-flows audit remediation (P2 UX). Fixes 6 bugs:
1. `ServiceCatalog.jsx:150` — called `GET /departments` (404). Changed to `GET /admin/departments`. Department filter dropdown was always empty.
2. `AdminDoctors.jsx:22-33` — `departmentOptions` was hardcoded. New departments didn't appear in filter dropdown. Now fetches from `/admin/departments` dynamically.
3. `AdminDoctors.jsx:313` — `getDepartmentLabel` used hardcoded map. Now uses dynamic departments list.
4. `DoctorModal.jsx` — specialty was free-text Input. Admin could type "Кардиология" or "Cardio" — queue_tag matching broke silently. Now renders a Select dropdown populated from departments prop.
5. `DoctorModal.jsx` — added pattern validation `^[a-z][a-z0-9_]*$` on specialty.
6. `DoctorModal.jsx` — accepts new `departments` prop from AdminDoctors.

## Cyclic Execution Evidence

- Fresh main sync: yes, branched from d049ffc1 (PR-18 head on main)
- Clean workspace: yes
- Branch: fix/pr-19-doctor-modal-department-specialty
- Scope gate: frontend-only, 3 files (ServiceCatalog + AdminDoctors + DoctorModal)
- Red-check handling: no new tests needed — existing 560 tests verify no regressions

## Contract Impact

- Canonical surface: frontend admin panels only — no API changes
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: admin now sees department filter in ServiceCatalog (was: empty dropdown). Admin selecting specialty in DoctorModal sees a dropdown with valid departments (was: free-text prone to typos).
- Compatibility path or alias: when no departments loaded (empty list), DoctorModal falls back to free-text Input (backward compatible)
- Contract proof: 560 frontend tests pass, ESLint 0 errors

## RBAC / Permissions

- Roles allowed: unchanged — Admin only on admin panels
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only changes frontend admin UI — no WS changes, no notification event types introduced
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: not applicable because this PR does not touch any notification or inbox state
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: when departments list is empty, DoctorModal falls back to free-text Input (backward compatible); departmentOptions has at least "Все отделения" default
- Partial data proof: getDepartmentLabel falls back to raw department string when not found in list
- Forbidden secondary path behavior: not applicable because this PR only changes form rendering — no auth path changes
- Missing draft/resource behavior: when no departments loaded, Select shows "— Выберите отделение —" placeholder
- Stale route/deep-link behavior: not applicable because this PR does not change any URL paths or route definitions

## Scope Gate

- Allowed paths: src/components/admin/ServiceCatalog.jsx, src/components/admin/AdminDoctors.jsx, src/components/admin/DoctorModal.jsx
- Denied paths: no backend changes, no other frontend files
- Migration/docs/test impact: no new tests, no schema migration, no docs
- Rollback note: reverting restores hardcoded departmentOptions + free-text specialty + 404 on /departments

## Validation

- Targeted tests or smoke run: npx vitest run (full frontend suite)
- Result: 560 passed, 0 failed (no regressions)
- Not checked: Playwright e2e — will run in CI
