### PR TITLE
fix(registrar): UX-AUDIT R-1.7 — убрать lastQueueJoin polling 2s

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -723,42 +723,15 @@ const RegistrarPanel = () => {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [showWizard]);  
+  }, [showWizard]);
 
-  // ✅ Проверка localStorage для обновления после присоединения к очереди (fallback механизм)
-  useEffect(() => {
-    const checkLastQueueJoin = () => {
-      try {
-        const lastJoinStr = localStorage.getItem('lastQueueJoin');
-        if (!lastJoinStr) return;
-
-        const lastJoin = JSON.parse(lastJoinStr);
-        const joinTime = new Date(lastJoin.timestamp);
-        const now = new Date();
-        const diffMs = now - joinTime;
-
-        // Проверяем только если прошло меньше 10 секунд с момента присоединения
-        if (diffMs < 10000 && diffMs > 0) {
-          logger.info('[RegistrarPanel] Обнаружено недавнее присоединение к очереди, обновляем данные');
-          logger.info('[RegistrarPanel] Данные присоединения:', lastJoin);
-          // Удаляем флаг после использования
-          localStorage.removeItem('lastQueueJoin');
-          // Обновляем данные
-          setTimeout(() => {
-            loadAppointments({ source: 'queueJoin_fallback', silent: false });
-          }, 500);
-        }
-      } catch (err) {
-        logger.error('[RegistrarPanel] Ошибка проверки lastQueueJoin:', err);
-      }
-    };
-
-    // Проверяем при монтировании и каждые 2 секунды
-    checkLastQueueJoin();
-    const interval = setInterval(checkLastQueueJoin, 2000);
-
-    return () => clearInterval(interval);
-  }, [loadAppointments]);
+  // UX Audit R-1.7: lastQueueJoin polling (2s) удалён.
+  // Раньше: setInterval(checkLastQueueJoin, 2000) проверял localStorage
+  // каждые 2 секунды — 60 проверок в минуту, даже когда очередь не используется.
+  // Теперь: обновление приходит через `queueUpdated` window-event listener
+  // (строки ниже), который запускается WebSocket'ом ModernQueueManager.
+  // Для fallback между вкладками можно использовать BroadcastChannel,
+  // но polling localStorage — это неэффективный паттерн.
 
   // Автообновление очереди с возможностью паузы (в тихом режиме)
   useEffect(() => {


### PR DESCRIPTION
## Summary

- UX-аудит R-1.7: удалить `setInterval(checkLastQueueJoin, 2000)` — polling localStorage каждые 2 секунды.
- 60 проверок в минуту, даже когда очередь не использовалась.
- Обновление приходит через `queueUpdated` window-event listener (WebSocket).
- Nielsen #8 (aesthetic and minimalist design) + ISO 25010 Performance efficiency.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/registrar-queue-join-polling` создана из актуального `origin/main`.
- Clean workspace: inspected before edits; только `frontend/src/pages/RegistrarPanel.jsx` изменён.
- Branch: fix/registrar-queue-join-polling
- Scope gate: allowed указанный файл; denied backend, migrations, other panels.
- Red-check handling: если CI зайдёт в красный, фикс в этом же PR до merge.

## Contract Impact

- Canonical surface: `frontend/src/pages/RegistrarPanel.jsx` — removed `useEffect` with `setInterval(checkLastQueueJoin, 2000)`.
- Request shape: не изменён.
- Response shape: не изменён.
- Status codes: не применимо (frontend-only).
- Frontend consumer: RegistrarPanel — `queueUpdated` window-event listener сохранён.
- Compatibility path or alias: WebSocket fallback для real-time обновлений сохранён.
- Contract proof: `RegistrarPanel.contract.test.jsx` — 13/13 ✓.

## RBAC / Permissions

- Roles allowed: Registrar, Admin (без изменений).
- Roles denied: остальные роли (без изменений).
- Positive auth proof: не применимо.
- Negative auth proof: не применимо.

## Notification / Realtime

- Изменение затрагивает fallback-мост для синхронизации записей между вкладками. WebSocket (`queueUpdated` event) остаётся основным каналом real-time обновлений.

## Frontend Resilience

- Empty data proof: при отсутствии `lastQueueJoin` в localStorage polling был no-op.
- Partial data proof: `queueUpdated` event ловит все изменения очереди через WebSocket.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: not applicable.
- Stale route/deep-link behavior: not applicable.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`.
- Denied paths: backend, migrations, ModernQueueManager, other panels.
- Migration/docs/test impact: нет миграций; контракт-тесты без изменений.
- Rollback note: revert единственного коммита в этом PR.

## Validation

- Targeted tests or smoke run: `RegistrarPanel.contract.test.jsx` (13/13), ESLint `RegistrarPanel.jsx` (0 errors / 3 pre-existing warnings).
- Result: passed.
- Not checked: full Playwright e2e (запущен в CI).