### PR TITLE
fix(cashier): UX-AUDIT 2.6 — tooltip для grouped платежей + badge «Групповой»

### DIFF
--- a/frontend/src/pages/CashierPanel.jsx
+++ b/frontend/src/pages/CashierPanel.jsx
@@ -1315,6 +1315,13 @@ const CashierPanel = () => {
                         `${appointment.patient_last_name} ${appointment.patient_first_name}` :
                         appointment.patient_name || `Пациент #${appointment.patient_id}`
                         }
+                              {/* UX Audit #2.6: badge «Групповой» для grouped-платежей,
+                                  чтобы было видно, почему кнопка «Онлайн» дизейблится. */}
+                              {isBackendGroupedCashierPayment(appointment) && (
+                                <span className="cashier-badge cashier-badge-grouped" title="Несколько визитов в одном платеже">
+                                  Групповой
+                                </span>
+                              )}
                             </td>
                             <td className="cashier-text-sm cashier-text-primary">
                               {renderServiceBadges(appointment.services, appointment.services_names)}
@@ -1338,7 +1345,9 @@ const CashierPanel = () => {
                             onClick={() => openPaymentWidget(appointment)}
                             disabled={!canCreateDirectCashierPayment(appointment) || isBackendGroupedCashierPayment(appointment)}
                             aria-label="Начать онлайн-оплату"
-                            title={!canCreateDirectCashierPayment(appointment) || isBackendGroupedCashierPayment(appointment) ? 'Онлайн-оплата недоступна для этой записи' : 'Оплата онлайн'}>
+                            title={!canCreateDirectCashierPayment(appointment) || isBackendGroupedCashierPayment(appointment)
+                              ? 'Онлайн-оплата недоступна для групповых платежей (несколько визитов). Используйте кнопку «Касса».'
+                              : 'Оплата онлайн через Click/PayMe/Kaspi'}>
 
                                   Онлайн
                                 </Button>

--- a/frontend/src/pages/cashier.css
+++ b/frontend/src/pages/cashier.css
@@ -350,3 +350,18 @@
 .cashier-session-warning-btn--primary:hover {
   filter: brightness(0.95);
 }
+
+/* ─── Grouped payment badge (UX Audit #2.6) ─── */
+.cashier-badge-grouped {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 2px 6px;
+  background: color-mix(in srgb, var(--mac-accent-orange, #ff9500), transparent 88%);
+  color: var(--mac-accent-orange, #ff9500);
+  border: 1px solid color-mix(in srgb, var(--mac-accent-orange, #ff9500), transparent 60%);
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}


### PR DESCRIPTION
## Summary

- UX-аудит #2.6: уточнить tooltip для disabled-кнопки «Онлайн» + добавить badge «Групповой» в строке pending-платежа.
- Раньше: tooltip «Онлайн-оплата недоступна для этой записи» — не объяснял, почему именно.
- Теперь: tooltip «Онлайн-оплата недоступна для групповых платежей (несколько визитов). Используйте кнопку «Касса».» + визуальный badge в строке.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/cashier-grouped-tooltip` создана из актуального `origin/main` (после merge PR #2161..#2170).
- Clean workspace: inspected before edits; только `frontend/src/pages/CashierPanel.jsx` и `frontend/src/pages/cashier.css` изменены.
- Branch: fix/cashier-grouped-tooltip
- Scope gate: allowed `frontend/src/pages/CashierPanel.{jsx,css}` (pending-tab online button + badge); denied backend, migrations, other panels.
- Red-check handling: если CI зайдёт в красный, фикс в этом же PR до merge.

## Contract Impact

- Canonical surface: `frontend/src/pages/CashierPanel.jsx` — pending-tab online-button title + patient-cell badge.
- Request shape: не изменён.
- Response shape: не изменён.
- Status codes: не применимо (frontend-only).
- Frontend consumer: CashierPanel pending tab.
- Compatibility path or alias: `isBackendGroupedCashierPayment(appointment)` и `canCreateDirectCashierPayment(appointment)` без изменений; добавлен только визуальный badge рядом с patient name.
- Contract proof: `CashierPanel.contract.test.jsx` — 6/6 ✓ (контракт `disabled={!canCreateDirectCashierPayment(appointment) || isBackendGroupedCashierPayment(appointment)}` без изменений).

## RBAC / Permissions

- Roles allowed: Cashier, Admin (без изменений).
- Roles denied: остальные роли (без изменений).
- Positive auth proof: не применимо (изменение только UI-рендера).
- Negative auth proof: не применимо.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: при `appointment=null` badge не рендерится (условие `isBackendGroupedCashierPayment(appointment)` возвращает false для null).
- Partial data proof: при `can_create_grouped_payment=false` badge не показывается.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: not applicable, badge не создаёт drafts/resources.
- Stale route/deep-link behavior: not applicable, badge не зависит от route state.

## Scope Gate

- Allowed paths: `frontend/src/pages/CashierPanel.jsx`, `frontend/src/pages/cashier.css`.
- Denied paths: backend, migrations, CashPaymentModal, PaymentWidget, routing.
- Migration/docs/test impact: нет миграций; контракт-тесты без изменений.
- Rollback note: revert единственного коммита в этом PR.

## Validation

- Targeted tests or smoke run: `CashierPanel.contract.test.jsx` (6/6), ESLint `CashierPanel.jsx` (0 errors / 3 pre-existing warnings).
- Result: passed.
- Not checked: full Playwright e2e (запущен в CI).