### PR TITLE
fix(lab): UX-AUDIT-FIX7 — bulk 'Load all reference ranges from catalog' button

### DIFF
--- a/frontend/src/components/laboratory/templateEditor/ContentTab.jsx
+++ b/frontend/src/components/laboratory/templateEditor/ContentTab.jsx
@@ -81,6 +81,34 @@ function ContentTab({
     if (ok) onRemoveField(sectionIndex, fieldIndex);
   }
 
+  // UX-AUDIT-FIX7: Bulk-загрузка всех референсных интервалов из каталога.
+  // Ранее лаборант кликал «Загрузить из каталога» на каждом поле отдельно —
+  // при 20 показателях это 20 микро-решений вместо одного (закон Хика,
+  // Fitts's Law). Теперь одна кнопка в шапке ContentTab.
+  function handleBulkLoadCatalogReferenceRanges() {
+    if (!draftVersion?.sections) return;
+    let loaded = 0;
+    let skipped = 0;
+    draftVersion.sections.forEach((section, sectionIndex) => {
+      (section.fields || []).forEach((field, fieldIndex) => {
+        if (field.reference_mode === 'catalog' && field.analyte_code) {
+          onLoadCatalogReferenceRange(sectionIndex, fieldIndex, field.analyte_code);
+          loaded += 1;
+        } else {
+          skipped += 1;
+        }
+      });
+    });
+    // Используем глобальный notify (если передан) или тихий возврат.
+    // Parent (LabTemplateWorkbench) сам обработает уведомление, т.к.
+    // каждый вызов onLoadCatalogReferenceRange триггерит его callback.
+    // Здесь только логируем для отладки.
+    if (typeof window !== 'undefined' && window.console) {
+      // eslint-disable-next-line no-console
+      console.debug('[ContentTab] bulk-load reference ranges:', { loaded, skipped });
+    }
+  }
+
   return (
     <div className="ltw-grid">
       <div className="ltw-flex-between">
@@ -106,6 +134,24 @@ function ContentTab({
           <Button variant="outline" onClick={onAddSection}>
             <Icon name="plus" size={16} />
             Добавить секцию
+          </Button>
+          {/* UX-AUDIT-FIX7: Bulk-кнопка для загрузки всех референсных
+              интервалов из каталога одним кликом. Показывается всегда,
+              но активна только если есть хотя бы одно поле с reference_mode
+              === 'catalog' и непустым analyte_code. */}
+          <Button
+            variant="outline"
+            size="small"
+            onClick={handleBulkLoadCatalogReferenceRanges}
+            disabled={!draftVersion?.sections?.some((s) =>
+              (s.fields || []).some((f) =>
+                f.reference_mode === 'catalog' && f.analyte_code
+              )
+            )}
+            title="Загрузить референсные интервалы из каталога для всех полей, у которых указан код аналита"
+          >
+            <Icon name="square.and.arrow.down.on.square" size={14} />
+            Загрузить все нормы
           </Button>
         </span>
       </div>

--- a/frontend/src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx
+++ b/frontend/src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx
@@ -76,4 +76,19 @@ describe('ContentTab UX-AUDIT-FIX4 — confirm dialog on field/section delete', 
     expect(source).toContain('visibility_rule_text');
     expect(source).toContain('highlight_rule_text');
   });
+
+  it('UX-AUDIT-FIX7: bulk-loads all reference ranges from catalog in one click', () => {
+    // FIX7: bulk-кнопка «Загрузить все нормы» в шапке ContentTab.
+    // Должна итерировать по всем секциям/полям и вызывать
+    // onLoadCatalogReferenceRange для полей с reference_mode='catalog'.
+    expect(source).toContain('handleBulkLoadCatalogReferenceRanges');
+    expect(source).toContain("reference_mode === 'catalog'");
+    expect(source).toContain('onLoadCatalogReferenceRange(sectionIndex, fieldIndex, field.analyte_code)');
+    // Кнопка в UI
+    expect(source).toContain('Загрузить все нормы');
+    // Disabled когда нет валидных полей
+    expect(source).toContain("disabled={!draftVersion?.sections?.some");
+    // Иконка square.and.arrow.down.on.square
+    expect(source).toContain('square.and.arrow.down.on.square');
+  });
 });


### PR DESCRIPTION
## Summary

- Add a bulk «Загрузить все нормы» button in the `ContentTab` header that loads reference ranges from the catalog for all eligible fields in one click.
- Previously, lab technicians had to click «Загрузить из каталога» on every individual field — for a 20-field template, that meant 20 separate micro-decisions instead of one.
- Closes Nielsen Heuristic #8 (Aesthetic and Minimalist Design — fewer repetitive controls) and supports Fitts's Law + Hick's Law (one large target vs. 20 small ones).

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/ux-audit-fix7-bulk-load-reference-ranges` from `origin/main` at `52423b92` (post-FIX6).
- Clean workspace: inspected before edits; only `ContentTab.jsx` and its contract test changed.
- Branch: `fix/ux-audit-fix7-bulk-load-reference-ranges`
- Scope gate: allowed `frontend/src/components/laboratory/templateEditor/ContentTab.jsx` + `__tests__/ContentTab.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted test fails, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only UX change. No API, websocket, event, or backend contract changed. The bulk handler calls the existing `onLoadCatalogReferenceRange` prop in a loop — same backend endpoint, same payload shape per call, just multiple sequential invocations.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. Same roles see same UI; the new button only re-uses the existing per-field callback.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: button is `disabled` when no field has `reference_mode === 'catalog' && analyte_code` (via `.some()` guard). Cannot fire on empty draft.
- Partial data proof: handler iterates all sections/fields, skipping fields without `analyte_code` — no crash on partially-populated drafts.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: early `if (!draftVersion?.sections) return;` guard prevents null deref.
- Stale route/deep-link behavior: not applicable, operates on local draft state only.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/templateEditor/ContentTab.jsx`, `frontend/src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; one new test added (6 total tests in file)
- Rollback note: revert both files; per-field «Загрузить из каталога» buttons still work (unchanged)

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx`
- Result: passed (6/6 tests, 765ms)
- Not checked: full browser panel smoke — out of scope for a single-button UX fix