### PR TITLE
refactor(admin): UX-AUDIT Phase 3 — ServiceCatalog stat colors inline to CSS

### DIFF
--- a/frontend/src/components/admin/ServiceCatalog.jsx
+++ b/frontend/src/components/admin/ServiceCatalog.jsx
@@ -489,7 +489,7 @@ const ServiceCatalog = () => {
           className="p-6">
 
           <div className="text-center">
-            <div className="admin-stat-num-xl-bold-dynamic-m0" style={{ '--admin-stat-color': 'var(--mac-info)' }}>
+            <div className="admin-stat-num-xl-bold-dynamic-m0 admin-stat-info">
               {services.length}
             </div>
             <div className="admin-stat-label-sm-secondary-mt-4">
@@ -502,7 +502,7 @@ const ServiceCatalog = () => {
           className="p-6">
 
           <div className="text-center">
-            <div className="admin-stat-num-xl-bold-dynamic-m0" style={{ '--admin-stat-color': 'var(--mac-success)' }}>
+            <div className="admin-stat-num-xl-bold-dynamic-m0 admin-stat-success">
               {services.filter((s) => s.active).length}
             </div>
             <div className="admin-stat-label-sm-secondary-mt-4">
@@ -515,7 +515,7 @@ const ServiceCatalog = () => {
           className="p-6">
 
           <div className="text-center">
-            <div className="admin-stat-num-xl-bold-dynamic-m0" style={{ '--admin-stat-color': 'var(--mac-warning)' }}>
+            <div className="admin-stat-num-xl-bold-dynamic-m0 admin-stat-warning">
               {categories.length}
             </div>
             <div className="admin-stat-label-sm-secondary-mt-4">
@@ -528,7 +528,7 @@ const ServiceCatalog = () => {
           className="p-6">
 
           <div className="text-center">
-            <div className="admin-stat-num-xl-bold-dynamic-m0" style={{ '--admin-stat-color': 'var(--mac-accent)' }}>
+            <div className="admin-stat-num-xl-bold-dynamic-m0 admin-stat-accent">
               {filteredServices.length}
             </div>
             <div className="admin-stat-label-sm-secondary-mt-4">

--- a/frontend/src/components/admin/admin.css
+++ b/frontend/src/components/admin/admin.css
@@ -12579,6 +12579,8 @@ button[class*="admin-btn"]:active:not(:disabled) {
 .admin-stat-success { --admin-stat-color: var(--mac-success); }
 .admin-stat-warning { --admin-stat-color: var(--mac-warning); }
 .admin-stat-error { --admin-stat-color: var(--mac-error); }
+.admin-stat-info { --admin-stat-color: var(--mac-info); }
+.admin-stat-accent { --admin-stat-color: var(--mac-accent); }
 
 /* ─── Phase 3: ActivationSystem extend dialog ─── */
 /* Replaces 3 static inline style blocks in the extend activation dialog. */


### PR DESCRIPTION
## Summary

- Extracts 4 static CSS custom property injections from ServiceCatalog.jsx into modifier classes (.admin-stat-info, .admin-stat-accent) in admin.css, reusing .admin-stat-success and .admin-stat-warning from PR #2259.
- ServiceCatalog.jsx: 6 to 2 inline blocks. The 2 remaining are dynamic CSS custom property injections (specialtyColors lookup + isActive tab ternary) — the canonical modern pattern.
- Added 2 new modifier classes to admin.css (.admin-stat-info, .admin-stat-accent) complementing the 4 from PR #2259.

## Cyclic Execution Evidence

- Fresh main sync: yes — branch cut from main at commit 8c74a275 (PR #2259 merge).
- Clean workspace: yes.
- Branch: fix/ux-phase3-servicecatalog-css, single commit 0baf341a.
- Scope gate: 2 files changed (ServiceCatalog.jsx + admin.css). No backend, no migrations, no CI.
- Red-check handling: no red checks at PR creation — 626/626 tests pass, 0 lint errors. If CI surfaces a red check, the fix will be amended.

## Contract Impact

- not applicable - pure CSS extraction, no API/backend contracts changed. Visual output is identical (same var(--mac-*) tokens).

## RBAC / Permissions

- not applicable - no role logic touched. Admin-only component (unchanged).

## Notification / Realtime

- not applicable - no websocket/notification behavior changed.

## Frontend Resilience

- not applicable - no user-facing logic changed. CSS extraction is mechanical.

## Scope Gate

- Allowed paths: frontend/src/components/admin/ServiceCatalog.jsx, frontend/src/components/admin/admin.css.
- Denied paths: no backend, no migrations, no other frontend files.
- Migration/docs/test impact: none.
- Rollback note: revert commit 0baf341a.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests: npm test -- --run (626/626 passed), npm run lint (0 errors).
- Result: 626/626 passing, 0 regressions. ServiceCatalog inline blocks: 6 to 2.
- Not checked: npm run build — pre-existing react-is issue on main (unrelated).