### PR TITLE
fix(chat,P0): PR-68 — 5 critical chat fixes (notification click, AudioContext leak, voice axios, typing position, scroll preservation)

### DIFF
--- a/frontend/src/components/chat/ChatButton.jsx
+++ b/frontend/src/components/chat/ChatButton.jsx
@@ -2,7 +2,7 @@
  * Кнопка чата для хедера (macOS стиль)
  */
 
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { MessageCircle } from 'lucide-react';
 import { useChat } from '../../hooks/useChat';
 import ChatWindow from './ChatWindow';
@@ -12,7 +12,28 @@ import ChatWindow from './ChatWindow';
  */
 const ChatButton = () => {
     const [isOpen, setIsOpen] = useState(false);
-    const { unreadCount, isConnected } = useChat();
+    const { unreadCount, isConnected, loadMessages } = useChat();
+    // PR-68 / P0-1: listen for 'openChat' CustomEvent from desktop notifications
+    const pendingUserIdRef = useRef(null);
+
+    useEffect(() => {
+        const handleOpenChat = (event) => {
+            setIsOpen(true);
+            if (event?.detail?.userId && loadMessages) {
+                pendingUserIdRef.current = event.detail.userId;
+            }
+        };
+        window.addEventListener('openChat', handleOpenChat);
+        return () => window.removeEventListener('openChat', handleOpenChat);
+    }, [loadMessages]);
+
+    // When chat opens with a pending userId, load that conversation
+    useEffect(() => {
+        if (isOpen && pendingUserIdRef.current && loadMessages) {
+            loadMessages(pendingUserIdRef.current);
+            pendingUserIdRef.current = null;
+        }
+    }, [isOpen, loadMessages]);
 
     return (
         <>

--- a/frontend/src/components/chat/ChatWindow.jsx
+++ b/frontend/src/components/chat/ChatWindow.jsx
@@ -226,6 +226,15 @@ const ChatWindow = ({ isOpen, onClose }) => {
     if (container.scrollTop === 0 && hasMore && !isLoading) {
       prevScrollHeightRef.current = container.scrollHeight;
       await loadMoreMessages();
+      // PR-68 / P0-5: preserve scroll position after loading older messages
+      // (was: prevScrollHeightRef set but never read — view jumped to top)
+      if (prevScrollHeightRef.current) {
+        requestAnimationFrame(() => {
+          const newScrollHeight = container.scrollHeight;
+          container.scrollTop = newScrollHeight - prevScrollHeightRef.current;
+          prevScrollHeightRef.current = null;
+        });
+      }
     }
   };
 
@@ -326,23 +335,13 @@ const ChatWindow = ({ isOpen, onClose }) => {
       formData.append('audio_file', audioBlob, 'voice.webm');
       formData.append('recipient_id', activeConversation);
 
-      const token = auth.getState().token;
-      const response = await fetch('/messages/send-voice', {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`
-        },
-        body: formData
+      // PR-68 / P0-3: replaced raw fetch with axios client
+      // (was: fetch('/messages/send-voice') — no /api/v1 prefix, no CSRF, no token refresh)
+      const response = await api.post('/messages/send-voice', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
       });
 
-      if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.detail || 'Ошибка отправки');
-      }void (
-
-      await response.json());
-
-
+      // PR-68: axios response already has .data, no need for .json()
       // Обновляем только список бесед - сообщение придет через WebSocket
       loadConversations();
     } catch (error) {
@@ -1117,7 +1116,8 @@ const ChatWindow = ({ isOpen, onClose }) => {
                   className="typing-indicator-modern"
                   style={{
                     position: 'absolute',
-                    bottom: -40,
+                    // PR-68 / P0-4: fixed position — was bottom: -40 (clipped by overflow: hidden)
+                    bottom: 8,
                     left: 12,
                     display: 'flex',
                     alignItems: 'center',

--- a/frontend/src/contexts/ChatContext.jsx
+++ b/frontend/src/contexts/ChatContext.jsx
@@ -41,6 +41,8 @@ export const ChatProvider = ({ children }) => {
   const readSyncInFlightRef = useRef(new Set());
   const contractVersionMismatchRef = useRef(false);
   const initialConversationLoadUserRef = useRef(null);
+  // PR-68 / P0-2: singleton AudioContext to prevent leak
+  const chatAudioContextRef = useRef(null);
 
   // Храним актуальные функции в ref
   // Это предотвращает разрыв соединения WebSocket при обновлении функций/стейта
@@ -209,7 +211,16 @@ export const ChatProvider = ({ children }) => {
 
       if (shouldPlaySound) {
         try {
-          const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+          // PR-68 / P0-2: reuse singleton AudioContext to prevent leak
+          // (browsers cap ~6 concurrent contexts; was creating one per message)
+          if (!chatAudioContextRef.current) {
+            chatAudioContextRef.current = new (window.AudioContext || window.webkitAudioContext)();
+          }
+          const audioContext = chatAudioContextRef.current;
+          // Resume if suspended (browsers auto-suspend after inactivity)
+          if (audioContext.state === 'suspended') {
+            audioContext.resume();
+          }
           const oscillator = audioContext.createOscillator();
           const gainNode = audioContext.createGain();
 


### PR DESCRIPTION
## Summary

5 P0 chat fixes: notification click listener, AudioContext singleton, voice send axios, typing indicator position, scroll preservation.

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/pr-68-chat-p0-fixes
- Scope gate: 3 files
- Red-check handling: N/A — bug fixes

## Contract Impact

- Canonical surface: voice endpoint now goes through axios (was raw fetch)
- Request shape: unchanged (same FormData payload)
- Response shape: unchanged (axios response.data = fetch response.json())
- Status codes: unchanged
- Frontend consumer: improved — notifications open chat, sound works consistently, voice works behind proxy, typing visible, scroll stable
- Compatibility path or alias: none
- Contract proof: 626 tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not changed because this PR only fixes client-side handling of WS events and desktop notifications — no WS protocol changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: not applicable because this PR does not change WS reconnection logic — existing exponential backoff in ChatContext is unchanged

## Frontend Resilience

- Empty data proof: empty conversations → notification listener is no-op (no userId to load)
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes

## Scope Gate

- Allowed paths: frontend/src/components/chat/ChatButton.jsx, frontend/src/contexts/ChatContext.jsx, frontend/src/components/chat/ChatWindow.jsx
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration
- Rollback note: reverting restores all 5 P0 bugs

## Validation

- Targeted tests or smoke run: npx vitest run
- Result: 626 passed, 0 failed
- Not checked: full e2e suite — will run in CI