### PR TITLE
fix(admin): PR-21 — P3 cleanup: DoctorOut department + QueueProfilesManager department_key Select

### DIFF
--- a/backend/app/api/v1/endpoints/admin_doctors.py
+++ b/backend/app/api/v1/endpoints/admin_doctors.py
@@ -98,6 +98,9 @@ def _serialize_doctor(db: Session, doctor) -> DoctorOut:
         "active": doctor.active,
         "created_at": doctor.created_at,
         "updated_at": doctor.updated_at,
+        # PR-21: include department fields
+        "department_id": doctor.department_id,
+        "department": doctor.department.name_ru if doctor.department else None,
         "user": _serialize_doctor_user(doctor.user, linked_doctor_id=doctor.id),
     }
     schedules = crud_clinic.get_doctor_schedules(db, doctor.id)

--- a/backend/app/schemas/clinic.py
+++ b/backend/app/schemas/clinic.py
@@ -115,6 +115,9 @@ class DoctorOut(DoctorBase):
     id: int
     created_at: datetime | None = None
     updated_at: datetime | None = None
+    # PR-21: include department fields so AdminDoctors can show "Отделение"
+    department_id: int | None = None
+    department: str | None = None
 
     # Связанные данные
     user: dict[str, Any] | None = None

--- a/frontend/src/components/admin/QueueProfilesManager.jsx
+++ b/frontend/src/components/admin/QueueProfilesManager.jsx
@@ -86,6 +86,8 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
     const [error, setError] = useState(null);
     const [editingProfile, setEditingProfile] = useState(null);
     const [showCreateForm, setShowCreateForm] = useState(false);
+    // PR-21: load departments for department_key Select in ProfileForm
+    const [departments, setDepartments] = useState([]);
 
     // ⭐ New: Search and filter
     const [searchTerm, setSearchTerm] = useState('');
@@ -115,6 +117,10 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
 
     useEffect(() => {
         loadProfiles();
+        // PR-21: load departments for department_key Select
+        api.get('/admin/departments').then(res => {
+            setDepartments(res.data?.data || []);
+        }).catch(err => logger.error('Failed to load departments:', err));
     }, [loadProfiles]);
 
     // ⭐ New: Filtered profiles
@@ -560,6 +566,7 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                         onCancel={() => setShowCreateForm(false)}
                         saving={saving}
                         isDark={isDark}
+                        departments={departments}
                     />
                 )}
 
@@ -713,6 +720,7 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
                         saving={saving}
                         isDark={isDark}
                         isEdit
+                        departments={departments}
                     />
                 )}
                 {/* P-013 fix: portal-mounted ConfirmDialog rendered once per panel */}
@@ -722,7 +730,7 @@ const QueueProfilesManager = ({ theme = 'light' }) => {
     );
 };
 // Profile form component with show_on_qr_page support
-const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = false }) => {
+const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = false, departments = [] }) => {
     const [formData, setFormData] = useState({
         key: profile?.key || '',
         title: profile?.title || '',
@@ -827,6 +835,23 @@ const ProfileForm = ({ profile, onSubmit, onCancel, saving, isDark, isEdit = fal
                             placeholder="cardio, cardiology, cardiology_common"
                         />
                         <div className="admin-qp-hint">Разделяйте запятыми. Записи с этими тегами появятся на вкладке.</div>
+                    </div>
+
+                    {/* PR-21: Department key Select */}
+                    <div className="admin-qp-field">
+                        <label className="admin-qp-label">Отделение (необязательно)</label>
+                        <select
+                            className="admin-w-100pct-p-10px-12px-radius-8-bd-1px-solid-var-mac-bo-primary-fs-14-bsz-border-box-w-100-bgc-dyn"
+                            style={{ '--admin-bgc0': isDark ? 'var(--mac-bg-secondary)' : 'var(--mac-bg-primary)' }}
+                            value={formData.department_key}
+                            onChange={e => setFormData({ ...formData, department_key: e.target.value })}
+                        >
+                            <option value="">— Не привязано —</option>
+                            {departments.map(d => (
+                                <option key={d.key} value={d.key}>{d.name_ru || d.key}</option>
+                            ))}
+                        </select>
+                        <div className="admin-qp-hint">Привязка к отделению для синхронизации данных</div>
                     </div>
 
                     {/* Order */}


### PR DESCRIPTION
## Summary

PR-21 of the admin-flows audit remediation (P3 cleanup). Fixes 2 remaining P3 bugs:
1. `DoctorOut` schema did not include `department_id` or `department` fields — `AdminDoctors.jsx` "Отделение" column always fell back to `specialty`. Now includes both fields.
2. `QueueProfilesManager.jsx` `ProfileForm` had `department_key` in form state but no UI input — always sent empty. Now renders a `<select>` dropdown populated from `/admin/departments`.

## Cyclic Execution Evidence

- Fresh main sync: yes, branched from b2fd5e46 (PR-20 head on main)
- Clean workspace: yes
- Branch: fix/pr-21-p3-cleanup-doctor-dept-queue-profile-cascade
- Scope gate: 3 files (1 backend schema + 1 backend endpoint + 1 frontend component)
- Red-check handling: existing 983 backend + 560 frontend tests verify no regressions

## Contract Impact

- Canonical surface: GET /api/v1/admin/doctors (now returns department_id + department), POST/PUT /api/v1/queues/profiles (now receives department_key from UI)
- Request shape: unchanged — department_key was already in QueueProfileCreate schema, just wasn't sent from UI
- Response shape: GET /admin/doctors now includes department_id and department fields in each doctor object
- Status codes: unchanged
- Frontend consumer: AdminDoctors "Отделение" column now shows department.name_ru (was: specialty fallback). QueueProfilesManager now lets admin select department from dropdown.
- Compatibility path or alias: department_id/department are optional fields (None when no department linked)
- Contract proof: 983 backend + 560 frontend tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only changes API response fields + frontend form — no WS changes, no notification event types introduced
- Payload version / ack behavior: GET /admin/doctors response now includes 2 new optional fields
- Read/unread or delivery semantics: not applicable because this PR does not touch any notification or inbox state
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: when doctor has no department, department_id=None, department=None — AdminDoctors shows "Не указано"
- Partial data proof: when departments list is empty in QueueProfilesManager, select shows only "— Не привязано —" option
- Forbidden secondary path behavior: not applicable because this PR only changes display fields — no auth path changes
- Missing draft/resource behavior: when doctor.department is None, department field is None (not 500)
- Stale route/deep-link behavior: not applicable because this PR does not change any URL paths or route definitions

## Scope Gate

- Allowed paths: app/schemas/clinic.py, app/api/v1/endpoints/admin_doctors.py, frontend/src/components/admin/QueueProfilesManager.jsx
- Denied paths: no other files
- Migration/docs/test impact: no new tests, no schema migration (department_id column already exists on Doctor model), no docs
- Rollback note: reverting removes department fields from DoctorOut + department_key Select from QueueProfilesManager

## Validation

- Targeted tests or smoke run: pytest tests/architecture/ tests/unit/ tests/test_openapi_contract.py + npx vitest run
- Result: 983 backend + 560 frontend passed, 0 failures
- Not checked: full integration suite — will run in CI
