### PR TITLE
fix(lab): UX-AUDIT-QW2 — confirm dialog before resetting template draft

### DIFF
--- a/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
@@ -547,11 +547,28 @@ export default function LabTemplateWorkbench({
                 </Button>
                 <Button
                   variant="outline"
-                  onClick={() => {
-                    if (activeVersion) {
-                      setDraftVersion(hydrateVersion(activeVersion));
-                      notify('info', 'Изменения отменены. Восстановлена версия с сервера.');
-                    }
+                  onClick={async () => {
+                    if (!activeVersion) return;
+                    // UX-AUDIT-QW2: Reset — необратимая потеря черновика.
+                    // Ранее выполнялся мгновенно через notify('info', ...),
+                    // что диссонировало с ConfirmDialog на Archive/Publish.
+                    // Теперь обёрнут в useConfirm() — соответствует
+                    // Nielsen Heuristic #5 (Error Prevention) и эвристике #4
+                    // (Consistency & Standards).
+                    const ok = await confirm({
+                      title: 'Сброс черновика',
+                      message: 'Все несохранённые изменения будут потеряны.',
+                      description:
+                        'Восстановится последняя версия с сервера. ' +
+                        'Действие нельзя отменить. Если нужно сохранить ' +
+                        'текущее состояние — нажмите «Отмена» и «Сохранить черновик».',
+                      confirmLabel: 'Сбросить',
+                      cancelLabel: 'Отмена',
+                      intent: 'warning',
+                    });
+                    if (!ok) return;
+                    setDraftVersion(hydrateVersion(activeVersion));
+                    notify('success', 'Черновик восстановлен из серверной версии.');
                   }}
                   disabled={saving || !activeVersion}
                   title="Отменить изменения и восстановить версию с сервера"

--- a/frontend/src/components/laboratory/__tests__/LabTemplateWorkbench.contract.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabTemplateWorkbench.contract.test.jsx
@@ -50,4 +50,25 @@ describe('LabTemplateWorkbench template version command contract', () => {
     expect(ensureDraftBlock).toContain('labReportingApi.createTemplateVersion');
     expect(ensureDraftBlock).not.toContain('activeVersion?.status === \'DRAFT\'');
   });
+
+  it('UX-AUDIT-QW2: Reset button requires confirm dialog before discarding draft', () => {
+    // QW2 fix: кнопка «Отменить» (Reset) ранее мгновенно сбрасывала черновик
+    // через notify('info', ...). Должна вызывать useConfirm() — как Archive и Publish.
+    const resetBlock = source.indexOf('Отменить');
+    expect(resetBlock).toBeGreaterThan(-1);
+    // Находим блок onClick рядом с кнопкой «Отменить»
+    const onClickStart = source.lastIndexOf('onClick={async () => {', resetBlock);
+    expect(onClickStart).toBeGreaterThan(-1);
+    const onClickEnd = source.indexOf('}}', onClickStart);
+    const onClickBody = source.slice(onClickStart, onClickEnd);
+
+    expect(onClickBody).toContain('await confirm(');
+    expect(onClickBody).toContain("'Сброс черновика'");
+    expect(onClickBody).toContain("intent: 'warning'");
+    expect(onClickBody).toContain('if (!ok) return;');
+    // Не должно быть мгновенного setDraftVersion без confirm
+    const setDraftIdx = onClickBody.indexOf('setDraftVersion(hydrateVersion(');
+    const confirmIdx = onClickBody.indexOf('await confirm(');
+    expect(setDraftIdx).toBeGreaterThan(confirmIdx);
+  });
 });


### PR DESCRIPTION
## Summary

- Add ConfirmDialog to the «Отменить» (Reset draft) button in `LabTemplateWorkbench.jsx`.
- Previously Reset discarded unsaved draft changes instantly via `notify('info', ...)`, while sibling destructive actions (Archive, Publish) already used `useConfirm()`.
- Aligns Reset with the same confirmation pattern, closing Nielsen Heuristic #5 (Error Prevention) and Heuristic #4 (Consistency & Standards).

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/ux-audit-qw2-reset-confirm` from `origin/main` at `f0dab84a`.
- Clean workspace: inspected before edits; only `LabTemplateWorkbench.jsx` and its contract test changed.
- Branch: `fix/ux-audit-qw2-reset-confirm`
- Scope gate: allowed `frontend/src/components/laboratory/LabTemplateWorkbench.jsx` + `__tests__/LabTemplateWorkbench.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted test fails, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only UX change. No API, websocket, event, or backend contract changed. `useConfirm()` was already imported and used by other handlers in the same file.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. Confirmation dialog is shown to all roles with template-edit access; no new role gating introduced.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: when `activeVersion` is null, button is `disabled` and confirm dialog is never shown (early `if (!activeVersion) return` inside the handler).
- Partial data proof: confirm dialog is independent of draft content; works whether draft has 0 or N sections.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: button disabled when no `activeVersion`, so reset cannot fire without a server version to restore.
- Stale route/deep-link behavior: not applicable, Reset operates on local draft state only.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/LabTemplateWorkbench.jsx`, `frontend/src/components/laboratory/__tests__/LabTemplateWorkbench.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; one contract test added
- Rollback note: revert both files; pre-QW2 behavior restored (instant reset with info toast)

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/laboratory/__tests__/LabTemplateWorkbench.contract.test.jsx`
- Result: passed (2/2 tests, 681ms)
- Not checked: full browser panel smoke — out of scope for a single-button UX fix