### PR TITLE
fix(wizard): PR-23 — P0: doctor filter by service + quantity stepper + QueueTable source badge

### DIFF
--- a/frontend/src/components/queue/QueueTable.jsx
+++ b/frontend/src/components/queue/QueueTable.jsx
@@ -125,6 +125,30 @@ const QueueTable = ({
                                 </td>
                                 <td className="qt-table-cell-primary">
                                     {entry.patient_name || entry.name || '—'}
+                                    {/* PR-23 P0 #3: source badge (QR vs Desk) */}
+                                    {entry.source === 'online' || entry.source_kind === 'online_queue' || entry.source === 'qr' ? (
+                                        <span style={{
+                                            display: 'inline-block',
+                                            marginLeft: '6px',
+                                            padding: '1px 6px',
+                                            borderRadius: '4px',
+                                            fontSize: '10px',
+                                            fontWeight: 600,
+                                            background: 'rgba(139, 92, 246, 0.15)',
+                                            color: '#7c3aed'
+                                        }}>QR</span>
+                                    ) : (
+                                        <span style={{
+                                            display: 'inline-block',
+                                            marginLeft: '6px',
+                                            padding: '1px 6px',
+                                            borderRadius: '4px',
+                                            fontSize: '10px',
+                                            fontWeight: 500,
+                                            background: 'rgba(100, 116, 139, 0.15)',
+                                            color: '#64748b'
+                                        }}>Desk</span>
+                                    )}
                                 </td>
                                 <td className="qt-table-cell-phone">
                                     {entry.patient_phone || entry.phone || '—'}

--- a/frontend/src/components/wizard/CartStepV2.jsx
+++ b/frontend/src/components/wizard/CartStepV2.jsx
@@ -100,13 +100,14 @@ const CartStepV2 = ({
 
   const displayedServices = getDisplayedServices();
 
-  // Обработка выбора услуги
+  // PR-23 P0 #2: clicking a service that's already in cart increments quantity
+  // instead of toggling it off. Remove is via the X button in the cart mini-card.
   const handleServiceToggle = (service) => {
-    const isInCart = cart?.items?.some((item) => item.service_id === service.id);
+    const existingItem = cart?.items?.find((item) => item.service_id === service.id);
 
-    if (isInCart) {
-      const cartItem = cart.items.find((item) => item.service_id === service.id);
-      onRemoveFromCart(cartItem.id);
+    if (existingItem) {
+      // Already in cart → increment quantity
+      onUpdateItem?.(existingItem.id, 'quantity', (existingItem.quantity || 1) + 1);
     } else {
       onAddToCart(service);
     }
@@ -280,7 +281,7 @@ const CartStepV2 = ({
           fontSize: 'var(--mac-font-size-sm)',
           color: 'var(--mac-text-secondary)'
         }}>
-          <span>Выбрано: {cart?.items?.length || 0} шт.</span>
+          <span>Выбрано: {cart?.items?.reduce((sum, item) => sum + (item.quantity || 1), 0) || 0} шт.</span>
           <span style={{ color: 'var(--mac-success)', fontWeight: 'var(--mac-font-weight-semibold)' }}>
             Итого: {cartTotal.toLocaleString()} сум
           </span>
@@ -442,7 +443,20 @@ const CartStepV2 = ({
             const displayName = getServiceName ? getServiceName(item) : item.service_name || 'Неизвестная услуга';
             const service = servicesData?.find((s) => s.id === item.service_id);
             const requiresDoctor = Boolean(service?.requires_doctor || service?.is_consultation);
-            const doctorOptions = normalizedDoctorsData;
+
+            // PR-23 P0 #1: filter doctors by service specialty/department_key
+            // so registrar can't assign a cardiologist to a dermatology consult
+            const serviceDepartmentKey = String(service?.department_key || '').toLowerCase().trim();
+            const filteredDoctors = serviceDepartmentKey
+              ? normalizedDoctorsData.filter((d) => {
+                  const docSpecialty = String(d.specialty || '').toLowerCase().trim();
+                  // Match if doctor's specialty matches service's department_key,
+                  // or if doctor has no specialty (show all as fallback)
+                  return !docSpecialty || docSpecialty === serviceDepartmentKey ||
+                    docSpecialty.includes(serviceDepartmentKey) || serviceDepartmentKey.includes(docSpecialty);
+                })
+              : normalizedDoctorsData;
+            const doctorOptions = filteredDoctors.length > 0 ? filteredDoctors : normalizedDoctorsData;
 
             return (
               <div key={item.id} style={{
@@ -455,7 +469,7 @@ const CartStepV2 = ({
                 border: '1px solid var(--mac-border)',
                 borderRadius: 'var(--mac-radius-sm)',
                 fontSize: 'var(--mac-font-size-xs)',
-                minWidth: requiresDoctor ? '220px' : 'auto'
+                minWidth: requiresDoctor ? '240px' : 'auto'
               }}>
                   <div style={{
                   display: 'flex',
@@ -463,9 +477,28 @@ const CartStepV2 = ({
                   gap: 'var(--mac-spacing-2)',
                   whiteSpace: 'nowrap'
                 }}>
-                    <span style={{ maxWidth: '150px', overflow: 'hidden', textOverflow: 'ellipsis' }} title={displayName}>
+                    <span style={{ maxWidth: '140px', overflow: 'hidden', textOverflow: 'ellipsis' }} title={displayName}>
                       {displayName}
                     </span>
+                    {/* PR-23 P0 #2: quantity stepper */}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
+                      <button
+                        onClick={() => {
+                          const newQty = (item.quantity || 1) - 1;
+                          if (newQty <= 0) {
+                            onRemoveFromCart(item.id);
+                          } else {
+                            onUpdateItem?.(item.id, 'quantity', newQty);
+                          }
+                        }}
+                        aria-label={`Decrease quantity for ${displayName}`}
+                        style={{ border: '1px solid var(--mac-border)', background: 'var(--mac-bg-primary)', color: 'var(--mac-text-primary)', cursor: 'pointer', borderRadius: '3px', width: '20px', height: '20px', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '12px', lineHeight: 1 }}>−</button>
+                      <span style={{ minWidth: '20px', textAlign: 'center', fontWeight: 600 }}>{item.quantity || 1}</span>
+                      <button
+                        onClick={() => onUpdateItem?.(item.id, 'quantity', (item.quantity || 1) + 1)}
+                        aria-label={`Increase quantity for ${displayName}`}
+                        style={{ border: '1px solid var(--mac-border)', background: 'var(--mac-bg-primary)', color: 'var(--mac-text-primary)', cursor: 'pointer', borderRadius: '3px', width: '20px', height: '20px', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '12px', lineHeight: 1 }}>+</button>
+                    </div>
                     <button
                     onClick={() => onRemoveFromCart(item.id)}
                     aria-label={`Remove ${displayName} from appointment cart`}
@@ -508,6 +541,11 @@ const CartStepV2 = ({
                             {getDoctorDisplayName(doctor)}{doctor.specialty ? ` · ${doctor.specialty}` : ''}{doctor.cabinet ? ` · каб. ${doctor.cabinet}` : ''}
                           </option>)}
                       </select>
+                      {filteredDoctors.length === 0 && normalizedDoctorsData.length > 0 && (
+                        <span style={{ fontSize: '10px', color: 'var(--mac-text-tertiary)' }}>
+                          Нет врача для этого отделения — показаны все
+                        </span>
+                      )}
                     </div>
                 }
                 </div>);


### PR DESCRIPTION
## Summary

PR-23 — 3 P0 UX fixes from the wizard/QR UX audit:
1. **Doctor `<select>` filter by service** — was showing ALL doctors; now filters by `service.department_key` matched against `doctor.specialty`
2. **Quantity stepper** — clicking a service already in cart now increments quantity (was: toggled off). Added −/+ stepper in cart mini-card. Updated "Выбрано: N шт." to show total quantity.
3. **QueueTable source badge** — was no QR/Desk distinction; now shows purple "QR" badge for online source, gray "Desk" for desk source.

## Cyclic Execution Evidence

- Fresh main sync: yes, branched from 8c763c4b (PR-22 head on main)
- Clean workspace: yes
- Branch: fix/pr-23-p0-doctor-filter-quantity-source-badge
- Scope gate: frontend-only, 2 files (CartStepV2.jsx + QueueTable.jsx)
- Red-check handling: 554 tests pass, 0 failures, ESLint 0 errors

## Contract Impact

- Canonical surface: wizard cart step (UI only), QueueTable (UI only)
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: registrar sees filtered doctor list, can add quantity, sees source badge in queue table
- Compatibility path or alias: when no doctors match service department, falls back to showing all doctors with a hint
- Contract proof: 554 frontend tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only changes frontend UI — no WS changes, no notification event types introduced
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: not applicable because this PR does not touch any notification or inbox state
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: when no doctors match service department, falls back to all doctors with "Нет врача для этого отделения" hint
- Partial data proof: quantity stepper handles quantity=1 correctly (− button removes item at qty 0)
- Forbidden secondary path behavior: not applicable because this PR only changes UI rendering — no auth path changes
- Missing draft/resource behavior: when entry.source is undefined, defaults to "Desk" badge
- Stale route/deep-link behavior: not applicable because this PR does not change any URL paths or route definitions

## Scope Gate

- Allowed paths: src/components/wizard/CartStepV2.jsx, src/components/queue/QueueTable.jsx
- Denied paths: no backend changes, no other frontend files
- Migration/docs/test impact: no new tests, no schema migration, no docs
- Rollback note: reverting restores unfiltered doctor list, toggle-off behavior, and no source badge

## Validation

- Targeted tests or smoke run: npx vitest run (full frontend suite)
- Result: 554 passed, 0 failed (no regressions)
- Not checked: Playwright e2e — will run in CI
