### PR TITLE
fix(cashier): UX-AUDIT 1.3 — убрать дублирующую кнопку обновления в RefundRequestsTable

### DIFF
--- a/frontend/src/components/cashier/RefundRequestsTable.jsx
+++ b/frontend/src/components/cashier/RefundRequestsTable.jsx
@@ -13,7 +13,6 @@ import {
   DollarSign,
   Clock,
   CheckCircle,
-  RefreshCw,
   Loader2,
   User,
   CreditCard
@@ -380,16 +379,13 @@ const RefundRequestsTable = ({ onRefresh }) => {
             size="small"
             aria-label="Фильтр заявок на возврат"
           />
-
-          <Button
-            variant="secondary"
-            size="small"
-            onClick={loadRequests}
-            disabled={loading}
-            aria-label="Обновить список заявок на возврат"
-          >
-            <RefreshCw size={14} className={loading ? 'animate-spin' : ''} aria-hidden="true" />
-          </Button>
+          {/* UX Audit #1.3: дублирующая кнопка «Обновить» убрана.
+              Глобальная кнопка «Обновить» в stats-card CashierPanel
+              вызывает onRefresh → loadRequests. Лишний триггер (Nielsen #8 —
+              эстетический и минималистичный дизайн) создавал когнитивную
+              неоднозначность: «обновляет ли кнопка весь экран или только
+              эту таблицу?». При смене фильтра список всё равно
+              авто-обновляется через useEffect → loadRequests. */}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- UX-аудит #1.3: убрать дублирующую кнопку «Обновить» (RefreshCw icon) из header `RefundRequestsTable`.
- Кнопка дублировала глобальную кнопку «Обновить» в stats-card `CashierPanel`, создавая когнитивную неоднозначность.
- Список возвратов продолжает автообновляться через `useEffect` при смене фильтра.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/cashier-refund-refresh-dedupe` создана из актуального `origin/main` (после merge PR #2161, #2162).
- Clean workspace: inspected before edits; только `frontend/src/components/cashier/RefundRequestsTable.jsx` изменён.
- Branch: fix/cashier-refund-refresh-dedupe
- Scope gate: allowed `frontend/src/components/cashier/RefundRequestsTable.jsx`; denied backend, migrations, other panels.
- Red-check handling: если CI зайдёт в красный, фикс в этом же PR до merge.

## Contract Impact

- Canonical surface: `frontend/src/components/cashier/RefundRequestsTable.jsx` — UI only (удалён button + неиспользуемый импорт).
- Request shape: не изменён — `loadRequests()` по-прежнему вызывается через `useEffect` при смене `filter`.
- Response shape: не изменён.
- Status codes: не применимо (frontend-only).
- Frontend consumer: `CashierPanel` → `<RefundRequestsTable onRefresh={handleRefresh} />` — без изменений в пропах.
- Compatibility path or alias: глобальная кнопка «Обновить» в `CashierPanel` вызывает `onRefresh` → `loadRequests`, путь сохранён.
- Contract proof: `RefundRequestsTable.contract.test.jsx` — 3/3 ✓.

## RBAC / Permissions

- Roles allowed: Cashier, Admin (без изменений).
- Roles denied: остальные роли (без изменений).
- Positive auth proof: не применимо (изменение только UI-рендера).
- Negative auth proof: не применимо.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: при `requests=[]` пустое состояние рендерится как прежде через `AppEmpty`.
- Partial data proof: при `error` рендерится `AppError` с кнопкой «Повторить», которая вызывает `loadRequests` — путь сохранён.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: not applicable, table не создаёт drafts/resources.
- Stale route/deep-link behavior: not applicable, table не зависит от route state.

## Scope Gate

- Allowed paths: `frontend/src/components/cashier/RefundRequestsTable.jsx`.
- Denied paths: backend, migrations, CashierPanel.jsx, routing, other modals.
- Migration/docs/test impact: нет миграций; контракт-тесты без изменений.
- Rollback note: revert единственного коммита в этом PR.

## Validation

- Targeted tests or smoke run: `CashierPanel.contract.test.jsx` (6/6), `RefundRequestsTable.contract.test.jsx` (3/3), ESLint `RefundRequestsTable.jsx` (0 errors / 0 warnings).
- Result: passed.
- Not checked: full Playwright e2e (запущен в CI).