### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to Modal close button

### DIFF
--- a/frontend/src/components/ui/macos/Modal.jsx
+++ b/frontend/src/components/ui/macos/Modal.jsx
@@ -189,6 +189,7 @@ const Modal = ({
           variant="ghost"
           size="small"
           onClick={onClose}
+          aria-label="Закрыть"
           style={{
             position: 'absolute',
             top: '12px',


### PR DESCRIPTION
💡 What: Added an `aria-label="Закрыть"` to the fullscreen Modal close button.
🎯 Why: Screen readers could not correctly interpret the purpose of the '✕' icon-only button used for closing fullscreen modals, making it difficult for visually impaired users to dismiss the dialog.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: The close button is now properly announced by screen readers as a "Close" button.

---
*PR created automatically by Jules for task [14103952555983990493](https://jules.google.com/task/14103952555983990493) started by @drsapaev*