### PR TITLE
fix(lab): PR-61 — sex enum, tab label count, AI button secondary

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -750,10 +750,13 @@ export default function LabReportWorkbench({
                       с сохранением P-02 fix (блокировка при отсутствии возраста/пола).
                       Использует patient_snapshot из activeInstance — отдельный
                       запрос GET /patients/{id} не нужен. */}
+                  {/* PR-61 / Medium-22: AI button styled as secondary (was visually mixed with operational buttons) */}
+                  <span style={{ opacity: 0.85, borderLeft: '1px solid var(--mac-border)', paddingLeft: 'var(--mac-spacing-2)' }}>
                   <LabReportAIAnalysis
                     activeInstance={activeInstance}
                     notify={notify}
                   />
+                  </span>
                 </div>
               </div>
 

--- a/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
@@ -511,12 +511,26 @@ function ReferenceRuleEditor({ sectionIndex, fieldIndex, field, updateField }) {
               ) : (
                 <label style={{ display: 'grid', gap: '4px' }}>
                   <span style={{ fontSize: '12px' }}>Значение</span>
-                  <input
-                    className="macos-input"
-                    aria-label="Значение условия"
-                    value={caseItem.when?.value ?? ''}
-                    onChange={(e) => updateCaseWhen(caseIndex, 'value', e.target.value)}
-                  />
+                  {/* PR-61 / Medium-18: sex enum when source is patient.sex */}
+                  {caseItem.when?.source === 'patient.sex' ? (
+                    <select
+                      className="macos-input"
+                      aria-label="Значение условия"
+                      value={caseItem.when?.value ?? ''}
+                      onChange={(e) => updateCaseWhen(caseIndex, 'value', e.target.value)}
+                    >
+                      <option value="">Выберите...</option>
+                      <option value="M">Мужской (M)</option>
+                      <option value="F">Женский (F)</option>
+                    </select>
+                  ) : (
+                    <input
+                      className="macos-input"
+                      aria-label="Значение условия"
+                      value={caseItem.when?.value ?? ''}
+                      onChange={(e) => updateCaseWhen(caseIndex, 'value', e.target.value)}
+                    />
+                  )}
                 </label>
               )}
             </div>
@@ -1023,7 +1037,8 @@ export default function LabTemplateWorkbench({
   const renderContentTab = () => (
     <div style={{ display: 'grid', gap: '12px' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <div style={{ fontWeight: 600 }}>Секции и показатели ({draftVersion.sections.length})</div>
+        {/* PR-61 / Low-29: count fields not just sections (was misleading) */}
+        <div style={{ fontWeight: 600 }}>Секции и показатели ({draftVersion?.sections?.reduce((acc, s) => acc + (s.fields?.length || 0), 0) || 0} показателей в {draftVersion?.sections?.length || 0} секц.)</div>
         <Button variant="outline" onClick={addSection}>
           <Icon name="plus" size={16} />
           Добавить секцию


### PR DESCRIPTION
## Summary

3 lab fixes: Medium-18 (sex enum), Low-29 (tab label count), Medium-22 (AI button secondary).

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/pr-61-lab-medium-fixes-2
- Scope gate: 2 files
- Red-check handling: N/A — additive UI improvements

## Contract Impact

- Canonical surface: unchanged
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — sex enum prevents typos, accurate field count, cleaner action bar
- Compatibility path or alias: none
- Contract proof: 626 tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches UI rendering — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: not applicable because these are UI rendering fixes
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes

## Scope Gate

- Allowed paths: frontend/src/components/laboratory/LabTemplateWorkbench.jsx, frontend/src/components/laboratory/LabReportWorkbench.jsx
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration
- Rollback note: reverting restores plain text value input, misleading section count, AI button in main action bar

## Validation

- Targeted tests or smoke run: npx vitest run
- Result: 626 passed, 0 failed
- Not checked: full e2e suite — will run in CI