### PR TITLE
fix(lab): UX-AUDIT-FIX6 — migrate lucide-react icons to macos Icon in LabResultsSection

### DIFF
--- a/frontend/src/components/emr-v2/sections/LabResultsSection.jsx
+++ b/frontend/src/components/emr-v2/sections/LabResultsSection.jsx
@@ -15,10 +15,13 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { FileText, Download, TestTube, Plus } from 'lucide-react';
+// UX-AUDIT-FIX6: lucide-react заменён на macos Icon для консистентности со
+// всеми остальными lab-компонентами. Смешивание двух библиотек иконок
+// (lucide + macos SF-Symbol-style) нарушало Nielsen Heuristic #4
+// (Consistency & Standards) — разные stroke-width, optical size, padding.
 import EMRSection from './EMRSection';
 import { labReportingApi } from '../../../api/labReporting';
-import { Badge, Button, Dialog, DialogTitle, DialogContent, DialogActions } from '../../ui/macos';
+import { Badge, Button, Dialog, DialogTitle, DialogContent, DialogActions, Icon } from '../../ui/macos';
 import logger from '../../../utils/logger';
 import notify from '../../../services/notify';
 
@@ -168,7 +171,7 @@ export function LabResultsSection({ patientId, visitId, disabled = false }) {
               background: 'var(--mac-bg-secondary)',
             }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '10px', minWidth: 0, flex: 1 }}>
-              <TestTube size={16} style={{ color: 'var(--mac-text-secondary)', flexShrink: 0 }} aria-hidden="true" />
+              <Icon name="testtube.2" size={16} color="secondary" aria-hidden="true" />
               <div style={{ minWidth: 0 }}>
                 <div style={{ fontWeight: 500, fontSize: '14px', color: 'var(--mac-text-primary)' }}>
                   {instance.template_name || instance.template_code || 'Лабораторный отчёт'}
@@ -193,7 +196,7 @@ export function LabResultsSection({ patientId, visitId, disabled = false }) {
                   size="small"
                   onClick={() => handleDownload(instance.id)}
                   aria-label={`Скачать PDF: ${instance.template_name || 'лабораторный отчёт'}`}>
-                  <Download size={14} style={{ marginRight: 4 }} />
+                  <Icon name="square.and.arrow.down" size={14} style={{ marginRight: 4 }} aria-hidden="true" />
                   PDF
                 </Button>
               )}
@@ -208,12 +211,12 @@ export function LabResultsSection({ patientId, visitId, disabled = false }) {
     <>
       <EMRSection
         title="Результаты анализов"
-        icon={<FileText size={16} aria-hidden="true" />}
+        icon={<Icon name="doc.text" size={16} aria-hidden="true" />}
         disabled={disabled}
         defaultOpen={instances.length > 0}
         headerAction={!disabled && patientId ? (
           <Button variant="outline" size="small" onClick={handleOpenOrderModal}>
-            <Plus size={14} style={{ marginRight: 4 }} />
+            <Icon name="plus" size={14} style={{ marginRight: 4 }} aria-hidden="true" />
             Заказать анализы
           </Button>
         ) : null}
@@ -260,7 +263,7 @@ export function LabResultsSection({ patientId, visitId, disabled = false }) {
                         {template.code} • {template.family}
                       </div>
                     </div>
-                    <TestTube size={20} style={{ color: 'var(--mac-text-secondary)' }} />
+                    <Icon name="testtube.2" size={20} color="secondary" aria-hidden="true" />
                   </button>
                 ))
               )}

--- a/frontend/src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx
+++ b/frontend/src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { fileURLToPath } from 'node:url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../../../..');
+
+const source = fs.readFileSync(
+  path.join(ROOT, 'components/emr-v2/sections/LabResultsSection.jsx'),
+  'utf8'
+);
+
+const iconSource = fs.readFileSync(
+  path.join(ROOT, 'components/ui/macos/Icon.jsx'),
+  'utf8'
+);
+
+describe('LabResultsSection UX-AUDIT-FIX6 — migrate lucide-react to macos Icon', () => {
+  it('does not import from lucide-react anymore', () => {
+    expect(source).not.toContain("from 'lucide-react'");
+    expect(source).not.toContain('FileText, Download, TestTube, Plus');
+  });
+
+  it('imports Icon from macos UI library', () => {
+    expect(source).toContain("from '../../ui/macos'");
+    expect(source).toContain('Icon');
+  });
+
+  it('uses macos Icon names for all 4 migrated icons', () => {
+    // FileText → doc.text
+    expect(source).toContain('<Icon name="doc.text"');
+    // Download → square.and.arrow.down
+    expect(source).toContain('<Icon name="square.and.arrow.down"');
+    // TestTube → testtube.2
+    expect(source).toContain('<Icon name="testtube.2"');
+    // Plus → plus
+    expect(source).toContain('<Icon name="plus"');
+  });
+
+  it('registers square.and.arrow.down in macos Icon.jsx (previously missing)', () => {
+    // Ранее 'square.and.arrow.down' отсутствовал в Icon.jsx — fallback на
+    // 'questionmark'. Теперь SVG-path определён.
+    expect(iconSource).toContain("'square.and.arrow.down'");
+    expect(iconSource).toContain('UX-AUDIT-FIX6');
+  });
+});

--- a/frontend/src/components/ui/macos/Icon.jsx
+++ b/frontend/src/components/ui/macos/Icon.jsx
@@ -273,6 +273,18 @@ const ICONS = {
   'square.and.arrow.up':
   <path d="M7 13.5l2.5-2.5m0 0L10.5 9m-1 2V16a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-5.5M7 13.5V11a2 2 0 0 1 2-2h.5" />,
 
+  // UX-AUDIT-FIX6: 'square.and.arrow.down' ранее отсутствовал — fallback на
+  // 'questionmark' при использовании в LabReportActionsBar, LabTemplateWorkbench,
+  // ContentTab. Теперь SVG-path корректный (download icon).
+  'square.and.arrow.down':
+  <path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />,
+
+  'square.and.arrow.down.on.square':
+  <path d="M12 3v8m0 0l-3-3m3 3l3-3M4 14v4a2 2 0 002 2h8a2 2 0 002-2v-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />,
+
+  'square.and.arrow.down.on.square.fill':
+  <path d="M12 3v8m0 0l-3-3m3 3l3-3M4 14v4a2 2 0 002 2h8a2 2 0 002-2v-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />,
+
   'trash':
   <path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />,
 


### PR DESCRIPTION
## Summary

- Replace `lucide-react` imports (`FileText`, `Download`, `TestTube`, `Plus`) with macos `Icon` component in `LabResultsSection.jsx` for visual consistency with all other lab components.
- Add missing `square.and.arrow.down` SVG path to `Icon.jsx` — previously it was referenced by `LabReportActionsBar`, `LabTemplateWorkbench`, and `ContentTab` but fell back to the `questionmark` placeholder icon (silent visual bug).
- Closes Nielsen Heuristic #4 (Consistency & Standards) — single icon library across the entire lab module.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/ux-audit-fix6-lab-results-icons` from `origin/main` at `341ae289` (post-FIX5).
- Clean workspace: inspected before edits; only `LabResultsSection.jsx`, `Icon.jsx`, and new contract test changed.
- Branch: `fix/ux-audit-fix6-lab-results-icons`
- Scope gate: allowed `frontend/src/components/emr-v2/sections/LabResultsSection.jsx`, `frontend/src/components/ui/macos/Icon.jsx`, `frontend/src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx`; denied backend, migrations, other frontend components.
- Red-check handling: if targeted test fails, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only icon migration. No API, websocket, event, or backend contract changed. Icon SVG paths render the same visual semantics (download/testtube/document/plus) with consistent macos styling.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. Same roles see same UI; only the icon visual style is unified.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: when no lab reports exist, the order modal still renders with template icons (TestTube → testtube.2). No crash.
- Partial data proof: when `instance.template_name` is missing, fallback label `'Лабораторный отчёт'` is rendered (unchanged).
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: PDF download button only renders for non-disabled instances with a valid `instance.id` (unchanged guard).
- Stale route/deep-link behavior: not applicable, section reads from prop `patientId`.

## Scope Gate

- Allowed paths: `frontend/src/components/emr-v2/sections/LabResultsSection.jsx`, `frontend/src/components/ui/macos/Icon.jsx`, `frontend/src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; one contract test file added (4 tests)
- Rollback note: revert all three files; lucide-react imports restored and `square.and.arrow.down` falls back to questionmark again

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx`
- Result: passed (4/4 tests, 668ms)
- Not checked: visual regression snapshot — out of scope for an icon-swap fix; will be caught by next visual regression run