### PR TITLE
fix(lab): PR-AUDIT-L-H-batch-a — High priority lab panel fixes (6 issues)

### DIFF
--- a/frontend/src/api/labReporting.js
+++ b/frontend/src/api/labReporting.js
@@ -195,11 +195,10 @@ export const labReportingApi = {
     });
   },
 
-  markReady(instanceId) {
-    return request(`/lab/report-instances/${instanceId}/mark-ready`, {
-      method: 'POST'
-    });
-  },
+  // L-H-2 fix: markReady endpoint удалён как мёртвый код.
+  // WF-round5 убрал UI-кнопку (действие было функционально пустой операцией —
+  // backend разрешал одинаковые действия для DRAFT/IN_PROGRESS/READY).
+  // Если backend endpoint потребуется снова — добавлять вместе с UI-кнопкой.
 
   finalize(instanceId) {
     return request(`/lab/report-instances/${instanceId}/finalize`, {

--- a/frontend/src/components/laboratory/LabQueueWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabQueueWorkbench.jsx
@@ -30,10 +30,11 @@ function maskPhone(phone) {
 }
 
 // P-05 fix: компонент-обёртка для переключения маска/открыто.
+// L-H-4 fix: миграция inline-стилей в CSS (.lqw-masked-phone*).
 // Раскрытие может быть ограничено ролью через prop canReveal.
 function MaskedPhone({ phone, canReveal = true }) {
   const [revealed, setRevealed] = useState(false);
-  if (!phone) return <span style={{ color: 'var(--mac-text-secondary)' }}>не указан</span>;
+  if (!phone) return <span className="lqw-masked-phone-empty">не указан</span>;
   if (!canReveal) {
     return <span>{maskPhone(phone)}</span>;
   }
@@ -46,16 +47,7 @@ function MaskedPhone({ phone, canReveal = true }) {
       }}
       title={revealed ? 'Скрыть номер' : 'Показать номер (доступ ограничен)'}
       aria-label={revealed ? 'Скрыть номер телефона' : 'Показать номер телефона'}
-      style={{
-        background: 'none',
-        border: 'none',
-        padding: 0,
-        cursor: 'pointer',
-        color: 'inherit',
-        font: 'inherit',
-        textDecoration: 'underline dotted',
-        textUnderlineOffset: '2px',
-      }}
+      className="lqw-masked-phone"
     >
       {revealed ? phone : maskPhone(phone)}
     </button>
@@ -65,27 +57,6 @@ function MaskedPhone({ phone, canReveal = true }) {
 MaskedPhone.propTypes = {
   phone: PropTypes.string,
   canReveal: PropTypes.bool,
-};
-
-const cardGridStyle = {
-  display: 'grid',
-  gap: 'var(--mac-spacing-4)'
-};
-
-const queueCardStyle = {
-  border: '1px solid var(--mac-border)',
-  borderRadius: 'var(--mac-radius-xl)',
-  background: 'var(--mac-bg-primary)',
-  padding: 'var(--mac-spacing-4)',
-  display: 'grid',
-  gap: 'var(--mac-spacing-3)'
-};
-
-const metaRowStyle = {
-  display: 'flex',
-  flexWrap: 'wrap',
-  gap: 'var(--mac-spacing-2)',
-  alignItems: 'center'
 };
 
 const activeQueueStatuses = new Set([
@@ -135,9 +106,6 @@ export default function LabQueueWorkbench({
   reportHistory = []
 }) {
   // QW-8 fix: локальный state поиска и фильтра статусов.
-  // Раньше при 30+ записях в очереди лаборант вынужден был скроллить
-  // и визуально искать нужного пациента. Теперь — мгновенный поиск
-  // по ФИО + фильтр по статусу (waiting/in_progress/completed).
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   // PR-64 / Medium-14: client-side sorting
@@ -177,27 +145,14 @@ export default function LabQueueWorkbench({
   });
 
   return (
-    <div style={{ display: 'grid', gap: 'var(--mac-spacing-4)' }}>
+    <div className="lqw-root">
       <Card variant="filled" padding="none">
-        <CardHeader
-          style={{
-            background: 'var(--mac-bg-tertiary)',
-            borderBottom: '1px solid var(--mac-border)',
-            padding: 'var(--mac-spacing-4)'
-          }}
-        >
-          <CardTitle
-            style={{
-              margin: 0,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--mac-spacing-2)'
-            }}
-          >
+        <CardHeader className="lqw-card-header">
+          <CardTitle className="lqw-card-title">
             <Icon name="testtube.2" size={20} />
             Очередь лаборатории
           </CardTitle>
-          <div style={metaRowStyle}>
+          <div className="lqw-meta-row">
             <Badge variant="info">Всего: {appointments.length}</Badge>
             <Badge variant="warning">
               В работе: {appointments.filter((item) => activeQueueStatuses.has(item.status)).length}
@@ -207,34 +162,13 @@ export default function LabQueueWorkbench({
               Обновить
             </Button>
           </div>
-          {/* QW-8 fix: панель поиска и фильтра статусов. */}
-          <div
-            style={{
-              display: 'flex',
-              gap: 'var(--mac-spacing-3)',
-              flexWrap: 'wrap',
-              marginTop: 'var(--mac-spacing-3)',
-              alignItems: 'center',
-            }}
-          >
-            <div
-              style={{
-                position: 'relative',
-                flex: '1 1 240px',
-                minWidth: '200px',
-              }}
-            >
+          {/* QW-8 fix: панель поиска и фильтра статусов. L-H-4: CSS-классы. */}
+          <div className="lqw-search-filter-row">
+            <div className="lqw-search-wrapper">
               <Icon
                 name="magnifyingglass"
                 size={14}
-                styleAttr={{
-                  position: 'absolute',
-                  left: '10px',
-                  top: '50%',
-                  transform: 'translateY(-50%)',
-                  color: 'var(--mac-text-muted)',
-                  pointerEvents: 'none',
-                }}
+                className="lqw-search-icon"
               />
               <Input
                 type="search"
@@ -242,35 +176,14 @@ export default function LabQueueWorkbench({
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Поиск по ФИО, телефону, ID…"
                 aria-label="Поиск по очереди лаборатории"
-                style={{
-                  width: '100%',
-                  padding: '8px 12px 8px 32px',
-                  borderRadius: 'var(--mac-radius-lg)',
-                  border: '1px solid var(--mac-border)',
-                  background: 'var(--mac-bg-primary)',
-                  color: 'var(--mac-text-primary)',
-                  fontSize: 'var(--mac-font-size-base)',
-                  outline: 'none',
-                }}
+                className="lqw-search-input"
               />
               {searchQuery && (
                 <button
                   type="button"
                   onClick={() => setSearchQuery('')}
                   aria-label="Очистить поиск"
-                  style={{
-                    position: 'absolute',
-                    right: '8px',
-                    top: '50%',
-                    transform: 'translateY(-50%)',
-                    background: 'none',
-                    border: 'none',
-                    cursor: 'pointer',
-                    color: 'var(--mac-text-muted)',
-                    padding: 'var(--mac-spacing-1)',
-                    fontSize: 'var(--mac-font-size-lg)',
-                    lineHeight: 1,
-                  }}
+                  className="lqw-search-clear"
                 >
                   ×
                 </button>
@@ -279,7 +192,7 @@ export default function LabQueueWorkbench({
             <div
               role="group"
               aria-label="Фильтр по статусу"
-              style={{ display: 'flex', gap: 'var(--mac-spacing-1)' }}
+              className="lqw-status-filter-group"
             >
               {[
                 { key: 'all',        label: 'Все' },
@@ -291,16 +204,7 @@ export default function LabQueueWorkbench({
                   type="button"
                   onClick={() => setStatusFilter(opt.key)}
                   aria-pressed={statusFilter === opt.key}
-                  style={{
-                    padding: 'var(--mac-spacing-2) var(--mac-spacing-3)',
-                    borderRadius: 'var(--mac-radius-md)',
-                    border: `1px solid ${statusFilter === opt.key ? 'var(--mac-accent)' : 'var(--mac-border)'}`,
-                    background: statusFilter === opt.key ? 'var(--mac-accent)' : 'var(--mac-bg-primary)',
-                    color: statusFilter === opt.key ? 'white' : 'var(--mac-text-primary)',
-                    cursor: 'pointer',
-                    fontSize: 'var(--mac-font-size-sm)',
-                    fontWeight: statusFilter === opt.key ? 600 : 400,
-                  }}
+                  className={`lqw-status-filter-btn ${statusFilter === opt.key ? 'lqw-status-filter-btn-active' : ''}`}
                 >
                   {opt.label}
                 </button>
@@ -308,14 +212,13 @@ export default function LabQueueWorkbench({
             </div>
           </div>
           {/* PR-64 / Medium-14: sort controls */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--mac-spacing-2)' }}>
-            <span style={{ fontSize: 'var(--mac-font-size-xs)', color: 'var(--mac-text-muted)' }}>Сортировать:</span>
+          <div className="lqw-sort-row">
+            <span className="lqw-sort-label">Сортировать:</span>
             <select
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value)}
               aria-label="Сортировка очереди"
-              className="macos-input"
-              style={{ fontSize: 'var(--mac-font-size-xs)', padding: '4px 8px', width: 'auto' }}
+              className="macos-input lqw-sort-select"
             >
               <option value="default">По умолчанию</option>
               <option value="name">По имени</option>
@@ -324,13 +227,7 @@ export default function LabQueueWorkbench({
           </div>
           {/* QW-8 fix: индикатор количества отфильтрованных записей. */}
           {(searchQuery || statusFilter !== 'all') && (
-            <div
-              style={{
-                marginTop: 'var(--mac-spacing-2)',
-                fontSize: 'var(--mac-font-size-xs)',
-                color: 'var(--mac-text-muted)',
-              }}
-            >
+            <div className="lqw-filter-count">
               Показано: {filteredAppointments.length} из {appointments.length}
               {searchQuery && ` · поиск: «${searchQuery}»`}
               {statusFilter !== 'all' && ` · фильтр: ${
@@ -339,77 +236,29 @@ export default function LabQueueWorkbench({
             </div>
           )}
         </CardHeader>
-        <CardContent style={{ padding: 'var(--mac-spacing-4)', background: 'var(--mac-bg-secondary)' }}>
+        <CardContent className="lqw-card-content">
           {loading ? (
             // QW-3 fix: skeleton-загрузка вместо текста «Загрузка…».
-            // Skeleton показывает структуру будущих карточек и снижает
-            // ощущение медлительности. 3 карточки-заглушки с shimmer-анимацией.
-            <div style={cardGridStyle} aria-busy="true" aria-live="polite">
+            // L-H-4: используется CSS-класс .lqw-skeleton с @media (prefers-reduced-motion).
+            // L-M-4 fix: при prefers-reduced-motion skeleton остаётся статичным
+            // (без мигания), но структура всё ещё видна — лучше, чем белый экран.
+            <div className="lqw-card-grid" aria-busy="true" aria-live="polite">
               {[0, 1, 2].map((i) => (
                 <div
                   key={i}
-                  style={{
-                    ...queueCardStyle,
-                    background: 'var(--mac-bg-tertiary)',
-                  }}
+                  className="lqw-queue-card"
+                  style={{ background: 'var(--mac-bg-tertiary)' }}
                 >
-                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 'var(--mac-spacing-3)' }}>
-                    <div style={{ display: 'grid', gap: 'var(--mac-spacing-2)', flex: 1 }}>
-                      <div
-                        style={{
-                          height: '18px',
-                          width: '60%',
-                          borderRadius: 'var(--mac-radius-sm)',
-                          background: 'linear-gradient(90deg, var(--mac-border) 25%, var(--mac-bg-secondary) 50%, var(--mac-border) 75%)',
-                          backgroundSize: '200% 100%',
-                          animation: 'lab-skeleton-shimmer 1.5s infinite',
-                        }}
-                      />
-                      <div
-                        style={{
-                          height: '14px',
-                          width: '80%',
-                          borderRadius: 'var(--mac-radius-sm)',
-                          background: 'linear-gradient(90deg, var(--mac-border) 25%, var(--mac-bg-secondary) 50%, var(--mac-border) 75%)',
-                          backgroundSize: '200% 100%',
-                          animation: 'lab-skeleton-shimmer 1.5s infinite',
-                        }}
-                      />
-                      <div
-                        style={{
-                          height: '14px',
-                          width: '50%',
-                          borderRadius: 'var(--mac-radius-sm)',
-                          background: 'linear-gradient(90deg, var(--mac-border) 25%, var(--mac-bg-secondary) 50%, var(--mac-border) 75%)',
-                          backgroundSize: '200% 100%',
-                          animation: 'lab-skeleton-shimmer 1.5s infinite',
-                        }}
-                      />
+                  <div className="lqw-card-top">
+                    <div className="lqw-card-info" style={{ flex: 1 }}>
+                      <div className="lqw-skeleton" style={{ height: '18px', width: '60%' }} />
+                      <div className="lqw-skeleton" style={{ height: '14px', width: '80%' }} />
+                      <div className="lqw-skeleton" style={{ height: '14px', width: '50%' }} />
                     </div>
-                    <div
-                      style={{
-                        height: '22px',
-                        width: '80px',
-                        borderRadius: '11px',
-                        background: 'linear-gradient(90deg, var(--mac-border) 25%, var(--mac-bg-secondary) 50%, var(--mac-border) 75%)',
-                        backgroundSize: '200% 100%',
-                        animation: 'lab-skeleton-shimmer 1.5s infinite',
-                      }}
-                    />
+                    <div className="lqw-skeleton" style={{ height: '22px', width: '80px', borderRadius: '11px' }} />
                   </div>
                 </div>
               ))}
-              <style>{`
-                @keyframes lab-skeleton-shimmer {
-                  0% { background-position: 200% 0; }
-                  100% { background-position: -200% 0; }
-                }
-                @media (prefers-reduced-motion: reduce) {
-                  [style*="lab-skeleton-shimmer"] {
-                    animation: none !important;
-                  }
-                }
-              `}</style>
             </div>
           ) : filteredAppointments.length === 0 ? (
             <Alert severity="info">
@@ -418,7 +267,7 @@ export default function LabQueueWorkbench({
                 : 'Ничего не найдено. Измените поисковый запрос или фильтр.'}
             </Alert>
           ) : (
-            <div style={cardGridStyle}>
+            <div className="lqw-card-grid">
               {sortedAppointments.map((appointment) => {
                 const isSelected = selectedAppointment?.id === appointment.id;
                 return (
@@ -433,35 +282,30 @@ export default function LabQueueWorkbench({
                         onOpenAppointment(appointment);
                       }
                     }}
-                    style={{
-                      ...queueCardStyle,
-                      borderColor: isSelected ? 'var(--mac-accent)' : 'var(--mac-border)',
-                      boxShadow: isSelected ? '0 0 0 2px color-mix(in oklab, var(--mac-accent) 20%, transparent)' : 'none',
-                      cursor: 'pointer',
-                    }}
+                    className={`lqw-queue-card ${isSelected ? 'lqw-queue-card-selected' : ''}`}
                   >
-                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 'var(--mac-spacing-3)', alignItems: 'flex-start' }}>
-                      <div style={{ display: 'grid', gap: 'var(--mac-spacing-2)' }}>
-                        <div style={{ fontSize: 'var(--mac-font-size-xl)', fontWeight: 'var(--mac-font-weight-semibold)', color: 'var(--mac-text-primary)' }}>
+                    <div className="lqw-card-top">
+                      <div className="lqw-card-info">
+                        <div className="lqw-card-name">
                           {appointment.patient_fio || 'Пациент без имени'}
                         </div>
-                      <div style={{ color: 'var(--mac-text-secondary)', fontSize: 'var(--mac-font-size-base)' }}>
-                        Визит: {appointment.visit_id || 'не привязан'} | Телефон:{' '}
-                        {/* P-05 fix: маскирование номера телефона в публичном
-                            пространстве лаборатории. Раскрытие — по клику. */}
-                        <MaskedPhone phone={appointment.patient_phone} />
+                        <div className="lqw-card-meta">
+                          Визит: {appointment.visit_id || 'не привязан'} | Телефон:{' '}
+                          {/* P-05 fix: маскирование номера телефона в публичном
+                              пространстве лаборатории. Раскрытие — по клику. */}
+                          <MaskedPhone phone={appointment.patient_phone} />
+                        </div>
                       </div>
-                    </div>
                       <Badge variant={getLabStatusVariant(appointment.status)}>
                         {formatLabStatus(appointment.status)}
                       </Badge>
                     </div>
 
-                    <div style={{ color: 'var(--mac-text-secondary)', fontSize: 'var(--mac-font-size-base)', lineHeight: 1.5 }}>
-                      <strong style={{ color: 'var(--mac-text-primary)' }}>Услуги:</strong> {formatServices(appointment)}
+                    <div className="lqw-card-services">
+                      <strong>Услуги:</strong> {formatServices(appointment)}
                     </div>
 
-                    <div style={metaRowStyle}>
+                    <div className="lqw-meta-row">
                       <Badge variant="primary">{formatSpecialtyLabel(appointment.specialty)}</Badge>
                       {appointment.payment_status && <Badge variant="info">Оплата: {formatPaymentStatus(appointment.payment_status)}</Badge>}
                       {/* PR-60 / Medium-13: was variant="success" (green implies positive status, but time is not a status) */}
@@ -469,34 +313,32 @@ export default function LabQueueWorkbench({
                       {appointment.report_template_name && <Badge variant="info">{appointment.report_template_name}</Badge>}
                     </div>
 
-                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 'var(--mac-spacing-3)', alignItems: 'center' }}>
-                      <div style={{ color: 'var(--mac-text-secondary)', fontSize: 'var(--mac-font-size-sm)' }}>
+                    <div className="lqw-card-bottom">
+                      <div className="lqw-card-id">
                         {/* P-05 fix: patient_id — внутренний идентификатор, не нужен
                             лаборанту для работы. Скрываем по умолчанию, раскрытие —
-                            по клику. Снижает риск утечки PII через скриншоты. */}
-                        {/* PR-66 / Low-30: added custom marker + ::marker CSS reset */}
-                        <details style={{ display: 'inline' }}>
+                            по клику. Снижает риск утечки PII через скриншоты.
+                            L-M-5 fix: используем CSS-класс .lqw-pii-* вместо inline
+                            style-hack с ::-webkit-details-marker. */}
+                        <details className="lqw-pii-details">
                           <summary
-                            style={{
-                              display: 'inline-block',
-                              cursor: 'pointer',
-                              color: 'var(--mac-text-muted)',
-                              listStyle: 'none',
-                            }}
+                            className="lqw-pii-summary"
                             aria-label="Показать внутренний ID пациента"
                           >
-                            <style>{`summary::-webkit-details-marker { display: none; } summary::marker { content: ''; }`}</style>
                             ID пациента ▸
                           </summary>
-                          <span style={{ marginLeft: 6, fontFamily: 'monospace' }}>
+                          <span className="lqw-pii-value">
                             {appointment.patient_id}
                           </span>
                         </details>
                       </div>
-                      <Button variant="primary" onClick={() => onOpenAppointment(appointment)}>
-                        <Icon name="doc.text" size={16} />
-                        {appointment.report_instance_id ? 'Открыть отчёт' : 'Открыть в редакторе'}
-                      </Button>
+                      {/* L-M-3 fix: убрана вложенная Button внутри role="button".
+                          Карточка целиком кликабельна, отдельная кнопка избыточна
+                          и создавала a11y anti-pattern (click bubbles to parent). */}
+                      <Badge variant={appointment.report_instance_id ? 'success' : 'info'}>
+                        <Icon name="doc.text" size={12} />
+                        {appointment.report_instance_id ? 'Отчёт существует' : 'Новый отчёт'}
+                      </Badge>
                     </div>
                   </div>
                 );
@@ -508,46 +350,28 @@ export default function LabQueueWorkbench({
 
       {selectedAppointment && (
         <Card variant="filled" padding="none">
-          <CardHeader
-            style={{
-              background: 'var(--mac-bg-tertiary)',
-              borderBottom: '1px solid var(--mac-border)',
-              padding: 'var(--mac-spacing-4)'
-            }}
-          >
-            <CardTitle style={{ margin: 0, display: 'flex', alignItems: 'center', gap: 'var(--mac-spacing-2)' }}>
+          <CardHeader className="lqw-card-header">
+            <CardTitle className="lqw-card-title">
               <Icon name="clock.arrow.circlepath" size={20} />
               История отчётов пациента
             </CardTitle>
           </CardHeader>
-          <CardContent style={{ padding: 'var(--mac-spacing-4)', background: 'var(--mac-bg-secondary)' }}>
+          <CardContent className="lqw-card-content">
             {reportHistory.length === 0 ? (
               <Alert severity="info">Для выбранного пациента ещё нет лабораторных отчётов.</Alert>
             ) : (
-              <div style={{ display: 'grid', gap: 'var(--mac-spacing-3)' }}>
+              <div className="lqw-card-grid">
                 {reportHistory.map((item) => (
-                  <div
-                    key={item.id}
-                    style={{
-                      border: '1px solid var(--mac-border)',
-                      borderRadius: '14px',
-                      padding: '12px 14px',
-                      background: 'var(--mac-bg-primary)',
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      gap: 'var(--mac-spacing-3)',
-                      alignItems: 'center'
-                    }}
-                  >
-                    <div style={{ display: 'grid', gap: 'var(--mac-spacing-1)' }}>
-                      <div style={{ fontWeight: 'var(--mac-font-weight-semibold)', color: 'var(--mac-text-primary)' }}>
+                  <div key={item.id} className="lqw-history-card">
+                    <div className="lqw-history-info">
+                      <div className="lqw-history-title">
                         {item.template?.name || `Отчёт #${item.id}`}
                       </div>
-                      <div style={{ color: 'var(--mac-text-secondary)', fontSize: 'var(--mac-font-size-sm)' }}>
+                      <div className="lqw-history-meta">
                         Создан: {new Date(item.created_at).toLocaleString()} | Статус: {formatLabStatus(item.status)}
                       </div>
                     </div>
-                    <div style={{ display: 'flex', gap: 'var(--mac-spacing-2)', alignItems: 'center', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+                    <div className="lqw-history-badges">
                       <Badge variant={getLabStatusVariant(item.status)}>
                         {formatLabStatus(item.status)}
                       </Badge>

--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -846,17 +846,11 @@ export default function LabReportWorkbench({
                         return (
                           <div
                             key={field.field_key}
-                            style={{
-                              display: 'grid',
-                              gridTemplateColumns:
-                                'minmax(220px, 1.2fr) minmax(140px, 0.9fr) minmax(80px, 0.5fr) minmax(90px, 0.7fr) minmax(70px, 0.4fr)',
-                              gap: 'var(--mac-spacing-2)',
-                              alignItems: 'center'
-                            }}
+                            className="lrw-field-row"
                           >
-                            <div style={{ display: 'grid', gap: 'var(--mac-spacing-1)' }}>
-                              <strong style={{ color: 'var(--mac-text-primary)' }}>{field.label}</strong>
-                              <div style={{ display: 'grid', gap: 'var(--mac-spacing-1)', color: 'var(--mac-text-secondary)', fontSize: 'var(--mac-font-size-xs)' }}>
+                            <div className="lrw-field-label">
+                              <strong className="lrw-field-label-name">{field.label}</strong>
+                              <div className="lrw-field-meta">
                                 <span>Норма: {field.reference_text || 'не задана'}</span>
                                 {field.resolved_flag_meta?.matched_threshold && (
                                   <span>

--- a/frontend/src/components/laboratory/LabStatusStepper.jsx
+++ b/frontend/src/components/laboratory/LabStatusStepper.jsx
@@ -1,5 +1,9 @@
 import PropTypes from 'prop-types';
 import { Icon } from '../ui/macos';
+import {
+  LAB_REPORT_STATUS_CONFIG,
+  getLabReportStepIndex,
+} from './utils/labStatusConfig';
 
 /**
  * P-04 fix: LabStatusStepper выделен в отдельный файл.
@@ -10,21 +14,11 @@ import { Icon } from '../ui/macos';
  *
  * Раньше статус отображался одним Badge без контекста «куда двигаться
  * дальше». Stepper показывает пройденные шаги, текущий и будущие.
+ *
+ * L-H-3 fix: вместо локального LAB_REPORT_STEPS используется единый
+ * источник истины — utils/labStatusConfig.js. Маппинг статусов больше
+ * не дублируется между этим файлом и labUiLabels.js.
  */
-const LAB_REPORT_STEPS = [
-  { key: 'DRAFT',       label: 'Черновик' },
-  { key: 'IN_PROGRESS', label: 'Заполняется' },
-  { key: 'READY',       label: 'Готов к проверке' },  // PR-59: was missing from stepper
-  { key: 'FINALIZED',   label: 'Утверждён' },
-  { key: 'PRINTED',     label: 'Напечатан' },
-];
-
-function getLabReportStepIndex(status) {
-  if (!status) return -1;
-  const idx = LAB_REPORT_STEPS.findIndex((s) => s.key === status);
-  return idx;
-}
-
 export default function LabStatusStepper({ status }) {
   const currentIndex = getLabReportStepIndex(status);
   if (currentIndex < 0) {
@@ -44,11 +38,11 @@ export default function LabStatusStepper({ status }) {
         marginTop: 'var(--mac-spacing-2)',
       }}
     >
-      {LAB_REPORT_STEPS.map((step, index) => {
+      {LAB_REPORT_STATUS_CONFIG.map((step, index) => {
         const isCompleted = index < currentIndex;
         const isCurrent = index === currentIndex;
         const isFuture = index > currentIndex;
-        const isLast = index === LAB_REPORT_STEPS.length - 1;
+        const isLast = index === LAB_REPORT_STATUS_CONFIG.length - 1;
 
         return (
           <div

--- a/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
@@ -2,635 +2,30 @@ import { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Alert, Badge, Button, Card, CardContent, CardHeader, CardTitle, Icon,
-  Dialog, DialogTitle, DialogContent, DialogActions, Input, Label, Textarea,
 } from '../ui/macos';
+import { useConfirm } from '../common/ConfirmDialog';
 import { labReportingApi } from '../../api/labReporting';
 import './LabTemplateWorkbench.css';
 
-const blankField = () => ({
-  analyte_code: '',
-  unit_code: '',
-  field_key: '',
-  label: '',
-  value_type: 'numeric',
-  unit: '',
-  reference_mode: 'static_text',
-  reference_text: '',
-  reference_rule: null,
-  visibility_rule: null,
-  highlight_rule: null,
-  choice_options: null,
-  sort_order: 0,
-  required: false
-});
-
-const blankSection = (index) => ({
-  key: `section_${index}`,
-  title: `Раздел ${index}`,
-  sort_order: index * 10,
-  section_style: {},
-  fields: [blankField()]
-});
-
-const blankVersion = {
-  layout_preset: 'lab_table_classic_v1',
-  page_settings: { paper_size: 'A4', orientation: 'portrait' },
-  branding_overrides: {
-    document_title: '',
-    document_subtitle: '',
-    clinic_name: '',
-    address: '',
-    phone: '',
-    logo_url: ''
-  },
-  signer_defaults: {
-    lab_technician_label: 'Лаборант',
-    lab_technician_name: '',
-    approver_label: 'Подпись',
-    approver_name: ''
-  },
-  footer_notes: '',
-  sections: [blankSection(1)]
-};
-
-const layoutOptions = [
-  { value: 'lab_table_classic_v1', label: 'Классический' },
-  { value: 'lab_table_compact_v1', label: 'Компактный' }
-];
-
-const versionStatusLabels = {
-  PUBLISHED: 'Опубликован',
-  DRAFT: 'Черновик',
-  ARCHIVED: 'Архив'
-};
-
-const brandingFieldLabels = {
-  document_title: 'Заголовок документа',
-  document_subtitle: 'Подзоловок документа',
-  clinic_name: 'Название клиники',
-  address: 'Адрес',
-  phone: 'Телефон',
-  logo_url: 'Логотип (URL)'
-};
-
-const signerFieldLabels = {
-  lab_technician_label: 'Подпись лаборанта',
-  lab_technician_name: 'ФИО лаборанта',
-  approver_label: 'Подпись утверждающего',
-  approver_name: 'ФИО утверждающего'
-};
-
-const fieldTypeOptions = [
-  { value: 'numeric', label: 'Число' },
-  { value: 'text', label: 'Текст' },
-  { value: 'choice', label: 'Выбор из списка' },
-  { value: 'multiline', label: 'Многострочный текст' }
-];
-
-const referenceModeOptions = [
-  { value: 'static_text', label: 'Текстовая норма' },
-  { value: 'rule_based', label: 'Норма по правилам' },
-  { value: 'catalog', label: 'Из каталога' }
-];
-
-// Phase 4+ refactor: editor tabs — Content / Design / Signers / Preview.
-const EDITOR_TABS = [
-  { id: 'content',  label: 'Содержимое' },
-  { id: 'design',   label: 'Оформление' },
-  { id: 'signers',  label: 'Подписи' },
-  { id: 'preview',  label: 'Предпросмотр' },
-];
-
-function formatVersionStatus(status) {
-  return versionStatusLabels[status] || status;
-}
-
-const TEMPLATE_VERSION_ACTION_CAN_FIELD = {
-  update: 'can_update',
-  publish: 'can_publish',
-  create_draft: 'can_create_draft'
-};
-
-function hasTemplateVersionAction(version, action) {
-  const normalizedAction = String(action || '').trim().toLowerCase();
-  if (!normalizedAction) {
-    return false;
-  }
-
-  if (Array.isArray(version?.available_actions)) {
-    return version.available_actions.some(
-      (availableAction) => String(availableAction || '').trim().toLowerCase() === normalizedAction
-    );
-  }
-
-  const flagName = TEMPLATE_VERSION_ACTION_CAN_FIELD[normalizedAction];
-  if (flagName && Object.prototype.hasOwnProperty.call(version || {}, flagName)) {
-    return Boolean(version[flagName]);
-  }
-
-  return false;
-}
-
-function parseJsonInput(value) {
-  if (!value?.trim()) {
-    return null;
-  }
-  try {
-    return JSON.parse(value);
-  } catch {
-    return Symbol.for('invalid-json');
-  }
-}
-
-function stringifyJson(value) {
-  if (!value) {
-    return '';
-  }
-  return JSON.stringify(value, null, 2);
-}
-
-function buildVersionPayload(draftVersion) {
-  const sections = draftVersion.sections.map((section, sectionIndex) => ({
-    ...section,
-    sort_order: section.sort_order ?? (sectionIndex + 1) * 10,
-    section_style: section.section_style || {},
-    fields: section.fields.map((field, fieldIndex) => {
-      const referenceRule = parseJsonInput(field.reference_rule_text || '');
-      const visibilityRule = parseJsonInput(field.visibility_rule_text || '');
-      const highlightRule = parseJsonInput(field.highlight_rule_text || '');
-      if ([referenceRule, visibilityRule, highlightRule].includes(Symbol.for('invalid-json'))) {
-        throw new Error('Один из JSON-блоков правил заполнен некорректно');
-      }
-      return {
-        ...field,
-        sort_order: field.sort_order ?? (fieldIndex + 1) * 10,
-        reference_rule: referenceRule,
-        visibility_rule: visibilityRule,
-        highlight_rule: highlightRule,
-        reference_rule_text: undefined,
-        visibility_rule_text: undefined,
-        highlight_rule_text: undefined
-      };
-    })
-  }));
-
-  return {
-    layout_preset: draftVersion.layout_preset,
-    page_settings: draftVersion.page_settings || { paper_size: 'A4', orientation: 'portrait' },
-    branding_overrides: draftVersion.branding_overrides || {},
-    signer_defaults: draftVersion.signer_defaults || {},
-    footer_notes: draftVersion.footer_notes || '',
-    sections
-  };
-}
-
-function hydrateVersion(version) {
-  if (!version) {
-    return { ...blankVersion, sections: [blankSection(1)] };
-  }
-  return {
-    layout_preset: version.layout_preset,
-    page_settings: version.page_settings || { paper_size: 'A4', orientation: 'portrait' },
-    branding_overrides: {
-      clinic_name: '',
-      address: '',
-      phone: '',
-      logo_url: '',
-      document_title: '',
-      document_subtitle: '',
-      ...(version.branding_overrides || {})
-    },
-    signer_defaults: {
-      lab_technician_label: 'Лаборант',
-      lab_technician_name: '',
-      approver_label: 'Подпись',
-      approver_name: '',
-      ...(version.signer_defaults || {})
-    },
-    footer_notes: version.footer_notes || '',
-    sections: (version.sections || []).map((section) => ({
-      ...section,
-      fields: (section.fields || []).map((field) => ({
-        ...field,
-        reference_rule_text: stringifyJson(field.reference_rule),
-        visibility_rule_text: stringifyJson(field.visibility_rule),
-        highlight_rule_text: stringifyJson(field.highlight_rule)
-      }))
-    }))
-  };
-}
-
-// ============================================================
-// Phase 4+: New Template Dialog (was always-visible form)
-// ============================================================
-function NewTemplateDialog({ open, onClose, onCreate, saving }) {
-  const [form, setForm] = useState({
-    code: '',
-    name: '',
-    family: 'hematology',
-    description: ''
-  });
-
-  useEffect(() => {
-    if (open) {
-      setForm({ code: '', name: '', family: 'hematology', description: '' });
-    }
-  }, [open]);
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    onCreate(form);
-  };
-
-  return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Новый шаблон</DialogTitle>
-      <DialogContent>
-        <form onSubmit={handleSubmit} id="new-template-form" className="ltw-form-grid">
-          <div>
-            <Label htmlFor="new-template-code" className="ltw-label">Код шаблона</Label>
-            <Input
-              id="new-template-code"
-              aria-label="Код шаблона"
-              value={form.code}
-              onChange={(e) => setForm((prev) => ({ ...prev, code: e.target.value }))}
-              placeholder="Напр. hematology_basic"
-              className="ltw-input-full"
-              required
-            />
-          </div>
-          <div>
-            <Label htmlFor="new-template-name" className="ltw-label">Название</Label>
-            <Input
-              id="new-template-name"
-              aria-label="Название шаблона"
-              value={form.name}
-              onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
-              placeholder="Напр. Общий анализ крови"
-              className="ltw-input-full"
-              required
-            />
-          </div>
-          <div>
-            <Label htmlFor="new-template-family" className="ltw-label">Семейство</Label>
-            {/* PR-59: replaced free-text Input with <select> to prevent typo-induced fragmentation */}
-            <select
-              id="new-template-family"
-              aria-label="Семейство шаблона"
-              value={form.family}
-              onChange={(e) => setForm((prev) => ({ ...prev, family: e.target.value }))}
-              className="macos-input ltw-input-full"
-            >
-              <option value="hematology">Гематология</option>
-              <option value="biochemistry">Биохимия</option>
-              <option value="coagulation">Коагулология</option>
-              <option value="urinalysis">Общий анализ мочи</option>
-              <option value="immunology">Иммунология</option>
-              <option value="microbiology">Микробиология</option>
-              <option value="endocrinology">Эндокринология</option>
-              <option value="other">Прочее</option>
-            </select>
-          </div>
-          <div>
-            <Label htmlFor="new-template-description" className="ltw-label">Описание</Label>
-            <Textarea
-              id="new-template-description"
-              aria-label="Описание шаблона"
-              value={form.description}
-              onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
-              placeholder="Краткое описание шаблона"
-              minRows={3}
-              className="ltw-input-full"
-            />
-          </div>
-        </form>
-      </DialogContent>
-      <DialogActions>
-        <Button variant="outline" onClick={onClose}>Отмена</Button>
-        <Button variant="primary" type="submit" form="new-template-form" disabled={saving}>
-          <Icon name="plus" size={16} />
-          Создать
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
-}
-
-NewTemplateDialog.propTypes = {
-  open: PropTypes.bool,
-  onClose: PropTypes.func.isRequired,
-  onCreate: PropTypes.func.isRequired,
-  saving: PropTypes.bool,
-};
-
-// ============================================================
-// Phase 3: ReferenceRuleEditor — structured editor for reference_rule JSON.
-// Replaces raw JSON textarea with a visual cases editor.
-//
-// Rule format (from backend _sex_reference_rule / _ige_reference_rule):
-// {
-//   "cases": [
-//     { "when": {"source":"patient.sex","op":"eq","value":"M"},
-//       "text":"3.5-5.0", "low":3.5, "high":5.0 }
-//   ],
-//   "default": { "text":"3.5-5.0", "low":3.5, "high":5.0 }
-// }
-//
-// Supports:
-//   - source: patient.sex | patient.age | patient.age_months
-//   - op: eq | ne | lt | gt | le | ge | between
-//   - value: string or number (for eq/ne/lt/gt/le/ge)
-//   - min/max: numbers (for between)
-//   - text/low/high: reference range for this case
-// ============================================================
-
-const RULE_SOURCE_OPTIONS = [
-  { value: 'patient.sex', label: 'Пол пациента' },
-  { value: 'patient.age', label: 'Возраст (лет)' },
-  { value: 'patient.age_months', label: 'Возраст (мес.)' },
-];
-
-const RULE_OP_OPTIONS = [
-  { value: 'eq', label: '=' },
-  { value: 'ne', label: '≠' },
-  { value: 'lt', label: '<' },
-  { value: 'gt', label: '>' },
-  { value: 'le', label: '≤' },
-  { value: 'ge', label: '≥' },
-  { value: 'between', label: 'между' },
-];
-
-function parseRuleText(text) {
-  if (!text?.trim()) return null;
-  try {
-    return JSON.parse(text);
-  } catch {
-    return null;
-  }
-}
-
-function serializeRule(rule) {
-  if (!rule) return '';
-  return JSON.stringify(rule, null, 2);
-}
-
-function ReferenceRuleEditor({ sectionIndex, fieldIndex, field, updateField }) {
-  const rule = parseRuleText(field.reference_rule_text);
-  const isStructured = rule === null || (rule && Array.isArray(rule.cases));
-
-  // If the rule doesn't match our expected format, show raw JSON fallback.
-  if (!isStructured) {
-    return (
-      <div className="ltw-grid-6">
-        <span>Правила нормы (raw JSON)</span>
-        <textarea
-          className="macos-input"
-          aria-label="JSON правил нормы"
-          rows={6}
-          value={field.reference_rule_text || ''}
-          onChange={(event) => updateField(sectionIndex, fieldIndex, 'reference_rule_text', event.target.value)}
-        />
-        <span className="ltw-text-12 ltw-text-secondary">
-          Структурированный редактор недоступен — формат не распознан.
-        </span>
-      </div>
-    );
-  }
-
-  const cases = rule?.cases || [];
-  const defaultRule = rule?.default || { text: '', low: '', high: '' };
-
-  const updateRule = (nextRule) => {
-    updateField(sectionIndex, fieldIndex, 'reference_rule_text', serializeRule(nextRule));
-  };
-
-  const addCase = () => {
-    const newCase = {
-      when: { source: 'patient.sex', op: 'eq', value: 'M' },
-      text: '',
-      low: '',
-      high: '',
-    };
-    updateRule({ ...rule, cases: [...cases, newCase] });
-  };
-
-  const updateCase = (caseIndex, key, value) => {
-    const nextCases = cases.map((c, i) => i === caseIndex ? { ...c, [key]: value } : c);
-    updateRule({ ...rule, cases: nextCases });
-  };
-
-  const updateCaseWhen = (caseIndex, whenKey, value) => {
-    const nextCases = cases.map((c, i) => {
-      if (i !== caseIndex) return c;
-      return { ...c, when: { ...c.when, [whenKey]: value } };
-    });
-    updateRule({ ...rule, cases: nextCases });
-  };
-
-  const removeCase = (caseIndex) => {
-    updateRule({ ...rule, cases: cases.filter((_, i) => i !== caseIndex) });
-  };
-
-  const updateDefault = (key, value) => {
-    updateRule({ ...rule, default: { ...defaultRule, [key]: value } });
-  };
-
-  return (
-    <div className="ltw-rule-editor">
-      <div className="ltw-flex-between">
-        <span className="ltw-fw-600 ltw-text-14">Правила нормы</span>
-        <Button variant="outline" size="small" onClick={addCase}>
-          <Icon name="plus" size={12} />
-          Добавить условие
-        </Button>
-      </div>
-
-      {cases.length === 0 && (
-        <span className="ltw-text-13 ltw-text-secondary">
-          Нет условий. Будет использоваться значение по умолчанию.
-        </span>
-      )}
-
-      {cases.map((caseItem, caseIndex) => {
-        const isBetween = caseItem.when?.op === 'between';
-        return (
-          <div key={caseIndex} className="ltw-case-card">
-            <div className="ltw-flex-between">
-              <span className="ltw-text-13 ltw-fw-500">Условие {caseIndex + 1}</span>
-              <Button variant="ghost" size="small" onClick={() => removeCase(caseIndex)} aria-label="Удалить условие">
-                <Icon name="trash" size={12} />
-              </Button>
-            </div>
-
-            <div className="ltw-grid-3">
-              <label className="ltw-label-grid">
-                <span className="ltw-text-12">Источник</span>
-                <select
-                  className="macos-input"
-                  aria-label="Источник условия"
-                  value={caseItem.when?.source || 'patient.sex'}
-                  onChange={(e) => updateCaseWhen(caseIndex, 'source', e.target.value)}
-                >
-                  {RULE_SOURCE_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </select>
-              </label>
-              <label className="ltw-label-grid">
-                <span className="ltw-text-12">Оператор</span>
-                <select
-                  className="macos-input"
-                  aria-label="Оператор условия"
-                  value={caseItem.when?.op || 'eq'}
-                  onChange={(e) => updateCaseWhen(caseIndex, 'op', e.target.value)}
-                >
-                  {RULE_OP_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </select>
-              </label>
-              {isBetween ? (
-                <div className="ltw-grid-2-50-50">
-                  <label className="ltw-label-grid">
-                    <span className="ltw-text-12">Минимум</span>
-                    <input
-                      className="macos-input"
-                      aria-label="Минимум условия"
-                      type="number"
-                      value={caseItem.when?.min ?? ''}
-                      onChange={(e) => updateCaseWhen(caseIndex, 'min', parseFloat(e.target.value) || 0)}
-                    />
-                  </label>
-                  <label className="ltw-label-grid">
-                    <span className="ltw-text-12">Максимум</span>
-                    <input
-                      className="macos-input"
-                      aria-label="Максимум условия"
-                      type="number"
-                      value={caseItem.when?.max ?? ''}
-                      onChange={(e) => updateCaseWhen(caseIndex, 'max', parseFloat(e.target.value) || 0)}
-                    />
-                  </label>
-                </div>
-              ) : (
-                <label className="ltw-label-grid">
-                  <span className="ltw-text-12">Значение</span>
-                  {/* PR-61 / Medium-18: sex enum when source is patient.sex */}
-                  {caseItem.when?.source === 'patient.sex' ? (
-                    <select
-                      className="macos-input"
-                      aria-label="Значение условия"
-                      value={caseItem.when?.value ?? ''}
-                      onChange={(e) => updateCaseWhen(caseIndex, 'value', e.target.value)}
-                    >
-                      <option value="">Выберите...</option>
-                      <option value="M">Мужской (M)</option>
-                      <option value="F">Женский (F)</option>
-                    </select>
-                  ) : (
-                    <input
-                      className="macos-input"
-                      aria-label="Значение условия"
-                      value={caseItem.when?.value ?? ''}
-                      onChange={(e) => updateCaseWhen(caseIndex, 'value', e.target.value)}
-                    />
-                  )}
-                </label>
-              )}
-            </div>
-
-            <div className="ltw-grid-3-ranges">
-              <label className="ltw-label-grid">
-                <span className="ltw-text-12">Текст нормы</span>
-                <input
-                  className="macos-input"
-                  aria-label="Текст нормы для условия"
-                  value={caseItem.text || ''}
-                  onChange={(e) => updateCase(caseIndex, 'text', e.target.value)}
-                  placeholder="3.5-5.0"
-                />
-              </label>
-              <label className="ltw-label-grid">
-                <span className="ltw-text-12">Нижняя граница</span>
-                <input
-                  className="macos-input"
-                  aria-label="Нижняя граница нормы"
-                  type="number"
-                  value={caseItem.low ?? ''}
-                  onChange={(e) => updateCase(caseIndex, 'low', parseFloat(e.target.value) || null)}
-                />
-              </label>
-              <label className="ltw-label-grid">
-                <span className="ltw-text-12">Верхняя граница</span>
-                <input
-                  className="macos-input"
-                  aria-label="Верхняя граница нормы"
-                  type="number"
-                  value={caseItem.high ?? ''}
-                  onChange={(e) => updateCase(caseIndex, 'high', parseFloat(e.target.value) || null)}
-                />
-              </label>
-            </div>
-          </div>
-        );
-      })}
-
-      {/* Default case */}
-      <div className="ltw-default-card">
-        <span className="ltw-text-13 ltw-fw-500">По умолчанию (если ни одно условие не сработало)</span>
-        <div className="ltw-grid-3-ranges">
-          <label className="ltw-label-grid">
-            <span className="ltw-text-12">Текст нормы</span>
-            <input
-              className="macos-input"
-              aria-label="Текст нормы по умолчанию"
-              value={defaultRule.text || ''}
-              onChange={(e) => updateDefault('text', e.target.value)}
-              placeholder="3.5-5.0"
-            />
-          </label>
-          <label className="ltw-label-grid">
-            <span className="ltw-text-12">Нижняя граница</span>
-            <input
-              className="macos-input"
-              aria-label="Нижняя граница по умолчанию"
-              type="number"
-              value={defaultRule.low ?? ''}
-              onChange={(e) => updateDefault('low', parseFloat(e.target.value) || null)}
-            />
-          </label>
-          <label className="ltw-label-grid">
-            <span className="ltw-text-12">Верхняя граница</span>
-            <input
-              className="macos-input"
-              aria-label="Верхняя граница по умолчанию"
-              type="number"
-              value={defaultRule.high ?? ''}
-              onChange={(e) => updateDefault('high', parseFloat(e.target.value) || null)}
-            />
-          </label>
-        </div>
-      </div>
-
-      {/* Raw JSON toggle for advanced users */}
-      <details>
-        <summary className="ltw-summary-12">
-          Raw JSON (для продвинутых)
-        </summary>
-        <textarea
-          className="macos-input ltw-raw-json-textarea"
-          aria-label="Raw JSON правил нормы"
-          rows={6}
-          value={field.reference_rule_text || ''}
-          onChange={(event) => updateField(sectionIndex, fieldIndex, 'reference_rule_text', event.target.value)}
-        />
-      </details>
-    </div>
-  );
-}
-
-ReferenceRuleEditor.propTypes = {
-  sectionIndex: PropTypes.number.isRequired,
-  fieldIndex: PropTypes.number.isRequired,
-  field: PropTypes.object.isRequired,
-  updateField: PropTypes.func.isRequired,
-};
+// L-H-6 fix: декомпозиция монолита (1598 → ~600 строк).
+// Helper-функции и подкомпоненты вынесены в отдельные модули:
+import {
+  blankField,
+  blankSection,
+  blankVersion,
+  hydrateVersion,
+  buildVersionPayload,
+  hasTemplateVersionAction,
+} from './templateEditor/utils';
+import {
+  EDITOR_TABS,
+  formatVersionStatus,
+} from './templateEditor/config';
+import NewTemplateDialog from './templateEditor/NewTemplateDialog';
+import ContentTab from './templateEditor/ContentTab';
+import DesignTab from './templateEditor/DesignTab';
+import SignersTab from './templateEditor/SignersTab';
+import PreviewTab from './templateEditor/PreviewTab';
 
 export default function LabTemplateWorkbench({
   templates,
@@ -639,6 +34,11 @@ export default function LabTemplateWorkbench({
   onTemplatesChanged,
   notify
 }) {
+  // L-H-1 fix: useConfirm() для всех destructive actions (вместо native confirm()).
+  // Согласованность с LabReportWorkbench — единый стилизованный portal-dialog
+  // с focus-trap, Esc-to-cancel, явным описанием последствий.
+  const [confirm, confirmDialog] = useConfirm();
+
   // Phase 4+: New Template dialog state (was always-visible form).
   const [showNewTemplateDialog, setShowNewTemplateDialog] = useState(false);
 
@@ -653,8 +53,8 @@ export default function LabTemplateWorkbench({
   const [catalogAnalytes, setCatalogAnalytes] = useState([]);
 
   // Phase 4+ Phase 2: collapsible sections + field cards + duplicate + reorder.
-  const [expandedSections, setExpandedSections] = useState(new Set([0])); // first section open
-  const [expandedFields, setExpandedFields] = useState(new Set()); // all fields collapsed by default
+  const [expandedSections, setExpandedSections] = useState(new Set([0]));
+  const [expandedFields, setExpandedFields] = useState(new Set());
 
   const toggleSection = (sectionIndex) => {
     setExpandedSections((prev) => {
@@ -763,17 +163,15 @@ export default function LabTemplateWorkbench({
     if (!draftVersion?.sections) return [];
     const errors = [];
     draftVersion.sections.forEach((section, sIdx) => {
-      (section.fields || []).forEach((field, fIdx) => {
+      (section.fields || []).forEach((field) => {
         const rule = field.reference_rule;
         if (!rule) return;
-        // Check default case
         const def = rule.default;
         if (def && def.low != null && def.high != null && def.low !== '' && def.high !== '') {
           if (parseFloat(def.low) >= parseFloat(def.high)) {
             errors.push(`Секция "${section.title || sIdx + 1}", поле "${field.label || field.field_key}": default low (${def.low}) ≥ high (${def.high})`);
           }
         }
-        // Check each case
         (rule.cases || []).forEach((c, cIdx) => {
           if (c.low != null && c.high != null && c.low !== '' && c.high !== '') {
             if (parseFloat(c.low) >= parseFloat(c.high)) {
@@ -792,7 +190,7 @@ export default function LabTemplateWorkbench({
     const errors = [];
     const seenKeys = new Set();
     draftVersion.sections.forEach((section, sIdx) => {
-      (section.fields || []).forEach((field, fIdx) => {
+      (section.fields || []).forEach((field) => {
         const key = field.field_key;
         if (!key) return;
         if (seenKeys.has(key)) {
@@ -809,7 +207,6 @@ export default function LabTemplateWorkbench({
       notify('error', 'Выберите шаблон для редактирования.');
       return;
     }
-    // PR-57: validate before saving
     const rangeErrors = validateReferenceRanges();
     const keyErrors = validateFieldKeyUniqueness();
     if (rangeErrors.length > 0 || keyErrors.length > 0) {
@@ -836,7 +233,6 @@ export default function LabTemplateWorkbench({
       notify('error', 'Выберите шаблон.');
       return;
     }
-    // PR-57: validate before publishing
     const rangeErrors = validateReferenceRanges();
     const keyErrors = validateFieldKeyUniqueness();
     if (rangeErrors.length > 0 || keyErrors.length > 0) {
@@ -859,14 +255,24 @@ export default function LabTemplateWorkbench({
   }
 
   // PR-65 / Medium-19: archive template version (soft-delete)
+  // L-H-1 fix: native confirm() заменён на useConfirm() — стилизованный
+  // portal-dialog с focus-trap, Esc-to-cancel, явным описанием последствий.
   async function handleArchiveTemplate() {
     if (!selectedTemplate || !activeVersion) {
       notify('error', 'Выберите версию для архивирования.');
       return;
     }
-    if (!confirm('Архивировать эту версию шаблона? Она станет недоступна для новых отчётов.')) {
-      return;
-    }
+    const ok = await confirm({
+      title: 'Архивирование версии шаблона',
+      message: 'Версия станет недоступна для создания новых отчётов.',
+      description: 'Существующие отчёты, созданные по этой версии, ' +
+        'сохранят доступ к данным. Восстановить архивированную версию нельзя — ' +
+        'потребуется создать новый черновик на основе существующей.',
+      confirmLabel: 'Архивировать',
+      cancelLabel: 'Отмена',
+      intent: 'warning',
+    });
+    if (!ok) return;
     setSaving(true);
     try {
       await labReportingApi.archiveTemplateVersion(activeVersion.id);
@@ -896,23 +302,19 @@ export default function LabTemplateWorkbench({
     }
   }
 
+  // ─── Field/Section mutation helpers (used by ContentTab) ───
+
   function updateBranding(key, value) {
     setDraftVersion((prev) => ({
       ...prev,
-      branding_overrides: {
-        ...prev.branding_overrides,
-        [key]: value
-      }
+      branding_overrides: { ...prev.branding_overrides, [key]: value }
     }));
   }
 
   function updateSigner(key, value) {
     setDraftVersion((prev) => ({
       ...prev,
-      signer_defaults: {
-        ...prev.signer_defaults,
-        [key]: value
-      }
+      signer_defaults: { ...prev.signer_defaults, [key]: value }
     }));
   }
 
@@ -929,9 +331,7 @@ export default function LabTemplateWorkbench({
     setDraftVersion((prev) => ({
       ...prev,
       sections: prev.sections.map((section, index) => {
-        if (index !== sectionIndex) {
-          return section;
-        }
+        if (index !== sectionIndex) return section;
         return {
           ...section,
           fields: section.fields.map((field, nestedIndex) => (
@@ -951,15 +351,11 @@ export default function LabTemplateWorkbench({
     setDraftVersion((prev) => ({
       ...prev,
       sections: prev.sections.map((section, index) => {
-        if (index !== sectionIndex) {
-          return section;
-        }
+        if (index !== sectionIndex) return section;
         return {
           ...section,
           fields: section.fields.map((field, nestedIndex) => {
-            if (nestedIndex !== fieldIndex) {
-              return field;
-            }
+            if (nestedIndex !== fieldIndex) return field;
             return {
               ...field,
               analyte_code: value,
@@ -969,6 +365,24 @@ export default function LabTemplateWorkbench({
         };
       })
     }));
+  }
+
+  async function loadCatalogReferenceRange(sectionIndex, fieldIndex, analyteCode) {
+    try {
+      const ranges = await labReportingApi.listCatalogReferenceRanges(analyteCode);
+      if (ranges && ranges.length > 0) {
+        const range = ranges[0];
+        updateField(sectionIndex, fieldIndex, 'reference_text',
+          range.text || `${range.low || ''}–${range.high || ''}`);
+        if (range.low != null) updateField(sectionIndex, fieldIndex, 'reference_low', range.low);
+        if (range.high != null) updateField(sectionIndex, fieldIndex, 'reference_high', range.high);
+        notify('success', `Норма загружена из каталога: ${range.text || ''}`);
+      } else {
+        notify('info', 'В каталоге нет норм для этого аналита.');
+      }
+    } catch (e) {
+      notify('error', `Ошибка загрузки из каталога: ${e.message}`);
+    }
   }
 
   function addSection() {
@@ -1007,7 +421,6 @@ export default function LabTemplateWorkbench({
     }));
   }
 
-  // Phase 4+ Phase 2: duplicate + reorder helpers.
   function duplicateField(sectionIndex, fieldIndex) {
     setDraftVersion((prev) => ({
       ...prev,
@@ -1051,372 +464,9 @@ export default function LabTemplateWorkbench({
     });
   }
 
-  // ============================================================
-  // Editor tab renderers
-  // ============================================================
-  const renderContentTab = () => (
-    <div className="ltw-grid">
-      <div className="ltw-flex-between">
-        {/* PR-61 / Low-29: count fields not just sections (was misleading) */}
-        <div className="ltw-fw-600">Секции и показатели ({draftVersion?.sections?.reduce((acc, s) => acc + (s.fields?.length || 0), 0) || 0} показателей в {draftVersion?.sections?.length || 0} секц.)</div>
-        <Button variant="outline" onClick={addSection}>
-          <Icon name="plus" size={16} />
-          Добавить секцию
-        </Button>
-      </div>
-
-      {draftVersion.sections.map((section, sectionIndex) => {
-        const isSectionExpanded = expandedSections.has(sectionIndex);
-        return (
-          <div key={`${section.key}-${sectionIndex}`} className="ltw-section-card">
-            {/* Section header — collapsible */}
-            <button
-              type="button"
-              className={`ltw-section-header ${isSectionExpanded ? 'ltw-section-header-expanded' : ''}`}
-              onClick={() => toggleSection(sectionIndex)}
-              aria-expanded={isSectionExpanded}
-              aria-label={`Секция: ${section.title || section.key}`}>
-              <div className="ltw-flex-center">
-                <Icon name={isSectionExpanded ? 'chevron.down' : 'chevron.right'} size={16} />
-                <span className="ltw-section-title">{section.title || section.key}</span>
-                <Badge variant="default">{section.fields.length} полей</Badge>
-              </div>
-              <span className="ltw-flex-gap-4">
-                <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); moveSection(sectionIndex, 'up'); }} disabled={sectionIndex === 0} aria-label="Переместить секцию вверх">
-                  <Icon name="arrow.up" size={14} />
-                </Button>
-                <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); moveSection(sectionIndex, 'down'); }} disabled={sectionIndex === draftVersion.sections.length - 1} aria-label="Переместить секцию вниз">
-                  <Icon name="arrow.down" size={14} />
-                </Button>
-                <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); removeSection(sectionIndex); }} aria-label="Удалить секцию">
-                  <Icon name="trash" size={14} />
-                </Button>
-              </span>
-            </button>
-
-            {/* Section content — only when expanded */}
-            {isSectionExpanded && (
-              <div className="ltw-section-content">
-                {/* Section key + title editors */}
-                <div className="ltw-grid-2">
-                  <label className="ltw-grid-6">
-                    <span>Ключ секции</span>
-                    <input className="macos-input" aria-label="Ключ секции" value={section.key} onChange={(event) => updateSection(sectionIndex, 'key', event.target.value)} />
-                  </label>
-                  <label className="ltw-grid-6">
-                    <span>Заголовок секции</span>
-                    <input className="macos-input" aria-label="Заголовок секции" value={section.title || ''} onChange={(event) => updateSection(sectionIndex, 'title', event.target.value)} />
-                  </label>
-                </div>
-
-                {/* Fields */}
-                <div className="ltw-grid-8">
-                  {section.fields.map((field, fieldIndex) => {
-                    const fieldKey = `${sectionIndex}-${fieldIndex}`;
-                    const isFieldExpanded = expandedFields.has(fieldKey);
-                    return (
-                      <div key={`${field.field_key}-${fieldIndex}`} className="ltw-field-card">
-                        {/* Field header — collapsible */}
-                        <button
-                          type="button"
-                          className={`ltw-field-header ${isFieldExpanded ? 'ltw-field-header-expanded' : ''}`}
-                          onClick={() => toggleField(sectionIndex, fieldIndex)}
-                          aria-expanded={isFieldExpanded}
-                          aria-label={`Поле: ${field.label || field.field_key}`}>
-                          <div className="ltw-flex-center">
-                            <Icon name={isFieldExpanded ? 'chevron.down' : 'chevron.right'} size={14} />
-                            <span className="ltw-field-title">{field.label || field.field_key || '(без названия)'}</span>
-                            <Badge variant="info">{fieldTypeOptions.find((o) => o.value === field.value_type)?.label || field.value_type}</Badge>
-                            {field.required && <Badge variant="warning">обязательное</Badge>}
-                          </div>
-                          <span className="ltw-flex-gap-4">
-                            <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); moveField(sectionIndex, fieldIndex, 'up'); }} disabled={fieldIndex === 0} aria-label="Переместить поле вверх">
-                              <Icon name="arrow.up" size={12} />
-                            </Button>
-                            <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); moveField(sectionIndex, fieldIndex, 'down'); }} disabled={fieldIndex === section.fields.length - 1} aria-label="Переместить поле вниз">
-                              <Icon name="arrow.down" size={12} />
-                            </Button>
-                            <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); duplicateField(sectionIndex, fieldIndex); }} aria-label="Дублировать поле">
-                              <Icon name="doc.on.doc" size={12} />
-                            </Button>
-                            <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); removeField(sectionIndex, fieldIndex); }} aria-label="Удалить поле">
-                              <Icon name="trash" size={12} />
-                            </Button>
-                          </span>
-                        </button>
-
-                        {/* Field content — only when expanded */}
-                        {isFieldExpanded && (
-                          <div className="ltw-field-content">
-                            <div className="ltw-grid-4">
-                              <label className="ltw-grid-6">
-                                <span>Ключ поля</span>
-                                <input className="macos-input" aria-label="Ключ поля" value={field.field_key} onChange={(event) => updateField(sectionIndex, fieldIndex, 'field_key', event.target.value)} />
-                              </label>
-                              <label className="ltw-grid-6">
-                                <span>Название поля</span>
-                                <input className="macos-input" aria-label="Название поля" value={field.label} onChange={(event) => updateField(sectionIndex, fieldIndex, 'label', event.target.value)} />
-                              </label>
-                              <label className="ltw-grid-6">
-                                <span>Тип значения</span>
-                                <select className="macos-input" aria-label="Тип значения" value={field.value_type} onChange={(event) => updateField(sectionIndex, fieldIndex, 'value_type', event.target.value)}>
-                                  {fieldTypeOptions.map((option) => (
-                                    <option key={option.value} value={option.value}>{option.label}</option>
-                                  ))}
-                                </select>
-                              </label>
-                              <label className="ltw-grid-6">
-                                <span>Единица измерения</span>
-                                <input className="macos-input" aria-label="Единица измерения" value={field.unit || ''} onChange={(event) => updateField(sectionIndex, fieldIndex, 'unit', event.target.value)} />
-                              </label>
-                            </div>
-
-                            <div className="ltw-grid-5">
-                              <label className="ltw-grid-6">
-                                <span>Код анализируемого показателя</span>
-                                <input
-                                  className="macos-input"
-                                  aria-label="Код анализируемого показателя"
-                                  list="lab-analyte-catalog"
-                                  value={field.analyte_code || ''}
-                                  onChange={(event) => updateFieldCatalog(sectionIndex, fieldIndex, 'analyte_code', event.target.value)}
-                                />
-                              </label>
-                              <label className="ltw-grid-6">
-                                <span>Код единицы измерения</span>
-                                <input
-                                  className="macos-input"
-                                  aria-label="Код единицы измерения"
-                                  list="lab-unit-catalog"
-                                  value={field.unit_code || ''}
-                                  onChange={(event) => updateField(sectionIndex, fieldIndex, 'unit_code', event.target.value)}
-                                />
-                              </label>
-                              <label className="ltw-grid-6">
-                                <span>Источник нормы</span>
-                                <select className="macos-input" aria-label="Источник нормы" value={field.reference_mode} onChange={(event) => updateField(sectionIndex, fieldIndex, 'reference_mode', event.target.value)}>
-                                  {referenceModeOptions.map((option) => (
-                                    <option key={option.value} value={option.value}>{option.label}</option>
-                                  ))}
-                                </select>
-                              </label>
-                              {/* PR-67 / High-10: catalog reference_mode UI — fetch from labReportingApi */}
-                              {field.reference_mode === 'catalog' && field.analyte_code && (
-                                <div className="ltw-label-grid">
-                                  <Button
-                                    variant="outline"
-                                    size="small"
-                                    onClick={async () => {
-                                      try {
-                                        const ranges = await labReportingApi.listCatalogReferenceRanges(field.analyte_code);
-                                        if (ranges && ranges.length > 0) {
-                                          const range = ranges[0];
-                                          updateField(sectionIndex, fieldIndex, 'reference_text',
-                                            range.text || `${range.low || ''}–${range.high || ''}`);
-                                          if (range.low != null) updateField(sectionIndex, fieldIndex, 'reference_low', range.low);
-                                          if (range.high != null) updateField(sectionIndex, fieldIndex, 'reference_high', range.high);
-                                          notify('success', `Норма загружена из каталога: ${range.text || ''}`);
-                                        } else {
-                                          notify('info', 'В каталоге нет норм для этого аналита.');
-                                        }
-                                      } catch (e) {
-                                        notify('error', `Ошибка загрузки из каталога: ${e.message}`);
-                                      }
-                                    }}
-                                  >
-                                    <Icon name="square.and.arrow.down.on.square" size={14} />
-                                    Загрузить из каталога
-                                  </Button>
-                                </div>
-                              )}
-                              {field.reference_mode === 'catalog' && !field.analyte_code && (
-                                <span className="ltw-catalog-hint">
-                                  Укажите код аналита для загрузки нормы из каталога
-                                </span>
-                              )}
-                              <label className="ltw-grid-6">
-                                <span>Текст нормы</span>
-                                <input className="macos-input" aria-label="Текст нормы" value={field.reference_text || ''} onChange={(event) => updateField(sectionIndex, fieldIndex, 'reference_text', event.target.value)} />
-                              </label>
-                              <label className="ltw-checkbox-label">
-                                <input type="checkbox" aria-label="Обязательное поле" checked={Boolean(field.required)} onChange={(event) => updateField(sectionIndex, fieldIndex, 'required', event.target.checked)} />
-                                Обязательное
-                              </label>
-                            </div>
-
-                            {/* Phase 3: structured editor for reference rules.
-                                Replaces raw JSON textarea with a visual cases editor.
-                                Rule format (from backend _sex_reference_rule):
-                                {
-                                  "cases": [
-                                    { "when": {"source":"patient.sex","op":"eq","value":"M"},
-                                      "text":"3.5-5.0", "low":3.5, "high":5.0 }
-                                  ],
-                                  "default": { "text":"3.5-5.0", "low":3.5, "high":5.0 }
-                                }
-                                Visibility + highlight rules stay as raw JSON (rarely used,
-                                advanced-only) — they're collapsed by default. */}
-                            <ReferenceRuleEditor
-                              sectionIndex={sectionIndex}
-                              fieldIndex={fieldIndex}
-                              field={field}
-                              updateField={updateField}
-                            />
-
-                            <details className="ltw-details">
-                              <summary className="ltw-summary">
-                                Расширенные правила (видимость / подсветка) — raw JSON
-                              </summary>
-                              <div className="ltw-raw-json-grid">
-                                <label className="ltw-grid-6">
-                                  <span>JSON правил видимости</span>
-                                  <textarea className="macos-input" aria-label="JSON правил видимости" rows={3} value={field.visibility_rule_text || ''} onChange={(event) => updateField(sectionIndex, fieldIndex, 'visibility_rule_text', event.target.value)} />
-                                </label>
-                                <label className="ltw-grid-6">
-                                  <span>JSON правил подсветки</span>
-                                  <textarea className="macos-input" aria-label="JSON правил подсветки" rows={3} value={field.highlight_rule_text || ''} onChange={(event) => updateField(sectionIndex, fieldIndex, 'highlight_rule_text', event.target.value)} />
-                                </label>
-                              </div>
-                            </details>
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
-                  <Button variant="outline" onClick={() => addField(sectionIndex)}>
-                    <Icon name="plus" size={16} />
-                    Добавить показатель
-                  </Button>
-                </div>
-              </div>
-            )}
-          </div>
-        );
-      })}
-    </div>
-  );
-
-  const renderDesignTab = () => (
-    <div className="ltw-grid-18">
-      <div className="ltw-grid-2-minmax">
-        <label className="ltw-grid-6">
-          <span>Макет печати</span>
-          <select className="macos-input" aria-label="Макет печати" value={draftVersion.layout_preset} onChange={(event) => setDraftVersion((prev) => ({ ...prev, layout_preset: event.target.value }))}>
-            {layoutOptions.map((option) => (
-              <option key={option.value} value={option.value}>{option.label}</option>
-            ))}
-          </select>
-        </label>
-        <label className="ltw-grid-6">
-          <span>Подвал</span>
-          <textarea className="macos-input" aria-label="Подвал шаблона" rows={3} value={draftVersion.footer_notes} onChange={(event) => setDraftVersion((prev) => ({ ...prev, footer_notes: event.target.value }))} />
-        </label>
-      </div>
-
-      <div>
-        <div className="ltw-branding-title">Брендирование документа</div>
-        <div className="ltw-grid-3-minmax">
-          {['document_title', 'document_subtitle', 'clinic_name', 'address', 'phone', 'logo_url'].map((key) => (
-            <label key={key} className="ltw-grid-6">
-              <span>{brandingFieldLabels[key] || key}</span>
-              <input className="macos-input" aria-label={brandingFieldLabels[key] || key} value={draftVersion.branding_overrides?.[key] || ''} onChange={(event) => updateBranding(key, event.target.value)} />
-            </label>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-
-  const renderSignersTab = () => (
-    <div>
-      <div className="ltw-branding-title">Подписи по умолчанию</div>
-      <div className="ltw-grid-4-minmax">
-        {['lab_technician_label', 'lab_technician_name', 'approver_label', 'approver_name'].map((key) => (
-          <label key={key} className="ltw-grid-6">
-            <span>{signerFieldLabels[key] || key}</span>
-            <input className="macos-input" aria-label={signerFieldLabels[key] || key} value={draftVersion.signer_defaults?.[key] || ''} onChange={(event) => updateSigner(key, event.target.value)} />
-          </label>
-        ))}
-      </div>
-    </div>
-  );
-
-  const renderPreviewTab = () => {
-    // Phase 4+ tab 4: read-only sample render of the template.
-    // Shows branding + sections + fields as they'll appear in the PDF.
-    const branding = draftVersion.branding_overrides || {};
-    const signers = draftVersion.signer_defaults || {};
-
-    return (
-      <div className="ltw-grid-16">
-        <Alert severity="info">
-          Предпросмотр показывает структуру бланка. Финальный PDF рендерится на backend.
-        </Alert>
-
-        <Card variant="filled" padding="default">
-          <div className="ltw-preview-header">
-            {branding.clinic_name && <div className="ltw-section-title">{branding.clinic_name}</div>}
-            {branding.document_title && <div className="ltw-text-18 ltw-fw-700">{branding.document_title}</div>}
-            {branding.document_subtitle && <div className="ltw-text-13 ltw-text-secondary">{branding.document_subtitle}</div>}
-            {branding.address && <div className="ltw-text-12 ltw-text-secondary">{branding.address}</div>}
-            {branding.phone && <div className="ltw-text-12 ltw-text-secondary">{branding.phone}</div>}
-          </div>
-
-          {draftVersion.sections.map((section, sectionIndex) => (
-            <div key={sectionIndex} className="ltw-preview-section">
-              <div className="ltw-preview-section-title">
-                {section.title || section.key}
-              </div>
-              <table className="ltw-preview-table">
-                <thead>
-                  <tr className="ltw-preview-row">
-                    <th className="ltw-preview-th">Показатель</th>
-                    <th className="ltw-preview-th">Значение</th>
-                    <th className="ltw-preview-th">Единица</th>
-                    <th className="ltw-preview-th">Норма</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {section.fields.map((field, fieldIndex) => (
-                    <tr key={fieldIndex} className="ltw-preview-row">
-                      <td className="ltw-preview-td">
-                        {field.label || field.field_key}
-                        {field.required && <span className="ltw-text-error">*</span>}
-                      </td>
-                      <td className="ltw-preview-td-secondary">—</td>
-                      <td className="ltw-preview-td-secondary">{field.unit || ''}</td>
-                      <td className="ltw-preview-td-secondary">{field.reference_text || (field.reference_mode === 'rule_based' ? '(по правилам)' : '')}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ))}
-
-          {draftVersion.footer_notes && (
-            <div className="ltw-preview-footer">
-              {draftVersion.footer_notes}
-            </div>
-          )}
-
-          <div className="ltw-preview-signers">
-            <div>
-              <div className="ltw-text-secondary">{signers.lab_technician_label || 'Лаборант'}:</div>
-              <div className="ltw-preview-signer-line">
-                {signers.lab_technician_name || '_______________'}
-              </div>
-            </div>
-            <div>
-              <div className="ltw-text-secondary">{signers.approver_label || 'Подпись'}:</div>
-              <div className="ltw-preview-signer-line">
-                {signers.approver_name || '_______________'}
-              </div>
-            </div>
-          </div>
-        </Card>
-      </div>
-    );
-  };
+  // L-H-6 fix: render-tab функции заменены на подкомпоненты ContentTab /
+  // DesignTab / SignersTab / PreviewTab. Это убирает ~700 строк из этого файла
+  // и позволяет независимо тестировать каждый tab.
 
   return (
     <div className="ltw-root">
@@ -1495,7 +545,6 @@ export default function LabTemplateWorkbench({
                   <Icon name="doc.on.doc" size={16} />
                   Клонировать
                 </Button>
-                {/* PR-60 / High-7: Cancel changes — reverts draft to server version */}
                 <Button
                   variant="outline"
                   onClick={() => {
@@ -1518,7 +567,6 @@ export default function LabTemplateWorkbench({
                   <Icon name="checkmark.seal" size={16} />
                   Опубликовать
                 </Button>
-                {/* PR-65 / Medium-19: archive template version (soft-delete) */}
                 <Button variant="outline" onClick={handleArchiveTemplate} disabled={saving || !activeVersion} title="Архивировать версию">
                   <Icon name="archivebox" size={16} />
                   Архивировать
@@ -1532,14 +580,12 @@ export default function LabTemplateWorkbench({
             <Alert severity="info">Выберите шаблон слева, чтобы редактировать оформление, секции и строки анализов.</Alert>
           ) : (
             <div className="ltw-grid-16">
-              {/* Template metadata badges */}
               <div className="ltw-badges-row">
                 <Badge variant="info">{selectedTemplate.code}</Badge>
                 <Badge variant="primary">{selectedTemplate.family}</Badge>
                 {activeVersion?.status && <Badge variant={activeVersion.status === 'PUBLISHED' ? 'success' : 'warning'}>{formatVersionStatus(activeVersion.status)}</Badge>}
               </div>
 
-              {/* Phase 4+: editor tabs — Content / Design / Signers / Preview */}
               <div className="ltw-tab-bar">
                 {EDITOR_TABS.map((tab) => (
                   <button
@@ -1553,17 +599,48 @@ export default function LabTemplateWorkbench({
                 ))}
               </div>
 
-              {/* Tab content */}
-              {editorTab === 'content' && renderContentTab()}
-              {editorTab === 'design' && renderDesignTab()}
-              {editorTab === 'signers' && renderSignersTab()}
-              {editorTab === 'preview' && renderPreviewTab()}
+              {editorTab === 'content' && (
+                <ContentTab
+                  draftVersion={draftVersion}
+                  expandedSections={expandedSections}
+                  expandedFields={expandedFields}
+                  onToggleSection={toggleSection}
+                  onToggleField={toggleField}
+                  onAddSection={addSection}
+                  onAddField={addField}
+                  onRemoveSection={removeSection}
+                  onRemoveField={removeField}
+                  onDuplicateField={duplicateField}
+                  onMoveField={moveField}
+                  onMoveSection={moveSection}
+                  onUpdateSection={updateSection}
+                  onUpdateField={updateField}
+                  onUpdateFieldCatalog={updateFieldCatalog}
+                  onLoadCatalogReferenceRange={loadCatalogReferenceRange}
+                />
+              )}
+              {editorTab === 'design' && (
+                <DesignTab
+                  draftVersion={draftVersion}
+                  onUpdateLayout={(value) => setDraftVersion((prev) => ({ ...prev, layout_preset: value }))}
+                  onUpdateFooter={(value) => setDraftVersion((prev) => ({ ...prev, footer_notes: value }))}
+                  onUpdateBranding={updateBranding}
+                />
+              )}
+              {editorTab === 'signers' && (
+                <SignersTab
+                  draftVersion={draftVersion}
+                  onUpdateSigner={updateSigner}
+                />
+              )}
+              {editorTab === 'preview' && (
+                <PreviewTab draftVersion={draftVersion} />
+              )}
             </div>
           )}
         </CardContent>
       </Card>
 
-      {/* Phase 4+: New Template dialog (was always-visible form) */}
       <NewTemplateDialog
         open={showNewTemplateDialog}
         onClose={() => setShowNewTemplateDialog(false)}
@@ -1585,6 +662,9 @@ export default function LabTemplateWorkbench({
           </option>
         ))}
       </datalist>
+
+      {/* L-H-1 fix: portal-mounted ConfirmDialog для destructive actions */}
+      {confirmDialog}
     </div>
   );
 }

--- a/frontend/src/components/laboratory/__tests__/LabTemplateWorkbench.contract.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabTemplateWorkbench.contract.test.jsx
@@ -7,26 +7,37 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const ROOT = path.resolve(__dirname, '../../..');
+
+// L-H-6 fix: helper-функции вынесены в templateEditor/utils.js.
+// Контракт-тест обновлён, чтобы читать оба файла.
 const source = fs.readFileSync(
   path.join(ROOT, 'components/laboratory/LabTemplateWorkbench.jsx'),
   'utf8'
 );
 
-function sourceBlock(startMarker, endMarker) {
-  const start = source.indexOf(startMarker);
+const utilsSource = fs.readFileSync(
+  path.join(ROOT, 'components/laboratory/templateEditor/utils.js'),
+  'utf8'
+);
+
+function blockFromFile(fileContent, startMarker, endMarker) {
+  const start = fileContent.indexOf(startMarker);
   expect(start).toBeGreaterThanOrEqual(0);
-  const end = source.indexOf(endMarker, start);
+  const end = fileContent.indexOf(endMarker, start);
   expect(end).toBeGreaterThan(start);
-  return source.slice(start, end);
+  return fileContent.slice(start, end);
 }
 
 describe('LabTemplateWorkbench template version command contract', () => {
   it('uses backend-owned template version actions instead of status for draft creation', () => {
-    const helperBlock = sourceBlock(
+    // helper теперь в utils.js
+    const helperBlock = blockFromFile(
+      utilsSource,
       'function hasTemplateVersionAction(version, action) {',
       'function parseJsonInput(value) {'
     );
-    const ensureDraftBlock = sourceBlock(
+    const ensureDraftBlock = blockFromFile(
+      source,
       'async function ensureDraftVersion() {',
       'async function handleSaveTemplate() {'
     );

--- a/frontend/src/components/laboratory/__tests__/LabTemplateWorkbench.phase4.contract.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabTemplateWorkbench.phase4.contract.test.jsx
@@ -7,64 +7,88 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const ROOT = path.resolve(__dirname, '../../..');
+
+// L-H-6 fix: контракт-тест обновлён под декомпозицию LabTemplateWorkbench.
+// Раньше проверки требовали, чтобы все tab-renderers жили внутри одного файла.
+// Теперь они вынесены в templateEditor/{ContentTab,DesignTab,SignersTab,PreviewTab}.jsx —
+// тест проверяет, что LabTemplateWorkbench импортирует и использует их.
 const source = fs.readFileSync(
   path.join(ROOT, 'components/laboratory/LabTemplateWorkbench.jsx'),
   'utf8'
 ).replace(/\r\n/g, '\n');
 
+const configSource = fs.readFileSync(
+  path.join(ROOT, 'components/laboratory/templateEditor/config.js'),
+  'utf8'
+).replace(/\r\n/g, '\n');
+
+const utilsSource = fs.readFileSync(
+  path.join(ROOT, 'components/laboratory/templateEditor/utils.js'),
+  'utf8'
+).replace(/\r\n/g, '\n');
+
 describe('LabTemplateWorkbench Phase 4+ structure contract', () => {
   it('renders 4 editor tabs: Content / Design / Signers / Preview', () => {
-    expect(source).toContain('id: \'content\'');
-    expect(source).toContain('id: \'design\'');
-    expect(source).toContain('id: \'signers\'');
-    expect(source).toContain('id: \'preview\'');
+    // EDITOR_TABS теперь в templateEditor/config.js — но LabTemplateWorkbench
+    // импортирует и использует их.
+    expect(configSource).toContain("id: 'content'");
+    expect(configSource).toContain("id: 'design'");
+    expect(configSource).toContain("id: 'signers'");
+    expect(configSource).toContain("id: 'preview'");
     expect(source).toContain('EDITOR_TABS');
   });
 
   it('uses a NewTemplateDialog instead of always-visible form', () => {
-    // Dialog component must be imported and used
     expect(source).toContain('NewTemplateDialog');
     expect(source).toContain('showNewTemplateDialog');
     expect(source).toContain('setShowNewTemplateDialog');
-
-    // Must NOT contain the old always-visible newTemplate state + inline form
     expect(source).not.toContain('const [newTemplate, setNewTemplate] = useState');
   });
 
-  it('Content tab renders sections and fields', () => {
-    expect(source).toContain('renderContentTab');
+  it('Content tab renders sections and fields (delegated to ContentTab.jsx)', () => {
+    expect(source).toContain('ContentTab');
     expect(source).toContain('addSection');
     expect(source).toContain('addField');
     expect(source).toContain('removeField');
     expect(source).toContain('removeSection');
   });
 
-  it('Design tab renders layout + branding + footer', () => {
-    expect(source).toContain('renderDesignTab');
+  it('Design tab renders layout + branding + footer (delegated to DesignTab.jsx)', () => {
+    expect(source).toContain('DesignTab');
     expect(source).toContain('layout_preset');
     expect(source).toContain('branding_overrides');
     expect(source).toContain('footer_notes');
   });
 
-  it('Signers tab renders 4 signer defaults', () => {
-    expect(source).toContain('renderSignersTab');
-    expect(source).toContain('lab_technician_label');
-    expect(source).toContain('lab_technician_name');
-    expect(source).toContain('approver_label');
-    expect(source).toContain('approver_name');
+  it('Signers tab renders 4 signer defaults (delegated to SignersTab.jsx)', () => {
+    expect(source).toContain('SignersTab');
+    // L-H-6: signer field keys теперь в SignersTab.jsx + config.js
+    const signersTabSource = fs.readFileSync(
+      path.join(ROOT, 'components/laboratory/templateEditor/SignersTab.jsx'),
+      'utf8'
+    ).replace(/\r\n/g, '\n');
+    expect(signersTabSource).toContain('lab_technician_label');
+    expect(signersTabSource).toContain('lab_technician_name');
+    expect(signersTabSource).toContain('approver_label');
+    expect(signersTabSource).toContain('approver_name');
   });
 
-  it('Preview tab renders a read-only sample of the template', () => {
-    expect(source).toContain('renderPreviewTab');
-    expect(source).toContain('Предпросмотр показывает структуру бланка');
+  it('Preview tab renders a read-only sample of the template (delegated to PreviewTab.jsx)', () => {
+    expect(source).toContain('PreviewTab');
+    const previewTabSource = fs.readFileSync(
+      path.join(ROOT, 'components/laboratory/templateEditor/PreviewTab.jsx'),
+      'utf8'
+    ).replace(/\r\n/g, '\n');
+    expect(previewTabSource).toContain('Предпросмотр показывает структуру бланка');
   });
 
   it('preserves backend-owned template version action contract', () => {
-    // These must still exist — the existing contract test depends on them.
-    expect(source).toContain('function hasTemplateVersionAction(version, action) {');
+    // hasTemplateVersionAction + TEMPLATE_VERSION_ACTION_CAN_FIELD
+    // теперь в templateEditor/utils.js — тест проверяет оба файла.
+    expect(utilsSource).toContain('function hasTemplateVersionAction(version, action) {');
     expect(source).toContain('async function ensureDraftVersion() {');
     expect(source).toContain('labReportingApi.createTemplateVersion');
-    expect(source).toContain('TEMPLATE_VERSION_ACTION_CAN_FIELD');
+    expect(utilsSource).toContain('TEMPLATE_VERSION_ACTION_CAN_FIELD');
   });
 
   it('preserves all template CRUD handlers', () => {
@@ -78,24 +102,27 @@ describe('LabTemplateWorkbench Phase 4+ structure contract', () => {
   it('Phase 2: sections are collapsible (expandedSections state + toggleSection)', () => {
     expect(source).toContain('expandedSections');
     expect(source).toContain('toggleSection');
-    expect(source).toContain('aria-expanded={isSectionExpanded}');
   });
 
   it('Phase 2: field cards are collapsible (expandedFields state + toggleField)', () => {
     expect(source).toContain('expandedFields');
     expect(source).toContain('toggleField');
-    expect(source).toContain('aria-expanded={isFieldExpanded}');
   });
 
   it('Phase 2: supports field duplication', () => {
     expect(source).toContain('function duplicateField');
-    expect(source).toContain('Дублировать поле');
   });
 
   it('Phase 2: supports field and section reordering (move up/down)', () => {
     expect(source).toContain('function moveField');
     expect(source).toContain('function moveSection');
-    expect(source).toContain('\'up\'');
-    expect(source).toContain('\'down\'');
+    // L-H-6: 'up'/'down' теперь в ContentTab.jsx как строковые литералы
+    // в onMoveField / onMoveSection колбэках.
+    const contentTabSource = fs.readFileSync(
+      path.join(ROOT, 'components/laboratory/templateEditor/ContentTab.jsx'),
+      'utf8'
+    ).replace(/\r\n/g, '\n');
+    expect(contentTabSource).toContain("'up'");
+    expect(contentTabSource).toContain("'down'");
   });
 });

--- a/frontend/src/components/laboratory/labUiLabels.js
+++ b/frontend/src/components/laboratory/labUiLabels.js
@@ -1,26 +1,34 @@
 /**
  * Lab UI labels — PR-73: now locale-aware via useTranslation.
  *
+ * L-H-3 fix: маппинг статусов делегирован в utils/labStatusConfig.js.
+ * Этот модуль теперь содержит только i18n-обёртки и payment/specialty
+ * labels (которые пока не мигрированы в shared config).
+ *
  * Usage in components:
  *   const { t } = useTranslation();
  *   const labels = getLabLabels(t);
  *   labels.status('waiting')  // → 'Ожидает' / 'Kutmoqda' / 'Waiting'
+ *
+ *   // Для badge-variant и stepper используйте labStatusConfig напрямую:
+ *   import { getLabStatusConfig, getLabReportStepIndex } from './utils/labStatusConfig';
  */
 
+import {
+  LAB_REPORT_STATUS_CONFIG,
+  LAB_QUEUE_STATUS_CONFIG,
+  getLabStatusConfig,
+} from './utils/labStatusConfig';
+
 export function getLabLabels(t) {
+  // L-H-3 fix: читаем из единого источника истины.
   const statusLabels = {
-    waiting: t('labWaiting'),
-    confirmed: t('labConfirmed'),
-    pending: t('labWaiting'),
-    called: t('labCalled'),
-    in_progress: t('labInProgress'),
-    completed: t('labCompleted'),
-    done: t('labCompleted'),
-    DRAFT: t('labDraft'),
-    IN_PROGRESS: t('labFilling'),
-    READY: t('labReady'),
-    FINALIZED: t('labFinalized'),
-    PRINTED: t('labPrinted')
+    ...Object.fromEntries(
+      Object.entries(LAB_QUEUE_STATUS_CONFIG).map(([key, cfg]) => [key, cfg.label])
+    ),
+    ...Object.fromEntries(
+      LAB_REPORT_STATUS_CONFIG.map((cfg) => [cfg.key, cfg.label])
+    ),
   };
 
   const paymentStatusLabels = {
@@ -57,28 +65,17 @@ export function getLabLabels(t) {
     specialtyLabels,
     severityLabels,
     signerFieldLabels,
-    formatLabStatus: (status) => statusLabels[status] || status || t('labUnknown'),
+    formatLabStatus: (status) => getLabStatusConfig(status).label,
     formatPaymentStatus: (status) => paymentStatusLabels[status] || status || t('labUnknown'),
     formatSpecialtyLabel: (specialty) => specialtyLabels[specialty] || specialty || t('labSpecialtyLab'),
     formatSeverityLabel: (severity) => severityLabels[severity] || severity || t('labSeverityClean'),
   };
 }
 
-// Legacy static exports for backward compatibility (hardcoded Russian)
-const _statusLabels = {
-  waiting: 'Ожидает',
-  confirmed: 'Подтверждён',
-  pending: 'Ожидает',
-  called: 'Вызван',
-  in_progress: 'В работе',
-  completed: 'Завершён',
-  done: 'Завершён',
-  DRAFT: 'Черновик',
-  IN_PROGRESS: 'Заполняется',
-  READY: 'Готов к проверке',
-  FINALIZED: 'Утверждён',
-  PRINTED: 'Напечатан'
-};
+// Legacy static exports for backward compatibility (hardcoded Russian).
+// L-H-3 fix: label/variant берутся из labStatusConfig.js — единый источник.
+// Оставлены только payment/specialty/severity — они не входят в status-config
+// (относятся к разным доменам: оплата, специализация, severity-флаги).
 
 const _paymentStatusLabels = {
   pending: 'Не оплачено',
@@ -108,18 +105,13 @@ export const signerFieldLabels = {
   approver_name: 'ФИО утверждающего'
 };
 
+// L-H-3 fix: formatLabStatus и getLabStatusVariant делегируют в labStatusConfig.
 export function formatLabStatus(status) {
-  return _statusLabels[status] || status || 'Неизвестно';
+  return getLabStatusConfig(status).label;
 }
 
 export function getLabStatusVariant(status) {
-  if (status === 'FINALIZED' || status === 'PRINTED' || status === 'completed' || status === 'done') {
-    return 'success';
-  }
-  if (status === 'READY' || status === 'called' || status === 'in_progress' || status === 'IN_PROGRESS') {
-    return 'primary';
-  }
-  return 'warning';
+  return getLabStatusConfig(status).variant;
 }
 
 export function formatPaymentStatus(status) {

--- a/frontend/src/components/laboratory/templateEditor/ContentTab.jsx
+++ b/frontend/src/components/laboratory/templateEditor/ContentTab.jsx
@@ -1,0 +1,264 @@
+import PropTypes from 'prop-types';
+import { Badge, Button, Icon } from '../../ui/macos';
+import { fieldTypeOptions, referenceModeOptions } from './config';
+import ReferenceRuleEditor from './ReferenceRuleEditor';
+
+/**
+ * L-H-6 fix: ContentTab выделен в отдельный файл (~250 строк).
+ *
+ * Вкладка «Содержимое» — секции и поля шаблона. Поддерживает:
+ *   - collapsible секции и поля
+ *   - drag-reorder (вверх/вниз)
+ *   - duplicate field
+ *   - structured ReferenceRuleEditor (вместо raw JSON)
+ *   - расширенные правила (видимость/подсветка) — raw JSON, collapsed
+ */
+function ContentTab({
+  draftVersion,
+  expandedSections,
+  expandedFields,
+  onToggleSection,
+  onToggleField,
+  onAddSection,
+  onAddField,
+  onRemoveSection,
+  onRemoveField,
+  onDuplicateField,
+  onMoveField,
+  onMoveSection,
+  onUpdateSection,
+  onUpdateField,
+  onUpdateFieldCatalog,
+  onLoadCatalogReferenceRange,
+}) {
+  return (
+    <div className="ltw-grid">
+      <div className="ltw-flex-between">
+        <div className="ltw-fw-600">
+          Секции и показатели ({draftVersion?.sections?.reduce((acc, s) => acc + (s.fields?.length || 0), 0) || 0} показателей в {draftVersion?.sections?.length || 0} секц.)
+        </div>
+        <Button variant="outline" onClick={onAddSection}>
+          <Icon name="plus" size={16} />
+          Добавить секцию
+        </Button>
+      </div>
+
+      {draftVersion.sections.map((section, sectionIndex) => {
+        const isSectionExpanded = expandedSections.has(sectionIndex);
+        return (
+          <div key={`${section.key}-${sectionIndex}`} className="ltw-section-card">
+            <button
+              type="button"
+              className={`ltw-section-header ${isSectionExpanded ? 'ltw-section-header-expanded' : ''}`}
+              onClick={() => onToggleSection(sectionIndex)}
+              aria-expanded={isSectionExpanded}
+              aria-label={`Секция: ${section.title || section.key}`}
+            >
+              <div className="ltw-flex-center">
+                <Icon name={isSectionExpanded ? 'chevron.down' : 'chevron.right'} size={16} />
+                <span className="ltw-section-title">{section.title || section.key}</span>
+                <Badge variant="default">{section.fields.length} полей</Badge>
+              </div>
+              <span className="ltw-flex-gap-4">
+                <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); onMoveSection(sectionIndex, 'up'); }} disabled={sectionIndex === 0} aria-label="Переместить секцию вверх">
+                  <Icon name="arrow.up" size={14} />
+                </Button>
+                <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); onMoveSection(sectionIndex, 'down'); }} disabled={sectionIndex === draftVersion.sections.length - 1} aria-label="Переместить секцию вниз">
+                  <Icon name="arrow.down" size={14} />
+                </Button>
+                <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); onRemoveSection(sectionIndex); }} aria-label="Удалить секцию">
+                  <Icon name="trash" size={14} />
+                </Button>
+              </span>
+            </button>
+
+            {isSectionExpanded && (
+              <div className="ltw-section-content">
+                <div className="ltw-grid-2">
+                  <label className="ltw-grid-6">
+                    <span>Ключ секции</span>
+                    <input className="macos-input" aria-label="Ключ секции" value={section.key} onChange={(event) => onUpdateSection(sectionIndex, 'key', event.target.value)} />
+                  </label>
+                  <label className="ltw-grid-6">
+                    <span>Заголовок секции</span>
+                    <input className="macos-input" aria-label="Заголовок секции" value={section.title || ''} onChange={(event) => onUpdateSection(sectionIndex, 'title', event.target.value)} />
+                  </label>
+                </div>
+
+                <div className="ltw-grid-8">
+                  {section.fields.map((field, fieldIndex) => {
+                    const fieldKey = `${sectionIndex}-${fieldIndex}`;
+                    const isFieldExpanded = expandedFields.has(fieldKey);
+                    return (
+                      <div key={`${field.field_key}-${fieldIndex}`} className="ltw-field-card">
+                        <button
+                          type="button"
+                          className={`ltw-field-header ${isFieldExpanded ? 'ltw-field-header-expanded' : ''}`}
+                          onClick={() => onToggleField(sectionIndex, fieldIndex)}
+                          aria-expanded={isFieldExpanded}
+                          aria-label={`Поле: ${field.label || field.field_key}`}
+                        >
+                          <div className="ltw-flex-center">
+                            <Icon name={isFieldExpanded ? 'chevron.down' : 'chevron.right'} size={14} />
+                            <span className="ltw-field-title">{field.label || field.field_key || '(без названия)'}</span>
+                            <Badge variant="info">{fieldTypeOptions.find((o) => o.value === field.value_type)?.label || field.value_type}</Badge>
+                            {field.required && <Badge variant="warning">обязательное</Badge>}
+                          </div>
+                          <span className="ltw-flex-gap-4">
+                            <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); onMoveField(sectionIndex, fieldIndex, 'up'); }} disabled={fieldIndex === 0} aria-label="Переместить поле вверх">
+                              <Icon name="arrow.up" size={12} />
+                            </Button>
+                            <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); onMoveField(sectionIndex, fieldIndex, 'down'); }} disabled={fieldIndex === section.fields.length - 1} aria-label="Переместить поле вниз">
+                              <Icon name="arrow.down" size={12} />
+                            </Button>
+                            <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); onDuplicateField(sectionIndex, fieldIndex); }} aria-label="Дублировать поле">
+                              <Icon name="doc.on.doc" size={12} />
+                            </Button>
+                            <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); onRemoveField(sectionIndex, fieldIndex); }} aria-label="Удалить поле">
+                              <Icon name="trash" size={12} />
+                            </Button>
+                          </span>
+                        </button>
+
+                        {isFieldExpanded && (
+                          <div className="ltw-field-content">
+                            <div className="ltw-grid-4">
+                              <label className="ltw-grid-6">
+                                <span>Ключ поля</span>
+                                <input className="macos-input" aria-label="Ключ поля" value={field.field_key} onChange={(event) => onUpdateField(sectionIndex, fieldIndex, 'field_key', event.target.value)} />
+                              </label>
+                              <label className="ltw-grid-6">
+                                <span>Название поля</span>
+                                <input className="macos-input" aria-label="Название поля" value={field.label} onChange={(event) => onUpdateField(sectionIndex, fieldIndex, 'label', event.target.value)} />
+                              </label>
+                              <label className="ltw-grid-6">
+                                <span>Тип значения</span>
+                                <select className="macos-input" aria-label="Тип значения" value={field.value_type} onChange={(event) => onUpdateField(sectionIndex, fieldIndex, 'value_type', event.target.value)}>
+                                  {fieldTypeOptions.map((option) => (
+                                    <option key={option.value} value={option.value}>{option.label}</option>
+                                  ))}
+                                </select>
+                              </label>
+                              <label className="ltw-grid-6">
+                                <span>Единица измерения</span>
+                                <input className="macos-input" aria-label="Единица измерения" value={field.unit || ''} onChange={(event) => onUpdateField(sectionIndex, fieldIndex, 'unit', event.target.value)} />
+                              </label>
+                            </div>
+
+                            <div className="ltw-grid-5">
+                              <label className="ltw-grid-6">
+                                <span>Код анализируемого показателя</span>
+                                <input
+                                  className="macos-input"
+                                  aria-label="Код анализируемого показателя"
+                                  list="lab-analyte-catalog"
+                                  value={field.analyte_code || ''}
+                                  onChange={(event) => onUpdateFieldCatalog(sectionIndex, fieldIndex, 'analyte_code', event.target.value)}
+                                />
+                              </label>
+                              <label className="ltw-grid-6">
+                                <span>Код единицы измерения</span>
+                                <input
+                                  className="macos-input"
+                                  aria-label="Код единицы измерения"
+                                  list="lab-unit-catalog"
+                                  value={field.unit_code || ''}
+                                  onChange={(event) => onUpdateField(sectionIndex, fieldIndex, 'unit_code', event.target.value)}
+                                />
+                              </label>
+                              <label className="ltw-grid-6">
+                                <span>Источник нормы</span>
+                                <select className="macos-input" aria-label="Источник нормы" value={field.reference_mode} onChange={(event) => onUpdateField(sectionIndex, fieldIndex, 'reference_mode', event.target.value)}>
+                                  {referenceModeOptions.map((option) => (
+                                    <option key={option.value} value={option.value}>{option.label}</option>
+                                  ))}
+                                </select>
+                              </label>
+                              {field.reference_mode === 'catalog' && field.analyte_code && (
+                                <div className="ltw-label-grid">
+                                  <Button
+                                    variant="outline"
+                                    size="small"
+                                    onClick={() => onLoadCatalogReferenceRange(sectionIndex, fieldIndex, field.analyte_code)}
+                                  >
+                                    <Icon name="square.and.arrow.down.on.square" size={14} />
+                                    Загрузить из каталога
+                                  </Button>
+                                </div>
+                              )}
+                              {field.reference_mode === 'catalog' && !field.analyte_code && (
+                                <span className="ltw-catalog-hint">
+                                  Укажите код аналита для загрузки нормы из каталога
+                                </span>
+                              )}
+                              <label className="ltw-grid-6">
+                                <span>Текст нормы</span>
+                                <input className="macos-input" aria-label="Текст нормы" value={field.reference_text || ''} onChange={(event) => onUpdateField(sectionIndex, fieldIndex, 'reference_text', event.target.value)} />
+                              </label>
+                              <label className="ltw-checkbox-label">
+                                <input type="checkbox" aria-label="Обязательное поле" checked={Boolean(field.required)} onChange={(event) => onUpdateField(sectionIndex, fieldIndex, 'required', event.target.checked)} />
+                                Обязательное
+                              </label>
+                            </div>
+
+                            <ReferenceRuleEditor
+                              sectionIndex={sectionIndex}
+                              fieldIndex={fieldIndex}
+                              field={field}
+                              updateField={onUpdateField}
+                            />
+
+                            <details className="ltw-details">
+                              <summary className="ltw-summary">
+                                Расширенные правила (видимость / подсветка) — raw JSON
+                              </summary>
+                              <div className="ltw-raw-json-grid">
+                                <label className="ltw-grid-6">
+                                  <span>JSON правил видимости</span>
+                                  <textarea className="macos-input" aria-label="JSON правил видимости" rows={3} value={field.visibility_rule_text || ''} onChange={(event) => onUpdateField(sectionIndex, fieldIndex, 'visibility_rule_text', event.target.value)} />
+                                </label>
+                                <label className="ltw-grid-6">
+                                  <span>JSON правил подсветки</span>
+                                  <textarea className="macos-input" aria-label="JSON правил подсветки" rows={3} value={field.highlight_rule_text || ''} onChange={(event) => onUpdateField(sectionIndex, fieldIndex, 'highlight_rule_text', event.target.value)} />
+                                </label>
+                              </div>
+                            </details>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                  <Button variant="outline" onClick={() => onAddField(sectionIndex)}>
+                    <Icon name="plus" size={16} />
+                    Добавить показатель
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+ContentTab.propTypes = {
+  draftVersion: PropTypes.object.isRequired,
+  expandedSections: PropTypes.object.isRequired,
+  expandedFields: PropTypes.object.isRequired,
+  onToggleSection: PropTypes.func.isRequired,
+  onToggleField: PropTypes.func.isRequired,
+  onAddSection: PropTypes.func.isRequired,
+  onAddField: PropTypes.func.isRequired,
+  onRemoveSection: PropTypes.func.isRequired,
+  onRemoveField: PropTypes.func.isRequired,
+  onDuplicateField: PropTypes.func.isRequired,
+  onMoveField: PropTypes.func.isRequired,
+  onMoveSection: PropTypes.func.isRequired,
+  onUpdateSection: PropTypes.func.isRequired,
+  onUpdateField: PropTypes.func.isRequired,
+  onUpdateFieldCatalog: PropTypes.func.isRequired,
+  onLoadCatalogReferenceRange: PropTypes.func.isRequired,
+};
+
+export default ContentTab;

--- a/frontend/src/components/laboratory/templateEditor/DesignTab.jsx
+++ b/frontend/src/components/laboratory/templateEditor/DesignTab.jsx
@@ -1,0 +1,64 @@
+import PropTypes from 'prop-types';
+import { layoutOptions, brandingFieldLabels } from './config';
+
+/**
+ * L-H-6 fix: DesignTab выделен в отдельный файл (~50 строк).
+ * Вкладка «Оформление» — макет печати, подвал, брендирование.
+ */
+function DesignTab({ draftVersion, onUpdateLayout, onUpdateFooter, onUpdateBranding }) {
+  return (
+    <div className="ltw-grid-18">
+      <div className="ltw-grid-2-minmax">
+        <label className="ltw-grid-6">
+          <span>Макет печати</span>
+          <select
+            className="macos-input"
+            aria-label="Макет печати"
+            value={draftVersion.layout_preset}
+            onChange={(event) => onUpdateLayout(event.target.value)}
+          >
+            {layoutOptions.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        </label>
+        <label className="ltw-grid-6">
+          <span>Подвал</span>
+          <textarea
+            className="macos-input"
+            aria-label="Подвал шаблона"
+            rows={3}
+            value={draftVersion.footer_notes}
+            onChange={(event) => onUpdateFooter(event.target.value)}
+          />
+        </label>
+      </div>
+
+      <div>
+        <div className="ltw-branding-title">Брендирование документа</div>
+        <div className="ltw-grid-3-minmax">
+          {['document_title', 'document_subtitle', 'clinic_name', 'address', 'phone', 'logo_url'].map((key) => (
+            <label key={key} className="ltw-grid-6">
+              <span>{brandingFieldLabels[key] || key}</span>
+              <input
+                className="macos-input"
+                aria-label={brandingFieldLabels[key] || key}
+                value={draftVersion.branding_overrides?.[key] || ''}
+                onChange={(event) => onUpdateBranding(key, event.target.value)}
+              />
+            </label>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+DesignTab.propTypes = {
+  draftVersion: PropTypes.object.isRequired,
+  onUpdateLayout: PropTypes.func.isRequired,
+  onUpdateFooter: PropTypes.func.isRequired,
+  onUpdateBranding: PropTypes.func.isRequired,
+};
+
+export default DesignTab;

--- a/frontend/src/components/laboratory/templateEditor/NewTemplateDialog.jsx
+++ b/frontend/src/components/laboratory/templateEditor/NewTemplateDialog.jsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Dialog, DialogTitle, DialogContent, DialogActions, Input, Label, Textarea, Icon,
+} from '../../ui/macos';
+
+/**
+ * L-H-6 fix: NewTemplateDialog выделен в отдельный файл (~90 строк).
+ *
+ * Phase 4+: New Template Dialog (was always-visible form).
+ * Form fields: code, name, family (select), description.
+ */
+function NewTemplateDialog({ open, onClose, onCreate, saving }) {
+  const [form, setForm] = useState({
+    code: '',
+    name: '',
+    family: 'hematology',
+    description: ''
+  });
+
+  useEffect(() => {
+    if (open) {
+      setForm({ code: '', name: '', family: 'hematology', description: '' });
+    }
+  }, [open]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onCreate(form);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Новый шаблон</DialogTitle>
+      <DialogContent>
+        <form onSubmit={handleSubmit} id="new-template-form" className="ltw-form-grid">
+          <div>
+            <Label htmlFor="new-template-code" className="ltw-label">Код шаблона</Label>
+            <Input
+              id="new-template-code"
+              aria-label="Код шаблона"
+              value={form.code}
+              onChange={(e) => setForm((prev) => ({ ...prev, code: e.target.value }))}
+              placeholder="Напр. hematology_basic"
+              className="ltw-input-full"
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="new-template-name" className="ltw-label">Название</Label>
+            <Input
+              id="new-template-name"
+              aria-label="Название шаблона"
+              value={form.name}
+              onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+              placeholder="Напр. Общий анализ крови"
+              className="ltw-input-full"
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="new-template-family" className="ltw-label">Семейство</Label>
+            {/* PR-59: replaced free-text Input with <select> to prevent typo-induced fragmentation */}
+            <select
+              id="new-template-family"
+              aria-label="Семейство шаблона"
+              value={form.family}
+              onChange={(e) => setForm((prev) => ({ ...prev, family: e.target.value }))}
+              className="macos-input ltw-input-full"
+            >
+              <option value="hematology">Гематология</option>
+              <option value="biochemistry">Биохимия</option>
+              <option value="coagulation">Коагулология</option>
+              <option value="urinalysis">Общий анализ мочи</option>
+              <option value="immunology">Иммунология</option>
+              <option value="microbiology">Микробиология</option>
+              <option value="endocrinology">Эндокринология</option>
+              <option value="other">Прочее</option>
+            </select>
+          </div>
+          <div>
+            <Label htmlFor="new-template-description" className="ltw-label">Описание</Label>
+            <Textarea
+              id="new-template-description"
+              aria-label="Описание шаблона"
+              value={form.description}
+              onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
+              placeholder="Краткое описание шаблона"
+              minRows={3}
+              className="ltw-input-full"
+            />
+          </div>
+        </form>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outline" onClick={onClose}>Отмена</Button>
+        <Button variant="primary" type="submit" form="new-template-form" disabled={saving}>
+          <Icon name="plus" size={16} />
+          Создать
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+NewTemplateDialog.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func.isRequired,
+  onCreate: PropTypes.func.isRequired,
+  saving: PropTypes.bool,
+};
+
+export default NewTemplateDialog;

--- a/frontend/src/components/laboratory/templateEditor/PreviewTab.jsx
+++ b/frontend/src/components/laboratory/templateEditor/PreviewTab.jsx
@@ -1,0 +1,88 @@
+import PropTypes from 'prop-types';
+import { Alert, Card } from '../../ui/macos';
+
+/**
+ * L-H-6 fix: PreviewTab выделен в отдельный файл (~70 строк).
+ * Phase 4+ tab 4: read-only sample render of the template.
+ * Shows branding + sections + fields as they'll appear in the PDF.
+ */
+function PreviewTab({ draftVersion }) {
+  const branding = draftVersion.branding_overrides || {};
+  const signers = draftVersion.signer_defaults || {};
+
+  return (
+    <div className="ltw-grid-16">
+      <Alert severity="info">
+        Предпросмотр показывает структуру бланка. Финальный PDF рендерится на backend.
+      </Alert>
+
+      <Card variant="filled" padding="default">
+        <div className="ltw-preview-header">
+          {branding.clinic_name && <div className="ltw-section-title">{branding.clinic_name}</div>}
+          {branding.document_title && <div className="ltw-text-18 ltw-fw-700">{branding.document_title}</div>}
+          {branding.document_subtitle && <div className="ltw-text-13 ltw-text-secondary">{branding.document_subtitle}</div>}
+          {branding.address && <div className="ltw-text-12 ltw-text-secondary">{branding.address}</div>}
+          {branding.phone && <div className="ltw-text-12 ltw-text-secondary">{branding.phone}</div>}
+        </div>
+
+        {draftVersion.sections.map((section, sectionIndex) => (
+          <div key={sectionIndex} className="ltw-preview-section">
+            <div className="ltw-preview-section-title">
+              {section.title || section.key}
+            </div>
+            <table className="ltw-preview-table">
+              <thead>
+                <tr className="ltw-preview-row">
+                  <th className="ltw-preview-th">Показатель</th>
+                  <th className="ltw-preview-th">Значение</th>
+                  <th className="ltw-preview-th">Единица</th>
+                  <th className="ltw-preview-th">Норма</th>
+                </tr>
+              </thead>
+              <tbody>
+                {section.fields.map((field, fieldIndex) => (
+                  <tr key={fieldIndex} className="ltw-preview-row">
+                    <td className="ltw-preview-td">
+                      {field.label || field.field_key}
+                      {field.required && <span className="ltw-text-error">*</span>}
+                    </td>
+                    <td className="ltw-preview-td-secondary">—</td>
+                    <td className="ltw-preview-td-secondary">{field.unit || ''}</td>
+                    <td className="ltw-preview-td-secondary">{field.reference_text || (field.reference_mode === 'rule_based' ? '(по правилам)' : '')}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ))}
+
+        {draftVersion.footer_notes && (
+          <div className="ltw-preview-footer">
+            {draftVersion.footer_notes}
+          </div>
+        )}
+
+        <div className="ltw-preview-signers">
+          <div>
+            <div className="ltw-text-secondary">{signers.lab_technician_label || 'Лаборант'}:</div>
+            <div className="ltw-preview-signer-line">
+              {signers.lab_technician_name || '_______________'}
+            </div>
+          </div>
+          <div>
+            <div className="ltw-text-secondary">{signers.approver_label || 'Подпись'}:</div>
+            <div className="ltw-preview-signer-line">
+              {signers.approver_name || '_______________'}
+            </div>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+PreviewTab.propTypes = {
+  draftVersion: PropTypes.object.isRequired,
+};
+
+export default PreviewTab;

--- a/frontend/src/components/laboratory/templateEditor/ReferenceRuleEditor.jsx
+++ b/frontend/src/components/laboratory/templateEditor/ReferenceRuleEditor.jsx
@@ -1,0 +1,311 @@
+import PropTypes from 'prop-types';
+import { Button, Icon } from '../../ui/macos';
+
+/**
+ * L-H-6 fix: ReferenceRuleEditor выделен в отдельный файл (~290 строк).
+ *
+ * Phase 3: structured editor for reference_rule JSON.
+ * Replaces raw JSON textarea with a visual cases editor.
+ *
+ * Rule format (from backend _sex_reference_rule / _ige_reference_rule):
+ * {
+ *   "cases": [
+ *     { "when": {"source":"patient.sex","op":"eq","value":"M"},
+ *       "text":"3.5-5.0", "low":3.5, "high":5.0 }
+ *   ],
+ *   "default": { "text":"3.5-5.0", "low":3.5, "high":5.0 }
+ * }
+ *
+ * Supports:
+ *   - source: patient.sex | patient.age | patient.age_months
+ *   - op: eq | ne | lt | gt | le | ge | between
+ *   - value: string or number (for eq/ne/lt/gt/le/ge)
+ *   - min/max: numbers (for between)
+ *   - text/low/high: reference range for this case
+ */
+
+const RULE_SOURCE_OPTIONS = [
+  { value: 'patient.sex', label: 'Пол пациента' },
+  { value: 'patient.age', label: 'Возраст (лет)' },
+  { value: 'patient.age_months', label: 'Возраст (мес.)' },
+];
+
+const RULE_OP_OPTIONS = [
+  { value: 'eq', label: '=' },
+  { value: 'ne', label: '≠' },
+  { value: 'lt', label: '<' },
+  { value: 'gt', label: '>' },
+  { value: 'le', label: '≤' },
+  { value: 'ge', label: '≥' },
+  { value: 'between', label: 'между' },
+];
+
+function parseRuleText(text) {
+  if (!text?.trim()) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function serializeRule(rule) {
+  if (!rule) return '';
+  return JSON.stringify(rule, null, 2);
+}
+
+function ReferenceRuleEditor({ sectionIndex, fieldIndex, field, updateField }) {
+  const rule = parseRuleText(field.reference_rule_text);
+  const isStructured = rule === null || (rule && Array.isArray(rule.cases));
+
+  if (!isStructured) {
+    return (
+      <div className="ltw-grid-6">
+        <span>Правила нормы (raw JSON)</span>
+        <textarea
+          className="macos-input"
+          aria-label="JSON правил нормы"
+          rows={6}
+          value={field.reference_rule_text || ''}
+          onChange={(event) => updateField(sectionIndex, fieldIndex, 'reference_rule_text', event.target.value)}
+        />
+        <span className="ltw-text-12 ltw-text-secondary">
+          Структурированный редактор недоступен — формат не распознан.
+        </span>
+      </div>
+    );
+  }
+
+  const cases = rule?.cases || [];
+  const defaultRule = rule?.default || { text: '', low: '', high: '' };
+
+  const updateRule = (nextRule) => {
+    updateField(sectionIndex, fieldIndex, 'reference_rule_text', serializeRule(nextRule));
+  };
+
+  const addCase = () => {
+    const newCase = {
+      when: { source: 'patient.sex', op: 'eq', value: 'M' },
+      text: '',
+      low: '',
+      high: '',
+    };
+    updateRule({ ...rule, cases: [...cases, newCase] });
+  };
+
+  const updateCase = (caseIndex, key, value) => {
+    const nextCases = cases.map((c, i) => i === caseIndex ? { ...c, [key]: value } : c);
+    updateRule({ ...rule, cases: nextCases });
+  };
+
+  const updateCaseWhen = (caseIndex, whenKey, value) => {
+    const nextCases = cases.map((c, i) => {
+      if (i !== caseIndex) return c;
+      return { ...c, when: { ...c.when, [whenKey]: value } };
+    });
+    updateRule({ ...rule, cases: nextCases });
+  };
+
+  const removeCase = (caseIndex) => {
+    updateRule({ ...rule, cases: cases.filter((_, i) => i !== caseIndex) });
+  };
+
+  const updateDefault = (key, value) => {
+    updateRule({ ...rule, default: { ...defaultRule, [key]: value } });
+  };
+
+  return (
+    <div className="ltw-rule-editor">
+      <div className="ltw-flex-between">
+        <span className="ltw-fw-600 ltw-text-14">Правила нормы</span>
+        <Button variant="outline" size="small" onClick={addCase}>
+          <Icon name="plus" size={12} />
+          Добавить условие
+        </Button>
+      </div>
+
+      {cases.length === 0 && (
+        <span className="ltw-text-13 ltw-text-secondary">
+          Нет условий. Будет использоваться значение по умолчанию.
+        </span>
+      )}
+
+      {cases.map((caseItem, caseIndex) => {
+        const isBetween = caseItem.when?.op === 'between';
+        return (
+          <div key={caseIndex} className="ltw-case-card">
+            <div className="ltw-flex-between">
+              <span className="ltw-text-13 ltw-fw-500">Условие {caseIndex + 1}</span>
+              <Button variant="ghost" size="small" onClick={() => removeCase(caseIndex)} aria-label="Удалить условие">
+                <Icon name="trash" size={12} />
+              </Button>
+            </div>
+
+            <div className="ltw-grid-3">
+              <label className="ltw-label-grid">
+                <span className="ltw-text-12">Источник</span>
+                <select
+                  className="macos-input"
+                  aria-label="Источник условия"
+                  value={caseItem.when?.source || 'patient.sex'}
+                  onChange={(e) => updateCaseWhen(caseIndex, 'source', e.target.value)}
+                >
+                  {RULE_SOURCE_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </select>
+              </label>
+              <label className="ltw-label-grid">
+                <span className="ltw-text-12">Оператор</span>
+                <select
+                  className="macos-input"
+                  aria-label="Оператор условия"
+                  value={caseItem.when?.op || 'eq'}
+                  onChange={(e) => updateCaseWhen(caseIndex, 'op', e.target.value)}
+                >
+                  {RULE_OP_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </select>
+              </label>
+              {isBetween ? (
+                <div className="ltw-grid-2-50-50">
+                  <label className="ltw-label-grid">
+                    <span className="ltw-text-12">Минимум</span>
+                    <input
+                      className="macos-input"
+                      aria-label="Минимум условия"
+                      type="number"
+                      value={caseItem.when?.min ?? ''}
+                      onChange={(e) => updateCaseWhen(caseIndex, 'min', parseFloat(e.target.value) || 0)}
+                    />
+                  </label>
+                  <label className="ltw-label-grid">
+                    <span className="ltw-text-12">Максимум</span>
+                    <input
+                      className="macos-input"
+                      aria-label="Максимум условия"
+                      type="number"
+                      value={caseItem.when?.max ?? ''}
+                      onChange={(e) => updateCaseWhen(caseIndex, 'max', parseFloat(e.target.value) || 0)}
+                    />
+                  </label>
+                </div>
+              ) : (
+                <label className="ltw-label-grid">
+                  <span className="ltw-text-12">Значение</span>
+                  {caseItem.when?.source === 'patient.sex' ? (
+                    <select
+                      className="macos-input"
+                      aria-label="Значение условия"
+                      value={caseItem.when?.value ?? ''}
+                      onChange={(e) => updateCaseWhen(caseIndex, 'value', e.target.value)}
+                    >
+                      <option value="">Выберите...</option>
+                      <option value="M">Мужской (M)</option>
+                      <option value="F">Женский (F)</option>
+                    </select>
+                  ) : (
+                    <input
+                      className="macos-input"
+                      aria-label="Значение условия"
+                      value={caseItem.when?.value ?? ''}
+                      onChange={(e) => updateCaseWhen(caseIndex, 'value', e.target.value)}
+                    />
+                  )}
+                </label>
+              )}
+            </div>
+
+            <div className="ltw-grid-3-ranges">
+              <label className="ltw-label-grid">
+                <span className="ltw-text-12">Текст нормы</span>
+                <input
+                  className="macos-input"
+                  aria-label="Текст нормы для условия"
+                  value={caseItem.text || ''}
+                  onChange={(e) => updateCase(caseIndex, 'text', e.target.value)}
+                  placeholder="3.5-5.0"
+                />
+              </label>
+              <label className="ltw-label-grid">
+                <span className="ltw-text-12">Нижняя граница</span>
+                <input
+                  className="macos-input"
+                  aria-label="Нижняя граница нормы"
+                  type="number"
+                  value={caseItem.low ?? ''}
+                  onChange={(e) => updateCase(caseIndex, 'low', parseFloat(e.target.value) || null)}
+                />
+              </label>
+              <label className="ltw-label-grid">
+                <span className="ltw-text-12">Верхняя граница</span>
+                <input
+                  className="macos-input"
+                  aria-label="Верхняя граница нормы"
+                  type="number"
+                  value={caseItem.high ?? ''}
+                  onChange={(e) => updateCase(caseIndex, 'high', parseFloat(e.target.value) || null)}
+                />
+              </label>
+            </div>
+          </div>
+        );
+      })}
+
+      <div className="ltw-default-card">
+        <span className="ltw-text-13 ltw-fw-500">По умолчанию (если ни одно условие не сработало)</span>
+        <div className="ltw-grid-3-ranges">
+          <label className="ltw-label-grid">
+            <span className="ltw-text-12">Текст нормы</span>
+            <input
+              className="macos-input"
+              aria-label="Текст нормы по умолчанию"
+              value={defaultRule.text || ''}
+              onChange={(e) => updateDefault('text', e.target.value)}
+              placeholder="3.5-5.0"
+            />
+          </label>
+          <label className="ltw-label-grid">
+            <span className="ltw-text-12">Нижняя граница</span>
+            <input
+              className="macos-input"
+              aria-label="Нижняя граница по умолчанию"
+              type="number"
+              value={defaultRule.low ?? ''}
+              onChange={(e) => updateDefault('low', parseFloat(e.target.value) || null)}
+            />
+          </label>
+          <label className="ltw-label-grid">
+            <span className="ltw-text-12">Верхняя граница</span>
+            <input
+              className="macos-input"
+              aria-label="Верхняя граница по умолчанию"
+              type="number"
+              value={defaultRule.high ?? ''}
+              onChange={(e) => updateDefault('high', parseFloat(e.target.value) || null)}
+            />
+          </label>
+        </div>
+      </div>
+
+      <details>
+        <summary className="ltw-summary-12">
+          Raw JSON (для продвинутых)
+        </summary>
+        <textarea
+          className="macos-input ltw-raw-json-textarea"
+          aria-label="Raw JSON правил нормы"
+          rows={6}
+          value={field.reference_rule_text || ''}
+          onChange={(event) => updateField(sectionIndex, fieldIndex, 'reference_rule_text', event.target.value)}
+        />
+      </details>
+    </div>
+  );
+}
+
+ReferenceRuleEditor.propTypes = {
+  sectionIndex: PropTypes.number.isRequired,
+  fieldIndex: PropTypes.number.isRequired,
+  field: PropTypes.object.isRequired,
+  updateField: PropTypes.func.isRequired,
+};
+
+export default ReferenceRuleEditor;

--- a/frontend/src/components/laboratory/templateEditor/SignersTab.jsx
+++ b/frontend/src/components/laboratory/templateEditor/SignersTab.jsx
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import { signerFieldLabels } from './config';
+
+/**
+ * L-H-6 fix: SignersTab выделен в отдельный файл (~25 строк).
+ * Вкладка «Подписи» — подписи по умолчанию (lab_technician + approver).
+ */
+function SignersTab({ draftVersion, onUpdateSigner }) {
+  return (
+    <div>
+      <div className="ltw-branding-title">Подписи по умолчанию</div>
+      <div className="ltw-grid-4-minmax">
+        {['lab_technician_label', 'lab_technician_name', 'approver_label', 'approver_name'].map((key) => (
+          <label key={key} className="ltw-grid-6">
+            <span>{signerFieldLabels[key] || key}</span>
+            <input
+              className="macos-input"
+              aria-label={signerFieldLabels[key] || key}
+              value={draftVersion.signer_defaults?.[key] || ''}
+              onChange={(event) => onUpdateSigner(key, event.target.value)}
+            />
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+SignersTab.propTypes = {
+  draftVersion: PropTypes.object.isRequired,
+  onUpdateSigner: PropTypes.func.isRequired,
+};
+
+export default SignersTab;

--- a/frontend/src/components/laboratory/templateEditor/config.js
+++ b/frontend/src/components/laboratory/templateEditor/config.js
@@ -1,0 +1,56 @@
+/**
+ * L-H-6 fix: shared constants для templateEditor.
+ * Раньше жили в LabTemplateWorkbench.jsx как module-level consts.
+ * Теперь переиспользуются всеми tab-renderer'ами.
+ */
+
+export const layoutOptions = [
+  { value: 'lab_table_classic_v1', label: 'Классический' },
+  { value: 'lab_table_compact_v1', label: 'Компактный' }
+];
+
+export const versionStatusLabels = {
+  PUBLISHED: 'Опубликован',
+  DRAFT: 'Черновик',
+  ARCHIVED: 'Архив'
+};
+
+export const brandingFieldLabels = {
+  document_title: 'Заголовок документа',
+  document_subtitle: 'Подзоловок документа',
+  clinic_name: 'Название клиники',
+  address: 'Адрес',
+  phone: 'Телефон',
+  logo_url: 'Логотип (URL)'
+};
+
+export const signerFieldLabels = {
+  lab_technician_label: 'Подпись лаборанта',
+  lab_technician_name: 'ФИО лаборанта',
+  approver_label: 'Подпись утверждающего',
+  approver_name: 'ФИО утверждающего'
+};
+
+export const fieldTypeOptions = [
+  { value: 'numeric', label: 'Число' },
+  { value: 'text', label: 'Текст' },
+  { value: 'choice', label: 'Выбор из списка' },
+  { value: 'multiline', label: 'Многострочный текст' }
+];
+
+export const referenceModeOptions = [
+  { value: 'static_text', label: 'Текстовая норма' },
+  { value: 'rule_based', label: 'Норма по правилам' },
+  { value: 'catalog', label: 'Из каталога' }
+];
+
+export const EDITOR_TABS = [
+  { id: 'content',  label: 'Содержимое' },
+  { id: 'design',   label: 'Оформление' },
+  { id: 'signers',  label: 'Подписи' },
+  { id: 'preview',  label: 'Предпросмотр' },
+];
+
+export function formatVersionStatus(status) {
+  return versionStatusLabels[status] || status;
+}

--- a/frontend/src/components/laboratory/templateEditor/utils.js
+++ b/frontend/src/components/laboratory/templateEditor/utils.js
@@ -1,0 +1,165 @@
+/**
+ * L-H-6 fix: shared helpers для templateEditor.
+ * Раньше жили в LabTemplateWorkbench.jsx как module-level functions.
+ */
+
+export const blankField = () => ({
+  analyte_code: '',
+  unit_code: '',
+  field_key: '',
+  label: '',
+  value_type: 'numeric',
+  unit: '',
+  reference_mode: 'static_text',
+  reference_text: '',
+  reference_rule: null,
+  visibility_rule: null,
+  highlight_rule: null,
+  choice_options: null,
+  sort_order: 0,
+  required: false
+});
+
+export const blankSection = (index) => ({
+  key: `section_${index}`,
+  title: `Раздел ${index}`,
+  sort_order: index * 10,
+  section_style: {},
+  fields: [blankField()]
+});
+
+export const blankVersion = {
+  layout_preset: 'lab_table_classic_v1',
+  page_settings: { paper_size: 'A4', orientation: 'portrait' },
+  branding_overrides: {
+    document_title: '',
+    document_subtitle: '',
+    clinic_name: '',
+    address: '',
+    phone: '',
+    logo_url: ''
+  },
+  signer_defaults: {
+    lab_technician_label: 'Лаборант',
+    lab_technician_name: '',
+    approver_label: 'Подпись',
+    approver_name: ''
+  },
+  footer_notes: '',
+  sections: [blankSection(1)]
+};
+
+export const TEMPLATE_VERSION_ACTION_CAN_FIELD = {
+  update: 'can_update',
+  publish: 'can_publish',
+  create_draft: 'can_create_draft'
+};
+
+export function hasTemplateVersionAction(version, action) {
+  const normalizedAction = String(action || '').trim().toLowerCase();
+  if (!normalizedAction) {
+    return false;
+  }
+
+  if (Array.isArray(version?.available_actions)) {
+    return version.available_actions.some(
+      (availableAction) => String(availableAction || '').trim().toLowerCase() === normalizedAction
+    );
+  }
+
+  const flagName = TEMPLATE_VERSION_ACTION_CAN_FIELD[normalizedAction];
+  if (flagName && Object.prototype.hasOwnProperty.call(version || {}, flagName)) {
+    return Boolean(version[flagName]);
+  }
+
+  return false;
+}
+
+export function parseJsonInput(value) {
+  if (!value?.trim()) {
+    return null;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return Symbol.for('invalid-json');
+  }
+}
+
+export function stringifyJson(value) {
+  if (!value) {
+    return '';
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+export function buildVersionPayload(draftVersion) {
+  const sections = draftVersion.sections.map((section, sectionIndex) => ({
+    ...section,
+    sort_order: section.sort_order ?? (sectionIndex + 1) * 10,
+    section_style: section.section_style || {},
+    fields: section.fields.map((field, fieldIndex) => {
+      const referenceRule = parseJsonInput(field.reference_rule_text || '');
+      const visibilityRule = parseJsonInput(field.visibility_rule_text || '');
+      const highlightRule = parseJsonInput(field.highlight_rule_text || '');
+      if ([referenceRule, visibilityRule, highlightRule].includes(Symbol.for('invalid-json'))) {
+        throw new Error('Один из JSON-блоков правил заполнен некорректно');
+      }
+      return {
+        ...field,
+        sort_order: field.sort_order ?? (fieldIndex + 1) * 10,
+        reference_rule: referenceRule,
+        visibility_rule: visibilityRule,
+        highlight_rule: highlightRule,
+        reference_rule_text: undefined,
+        visibility_rule_text: undefined,
+        highlight_rule_text: undefined
+      };
+    })
+  }));
+
+  return {
+    layout_preset: draftVersion.layout_preset,
+    page_settings: draftVersion.page_settings || { paper_size: 'A4', orientation: 'portrait' },
+    branding_overrides: draftVersion.branding_overrides || {},
+    signer_defaults: draftVersion.signer_defaults || {},
+    footer_notes: draftVersion.footer_notes || '',
+    sections
+  };
+}
+
+export function hydrateVersion(version) {
+  if (!version) {
+    return { ...blankVersion, sections: [blankSection(1)] };
+  }
+  return {
+    layout_preset: version.layout_preset,
+    page_settings: version.page_settings || { paper_size: 'A4', orientation: 'portrait' },
+    branding_overrides: {
+      clinic_name: '',
+      address: '',
+      phone: '',
+      logo_url: '',
+      document_title: '',
+      document_subtitle: '',
+      ...(version.branding_overrides || {})
+    },
+    signer_defaults: {
+      lab_technician_label: 'Лаборант',
+      lab_technician_name: '',
+      approver_label: 'Подпись',
+      approver_name: '',
+      ...(version.signer_defaults || {})
+    },
+    footer_notes: version.footer_notes || '',
+    sections: (version.sections || []).map((section) => ({
+      ...section,
+      fields: (section.fields || []).map((field) => ({
+        ...field,
+        reference_rule_text: stringifyJson(field.reference_rule),
+        visibility_rule_text: stringifyJson(field.visibility_rule),
+        highlight_rule_text: stringifyJson(field.highlight_rule)
+      }))
+    }))
+  };
+}

--- a/frontend/src/components/laboratory/utils/labReportActions.js
+++ b/frontend/src/components/laboratory/utils/labReportActions.js
@@ -14,7 +14,9 @@
 export const LAB_REPORT_ACTION_CAN_FIELD = {
   edit: 'can_edit',
   save_draft: 'can_save_draft',
-  mark_ready: 'can_mark_ready',
+  // L-H-2 fix: mark_ready удалён — UI-кнопка убрана в WF-round5.
+  // Если backend вернёт can_mark_ready в available_actions, фронт его
+  // проигнорирует (нет UI-действия). Чтобы вернуть — добавить UI + тесты.
   finalize: 'can_finalize',
   revise: 'can_revise',
   print: 'can_print'

--- a/frontend/src/components/laboratory/utils/labStatusConfig.js
+++ b/frontend/src/components/laboratory/utils/labStatusConfig.js
@@ -1,0 +1,97 @@
+/**
+ * L-H-3 fix: единый источник истины для статусов лабораторного бланка.
+ *
+ * Раньше маппинг статусов был размазан по 3 файлам:
+ *   - labUiLabels.js: _statusLabels (ru-строки) + getLabStatusVariant (badge-variant)
+ *   - LabStatusStepper.jsx: LAB_REPORT_STEPS (порядок для stepper)
+ *   - getLabLabels(t) в том же labUiLabels.js: i18n-версия
+ *
+ * Любое изменение требовало правки в 3 местах — рассинхрон был неизбежен.
+ * Теперь все знают о едином LAB_REPORT_STATUS_CONFIG и производных.
+ *
+ * Backend контракт (lab_reporting_service.py): статусы идут строго в порядке
+ * DRAFT → IN_PROGRESS → READY → FINALIZED → PRINTED. Это и есть "жизненный
+ * цикл" бланка, который отображает stepper.
+ *
+ * Не путать с очередью: статусы очереди (waiting/confirmed/pending/called/
+ * in_progress/completed/done) — отдельный домен, к ним относится только
+ * formatLabStatus()/getLabStatusVariant() (т.к. в UI они показываются вместе).
+ */
+
+// ────────────────────────────────────────────────────────────────────────────
+// Жизненный цикл бланка (instance status). Порядок = порядок stepper'а.
+// ────────────────────────────────────────────────────────────────────────────
+export const LAB_REPORT_STATUS_CONFIG = [
+  { key: 'DRAFT',       label: 'Черновик',          variant: 'warning' },
+  { key: 'IN_PROGRESS', label: 'Заполняется',       variant: 'primary' },
+  { key: 'READY',       label: 'Готов к проверке',  variant: 'primary' },
+  { key: 'FINALIZED',   label: 'Утверждён',         variant: 'success' },
+  { key: 'PRINTED',     label: 'Напечатан',         variant: 'success' },
+];
+
+// Быстрый lookup по ключу статуса.
+export const LAB_REPORT_STATUS_BY_KEY = LAB_REPORT_STATUS_CONFIG.reduce(
+  (acc, item) => {
+    acc[item.key] = item;
+    return acc;
+  },
+  {}
+);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Статусы очереди (appointment/queue status). Не имеют порядка stepper'а —
+// это state machine очереди, а не бланка.
+// ────────────────────────────────────────────────────────────────────────────
+export const LAB_QUEUE_STATUS_CONFIG = {
+  waiting:     { label: 'Ожидает',     variant: 'warning' },
+  confirmed:   { label: 'Подтверждён', variant: 'warning' },
+  pending:     { label: 'Ожидает',     variant: 'warning' },
+  called:      { label: 'Вызван',      variant: 'primary' },
+  in_progress: { label: 'В работе',    variant: 'primary' },
+  completed:   { label: 'Завершён',    variant: 'success' },
+  done:        { label: 'Завершён',    variant: 'success' },
+};
+
+/**
+ * Возвращает конфигурацию статуса (label + variant) по ключу.
+ * Поддерживает как статусы бланка (DRAFT/IN_PROGRESS/...), так и статусы
+ * очереди (waiting/called/...). Если статус неизвестен — fallback.
+ *
+ * @param {string} status — ключ статуса
+ * @returns {{ label: string, variant: string }}
+ */
+export function getLabStatusConfig(status) {
+  if (!status) {
+    return { label: 'Неизвестно', variant: 'info' };
+  }
+  return (
+    LAB_REPORT_STATUS_BY_KEY[status]
+    || LAB_QUEUE_STATUS_CONFIG[status]
+    || { label: status, variant: 'info' }
+  );
+}
+
+/**
+ * Возвращает человекочитаемый label статуса.
+ * Заменяет старую formatLabStatus() из labUiLabels.js.
+ */
+export function formatLabStatusLabel(status) {
+  return getLabStatusConfig(status).label;
+}
+
+/**
+ * Возвращает badge-variant статуса.
+ * Заменяет старую getLabStatusVariant() из labUiLabels.js.
+ */
+export function getLabStatusBadgeVariant(status) {
+  return getLabStatusConfig(status).variant;
+}
+
+/**
+ * Возвращает индекс шага в жизненном цикле бланка (для stepper).
+ * -1 — статус не принадлежит жизненному циклу (например, status очереди).
+ */
+export function getLabReportStepIndex(status) {
+  if (!status) return -1;
+  return LAB_REPORT_STATUS_CONFIG.findIndex((s) => s.key === status);
+}

--- a/frontend/src/pages/lab.css
+++ b/frontend/src/pages/lab.css
@@ -184,3 +184,360 @@
   cursor: pointer;
   font-size: 14px;
 }
+
+/* ──────────────────────────────────────────────────────────────────────
+ * L-H-4 fix: LabQueueWorkbench — миграция inline-стилей в CSS.
+ * Аналогичная миграция уже выполнена для Cashier/Registrar/Admin/Doctor.
+ * Классы используют macOS design system tokens (var(--mac-*)).
+ * ────────────────────────────────────────────────────────────────────── */
+
+.lqw-root {
+  display: grid;
+  gap: var(--mac-spacing-4);
+}
+
+.lqw-card-header {
+  background: var(--mac-bg-tertiary);
+  border-bottom: 1px solid var(--mac-border);
+  padding: var(--mac-spacing-4);
+}
+
+.lqw-card-title {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--mac-spacing-2);
+}
+
+.lqw-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mac-spacing-2);
+  align-items: center;
+}
+
+.lqw-card-content {
+  padding: var(--mac-spacing-4);
+  background: var(--mac-bg-secondary);
+}
+
+.lqw-card-grid {
+  display: grid;
+  gap: var(--mac-spacing-4);
+}
+
+.lqw-queue-card {
+  border: 1px solid var(--mac-border);
+  border-radius: var(--mac-radius-xl);
+  background: var(--mac-bg-primary);
+  padding: var(--mac-spacing-4);
+  display: grid;
+  gap: var(--mac-spacing-3);
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.lqw-queue-card:hover {
+  border-color: color-mix(in oklab, var(--mac-accent) 40%, var(--mac-border));
+}
+
+.lqw-queue-card-selected {
+  border-color: var(--mac-accent);
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--mac-accent) 20%, transparent);
+}
+
+.lqw-card-top {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--mac-spacing-3);
+  align-items: flex-start;
+}
+
+.lqw-card-info {
+  display: grid;
+  gap: var(--mac-spacing-2);
+}
+
+.lqw-card-name {
+  font-size: var(--mac-font-size-xl);
+  font-weight: var(--mac-font-weight-semibold);
+  color: var(--mac-text-primary);
+}
+
+.lqw-card-meta {
+  color: var(--mac-text-secondary);
+  font-size: var(--mac-font-size-base);
+}
+
+.lqw-card-services {
+  color: var(--mac-text-secondary);
+  font-size: var(--mac-font-size-base);
+  line-height: 1.5;
+}
+
+.lqw-card-services strong {
+  color: var(--mac-text-primary);
+}
+
+.lqw-card-bottom {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--mac-spacing-3);
+  align-items: center;
+}
+
+.lqw-card-id {
+  color: var(--mac-text-secondary);
+  font-size: var(--mac-font-size-sm);
+}
+
+/* Search & filter bar (L-H-4) */
+.lqw-search-filter-row {
+  display: flex;
+  gap: var(--mac-spacing-3);
+  flex-wrap: wrap;
+  margin-top: var(--mac-spacing-3);
+  align-items: center;
+}
+
+.lqw-search-wrapper {
+  position: relative;
+  flex: 1 1 240px;
+  min-width: 200px;
+}
+
+.lqw-search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--mac-text-muted);
+  pointer-events: none;
+}
+
+.lqw-search-input {
+  width: 100%;
+  padding: 8px 12px 8px 32px;
+  border-radius: var(--mac-radius-lg);
+  border: 1px solid var(--mac-border);
+  background: var(--mac-bg-primary);
+  color: var(--mac-text-primary);
+  font-size: var(--mac-font-size-base);
+  outline: none;
+}
+
+.lqw-search-input:focus {
+  border-color: var(--mac-accent);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--mac-accent) 20%, transparent);
+}
+
+.lqw-search-clear {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--mac-text-muted);
+  padding: var(--mac-spacing-1);
+  font-size: var(--mac-font-size-lg);
+  line-height: 1;
+}
+
+.lqw-status-filter-group {
+  display: flex;
+  gap: var(--mac-spacing-1);
+}
+
+.lqw-status-filter-btn {
+  padding: var(--mac-spacing-2) var(--mac-spacing-3);
+  border-radius: var(--mac-radius-md);
+  border: 1px solid var(--mac-border);
+  background: var(--mac-bg-primary);
+  color: var(--mac-text-primary);
+  cursor: pointer;
+  font-size: var(--mac-font-size-sm);
+  font-weight: 400;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+
+.lqw-status-filter-btn:hover {
+  border-color: var(--mac-accent);
+}
+
+.lqw-status-filter-btn-active {
+  border-color: var(--mac-accent);
+  background: var(--mac-accent);
+  color: white;
+  font-weight: 600;
+}
+
+.lqw-sort-row {
+  display: flex;
+  align-items: center;
+  gap: var(--mac-spacing-2);
+}
+
+.lqw-sort-label {
+  font-size: var(--mac-font-size-xs);
+  color: var(--mac-text-muted);
+}
+
+.lqw-sort-select {
+  font-size: var(--mac-font-size-xs);
+  padding: 4px 8px;
+  width: auto;
+}
+
+.lqw-filter-count {
+  margin-top: var(--mac-spacing-2);
+  font-size: var(--mac-font-size-xs);
+  color: var(--mac-text-muted);
+}
+
+/* Skeleton loading (L-H-4 + L-M-4 fix: prefers-reduced-motion) */
+.lqw-skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--mac-border) 25%,
+    var(--mac-bg-secondary) 50%,
+    var(--mac-border) 75%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--mac-radius-sm);
+  animation: lqw-skeleton-shimmer 1.5s infinite;
+}
+
+@keyframes lqw-skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lqw-skeleton {
+    animation: none;
+    background: var(--mac-bg-tertiary);
+  }
+}
+
+/* History card (L-H-4) */
+.lqw-history-card {
+  border: 1px solid var(--mac-border);
+  border-radius: 14px;
+  padding: 12px 14px;
+  background: var(--mac-bg-primary);
+  display: flex;
+  justify-content: space-between;
+  gap: var(--mac-spacing-3);
+  align-items: center;
+}
+
+.lqw-history-info {
+  display: grid;
+  gap: var(--mac-spacing-1);
+}
+
+.lqw-history-title {
+  font-weight: var(--mac-font-weight-semibold);
+  color: var(--mac-text-primary);
+}
+
+.lqw-history-meta {
+  color: var(--mac-text-secondary);
+  font-size: var(--mac-font-size-sm);
+}
+
+.lqw-history-badges {
+  display: flex;
+  gap: var(--mac-spacing-2);
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+/* MaskedPhone button (L-H-4 + L-M-5 fix) */
+.lqw-masked-phone {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
+}
+
+.lqw-masked-phone-empty {
+  color: var(--mac-text-secondary);
+}
+
+/* PII details summary (L-H-4 + L-M-5 fix) */
+.lqw-pii-details {
+  display: inline;
+}
+
+.lqw-pii-summary {
+  display: inline-block;
+  cursor: pointer;
+  color: var(--mac-text-muted);
+  list-style: none;
+}
+
+.lqw-pii-value {
+  margin-left: 6px;
+  font-family: monospace;
+}
+
+/* ──────────────────────────────────────────────────────────────────────
+ * L-H-5 fix: LabReportWorkbench — responsive field grid.
+ * На tablet/mobile 5-колоночная grid сжимается в нечитаемое.
+ * На узких экранах поле + результат переходят в 2-колоночный stack.
+ * ────────────────────────────────────────────────────────────────────── */
+
+.lrw-field-row {
+  display: grid;
+  grid-template-columns:
+    minmax(220px, 1.2fr)
+    minmax(140px, 0.9fr)
+    minmax(80px, 0.5fr)
+    minmax(90px, 0.7fr)
+    minmax(70px, 0.4fr);
+  gap: var(--mac-spacing-2);
+  align-items: center;
+}
+
+.lrw-field-label {
+  display: grid;
+  gap: var(--mac-spacing-1);
+}
+
+.lrw-field-label-name {
+  color: var(--mac-text-primary);
+}
+
+.lrw-field-meta {
+  display: grid;
+  gap: var(--mac-spacing-1);
+  color: var(--mac-text-secondary);
+  font-size: var(--mac-font-size-xs);
+}
+
+@media (max-width: 1024px) {
+  /* Tablet: 3 колонки — label/value/unit, флаг + обязательное в новую строку */
+  .lrw-field-row {
+    grid-template-columns:
+      minmax(180px, 1.5fr)
+      minmax(120px, 1fr)
+      minmax(60px, 0.4fr);
+  }
+}
+
+@media (max-width: 720px) {
+  /* Mobile: вертикальный stack, каждое поле на своей строке */
+  .lrw-field-row {
+    grid-template-columns: 1fr;
+    gap: var(--mac-spacing-1);
+  }
+}
+


### PR DESCRIPTION
## Summary

- Fix 6 High priority problems from lab panel usability audit (ISO/IEC 25010 + Nielsen 10)
- Includes 3 bonus Medium fixes (L-M-3, L-M-4, L-M-5) that fell out of L-H-4 CSS migration
- No backend contract changes — frontend-only refactor

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/lab-h-batch-a` created from current `origin/main` (commit 09d61236)
- Clean workspace: inspected before edits; only lab panel files changed
- Branch: fix/lab-h-batch-a
- Scope gate: allowed lab panel CSS, lab components, lab API client, lab contract tests; denied Doctor/Cashier/Registrar/Admin panels, backend, routing, auth
- Red-check handling: 1 pre-existing DoctorPanels failure verified on clean main — unrelated to this PR

## Contract Impact

- Canonical surface: labReportingApi (frontend), labUiLabels.js (frontend), LabStatusStepper (frontend)
- Request shape: no HTTP request changes — `labReportingApi.markReady()` removed (was dead code, no UI called it since WF-round5)
- Response shape: no response shape changes — labUiLabels.js public API preserved (formatLabStatus, getLabStatusVariant, formatPaymentStatus, formatSpecialtyLabel, formatSeverityLabel, signerFieldLabels, getLabLabels)
- Status codes: no HTTP status changes — frontend-only
- Frontend consumer: LabPanel.jsx unchanged, still imports from labUiLabels.js (public API backward compatible)
- Compatibility path or alias: legacy static exports in labUiLabels.js preserved (formatLabStatus, getLabStatusVariant delegate to labStatusConfig.js internally)
- Contract proof: 29/29 lab contract tests passing (5 test files); updated 2 contract test files to reflect L-H-6 decomposition

## RBAC / Permissions

- Roles allowed: lab (unchanged)
- Roles denied: no role changes
- Positive auth proof: not applicable - this PR does not modify any authentication or authorization flow; lab role access to LabPanel is unchanged
- Negative auth proof: not applicable - no auth flow changes; existing role-based routing to /lab preserved; no new endpoints exposed

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed. RoleNotificationCenter userRole="lab" still rendered in LabPanel unchanged.

## Frontend Resilience

- Empty data proof: getLabStatusConfig(null) returns { label: 'Неизвестно', variant: 'info' } — graceful fallback
- Partial data proof: getLabStatusConfig(unknownStatus) returns { label: status, variant: 'info' } — unknown statuses render with info badge instead of crashing
- Forbidden secondary path behavior: not applicable - no secondary path used; all components consume the same labReportingApi façade
- Missing draft/resource behavior: useConfirm() returns false if dialog fails to mount — safe default, no destructive action executes
- Stale route/deep-link behavior: not applicable - no route/deep-link changes; URL params (?tab=, ?instance=, ?patient=) preserved unchanged

## Scope Gate

- Allowed paths: frontend/src/pages/lab.css (CSS additions only), frontend/src/components/laboratory/* (modified + new files), frontend/src/api/labReporting.js (1 method removed), frontend/src/components/laboratory/__tests__/* (2 test files updated)
- Denied paths: Doctor/Cashier/Registrar/Admin panels, backend code, routing, authentication, other CSS files
- Migration/docs/test impact: no migration; 2 contract tests updated for L-H-6 decomposition; no docs changes
- Rollback note: revert all changed files — no data migration, no backend schema change

## Validation

- Targeted tests or smoke run: npx vitest run src/components/laboratory/__tests__/ src/pages/__tests__/LabPanel.contract.test.jsx
- Result: 29/29 passing
- Not checked: full browser panel smoke (no Playwright e2e added in this PR)