### PR TITLE
fix(security): PR-33 — Sprint 4 token expiry (High-43) + /mobile/auth/refresh endpoint

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,7 +17,10 @@ DATABASE_URL=
 # Required. Generate with: python -c "import secrets; print(secrets.token_urlsafe(48))"
 SECRET_KEY=
 ALGORITHM=HS256
-ACCESS_TOKEN_EXPIRE_MINUTES=10080
+# PR-33 / High-43: access tokens must be short-lived (15-60 min, industry standard).
+# Refresh tokens (30-day expiry) handle long sessions. A stolen access token
+# with 7-day expiry (was 10080) gives an attacker a week of access.
+ACCESS_TOKEN_EXPIRE_MINUTES=30
 
 # Legacy/fallback auth endpoints. Keep disabled outside explicit break-glass or dev use.
 ENABLE_FALLBACK_AUTH=0

--- a/backend/app/api/v1/endpoints/mobile_api.py
+++ b/backend/app/api/v1/endpoints/mobile_api.py
@@ -161,6 +161,45 @@ def mobile_login(credentials: MobileLoginRequest, db: Session = Depends(get_db))
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@router.post("/auth/refresh")
+def mobile_refresh_token(
+    refresh_token: str = Query(..., description="Refresh token issued at login"),
+    db: Session = Depends(get_db),
+):
+    """PR-33: Mobile-friendly refresh endpoint.
+
+    Wraps the same authentication_service.refresh_access_token logic as
+    /authentication/refresh, but lives under /mobile/ for a consistent
+    mobile API surface. Returns BOTH access_token and refresh_token
+    because the service implements refresh-token rotation (RFC 6749 §10.4):
+    each refresh issues a NEW refresh token and revokes the old one.
+    """
+    try:
+        from app.services.authentication_service import get_authentication_service
+
+        service = get_authentication_service()
+        result = service.refresh_access_token(db, refresh_token)
+
+        if not result.get("success"):
+            raise HTTPException(
+                status_code=401,
+                detail=result.get("message", "Invalid refresh token"),
+            )
+
+        return {
+            "access_token": result["access_token"],
+            "refresh_token": result.get("refresh_token") or refresh_token,
+            "token_type": result.get("token_type", "bearer"),
+            "expires_in": result.get("expires_in", settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60),
+        }
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log_endpoint_error("app/api/v1/endpoints/mobile_api.py", exc)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
 @router.get("/patients/me", response_model=PatientProfileOut)
 def get_mobile_patient_profile(
     current_user=Depends(get_current_user), db: Session = Depends(get_db)

--- a/backend/tests/integration/test_pr33_token_expiry_and_refresh.py
+++ b/backend/tests/integration/test_pr33_token_expiry_and_refresh.py
@@ -1,0 +1,82 @@
+"""
+PR-33 — Sprint 4 quick wins: token expiry + mobile auth refresh.
+
+Tests for:
+1. High-43: ACCESS_TOKEN_EXPIRE_MINUTES reduced from 10080 (7 days) to <=60 in .env.example
+2. New /mobile/auth/refresh endpoint exists for cleaner mobile API surface
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_DIR = REPO_ROOT / "backend"
+ENV_EXAMPLE = BACKEND_DIR / ".env.example"
+MOBILE_API_PY = BACKEND_DIR / "app" / "api" / "v1" / "endpoints" / "mobile_api.py"
+
+
+# ---------- 1. High-43: Reduce ACCESS_TOKEN_EXPIRE_MINUTES ----------
+
+def test_env_example_access_token_expiry_is_short():
+    """High-43: ACCESS_TOKEN_EXPIRE_MINUTES in .env.example must be <= 60.
+
+    Previously: 10080 (7 days) — way too long for an access token.
+    Industry standard: 15-60 minutes. Refresh tokens handle long sessions.
+
+    A stolen access token with 7-day expiry gives an attacker a week of
+    access. With 30-minute expiry, the window is 30 minutes max.
+    """
+    text = ENV_EXAMPLE.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        m = re.match(r"^ACCESS_TOKEN_EXPIRE_MINUTES\s*=\s*(\d+)", stripped)
+        if m:
+            value = int(m.group(1))
+            assert value <= 60, (
+                f"ACCESS_TOKEN_EXPIRE_MINUTES={value} in .env.example is too long "
+                f"(should be <= 60 minutes, was {value}). High-43."
+            )
+            return
+    pytest.fail("ACCESS_TOKEN_EXPIRE_MINUTES not found in .env.example")
+
+
+# ---------- 2. /mobile/auth/refresh endpoint ----------
+
+def test_mobile_auth_refresh_endpoint_exists():
+    """A /mobile/auth/refresh endpoint must exist for the mobile API.
+
+    Mobile clients need a clean refresh endpoint under /mobile/ that
+    wraps the same refresh_access_token logic as /authentication/refresh.
+    This gives the mobile app a consistent API surface.
+    """
+    src = MOBILE_API_PY.read_text(encoding="utf-8")
+    # Look for a /auth/refresh route (the /mobile prefix is added by the router)
+    assert re.search(
+        r'@router\.(post|get)\(\s*["\']/?auth/refresh["\']',
+        src,
+    ), "Expected @router.post('/auth/refresh') endpoint not found in mobile_api.py"
+
+
+def test_mobile_auth_refresh_returns_access_and_refresh_tokens():
+    """The /mobile/auth/refresh endpoint must return both access_token and refresh_token.
+
+    This is required for refresh-token rotation (RFC 6749 §10.4): each refresh
+    issues a NEW refresh token and revokes the old one.
+    """
+    src = MOBILE_API_PY.read_text(encoding="utf-8")
+    # Find the refresh endpoint function body and check it returns both tokens
+    m = re.search(
+        r'@router\.(post|get)\(\s*["\']/?auth/refresh["\'][^@]*?def\s+\w+\([^)]*\)[^:]*:(.*?)(?=\n@|\Z)',
+        src,
+        re.DOTALL,
+    )
+    assert m, "Could not extract /auth/refresh endpoint body"
+    body = m.group(2)
+    assert "access_token" in body, "Refresh endpoint must return access_token"
+    assert "refresh_token" in body, "Refresh endpoint must return refresh_token (rotation)"


### PR DESCRIPTION
## Summary

PR-33 — Sprint 4 quick wins: token expiry + mobile auth refresh. 2 fixes:

1. **High-43**: `ACCESS_TOKEN_EXPIRE_MINUTES` reduced from `10080` (7 days) to `30` in `backend/.env.example`. Industry standard is 15-60 minutes for access tokens. Refresh tokens (30-day expiry) handle long sessions. A stolen access token with 7-day expiry gave an attacker a week of access; with 30-minute expiry, the window is 30 minutes max.

2. **New `/mobile/auth/refresh` endpoint**: Wraps `authentication_service.refresh_access_token` (same logic as `/authentication/refresh`). Returns BOTH `access_token` and `refresh_token` because the service implements refresh-token rotation (RFC 6749 §10.4): each refresh issues a NEW refresh token and revokes the old one. Cleaner mobile API surface — mobile clients no longer need to call `/authentication/refresh`.

## Cyclic Execution Evidence

- Fresh main sync: yes (branched from `b3d1611d` PR-32 merge)
- Clean workspace: yes
- Branch: `fix/pr-33-sprint4-token-expiry-and-mobile-refresh`
- Scope gate: 3 files (2 backend source/config + 1 test file)
- Red-check handling: 3 tests RED initially, all GREEN after fixes applied

## Contract Impact

- Canonical surface: NEW endpoint POST /api/v1/mobile/auth/refresh; .env.example config change (ACCESS_TOKEN_EXPIRE_MINUTES)
- Request shape: /mobile/auth/refresh takes `refresh_token` as query param
- Response shape: /mobile/auth/refresh returns `{access_token, refresh_token, token_type, expires_in}`
- Status codes: 200 on success, 401 on invalid/expired refresh token, 500 on internal error
- Frontend consumer: existing /authentication/refresh still works — this is an additional endpoint, not a replacement. Mobile clients can switch to /mobile/auth/refresh for consistent API surface.
- Compatibility path or alias: /authentication/refresh remains as the canonical endpoint
- Contract proof: 111 regression tests pass (mobile + auth + security + architecture + openapi_contract)

## RBAC / Permissions

- Roles allowed: any authenticated user with a valid refresh token — same as /authentication/refresh
- Roles denied: none — refresh tokens are role-agnostic
- Positive auth proof: refresh token must be valid, not expired, not revoked, not blacklisted
- Negative auth proof: revoked/blacklisted/reused refresh tokens are rejected (and trigger session-family revocation per RFC 6749 §10.4)

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only adds a REST endpoint and changes a config default — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: when refresh_token is missing, returns 422 (FastAPI Query validation)
- Partial data proof: not applicable because response is a flat dict
- Forbidden secondary path behavior: if refresh_token is revoked, service returns success=false → endpoint returns 401 (not 200 with error body)
- Missing draft/resource behavior: not applicable because no draft or resource lookup — just refresh token validation
- Stale route/deep-link behavior: new endpoint, no stale routes

## Scope Gate

- Allowed paths: `backend/.env.example`, `backend/app/api/v1/endpoints/mobile_api.py`, `backend/tests/integration/test_pr33_token_expiry_and_refresh.py`
- Denied paths: no other backend/frontend source changes
- Migration/docs/test impact: 1 new test file (3 tests), no schema migration, no docs update needed
- Rollback note: reverting restores 7-day access token expiry and removes /mobile/auth/refresh

## Validation

- Targeted tests or smoke run: `pytest tests/integration/test_pr33_token_expiry_and_refresh.py tests/integration/test_pr32_perf_n_plus_1.py tests/integration/test_mobile_api_core.py tests/integration/test_pr31_pii_masking.py tests/integration/test_pr30_security_hardening.py tests/integration/test_mobile_auth_login_guard.py tests/test_openapi_contract.py tests/architecture/ tests/unit/test_confirmation_security.py tests/test_security_middleware.py`
- Result: 111 passed, 0 failed
- Not checked: full integration suite — will run in CI
