### PR TITLE
fix(chat): PR-70 — jitter backoff, typing throttle, voice duration, reduced-motion, focus-visible

### DIFF
--- a/frontend/src/components/chat/Chat.css
+++ b/frontend/src/components/chat/Chat.css
@@ -1285,3 +1285,23 @@
 .file-link:hover {
   text-decoration: underline;
 }
+
+/* PR-70 / M-3: reduced-motion support */
+@media (prefers-reduced-motion: reduce) {
+  .typing-bubble, .typing-indicator-modern, .chat-status-indicator,
+  .message-appear, .shimmer, .record-pulse, .pulse {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+/* PR-70 / M-2: focus-visible styles for keyboard users */
+.chat-window button:focus-visible,
+.chat-window .conv-item:focus-visible,
+.chat-window input:focus-visible,
+.chat-window textarea:focus-visible,
+.chat-window select:focus-visible {
+  outline: 2px solid var(--mac-accent-blue, #007aff);
+  outline-offset: 2px;
+}
+

--- a/frontend/src/components/chat/ChatWindow.jsx
+++ b/frontend/src/components/chat/ChatWindow.jsx
@@ -151,6 +151,7 @@ const ChatWindow = ({ isOpen, onClose }) => {
   const prevScrollHeightRef = useRef(null);
   const inputRef = useRef(null);
   const typingTimeoutRef = useRef(null);
+  const typingThrottleRef = useRef(null); // PR-70 / M-8: throttle typing events
 
   // Scroll to bottom button state
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
@@ -321,7 +322,8 @@ const ChatWindow = ({ isOpen, onClose }) => {
   };
 
   // Отправка голосового сообщения
-  const handleSendVoice = async (audioBlob) => {
+  // PR-70 / L-10: accept duration argument (was dropped by parent)
+  const handleSendVoice = async (audioBlob, duration) => {
 
 
     if (!activeConversation || isSending) {
@@ -336,6 +338,10 @@ const ChatWindow = ({ isOpen, onClose }) => {
       const formData = new FormData();
       formData.append('audio_file', audioBlob, 'voice.webm');
       formData.append('recipient_id', activeConversation);
+      // PR-70 / L-10: send voice_duration (was silently dropped)
+      if (duration) {
+        formData.append('voice_duration', String(duration));
+      }
 
       // PR-68 / P0-3: replaced raw fetch with axios client
       // (was: fetch('/messages/send-voice') — no /api/v1 prefix, no CSRF, no token refresh)
@@ -368,7 +374,13 @@ const ChatWindow = ({ isOpen, onClose }) => {
     textarea.style.height = 'auto';
     textarea.style.height = Math.min(textarea.scrollHeight, 120) + 'px';
     if (activeConversation) {
-      sendTyping(activeConversation, true);
+      // PR-70 / M-8: throttle sendTyping to max once per 500ms (was every keystroke)
+      if (!typingThrottleRef.current) {
+        sendTyping(activeConversation, true);
+        typingThrottleRef.current = setTimeout(() => {
+          typingThrottleRef.current = null;
+        }, 500);
+      }
       clearTimeout(typingTimeoutRef.current);
       typingTimeoutRef.current = setTimeout(() => {
         sendTyping(activeConversation, false);

--- a/frontend/src/contexts/ChatContext.jsx
+++ b/frontend/src/contexts/ChatContext.jsx
@@ -464,7 +464,10 @@ export const ChatProvider = ({ children }) => {
         }
         // Если не нормальное закрытие (1000) - пробуем переподключиться
         if (e.code !== 1000) {
-          const delay = Math.min(1000 * 2 ** retryCountRef.current, 30000);
+          // PR-70 / M-1: added jitter to prevent thundering herd on server restart
+          const baseDelay = Math.min(1000 * 2 ** retryCountRef.current, 30000);
+          const jitter = Math.random() * 500; // 0-500ms random jitter
+          const delay = baseDelay + jitter;
           retryCountRef.current += 1;
           logger.info('[FIX:WS] Chat WebSocket closed, scheduling reconnect', {
             code: e.code,


### PR DESCRIPTION
## Summary

5 chat fixes: M-1 (jitter backoff), M-8 (typing throttle), L-10 (voice duration), M-3 (reduced-motion), M-2 (focus-visible).

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/pr-70-chat-medium-fixes
- Scope gate: 3 files
- Red-check handling: N/A — bug fixes + CSS

## Contract Impact

- Canonical surface: unchanged
- Request shape: voice_duration field added to FormData (additive, backend can ignore)
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — reduced WS flooding, accessible animations, keyboard focus
- Compatibility path or alias: none
- Contract proof: 626 tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not changed because this PR only adds jitter to existing reconnect logic and throttles existing typing events — no WS protocol changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged
- Reconnect/resync proof: jitter added to existing exponential backoff (1s→30s cap + 0-500ms random)

## Frontend Resilience

- Empty data proof: empty duration is null-checked (if (duration) guard)
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: not applicable because no draft or resource lookup is performed
- Stale route/deep-link behavior: no route changes

## Scope Gate

- Allowed paths: frontend/src/contexts/ChatContext.jsx, frontend/src/components/chat/ChatWindow.jsx, frontend/src/components/chat/Chat.css
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration
- Rollback note: reverting removes jitter, throttle, duration, reduced-motion, focus-visible

## Validation

- Targeted tests or smoke run: npx vitest run
- Result: 626 passed, 0 failed
- Not checked: full e2e suite — will run in CI