### PR TITLE
fix(admin): PR-AUDIT-A-1.1 — кнопка «Сбросить фильтры» (QW#2)

### DIFF
--- a/frontend/src/components/admin/AdminAppointments.jsx
+++ b/frontend/src/components/admin/AdminAppointments.jsx
@@ -334,6 +334,17 @@ const AdminAppointments = () => {
           />
         </div>
 
+        {/* UX Audit Admin #1.1: кнопка «Сбросить» для быстрой очистки фильтров. */}
+        {filtersActive && (
+          <div style={{ marginBottom: '12px' }}>
+            <Button variant="ghost" size="sm" onClick={() => {
+              setSearchTerm(''); setFilterStatus(''); setFilterDate(''); setFilterDoctor('');
+            }} aria-label="Сбросить все фильтры">
+              ✕ Сбросить фильтры
+            </Button>
+          </div>
+        )}
+
         <div className="admin-ovx-auto">
           {loading ? (
             <Skeleton type="table" count={5} />

--- a/frontend/src/components/admin/AdminDoctors.jsx
+++ b/frontend/src/components/admin/AdminDoctors.jsx
@@ -206,6 +206,17 @@ const AdminDoctors = () => {
           />
         </div>
 
+        {/* UX Audit Admin #1.1: кнопка «Сбросить» для быстрой очистки фильтров. */}
+        {filtersActive && (
+          <div style={{ marginBottom: '12px' }}>
+            <Button variant="ghost" size="sm" onClick={() => {
+              setSearchTerm(''); setFilterSpecialization(''); setFilterDepartment(''); setFilterStatus('');
+            }} aria-label="Сбросить все фильтры">
+              ✕ Сбросить фильтры
+            </Button>
+          </div>
+        )}
+
         <div className="admin-overflow-x-auto">
           {loading ? (
             <Skeleton type="table" count={5} />

--- a/frontend/src/components/admin/AdminPatients.jsx
+++ b/frontend/src/components/admin/AdminPatients.jsx
@@ -223,6 +223,17 @@ const AdminPatients = () => {
           />
         </div>
 
+        {/* UX Audit Admin #1.1: кнопка «Сбросить» для быстрой очистки фильтров. */}
+        {filtersActive && (
+          <div style={{ marginBottom: '12px' }}>
+            <Button variant="ghost" size="sm" onClick={() => {
+              setSearchTerm(''); setFilterGender(''); setFilterAgeRange(''); setFilterBloodType('');
+            }} aria-label="Сбросить все фильтры">
+              ✕ Сбросить фильтры
+            </Button>
+          </div>
+        )}
+
         <div className="admin-overflow-x-auto">
           {loading ? (
             <Skeleton type="table" count={5} />


### PR DESCRIPTION
## Summary

- UX-аудит Admin #1.1: кнопка «Сбросить фильтры» в 3 админ-таблицах.
- Показывается при `filtersActive=true`.
- variant='ghost', size='sm', aria-label.

## Cyclic Execution Evidence

- Fresh main sync.
- Clean workspace: 3 admin JSX.
- Branch: fix/admin-reset-filters-button
- Scope gate: allowed указанные файлы.
- Red-check handling: фикс в этом же PR.

## Contract Impact

- Canonical surface: 3 admin JSX — reset button added.
- Request shape: не изменён.
- Response shape: не изменён.
- Status codes: не применимо.
- Frontend consumer: admin tables.
- Compatibility path or alias: filtersActive уже существует; setState calls already exist.
- Contract proof: ESLint passes.

## RBAC / Permissions

- Roles allowed: Admin.
- Roles denied: не применимо.
- Positive auth proof: не применимо.
- Negative auth proof: не применимо.

## Notification / Realtime

not applicable.

## Frontend Resilience

- Empty data proof: кнопка показывается только при filtersActive.
- Partial data proof: очищает все 4 фильтра.
- Forbidden secondary path behavior: not applicable.
- Missing draft/resource behavior: not applicable.
- Stale route/deep-link behavior: not applicable.

## Scope Gate

- Allowed paths: 3 admin JSX.
- Denied paths: backend, migrations, CSS, other components.
- Migration/docs/test impact: нет.
- Rollback note: revert единственного коммита.

## Validation

- Targeted tests or smoke run: ESLint (0 errors).
- Result: passed.
- Not checked: full Playwright e2e (CI).