### PR TITLE
fix(registrar): UX-AUDIT R-4.1 — консолидация auto-refresh (30s + WS skip)

### DIFF
--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -569,6 +569,8 @@ const RegistrarPanel = () => {
   const loadAppointmentsInFlightRef = useRef(false);
   const autoRefreshCooldownUntilRef = useRef(0);
   const autoRefreshCooldownLoggedRef = useRef(false);
+  // UX Audit R-4.1: track last WebSocket update timestamp to skip redundant interval refresh.
+  const lastQueueUpdatedRef = useRef(0);
   useEffect(() => {
     if (initialLoadRef.current) return;
     initialLoadRef.current = true;
@@ -581,6 +583,8 @@ const RegistrarPanel = () => {
   useEffect(() => {
     const handleQueueUpdate = (event) => {
       const { action, specialty } = event.detail || {};
+      // UX Audit R-4.1: record WebSocket update timestamp to skip redundant interval refresh.
+      lastQueueUpdatedRef.current = Date.now();
       logger.info('[RegistrarPanel] Получено событие обновления очереди:', { action, specialty, detail: event.detail });
 
       // Для критических действий обновляем немедленно без silent режима
@@ -751,10 +755,19 @@ const RegistrarPanel = () => {
       if (Date.now() < autoRefreshCooldownUntilRef.current || loadAppointmentsInFlightRef.current) {
         return;
       }
+      // UX Audit R-4.1: skip interval refresh if WebSocket updated recently.
+      // Раньше: setInterval(15000) работал ВСЕГДА, даже когда WebSocket уже
+      // обновил данные. Это создавало race conditions и дублирующие network-запросы.
+      // Теперь: если queueUpdated event был < 30s назад, пропускаем interval refresh.
+      const lastWsUpdate = lastQueueUpdatedRef.current;
+      if (lastWsUpdate && (Date.now() - lastWsUpdate) < 30000) {
+        logger.info('⏰ Автообновление: пропускаем (WebSocket обновил недавно)');
+        return;
+      }
       // Загружаем только записи тихо, без смены индикаторов
       logger.info('⏰ Автообновление: вызов loadAppointments (dialog-open resilient)');
       loadAppointments({ silent: true, source: 'auto_refresh' });
-    }, 15000);
+    }, 30000); // UX Audit R-4.1: 15s → 30s (WebSocket покрывает real-time)
 
     return () => clearInterval(id);
   }, [autoRefresh, showWizard, loadAppointments]);


### PR DESCRIPTION
## Summary

- UX-аудит R-4.1: увеличить interval refresh с 15s до 30s + skip если WebSocket обновил недавно.
- Раньше: `setInterval(15000)` работал ВСЕГДА, даже когда WebSocket уже обновил данные — race conditions + дублирующие network-запросы.
- Теперь: `lastQueueUpdatedRef` tracking + skip interval refresh если WS event был < 30s назад.
- Nielsen #8 (efficiency) + ISO 25010 Performance efficiency.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/registrar-auto-refresh-consolidation` создана из актуального `origin/main`.
- Clean workspace: inspected before edits; только `frontend/src/pages/RegistrarPanel.jsx` изменён.
- Branch: fix/registrar-auto-refresh-consolidation
- Scope gate: allowed указанный файл; denied backend, migrations, other panels.
- Red-check handling: если CI зайдёт в красный, фикс в этом же PR до merge.

## Contract Impact

- Canonical surface: `frontend/src/pages/RegistrarPanel.jsx` — auto-refresh useEffect + queueUpdated listener + new `lastQueueUpdatedRef`.
- Request shape: не изменён — `loadAppointments({ silent, source })` вызывается с теми же параметрами.
- Response shape: не изменён.
- Status codes: не применимо (frontend-only).
- Frontend consumer: RegistrarPanel auto-refresh + WebSocket event handling.
- Compatibility path or alias: WebSocket (`queueUpdated` event) остаётся основным каналом; interval — fallback.
- Contract proof: `RegistrarPanel.contract.test.jsx` — 13/13 ✓.

## RBAC / Permissions

- Roles allowed: Registrar, Admin (без изменений).
- Roles denied: остальные роли (без изменений).
- Positive auth proof: не применимо (изменение только refresh logic).
- Negative auth proof: не применимо.

## Notification / Realtime

- Изменение затрагивает fallback refresh mechanism. WebSocket (`queueUpdated` event) остаётся основным каналом real-time обновлений. Interval refresh теперь не дублирует WS updates.

## Frontend Resilience

- Empty data proof: при `lastQueueUpdatedRef.current=0` (initial state) interval refresh работает как прежде.
- Partial data proof: если WS event был > 30s назад, interval refresh срабатывает.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: not applicable, refresh logic не создаёт drafts/resources.
- Stale route/deep-link behavior: not applicable, refresh не зависит от route state.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`.
- Denied paths: backend, migrations, ModernQueueManager, other panels.
- Migration/docs/test impact: нет миграций; контракт-тесты без изменений.
- Rollback note: revert единственного коммита в этом PR.

## Validation

- Targeted tests or smoke run: `RegistrarPanel.contract.test.jsx` (13/13), ESLint `RegistrarPanel.jsx` (0 errors / 3 pre-existing warnings).
- Result: passed.
- Not checked: full Playwright e2e (запущен в CI).