### PR TITLE
fix(lab): PR-59 — medium fixes: family select, READY status, role=alert, auto-dismiss

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -475,6 +475,8 @@ export default function LabReportWorkbench({
           severity: 'success',
           text: `Лабораторный отчёт отправлен на печать${printResult.data?.printer ? ` (${printResult.data.printer})` : ''}.`
         });
+        // PR-59: auto-dismiss success feedback after 5 seconds
+        setTimeout(() => setPrintFeedback(null), 5000);
         return;
       }
 
@@ -756,7 +758,7 @@ export default function LabReportWorkbench({
               )}
 
               {activeInstance.critical_findings?.length > 0 && (
-                <Alert severity="error">
+                <Alert severity="error" role="alert">  {/* PR-59: role=alert for screen readers */}
                   <div style={{ display: 'grid', gap: 'var(--mac-spacing-2)' }}>
                     <strong>Критические результаты</strong>
                     {activeInstance.critical_findings.map((finding) => (

--- a/frontend/src/components/laboratory/LabStatusStepper.jsx
+++ b/frontend/src/components/laboratory/LabStatusStepper.jsx
@@ -14,6 +14,7 @@ import { Icon } from '../ui/macos';
 const LAB_REPORT_STEPS = [
   { key: 'DRAFT',       label: 'Черновик' },
   { key: 'IN_PROGRESS', label: 'Заполняется' },
+  { key: 'READY',       label: 'Готов к проверке' },  // PR-59: was missing from stepper
   { key: 'FINALIZED',   label: 'Утверждён' },
   { key: 'PRINTED',     label: 'Напечатан' },
 ];

--- a/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
@@ -272,14 +272,24 @@ function NewTemplateDialog({ open, onClose, onCreate, saving }) {
           </div>
           <div>
             <Label htmlFor="new-template-family" style={{ display: 'block', marginBottom: 4 }}>Семейство</Label>
-            <Input
+            {/* PR-59: replaced free-text Input with <select> to prevent typo-induced fragmentation */}
+            <select
               id="new-template-family"
               aria-label="Семейство шаблона"
               value={form.family}
               onChange={(e) => setForm((prev) => ({ ...prev, family: e.target.value }))}
-              placeholder="hematology / biochemistry / ..."
+              className="macos-input"
               style={{ width: '100%', boxSizing: 'border-box' }}
-            />
+            >
+              <option value="hematology">Гематология</option>
+              <option value="biochemistry">Биохимия</option>
+              <option value="coagulation">Коагулология</option>
+              <option value="urinalysis">Общий анализ мочи</option>
+              <option value="immunology">Иммунология</option>
+              <option value="microbiology">Микробиология</option>
+              <option value="endocrinology">Эндокринология</option>
+              <option value="other">Прочее</option>
+            </select>
           </div>
           <div>
             <Label htmlFor="new-template-description" style={{ display: 'block', marginBottom: 4 }}>Описание</Label>


### PR DESCRIPTION
## Summary

4 medium/low fixes: family <select>, READY status in stepper, role=alert on critical findings, print success auto-dismiss.

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/pr-59-lab-medium-fixes
- Scope gate: 3 files
- Red-check handling: N/A — additive fixes

## Contract Impact

- Canonical surface: unchanged
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — predefined families, complete status stepper, screen reader alerts, auto-dismiss print feedback
- Compatibility path or alias: none
- Contract proof: 626 tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches UI components — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: not applicable because these are UI fixes
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes

## Scope Gate

- Allowed paths: frontend/src/components/laboratory/LabTemplateWorkbench.jsx, frontend/src/components/laboratory/LabStatusStepper.jsx, frontend/src/components/laboratory/LabReportWorkbench.jsx
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration
- Rollback note: reverting restores free-text family, missing READY status, no role=alert, persistent print alert

## Validation

- Targeted tests or smoke run: npx vitest run
- Result: 626 passed, 0 failed
- Not checked: full e2e suite — will run in CI