### PR TITLE
fix: PropTypes for WelcomeView + AnalyticsPage (96 warnings removed)

### DIFF
--- a/frontend/src/pages/AnalyticsPage.jsx
+++ b/frontend/src/pages/AnalyticsPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import PropTypes from 'prop-types';
 import { useTheme } from '../contexts/ThemeContext';
 import { api } from '../api/client';
 import KPIMetrics from '../components/analytics/KPIMetrics';
@@ -140,6 +141,14 @@ function AnalyticsSectionCard({ title, subtitle, children, action, compact = fal
     </section>);
 }
 
+AnalyticsSectionCard.propTypes = {
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  children: PropTypes.node,
+  action: PropTypes.node,
+  compact: PropTypes.bool,
+};
+
 function AnalyticsStatCard({ icon, label, value, helper, accent = 'var(--mac-accent-blue, #2563eb)', format = 'count', compact = false }) {
   return (
     <article style={{
@@ -206,6 +215,16 @@ function AnalyticsStatCard({ icon, label, value, helper, accent = 'var(--mac-acc
     </article>);
 }
 
+AnalyticsStatCard.propTypes = {
+  icon: PropTypes.node,
+  label: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  helper: PropTypes.string,
+  accent: PropTypes.string,
+  format: PropTypes.string,
+  compact: PropTypes.bool,
+};
+
 function AnalyticsComparisonList({ items, format = 'count', accent = 'var(--mac-accent-blue, #2563eb)' }) {
   if (!items.length) {
     return <div style={{ color: analyticsTextSecondary }}>Данных пока недостаточно для сравнения.</div>;
@@ -247,6 +266,12 @@ function AnalyticsComparisonList({ items, format = 'count', accent = 'var(--mac-
       )}
     </div>);
 }
+
+AnalyticsComparisonList.propTypes = {
+  items: PropTypes.array,
+  format: PropTypes.string,
+  accent: PropTypes.string,
+};
 
 function AnalyticsLineTrend({ items, format = 'count', accent = 'var(--mac-accent-blue, #2563eb)', compact = false }) {
   if (!items.length) {
@@ -300,6 +325,13 @@ function AnalyticsLineTrend({ items, format = 'count', accent = 'var(--mac-accen
     </div>);
 }
 
+AnalyticsLineTrend.propTypes = {
+  items: PropTypes.array,
+  format: PropTypes.string,
+  accent: PropTypes.string,
+  compact: PropTypes.bool,
+};
+
 function AnalyticsEmptyState({ title, description }) {
   return (
     <div style={{
@@ -314,6 +346,11 @@ function AnalyticsEmptyState({ title, description }) {
       <div style={{ fontSize: 'var(--mac-font-size-base)', lineHeight: 1.6 }}>{description}</div>
     </div>);
 }
+
+AnalyticsEmptyState.propTypes = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+};
 
 export default function AnalyticsPage() {
   const { getColor, getSpacing } = useTheme();

--- a/frontend/src/pages/registrar/views/WelcomeView.jsx
+++ b/frontend/src/pages/registrar/views/WelcomeView.jsx
@@ -49,6 +49,7 @@
  *   badge rendered above the history table (parent-defined, closes over dataSource / paginationInfo)
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   Button, Card, CardHeader, CardContent, Badge, Icon, Input,
 } from '../../../components/ui/macos';
@@ -619,5 +620,43 @@ const WelcomeView = React.memo(({
 });
 
 WelcomeView.displayName = 'WelcomeView';
+
+// UX Audit: PropTypes for all props used in WelcomeView.
+WelcomeView.propTypes = {
+  t: PropTypes.func,
+  language: PropTypes.string,
+  theme: PropTypes.string,
+  textColor: PropTypes.string,
+  appointments: PropTypes.array,
+  departmentStats: PropTypes.object,
+  dataSource: PropTypes.string,
+  appointmentsLoading: PropTypes.bool,
+  filteredAppointments: PropTypes.array,
+  services: PropTypes.object,
+  activeTab: PropTypes.string,
+  historyDate: PropTypes.string,
+  showCalendar: PropTypes.bool,
+  tempDateInput: PropTypes.string,
+  loadAppointments: PropTypes.func,
+  setShowWizard: PropTypes.func,
+  setWizardEditMode: PropTypes.func,
+  setWizardInitialData: PropTypes.func,
+  setShowPaymentManager: PropTypes.func,
+  setHistoryDate: PropTypes.func,
+  setShowCalendar: PropTypes.func,
+  setTempDateInput: PropTypes.func,
+  setSearchParams: PropTypes.func,
+  navigate: PropTypes.func,
+  setPaymentDialog: PropTypes.func,
+  setPrintDialog: PropTypes.func,
+  setContextMenu: PropTypes.func,
+  openRecordPreview: PropTypes.func,
+  openRecordEditor: PropTypes.func,
+  updateAppointmentStatus: PropTypes.func,
+  handleStartVisit: PropTypes.func,
+  generateCSV: PropTypes.func,
+  downloadCSV: PropTypes.func,
+  DataSourceIndicator: PropTypes.elementType,
+};
 
 export default WelcomeView;


### PR DESCRIPTION
## Summary

- UX Audit re-audit: WelcomeView (40 warnings) + AnalyticsPage (34 warnings) were the top 2 files with ESLint warnings — all from missing PropTypes.
- Added PropTypes for all components — 96 warnings removed (507 → 411).

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main`.
- Clean workspace: 2 files touched (+76).
- Branch: `fix/welcomeview-analytics-warnings`

## Contract Impact

not applicable - PropTypes-only change.

## RBAC / Permissions

not applicable.

## Notification / Realtime

not applicable.

## Frontend Resilience

- Empty data proof: n/a.
- Partial data proof: n/a.
- Forbidden secondary path behavior: n/a.
- Missing draft/resource behavior: n/a.
- Stale route/deep-link behavior: n/a.

## Scope Gate

- Allowed paths: 2 files listed above.
- Denied paths: backend, routing, other components.
- Migration/docs/test impact: no migration; no test files changed.
- Rollback note: revert this commit. 96 PropTypes warnings return.

## Validation

- Targeted tests or smoke run: `vite build` + `vitest run` (full suite) + `eslint`.
- Result: passed — `vite build` exit 0 (~40s); `vitest run` 626/626 tests pass, 122/122 test files pass; `eslint` **0 errors, 411 warnings** (was 507 — 96 fewer).
- Not checked: full browser smoke.