### PR TITLE
fix(i18n): PR-40 — Frontend i18n + locale (P0-18 unified key, High-20 locale-aware formatting)

### DIFF
--- a/frontend/src/__tests__/pr40I18nLocale.test.js
+++ b/frontend/src/__tests__/pr40I18nLocale.test.js
@@ -1,0 +1,70 @@
+/**
+ * PR-40 — Frontend i18n + locale: P0-18 + High-20.
+ *
+ * Tests for:
+ * 1. P0-18: RegistrarPanel uses the same localStorage key as useTranslation
+ *    (was 'ui_lang' vs 'language' — language switcher silently broken)
+ * 2. High-20: dateUtils and formatCurrency provide a getLocale() helper that
+ *    reads the active language, and at least one function uses it
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(process.cwd());
+const REGISTRAR = path.join(ROOT, 'src/pages/RegistrarPanel.jsx');
+const DATE_UTILS = path.join(ROOT, 'src/utils/dateUtils.js');
+const FORMAT_CURRENCY = path.join(ROOT, 'src/utils/formatCurrency.js');
+
+// ---------- 1. P0-18: Unified localStorage key ----------
+
+describe('P0-18: Unified i18n localStorage key', () => {
+  const src = fs.readFileSync(REGISTRAR, 'utf-8');
+
+  it('RegistrarPanel does not use the divergent ui_lang localStorage key', () => {
+    const stripped = src
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    // Must NOT read from 'ui_lang' (the divergent key)
+    expect(stripped).not.toMatch(/localStorage\.getItem\(\s*['"]ui_lang['"]\)/);
+  });
+
+  it('RegistrarPanel reads language from the unified key (language or app_language)', () => {
+    const stripped = src
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    // Must read from 'language' or 'app_language' (the unified keys used by useTranslation)
+    expect(stripped).toMatch(/localStorage\.getItem\(\s*['"](?:language|app_language)['"]\)/);
+  });
+});
+
+// ---------- 2. High-20: Locale-aware date/currency formatting ----------
+
+describe('High-20: Locale-aware formatting', () => {
+  const dateUtilsSrc = fs.readFileSync(DATE_UTILS, 'utf-8');
+
+  it('dateUtils.js exports a getLocale() helper or reads active language', () => {
+    // We accept either:
+    // (a) a getLocale() function that reads localStorage
+    // (b) a getActiveLocale() function
+    // (c) import from useTranslation
+    const hasGetLocale = /export\s+(?:const|function)\s+getLocale\b/.test(dateUtilsSrc);
+    const hasGetActiveLocale = /export\s+(?:const|function)\s+getActiveLocale\b/.test(dateUtilsSrc);
+    const hasUseTranslationImport = /from\s+['"][^'"]*useTranslation['"]/.test(dateUtilsSrc);
+    const hasLanguageRead = /localStorage\.getItem\(\s*['"]language['"]/.test(dateUtilsSrc)
+      || /localStorage\.getItem\(\s*['"]app_language['"]/.test(dateUtilsSrc);
+    expect(hasGetLocale || hasGetActiveLocale || hasUseTranslationImport || hasLanguageRead).toBe(true);
+  });
+
+  it('at least one date format function uses the dynamic locale (not hardcoded ru-RU default only)', () => {
+    // The old code: formatRegistrarDate(value, locale = 'ru-RU')
+    // The fix: formatRegistrarDate(value, locale = getLocale())
+    // We check that at least one function uses getLocale() as the default
+    const stripped = dateUtilsSrc
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    // Look for: locale = getLocale() or locale = getActiveLocale()
+    const usesDynamicLocale = /locale\s*=\s*(?:getLocale|getActiveLocale)\(\)/.test(stripped);
+    expect(usesDynamicLocale).toBe(true);
+  });
+});

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -257,7 +257,7 @@ const RegistrarPanel = () => {
     resolveRescheduleVisitId,
     removeRescheduledAppointmentFromView,
   } = useRegistrarReschedule({ setAppointments });
-  const [doctors, setDoctors] = useState([]);const [services, setServices] = useState({});const [showCalendar, setShowCalendar] = useState(false);const [historyDate, setHistoryDate] = useState(getLocalDateString());const [tempDateInput, setTempDateInput] = useState(getLocalDateString());const language = useMemo(() => localStorage.getItem('ui_lang') || 'ru', []); // Выбор врача остаётся явным: URL-параметр или ручной выбор в очереди
+  const [doctors, setDoctors] = useState([]);const [services, setServices] = useState({});const [showCalendar, setShowCalendar] = useState(false);const [historyDate, setHistoryDate] = useState(getLocalDateString());const [tempDateInput, setTempDateInput] = useState(getLocalDateString());const language = useMemo(() => localStorage.getItem('language') || localStorage.getItem('app_language') || 'ru', []); // Выбор врача остаётся явным: URL-параметр или ручной выбор в очереди
   // QW-06 fix: translations moved to ./registrarTranslations.js (was 50+ inline keys).
   // EN translations added (previously missing — EN users saw RU fallback).
   // Full migration to locales/{ru,uz,en}.js deferred until useTranslation.jsx

--- a/frontend/src/utils/dateUtils.js
+++ b/frontend/src/utils/dateUtils.js
@@ -1,9 +1,36 @@
 /**
  * Date utility functions for the application
  * Provides consistent date formatting across the app
+ *
+ * PR-40 / High-20: Locale is now dynamic via getLocale() — reads the active
+ * language from localStorage (set by useTranslation hook). Previously every
+ * function hardcoded 'ru-RU', ignoring the user's language selection.
  */
 
 export const REGISTRAR_TIME_ZONE = 'Asia/Tashkent';
+
+/**
+ * PR-40 / High-20: Returns the active locale based on the user's language
+ * selection. Reads from the unified 'language' key (set by useTranslation).
+ * Falls back to 'ru-RU' for Russian (default clinic language).
+ *
+ * @returns {string} BCP-47 locale tag (e.g. 'ru-RU', 'uz-UZ', 'en-US')
+ */
+export const getLocale = () => {
+  try {
+    const lang = localStorage.getItem('language')
+      || localStorage.getItem('app_language')
+      || 'ru';
+    switch (lang) {
+      case 'uz': return 'uz-UZ';
+      case 'en': return 'en-US';
+      case 'ru':
+      default: return 'ru-RU';
+    }
+  } catch {
+    return 'ru-RU';
+  }
+};
 
 /**
  * Parses registrar timestamps using the clinic timezone contract.
@@ -35,7 +62,7 @@ export const parseRegistrarTimestamp = (value) => {
     return Number.isNaN(parsed.getTime()) ? null : parsed;
 };
 
-export const formatRegistrarDate = (value, locale = 'ru-RU') => {
+export const formatRegistrarDate = (value, locale = getLocale()) => {
     const parsed = parseRegistrarTimestamp(value);
     if (!parsed) return '';
     return parsed.toLocaleDateString(locale, {
@@ -46,7 +73,7 @@ export const formatRegistrarDate = (value, locale = 'ru-RU') => {
     });
 };
 
-export const formatRegistrarTime = (value, locale = 'ru-RU', options = {}) => {
+export const formatRegistrarTime = (value, locale = getLocale(), options = {}) => {
     const parsed = parseRegistrarTimestamp(value);
     if (!parsed) return '';
     return parsed.toLocaleTimeString(locale, {
@@ -57,7 +84,7 @@ export const formatRegistrarTime = (value, locale = 'ru-RU', options = {}) => {
     });
 };
 
-export const formatRegistrarDateTime = (value, locale = 'ru-RU', options = {}) => {
+export const formatRegistrarDateTime = (value, locale = getLocale(), options = {}) => {
     const date = formatRegistrarDate(value, locale);
     const time = formatRegistrarTime(value, locale, options);
     return [date, time].filter(Boolean).join(' ');
@@ -73,7 +100,7 @@ const timestampsDiffer = (a, b, thresholdMs = REGISTRAR_CHANGED_TIMESTAMP_THRESH
     return Math.abs(first.getTime() - second.getTime()) > thresholdMs;
 };
 
-export const getRegistrarTimestampDisplay = (record = {}, locale = 'ru-RU') => {
+export const getRegistrarTimestampDisplay = (record = {}, locale = getLocale()) => {
     const requestedPrimaryKind = REGISTRAR_PRIMARY_TIME_KINDS.has(record.display_time_kind)
         ? record.display_time_kind
         : null;
@@ -179,7 +206,7 @@ export const getWeekEnd = (date = new Date()) => {
  * @param {string} locale - The locale to use (defaults to 'ru-RU')
  * @returns {string} Formatted date string
  */
-export const formatDate = (date, locale = 'ru-RU') => {
+export const formatDate = (date, locale = getLocale()) => {
     const d = typeof date === 'string' ? new Date(date) : date;
     return d.toLocaleDateString(locale, {
         day: '2-digit',
@@ -194,7 +221,7 @@ export const formatDate = (date, locale = 'ru-RU') => {
  * @param {string} locale - The locale to use (defaults to 'ru-RU')
  * @returns {string} Formatted date-time string
  */
-export const formatDateTime = (date, locale = 'ru-RU') => {
+export const formatDateTime = (date, locale = getLocale()) => {
     const d = typeof date === 'string' ? new Date(date) : date;
     return d.toLocaleString(locale, {
         day: '2-digit',
@@ -238,7 +265,7 @@ export const isFuture = (dateString) => {
  * @param {string} locale - Locale to use (defaults to 'ru-RU')
  * @returns {string} Formatted date string
  */
-export const formatDateDisplay = (date, locale = 'ru-RU') => {
+export const formatDateDisplay = (date, locale = getLocale()) => {
     if (!date) return '';
 
     try {

--- a/frontend/src/utils/formatCurrency.js
+++ b/frontend/src/utils/formatCurrency.js
@@ -2,24 +2,37 @@
  * formatCurrency — shared currency formatter for admin components (P2 dedup, Sprint 4).
  *
  * Replaces 2 identical copies that lived in AdminDashboard.jsx and
- * AdminFinanceOverview.jsx. Uses Intl.NumberFormat with ru-RU locale
+ * AdminFinanceOverview.jsx. Uses Intl.NumberFormat with locale-aware formatting
  * and UZS currency, 0 fractional digits (matches the original behavior).
+ *
+ * PR-40 / High-20: Locale is now dynamic via getLocale() from dateUtils.
+ * Previously hardcoded 'ru-RU' — ignored the user's language selection.
  *
  * Note: useUtils.js has a separate formatCurrency that goes through
  * formatNumber — kept as-is because it has different null-handling and
  * is consumed by hooks with different call sites.
  */
-const formatter = new Intl.NumberFormat('ru-RU', {
-  style: 'currency',
-  currency: 'UZS',
-  minimumFractionDigits: 0,
-});
+import { getLocale } from './dateUtils';
+
+// PR-40 / High-20: cache formatters per-locale to avoid re-creating on every call
+const _formatterCache = new Map();
+
+function getFormatter(locale) {
+  if (!_formatterCache.has(locale)) {
+    _formatterCache.set(locale, new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: 'UZS',
+      minimumFractionDigits: 0,
+    }));
+  }
+  return _formatterCache.get(locale);
+}
 
 function formatCurrency(amount) {
   if (amount === null || amount === undefined || Number.isNaN(amount)) {
     return '';
   }
-  return formatter.format(amount);
+  return getFormatter(getLocale()).format(amount);
 }
 
 export default formatCurrency;


### PR DESCRIPTION
## Summary

PR-40 — Frontend i18n + locale. 2 fixes:

1. **P0-18**: Unified i18n localStorage key. `RegistrarPanel.jsx`: `'ui_lang'` → `'language'` / `'app_language'`. Was divergent from `useTranslation` hook (which uses `'language'`). Language switcher was silently broken for RegistrarPanel — switching language in the header didn't affect RegistrarPanel's translations.

2. **High-20**: Locale-aware date/currency formatting. `dateUtils.js`: new `getLocale()` helper reads active language from localStorage (`'ru'` → `'ru-RU'`, `'uz'` → `'uz-UZ'`, `'en'` → `'en-US'`). All format functions: `locale = 'ru-RU'` (hardcoded) → `locale = getLocale()`. `formatCurrency.js`: hardcoded `'ru-RU'` `Intl.NumberFormat` → `getLocale()`. Formatter cached per-locale to avoid re-creating on every call.

## Cyclic Execution Evidence

- Fresh main sync: yes (branched from `9871e8d1` PR-39 merge)
- Clean workspace: yes
- Branch: `fix/pr-40-frontend-i18n-locale`
- Scope gate: 4 files (3 source + 1 test file)
- Red-check handling: 4 tests RED initially, all GREEN after fixes applied

## Contract Impact

- Canonical surface: unchanged — no API endpoint signature changes. dateUtils and formatCurrency keep the same function signatures (the `locale` parameter is still accepted, just defaults to `getLocale()` instead of `'ru-RU'`)
- Request shape: unchanged
- Response shape: unchanged — date/currency formatting is client-side only
- Status codes: unchanged
- Frontend consumer: improved — dates and currency now respect the user's language selection (Uzbek users see `uz-UZ` formatting, English users see `en-US`)
- Compatibility path or alias: callers that explicitly pass a `locale` argument are unaffected (the default just changed)
- Contract proof: 602 frontend tests pass (no breakage)

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches client-side locale detection and date/currency formatting — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: `getLocale()` returns `'ru-RU'` if `localStorage` is empty or unreadable. `formatCurrency(null/undefined/NaN)` returns `''` (unchanged).
- Partial data proof: not applicable because no API response shape changes — only client-side locale detection and formatting
- Forbidden secondary path behavior: not applicable because no auth path changes — only locale string selection
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed — only localStorage language key read
- Stale route/deep-link behavior: no route changes — frontend routing unaffected

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`, `frontend/src/utils/dateUtils.js`, `frontend/src/utils/formatCurrency.js`, `frontend/src/__tests__/pr40I18nLocale.test.js`
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: 1 new test file (4 tests), no schema migration, no docs update needed
- Rollback note: reverting restores divergent `ui_lang` key and hardcoded `ru-RU` locale

## Validation

- Targeted tests or smoke run: `npx vitest run`
- Result: 602 passed, 0 failed (117 test files including the new pr40I18nLocale.test.js with 4 tests)
- Lint: 0 errors
- Not checked: full e2e suite — will run in CI
