### PR TITLE
fix(cashier): UX-AUDIT 4.1 — "+N ещё" для бейджей услуг

### DIFF
--- a/frontend/src/pages/CashierPanel.jsx
+++ b/frontend/src/pages/CashierPanel.jsx
@@ -941,9 +941,16 @@ const CashierPanel = () => {
         followCursor>
 
         <div className="cashier-badge-wrap">
-          {codes.map((code, idx) =>
+          {/* UX Audit #4.1: показываем только первые 2 бейджа + счётчик «+N».
+              Раньше все бейджи рендерились, что раздувало строку при 5+ услугах. */}
+          {codes.slice(0, 2).map((code, idx) =>
           <span key={idx} className="cashier-badge">
               {typeof code === 'string' ? code : String(code)}
+            </span>
+          )}
+          {codes.length > 2 && (
+            <span className="cashier-badge cashier-badge-more" title={`Ещё ${codes.length - 2} услуг`}>
+              +{codes.length - 2}
             </span>
           )}
         </div>

--- a/frontend/src/pages/cashier.css
+++ b/frontend/src/pages/cashier.css
@@ -413,3 +413,12 @@
   font-size: 13px;
   color: var(--mac-text-secondary, #6b7280);
 }
+
+/* ─── Service badge "+N more" (UX Audit #4.1) ─── */
+.cashier-badge-more {
+  background-color: var(--mac-bg-tertiary, #f5f5f7);
+  color: var(--mac-text-secondary, #6b7280);
+  border: 1px dashed var(--mac-border, #d8dde8);
+  font-weight: 500;
+  cursor: help;
+}


### PR DESCRIPTION
## Summary

- UX-аудит #4.1: показывать только первые 2 бейджа услуг + счётчик «+N» для оставшихся.
- Раньше: все бейджи рендерились, при 5+ услугах строка раздувалась.
- Теперь: 2 видимых бейджа + «+N» badge, полный список в tooltip.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/cashier-service-badge-truncate` создана из актуального `origin/main` (после merge PR #2161..#2179).
- Clean workspace: inspected before edits; только `frontend/src/pages/CashierPanel.jsx` и `frontend/src/pages/cashier.css` изменены.
- Branch: fix/cashier-service-badge-truncate
- Scope gate: allowed `frontend/src/pages/CashierPanel.{jsx,css}` (renderServiceBadges only); denied backend, migrations, other panels.
- Red-check handling: если CI зайдёт в красный, фикс в этом же PR до merge.

## Contract Impact

- Canonical surface: `frontend/src/pages/CashierPanel.jsx` — renderServiceBadges function.
- Request shape: не изменён.
- Response shape: не изменён.
- Status codes: не применимо (frontend-only).
- Frontend consumer: CashierPanel pending tab services column.
- Compatibility path or alias: Tooltip по-прежнему показывает полный список; добавлен только visual truncate.
- Contract proof: `CashierPanel.contract.test.jsx` — 6/6 ✓.

## RBAC / Permissions

- Roles allowed: Cashier, Admin (без изменений).
- Roles denied: остальные роли (без изменений).
- Positive auth proof: не применимо (изменение только UI-рендера).
- Negative auth proof: не применимо.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: при `codes=[]` возвращается `<span className="cashier-empty">—</span>` как прежде.
- Partial data proof: при `codes.length <= 2` badge «+N» не рендерится (условие `codes.length > 2`).
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: not applicable, badges не создаёт drafts/resources.
- Stale route/deep-link behavior: not applicable, badges не зависят от route state.

## Scope Gate

- Allowed paths: `frontend/src/pages/CashierPanel.jsx`, `frontend/src/pages/cashier.css`.
- Denied paths: backend, migrations, Tooltip component, routing.
- Migration/docs/test impact: нет миграций; контракт-тесты без изменений.
- Rollback note: revert единственного коммита в этом PR.

## Validation

- Targeted tests or smoke run: `CashierPanel.contract.test.jsx` (6/6), ESLint `CashierPanel.jsx` (0 errors / 2 pre-existing warnings).
- Result: passed.
- Not checked: full Playwright e2e (запущен в CI).