### PR TITLE
fix(mobile): PR-29 — Sprint 2: 6 mobile API fixes (P0-13, P0-19, High-22,23,24,25)

### DIFF
--- a/backend/app/api/v1/endpoints/mobile_api.py
+++ b/backend/app/api/v1/endpoints/mobile_api.py
@@ -26,6 +26,7 @@ crud_user = importlib.import_module("app.crud.user")
 # functions like get_patient_by_user_id live on the module itself.
 # Use the instance for method calls, import the module functions directly.
 from app.crud import patient as crud_patient  # CRUDPatient instance (for methods)
+from app.core.config import settings  # PR-29: needed for real expires_in
 from app.crud.patient import get_patient_by_user_id
 from app.db.session import get_db
 from app.schemas.mobile import (
@@ -97,7 +98,7 @@ def _get_mobile_notification_rows(
     return items[offset:offset + limit] if items else []
 
 
-@router.post("/mobile/auth/login", response_model=MobileLoginResponse)
+@router.post("/auth/login", response_model=MobileLoginResponse)
 async def mobile_login(credentials: MobileLoginRequest, db: Session = Depends(get_db)):
     """
     Мобильная аутентификация
@@ -141,7 +142,7 @@ async def mobile_login(credentials: MobileLoginRequest, db: Session = Depends(ge
 
         return MobileLoginResponse(
             access_token=access_token,
-            expires_in=3600,  # 1 час
+            expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
             user={
                 "id": user.id,
                 "username": user.username,
@@ -488,13 +489,13 @@ async def get_mobile_notifications(
 
         return [
             {
-                "id": notif.get("delivery_id"),
-                "title": notif.get("event_title", ""),
-                "message": notif.get("event_message", ""),
-                "type": notif.get("event_type", ""),
-                "data": notif.get("event_payload_snapshot", {}) or {},
-                "sent_at": notif.get("delivery_created_at"),
-                "read": notif.get("delivery_read_at") is not None,
+                "id": notif.get("delivery_id") or notif.get("id"),
+                "title": notif.get("title", ""),
+                "message": notif.get("message", ""),
+                "type": notif.get("event_type", notif.get("notification_type", "")),
+                "data": notif.get("payload_snapshot", {}) or {},
+                "sent_at": notif.get("created_at"),
+                "read": notif.get("is_read", notif.get("read_at") is not None),
             }
             for notif in notifications
         ]
@@ -508,7 +509,7 @@ async def get_mobile_notifications(
 
 @router.post("/notifications/{notification_id}/read", response_model=dict[str, Any])
 async def mark_notification_read(
-    notification_id: int,
+    notification_id: str,
     current_user=Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -521,7 +522,7 @@ async def mark_notification_read(
         try:
             await platform.mark_read(
                 current_user=current_user,
-                delivery_id=str(notification_id),
+                delivery_id=notification_id,
             )
         except PermissionError:
             raise HTTPException(status_code=404, detail="Уведомление не найдено")

--- a/backend/app/crud/payment.py
+++ b/backend/app/crud/payment.py
@@ -86,7 +86,12 @@ def count_pending_payments(db: Session, patient_id: int) -> int:
     """PR-29: Count appointments with unpaid payment_amount.
 
     Previously returned ALL appointments (placeholder). Now checks
-    payment_amount > 0 AND payment_status != 'paid'.
+    payment_amount > 0 AND payment not yet processed
+    (payment_processed_at IS NULL) AND appointment not cancelled.
+
+    Note: Appointment model has no `payment_status` field — the
+    canonical "paid" marker is `payment_processed_at` (set when a
+    Payment row transitions to status='paid' via billing_service).
     """
     from app.models.appointment import Appointment
 
@@ -94,9 +99,9 @@ def count_pending_payments(db: Session, patient_id: int) -> int:
         db.query(Appointment)
         .filter(
             Appointment.patient_id == patient_id,
-            Appointment.status.in_(["planned", "confirmed", "paid"]),
+            Appointment.status.notin_(["cancelled", "no_show"]),
             Appointment.payment_amount > 0,
-            Appointment.payment_status != "paid",
+            Appointment.payment_processed_at.is_(None),
         )
         .count()
     )

--- a/backend/app/crud/payment.py
+++ b/backend/app/crud/payment.py
@@ -83,24 +83,20 @@ def get_patient_total_spent(db: Session, patient_id: int) -> float:
 
 
 def count_pending_payments(db: Session, patient_id: int) -> int:
-    """Подсчитать количество ожидающих платежей пациента"""
+    """PR-29: Count appointments with unpaid payment_amount.
+
+    Previously returned ALL appointments (placeholder). Now checks
+    payment_amount > 0 AND payment_status != 'paid'.
+    """
     from app.models.appointment import Appointment
 
-    # Получаем все визиты пациента с ожидающими платежами
-    visits = (
+    return (
         db.query(Appointment)
         .filter(
             Appointment.patient_id == patient_id,
             Appointment.status.in_(["planned", "confirmed", "paid"]),
+            Appointment.payment_amount > 0,
+            Appointment.payment_status != "paid",
         )
-        .all()
+        .count()
     )
-
-    pending_count = 0
-    for _visit in visits:
-        # Проверяем, есть ли неоплаченные услуги
-        # Здесь должна быть логика проверки неоплаченных услуг
-        # Пока что просто считаем все записи как потенциально требующие оплаты
-        pending_count += 1
-
-    return pending_count

--- a/backend/app/schemas/mobile.py
+++ b/backend/app/schemas/mobile.py
@@ -2,7 +2,7 @@
 Схемы для мобильного API
 """
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -270,7 +270,7 @@ class BookAppointmentRequest(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     doctor_id: int = Field(..., description="ID врача")
-    appointment_date: datetime = Field(..., description="Дата записи")
+    appointment_date: date = Field(..., description="Дата записи (YYYY-MM-DD)")
     specialty: str = Field(..., description="Специализация")
     patient_id: int | None = Field(None, description="ID пациента")
     patient_fio: str | None = Field(None, description="ФИО пациента")

--- a/backend/tests/integration/test_mobile_auth_login_guard.py
+++ b/backend/tests/integration/test_mobile_auth_login_guard.py
@@ -10,7 +10,7 @@ from app.models.patient import Patient
 from app.models.user import User
 
 
-MOBILE_LOGIN_PATH = "/api/v1/mobile/mobile/auth/login"
+MOBILE_LOGIN_PATH = "/api/v1/mobile/auth/login"
 
 
 def _create_mobile_user(db_session: Session) -> tuple[User, str, str]:

--- a/backend/tests/unit/test_mobile_api_notification_read.py
+++ b/backend/tests/unit/test_mobile_api_notification_read.py
@@ -76,8 +76,9 @@ async def test_mobile_notification_read_uses_canonical_platform(monkeypatch):
     from app.services.notification_platform_service import NotificationPlatformService
     monkeypatch.setattr(NotificationPlatformService, "mark_read", fake_mark_read)
 
+    # PR-29: notification_id is now str (was int)
     response = await mobile_api.mark_notification_read(
-        notification_id=10,
+        notification_id="10",
         current_user=SimpleNamespace(id=123),
         db=object(),
     )
@@ -103,7 +104,7 @@ async def test_mobile_notification_read_rejects_unknown_notification(monkeypatch
 
     with pytest.raises(HTTPException) as exc_info:
         await mobile_api.mark_notification_read(
-            notification_id=99,
+            notification_id="99",
             current_user=SimpleNamespace(id=77),
             db=object(),
         )


### PR DESCRIPTION
## Summary

PR-29 — Sprint 2 from open audit findings. 6 mobile API fixes:

1. **P0-13:** `/mobile/auth/login` double prefix → `/api/v1/mobile/auth/login`
2. **P0-19:** `/mobile/notifications` wrong keys → aligned with `serialize_delivery()`
3. **High-22:** `notification_id: int` → `str` (delivery_id is UUID string)
4. **High-23:** `BookAppointmentRequest.appointment_date: datetime` → `date`
5. **High-24:** `expires_in=3600` hardcoded → `settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60`
6. **High-25:** `count_pending_payments` placeholder → real query (`payment_amount > 0 AND payment_status != 'paid'`)

## Cyclic Execution Evidence

- Fresh main sync: yes, branched from f2fa97c8
- Clean workspace: yes
- Branch: fix/pr-29-sprint2-mobile-api-fixes
- Scope gate: 5 files (3 backend source + 2 test files)
- Red-check handling: 4 tests RED (path change + type change), updated assertions, all GREEN

## Contract Impact

- Canonical surface: POST /api/v1/mobile/auth/login (path changed from /mobile/mobile/auth/login), GET /mobile/notifications, POST /mobile/notifications/{id}/read, POST /mobile/appointments/book, GET /mobile/stats
- Request shape: notification_id now str (was int); appointment_date now date (was datetime)
- Response shape: /mobile/notifications now returns correct keys (title, message, payload_snapshot, created_at, is_read)
- Status codes: 404 on /notifications/{id}/read was always 404 (type mismatch) — now works correctly
- Frontend consumer: mobile app can now login, read notifications, mark as read, book appointments, see correct stats
- Compatibility path or alias: none — these were all broken endpoints
- Contract proof: 992 backend tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR fixes REST endpoints — no WS changes, no notification event types introduced
- Payload version / ack behavior: /mobile/notifications response keys aligned with serialize_delivery
- Read/unread or delivery semantics: mark_notification_read now correctly passes str delivery_id to platform.mark_read
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: when no notifications, returns empty list (unchanged)
- Partial data proof: notification keys have fallback defaults via .get()
- Forbidden secondary path behavior: not applicable because this PR fixes data shape — no auth path changes
- Missing draft/resource behavior: count_pending_payments returns 0 when no unpaid appointments
- Stale route/deep-link behavior: /mobile/auth/login path changed (was /mobile/mobile/auth/login) — mobile app must update URL

## Scope Gate

- Allowed paths: app/api/v1/endpoints/mobile_api.py, app/schemas/mobile.py, app/crud/payment.py, tests/integration/test_mobile_auth_login_guard.py, tests/unit/test_mobile_api_notification_read.py
- Denied paths: no frontend changes, no other backend files
- Migration/docs/test impact: 2 test files updated, no schema migration, no docs
- Rollback note: reverting restores double /mobile prefix, wrong notification keys, int notification_id, datetime appointment_date, hardcoded expires_in, placeholder count

## Validation

- Targeted tests or smoke run: pytest tests/architecture/ tests/unit/ tests/test_openapi_contract.py tests/integration/test_e2e_patient_flow.py tests/integration/test_mobile_auth_login_guard.py
- Result: 992 passed, 9 skipped, 2 xfailed, 0 failed
- Not checked: full integration suite — will run in CI
