### PR TITLE
refactor(admin): UX-AUDIT Phase 3 — CloudPrintingManager stat colors inline to CSS (5 to 0)

### DIFF
--- a/frontend/src/components/admin/CloudPrintingManager.jsx
+++ b/frontend/src/components/admin/CloudPrintingManager.jsx
@@ -327,23 +327,23 @@ const CloudPrintingManager = () => {
         {statistics &&
     <div className="admin-grid-auto-200-mb-24-printing">
           <MacOSCard className="p-6">
-            <div className="admin-stat-num-2xl-bold-dynamic" style={{ '--admin-stat-color': 'var(--mac-accent)' }}>{statistics.total_printers}</div>
+            <div className="admin-stat-num-2xl-bold-dynamic admin-stat-accent">{statistics.total_printers}</div>
             <div className="admin-stat-label-sm-secondary-block">Всего принтеров</div>
           </MacOSCard>
           <MacOSCard className="p-6">
-            <div className="admin-stat-num-2xl-bold-dynamic" style={{ '--admin-stat-color': 'var(--mac-success)' }}>{statistics.online_printers}</div>
+            <div className="admin-stat-num-2xl-bold-dynamic admin-stat-success">{statistics.online_printers}</div>
             <div className="admin-stat-label-sm-secondary-block">В сети</div>
           </MacOSCard>
           <MacOSCard className="p-6">
-            <div className="admin-stat-num-2xl-bold-dynamic" style={{ '--admin-stat-color': 'var(--mac-destructive)' }}>{statistics.offline_printers}</div>
+            <div className="admin-stat-num-2xl-bold-dynamic admin-stat-destructive">{statistics.offline_printers}</div>
             <div className="admin-stat-label-sm-secondary-block">Не в сети</div>
           </MacOSCard>
           <MacOSCard className="p-6">
-            <div className="admin-stat-num-2xl-bold-dynamic" style={{ '--admin-stat-color': 'var(--mac-warning)' }}>{statistics.providers_count}</div>
+            <div className="admin-stat-num-2xl-bold-dynamic admin-stat-warning">{statistics.providers_count}</div>
             <div className="admin-stat-label-sm-secondary-block">Провайдеров</div>
           </MacOSCard>
           <MacOSCard className="p-6">
-            <div className="admin-stat-num-2xl-bold-dynamic" style={{ '--admin-stat-color': 'var(--mac-accent)' }}>{localPrinters.length}</div>
+            <div className="admin-stat-num-2xl-bold-dynamic admin-stat-accent">{localPrinters.length}</div>
             <div className="admin-stat-label-sm-secondary-block">Локальных ОС-принтеров</div>
           </MacOSCard>
         </div>

--- a/frontend/src/components/admin/admin.css
+++ b/frontend/src/components/admin/admin.css
@@ -12581,6 +12581,7 @@ button[class*="admin-btn"]:active:not(:disabled) {
 .admin-stat-error { --admin-stat-color: var(--mac-error); }
 .admin-stat-info { --admin-stat-color: var(--mac-info); }
 .admin-stat-accent { --admin-stat-color: var(--mac-accent); }
+.admin-stat-destructive { --admin-stat-color: var(--mac-destructive); }
 
 /* ─── Phase 3: ActivationSystem extend dialog ─── */
 /* Replaces 3 static inline style blocks in the extend activation dialog. */


### PR DESCRIPTION
## Summary

- Extracts 5 static CSS custom property injections from CloudPrintingManager.jsx into stat color modifier classes in admin.css. CloudPrintingManager.jsx: 5 to 0 inline style blocks.
- Added 1 new modifier class (.admin-stat-destructive) complementing the 7 from PRs #2259 + #2260. The stat color modifier library now covers 8 tokens: blue, success, warning, error, info, accent, destructive.

## Cyclic Execution Evidence

- Fresh main sync: yes — branch cut from main at commit 27ebda06 (PR #2260 merge).
- Clean workspace: yes.
- Branch: fix/ux-phase3-cloudprinting-css, single commit 77e5f50f.
- Scope gate: 2 files changed (CloudPrintingManager.jsx + admin.css).
- Red-check handling: no red checks at PR creation — 626/626 tests pass.

## Contract Impact

- not applicable - pure CSS extraction, no API/backend contracts changed.

## RBAC / Permissions

- not applicable - no role logic touched.

## Notification / Realtime

- not applicable - no websocket/notification behavior changed.

## Frontend Resilience

- not applicable - no user-facing logic changed.

## Scope Gate

- Allowed paths: frontend/src/components/admin/CloudPrintingManager.jsx, frontend/src/components/admin/admin.css.
- Rollback note: revert commit 77e5f50f.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- npm test -- --run (626/626 passed), npm run lint (0 errors).
- CloudPrintingManager inline blocks: 5 to 0.