### PR TITLE
fix(lab): PR-58 — autosave + keyboard queue cards + status label fix

### DIFF
--- a/frontend/src/components/emr-v2/sections/LabResultsSection.jsx
+++ b/frontend/src/components/emr-v2/sections/LabResultsSection.jsx
@@ -25,7 +25,7 @@ import notify from '../../../services/notify';
 const STATUS_LABELS = {
   DRAFT: 'Черновик',
   IN_PROGRESS: 'В работе',
-  FINALIZED: 'Готов',
+  FINALIZED: 'Утверждён',  // PR-58: unified with labUiLabels.js (was 'Готов')
   PRINTED: 'Напечатан',
   ARCHIVED: 'Архив',
 };

--- a/frontend/src/components/laboratory/LabQueueWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabQueueWorkbench.jsx
@@ -396,10 +396,20 @@ export default function LabQueueWorkbench({
                 return (
                   <div
                     key={appointment.id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => onOpenAppointment(appointment)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        onOpenAppointment(appointment);
+                      }
+                    }}
                     style={{
                       ...queueCardStyle,
                       borderColor: isSelected ? 'var(--mac-accent)' : 'var(--mac-border)',
-                      boxShadow: isSelected ? '0 0 0 2px color-mix(in oklab, var(--mac-accent) 20%, transparent)' : 'none'
+                      boxShadow: isSelected ? '0 0 0 2px color-mix(in oklab, var(--mac-accent) 20%, transparent)' : 'none',
+                      cursor: 'pointer',
                     }}
                   >
                     <div style={{ display: 'flex', justifyContent: 'space-between', gap: 'var(--mac-spacing-3)', alignItems: 'flex-start' }}>

--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -258,6 +258,28 @@ export default function LabReportWorkbench({
     return () => window.removeEventListener('keydown', handler);
   }, [canSaveDraft, saving]);
 
+  // PR-58: autosave — 30-second debounce when dirty + canSaveDraft
+  const [lastAutoSave, setLastAutoSave] = useState(null);
+  const autoSaveTimerRef = useRef(null);
+  useEffect(() => {
+    if (!isDirty || !canSaveDraft || saving) return;
+    if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
+    autoSaveTimerRef.current = setTimeout(async () => {
+      if (handleSaveDraftRef.current && !saving) {
+        try {
+          await handleSaveDraftRef.current();
+          setLastAutoSave(new Date());
+        } catch (e) {
+          // Autosave failure is non-fatal — manual save is still available
+          logger.warn('Lab autosave failed:', e);
+        }
+      }
+    }, 30000); // 30 seconds
+    return () => {
+      if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
+    };
+  }, [isDirty, canSaveDraft, saving, draftValues]);
+
   useEffect(() => {
     if (activeInstance || !selectedAppointment) {
       return;
@@ -689,6 +711,16 @@ export default function LabReportWorkbench({
                       fontWeight: 'var(--mac-font-weight-medium)',
                     }}>
                       ● несохранённые изменения
+                    </span>
+                  )}
+                  {/* PR-58: autosave indicator */}
+                  {!isDirty && lastAutoSave && (
+                    <span style={{
+                      fontSize: 'var(--mac-font-size-xs)',
+                      color: 'var(--mac-text-tertiary, #6b7280)',
+                      marginLeft: 'var(--mac-spacing-2)',
+                    }}>
+                      ✓ сохранено {lastAutoSave.toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
                     </span>
                   )}
                   {/* P-01 fix: AI-анализ бланка. Перенесён из LabResultsManager


### PR DESCRIPTION
## Summary

High-4: Autosave (30s debounce) + High-5: Keyboard-activatable queue cards + High-12: Status label unified.

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/pr-58-lab-autosave-keyboard-statusfix
- Scope gate: 3 files
- Red-check handling: N/A — additive features

## Contract Impact

- Canonical surface: unchanged
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — autosave prevents data loss, keyboard nav for queue, consistent labels
- Compatibility path or alias: none
- Contract proof: 626 tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches UI behavior — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: autosave only triggers when isDirty (no empty saves)
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes

## Scope Gate

- Allowed paths: frontend/src/components/laboratory/LabReportWorkbench.jsx, frontend/src/components/laboratory/LabQueueWorkbench.jsx, frontend/src/components/emr-v2/sections/LabResultsSection.jsx
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration
- Rollback note: reverting removes autosave, keyboard nav, restores label inconsistency

## Validation

- Targeted tests or smoke run: npx vitest run
- Result: 626 passed, 0 failed
- Not checked: full e2e suite — will run in CI