### PR TITLE
fix(security): PR-31 — Sprint 3 PII masking (High-8) + audit middleware for mutating requests

### DIFF
--- a/backend/app/core/pii_masker.py
+++ b/backend/app/core/pii_masker.py
@@ -102,6 +102,45 @@ def mask_name(name: str | None) -> str | None:
     return ".".join(p[0].upper() for p in parts[:3]) + "."
 
 
+def mask_identifier(value: str | None) -> str | None:
+    """Auto-detect phone/email/username format and apply appropriate masking.
+
+    Used for auth_svc logs where the same `username` field can be:
+    - A phone number (mobile login): "+998901234567" → "+998901•••567"
+    - An email (web admin login): "john.doe@example.com" → "j•••@example.com"
+    - A plain username: "admin" → "a•••n"
+
+    Plain usernames are partially masked (first char + dots + last char)
+    so that debug logs remain useful without exposing the full identifier.
+    Single-character values are returned unchanged (too short to mask).
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return value
+    s = value.strip()
+    if not s:
+        return value
+
+    # Phone: starts with + and digits (use existing PHONE_REGEX)
+    if s.startswith("+") and any(c.isdigit() for c in s):
+        return mask_phone(s)
+
+    # Email: contains @
+    if "@" in s:
+        return mask_email(s)
+
+    # Plain username: partial mask preserving first + last char
+    if len(s) == 1:
+        return s
+    if len(s) == 2:
+        return s[0] + "•"
+    if len(s) == 3:
+        return s[0] + "•" + s[-1]
+    # 4+ chars: first + ••• + last
+    return s[0] + "•••" + s[-1]
+
+
 def mask_birth_date(d: Any) -> str | None:
     """date(1985, 6, 15) → '1985-••-••'"""
     if d is None:

--- a/backend/app/middleware/audit_middleware.py
+++ b/backend/app/middleware/audit_middleware.py
@@ -1,5 +1,10 @@
 """
 Middleware для автоматического аудит-логирования критичных операций.
+
+PR-31: AuditMiddleware now logs mutating requests (POST/PUT/PATCH/DELETE)
+with PII masking applied to the query string. This provides a basic audit
+trail for HIPAA compliance without leaking patient phone numbers, emails,
+or other PII that may appear in query parameters.
 """
 import logging
 from collections.abc import Callable
@@ -9,10 +14,16 @@ from uuid import uuid4
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from app.core.pii_masker import mask_pii  # PR-31: PII scrubber for query strings
+
 logger = logging.getLogger(__name__)
 
 # ContextVar для хранения Request в текущем контексте (для использования в dependencies)
 _request_context: ContextVar[Request] = ContextVar("request_context", default=None)
+
+
+# PR-31: HTTP methods that mutate server state and must be audit-logged.
+MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
 
 def get_current_request() -> Request | None:
@@ -22,8 +33,19 @@ def get_current_request() -> Request | None:
 
 class AuditMiddleware(BaseHTTPMiddleware):
     """
-    Middleware для установки request_id в каждом запросе.
-    Это позволяет трассировать все операции в рамках одного запроса.
+    Middleware для установки request_id в каждом запросе и аудит-логирования
+    mutating-запросов (POST/PUT/PATCH/DELETE).
+
+    Аудит-лог содержит:
+    - HTTP method + path
+    - PII-маскированную query string (телефоны/emails скрываются)
+    - request_id для трассировки
+    - user_id если доступен (после авторизации)
+
+    Не логирует:
+    - Тело запроса (может содержать пароли, медицинские данные)
+    - GET-запросы (не изменяют состояние)
+    - WebSocket-соединения
     """
 
     async def dispatch(  # type: ignore[override]
@@ -37,6 +59,13 @@ class AuditMiddleware(BaseHTTPMiddleware):
         token = _request_context.set(request)
 
         try:
+            # PR-31: Audit-log mutating requests BEFORE processing.
+            # We log here (not after) so that even if the handler crashes,
+            # the audit trail captures the attempt.
+            method = request.method.upper()
+            if method in MUTATING_METHODS:
+                self._audit_log_request(request, request_id, method)
+
             # Добавляем request_id в заголовки ответа для отладки
             response = await call_next(request)
             response.headers["X-Request-ID"] = request_id
@@ -46,3 +75,44 @@ class AuditMiddleware(BaseHTTPMiddleware):
             # Восстанавливаем предыдущее значение contextvar
             _request_context.reset(token)
 
+    @staticmethod
+    def _audit_log_request(request: Request, request_id: str, method: str) -> None:
+        """Log a mutating request with PII masking applied to query string."""
+        path = request.url.path
+        # Mask PII in query string — phones/emails are common in ?param=...
+        # (e.g., /mobile/patients/lookup?phone=+998901234567)
+        query_string = ""
+        if request.url.query:
+            # Parse query params into a dict and mask recursively.
+            # This catches both `phone=...` and `email=...` style params.
+            try:
+                from urllib.parse import parse_qs
+                params = {k: v if len(v) > 1 else v[0]
+                          for k, v in parse_qs(request.url.query).items()}
+                masked = mask_pii(params)
+                # Re-serialize as k=v pairs for compact log line
+                parts = []
+                for k, v in masked.items():
+                    if isinstance(v, list):
+                        parts.append(f"{k}={','.join(str(x) for x in v)}")
+                    else:
+                        parts.append(f"{k}={v}")
+                query_string = "?" + "&".join(parts) if parts else ""
+            except Exception:
+                # If query parsing fails, log the raw string through mask_pii
+                # (string mode applies regex-based phone/email masking)
+                query_string = "?" + str(mask_pii(request.url.query))
+
+        # Try to extract user_id from the JWT in Authorization header (best-effort).
+        # We do NOT decode the JWT here — just check if the header is present.
+        # Full user identification is the responsibility of downstream audit hooks.
+        user_id = getattr(request.state, "user_id", None) or "anonymous"
+
+        logger.info(
+            "audit.mutating_request method=%s path=%s%s user_id=%s request_id=%s",
+            method,
+            path,
+            query_string,
+            user_id,
+            request_id,
+        )

--- a/backend/app/services/auth_svc/_tokens.py
+++ b/backend/app/services/auth_svc/_tokens.py
@@ -4,6 +4,7 @@ Split from authentication_service.py.
 """
 from __future__ import annotations
 
+from app.core.pii_masker import mask_identifier  # PR-31: mask usernames in logs
 from app.services.auth_svc._base import *  # noqa: F401, F403
 from app.services.auth_svc._base import AuthenticationServiceMixinBase
 
@@ -105,7 +106,7 @@ class TokensMixin(AuthenticationServiceMixinBase):
     ) -> tuple[User | None, str]:
         """Аутентифицирует пользователя"""
         try:
-            logger.debug("authenticate_user called with username=%s", username)
+            logger.debug("authenticate_user called with username=%s", mask_identifier(username))
 
             # Ищем пользователя по username или email
             user = (
@@ -115,7 +116,7 @@ class TokensMixin(AuthenticationServiceMixinBase):
             )
 
             if not user:
-                logger.debug("User not found for username=%s", username)
+                logger.debug("User not found for username=%s", mask_identifier(username))
                 self._log_login_attempt(
                     db, None, username, ip_address, user_agent, False, "user_not_found"
                 )
@@ -124,7 +125,7 @@ class TokensMixin(AuthenticationServiceMixinBase):
             logger.debug(
                 "User found: ID=%d, Username=%s, IsActive=%s",
                 user.id,
-                user.username,
+                mask_identifier(user.username),
                 user.is_active,
             )
 
@@ -197,7 +198,7 @@ class TokensMixin(AuthenticationServiceMixinBase):
         remember_me: bool = False,
     ) -> dict[str, Any]:
         """Выполняет вход пользователя"""
-        logger.debug("login_user called with username=%s", username)
+        logger.debug("login_user called with username=%s", mask_identifier(username))
 
         user, message = self.authenticate_user(
             db, username, password, ip_address, user_agent

--- a/backend/tests/integration/test_pr31_pii_masking.py
+++ b/backend/tests/integration/test_pr31_pii_masking.py
@@ -1,0 +1,149 @@
+"""
+PR-31 — Sprint 3 PII masking (High-8).
+
+Tests for:
+1. New mask_identifier() helper that detects phone/email/username format
+2. auth_svc/_tokens.py no longer logs raw usernames (must use mask_identifier)
+3. AuditMiddleware logs mutating requests with PII masking
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_DIR = REPO_ROOT / "backend"
+PII_MASKER_PY = BACKEND_DIR / "app" / "core" / "pii_masker.py"
+TOKENS_PY = BACKEND_DIR / "app" / "services" / "auth_svc" / "_tokens.py"
+AUDIT_MIDDLEWARE_PY = BACKEND_DIR / "app" / "middleware" / "audit_middleware.py"
+
+
+# ---------- 1. mask_identifier helper ----------
+
+def test_mask_identifier_function_exists():
+    """A new mask_identifier() helper must be exported from pii_masker.py.
+
+    It auto-detects phone (+998901234567), email (foo@bar.com), or username
+    format and applies the appropriate masking. This is needed because
+    auth_svc logs 'username=%s' where the value can be a phone (mobile login)
+    or an email (web admin login) — both are PII.
+    """
+    src = PII_MASKER_PY.read_text(encoding="utf-8")
+    assert re.search(r"^def\s+mask_identifier\s*\(", src, re.MULTILINE), (
+        "mask_identifier() function not found in pii_masker.py"
+    )
+
+
+def test_mask_identifier_masks_phone():
+    """+998901234567 → +998901•••567"""
+    from app.core.pii_masker import mask_identifier
+    assert mask_identifier("+998901234567") == "+998901•••567"
+
+
+def test_mask_identifier_masks_email():
+    """john.doe@example.com → j•••@example.com"""
+    from app.core.pii_masker import mask_identifier
+    assert mask_identifier("john.doe@example.com") == "j•••@example.com"
+
+
+def test_mask_identifier_masks_plain_username_partially():
+    """Plain usernames (not phone, not email) are partially masked.
+
+    'admin' → 'a•••n' (first char + dots + last char, min 4 chars displayed).
+    'a'     → 'a' (single char unchanged — too short to mask).
+    None    → None.
+    """
+    from app.core.pii_masker import mask_identifier
+    assert mask_identifier("admin") == "a•••n"
+    assert mask_identifier("a") == "a"
+    assert mask_identifier(None) is None
+    assert mask_identifier("") == ""
+
+
+def test_mask_identifier_handles_short_usernames():
+    """Short usernames (2-3 chars) get partial masking."""
+    from app.core.pii_masker import mask_identifier
+    # 2 chars: ab → a•
+    assert mask_identifier("ab") == "a•"
+    # 3 chars: abc → a•c
+    assert mask_identifier("abc") == "a•c"
+
+
+# ---------- 2. auth_svc/_tokens.py masks usernames ----------
+
+def test_auth_tokens_does_not_log_raw_username():
+    """auth_svc/_tokens.py must NOT log raw username values.
+
+    Previously:
+        logger.debug("authenticate_user called with username=%s", username)
+        logger.debug("User not found for username=%s", username)
+        logger.debug("User found: ID=%d, Username=%s, IsActive=%s", ...)
+        logger.debug("login_user called with username=%s", username)
+
+    These leak PII because usernames can be phone numbers (mobile login) or
+    emails (web admin login). Fix: wrap username in mask_identifier() or
+    log only the user ID once resolved.
+    """
+    src = TOKENS_PY.read_text(encoding="utf-8")
+    # Find any log statement that interpolates a raw `username` variable
+    # (not wrapped in mask_identifier).
+    # Pattern: logger.<level>("...%s...", username)  — NOT mask_identifier(username)
+    bad_patterns = [
+        r'username=%s",\s*username\b',
+        r'Username=%s",\s*user\.username\b',
+        r'username=%s",\s*user\.username\b',
+        r'Username=%s",\s*username\b',
+    ]
+    for pat in bad_patterns:
+        matches = re.findall(pat, src)
+        assert not matches, (
+            f"_tokens.py still logs raw username (pattern: {pat!r}) — "
+            f"found {len(matches)} match(es). Wrap with mask_identifier()."
+        )
+
+
+def test_auth_tokens_imports_mask_identifier():
+    """_tokens.py must import mask_identifier from pii_masker."""
+    src = TOKENS_PY.read_text(encoding="utf-8")
+    assert "mask_identifier" in src, (
+        "mask_identifier not imported/used in _tokens.py"
+    )
+
+
+# ---------- 3. AuditMiddleware logs mutating requests ----------
+
+def test_audit_middleware_logs_mutating_requests():
+    """AuditMiddleware must log POST/PUT/PATCH/DELETE requests with PII masking.
+
+    Currently it only sets request_id — no actual audit logging.
+    Fix: log method + path + user_id (if available) for mutating requests,
+    with PII masking applied to query string and any logged payload summary.
+    """
+    src = AUDIT_MIDDLEWARE_PY.read_text(encoding="utf-8")
+    # The middleware must have an explicit check for mutating methods.
+    assert re.search(
+        r'(POST|PUT|PATCH|DELETE)',
+        src,
+    ), "AuditMiddleware must check for mutating HTTP methods (POST/PUT/PATCH/DELETE)"
+    # Must log via logger (audit log entry).
+    assert re.search(
+        r'logger\.(info|warning|audit)\s*\([^)]*method',
+        src,
+        re.DOTALL,
+    ), "AuditMiddleware must call logger with method info for mutating requests"
+
+
+def test_audit_middleware_masks_query_string():
+    """Query string in audit log must be PII-masked.
+
+    Phone numbers and emails in ?param=... are PII and must not appear
+    in the audit log in plaintext.
+    """
+    src = AUDIT_MIDDLEWARE_PY.read_text(encoding="utf-8")
+    # Must import or reference mask_pii / mask_identifier
+    assert "mask_pii" in src or "mask_identifier" in src, (
+        "AuditMiddleware must use mask_pii or mask_identifier to scrub query strings"
+    )


### PR DESCRIPTION
## Summary

PR-31 — Sprint 3 PII masking (High-8). 3 fixes:

1. **New `mask_identifier()` helper** in `pii_masker.py`: auto-detects phone / email / username format and applies the appropriate masking. Phone `+998901234567` → `+998901•••567`. Email `foo@bar.com` → `f•••@bar.com`. Plain username `admin` → `a•••n`.

2. **High-8**: `auth_svc/_tokens.py` no longer logs raw usernames. 4 log statements updated to wrap `username` in `mask_identifier()`. Previously `logger.debug("authenticate_user called with username=%s", username)` leaked PII because mobile logins use phone numbers as the username.

3. **AuditMiddleware now logs mutating requests** (POST/PUT/PATCH/DELETE) with PII-masked query string. Logs `method + path + PII-masked query + user_id + request_id`. Catches phone/email in `?param=...` (e.g., `/mobile/patients/lookup?phone=+998901234567`). Does NOT log request body (may contain passwords, medical data).

## Cyclic Execution Evidence

- Fresh main sync: yes (branched from `fc5d3447` PR-30 merge)
- Clean workspace: yes
- Branch: `fix/pr-31-sprint3-pii-masking`
- Scope gate: 4 files (3 backend source + 1 test file)
- Red-check handling: 9 tests RED initially, all GREEN after fixes applied

## Contract Impact

- Canonical surface: unchanged — no API endpoint signature or response shape changes
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: unchanged — logging-only changes are invisible to API clients
- Compatibility path or alias: none — these are internal security hardening changes
- Contract proof: 111 regression tests pass (mobile + auth + security + architecture + openapi_contract)

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged — auth flow untouched
- Negative auth proof: unchanged — only log output is masked, no behavior change

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches log output and audit middleware — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: not applicable because no API response shape changes
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes — auth_svc logs are debug-level and only the masking changed
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed by the changed code (logging utilities + audit middleware)
- Stale route/deep-link behavior: no route changes — frontend unaffected

## Scope Gate

- Allowed paths: `backend/app/core/pii_masker.py`, `backend/app/services/auth_svc/_tokens.py`, `backend/app/middleware/audit_middleware.py`, `backend/tests/integration/test_pr31_pii_masking.py`
- Denied paths: no other backend/frontend source changes
- Migration/docs/test impact: 1 new test file (9 tests), no schema migration, no docs update needed
- Rollback note: reverting restores raw username logging in auth_svc and the request_id-only AuditMiddleware

## Validation

- Targeted tests or smoke run: `pytest tests/integration/test_pr31_pii_masking.py tests/integration/test_mobile_api_core.py tests/integration/test_pr30_security_hardening.py tests/integration/test_mobile_auth_login_guard.py tests/test_openapi_contract.py tests/architecture/ tests/unit/test_confirmation_security.py tests/test_security_middleware.py tests/test_auth_profile_api.py tests/unit/test_authentication_api_service.py`
- Result: 111 passed, 0 failed
- Not checked: full integration suite — will run in CI
