### PR TITLE
fix(admin): PR-AUDIT-A-1.3+4.2 — удалить мёртвый Settings-tab в SystemManagement

### DIFF
--- a/frontend/src/components/admin/SystemManagement.jsx
+++ b/frontend/src/components/admin/SystemManagement.jsx
@@ -667,8 +667,8 @@ const SystemManagement = () => {
           {[
         { id: 'monitoring', label: 'Мониторинг', icon: Activity },
         { id: 'backups', label: 'Бэкапы', icon: Database },
-        { id: 'settings', label: 'Настройки', icon: Settings }].
-        map((tab) => {
+        // UX Audit Admin #1.3+4.2: Settings-tab удалён — все кнопки были нерабочие (dead code).
+        ].map((tab) => {
           const IconComponent = tab.icon;
           const isActive = activeTab === tab.id;
 
@@ -695,7 +695,7 @@ const SystemManagement = () => {
       {/* Контент табов */}
       {activeTab === 'monitoring' && renderMonitoringTab()}
       {activeTab === 'backups' && renderBackupsTab()}
-      {activeTab === 'settings' && renderSettingsTab()}
+      {/* UX Audit Admin #1.3+4.2: Settings-tab удалён. */}
       {/* P-013 fix: portal-mounted ConfirmDialog rendered once per panel */}
       {confirmDialog}
     </div>);


### PR DESCRIPTION
## Summary

- UX-аудит Admin #1.3 + #4.2: удалить нерабочий Settings-tab.
- 3 кнопки без onClick: «Настроить» (×2), «Сохранить настройки».
- Таб удалён из массива; renderSettingsTab() оставлен для future wiring.

## Cyclic Execution Evidence

- Fresh main sync.
- Clean workspace: SystemManagement.jsx.
- Branch: fix/admin-system-mgmt-dead-settings
- Scope gate: allowed указанный файл.
- Red-check handling: фикс в этом же PR.

## Contract Impact

- Canonical surface: SystemManagement.jsx — settings tab removed from tabs array + render.
- Request shape: не изменён.
- Response shape: не изменён.
- Status codes: не применимо.
- Frontend consumer: admin system management page.
- Compatibility path or alias: monitoring + backups tabs preserved.
- Contract proof: ESLint passes.

## RBAC / Permissions

- Roles allowed: Admin.
- Roles denied: не применимо.
- Positive auth proof: не применимо.
- Negative auth proof: не применимо.

## Notification / Realtime

not applicable.

## Frontend Resilience

- Empty data proof: tabs array без settings работает корректно.
- Partial data proof: monitoring + backups tabs сохранены.
- Forbidden secondary path behavior: not applicable.
- Missing draft/resource behavior: not applicable.
- Stale route/deep-link behavior: not applicable.

## Scope Gate

- Allowed paths: SystemManagement.jsx.
- Denied paths: backend, migrations, other components.
- Migration/docs/test impact: нет.
- Rollback note: revert единственного коммита.

## Validation

- Targeted tests or smoke run: ESLint (0 errors).
- Result: passed.
- Not checked: full Playwright e2e (CI).