### PR TITLE
feat(chat): PR-71 — quick-reply templates, urgent flag, mute conversation, draft persistence

### DIFF
--- a/frontend/src/components/chat/ChatWindow.jsx
+++ b/frontend/src/components/chat/ChatWindow.jsx
@@ -6,7 +6,7 @@ import { api } from '../../api/client';
 import { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import { X, Send, MessageCircle, ChevronLeft, ChevronDown, Plus, Search, Check, CheckCheck, Mic, Filter, Smile, Paperclip } from 'lucide-react';
+import { X, Send, MessageCircle, ChevronLeft, ChevronDown, Plus, Search, Check, CheckCheck, Mic, Filter, Smile, Paperclip, Zap, AlertCircle, VolumeX, Volume2 } from 'lucide-react';
 import { useChat } from '../../hooks/useChat';
 import auth from '../../stores/auth';
 import VoiceRecorder from './VoiceRecorder';
@@ -106,6 +106,9 @@ const ChatWindow = ({ isOpen, onClose }) => {
     sendTyping,
     searchUsers,
     closeConversation,
+    // PR-71: muted conversations from context
+    mutedConversations,
+    setMutedConversations,
 
     toggleReaction,
     deleteMessage,
@@ -142,6 +145,21 @@ const ChatWindow = ({ isOpen, onClose }) => {
   const [convFilter, setConvFilter] = useState('all'); // 'all' | 'unread'
   const [showMsgSearch, setShowMsgSearch] = useState(false);
   const [msgSearchQuery, setMsgSearchQuery] = useState('');
+  // PR-71: new features — draft persistence, urgent flag
+  const [drafts, setDrafts] = useState({}); // { [conversationId]: text }
+  // mutedConversations comes from ChatContext now (for sound suppression)
+  const [isUrgent, setIsUrgent] = useState(false);
+  const [showQuickReplies, setShowQuickReplies] = useState(false);
+
+  // PR-71: quick-reply templates for clinic workflow
+  const quickReplies = [
+    'Пациент готов',
+    'Подойдите в регистратуру',
+    'Подойдите в кабинет 3',
+    'Вызовите следующего пациента',
+    'Перерыв на обед',
+    'Телефонный звонок от МЗ',
+  ];
 
   // Список всех пользователей для отображения по дефолту
   const [allUsers, setAllUsers] = useState([]);
@@ -308,13 +326,20 @@ const ChatWindow = ({ isOpen, onClose }) => {
 
     const content = inputValue.trim();
     setInputValue('');
+    // PR-71: clear draft on send
+    setDrafts((prev) => { const next = { ...prev }; delete next[activeConversation]; return next; });
     setIsSending(true);
+    const wasUrgent = isUrgent;
+    setIsUrgent(false);
 
     try {
-      await sendMessage(activeConversation, content);
+      // PR-71: prepend urgent marker if flagged
+      const messageContent = wasUrgent ? `🚨 СРОЧНО: ${content}` : content;
+      await sendMessage(activeConversation, messageContent);
       sendTyping(activeConversation, false);
     } catch {
       setInputValue(content);
+      if (wasUrgent) setIsUrgent(true);
       addToast({ type: 'error', message: 'Ошибка отправки сообщения' });
     } finally {
       setIsSending(false);
@@ -541,7 +566,12 @@ const ChatWindow = ({ isOpen, onClose }) => {
       setSearchQuery('');
       setSearchResults([]);
     } else {
+      // PR-71: save draft before closing conversation
+      if (activeConversation && inputValue) {
+        setDrafts((prev) => ({ ...prev, [activeConversation]: inputValue }));
+      }
       closeConversation();
+      setInputValue('');
     }
   };
 
@@ -577,6 +607,16 @@ const ChatWindow = ({ isOpen, onClose }) => {
   });
 
   const isCompactViewport = viewport.width <= COMPACT_CHAT_BREAKPOINT;
+
+  // PR-71: restore draft when switching to a conversation
+  useEffect(() => {
+    if (activeConversation && drafts[activeConversation]) {
+      setInputValue(drafts[activeConversation]);
+    } else if (activeConversation) {
+      setInputValue('');
+    }
+    setIsUrgent(false); // reset urgent flag on conversation switch
+  }, [activeConversation]);
 
   useEffect(() => {
     const updateViewport = () => {
@@ -698,10 +738,28 @@ const ChatWindow = ({ isOpen, onClose }) => {
               className={`chat-btn-icon ${showMsgSearch ? 'active' : ''}`}
               title="Поиск в переписке"
               aria-label={showMsgSearch ? 'Скрыть поиск в переписке' : 'Открыть поиск в переписке'}>
-              
+
                                 <Search size={18} />
                             </button>
             }
+            {/* PR-71: Mute conversation toggle */}
+            {activeConversation && (
+              <button
+                onClick={() => {
+                  setMutedConversations((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(activeConversation)) next.delete(activeConversation);
+                    else next.add(activeConversation);
+                    return next;
+                  });
+                }}
+                className="chat-btn-icon"
+                title={mutedConversations.has(activeConversation) ? 'Включить уведомления' : 'Отключить уведомления'}
+                aria-label={mutedConversations.has(activeConversation) ? 'Включить уведомления' : 'Отключить уведомления'}
+                style={{ color: mutedConversations.has(activeConversation) ? 'var(--mac-text-tertiary)' : 'var(--mac-text-secondary)' }}>
+                {mutedConversations.has(activeConversation) ? <VolumeX size={16} /> : <Volume2 size={16} />}
+              </button>
+            )}
                         <button
               onClick={() => setShowNewChat(true)}
               className="chat-btn-icon"
@@ -1182,6 +1240,47 @@ const ChatWindow = ({ isOpen, onClose }) => {
                             </div>
 
                             <div className="message-input-container">
+                                {/* PR-71: Quick-reply templates popover */}
+                                {showQuickReplies && (
+                                  <div style={{
+                                    position: 'absolute',
+                                    bottom: '100%',
+                                    left: 0,
+                                    right: 0,
+                                    background: 'var(--mac-bg-primary)',
+                                    border: '1px solid var(--mac-border)',
+                                    borderRadius: 'var(--mac-radius-md)',
+                                    padding: '8px',
+                                    display: 'grid',
+                                    gridTemplateColumns: '1fr 1fr',
+                                    gap: '4px',
+                                    zIndex: 10,
+                                    boxShadow: 'var(--mac-shadow-md)',
+                                  }}>
+                                    {quickReplies.map((reply) => (
+                                      <button
+                                        key={reply}
+                                        onClick={() => {
+                                          setInputValue(reply);
+                                          setShowQuickReplies(false);
+                                          inputRef.current?.focus();
+                                        }}
+                                        style={{
+                                          padding: '6px 10px',
+                                          textAlign: 'left',
+                                          background: 'var(--mac-bg-secondary)',
+                                          border: 'none',
+                                          borderRadius: 'var(--mac-radius-sm)',
+                                          cursor: 'pointer',
+                                          fontSize: 'var(--mac-font-size-sm)',
+                                          color: 'var(--mac-text-primary)',
+                                        }}
+                                      >
+                                        {reply}
+                                      </button>
+                                    ))}
+                                  </div>
+                                )}
                                 {showVoiceRecorder ?
               <VoiceRecorder
                 onSend={handleSendVoice}
@@ -1210,21 +1309,42 @@ const ChatWindow = ({ isOpen, onClose }) => {
                                         <FileUploader
                   onUpload={handleFileUpload}
                   disabled={isSending} />
-                
+
+                                        {/* PR-71: Quick-reply templates */}
+                                        <button
+                  onClick={() => setShowQuickReplies((v) => !v)}
+                  className="voice-btn"
+                  title="Быстрые ответы"
+                  aria-label="Быстрые ответы"
+                  disabled={isSending}>
+                  <Zap size={16} />
+                </button>
+
                                         <EmojiPicker
                   onEmojiSelect={(emoji) => {
                     setInputValue((prev) => prev + emoji);
                     inputRef.current?.focus();
                   }}
                   disabled={isSending} />
-                
+
+                                        {/* PR-71: Urgent flag toggle */}
+                                        <button
+                  onClick={() => setIsUrgent((v) => !v)}
+                  className="voice-btn"
+                  title={isUrgent ? 'Снять срочность' : 'Пометить как срочное'}
+                  aria-label={isUrgent ? 'Снять срочность' : 'Пометить как срочное'}
+                  style={{ color: isUrgent ? 'var(--mac-error, #dc2626)' : 'var(--mac-text-secondary)' }}
+                  disabled={isSending}>
+                  <AlertCircle size={16} />
+                </button>
+
                                         <button
                   onClick={() => setShowVoiceRecorder(true)}
                   className="voice-btn"
                   title="Голосовое сообщение"
                   aria-label="Записать голосовое сообщение"
                   disabled={isSending}>
-                  
+
                                             <Mic size={18} />
                                         </button>
                                         <button

--- a/frontend/src/contexts/ChatContext.jsx
+++ b/frontend/src/contexts/ChatContext.jsx
@@ -32,6 +32,8 @@ export const ChatProvider = ({ children }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [typingUsers, setTypingUsers] = useState({});
   const [isChatOpen, setIsChatOpen] = useState(false); // Track if chat window is open
+  // PR-71: muted conversations (client-side, no sound/notification for these)
+  const [mutedConversations, setMutedConversations] = useState(new Set());
   const [onlineUsers, setOnlineUsers] = useState({}); // Track online status of users
 
   const wsRef = useRef(null);
@@ -207,7 +209,9 @@ export const ChatProvider = ({ children }) => {
       // 1. Tab is not focused (user is in another tab/window)
       // 2. OR the chat window is closed
       // 3. Never play sound if actively viewing that conversation
-      const shouldPlaySound = !document.hasFocus() || !isChatOpen;
+      // PR-71: skip sound if conversation is muted
+      const isMuted = mutedConversations.has(message.sender_id);
+      const shouldPlaySound = (!document.hasFocus() || !isChatOpen) && !isMuted;
 
       if (shouldPlaySound) {
         try {
@@ -637,6 +641,9 @@ export const ChatProvider = ({ children }) => {
     typingUsers,
     isChatOpen,
     setIsChatOpen,
+    // PR-71: muted conversations
+    mutedConversations,
+    setMutedConversations,
     onlineUsers,
     requestOnlineStatus,
     loadConversations,


### PR DESCRIPTION
## Summary

4 new chat features: quick-reply templates (6 clinic-specific), urgent flag (🚨 СРОЧНО prefix), mute conversation (suppresses sound/notifications), draft persistence (save/restore on conversation switch).

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/pr-71-chat-features
- Scope gate: 2 files (ChatWindow.jsx + ChatContext.jsx)
- Red-check handling: N/A — new features, no existing tests broken

## Contract Impact

- Canonical surface: unchanged — same endpoints, urgent is client-side prefix
- Request shape: urgent messages have 🚨 prefix in content (backend treats as text)
- Response shape: unchanged
- Status codes: unchanged
- Frontend consumer: improved — clinic-specific quick replies, urgent priority, mute, draft persistence
- Compatibility path or alias: none
- Contract proof: 626 tests pass

## RBAC / Permissions

- Roles allowed: unchanged
- Roles denied: unchanged
- Positive auth proof: unchanged
- Negative auth proof: unchanged

## Notification / Realtime

- Event type or websocket channel: not changed because this PR only adds client-side features — no WS protocol changes
- Payload version / ack behavior: unchanged
- Read/unread or delivery semantics: unchanged — mute is client-side sound/notification suppression only
- Reconnect/resync proof: not applicable because this PR does not change WS reconnection logic

## Frontend Resilience

- Empty data proof: empty drafts map returns undefined → input cleared
- Partial data proof: not applicable because no API response shape changes
- Forbidden secondary path behavior: not applicable because no auth path changes
- Missing draft/resource behavior: draft lookup is safe (undefined → empty string)
- Stale route/deep-link behavior: no route changes

## Scope Gate

- Allowed paths: frontend/src/components/chat/ChatWindow.jsx, frontend/src/contexts/ChatContext.jsx
- Denied paths: no other frontend/backend source changes
- Migration/docs/test impact: no schema migration
- Rollback note: reverting removes quick replies, urgent, mute, drafts

## Validation

- Targeted tests or smoke run: npx vitest run
- Result: 626 passed, 0 failed
- Not checked: full e2e suite — will run in CI