### PR TITLE
fix(security): migrate 3 WS hooks from JWT-in-URL to subprotocol auth (P0)

### DIFF
--- a/frontend/src/hooks/useAIChat.js
+++ b/frontend/src/hooks/useAIChat.js
@@ -267,10 +267,14 @@ export const useAIChat = (options = {}) => {
             return;
         }
 
-        const wsUrl = `${buildWsUrl('/api/v1/ai/chat/ws')}?token=${token}`;
+        // P0 security fix: JWT sent via Sec-WebSocket-Protocol subprotocol (bearer.<token>)
+        // instead of URL query (?token=...). The URL query form leaked the JWT into nginx
+        // access logs, browser history, and Referer headers. Backend supports subprotocol
+        // auth since PR-4 (backend).
+        const wsUrl = `${buildWsUrl('/api/v1/ai/chat/ws')}`;
 
         try {
-            wsRef.current = new WebSocket(wsUrl);
+            wsRef.current = new WebSocket(wsUrl, [`bearer.${token}`]);
 
             wsRef.current.onopen = () => {
                 logger.info('AI Chat WebSocket connected');

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -247,10 +247,14 @@ export function useWebSocket(url, options = {}) {
 
     // Добавляем токен аутентификации к URL
     const token = tokenManager.getAccessToken();
-    const separator = url.includes('?') ? '&' : '?';
-    const authenticatedUrl = token ? `${url}${separator}token=${encodeURIComponent(token)}` : url;
+    // P0 security fix: JWT sent via Sec-WebSocket-Protocol subprotocol (bearer.<token>)
+    // instead of URL query (?token=...). The URL query form leaked the JWT into nginx
+    // access logs, browser history, and Referer headers. Backend supports subprotocol
+    // auth since PR-4 (backend).
+    const authenticatedUrl = url;
+    const subprotocols = token ? [`bearer.${token}`] : [];
 
-    const ws = new WebSocket(authenticatedUrl);
+    const ws = new WebSocket(authenticatedUrl, subprotocols);
 
     ws.onopen = () => {
       setConnected(true);

--- a/frontend/src/hooks/useQueueWebSocket.js
+++ b/frontend/src/hooks/useQueueWebSocket.js
@@ -8,7 +8,8 @@
  * который вызывается из queue endpoints при мутациях.
  *
  * Архитектура:
- *   1. Hook подключается к /ws/queue?department=specialist_{id}&date={date}&token={token}
+ *   1. Hook подключается к /ws/queue?department=specialist_{id}&date={date}
+ *      (JWT передаётся через Sec-WebSocket-Protocol subprotocol, не через URL query)
  *   2. При получении сообщения {type: 'queue_update', ...} вызывает onUpdate callback
  *   3. Callback перезагружает snapshot очереди (loadQueueSnapshot)
  *   4. Polling остаётся как fallback (на случай обрыва WS)
@@ -82,12 +83,16 @@ export function useQueueWebSocket({ specialistId, date, enabled = true, onUpdate
     }
 
     const department = `specialist_${specialistId}`;
-    const wsUrl = `${buildWsUrl('/ws/queue')}?department=${encodeURIComponent(department)}&date=${encodeURIComponent(date)}&token=${encodeURIComponent(token)}`;
+    // P0 security fix: JWT sent via Sec-WebSocket-Protocol subprotocol (bearer.<token>)
+    // instead of URL query (?token=...). The URL query form leaked the JWT into nginx
+    // access logs, browser history, and Referer headers. Backend supports subprotocol
+    // auth since PR-4 (backend). Query params kept for non-token data (department, date).
+    const wsUrl = `${buildWsUrl('/ws/queue')}?department=${encodeURIComponent(department)}&date=${encodeURIComponent(date)}`;
 
     setConnectionState(reconnectAttemptRef.current > 0 ? 'reconnecting' : 'connecting');
 
     try {
-      const ws = new WebSocket(wsUrl);
+      const ws = new WebSocket(wsUrl, [`bearer.${token}`]);
       wsRef.current = ws;
 
       ws.onopen = () => {


### PR DESCRIPTION
## Summary

- **P0 security fix:** 3 WebSocket hooks were sending JWT via URL query string (`?token=...`), leaking the token into nginx access logs, browser history, and Referer headers.
- Migrated all 3 to `Sec-WebSocket-Protocol: bearer.<token>` subprotocol auth, matching the pattern established by `websocketAuth.js` (PR-36) and `NotificationWebSocketContext` (PR-36).
- This is the same vulnerability that frontend audit PR-36/P0-3 was supposed to fix — but PR-36 only migrated 1 of 4 affected sites. This PR closes the remaining 3.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/ws-jwt-subprotocol-migration` created from current `origin/main` (commit `cba81a3` — PR-48 ADR updates)
- Clean workspace: 1 commit, 3 files changed (useQueueWebSocket.js, useAIChat.js, useApi.js)
- Branch: `fix/ws-jwt-subprotocol-migration`
- Scope gate: allowed — `frontend/src/hooks/useQueueWebSocket.js`, `frontend/src/hooks/useAIChat.js`, `frontend/src/hooks/useApi.js`; denied — backend, migrations, env, routing, RBAC, any other file
- Red-check handling: any failing CI check will be fixed in this same PR before merge

## Contract Impact

- Canonical surface: WebSocket endpoints `/ws/queue`, `/api/v1/ai/chat/ws`, and any URL passed to `useApi`'s WS hook. No HTTP API change.
- Request shape: WS connection upgrade now includes `Sec-WebSocket-Protocol: bearer.<token>` header. The URL no longer contains `?token=...`. The backend already supports subprotocol auth (PR-4, backend).
- Response shape: not applicable - WS connection upgrade response, no HTTP body change
- Status codes: not applicable - WS upgrade uses HTTP 101 Switching Protocols, unchanged
- Frontend consumer: `useQueueWebSocket` (consumed by ModernQueueManager), `useAIChat` (consumed by AI chat UI), `useApi` WS hook (consumed by various callers)
- Compatibility path or alias: none - the backend already supports subprotocol auth; the URL query form was redundant and insecure. No fallback needed.
- Contract proof: `npx vitest run` - 626/626 tests pass; manual grep confirms 0 remaining `?token=` in WS URLs

## RBAC / Permissions

- Roles allowed: not applicable - no role change. All authenticated users who previously connected via `?token=` will now connect via subprotocol.
- Roles denied: not applicable - no role change
- Positive auth proof: not applicable - WS auth is token-based, not role-based; the same token that was in the URL is now in the subprotocol
- Negative auth proof: not applicable - no auth surface change; if a user has no token, the hook already skipped connection (useQueueWebSocket) or set an error (useAIChat)

## Notification / Realtime

- Event type or websocket channel: 3 WS channels affected - `/ws/queue`, `/api/v1/ai/chat/ws`, and the generic `useApi` WS. No new channels; no event type changes.
- Payload version / ack behavior: not applicable - the WS message payloads are unchanged; only the connection upgrade mechanism changed
- Read/unread or delivery semantics: not applicable - no delivery semantics change; the same messages flow over the same WS connections
- Reconnect/resync proof: not applicable - reconnect logic in `useQueueWebSocket` (exponential backoff) is unchanged; `useAIChat` and `useApi` still have no reconnect (pre-existing gap, tracked in ADR-0005)

## Frontend Resilience

- Empty data proof: not applicable - no data flow change; only auth transport changed
- Partial data proof: not applicable - no data flow change
- Forbidden secondary path behavior: if the backend rejects the subprotocol (e.g. invalid token), the WS connection will close with code 1008 (policy violation). The existing `onclose` handlers in each hook will treat this as a disconnect and (in useQueueWebSocket) trigger reconnect backoff. This matches the previous behaviour when `?token=` was rejected.
- Missing draft/resource behavior: not applicable - no draft/resource concept in WS auth
- Stale route/deep-link behavior: not applicable - no route change

## Scope Gate

- Allowed paths: `frontend/src/hooks/useQueueWebSocket.js`, `frontend/src/hooks/useAIChat.js`, `frontend/src/hooks/useApi.js`
- Denied paths: `backend/**`, `frontend/src/routing/**`, `frontend/src/api/**` (except the 3 hooks above), database migrations, env files, CI workflow files
- Migration/docs/test impact: no migration; no test changes (626/626 tests pass as before); ADR-0005 already documents the migration plan (this PR implements part of it)
- Rollback note: revert this single commit; the `?token=` form will return and the 3 hooks will leak JWT in URL query again. No DB state; no env vars.

## Validation

- Targeted tests or smoke run: `npx vitest run` (full suite - 626 tests), `npx eslint` on touched files, manual `grep -rn '?token=' frontend/src/` to verify 0 WS URL leaks remain
- Result: passed - 626/626 tests pass, 0 lint errors, 0 new warnings. Grep confirms only `med-queue.uz/queue/join?token=` remains (patient-facing QR queue join token, NOT a JWT — different security context, intentionally in URL for QR scanning).
- Not checked: manual WS connection test with live backend (requires local backend running); Playwright e2e (will run in CI as `Frontend e2e` check)

**Affected files (3):**
1. `frontend/src/hooks/useQueueWebSocket.js:85` — was `?token=${encodeURIComponent(token)}`, now `new WebSocket(url, [`bearer.${token}`])`
2. `frontend/src/hooks/useAIChat.js:270` — was `?token=${token}`, now `new WebSocket(url, [`bearer.${token}`])`
3. `frontend/src/hooks/useApi.js:251` — was `?token=${encodeURIComponent(token)}` appended to URL, now `new WebSocket(url, [`bearer.${token}`])`

Refs: `docs/FRONTEND_AUDIT_2026-07-12.md` P0-3, `docs/architecture/ADR-0005-unified-ws-manager.md`, PR-36 (#2110)
