### PR TITLE
fix(admin): PR-AUDIT-A-3.2 — убрать дублирование backups (SystemManagement → ClinicManagement)

### DIFF
--- a/frontend/src/components/admin/SystemManagement.jsx
+++ b/frontend/src/components/admin/SystemManagement.jsx
@@ -666,8 +666,8 @@ const SystemManagement = () => {
       <div className="admin-tab-bar-simple">
           {[
         { id: 'monitoring', label: 'Мониторинг', icon: Activity },
-        { id: 'backups', label: 'Бэкапы', icon: Database },
-        // UX Audit Admin #1.3+4.2: Settings-tab удалён — все кнопки были нерабочие (dead code).
+        // UX Audit Admin #3.2: backups-tab удалён — дублирует BackupManagement
+        // компонент в ClinicManagement. SystemManagement фокусируется на мониторинге.
         ].map((tab) => {
           const IconComponent = tab.icon;
           const isActive = activeTab === tab.id;
@@ -694,8 +694,7 @@ const SystemManagement = () => {
 
       {/* Контент табов */}
       {activeTab === 'monitoring' && renderMonitoringTab()}
-      {activeTab === 'backups' && renderBackupsTab()}
-      {/* UX Audit Admin #1.3+4.2: Settings-tab удалён. */}
+      {/* UX Audit Admin #3.2: backups-tab удалён — дублирует ClinicManagement. */}
       {/* P-013 fix: portal-mounted ConfirmDialog rendered once per panel */}
       {confirmDialog}
     </div>);


### PR DESCRIPTION
## Summary

- UX-аудит Admin #3.2: убрать backups-tab из SystemManagement (дублирует ClinicManagement).
- SystemManagement теперь monitoring-only.
- BackupManagement в ClinicManagement — единственное место для бэкапов.

## Cyclic Execution Evidence

- Fresh main sync.
- Clean workspace: SystemManagement.jsx.
- Branch: fix/admin-backups-dedup
- Scope gate: allowed указанный файл.
- Red-check handling: фикс в этом же PR.

## Contract Impact

- Canonical surface: SystemManagement.jsx — backups tab removed.
- Request shape: не изменён.
- Response shape: не изменён.
- Status codes: не применимо.
- Frontend consumer: admin system management page.
- Compatibility path or alias: BackupManagement in ClinicManagement preserved.
- Contract proof: ESLint passes.

## RBAC / Permissions

- Roles allowed: Admin.
- Roles denied: не применимо.
- Positive auth proof: не применимо.
- Negative auth proof: не применимо.

## Notification / Realtime

not applicable.

## Frontend Resilience

- Empty data proof: monitoring tab works independently.
- Partial data proof: backups accessible via ClinicManagement.
- Forbidden secondary path behavior: not applicable.
- Missing draft/resource behavior: not applicable.
- Stale route/deep-link behavior: not applicable.

## Scope Gate

- Allowed paths: SystemManagement.jsx.
- Denied paths: backend, migrations, ClinicManagement, other components.
- Migration/docs/test impact: нет.
- Rollback note: revert единственного коммита.

## Validation

- Targeted tests or smoke run: ESLint (0 errors).
- Result: passed.
- Not checked: full Playwright e2e (CI).