### PR TITLE
fix(registrar): UX-AUDIT R-1.2 — confirm для критичных действий в context menu

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -1283,17 +1283,42 @@ const RegistrarPanel = () => {
         openRecordEditor(row);
         logger.info('Редактирование записи:', row);
         break;
-      case 'in_cabinet':
+      case 'in_cabinet': {
+        // UX Audit R-1.2: добавлен confirm для критичных действий в context menu.
+        // Раньше: handleContextMenuAction вызывал updateAppointmentStatus напрямую,
+        // без подтверждения. В то же время inline onActionClick в таблице требовал
+        // confirm. Это нарушение Nielsen #4 (consistency) + #5 (error prevention).
+        const inCabinetName = row.patient_fio || row.patient_name || '';
+        const inCabinetOk = await confirm({
+          title: 'Отправить в кабинет',
+          message: `Отправить пациента «${inCabinetName}» в кабинет?`,
+          confirmLabel: 'Отправить',
+          cancelLabel: 'Отмена',
+          intent: 'primary',
+        });
+        if (!inCabinetOk) break;
         await updateAppointmentStatus(row.id, 'in_cabinet', '', row);
         notify.success('Пациент отправлен в кабинет');
         break;
+      }
       case 'call':
         await handleStartVisit(row);
         break;
-      case 'complete':
+      case 'complete': {
+        // UX Audit R-1.2: confirm для завершения приёма в context menu.
+        const completeName = row.patient_fio || row.patient_name || '';
+        const completeOk = await confirm({
+          title: 'Завершение приёма',
+          message: `Завершить приём пациента «${completeName}»?`,
+          confirmLabel: 'Завершить',
+          cancelLabel: 'Отмена',
+          intent: 'primary',
+        });
+        if (!completeOk) break;
         await updateAppointmentStatus(row.id, 'done', '', row);
         notify.success('Приём завершён');
         break;
+      }
       case 'payment':
         setPaymentDialog({ open: true, row, paid: false, source: 'context' });
         break;
@@ -1336,7 +1361,7 @@ const RegistrarPanel = () => {
         logger.info('Неизвестное действие:', action);
         break;
     }
-  }, [updateAppointmentStatus, handleStartVisit, openRecordPreview, openRecordEditor]);
+  }, [updateAppointmentStatus, handleStartVisit, openRecordPreview, openRecordEditor, confirm, setPaymentDialog, setPrintDialog, setCancelDialog, setForceMajeureModal]);
 
   return (
     <div


### PR DESCRIPTION
## Summary

- UX-аудит R-1.2: добавить `confirm()` для `in_cabinet` и `complete` actions в `handleContextMenuAction`.
- Раньше: context menu вызывал `updateAppointmentStatus` напрямую без подтверждения; inline `onActionClick` в таблице требовал confirm для тех же действий.
- Теперь: оба пути требуют confirm — Nielsen #4 (consistency) + #5 (error prevention).

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/registrar-context-menu-confirm` создана из актуального `origin/main`.
- Clean workspace: inspected before edits; только `frontend/src/pages/RegistrarPanel.jsx` изменён.
- Branch: fix/registrar-context-menu-confirm
- Scope gate: allowed указанный файл; denied backend, migrations, other panels.
- Red-check handling: если CI зайдёт в красный, фикс в этом же PR до merge.

## Contract Impact

- Canonical surface: `frontend/src/pages/RegistrarPanel.jsx` — `handleContextMenuAction` useCallback.
- Request shape: не изменён — `updateAppointmentStatus(row.id, status, reason, row)` вызывается с теми же параметрами.
- Response shape: не изменён.
- Status codes: не применимо (frontend-only).
- Frontend consumer: AppointmentContextMenu → registrar `handleContextMenuAction`.
- Compatibility path or alias: confirm dialog добавлен перед вызовом `updateAppointmentStatus`; если пользователь отменяет, действие не выполняется.
- Contract proof: `RegistrarPanel.contract.test.jsx` — 13/13 ✓.

## RBAC / Permissions

- Roles allowed: Registrar, Admin (без изменений).
- Roles denied: остальные роли (без изменений).
- Positive auth proof: не применимо (изменение только UX confirm).
- Negative auth proof: не применимо.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: при `row.patient_fio` и `row.patient_name` оба falsy — `inCabinetName=''` (пустая строка в confirm).
- Partial data proof: confirm требует явного user action (OK/Cancel); если Cancel — break без вызова API.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: not applicable, confirm не создаёт drafts/resources.
- Stale route/deep-link behavior: not applicable, confirm не зависит от route state.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`.
- Denied paths: backend, migrations, ConfirmDialog component, AppointmentContextMenu.
- Migration/docs/test impact: нет миграций; контракт-тесты без изменений.
- Rollback note: revert единственного коммита в этом PR.

## Validation

- Targeted tests or smoke run: `RegistrarPanel.contract.test.jsx` (13/13), ESLint `RegistrarPanel.jsx` (0 errors / 3 pre-existing warnings).
- Result: passed.
- Not checked: full Playwright e2e (запущен в CI).