### PR TITLE
fix(lab): PR-67 — previous-result trending + catalog reference_mode UI

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -866,6 +866,28 @@ export default function LabReportWorkbench({
                                 )}
                               </div>
                             </div>
+                            {/* PR-67 / High-9: previous-result trending — show last value from reportHistory */}
+                            {reportHistory.length > 1 && (() => {
+                              const prevReport = reportHistory[1]; // [0] = current, [1] = previous
+                              if (!prevReport?.sections) return null;
+                              let prevValue = null;
+                              for (const sec of prevReport.sections) {
+                                for (const f of (sec.fields || [])) {
+                                  if (f.field_key === field.field_key && f.value_text) {
+                                    prevValue = f.value_text;
+                                    break;
+                                  }
+                                }
+                                if (prevValue) break;
+                              }
+                              if (!prevValue) return null;
+                              const prevDate = prevReport.created_at ? new Date(prevReport.created_at).toLocaleDateString('ru-RU', { day: 'numeric', month: 'short' }) : '';
+                              return (
+                                <span style={{ fontSize: 'var(--mac-font-size-xs)', color: 'var(--mac-text-tertiary)', whiteSpace: 'nowrap' }}>
+                                  ↗ {prevValue} {prevDate && `(${prevDate})`}
+                                </span>
+                              );
+                            })()}
                             {field.value_type === 'choice' && choiceOptions.length > 0 ? (
                               <select
                                 className="macos-input"

--- a/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
@@ -1201,6 +1201,40 @@ export default function LabTemplateWorkbench({
                                   ))}
                                 </select>
                               </label>
+                              {/* PR-67 / High-10: catalog reference_mode UI — fetch from labReportingApi */}
+                              {field.reference_mode === 'catalog' && field.analyte_code && (
+                                <div style={{ display: 'grid', gap: '4px' }}>
+                                  <Button
+                                    variant="outline"
+                                    size="small"
+                                    onClick={async () => {
+                                      try {
+                                        const ranges = await labReportingApi.listCatalogReferenceRanges(field.analyte_code);
+                                        if (ranges && ranges.length > 0) {
+                                          const range = ranges[0];
+                                          updateField(sectionIndex, fieldIndex, 'reference_text',
+                                            range.text || `${range.low || ''}–${range.high || ''}`);
+                                          if (range.low != null) updateField(sectionIndex, fieldIndex, 'reference_low', range.low);
+                                          if (range.high != null) updateField(sectionIndex, fieldIndex, 'reference_high', range.high);
+                                          notify('success', `Норма загружена из каталога: ${range.text || ''}`);
+                                        } else {
+                                          notify('info', 'В каталоге нет норм для этого аналита.');
+                                        }
+                                      } catch (e) {
+                                        notify('error', `Ошибка загрузки из каталога: ${e.message}`);
+                                      }
+                                    }}
+                                  >
+                                    <Icon name="square.and.arrow.down.on.square" size={14} />
+                                    Загрузить из каталога
+                                  </Button>
+                                </div>
+                              )}
+                              {field.reference_mode === 'catalog' && !field.analyte_code && (
+                                <span style={{ fontSize: 'var(--mac-font-size-xs)', color: 'var(--mac-text-muted)' }}>
+                                  Укажите код аналита для загрузки нормы из каталога
+                                </span>
+                              )}
                               <label style={{ display: 'grid', gap: '6px' }}>
                                 <span>Текст нормы</span>
                                 <input className="macos-input" aria-label="Текст нормы" value={field.reference_text || ''} onChange={(event) => updateField(sectionIndex, fieldIndex, 'reference_text', event.target.value)} />


### PR DESCRIPTION
## Summary

High-9: Previous-result trending inline (↗ 14.2 (15 мая)). High-10: Catalog reference_mode UI (was dead dropdown option).

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/pr-67-lab-trending-catalog
- Scope gate: 2 files
- Red-check handling: N/A — additive features

## Contract Impact

- Canonical surface: unchanged
- Request shape: unchanged
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — trending data visible, catalog ranges loadable
- Compatibility path or alias: none
- Contract proof: 626 tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not applicable because this PR only touches UI rendering — no WS or notification changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change any realtime channel

## Frontend Resilience

- Empty data proof: trending shows nothing when reportHistory has < 2 entries or no previous value
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: catalog button only shows when analyte_code is set
- Stale route/deep-link behavior: no route changes

## Scope Gate

- Allowed paths: frontend/src/components/laboratory/LabReportWorkbench.jsx, frontend/src/components/laboratory/LabTemplateWorkbench.jsx
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration
- Rollback note: reverting removes trending display and catalog button

## Validation

- Targeted tests or smoke run: npx vitest run
- Result: 626 passed, 0 failed
- Not checked: full e2e suite — will run in CI