### PR TITLE
fix(lab): UX-AUDIT-FIX4 — confirm dialog on field/section delete in ContentTab

### DIFF
--- a/frontend/src/components/laboratory/templateEditor/ContentTab.jsx
+++ b/frontend/src/components/laboratory/templateEditor/ContentTab.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import { Badge, Button, Icon } from '../../ui/macos';
+import { useConfirm } from '../../common/ConfirmDialog';
 import { fieldTypeOptions, referenceModeOptions } from './config';
 import ReferenceRuleEditor from './ReferenceRuleEditor';
 
@@ -12,6 +13,11 @@ import ReferenceRuleEditor from './ReferenceRuleEditor';
  *   - duplicate field
  *   - structured ReferenceRuleEditor (вместо raw JSON)
  *   - расширенные правила (видимость/подсветка) — raw JSON, collapsed
+ *
+ * UX-AUDIT-FIX4: удаление секции и поля теперь требует подтверждения.
+ * Ранее single-click на trash удалял элемент со всеми правилами референсов
+ * без возможности отмены. Потеря сложного поля — 5–10 минут работы.
+ * Соответствует Nielsen Heuristic #5 (Error Prevention).
  */
 function ContentTab({
   draftVersion,
@@ -31,6 +37,37 @@ function ContentTab({
   onUpdateFieldCatalog,
   onLoadCatalogReferenceRange,
 }) {
+  // UX-AUDIT-FIX4: useConfirm для деструктивных действий (удаление секции/поля).
+  const [confirm] = useConfirm();
+
+  async function handleRemoveSection(sectionIndex, section) {
+    const ok = await confirm({
+      title: 'Удалить секцию?',
+      message: `«${section?.title || section?.key || `Секция #${sectionIndex + 1}`}» будет удалена со всеми полями и правилами нормы.`,
+      description:
+        'Действие нельзя отменить после сохранения черновика. ' +
+        'Если нужно сохранить структуру — нажмите «Отмена» и сохраните текущий черновик перед удалением.',
+      confirmLabel: 'Удалить секцию',
+      cancelLabel: 'Отмена',
+      intent: 'danger',
+    });
+    if (ok) onRemoveSection(sectionIndex);
+  }
+
+  async function handleRemoveField(sectionIndex, fieldIndex, field) {
+    const ok = await confirm({
+      title: 'Удалить показатель?',
+      message: `«${field?.label || field?.field_key || `Поле #${fieldIndex + 1}`}» будет удалён со всеми правилами нормы.`,
+      description:
+        'Действие нельзя отменить после сохранения черновика. ' +
+        'Если нужно сохранить поле — нажмите «Отмена».',
+      confirmLabel: 'Удалить поле',
+      cancelLabel: 'Отмена',
+      intent: 'danger',
+    });
+    if (ok) onRemoveField(sectionIndex, fieldIndex);
+  }
+
   return (
     <div className="ltw-grid">
       <div className="ltw-flex-between">
@@ -66,7 +103,7 @@ function ContentTab({
                 <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); onMoveSection(sectionIndex, 'down'); }} disabled={sectionIndex === draftVersion.sections.length - 1} aria-label="Переместить секцию вниз">
                   <Icon name="arrow.down" size={14} />
                 </Button>
-                <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); onRemoveSection(sectionIndex); }} aria-label="Удалить секцию">
+                <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); handleRemoveSection(sectionIndex, section); }} aria-label="Удалить секцию">
                   <Icon name="trash" size={14} />
                 </Button>
               </span>
@@ -114,7 +151,7 @@ function ContentTab({
                             <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); onDuplicateField(sectionIndex, fieldIndex); }} aria-label="Дублировать поле">
                               <Icon name="doc.on.doc" size={12} />
                             </Button>
-                            <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); onRemoveField(sectionIndex, fieldIndex); }} aria-label="Удалить поле">
+                            <Button variant="ghost" size="small" onClick={(e) => { e.stopPropagation(); handleRemoveField(sectionIndex, fieldIndex, field); }} aria-label="Удалить поле">
                               <Icon name="trash" size={12} />
                             </Button>
                           </span>

--- a/frontend/src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx
+++ b/frontend/src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { fileURLToPath } from 'node:url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../../../..');
+
+const source = fs.readFileSync(
+  path.join(ROOT, 'components/laboratory/templateEditor/ContentTab.jsx'),
+  'utf8'
+);
+
+describe('ContentTab UX-AUDIT-FIX4 — confirm dialog on field/section delete', () => {
+  it('imports useConfirm from common/ConfirmDialog', () => {
+    expect(source).toContain("from '../../common/ConfirmDialog'");
+    expect(source).toContain('useConfirm');
+  });
+
+  it('wraps section removal in confirm dialog', () => {
+    expect(source).toContain('async function handleRemoveSection(');
+    const handlerStart = source.indexOf('async function handleRemoveSection(');
+    const handlerEnd = source.indexOf('\n  }', handlerStart);
+    const handlerBody = source.slice(handlerStart, handlerEnd);
+
+    expect(handlerBody).toContain('await confirm(');
+    expect(handlerBody).toContain("'Удалить секцию?'");
+    expect(handlerBody).toContain("intent: 'danger'");
+    expect(handlerBody).toContain('if (ok) onRemoveSection(sectionIndex)');
+  });
+
+  it('wraps field removal in confirm dialog', () => {
+    expect(source).toContain('async function handleRemoveField(');
+    const handlerStart = source.indexOf('async function handleRemoveField(');
+    const handlerEnd = source.indexOf('\n  }', handlerStart);
+    const handlerBody = source.slice(handlerStart, handlerEnd);
+
+    expect(handlerBody).toContain('await confirm(');
+    expect(handlerBody).toContain("'Удалить показатель?'");
+    expect(handlerBody).toContain("intent: 'danger'");
+    expect(handlerBody).toContain('if (ok) onRemoveField(sectionIndex, fieldIndex)');
+  });
+
+  it('wires the new handlers into trash buttons', () => {
+    const trashSectionIdx = source.indexOf('aria-label="Удалить секцию"');
+    expect(trashSectionIdx).toBeGreaterThan(-1);
+    const sectionButtonLine = source.lastIndexOf('onClick=', trashSectionIdx);
+    const sectionButtonEnd = source.indexOf('aria-label="Удалить секцию"', sectionButtonLine);
+    const sectionOnClickBody = source.slice(sectionButtonLine, sectionButtonEnd);
+    expect(sectionOnClickBody).toContain('handleRemoveSection');
+    expect(sectionOnClickBody).not.toContain('onRemoveSection(sectionIndex);');
+
+    const trashFieldIdx = source.indexOf('aria-label="Удалить поле"');
+    expect(trashFieldIdx).toBeGreaterThan(-1);
+    const fieldButtonLine = source.lastIndexOf('onClick=', trashFieldIdx);
+    const fieldButtonEnd = source.indexOf('aria-label="Удалить поле"', fieldButtonLine);
+    const fieldOnClickBody = source.slice(fieldButtonLine, fieldButtonEnd);
+    expect(fieldOnClickBody).toContain('handleRemoveField');
+    expect(fieldOnClickBody).not.toContain('onRemoveField(sectionIndex, fieldIndex);');
+  });
+});


### PR DESCRIPTION
## Summary

- Add ConfirmDialog to «Удалить секцию» and «Удалить поле» buttons in `ContentTab.jsx`.
- Previously a single click on the trash icon deleted a section/field with all its reference rules — no confirmation, no undo. Loss of a complex field with a configured `ReferenceRuleEditor` cost 5–10 minutes of rework.
- Closes Nielsen Heuristic #5 (Error Prevention) and aligns ContentTab with sibling destructive actions (Archive, Publish, Reset) that already use `useConfirm()`.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/ux-audit-fix4-confirm-delete-field-section` from `origin/main` at `fbbe21ea` (post-QW3).
- Clean workspace: inspected before edits; only `ContentTab.jsx` and new contract test changed.
- Branch: `fix/ux-audit-fix4-confirm-delete-field-section`
- Scope gate: allowed `frontend/src/components/laboratory/templateEditor/ContentTab.jsx` + new `__tests__/ContentTab.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted test fails, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only UX change. No API, websocket, event, or backend contract changed. `useConfirm()` is called locally inside ContentTab (no new props from parent).

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. Confirmation dialog is shown to all roles with template-edit access; no new role gating introduced.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: when section/field is missing, confirm dialog uses fallback labels (`Секция #N`, `Поле #N`) — no crash on null fields.
- Partial data proof: confirm dialog uses `section?.title || section?.key` chain, so partially-populated entities still render a meaningful title.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: trash buttons only render when there is a draft section/field to delete — no chance of firing on an empty state.
- Stale route/deep-link behavior: not applicable, delete operates on local draft state only.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/templateEditor/ContentTab.jsx`, `frontend/src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; one contract test file added (4 tests)
- Rollback note: revert both files; pre-FIX4 behaviour restored (single-click delete with no confirmation)

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx`
- Result: passed (4/4 tests, 618ms)
- Not checked: full browser panel smoke — out of scope for a button-only UX fix