### PR TITLE
fix(admin): PR-22 — cascade-delete for queue_profile/department + UserManagement pagination

### DIFF
--- a/backend/app/api/v1/endpoints/admin_departments/_crud.py
+++ b/backend/app/api/v1/endpoints/admin_departments/_crud.py
@@ -363,7 +363,10 @@ def delete_department(
     """
     Удалить отделение
 
-    Доступно только для администраторов
+    Доступно только для администраторов.
+    PR-22: cascades cleanup — clears department_key from services, deletes
+    DepartmentService/DepartmentQueueSettings/DepartmentRegistrationSettings,
+    and deletes associated QueueProfile.
     """
     department = db.query(Department).filter(Department.id == department_id).first()
 
@@ -373,12 +376,61 @@ def delete_department(
             detail=f"Department with id {department_id} not found",
         )
 
+    # PR-22: cascade cleanup
+    cleaned = {"services": 0, "department_services": 0, "queue_settings": 0,
+               "registration_settings": 0, "queue_profile": False}
+
+    # Clear department_key from services
+    from app.models.service import Service
+    services = db.query(Service).filter(Service.department_key == department.key).all()
+    for svc in services:
+        svc.department_key = None
+        cleaned["services"] += 1
+
+    # Delete DepartmentService links
+    dept_services = db.query(DepartmentService).filter(
+        DepartmentService.department_id == department_id
+    ).all()
+    for ds in dept_services:
+        db.delete(ds)
+        cleaned["department_services"] += 1
+
+    # Delete DepartmentQueueSettings
+    queue_settings = db.query(DepartmentQueueSettings).filter(
+        DepartmentQueueSettings.department_id == department_id
+    ).first()
+    if queue_settings:
+        db.delete(queue_settings)
+        cleaned["queue_settings"] = 1
+
+    # Delete DepartmentRegistrationSettings
+    reg_settings = db.query(DepartmentRegistrationSettings).filter(
+        DepartmentRegistrationSettings.department_id == department_id
+    ).first()
+    if reg_settings:
+        db.delete(reg_settings)
+        cleaned["registration_settings"] = 1
+
+    # Delete associated QueueProfile
+    from app.models.queue_profile import QueueProfile
+    queue_profile = db.query(QueueProfile).filter(
+        QueueProfile.key == department.key
+    ).first()
+    if queue_profile:
+        db.delete(queue_profile)
+        cleaned["queue_profile"] = True
+
     db.delete(department)
     db.commit()
+
+    logger.info(
+        f"Deleted department '{department.name_ru}' (cascade: {cleaned})"
+    )
 
     return {
         "success": True,
         "message": f"Department '{department.name_ru}' deleted successfully",
+        "cascade": cleaned,
     }
 
 

--- a/backend/app/api/v1/endpoints/registrar_integration/_queue_profiles.py
+++ b/backend/app/api/v1/endpoints/registrar_integration/_queue_profiles.py
@@ -365,20 +365,36 @@ def delete_queue_profile(
     """
     try:
         from app.models.queue_profile import QueueProfile
+        from app.models.service import Service
 
         # Find profile
         profile = db.query(QueueProfile).filter(QueueProfile.key == profile_key).first()
         if not profile:
             raise HTTPException(status_code=404, detail=f"Profile '{profile_key}' not found")
 
+        # PR-22: cascade cleanup — clear queue_tag from services that
+        # matched this profile's tags. Without this, services keep
+        # orphaned queue_tags that silently disappear from registrar.
+        tags_to_clean = profile.queue_tags or []
+        services_cleaned = 0
+        if tags_to_clean:
+            services = db.query(Service).filter(
+                Service.queue_tag.in_(tags_to_clean)
+            ).all()
+            for svc in services:
+                if svc.queue_tag in tags_to_clean:
+                    svc.queue_tag = None
+                    services_cleaned += 1
+
         db.delete(profile)
         db.commit()
 
-        logger.info(f"Deleted QueueProfile: {profile_key}")
+        logger.info(f"Deleted QueueProfile: {profile_key} (cleaned {services_cleaned} services)")
 
         return {
             "success": True,
             "message": f"Profile '{profile_key}' deleted successfully",
+            "services_cleaned": services_cleaned,
         }
 
     except HTTPException:

--- a/frontend/src/components/admin/UserManagement.jsx
+++ b/frontend/src/components/admin/UserManagement.jsx
@@ -40,6 +40,11 @@ const UserManagement = () => {
   const [statusFilter, setStatusFilter] = useState('');
   const [selectedUser, setSelectedUser] = useState(null);
   const [showUserModal, setShowUserModal] = useState(false);
+  // PR-22: pagination state (was hardcoded per_page=100, no pagination UI)
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalUsers, setTotalUsers] = useState(0);
+  const perPage = 50;
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [currentProfile, setCurrentProfile] = useState(null);
   const [deleteDialogMode, setDeleteDialogMode] = useState('confirm');
@@ -74,8 +79,16 @@ const UserManagement = () => {
 
 
   useEffect(() => {
-    loadUsers();
+    loadUsers(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // PR-22: reload when filters or search change
+  useEffect(() => {
+    setCurrentPage(1);
+    loadUsers(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchTerm, roleFilter, statusFilter]);
 
   useEffect(() => {
     let isMounted = true;
@@ -139,12 +152,18 @@ const UserManagement = () => {
     };
   }, [actionsMenuUser]);
 
-  const loadUsers = async () => {
+  const loadUsers = async (page = currentPage) => {
     try {
       setLoading(true);
-      // Request up to 100 users per page to show all users
-      const response = await api.get('/users/users', { params: { per_page: 100 } });
+      // PR-22: use pagination — was per_page=100 with no pagination UI
+      const params = { page, per_page: perPage };
+      if (roleFilter) params.role = roleFilter;
+      if (statusFilter) params.status = statusFilter;
+      if (searchTerm) params.search = searchTerm;
+      const response = await api.get('/users/users', { params });
       setUsers(response.data.users || response.data || []);
+      setTotalPages(response.data.total_pages || 1);
+      setTotalUsers(response.data.total || 0);
       setError('');
     } catch (err) {
       const errorMessage = err.response?.data?.detail || err.message || 'Ошибка подключения к серверу';
@@ -165,7 +184,7 @@ const UserManagement = () => {
         setSuccess('Пользователь успешно создан');
       }
       setError('');
-      loadUsers();
+      loadUsers(currentPage);
       setShowUserModal(false);
       setSelectedUser(null);
     } catch (err) {
@@ -193,7 +212,7 @@ const UserManagement = () => {
       await api.delete(`/users/users/${selectedUser.id}`);
       setSuccess('Пользователь успешно удален');
       setError('');
-      loadUsers();
+      loadUsers(currentPage);
       setShowDeleteDialog(false);
       setSelectedUser(null);
     } catch (err) {
@@ -228,7 +247,7 @@ const UserManagement = () => {
       await api.put(`/users/users/${selectedUser.id}`, { is_active: false });
       setSuccess('Пользователь деактивирован');
       setError('');
-      loadUsers();
+      loadUsers(currentPage);
       setShowDeleteDialog(false);
       setSelectedUser(null);
       setDeleteDialogMode('confirm');
@@ -259,7 +278,7 @@ const UserManagement = () => {
       await api.put(`/users/users/${userId}`, { is_active: !isActive });
       setSuccess(`Пользователь ${!isActive ? 'активирован' : 'деактивирован'}`);
       setError('');
-      loadUsers();
+      loadUsers(currentPage);
     } catch (err) {
       const errorMessage = err.response?.data?.detail || err.message || 'Ошибка изменения статуса пользователя';
       setError(errorMessage);
@@ -526,7 +545,7 @@ const UserManagement = () => {
             <label className="admin-d-block-mb-6-fs-13-fw-500-vis-hidden">Действие</label>
             <Button
               variant="secondary"
-              onClick={loadUsers}
+              onClick={() => loadUsers(currentPage)}
               startIcon={<RefreshCw size={16} />}
               className="admin-w-100pct-jc-center"
               disabled={loading}>
@@ -543,7 +562,32 @@ const UserManagement = () => {
           data={filteredUsers}
           loading={loading}
           hoverable />
-        
+
+        {/* PR-22: Pagination controls */}
+        {totalPages > 1 && (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px', borderTop: '1px solid var(--mac-border)' }}>
+            <span style={{ fontSize: '13px', color: 'var(--mac-text-secondary)' }}>
+              Всего: {totalUsers} · Страница {currentPage} из {totalPages}
+            </span>
+            <div style={{ display: 'flex', gap: '8px' }}>
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={currentPage <= 1 || loading}
+                onClick={() => { setCurrentPage(p => p - 1); loadUsers(currentPage - 1); }}>
+                ← Назад
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={currentPage >= totalPages || loading}
+                onClick={() => { setCurrentPage(p => p + 1); loadUsers(currentPage + 1); }}>
+                Вперёд →
+              </Button>
+            </div>
+          </div>
+        )}
+
       </MacOSCard>
 
       {/* Actions Menu */}


### PR DESCRIPTION
## Summary

PR-22 — final cleanup. Fixes cascade-delete for queue_profile/department + UserManagement pagination.

1. **delete_queue_profile cascade**: Was just `db.delete(profile)` — services kept orphaned `queue_tags`. Now clears `queue_tag` from all matching services before deleting. Returns `services_cleaned` count.

2. **delete_department cascade**: Was just `db.delete(department)` — orphaned DepartmentService, DepartmentQueueSettings, DepartmentRegistrationSettings, Service.department_key. Now clears department_key from services, deletes all related rows + QueueProfile. Returns `cascade` dict.

3. **UserManagement pagination**: Was `per_page=100` with no pagination UI. Now `per_page=50` with currentPage/totalPages/totalUsers state + pagination controls (← Назад / Вперёд →). Filters sent as API params and trigger page reset.

## Cyclic Execution Evidence

- Fresh main sync: yes, branched from f72fbe77 (PR-21 head on main)
- Clean workspace: yes
- Branch: fix/pr-22-cascade-delete-and-user-pagination
- Scope gate: 3 files (2 backend endpoints + 1 frontend component)
- Red-check handling: 983 backend + 560 frontend tests pass

## Contract Impact

- Canonical surface: DELETE /api/v1/queues/profiles/{key}, DELETE /api/v1/admin/departments/{id}, GET /api/v1/users/users
- Request shape: GET /users/users now accepts page/per_page/search/role/status params (already supported by backend, frontend was just not using them)
- Response shape: DELETE /queues/profiles response now includes services_cleaned; DELETE /admin/departments response now includes cascade dict
- Status codes: unchanged — 200 on success, 404 when not found
- Frontend consumer: UserManagement now shows pagination controls when totalPages > 1; cascade cleanup prevents orphaned services/settings
- Compatibility path or alias: none — new fields are additive to response
- Contract proof: 983 backend + 560 frontend tests pass

## RBAC / Permissions

- Roles allowed: Admin only on all endpoints (unchanged)
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only changes delete cascade + pagination — no WS changes, no notification event types introduced
- Payload version / ack behavior: DELETE responses now include cascade/services_cleaned fields
- Read/unread or delivery semantics: not applicable because this PR does not touch any notification or inbox state
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: when 0 users, pagination hidden (totalPages=1)
- Partial data proof: cascade cleanup handles missing related rows gracefully (null checks)
- Forbidden secondary path behavior: unchanged
- Missing draft/resource behavior: cascade skips missing rows (defensive null checks)
- Stale route/deep-link behavior: not applicable because this PR does not change any URL paths or route definitions

## Scope Gate

- Allowed paths: app/api/v1/endpoints/registrar_integration/_queue_profiles.py, app/api/v1/endpoints/admin_departments/_crud.py, frontend/src/components/admin/UserManagement.jsx
- Denied paths: no other files
- Migration/docs/test impact: no new tests, no schema migration, no docs
- Rollback note: reverting restores non-cascading deletes + no pagination

## Validation

- Targeted tests or smoke run: pytest tests/architecture/ tests/unit/ tests/test_openapi_contract.py + npx vitest run
- Result: 983 backend + 560 frontend passed, 0 failures
- Not checked: full integration suite — will run in CI
