### PR TITLE
🎨 Palette: Add aria-invalid to macOS inputs with error states

### DIFF
--- a/frontend/src/components/ui/macos/Input.jsx
+++ b/frontend/src/components/ui/macos/Input.jsx
@@ -146,6 +146,7 @@ const Input = React.forwardRef(({
         disabled={disabled}
         onFocus={handleFocus}
         onBlur={handleBlur}
+        aria-invalid={!!error}
         {...props}
       />
       {showClearButton && (

--- a/frontend/src/components/ui/macos/Textarea.jsx
+++ b/frontend/src/components/ui/macos/Textarea.jsx
@@ -121,6 +121,7 @@ const Textarea = React.forwardRef(({
       onBlur={handleBlur}
       onInput={adjustHeight}
       rows={minRows}
+      aria-invalid={!!error}
       {...props}
     />
   );

--- a/frontend/src/components/ui/macos/__tests__/MacOSInput.test.jsx
+++ b/frontend/src/components/ui/macos/__tests__/MacOSInput.test.jsx
@@ -37,4 +37,17 @@ describe('Input', () => {
 
     expect(screen.queryByRole('button', { name: /clear input/i })).not.toBeInTheDocument();
   });
+
+  it('sets aria-invalid to true when error prop is truthy', () => {
+    render(
+      <Input
+        value=""
+        onChange={() => {}}
+        error="Field is required"
+        placeholder="Error input"
+      />,
+    );
+    const input = screen.getByPlaceholderText('Error input');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
 });

--- a/frontend/src/components/ui/macos/__tests__/MacOSInput.test.jsx
+++ b/frontend/src/components/ui/macos/__tests__/MacOSInput.test.jsx
@@ -51,3 +51,4 @@ describe('Input', () => {
     expect(input).toHaveAttribute('aria-invalid', 'true');
   });
 });
+// test comment


### PR DESCRIPTION
💡 What: Added the `aria-invalid` attribute to the macOS `Input` and `Textarea` UI components.
🎯 Why: To properly announce when these form fields are in an error state to screen readers.
📸 Before/After: Visual presentation is identical, but DOM representation now includes `aria-invalid="true"` on the underlying native elements when `error` prop is truthy.
♿ Accessibility: Assistive technologies will now read the field as "invalid" when it contains an error.

---
*PR created automatically by Jules for task [3362505145982308615](https://jules.google.com/task/3362505145982308615) started by @drsapaev*