### PR TITLE
fix(lab): UX-AUDIT-QW1 — confirm dialog before sending lab results to patient via Telegram

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -558,8 +558,25 @@ export default function LabReportWorkbench({
 
   // P1 fix: Notify patient via Telegram — sends lab results PDF to patient's
   // Telegram chat via POST /telegram/send-lab-results backend endpoint.
+  //
+  // UX-AUDIT-QW1: Добавлен ConfirmDialog. Отправка в Telegram необратима
+  // (нельзя отозвать сообщение). Соответствие Nielsen Heuristic #5
+  // (Error Prevention) и консистентность с handleFinalize/handleRevise,
+  // которые уже используют useConfirm() для необратимых действий.
   async function handleNotifyPatient() {
     if (!activeInstance) return;
+    const ok = await confirm({
+      title: 'Отправка результатов пациенту',
+      message: 'Результаты будут отправлены в Telegram.',
+      description:
+        'Сообщение нельзя отозвать. Пациент получит PDF с результатами ' +
+        'лабораторных анализов. Перед отправкой убедитесь, что отчёт ' +
+        'утверждён и не содержит ошибок.',
+      confirmLabel: 'Отправить',
+      cancelLabel: 'Отмена',
+      intent: 'warning',
+    });
+    if (!ok) return;
     setSaving(true);
     setBusyAction('notify');
     try {

--- a/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
@@ -243,4 +243,26 @@ describe('LabReportWorkbench', () => {
     expect(screen.getByRole('combobox').closest('div')?.querySelector('button')).toBeDisabled();
     expect(labReportingApi.createInstance).not.toHaveBeenCalled();
   });
+
+  it('UX-AUDIT-QW1: requires confirm dialog before sending results to patient via Telegram', () => {
+    // QW1 fix: handleNotifyPatient — необратимая отправка в Telegram.
+    // Должен вызывать useConfirm() перед POST /telegram/send-lab-results.
+    const source = fs.readFileSync(workbenchPath, 'utf8');
+
+    // Ищем функцию handleNotifyPatient и проверяем, что она вызывает confirm()
+    const fnStart = source.indexOf('async function handleNotifyPatient()');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('\n  }', fnStart);
+    const fnBody = source.slice(fnStart, fnEnd);
+
+    expect(fnBody).toContain('await confirm(');
+    expect(fnBody).toContain("'Отправка результатов пациенту'");
+    expect(fnBody).toContain("intent: 'warning'");
+    // Действие не должно выполняться без подтверждения
+    expect(fnBody).toContain('if (!ok) return;');
+    // Не должен быть POST до confirm
+    const postIndex = fnBody.indexOf("api.post('/telegram/send-lab-results'");
+    const confirmIndex = fnBody.indexOf('await confirm(');
+    expect(postIndex).toBeGreaterThan(confirmIndex);
+  });
 });


### PR DESCRIPTION
## UX-AUDIT-QW1: Confirm dialog на «Отправить пациенту» (Telegram)

### Контекст
Юзабилити-аудит лабораторной панели (`/lab`) выявил, что кнопка «Отправить пациенту»
в `LabReportWorkbench` отправляла PDF с результатами в Telegram пациента **без подтверждения**.

Это нарушает:
- **Nielsen Heuristic #5** (Error Prevention) — необратимое действие без guard
- **Консистентность (Heuristic #4)** — `handleFinalize` и `handleRevise` уже используют
  `useConfirm()`, а `handleNotifyPatient` — нет

### Изменение
В `LabReportWorkbench.jsx` функция `handleNotifyPatient` теперь вызывает `confirm()` 
перед `api.post('/telegram/send-lab-results', ...)`:

- Title: «Отправка результатов пациенту»
- Description: явно warns о необратимости («Сообщение нельзя отозвать»)
- Intent: `warning`
- Действие прерывается, если пользователь нажал «Отмена»

### Тестирование
Добавлен source-text assertion в `LabReportWorkbench.test.jsx`:
- Проверяет, что `confirm()` вызывается перед `api.post('/telegram/send-lab-results')`
- Проверяет наличие `intent: 'warning'` и guard `if (!ok) return;`

### Файлы
- `frontend/src/components/laboratory/LabReportWorkbench.jsx` — +13 строк в `handleNotifyPatient`
- `frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx` — +22 строки теста

### Критичность
**High** — предотвращает случайную отправку неверных результатов пациенту.

### Связанный аудит
Quick Win #1 из юзабилити-аудита панели лаборатории.