### PR TITLE
fix(security): PR-30 — Sprint 3 quick security hardening (High-10, High-12, CORS, Sentry DSN, CSRF cookie)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -75,9 +75,12 @@ LICENSE_ALLOW_HEALTH=1
 # REDIS_URL=redis://redis:6379/0
 
 # --- Sentry (backend error monitoring) ---
-# DSN is a public send-only key — safe to commit. sentry-sdk is in backend/requirements-monitoring.txt.
-# Leave commented for local dev to disable Sentry.
-SENTRY_DSN="https://65b5195082de2f0522c27dd6695536b7@o4511673323749376.ingest.us.sentry.io/4511673347670016"
+# sentry-sdk is in backend/requirements-monitoring.txt.
+# PR-30: SENTRY_DSN must NOT be checked in with an active value — otherwise
+# every dev clone auto-reports errors to a shared Sentry project. Uncomment
+# and set your own project's DSN in your local .env (or CI/CD secret store).
+# SENTRY_DSN="https://<your-org-key>@<your-sentry-host>/<project-id>"
+SENTRY_DSN=""
 SENTRY_ENV="development"                # set to 'staging' / 'production' in deployment
 SENTRY_TRACES_SAMPLE_RATE=0.05          # 5% perf traces — errors always captured
 APP_VERSION="0.9.0"                     # used as Sentry release tag

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -138,12 +138,18 @@ async def get_csrf_token(request: Request, response: Response) -> CSRFTokenRespo
     Даже если CSRF middleware отключен, endpoint нужен frontend-клиенту,
     чтобы не шуметь 404 в консоли при state-changing запросах.
     """
+    # PR-30: secure flag must follow production status. Previously secure=False
+    # always — cookie was sent over plain HTTP, allowing MITM interception.
+    import os
+
+    is_prod = os.getenv("ENV", "dev").lower() in ("prod", "production")
+
     token = request.cookies.get("csrf_token") or secrets.token_urlsafe(32)
     response.set_cookie(
         key="csrf_token",
         value=token,
         httponly=False,
-        secure=False,
+        secure=is_prod,
         samesite="lax",
         path="/",
         max_age=60 * 60 * 8,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -113,9 +113,10 @@ if IS_PROD and (CORS_DISABLE or CORS_ALLOW_ALL):
         "Set BACKEND_CORS_ORIGINS to a strict whitelist."
     )
 
-# Disallow DEV auth fallback knob in production
-if IS_PROD and os.getenv("ENABLE_DEV_AUTH", "false").lower() == "true":
-    raise ValueError("ENABLE_DEV_AUTH must be false in production.")
+# PR-30 / High-10: The previous DEV auth fallback has been removed entirely.
+# Previously: a non-prod env could register dummy /auth/login and /auth/me
+# endpoints returning dev tokens. Now: auth imports must succeed in every
+# environment; failures raise RuntimeError unconditionally (handled below).
 
 
 # -----------------------------------------------------------------------------
@@ -298,21 +299,26 @@ log.info("Idempotency middleware registered")
 # -----------------------------------------------------------------------------
 # CSRF Protection Middleware (optional, enable via CSRF_ENABLED=1)
 # -----------------------------------------------------------------------------
-CSRF_ENABLED = os.getenv("CSRF_ENABLED", "0") == "1"
+# PR-30 / High-12: CSRF protection defaults to ON in production.
+# Set CSRF_ENABLED=0 to explicitly disable (e.g., for local dev).
+CSRF_ENABLED = os.getenv("CSRF_ENABLED", "1" if IS_PROD else "0") == "1"
 if CSRF_ENABLED:
     from app.middleware.csrf_middleware import CSRFMiddleware  # noqa: E402
     app.add_middleware(CSRFMiddleware, enabled=True)
-    log.info("CSRF protection middleware registered")
+    log.info("CSRF protection middleware registered (CSRF_ENABLED=%s, IS_PROD=%s)", CSRF_ENABLED, IS_PROD)
 else:
-    log.info("CSRF protection disabled (set CSRF_ENABLED=1 to enable)")
+    log.info("CSRF protection disabled (CSRF_ENABLED=0)")
 
 # -----------------------------------------------------------------------------
 # CORS
 # -----------------------------------------------------------------------------
 if not CORS_DISABLE:
+    # PR-30: restrict allow_methods to the explicit set the API actually uses.
+    # Wildcard ["*"] would also permit CONNECT/TRACE/PATCH verbs the API never
+    # handles, expanding the attack surface for CORS preflight forgery.
     cfg = {
         "allow_credentials": True,
-        "allow_methods": ["*"],
+        "allow_methods": ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
         "allow_headers": ["*"],
     }
     if CORS_ALLOW_ALL:
@@ -325,19 +331,20 @@ else:
     log.warning("[FIX:CORS] CORS middleware is disabled via CORS_DISABLE=1")
 
 # -----------------------------------------------------------------------------
-# Попытка импортировать реальную аутентификацию.
-# Если не получилось — включим dev-fallback ниже.
+# PR-30 / High-10: Real auth imports are mandatory in every environment.
+# Previously: a non-prod env could register dummy /auth/login and /auth/me
+# endpoints returning dev tokens. That fallback is now removed — if auth
+# imports fail, the app refuses to start.
 # -----------------------------------------------------------------------------
-_USE_DEV_AUTH_FALLBACK = False
 try:
     from app.api.deps import (  # type: ignore  # noqa: E402
         create_access_token,
     )
 except Exception as e:  # pragma: no cover
-    if IS_PROD:
-        raise RuntimeError("Authentication dependencies unavailable in production") from e
-    log.error("dev-fallback: cannot import deps auth (%s) -> will use dummy token", e)
-    _USE_DEV_AUTH_FALLBACK = True
+    raise RuntimeError(
+        "Authentication dependencies unavailable — fix the import error. "
+        "DEV auth fallback has been removed (PR-30 / High-10)."
+    ) from e
 
 # -----------------------------------------------------------------------------
 # Основные API-роутеры проекта
@@ -351,32 +358,6 @@ log.info("Included api.v1.api router at %s", API_V1_STR)
 # GraphQL API
 app.include_router(graphql_router, prefix="/api")
 log.info("Included GraphQL router at /api/graphql")
-
-# -----------------------------------------------------------------------------
-# DEV fallback для аутентификации — регистрируем ТОЛЬКО если импорты auth упали
-# -----------------------------------------------------------------------------
-if _USE_DEV_AUTH_FALLBACK:
-    enable_dev = os.getenv("ENABLE_DEV_AUTH", "false").lower() == "true"
-
-    if IS_PROD or not enable_dev:
-        log.warning("DEV auth fallback DISABLED (ENV=%s, ENABLE_DEV_AUTH=%s)", ENV, enable_dev)
-    else:
-        log.warning("Using DEV auth fallback endpoints at %s/auth", API_V1_STR)
-
-        def create_access_token(sub: str) -> str:  # type: ignore[no-redef]
-            # простой dev-токен
-            return f"dev.{sub}"
-
-        @app.post(f"{API_V1_STR}/auth/login", tags=["auth"], summary="DEV fallback login")
-        async def _fallback_login(form: OAuth2PasswordRequestForm = Depends()):
-            log.info("Using DEV fallback login for user: %s", form.username)
-            token = create_access_token(form.username)
-            return {"access_token": token, "token_type": "bearer"}
-
-        @app.get(f"{API_V1_STR}/auth/me", tags=["auth"], summary="DEV fallback me")
-        async def _fallback_me():
-            return {"username": "dev", "role": "Admin", "is_active": True}
-
 
 # -----------------------------------------------------------------------------
 # Health

--- a/backend/staging.env.sample
+++ b/backend/staging.env.sample
@@ -24,7 +24,8 @@ REQUIRE_LICENSE=0
 LICENSE_ALLOW_HEALTH=1
 AUTO_BACKUP_ENABLED=0
 EMR_LEGACY_WRITE_FREEZE=1
-ENABLE_DEV_AUTH=false
+# PR-30: ENABLE_DEV_AUTH has been removed. Auth imports must succeed in every
+# environment; the previous dev fallback is gone.
 
 BACKEND_HOST=0.0.0.0
 BACKEND_PORT=18000

--- a/backend/tests/integration/test_pr30_security_hardening.py
+++ b/backend/tests/integration/test_pr30_security_hardening.py
@@ -1,0 +1,176 @@
+"""
+PR-30 — Sprint 3 quick security hardening.
+
+Tests for:
+1. CORS allow_methods is an explicit list (not ["*"])
+2. CSRF auto-enabled in production (CSRF_ENABLED defaults to True when IS_PROD)
+3. CSRF cookie secure flag matches IS_PROD
+4. SENTRY_DSN removed from .env.example files (default empty)
+5. ENABLE_DEV_AUTH fallback code removed from main.py
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_DIR = REPO_ROOT / "backend"
+MAIN_PY = BACKEND_DIR / "app" / "main.py"
+AUTH_PY = BACKEND_DIR / "app" / "api" / "v1" / "endpoints" / "auth.py"
+BACKEND_ENV_EXAMPLE = BACKEND_DIR / ".env.example"
+FRONTEND_ENV_EXAMPLE = REPO_ROOT / "frontend" / ".env.example"
+
+
+# ---------- 1. CORS allow_methods ----------
+
+def test_cors_allow_methods_is_explicit_list_not_wildcard():
+    """CORS middleware must NOT use allow_methods=['*'].
+
+    Wildcard methods allow dangerous verbs like CONNECT/TRACE/PATCH
+    that the API never uses. Restrict to the actual method set.
+    """
+    src = MAIN_PY.read_text(encoding="utf-8")
+    # The wildcard pattern under allow_methods must be gone.
+    assert '"allow_methods": ["*"]' not in src, (
+        "CORS allow_methods still uses wildcard ['*'] — must use explicit list"
+    )
+    # Verify an explicit list is present.
+    assert re.search(
+        r'"allow_methods":\s*\[\s*"GET"[^]]*"OPTIONS"\s*\]',
+        src,
+    ), "Expected explicit allow_methods list including GET..OPTIONS not found"
+
+
+# ---------- 2. CSRF auto-enable in production ----------
+
+def test_csrf_auto_enabled_in_production():
+    """CSRF_ENABLED must default to ON when IS_PROD is True.
+
+    Currently CSRF_ENABLED defaults to '0' (off). In production this
+    is a security hole — form-based admin endpoints are unprotected.
+    Fix: when IS_PROD and CSRF_ENABLED env var is unset, default to True.
+    """
+    src = MAIN_PY.read_text(encoding="utf-8")
+    # Look for the pattern: CSRF_ENABLED should consult IS_PROD.
+    # Acceptable forms:
+    #   CSRF_ENABLED = os.getenv("CSRF_ENABLED", "1" if IS_PROD else "0") == "1"
+    #   CSRF_ENABLED = (os.getenv("CSRF_ENABLED", "1" if IS_PROD else "0") == "1")
+    assert "IS_PROD" in src, "IS_PROD not found in main.py"
+    pattern = re.compile(
+        r'CSRF_ENABLED\s*=\s*.*os\.getenv\(\s*["\']CSRF_ENABLED["\']\s*,\s*["\']1["\']\s+if\s+IS_PROD',
+        re.DOTALL,
+    )
+    assert pattern.search(src), (
+        "CSRF_ENABLED must default to '1' when IS_PROD is True — "
+        "pattern not found in main.py"
+    )
+
+
+# ---------- 3. CSRF cookie secure flag ----------
+
+def test_csrf_cookie_secure_follows_is_prod():
+    """The /auth/csrf-token cookie must set secure=True in production.
+
+    Currently secure=False always — cookie sent over plain HTTP,
+    allowing MITM interception. Fix: secure=IS_PROD (or equivalent).
+    """
+    src = AUTH_PY.read_text(encoding="utf-8")
+    # Look for set_cookie call with secure= parameter
+    # The fix should reference IS_PROD or ENV == 'production'
+    # Pattern: set_cookie(..., secure=<something with IS_PROD or production>)
+    assert re.search(
+        r"set_cookie\([^)]*secure\s*=\s*(?:IS_PROD|is_prod|ENV\s*==\s*[\"']production[\"'])",
+        src,
+        re.DOTALL,
+    ), (
+        "CSRF cookie set_cookie must use secure=IS_PROD (or is_prod) or ENV=='production' — not found"
+    )
+
+
+# ---------- 4. SENTRY_DSN removed from .env.example ----------
+
+def test_backend_env_example_sentry_dsn_is_empty_or_commented():
+    """backend/.env.example must NOT ship an active SENTRY_DSN.
+
+    Currently has a hardcoded DSN that sends errors to a shared Sentry
+    project when anyone copies .env.example → .env. Fix: comment out
+    or set to empty string so dev clones don't auto-report.
+    """
+    text = BACKEND_ENV_EXAMPLE.read_text(encoding="utf-8")
+    # Find any line that sets SENTRY_DSN to a non-empty URL
+    for line in text.splitlines():
+        stripped = line.strip()
+        # Skip commented lines
+        if stripped.startswith("#"):
+            continue
+        # Match: SENTRY_DSN="https://..." or SENTRY_DSN=https://...
+        m = re.match(r'^SENTRY_DSN\s*=\s*["\']?(https?://[^"\']+)', stripped)
+        assert not m, (
+            f"backend/.env.example has active SENTRY_DSN URL — must be commented or empty: {stripped}"
+        )
+
+
+def test_frontend_env_example_sentry_dsn_is_empty_or_commented():
+    """frontend/.env.example must NOT ship an active VITE_SENTRY_DSN."""
+    if not FRONTEND_ENV_EXAMPLE.exists():
+        pytest.skip("frontend/.env.example not found")
+    text = FRONTEND_ENV_EXAMPLE.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        m = re.match(r'^VITE_SENTRY_DSN\s*=\s*["\']?(https?://[^"\']+)', stripped)
+        assert not m, (
+            f"frontend/.env.example has active VITE_SENTRY_DSN URL — must be commented or empty: {stripped}"
+        )
+
+
+# ---------- 5. ENABLE_DEV_AUTH fallback removed ----------
+
+def test_enable_dev_auth_fallback_branch_removed_from_main():
+    """The _USE_DEV_AUTH_FALLBACK branch and ENABLE_DEV_AUTH env var
+    support must be removed from main.py.
+
+    The branch is dead code in production (raises RuntimeError before
+    reaching it) and a security risk in non-prod environments where
+    ENABLE_DEV_AUTH=true could be set accidentally, registering fake
+    /auth/login and /auth/me endpoints that return dev tokens.
+    """
+    src = MAIN_PY.read_text(encoding="utf-8")
+    assert "_USE_DEV_AUTH_FALLBACK" not in src, (
+        "_USE_DEV_AUTH_FALLBACK branch still present in main.py — remove it"
+    )
+    assert "ENABLE_DEV_AUTH" not in src, (
+        "ENABLE_DEV_AUTH env var support still in main.py — remove it"
+    )
+
+
+def test_dev_auth_fallback_raises_runtime_error_on_import_failure(monkeypatch):
+    """If app.api.deps auth imports fail, the app MUST raise RuntimeError
+    unconditionally — regardless of environment.
+
+    Previously the dev fallback would silently register dummy auth
+    endpoints in non-prod. Now: fail loudly everywhere.
+    """
+    # We verify by reading source — the try/except for the auth import
+    # must raise RuntimeError unconditionally, not just in IS_PROD.
+    src = MAIN_PY.read_text(encoding="utf-8")
+    # Find the try/except block around `from app.api.deps import`
+    # The except branch must raise RuntimeError unconditionally.
+    # We accept:
+    #   except Exception as e:
+    #       raise RuntimeError("Authentication dependencies unavailable") from e
+    # without any IS_PROD gate.
+    pattern = re.compile(
+        r'except\s+Exception\s+as\s+\w+\s*:[^\n]*\n'
+        r'\s*raise\s+RuntimeError\s*\(\s*["\']Authentication dependencies unavailable',
+        re.MULTILINE,
+    )
+    assert pattern.search(src), (
+        "Auth import except block must raise RuntimeError unconditionally "
+        "(not gated by IS_PROD) — pattern not found in main.py"
+    )

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,9 +7,11 @@ VITE_APP_NAME="Clinic Queue Manager"
 # при необходимости добавляйте другие переменные вида VITE_*
 
 # --- Sentry (frontend error monitoring) ---
-# DSN is a public send-only key — safe to commit. Set in Vercel env for production.
-# Leave commented for local dev to disable Sentry.
-VITE_SENTRY_DSN="https://57fde20209e223ec5a4a96e3a5a59fa2@o4511673323749376.ingest.us.sentry.io/4511673366282240"
+# PR-30: VITE_SENTRY_DSN must NOT be checked in with an active value — otherwise
+# every dev clone auto-reports errors to a shared Sentry project. Set your own
+# project's DSN in your local .env.local (or Vercel/CI env).
+# VITE_SENTRY_DSN="https://<your-org-key>@<your-sentry-host>/<project-id>"
+VITE_SENTRY_DSN=""
 VITE_SENTRY_ENV="development"            # set to 'production' / 'preview' in Vercel per-env
 VITE_SENTRY_TRACES_SAMPLE_RATE=0.05      # 5% of perf traces — errors always captured
 VITE_APP_VERSION="0.9.0"                 # used as Sentry release tag (match package.json)


### PR DESCRIPTION
## Summary

PR-30 — Sprint 3 quick security hardening. 5 fixes:

1. **High-12**: CSRF auto-enabled in production (`CSRF_ENABLED` defaults to `'1'` when `IS_PROD=True`)
2. **CORS allow_methods**: Replaced `['*']` with explicit `['GET','POST','PUT','PATCH','DELETE','OPTIONS']` — prevents CORS preflight forgery via unused verbs (CONNECT/TRACE)
3. **CSRF cookie secure flag**: `/auth/csrf-token` cookie now uses `secure=is_prod` (was hardcoded `secure=False`) — prevents MITM cookie interception over plain HTTP in production
4. **Sentry DSN removed from .env.example files**: backend + frontend `.env.example` now ship with `SENTRY_DSN=""` — dev clones no longer auto-report to a shared Sentry project
5. **High-10**: `ENABLE_DEV_AUTH` fallback branch removed entirely from `main.py`. Dummy `/auth/login` and `/auth/me` endpoints no longer registered. Auth import failures now raise `RuntimeError` unconditionally (any env).

## Cyclic Execution Evidence

- Fresh main sync: yes (branched from `2b98e2dd` PR-29 merge)
- Clean workspace: yes
- Branch: `fix/pr-30-sprint3-quick-security-hardening`
- Scope gate: 6 files (5 source/config + 1 test file)
- Red-check handling: 7 tests RED initially, all GREEN after fixes applied

## Contract Impact

- Canonical surface: GET /api/v1/auth/csrf-token (cookie secure flag changed), CORS preflight response (methods list narrowed), POST /api/v1/auth/login (dev fallback removed — but real auth endpoints unchanged)
- Request shape: unchanged
- Response shape: CORS preflight `Access-Control-Allow-Methods` header now lists explicit verbs instead of `*`
- Status codes: unchanged — all real auth endpoints (login, me, refresh, csrf-token) keep their existing behavior
- Frontend consumer: frontend already sends CSRF token via `X-CSRF-Token` header — no change needed. Mobile app does not use CSRF. Cookie `secure` flag only affects browsers over HTTPS (production) — local dev with HTTP still works (secure=False in dev).
- Compatibility path or alias: none — these are security hardening changes
- Contract proof: 99 regression tests pass (mobile_api + auth + security_middleware + architecture + openapi_contract)

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged — real `/auth/login` endpoint still issues real JWT tokens
- Negative auth proof: previously `ENABLE_DEV_AUTH=true` in non-prod could register dummy `/auth/login` returning `dev.<username>` tokens with Admin role — this attack surface is now removed

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches REST middleware and auth import logic — no WS changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: not applicable because no new data shapes introduced
- Partial data proof: not applicable because no response schema changes
- Forbidden secondary path behavior: the dev fallback `/auth/login` and `/auth/me` endpoints are gone. If any frontend code (or test) was calling these in non-prod, it now gets 404 — but real auth endpoints at the same paths still work via `app.api.deps.create_access_token`. No frontend code referenced the dummy endpoints.
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed by the changed code (CSRF cookie, CORS middleware, Sentry DSN env var, and auth import gate)
- Stale route/deep-link behavior: no route changes — frontend auth flow unaffected

## Scope Gate

- Allowed paths: `backend/app/main.py`, `backend/app/api/v1/endpoints/auth.py`, `backend/.env.example`, `backend/staging.env.sample`, `frontend/.env.example`, `backend/tests/integration/test_pr30_security_hardening.py`
- Denied paths: no other backend/frontend source changes
- Migration/docs/test impact: 1 new test file (7 tests), no schema migration, no docs update needed (CHANGELOG/README do not reference ENABLE_DEV_AUTH)
- Rollback note: reverting restores wildcard CORS, CSRF disabled by default, hardcoded Sentry DSN, and the dev auth fallback branch

## Validation

- Targeted tests or smoke run: `pytest tests/integration/test_pr30_security_hardening.py tests/integration/test_mobile_api_core.py tests/integration/test_mobile_auth_login_guard.py tests/test_openapi_contract.py tests/architecture/ tests/unit/test_confirmation_security.py tests/test_security_middleware.py tests/test_auth_profile_api.py`
- Result: 99 passed, 0 failed
- Not checked: full integration suite — will run in CI
