### PR TITLE
fix(lab,P0): PR-56 — out-of-range confirmation for lab results

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -838,6 +838,41 @@ export default function LabReportWorkbench({
                                   if (isNaN(parsed)) {
                                     toast.error(`Некорректное числовое значение: "${val}"`);
                                     updateField(field.field_key, '');
+                                    return;
+                                  }
+                                  // PR-56: out-of-range confirmation
+                                  // Check if value exceeds matched_threshold (critical value)
+                                  const threshold = field.resolved_flag_meta?.matched_threshold;
+                                  if (threshold && threshold.value) {
+                                    const thresholdVal = parseFloat(threshold.value);
+                                    if (!isNaN(thresholdVal)) {
+                                      const op = threshold.operator;
+                                      let isCritical = false;
+                                      if (op === 'gt' && parsed > thresholdVal) isCritical = true;
+                                      else if (op === 'gte' && parsed >= thresholdVal) isCritical = true;
+                                      else if (op === 'lt' && parsed < thresholdVal) isCritical = true;
+                                      else if (op === 'lte' && parsed <= thresholdVal) isCritical = true;
+                                      if (isCritical) {
+                                        toast.warning(
+                                          `⚠ Критическое значение: ${field.label} = ${parsed} ${field.unit || ''} ` +
+                                          `(порог: ${op} ${thresholdVal}). Проверьте правильность ввода.`,
+                                          { autoClose: 8000 }
+                                        );
+                                      }
+                                    }
+                                  }
+                                  // Check if value is outside reference_text range (e.g., "120-160")
+                                  const refText = field.reference_text || '';
+                                  const rangeMatch = refText.match(/(\d+\.?\d*)\s*[-–]\s*(\d+\.?\d*)/);
+                                  if (rangeMatch) {
+                                    const low = parseFloat(rangeMatch[1]);
+                                    const high = parseFloat(rangeMatch[2]);
+                                    if (!isNaN(low) && !isNaN(high) && (parsed < low || parsed > high)) {
+                                      toast.info(
+                                        `Значение ${parsed} вне референсного диапазона (${low}–${high}) для «${field.label}».`,
+                                        { autoClose: 5000 }
+                                      );
+                                    }
                                   }
                                 }}
                               />


### PR DESCRIPTION
## Summary

P0-2: Two-tier out-of-range validation on numeric field blur.

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/pr-56-lab-out-of-range-confirmation
- Scope gate: 1 file (LabReportWorkbench.jsx)
- Red-check handling: N/A — additive onBlur logic

## Contract Impact

- Canonical surface: unchanged
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — critical values flagged with warning toast, out-of-range values flagged with info toast
- Compatibility path or alias: none
- Contract proof: 626 tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches input validation logic — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: empty values skip validation (onBlur returns early)
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes

## Scope Gate

- Allowed paths: frontend/src/components/laboratory/LabReportWorkbench.jsx
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration
- Rollback note: reverting removes out-of-range confirmation toasts

## Validation

- Targeted tests or smoke run: npx vitest run
- Result: 626 passed, 0 failed
- Not checked: full e2e suite — will run in CI