### PR TITLE
fix(ci): cashier route ordering — /payments/export shadowed by /payments/{payment_id}

### DIFF
--- a/backend/app/api/v1/endpoints/cashier/__init__.py
+++ b/backend/app/api/v1/endpoints/cashier/__init__.py
@@ -9,8 +9,8 @@ to avoid the parameter route shadowing the static export route.
 from __future__ import annotations
 
 from app.api.v1.endpoints.cashier import (
-    _payments,  # noqa: F401  — registers /payments/{payment_id}
-    _stats,  # noqa: F401  — must be first: registers /payments/export
+    _stats,  # noqa: F401  — must be first: registers /payments/export (static)
+    _payments,  # noqa: F401  — registers /payments/{payment_id} (parametric)
     _visits,  # noqa: F401
 )
 from app.api.v1.endpoints.cashier._helpers import *  # noqa: F401, F403


### PR DESCRIPTION
## Summary

The **🐍 Backend тесты** CI job was failing with 1 test:
```
tests/test_openapi_contract.py::test_published_fastapi_routes_do_not_shadow_static_paths_across_routers
AssertionError: Published static routes shadowed by app order:
  1090: GET /api/v1/cashier/payments/export (export_payments)
       is shadowed by /api/v1/cashier/payments/{payment_id} (get_payment_by_id) at 1085
```

## Root cause

In `backend/app/api/v1/endpoints/cashier/__init__.py`, the import order contradicted the documented requirement.

The module docstring states: *"_stats must be first: registers /payments/export"* (static route), but the actual import order had `_payments` FIRST (registers `/payments/{payment_id}` parametric route) and `_stats` SECOND.

Since both modules decorate the shared `router` from `_helpers.py`, the registration order = import order. With `_payments` first, the parametric route `/payments/{payment_id}` was registered before the static `/payments/export`, causing FastAPI to match `"export"` as a `payment_id` value.

## Fix

Swapped import order in `__init__.py` to match the documented contract:

```python
from app.api.v1.endpoints.cashier import (
    _stats,     # must be first: registers /payments/export (static)
    _payments,  # registers /payments/{payment_id} (parametric)
    _visits,
)
```

## Cyclic Execution Evidence

- Fresh main sync: yes — cloned 2026-07-13
- Clean workspace: yes
- Branch: fix/ci-cashier-route-ordering
- Scope gate: 1 file (cashier/__init__.py)
- Red-check handling: N/A — single import order swap, verified with openapi contract tests

## Contract Impact

- Canonical surface: unchanged — same routes, same handlers, same response models
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — `/api/v1/cashier/payments/export` now correctly returns export data instead of being shadowed by `/payments/{payment_id}`
- Compatibility path or alias: none
- Contract proof: 26 openapi contract tests pass, including the previously-failing shadow detection test

## RBAC / Permissions

- Roles allowed: unchanged — Cashier, Admin (same as before)
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only fixes import order — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: not applicable because this is a backend route ordering fix — no frontend data rendering changes
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes — frontend routing unaffected

## Scope Gate

- Allowed paths: backend/app/api/v1/endpoints/cashier/__init__.py
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration, no docs update needed
- Rollback note: reverting restores the shadowing bug — /payments/export would 422/404 again

## Validation

- Targeted tests or smoke run: yes — `pytest tests/test_openapi_contract.py -v` returns 26 passed, 0 failed
- Result: 26 passed, 0 failed
- Not checked: full e2e suite — will run in CI

## Net

1 file changed, +2/−2 LOC.

This was the only remaining failing test on main (all other CI jobs green). After this fix, the 🐍 Backend тесты job should be green and main should be fully release-ready.