### PR TITLE
fix(lab,P0): PR-57 — low<high validation + field_key uniqueness in template editor

### DIFF
--- a/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
@@ -735,9 +735,63 @@ export default function LabTemplateWorkbench({
     return version.id;
   }
 
+  // PR-57: validate reference ranges (low < high) before save/publish
+  function validateReferenceRanges() {
+    if (!draftVersion?.sections) return [];
+    const errors = [];
+    draftVersion.sections.forEach((section, sIdx) => {
+      (section.fields || []).forEach((field, fIdx) => {
+        const rule = field.reference_rule;
+        if (!rule) return;
+        // Check default case
+        const def = rule.default;
+        if (def && def.low != null && def.high != null && def.low !== '' && def.high !== '') {
+          if (parseFloat(def.low) >= parseFloat(def.high)) {
+            errors.push(`Секция "${section.title || sIdx + 1}", поле "${field.label || field.field_key}": default low (${def.low}) ≥ high (${def.high})`);
+          }
+        }
+        // Check each case
+        (rule.cases || []).forEach((c, cIdx) => {
+          if (c.low != null && c.high != null && c.low !== '' && c.high !== '') {
+            if (parseFloat(c.low) >= parseFloat(c.high)) {
+              errors.push(`Секция "${section.title || sIdx + 1}", поле "${field.label || field.field_key}", условие ${cIdx + 1}: low (${c.low}) ≥ high (${c.high})`);
+            }
+          }
+        });
+      });
+    });
+    return errors;
+  }
+
+  // PR-57: validate field_key uniqueness before save/publish
+  function validateFieldKeyUniqueness() {
+    if (!draftVersion?.sections) return [];
+    const errors = [];
+    const seenKeys = new Set();
+    draftVersion.sections.forEach((section, sIdx) => {
+      (section.fields || []).forEach((field, fIdx) => {
+        const key = field.field_key;
+        if (!key) return;
+        if (seenKeys.has(key)) {
+          errors.push(`Дубликат field_key "${key}" в секции "${section.title || sIdx + 1}"`);
+        }
+        seenKeys.add(key);
+      });
+    });
+    return errors;
+  }
+
   async function handleSaveTemplate() {
     if (!selectedTemplate) {
       notify('error', 'Выберите шаблон для редактирования.');
+      return;
+    }
+    // PR-57: validate before saving
+    const rangeErrors = validateReferenceRanges();
+    const keyErrors = validateFieldKeyUniqueness();
+    if (rangeErrors.length > 0 || keyErrors.length > 0) {
+      const allErrors = [...rangeErrors, ...keyErrors];
+      notify('error', `Ошибки валидации (${allErrors.length}):\n${allErrors.slice(0, 5).join('\n')}${allErrors.length > 5 ? '\n...' : ''}`);
       return;
     }
     setSaving(true);
@@ -757,6 +811,14 @@ export default function LabTemplateWorkbench({
   async function handlePublishVersion() {
     if (!selectedTemplate) {
       notify('error', 'Выберите шаблон.');
+      return;
+    }
+    // PR-57: validate before publishing
+    const rangeErrors = validateReferenceRanges();
+    const keyErrors = validateFieldKeyUniqueness();
+    if (rangeErrors.length > 0 || keyErrors.length > 0) {
+      const allErrors = [...rangeErrors, ...keyErrors];
+      notify('error', `Ошибки валидации (${allErrors.length}):\n${allErrors.slice(0, 5).join('\n')}${allErrors.length > 5 ? '\n...' : ''}`);
       return;
     }
     setSaving(true);


### PR DESCRIPTION
## Summary

P0-3: Reference range low<high validation + High-8: field_key uniqueness validation. Both block Save Draft and Publish.

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/pr-57-lab-template-validation
- Scope gate: 1 file (LabTemplateWorkbench.jsx)
- Red-check handling: N/A — additive validation functions

## Contract Impact

- Canonical surface: unchanged — validation is client-side only
- Request shape: unchanged — invalid data is blocked before API call
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — invalid templates cannot be saved/published
- Compatibility path or alias: none
- Contract proof: 626 tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches client-side validation — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: empty low/high values skip validation (null/empty checks)
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes

## Scope Gate

- Allowed paths: frontend/src/components/laboratory/LabTemplateWorkbench.jsx
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration
- Rollback note: reverting removes validation, allowing invalid ranges and duplicate keys

## Validation

- Targeted tests or smoke run: npx vitest run
- Result: 626 passed, 0 failed
- Not checked: full e2e suite — will run in CI