### PR TITLE
fix(security): PR-34 — Sprint 4 P0 Redis rate limit + X-Forwarded-For whitelist

### DIFF
--- a/backend/app/core/rate_limiter.py
+++ b/backend/app/core/rate_limiter.py
@@ -1,11 +1,25 @@
 """
 Rate limiting infrastructure using slowapi.
 
-Provides per-IP and per-user rate limiting for sensitive endpoints.
+PR-34 (Sprint 4 P0): Redis-backed rate limiting + X-Forwarded-For whitelist.
+
+Changes:
+1. Custom get_client_ip key function that respects X-Forwarded-For ONLY when
+   the request comes from a trusted proxy (TRUSTED_PROXIES env var, comma-separated).
+   Prevents IP spoofing from arbitrary clients.
+
+2. Redis storage backend when REDIS_URL is configured. Without Redis, slowapi
+   uses in-memory storage — rate limits are per-process. With 4 uvicorn workers,
+   the effective limit is 4x what's configured. Redis makes limits shared.
+
+3. Configurable rate limit thresholds via env vars (CHAT-10.1 P2).
+   Operators can tune limits without code changes.
 """
 from __future__ import annotations
 
+import logging
 import os
+from ipaddress import AddressValueError, ip_address
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
@@ -14,24 +28,139 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
 
+logger = logging.getLogger(__name__)
+
 # Disable rate limiting in test mode to prevent 429 failures
 _TESTING = os.getenv("TESTING", "").lower() in ("1", "true", "yes")
 
-# Create limiter instance (disabled in test mode)
-limiter = Limiter(key_func=get_remote_address, enabled=not _TESTING)
 
-# Rate limit configurations
+# ---------------------------------------------------------------------------
+# PR-34: Trusted proxy whitelist for X-Forwarded-For
+# ---------------------------------------------------------------------------
+
+def _load_trusted_proxies() -> set[str]:
+    """Load trusted proxy IPs from TRUSTED_PROXIES env var.
+
+    Format: comma-separated list of IPs or CIDR ranges.
+    Example: TRUSTED_PROXIES=10.0.0.1,10.0.0.2,172.16.0.0/12
+
+    Default: empty set (no trusted proxies — always use direct peer IP).
+    """
+    raw = os.getenv("TRUSTED_PROXIES", "").strip()
+    if not raw:
+        return set()
+    return {p.strip() for p in raw.split(",") if p.strip()}
+
+
+TRUSTED_PROXIES = _load_trusted_proxies()
+
+
+def _is_trusted_proxy(peer_ip: str) -> bool:
+    """Check if the direct peer IP is in the trusted proxy whitelist.
+
+    Supports both exact IP match and CIDR range match.
+    """
+    if not TRUSTED_PROXIES:
+        return False
+    try:
+        peer = ip_address(peer_ip)
+    except (ValueError, AddressValueError):
+        return False
+
+    for entry in TRUSTED_PROXIES:
+        try:
+            if "/" in entry:
+                # CIDR range
+                import ipaddress
+                network = ipaddress.ip_network(entry, strict=False)
+                if peer in network:
+                    return True
+            else:
+                # Exact IP match
+                if peer == ip_address(entry):
+                    return True
+        except (ValueError, AddressValueError):
+            continue
+    return False
+
+
+def get_client_ip(request: Request) -> str:
+    """Custom key function for slowapi Limiter.
+
+    Returns the real client IP, respecting X-Forwarded-For ONLY when the
+    request comes from a trusted proxy. This prevents IP spoofing via
+    X-Forwarded-For from arbitrary clients.
+
+    Logic:
+    1. Get the direct TCP peer IP (request.client.host).
+    2. If peer is a trusted proxy, parse X-Forwarded-For and return the
+       leftmost (original client) IP.
+    3. Otherwise, return the direct peer IP.
+    """
+    peer_ip = request.client.host if request.client else "0.0.0.0"
+
+    if _is_trusted_proxy(peer_ip):
+        xff = request.headers.get("X-Forwarded-For", "")
+        if xff:
+            # X-Forwarded-For: client, proxy1, proxy2, ...
+            # The leftmost entry is the original client.
+            first = xff.split(",")[0].strip()
+            try:
+                # Validate it's a real IP
+                ip_address(first)
+                return first
+            except (ValueError, AddressValueError):
+                logger.warning("Invalid IP in X-Forwarded-For header: %r", first)
+                return peer_ip
+
+    return peer_ip
+
+
+# ---------------------------------------------------------------------------
+# PR-34: Redis storage backend
+# ---------------------------------------------------------------------------
+
+def _get_storage_uri() -> str | None:
+    """Return Redis storage URI if REDIS_URL is configured, else None (in-memory)."""
+    redis_url = os.getenv("REDIS_URL", "").strip()
+    if not redis_url:
+        return None
+    return redis_url
+
+
+_STORAGE_URI = _get_storage_uri() if not _TESTING else None
+
+
+# PR-34: Use custom get_client_ip instead of slowapi's get_remote_address.
+# Use Redis storage if configured (shared across workers), else in-memory.
+limiter = Limiter(
+    key_func=get_client_ip,
+    enabled=not _TESTING,
+    storage_uri=_STORAGE_URI,
+)
+
+
+# ---------------------------------------------------------------------------
+# PR-34 / CHAT-10.1 P2: Configurable rate limits via env vars
+# ---------------------------------------------------------------------------
+
+def _env_rate_limit(key: str, default: str) -> str:
+    """Read a rate limit from env var RATE_LIMIT_<KEY>, fall back to default."""
+    env_name = f"RATE_LIMIT_{key.upper()}"
+    return os.getenv(env_name, default).strip() or default
+
+
 RATE_LIMITS = {
-    "login": "5/minute",
-    "sms_send": "10/minute",
-    "email_send": "20/minute",
-    "ai_request": "30/minute",
-    "payment_init": "10/minute",
-    "broadcast": "1/5minute",
-    "file_upload": "20/minute",
-    "export": "5/minute",
-    "migration": "1/minute",
-    "default": "60/minute",
+    "login": _env_rate_limit("login", "5/minute"),
+    "sms_send": _env_rate_limit("sms_send", "10/minute"),
+    "email_send": _env_rate_limit("email_send", "20/minute"),
+    "ai_request": _env_rate_limit("ai_request", "30/minute"),
+    "payment_init": _env_rate_limit("payment_init", "10/minute"),
+    "broadcast": _env_rate_limit("broadcast", "1/5minute"),
+    "file_upload": _env_rate_limit("file_upload", "20/minute"),
+    "export": _env_rate_limit("export", "5/minute"),
+    "migration": _env_rate_limit("migration", "1/minute"),
+    "default": _env_rate_limit("default", "60/minute"),
 }
 
 
@@ -40,6 +169,12 @@ def setup_rate_limiting(app: FastAPI) -> None:
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
     app.add_middleware(SlowAPIMiddleware)
+    if _STORAGE_URI:
+        logger.info("Rate limiter using Redis storage: %s", _STORAGE_URI)
+    else:
+        logger.info("Rate limiter using in-memory storage (set REDIS_URL for shared limits)")
+    if TRUSTED_PROXIES:
+        logger.info("Rate limiter trusting X-Forwarded-For from proxies: %s", TRUSTED_PROXIES)
 
 
 async def _rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:

--- a/backend/app/core/rate_limiter.py
+++ b/backend/app/core/rate_limiter.py
@@ -170,11 +170,13 @@ def setup_rate_limiting(app: FastAPI) -> None:
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
     app.add_middleware(SlowAPIMiddleware)
     if _STORAGE_URI:
-        logger.info("Rate limiter using Redis storage: %s", _STORAGE_URI)
+        # PR-34: don't log the full Redis URI — it may contain a password.
+        logger.info("Rate limiter using Redis storage (REDIS_URL configured)")
     else:
         logger.info("Rate limiter using in-memory storage (set REDIS_URL for shared limits)")
     if TRUSTED_PROXIES:
-        logger.info("Rate limiter trusting X-Forwarded-For from proxies: %s", TRUSTED_PROXIES)
+        # PR-34: log only the count, not the actual proxy IPs.
+        logger.info("Rate limiter trusting X-Forwarded-For from %d proxy/ies", len(TRUSTED_PROXIES))
 
 
 async def _rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:

--- a/backend/tests/integration/test_pr34_redis_rate_limit.py
+++ b/backend/tests/integration/test_pr34_redis_rate_limit.py
@@ -1,0 +1,100 @@
+"""
+PR-34 — Sprint 4 P0: Redis-backed rate limiting + X-Forwarded-For whitelist.
+
+Tests for:
+1. Rate limiter uses a custom key function that respects X-Forwarded-For
+   ONLY when the request comes from a trusted proxy (whitelist).
+2. Rate limiter uses Redis storage when REDIS_URL is configured (so rate
+   limits are shared across multiple uvicorn workers).
+3. Rate limit thresholds are configurable via env vars.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_DIR = REPO_ROOT / "backend"
+RATE_LIMITER_PY = BACKEND_DIR / "app" / "core" / "rate_limiter.py"
+
+
+# ---------- 1. X-Forwarded-For whitelist key function ----------
+
+def test_rate_limiter_uses_custom_key_function():
+    """The rate limiter must NOT use slowapi.util.get_remote_address directly.
+
+    Default get_remote_address returns request.client.host (direct TCP peer).
+    Behind a reverse proxy (nginx, Cloudflare, Vercel), all requests appear
+    to come from the proxy's IP, so a single abuser can exhaust the rate
+    limit for ALL users.
+
+    Fix: use a custom key function that:
+    - Returns the direct peer IP by default
+    - If the request comes from a trusted proxy (whitelist), use X-Forwarded-For
+    """
+    src = RATE_LIMITER_PY.read_text(encoding="utf-8")
+    # Must define a custom key function (not just use get_remote_address)
+    assert re.search(r"def\s+get_client_ip\s*\(", src), (
+        "Custom get_client_ip function not found in rate_limiter.py — "
+        "must replace slowapi.util.get_remote_address with a whitelist-aware function"
+    )
+
+
+def test_rate_limiter_has_trusted_proxy_whitelist():
+    """A TRUSTED_PROXIES env var must be consulted for the X-Forwarded-For whitelist.
+
+    Only requests from trusted proxy IPs are allowed to use X-Forwarded-For.
+    This prevents IP spoofing from arbitrary clients.
+    """
+    src = RATE_LIMITER_PY.read_text(encoding="utf-8")
+    assert "TRUSTED_PROXIES" in src, (
+        "TRUSTED_PROXIES env var not referenced in rate_limiter.py — "
+        "must whitelist trusted proxies before trusting X-Forwarded-For"
+    )
+
+
+# ---------- 2. Redis storage backend ----------
+
+def test_rate_limiter_supports_redis_storage():
+    """The rate limiter must use Redis storage when REDIS_URL is configured.
+
+    Without Redis, slowapi uses in-memory storage — rate limits are per-process.
+    With 4 uvicorn workers, the effective limit is 4x what's configured.
+    Redis makes rate limits shared across all workers.
+    """
+    src = RATE_LIMITER_PY.read_text(encoding="utf-8")
+    # Must reference REDIS_URL and pass storage_uri to Limiter
+    assert "REDIS_URL" in src, (
+        "REDIS_URL not referenced in rate_limiter.py — must support Redis backend"
+    )
+    assert "storage_uri" in src, (
+        "storage_uri parameter not passed to Limiter — must configure Redis backend"
+    )
+
+
+# ---------- 3. Configurable rate limits ----------
+
+def test_rate_limits_are_configurable_via_env():
+    """Rate limit thresholds must be configurable via env vars (CHAT-10.1 P2).
+
+    Currently hardcoded in RATE_LIMITS dict. Operators need to tune limits
+    without code changes (e.g., higher login limit for staging, lower for prod).
+    """
+    src = RATE_LIMITER_PY.read_text(encoding="utf-8")
+    # Must reference env var for at least the default rate limit.
+    # Acceptable patterns:
+    #   getenv("RATE_LIMIT_DEFAULT", ...)
+    #   getenv(f"RATE_LIMIT_{key}", ...)
+    #   RATE_LIMIT_DEFAULT env var name in any form
+    assert (
+        re.search(r"RATE_LIMIT.*DEFAULT", src)
+        or re.search(r'getenv\(\s*[\'"]RATE_LIMIT', src)
+        or re.search(r'getenv\(\s*env_name', src)  # f-string pattern: env_name = f"RATE_LIMIT_{key}"
+    ), (
+        "RATE_LIMIT env var not referenced in rate_limiter.py — "
+        "rate limits must be configurable via env (CHAT-10.1 P2)"
+    )


### PR DESCRIPTION
## Summary

PR-34 — Sprint 4 P0: Redis-backed rate limiting + X-Forwarded-For whitelist. 3 fixes:

1. **X-Forwarded-For whitelist (P0)**: Custom `get_client_ip` key function replaces `slowapi.util.get_remote_address`. Returns the direct peer IP by default. Only trusts `X-Forwarded-For` header when the peer IP is in the `TRUSTED_PROXIES` env var whitelist (supports exact IP + CIDR range matching). Prevents IP spoofing from arbitrary clients — a critical security fix for any deployment behind a reverse proxy.

2. **Redis storage backend (P0)**: When `REDIS_URL` is set, slowapi uses Redis for rate limit counters. Without Redis: in-memory storage = per-process limits (4x effective with 4 uvicorn workers). With Redis: shared limits across all workers. Auto-detected from env, no code change needed.

3. **Configurable rate limits via env (CHAT-10.1 P2)**: `RATE_LIMIT_LOGIN`, `RATE_LIMIT_DEFAULT`, etc. env vars. Falls back to hardcoded defaults if env vars unset. Operators can tune limits without code changes.

## Cyclic Execution Evidence

- Fresh main sync: yes (branched from `86773a9d` PR-33 merge)
- Clean workspace: yes
- Branch: `fix/pr-34-sprint4-redis-rate-limit-xforwarded-for`
- Scope gate: 2 files (1 backend source + 1 test file)
- Red-check handling: 4 tests RED initially, all GREEN after fixes applied

## Contract Impact

- Canonical surface: unchanged — no API endpoint signature or response shape changes
- Request shape: unchanged
- Response shape: unchanged (429 response format preserved)
- Status codes: unchanged — 429 on rate limit exceeded, same as before
- Frontend consumer: unchanged — rate limiting is transparent to API clients
- Compatibility path or alias: none — these are internal security/perf hardening changes
- Contract proof: 101 regression tests pass (mobile + auth + security + architecture + openapi_contract)

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged — auth flow untouched
- Negative auth proof: improved — rate limits now correctly identify client IP behind trusted proxies (previously all proxied requests shared a single rate limit bucket)

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches REST rate limiting — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: not applicable because no API response shape changes
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes — only rate limit key function changed
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed — only IP extraction and env var configuration
- Stale route/deep-link behavior: no route changes — frontend unaffected

## Scope Gate

- Allowed paths: `backend/app/core/rate_limiter.py`, `backend/tests/integration/test_pr34_redis_rate_limit.py`
- Denied paths: no other backend/frontend source changes
- Migration/docs/test impact: 1 new test file (4 tests), no schema migration, no docs update needed
- Rollback note: reverting restores slowapi.util.get_remote_address (no X-Forwarded-For support), in-memory storage, and hardcoded rate limits

## Validation

- Targeted tests or smoke run: `pytest tests/integration/test_pr34_redis_rate_limit.py tests/integration/test_pr33_token_expiry_and_refresh.py tests/integration/test_pr32_perf_n_plus_1.py tests/integration/test_mobile_api_core.py tests/integration/test_pr31_pii_masking.py tests/integration/test_pr30_security_hardening.py tests/test_openapi_contract.py tests/architecture/ tests/test_security_middleware.py tests/test_auth_profile_api.py`
- Result: 101 passed, 0 failed
- Not checked: full integration suite — will run in CI
