### PR TITLE
fix(security): PR-36 — Frontend Sprint 1 (P0-1 PHI localStorage, P0-3 WS JWT subprotocol, P0-4 file upload validation)

### DIFF
--- a/frontend/src/__tests__/pr36Sprint1Security.test.js
+++ b/frontend/src/__tests__/pr36Sprint1Security.test.js
@@ -1,0 +1,119 @@
+/**
+ * PR-36 — Frontend Sprint 1 security: PHI localStorage + WS JWT subprotocol + file upload validation.
+ *
+ * Tests for:
+ * 1. P0-1: OfflineIndicator does not store PHI in plaintext localStorage
+ * 2. P0-3: WS auth uses Sec-WebSocket-Protocol subprotocol (not URL query ?token=)
+ * 3. P0-4: At least one file upload component uses validateFile() from fileValidator.js
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(process.cwd());
+const OFFLINE_INDICATOR = path.join(ROOT, 'src/components/mobile/OfflineIndicator.jsx');
+const WS_AUTH = path.join(ROOT, 'src/utils/websocketAuth.js');
+const WS_JS = path.join(ROOT, 'src/api/ws.js');
+
+// ---------- 1. P0-1: No PHI in plaintext localStorage ----------
+
+describe('P0-1: OfflineIndicator PHI localStorage', () => {
+  const src = fs.readFileSync(OFFLINE_INDICATOR, 'utf-8');
+
+  it('does not write cached_appointments to localStorage in plaintext', () => {
+    // Strip comments before checking — the fix may mention the old pattern
+    // in an explanatory comment.
+    const stripped = src
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    // Must NOT have localStorage.setItem('cached_appointments', ...) or
+    // localStorage.setItem('cached_notifications', ...) writing raw data
+    expect(stripped).not.toMatch(/localStorage\.setItem\(\s*['"]cached_appointments['"]/);
+    expect(stripped).not.toMatch(/localStorage\.setItem\(\s*['"]cached_notifications['"]/);
+  });
+
+  it('if offline cache is kept, uses a non-PHI key or a safe storage helper', () => {
+    // We accept either:
+    // (a) the entire localStorage cache removed (no setItem for cached_*)
+    // (b) a sanitization step that strips PHI fields before caching
+    // (c) using sessionStorage instead of localStorage (slightly better)
+    // The simplest correct fix is (a) — remove the cache entirely.
+    const stripped = src
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    // Verify no raw JSON.stringify(data) is written to cached_* keys
+    expect(stripped).not.toMatch(
+      /localStorage\.setItem\(\s*['"]cached_(?:appointments|patients|notifications)['"]\s*,\s*JSON\.stringify\(\s*data\s*\)/,
+    );
+  });
+});
+
+// ---------- 2. P0-3: WS auth uses subprotocol, not URL query ----------
+
+describe('P0-3: WebSocket auth via Sec-WebSocket-Protocol subprotocol', () => {
+  const wsAuthSrc = fs.readFileSync(WS_AUTH, 'utf-8');
+  const wsJsSrc = fs.readFileSync(WS_JS, 'utf-8');
+
+  it('websocketAuth.js does not append ?token= to the URL', () => {
+    // Strip comments before checking.
+    const stripped = wsAuthSrc
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    // Must NOT have urlParams.append('token', token) or ?token= in URL
+    expect(stripped).not.toMatch(/urlParams\.append\(\s*['"]token['"]\s*,\s*token\s*\)/);
+  });
+
+  it('websocketAuth.js passes token via WebSocket subprotocol (second arg)', () => {
+    // The fix should construct the WebSocket like:
+    //   new WebSocket(url, [`bearer.${token}`])
+    // or similar — passing an array as the second argument.
+    const stripped = wsAuthSrc
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(stripped).toMatch(/new\s+WebSocket\(\s*\w+\s*,\s*\[?[^\]]*token[^\]]*\]?\s*\)/);
+  });
+
+  it('api/ws.js does not append ?token= to the display board WS URL', () => {
+    const stripped = wsJsSrc
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    // Must NOT have ?token=${...} in the URL
+    expect(stripped).not.toMatch(/['"`]\?token=\$\{[^}]+\}/);
+  });
+});
+
+// ---------- 3. P0-4: At least one file upload uses validateFile() ----------
+
+describe('P0-4: File upload validation via validateFile()', () => {
+  it('at least one file-upload component imports and calls validateFile from fileValidator.js', () => {
+    // Scan all source files for: import ... validateFile ... from '.../fileValidator'
+    // AND a call to validateFile(...) somewhere in the same file.
+    const srcDir = path.join(ROOT, 'src');
+    const files = collectSourceFiles(srcDir);
+    const filesUsingValidateFile = [];
+    for (const file of files) {
+      const src = fs.readFileSync(file, 'utf-8');
+      if (/from\s+['"][^'"]*fileValidator['"]/.test(src) && /validateFile\s*\(/.test(src)) {
+        filesUsingValidateFile.push(path.relative(ROOT, file));
+      }
+    }
+    expect(filesUsingValidateFile.length).toBeGreaterThan(0);
+  });
+});
+
+function collectSourceFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (fullPath.includes('__tests__')) continue;
+      files.push(...collectSourceFiles(fullPath));
+      continue;
+    }
+    if (/\.(js|jsx|ts|tsx)$/.test(entry.name) && !/\.(test|spec)\.(js|jsx|ts|tsx)$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}

--- a/frontend/src/api/ws.js
+++ b/frontend/src/api/ws.js
@@ -58,13 +58,16 @@ export function openDisplayBoardWS(boardId, onMessage, onConnect, onDisconnect) 
 
   function connect() {
     try {
+      // PR-36 / P0-3: JWT now sent via Sec-WebSocket-Protocol subprotocol
+      // (bearer.<token>) instead of URL query. Avoids leaking the token
+      // into nginx access logs, browser history, and Referer headers.
       const token = tokenManager.getAccessToken();
-      const tokenParam = token ? `?token=${encodeURIComponent(token)}` : '';
-      const url = buildWsUrl(`/api/v1/display/ws/board/${encodeURIComponent(boardId)}${tokenParam}`);
-      
-      logger.log(`🔌 Подключаемся к WebSocket: ${url}`);
-      
-      ws = new WebSocket(url);
+      const url = buildWsUrl(`/api/v1/display/ws/board/${encodeURIComponent(boardId)}`);
+      const subprotocols = token ? [`bearer.${token}`] : [];
+
+      logger.log('🔌 Подключаемся к WebSocket (token via subprotocol)');
+
+      ws = new WebSocket(url, subprotocols);
       
       ws.onopen = () => {
         logger.log(`✅ WebSocket подключен к табло ${boardId}`);

--- a/frontend/src/components/chat/FileUploader.jsx
+++ b/frontend/src/components/chat/FileUploader.jsx
@@ -1,16 +1,46 @@
 
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { Paperclip } from 'lucide-react';
 import './FileUploader.css';
 import PropTypes from 'prop-types';
+import { validateFile } from '../../utils/fileValidator';  // PR-36 / P0-4
+import { toast } from 'react-toastify';
 
 const FileUploader = ({ onUpload, disabled }) => {
   const fileInputRef = useRef(null);
+  const [isValidating, setIsValidating] = useState(false);
 
-  const handleFileChange = (e) => {
+  const handleFileChange = async (e) => {
     const file = e.target.files[0];
     if (file) {
-      onUpload(file);
+      // PR-36 / P0-4: Validate file via magic-number check before upload.
+      // Previously: file was passed directly to onUpload() with only the
+      // UX-only `accept` attribute as a guard (trivially bypassed).
+      // Now: validateFile() reads the file header and verifies the magic
+      // number matches the declared MIME type. Blocks spoofed uploads
+      // (e.g., .exe renamed to .jpg).
+      setIsValidating(true);
+      try {
+        const result = await validateFile(file, {
+          allowedCategories: ['images', 'documents'],
+          maxSize: 25 * 1024 * 1024, // 25MB — matches nginx client_max_body_size
+        });
+        if (!result.valid) {
+          const msg = result.errors.join('; ');
+          toast.error(`Файл отклонён: ${msg}`);
+          e.target.value = null;
+          return;
+        }
+        if (result.warnings.length > 0) {
+          result.warnings.forEach((w) => toast.warn(w));
+        }
+        onUpload(file);
+      } catch (_err) {
+        toast.error('Не удалось проверить файл. Попробуйте ещё раз.');
+        return;
+      } finally {
+        setIsValidating(false);
+      }
       // Reset input
       e.target.value = null;
     }
@@ -30,7 +60,7 @@ const FileUploader = ({ onUpload, disabled }) => {
         type="button"
         className="file-uploader-btn"
         onClick={() => fileInputRef.current?.click()}
-        disabled={disabled}
+        disabled={disabled || isValidating}
         title="Прикрепить файл"
         aria-label="Прикрепить файл">
         

--- a/frontend/src/components/mobile/OfflineIndicator.jsx
+++ b/frontend/src/components/mobile/OfflineIndicator.jsx
@@ -51,15 +51,18 @@ const OfflineIndicator = () => {
 
   const loadCachedData = async () => {
     try {
-      // Загружаем кэшированные данные из IndexedDB или localStorage
-      const cachedAppointments = localStorage.getItem('cached_appointments');
-      const cachedPatients = localStorage.getItem('cached_patients');
-      const cachedNotifications = localStorage.getItem('cached_notifications');
-
+      // PR-36 / P0-1: PHI localStorage cache removed for security.
+      // Previously: cached_appointments / cached_patients / cached_notifications
+      // were stored in plaintext localStorage — XSS or device theft would
+      // expose patient PHI (ФИО, телефоны, записи).
+      // Now: we only track whether the user has been online recently (a
+      // non-PHI flag) and show the offline indicator. The mobile app can
+      // re-fetch data from the server when connectivity is restored —
+      // there is no real offline mode that justifies storing PHI locally.
       setCachedData({
-        appointments: cachedAppointments ? JSON.parse(cachedAppointments).length : 0,
-        patients: cachedPatients ? JSON.parse(cachedPatients).length : 0,
-        notifications: cachedNotifications ? JSON.parse(cachedNotifications).length : 0
+        appointments: 0,
+        patients: 0,
+        notifications: 0
       });
     } catch (error) {
       logger.error('Ошибка загрузки кэшированных данных:', error);
@@ -70,7 +73,9 @@ const OfflineIndicator = () => {
     setSyncStatus('syncing');
 
     try {
-      // Синхронизируем данные с сервером
+      // PR-36 / P0-1: Sync now only verifies connectivity + auth —
+      // we no longer write PHI to localStorage. The mobile app refetches
+      // data through the normal API hooks when it comes back online.
       const promises = [
       fetch('/api/v1/mobile/appointments', {
         headers: {
@@ -86,15 +91,15 @@ const OfflineIndicator = () => {
 
       const responses = await Promise.allSettled(promises);
 
-      // Обновляем кэш
-      responses.forEach((response, index) => {
-        if (response.status === 'fulfilled' && response.value.ok) {
-          const dataKey = index === 0 ? 'cached_appointments' : 'cached_notifications';
-          response.value.json().then((data) => {
-            localStorage.setItem(dataKey, JSON.stringify(data));
-          });
-        }
-      });
+      // PR-36 / P0-1: removed the localStorage.setItem loop that wrote
+      // PHI (appointments, notifications) to plaintext localStorage.
+      // We now just count successful fetches for the UI indicator.
+      const succeeded = responses.filter(
+        (r) => r.status === 'fulfilled' && r.value.ok
+      ).length;
+      if (succeeded > 0) {
+        logger.info(`Sync succeeded for ${succeeded}/${responses.length} endpoints`);
+      }
 
       setSyncStatus('success');
 

--- a/frontend/src/utils/websocketAuth.js
+++ b/frontend/src/utils/websocketAuth.js
@@ -33,16 +33,20 @@ export function createAuthenticatedWebSocket(baseUrl, params = {}, options = {})
     throw new Error('Authentication required but no token found');
   }
 
-  // Добавляем токен к параметрам, если он есть
+  // PR-36 / P0-3: JWT now sent via Sec-WebSocket-Protocol subprotocol
+  // (bearer.<token>) instead of URL query (?token=...). The previous
+  // approach leaked the JWT into nginx access logs, browser history,
+  // and Referer headers. The backend has supported the subprotocol form
+  // since PR-4 (backend). Query params are kept for non-token data only.
   const urlParams = new URLSearchParams(params);
-  if (token) {
-    urlParams.append('token', token);
-  }
 
   const wsUrl = `${baseUrl}?${urlParams.toString()}`;
-  logger.log(`🔌 Создаем аутентифицированное WebSocket соединение: ${wsUrl}`);
+  // Subprotocols are passed as the second argument to WebSocket().
+  // The backend extracts the token from the bearer.<token> entry.
+  const subprotocols = token ? [`bearer.${token}`] : [];
+  logger.log('🔌 Создаем аутентифицированное WebSocket соединение (token via subprotocol)');
 
-  const ws = new WebSocket(wsUrl);
+  const ws = new WebSocket(wsUrl, subprotocols);
 
   ws.onopen = (event) => {
     logger.log('✅ Аутентифицированное WebSocket подключено');


### PR DESCRIPTION
## Summary

PR-36 — Frontend Sprint 1 security. 3 fixes:

1. **P0-1**: PHI localStorage cache removed from `OfflineIndicator.jsx`. Previously `cached_appointments`, `cached_patients`, `cached_notifications` were written to plaintext localStorage — XSS or device theft would expose patient PHI (ФИО, телефоны, записи). Now: sync only verifies connectivity + auth (no PHI persistence). The mobile app refetches data through normal API hooks when connectivity is restored.

2. **P0-3**: WebSocket JWT moved from URL query to `Sec-WebSocket-Protocol` subprotocol. `websocketAuth.js`: `?token=...` → `new WebSocket(url, [\`bearer.\${token}\`])`. `api/ws.js`: `openDisplayBoardWS` uses the same subprotocol pattern. Backend already supports subprotocol since PR-4 (backend). Token no longer leaks into nginx access logs, browser history, Referer headers.

3. **P0-4**: `validateFile()` wired into chat `FileUploader`. Magic-number check (file header signature) before upload — blocks spoofed uploads (e.g., `.exe` renamed to `.jpg`). 25MB max size (matches nginx `client_max_body_size`). User-facing toast on validation failure. Button disabled during async validation.

## Cyclic Execution Evidence

- Fresh main sync: yes (branched from `e94c69b6` PR-35 merge)
- Clean workspace: yes
- Branch: `fix/pr-36-frontend-sprint1-security`
- Scope gate: 5 files (4 source + 1 test file)
- Red-check handling: 6 tests RED initially (4 failed), all GREEN after fixes applied

## Contract Impact

- Canonical surface: unchanged — WS endpoints keep the same paths; OfflineIndicator still calls the same `/api/v1/mobile/*` endpoints; FileUploader still calls `onUpload(file)`
- Request shape: WS connection now sends `Sec-WebSocket-Protocol: bearer.<token>` header instead of `?token=` query param. Backend has supported both forms since PR-4 (backend).
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — WS auth no longer leaks token in URL; file uploads now validate before sending; PHI no longer persisted client-side
- Compatibility path or alias: backend still accepts `?token=` as a deprecated fallback (PR-4 kept it for transition), so this change is backward-compatible
- Contract proof: 56 frontend tests pass (no breakage)

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged — auth flow untouched, token still required for WS
- Negative auth proof: improved — token no longer in URL means it cannot leak via logs/history/Referer to unauthorized parties

## Notification / Realtime

- Event type or websocket channel: WS auth transport changed (URL query → subprotocol), but channel names and message formats are unchanged
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: WS reconnect logic in `openDisplayBoardWS` is unchanged — only the auth header transport changed. Reconnect still uses exponential backoff with `maxReconnectAttempts = 5`.

## Frontend Resilience

- Empty data proof: OfflineIndicator — `loadCachedData` now returns zeros instead of reading localStorage, so the offline UI shows "0 records" instead of stale cached data. This is intentional — we no longer cache PHI client-side.
- Partial data proof: FileUploader — `validateFile()` returns `{valid, errors, warnings}`. If `errors.length > 0`, upload is blocked with a toast. If only `warnings`, upload proceeds with a warning toast.
- Forbidden secondary path behavior: FileUploader — if `validateFile()` throws (e.g., file unreadable), catch block shows user-facing toast and aborts upload. Previously: no validation, any file was passed to `onUpload`.
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes — frontend routing unaffected

## Scope Gate

- Allowed paths: `frontend/src/components/mobile/OfflineIndicator.jsx`, `frontend/src/utils/websocketAuth.js`, `frontend/src/api/ws.js`, `frontend/src/components/chat/FileUploader.jsx`, `frontend/src/__tests__/pr36Sprint1Security.test.js`
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: 1 new test file (6 tests), no schema migration, no docs update needed
- Rollback note: reverting restores plaintext PHI localStorage, `?token=` in WS URLs, and no file-upload validation

## Validation

- Targeted tests or smoke run: `npx vitest run src/__tests__/`
- Result: 56 passed, 0 failed (13 test files including the new pr36Sprint1Security.test.js with 6 tests)
- Lint: 0 errors, 0 warnings on changed files
- Not checked: full e2e suite — will run in CI
