### PR TITLE
fix(lint): PR-63 — eslint auto-fix + MetricCard hardcoded colors → CSS tokens (-23 warnings)

### DIFF
--- a/frontend/src/components/medical/MetricCard.jsx
+++ b/frontend/src/components/medical/MetricCard.jsx
@@ -19,26 +19,27 @@ const MetricCard = ({
 }) => {
   const { isDark } = useTheme();
 
+  // PR-63: replaced hardcoded hex colors with CSS custom properties
   const colorClasses = {
     blue: {
       bg: isDark ? 'var(--mac-accent-blue-active)' : 'var(--mac-accent-bg)',
       text: isDark ? 'var(--mac-accent-blue-light, color-mix(in srgb, var(--mac-accent-blue), white 60%))' : 'var(--mac-accent-blue-hover)',
-      icon: isDark ? '#60a5fa' : 'var(--mac-accent-blue)'
+      icon: isDark ? 'var(--mac-accent-blue-light, color-mix(in srgb, var(--mac-accent-blue), white 40%))' : 'var(--mac-accent-blue)'
     },
     green: {
-      bg: isDark ? '#14532d' : 'var(--mac-success-bg)',
-      text: isDark ? '#86efac' : 'var(--mac-success)',
-      icon: isDark ? '#4ade80' : 'var(--mac-success)'
+      bg: isDark ? 'var(--mac-success-bg, color-mix(in srgb, var(--mac-success), transparent 80%))' : 'var(--mac-success-bg)',
+      text: isDark ? 'var(--mac-success-light, color-mix(in srgb, var(--mac-success), white 40%))' : 'var(--mac-success)',
+      icon: isDark ? 'var(--mac-success-light, color-mix(in srgb, var(--mac-success), white 20%))' : 'var(--mac-success)'
     },
     purple: {
-      bg: isDark ? '#581c87' : '#f3e8ff',
-      text: isDark ? '#c084fc' : '#9333ea',
-      icon: isDark ? '#a855f7' : 'var(--mac-accent-purple)'
+      bg: isDark ? 'var(--mac-accent-purple-bg, color-mix(in srgb, var(--mac-accent-purple), transparent 80%))' : 'var(--mac-accent-purple-bg, color-mix(in srgb, var(--mac-accent-purple), transparent 90%))',
+      text: isDark ? 'var(--mac-accent-purple-light, color-mix(in srgb, var(--mac-accent-purple), white 40%))' : 'var(--mac-accent-purple)',
+      icon: isDark ? 'var(--mac-accent-purple-light, color-mix(in srgb, var(--mac-accent-purple), white 20%))' : 'var(--mac-accent-purple)'
     },
     orange: {
-      bg: isDark ? '#9a3412' : 'var(--mac-error-border, color-mix(in srgb, var(--mac-warning), transparent 50%))',
-      text: isDark ? '#fdba74' : 'var(--mac-warning)',
-      icon: isDark ? '#fb923c' : '#f97316'
+      bg: isDark ? 'var(--mac-warning-bg, color-mix(in srgb, var(--mac-warning), transparent 80%))' : 'var(--mac-error-border, color-mix(in srgb, var(--mac-warning), transparent 50%))',
+      text: isDark ? 'var(--mac-warning-light, color-mix(in srgb, var(--mac-warning), white 40%))' : 'var(--mac-warning)',
+      icon: isDark ? 'var(--mac-warning-light, color-mix(in srgb, var(--mac-warning), white 20%))' : 'var(--mac-warning)'
     },
     red: {
       bg: isDark ? 'var(--mac-error)' : 'var(--mac-error-border, color-mix(in srgb, var(--mac-error), transparent 70%))',

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -442,7 +442,7 @@ const DentistPanelUnified = () => {
       try {
         const token = tokenManager.getAccessToken();
         if (!token) return null;
-        const response = await apiClient.get(`/registrar/services`);
+        const response = await apiClient.get('/registrar/services');
         if (response.status < 400) {
           const data = response.data;
           const servicesData = data.services_by_group || {};
@@ -501,7 +501,7 @@ const DentistPanelUnified = () => {
         }
 
         // Загружаем ВСЕ очереди для получения полной картины услуг пациентов
-        const response = await apiClient.get(`/registrar/queues/today`);
+        const response = await apiClient.get('/registrar/queues/today');
 
         if (response.status < 400) {
           const data = response.data;
@@ -1431,7 +1431,7 @@ const DentistPanelUnified = () => {
   const handleExaminationSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await apiClient.post(`/dental/examinations`, examinationForm);
+      const res = await apiClient.post('/dental/examinations', examinationForm);
       if (res.status < 400) {
         setShowExaminationForm(false);
         setExaminationForm({

--- a/frontend/src/pages/DermatologistPanelUnified.jsx
+++ b/frontend/src/pages/DermatologistPanelUnified.jsx
@@ -353,7 +353,7 @@ const DermatologistPanelUnified = () => {
       try {
         const token = tokenManager.getAccessToken();
         if (!token) return {};
-        const response = await api.get(`/registrar/services`);
+        const response = await api.get('/registrar/services');
         if (response.status < 400) {
           const data = response.data;
           const servicesData = data.services_by_group || {};
@@ -742,7 +742,7 @@ const DermatologistPanelUnified = () => {
     const loadPromise = (async () => {
       dermatologyRequestCache.skinExaminations.lastAttemptAt = Date.now();
       try {
-        const response = await api.get(`/derma/examinations?limit=100`);
+        const response = await api.get('/derma/examinations?limit=100');
         if (response.status < 400) {
           const data = response.data;
           const nextSkinExaminations = Array.isArray(data) ? data : [];
@@ -784,7 +784,7 @@ const DermatologistPanelUnified = () => {
     const loadPromise = (async () => {
       dermatologyRequestCache.cosmeticProcedures.lastAttemptAt = Date.now();
       try {
-        const response = await api.get(`/derma/procedures?limit=100`);
+        const response = await api.get('/derma/procedures?limit=100');
         if (response.status < 400) {
           const data = response.data;
           const nextCosmeticProcedures = Array.isArray(data) ? data : [];
@@ -1259,7 +1259,7 @@ const DermatologistPanelUnified = () => {
       };
       logger.info('[Dermatology] Сохранение осмотра кожи', payload);
 
-      const response = await api.post(`/derma/examinations`, payload);
+      const response = await api.post('/derma/examinations', payload);
 
       if (response.status < 400) {
         setShowSkinForm(false);
@@ -1299,7 +1299,7 @@ const DermatologistPanelUnified = () => {
       };
       logger.info('[Dermatology] Сохранение косметической процедуры', payload);
 
-      const response = await api.post(`/derma/procedures`, payload);
+      const response = await api.post('/derma/procedures', payload);
 
       if (response.status < 400) {
         setShowCosmeticForm(false);

--- a/frontend/src/pages/MobilePatientDashboard.jsx
+++ b/frontend/src/pages/MobilePatientDashboard.jsx
@@ -45,7 +45,7 @@ const MobilePatientDashboard = () => {
       setLoading(true);
 
       // Загружаем данные пациента
-      const response = await api.get(`/mobile/auth/profile`);
+      const response = await api.get('/mobile/auth/profile');
 
       if (response.status < 400) {
         const data = response.data;
@@ -53,7 +53,7 @@ const MobilePatientDashboard = () => {
       }
 
       // Загружаем записи
-      const appointmentsResponse = await api.get(`/mobile/appointments`);
+      const appointmentsResponse = await api.get('/mobile/appointments');
 
       if (appointmentsResponse.status < 400) {
         const appointmentsData = appointmentsResponse.data;


### PR DESCRIPTION
## Summary

ESLint warnings reduced: 433 → 410 (-23). Auto-fix formatting (10) + MetricCard hardcoded colors (13).

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/pr-63-eslint-proptypes-batch
- Scope gate: 4 files
- Red-check handling: N/A — formatting + color token migration

## Contract Impact

- Canonical surface: unchanged
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — dark mode colors now use CSS custom properties with fallbacks
- Compatibility path or alias: none
- Contract proof: 626 tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches CSS tokens and formatting — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: not applicable because these are CSS token changes
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes

## Scope Gate

- Allowed paths: frontend/src/pages/DentistPanelUnified.jsx, frontend/src/pages/DermatologistPanelUnified.jsx, frontend/src/pages/MobilePatientDashboard.jsx, frontend/src/components/medical/MetricCard.jsx
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration
- Rollback note: reverting restores hardcoded hex colors and formatting inconsistencies

## Validation

- Targeted tests or smoke run: npx vitest run
- Result: 626 passed, 0 failed
- Not checked: full e2e suite — will run in CI