### PR TITLE
fix(refactor): PR-45 — AppointmentWizardV2 god component split (High-15)

### DIFF
--- a/frontend/src/__tests__/pr45WizardSplit.test.js
+++ b/frontend/src/__tests__/pr45WizardSplit.test.js
@@ -1,0 +1,68 @@
+/**
+ * PR-45 — AppointmentWizardV2 god component split (partial).
+ *
+ * Tests for:
+ * 1. EditModeBanner extracted to its own component file
+ * 2. StepProgressIndicator extracted to its own component file
+ * 3. AppointmentWizardV2 imports and uses the extracted components
+ * 4. AppointmentWizardV2 LOC reduced (was 2945)
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(process.cwd());
+const WIZARD = path.join(ROOT, 'src/components/wizard/AppointmentWizardV2.jsx');
+const WIZARD_DIR = path.join(ROOT, 'src/components/wizard');
+
+// ---------- 1. EditModeBanner extracted ----------
+
+describe('PR-45: EditModeBanner extraction', () => {
+  it('EditModeBanner.jsx exists in wizard directory', () => {
+    const bannerPath = path.join(WIZARD_DIR, 'EditModeBanner.jsx');
+    expect(fs.existsSync(bannerPath)).toBe(true);
+  });
+
+  it('EditModeBanner.jsx exports a component', () => {
+    const bannerPath = path.join(WIZARD_DIR, 'EditModeBanner.jsx');
+    const src = fs.readFileSync(bannerPath, 'utf-8');
+    expect(src).toMatch(/export\s+(?:default|const)\s+EditModeBanner/);
+  });
+
+  it('AppointmentWizardV2 imports EditModeBanner', () => {
+    const src = fs.readFileSync(WIZARD, 'utf-8');
+    expect(src).toMatch(/import\s+EditModeBanner/);
+  });
+});
+
+// ---------- 2. StepProgressIndicator extracted ----------
+
+describe('PR-45: StepProgressIndicator extraction', () => {
+  it('StepProgressIndicator.jsx exists in wizard directory', () => {
+    const indicatorPath = path.join(WIZARD_DIR, 'StepProgressIndicator.jsx');
+    expect(fs.existsSync(indicatorPath)).toBe(true);
+  });
+
+  it('StepProgressIndicator.jsx exports a component', () => {
+    const indicatorPath = path.join(WIZARD_DIR, 'StepProgressIndicator.jsx');
+    const src = fs.readFileSync(indicatorPath, 'utf-8');
+    expect(src).toMatch(/export\s+(?:default|const)\s+StepProgressIndicator/);
+  });
+
+  it('AppointmentWizardV2 imports StepProgressIndicator', () => {
+    const src = fs.readFileSync(WIZARD, 'utf-8');
+    expect(src).toMatch(/import\s+StepProgressIndicator/);
+  });
+});
+
+// ---------- 3. Wizard file size reduced ----------
+
+describe('PR-45: AppointmentWizardV2 size reduction', () => {
+  it('AppointmentWizardV2.jsx is smaller than original 3015 LOC', () => {
+    const src = fs.readFileSync(WIZARD, 'utf-8');
+    const lineCount = src.split('\n').length;
+    // Original was 3015 LOC (per audit doc). After extraction of EditModeBanner
+    // and StepProgressIndicator, should be at least 40 lines smaller.
+    expect(lineCount).toBeLessThan(3015);
+  });
+});

--- a/frontend/src/components/wizard/AppointmentWizardV2.jsx
+++ b/frontend/src/components/wizard/AppointmentWizardV2.jsx
@@ -65,6 +65,9 @@ import './AppointmentWizardV2.css';
 // PatientStepV2 и CartStepV2 вынесены в отдельные файлы для уменьшения размера.
 import PatientStepV2 from './PatientStepV2';
 import CartStepV2 from './CartStepV2';
+// PR-45 / High-15: extracted sub-components to reduce god component size
+import EditModeBanner from './EditModeBanner';
+import StepProgressIndicator from './StepProgressIndicator';
 
 
 // UX Audit Stage 3 (Wizard issue 5.1):
@@ -2613,35 +2616,8 @@ const AppointmentWizardV2 = ({
     boxShadow: 'var(--mac-shadow-sm)'
   };
 
-  // Кастомный заголовок для Шага 1
-  // PR-24: show edit-mode banner when editing
-  const editModeBanner = editMode ? (
-    <div style={{
-      display: 'flex',
-      alignItems: 'center',
-      gap: '6px',
-      padding: '4px 10px',
-      borderRadius: 'var(--mac-radius-sm)',
-      background: 'rgba(59, 130, 246, 0.12)',
-      color: '#2563eb',
-      fontSize: '12px',
-      fontWeight: 600,
-      marginBottom: '4px'
-    }}>
-      ✏️ Редактирование записи
-      {initialData?.source_kind === 'online' || initialData?.source === 'online' ? (
-        <span style={{
-          padding: '1px 6px', borderRadius: '4px', fontSize: '10px',
-          background: 'rgba(139, 92, 246, 0.15)', color: '#7c3aed'
-        }}>QR</span>
-      ) : (
-        <span style={{
-          padding: '1px 6px', borderRadius: '4px', fontSize: '10px',
-          background: 'rgba(100, 116, 139, 0.15)', color: '#475569'
-        }}>Desk</span>
-      )}
-    </div>
-  ) : null;
+  // PR-45 / High-15: editModeBanner extracted to EditModeBanner.jsx component
+  const editModeBanner = <EditModeBanner editMode={editMode} initialData={initialData} />;
 
   const Step1Header =
   <div style={wizardHeaderShellStyle}>
@@ -2894,30 +2870,8 @@ const AppointmentWizardV2 = ({
         }}>
 
         <div className="wizard-container-v2">
-          {/* UX Audit Registrar #22: Progress indicator — визуальный progress bar.
-              Текст «Шаг 1 из 2» уже есть в header, но визуальный bar даёт
-              мгновенное понимание прогресса без чтения. */}
-          <div style={{
-            display: 'flex',
-            gap: 'var(--mac-spacing-2)',
-            marginBottom: 'var(--mac-spacing-3)',
-            padding: '0 4px',
-          }}>
-            {Array.from({ length: totalSteps }, (_, i) => i + 1).map((step) => (
-              <div
-                key={step}
-                style={{
-                  flex: 1,
-                  height: '4px',
-                  borderRadius: 'var(--mac-radius-sm)',
-                  backgroundColor: currentStep >= step
-                    ? 'var(--mac-accent-blue, #007aff)'
-                    : 'color-mix(in srgb, var(--mac-text-secondary, #8e8e93), transparent 70%)',
-                  transition: 'background-color 200ms ease',
-                }}
-              />
-            ))}
-          </div>
+          {/* PR-45 / High-15: StepProgressIndicator extracted to its own component */}
+          <StepProgressIndicator currentStep={currentStep} totalSteps={totalSteps} />
 
           {/* Контент шагов */}
           <div className="wizard-content-v2">

--- a/frontend/src/components/wizard/EditModeBanner.jsx
+++ b/frontend/src/components/wizard/EditModeBanner.jsx
@@ -1,0 +1,49 @@
+/**
+ * EditModeBanner — extracted from AppointmentWizardV2.jsx (PR-45 / High-15).
+ *
+ * Shows a banner when the wizard is in edit mode, with a QR/Desk source badge.
+ * Previously inline in AppointmentWizardV2.jsx (lines 2617-2643).
+ */
+import PropTypes from 'prop-types';
+
+const EditModeBanner = ({ editMode, initialData }) => {
+  if (!editMode) return null;
+
+  const isOnlineSource =
+    initialData?.source_kind === 'online' || initialData?.source === 'online';
+
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: '6px',
+      padding: '4px 10px',
+      borderRadius: 'var(--mac-radius-sm)',
+      background: 'rgba(59, 130, 246, 0.12)',
+      color: '#2563eb',
+      fontSize: '12px',
+      fontWeight: 600,
+      marginBottom: '4px'
+    }}>
+      ✏️ Редактирование записи
+      {isOnlineSource ? (
+        <span style={{
+          padding: '1px 6px', borderRadius: '4px', fontSize: '10px',
+          background: 'rgba(139, 92, 246, 0.15)', color: '#7c3aed'
+        }}>QR</span>
+      ) : (
+        <span style={{
+          padding: '1px 6px', borderRadius: '4px', fontSize: '10px',
+          background: 'rgba(100, 116, 139, 0.15)', color: '#475569'
+        }}>Desk</span>
+      )}
+    </div>
+  );
+};
+
+EditModeBanner.propTypes = {
+  editMode: PropTypes.bool,
+  initialData: PropTypes.object,
+};
+
+export default EditModeBanner;

--- a/frontend/src/components/wizard/StepProgressIndicator.jsx
+++ b/frontend/src/components/wizard/StepProgressIndicator.jsx
@@ -1,0 +1,40 @@
+/**
+ * StepProgressIndicator — extracted from AppointmentWizardV2.jsx (PR-45 / High-15).
+ *
+ * Visual progress bar showing the current step in the wizard.
+ * Previously inline in AppointmentWizardV2.jsx (lines 2897-2921).
+ */
+import PropTypes from 'prop-types';
+
+const StepProgressIndicator = ({ currentStep, totalSteps }) => {
+  return (
+    <div style={{
+      display: 'flex',
+      gap: 'var(--mac-spacing-2)',
+      marginBottom: 'var(--mac-spacing-3)',
+      padding: '0 4px',
+    }}>
+      {Array.from({ length: totalSteps }, (_, i) => i + 1).map((step) => (
+        <div
+          key={step}
+          style={{
+            flex: 1,
+            height: '4px',
+            borderRadius: 'var(--mac-radius-sm)',
+            backgroundColor: currentStep >= step
+              ? 'var(--mac-accent-blue, #007aff)'
+              : 'color-mix(in srgb, var(--mac-text-secondary, #8e8e93), transparent 70%)',
+            transition: 'background-color 200ms ease',
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+StepProgressIndicator.propTypes = {
+  currentStep: PropTypes.number.isRequired,
+  totalSteps: PropTypes.number.isRequired,
+};
+
+export default StepProgressIndicator;


### PR DESCRIPTION
## Summary

PR-45 — AppointmentWizardV2 god component split (High-15). 2 sub-components extracted:

1. **EditModeBanner.jsx** (new, 50 LOC): Banner showing edit mode with QR/Desk source badge. Previously inline JSX in AppointmentWizardV2.jsx (27 lines). Props: `editMode`, `initialData`.

2. **StepProgressIndicator.jsx** (new, 40 LOC): Visual progress bar showing current step. Previously inline JSX in AppointmentWizardV2.jsx (25 lines). Props: `currentStep`, `totalSteps`.

AppointmentWizardV2.jsx: 3015 → 2969 LOC (-46 lines). Pattern demonstrated for future extractions (Step1Header, Step2Header, handleComplete are candidates for PR-46+).

## Cyclic Execution Evidence

- Fresh main sync: yes (branched from `45cd6ab4` PR-44 merge)
- Clean workspace: yes
- Branch: `fix/pr-45-appointment-wizard-split`
- Scope gate: 4 files (2 new components + 1 modified wizard + 1 test file)
- Red-check handling: 7 tests RED initially, all GREEN after extraction

## Contract Impact

- Canonical surface: unchanged — AppointmentWizardV2 keeps the same props and renders the same DOM. EditModeBanner and StepProgressIndicator are internal extractions.
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: unchanged — only internal component structure changed
- Compatibility path or alias: none — these are internal refactors
- Contract proof: 626 frontend tests pass (no breakage)

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches React component structure — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: EditModeBanner returns null when editMode is false. StepProgressIndicator renders an empty bar array when totalSteps is 0.
- Partial data proof: not applicable because no API response shape changes — only component extraction
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes — frontend routing unaffected

## Scope Gate

- Allowed paths: `frontend/src/components/wizard/EditModeBanner.jsx`, `frontend/src/components/wizard/StepProgressIndicator.jsx`, `frontend/src/components/wizard/AppointmentWizardV2.jsx`, `frontend/src/__tests__/pr45WizardSplit.test.js`
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: 2 new component files, 1 new test file (7 tests), no schema migration
- Rollback note: reverting restores inline EditModeBanner and StepProgressIndicator JSX in AppointmentWizardV2.jsx

## Validation

- Targeted tests or smoke run: `npx vitest run`
- Result: 626 passed, 0 failed (122 test files including the new pr45WizardSplit.test.js with 7 tests)
- Lint: 0 errors
- Not checked: full e2e suite — will run in CI
