### PR TITLE
fix(validation): PR-20 — key pattern validation + dedupe service creation + Registrar role

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_integration/_queue_profiles.py
+++ b/backend/app/api/v1/endpoints/registrar_integration/_queue_profiles.py
@@ -208,7 +208,7 @@ def _get_emoji_for_key(key: str) -> str:
 
 class QueueProfileCreate(BaseModel):
     """Schema for creating a new QueueProfile"""
-    key: str = Field(..., min_length=1, max_length=50, description="Unique key (e.g., 'cardiology')")
+    key: str = Field(..., min_length=1, max_length=50, pattern=r"^[a-z][a-z0-9_]*$", description="Unique key (e.g., 'cardiology')")
     title: str = Field(..., min_length=1, max_length=100, description="English title")
     title_ru: str | None = Field(None, max_length=100, description="Russian title")
     queue_tags: list[str] = Field(default=[], description="List of queue_tag values for this profile")

--- a/backend/app/schemas/department.py
+++ b/backend/app/schemas/department.py
@@ -126,7 +126,8 @@ class DepartmentRegistrationSettingsResponse(BaseModel):
 class DepartmentBase(BaseModel):
     """Базовая схема отделения"""
 
-    key: str = Field(..., max_length=50)
+    # PR-20: validate key format — must match queue_tag pattern
+    key: str = Field(..., max_length=50, pattern=r"^[a-z][a-z0-9_]*$")
     name_ru: str = Field(..., max_length=200)
     name_uz: str | None = Field(None, max_length=200)
     icon: str | None = Field("folder", max_length=50)
@@ -148,7 +149,7 @@ class DepartmentCreate(DepartmentBase):
 class DepartmentUpdate(BaseModel):
     """Обновление отделения"""
 
-    key: str | None = Field(None, max_length=50)
+    key: str | None = Field(None, max_length=50, pattern=r"^[a-z][a-z0-9_]*$")
     name_ru: str | None = Field(None, max_length=200)
     name_uz: str | None = Field(None, max_length=200)
     icon: str | None = Field(None, max_length=50)

--- a/backend/app/schemas/user_management.py
+++ b/backend/app/schemas/user_management.py
@@ -517,7 +517,7 @@ class UserCreateRequest(BaseModel):
     email: str = Field(..., min_length=3, max_length=254)
     password: str = Field(..., min_length=8, max_length=100)
     # TODO(DB_ROLES): Replace regex with DB-driven validation in Phase 0.5
-    role: str = Field(..., pattern="^(Admin|Doctor|Nurse|Receptionist|Cashier|Lab|Patient)$")
+    role: str = Field(..., pattern="^(Admin|Registrar|Doctor|Nurse|Receptionist|Cashier|Lab|Patient|SuperAdmin|Manager)$")
     is_active: bool | None = True
     is_superuser: bool | None = False
     must_change_password: bool | None = False  # Требуется смена пароля при первом входе
@@ -559,7 +559,7 @@ class UserUpdateRequest(BaseModel):
     email: str | None = Field(None, min_length=3, max_length=254)
     # TODO(DB_ROLES): Replace regex with DB-driven validation in Phase 0.5
     role: str | None = Field(
-        None, pattern="^(Admin|Doctor|Nurse|Receptionist|Cashier|Lab|Patient)$"
+        None, pattern="^(Admin|Registrar|Doctor|Nurse|Receptionist|Cashier|Lab|Patient|SuperAdmin|Manager)$"
     )
     is_active: bool | None = None
     is_superuser: bool | None = None
@@ -638,7 +638,7 @@ class UserSearchRequest(BaseModel):
     query: str | None = Field(None, min_length=1, max_length=100)
     # TODO(DB_ROLES): Replace regex with DB-driven validation in Phase 0.5
     role: str | None = Field(
-        None, pattern="^(Admin|Doctor|Nurse|Receptionist|Cashier|Lab|Patient)$"
+        None, pattern="^(Admin|Registrar|Doctor|Nurse|Receptionist|Cashier|Lab|Patient|SuperAdmin|Manager)$"
     )
     status: UserStatus | None = None
     is_active: bool | None = None
@@ -662,7 +662,7 @@ class UserBulkActionRequest(BaseModel):
     )
     # TODO(DB_ROLES): Replace regex with DB-driven validation in Phase 0.5
     role: str | None = Field(
-        None, pattern="^(Admin|Doctor|Nurse|Receptionist|Cashier|Lab|Patient)$"
+        None, pattern="^(Admin|Registrar|Doctor|Nurse|Receptionist|Cashier|Lab|Patient|SuperAdmin|Manager)$"
     )
     reason: str | None = Field(None, max_length=500)
 

--- a/frontend/src/components/admin/DepartmentManagement.jsx
+++ b/frontend/src/components/admin/DepartmentManagement.jsx
@@ -272,26 +272,12 @@ const DepartmentManagement = () => {
       setIntegrationForm(DEFAULT_INTEGRATION_OPTIONS);
       setServiceMapping(DEFAULT_SERVICE_MAPPING);
 
-      // ✅ НОВОЕ: Создание услуги при создании отделения (если включено)
-      if (serviceMapping.create_service && serviceMapping.service_name) {
-        try {
-          const serviceData = {
-            name: serviceMapping.service_name,
-            category_code: serviceMapping.service_category_code || null,
-            service_code: serviceMapping.service_code_pattern || null,
-            department_key: formData.key,
-            queue_tag: serviceMapping.queue_tag || null,
-            price: serviceMapping.service_price ? parseFloat(serviceMapping.service_price) : null,
-            currency: 'UZS',
-            active: true
-          };
-          await api.post('/services', serviceData);
-          toast.success('Услуга создана автоматически');
-        } catch (err) {
-          logger.error('Ошибка создания услуги:', err);
-          toast.warning('Отделение создано, но услуга не была создана: ' + (err.response?.data?.detail || 'Ошибка'));
-        }
-      }
+      // PR-20: Removed frontend POST /services call — backend's
+      // _ensure_department_integrations already creates a default service
+      // with name "Консультация {department.name_ru}". The frontend call
+      // was causing DOUBLE service creation (one from frontend, one from
+      // backend). If admin wants a custom service, they can create it
+      // separately in ServiceCatalog after the department is created.
 
       await loadDepartments();
       broadcastDepartmentsUpdate();
@@ -330,26 +316,8 @@ const DepartmentManagement = () => {
       await api.put(`/admin/departments/${editingDepartment.id}`, formData);
       toast.success('Отделение обновлено');
 
-      // ✅ НОВОЕ: Создание услуги при редактировании (если включено)
-      if (serviceMapping.create_service && serviceMapping.service_name) {
-        try {
-          const serviceData = {
-            name: serviceMapping.service_name,
-            category_code: serviceMapping.service_category_code || null,
-            service_code: serviceMapping.service_code_pattern || null,
-            department_key: formData.key,
-            queue_tag: serviceMapping.queue_tag || null,
-            price: serviceMapping.service_price ? parseFloat(serviceMapping.service_price) : null,
-            currency: 'UZS',
-            active: true
-          };
-          await api.post('/services', serviceData);
-          toast.success('Услуга создана');
-        } catch (err) {
-          logger.error('Ошибка создания услуги:', err);
-          toast.warning('Отделение обновлено, но услуга не была создана: ' + (err.response?.data?.detail || 'Ошибка'));
-        }
-      }
+      // PR-20: Removed frontend POST /services call (same as create handler).
+      // Backend already handles default service via _ensure_department_integrations.
 
       setShowEditModal(false);
       setEditingDepartment(null);


### PR DESCRIPTION
## Summary

PR-20 of the admin-flows audit remediation (P2). Fixes 4 bugs:
1. `DepartmentCreate.key` had no pattern validation — added `^[a-z][a-z0-9_]*$` to `DepartmentBase.key` and `DepartmentUpdate.key`
2. `QueueProfileCreate.key` had no pattern validation — added same pattern
3. `DepartmentManagement.jsx` double-created services when `create_service=true` — removed frontend `POST /services` call (backend `_ensure_department_integrations` already creates default service)
4. `UserCreateRequest.role` pattern excluded `Registrar`, `SuperAdmin`, `Manager` — added all three to pattern in both Create and Update schemas

## Cyclic Execution Evidence

- Fresh main sync: yes, branched from 6a7b6f90 (PR-19 head on main)
- Clean workspace: yes
- Branch: fix/pr-20-key-validation-dedupe-registrar-role
- Scope gate: 4 files (2 backend schemas + 1 backend endpoint + 1 frontend component)
- Red-check handling: existing 983 backend + 560 frontend tests verify no regressions

## Contract Impact

- Canonical surface: POST/PUT /admin/departments (key now validated), POST /queues/profiles (key now validated), POST/PUT /users/users (role now accepts Registrar/SuperAdmin/Manager)
- Request shape: unchanged — key and role fields already existed, just validated now
- Response shape: unchanged — 422 for invalid key/role (was: silent acceptance)
- Status codes: NEW — 422 for keys not matching `^[a-z][a-z0-9_]*$`; 422 for roles not in expanded pattern
- Frontend consumer: admin typing "Cardio Logy" as department key now gets 422 (was: silently accepted, broke queue routing). Admin selecting "Registrar" role now works (was: 422).
- Compatibility path or alias: existing valid keys/roles still accepted
- Contract proof: 983 backend + 560 frontend tests pass

## RBAC / Permissions

- Roles allowed: unchanged — now includes Registrar, SuperAdmin, Manager in the allowed pattern
- Roles denied: unchanged — roles not in pattern still get 422
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only changes schema validation — no WS changes, no notification event types introduced
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: not applicable because this PR does not touch any notification or inbox state
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: N/A — validation fix
- Partial data proof: not applicable because this PR only changes validation — no partial data scenario to handle
- Forbidden secondary path behavior: not applicable because this PR only changes validation — no auth path changes
- Missing draft/resource behavior: not applicable because this PR only changes validation
- Stale route/deep-link behavior: not applicable because this PR does not change any URL paths or route definitions

## Scope Gate

- Allowed paths: app/schemas/department.py, app/api/v1/endpoints/registrar_integration/_queue_profiles.py, app/schemas/user_management.py, frontend/src/components/admin/DepartmentManagement.jsx
- Denied paths: no other files
- Migration/docs/test impact: no new tests, no schema migration, no docs
- Rollback note: reverting restores unvalidated keys/roles and double service creation

## Validation

- Targeted tests or smoke run: pytest tests/architecture/ tests/unit/ tests/test_openapi_contract.py + npx vitest run
- Result: 983 backend passed + 560 frontend passed, 0 failures
- Not checked: full integration suite — will run in CI
