### PR TITLE
fix(a11y): PR-42 — Frontend a11y medium (Medium-E htmlFor, Medium-F dark mode, Medium-G tabIndex)

### DIFF
--- a/frontend/src/__tests__/pr42A11yMedium.test.js
+++ b/frontend/src/__tests__/pr42A11yMedium.test.js
@@ -1,0 +1,112 @@
+/**
+ * PR-42 — Frontend a11y medium: Medium-E + Medium-F + Medium-G.
+ *
+ * Tests for:
+ * 1. Medium-E: at least one form component has <label htmlFor> association
+ * 2. Medium-F: ResponsiveModal, ResponsiveForm, PhotoComparison do not use
+ *    hardcoded backgroundColor: 'white' (breaks dark mode)
+ * 3. Medium-G: ModernInput, ModernSelect do not use tabIndex={-1} on action icons
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(process.cwd());
+const RESPONSIVE_MODAL = path.join(ROOT, 'src/components/ResponsiveModal.jsx');
+const RESPONSIVE_FORM = path.join(ROOT, 'src/components/forms/ResponsiveForm.jsx');
+const PHOTO_COMPARISON = path.join(ROOT, 'src/components/dermatology/PhotoComparison.jsx');
+const MODERN_INPUT = path.join(ROOT, 'src/components/forms/ModernInput.jsx');
+const MODERN_SELECT = path.join(ROOT, 'src/components/forms/ModernSelect.jsx');
+
+// ---------- 1. Medium-E: label htmlFor association ----------
+
+describe('Medium-E: label htmlFor association', () => {
+  it('at least one form component uses <label htmlFor=...> association', () => {
+    const srcDir = path.join(ROOT, 'src/components/forms');
+    if (!fs.existsSync(srcDir)) {
+      // Skip if no forms dir
+      return;
+    }
+    const files = collectSourceFiles(srcDir);
+    let found = false;
+    for (const f of files) {
+      const src = fs.readFileSync(f, 'utf-8');
+      // Look for <label htmlFor=...> (JSX)
+      if (/<label[^>]*htmlFor\s*=/.test(src)) {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+  });
+});
+
+// ---------- 2. Medium-F: dark mode backgroundColor ----------
+
+describe('Medium-F: dark mode backgroundColor fix', () => {
+  it('ResponsiveModal does not use hardcoded backgroundColor: white', () => {
+    const src = fs.readFileSync(RESPONSIVE_MODAL, 'utf-8');
+    const stripped = src
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(stripped).not.toMatch(/backgroundColor:\s*['"]white['"]/);
+    expect(stripped).not.toMatch(/backgroundColor:\s*['"]#fff['"]/);
+    expect(stripped).not.toMatch(/backgroundColor:\s*['"]#ffffff['"]/i);
+  });
+
+  it('ResponsiveForm does not use hardcoded backgroundColor: white', () => {
+    const src = fs.readFileSync(RESPONSIVE_FORM, 'utf-8');
+    const stripped = src
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(stripped).not.toMatch(/backgroundColor:\s*['"]white['"]/);
+    expect(stripped).not.toMatch(/backgroundColor:\s*['"]#fff['"]/);
+    expect(stripped).not.toMatch(/backgroundColor:\s*['"]#ffffff['"]/i);
+  });
+
+  it('PhotoComparison does not use hardcoded backgroundColor: white', () => {
+    const src = fs.readFileSync(PHOTO_COMPARISON, 'utf-8');
+    const stripped = src
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(stripped).not.toMatch(/backgroundColor:\s*['"]white['"]/);
+    expect(stripped).not.toMatch(/backgroundColor:\s*['"]#fff['"]/);
+    expect(stripped).not.toMatch(/backgroundColor:\s*['"]#ffffff['"]/i);
+  });
+});
+
+// ---------- 3. Medium-G: tabIndex on action icons ----------
+
+describe('Medium-G: tabIndex on action icons', () => {
+  it('ModernInput does not use tabIndex={-1} on action icons', () => {
+    const src = fs.readFileSync(MODERN_INPUT, 'utf-8');
+    const stripped = src
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(stripped).not.toMatch(/tabIndex\s*=\s*\{\s*-1\s*\}/);
+  });
+
+  it('ModernSelect does not use tabIndex={-1} on action icons', () => {
+    const src = fs.readFileSync(MODERN_SELECT, 'utf-8');
+    const stripped = src
+      .replace(/\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(stripped).not.toMatch(/tabIndex\s*=\s*\{\s*-1\s*\}/);
+  });
+});
+
+function collectSourceFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+      continue;
+    }
+    if (/\.(js|jsx|ts|tsx)$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}

--- a/frontend/src/components/ResponsiveModal.jsx
+++ b/frontend/src/components/ResponsiveModal.jsx
@@ -106,7 +106,7 @@ const ResponsiveModal = ({
       
       <div
         style={{
-          backgroundColor: 'white',
+          backgroundColor: 'var(--mac-bg-primary)',  // PR-42 / Medium-F: was 'white' (broke dark mode)
           borderRadius: isMobile ? '16px 16px 0 0' : '20px',
           boxShadow: 'var(--mac-shadow-xl)',
           maxHeight: isMobile ? '90vh' : '90vh',

--- a/frontend/src/components/dermatology/PhotoComparison.jsx
+++ b/frontend/src/components/dermatology/PhotoComparison.jsx
@@ -342,7 +342,7 @@ const PhotoComparison = ({ beforePhoto, afterPhoto, metadata = {} }) => {
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                backgroundColor: 'white',
+                backgroundColor: 'var(--mac-bg-primary)',  // PR-42 / Medium-F: was 'white' (broke dark mode)
                 boxShadow: 'var(--mac-shadow-md)'
               }}>
               

--- a/frontend/src/components/forms/ModernInput.jsx
+++ b/frontend/src/components/forms/ModernInput.jsx
@@ -179,7 +179,7 @@ const ModernInput = ({
             type="button"
             className="input-action-btn"
             onClick={() => setShowPassword(!showPassword)}
-            tabIndex={-1}
+            tabIndex={0}  // PR-42 / Medium-G: was -1 (removed from tab order)
             aria-label={showPassword ? 'Скрыть пароль' : 'Показать пароль'}
             title={showPassword ? 'Скрыть пароль' : 'Показать пароль'}>
             
@@ -193,7 +193,7 @@ const ModernInput = ({
             type="button"
             className="input-action-btn"
             onClick={handleClear}
-            tabIndex={-1}
+            tabIndex={0}  // PR-42 / Medium-G: was -1 (removed from tab order)
             aria-label="Очистить поле"
             title="Очистить поле">
             

--- a/frontend/src/components/forms/ModernSelect.jsx
+++ b/frontend/src/components/forms/ModernSelect.jsx
@@ -249,7 +249,7 @@ const ModernSelect = ({
                   type="button"
                   className="tag-remove"
                   onClick={(e) => handleRemoveOption(e, val)}
-                  tabIndex={-1}
+                  tabIndex={0}  // PR-42 / Medium-G: was -1 (removed from tab order)
                   aria-label="Удалить"
                   title="Удалить">
                   
@@ -315,8 +315,9 @@ const ModernSelect = ({
       {label &&
       <label
         className={`select-label ${focused || hasValue || isOpen ? 'focused' : ''} ${size}`}
-        style={labelStyles}>
-        
+        style={labelStyles}
+        htmlFor={props.id}>  {/* PR-42 / Medium-E: htmlFor association for screen readers */}
+
           {label}
           {required && <span className="required-mark">*</span>}
         </label>
@@ -351,7 +352,7 @@ const ModernSelect = ({
             type="button"
             className="select-action-btn"
             onClick={handleClear}
-            tabIndex={-1}
+            tabIndex={0}  // PR-42 / Medium-G: was -1 (removed from tab order)
             aria-label="Очистить выбор"
             title="Очистить выбор">
             

--- a/frontend/src/components/forms/ResponsiveForm.jsx
+++ b/frontend/src/components/forms/ResponsiveForm.jsx
@@ -145,7 +145,7 @@ const FormSelect = ({
         borderRadius: isMobile ? '8px' : '12px',
         fontSize: isMobile ? '16px' : '16px',
         fontFamily: 'inherit',
-        backgroundColor: 'white',
+        backgroundColor: 'var(--mac-bg-primary)',  // PR-42 / Medium-F: was 'white' (broke dark mode)
         transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
         outline: 'none',
         ...style


### PR DESCRIPTION
## Summary

PR-42 — Frontend a11y medium. 3 fixes:

1. **Medium-E**: `label htmlFor` association. `ModernSelect.jsx`: added `htmlFor={props.id}` to `<label>`. `ModernInput.jsx` already had `htmlFor` (verified). Screen readers can now announce the label when the select is focused.

2. **Medium-F**: dark mode `backgroundColor` fix. `ResponsiveModal.jsx`, `ResponsiveForm.jsx`, `PhotoComparison.jsx`: `'white'` → `'var(--mac-bg-primary)'`. Hardcoded `'white'` broke dark mode (white box on dark background). Now uses the theme variable that adapts to light/dark mode.

3. **Medium-G**: `tabIndex` on action icons. `ModernInput.jsx` (2 places), `ModernSelect.jsx` (2 places): `tabIndex={-1}` → `tabIndex={0}`. `tabIndex={-1}` removed action icons (clear button, password toggle, dropdown chevron) from the keyboard tab order — keyboard users couldn't reach them. Now they're in the natural tab order.

## Cyclic Execution Evidence

- Fresh main sync: yes (branched from `6872bdf7` PR-41 merge)
- Clean workspace: yes
- Branch: `fix/pr-42-frontend-a11y-medium`
- Scope gate: 6 files (5 source + 1 test file)
- Red-check handling: 6 tests RED initially (5 failed), all GREEN after fixes applied

## Contract Impact

- Canonical surface: unchanged — no API endpoint signature changes. All components keep the same props and render the same DOM structure.
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — dark mode no longer shows white boxes; keyboard users can reach action icons; screen readers announce labels
- Compatibility path or alias: none — these are a11y fixes
- Contract proof: 612 frontend tests pass (no breakage)

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches UI component styling and accessibility attributes — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: not applicable because these are static style and accessibility attribute changes — no data rendering involved
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes — frontend routing unaffected

## Scope Gate

- Allowed paths: `frontend/src/components/ResponsiveModal.jsx`, `frontend/src/components/forms/ResponsiveForm.jsx`, `frontend/src/components/dermatology/PhotoComparison.jsx`, `frontend/src/components/forms/ModernInput.jsx`, `frontend/src/components/forms/ModernSelect.jsx`, `frontend/src/__tests__/pr42A11yMedium.test.js`
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: 1 new test file (6 tests), no schema migration, no docs update needed
- Rollback note: reverting restores hardcoded 'white' backgrounds, tabIndex={-1} on action icons, and missing htmlFor on ModernSelect label

## Validation

- Targeted tests or smoke run: `npx vitest run`
- Result: 612 passed, 0 failed (119 test files including the new pr42A11yMedium.test.js with 6 tests)
- Lint: 0 errors
- Not checked: full e2e suite — will run in CI
