### PR TITLE
fix(lab,P0): PR-55 — numeric input safety for lab results

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import { toast } from 'react-toastify';  // PR-55: numeric validation toast
 import {
   Alert, Badge, Button, Card, CardContent, CardHeader, CardTitle, Icon,
   Input } from '../ui/macos';
@@ -825,6 +826,20 @@ export default function LabReportWorkbench({
                                 value={currentValue}
                                 onChange={(event) => updateField(field.field_key, event.target.value)}
                                 disabled={!canEditActiveInstance}
+                                // PR-55: numeric input safety — type=number + inputMode=decimal + validation
+                                type={field.value_type === 'numeric' ? 'number' : 'text'}
+                                inputMode={field.value_type === 'numeric' ? 'decimal' : undefined}
+                                step={field.value_type === 'numeric' ? 'any' : undefined}
+                                onBlur={(event) => {
+                                  if (field.value_type !== 'numeric') return;
+                                  const val = event.target.value;
+                                  if (val === '' || val === null || val === undefined) return;
+                                  const parsed = parseFloat(val);
+                                  if (isNaN(parsed)) {
+                                    toast.error(`Некорректное числовое значение: "${val}"`);
+                                    updateField(field.field_key, '');
+                                  }
+                                }}
                               />
                             )}
                             <div style={{ color: 'var(--mac-text-secondary)', fontSize: 'var(--mac-font-size-sm)' }}>


### PR DESCRIPTION
## Summary

P0-1: Numeric fields in lab results now use type=number + inputMode=decimal + step=any + onBlur validation.

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/pr-55-lab-numeric-input-safety
- Scope gate: 1 file (LabReportWorkbench.jsx)
- Red-check handling: N/A — additive props to existing Input component

## Contract Impact

- Canonical surface: unchanged — same endpoints, same payload shape
- Request shape: unchanged — value_numeric still sent as string (backend casts)
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — numeric keyboard on mobile, validation on blur
- Compatibility path or alias: none
- Contract proof: 626 tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches input element props — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: empty values pass through unchanged (onBlur returns early for empty)
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes

## Scope Gate

- Allowed paths: frontend/src/components/laboratory/LabReportWorkbench.jsx
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration, no docs update needed
- Rollback note: reverting restores plain text Input for all value types

## Validation

- Targeted tests or smoke run: npx vitest run
- Result: 626 passed, 0 failed
- Not checked: full e2e suite — will run in CI