### PR TITLE
fix(registrar): UX-AUDIT R-3.9 — unicode › → lucide chevron.right в breadcrumb

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -1406,19 +1406,19 @@ const RegistrarPanel = () => {
         </button>
         {activeTab && (
           <>
-            <span>›</span>
+            <Icon name="chevron.right" size="small" className="registrar-breadcrumb-separator" aria-hidden="true" />
             <span>{queueProfiles.find(p => p.key === activeTab)?.title || activeTab}</span>
           </>
         )}
         {searchQuery && (
           <>
-            <span>›</span>
+            <Icon name="chevron.right" size="small" className="registrar-breadcrumb-separator" aria-hidden="true" />
             <span>Поиск: «{searchQuery}»</span>
           </>
         )}
         {showWizard && (
           <>
-            <span>›</span>
+            <Icon name="chevron.right" size="small" className="registrar-breadcrumb-separator" aria-hidden="true" />
             <span>{wizardEditMode ? 'Редактирование' : 'Новая запись'}</span>
           </>
         )}

--- a/frontend/src/pages/registrar/registrar.css
+++ b/frontend/src/pages/registrar/registrar.css
@@ -760,3 +760,10 @@
   gap: var(--mac-spacing-2);
   flex-wrap: wrap;
 }
+
+/* ─── Breadcrumb separator (UX Audit R-3.9) ─── */
+.registrar-breadcrumb-separator {
+  color: var(--mac-text-tertiary, #8e8e93);
+  display: inline-flex;
+  align-items: center;
+}


### PR DESCRIPTION
## Summary

- UX-аудит R-3.9: заменить 3 вхождения `<span>›</span>` в breadcrumb на `<Icon name="chevron.right" />`.
- Nielsen #4 (consistency) — lucide иконки уже используются в других частях приложения.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/registrar-breadcrumb-chevron` создана из актуального `origin/main`.
- Clean workspace: inspected before edits; только `frontend/src/pages/RegistrarPanel.jsx` и `frontend/src/pages/registrar/registrar.css` изменены.
- Branch: fix/registrar-breadcrumb-chevron
- Scope gate: allowed указанные 2 файла; denied backend, migrations, other panels.
- Red-check handling: если CI зайдёт в красный, фикс в этом же PR до merge.

## Contract Impact

- Canonical surface: `frontend/src/pages/RegistrarPanel.jsx` — breadcrumb JSX; `registrar.css` — new `.registrar-breadcrumb-separator` class.
- Request shape: не изменён.
- Response shape: не изменён.
- Status codes: не применимо (frontend-only).
- Frontend consumer: RegistrarPanel breadcrumb nav.
- Compatibility path or alias: `chevron.right` уже определён в `Icon.jsx`; путь рендеринга сохранён.
- Contract proof: `RegistrarPanel.contract.test.jsx` — 13/13 ✓.

## RBAC / Permissions

- Roles allowed: Registrar, Admin (без изменений).
- Roles denied: остальные роли (без изменений).
- Positive auth proof: не применимо (изменение только UI-иконок).
- Negative auth proof: не применимо.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: separator показывается только если есть `activeTab`/`searchQuery`/`showWizard`.
- Partial data proof: при отсутствии одного из условий separator не рендерится.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: not applicable, separator не создаёт drafts/resources.
- Stale route/deep-link behavior: not applicable, separator не зависит от route state.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`, `frontend/src/pages/registrar/registrar.css`.
- Denied paths: backend, migrations, Icon.jsx, other panels.
- Migration/docs/test impact: нет миграций; контракт-тесты без изменений.
- Rollback note: revert единственного коммита в этом PR.

## Validation

- Targeted tests or smoke run: `RegistrarPanel.contract.test.jsx` (13/13), ESLint `RegistrarPanel.jsx` (0 errors / 3 pre-existing warnings).
- Result: passed.
- Not checked: full Playwright e2e (запущен в CI).