### PR TITLE
fix(lab): PR-66 — details marker reset + dirty/missing Badge indicators

### DIFF
--- a/frontend/src/components/laboratory/LabQueueWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabQueueWorkbench.jsx
@@ -474,6 +474,7 @@ export default function LabQueueWorkbench({
                         {/* P-05 fix: patient_id — внутренний идентификатор, не нужен
                             лаборанту для работы. Скрываем по умолчанию, раскрытие —
                             по клику. Снижает риск утечки PII через скриншоты. */}
+                        {/* PR-66 / Low-30: added custom marker + ::marker CSS reset */}
                         <details style={{ display: 'inline' }}>
                           <summary
                             style={{
@@ -484,6 +485,7 @@ export default function LabQueueWorkbench({
                             }}
                             aria-label="Показать внутренний ID пациента"
                           >
+                            <style>{`summary::-webkit-details-marker { display: none; } summary::marker { content: ''; }`}</style>
                             ID пациента ▸
                           </summary>
                           <span style={{ marginLeft: 6, fontFamily: 'monospace' }}>

--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -718,26 +718,16 @@ export default function LabReportWorkbench({
                   {/* WF-10 fix: inline-индикатор missing required fields.
                       Показываем сколько обязательных полей ещё не заполнено,
                       чтобы лаборант понимал, почему Finalize disabled. */}
+                  {/* PR-66 / Low-27: replaced plain text spans with Badge components */}
                   {canFinalize && hasMissingRequired && (
-                    <span style={{
-                      fontSize: 'var(--mac-font-size-xs)',
-                      color: 'var(--mac-accent-orange, #c2410c)',
-                      marginLeft: 'var(--mac-spacing-2)',
-                    }}>
-                      Не заполнено обязательных полей: {missingRequiredFields.length}
-                    </span>
+                    <Badge variant="warning" style={{ marginLeft: 'var(--mac-spacing-2)' }}>
+                      ⚠ Не заполнено: {missingRequiredFields.length}
+                    </Badge>
                   )}
-                  {/* Dirty state indicator: показываем, что есть несохранённые
-                      изменения. Предотвращает потерю данных при переключении. */}
                   {isDirty && canEditActiveInstance && (
-                    <span style={{
-                      fontSize: 'var(--mac-font-size-xs)',
-                      color: 'var(--mac-accent-orange, #c2410c)',
-                      marginLeft: 'var(--mac-spacing-2)',
-                      fontWeight: 'var(--mac-font-weight-medium)',
-                    }}>
+                    <Badge variant="warning" style={{ marginLeft: 'var(--mac-spacing-2)' }}>
                       ● несохранённые изменения
-                    </span>
+                    </Badge>
                   )}
                   {/* PR-58: autosave indicator */}
                   {!isDirty && lastAutoSave && (


### PR DESCRIPTION
## Summary

Low-30: details marker CSS reset. Low-27: dirty/missing indicators upgraded to Badge.

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/pr-66-lab-remaining-fixes
- Scope gate: 2 files
- Red-check handling: N/A — UI polish

## Contract Impact

- Canonical surface: unchanged
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — consistent marker, visible badges
- Compatibility path or alias: none
- Contract proof: 626 tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches UI rendering — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: not applicable because these are UI polish fixes
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes

## Scope Gate

- Allowed paths: frontend/src/components/laboratory/LabQueueWorkbench.jsx, frontend/src/components/laboratory/LabReportWorkbench.jsx
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration
- Rollback note: reverting restores default marker and plain text spans

## Validation

- Targeted tests or smoke run: npx vitest run
- Result: 626 passed, 0 failed
- Not checked: full e2e suite — will run in CI