### PR TITLE
fix(cashier): UX-AUDIT 1.5 — убрать двойное подтверждение в PaymentWidget

### DIFF
--- a/frontend/src/components/payment/PaymentWidget.jsx
+++ b/frontend/src/components/payment/PaymentWidget.jsx
@@ -13,10 +13,6 @@ import {
   Button,
   Alert,
   CircularProgress,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
   Select,
 } from '../ui/macos';
 
@@ -72,7 +68,6 @@ const PaymentWidget = ({
   const [error, setError] = useState(null);
   const [paymentData, setPaymentData] = useState(null);
   const [paymentStatus, setPaymentStatus] = useState('pending');
-  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
 
   // HIGH #7 fix: auto-polling for online payment status.
   // Previously the cashier had to click "Проверить статус" manually.
@@ -345,10 +340,8 @@ const PaymentWidget = ({
     }
   };
 
-  // Подтверждение платежа
-  const confirmPayment = () => {
-    setShowConfirmDialog(true);
-  };
+  // UX Audit #1.5: confirmPayment() и showConfirmDialog state удалены —
+  // двойное подтверждение убрано. initializePayment() вызывается напрямую.
 
   // Форматирование суммы
   const formatAmount = (amountValue, currencyCode) => {
@@ -544,15 +537,19 @@ const PaymentWidget = ({
         }
 
         {/* Кнопки действий */}
+        {/* UX Audit #1.5: убран двойной confirm-dialog (Nielsen #7 — flexibility & efficiency).
+            Раньше: click «Оплатить» → модалка подтверждения → click «Продолжить» → реальная инициализация.
+            Теперь: click «Оплатить» сразу инициализирует платёж. Защита от случайного клика —
+            через `loading` state (кнопка дизейблится на время инициализации). */}
         <Box display="flex" className="pw-actions-row">
           <Button
             variant="contained"
             color="primary"
             size="large"
             fullWidth
-            onClick={confirmPayment}
+            onClick={initializePayment}
             disabled={loading || !selectedProvider || paymentStatus === 'paid'}>
-            
+
             {loading ?
             <>
                 <CircularProgress size={20} className="pw-submit-spinner" />
@@ -570,47 +567,11 @@ const PaymentWidget = ({
             size="large"
             onClick={cancelPayment}
             disabled={loading}>
-            
+
               Отмена
             </Button>
           }
         </Box>
-
-        {/* Диалог подтверждения */}
-        <Dialog open={showConfirmDialog} onClose={() => setShowConfirmDialog(false)}>
-          <DialogTitle>Подтверждение оплаты</DialogTitle>
-          <DialogContent>
-            <Typography variant="body1" gutterBottom>
-              Вы собираетесь оплатить:
-            </Typography>
-            <Box className="pw-confirm-amount-box">
-              <Typography variant="h6" color="primary">
-                {formatAmount(amount, currency)}
-              </Typography>
-              <Typography variant="body2" color="textSecondary">
-                через {providers.find((p) => p.code === selectedProvider)?.name}
-              </Typography>
-            </Box>
-            <Typography variant="body2" color="textSecondary">
-              После нажатия «Продолжить» вы будете перенаправлены на страницу оплаты.
-            </Typography>
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setShowConfirmDialog(false)}>
-              Отмена
-            </Button>
-            <Button
-              variant="contained"
-              onClick={() => {
-                setShowConfirmDialog(false);
-                initializePayment();
-              }}
-              disabled={loading}>
-              
-              Продолжить
-            </Button>
-          </DialogActions>
-        </Dialog>
       </CardContent>
     </Card>);
 


### PR DESCRIPTION
## Summary

- UX-аудит #1.5: убрать `Dialog` подтверждения из `PaymentWidget`.
- Раньше: click «Оплатить» → модалка подтверждения → click «Продолжить» → реальная инициализация (2 клика).
- Теперь: click «Оплатить» сразу инициализирует платёж (1 клик). Защита от случайного клика — через `loading` state (кнопка дизейблится на время инициализации).

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/cashier-payment-confirm-dedupe` создана из актуального `origin/main` (после merge PR #2161..#2164).
- Clean workspace: inspected before edits; только `frontend/src/components/payment/PaymentWidget.jsx` изменён.
- Branch: fix/cashier-payment-confirm-dedupe
- Scope gate: allowed `frontend/src/components/payment/PaymentWidget.jsx`; denied backend, migrations, other panels.
- Red-check handling: если CI зайдёт в красный, фикс в этом же PR до merge.

## Contract Impact

- Canonical surface: `frontend/src/components/payment/PaymentWidget.jsx` — UI only (удалён confirm-dialog, state, function, неиспользуемые импорты).
- Request shape: не изменён — `initializePayment()` по-прежнему отправляет `{ visit_id, provider, amount, currency, description, return_url, cancel_url }` на `/payments/init`.
- Response shape: не изменён.
- Status codes: не применимо (frontend-only).
- Frontend consumer: `CashierPanel` оборачивает `PaymentWidget` в Dialog; контракт не изменился.
- Compatibility path or alias: `onSuccess`/`onError`/`onCancel` колбэки без изменений; `loading` state остаётся.
- Contract proof: `CashierPanel.contract.test.jsx` — 6/6 ✓.

## RBAC / Permissions

- Roles allowed: Cashier, Admin (без изменений).
- Roles denied: остальные роли (без изменений).
- Positive auth proof: не применимо (изменение только UI-рендера).
- Negative auth proof: не применимо.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: при `amount=0` `initializePayment` всё равно валидирует `if (!selectedProvider || !visitId || !amount)` и выходит.
- Partial data proof: при отсутствии `selectedProvider` кнопка уже disabled на уровне JSX (`disabled={loading || !selectedProvider || ...}`).
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: not applicable, widget не создаёт drafts/resources.
- Stale route/deep-link behavior: not applicable, widget не зависит от route state.

## Scope Gate

- Allowed paths: `frontend/src/components/payment/PaymentWidget.jsx`.
- Denied paths: backend, migrations, CashierPanel.jsx, CashPaymentModal, routing.
- Migration/docs/test impact: нет миграций; контракт-тесты без изменений.
- Rollback note: revert единственного коммита в этом PR.

## Validation

- Targeted tests or smoke run: `CashierPanel.contract.test.jsx` (6/6), `RefundRequestsTable.contract.test.jsx` (3/3), ESLint `PaymentWidget.jsx` (0 errors / 4 pre-existing warnings — hex colors и useCallback dep).
- Result: passed.
- Not checked: full Playwright e2e (запущен в CI).